### PR TITLE
Introduce a Go problem matcher

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -494,6 +494,13 @@ _defaultPatterns['eslint-stylish'] = [
 		loop: true
 	}
 ];
+_defaultPatterns['go'] = {
+	regexp: /^([^:]*: )?((.:)?[^:]*):(\d+)(:(\d+))?: (.*)$/,
+	file: 2,
+	line: 4,
+	column: 6,
+	message: 7
+};
 
 export function defaultPattern(name: 'msCompile'): ProblemPattern;
 export function defaultPattern(name: 'tsc'): ProblemPattern;
@@ -503,6 +510,7 @@ export function defaultPattern(name: 'vb'): ProblemPattern;
 export function defaultPattern(name: 'lessCompile'): ProblemPattern;
 export function defaultPattern(name: 'jshint'): ProblemPattern;
 export function defaultPattern(name: 'gulp-tsc'): ProblemPattern;
+export function defaultPattern(name: 'go'): ProblemPattern;
 export function defaultPattern(name: 'jshint-stylish'): ProblemPattern[];
 export function defaultPattern(name: string): ProblemPattern | ProblemPattern[];
 export function defaultPattern(name: string): ProblemPattern | ProblemPattern[] {
@@ -1127,4 +1135,12 @@ registry.add('eslint-stylish', {
 	applyTo: ApplyToKind.allDocuments,
 	fileLocation: FileLocationKind.Absolute,
 	pattern: defaultPattern('eslint-stylish')
+});
+
+registry.add('go', {
+	owner: 'typescript',
+	applyTo: ApplyToKind.allDocuments,
+	fileLocation: FileLocationKind.Relative,
+	filePrefix: '${cwd}',
+	pattern: defaultPattern('go')
 });

--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -1138,7 +1138,7 @@ registry.add('eslint-stylish', {
 });
 
 registry.add('go', {
-	owner: 'typescript',
+	owner: 'go',
 	applyTo: ApplyToKind.allDocuments,
 	fileLocation: FileLocationKind.Relative,
 	filePrefix: '${cwd}',

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -867,7 +867,7 @@ if (Env.enableTasks) {
 					'anyOf': [
 						{
 							'type': 'string',
-							'enum': ['$tsc', '$tsc-watch' ,'$msCompile', '$lessCompile', '$gulp-tsc', '$cpp', '$csc', '$vb', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish']
+							'enum': ['$tsc', '$tsc-watch' ,'$msCompile', '$lessCompile', '$gulp-tsc', '$cpp', '$csc', '$vb', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish', '$go']
 						},
 						{
 							'$ref': '#/definitions/pattern'
@@ -939,7 +939,7 @@ if (Env.enableTasks) {
 					'oneOf': [
 						{
 							'type': 'string',
-							'enum': ['$tsc', '$tsc-watch', '$msCompile', '$lessCompile', '$gulp-tsc', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish']
+							'enum': ['$tsc', '$tsc-watch', '$msCompile', '$lessCompile', '$gulp-tsc', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish', '$go']
 						},
 						{
 							'$ref': '#/definitions/problemMatcher'
@@ -953,7 +953,7 @@ if (Env.enableTasks) {
 									},
 									{
 										'type': 'string',
-										'enum': ['$tsc', '$tsc-watch', '$msCompile', '$lessCompile', '$gulp-tsc', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish']
+										'enum': ['$tsc', '$tsc-watch', '$msCompile', '$lessCompile', '$gulp-tsc', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish', '$go']
 									}
 								]
 							}
@@ -980,7 +980,7 @@ if (Env.enableTasks) {
 					'properties': {
 						'base': {
 							'type': 'string',
-							'enum': ['$tsc', '$tsc-watch', '$msCompile', '$lessCompile', '$gulp-tsc', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish'],
+							'enum': ['$tsc', '$tsc-watch', '$msCompile', '$lessCompile', '$gulp-tsc', '$jshint', '$jshint-stylish', '$eslint-compact', '$eslint-stylish', '$go'],
 							'description': nls.localize('JsonSchema.problemMatcher.base', 'The name of a base problem matcher to use.')
 						},
 						'owner': {


### PR DESCRIPTION
Add a $go problem matcher which can interpret errors produced by the
go build, install, and lint commands.
