### PR TITLE
[editorconfig] Use tab_width instead of indent_size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 # Tab indentation
 [*]
 indent_style = tab
-indent_size = 4
+tab_width = 4
 
 # The indent size used in the `package.json` file cannot be changed
 # https://github.com/npm/npm/pull/3180#issuecomment-16336516


### PR DESCRIPTION
If `indent_style` is set to tab on editorconfig, the proper value to use in setting indentation size is `tab_width`, as per the [EditorConfig specifications](http://editorconfig.org/):

> For example, tab_width need not be specified unless it differs from the value of indent_size. Also, when indent_style is set to "tab", it may be desirable to leave indent_size unspecified so readers may view the file using their preferred indentation format.
