### PR TITLE
Adding option to configure cursor blinking

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -136,6 +136,7 @@ export class ViewCursors extends ViewPart {
 	}
 	public onConfigurationChanged(e:EditorCommon.IConfigurationChangedEvent): boolean {
 		this._primaryCursor.onConfigurationChanged(e);
+		this._updateBlinking();
 		for (var i = 0, len = this._secondaryCursors.length; i < len; i++) {
 			this._secondaryCursors[i].onConfigurationChanged(e);
 		}

--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -172,7 +172,16 @@ export class ViewCursors extends ViewPart {
 	private _getRenderType(): RenderType {
 		if (this._editorHasFocus) {
 			if (this._primaryCursor.getIsInEditableRange() && !this._context.configuration.editor.readOnly) {
-				return RenderType.Blink;
+				switch (this._context.configuration.editor.cursorBlinking) {
+					case ("blink"):
+						return RenderType.Blink;
+					case ("visible"):
+						return RenderType.Visible;
+					case ("hidden"):
+						return RenderType.Hidden;
+					default:
+						return RenderType.Blink;
+				}
 			}
 			return RenderType.Visible;
 		}

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -141,6 +141,7 @@ class InternalEditorOptionsHelper {
 			readOnly: toBoolean(opts.readOnly),
 			scrollbar: scrollbar,
 			overviewRulerLanes: toInteger(opts.overviewRulerLanes, 0, 3),
+			cursorBlinking: opts.cursorBlinking,
 			hideCursorInOverviewRuler: toBoolean(opts.hideCursorInOverviewRuler),
 			scrollBeyondLastLine: toBoolean(opts.scrollBeyondLastLine),
 			wrappingIndent: opts.wrappingIndent,
@@ -236,6 +237,7 @@ class InternalEditorOptionsHelper {
 			readOnly:						(prevOpts.readOnly !== newOpts.readOnly),
 			scrollbar:						(!this._scrollbarOptsEqual(prevOpts.scrollbar, newOpts.scrollbar)),
 			overviewRulerLanes:				(prevOpts.overviewRulerLanes !== newOpts.overviewRulerLanes),
+			cursorBlinking:					(prevOpts.cursorBlinking !== newOpts.cursorBlinking),
 			hideCursorInOverviewRuler:		(prevOpts.hideCursorInOverviewRuler !== newOpts.hideCursorInOverviewRuler),
 			scrollBeyondLastLine:			(prevOpts.scrollBeyondLastLine !== newOpts.scrollBeyondLastLine),
 			wrappingIndent:					(prevOpts.wrappingIndent !== newOpts.wrappingIndent),
@@ -793,6 +795,12 @@ configurationRegistry.registerConfiguration({
 			'type': 'integer',
 			'default': 3,
 			'description': nls.localize('overviewRulerLanes', "Controls the number of decorations that can show up at the same position in the overview ruler")
+		},
+		'editor.cursorBlinking' : {
+			'type': 'string',
+			'enum': ['blink', 'visible', 'hidden'],
+			'default': DefaultConfig.editor.cursorBlinking,
+			'description': nls.localize('cursorBlinking', "Controls the cursor blinking animation.")
 		},
 		'editor.hideCursorInOverviewRuler' : {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/defaultConfig.ts
+++ b/src/vs/editor/common/config/defaultConfig.ts
@@ -33,6 +33,7 @@ class ConfigClass implements IConfiguration {
 				horizontalHasArrows: false
 			},
 			overviewRulerLanes: 2,
+			cursorBlinking: 'blink',
 			hideCursorInOverviewRuler: false,
 			scrollBeyondLastLine: true,
 			automaticLayout: false,

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -334,6 +334,11 @@ export interface ICommonEditorOptions {
 	 */
 	overviewRulerLanes?:number;
 	/**
+	 * Control the cursor blinking animation.
+	 * Defaults to 'blink'.
+	 */
+	cursorBlinking?:string;
+	/**
 	 * Should the cursor be hidden in the overview ruler.
 	 * Defaults to false.
 	 */
@@ -577,6 +582,7 @@ export interface IInternalEditorOptions {
 	readOnly:boolean;
 	scrollbar:IInternalEditorScrollbarOptions;
 	overviewRulerLanes:number;
+	cursorBlinking:string;
 	hideCursorInOverviewRuler:boolean;
 	scrollBeyondLastLine:boolean;
 	wrappingIndent: string;
@@ -667,6 +673,7 @@ export interface IConfigurationChangedEvent {
 	readOnly:boolean;
 	scrollbar:boolean;
 	overviewRulerLanes:boolean;
+	cursorBlinking:boolean;
 	hideCursorInOverviewRuler:boolean;
 	scrollBeyondLastLine:boolean;
 	wrappingIndent:boolean;


### PR DESCRIPTION
Aims to solve #460.

This adds the possibility to change the cursor's blink in the config file : 

``` json
    // Controls the cursor blinking animation.
    "editor.cursorBlinking": "blink"
```

Possible values are the already implemented `"blink"`, `"visible"` and `"hidden"`.
