### PR TITLE
Use auth tokens for downloading omnisharp builds from GitHub

### DIFF
--- a/extensions/csharp-o/package.json
+++ b/extensions/csharp-o/package.json
@@ -22,7 +22,6 @@
     "vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../gulpfile.plugins.js compile-plugin:csharp-o ./tsconfig.json"
   },
   "dependencies": {
-    "applicationinsights": "0.15.6",
     "run-in-terminal": "*",
     "semver": "*"
   },
@@ -33,7 +32,6 @@
     "gulp": "^3.8.9",
     "gulp-decompress": "^1.2.0",
     "tmp": "0.0.28",
-    "typescript": "^1.6.2",
     "vinyl-fs": "^2.2.1"
   },
   "extensionDependencies": [

--- a/extensions/csharp-o/package.json
+++ b/extensions/csharp-o/package.json
@@ -1,101 +1,104 @@
 {
-	"name": "csharp-o",
-	"version": "0.1.0",
-	"publisher": "vscode",
-	"engines": {
-		"node": "^4.0.0",
-		"vscode": "*"
-	},
-	"activationEvents": [
-		"onLanguage:csharp",
-		"onCommand:o.restart",
-		"onCommand:o.pickProjectAndStart",
-		"onCommand:o.restore",
-		"onCommand:o.execute",
-		"onCommand:o.showOutput",
-		"onCommand:o.execute",
-		"onCommand:o.execute-last-command"
-	],
-	"main": "./out/omnisharpMain",
-	"scripts": {
-		"postinstall": "node ./node_modules/gulp/bin/gulp.js omnisharp",
-		"vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../gulpfile.plugins.js compile-plugin:csharp-o ./tsconfig.json"
-	},
-	"dependencies": {
-		"applicationinsights": "0.15.6",
-		"run-in-terminal": "*",
-		"semver": "*"
-	},
-	"devDependencies": {
-		"del": "^2.0.2",
-		"gulp": "^3.8.9",
-		"gulp-decompress": "^1.2.0",
-		"gulp-download": "^0.0.1",
-		"typescript": "^1.6.2"
-	},
-	"extensionDependencies": [
-		"vscode.csharp"
-	],
-	"contributes": {
-		"commands": [
-			{
-				"command": "o.restart",
-				"title": "Restart OmniSharp",
-				"category": "OmniSharp"
-			},
-			{
-				"command": "o.pickProjectAndStart",
-				"title": "Select Project",
-				"category": "OmniSharp"
-			},
-			{
-				"command": "o.restore",
-				"title": "Restore Packages",
-				"category": "dnx"
-			},
-			{
-				"command": "o.execute",
-				"title": "Run Command",
-				"category": "dnx"
-			}
-		],
-		"keybindings": [
-			{
-				"command": "o.showOutput",
-				"key": "Ctrl+L L",
-				"mac": "Cmd+L L"
-			},
-			{
-				"command": "o.execute",
-				"key": "Ctrl+L Shift+R",
-				"mac": "Cmd+L Shift+R"
-			},
-			{
-				"command": "o.execute-last-command",
-				"key": "Ctrl+L R",
-				"mac": "Cmd+L R"
-			},
-			{
-				"key": "shift+0",
-				"command": "^acceptSelectedSuggestion",
-				"when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'csharp' && suggestionSupportsAcceptOnKey"
-			},
-			{
-				"key": "shift+9",
-				"command": "^acceptSelectedSuggestion",
-				"when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'csharp' && suggestionSupportsAcceptOnKey"
-			},
-			{
-				"key": ".",
-				"command": "^acceptSelectedSuggestion",
-				"when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'csharp' && suggestionSupportsAcceptOnKey"
-			}
-		],
-		"snippets": [
-			{
-				"language": "csharp",
-				"path": "./snippets/csharp.json"
-			}
-		]
-	}
+  "name": "csharp-o",
+  "version": "0.1.0",
+  "publisher": "vscode",
+  "engines": {
+    "node": "^4.0.0",
+    "vscode": "*"
+  },
+  "activationEvents": [
+    "onLanguage:csharp",
+    "onCommand:o.restart",
+    "onCommand:o.pickProjectAndStart",
+    "onCommand:o.restore",
+    "onCommand:o.execute",
+    "onCommand:o.showOutput",
+    "onCommand:o.execute",
+    "onCommand:o.execute-last-command"
+  ],
+  "main": "./out/omnisharpMain",
+  "scripts": {
+    "postinstall": "node ./node_modules/gulp/bin/gulp.js omnisharp",
+    "vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../gulpfile.plugins.js compile-plugin:csharp-o ./tsconfig.json"
+  },
+  "dependencies": {
+    "applicationinsights": "0.15.6",
+    "run-in-terminal": "*",
+    "semver": "*"
+  },
+  "devDependencies": {
+    "del": "^2.0.2",
+    "event-stream": "^3.3.2",
+    "github-releases": "^0.3.0",
+    "gulp": "^3.8.9",
+    "gulp-decompress": "^1.2.0",
+    "tmp": "0.0.28",
+    "typescript": "^1.6.2",
+    "vinyl-fs": "^2.2.1"
+  },
+  "extensionDependencies": [
+    "vscode.csharp"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "o.restart",
+        "title": "Restart OmniSharp",
+        "category": "OmniSharp"
+      },
+      {
+        "command": "o.pickProjectAndStart",
+        "title": "Select Project",
+        "category": "OmniSharp"
+      },
+      {
+        "command": "o.restore",
+        "title": "Restore Packages",
+        "category": "dnx"
+      },
+      {
+        "command": "o.execute",
+        "title": "Run Command",
+        "category": "dnx"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "o.showOutput",
+        "key": "Ctrl+L L",
+        "mac": "Cmd+L L"
+      },
+      {
+        "command": "o.execute",
+        "key": "Ctrl+L Shift+R",
+        "mac": "Cmd+L Shift+R"
+      },
+      {
+        "command": "o.execute-last-command",
+        "key": "Ctrl+L R",
+        "mac": "Cmd+L R"
+      },
+      {
+        "key": "shift+0",
+        "command": "^acceptSelectedSuggestion",
+        "when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'csharp' && suggestionSupportsAcceptOnKey"
+      },
+      {
+        "key": "shift+9",
+        "command": "^acceptSelectedSuggestion",
+        "when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'csharp' && suggestionSupportsAcceptOnKey"
+      },
+      {
+        "key": ".",
+        "command": "^acceptSelectedSuggestion",
+        "when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'csharp' && suggestionSupportsAcceptOnKey"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "csharp",
+        "path": "./snippets/csharp.json"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
@jrieken Please review.

Our CI builds are failing because Travis constantly hits download count limits when fetching stuff from GitHub. It's possible to use an auth token to mitigate this. We are already using one everywhere else in our build. This enables the same for the OmniSharp bits.
