### PR TITLE
[themes] Add styles to git commit changed, deleted, inserted

### DIFF
--- a/extensions/theme-colorful-defaults/themes/dark_plus.tmTheme
+++ b/extensions/theme-colorful-defaults/themes/dark_plus.tmTheme
@@ -97,6 +97,45 @@
 				<string>#D7BA7D</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup changed</string>
+			<key>scope</key>
+			<string>markup.changed</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#cd9731</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup deleted</string>
+			<key>scope</key>
+			<string>markup.deleted</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#cd3131</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup inserted</string>
+			<key>scope</key>
+			<string>markup.inserted</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#7CAF64</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/extensions/theme-colorful-defaults/themes/light_plus.tmTheme
+++ b/extensions/theme-colorful-defaults/themes/light_plus.tmTheme
@@ -98,8 +98,45 @@
 				<string>#800000</string>
 			</dict>
 		</dict>
-
-
+		<dict>
+			<key>name</key>
+			<string>Markup changed</string>
+			<key>scope</key>
+			<string>markup.changed</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#cd9731</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup deleted</string>
+			<key>scope</key>
+			<string>markup.deleted</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#cd3131</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markup inserted</string>
+			<key>scope</key>
+			<string>markup.inserted</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+				<key>foreground</key>
+				<string>#7CAF64</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #3991

---

@aeschli @bpasero 

The yellow/orange is .warn, red is .error, green is .comment but slightly lightened. I ended up going with `markup` instead of `git-commit` as that's what other themes seemed to be using.

![image](https://cloud.githubusercontent.com/assets/2193314/13720730/dcf4ac7a-e7c4-11e5-928c-4bbe392bef8c.png)

![image](https://cloud.githubusercontent.com/assets/2193314/13720731/dfae4bb0-e7c4-11e5-94ea-1e7366eac7ee.png)
