### PR TITLE
[xml] Associate .atom with XML

### DIFF
--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -8,6 +8,7 @@
 			"id": "xml",
 			"extensions": [
 				".ascx",
+				".atom",
 				".axml",
 				".bpmn",
 				".config",


### PR DESCRIPTION
.atom feeds (application/atom+xml) are similar to .rss.
