### PR TITLE
fix TextEditorOptions declaration - fixes #2797

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -533,12 +533,12 @@ declare namespace vscode {
 		 *  - the rendering width of a tab character;
 		 *  - the number of spaces to insert when [insertSpaces](#TextEditorOptions.insertSpaces) is true.
 		 */
-		tabSize: number;
+		tabSize: number | string;
 
 		/**
 		 * When pressing Tab insert [n](#TextEditorOptions.tabSize) spaces.
 		 */
-		insertSpaces: boolean;
+		insertSpaces: boolean | string;
 	}
 
 	/**


### PR DESCRIPTION
It is possible to provide the value `auto` to either one of the properties. So the declaration is not entirely correct.

This fixes #2797 

// @alexandrudima 
