### PR TITLE
[c++] keyword "noexcept" added

### DIFF
--- a/extensions/cpp/syntaxes/c++.plist
+++ b/extensions/cpp/syntaxes/c++.plist
@@ -97,7 +97,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(constexpr|export|mutable|typename|thread_local)\b</string>
+			<string>\b(constexpr|export|mutable|typename|thread_local|noexcept)\b</string>
 			<key>name</key>
 			<string>storage.modifier.c++</string>
 		</dict>


### PR DESCRIPTION
C++11 added keyword "noexcept" to the standard which was missing in the syntax file yet.
