### PR TITLE
Support for middle click to paste selection on Linux

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -8,12 +8,15 @@ import 'vs/css!./media/editor';
 import 'vs/css!./media/tokens';
 import 'vs/css!./media/default-theme';
 
+import {clipboard} from 'electron';
 import * as EditorCommon from 'vs/editor/common/editorCommon';
+import {EditOperation} from 'vs/editor/common/core/editOperation';
 import * as Browser from 'vs/base/browser/browser';
 import {colorizeLine} from 'vs/editor/browser/standalone/colorizer';
 import {TPromise} from 'vs/base/common/winjs.base';
 import {onUnexpectedError} from 'vs/base/common/errors';
 import * as DOM from 'vs/base/browser/dom';
+import {StandardMouseEvent} from 'vs/base/browser/mouseEvent';
 import {IEventEmitter} from 'vs/base/common/eventEmitter';
 import {Configuration} from 'vs/editor/browser/config/configuration';
 import * as EditorBrowser from 'vs/editor/browser/editorBrowser';
@@ -66,6 +69,13 @@ export class CodeEditorWidget extends CommonCodeEditor implements EditorBrowser.
 			if (this.forcedWidgetFocusCount === 0) {
 				this._editorFocusContextKey.reset();
 				this.emit(EditorCommon.EventType.EditorBlur, {});
+			}
+		});
+		this.on(DOM.EventType.MOUSE_UP, (e: {event: StandardMouseEvent, target: EditorBrowser.IMouseTarget}) => {
+			DOM.EventHelper.stop(e.event, false);
+			if (e.event.middleButton && process.platform === 'linux') {
+				this.focus();
+				this.executeEdits('editor.browser.linuxInsertSelection', [EditOperation.insert(this.getPosition(), clipboard.readText('selection'))]);
 			}
 		});
 


### PR DESCRIPTION
I hope to make this PR eventually fix #110. Currently it inserts the selection from the clipboard on Linux at the current cursor position. The following needs to be done to the PR:
- [ ] Do it the proper way (should this live in `codeEditorWidget.ts`?)
- [ ] Update the cursor to be under the mouse (emit some event that's picked up by `MouseHandler`?)
- [ ] Clear the selection after pasting
- [ ] Add tests if possible

Any advice on the first two points by people familiar with the code would be greatly appreciated.
