### PR TITLE
JavaScript: Enable ES6 by Default

### DIFF
--- a/src/vs/editor/browser/standalone/standaloneSchemas.ts
+++ b/src/vs/editor/browser/standalone/standaloneSchemas.ts
@@ -1015,7 +1015,7 @@ MonacoEditorSchemas['http://json.schemastore.org/tsconfig'] = {
 MonacoEditorSchemas['http://opentools.azurewebsites.net/jsconfig'] = {
 	'title': nls.localize('jsconfig.json.title', "JSON schema for the JavaScript configuration file"),
 	'type': 'object',
-	'default': { 'compilerOptions': { 'target': 'ES5' } },
+	'default': { 'compilerOptions': { 'target': 'ES6' } },
 	'properties': {
 		'compilerOptions': {
 			'type': 'object',

--- a/src/vs/languages/typescript/common/project/projectService.ts
+++ b/src/vs/languages/typescript/common/project/projectService.ts
@@ -113,6 +113,7 @@ export class LanguageServiceHost implements ts.LanguageServiceHost {
 		this._compilerOptions = options || ts.getDefaultCompilerOptions();
 		this._compilerOptions.allowNonTsExtensions = true; // because of JS* and mirror model we need this
 		this._compilerOptions.module = ts.ModuleKind.CommonJS; // because of JS*
+		this._compilerOptions.target = options && options.target !== undefined ? options.target : ts.ScriptTarget.Latest; // because of JS*
 	}
 
 	getCompilationSettings(): ts.CompilerOptions {


### PR DESCRIPTION
- This tiny commit enables ES6 support for JavaScript files by default, ensuring that VS Code supports popular JavaScript frameworks and modules out of the box.
- Tests pass, behaviour otherwise unchanged.

Closes #318 
:ship: @joaomoreno @poteto @wycats
