### PR TITLE
Add Vagrantfile as a ruby language file extension

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "ruby",
-			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".pp", ".rake" ],
+			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".pp", ".rake", "Vagrantfile" ],
 			"filenames": [ "rakefile", "gemfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"configuration": "./ruby.configuration.json"


### PR DESCRIPTION
As those are just some regular ruby files.

See https://www.vagrantup.com/ for more information about the tool.

![image](https://cloud.githubusercontent.com/assets/2091902/13006519/b7abe592-d189-11e5-86bb-60659e0a1ed5.png)
