### PR TITLE
[css] Fix linear-gradient() snippet syntax

### DIFF
--- a/extensions/css/snippets/css.json
+++ b/extensions/css/snippets/css.json
@@ -18,10 +18,10 @@
 	"gradient": {
 		"prefix": "gradient",
 		"body": [
-			"background-image: -moz-linear-gradient(top, ${start-color}, ${end-color});",
 			"background-image: -webkit-gradient(linear, left top, left bottom, from(${start-color}), to(${end-color}));",
 			"background-image: -webkit-linear-gradient(top, ${start-color}, ${end-color});",
-			"background-image: linear-gradient(top, ${start-color}, ${end-color});"
+			"background-image: -moz-linear-gradient(top, ${start-color}, ${end-color});",
+			"background-image: linear-gradient(to bottom, ${start-color}, ${end-color});"
 		],
 		"description": "Set the 'background-image' property to a linear gradient"
 	}


### PR DESCRIPTION
- corrected the unprefixed syntax
- Moved the -moz- property below the webkit ones, so that all the mid period syntaxes are together and the prefixes follow the recommended webkit -> moz -> ms (not included here) -> o (also not included) -> unprefixed order. 

Fixes #1219
