### PR TITLE
Understand update.channel set to none

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -64,3 +64,19 @@ configurationRegistry.registerConfiguration({
 		}
 	}
 });
+
+// Configuration: Update
+configurationRegistry.registerConfiguration({
+	'id': 'update',
+	'order': 10,
+	'title': nls.localize('updateConfigurationTitle', "Update configuration"),
+	'type': 'object',
+	'properties': {
+		'update.channel': {
+			'type': 'string',
+			'enum': ['none', 'default'],
+			'default': 'default',
+			'description': nls.localize('updateChannel', "Configure the update channel to receive updates from. Requires a restart after change.")
+		}
+	}
+});


### PR DESCRIPTION
This fixes #2520 

There are some users which would like to prevent automatic updates. These users either set the update channel to `none` in the `storage.json` or the `settings.json`.

I want to drop `storage.json` and will explain it in the release notes/blog post. But we still need to respect disablement via the settings.

This PR brings back the setting and disables updates if the value is set to `none`.

@bpasero please review the code flow in `update-manager.ts`. Thanks.
