### PR TITLE
Add CJK-aware line wrapping, and basic Kinsoku Shori (禁則処理) to Visual Studio Code

### DIFF
--- a/src/vs/editor/common/config/defaultConfig.ts
+++ b/src/vs/editor/common/config/defaultConfig.ts
@@ -54,8 +54,8 @@ class ConfigClass implements IConfiguration {
 			automaticLayout: false,
 			wrappingColumn: 300,
 			wrappingIndent: 'same',
-			wordWrapBreakBeforeCharacters: '{([+',
-			wordWrapBreakAfterCharacters: ' \t})]?|&,;',
+			wordWrapBreakBeforeCharacters: '([{‘“〈《「『【〔（［｛｢£¥＄￡￥+＋',
+			wordWrapBreakAfterCharacters: ' \t})]?|&,;¢°′″‰℃、。｡､￠，．：；？！％・･ゝゞヽヾーァィゥェォッャュョヮヵヶぁぃぅぇぉっゃゅょゎゕゖㇰㇱㇲㇳㇴㇵㇶㇷㇸㇹㇺㇻㇼㇽㇾㇿ々〻ｧｨｩｪｫｬｭｮｯｰ’”〉》」』】〕）］｝｣',
 			wordWrapBreakObtrusiveCharacters: '.',
 			tabFocusMode: false,
 			// stopLineTokenizationAfter

--- a/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
+++ b/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
@@ -37,9 +37,15 @@ function buildCharacterClassesMap(BREAK_BEFORE:string, BREAK_AFTER:string, BREAK
 	// 1. CJK Unified Ideographs (0x4E00 -- 0x9FFF)
 	// 2. CJK Unified Ideographs Extension A (0x3400 -- 0x4DBF)
 	// 3. Hiragana and Katakana (0x3040 -- 0x30FF)
-	for (i = 0x3040; i <= 0x30FF; i++) result[i] = BREAK_IDEOGRAPHIC;
-	for (i = 0x3400; i <= 0x4DBF; i++) result[i] = BREAK_IDEOGRAPHIC;
-	for (i = 0x4E00; i <= 0x9FFF; i++) result[i] = BREAK_IDEOGRAPHIC;
+	for (i = 0x3040; i <= 0x30FF; i++) {
+		result[i] = BREAK_IDEOGRAPHIC;
+	}
+	for (i = 0x3400; i <= 0x4DBF; i++) {
+		result[i] = BREAK_IDEOGRAPHIC;
+	}
+	for (i = 0x4E00; i <= 0x9FFF; i++) {
+		result[i] = BREAK_IDEOGRAPHIC;
+	}
 
 	for (i = 0; i < BREAK_BEFORE.length; i++) {
 		result[BREAK_BEFORE.charCodeAt(i)] = BREAK_BEFORE_CLASS;

--- a/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
+++ b/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
@@ -149,7 +149,7 @@ export class CharacterHardWrappingLineMapperFactory implements ILineMapperFactor
 			if (charCodeClass === BREAK_IDEOGRAPHIC && i > 0) {
 				prevCode = lineText.charCodeAt(i - 1);
 				prevClass = prevCode < characterClasses.length ? characterClasses[prevCode] : 0;
-				if (prevClass !== BREAK_BEFORE_CLASS) { // Kinsoku Shori: Don't break before a trailing character
+				if (prevClass !== BREAK_BEFORE_CLASS) { // Kinsoku Shori: Don't break after a leading character, like an open bracket
 					niceBreakOffset = i;
 					niceBreakVisibleColumn = 0;
 				}
@@ -224,7 +224,7 @@ export class CharacterHardWrappingLineMapperFactory implements ILineMapperFactor
 			if (charCodeClass === BREAK_IDEOGRAPHIC && i < len - 1) {
 				nextCode = lineText.charCodeAt(i + 1);
 				nextClass = nextCode < characterClasses.length ? characterClasses[nextCode] : 0;
-				if (nextClass !== BREAK_AFTER_CLASS) { // Kinsoku Shori: Don't break before a trailing character
+				if (nextClass !== BREAK_AFTER_CLASS) { // Kinsoku Shori: Don't break before a trailing character, like a period
 					niceBreakOffset = i + 1;
 					niceBreakVisibleColumn = 0;
 				}

--- a/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
+++ b/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
@@ -141,8 +141,8 @@ export class CharacterHardWrappingLineMapperFactory implements ILineMapperFactor
 
 			// CJK breaking : before break
 			if (charCodeClass === BREAK_IDEOGRAPHIC && i > 0) {
-				var prevCode:number = lineText.charCodeAt(i - 1);
-				var prevClass:number = nextCode < characterClasses.length ? characterClasses[nextCode] : 0;
+				prevCode = lineText.charCodeAt(i - 1);
+				prevClass = nextCode < characterClasses.length ? characterClasses[nextCode] : 0;
 				if (prevClass !== BREAK_BEFORE_CLASS) { // Kinsoku Shori: Don't break before a trailing character
 					niceBreakOffset = i;
 					niceBreakVisibleColumn = 0;
@@ -216,8 +216,8 @@ export class CharacterHardWrappingLineMapperFactory implements ILineMapperFactor
 			
 			// CJK breaking : after break
 			if (charCodeClass === BREAK_IDEOGRAPHIC && i < len - 1) {
-				var nextCode:number = lineText.charCodeAt(i + 1);
-				var nextClass:number = nextCode < characterClasses.length ? characterClasses[nextCode] : 0;
+				nextCode = lineText.charCodeAt(i + 1);
+				nextClass = nextCode < characterClasses.length ? characterClasses[nextCode] : 0;
 				if (nextClass !== BREAK_AFTER_CLASS) { // Kinsoku Shori: Don't break before a trailing character
 					niceBreakOffset = i + 1;
 					niceBreakVisibleColumn = 0;

--- a/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
+++ b/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
@@ -142,7 +142,7 @@ export class CharacterHardWrappingLineMapperFactory implements ILineMapperFactor
 			// CJK breaking : before break
 			if (charCodeClass === BREAK_IDEOGRAPHIC && i > 0) {
 				prevCode = lineText.charCodeAt(i - 1);
-				prevClass = nextCode < characterClasses.length ? characterClasses[nextCode] : 0;
+				prevClass = prevCode < characterClasses.length ? characterClasses[prevCode] : 0;
 				if (prevClass !== BREAK_BEFORE_CLASS) { // Kinsoku Shori: Don't break before a trailing character
 					niceBreakOffset = i;
 					niceBreakVisibleColumn = 0;

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -111,13 +111,20 @@ suite('Editor ViewModel - CharacterHardWrappingLineMapper', () => {
 		assertLineMapping(factory, 4, 5, 'aaa(|()|.aaa');
 		assertLineMapping(factory, 4, 5, 'aa.(|()|.aaa');
 		assertLineMapping(factory, 4, 5, 'aa.|(.)|.aaa');
-		
-		// Handles CJK wrapping and Kinsoku Shori
+	});
+	test('CJK Wrapping: Should wrap after an ideograph', () => {
+		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa 安|安');
 		assertLineMapping(factory, 4, 5, 'あ 安|安');
 		assertLineMapping(factory, 4, 5, 'ああ|安安');
+	});
+	test('CJK Wrapping: Should respect trailing punctuations', () => {
+		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa |安)安|安');
 		assertLineMapping(factory, 4, 5, 'aa あ|安あ)|安');
+	});
+	test('CJK Wrapping: Should respect leading punctuations', () => {
+		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa |(安aa|安');
 	});
 });

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -62,7 +62,7 @@ function assertLineMapping(factory:ILineMapperFactory, tabSize:number, breakAfte
 		}
 	}
 
-	var mapper = factory.createLineMapping(rawText, tabSize, breakAfter, 1, WrappingIndent.None);
+	var mapper = factory.createLineMapping(rawText, tabSize, breakAfter, 2, WrappingIndent.None);
 
 	assert.equal(safeGetOutputLineCount(mapper), (lineIndices.length > 0 ? lineIndices[lineIndices.length - 1] + 1 : 1));
 	for (var i = 0, len = rawText.length; i < len; i++) {

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -112,19 +112,28 @@ suite('Editor ViewModel - CharacterHardWrappingLineMapper', () => {
 		assertLineMapping(factory, 4, 5, 'aa.(|()|.aaa');
 		assertLineMapping(factory, 4, 5, 'aa.|(.)|.aaa');
 	});
-	test('CJK Wrapping: Should wrap after an ideograph', () => {
+	test('CJK Wrapping: Should wrap after an ideograph, 1', () => {
 		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
-		assertLineMapping(factory, 4, 5, 'aa 安|安');
-		assertLineMapping(factory, 4, 5, 'あ 安|安');
-		assertLineMapping(factory, 4, 5, 'ああ|安安');
+		assertLineMapping(factory, 4, 5, 'aa \u5b89|\u5b89');
 	});
-	test('CJK Wrapping: Should respect trailing punctuations', () => {
+	test('CJK Wrapping: Should wrap after an ideograph, 2', () => {
 		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
-		assertLineMapping(factory, 4, 5, 'aa |安)安|安');
-		assertLineMapping(factory, 4, 5, 'aa あ|安あ)|安');
+		assertLineMapping(factory, 4, 5, '\u3042 \u5b89|\u5b89');
+	});
+	test('CJK Wrapping: Should wrap after an ideograph, 3', () => {
+		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
+		assertLineMapping(factory, 4, 5, '\u3042\u3042|\u5b89\u5b89');
+	});
+	test('CJK Wrapping: Should respect trailing punctuations, 1', () => {
+		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
+		assertLineMapping(factory, 4, 5, 'aa |\u5b89)\u5b89|\u5b89');
+	});
+	test('CJK Wrapping: Should respect trailing punctuations, 2', () => {
+		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
+		assertLineMapping(factory, 4, 5, 'aa \u3042|\u5b89\u3042)|\u5b89');
 	});
 	test('CJK Wrapping: Should respect leading punctuations', () => {
 		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
-		assertLineMapping(factory, 4, 5, 'aa |(安aa|安');
+		assertLineMapping(factory, 4, 5, 'aa |(\u5b89aa|\u5b89');
 	});
 });

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -116,9 +116,8 @@ suite('Editor ViewModel - CharacterHardWrappingLineMapper', () => {
 		assertLineMapping(factory, 4, 5, 'aa 安|安');
 		assertLineMapping(factory, 4, 5, 'あ 安|安');
 		assertLineMapping(factory, 4, 5, 'ああ|安安');
-		assertLineMapping(factory, 4, 5, 'aa |安，|安');
-		assertLineMapping(factory, 4, 5, 'aa |安,安');
-		assertLineMapping(factory, 4, 5, 'aa あ|安あ,|安');
-		assertLineMapping(factory, 4, 5, 'aa |（安a|安');
+		assertLineMapping(factory, 4, 5, 'aa |安)安|安');
+		assertLineMapping(factory, 4, 5, 'aa あ|安あ)|安');
+		assertLineMapping(factory, 4, 5, 'aa |(安aa|安');
 	});
 });

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -111,5 +111,14 @@ suite('Editor ViewModel - CharacterHardWrappingLineMapper', () => {
 		assertLineMapping(factory, 4, 5, 'aaa(|()|.aaa');
 		assertLineMapping(factory, 4, 5, 'aa.(|()|.aaa');
 		assertLineMapping(factory, 4, 5, 'aa.|(.)|.aaa');
+		
+		// Handles CJK wrapping and Kinsoku Shori
+		assertLineMapping(factory, 4, 5, 'aa 安|安');
+		assertLineMapping(factory, 4, 5, 'あ 安|安');
+		assertLineMapping(factory, 4, 5, 'ああ|安安');
+		assertLineMapping(factory, 4, 5, 'aa |安，|安');
+		assertLineMapping(factory, 4, 5, 'aa |安,安');
+		assertLineMapping(factory, 4, 5, 'aa あ|安あ,|安');
+		assertLineMapping(factory, 4, 5, 'aa |（安a|安');
 	});
 });

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -112,28 +112,13 @@ suite('Editor ViewModel - CharacterHardWrappingLineMapper', () => {
 		assertLineMapping(factory, 4, 5, 'aa.(|()|.aaa');
 		assertLineMapping(factory, 4, 5, 'aa.|(.)|.aaa');
 	});
-	test('CJK Wrapping: Should wrap after an ideograph, 1', () => {
+	test('CharacterHardWrappingLineMapper - CJK and Kinsoku Shori', () => {
 		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa \u5b89|\u5b89');
-	});
-	test('CJK Wrapping: Should wrap after an ideograph, 2', () => {
-		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, '\u3042 \u5b89|\u5b89');
-	});
-	test('CJK Wrapping: Should wrap after an ideograph, 3', () => {
-		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, '\u3042\u3042|\u5b89\u5b89');
-	});
-	test('CJK Wrapping: Should respect trailing punctuations, 1', () => {
-		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa |\u5b89)\u5b89|\u5b89');
-	});
-	test('CJK Wrapping: Should respect trailing punctuations, 2', () => {
-		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa \u3042|\u5b89\u3042)|\u5b89');
-	});
-	test('CJK Wrapping: Should respect leading punctuations', () => {
-		var factory = new CharacterHardWrappingLineMapperFactory('(', ')', '.');
 		assertLineMapping(factory, 4, 5, 'aa |(\u5b89aa|\u5b89');
 	});
 });


### PR DESCRIPTION
The main idea is adding a forth character class, `BREAK_IDEOGRAPHIC`, which behaves normally like both `BREAK_BEFORE_CLASS` and `BREAK_AFTER_CLASS`, unless it is before a `BREAK_AFTER_CLASS` character, or after a `BREAK_BEFORE_CLASS` character.
