### PR TITLE
use os-specific EOL while creating the copyrightHeader for hygiene checks

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -8,6 +8,7 @@ var filter = require('gulp-filter');
 var es = require('event-stream');
 var gulptslint = require('gulp-tslint');
 var tslint = require('tslint');
+var os = require('os');
 
 var all = [
 	'*',
@@ -90,7 +91,7 @@ var copyrightHeader = [
 	' *  Copyright (c) Microsoft Corporation. All rights reserved.',
 	' *  Licensed under the MIT License. See License.txt in the project root for license information.',
 	' *--------------------------------------------------------------------------------------------*/'
-].join('\n');
+].join(os.EOL);
 
 function failureReporter(failure) {
 	var name = failure.name || failure.fileName;


### PR DESCRIPTION
Right now, the hygiene checks fail on windows machines because the `copyrightHeader` standard is being by joining an array of strings with a `\n`, which doesn't work on Windows with it's CRLF line-endings. This PR addresses that by using OS-specific line endings while building the copyrightHeader standard string.
