### PR TITLE
Use local version of gulp in ./scripts/code.sh

### DIFF
--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -14,10 +14,10 @@ function code() {
 	test -d node_modules || ./scripts/npm.sh install
 
 	# Get electron
-	node node_modules/gulp/bin/gulp.js electron
+	./node_modules/.bin/gulp electron
 
 	# Build
-	test -d out || gulp compile
+	test -d out || ./node_modules/.bin/gulp compile
 
 	# Configuration
 	export NODE_ENV=development


### PR DESCRIPTION
As with #3649 it removes the need for global installation of gulp. This was already the case for the windows, in ./scripts/code.bat.

This made me able to build and run a dev version of VS Code without gulp globally :dancers: 
