### PR TITLE
Do not mkdir if saving to drive root (fixes #379)

### DIFF
--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -416,7 +416,8 @@ export enum FileOperationResult {
 	FILE_MODIFIED_SINCE,
 	FILE_MOVE_CONFLICT,
 	FILE_READ_ONLY,
-	FILE_TOO_LARGE
+	FILE_TOO_LARGE,
+	FILE_INVALID_PARENT
 }
 
 export interface IFilesConfiguration {

--- a/src/vs/workbench/services/files/node/fileService.ts
+++ b/src/vs/workbench/services/files/node/fileService.ts
@@ -222,12 +222,12 @@ export class FileService implements files.IFileService {
 				createParentsPromise = Promise.as(null);
 			} else {
 				//Do not try to make parent directory if saving to drive root
-                var dirName = paths.dirname(absolutePath);
-                if(dirName.slice(-2) != ':\\') {
-                    createParentsPromise = pfs.mkdirp(dirName);
-                } else {
-                    createParentsPromise = Promise.as(null);
-                }
+				var dirName = paths.dirname(absolutePath);
+				if(dirName.slice(-2) != ':\\') {
+					createParentsPromise = pfs.mkdirp(dirName);
+				} else {
+					createParentsPromise = Promise.as(null);
+				}
 
 			}
 

--- a/src/vs/workbench/services/files/node/fileService.ts
+++ b/src/vs/workbench/services/files/node/fileService.ts
@@ -221,7 +221,14 @@ export class FileService implements files.IFileService {
 			if (exists) {
 				createParentsPromise = Promise.as(null);
 			} else {
-				createParentsPromise = pfs.mkdirp(paths.dirname(absolutePath));
+				//Do not try to make parent directory if saving to drive root
+                var dirName = paths.dirname(absolutePath);
+                if(dirName.slice(-2) != ':\\') {
+                    createParentsPromise = pfs.mkdirp(dirName);
+                } else {
+                    createParentsPromise = Promise.as(null);
+                }
+
 			}
 
 			// 2.) create parents as needed

--- a/src/vs/workbench/services/files/node/fileService.ts
+++ b/src/vs/workbench/services/files/node/fileService.ts
@@ -226,6 +226,14 @@ export class FileService implements files.IFileService {
 					//Directory already exists so do not create it
 					if (stat.isDirectory()) {
 						return Promise.as(null);
+					}
+
+					//Parent Directory is a file, throw FILE_INVALID_PARENT error
+					else if (stat.isFile()) {
+						return Promise.wrapError(<files.IFileOperationResult>{
+							message: nls.localize('fileInvalidParentError', "File has an invalid parent directory ({0})", paths.dirname(absolutePath)),
+							fileOperationResult: files.FileOperationResult.FILE_INVALID_PARENT
+						});
 					} else {
 						return pfs.mkdirp(paths.dirname(absolutePath));
 					}

--- a/src/vs/workbench/services/files/node/fileService.ts
+++ b/src/vs/workbench/services/files/node/fileService.ts
@@ -224,7 +224,7 @@ export class FileService implements files.IFileService {
 				//Do not try to make parent directory if exists
 				createParentsPromise = pfs.stat(paths.dirname(absolutePath)).then((stat) => {
 					//Directory already exists so do not create it
-					if(stat.isDirectory()) {
+					if (stat.isDirectory()) {
 						return Promise.as(null);
 					} else {
 						return pfs.mkdirp(paths.dirname(absolutePath));

--- a/src/vs/workbench/services/files/test/node/service.test.ts
+++ b/src/vs/workbench/services/files/test/node/service.test.ts
@@ -248,7 +248,7 @@ suite('FileService', () => {
 
 	test('resolveFile', function(done: () => void) {
 		service.resolveFile(uri.file(testDir), { resolveTo: [uri.file(path.join(testDir, 'deep'))]}).done(r => {
-			assert.equal(r.children.length, 5);
+			assert.equal(r.children.length, 6);
 
 			let deep = utils.getByName(r, 'deep');
 			assert.equal(deep.children.length, 4);
@@ -306,6 +306,16 @@ suite('FileService', () => {
 					done();
 				});
 			});
+		});
+	});
+
+	test('updateContent - FILE_INVALID_PARENT', function(done: () => void) {
+		let resource = uri.file(path.join(testDir, 'invalid_parent_path', 'invalid_path.txt'));
+
+		return service.updateContent(resource, 'Some updates').done(null, (e:IFileOperationResult) => {
+			assert.equal(e.fileOperationResult, FileOperationResult.FILE_INVALID_PARENT);
+
+			done();
 		});
 	});
 


### PR DESCRIPTION
Does a pretty janky check, and only works for windows (not sure if this happens on other OS's)

May make more sense to check if the first character is \ or if starts with Letter then Colon.

(fixes #379)

Update: Uses fs.stat to check if directory exists... and removes the initial Jank. Should work across OS's
