### PR TITLE
Untitled Save As dialog defaults to All Types with blank name 

### DIFF
--- a/src/vs/workbench/browser/parts/editor/untitledEditorInput.ts
+++ b/src/vs/workbench/browser/parts/editor/untitledEditorInput.ts
@@ -75,14 +75,10 @@ export class UntitledEditorInput extends EditorInput implements IResourceEditorI
 	}
 
 	public suggestFileName(): string {
-		if (!this.hasAssociatedFilePath) {
-			let mime = this.getMime();
-			if (mime) {
-				return suggestFilename(mime, this.getName());
-			}
-		}
-
-		return this.getName();
+		//Temporarily return empty name as electron appends *.* as extension.
+		//This is fixed in electron v0.34.2, where it should return name w/o extenstion (ex. "Untitled-1")
+		//return this.getName();
+		return '';
 	}
 
 	public getMime(): string {

--- a/src/vs/workbench/browser/parts/editor/untitledEditorInput.ts
+++ b/src/vs/workbench/browser/parts/editor/untitledEditorInput.ts
@@ -75,10 +75,15 @@ export class UntitledEditorInput extends EditorInput implements IResourceEditorI
 	}
 
 	public suggestFileName(): string {
-		//Temporarily return empty name as electron appends *.* as extension.
-		//This is fixed in electron v0.34.2, where it should return name w/o extenstion (ex. "Untitled-1")
-		//return this.getName();
-		return '';
+		//If the mime type is specified and not text/plain, use that as type, otherwise use All Files
+		if (!this.hasAssociatedFilePath) {
+            let mime = this.getMime();
+            if (mime != 'text/plain') {
+                return suggestFilename(mime, this.getName());
+            }
+        }
+
+        return this.getName();
 	}
 
 	public getMime(): string {

--- a/src/vs/workbench/browser/parts/editor/untitledEditorInput.ts
+++ b/src/vs/workbench/browser/parts/editor/untitledEditorInput.ts
@@ -77,13 +77,13 @@ export class UntitledEditorInput extends EditorInput implements IResourceEditorI
 	public suggestFileName(): string {
 		//If the mime type is specified and not text/plain, use that as type, otherwise use All Files
 		if (!this.hasAssociatedFilePath) {
-            let mime = this.getMime();
-            if (mime != 'text/plain') {
-                return suggestFilename(mime, this.getName());
-            }
-        }
+			let mime = this.getMime();
+			if (mime != 'text/plain') {
+				return suggestFilename(mime, this.getName());
+			}
+		}
 
-        return this.getName();
+		return this.getName();
 	}
 
 	public getMime(): string {


### PR DESCRIPTION
This fixes issue #450

This is a UX change so reject if undesired behavior.
