### PR TITLE
Add "launch"-type config to launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,8 +45,14 @@
 			"type": "chrome",
 			"request": "attach",
 			"port": 9222,
-			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out"
+			"sourceMaps": true
+		},
+		{
+			"name": "Launch VSCode",
+			"type": "chrome",
+			"request": "launch",
+			"runtimeExecutable": "${workspaceRoot}/scripts/code.bat",
+			"sourceMaps": true
 		},
 		{
 			"name": "Convert css-schema to browser.js",


### PR DESCRIPTION
Now I can just hit F5 to build and debug vscode. Also removed 'outDir' which isn't used anymore.
