### PR TITLE
Fix bug #103

### DIFF
--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -26,7 +26,7 @@ export class EditorAccessor implements emmet.Editor {
 
 	public noExpansionOccurred(): void {
 		// return the tab key handling back to the editor
-		this.editor.trigger('emmet', Handler.Tab, {});
+		this.editor.trigger('keyboard', Handler.Tab, {});
 	}
 
 	public isEmmetEnabledMode(): boolean {


### PR DESCRIPTION
The event source should be set to 'keyboard' when there is no emmet expansion.
This change fixes the bug in column counter mentioned in #103 
