### PR TITLE
Fix connecting to debugAdapter by port when offline

### DIFF
--- a/src/vs/workbench/parts/debug/node/rawDebugSession.ts
+++ b/src/vs/workbench/parts/debug/node/rawDebugSession.ts
@@ -174,7 +174,7 @@ export class RawDebugSession extends v8.V8Protocol implements debug.IRawDebugSes
 
 	private connectServer(port: number): Promise {
 		return new Promise((c, e) => {
-			this.socket = net.createConnection(port, null, () => {
+			this.socket = net.createConnection(port, '127.0.0.1', () => {
 				this.connect(this.socket, <any>this.socket);
 				c(null);
 			});


### PR DESCRIPTION
Just remembered that I need to try #1641 again :)

I sent a PR to fix offline debugging in vscode-node-debug, and this is fixing basically the same problem that shows up when you try to debug a debugadapter by connecting via a local port.
