### PR TITLE
Use local version of gulp in build steps

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,6 @@
 {
 	"version": "0.1.0",
-	"command": "gulp",
+	"command": "./node_modules/.bin/gulp",
 	"isShellCommand": true,
 	"tasks": [
 		{

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "test": "node node_modules/mocha/bin/_mocha",
     "preinstall": "node build/npm/preinstall.js",
-    "postinstall": "npm --prefix extensions/vscode-api-tests/ install extensions/vscode-api-tests/ && npm --prefix extensions/json/ install extensions/json/ && npm --prefix extensions/typescript/ install extensions/typescript/"
+    "postinstall": "npm --prefix extensions/vscode-api-tests/ install extensions/vscode-api-tests/ && npm --prefix extensions/json/ install extensions/json/ && npm --prefix extensions/typescript/ install extensions/typescript/",
+    "watch": "gulp watch"
   },
   "dependencies": {
     "applicationinsights": "0.15.6",


### PR DESCRIPTION
Previously developers had to install gulp globally on their machine to build the project. These changes changes that by using the already locally installed version of gulp, removing the environment requirements aswell as ensuring everyone are using the same version of gulp.

It fixes the VS Code build tasks, aswell as creating a npm script to trigger the watch task:

``` bash
$ npm run watch
```
