### PR TITLE
Add "new window" action to code.desktop

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -6,5 +6,13 @@ Exec=/usr/bin/@@NAME@@ %U
 Icon=@@NAME@@
 Type=Application
 StartupNotify=true
+StartupWMClass=@@NAME@@
 Categories=Utility;TextEditor;Development;IDE;
 MimeType=text/plain;
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Name[de]=Neues Fenster
+Exec=/usr/bin/@@NAME@@ --new-window %U
+Icon=@@NAME@@


### PR DESCRIPTION
In Gnome and Unity desktop (and maybe some others) this can be used to open a new Code window through right click on the launcher icon and then on "New Window".
