### PR TITLE
add the `extensions` folder to gitignore to prevent accidental commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out-editor-ossfree-min/
 out-vscode/
 out-vscode-min/
 build/node_modules
+extensions/


### PR DESCRIPTION
The npm postinstall hook installs extensions into an `extensions` folder, which pollutes the `git status` output, and someone may commit some of those files by mistake. This addition to the `.gitignore` file guards against that.
