### PR TITLE
#2500 and #2352 add focus indication to text editors / panels.

### DIFF
--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -56,7 +56,8 @@
 .monaco-shell.vs input[type="submit"]:focus,
 .monaco-shell.vs input[type="text"]:focus, .monaco-shell.vs textarea:focus,
 .monaco-shell.vs input[type="checkbox"]:focus,
-.monaco-shell.vs .monaco-editor.focused {
+.monaco-shell.vs .monaco-editor.focused,
+.monaco-shell.vs .action-button:focus {
 	outline: 1px solid rgba(0, 122, 204, 0.4);
 	outline-offset: -1px;
 	opacity: 1 !important;
@@ -69,7 +70,8 @@
 .monaco-shell.vs-dark input[type="submit"]:focus,
 .monaco-shell.vs-dark input[type="text"]:focus, .monaco-shell.vs-dark textarea:focus,
 .monaco-shell.vs-dark input[type="checkbox"]:focus,
-.monaco-shell.vs-dark .monaco-editor.focused {
+.monaco-shell.vs-dark .monaco-editor.focused,
+.monaco-shell.vs-dark .action-button:focus {
 	outline: 1px solid rgba(14, 99, 156, 0.6);
 	outline-offset: -1px;
 	opacity: 1 !important;
@@ -82,9 +84,19 @@
 .monaco-shell.hc-black input[type="submit"]:focus,
 .monaco-shell.hc-black input[type="text"]:focus, .monaco-shell.hc-black textarea:focus,
 .monaco-shell.hc-black input[type="checkbox"]:focus,
-.monaco-shell.hc-black .monaco-editor.focused {
+.monaco-shell.hc-black .monaco-editor.focused,
+.monaco-shell.hc-black .action-button:focus {
 	outline: 2px solid #f38518;
 	outline-offset: -1px;
+}
+
+.monaco-shell.vs .action-button:focus,
+.monaco-shell.vs-dark .action-button:focus {
+	outline-color: rgba(255,255,255,.5);
+}
+
+.monaco-shell.hc-black .action-button:focus {
+	outline-offset: -4px;
 }
 
 .monaco-shell.vs-dark .monaco-editor.focused,

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -75,21 +75,23 @@
 	opacity: 1 !important;
 }
 
-.monaco-shell.vs-dark .monaco-editor.focused,
-.monaco-shell.vs .monaco-editor.focused {
-	outline-offset: 0;
-	z-index: 1;
-}
-
 .monaco-shell.hc-black [tabindex="0"]:focus,
 .monaco-shell.hc-black .synthetic-focus,
 .monaco-shell.hc-black select:focus,
 .monaco-shell.hc-black input[type="button"]:focus,
 .monaco-shell.hc-black input[type="submit"]:focus,
 .monaco-shell.hc-black input[type="text"]:focus, .monaco-shell.hc-black textarea:focus,
-.monaco-shell.hc-black input[type="checkbox"]:focus {
+.monaco-shell.hc-black input[type="checkbox"]:focus,
+.monaco-shell.hc-black .monaco-editor.focused {
 	outline: 2px solid #f38518;
 	outline-offset: -1px;
+}
+
+.monaco-shell.vs-dark .monaco-editor.focused,
+.monaco-shell.vs .monaco-editor.focused,
+.monaco-shell.hc-black .monaco-editor.focused {
+	outline-offset: 0;
+	z-index: 1;
 }
 
 .monaco-shell.hc-black .synthetic-focus input {

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -55,7 +55,8 @@
 .monaco-shell.vs input[type="button"]:focus,
 .monaco-shell.vs input[type="submit"]:focus,
 .monaco-shell.vs input[type="text"]:focus, .monaco-shell.vs textarea:focus,
-.monaco-shell.vs input[type="checkbox"]:focus {
+.monaco-shell.vs input[type="checkbox"]:focus,
+.monaco-shell.vs .monaco-editor.focused {
 	outline: 1px solid rgba(0, 122, 204, 0.4);
 	outline-offset: -1px;
 	opacity: 1 !important;
@@ -67,10 +68,17 @@
 .monaco-shell.vs-dark input[type="button"]:focus,
 .monaco-shell.vs-dark input[type="submit"]:focus,
 .monaco-shell.vs-dark input[type="text"]:focus, .monaco-shell.vs-dark textarea:focus,
-.monaco-shell.vs-dark input[type="checkbox"]:focus {
+.monaco-shell.vs-dark input[type="checkbox"]:focus,
+.monaco-shell.vs-dark .monaco-editor.focused {
 	outline: 1px solid rgba(14, 99, 156, 0.6);
 	outline-offset: -1px;
 	opacity: 1 !important;
+}
+
+.monaco-shell.vs-dark .monaco-editor.focused,
+.monaco-shell.vs .monaco-editor.focused {
+	outline-offset: 0;
+	z-index: 1;
 }
 
 .monaco-shell.hc-black [tabindex="0"]:focus,


### PR DESCRIPTION
I added a `z-index` to this, otherwise the right part of the focus outline would not appear (it get's covered by some other elements).  I tested it, and it looks fine, but I wanted someone else to review just in case unexpected side-effects occur.
