### PR TITLE
Changed code.visualstudio.com hyperlink to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Microsoft/vscode.svg?branch=master)](https://travis-ci.org/Microsoft/vscode) [![Build status](https://ci.appveyor.com/api/projects/status/vuhlhg80tj3e2a0l?svg=true)](https://ci.appveyor.com/project/VSCode/vscode)
 
-[VS Code](http://code.visualstudio.com) is a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle. Code provides comprehensive editing and debugging support, an extensibility model, and lightweight integration with existing tools.
+[VS Code](https://code.visualstudio.com) is a new type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle. Code provides comprehensive editing and debugging support, an extensibility model, and lightweight integration with existing tools.
 
 <p align="center">
   <img width="550" alt="vscodereadme" src="https://cloud.githubusercontent.com/assets/1487073/11243985/98562110-8e0b-11e5-9922-29a0b4884eab.png">


### PR DESCRIPTION
Was previously HTTP; server automatically redirects to HTTPS, but irritating when using it on a phone as it adds a few seconds of additional loading.
