### PR TITLE
Fix opening code via command line using relative paths

### DIFF
--- a/src/vs/workbench/electron-main/env.ts
+++ b/src/vs/workbench/electron-main/env.ts
@@ -317,7 +317,9 @@ function massagePath(path: string): string {
 	path = strings.trim(strings.trim(path, ' '), '\t');
 
 	// Remove trailing dots
-	path = strings.rtrim(path, '.');
+	if (platform.isWindows) {
+		path = strings.rtrim(path, '.');
+	}
 
 	return path;
 }

--- a/src/vs/workbench/electron-main/env.ts
+++ b/src/vs/workbench/electron-main/env.ts
@@ -316,11 +316,6 @@ function massagePath(path: string): string {
 	// Trim whitespaces
 	path = strings.trim(strings.trim(path, ' '), '\t');
 
-	// Remove trailing dots
-	if (platform.isWindows) {
-		path = strings.rtrim(path, '.');
-	}
-
 	return path;
 }
 


### PR DESCRIPTION
Opening code using `code ..`, `code ../..`  was opening the wrong directory
since trailing '.' characters were being trimmed by the launch code.

Fixes #3127 

---

@bpasero I'm assuming that the trimming was added for Windows, just wanted to make sure that was the intent. Or can we remove it?
