### PR TITLE
issue #527 with optional cursor scroll

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -115,6 +115,28 @@ export class ViewLines extends ViewLayer {
 		return true;
 	}
 
+	public onCursorLineScroll(e:EditorCommon.IViewLineScrollEvent): boolean {
+		var currentViewport = this._layoutProvider.getCurrentViewport();
+		var residualOffset = currentViewport.top - this._layoutProvider.getVerticalOffsetForLineNumber(this._currentVisibleRange.startLineNumber);
+		var newTopLineNumber: number;
+		if (e.lineOffset < 0) {
+			newTopLineNumber = this._currentVisibleRange.startLineNumber + e.lineOffset;
+			if (newTopLineNumber < 1) {
+				newTopLineNumber = 1;
+				residualOffset = 0;
+			}
+		} else {
+			newTopLineNumber = this._currentVisibleRange.startLineNumber + e.lineOffset;
+			if (newTopLineNumber > this._currentVisibleRange.endLineNumber) {
+				newTopLineNumber = this._currentVisibleRange.endLineNumber;
+				residualOffset = 0;
+			}
+		}
+		var newScrollTop = this._layoutProvider.getVerticalOffsetForLineNumber(newTopLineNumber) + residualOffset;
+		this._layoutProvider.setScrollTop(newScrollTop);
+		return true;
+	}
+
 	private _hasVerticalScroll = false;
 	private _hasHorizontalScroll = false;
 	public onScrollChanged(e:EditorCommon.IScrollEvent): boolean {

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -166,6 +166,7 @@ class InternalEditorOptionsHelper {
 			outlineMarkers: toBoolean(opts.outlineMarkers),
 			referenceInfos: toBoolean(opts.referenceInfos),
 			renderWhitespace: toBoolean(opts.renderWhitespace),
+			scrollCursorWithLine: toBoolean(opts.scrollCursorWithLine),
 
 			layoutInfo: layoutInfo,
 			stylingInfo: {
@@ -816,6 +817,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'default': DefaultConfig.editor.referenceInfos,
 			'description': nls.localize('referenceInfos', "Controls if the editor shows reference information for the modes that support it")
+		},
+		'editor.scrollCursorWithLine' : {
+			'type': 'boolean',
+			'default': DefaultConfig.editor.scrollCursorWithLine,
+			'description': nls.localize('scrollCursorWithLine', "Controls if the edition cursor moves when the user scrolls the editor line by line")
 		},
 		'diffEditor.renderSideBySide' : {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/config.ts
+++ b/src/vs/editor/common/config/config.ts
@@ -197,6 +197,13 @@ registerCoreCommand(H.CursorEndSelect, {
 	mac: { primary: KeyMod.Shift | KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.RightArrow] }
 });
 
+registerCoreCommand(H.ScrollLineUp, {
+	primary: KeyMod.CtrlCmd | KeyCode.UpArrow
+});
+registerCoreCommand(H.ScrollLineDown, {
+	primary: KeyMod.CtrlCmd | KeyCode.DownArrow
+});
+
 registerCoreCommand(H.Tab, {
 	primary: KeyCode.Tab
 }, KeybindingsRegistry.WEIGHT.editorCore(), [

--- a/src/vs/editor/common/config/defaultConfig.ts
+++ b/src/vs/editor/common/config/defaultConfig.ts
@@ -62,6 +62,7 @@ class ConfigClass implements IConfiguration {
 			outlineMarkers: false,
 			referenceInfos: true,
 			renderWhitespace: false,
+			scrollCursorWithLine: false,
 
 			tabSize: 'auto',
 			insertSpaces: 'auto',

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -41,6 +41,7 @@ interface IMultipleCursorOperationContext {
 	isCursorUndo: boolean;
 	executeCommands: EditorCommon.ICommand[];
 	postOperationRunnables: IPostOperationRunnable[];
+	lineScrollOffset: number;
 }
 
 interface IExecContext {
@@ -85,7 +86,8 @@ export class Cursor extends EventEmitter {
 		super([
 			EditorCommon.EventType.CursorPositionChanged,
 			EditorCommon.EventType.CursorSelectionChanged,
-			EditorCommon.EventType.CursorRevealRange
+			EditorCommon.EventType.CursorRevealRange,
+			EditorCommon.EventType.CursorLineScroll
 		]);
 		this.editorId = editorId;
 		this.configuration = configuration;
@@ -306,7 +308,8 @@ export class Cursor extends EventEmitter {
 			isCursorUndo: false,
 			postOperationRunnables: [],
 			shouldPushStackElementBefore: false,
-			shouldPushStackElementAfter: false
+			shouldPushStackElementAfter: false,
+			lineScrollOffset: 0
 		};
 
 		callback(currentHandlerCtx);
@@ -336,6 +339,7 @@ export class Cursor extends EventEmitter {
 			var shouldRevealHorizontal: boolean;
 			var shouldRevealTarget: RevealTarget;
 			var isCursorUndo: boolean;
+			var lineScrollOffset: number;
 
 			var hasExecutedCommands = this._createAndInterpretHandlerCtx(eventSource, e.getData(), (currentHandlerCtx:IMultipleCursorOperationContext) => {
 				handled = handler(currentHandlerCtx);
@@ -346,6 +350,7 @@ export class Cursor extends EventEmitter {
 				shouldRevealVerticalInCenter = currentHandlerCtx.shouldRevealVerticalInCenter;
 				shouldRevealHorizontal = currentHandlerCtx.shouldRevealHorizontal;
 				isCursorUndo = currentHandlerCtx.isCursorUndo;
+				lineScrollOffset = currentHandlerCtx.lineScrollOffset;
 			});
 
 			if (hasExecutedCommands) {
@@ -401,6 +406,10 @@ export class Cursor extends EventEmitter {
 					this.emitCursorRevealRange(shouldRevealTarget, shouldRevealVerticalInCenter ? EditorCommon.VerticalRevealType.Center : EditorCommon.VerticalRevealType.Simple, shouldRevealHorizontal);
 				}
 				this.emitCursorSelectionChanged(eventSource, cursorPositionChangeReason);
+			}
+
+			if (lineScrollOffset) {
+				this.emitCursorLineScroll(lineScrollOffset);
 			}
 		} catch (err) {
 			Errors.onUnexpectedError(err);
@@ -845,6 +854,13 @@ export class Cursor extends EventEmitter {
 		this.emit(EditorCommon.EventType.CursorSelectionChanged, e);
 	}
 
+	private emitCursorLineScroll(lineScrollOffset: number): void {
+		var e:EditorCommon.ICursorLineScrollEvent = {
+			lineOffset: lineScrollOffset
+		};
+		this.emit(EditorCommon.EventType.CursorLineScroll, e);
+	}
+
 	private emitCursorRevealRange(revealTarget: RevealTarget, verticalType: EditorCommon.VerticalRevealType, revealHorizontal: boolean): void {
 		var positions = this.cursors.getPositions();
 		var viewPositions = this.cursors.getViewPositions();
@@ -958,6 +974,9 @@ export class Cursor extends EventEmitter {
 		handlersMap[H.Outdent] =					(ctx:IMultipleCursorOperationContext) => this._outdent(ctx);
 		handlersMap[H.Paste] =						(ctx:IMultipleCursorOperationContext) => this._paste(ctx);
 
+		handlersMap[H.ScrollLineUp] =				(ctx:IMultipleCursorOperationContext) => this._scrollLineUp(ctx);
+		handlersMap[H.ScrollLineDown] =				(ctx:IMultipleCursorOperationContext) => this._scrollLineDown(ctx);
+
 		handlersMap[H.DeleteLeft] =					(ctx:IMultipleCursorOperationContext) => this._deleteLeft(ctx);
 		handlersMap[H.DeleteWordLeft] =				(ctx:IMultipleCursorOperationContext) => this._deleteWordLeft(ctx);
 		handlersMap[H.DeleteRight] =				(ctx:IMultipleCursorOperationContext) => this._deleteRight(ctx);
@@ -1002,7 +1021,8 @@ export class Cursor extends EventEmitter {
 				executeCommand: null,
 				postOperationRunnable: null,
 				shouldPushStackElementBefore: false,
-				shouldPushStackElementAfter: false
+				shouldPushStackElementAfter: false,
+				lineScrollOffset: 0
 			};
 
 			result = callable(i, cursors[i], context) || result;
@@ -1012,6 +1032,7 @@ export class Cursor extends EventEmitter {
 				ctx.shouldRevealHorizontal = context.shouldRevealHorizontal;
 				ctx.shouldReveal = context.shouldReveal;
 				ctx.shouldRevealVerticalInCenter = context.shouldRevealVerticalInCenter;
+				ctx.lineScrollOffset = context.lineScrollOffset;
 			}
 
 			ctx.shouldPushStackElementBefore = ctx.shouldPushStackElementBefore || context.shouldPushStackElementBefore;
@@ -1290,6 +1311,20 @@ export class Cursor extends EventEmitter {
 		} else {
 			return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.paste(oneCursor, ctx.eventData.text, ctx.eventData.pasteOnNewLine, oneCtx));
 		}
+	}
+
+	private _scrollLineUp(ctx: IMultipleCursorOperationContext): boolean {
+		if (this.configuration.editor.scrollCursorWithLine) {
+			if (!this._moveUp(false, false, ctx)) return false;
+		}
+		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.scrollLineUp(oneCursor, oneCtx));
+	}
+
+	private _scrollLineDown(ctx: IMultipleCursorOperationContext): boolean {
+		if (this.configuration.editor.scrollCursorWithLine) {
+			if (!this._moveDown(false, false, ctx)) return false;
+		}
+		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.scrollLineDown(oneCursor, oneCtx));
 	}
 
 	private _distributePasteToCursors(ctx: IMultipleCursorOperationContext): string[] {

--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -29,6 +29,7 @@ export interface IOneCursorOperationContext {
 	shouldPushStackElementAfter: boolean;
 	executeCommand: EditorCommon.ICommand;
 	postOperationRunnable: IPostOperationRunnable;
+	lineScrollOffset: number;
 }
 
 export interface IModeConfiguration {
@@ -1361,6 +1362,16 @@ export class OneCursorOp {
 		});
 		ctx.shouldRevealHorizontal = false;
 
+		return true;
+	}
+
+	public static scrollLineUp(cursor:OneCursor, ctx: IOneCursorOperationContext): boolean {
+		ctx.lineScrollOffset = -1;
+		return true;
+	}
+
+	public static scrollLineDown(cursor:OneCursor, ctx: IOneCursorOperationContext): boolean {
+		ctx.lineScrollOffset = +1;
 		return true;
 	}
 

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -482,6 +482,11 @@ export interface ICommonEditorOptions {
 	 * Defaults to false.
 	 */
 	renderWhitespace?: boolean;
+	/**
+	 * Make the cursor move with scrolling.
+	 * Defaults to false.
+	 */
+	scrollCursorWithLine?: boolean;
 }
 
 /**
@@ -608,6 +613,7 @@ export interface IInternalEditorOptions {
 	outlineMarkers: boolean;
 	referenceInfos: boolean;
 	renderWhitespace: boolean;
+	scrollCursorWithLine: boolean;
 
 	// ---- Options that are computed
 
@@ -2059,6 +2065,10 @@ export interface ICursorRevealRangeEvent {
 	revealHorizontal:boolean;
 }
 
+export interface ICursorLineScrollEvent {
+	lineOffset: number;
+}
+
 export interface IModelChangedEvent {
 	oldModelUrl: string;
 	newModelUrl: string;
@@ -2500,7 +2510,8 @@ export var ViewEventNames = {
 	CursorPositionChangedEvent: 'cursorPositionChangedEvent',
 	CursorSelectionChangedEvent: 'cursorSelectionChangedEvent',
 	RevealRangeEvent: 'revealRangeEvent',
-	LineMappingChangedEvent: 'lineMappingChangedEvent'
+	LineMappingChangedEvent: 'lineMappingChangedEvent',
+	LineScrollEvent: 'lineScrollEvent'
 };
 
 export interface IScrollEvent {
@@ -2595,6 +2606,10 @@ export interface IViewRevealRangeEvent {
 	 * If false: there should be just a vertical revealing
 	 */
 	revealHorizontal: boolean;
+}
+
+export interface IViewLineScrollEvent {
+	lineOffset: number;
 }
 
 export interface IViewWhitespaceViewportData {
@@ -3229,6 +3244,7 @@ export var EventType = {
 	CursorPositionChanged: 'positionChanged',
 	CursorSelectionChanged: 'selectionChanged',
 	CursorRevealRange: 'revealRange',
+	CursorLineScroll: 'lineScroll',
 
 	ViewFocusGained: 'focusGained',
 	ViewFocusLost: 'focusLost',
@@ -3334,5 +3350,8 @@ export var Handler = {
 	LineInsertAfter:			'lineInsertAfter',
 	LineBreakInsert:			'lineBreakInsert',
 
-	SelectAll:					'selectAll'
+	SelectAll:					'selectAll',
+
+	ScrollLineUp:				'scrollLineUp',
+	ScrollLineDown:				'scrollLineDown'
 };

--- a/src/vs/editor/common/viewModel/viewEventHandler.ts
+++ b/src/vs/editor/common/viewModel/viewEventHandler.ts
@@ -47,6 +47,9 @@ export class ViewEventHandler {
 	public onCursorRevealRange(e:EditorCommon.IViewRevealRangeEvent): boolean {
 		return false;
 	}
+	public onCursorLineScroll(e:EditorCommon.IViewLineScrollEvent): boolean {
+		return false;
+	}
 	public onConfigurationChanged(e:EditorCommon.IConfigurationChangedEvent): boolean {
 		return false;
 	}
@@ -121,6 +124,10 @@ export class ViewEventHandler {
 
 				case EditorCommon.ViewEventNames.RevealRangeEvent:
 					this.shouldRender = this.onCursorRevealRange(<EditorCommon.IViewRevealRangeEvent>data) || this.shouldRender;
+					break;
+
+				case EditorCommon.ViewEventNames.LineScrollEvent:
+					this.shouldRender = this.onCursorLineScroll(<EditorCommon.IViewLineScrollEvent>data) || this.shouldRender;
 					break;
 
 				case EditorCommon.EventType.ConfigurationChanged:

--- a/src/vs/editor/common/viewModel/viewModel.ts
+++ b/src/vs/editor/common/viewModel/viewModel.ts
@@ -235,6 +235,10 @@ export class ViewModel extends EventEmitter implements EditorCommon.IViewModel {
 						this.onCursorRevealRange(<EditorCommon.ICursorRevealRangeEvent>data);
 						break;
 
+					case EditorCommon.EventType.CursorLineScroll:
+						this.onCursorLineScroll(<EditorCommon.ICursorLineScrollEvent>data);
+						break;
+
 					case EditorCommon.EventType.ConfigurationChanged:
 						revealPreviousCenteredModelRange = this._onTabSizeChange(this.configuration.getIndentationOptions().tabSize) || revealPreviousCenteredModelRange;
 						revealPreviousCenteredModelRange = this._onWrappingIndentChange(this.configuration.editor.wrappingIndent) || revealPreviousCenteredModelRange;
@@ -338,6 +342,9 @@ export class ViewModel extends EventEmitter implements EditorCommon.IViewModel {
 	}
 	private onCursorRevealRange(e:EditorCommon.ICursorRevealRangeEvent): void {
 		this.cursors.onCursorRevealRange(e, (eventType:string, payload:any) => this.emit(eventType, payload));
+	}
+	private onCursorLineScroll(e:EditorCommon.ICursorLineScrollEvent): void {
+		this.cursors.onCursorLineScroll(e, (eventType:string, payload:any) => this.emit(eventType, payload));
 	}
 	// --- end inbound event conversion
 

--- a/src/vs/editor/common/viewModel/viewModelCursors.ts
+++ b/src/vs/editor/common/viewModel/viewModelCursors.ts
@@ -105,6 +105,13 @@ export class ViewModelCursors {
 		emit(EditorCommon.ViewEventNames.RevealRangeEvent, newEvent);
 	}
 
+	public onCursorLineScroll(e:EditorCommon.ICursorLineScrollEvent, emit:(eventType:string, payload:any)=>void): void {
+		var newEvent:EditorCommon.IViewLineScrollEvent = {
+			lineOffset: e.lineOffset
+		};
+		emit(EditorCommon.ViewEventNames.LineScrollEvent, newEvent);
+	}
+
 	public onLineMappingChanged(emit:(eventType:string, payload:any)=>void): void {
 		if (this.lastCursorPositionChangedEvent) {
 			this.onCursorPositionChanged(this.lastCursorPositionChangedEvent, emit);


### PR DESCRIPTION
This pull request adds support for Ctrl+Up/Down arrows to scroll the viewport by one line height, as asked in issue #527 . This reproduces the behavior in Visual Studio.

Additionally, the setting "editor.scrollCursorWithLine" was added (defaults to false). When set to true, the caret will be moved up/down along with scrolling. This feature makes it possible for the user to scroll in a document by using keyboard shortcuts while keeping the same number of visible lines before and after the cursor.
