### PR TITLE
Change accelerator key for menu item: User Snippets from 'U' to 'S'

### DIFF
--- a/src/vs/workbench/electron-main/menus.ts
+++ b/src/vs/workbench/electron-main/menus.ts
@@ -357,7 +357,7 @@ export class VSCodeMenu {
 		let userSettings = this.createMenuItem(nls.localize('miOpenSettings', "&&User Settings"), 'workbench.action.openGlobalSettings');
 		let workspaceSettings = this.createMenuItem(nls.localize('miOpenWorkspaceSettings', "&&Workspace Settings"), 'workbench.action.openWorkspaceSettings');
 		let kebindingSettings = this.createMenuItem(nls.localize('miOpenKeymap', "&&Keyboard Shortcuts"), 'workbench.action.openGlobalKeybindings');
-		let snippetsSettings = this.createMenuItem(nls.localize('miOpenSnippets', "&&User Snippets"), 'workbench.action.openSnippets');
+		let snippetsSettings = this.createMenuItem(nls.localize('miOpenSnippets', "User &&Snippets"), 'workbench.action.openSnippets');
 		let themeSelection = this.createMenuItem(nls.localize('miSelectTheme', "&&Color Theme"), 'workbench.action.selectTheme');
 		let preferencesMenu = new Menu();
 		preferencesMenu.append(userSettings);


### PR DESCRIPTION
I often like to go into the user settings, which should be just a `alt+f p u` away. However both the "User Settings" and "User Snippets" menu items have the same accelerator key: U, which means having to press Enter as well.
![menu](https://cloud.githubusercontent.com/assets/6125444/13154994/e52c10cc-d67b-11e5-8959-e9770b1d6b5e.png)

So this commit changes the key or "User Snippets" from 'U' to 'S'. There's other instances of accelerator key duplication in the menus, but this one seemed easy to tackle.
