### PR TITLE
Global envvars overwrites process.env only when there's no terminal attached.

### DIFF
--- a/src/vs/workbench/electron-main/main.ts
+++ b/src/vs/workbench/electron-main/main.ts
@@ -5,8 +5,10 @@
 
 'use strict';
 
-import {app} from 'electron';
 import fs = require('fs');
+import tty = require('tty');
+
+import {app} from 'electron';
 import nls = require('vs/nls');
 import {assign} from 'vs/base/common/objects';
 import platform = require('vs/base/common/platform');
@@ -253,7 +255,11 @@ function setupIPC(): TPromise<Server> {
 // and assign them to the process environment (e.g. when doubleclick app on Mac)
 getUserEnvironment()
 	.then(userEnv => {
-		assign(process.env, userEnv);
+		if (!tty.isatty(1)) {
+			// Only assign global environment variables when
+			// STDOUT is not attached to terminal.
+			assign(process.env, userEnv);
+		}
 		// Make sure the NLS Config travels to the rendered process
 		// See also https://github.com/Microsoft/vscode/issues/4558
 		userEnv['VSCODE_NLS_CONFIG'] = process.env['VSCODE_NLS_CONFIG'];


### PR DESCRIPTION
fixes #4779

Sometimes users want to launch `code` from terminal after
modifying environment variables.
When `code` is launched from terminal, it respects those modifications.
