### PR TITLE
IWorkbenchEditorService dependency for MainThreadOutputService

### DIFF
--- a/src/vs/workbench/api/browser/extHostOutputService.ts
+++ b/src/vs/workbench/api/browser/extHostOutputService.ts
@@ -79,7 +79,7 @@ export class MainThreadOutputService {
 	private _outputService: IOutputService;
 	private _editorService: IWorkbenchEditorService;
 
-	constructor(@IOutputService outputService: IOutputService, editorService: IWorkbenchEditorService) {
+	constructor(@IOutputService outputService: IOutputService,@IWorkbenchEditorService editorService: IWorkbenchEditorService) {
 		this._outputService = outputService;
 		this._editorService = editorService;
 	}


### PR DESCRIPTION
Allows MainThreadOutputService to be created w/ editorService (fixes #377)

Only fixes the error. Method for hiding the output window itself does not appear to work.
