### PR TITLE
Highlight CSS property values in Dark+

### DIFF
--- a/extensions/theme-colorful-defaults/themes/dark_plus.tmTheme
+++ b/extensions/theme-colorful-defaults/themes/dark_plus.tmTheme
@@ -65,6 +65,17 @@
 				<string>#9CDCFE</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>CSS property value</string>
+			<key>scope</key>
+			<string>css.support.property-value, css.constant.rgb-value</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#CE9178</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This makes highlighting more consistent with Light+ and adds some much needed
color to CSS files.

Fixes #1656

---

Waiting for Feb release to be finalized before pushing.

Light+ (unchanged):

![light_plus](https://cloud.githubusercontent.com/assets/2193314/13377558/2a311cb0-dd95-11e5-8c44-af21a23b3b43.png)

Dark+ (old):

![dark_plus_old](https://cloud.githubusercontent.com/assets/2193314/13377559/35edd62e-dd95-11e5-9e11-76f2dae6b6bf.png)

Dark+ (new):

![dark_plus_new](https://cloud.githubusercontent.com/assets/2193314/13377560/38d55664-dd95-11e5-95ab-4d6177e7f9bf.png)
