### PR TITLE
[c#] Add support for new C# 6 keywords

### DIFF
--- a/src/vs/editor/standalone-languages/csharp.ts
+++ b/src/vs/editor/standalone-languages/csharp.ts
@@ -49,7 +49,8 @@ export var language = <ILanguage> {
 		'internal', 'private', 'abstract', 'sealed', 'static', 'struct', 'readonly',
 		'volatile', 'virtual', 'override', 'params', 'get', 'set', 'add', 'remove',
 		'operator', 'true', 'false', 'implicit', 'explicit', 'interface', 'enum',
-		'null', 'async', 'await','fixed','sizeof','stackalloc','unsafe'
+		'null', 'async', 'await','fixed','sizeof','stackalloc','unsafe', 'nameof',
+		'when'
 		],
 
 	namespaceFollows: [
@@ -57,7 +58,7 @@ export var language = <ILanguage> {
 	],
 
 	parenFollows: [
-		'if', 'for', 'while', 'switch', 'foreach', 'using', 'catch'
+		'if', 'for', 'while', 'switch', 'foreach', 'using', 'catch', 'when'
 	],
 
 	operators: [

--- a/src/vs/languages/razor/common/csharpTokenization.ts
+++ b/src/vs/languages/razor/common/csharpTokenization.ts
@@ -63,7 +63,7 @@ var isKeyword = objects.createKeywordMatcher([
 	'float', 'for', 'foreach', 'from',
 	'goto',	'group', 'if', 'implicit',
 	'in', 'int', 'interface', 'internal',
-	'into', 'is', 'lock', 'long',
+	'into', 'is', 'lock', 'long', 'nameof',
 	'new', 'null', 'namespace', 'object',
 	'operator', 'out', 'override', 'orderby',
 	'params', 'private', 'protected', 'public',
@@ -73,7 +73,7 @@ var isKeyword = objects.createKeywordMatcher([
 	'select', 'this', 'throw', 'true',
 	'try', 'typeof', 'uint', 'ulong',
 	'unchecked', 'unsafe', 'ushort', 'using',
-	'var', 'virtual', 'volatile', 'void',
+	'var', 'virtual', 'volatile', 'void', 'when',
 	'while', 'where', 'yield',
 	'model', 'inject' // Razor specific
 ]);


### PR DESCRIPTION
C# 6 introduces two new keywords, `nameof` and `when`. (For reference, here's the [Roslyn wiki](https://github.com/dotnet/roslyn/wiki/Languages-features-in-C%23-6-and-VB-14) on the subject which lists all the new features added to C# 6.)

This pull request adds support for the keywords to Razor/general `.cs` files so they'll be syntax highlighted in the editor.
