### PR TITLE
Register the apt repository as a source for official .deb builds

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -289,7 +289,20 @@ function prepareDebPackage(arch) {
 					.pipe(es.through(function (f) { that.emit('data', f); }, function () { that.emit('end'); }));
 			}));
 
-		return es.merge(control, desktop, icon, shortcut, code)
+		var all = es.merge(control, desktop, icon, shortcut, code);
+
+		// Register an apt repository if this is an official build
+		if (product.updateUrl && product.quality) {
+			var postinst = gulp.src('resources/linux/debian/postinst.template', { base: '.' })
+				.pipe(replace('@@NAME@@', product.applicationName))
+				.pipe(replace('@@UPDATEURL@@', product.updateUrl))
+				.pipe(replace('@@QUALITY@@', product.quality))
+				.pipe(replace('@@ARCHITECTURE@@', debArch))
+				.pipe(rename('DEBIAN/postinst'))
+			all = es.merge(all, postinst);
+		}
+
+		return all
 			.pipe(symdest(destination));
 	};
 }

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+get_apt_config_value() {
+	echo $(apt-config dump | grep "$1 " | sed -e "s/$1 \"//" -e "s/\";$//")
+}
+
+APT_DIR=$(get_apt_config_value Dir)
+APT_ETC=$APT_DIR$(get_apt_config_value Dir::Etc)
+APT_SOURCE_PARTS=$APT_ETC$(get_apt_config_value Dir::Etc::sourceparts)
+CODE_SOURCE_LIST=$APT_SOURCE_PARTS/visual-studio-@@NAME@@.list
+
+rm -f $CODE_SOURCE_LIST
+echo "deb @@UPDATEURL@@/api/deb/@@QUALITY@@/ @@ARCHITECTURE@@/" > $CODE_SOURCE_LIST


### PR DESCRIPTION
Part of #2973

---

Putting this out as a PR due to code freeze, this will be going in for March. It depends on a deployment of https://github.com/Microsoft/vscode-update-server (and subsequent testing).

/cc @joaomoreno 
