### PR TITLE
Make OSS product long name actually long

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,6 +1,6 @@
 {
 	"nameShort": "Code - OSS",
-	"nameLong": "Code - OSS",
+	"nameLong": "Visual Studio Code - OSS",
 	"applicationName": "code-oss",
 	"dataFolderName": ".vscode-oss",
 	"win32MutexName": "vscodeoss",


### PR DESCRIPTION
'Code - OSS' didn't look great in the launcher.

Fixes #2982

---

@joaomoreno is this is fine for Windows and Mac? Matches format of official build.
