### PR TITLE
[bat] Fix batch syntax

### DIFF
--- a/extensions/bat/syntaxes/Batch File.tmLanguage
+++ b/extensions/bat/syntaxes/Batch File.tmLanguage
@@ -150,7 +150,7 @@
                 <key>name</key>
                 <string>string.quoted.double.dosbatch</string>
                 <key>end</key>
-                <string>"</string>
+                <string>"|$</string>
             </dict>
             <dict>
                 <key>name</key>

--- a/extensions/bat/syntaxes/Batch File.tmLanguage
+++ b/extensions/bat/syntaxes/Batch File.tmLanguage
@@ -63,6 +63,34 @@
                 <string>\s*:\s*:.*$</string>
             </dict>
             <dict>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>variable.parameter.function.begin.shell</string>
+                    </dict>
+                </dict>
+                <key>name</key>
+                <string>variable.parameter.function.dosbatch</string>
+                <key>match</key>
+                <string>(?i)(%)(~(?:f|d|p|n|x|s|a|t|z|\$[^:]*:)*)?\d</string>
+            </dict>
+            <dict>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>variable.parameter.loop.begin.shell</string>
+                    </dict>
+                </dict>
+                <key>name</key>
+                <string>variable.parameter.loop.dosbatch</string>
+                <key>match</key>
+                <string>(?i)(%%)(~(?:f|d|p|n|x|s|a|t|z|\$[^:]*:)*)?[a-z]</string>
+            </dict>
+            <dict>
                 <key>begin</key>
                 <string>"</string>
                 <key>endCaptures</key>

--- a/extensions/bat/syntaxes/Batch File.tmLanguage
+++ b/extensions/bat/syntaxes/Batch File.tmLanguage
@@ -10,7 +10,7 @@
                 <key>name</key>
                 <string>keyword.command.dosbatch</string>
                 <key>match</key>
-                <string>\b(?i)(?:append|assoc|at|attrib|break|cacls|cd|chcp|chdir|chkdsk|chkntfs|cls|cmd|color|comp|compact|convert|copy|date|del|dir|diskcomp|diskcopy|doskey|echo|endlocal|erase|fc|find|findstr|format|ftype|graftabl|help|keyb|label|md|mkdir|mode|more|move|path|pause|popd|print|prompt|pushd|rd|recover|rem|ren|rename|replace|restore|rmdir|set|setlocal|shift|sort|start|subst|time|title|tree|type|ver|verify|vol|xcopy)\b</string>
+                <string>\b(?i)(?:append|assoc|at|attrib|break|cacls|cd|chcp|chdir|chkdsk|chkntfs|cls|cmd|color|comp|compact|convert|copy|date|del|dir|diskcomp|diskcopy|doskey|echo|endlocal|erase|fc|find|findstr|format|ftype|graftabl|help|keyb|label|md|mkdir|mode|more|move|path|pause|popd|print|prompt|pushd|rd|recover|ren|rename|replace|restore|rmdir|set|setlocal|shift|sort|start|subst|time|title|tree|type|ver|verify|vol|xcopy)\b</string>
             </dict>
             <dict>
                 <key>name</key>
@@ -54,7 +54,7 @@
                 <key>name</key>
                 <string>comment.line.rem.dosbatch</string>
                 <key>match</key>
-                <string>(?:^|\s)((?i)rem)(?:$|\s.*$)</string>
+                <string>\b((?i)rem)(?:$|\s.*$)</string>
             </dict>
             <dict>
                 <key>name</key>

--- a/extensions/bat/syntaxes/Batch File.tmLanguage
+++ b/extensions/bat/syntaxes/Batch File.tmLanguage
@@ -91,6 +91,44 @@
                 <string>(?i)(%%)(~(?:f|d|p|n|x|s|a|t|z|\$[^:]*:)*)?[a-z]</string>
             </dict>
             <dict>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>variable.other.parsetime.begin.shell</string>
+                    </dict>
+                    <key>2</key>
+                    <dict>
+                        <key>name</key>
+                        <string>variable.other.parsetime.end.shell</string>
+                    </dict>
+                </dict>
+                <key>name</key>
+                <string>variable.other.parsetime.dosbatch</string>
+                <key>match</key>
+                <string>(%)[^%]+(%)</string>
+            </dict>
+            <dict>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>variable.other.delayed.begin.shell</string>
+                    </dict>
+                    <key>2</key>
+                    <dict>
+                        <key>name</key>
+                        <string>variable.other.delayed.end.shell</string>
+                    </dict>
+                </dict>
+                <key>name</key>
+                <string>variable.other.delayed.dosbatch</string>
+                <key>match</key>
+                <string>(!)[^!]+(!)</string>
+            </dict>
+            <dict>
                 <key>begin</key>
                 <string>"</string>
                 <key>endCaptures</key>


### PR DESCRIPTION
Fixes some issues with batch syntax, addressing #487 
- `rem` comments are properly detected
- variables are properly parsed, including
  - `%regular_variables%`
  - `!delay_expanded_variables!`
  - Script parameters (`%1`, `%~dp0`, etc.)
  - Loop induction variables (`%%f`, `%%~nxf`, etc.)
- Incomplete strings now terminate at end of line, fixing cases like the following:

``` batch
   echo incomplete " string
   echo broken line, treated as string
```
