### PR TITLE
[ruby] Added .rake extension to use ruby syntax

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "ruby",
-			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".pp" ],
+			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".pp", ".rake" ],
 			"filenames": [ "rakefile", "gemfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"configuration": "./ruby.configuration.json"


### PR DESCRIPTION
This PR adds `.rake` file extension into ruby syntax.

P.S. other possible extensions and filenames here,
https://github.com/atom/language-ruby/blob/master/grammars/ruby.cson
