### PR TITLE
#4746: adjusted the send a tweet's maximum character limit to accomodate hashtags and via @code.

### DIFF
--- a/src/vs/workbench/parts/feedback/browser/feedback.ts
+++ b/src/vs/workbench/parts/feedback/browser/feedback.ts
@@ -21,6 +21,7 @@ export interface IFeedback {
 
 export interface IFeedbackService {
 	submitFeedback(feedback: IFeedback): void;
+	getCharacterLimit(sentiment: number): number;
 }
 
 export interface IFeedbackDropdownOptions {
@@ -35,7 +36,7 @@ enum FormEvent {
 }
 
 export class FeedbackDropdown extends Dropdown {
-	protected static MAX_FEEDBACK_CHARS: number = 140;
+	protected maxFeedbackCharacters: number;
 
 	protected feedback: string;
 	protected sentiment: number;
@@ -50,6 +51,7 @@ export class FeedbackDropdown extends Dropdown {
 	protected smileyInput: Builder;
 	protected frownyInput: Builder;
 	protected sendButton: Builder;
+	protected remainingCharacterCount: Builder;
 
 	protected requestFeatureLink: string;
 	protected reportIssueLink: string;
@@ -75,6 +77,7 @@ export class FeedbackDropdown extends Dropdown {
 
 		this.feedback = '';
 		this.sentiment = 1;
+		this.maxFeedbackCharacters = this.feedbackService.getCharacterLimit(this.sentiment);
 
 		this.feedbackForm = null;
 		this.feedbackDescriptionInput = null;
@@ -147,21 +150,20 @@ export class FeedbackDropdown extends Dropdown {
 		$('div').append($('a').attr('target', '_blank').attr('href', this.requestFeatureLink).text(nls.localize("request a missing feature", "Request a missing feature")).attr('tabindex', '0'))
 			.appendTo($contactUsContainer);
 
-		let $charCounter = $('span.char-counter').text(this.getCharCountText(0));
+		this.remainingCharacterCount = $('span.char-counter').text(this.getCharCountText(0));
 
 		$('h3').text(nls.localize("tell us why?", "Tell us why?"))
-			.append($charCounter)
+			.append(this.remainingCharacterCount)
 			.appendTo($form);
 
 		this.feedbackDescriptionInput = <HTMLTextAreaElement>$('textarea.feedback-description').attr({
 			rows: 3,
-			maxlength: FeedbackDropdown.MAX_FEEDBACK_CHARS,
+			maxlength: this.maxFeedbackCharacters,
 			'aria-label': nls.localize("commentsHeader", "Comments")
 		})
 			.text(this.feedback).attr('required', 'required')
 			.on('keyup', () => {
-				$charCounter.text(this.getCharCountText(this.feedbackDescriptionInput.value.length));
-				this.feedbackDescriptionInput.value ? this.sendButton.removeAttribute('disabled') : this.sendButton.attr('disabled', '');
+				this.updateCharCountText();
 			})
 			.appendTo($form).domFocus().getHTMLElement();
 
@@ -185,12 +187,17 @@ export class FeedbackDropdown extends Dropdown {
 	}
 
 	private getCharCountText(charCount: number): string {
-		let remaining = FeedbackDropdown.MAX_FEEDBACK_CHARS - charCount;
+		let remaining = this.maxFeedbackCharacters - charCount;
 		let text = (remaining === 1)
 			? nls.localize("character left", "character left")
 			: nls.localize("characters left", "characters left");
 
 		return '(' + remaining + ' ' + text + ')';
+	}
+
+	private updateCharCountText(): void {
+		this.remainingCharacterCount.text(this.getCharCountText(this.feedbackDescriptionInput.value.length));
+		this.feedbackDescriptionInput.value ? this.sendButton.removeAttribute('disabled') : this.sendButton.attr('disabled', '');
 	}
 
 	protected setSentiment(smile: boolean): void {
@@ -206,6 +213,8 @@ export class FeedbackDropdown extends Dropdown {
 			this.smileyInput.attr('aria-checked', 'false');
 		}
 		this.sentiment = smile ? 1 : 0;
+		this.maxFeedbackCharacters = this.feedbackService.getCharacterLimit(this.sentiment);
+		this.updateCharCountText();
 	}
 
 	protected invoke(element: Builder, callback: () => void): Builder {
@@ -291,6 +300,7 @@ export class FeedbackDropdown extends Dropdown {
 			this.feedbackDescriptionInput.value = '';
 		}
 		this.sentiment = 1;
+		this.maxFeedbackCharacters = this.feedbackService.getCharacterLimit(this.sentiment);
 		this.aliasEnabled = false;
 	}
 }

--- a/src/vs/workbench/parts/feedback/electron-browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/parts/feedback/electron-browser/feedbackStatusbarItem.ts
@@ -15,11 +15,32 @@ import {shell} from 'electron';
 class TwitterFeedbackService implements IFeedbackService {
 
 	private static TWITTER_URL: string = 'https://twitter.com/intent/tweet';
+	private static VIA_NAME: string = 'code';
+	private static HASHTAGS: string[]  = ['HappyCoding'];
+
+	private combineHashTagsAsString() : string {
+		return TwitterFeedbackService.HASHTAGS.join(',');
+	}
 
 	public submitFeedback(feedback: IFeedback): void {
-		var queryString = `?${feedback.sentiment === 1 ? 'hashtags=HappyCoding&' : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${feedback.feedback}&tw_p=tweetbutton&via=code`;
+		var queryString = `?${feedback.sentiment === 1 ? `hashtags=${this.combineHashTagsAsString()}&` : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${feedback.feedback}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
 		var url = TwitterFeedbackService.TWITTER_URL + queryString;
 		shell.openExternal(url);
+	}
+
+	public getCharacterLimit(sentiment: number): number {
+		let length : number = 0;
+		if (sentiment === 1)
+		{
+			TwitterFeedbackService.HASHTAGS.forEach(element => {
+				length += element.length + 2;
+			});
+		}
+
+		if (TwitterFeedbackService.VIA_NAME) {
+			length += ` via @${TwitterFeedbackService.VIA_NAME}`.length;
+		}
+		return 140 - length;
 	}
 }
 


### PR DESCRIPTION
Modified the IFeedback service to provide the character limit that the feedback service supports.
Implemented this logic in TwitterFeedbackService to give the remaining characters after accommodating hashtags (modified to be an array now) and the VIA tag, if one exists.

Fixes #4746 
