### PR TITLE
One click script for installing on linux

### DIFF
--- a/linux_install.sh
+++ b/linux_install.sh
@@ -30,5 +30,3 @@ if [[ $cmd -eq 0 ]]; then
 else
 	echo "something went wrong with installing app"
 fi
-
-echo 'export PATH=$PATH:/usr/local/vscode' >> ~/.bashrc

--- a/linux_install.sh
+++ b/linux_install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is the install script for installing vs code onto a linux machine
+# Usage: sudo bash linux_install.sh 
+userid=`id -u`
+if [[ $userid -ne 0 ]]
+then
+   echo "Sorry, you aren't a root user"
+fi
+
+cmd=`mkdir "/usr/local/vscode/"`
+
+if [[ $cmd -eq 0 ]]; then
+	echo "folder creation successful"
+else
+	echo "something went wrong creating folder"
+fi
+
+cmd=`cp vscode.desktop /usr/share/applications`
+
+if [[ $cmd -eq 0 ]]; then
+	echo "successfully installed app shortcut"
+else
+	echo "something went wrong with installing app shortcut"
+fi
+
+cmd=`cp -r * /usr/local/vscode/`
+
+if [[ $cmd -eq 0 ]]; then
+	echo "successfully installed app"
+else
+	echo "something went wrong with installing app"
+fi
+
+echo 'export PATH=$PATH:/usr/local/vscode' >> ~/.bashrc

--- a/vscode.desktop
+++ b/vscode.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=0.10
+Name=VS Code
+GenericName=Text Editor
+Comment=Code Editing. Redefined.
+Exec=/usr/local/vscode/Code
+Icon=/usr/local/vscode/resources/app/resources/linux/vscode.png
+Terminal=false
+Categories=GTK;Development;IDE;
+MimeType=text/plain;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-java;text/x-dsrc;text/x-pascal;text/x-perl;text/x-python;application/x-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/xml;text/html;text/css;text/x-sql;text/x-diff;
+StartupNotify=true


### PR DESCRIPTION
This makes an entry of visual studio code in the main menu bar of Linux based Operating systems and gives a one click script to install VSCode to the `/usr/local/vscode` folder, using this script the menu bar can identify that VSCode is a development tool and the users won't have to do the manual stuff which is too boring and frankly ruins the reputation of such an amazing tool, Microsoft just revolutionized the way many write code on Linux, this is a statement which none of us imagined to be hearing ever.
