### PR TITLE
Adding a global Env to the extension API

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -9,10 +9,28 @@
 
 declare namespace vscode {
 
-	/**
-	 * The version of the editor.
-	 */
-	export var version: string;
+	export const env: {
+		/**
+		 * The version of the editor.
+		 */
+		version: string;
+
+		/**
+		 * locale, like de-ch, en-us
+		 */
+		locale: string;
+
+		/**
+		 * A unique UUID that identifies the machine
+		 */
+		machineId: string;
+
+		/**
+		 * A unique UUID that identifies the session
+		 */
+		sessionId: string;
+	}
+
 
 	/**
 	 * Represents a reference to a command. Provides a title which

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -9,12 +9,12 @@
 
 declare namespace vscode {
 
-	export const env: {
-		/**
-		 * The version of the editor.
-		 */
-		version: string;
+	/**
+	 * The version of the editor.
+	*/
+	export var version: string;
 
+	export const env: {
 		/**
 		 * locale, like de-ch, en-us
 		 */

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -11,7 +11,7 @@ declare namespace vscode {
 
 	/**
 	 * The version of the editor.
-	*/
+	 */
 	export var version: string;
 
 	export const env: {

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -57,6 +57,7 @@ export class ExtHostAPIImplementation {
 	private _pluginService: IPluginService;
 	private _telemetryService: ITelemetryService;
 
+	version: typeof vscode.version;
 	env: typeof vscode.env;
 	Uri: typeof vscode.Uri;
 	Location: typeof vscode.Location;
@@ -102,9 +103,9 @@ export class ExtHostAPIImplementation {
 		this._telemetryService = telemetryService;
 		this._proxy = threadService.getRemotable(MainProcessVSCodeAPIHelper);
 
+		this.version = contextService.getConfiguration().env.version;
 		this._telemetryService.getTelemetryInfo().then((info) => {
 			this.env = {
-				version:contextService.getConfiguration().env.version,
 				machineId: info.machineId,
 				sessionId: info.sessionId,
 				locale: null

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -39,6 +39,7 @@ import {CancellationTokenSource} from 'vs/base/common/cancellation';
 import vscode = require('vscode');
 import {TextEditorRevealType} from 'vs/workbench/api/node/mainThreadEditors';
 import * as paths from 'vs/base/common/paths';
+import {ITelemetryService} from 'vs/platform/telemetry/common/telemetry';
 
 /**
  * This class implements the API described in vscode.d.ts,
@@ -54,8 +55,9 @@ export class ExtHostAPIImplementation {
 	private _threadService: IThreadService;
 	private _proxy: MainProcessVSCodeAPIHelper;
 	private _pluginService: IPluginService;
+	private _telemetryService: ITelemetryService;
 
-	version: typeof vscode.version;
+	env: typeof vscode.env;
 	Uri: typeof vscode.Uri;
 	Location: typeof vscode.Location;
 	Diagnostic: typeof vscode.Diagnostic;
@@ -92,13 +94,23 @@ export class ExtHostAPIImplementation {
 	constructor(
 		@IThreadService threadService: IThreadService,
 		@IPluginService pluginService: IPluginService,
-		@IWorkspaceContextService contextService: IWorkspaceContextService
+		@IWorkspaceContextService contextService: IWorkspaceContextService,
+		@ITelemetryService telemetryService: ITelemetryService
 	) {
 		this._pluginService = pluginService;
 		this._threadService = threadService;
+		this._telemetryService = telemetryService;
 		this._proxy = threadService.getRemotable(MainProcessVSCodeAPIHelper);
 
-		this.version = contextService.getConfiguration().env.version;
+		this._telemetryService.getTelemetryInfo().then((info) => {
+			this.env = {
+				version:contextService.getConfiguration().env.version,
+				machineId: info.machineId,
+				sessionId: info.sessionId,
+				locale: null
+			}
+		});
+
 		this.Uri = URI;
 		this.Location = extHostTypes.Location;
 		this.Diagnostic = <any> extHostTypes.Diagnostic;

--- a/src/vs/workbench/node/pluginHostMain.ts
+++ b/src/vs/workbench/node/pluginHostMain.ts
@@ -61,12 +61,12 @@ export function exit(code?: number) {
 export function createServices(remoteCom: IPluginsIPC, initData: IInitData, sharedProcessClient: Client): IInstantiationService {
 	// the init data is not demarshalled
 	initData = marshalling.deserialize(initData);
-
+	
 	let contextService = new BaseWorkspaceContextService(initData.contextService.workspace, initData.contextService.configuration, initData.contextService.options);
 	let threadService = new PluginHostThreadService(remoteCom);
 	threadService.setInstantiationService(InstantiationService.create({ threadService: threadService }));
-	let telemetryServiceInstance = new ExtHostTelemetryService(threadService);
-	let requestService = new BaseRequestService(contextService, telemetryServiceInstance);
+	let telemetryService = new ExtHostTelemetryService(threadService);
+	let requestService = new BaseRequestService(contextService, telemetryService);
 	let modelService = threadService.getRemotable(ExtHostModelService);
 
 	let pluginService = new PluginHostPluginService(threadService);
@@ -78,7 +78,7 @@ export function createServices(remoteCom: IPluginsIPC, initData: IInitData, shar
 		threadService: threadService,
 		modeService: modeService,
 		pluginService: pluginService,
-		telemetryService: ExtHostTelemetryService
+		telemetryService: telemetryService
 	};
 	let instantiationService = InstantiationService.create(_services);
 	threadService.setInstantiationService(instantiationService);


### PR DESCRIPTION
This will add a global Env variable that can contain information about VSCode. 

The Evn variable for now contains: 
- Version
- Machine Id. 
- Session Id. 
- Locale (to be implemented). 
