### PR TITLE
debugProtocol update: Add types for function breakpoints

### DIFF
--- a/src/vs/workbench/parts/debug/common/debugModel.ts
+++ b/src/vs/workbench/parts/debug/common/debugModel.ts
@@ -406,7 +406,7 @@ export class Model extends ee.EventEmitter implements debug.IModel {
 		this.emit(debug.ModelEvents.BREAKPOINTS_UPDATED);
 	}
 
-	public updateBreakpoints(data: { [id: string]: { line: number, verified: boolean } }): void {
+	public updateBreakpoints(data: { [id: string]: { line?: number, verified: boolean } }): void {
 		this.breakpoints.forEach(bp => {
 			const bpData = data[bp.getId()];
 			if (bpData) {

--- a/src/vs/workbench/parts/debug/common/debugProtocol.d.ts
+++ b/src/vs/workbench/parts/debug/common/debugProtocol.d.ts
@@ -117,6 +117,18 @@ declare module DebugProtocol {
 		};
 	}
 
+	/** Event message for "breakpoint" event type.
+		The event indicates that some information about a breakpoint has changed.
+	*/
+	export interface BreakpointEvent extends Event {
+		body: {
+			/** The reason for the event (such as: 'changed', 'new'). */
+			reason: string;
+			/** The breakpoint. */
+			breakpoint: Breakpoint;
+		}
+	}
+
 	//---- Requests
 
 	/** On error that is whenever 'success' is false, the body can provide more details.
@@ -225,7 +237,30 @@ declare module DebugProtocol {
 	*/
 	export interface SetBreakpointsResponse extends Response {
 		body: {
-			/** Information about the breakpoints. The array elements correspond to the elements of the 'lines' array. */
+			/** Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' (or the deprecated 'lines) array. */
+			breakpoints: Breakpoint[];
+		};
+	}
+
+	/** SetFunctionBreakpoints request; value of command field is "setFunctionBreakpoints".
+		Sets multiple function breakpoints and clears all previous function breakpoints.
+		To clear all function breakpoint, specify an empty array.
+		When a function breakpoint is hit, a StoppedEvent (event type 'function breakpoint') is generated.
+	*/
+	export interface SetFunctionBreakpointsRequest extends Request {
+		arguments: SetFunctionBreakpointsArguments;
+	}
+	/** Arguments for "setFunctionBreakpoints" request. */
+	export interface SetFunctionBreakpointsArguments {
+		/** The function names of the breakpoints. */
+		breakpoints: FunctionBreakpoint[];
+	}
+	/** Response to "setFunctionBreakpoints" request.
+		Returned is information about each breakpoint created by this request.
+	*/
+	export interface SetFunctionBreakpointsResponse extends Response {
+		body: {
+			/** Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array. */
 			breakpoints: Breakpoint[];
 		};
 	}
@@ -538,13 +573,28 @@ declare module DebugProtocol {
 		condition?: string;
 	}
 
-	/** Information about a Breakpoint created in the setBreakpoints request.
+	/** Properties of a breakpoint passed to the setFunctionBreakpoints request.
+	*/
+	export interface FunctionBreakpoint {
+		/** The name of the function. */
+		name: string;
+		/** An optional expression for conditional breakpoints. */
+		condition?: string;
+	}
+
+	/** Information about a Breakpoint created in setBreakpoints or setFunctionBreakpoints.
 	*/
 	export interface Breakpoint {
-		/** If true breakpoint could be set (but not necessarily at the correct location). */
+		/** An optional unique identifier for the breakpoint. */
+		id?: number;
+		/** If true breakpoint could be set (but not necessarily at the desired location).  */
 		verified: boolean;
+		/** An optional message about the state of the breakpoint. This is shown to the user and can be used to explain why a breakpoint could not be verified. */
+		message?: string;
+		/** The source where the breakpoint is located. */
+		source?: Source;
 		/** The actual line of the breakpoint. */
-		line: number;
+		line?: number;
 		/** The actual column of the breakpoint. */
 		column?: number;
 	}

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -774,7 +774,7 @@ export class DebugService extends ee.EventEmitter implements debug.IDebugService
 		return this.session.setBreakpoints({ source: rawSource, lines: breakpointsToSend.map(bp => bp.desiredLineNumber),
 			breakpoints: breakpointsToSend.map(bp => ({ line: bp.desiredLineNumber, condition: bp.condition })) }).then(response => {
 
-			const data: {[id: string]: { line: number, verified: boolean } } = { };
+			const data: {[id: string]: { line?: number, verified: boolean } } = { };
 			for (let i = 0; i < breakpointsToSend.length; i++) {
 				data[breakpointsToSend[i].getId()] = response.body.breakpoints[i];
 			}


### PR DESCRIPTION
I did not push this change because it introduces one small incompatibility that needs adoption.
In the Breakpoint type (that is returned form the setBreakpointRequests), the `line` attribute is now optional (like `column`) because function breakpoints do not necessarily provide line information on verification.
