### PR TITLE
Allow building binary on Linux ARM.

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -231,26 +231,31 @@ gulp.task('clean-vscode-win32', util.rimraf(path.join(path.dirname(root), 'VSCod
 gulp.task('clean-vscode-darwin', util.rimraf(path.join(path.dirname(root), 'VSCode-darwin')));
 gulp.task('clean-vscode-linux-ia32', util.rimraf(path.join(path.dirname(root), 'VSCode-linux-ia32')));
 gulp.task('clean-vscode-linux-x64', util.rimraf(path.join(path.dirname(root), 'VSCode-linux-x64')));
+gulp.task('clean-vscode-linux-arm', util.rimraf(path.join(path.dirname(root), 'VSCode-linux-arm')));
 
 gulp.task('vscode-win32', ['optimize-vscode', 'clean-vscode-win32'], packageTask('win32'));
 gulp.task('vscode-darwin', ['optimize-vscode', 'clean-vscode-darwin'], packageTask('darwin'));
 gulp.task('vscode-linux-ia32', ['optimize-vscode', 'clean-vscode-linux-ia32'], packageTask('linux', 'ia32'));
 gulp.task('vscode-linux-x64', ['optimize-vscode', 'clean-vscode-linux-x64'], packageTask('linux', 'x64'));
+gulp.task('vscode-linux-arm', ['optimize-vscode', 'clean-vscode-linux-arm'], packageTask('linux', 'arm'));
 
 gulp.task('vscode-win32-min', ['minify-vscode', 'clean-vscode-win32'], packageTask('win32', null, { minified: true }));
 gulp.task('vscode-darwin-min', ['minify-vscode', 'clean-vscode-darwin'], packageTask('darwin', null, { minified: true }));
 gulp.task('vscode-linux-ia32-min', ['minify-vscode', 'clean-vscode-linux-ia32'], packageTask('linux', 'ia32', { minified: true }));
 gulp.task('vscode-linux-x64-min', ['minify-vscode', 'clean-vscode-linux-x64'], packageTask('linux', 'x64', { minified: true }));
+gulp.task('vscode-linux-arm-min', ['minify-vscode', 'clean-vscode-linux-arm'], packageTask('linux', 'arm', { minified: true }));
 
 gulp.task('vscode-win32-zip', ['optimize-vscode'], packageTask('win32', null, { zip: true }));
 gulp.task('vscode-darwin-zip', ['optimize-vscode'], packageTask('darwin', null, { zip: true }));
 gulp.task('vscode-linux-ia32-zip', ['optimize-vscode'], packageTask('linux', 'ia32', { zip: true }));
 gulp.task('vscode-linux-x64-zip', ['optimize-vscode'], packageTask('linux', 'x64', { zip: true }));
+gulp.task('vscode-linux-arm-zip', ['optimize-vscode'], packageTask('linux', 'arm', { zip: true }));
 
 gulp.task('vscode-win32-zip-min', ['minify-vscode'], packageTask('win32', null, { zip: true, minified: true }));
 gulp.task('vscode-darwin-zip-min', ['minify-vscode'], packageTask('darwin', null, { zip: true, minified: true }));
 gulp.task('vscode-linux-zip-ia32-min', ['minify-vscode'], packageTask('linux', 'ia32', { zip: true, minified: true }));
 gulp.task('vscode-linux-zip-x64-min', ['minify-vscode'], packageTask('linux', 'x64', { zip: true, minified: true }));
+gulp.task('vscode-linux-zip-arm-min', ['minify-vscode'], packageTask('linux', 'arm', { zip: true, minified: true }));
 
 // Sourcemaps
 


### PR DESCRIPTION
Allows use `gulp vscode-linux-arm` for building Code [OSS Build] binary.

Looks like most functions works at Ubuntu Wily on ARMv7 Chromebook.
Used Node.js version is v4.2.3

But there is 15 failing tests and I'm not sure if it's related to Node version or ARMv7 cpu: http://pastebin.com/Xuz04H4e

I'll try to investigate that but any help\suggestions are welcome because I almost haven't experience with Node.js.
