### PR TITLE
Send smile to twitter

### DIFF
--- a/src/vs/workbench/parts/feedback/browser/feedback.ts
+++ b/src/vs/workbench/parts/feedback/browser/feedback.ts
@@ -172,7 +172,7 @@ export class FeedbackDropdown extends Dropdown {
 
 		let $buttons = $('div.form-buttons').appendTo($form);
 
-		this.sendButton = this.invoke($('input.send').type('submit').attr('disabled', '').value(nls.localize('send', "Send")).appendTo($buttons), () => {
+		this.sendButton = this.invoke($('input.send').type('submit').attr('disabled', '').value(nls.localize('tweet', "Tweet")).appendTo($buttons), () => {
 			if (this.isSendingFeedback) {
 				return;
 			}

--- a/src/vs/workbench/parts/feedback/browser/feedback.ts
+++ b/src/vs/workbench/parts/feedback/browser/feedback.ts
@@ -104,7 +104,7 @@ export class FeedbackDropdown extends Dropdown {
 
 		this.feedbackForm = <HTMLFormElement>$form.getHTMLElement();
 
-		$('h2.title').text(nls.localize("label.sendASmile", "Let us know how we're doing")).appendTo($form);
+		$('h2.title').text(nls.localize("label.sendASmile", "Tweet us your feedback")).appendTo($form);
 
 		this.invoke($('div.cancel').attr('tabindex', '0'), () => {
 			this.hide();

--- a/src/vs/workbench/parts/feedback/electron-browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/parts/feedback/electron-browser/feedbackStatusbarItem.ts
@@ -20,7 +20,7 @@ class TwitterFeedbackService implements IFeedbackService {
 	private static TWITTER_URL: string = 'https://twitter.com/intent/tweet';
 
 	public submitFeedback(feedback: IFeedback): void {
-		var queryString = `?${feedback.sentiment === 1 ? 'hashtags=LoveVSCode&' : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${feedback.feedback}&tw_p=tweetbutton&via=code`;
+		var queryString = `?${feedback.sentiment === 1 ? 'hashtags=HappyCoding&' : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${feedback.feedback}&tw_p=tweetbutton&via=code`;
 		var url = TwitterFeedbackService.TWITTER_URL + queryString;
 		shell.openExternal(url);
 	}


### PR DESCRIPTION
Changed the words in the feedback form to be straightforward about a tweet going out (per @egamma's feedback). 

![tweetfeedback](https://cloud.githubusercontent.com/assets/2449568/12524507/4829d35a-c112-11e5-9499-0880d3152961.png)
![image](https://cloud.githubusercontent.com/assets/2449568/12524551/8976ec58-c112-11e5-85ad-b8c3a088431f.png)
