### PR TITLE
Render ligatures

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/viewLine.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLine.ts
@@ -355,6 +355,10 @@ class ViewLine implements IViewLineData {
 
 			if (clientRects.length > 0) {
 				result = this._createRawVisibleRangesFromClientRects(clientRects, deltaTop, correctionTop, deltaLeft);
+
+				if (startElement === endElement && startOffset === endOffset && endOffset === endElement.textContent.length) {
+					result[0].left = Math.max(0, endElement.parentElement.getBoundingClientRect().right - deltaLeft);
+				}
 			}
 
 			return result;

--- a/src/vs/workbench/browser/parts/editor/media/texteditor.css
+++ b/src/vs/workbench/browser/parts/editor/media/texteditor.css
@@ -7,3 +7,7 @@
 .monaco-workbench > .editor > .content .inactive .monaco-editor .current-line {
 	border-width: 0;
 }
+
+.monaco-editor {
+	text-rendering: optimizeLegibility;
+}


### PR DESCRIPTION
Enable ligature rendering via the text-rendering style, and account for a client-rect bug in Chromium that resulted in improper editing cursor placement.

The proper fix for this is to get the latest version of Chromium, where the client-rect bug has been fixed. I'm just submitting this pull request in case anyone wants the change in the meantime.

(Hackily) Fixes #192 

---

The editor [gets a bad rectangle from the DOM](https://github.com/Microsoft/vscode/blob/014193f5043999ab80579fbd763a3171e22638cf/src/vs/editor/browser/viewParts/lines/viewLine.ts#L353) when the editing cursor is at the end of the line. Specifically, requesting the coordinates of the right side of the the last character yields an incorrect value.

With just the CSS to enable ligatures, the cursor renders in an incorrect position whenever it's at the end of a line (regardless of whether ligatures are present):
![broken demo](http://i.imgur.com/MHFc0HL.gif)

The bad-rectangle issue [has been fixed in Chromium](https://code.google.com/p/chromium/issues/detail?id=487028), so only the CSS change is necessary once VS Code uses newer Chromium.

In the meantime, the problem can be avoided by detecting requests for a point at the end of the line and using the bounding-box of the entire element to compute the correct value (i.e. instead of trying to get the right side of the last character inside the element, just get the right side of the entire element).

With the the ligature CSS and the bounding-box workaround, the caret renders in the correct position (and ligatures are rendered):
![ligature demo](http://i.imgur.com/1m6p4L8.gif)
