### PR TITLE
Regexp character class closing bracket should't be part of his beginning match

### DIFF
--- a/extensions/ruby/syntaxes/Ruby.plist
+++ b/extensions/ruby/syntaxes/Ruby.plist
@@ -3978,7 +3978,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>\[(?:\^?\])?</string>
+					<string>\[(?:\^?)?</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>


### PR DESCRIPTION
When you insert empty character class brackets pair into regex the syntax highlighter doesn't recognize the end of the character class and erroneously highlight rest of the code.
