### PR TITLE
Fix #2687: Stop capturing 'REM' as a keyword.command in Batch

### DIFF
--- a/extensions/bat/syntaxes/Batch File.tmLanguage
+++ b/extensions/bat/syntaxes/Batch File.tmLanguage
@@ -43,18 +43,10 @@
                 <string>\b(?:EQU|NEQ|LSS|LEQ|GTR|GEQ)\b</string>
             </dict>
             <dict>
-                <key>captures</key>
-                <dict>
-                    <key>1</key>
-                    <dict>
-                        <key>name</key>
-                        <string>keyword.command.rem.dosbatch</string>
-                    </dict>
-                </dict>
                 <key>name</key>
                 <string>comment.line.rem.dosbatch</string>
                 <key>match</key>
-                <string>\b((?i)rem)(?:$|\s.*$)</string>
+                <string>\b(?i)rem(?:$|\s.*$)</string>
             </dict>
             <dict>
                 <key>name</key>


### PR DESCRIPTION
PR #1678 fixed most batch comment syntax issues, but still kept capturing `REM` as a comment, which causes it to be colored differently from the rest of the line. This PR removes the special handling around the keyword, such that the whole line is treated as a comment.
