### PR TITLE
add the "Sync" command to the command palette as global command

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
@@ -31,7 +31,7 @@ import {IFileService, IFileStat} from 'vs/platform/files/common/files';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
 import wbar = require('vs/workbench/browser/actionRegistry');
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { OpenChangeAction } from './gitActions';
+import { OpenChangeAction, SyncAction } from './gitActions';
 import Severity from 'vs/base/common/severity';
 
 function getStatus(gitService: IGitService, contextService: IWorkspaceContextService, input: WorkbenchEditorCommon.IFileEditorInput): IFileStatus {
@@ -432,5 +432,7 @@ actionBarRegistry.registerActionBarContributor(abr.Scope.EDITOR, GitWorkingTreeD
 
 let workbenchActionRegistry = (<wbar.IWorkbenchActionRegistry> platform.Registry.as(wbar.Extensions.WorkbenchActions));
 
-// Register Action to Open Viewlet
-workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalOpenChangeAction, GlobalOpenChangeAction.ID, GlobalOpenChangeAction.LABEL), nls.localize('git', "Git"));
+// Register Actions
+const category = nls.localize('git', "Git");
+workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalOpenChangeAction, GlobalOpenChangeAction.ID, GlobalOpenChangeAction.LABEL), category);
+workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(SyncAction, SyncAction.ID, SyncAction.LABEL), category);

--- a/src/vs/workbench/parts/git/browser/gitActions.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.ts
@@ -941,9 +941,10 @@ export abstract class BaseSyncAction extends GitAction {
 export class SyncAction extends BaseSyncAction {
 
 	static ID = 'workbench.action.sync';
+	static LABEL = nls.localize('sync', "Sync");
 
-	constructor(@IGitService gitService: IGitService) {
-		super(SyncAction.ID, nls.localize('sync', "Sync"), 'git-action sync', gitService);
+	constructor(id: string, label: string, @IGitService gitService: IGitService) {
+		super(id, label, 'git-action sync', gitService);
 	}
 }
 

--- a/src/vs/workbench/parts/git/browser/views/changes/changesView.ts
+++ b/src/vs/workbench/parts/git/browser/views/changes/changesView.ts
@@ -246,7 +246,7 @@ export class ChangesView extends EventEmitter.EventEmitter implements GitView.IV
 	public getSecondaryActions(): Actions.IAction[] {
 		if (!this.secondaryActions) {
 			this.secondaryActions = [
-				this.instantiationService.createInstance(GitActions.SyncAction),
+				this.instantiationService.createInstance(GitActions.SyncAction, GitActions.SyncAction.ID, GitActions.SyncAction.LABEL),
 				this.instantiationService.createInstance(GitActions.PullAction),
 				this.instantiationService.createInstance(GitActions.PushAction),
 				new ActionBar.Separator(),


### PR DESCRIPTION
Given this is my Nr. 1 action, would love to not having to always use the mouse to pull down "Sync" from the git viewlet.
