### PR TITLE
debug: telemetry key contributed by debug adapters

### DIFF
--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -195,6 +195,7 @@ export interface IRawAdapter extends IRawEnvAdapter {
 	enableBreakpointsFor?: { languageIds: string[] };
 	configurationAttributes?: any;
 	initialConfigurations?: any[];
+	telemetryKey?: string;
 	win?: IRawEnvAdapter;
 	winx86?: IRawEnvAdapter;
 	windows?: IRawEnvAdapter;

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -195,7 +195,7 @@ export interface IRawAdapter extends IRawEnvAdapter {
 	enableBreakpointsFor?: { languageIds: string[] };
 	configurationAttributes?: any;
 	initialConfigurations?: any[];
-	telemetryKey?: string;
+	aiKey?: string;
 	win?: IRawEnvAdapter;
 	winx86?: IRawEnvAdapter;
 	windows?: IRawEnvAdapter;

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -284,7 +284,7 @@ export class DebugService extends ee.EventEmitter implements debug.IDebugService
 
 		this.toDispose.push(this.session.addListener2(debug.SessionEvents.OUTPUT, (event: DebugProtocol.OutputEvent) => {
 			if (event.body && event.body.category === 'telemetry') {
-				const key = this.configurationManager.getAdapter().telemetryKey;
+				const key = this.configurationManager.getAdapter().aiKey;
 				// only log telemetry events from debug adapter if the adapter provided the telemetry key
 				if (key) {
 					if (!this.telemetryAdapter) {

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -16,6 +16,7 @@ import severity from 'vs/base/common/severity';
 import { TPromise } from 'vs/base/common/winjs.base';
 import editor = require('vs/editor/common/editorCommon');
 import aria = require('vs/base/browser/ui/aria/aria');
+import { AIAdapter } from 'vs/base/node/aiAdapter';
 import editorbrowser = require('vs/editor/browser/editorBrowser');
 import { IKeybindingService, IKeybindingContextKey } from 'vs/platform/keybinding/common/keybindingService';
 import {IMarkerService} from 'vs/platform/markers/common/markers';
@@ -65,6 +66,7 @@ export class DebugService extends ee.EventEmitter implements debug.IDebugService
 	private viewModel: viewmodel.ViewModel;
 	private configurationManager: ConfigurationManager;
 	private debugStringEditorInputs: DebugStringEditorInput[];
+	private telemetryAdapter: AIAdapter;
 	private lastTaskEvent: TaskEvent;
 	private toDispose: lifecycle.IDisposable[];
 	private inDebugMode: IKeybindingContextKey<boolean>;
@@ -282,7 +284,15 @@ export class DebugService extends ee.EventEmitter implements debug.IDebugService
 
 		this.toDispose.push(this.session.addListener2(debug.SessionEvents.OUTPUT, (event: DebugProtocol.OutputEvent) => {
 			if (event.body && event.body.category === 'telemetry') {
-				this.telemetryService.publicLog(event.body.output, event.body.data);
+				const key = this.configurationManager.getAdapter().telemetryKey;
+				// only log telemetry events from debug adapter if the adapter provided the telemetry key
+				if (key) {
+					if (!this.telemetryAdapter) {
+						this.telemetryAdapter = new AIAdapter(key, this.session.getType());
+					}
+
+					this.telemetryAdapter.log(event.body.output, event.body.data);
+				}
 			} else if (event.body && typeof event.body.output === 'string' && event.body.output.length > 0) {
 				this.onOutput(event);
 			}
@@ -673,6 +683,10 @@ export class DebugService extends ee.EventEmitter implements debug.IDebugService
 		});
 		this.model.updateBreakpoints(data);
 
+		if (this.telemetryAdapter) {
+			this.telemetryAdapter.dispose();
+			this.telemetryAdapter = null;
+		}
 		this.inDebugMode.reset();
 	}
 

--- a/src/vs/workbench/parts/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/parts/debug/node/debugAdapter.ts
@@ -20,7 +20,7 @@ export class Adapter {
 	private configurationAttributes: any;
 	public initialConfigurations: any[];
 	public enableBreakpointsFor: { languageIds: string[] };
-	public telemetryKey: string;
+	public aiKey: string;
 
 	constructor(rawAdapter: debug.IRawAdapter, systemVariables: SystemVariables, extensionFolderPath: string) {
 		if (rawAdapter.windows) {
@@ -68,7 +68,7 @@ export class Adapter {
 		this.initialConfigurations = rawAdapter.initialConfigurations;
 		this._label = rawAdapter.label;
 		this.enableBreakpointsFor = rawAdapter.enableBreakpointsFor;
-		this.telemetryKey = rawAdapter.telemetryKey;
+		this.aiKey = rawAdapter.aiKey;
 	}
 
 	public get label() {

--- a/src/vs/workbench/parts/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/parts/debug/node/debugAdapter.ts
@@ -20,6 +20,7 @@ export class Adapter {
 	private configurationAttributes: any;
 	public initialConfigurations: any[];
 	public enableBreakpointsFor: { languageIds: string[] };
+	public telemetryKey: string;
 
 	constructor(rawAdapter: debug.IRawAdapter, systemVariables: SystemVariables, extensionFolderPath: string) {
 		if (rawAdapter.windows) {
@@ -67,6 +68,7 @@ export class Adapter {
 		this.initialConfigurations = rawAdapter.initialConfigurations;
 		this._label = rawAdapter.label;
 		this.enableBreakpointsFor = rawAdapter.enableBreakpointsFor;
+		this.telemetryKey = rawAdapter.telemetryKey;
 	}
 
 	public get label() {

--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -43,6 +43,10 @@ export var debuggersExtPoint = pluginsRegistry.PluginsRegistry.registerExtension
 				description: nls.localize('vscode.extension.contributes.debuggers.label', "Display name for this debug adapter."),
 				type: 'string'
 			},
+			telemetryKey: {
+				description: nls.localize('vscode.extension.contributes.debuggers.telemetryKey', "All telemetry information generated from the adapter will be tagged with this key."),
+				type: 'string'
+			},
 			enableBreakpointsFor: {
 				description: nls.localize('vscode.extension.contributes.debuggers.enableBreakpointsFor', "Allow breakpoints for these languages."),
 				type: 'object',

--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -43,10 +43,6 @@ export var debuggersExtPoint = pluginsRegistry.PluginsRegistry.registerExtension
 				description: nls.localize('vscode.extension.contributes.debuggers.label', "Display name for this debug adapter."),
 				type: 'string'
 			},
-			telemetryKey: {
-				description: nls.localize('vscode.extension.contributes.debuggers.telemetryKey', "All telemetry information generated from the adapter will be tagged with this key."),
-				type: 'string'
-			},
 			enableBreakpointsFor: {
 				description: nls.localize('vscode.extension.contributes.debuggers.enableBreakpointsFor', "Allow breakpoints for these languages."),
 				type: 'object',


### PR DESCRIPTION
Adds a telemetryKey to the debug world such that the telemetry events from adapters are seperated into buckets.

fixes #2931
