### PR TITLE
[ISSUE #226] Fix debug console word wrapping

### DIFF
--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -42,6 +42,7 @@
 	cursor: pointer;
 	overflow: hidden;
 	width: 100%;
+	height: inherit !important;
 	touch-action: none;
 }
 

--- a/src/vs/workbench/parts/debug/browser/media/repl.css
+++ b/src/vs/workbench/parts/debug/browser/media/repl.css
@@ -17,6 +17,7 @@
 
 .monaco-workbench .repl .repl-tree .monaco-tree .monaco-tree-row > .content {
 	line-height: 24px;
+	word-wrap: break-word;
 	-webkit-user-select: initial;
 }
 


### PR DESCRIPTION
Please see Issue 226:
https://github.com/Microsoft/vscode/issues/226

This fixes the word wrapping in the debug console by adding a word wrap css to the div that contains the input output elements. It also changes the height of the tree row to be inherited.

Please let me know if there is a better way of changing the height of the div, instead of using an `!important` declaration
