### PR TITLE
[python] Disassociate .gn with python language

### DIFF
--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "python",
-			"extensions": [ ".py", ".rpy", ".pyw", ".cpy", ".gn", ".gyp", ".gypi" ],
+			"extensions": [ ".py", ".rpy", ".pyw", ".cpy", ".gyp", ".gypi" ],
 			"aliases": [ "Python", "py" ],
 			"firstLine": "^#!/.*\\bpython[0-9.-]*\\b",
 			"configuration": "./python.configuration.json"


### PR DESCRIPTION
While Python worked well with GN in v0.10.3, since then the progress made with
the Python language syntax highlighting doesn't play well with the extra quirks
on top of Python that GN introduces (braces, no colons to indicate blocks).
Making it less usable than no language mode.
