### PR TITLE
[go syntax] Don't treat multiline `var` specially

### DIFF
--- a/extensions/go/syntaxes/go.json
+++ b/extensions/go/syntaxes/go.json
@@ -227,29 +227,6 @@
       }
     },
     {
-      "comment": "Multiline variable declarations/assignments",
-      "begin": "(\\bvar\\b)\\s+(\\()",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.var.go"
-        },
-        "2": {
-          "name": "punctuation.other.bracket.round.go"
-        }
-      },
-      "end": "\\)",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.other.bracket.round.go"
-        }
-      },
-      "patterns": [
-        {
-          "include": "#variables"
-        }
-      ]
-    },
-    {
       "comment": "Terminators",
       "match": ";",
       "name": "punctuation.terminator.go"


### PR DESCRIPTION
The pattern for multiline var appears to be unnecessary - variable declarations inside multiline var declarations colorize the same without this.  

It's presence cause the issue mentioned in https://github.com/Microsoft/vscode-go/issues/223 where comments inside the multiline var declaration are not colorized.

Fixes https://github.com/Microsoft/vscode-go/issues/223.
