### PR TITLE
Simplify test script definition in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">= 0.10.0 < 0.11.0"
   },
   "scripts": {
-    "test": "node node_modules/mocha/bin/_mocha",
+    "test": "mocha",
     "preinstall": "node build/npm/preinstall.js",
     "postinstall": "npm --prefix extensions/vscode-api-tests/ install extensions/vscode-api-tests/ && npm --prefix extensions/json/ install extensions/json/ && npm --prefix extensions/typescript/ install extensions/typescript/"
   },


### PR DESCRIPTION
As npm puts files from `./node_modules/.bin` in `$PATH` when running npm scripts, running bin commands from npm dependencies could be run directly, without a bin script deep inside `node_modules`.

P.S. great editor you've made so far!
