### PR TITLE
[python] Add .gn as a python file extension

### DIFF
--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "python",
-			"extensions": [ ".py", ".rpy", ".pyw", ".cpy", ".gyp", ".gypi" ],
+			"extensions": [ ".py", ".rpy", ".pyw", ".cpy", ".gn", ".gyp", ".gypi" ],
 			"aliases": [ "Python", "py" ],
 			"firstLine": "^#!/.*\\bpython[0-9.-]*\\b",
 			"configuration": "./python.configuration.json"


### PR DESCRIPTION
GN is a meta-build system that generates NinjaBuild files. GN syntax is a stripped down version of python.
