### PR TITLE
Expose FILE_SAVING event to extensions

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3012,6 +3012,11 @@ declare namespace vscode {
 		export const onDidChangeTextDocument: Event<TextDocumentChangeEvent>;
 
 		/**
+		 * An event that is emitted when a [text document](#TextDocument) is saving to disk (save may fail).
+		 */
+		export const onSavingTextDocument: Event<TextDocument>;
+
+		/**
 		 * An event that is emitted when a [text document](#TextDocument) is saved to disk.
 		 */
 		export const onDidSaveTextDocument: Event<TextDocument>;

--- a/src/vs/workbench/api/browser/pluginHost.api.impl.ts
+++ b/src/vs/workbench/api/browser/pluginHost.api.impl.ts
@@ -236,6 +236,9 @@ export class PluginHostAPIImplementation {
 			onDidChangeTextDocument: (listener, thisArgs?, disposables?) => {
 				return pluginHostDocuments.onDidChangeDocument(listener, thisArgs, disposables);
 			},
+			onSavingTextDocument: (listener, thisArgs?, disposables?) => {
+				return pluginHostDocuments.onSavingDocument(listener, thisArgs, disposables);
+			},
 			onDidSaveTextDocument: (listener, thisArgs?, disposables?) => {
 				return pluginHostDocuments.onDidSaveDocument(listener, thisArgs, disposables);
 			},

--- a/src/vs/workbench/api/common/pluginHostDocuments.ts
+++ b/src/vs/workbench/api/common/pluginHostDocuments.ts
@@ -57,6 +57,9 @@ export class PluginHostModelService {
 	private _onDidChangeDocumentEventEmitter: Emitter<vscode.TextDocumentChangeEvent>;
 	public onDidChangeDocument: Event<vscode.TextDocumentChangeEvent>;
 
+	private _onSavingDocumentEventEmitter: Emitter<BaseTextDocument>;
+	public onSavingDocument: Event<BaseTextDocument>;
+
 	private _onDidSaveDocumentEventEmitter: Emitter<BaseTextDocument>;
 	public onDidSaveDocument: Event<BaseTextDocument>;
 
@@ -75,6 +78,9 @@ export class PluginHostModelService {
 
 		this._onDidChangeDocumentEventEmitter = new Emitter<vscode.TextDocumentChangeEvent>();
 		this.onDidChangeDocument = this._onDidChangeDocumentEventEmitter.event;
+
+		this._onSavingDocumentEventEmitter = new Emitter<BaseTextDocument>();
+		this.onSavingDocument = this._onSavingDocumentEventEmitter.event;
 
 		this._onDidSaveDocumentEventEmitter = new Emitter<BaseTextDocument>();
 		this.onDidSaveDocument = this._onDidSaveDocumentEventEmitter.event;
@@ -135,6 +141,11 @@ export class PluginHostModelService {
 		this._onDidRemoveDocumentEventEmitter.fire(document);
 		document._acceptLanguageId(newModeId);
 		this._onDidAddDocumentEventEmitter.fire(document);
+	}
+
+	public _acceptModelSaving(url: URI): void {
+		let document = this._documents[url.toString()];
+		this._onSavingDocumentEventEmitter.fire(document);
 	}
 
 	public _acceptModelSaved(url: URI): void {
@@ -553,6 +564,9 @@ export class MainThreadDocuments {
 		modelService.onModelRemoved.add(this._onModelRemoved, this, this._toDispose);
 		modelService.onModelModeChanged.add(this._onModelModeChanged, this, this._toDispose);
 
+		this._toDispose.push(eventService.addListener2(FileEventType.FILE_SAVING, (e: LocalFileChangeEvent) => {
+			this._proxy._acceptModelSaving(e.getAfter().resource);
+		}));
 		this._toDispose.push(eventService.addListener2(FileEventType.FILE_SAVED, (e: LocalFileChangeEvent) => {
 			this._proxy._acceptModelSaved(e.getAfter().resource);
 		}));


### PR DESCRIPTION
Just allows extensions to use workspace.onSavingTextDocument to bind to FileEventType.FILE_SAVING events.

Not sure if there was a reason this event was not exposed to extensions.

My use case was for an extension that needs to know when a user tries to save a file, even if it fails (Write Protected). 

This change may be superseded by a Pre-Save hook that allows an extension to block saving ( #239 )
