### PR TITLE
Languages: Add `.php4` and `.php5` as extensions

### DIFF
--- a/src/vs/languages/php/common/php.contribution.ts
+++ b/src/vs/languages/php/common/php.contribution.ts
@@ -8,7 +8,7 @@ import {ModesRegistry} from 'vs/editor/common/modes/modesRegistry';
 
 ModesRegistry.registerCompatMode({
 	id: 'php',
-	extensions: ['.php', '.phtml', '.ctp'],
+	extensions: ['.php', '.php4', '.php5', '.phtml', '.ctp'],
 	aliases: ['PHP', 'php'],
 	mimetypes: ['application/x-php'],
 	moduleId: 'vs/languages/php/common/php',


### PR DESCRIPTION
I am not responsible of this stup_d_t\* but unfortunately these extensions are very common…
