### PR TITLE
Add "Show Extensions Updates" command

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -54,3 +54,26 @@ export class InstallExtensionAction extends Action {
 		return true;
 	}
 }
+
+export class ListExtensionsUpdatesAction extends Action {
+
+	static ID = 'workbench.extensions.action.listExtensionsUpdates';
+	static LABEL = nls.localize('showExtensionsUpdates', "Show Extensions Updates");
+
+	constructor(
+		id: string,
+		label: string,
+		@IExtensionsService private extensionsService: IExtensionsService,
+		@IQuickOpenService private quickOpenService: IQuickOpenService
+	) {
+		super(id, label, null, true);
+	}
+
+	public run(): Promise {
+		return this.quickOpenService.show('ext update ');
+	}
+
+	protected isEnabled(): boolean {
+		return true;
+	}
+}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsQuickOpen.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsQuickOpen.ts
@@ -473,3 +473,77 @@ export class GalleryExtensionsHandler extends QuickOpenHandler {
 		return { autoFocusFirstEntry: true };
 	}
 }
+
+class ExtensionsUpdateModel implements IModel<IExtensionEntry> {
+
+	public dataSource = new DataSource();
+	public renderer: IRenderer<IExtensionEntry>;
+	public runner: IRunner<IExtensionEntry>;
+	public entries: IExtensionEntry[];
+
+	constructor(
+		private galleryExtensions: IExtension[],
+		private localExtensions: IExtension[],
+		@IInstantiationService instantiationService: IInstantiationService
+	) {
+		this.renderer = instantiationService.createInstance(Renderer);
+		this.runner = instantiationService.createInstance(InstallRunner);
+		this.entries = [];
+	}
+
+	public set input(input: string) {
+		this.entries = this.galleryExtensions
+			.map(extension => ({ extension, highlights: getHighlights(input, extension) }))
+			.filter(({ extension, highlights }) => {
+				const local = this.localExtensions.filter(local => extensionEquals(local, extension))[0];
+				return local && local.version < extension.version && !!highlights;
+			})
+			.map(({ extension, highlights }: { extension: IExtension, highlights: IHighlights }) => {
+				return {
+					extension,
+					highlights,
+					state: ExtensionState.Outdated
+				};
+			})
+			.sort((a, b) => a.extension.name.localeCompare(b.extension.name));
+	}
+}
+
+export class ExtensionsUpdateHandler extends QuickOpenHandler {
+
+	private modelPromise: TPromise<ExtensionsUpdateModel>;
+
+	constructor(
+		@IInstantiationService private instantiationService: IInstantiationService,
+		@IExtensionsService private extensionsService: IExtensionsService,
+		@IGalleryService private galleryService: IGalleryService,
+		@ITelemetryService private telemetryService: ITelemetryService
+	) {
+		super();
+	}
+
+	getResults(input: string): TPromise<IModel<IExtensionEntry>> {
+		if (!this.modelPromise) {
+			this.telemetryService.publicLog('extensionGallery:open');
+			this.modelPromise = TPromise.join<any>([this.galleryService.query(), this.extensionsService.getInstalled()])
+				.then(result => this.instantiationService.createInstance(ExtensionsUpdateModel, result[0], result[1]));
+		}
+
+		return this.modelPromise.then(model => {
+			model.input = input;
+			return model;
+		});
+	}
+
+	onClose(canceled: boolean): void {
+		this.modelPromise = null;
+	}
+
+	getEmptyLabel(input: string): string {
+		return nls.localize('noOutdatedExtensions', "No outdated extensions found");
+	}
+
+	getAutoFocus(searchValue: string): IAutoFocus {
+		return { autoFocusFirstEntry: true };
+	}
+}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsWorkbenchExtension.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsWorkbenchExtension.ts
@@ -16,7 +16,7 @@ import { IWorkspaceContextService } from 'vs/workbench/services/workspace/common
 import { ReloadWindowAction } from 'vs/workbench/electron-browser/actions';
 import wbaregistry = require('vs/workbench/browser/actionRegistry');
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { ListExtensionsAction, InstallExtensionAction } from './extensionsActions';
+import { ListExtensionsAction, InstallExtensionAction, ListExtensionsUpdatesAction } from './extensionsActions';
 import { IQuickOpenRegistry, Extensions, QuickOpenHandlerDescriptor } from 'vs/workbench/browser/quickopen';
 
 import ipc = require('ipc');
@@ -64,6 +64,18 @@ export class ExtensionsWorkbenchExtension implements IWorkbenchContribution {
 					'GalleryExtensionsHandler',
 					'ext install ',
 					nls.localize('galleryExtensionsCommands', "Gallery Extensions Commands"),
+					true
+				)
+			);
+
+			actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(ListExtensionsUpdatesAction, ListExtensionsUpdatesAction.ID, ListExtensionsUpdatesAction.LABEL), extensionsCategory);
+
+			(<IQuickOpenRegistry>platform.Registry.as(Extensions.Quickopen)).registerQuickOpenHandler(
+				new QuickOpenHandlerDescriptor(
+					'vs/workbench/parts/extensions/electron-browser/extensionsQuickOpen',
+					'ExtensionsUpdateHandler',
+					'ext update ',
+					nls.localize('extensionsUpdateCommands', "Extensions Update Commands"),
 					true
 				)
 			);


### PR DESCRIPTION
Shows all installed  extensions that have updates available. Can also be accessed by "ext update". This is how it looks like:

![2015-11-24_11-35-22](https://cloud.githubusercontent.com/assets/954102/11369833/a700324e-929f-11e5-8491-00dc2b726c68.png)
It is showing just the extensions that are outdated.

I miss this feature, what does the team think about this?
