### PR TITLE
[ruby] Add Gemfile to supported filenames

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -7,7 +7,7 @@
 		"languages": [{
 			"id": "ruby",
 			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".pp" ],
-			"filenames": [ "rakefile" ],
+			"filenames": [ "rakefile", "gemfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"configuration": "./ruby.configuration.json"
 		}],


### PR DESCRIPTION
This adds built-in syntax highlighting support for [Gemfile](http://bundler.io/gemfile.html), a file used for managing Rubygem dependencies.
