### PR TITLE
Fix code folding keyboard mix up

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -437,7 +437,7 @@ abstract class FoldingAction extends EditorAction {
 }
 
 class FoldAction extends FoldingAction {
-	public static ID = 'editor.unfold';
+	public static ID = 'editor.fold';
 
 	invoke(foldingController: FoldingController, lineNumber: number): void {
 		foldingController.fold(lineNumber);
@@ -453,7 +453,7 @@ class FoldAllAction extends FoldingAction {
 }
 
 class UnfoldAction extends FoldingAction {
-	public static ID = 'editor.fold';
+	public static ID = 'editor.unfold';
 
 	invoke(foldingController: FoldingController, lineNumber: number): void {
 		foldingController.unfold(lineNumber);
@@ -474,7 +474,7 @@ CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(FoldAction,
 	context: ContextKey.EditorFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_OPEN_SQUARE_BRACKET
 }));
-CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(UnfoldAllAction, UnfoldAllAction.ID, nls.localize('foldAllAction.label', "Fold All"), {
+CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(FoldAllAction, FoldAllAction.ID, nls.localize('foldAllAction.label', "Fold All"), {
 	context: ContextKey.EditorFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.US_OPEN_SQUARE_BRACKET
 }));
@@ -482,7 +482,7 @@ CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(UnfoldActio
 	context: ContextKey.EditorFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_CLOSE_SQUARE_BRACKET
 }));
-CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(FoldAllAction, FoldAllAction.ID, nls.localize('unfoldAllAction.label', "Unfold All"), {
+CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(UnfoldAllAction, UnfoldAllAction.ID, nls.localize('unfoldAllAction.label', "Unfold All"), {
 	context: ContextKey.EditorFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.US_CLOSE_SQUARE_BRACKET
 }));

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -436,14 +436,6 @@ abstract class FoldingAction extends EditorAction {
 
 }
 
-class UnfoldAction extends FoldingAction {
-	public static ID = 'editor.fold';
-
-	invoke(foldingController: FoldingController, lineNumber: number): void {
-		foldingController.unfold(lineNumber);
-	}
-}
-
 class FoldAction extends FoldingAction {
 	public static ID = 'editor.unfold';
 
@@ -457,6 +449,14 @@ class FoldAllAction extends FoldingAction {
 
 	invoke(foldingController: FoldingController, lineNumber: number): void {
 		foldingController.changeAll(true);
+	}
+}
+
+class UnfoldAction extends FoldingAction {
+	public static ID = 'editor.fold';
+
+	invoke(foldingController: FoldingController, lineNumber: number): void {
+		foldingController.unfold(lineNumber);
 	}
 }
 

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -470,10 +470,6 @@ class UnfoldAllAction extends FoldingAction {
 
 EditorBrowserRegistry.registerEditorContribution(FoldingController);
 
-CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(UnfoldAction, UnfoldAction.ID, nls.localize('unfoldAction.label', "Unfold"), {
-	context: ContextKey.EditorFocus,
-	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_CLOSE_SQUARE_BRACKET
-}));
 CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(FoldAction, FoldAction.ID, nls.localize('foldAction.label', "Fold"), {
 	context: ContextKey.EditorFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_OPEN_SQUARE_BRACKET
@@ -481,6 +477,10 @@ CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(FoldAction,
 CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(UnfoldAllAction, UnfoldAllAction.ID, nls.localize('foldAllAction.label', "Fold All"), {
 	context: ContextKey.EditorFocus,
 	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyMod.Shift | KeyCode.US_OPEN_SQUARE_BRACKET
+}));
+CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(UnfoldAction, UnfoldAction.ID, nls.localize('unfoldAction.label', "Unfold"), {
+	context: ContextKey.EditorFocus,
+	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.US_CLOSE_SQUARE_BRACKET
 }));
 CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(FoldAllAction, FoldAllAction.ID, nls.localize('unfoldAllAction.label', "Unfold All"), {
 	context: ContextKey.EditorFocus,


### PR DESCRIPTION
The current implementation for keyboard bindings to code folding works as advertised (in the default keyboard bindings file) for single fold/unfold, but foldAll/unfoldAll is flipped.
This pull request fixes that.

Note: it is possible that the keyboard bindings are back to front i.e open/close square bracket. I have not changed them and do not know which you intended to do what. Feedback in the comments on this would be appreciated.
