### PR TITLE
Fixes Markdown header highlighting rule

### DIFF
--- a/src/vs/languages/markdown/common/markdown.ts
+++ b/src/vs/languages/markdown/common/markdown.ts
@@ -53,7 +53,7 @@ export const language =
 			root: [
 
 				// headers (with #)
-				[/^(\s{0,3})(#+)((?:[^\\#]|@escapes)+)((?:#+)?)/, ['white', markdownTokenTypes.TOKEN_HEADER_LEAD, markdownTokenTypes.TOKEN_HEADER, markdownTokenTypes.TOKEN_HEADER]],
+				[/^(\s{0,3})(#+)(.*)/, ['white', markdownTokenTypes.TOKEN_HEADER_LEAD, markdownTokenTypes.TOKEN_HEADER]],
 
 				// headers (with =)
 				[/^\s*(=+|\-+)\s*$/, markdownTokenTypes.TOKEN_EXT_HEADER],

--- a/src/vs/languages/markdown/common/markdown.ts
+++ b/src/vs/languages/markdown/common/markdown.ts
@@ -52,7 +52,7 @@ export const language =
 		tokenizer: {
 			root: [
 
-				// headers (with #)
+				// headers (with #*)
 				[/^(\s{0,3})(#+)(.*)/, ['white', markdownTokenTypes.TOKEN_HEADER_LEAD, markdownTokenTypes.TOKEN_HEADER]],
 
 				// headers (with =)


### PR DESCRIPTION
- In response to issue #1238.
- Fixed regular expression for Markdown headers, testing across a variety of my repositories that are Markdown heavy without issues, but additional testing is probably warranted.
