### PR TITLE
Minor tool-tip correction

### DIFF
--- a/src/vs/workbench/browser/viewlet.ts
+++ b/src/vs/workbench/browser/viewlet.ts
@@ -254,7 +254,7 @@ export class ToggleViewletAction extends Action {
 export class CollapseAction extends Action {
 
 	constructor(viewer: ITree, enabled: boolean, clazz: string) {
-		super('workbench.action.collapse', nls.localize('collapse', "Collapse"), clazz, enabled, (context: any) => {
+		super('workbench.action.collapse', nls.localize('collapse', "Collapse All"), clazz, enabled, (context: any) => {
 			if (viewer.getHighlight()) {
 				return TPromise.as(null); // Global action disabled if user is in edit mode from another action
 			}


### PR DESCRIPTION
Makes tool-tip consistent with class description, and consistent with "Working Files" tool-tips.

Helps avoid new-user confusion (a new user might think "Collapse" collapses the work-space rather than all the contained folders in the work-space).
