### PR TITLE
Enabling high contrast dark theme on all platforms + hc-dark improvements

### DIFF
--- a/src/vs/base/browser/ui/checkbox/checkbox.css
+++ b/src/vs/base/browser/ui/checkbox/checkbox.css
@@ -59,5 +59,5 @@
 }
 
 .hc-black .custom-checkbox.checked {
-	border: 1px solid #DF740C;
+	border: 1px solid #f38518;
 }

--- a/src/vs/base/browser/ui/list/list.css
+++ b/src/vs/base/browser/ui/list/list.css
@@ -45,14 +45,14 @@
 /* Hover */
 .monaco-list-row:hover { background-color: #F0F0F0; }
 .vs-dark .monaco-list-row:hover { background-color: rgba(255, 255, 255, 0.08); }
-.hc-black .monaco-list-row:hover { border: 1px dashed #DF740C; }
+.hc-black .monaco-list-row:hover { border: 1px dashed #f38518; }
 
 /* Selection */
 .monaco-list-row.selected { background-color: #4FA7FF; color: white; }
 .vs-dark .monaco-list-row.selected { background-color: #0E639C; color: white; }
-.hc-black .monaco-list-row.selected { border: 1px solid #DF740C; }
+.hc-black .monaco-list-row.selected { border: 1px solid #f38518; }
 
 /* Focus */
 .monaco-list-row.focused { background-color: #DCEBFC; }
 .vs-dark .monaco-list-row.focused { background-color: #073655; }
-.hc-black .monaco-list-row.focused { border: 1px dotted #DF740C; }
+.hc-black .monaco-list-row.focused { border: 1px dotted #f38518; }

--- a/src/vs/base/browser/ui/menu/menu.css
+++ b/src/vs/base/browser/ui/menu/menu.css
@@ -90,7 +90,7 @@
 
 /* Context Menu */
 
-.context-view.monaco-menu-container {	
+.context-view.monaco-menu-container {
 	font-family: "Segoe WPC", "Segoe UI", "SFUIText-Light", "HelveticaNeue-Light", sans-serif, "Droid Sans Fallback";
 	outline: 0;
 	box-shadow: 0 2px 8px #A8A8A8;
@@ -106,9 +106,9 @@
 
 .ie.ie9 .context-view.monaco-menu-container {
 	box-shadow: 0 2px 8px 2px #A8A8A8;
-}	
+}
 
-.context-view.monaco-menu-container :focus {	
+.context-view.monaco-menu-container :focus {
 	outline: 0;
 }
 
@@ -121,14 +121,14 @@
 	background-color: #3A3A3A;
 }
 
-.vs-dark .context-view.monaco-menu-container {	
+.vs-dark .context-view.monaco-menu-container {
 	box-shadow: 0 2px 8px #000;
 	color: #BBB;
-	background-color: #2D2F31; 
+	background-color: #2D2F31;
 }
 
 /* High Contrast Theming */
-.hc-black .context-view.monaco-menu-container {	
+.hc-black .context-view.monaco-menu-container {
 	border: 2px solid #6FC3DF;
 	color: white;
 	background-color: #0C141F;
@@ -137,10 +137,10 @@
 
 .hc-black .monaco-menu .monaco-action-bar.vertical .action-item.focused {
 	background: none;
-	border: 1px dotted #DF740C;
+	border: 1px dotted #f38518;
 }
 
 .hc-black .monaco-menu .monaco-action-bar.vertical .action-item:hover:not(.disabled) {
 	background: none;
-	border: 1px dashed #DF740C;
+	border: 1px dashed #f38518;
 }

--- a/src/vs/base/browser/ui/scrollbar/media/scrollbars.css
+++ b/src/vs/base/browser/ui/scrollbar/media/scrollbars.css
@@ -90,13 +90,13 @@
 .hc-black .monaco-scrollable-element > .scrollbar > .slider {
 	background: none;
 	border: 20px solid #6FC3DF;
-	opacity: .3;
+	opacity: .4;
 }
 
 .hc-black .monaco-scrollable-element > .scrollbar > .slider:hover {
-	opacity: .35;
+	opacity: .85;
 }
 
 .hc-black .monaco-scrollable-element > .scrollbar > .slider.active {
-	opacity: .4;
+	opacity: .9;
 }

--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -199,12 +199,12 @@
 
 /* High Contrast Theming */
 .hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row 														{ background: none !important; }
-.hc-black .monaco-tree.focused .monaco-tree-rows > .monaco-tree-row.focused:not(.highlighted) 						{ border: 1px dotted #DF740C; }
-.hc-black .monaco-tree.focused .monaco-tree-rows > .monaco-tree-row.selected:not(.highlighted) 					{ border: 1px solid #DF740C; }
-.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.selected:not(.highlighted)  							{ border: 1px solid #DF740C; }
-.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row:hover:not(.highlighted):not(.selected):not(.focused)  	{ border: 1px dashed #DF740C; margin-top:-1px; margin-bottom:1px; margin-left:-1px; }
+.hc-black .monaco-tree.focused .monaco-tree-rows > .monaco-tree-row.focused:not(.highlighted) 						{ border: 1px dotted #f38518; }
+.hc-black .monaco-tree.focused .monaco-tree-rows > .monaco-tree-row.selected:not(.highlighted) 					{ border: 1px solid #f38518; }
+.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.selected:not(.highlighted)  							{ border: 1px solid #f38518; }
+.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row:hover:not(.highlighted):not(.selected):not(.focused)  	{ border: 1px dashed #f38518; margin-top:-1px; margin-bottom:1px; margin-left:-1px; }
 .hc-black .monaco-tree .monaco-tree-wrapper.drop-target,
-.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.drop-target											{ background: none !important; border: 1px dashed #DF740C; }
+.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.drop-target											{ background: none !important; border: 1px dashed #f38518; }
 
 .hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.has-children > .content:before	{
 	border: none;

--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -202,7 +202,7 @@
 .hc-black .monaco-tree.focused .monaco-tree-rows > .monaco-tree-row.focused:not(.highlighted) 						{ border: 1px dotted #DF740C; }
 .hc-black .monaco-tree.focused .monaco-tree-rows > .monaco-tree-row.selected:not(.highlighted) 					{ border: 1px solid #DF740C; }
 .hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.selected:not(.highlighted)  							{ border: 1px solid #DF740C; }
-.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row:hover:not(.highlighted):not(.selected):not(.focused)  	{ border: 1px dashed #DF740C; }
+.hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row:hover:not(.highlighted):not(.selected):not(.focused)  	{ border: 1px dashed #DF740C; margin-top:-1px; margin-bottom:1px; margin-left:-1px; }
 .hc-black .monaco-tree .monaco-tree-wrapper.drop-target,
 .hc-black .monaco-tree .monaco-tree-rows > .monaco-tree-row.drop-target											{ background: none !important; border: 1px dashed #DF740C; }
 

--- a/src/vs/editor/browser/widget/media/tokens.css
+++ b/src/vs/editor/browser/widget/media/tokens.css
@@ -523,7 +523,7 @@
 
 .monaco-editor.hc-black .token.builtin.function					{ color: #569CD6; }
 
-.monaco-editor.hc-black .token.comment							{ color: #608B4E; }
+.monaco-editor.hc-black .token.comment							{ color: #7ca668; }
 
 .monaco-editor.hc-black .token.constant							{ color: #569CD6; }
 .monaco-editor.hc-black .token.constant.language				{ color: #569CD6; }

--- a/src/vs/editor/browser/widget/media/tokens.css
+++ b/src/vs/editor/browser/widget/media/tokens.css
@@ -172,7 +172,7 @@
 /* -------------------------------- End vs-dark tokens -------------------------------- */
 
 /* -------------------------------- Begin hc-black tokens -------------------------------- */
-.monaco-editor.hc-black .token							{ color: #FFFFFF; mix-blend-mode: difference; }
+.monaco-editor.hc-black .token							{ color: #FFFFFF; }
 .monaco-editor.hc-black .token.whitespace				{ color: #FFFF00 !important; }
 .monaco-editor.hc-black .token.terminal					{ color: #569CD6; }
 .monaco-editor.hc-black .token.terminal.code1			{ font-weight: bold; }

--- a/src/vs/editor/browser/widget/media/tokens.css
+++ b/src/vs/editor/browser/widget/media/tokens.css
@@ -172,7 +172,7 @@
 /* -------------------------------- End vs-dark tokens -------------------------------- */
 
 /* -------------------------------- Begin hc-black tokens -------------------------------- */
-.monaco-editor.hc-black .token							{ color: #FFFFFF; }
+.monaco-editor.hc-black .token							{ color: #FFFFFF; mix-blend-mode: difference; }
 .monaco-editor.hc-black .token.whitespace				{ color: #FFFF00 !important; }
 .monaco-editor.hc-black .token.terminal					{ color: #569CD6; }
 .monaco-editor.hc-black .token.terminal.code1			{ font-weight: bold; }

--- a/src/vs/editor/contrib/find/browser/findWidget.css
+++ b/src/vs/editor/contrib/find/browser/findWidget.css
@@ -406,7 +406,7 @@
 
 .monaco-editor.hc-black .findMatch {
 	background: none;
-	border: 1px dotted #DF740C;
+	border: 1px dotted #f38518;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
@@ -414,14 +414,14 @@
 .monaco-editor.hc-black .currentFindMatch {
 	background: none;
 	padding: 1px;
-	border: 2px solid #DF740C;
+	border: 2px solid #f38518;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }
 
 .monaco-editor.hc-black .findScope {
 	background: none;
-	border: 1px dashed #DF740C;
+	border: 1px dashed #f38518;
 	opacity: .4;
 }
 

--- a/src/vs/editor/contrib/referenceSearch/browser/referenceSearchWidget.css
+++ b/src/vs/editor/contrib/referenceSearch/browser/referenceSearchWidget.css
@@ -169,7 +169,7 @@
 
 .monaco-editor.hc-black .reference-zone-widget .preview .reference-decoration {
 	background: none;
-	border: 2px solid #DF740C;
+	border: 2px solid #f38518;
 }
 
 .monaco-editor.hc-black .reference-zone-widget .tree {
@@ -194,5 +194,5 @@
 
 .monaco-editor.hc-black .reference-zone-widget .tree .referenceMatch {
 	background: none;
-	border: 1px dotted #DF740C;
+	border: 1px dotted #f38518;
 }

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -46,11 +46,11 @@
 
 /* Selection */
 .monaco-editor.hc-black .view-overlays.focused .selected-text {
-	border: 2px solid #DF740C;
-	background: none;
+	mix-blend-mode: difference; /* TODO: this will not work in IE/Edge currently.  Monaco needs something extra. */
+	background: #1aebff;
 	box-sizing: border-box;
+	z-index: 1;
 	border-radius: 0;
-	opacity: .5;
 }
 .monaco-editor.hc-black .view-overlays .selected-text {
 	background: none;

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -184,3 +184,6 @@
 }
 
 /* Tokens colors are defined in tokens.css */
+.monaco-editor.hc-black .token:not(.comment) {
+	mix-blend-mode: difference;
+}

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -67,6 +67,13 @@
 	border-bottom-right-radius: 0;
 }
 
+.monaco-editor.hc-black .selectionHighlight {
+	background: none;
+	border: 1px dotted #DF740C;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
 /* Squigglies */
 .monaco-editor.hc-black .redsquiggly {
 	background: none;

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -36,7 +36,6 @@
 	background: none;
 	border: 2px solid #f38518;
 	box-sizing: border-box;
-	opacity: .5;
 }
 
 /* Highlight a line */

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -34,7 +34,7 @@
 }
 .monaco-editor.hc-black.focused .current-line {
 	background: none;
-	border: 2px solid #DF740C;
+	border: 2px solid #f38518;
 	box-sizing: border-box;
 	opacity: .5;
 }
@@ -69,7 +69,7 @@
 
 .monaco-editor.hc-black .selectionHighlight {
 	background: none;
-	border: 1px dotted #DF740C;
+	border: 1px dotted #f38518;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 }

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -191,6 +191,6 @@
 }
 
 /* Tokens colors are defined in tokens.css */
-.monaco-editor.hc-black .token:not(.comment) {
+.monaco-editor.hc-black .token {
 	mix-blend-mode: difference;
 }

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -46,10 +46,8 @@
 
 /* Selection */
 .monaco-editor.hc-black .view-overlays.focused .selected-text {
-	mix-blend-mode: difference; /* TODO: this will not work in IE/Edge currently.  Monaco needs something extra. */
-	background: #1aebff;
+	background: white;
 	box-sizing: border-box;
-	z-index: 1;
 	border-radius: 0;
 }
 .monaco-editor.hc-black .view-overlays .selected-text {

--- a/src/vs/editor/css/hc-black-theme.css
+++ b/src/vs/editor/css/hc-black-theme.css
@@ -141,7 +141,7 @@
 .monaco-editor.hc-black .snippet-placeholder		{ background-color: rgba(124, 124, 124, 0.1); }
 .monaco-editor.hc-black .finish-snippet-placeholder	{ outline: #525252 solid 1px; }
 
-/* Scrollbar */
+/* Scrollbar */    /* TODO: many of these are not doing anything, not specific enough.  Clean up */
 .hc-black.monaco-scrollable-element .slider {
 	background: none;
 	border: 20px solid #6FC3DF;

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -48,7 +48,7 @@
 
 .monaco-workbench.hc-black > .activitybar > .content .monaco-action-bar .badge:active:before,
 .monaco-workbench.hc-black > .activitybar > .content .monaco-action-bar .action-item .action-label:focus:before {
-	border-left-color: #DF740C;
+	border-left-color: #f38518;
 }
 
 .monaco-workbench > .activitybar.left > .content .monaco-action-bar .badge:active:before,
@@ -153,7 +153,7 @@
 }
 
 .monaco-workbench.hc-black > .activitybar > .content .monaco-action-bar .action-item .action-label.active:before {
-	border: 1px solid #DF740C;
+	border: 1px solid #f38518;
 }
 
 .monaco-workbench.hc-black > .activitybar > .content .monaco-action-bar.global .action-item .action-label.active:before {

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -153,7 +153,7 @@
 }
 
 .monaco-workbench.hc-black > .activitybar > .content .monaco-action-bar .action-item .action-label.active:before {
-	border: 1px solid #f38518;
+	outline: 1px solid #f38518;
 }
 
 .monaco-workbench.hc-black > .activitybar > .content .monaco-action-bar.global .action-item .action-label.active:before {

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -81,7 +81,11 @@
 .monaco-shell.hc-black input[type="text"]:focus, .monaco-shell.hc-black textarea:focus,
 .monaco-shell.hc-black input[type="checkbox"]:focus {
 	outline: 2px solid #f38518;
-	outline-offset: -2px;
+	outline-offset: -1px;
+}
+
+.monaco-shell.hc-black .synthetic-focus input {
+	background:transparent; /* Search input focus fix when in high contrast */
 }
 
 .monaco-shell.vs .monaco-tree.focused .monaco-tree-row.focused [tabindex="0"]:focus {

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -80,7 +80,7 @@
 .monaco-shell.hc-black input[type="submit"]:focus,
 .monaco-shell.hc-black input[type="text"]:focus, .monaco-shell.hc-black textarea:focus,
 .monaco-shell.hc-black input[type="checkbox"]:focus {
-	outline: 2px solid #DF740C;
+	outline: 2px solid #f38518;
 	outline-offset: -2px;
 }
 
@@ -114,7 +114,7 @@
 }
 
 .monaco-shell.hc-black .monaco-tree.focused.no-focused-item:focus:before {
-	outline: 2px solid #DF740C; /* we still need to handle the empty tree or no focus item case */
+	outline: 2px solid #f38518; /* we still need to handle the empty tree or no focus item case */
 	outline-offset: -2px;
 }
 

--- a/src/vs/workbench/parts/feedback/browser/media/feedback.css
+++ b/src/vs/workbench/parts/feedback/browser/media/feedback.css
@@ -369,7 +369,7 @@
 }
 
 .monaco-shell.hc-black .feedback-form .sentiment.checked {
-	border: 1px solid #DF740C;
+	border: 1px solid #f38518;
 }
 
 .monaco-shell.hc-black .feedback-form .sentiment:before {

--- a/src/vs/workbench/parts/themes/electron-browser/themes.contribution.ts
+++ b/src/vs/workbench/parts/themes/electron-browser/themes.contribution.ts
@@ -12,7 +12,6 @@ import {SyncActionDescriptor} from 'vs/platform/actions/common/actions';
 import {IMessageService, Severity} from 'vs/platform/message/common/message';
 import {IStorageService, StorageScope} from 'vs/platform/storage/common/storage';
 import platform = require('vs/platform/platform');
-import commonPlatform = require('vs/base/common/platform');
 import workbenchActionRegistry = require('vs/workbench/common/actionRegistry');
 import Themes = require('vs/platform/theme/common/themes');
 import {IQuickOpenService, IPickOpenEntry} from 'vs/workbench/services/quickopen/common/quickOpenService';
@@ -44,7 +43,7 @@ class SelectThemeAction extends actions.Action {
 			let currentTheme = this.storageService.get(Constants.Preferences.THEME, StorageScope.GLOBAL, DEFAULT_THEME_ID);
 
 			let picks: IPickOpenEntry[] = [];
-			Themes.getBaseThemes(commonPlatform.isWindows).forEach(baseTheme => {
+			Themes.getBaseThemes(true).forEach(baseTheme => {
 				picks.push({ label: Themes.toLabel(baseTheme), id: Themes.toId(baseTheme) });
 			});
 


### PR DESCRIPTION
Addresses #2711
- Enables the hc-dark theme on all platforms.
- Improves color contrast to AAA standard on many elements that weren't previously meeting it.
- Resolves visual bugs, such as synthetic-focus misplacement and action bar duplicate icons
- Differentiates the selection of text from current line and find/word matching
- Works well in Mac OSX even when OS-level accessibility features are enabled, such as increasing contrast.
### NOTE:

A CSS rule used (`mix-blend-mode: difference;`) currently works in all browsers but Opera, IE and Edge, so it will not be ideal for the online Monaco editor without suitable shims.  Let me know if we need to address this; we can do that now or in the future.
