### PR TITLE
'scripts\npm install' bugs in windows7

### DIFF
--- a/scripts/npm.bat
+++ b/scripts/npm.bat
@@ -2,7 +2,7 @@
 setlocal
 
 set npm_config_disturl="https://atom.io/download/atom-shell"
-for /f "delims=" %%A in ('powershell -Command "(Get-Content -Raw %~dp0..\package.json | ConvertFrom-Json).electronVersion"') do set "npm_config_target=%%A"
+for /f "tokens=2 delims=:, " %%a in ('findstr /R /C:"\"electronVersion\":.*" %~dp0..\package.json') do set npm_config_target=%%~a
 set npm_config_arch="ia32"
 set HOME=~\.electron-gyp
 


### PR DESCRIPTION
I use `scripts\npm install` to install vscode. But some native node modules (e.g `weak` `native-keymap`) can`t startup.

I found that the problem was setting  npm_config_target failed.

`ConvertFrom-Json` is introduced in Windows PowerShell 3.0. but my powershell`s version is 2.0.0.

https://technet.microsoft.com/en-us/library/hh849898.aspx

so I try to use `findstr` replace `poweshell` to setting  npm_config_target.
