### PR TITLE
fix activate extension telemetry event to include

### DIFF
--- a/src/vs/workbench/node/extensionHostMain.ts
+++ b/src/vs/workbench/node/extensionHostMain.ts
@@ -63,7 +63,7 @@ export function createServices(remoteCom: IMainProcessExtHostIPC, initData: IIni
 	let requestService = new BaseRequestService(contextService, telemetryService);
 	let modelService = threadService.getRemotable(ExtHostModelService);
 
-	let extensionService = new ExtHostExtensionService(threadService);
+	let extensionService = new ExtHostExtensionService(threadService, telemetryService);
 	let modeService = new ModeServiceImpl(threadService, extensionService);
 	let _services: any = {
 		contextService: contextService,


### PR DESCRIPTION
I noticed that eager extensions activation events were not being caught previously as they don't go through `_actualActivateExtension`. I am moving the reporting to `_doActualActivateExtension` where I think we catch all the activation scenarios for all events. 
