### PR TITLE
Fixes to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 # top-most EditorConfig file
 root = true
 
-# Tab indentation (no size specified)
+# Tab indentation
 [*]
 indent_style = tab
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,10 @@ root = true
 # Tab indentation (no size specified)
 [*]
 indent_style = tab
+indent_size = 4
 
-[{.travis.yml,npm-shrinkwrap.json}]
+# The indent size used in the `package.json` file cannot be changed
+# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+[{.travis.yml,npm-shrinkwrap.json,package.json}]
 indent_style = space
 indent_size = 2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "test": "node node_modules/mocha/bin/_mocha",
-		"preinstall": "node build/npm/preinstall.js",
+    "preinstall": "node build/npm/preinstall.js",
     "postinstall": "npm --prefix extensions/csharp-o/ install extensions/csharp-o/ && npm --prefix extensions/vscode-api-tests/ install extensions/vscode-api-tests/"
   },
   "dependencies": {


### PR DESCRIPTION
- Define `indent_size` so it will indent properly on VSCode. ([reference](https://github.com/Microsoft/vscode/pull/425#discussion_r45710574))
- `package.json` always uses 2-space indentation. ([reference](https://github.com/npm/npm/pull/3180#issuecomment-16336516))
