### PR TITLE
Add text/ng-template to the HTML mime types

### DIFF
--- a/src/vs/languages/html/common/html.contribution.ts
+++ b/src/vs/languages/html/common/html.contribution.ts
@@ -10,7 +10,7 @@ modesExtensions.registerMode({
 	id: 'html',
 	extensions: ['.html', '.htm', '.shtml', '.mdoc', '.jsp', '.asp', '.aspx', '.jshtm'],
 	aliases: ['HTML', 'htm', 'html', 'xhtml'],
-	mimetypes: ['text/html', 'text/x-jshtm', 'text/template'],
+	mimetypes: ['text/html', 'text/x-jshtm', 'text/template', 'text/ng-template'],
 	moduleId: 'vs/languages/html/common/html',
 	ctorName: 'HTMLMode'
 });


### PR DESCRIPTION
Added `'text/ng-template'` to the HTML mime types to enable HTML highlighting/help in Angular templates within `<script>` blocks
