### PR TITLE
Implementation of editor.action.insertCursorAtEndOfEachSelectedLine

### DIFF
--- a/src/vs/editor/contrib/multicursor/common/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/common/multicursor.ts
@@ -28,7 +28,7 @@ class InsertCursorBelow extends HandlerEditorAction {
 	}
 }
 
-class InsertCursorsFromLineSelection extends EditorAction {
+class InsertCursorAtEndOfEachLineSelected extends EditorAction {
 	static ID = 'editor.action.insertCursorAtEndOfEachLineSelected';
 
 	constructor(descriptor:EditorCommon.IEditorActionDescriptorData, editor:EditorCommon.ICommonCodeEditor, @INullService ns) {
@@ -36,31 +36,31 @@ class InsertCursorsFromLineSelection extends EditorAction {
 	}
 
 	public run(): TPromise<boolean> {
-		let sel = this.editor.getSelection();
-		if(!sel.isEmpty()) {
+		let selection = this.editor.getSelection();
+		if(!selection.isEmpty()) {
 			let model = this.editor.getModel();
-			let sels = new Array<EditorCommon.ISelection>();
-			let sStart = sel.getStartPosition();
-			let sEnd = sel.getEndPosition();
-			for (var i = sStart.lineNumber; i <= sEnd.lineNumber; i++) {
-				if(i !== sEnd.lineNumber) {
-					let lEnd = model.getLineMaxColumn(i);
-					sels.push({
+			let newSelections = new Array<EditorCommon.ISelection>();
+			let selectionStart = selection.getStartPosition();
+			let selectionEnd = selection.getEndPosition();
+			for (var i = selectionStart.lineNumber; i <= selectionEnd.lineNumber; i++) {
+				if(i !== selectionEnd.lineNumber) {
+					let currentLineMaxColumn = model.getLineMaxColumn(i);
+					newSelections.push({
 						selectionStartLineNumber: i,
-						selectionStartColumn: lEnd,
+						selectionStartColumn: currentLineMaxColumn,
 						positionLineNumber: i,
-						positionColumn: lEnd
+						positionColumn: currentLineMaxColumn
 					});
-				} else if( sEnd.column > 0 ) {
-					sels.push({
-						selectionStartLineNumber: sEnd.lineNumber,
-						selectionStartColumn: sEnd.column,
-						positionLineNumber: sEnd.lineNumber,
-						positionColumn: sEnd.column
+				} else if( selectionEnd.column > 0 ) {
+					newSelections.push({
+						selectionStartLineNumber: selectionEnd.lineNumber,
+						selectionStartColumn: selectionEnd.column,
+						positionLineNumber: selectionEnd.lineNumber,
+						positionColumn: selectionEnd.column
 					});
 				}
 			}
-			this.editor.setSelections(sels);
+			this.editor.setSelections(newSelections);
 		}
 		return TPromise.as(true);
 	}
@@ -84,7 +84,7 @@ CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(InsertCurso
 		secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]
 	}
 }));
-CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(InsertCursorsFromLineSelection, InsertCursorsFromLineSelection.ID, nls.localize('mutlicursor.insertAtEndOfEachLineSelected', "Create multiple cursors from selected lines"), {
+CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(InsertCursorAtEndOfEachLineSelected, InsertCursorAtEndOfEachLineSelected.ID, nls.localize('mutlicursor.insertAtEndOfEachLineSelected', "Create multiple cursors from selected lines"), {
 	context: ContextKey.EditorTextFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_I
 }));

--- a/src/vs/editor/contrib/multicursor/common/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/common/multicursor.ts
@@ -6,7 +6,8 @@
 
 import nls = require('vs/nls');
 import {CommonEditorRegistry, ContextKey, EditorActionDescriptor} from 'vs/editor/common/editorCommonExtensions';
-import {HandlerEditorAction} from 'vs/editor/common/editorAction';
+import {TPromise} from 'vs/base/common/winjs.base';
+import {EditorAction, HandlerEditorAction} from 'vs/editor/common/editorAction';
 import EditorCommon = require('vs/editor/common/editorCommon');
 import {INullService} from 'vs/platform/instantiation/common/instantiation';
 import {KeyMod, KeyCode} from 'vs/base/common/keyCodes';
@@ -27,6 +28,44 @@ class InsertCursorBelow extends HandlerEditorAction {
 	}
 }
 
+class InsertCursorsFromLineSelection extends EditorAction {
+	static ID = 'editor.action.insertCursorAtEndOfEachLineSelected';
+
+	constructor(descriptor:EditorCommon.IEditorActionDescriptorData, editor:EditorCommon.ICommonCodeEditor, @INullService ns) {
+		super(descriptor, editor);
+	}
+
+	public run(): TPromise<boolean> {
+		let sel = this.editor.getSelection();
+		if(!sel.isEmpty()) {
+			let model = this.editor.getModel();
+			let sels = new Array<EditorCommon.ISelection>();
+			let sStart = sel.getStartPosition();
+			let sEnd = sel.getEndPosition();
+			for (var i = sStart.lineNumber; i <= sEnd.lineNumber; i++) {
+				if(i !== sEnd.lineNumber) {
+					let lEnd = model.getLineMaxColumn(i);
+					sels.push({
+						selectionStartLineNumber: i,
+						selectionStartColumn: lEnd,
+						positionLineNumber: i,
+						positionColumn: lEnd
+					});
+				} else if( sEnd.column > 0 ) {
+					sels.push({
+						selectionStartLineNumber: sEnd.lineNumber,
+						selectionStartColumn: sEnd.column,
+						positionLineNumber: sEnd.lineNumber,
+						positionColumn: sEnd.column
+					});
+				}
+			}
+			this.editor.setSelections(sels);
+		}
+		return TPromise.as(true);
+	}
+}
+
 
 // register actions
 CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(InsertCursorAbove, InsertCursorAbove.ID, nls.localize('mutlicursor.insertAbove', "Add Cursor Above"), {
@@ -44,4 +83,8 @@ CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(InsertCurso
 		primary: KeyMod.Shift | KeyMod.Alt | KeyCode.DownArrow,
 		secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.DownArrow]
 	}
+}));
+CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(InsertCursorsFromLineSelection, InsertCursorsFromLineSelection.ID, nls.localize('mutlicursor.insertAtEndOfEachLineSelected', "Create multiple cursors from selected lines"), {
+	context: ContextKey.EditorTextFocus,
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_I
 }));


### PR DESCRIPTION
Inspired by issue #950 and pull #961
At Sublime I'm a big fan of ctrl+l (line select) and ctrl+shift+l (unselect and set multiple cursors at the end of each line selected).
I've made a VSCode [extension](https://marketplace.visualstudio.com/items/bigous.vscode-multi-line-tricks) with this 2 features about 2 weeks ago... 
But as the feature of LineSelection was incorporated to the VSCode itself and was released yesterday, I thought it would be nice to have both features at the VSCode itself.
So, I've made this little PR to set ctrl+alt+i to this action (sadly ctrl+l is used by another core feature and the chosen key combination for line selection was ctrl+i... ctrl+shift+i opens chrome dev tools inside VSCode, so I've chosen ctrl+alt+i to this feature).
Hope it helps people that are migrating from Sublime to VSCode like me ;)
[]'s
Richard
