### PR TITLE
vscode.d.ts: workspace.rootPath is read-only

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3104,6 +3104,8 @@ declare namespace vscode {
 		/**
 		 * The folder that is open in VS Code. `undefined` when no folder
 		 * has been opened.
+		 * 
+		 * @readonly
 		 */
 		export let rootPath: string;
 


### PR DESCRIPTION
Small change: added the `@readonly` flag to workspace.rootPath
