### PR TITLE
Match longer JavaScript operators first to support ligatures.

### DIFF
--- a/extensions/javascript/syntaxes/JavaScript.tmLanguage
+++ b/extensions/javascript/syntaxes/JavaScript.tmLanguage
@@ -704,7 +704,7 @@
 		<key>logic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\!|&amp;|~|\||&amp;&amp;|\|\|</string>
+			<string>\!|&amp;&amp;|\|\||&amp;|~|\|</string>
 			<key>name</key>
 			<string>keyword.operator.arithmetic.ts.js</string>
 		</dict>
@@ -1211,7 +1211,7 @@
 		<key>relational-operator</key>
 		<dict>
 			<key>match</key>
-			<string>===|==|=|!=|!==|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
+			<string>===|!==|==|=|!=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.ts.js</string>
 		</dict>

--- a/extensions/javascript/syntaxes/JavaScriptReact.tmLanguage
+++ b/extensions/javascript/syntaxes/JavaScriptReact.tmLanguage
@@ -1054,7 +1054,7 @@
 		<key>logic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\!|&amp;|~|\||&amp;&amp;|\|\|</string>
+			<string>\!|&amp;&amp;|\|\||&amp;|~|\|</string>
 			<key>name</key>
 			<string>keyword.operator.arithmetic.ts.jsx</string>
 		</dict>
@@ -1537,7 +1537,7 @@
 		<key>relational-operator</key>
 		<dict>
 			<key>match</key>
-			<string>===|==|=|!=|!==|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
+			<string>===|!==|==|=|!=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.ts.jsx</string>
 		</dict>

--- a/extensions/typescript/syntaxes/TypeScript.tmLanguage
+++ b/extensions/typescript/syntaxes/TypeScript.tmLanguage
@@ -704,7 +704,7 @@
 		<key>logic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\!|&amp;|~|\||&amp;&amp;|\|\|</string>
+			<string>\!|&amp;&amp;|\|\||&amp;|~|\|</string>
 			<key>name</key>
 			<string>keyword.operator.arithmetic.ts</string>
 		</dict>
@@ -1211,7 +1211,7 @@
 		<key>relational-operator</key>
 		<dict>
 			<key>match</key>
-			<string>===|==|=|!=|!==|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
+			<string>===|!==|==|=|!=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.ts</string>
 		</dict>

--- a/extensions/typescript/syntaxes/TypeScriptReact.tmLanguage
+++ b/extensions/typescript/syntaxes/TypeScriptReact.tmLanguage
@@ -1054,7 +1054,7 @@
 		<key>logic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\!|&amp;|~|\||&amp;&amp;|\|\|</string>
+			<string>\!|&amp;&amp;|\|\||&amp;|~|\|</string>
 			<key>name</key>
 			<string>keyword.operator.arithmetic.ts.tsx</string>
 		</dict>
@@ -1537,7 +1537,7 @@
 		<key>relational-operator</key>
 		<dict>
 			<key>match</key>
-			<string>===|==|=|!=|!==|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
+			<string>===|!==|==|=|!=|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.ts.tsx</string>
 		</dict>


### PR DESCRIPTION
With the new support in version 0.10.8 for font ligatures, I'd noticed that some operators weren't being combined properly in JavaScript. This is because the language file had some of the shorter operators being matched first, so `||` would match as two `|` operators and `!==` would match as `!=` followed by `=`. Switching the order in the language file has fixed the ligatures in addition to having more correct grouping.

I've made the same fix to the JavaScript, JavaScriptReact, TypeScript, and TypeScriptReact language files.
