### PR TITLE
Fix function keyword syntax

### DIFF
--- a/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
+++ b/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
@@ -522,7 +522,7 @@
 		<key>function</key>
 		<dict>
 			<key>begin</key>
-			<string>((?i:function|filter|configuration|workflow))\s+((?:\p{L}|\d|_|-|\.)+)</string>
+			<string>(?&lt;!\S)(?i)(function|filter|configuration|workflow)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -538,7 +538,12 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function</string>
+					<string>storage.modifier.scope.powershell</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.powershell</string>
 				</dict>
 			</dict>
 			<key>end</key>


### PR DESCRIPTION
This fixes a longstanding bug highlighting code like:

``` posh
# This is ok
Test-Highlight -Something StringValue
# This is not
Test-Highlight -TestFunction StringValue
# and it breaks this:
Test-Highlight -Something StringValue
```

I also fixed scope on function names, like:

``` posh
function Test-Thing { Get-Command $VariableName }
# the function name should be highlighted as above, and both "global"s should be the same...
function global:Test-Thing { Get-Command $global:VariableName }
Function LOCAL:Test-Thing { Get-Command $local:VariableName }
FUNCTION script:Test-Thing { Get-Command $script:VariableName }
```

Same change as https://github.com/SublimeText/PowerShell/pull/137
