### PR TITLE
Added an image dimensions label underneath the image preview (fixes #3414)

### DIFF
--- a/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
+++ b/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
@@ -91,11 +91,25 @@ export class ResourceViewer {
 				.empty()
 				.style({ paddingLeft: '20px' }) // restore CSS value in case the user saw a PDF before where we remove padding
 				.img({
+					id: 'image',
 					src: resource.toString() + '?' + new Date().getTime() // We really want to avoid the browser from caching this resource, so we add a fake query param that is unique
-				}).on(DOM.EventType.LOAD, () => {
+				})
+				.on(DOM.EventType.LOAD, () => {
 					if (scrollbar) {
 						scrollbar.onElementInternalDimensions();
 					}
+
+					var image = <HTMLImageElement>document.getElementById('image');
+					var imageDimensions = <HTMLSpanElement>document.getElementById('imageDimensions');
+
+					var dimensionsLabel = nls.localize('imageDimensions', "Image Dimensions") + ': ' + image.naturalWidth + ' x ' + image.naturalHeight;
+					imageDimensions.innerText = dimensionsLabel;
+				})
+				.div({
+					id: 'imageDimensions'
+				})
+				.style({
+					margin: '5px, 0'
 				});
 		}
 

--- a/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
+++ b/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
@@ -100,7 +100,7 @@ export class ResourceViewer {
 					}
 
 					var image = <HTMLImageElement>document.getElementById('image');
-					var imageDimensions = <HTMLSpanElement>document.getElementById('imageDimensions');
+					var imageDimensions = <HTMLDivElement>document.getElementById('imageDimensions');
 
 					var dimensionsLabel = nls.localize('imageDimensions', "Image Dimensions") + ': ' + image.naturalWidth + ' x ' + image.naturalHeight;
 					imageDimensions.innerText = dimensionsLabel;


### PR DESCRIPTION
Fixes #3414

Added a dimensions label under the image preview:

![Screenshot](http://i.imgur.com/8FFMBrv.png)

As my first submission to **vscode** I've done my best to follow the guidelines laid out, please let me know if anything needs improvement. I was unable to cover this code with tests as I do not believe there are any for `resourceViewer.ts` and couldn't find any that test for rendered output in the view that were applicable.
