### PR TITLE
When creating a delayer add it to delayers set

### DIFF
--- a/extensions/php/src/features/validationProvider.ts
+++ b/extensions/php/src/features/validationProvider.ts
@@ -152,7 +152,7 @@ export default class PHPValidationProvider {
 		let delayer = this.delayers[key];
 		if (!delayer) {
 			delayer = new ThrottledDelayer<void>(this.trigger === RunTrigger.onType ? 250 : 0);
-			this.delayers[key];
+			this.delayers[key] = delayer;
 		}
 		delayer.trigger(() => this.doValidate(textDocument) );
 	}


### PR DESCRIPTION
If no delayer is found for a given uri, a new delayer was created. However, that delayer was never added to the set of delayers for the uri so if the extension was configured to validate onType, each type event would create a new delayer leading to performance problems.
