### PR TITLE
Adding optout option for telemetry

### DIFF
--- a/src/vs/platform/telemetry/browser/mainTelemetryService.ts
+++ b/src/vs/platform/telemetry/browser/mainTelemetryService.ts
@@ -73,6 +73,11 @@ export class MainTelemetryService extends AbstractTelemetryService implements IT
 			return;
 		}
 
+		// don't send events when user is optout
+		if(!this.config.userOptIn) {
+			return;
+		}
+
 		this.eventCount++;
 
 		data = this.addCommonProperties(data);

--- a/src/vs/platform/telemetry/browser/mainTelemetryService.ts
+++ b/src/vs/platform/telemetry/browser/mainTelemetryService.ts
@@ -5,9 +5,8 @@
 
 'use strict';
 
-import Platform = require('vs/base/common/platform');
-import Objects = require('vs/base/common/objects');
-import uuid = require('vs/base/common/uuid');
+import * as Platform from 'vs/base/common/platform';
+import * as uuid from 'vs/base/common/uuid';
 import {AbstractTelemetryService} from 'vs/platform/telemetry/common/abstractTelemetryService';
 import {ITelemetryService, ITelemetryServiceConfig} from 'vs/platform/telemetry/common/telemetry';
 import {IdleMonitor, UserStatus} from 'vs/base/browser/idleMonitor';

--- a/src/vs/platform/telemetry/browser/mainTelemetryService.ts
+++ b/src/vs/platform/telemetry/browser/mainTelemetryService.ts
@@ -24,6 +24,7 @@ export class MainTelemetryService extends AbstractTelemetryService implements IT
 	private eventCount: number;
 	private userIdHash: string;
 	private startTime: Date;
+	private optInFriendly: string[];
 
 	constructor(config?: ITelemetryServiceConfig) {
 		super(config);
@@ -41,6 +42,9 @@ export class MainTelemetryService extends AbstractTelemetryService implements IT
 
 		this.eventCount = 0;
 		this.startTime = new Date();
+
+		//holds a cache of predefined events that can be sent regardress of user optin status
+		this.optInFriendly = ['optInStatus'];
 	}
 
 	private onUserIdle(): void {
@@ -68,13 +72,13 @@ export class MainTelemetryService extends AbstractTelemetryService implements IT
 			return;
 		}
 
-		// don't send telemetry when not enabled
+		// don't send telemetry when channel is not enabled
 		if (!this.config.enableTelemetry) {
 			return;
 		}
 
-		// don't send events when user is optout
-		if(!this.config.userOptIn) {
+		// don't send events when the user is optout unless the event is flaged as optin friendly
+		if(!this.config.userOptIn && this.optInFriendly.indexOf(eventName) === -1) {
 			return;
 		}
 

--- a/src/vs/platform/telemetry/browser/mainTelemetryService.ts
+++ b/src/vs/platform/telemetry/browser/mainTelemetryService.ts
@@ -9,24 +9,9 @@ import Platform = require('vs/base/common/platform');
 import Objects = require('vs/base/common/objects');
 import uuid = require('vs/base/common/uuid');
 import {AbstractTelemetryService} from 'vs/platform/telemetry/common/abstractTelemetryService';
-import {ITelemetryService} from 'vs/platform/telemetry/common/telemetry';
+import {ITelemetryService, ITelemetryServiceConfig} from 'vs/platform/telemetry/common/telemetry';
 import {IdleMonitor, UserStatus} from 'vs/base/browser/idleMonitor';
 
-export interface TelemetryServiceConfig {
-	enableTelemetry?: boolean;
-
-	enableHardIdle?: boolean;
-	enableSoftIdle?: boolean;
-	sessionID?: string;
-	commitHash?: string;
-	version?: string;
-}
-
-const DefaultTelemetryServiceConfig: TelemetryServiceConfig = {
-	enableTelemetry: true,
-	enableHardIdle: true,
-	enableSoftIdle: true
-};
 
 export class MainTelemetryService extends AbstractTelemetryService implements ITelemetryService {
 	// how long of inactivity before a user is considered 'inactive' - 2 minutes
@@ -34,17 +19,14 @@ export class MainTelemetryService extends AbstractTelemetryService implements IT
 	public static IDLE_START_EVENT_NAME = 'UserIdleStart';
 	public static IDLE_STOP_EVENT_NAME = 'UserIdleStop';
 
-	protected config: TelemetryServiceConfig;
-
 	private hardIdleMonitor: IdleMonitor;
 	private softIdleMonitor: IdleMonitor;
 	private eventCount: number;
 	private userIdHash: string;
 	private startTime: Date;
 
-	constructor(config?: TelemetryServiceConfig) {
-		this.config = Objects.withDefaults(config, DefaultTelemetryServiceConfig);
-		super();
+	constructor(config?: ITelemetryServiceConfig) {
+		super(config);
 
 		this.sessionId = this.config.sessionID || (uuid.generateUuid() + Date.now());
 

--- a/src/vs/platform/telemetry/common/abstractTelemetryService.ts
+++ b/src/vs/platform/telemetry/common/abstractTelemetryService.ts
@@ -17,7 +17,8 @@ import {IInstantiationService} from 'vs/platform/instantiation/common/instantiat
 const DefaultTelemetryServiceConfig: ITelemetryServiceConfig = {
 	enableTelemetry: true,
 	enableHardIdle: true,
-	enableSoftIdle: true
+	enableSoftIdle: true,
+	userOptIn: true
 };
 
 /**
@@ -28,7 +29,6 @@ export abstract class AbstractTelemetryService implements ITelemetryService {
 
 	public serviceId = ITelemetryService;
 
-	private toUnbind: any[];
 	private timeKeeper: TimeKeeper;
 	private appenders: ITelemetryAppender[];
 	private oldOnError: any;
@@ -40,6 +40,7 @@ export abstract class AbstractTelemetryService implements ITelemetryService {
 	protected sessionId: string;
 	protected instanceId: string;
 	protected machineId: string;
+	protected toUnbind: any[];
 
 	protected config: ITelemetryServiceConfig;
 

--- a/src/vs/platform/telemetry/common/abstractTelemetryService.ts
+++ b/src/vs/platform/telemetry/common/abstractTelemetryService.ts
@@ -8,11 +8,17 @@ import Errors = require('vs/base/common/errors');
 import Types = require('vs/base/common/types');
 import Platform = require('vs/base/common/platform');
 import {TimeKeeper, IEventsListener, ITimerEvent} from 'vs/base/common/timer';
-import {safeStringify} from 'vs/base/common/objects';
+import {safeStringify, withDefaults} from 'vs/base/common/objects';
 import {Registry} from 'vs/platform/platform';
-import {ITelemetryService, ITelemetryAppender, ITelemetryInfo} from 'vs/platform/telemetry/common/telemetry';
+import {ITelemetryService, ITelemetryAppender, ITelemetryInfo, ITelemetryServiceConfig} from 'vs/platform/telemetry/common/telemetry';
 import {SyncDescriptor0} from 'vs/platform/instantiation/common/descriptors';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
+
+const DefaultTelemetryServiceConfig: ITelemetryServiceConfig = {
+	enableTelemetry: true,
+	enableHardIdle: true,
+	enableSoftIdle: true
+};
 
 /**
  * Base class for main process telemetry services
@@ -35,7 +41,9 @@ export abstract class AbstractTelemetryService implements ITelemetryService {
 	protected instanceId: string;
 	protected machineId: string;
 
-	constructor() {
+	protected config: ITelemetryServiceConfig;
+
+	constructor(config?: ITelemetryServiceConfig) {
 		this.sessionId = 'SESSION_ID_NOT_SET';
 		this.timeKeeper = new TimeKeeper();
 		this.toUnbind = [];
@@ -49,6 +57,8 @@ export abstract class AbstractTelemetryService implements ITelemetryService {
 		this.enableGlobalErrorHandler();
 
 		this.errorFlushTimeout = -1;
+
+		this.config = withDefaults(config, DefaultTelemetryServiceConfig);
 	}
 
 	private _safeStringify(data: any): string {

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -63,6 +63,16 @@ export interface ITelemetryAppender extends Lifecycle.IDisposable {
 	log(eventName: string, data?: any): void;
 }
 
+export interface ITelemetryServiceConfig {
+	enableTelemetry?: boolean;
+
+	enableHardIdle?: boolean;
+	enableSoftIdle?: boolean;
+	sessionID?: string;
+	commitHash?: string;
+	version?: string;
+}
+
 export function anonymize(input: string): string {
 	if (!input) {
 		return input;

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -65,6 +65,7 @@ export interface ITelemetryAppender extends Lifecycle.IDisposable {
 
 export interface ITelemetryServiceConfig {
 	enableTelemetry?: boolean;
+	userOptIn?: boolean;
 
 	enableHardIdle?: boolean;
 	enableSoftIdle?: boolean;

--- a/src/vs/platform/telemetry/electron-browser/electronTelemetryService.ts
+++ b/src/vs/platform/telemetry/electron-browser/electronTelemetryService.ts
@@ -6,8 +6,8 @@
 import getmac = require('getmac');
 import crypto = require('crypto');
 
-import {MainTelemetryService, TelemetryServiceConfig} from 'vs/platform/telemetry/browser/mainTelemetryService';
-import {ITelemetryService, ITelemetryInfo} from 'vs/platform/telemetry/common/telemetry';
+import {MainTelemetryService} from 'vs/platform/telemetry/browser/mainTelemetryService';
+import {ITelemetryService, ITelemetryInfo, ITelemetryServiceConfig} from 'vs/platform/telemetry/common/telemetry';
 import {IStorageService} from 'vs/platform/storage/common/storage';
 import errors = require('vs/base/common/errors');
 import uuid = require('vs/base/common/uuid');
@@ -21,7 +21,7 @@ export class ElectronTelemetryService extends MainTelemetryService implements IT
 
 	private _setupIds: Promise<ITelemetryInfo>;
 
-	constructor( @IStorageService private storageService: IStorageService, config?: TelemetryServiceConfig) {
+	constructor( @IStorageService private storageService: IStorageService, config?: ITelemetryServiceConfig) {
 		super(config);
 
 		this._setupIds = this.setupIds();

--- a/src/vs/platform/telemetry/test/node/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/node/telemetryService.test.ts
@@ -16,6 +16,8 @@ import Platform = require('vs/platform/platform');
 import * as sinon from 'sinon';
 import {createSyncDescriptor} from 'vs/platform/instantiation/common/descriptors';
 
+const optInStatusEventName: string = 'optInStatus';
+
 class TestTelemetryAppender implements TelemetryService.ITelemetryAppender {
 
 	public events: any[];
@@ -776,6 +778,21 @@ suite('TelemetryService', () => {
 		service.publicLog('testEvent');
 		assert.equal(testAppender.getEventsCount(), 1);
 
+		service.dispose();
+	}));
+
+	test('Telemetry Service allows optin friendly events', sinon.test(function() {
+		let service = new MainTelemetryService.MainTelemetryService({userOptIn: false, enableTelemetry: true});
+		let testAppender = new TestTelemetryAppender();
+		service.addTelemetryAppender(testAppender);
+
+		service.publicLog('testEvent');
+		assert.equal(testAppender.getEventsCount(), 0);
+
+		service.publicLog(optInStatusEventName, {userOptIn: false});
+		assert.equal(testAppender.getEventsCount(), 1);
+		assert.equal(testAppender.events[0].eventName, optInStatusEventName);
+		assert.equal(testAppender.events[0].data.userOptIn, false);
 		service.dispose();
 	}));
 });

--- a/src/vs/platform/telemetry/test/node/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/node/telemetryService.test.ts
@@ -745,4 +745,37 @@ suite('TelemetryService', () => {
 		assert.equal(service.getSessionId(), testSessionId);
 		service.dispose();
 	}));
+
+	test('Telemetry Service respects user opt-in settings', sinon.test(function() {
+		let service = new MainTelemetryService.MainTelemetryService({userOptIn: false, enableTelemetry: true});
+		let testAppender = new TestTelemetryAppender();
+		service.addTelemetryAppender(testAppender);
+
+		service.publicLog('testEvent');
+		assert.equal(testAppender.getEventsCount(), 0);
+
+		service.dispose();
+	}));
+
+	test('Telemetry Service dont send events when enableTelemetry is off even if user is optin', sinon.test(function() {
+		let service = new MainTelemetryService.MainTelemetryService({userOptIn: true, enableTelemetry: false});
+		let testAppender = new TestTelemetryAppender();
+		service.addTelemetryAppender(testAppender);
+
+		service.publicLog('testEvent');
+		assert.equal(testAppender.getEventsCount(), 0);
+
+		service.dispose();
+	}));
+
+	test('Telemetry Service sends events when enableTelemetry is on even user optin is on', sinon.test(function() {
+		let service = new MainTelemetryService.MainTelemetryService({userOptIn: true, enableTelemetry: true});
+		let testAppender = new TestTelemetryAppender();
+		service.addTelemetryAppender(testAppender);
+
+		service.publicLog('testEvent');
+		assert.equal(testAppender.getEventsCount(), 1);
+
+		service.dispose();
+	}));
 });

--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -232,19 +232,19 @@ export class WorkbenchShell {
 		let disableWorkspaceStorage = this.configuration.env.pluginTestsPath || (!this.workspace && !this.configuration.env.pluginDevelopmentPath); // without workspace or in any plugin test, we use inMemory storage unless we develop a plugin where we want to preserve state
 		this.storageService = new Storage(this.contextService, window.localStorage, disableWorkspaceStorage ? inMemoryLocalStorageInstance : window.localStorage);
 
+		let configService = new ConfigurationService(
+			this.contextService,
+			eventService
+		);
+
 		// no telemetry in a window for plugin development!
 		let enableTelemetry = this.configuration.env.isBuilt && !this.configuration.env.pluginDevelopmentPath ? !!this.configuration.env.enableTelemetry : false;
-		this.telemetryService = new ElectronTelemetryService(this.storageService, { enableTelemetry: enableTelemetry, version: this.configuration.env.version, commitHash: this.configuration.env.commitHash });
+		this.telemetryService = new ElectronTelemetryService(configService, this.storageService, { enableTelemetry: enableTelemetry, version: this.configuration.env.version, commitHash: this.configuration.env.commitHash });
 
 		this.keybindingService = new WorkbenchKeybindingService(this.contextService, eventService, this.telemetryService, <any>window);
 
 		this.messageService = new MessageService(this.contextService, this.windowService, this.telemetryService, this.keybindingService);
 		this.keybindingService.setMessageService(this.messageService);
-
-		let configService = new ConfigurationService(
-			this.contextService,
-			eventService
-		);
 
 		let fileService = new FileService(
 			configService,


### PR DESCRIPTION
This change will add a user setting that will allow to optout of reporting telemetry. The product will allow a set of predefined events to pass the user optin settings. This way we can calculate the optin rates. 

The change include: 
- Refactor `ITelemetryConfiguration` from `mainTelemetryService` to `telemetry.ts`
- Add a configuration option from the `ElectronTelemetryService`. This service will be responsible for caching the events that are reported until the user optin settings are loaded. After that, the service will flush the events. This is to prevent race conditions as some events are reported on load (auto save, workspace stats, workspace load). 
- Add a mechanism to allow for a predefined events to pass user optout settings in `mainTelemetryService`. 
- Tests 
