### PR TITLE
add support for restarting debug session

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -287,7 +287,11 @@ export class DebugService extends ee.EventEmitter implements debug.IDebugService
 		this.toDispose.push(this.session.addListener2(debug.SessionEvents.DEBUGEE_TERMINATED, (event: DebugProtocol.TerminatedEvent) => {
 			aria.alert(nls.localize('programTerminated', "Program terminated."));
 			if (this.session && this.session.getId() === (<any>event).sessionId) {
-				this.session.disconnect().done(null, errors.onUnexpectedError);
+				if (event.body && typeof event.body.restart == 'boolean' && event.body.restart) {
+					this.restartSession().done(null, errors.onUnexpectedError);
+				} else {
+					this.session.disconnect().done(null, errors.onUnexpectedError);
+				}
 			}
 		}));
 


### PR DESCRIPTION
If a TerminatedEvent has an attribute 'restart' and its value is true, the debug session is restarted. This can be used to automatically reattach to a node process that is relaunched by nodemon (see #2103)
