### PR TITLE
Fixes #3650: Support stop-all-threads mode debugging for multi-thread…

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugEditorModelManager.ts
+++ b/src/vs/workbench/parts/debug/browser/debugEditorModelManager.ts
@@ -134,18 +134,18 @@ export class DebugEditorModelManager implements IWorkbenchContribution {
 		const result: editorcommon.IModelDeltaDecoration[] = [];
 		const focusedStackFrame = this.debugService.getViewModel().getFocusedStackFrame();
 		const allThreads = this.debugService.getModel().getThreads();
-		if (!focusedStackFrame || !allThreads[focusedStackFrame.threadId] || !allThreads[focusedStackFrame.threadId].callStack) {
+		if (!focusedStackFrame || !allThreads[focusedStackFrame.threadId] || !allThreads[focusedStackFrame.threadId].getCachedCallStack()) {
 			return result;
 		}
 
 		// only show decorations for the currently focussed thread.
 		const thread = allThreads[focusedStackFrame.threadId];
-		thread.callStack.filter(sf => sf.source.uri.toString() === modelUrlStr).forEach(sf => {
+		thread.getCachedCallStack().filter(sf => sf.source.uri.toString() === modelUrlStr).forEach(sf => {
 			const wholeLineRange = createRange(sf.lineNumber, sf.column, sf.lineNumber, Number.MAX_VALUE);
 
 			// compute how to decorate the editor. Different decorations are used if this is a top stack frame, focussed stack frame,
 			// an exception or a stack frame that did not change the line number (we only decorate the columns, not the whole line).
-			if (sf === thread.callStack[0]) {
+			if (sf === thread.getCachedCallStack()[0]) {
 				result.push({
 					options: DebugEditorModelManager.TOP_STACK_FRAME_MARGIN,
 					range: createRange(sf.lineNumber, sf.column, sf.lineNumber, sf.column + 1)

--- a/src/vs/workbench/parts/debug/browser/debugViewer.ts
+++ b/src/vs/workbench/parts/debug/browser/debugViewer.ts
@@ -189,6 +189,10 @@ export class BaseDebugController extends treedefaults.DefaultController {
 
 export class CallStackDataSource implements tree.IDataSource {
 
+	constructor(@debug.IDebugService private debugService: debug.IDebugService) {
+		// noop
+	}
+
 	public getId(tree: tree.ITree, element: any): string {
 		return element.getId();
 	}
@@ -199,7 +203,7 @@ export class CallStackDataSource implements tree.IDataSource {
 
 	public getChildren(tree: tree.ITree, element: any): TPromise<any> {
 		if (element instanceof model.Thread) {
-			return TPromise.as((<model.Thread> element).callStack);
+			return (<model.Thread> element).getCallStack(this.debugService);
 		}
 
 		const threads = (<model.Model> element).getThreads();
@@ -209,7 +213,7 @@ export class CallStackDataSource implements tree.IDataSource {
 		});
 
 		if (threadsArray.length === 1) {
-			return TPromise.as(threadsArray[0].callStack);
+			return threadsArray[0].getCallStack(this.debugService);
 		} else {
 			return TPromise.as(threadsArray);
 		}

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -25,6 +25,7 @@ export interface IRawModelUpdate {
 	thread?: DebugProtocol.Thread;
 	callStack?: DebugProtocol.StackFrame[];
 	stoppedDetails?: IRawStoppedDetails;
+	allThreadsStopped?: boolean;
 }
 
 export interface IRawStoppedDetails {
@@ -53,8 +54,31 @@ export interface IExpression extends ITreeElement, IExpressionContainer {
 export interface IThread extends ITreeElement {
 	threadId: number;
 	name: string;
-	callStack: IStackFrame[];
 	stoppedDetails: IRawStoppedDetails;
+
+	/**
+	 * Queries the debug adapter for the callstack and returns a promise with
+	 * the stack frames of the callstack.
+	 * If the thread is not stopped, it returns a promise to an empty array.
+	 */
+	getCallStack(debugService: IDebugService): TPromise<IStackFrame[]>;
+
+	/**
+	 * Gets the callstack if it has already been received from the debug
+	 * adapter, otherwise it returns undefined.
+	 */
+	getCachedCallStack(): IStackFrame[];
+
+	/**
+	 * Invalidates the callstack cache
+	 */
+	clearCallStack(): void;
+
+	/**
+	 * Indicates whether this thread is stopped. The callstack for stopped
+	 * threads can be retrieved from the debug adapter.
+	 */
+	stopped: boolean;
 }
 
 export interface IScope extends IExpressionContainer {
@@ -229,6 +253,7 @@ export interface IRawDebugSession extends ee.EventEmitter {
 	continue(args: DebugProtocol.ContinueArguments): TPromise<DebugProtocol.ContinueResponse>;
 	pause(args: DebugProtocol.PauseArguments): TPromise<DebugProtocol.PauseResponse>;
 
+	stackTrace(args: DebugProtocol.StackTraceArguments): TPromise<DebugProtocol.StackTraceResponse>;
 	scopes(args: DebugProtocol.ScopesArguments): TPromise<DebugProtocol.ScopesResponse>;
 	variables(args: DebugProtocol.VariablesArguments): TPromise<DebugProtocol.VariablesResponse>;
 	evaluate(args: DebugProtocol.EvaluateArguments): TPromise<DebugProtocol.EvaluateResponse>;

--- a/src/vs/workbench/parts/debug/common/debugModel.ts
+++ b/src/vs/workbench/parts/debug/common/debugModel.ts
@@ -13,6 +13,7 @@ import severity from 'vs/base/common/severity';
 import types = require('vs/base/common/types');
 import arrays = require('vs/base/common/arrays');
 import debug = require('vs/workbench/parts/debug/common/debug');
+import errors = require('vs/base/common/errors');
 import { Source } from 'vs/workbench/parts/debug/common/debugSource';
 
 const MAX_REPL_LENGTH = 10000;
@@ -92,15 +93,56 @@ export function getFullExpressionName(expression: debug.IExpression, sessionType
 }
 
 export class Thread implements debug.IThread {
-
+	private promisedCallStack: TPromise<debug.IStackFrame[]>;
+	private cachedCallStack: debug.IStackFrame[];
 	public stoppedDetails: debug.IRawStoppedDetails;
+	public stopped: boolean;
 
-	constructor(public name: string, public threadId, public callStack: debug.IStackFrame[]) {
+	constructor(public name: string, public threadId) {
+		this.promisedCallStack = undefined;
 		this.stoppedDetails = undefined;
+		this.cachedCallStack = undefined;
+		this.stopped = false;
 	}
 
 	public getId(): string {
 		return `thread:${ this.name }:${ this.threadId }`;
+	}
+
+	public clearCallStack(): void {
+		this.promisedCallStack = undefined;
+		this.cachedCallStack = undefined;
+	}
+
+	public getCachedCallStack(): debug.IStackFrame[] {
+		return this.cachedCallStack;
+	}
+
+	public getCallStack(debugService: debug.IDebugService): TPromise<debug.IStackFrame[]> {
+		if (!this.stopped) {
+			return TPromise.as([]);
+		}
+		if (!this.promisedCallStack) {
+			this.promisedCallStack = this.getCallStackImpl(debugService);
+			this.promisedCallStack.then(result => {
+				this.cachedCallStack = result;
+			}, errors.onUnexpectedError);
+		}
+
+		return this.promisedCallStack;
+	}
+
+	private getCallStackImpl(debugService: debug.IDebugService): TPromise<debug.IStackFrame[]> {
+		let session = debugService.getActiveSession();
+		return session.stackTrace({ threadId: this.threadId, levels: 20 }).then(response => {
+			return response.body.stackFrames.map((rsf, level) => {
+				if (!rsf) {
+					return new StackFrame(this.threadId, 0, new Source({ name: 'unknown' }), nls.localize('unknownStack', "Unknown stack location"), undefined, undefined);
+				}
+
+				return new StackFrame(this.threadId, rsf.id, rsf.source ? new Source(rsf.source) : new Source({ name: 'unknown' }), rsf.name, rsf.line, rsf.column);
+			});
+		});
 	}
 }
 
@@ -360,7 +402,7 @@ export class Model extends ee.EventEmitter implements debug.IModel {
 			if (removeThreads) {
 				delete this.threads[reference];
 			} else {
-				this.threads[reference].callStack = [];
+				this.threads[reference].clearCallStack();
 				this.threads[reference].stoppedDetails = undefined;
 			}
 		} else {
@@ -370,7 +412,7 @@ export class Model extends ee.EventEmitter implements debug.IModel {
 			} else {
 				for (let ref in this.threads) {
 					if (this.threads.hasOwnProperty(ref)) {
-						this.threads[ref].callStack = [];
+						this.threads[ref].clearCallStack();
 						this.threads[ref].stoppedDetails = undefined;
 					}
 				}
@@ -378,6 +420,16 @@ export class Model extends ee.EventEmitter implements debug.IModel {
 		}
 
 		this.emit(debug.ModelEvents.CALLSTACK_UPDATED);
+	}
+
+	public continueThreads(): void {
+		for (let ref in this.threads) {
+			if (this.threads.hasOwnProperty(ref)) {
+				this.threads[ref].stopped = false;
+			}
+		}
+
+		this.clearThreads(false);
 	}
 
 	public getBreakpoints(): debug.IBreakpoint[] {
@@ -624,11 +676,13 @@ export class Model extends ee.EventEmitter implements debug.IModel {
 
 	public sourceIsUnavailable(source: Source): void {
 		Object.keys(this.threads).forEach(key => {
-			this.threads[key].callStack.forEach(stackFrame => {
-				if (stackFrame.source.uri.toString() === source.uri.toString()) {
-					stackFrame.source.available = false;
-				}
-			});
+			if (this.threads[key].getCachedCallStack()) {
+				this.threads[key].getCachedCallStack().forEach(stackFrame => {
+					if (stackFrame.source.uri.toString() === source.uri.toString()) {
+						stackFrame.source.available = false;
+					}
+				});
+			}
 		});
 
 		this.emit(debug.ModelEvents.CALLSTACK_UPDATED);
@@ -636,21 +690,28 @@ export class Model extends ee.EventEmitter implements debug.IModel {
 
 	public rawUpdate(data: debug.IRawModelUpdate): void {
 		if (data.thread) {
-			this.threads[data.threadId] = new Thread(data.thread.name, data.thread.id, []);
+			this.threads[data.threadId] = new Thread(data.thread.name, data.thread.id);
 		}
 
-		if (data.callStack) {
-			// convert raw call stack into proper modelled call stack
-			this.threads[data.threadId].callStack = data.callStack.map(
-				(rsf, level) => {
-					if (!rsf) {
-						return new StackFrame(data.threadId, 0, new Source({ name: 'unknown' }), nls.localize('unknownStack', "Unknown stack location"), undefined, undefined);
+		if (data.stoppedDetails) {
+			// Set the availability of the threads' callstacks depending on
+			// whether the thread is stopped or not
+			for (let ref in this.threads) {
+				if (this.threads.hasOwnProperty(ref)) {
+					if (data.allThreadsStopped) {
+						// Only update the details if all the threads are stopped
+						// because we don't want to overwrite the details of other
+						// threads that have stopped for a different reason
+						this.threads[ref].stoppedDetails = data.stoppedDetails;
 					}
 
-					return new StackFrame(data.threadId, rsf.id, rsf.source ? new Source(rsf.source) : new Source({ name: 'unknown' }), rsf.name, rsf.line, rsf.column);
-				});
+					this.threads[ref].stopped = data.allThreadsStopped;
+					this.threads[ref].clearCallStack();
+				}
+			}
 
 			this.threads[data.threadId].stoppedDetails = data.stoppedDetails;
+			this.threads[data.threadId].stopped = true;
 		}
 
 		this.emit(debug.ModelEvents.CALLSTACK_UPDATED);

--- a/src/vs/workbench/parts/debug/common/debugSource.ts
+++ b/src/vs/workbench/parts/debug/common/debugSource.ts
@@ -40,8 +40,8 @@ export class Source {
 			// first try to find the raw source amongst the stack frames - since that represenation has more data (source reference),
 			const threads = model.getThreads();
 			for (let threadId in threads) {
-				if (threads.hasOwnProperty(threadId) && threads[threadId].callStack) {
-					const found = threads[threadId].callStack.filter(sf => sf.source.uri.toString() === uri.toString()).pop();
+				if (threads.hasOwnProperty(threadId) && threads[threadId].getCachedCallStack()) {
+					const found = threads[threadId].getCachedCallStack().filter(sf => sf.source.uri.toString() === uri.toString()).pop();
 					if (found) {
 						return found.source.raw;
 					}

--- a/src/vs/workbench/parts/debug/test/common/mockDebugService.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebugService.ts
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import debug = require('vs/workbench/parts/debug/common/debug');
+import editor = require('vs/editor/common/editorCommon');
+import ee = require('vs/base/common/eventEmitter');
+import uri from 'vs/base/common/uri';
+import editorbrowser = require('vs/editor/browser/editorBrowser');
+import severity from 'vs/base/common/severity';
+import { TPromise } from 'vs/base/common/winjs.base';
+import { Source } from 'vs/workbench/parts/debug/common/debugSource';
+
+export class MockDebugService extends ee.EventEmitter implements debug.IDebugService {
+	private session: MockRawSession;
+	public serviceId = debug.IDebugService;
+
+	constructor() {
+		super();
+		this.session = new MockRawSession();
+	}
+
+	public getState(): debug.State {
+		return null;
+	}
+
+	public canSetBreakpointsIn(model: editor.IModel): boolean {
+		return false;
+	}
+
+	public getConfigurationName(): string {
+		return null;
+	}
+
+	public setConfiguration(name: string): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public openConfigFile(sideBySide: boolean): TPromise<boolean> {
+		return TPromise.as(false);
+	}
+
+	public loadLaunchConfig(): TPromise<debug.IGlobalConfig> {
+		return TPromise.as(null);
+	}
+
+	public setFocusedStackFrameAndEvaluate(focusedStackFrame: debug.IStackFrame): void {}
+
+	public setBreakpointsForModel(modelUri: uri, rawData: debug.IRawBreakpoint[]): void {}
+
+	public toggleBreakpoint(IRawBreakpoint): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public enableOrDisableAllBreakpoints(enabled: boolean): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public toggleEnablement(element: debug.IEnablement): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public toggleBreakpointsActivated(): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public removeAllBreakpoints(): TPromise<any> {
+		return TPromise.as(null);
+	}
+
+	public sendAllBreakpoints(): TPromise<any> {
+		return TPromise.as(null);
+	}
+
+	public editBreakpoint(editor: editorbrowser.ICodeEditor, lineNumber: number): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public addFunctionBreakpoint(): void {}
+
+	public renameFunctionBreakpoint(id: string, newFunctionName: string): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public removeFunctionBreakpoints(id?: string): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public addReplExpression(name: string): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public clearReplExpressions(): void {}
+
+	public logToRepl(value: string, severity?: severity): void;
+	public logToRepl(value: { [key: string]: any }, severity?: severity): void;
+	public logToRepl(value: any, severity?: severity): void {}
+
+	public appendReplOutput(value: string, severity?: severity): void {}
+
+	public addWatchExpression(name?: string): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public renameWatchExpression(id: string, newName: string): TPromise<void> {
+		return TPromise.as(null);
+	}
+
+	public clearWatchExpressions(id?: string): void {}
+
+	public createSession(noDebug: boolean): TPromise<any> {
+		return TPromise.as(null);
+	}
+
+	public restartSession(): TPromise<any> {
+		return TPromise.as(null);
+	}
+
+	public getActiveSession(): debug.IRawDebugSession {
+		return this.session;
+	}
+
+	public getModel(): debug.IModel {
+		return null;
+	}
+
+	public getViewModel(): debug.IViewModel {
+		return null
+	}
+
+	public openOrRevealEditor(source: Source, lineNumber: number, preserveFocus: boolean, sideBySide: boolean): TPromise<any> {
+		return TPromise.as(null);
+	}
+
+	public revealRepl(focus?: boolean): TPromise<void> {
+		return TPromise.as(null);
+	}
+}
+
+
+class MockRawSession extends ee.EventEmitter implements debug.IRawDebugSession {
+	public isAttach: boolean = false;
+	public capabilities: DebugProtocol.Capabilites;
+
+	public getType(): string {
+		return null;
+	}
+
+	public disconnect(restart?: boolean, force?: boolean): TPromise<DebugProtocol.DisconnectResponse> {
+		return TPromise.as(null);
+	}
+
+	public next(args: DebugProtocol.NextArguments): TPromise<DebugProtocol.NextResponse> {
+		return TPromise.as(null);
+	}
+
+	public stepIn(args: DebugProtocol.StepInArguments): TPromise<DebugProtocol.StepInResponse> {
+		return TPromise.as(null);
+	}
+
+	public stepOut(args: DebugProtocol.StepOutArguments): TPromise<DebugProtocol.StepOutResponse> {
+		return TPromise.as(null);
+	}
+
+	public continue(args: DebugProtocol.ContinueArguments): TPromise<DebugProtocol.ContinueResponse> {
+		return TPromise.as(null);
+	}
+
+	public pause(args: DebugProtocol.PauseArguments): TPromise<DebugProtocol.PauseResponse> {
+		return TPromise.as(null);
+	}
+
+	public stackTrace(args: DebugProtocol.StackTraceArguments): TPromise<DebugProtocol.StackTraceResponse> {
+		return TPromise.as({
+			body: {
+				stackFrames: []
+			}
+		});
+	}
+
+	public scopes(args: DebugProtocol.ScopesArguments): TPromise<DebugProtocol.ScopesResponse> {
+		return TPromise.as(null);
+	}
+
+	public variables(args: DebugProtocol.VariablesArguments): TPromise<DebugProtocol.VariablesResponse> {
+		return TPromise.as(null);
+	}
+
+	evaluate(args: DebugProtocol.EvaluateArguments): TPromise<DebugProtocol.EvaluateResponse> {
+		return TPromise.as(null);
+	}
+}


### PR DESCRIPTION
As discussed in #3650, this adds support for stop-all-threads mode by adding a flag to the StoppedEvent that the debug adapter sends. Here's the fix in action:

<img src="https://cloud.githubusercontent.com/assets/637952/13693056/dd2e406c-e6fb-11e5-98b3-eeb0390d3794.gif" data-canonical-src="https://cloud.githubusercontent.com/assets/637952/13693056/dd2e406c-e6fb-11e5-98b3-eeb0390d3794.gif" width="335" height="315" />

I tested this change with a basic multi-threaded program, and verified:
- [x] Expanding threads that are not the one that sent the stopped event triggers a query for their callstack
- [x] Already expanded threads get updated when a new stopped event is sent
- [x] Node debugging works (including debugging VSCode extensions)
- [x] Mono debugging works (handling multiple threads work as before)
- [x] Go debugging works (handling multiple threads work as before)
- [x] C# debugging works (with the new omnisharp-based extension)
