### PR TITLE
Executing a built in command does not wait for it to be executed (fixes #617)

### DIFF
--- a/src/vs/platform/keybinding/browser/keybindingServiceImpl.ts
+++ b/src/vs/platform/keybinding/browser/keybindingServiceImpl.ts
@@ -309,7 +309,7 @@ export class KeybindingService extends AbstractKeybindingService implements IKey
 			args.context = contextValue;
 		}
 
-		return this._invokeHandler(commandId, args).done(undefined, err => {
+		return this._invokeHandler(commandId, args).then(undefined, err => {
 			this._messageService.show(Severity.Warning, err);
 		});
 	}

--- a/src/vs/workbench/browser/actionRegistry.ts
+++ b/src/vs/workbench/browser/actionRegistry.ts
@@ -171,7 +171,7 @@ export function createCommandHandler(descriptor: SyncActionDescriptor): ICommand
 		let telemetryServce = accessor.get(ITelemetryService);
 		let partService = accessor.get(IPartService);
 
-		TPromise.as(triggerAndDisposeAction(instantiationService, telemetryServce, partService, descriptor, args)).done(null, (err) => {
+		return TPromise.as(triggerAndDisposeAction(instantiationService, telemetryServce, partService, descriptor, args)).then(null, (err) => {
 			messageService.show(Severity.Error, err);
 		});
 	};


### PR DESCRIPTION
@alexandrudima this is for #617, can you please check if it makes sense? The intent is that commands executed via keybinding service properly connect the promises chain.

After this change I can execute a command from an extension and it will only complete when the action has completed on the renderer side.
