### PR TITLE
#3769 fixes the light theme focus on buttons in message bar and viewlet

### DIFF
--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -84,9 +84,20 @@
 	outline-offset: -1px;
 }
 
+.monaco-shell.vs .monaco-button:focus,
 .monaco-shell.vs-dark .monaco-button:focus,
+.monaco-shell.vs .action-button:focus,
 .monaco-shell.vs-dark .action-button:focus {
 	outline-color: rgba(255, 255, 255, .5); /* buttons have a blue color, so focus indication needs to be different */
+}
+
+.monaco-shell.vs .monaco-button:focus,
+.monaco-shell.vs .action-button:focus {
+	outline-offset: -2px; /* Inset outline so it stands out on light background. */
+}
+
+.monaco-shell.hc-black .action-button:focus {
+	outline-offset: -4px; /* Helps high-contrast outline avoid clipping. */
 }
 
 .monaco-shell.hc-black .synthetic-focus input {


### PR DESCRIPTION
I was able to stay consistent with the focus colors on light theme by insetting the outline.  Sample focus on each button below.
![screen shot 2016-03-17 at 11 19 39 pm](https://cloud.githubusercontent.com/assets/11839736/13870038/0399b99c-ec98-11e5-865d-64fa0c6e56aa.png)
