### PR TITLE
Add support for jsonSchema integer type in Intellisense

### DIFF
--- a/src/vs/languages/json/common/jsonIntellisense.ts
+++ b/src/vs/languages/json/common/jsonIntellisense.ts
@@ -126,7 +126,7 @@ export class JSONIntellisense {
 			}
 
 			// proposals for values
-			if (node && (node.type === 'string' || node.type === 'number' || node.type === 'boolean' || node.type === 'null')) {
+			if (node && (node.type === 'string' || node.type === 'number' || node.type === 'integer' || node.type === 'boolean' || node.type === 'null')) {
 				var nodeRange = modelMirror.getRangeFromOffsetAndLength(node.start, node.end - node.start);
 				overwriteBefore = position.column - nodeRange.startColumn;
 				overwriteAfter = nodeRange.endColumn - position.column;
@@ -365,6 +365,7 @@ export class JSONIntellisense {
 			case 'string':
 				return '"{{' + snippet.substr(1, snippet.length - 2) + '}}"';
 			case 'number':
+			case 'integer':
 			case 'boolean':
 				return '{{' + snippet + '}}';
 		}
@@ -428,6 +429,7 @@ export class JSONIntellisense {
 					result += '[\n\t{{}}\n]';
 					break;
 				case 'number':
+				case 'integer':
 					result += '{{0}}';
 					break;
 				case 'null':


### PR DESCRIPTION
http://json-schema.org/latest/json-schema-core.html#anchor8
JSON schema defines primitive type 'integer'. It should be generally handled the same way as number in terms of autocompletion.
