### PR TITLE
[TypeScript] Bug fixes #297 snippet on method suggest

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -58,8 +58,13 @@
 			"title": "TypeScript configuration",
 			"properties": {
 				"typescript.useCodeSnippetsOnMethodSuggest": {
-					"type": "boolean",
-					"default": false,
+					"type": "string",
+					"enum": [
+						"lambda",
+						"func",
+						"none"
+					],
+					"default": "lambda",
 					"description": "Complete functions with their parameter signature."
 				},
 				"typescript.tsdk": {

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -138,27 +138,40 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 				let openParentheses = 1;
 				let innerParameters = [];
 				while (openParentheses !== 0) {
-					if (displayParts[0].text === '(') openParentheses++
-					else if (displayParts[0].text === ')') openParentheses--
-					else innerParameters.push(displayParts.shift());
+					if (displayParts[0].text === '(') {
+						openParentheses++;
+					}
+					else if (displayParts[0].text === ')') {
+						openParentheses--;
+					}
+					else {
+						innerParameters.push(displayParts.shift());
+					}
 					if (openParentheses === 0) {
 						displayParts.shift();
-						if (mode === "lambda" ) {
-							result += innerParameters.length > 0 ? `${this.extractMethodParameters(innerParameters, mode, true) }` : '()';
-							result += ` => {\n\t\t{{}}\n\t}`
+						if (mode === "lambda") {
+							let comma = displayParts.length > 0 ? ', ' : ''
+							if (innerParameters.length === 0) {
+								result += `()`;
+							} else if (innerParameters.length === 1) {
+								result += innerParameters[0].text.substr(0, 3)
+							} else {
+								result += this.extractMethodParameters(innerParameters, mode, true)
+							}
+							result += ` => {\n\t\t{{}}\n\t}` + comma
+
 						} else {
 							result += `{{${currentFunctionName}}}`;
 						}
 					}
 				}
 			} else {
-				result += isNested ? displayParts.shift().text.substr(0,3) : `{{${displayParts.shift().text}}}`;
+				result += isNested ? displayParts.shift().text.substr(0, 3) : `{{${displayParts.shift().text}}}`;
 				result += displayParts.length > 0 ? ', ' : '';
 
 			}
 		}
-		return `(${result})`
-		.replace(/\}\s*\(/g,'},(');
+		return `(${result})`;
 
 	}
 
@@ -203,9 +216,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 					item.detail = Previewer.plain(detail.displayParts);
 				}
 
-				if (detail &&
-				(this.config.useCodeSnippetsOnMethodSuggest === "lambda" ||
-				this.config.useCodeSnippetsOnMethodSuggest === "func" ) && item.kind === CompletionItemKind.Function) {
+				if (detail && this.config.useCodeSnippetsOnMethodSuggest !== "none" && item.kind === CompletionItemKind.Function) {
 					let codeSnippet = detail.name;
 					codeSnippet += this.extractMethodParameters(this.simplifyItems(detail.displayParts),this.config.useCodeSnippetsOnMethodSuggest)
 

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -124,7 +124,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 
 	/**
 	 * This method extract parameters and functions for completion
-	 * Mode: true or lambda will generate lambda for functions as parameter and
+	 * Mode: lambda will generate lambda expression for functions as parameter and
 	 * anything else will keep place holder for function name.
 	 * isNested: will keep track of nested functions in parameter
 	 */
@@ -154,11 +154,11 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 							if (innerParameters.length === 0) {
 								result += `()`;
 							} else if (innerParameters.length === 1) {
-								result += innerParameters[0].text.substr(0, 3)
+								result += innerParameters[0].text.substr(0, 3);
 							} else {
-								result += this.extractMethodParameters(innerParameters, mode, true)
+								result += this.extractMethodParameters(innerParameters, mode, true);
 							}
-							result += ` => {\n\t\t{{}}\n\t}` + comma
+							result += ` => {\n\t\t{{}}\n\t}${comma}`;
 
 						} else {
 							result += `{{${currentFunctionName}}}${comma} `;

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -128,7 +128,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 	 * anything else will keep place holder for function name.
 	 * isNested: will keep track of nested functions in parameter
 	 */
-	private extractMethodParameters(displayParts:any, mode = "lambda", isNested = false) {
+	private extractMethodParameters(displayParts: any, mode = "lambda", isNested = false) {
 		let result = '';
 		while (displayParts.length > 0) {
 			let nextItem = displayParts.length > 1 ? displayParts[1].text : '';
@@ -149,8 +149,8 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 					}
 					if (openParentheses === 0) {
 						displayParts.shift();
+						let comma = displayParts.length > 0 ? ', ' : ''
 						if (mode === "lambda") {
-							let comma = displayParts.length > 0 ? ', ' : ''
 							if (innerParameters.length === 0) {
 								result += `()`;
 							} else if (innerParameters.length === 1) {
@@ -161,7 +161,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 							result += ` => {\n\t\t{{}}\n\t}` + comma
 
 						} else {
-							result += `{{${currentFunctionName}}}`;
+							result += `{{${currentFunctionName}}}${comma} `;
 						}
 					}
 				}
@@ -218,7 +218,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 
 				if (detail && this.config.useCodeSnippetsOnMethodSuggest !== "none" && item.kind === CompletionItemKind.Function) {
 					let codeSnippet = detail.name;
-					codeSnippet += this.extractMethodParameters(this.simplifyItems(detail.displayParts),this.config.useCodeSnippetsOnMethodSuggest)
+					codeSnippet += this.extractMethodParameters(this.simplifyItems(detail.displayParts), this.config.useCodeSnippetsOnMethodSuggest)
 
 					item.insertText = codeSnippet;
 				}

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -216,7 +216,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 					item.detail = Previewer.plain(detail.displayParts);
 				}
 
-				if (detail && this.config.useCodeSnippetsOnMethodSuggest !== "none" && item.kind === CompletionItemKind.Function) {
+				if (detail && ( this.config.useCodeSnippetsOnMethodSuggest === "lambda" ||  this.config.useCodeSnippetsOnMethodSuggest === "func" )  && item.kind === CompletionItemKind.Function) {
 					let codeSnippet = detail.name;
 					codeSnippet += this.extractMethodParameters(this.simplifyItems(detail.displayParts), this.config.useCodeSnippetsOnMethodSuggest)
 

--- a/extensions/typescript/src/features/configuration.ts
+++ b/extensions/typescript/src/features/configuration.ts
@@ -8,11 +8,11 @@
 import { workspace } from 'vscode';
 
 export interface IConfiguration {
-	useCodeSnippetsOnMethodSuggest?: boolean;
+	useCodeSnippetsOnMethodSuggest?: string;
 }
 
 export var defaultConfiguration: IConfiguration = {
-	useCodeSnippetsOnMethodSuggest: false
+	useCodeSnippetsOnMethodSuggest: "lambda"
 }
 
 export function load(myPluginId: string): IConfiguration {


### PR DESCRIPTION
## What is it?

This is bug fix for #297 related to completion and  also expand completion options.
## How?

"typescript.useCodeSnippetsOnMethodSuggest" option in settings now have 3 options to pick 
- [ default = lambda, func,  none   ] *

For signature like

``` typescript
interface IDoSomething {
    getData(url: string,data:{}, callback: (error, result) => void)
}
```
### lambda:

lambda option generate code like below and for ease of use just will keep first 3 letters of each parameters

``` typescript
var x: IDoSomething;
x.getData(url, data, (err, res) => {

    })
```

_Tab cycle = url, data, { } **lambda body**_
### func:

func option presume user wants to pass function as argument and generate this code

``` typescript
var x: IDoSomething;
x.getData(url, data, callback) 
```

_Tab cycle = url, data, callback_
### none:

just none ;)
