### PR TITLE
Remove Zoomout constraint (fixes #430)

### DIFF
--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -166,7 +166,7 @@ export class ZoomOutAction extends Action {
 
 	public run(): Promise {
 		if (webFrame.getZoomLevel() > -2) {
-			webFrame.setZoomLevel(webFrame.getZoomLevel() - 1); // prevent zoom out below 0 for now because it results in blurryness
+			webFrame.setZoomLevel(webFrame.getZoomLevel() - 1); // prevent zoom out below -2
 		}
 
 		return Promise.as(true);

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -165,7 +165,9 @@ export class ZoomOutAction extends Action {
 	}
 
 	public run(): Promise {
-		webFrame.setZoomLevel(webFrame.getZoomLevel() - 1);
+		if (webFrame.getZoomLevel() > -2) {
+			webFrame.setZoomLevel(webFrame.getZoomLevel() - 1); // prevent zoom out below 0 for now because it results in blurryness
+		}
 
 		return Promise.as(true);
 	}

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -165,9 +165,7 @@ export class ZoomOutAction extends Action {
 	}
 
 	public run(): Promise {
-		if (webFrame.getZoomLevel() > 0) {
-			webFrame.setZoomLevel(webFrame.getZoomLevel() - 1); // prevent zoom out below 0 for now because it results in blurryness
-		}
+		webFrame.setZoomLevel(webFrame.getZoomLevel() - 1);
 
 		return Promise.as(true);
 	}


### PR DESCRIPTION
As per issue #430, this is re-enabling zoom level < 100%

Curious for the reasoning of not allowing < 100%, as although it may cause blurryness in some cases, it works fine in others. I find the ability to zoomout very useful, as I am sure many other people do.

On the 1920x1080 and 1920x1200 displays I am using, I do not experience any blurring.

If there is still a desire to not allow the overall zoom <100%, what are your thoughts on having zooming only affect the editor panel (like Visual Studio)?
