### PR TITLE
syntax highlighting for c++: 'value' keyword removed.

### DIFF
--- a/src/vs/editor/standalone-languages/cpp.ts
+++ b/src/vs/editor/standalone-languages/cpp.ts
@@ -117,7 +117,6 @@ export var language = <ILanguage> {
 		'union',
 		'unsigned',
 		'using',
-		'value',
 		'virtual',
 		'void',
 		'volatile',


### PR DESCRIPTION
'value' is not a c++ keyword, so I've removed it.
