### PR TITLE
Integrate tslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
 		".build/**": true,
 		"out*/**": true,
 		"extensions/**/out/**": true
-	}
+	},
+	"tslint.rulesDirectory": "node_modules/tslint-microsoft-contrib"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,6 +26,25 @@
 			}
 		},
 		{
+			"taskName": "tslint",
+			"args": [],
+			"problemMatcher": {
+				"owner": "tslint",
+				"fileLocation": [
+					"relative",
+					"${workspaceRoot}"
+				],
+				"severity": "warning",
+				"pattern": {
+					"regexp": "^\\[tslint\\] (.*):(\\d+):(\\d+):\\s+(.*)$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"message": 4
+				}
+			}
+		},
+		{
 			"taskName": "test",
 			"args": [
 				"--no-color"

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -152,9 +152,9 @@ var tslintFilter = [
 	'!src/vs/editor/standalone-languages/test/**'
 ];
 
-const lintReporter = function (output, file, options) {
+var lintReporter = function (output, file, options) {
 	//emits: src/helloWorld.c:5:3: warning: implicit declaration of function ‘prinft’
-	var relativeBase = file.base.substring(file.cwd.length + 1);
+	var relativeBase = file.base.substring(file.cwd.length + 1).replace('\\', '/');
 	output.forEach(function(e) {
 		var message = relativeBase + e.name + ':' + (e.startPosition.line + 1) + ':' + (e.startPosition.character + 1) + ': ' + e.failure;
 		console.log('[tslint] ' + message);

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -7,6 +7,7 @@ var gulp = require('gulp');
 var filter = require('gulp-filter');
 var es = require('event-stream');
 var path = require('path');
+var tslint = require("gulp-tslint");
 
 var all = [
 	'*',
@@ -136,6 +137,40 @@ var hygiene = exports.hygiene = function (some) {
 
 gulp.task('hygiene', function () {
 	return hygiene();
+});
+
+var allTypeScript = [
+	'src/**/*.ts',
+	'extensions/**/*.ts'
+];
+
+var tslintFilter = [
+	'**',
+	'!**/*.d.ts',
+	'!**/typings/**',
+	'!**/*.test.ts',
+	'!src/vs/editor/standalone-languages/test/**'
+];
+
+const lintReporter = function (output, file, options) {
+	//emits: src/helloWorld.c:5:3: warning: implicit declaration of function ‘prinft’
+	var relativeBase = file.base.substring(file.cwd.length + 1);
+	output.forEach(function(e) {
+		var message = relativeBase + e.name + ':' + (e.startPosition.line + 1) + ':' + (e.startPosition.character + 1) + ': ' + e.failure;
+		console.log('[tslint] ' + message);
+	});
+};
+
+gulp.task('tslint', function () {
+	gulp.src(allTypeScript)
+	.pipe(filter(tslintFilter))
+	.pipe(tslint({
+		rulesDirectory: "node_modules/tslint-microsoft-contrib"
+	}))
+	.pipe(tslint.report(lintReporter, {
+		summarizeFailureOutput: false,
+		emitError: false
+	}))
 });
 
 // this allows us to run this as a git pre-commit hook

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "gulp-util": "^3.0.6",
     "gulp-vinyl-zip": "^1.1.0",
     "gulp-watch": "^4.2.4",
+	"gulp-tslint": "^4.3.0",
+	"tslint-microsoft-contrib": "^2.0.0",
     "innosetup-compiler": "^5.5.60",
     "istanbul": "^0.3.17",
     "jsdom-no-contextify": "^3.1.0",

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,5 @@
+{
+	"rules": {
+		"no-unused-variable": true
+	}
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
 	"rules": {
-		"no-unused-variable": true
+		"no-unused-expression": true,
+		"no-unreachable": true,
+		"no-duplicate-variable": true
 	}
 }


### PR DESCRIPTION
This PR integrates tslint. 

It adds:
- a `tslint.json` file. The rules defined in the tslint.json file are currently minimal. The only rule enabled is the `no-unused-variable`. 
- `gulp tslint` runs tslint across the vscode base.
- a task to run tslint from inside Code.
- the microsoft tslint rule [extensions](https://github.com/Microsoft/tslint-microsoft-contrib). The rules are currently not used, but they will enable us to use rules like `promise-must-complete`.

To get tslint checking as you type you need to install the [vscode-tslint](https://marketplace.visualstudio.com/items/eg2.tslint).
