### PR TITLE
fix uncaughtException endless loop

### DIFF
--- a/src/vs/workbench/node/pluginHostProcess.ts
+++ b/src/vs/workbench/node/pluginHostProcess.ts
@@ -40,11 +40,6 @@ function connectToRenderer(): TPromise<IRendererConnection> {
 				onUnexpectedError(reason);
 			});
 
-			// Print a console message when an exception isn't handled.
-			process.on('uncaughtException', function(err) {
-				onUnexpectedError(err);
-			});
-
 			// Kill oneself if one's parent dies. Much drama.
 			setInterval(function () {
 				try {


### PR DESCRIPTION
UncaughtException Event thrown a new Error and  Plugin host process will enter endless loop if uncaughtException occured.
we had addLisentener for uncaughtException in bootstrap.js.
Don't care my grammar mistakes, my English is poor.
