### PR TITLE
Use default cursor for .git-statusbar-item

### DIFF
--- a/src/vs/workbench/parts/git/browser/media/git.contribution.css
+++ b/src/vs/workbench/parts/git/browser/media/git.contribution.css
@@ -226,6 +226,7 @@
 	background-repeat: no-repeat;
 	background-position: 4px 50%;
 	background-size: 17px;
+	cursor: default;
 	padding: 0 5px 0 22px;
 }
 


### PR DESCRIPTION
Prevent the text selection cursor from showing on .git-statusbar-item. This is
happening because there is an &nbsp; being used currently to position the
element.

Fixes #307
