### PR TITLE
Update css <length> units used by CSS auto-complete

### DIFF
--- a/src/vs/languages/css/common/services/languageFacts.ts
+++ b/src/vs/languages/css/common/services/languageFacts.ts
@@ -194,7 +194,7 @@ export var colorKeywords : { [name:string]:string } = {
 };
 
 export var units : { [unitName:string]:string[] } = {
-	'length': ['em', 'rem', 'ex', 'px', 'cm', 'mm', 'in', 'pt', 'pc', 'cc'],
+	'length': ['em', 'rem', 'ex', 'px', 'cm', 'mm', 'in', 'pt', 'pc', 'ch'],
 	'angle': ['deg', 'rad', 'grad'],
 	'time': ['ms', 's'],
 	'frequency': ['hz', 'khz'],

--- a/src/vs/languages/css/common/services/languageFacts.ts
+++ b/src/vs/languages/css/common/services/languageFacts.ts
@@ -194,7 +194,7 @@ export var colorKeywords : { [name:string]:string } = {
 };
 
 export var units : { [unitName:string]:string[] } = {
-	'length': ['em', 'rem', 'ex', 'px', 'cm', 'mm', 'in', 'pt', 'pc', 'ch'],
+	'length': ['em', 'rem', 'ex', 'px', 'cm', 'mm', 'in', 'pt', 'pc', 'ch', 'vw', 'vh', 'vmin', 'vmax'],
 	'angle': ['deg', 'rad', 'grad'],
 	'time': ['ms', 's'],
 	'frequency': ['hz', 'khz'],


### PR DESCRIPTION
Fixes #289.

I’ve not added the 'q' unit as it isn’t supported by any browser. I’m not sure what VSCode’s policy is about that.
