### PR TITLE
Remove highlighting of "variable declaration" in rust highlighter

### DIFF
--- a/extensions/rust/syntaxes/rust.json
+++ b/extensions/rust/syntaxes/rust.json
@@ -419,19 +419,6 @@
           "include": "$self"
         }
       ]
-    },
-    {
-      "comment": "Variable declaration",
-      "begin": ":",
-      "end": "[=;,\\)\\|]",
-      "patterns": [
-        {
-          "include": "#type_params"
-        },
-        {
-          "include": "$self"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Removes highlighting of "variable declaration". The pattern falsely assumes that ":" only occurs in type declarations. This is not true as it is also used when initializing a struct:

``` rust
Struct {
    member: 1 << 2
}
```

As the pattern also includes `type_params`, any `<` in the member initialization code breaks the highlighting of the rest of the file. I simply removed the patterns as it is quite tricky to distinguish these cases.
