### PR TITLE
[WIP] add a visual divider between gutter (glyph area) and code area

### DIFF
--- a/src/vs/workbench/browser/media/vs-dark-theme.css
+++ b/src/vs/workbench/browser/media/vs-dark-theme.css
@@ -32,3 +32,8 @@
 /* Action labels */
 .monaco-workbench.vs-dark .stacked-view .action-label		{ color: inherit; }
 .monaco-workbench.vs-dark .stacked-view .action-label:hover { color: #3399FF; }
+
+.monaco-workbench.vs-dark .margin-view-overlays {
+	border-right: 1px solid #5a5a5a;
+	z-index: 1;
+}

--- a/src/vs/workbench/browser/media/vs-theme.css
+++ b/src/vs/workbench/browser/media/vs-theme.css
@@ -17,3 +17,7 @@
 .monaco-workbench.vs input:disabled {
 	background-color: #E1E1E1;
 }
+.monaco-workbench.vs .margin-view-overlays {
+	border-right: 1px solid #D3D3D3;
+	z-index: 1;
+}


### PR DESCRIPTION
This is a first-try to fix #3803 

Need some comments on:
1. To show the `right-border`, I have to do **either** of these things:
- Set the gutter's `z-index` to 1 (anything greater than code-areas)
- Set the gutter's `box-sizing` to `border-box`

I feel both are correct approaches though I'm a little surprised that vscode is not using the `*, *:before, *:after { box-sizing: border-box }` style at the root.
1. I feel a little margin is needed to the right of the gutter to add more aesthetics, but seeing that the positions are inlined, I think I'd need some guidance on how to approach this, before diving into the `ts` source files.
