### PR TITLE
[vb] Syntax Highlighting for Roku's BrightScript Language

### DIFF
--- a/extensions/vb/package.json
+++ b/extensions/vb/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "vb",
-			"extensions": [ ".vb" ],
+			"extensions": [ ".vb", ".brs" ],
 			"aliases": [ "Visual Basic", "vb" ],
 			"configuration": "./vb.configuration.json"
 		}],


### PR DESCRIPTION
BrightScript (.brs) files use the default visual basic syntax highlighting.
