### PR TITLE
Allow to match on paths in quick open (fixes #1065)

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
@@ -8,9 +8,10 @@ import WinJS = require('vs/base/common/winjs.base');
 import Types = require('vs/base/common/types');
 import URI from 'vs/base/common/uri';
 import Tree = require('vs/base/parts/tree/common/tree');
-import { IQuickNavigateConfiguration, IModel, IDataSource, IFilter, IRenderer, IRunner, Mode } from './quickOpen';
+import {IQuickNavigateConfiguration, IModel, IDataSource, IFilter, IRenderer, IRunner, Mode} from './quickOpen';
 import ActionsRenderer = require('vs/base/parts/tree/browser/actionsRenderer');
 import Actions = require('vs/base/common/actions');
+import {compareAnything} from 'vs/base/common/comparers';
 import ActionBar = require('vs/base/browser/ui/actionbar/actionbar');
 import TreeDefaults = require('vs/base/parts/tree/browser/treeDefaults');
 import HighlightedLabel = require('vs/base/browser/ui/highlightedlabel/highlightedLabel');
@@ -120,6 +121,39 @@ export class QuickOpenEntry {
 	 */
 	public run(mode: Mode, context: IContext): boolean {
 		return false;
+	}
+
+	/**
+	 * A good default sort implementation for quick open entries
+	 */
+	public static compare(elementA: QuickOpenEntry, elementB: QuickOpenEntry, lookFor: string): number {
+
+		// Give matches with label highlights higher priority over
+		// those with only description highlights
+		const labelHighlightsA = elementA.getHighlights()[0] || [];
+		const labelHighlightsB = elementB.getHighlights()[0] || [];
+
+		if (labelHighlightsA.length && !labelHighlightsB.length) {
+			return -1;
+		} else if (!labelHighlightsA.length && labelHighlightsB.length) {
+			return 1;
+		}
+
+		// Sort by name/path
+		let nameA = elementA.getLabel();
+		let nameB = elementB.getLabel();
+
+		if (nameA === nameB) {
+			let resourceA = elementA.getResource();
+			let resourceB = elementB.getResource();
+
+			if (resourceA && resourceB) {
+				nameA = elementA.getResource().fsPath;
+				nameB = elementB.getResource().fsPath;
+			}
+		}
+
+		return compareAnything(nameA, nameB, lookFor);
 	}
 }
 

--- a/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
@@ -138,11 +138,15 @@ export class QuickOpenEntry {
 	 */
 	public static compare(elementA: QuickOpenEntry, elementB: QuickOpenEntry, lookFor: string): number {
 
+		// Normalize
+		if (lookFor) {
+			lookFor = Strings.stripWildcards(lookFor).toLowerCase();
+		}
+
 		// Give matches with label highlights higher priority over
 		// those with only description highlights
 		const labelHighlightsA = elementA.getHighlights()[0] || [];
 		const labelHighlightsB = elementB.getHighlights()[0] || [];
-
 		if (labelHighlightsA.length && !labelHighlightsB.length) {
 			return -1;
 		} else if (!labelHighlightsA.length && labelHighlightsB.length) {
@@ -152,7 +156,6 @@ export class QuickOpenEntry {
 		// Sort by name/path
 		let nameA = elementA.getLabel();
 		let nameB = elementB.getLabel();
-
 		if (nameA === nameB) {
 			let resourceA = elementA.getResource();
 			let resourceB = elementB.getResource();

--- a/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
@@ -49,6 +49,13 @@ export class QuickOpenEntry {
 	}
 
 	/**
+	 * The prefix to show in front of the label if any
+	 */
+	public getPrefix(): string {
+		return null;
+	}
+
+	/**
 	 * The label of the entry to identify it from others in the list
 	 */
 	public getLabel(): string {
@@ -209,6 +216,10 @@ export class QuickOpenEntryGroup extends QuickOpenEntry {
 		this.withBorder = showBorder;
 	}
 
+	public getPrefix(): string {
+		return this.entry ? this.entry.getPrefix() : super.getPrefix();
+	}
+
 	public getLabel(): string {
 		return this.entry ? this.entry.getLabel() : super.getLabel();
 	}
@@ -299,6 +310,7 @@ class NoActionProvider implements ActionsRenderer.IActionProvider {
 export interface IQuickOpenEntryTemplateData {
 	container: HTMLElement;
 	icon: HTMLSpanElement;
+	prefix: HTMLSpanElement;
 	label: HighlightedLabel.HighlightedLabel;
 	meta: HTMLSpanElement;
 	description: HighlightedLabel.HighlightedLabel;
@@ -380,6 +392,10 @@ class Renderer implements IRenderer<QuickOpenEntry> {
 		let icon = document.createElement('span');
 		entry.appendChild(icon);
 
+		// Prefix
+		let prefix = document.createElement('span');
+		entry.appendChild(prefix);
+
 		// Label
 		let label = new HighlightedLabel.HighlightedLabel(entry);
 
@@ -397,6 +413,7 @@ class Renderer implements IRenderer<QuickOpenEntry> {
 		return {
 			container: container,
 			icon: icon,
+			prefix: prefix,
 			label: label,
 			meta: meta,
 			description: description,
@@ -458,7 +475,10 @@ class Renderer implements IRenderer<QuickOpenEntry> {
 			let iconClass = entry.getIcon() ? ('quick-open-entry-icon ' + entry.getIcon()) : '';
 			data.icon.className = iconClass;
 
-			// Label
+			// Prefix
+			let prefix = entry.getPrefix() || '';
+			data.prefix.textContent = prefix;
+
 			let labelHighlights = highlights[0];
 			data.label.set(entry.getLabel() || '', labelHighlights || []);
 

--- a/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
+++ b/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
@@ -227,19 +227,10 @@ export class EditorHistoryModel extends QuickOpenModel {
 
 			// Apply highlights
 			const {labelHighlights, descriptionHighlights} = QuickOpenEntry.highlight(entry, searchValue);
-			if ((labelHighlights && labelHighlights.length) || (descriptionHighlights && descriptionHighlights.length)) {
-				results.push(entry.clone(labelHighlights, descriptionHighlights));
-			}
+			results.push(entry.clone(labelHighlights, descriptionHighlights));
 		}
 
-		// If user is searching, use the same sorting that is used for other quick open handlers
-		if (searchValue) {
-			let normalizedSearchValue = strings.stripWildcards(searchValue.toLowerCase());
-
-			return results.sort((elementA: EditorHistoryEntry, elementB: EditorHistoryEntry) => QuickOpenEntry.compare(elementA, elementB, normalizedSearchValue));
-		}
-
-		// Leave default "most recently used" order if user is not actually searching
-		return results;
+		// Sort
+		return results.sort((elementA: EditorHistoryEntry, elementB: EditorHistoryEntry) => QuickOpenEntry.compare(elementA, elementB, strings.stripWildcards(searchValue.toLowerCase())));
 	}
 }

--- a/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
+++ b/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
@@ -211,6 +211,7 @@ export class EditorHistoryModel extends QuickOpenModel {
 
 	public getResults(searchValue: string): QuickOpenEntry[] {
 		searchValue = searchValue.trim();
+		const searchInPath = searchValue.indexOf(paths.nativeSep) >= 0;
 
 		let results: QuickOpenEntry[] = [];
 		for (let i = 0; i < this.entries.length; i++) {
@@ -220,7 +221,7 @@ export class EditorHistoryModel extends QuickOpenModel {
 			}
 
 			// Check if this entry is a match for the search value
-			let targetToMatch = searchValue.indexOf(paths.nativeSep) < 0 ? entry.getLabel() : labels.getPathLabel(entry.getResource(), this.contextService);
+			let targetToMatch = searchInPath ? labels.getPathLabel(entry.getResource(), this.contextService) : entry.getLabel();
 			if (!filters.matchesFuzzy(searchValue, targetToMatch)) {
 				continue;
 			}
@@ -231,6 +232,6 @@ export class EditorHistoryModel extends QuickOpenModel {
 		}
 
 		// Sort
-		return results.sort((elementA: EditorHistoryEntry, elementB: EditorHistoryEntry) => QuickOpenEntry.compare(elementA, elementB, strings.stripWildcards(searchValue.toLowerCase())));
+		return results.sort((elementA: EditorHistoryEntry, elementB: EditorHistoryEntry) => QuickOpenEntry.compare(elementA, elementB, searchValue));
 	}
 }

--- a/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
+++ b/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
@@ -245,30 +245,7 @@ export class EditorHistoryModel extends QuickOpenModel {
 		if (searchValue) {
 			let normalizedSearchValue = strings.stripWildcards(searchValue.toLowerCase());
 
-			return results.sort((elementA: EditorHistoryEntry, elementB: EditorHistoryEntry) => {
-
-				// Give matches with label highlights higher priority over
-				// those with only description highlights
-				const labelHighlightsA = elementA.getHighlights()[0] || [];
-				const labelHighlightsB = elementB.getHighlights()[0] || [];
-
-				if (labelHighlightsA.length && !labelHighlightsB.length) {
-					return -1;
-				} else if (!labelHighlightsA.length && labelHighlightsB.length) {
-					return 1;
-				}
-
-				// Sort by name/path
-				let nameA = elementA.getInput().getName();
-				let nameB = elementB.getInput().getName();
-
-				if (nameA === nameB) {
-					nameA = elementA.getResource().fsPath;
-					nameB = elementB.getResource().fsPath;
-				}
-
-				return comparers.compareAnything(nameA, nameB, normalizedSearchValue);
-			});
+			return results.sort((elementA: EditorHistoryEntry, elementB: EditorHistoryEntry) => QuickOpenEntry.compare(elementA, elementB, normalizedSearchValue));
 		}
 
 		// Leave default "most recently used" order if user is not actually searching

--- a/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
+++ b/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
@@ -219,7 +219,7 @@ export class EditorHistoryModel extends QuickOpenModel {
 				continue; //For now, only support to match on inputs that provide resource information
 			}
 
-			// Check if this entry is a match fo rthe search value
+			// Check if this entry is a match for the search value
 			let targetToMatch = searchValue.indexOf(paths.nativeSep) < 0 ? entry.getLabel() : labels.getPathLabel(entry.getResource(), this.contextService);
 			if (!filters.matchesFuzzy(searchValue, targetToMatch)) {
 				continue;

--- a/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
+++ b/src/vs/workbench/browser/parts/quickopen/editorHistoryModel.ts
@@ -58,12 +58,16 @@ export class EditorHistoryEntry extends EditorQuickOpenEntry {
 		return new EditorHistoryEntry(this.editorService, this.contextService, this.input, labelHighlights, descriptionHighlights, this.model);
 	}
 
-	public getLabel(): string {
+	public getPrefix(): string {
 		let status = this.input.getStatus();
 		if (status && status.decoration) {
-			return status.decoration + ' ' + this.input.getName();
+			return `${status.decoration} `;
 		}
 
+		return void 0;
+	}
+
+	public getLabel(): string {
 		return this.input.getName();
 	}
 

--- a/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
@@ -250,10 +250,12 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 				continue;
 			}
 
-			// Check for pattern match
-			let {labelHighlights, descriptionHighlights} = QuickOpenEntry.highlight(entry, searchValue);
-			entry.setHighlights(labelHighlights, descriptionHighlights);
-			results.push(entry);
+			// Apply highlights
+			const {labelHighlights, descriptionHighlights} = QuickOpenEntry.highlight(entry, searchValue);
+			if ((labelHighlights && labelHighlights.length) || (descriptionHighlights && descriptionHighlights.length)) {
+				entry.setHighlights(labelHighlights, descriptionHighlights);
+				results.push(entry);
+			}
 		}
 
 		// Sort

--- a/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
@@ -143,8 +143,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 				let result = [...results[0].entries, ...results[1].entries];
 
 				// Sort
-				let normalizedSearchValue = strings.stripWildcards(searchValue.toLowerCase());
-				result.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, normalizedSearchValue));
+				result.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, searchValue));
 
 				// Apply Range
 				result.forEach((element) => {
@@ -236,6 +235,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 		// Pattern match on results and adjust highlights
 		let results: QuickOpenEntry[] = [];
+		const searchInPath = searchValue.indexOf(paths.nativeSep) >= 0;
 		for (let i = 0; i < cachedEntries.length; i++) {
 			let entry = cachedEntries[i];
 
@@ -245,7 +245,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 			}
 
 			// Check if this entry is a match for the search value
-			let targetToMatch = searchValue.indexOf(paths.nativeSep) < 0 ? entry.getLabel() : labels.getPathLabel(entry.getResource(), this.contextService);
+			let targetToMatch = searchInPath ? labels.getPathLabel(entry.getResource(), this.contextService) : entry.getLabel();
 			if (!filters.matchesFuzzy(searchValue, targetToMatch)) {
 				continue;
 			}
@@ -258,8 +258,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 		}
 
 		// Sort
-		let normalizedSearchValue = strings.stripWildcards(searchValue.toLowerCase());
-		results.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, normalizedSearchValue));
+		results.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, searchValue));
 
 		// Apply Range
 		results.forEach((element) => {

--- a/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
@@ -141,7 +141,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 				// Sort
 				let normalizedSearchValue = strings.stripWildcards(searchValue.toLowerCase());
-				result.sort((elementA, elementB) => this.compareResults(elementA, elementB, normalizedSearchValue));
+				result.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, normalizedSearchValue));
 
 				// Apply Range
 				result.forEach((element) => {
@@ -248,7 +248,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 		// Sort
 		let normalizedSearchValue = strings.stripWildcards(searchValue.toLowerCase());
-		results.sort((elementA, elementB) => this.compareResults(elementA, elementB, normalizedSearchValue));
+		results.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, normalizedSearchValue));
 
 		// Apply Range
 		results.forEach((element) => {
@@ -258,36 +258,6 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 		});
 
 		return results;
-	}
-
-	private compareResults(elementA:QuickOpenEntry, elementB:QuickOpenEntry, searchValue: string): number {
-
-		// Give matches with label highlights higher priority over
-		// those with only description highlights
-		const labelHighlightsA = elementA.getHighlights()[0] || [];
-		const labelHighlightsB = elementB.getHighlights()[0] || [];
-
-		if (labelHighlightsA.length && !labelHighlightsB.length) {
-			return -1;
-		} else if (!labelHighlightsA.length && labelHighlightsB.length) {
-			return 1;
-		}
-
-		// Sort by name/path
-		let nameA = elementA.getLabel();
-		let nameB = elementB.getLabel();
-
-		if (nameA === nameB) {
-			let resourceA = elementA.getResource();
-			let resourceB = elementB.getResource();
-
-			if (resourceA && resourceB) {
-				nameA = elementA.getResource().fsPath;
-				nameB = elementB.getResource().fsPath;
-			}
-		}
-
-		return compareAnything(nameA, nameB, searchValue);
 	}
 
 	public getGroupLabel(): string {

--- a/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
@@ -252,10 +252,9 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 			// Apply highlights
 			const {labelHighlights, descriptionHighlights} = QuickOpenEntry.highlight(entry, searchValue);
-			if ((labelHighlights && labelHighlights.length) || (descriptionHighlights && descriptionHighlights.length)) {
-				entry.setHighlights(labelHighlights, descriptionHighlights);
-				results.push(entry);
-			}
+			entry.setHighlights(labelHighlights, descriptionHighlights);
+
+			results.push(entry);
 		}
 
 		// Sort

--- a/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
@@ -12,6 +12,7 @@ import types = require('vs/base/common/types');
 import strings = require('vs/base/common/strings');
 import paths = require('vs/base/common/paths');
 import filters = require('vs/base/common/filters');
+import labels = require('vs/base/common/labels');
 import {IRange} from 'vs/editor/common/editorCommon';
 import {compareAnything} from 'vs/base/common/comparers';
 import {IAutoFocus} from 'vs/base/parts/quickopen/browser/quickOpen';
@@ -21,6 +22,7 @@ import {FileEntry, OpenFileHandler} from 'vs/workbench/parts/search/browser/open
 import {OpenSymbolHandler as _OpenSymbolHandler} from 'vs/workbench/parts/search/browser/openSymbolHandler';
 import {IMessageService, Severity} from 'vs/platform/message/common/message';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
+import {IWorkspaceContextService} from 'vs/platform/workspace/common/workspace';
 
 // OpenSymbolHandler is used from an extension and must be in the main bundle file so it can load
 export const OpenSymbolHandler = _OpenSymbolHandler
@@ -43,6 +45,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 	constructor(
 		@IMessageService private messageService: IMessageService,
+		@IWorkspaceContextService private contextService: IWorkspaceContextService,
 		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super();
@@ -238,6 +241,12 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 			// Check for file entries if range is used
 			if (range && !(entry instanceof FileEntry)) {
+				continue;
+			}
+
+			// Check if this entry is a match for the search value
+			let targetToMatch = searchValue.indexOf(paths.nativeSep) < 0 ? entry.getLabel() : labels.getPathLabel(entry.getResource(), this.contextService);
+			if (!filters.matchesFuzzy(searchValue, targetToMatch)) {
 				continue;
 			}
 

--- a/src/vs/workbench/parts/search/browser/openFileHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openFileHandler.ts
@@ -144,11 +144,7 @@ export class OpenFileHandler extends QuickOpenHandler {
 			let searchResult = this.instantiationService.createInstance(SearchResult, null);
 			searchResult.append(complete.results);
 
-			// Sort (standalone only)
 			let matches = searchResult.matches();
-			if (this.isStandalone) {
-				matches = matches.sort((elementA, elementB) => this.sort(elementA, elementB, searchValue.toLowerCase()));
-			}
 
 			// Highlight
 			let results: QuickOpenEntry[] = [];
@@ -178,29 +174,13 @@ export class OpenFileHandler extends QuickOpenHandler {
 				results.push(this.instantiationService.createInstance(FileEntry, fileMatch.name(), description, fileMatch.resource(), labelHighlights, descriptionHighlights));
 			}
 
+			// Sort (standalone only)
+			if (this.isStandalone) {
+				results = results.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, searchValue.toLowerCase()));
+			}
+
 			return results;
 		});
-	}
-
-	private sort(elementA: FileMatch, elementB: FileMatch, searchValue: string): number {
-		let elementAName = elementA.name().toLowerCase();
-		let elementBName = elementB.name().toLowerCase();
-
-		// Sort matches that have search value in beginning to the top
-		let elementAPrefixMatch = elementAName.indexOf(searchValue) === 0;
-		let elementBPrefixMatch = elementBName.indexOf(searchValue) === 0;
-		if (elementAPrefixMatch !== elementBPrefixMatch) {
-			return elementAPrefixMatch ? -1 : 1;
-		}
-
-		// Compare by name
-		let r = comparers.compareFileNames(elementAName, elementBName);
-		if (r !== 0) {
-			return r;
-		}
-
-		// Otherwise do full compare with path info
-		return strings.localeCompare(elementA.resource().fsPath, elementB.resource().fsPath);
 	}
 
 	public getGroupLabel(): string {

--- a/src/vs/workbench/parts/search/browser/openFileHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openFileHandler.ts
@@ -147,6 +147,8 @@ export class OpenFileHandler extends QuickOpenHandler {
 				let description = labels.getPathLabel(paths.dirname(fileMatch.resource.fsPath), this.contextService);
 
 				let entry = this.instantiationService.createInstance(FileEntry, label, description, fileMatch.resource);
+
+				// Apply highlights
 				let {labelHighlights, descriptionHighlights} = QuickOpenEntry.highlight(entry, searchValue);
 				entry.setHighlights(labelHighlights, descriptionHighlights);
 

--- a/src/vs/workbench/parts/search/browser/openFileHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openFileHandler.ts
@@ -157,7 +157,7 @@ export class OpenFileHandler extends QuickOpenHandler {
 
 			// Sort (standalone only)
 			if (this.isStandalone) {
-				results = results.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, searchValue.toLowerCase()));
+				results = results.sort((elementA, elementB) => QuickOpenEntry.compare(elementA, elementB, searchValue));
 			}
 
 			return results;

--- a/src/vs/workbench/parts/search/browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/browser/search.contribution.ts
@@ -140,9 +140,30 @@ actionBarRegistry.registerActionBarContributor(Scope.VIEWER, ExplorerViewerActio
 		'vs/workbench/parts/search/browser/openAnythingHandler',
 		'OpenAnythingHandler',
 		'',
-		env.isMacintosh ? nls.localize('openAnythingHandlerDescriptionMac', "Open Files and Symbols by Name") : nls.localize('openAnythingHandlerDescriptionWin', "Open Files and Symbols by Name")
+		nls.localize('openAnythingHandlerDescription', "Open Files and Symbols by Name")
 	)
 );
+
+(<IQuickOpenRegistry>Registry.as(QuickOpenExtensions.Quickopen)).registerQuickOpenHandler(
+	new QuickOpenHandlerDescriptor(
+		'vs/workbench/parts/search/browser/openAnythingHandler',
+		'OpenSymbolHandler',
+		ALL_SYMBOLS_PREFIX,
+		[
+			{
+				prefix: ALL_SYMBOLS_PREFIX,
+				needsEditor: false,
+				description: nls.localize('openSymbolDescriptionNormal', "Open Symbol By Name")
+			}
+		]
+	)
+);
+
+// Actions
+const registry = <IWorkbenchActionRegistry>Registry.as(ActionExtensions.WorkbenchActions);
+registry.registerWorkbenchAction(new SyncActionDescriptor(ShowAllSymbolsAction, ACTION_ID, ACTION_LABEL, {
+	primary: KeyMod.CtrlCmd | KeyCode.KEY_T
+}));
 
 // Configuration
 const configurationRegistry = <IConfigurationRegistry>Registry.as(ConfigurationExtensions.Configuration);
@@ -179,23 +200,3 @@ configurationRegistry.registerConfiguration({
 		}
 	}
 });
-
-const registry = <IWorkbenchActionRegistry>Registry.as(ActionExtensions.WorkbenchActions);
-registry.registerWorkbenchAction(new SyncActionDescriptor(ShowAllSymbolsAction, ACTION_ID, ACTION_LABEL, {
-	primary: KeyMod.CtrlCmd | KeyCode.KEY_T
-}));
-
-(<IQuickOpenRegistry>Registry.as(QuickOpenExtensions.Quickopen)).registerQuickOpenHandler(
-	new QuickOpenHandlerDescriptor(
-		'vs/workbench/parts/search/browser/openAnythingHandler',
-		'OpenSymbolHandler',
-		ALL_SYMBOLS_PREFIX,
-		[
-			{
-				prefix: ALL_SYMBOLS_PREFIX,
-				needsEditor: false,
-				description: env.isMacintosh ? nls.localize('openSymbolDescriptionNormalMac', "Open Symbol By Name") : nls.localize('openSymbolDescriptionNormalWin', "Open Symbol By Name")
-			}
-		]
-	)
-);

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -31,6 +31,7 @@ export class FileWalker {
 	private isLimitHit: boolean;
 	private resultCount: number;
 	private isCanceled: boolean;
+	private searchInPath: boolean;
 
 	private walkedPaths: { [path: string]: boolean; };
 
@@ -41,6 +42,7 @@ export class FileWalker {
 		this.includePattern = config.includePattern;
 		this.maxResults = config.maxResults || null;
 		this.walkedPaths = Object.create(null);
+		this.searchInPath = this.filePattern && this.filePattern.indexOf(paths.sep) >= 0;
 	}
 
 	private resetState(): void {
@@ -81,7 +83,7 @@ export class FileWalker {
 					}
 
 					// Check for match on file pattern and include pattern
-					if (this.isFilePatternMatch(paths.basename(absolutePath)) && (!this.includePattern || glob.match(this.includePattern, absolutePath))) {
+					if (this.isFilePatternMatch(paths.basename(absolutePath), absolutePath) && (!this.includePattern || glob.match(this.includePattern, absolutePath))) {
 						this.resultCount++;
 
 						if (this.maxResults && this.resultCount > this.maxResults) {
@@ -156,7 +158,7 @@ export class FileWalker {
 				if ((<any>error).code === FileWalker.ENOTDIR && !this.isCanceled && !this.isLimitHit) {
 
 					// Check for match on file pattern and include pattern
-					if (this.isFilePatternMatch(file) && (!this.includePattern || glob.match(this.includePattern, relativeFilePath, children))) {
+					if (this.isFilePatternMatch(file, relativeFilePath) && (!this.includePattern || glob.match(this.includePattern, relativeFilePath, children))) {
 						this.resultCount++;
 
 						if (this.maxResults && this.resultCount > this.maxResults) {
@@ -183,11 +185,11 @@ export class FileWalker {
 		});
 	}
 
-	private isFilePatternMatch(path: string): boolean {
+	private isFilePatternMatch(name: string, path: string): boolean {
 
 		// Check for search pattern
 		if (this.filePattern) {
-			const res = filters.matchesFuzzy(this.filePattern, path);
+			const res = filters.matchesFuzzy(this.filePattern, this.searchInPath ? path : name);
 
 			return !!res && res.length > 0;
 		}

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -42,7 +42,12 @@ export class FileWalker {
 		this.includePattern = config.includePattern;
 		this.maxResults = config.maxResults || null;
 		this.walkedPaths = Object.create(null);
-		this.searchInPath = this.filePattern && this.filePattern.indexOf(paths.sep) >= 0;
+
+		// Normalize file patterns to forward slashs
+		if (this.filePattern.indexOf(paths.sep) >= 0) {
+			this.filePattern = strings.replaceAll(this.filePattern, '\\', '/');
+			this.searchInPath = true;
+		}
 	}
 
 	private resetState(): void {

--- a/src/vs/workbench/services/search/test/node/search.test.ts
+++ b/src/vs/workbench/services/search/test/node/search.test.ts
@@ -47,6 +47,24 @@ suite('Search', () => {
 		});
 	});
 
+	test('Files: examples/com*', function(done: () => void) {
+		let engine = new FileSearchEngine({
+			rootPaths: [require.toUrl('./fixtures')],
+			filePattern: 'examples' + path.sep + 'com*'
+		});
+
+		let count = 0;
+		engine.search((result) => {
+			if (result) {
+				count++;
+			}
+		}, () => { }, (error) => {
+			assert.ok(!error);
+			assert.equal(count, 1);
+			done();
+		});
+	});
+
 	test('Files: *.js (Files as roots)', function(done: () => void) {
 		let engine = new FileSearchEngine({
 			rootPaths: [require.toUrl('./fixtures/examples/company.js'), require.toUrl('./fixtures/examples/small.js')],

--- a/src/vs/workbench/services/search/test/node/search.test.ts
+++ b/src/vs/workbench/services/search/test/node/search.test.ts
@@ -9,6 +9,7 @@ import path = require('path');
 import assert = require('assert');
 
 import uri from 'vs/base/common/uri';
+import {join, normalize} from 'vs/base/common/paths';
 import {LineMatch} from 'vs/platform/search/common/search';
 
 import {FileWalker, Engine as FileSearchEngine} from 'vs/workbench/services/search/node/fileSearch';
@@ -50,7 +51,7 @@ suite('Search', () => {
 	test('Files: examples/com*', function(done: () => void) {
 		let engine = new FileSearchEngine({
 			rootPaths: [require.toUrl('./fixtures')],
-			filePattern: 'examples' + path.sep + 'com*'
+			filePattern: normalize(join('examples', 'com*'), true)
 		});
 
 		let count = 0;

--- a/src/vs/workbench/test/browser/parts/quickOpen/quickopen.test.ts
+++ b/src/vs/workbench/test/browser/parts/quickOpen/quickopen.test.ts
@@ -43,7 +43,7 @@ suite('Workbench QuickOpen', () => {
 		let model = new EditorHistoryModel(editorService, null, contextService);
 
 		let input1 = inst.createInstance(StringEditorInput, "name1", 'description', "value1", "text/plain", false);
-		let entry1 = new EditorHistoryEntry(editorService, contextService, input1, null, model);
+		let entry1 = new EditorHistoryEntry(editorService, contextService, input1, null, null, model);
 
 		assert.equal(input1.getName(), entry1.getLabel());
 		assert.equal(input1.getDescription(), entry1.getDescription());
@@ -63,7 +63,7 @@ suite('Workbench QuickOpen', () => {
 
 		let input2 = inst.createInstance(StringEditorInput, "name2", 'description', "value2", "text/plain", false);
 		(<any>input2).getResource = () => "path";
-		let entry2 = new EditorHistoryEntry(editorService, contextService, input2, null, model);
+		let entry2 = new EditorHistoryEntry(editorService, contextService, input2, null, null, model);
 		assert.equal(entry2.getResource(), "path");
 
 		assert(!entry1.matches(entry2.getInput()));


### PR DESCRIPTION
This enables matching on file paths once the pattern includes the platform path separator (slash on mac and linux and backslash on windows).
