### PR TITLE
Support menu bar visibility toggle also on Linux (fixes #1563)

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -33,7 +33,7 @@ workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(Reload
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(CloseMessagesAction, CloseMessagesAction.ID, CloseMessagesAction.LABEL, { primary: KeyCode.Escape }, [{ key: WorkbenchMessageService.GLOBAL_MESSAGES_SHOWING_CONTEXT }]));
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(CloseEditorAction, CloseEditorAction.ID, CloseEditorAction.LABEL, { primary: KeyMod.CtrlCmd | KeyCode.KEY_W, win: { primary: KeyMod.CtrlCmd | KeyCode.F4, secondary: [KeyMod.CtrlCmd | KeyCode.KEY_W] } }), viewCategory);
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ToggleFullScreenAction, ToggleFullScreenAction.ID, ToggleFullScreenAction.LABEL, { primary: KeyCode.F11, mac: { primary: KeyMod.CtrlCmd | KeyMod.WinCtrl | KeyCode.KEY_F } }), viewCategory);
-if (platform.isWindows) {
+if (platform.isWindows || platform.isLinux) {
 	workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ToggleMenuBarAction, ToggleMenuBarAction.ID, ToggleMenuBarAction.LABEL), viewCategory);
 }
 

--- a/src/vs/workbench/electron-main/menus.ts
+++ b/src/vs/workbench/electron-main/menus.ts
@@ -541,7 +541,7 @@ export class VSCodeMenu {
 			output,
 			__separator__(),
 			fullscreen,
-			platform.isWindows ? toggleMenuBar : void 0,
+			platform.isWindows || platform.isLinux ? toggleMenuBar : void 0,
 			__separator__(),
 			splitEditor,
 			toggleSidebar,

--- a/src/vs/workbench/electron-main/window.ts
+++ b/src/vs/workbench/electron-main/window.ts
@@ -549,8 +549,8 @@ export class VSCodeWindow {
 
 		this.win.setFullScreen(willBeFullScreen);
 
-		// Windows: Hide the menu bar but still allow to bring it up by pressing the Alt key
-		if (platform.isWindows) {
+		// Windows & Linux: Hide the menu bar but still allow to bring it up by pressing the Alt key
+		if (platform.isWindows || platform.isLinux) {
 			if (willBeFullScreen) {
 				this.setMenuBarVisibility(false);
 			} else {


### PR DESCRIPTION
Commit c34d2e771bb3e372e912e081a8bd8879a92a8c91 adds this functionality but restricting it to Windows. I created a new issue #1563 for having the same toggle available also when running on Linux. This pull request should fix the issue on at least some Linux window managers.

The changes done in the earlier commit worked perfectly on Linux Mint 17.2 which is running a GTK+ 3 toolkit based Cinnamon window manager. I would expect the changes to work at least on other GTK based window managers.

@bpasero noted that it didn't work on Ubuntu 15 which at least by default uses the Unity window manager. Unity has its own unique way of handling the menu bar. Ubuntu introduced an OS X style shared menu bar few versions back, and now Ubuntu 15 seems to refine the concept with a new "locally integrated menu". It would not be surprising if it caused incompatibility with more conventional approaches.
