### PR TITLE
Atom.io like multiline support for snippets

### DIFF
--- a/src/vs/editor/node/textMate/TMSnippets.ts
+++ b/src/vs/editor/node/textMate/TMSnippets.ts
@@ -32,14 +32,20 @@ function preParseSnippet (prejson: string) : string {
     var snippetCode : string[] = [];
     var processingSnippets: boolean = false;
 
+    const multilineSnippetOpenTag = "[/***";
+    const multilineSnippetCloseTag = "***/]";
+
     prejson.toString().match(/[^\r\n]+/g).forEach ( currentline => {
-        if (currentline.trim().indexOf("* * *") == -1) {
+
+        if (currentline.toString().trim() != multilineSnippetOpenTag && currentline.toString().trim() != multilineSnippetCloseTag) {
             if (processingSnippets)
                 snippetCode.push(currentline);
             else
                 finalJson = finalJson.concat(currentline);
         }
+
         else {
+
             processingSnippets = !processingSnippets;
             if (snippetCode.length > 0 ) {
                 finalJson = finalJson.concat(JSON.stringify(snippetCode));


### PR DESCRIPTION
Updates the JSON parsing of snippets to support the pasting of multiple
lines without the restriction that JSON places on strings that requires
quotations and commas for each line.

Enclose snippets between on separate line from the body attribute.

[/\* \* *

```
       * * */]
```

{

/*
     // Place your snippets for TypeScript here. Each snippet is defined
under a snippet name and has a prefix, body and
     // description. The prefix is what is used to trigger the snippet and
the body will be expanded and inserted. Possible variables are:
     // $1, $2 for tab stops, ${id} and ${id:label} and ${1:label} for
variables. Variables with the same id are connected.
     // Example:

_/
     "Print to console": {
        "prefix": "shelz",
        "body":
            [/_ \* *
export class AppComponent {
    constructor() {

```
}
```

}
           \* \* */]
        ,"description": "Log output to console"
    }
