### PR TITLE
Add more extensions to built-in PowerShell support

### DIFF
--- a/extensions/powershell/package.json
+++ b/extensions/powershell/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "powershell",
-			"extensions": [ ".ps1", ".psm1", ".psd1" ],
+			"extensions": [ ".ps1", ".psm1", ".psd1", ".pssc", ".psrc" ],
 			"aliases": [ "PowerShell", "powershell", "ps", "ps1" ],
 			"configuration": "./powershell.configuration.json"
 		}],


### PR DESCRIPTION
This change adds the .pssc and .psrc file extensions to the built-in
PowerShell support.
