### PR TITLE
Fix md image link with no alt text highlighting

### DIFF
--- a/src/vs/languages/markdown/common/markdown.ts
+++ b/src/vs/languages/markdown/common/markdown.ts
@@ -115,8 +115,8 @@ export const language =
 
 				// links
 				[/\{[^}]+\}/, 'string.target'],
-				[/(!?\[)((?:[^\]\\]|@escapes)+)(\]\([^\)]+\))/, ['string.link', '', 'string.link']],
-				[/(!?\[)((?:[^\]\\]|@escapes)+)(\])/, 'string.link'],
+				[/(!?\[)((?:[^\]\\]|@escapes)*)(\]\([^\)]+\))/, ['string.link', '', 'string.link']],
+				[/(!?\[)((?:[^\]\\]|@escapes)*)(\])/, 'string.link'],
 
 				// or html
 				{ include: 'html' },


### PR DESCRIPTION
Fixes #2565 

![md_links](https://cloud.githubusercontent.com/assets/2193314/12696775/d570f2be-c727-11e5-9ab5-297d504e269e.png)
