### PR TITLE
Forward arguments in the shell script correctly: use "$@" instead of $*

### DIFF
--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
@@ -27,10 +27,10 @@ function code() {
 
 	# Launch Code
 	if [[ "$OSTYPE" == "darwin"* ]]; then
-		./.build/electron/Electron.app/Contents/MacOS/Electron . $*
+		exec ./.build/electron/Electron.app/Contents/MacOS/Electron . "$@"
 	else
-		./.build/electron/electron . $*
+		exec ./.build/electron/electron . "$@"
 	fi
 }
 
-code $*
+code "$@"


### PR DESCRIPTION
Also made a few other changes:
- added an `exec` to improve performance (which replaces the current process instead of spawning a subshell)
- changed the shebang to `#!/usr/bin/env`, as this is best practice.
