### PR TITLE
Promote snippets over other suggestions

### DIFF
--- a/src/vs/editor/contrib/suggest/common/suggest.ts
+++ b/src/vs/editor/contrib/suggest/common/suggest.ts
@@ -66,9 +66,9 @@ export function suggest(model: IModel, position: IPosition, triggerCharacter: st
 	});
 
 	return sequence(factory).then(() => {
-		// add snippets to the first group
+		// add snippets to the zero group
 		const snippets = SnippetsRegistry.getSnippets(model, position);
-		result.push(snippets);
+		result.unshift(snippets);
 		return result;
 	});
 }

--- a/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
@@ -798,7 +798,7 @@ suite('ExtHostLanguageFeatures', function() {
 		threadService.sync().then(() => {
 
 			getParameterHints(model, { lineNumber: 1, column: 1 }, '(').then(value => {
-				done(new Error('error expeted'));
+				done(new Error('error expected'));
 			}, err => {
 				assert.equal(err.message, 'evil');
 				done();
@@ -825,9 +825,9 @@ suite('ExtHostLanguageFeatures', function() {
 		threadService.sync().then(() => {
 			suggest(model, { lineNumber: 1, column: 1 }, ',').then(value => {
 				assert.ok(value.length >= 1); // check for min because snippets and others contribute
-				let [first] = value;
-				assert.equal(first.suggestions.length, 1);
-				assert.equal(first.suggestions[0].codeSnippet, 'testing2');
+				let [,second] = value; // first for snippets
+				assert.equal(second.suggestions.length, 1);
+				assert.equal(second.suggestions[0].codeSnippet, 'testing2');
 				done();
 			});
 		});
@@ -850,9 +850,9 @@ suite('ExtHostLanguageFeatures', function() {
 		threadService.sync().then(() => {
 			suggest(model, { lineNumber: 1, column: 1 }, ',').then(value => {
 				assert.ok(value.length >= 1);
-				let [first] = value;
-				assert.equal(first.suggestions.length, 1);
-				assert.equal(first.suggestions[0].codeSnippet, 'weak-selector');
+				let [,second] = value; // first for snippets
+				assert.equal(second.suggestions.length, 1);
+				assert.equal(second.suggestions[0].codeSnippet, 'weak-selector');
 				done();
 			});
 		});
@@ -876,10 +876,10 @@ suite('ExtHostLanguageFeatures', function() {
 			threadService.sync().then(() => {
 				suggest(model, { lineNumber: 1, column: 1 }, ',').then(value => {
 					assert.ok(value.length >= 2);
-					let [first, second] = value;
-					assert.equal(first.suggestions.length, 1);
-					assert.equal(first.suggestions[0].codeSnippet, 'strong-2'); // last wins
-					assert.equal(second.suggestions[0].codeSnippet, 'strong-1');
+					let [, second, third] = value; // first for snippets
+					assert.equal(second.suggestions.length, 1);
+					assert.equal(second.suggestions[0].codeSnippet, 'strong-2'); // last wins
+					assert.equal(third.suggestions[0].codeSnippet, 'strong-1');
 					done();
 				});
 			});
@@ -904,7 +904,7 @@ suite('ExtHostLanguageFeatures', function() {
 		threadService.sync().then(() => {
 
 			suggest(model, { lineNumber: 1, column: 1 }, ',').then(value => {
-				assert.equal(value[0].incomplete, undefined);
+				assert.equal(value[1].incomplete, undefined);
 				done();
 			});
 		});
@@ -921,7 +921,7 @@ suite('ExtHostLanguageFeatures', function() {
 		return threadService.sync().then(() => {
 
 			suggest(model, { lineNumber: 1, column: 1 }, ',').then(value => {
-				assert.equal(value[0].incomplete, true);
+				assert.equal(value[1].incomplete, true);
 			});
 		});
 	});


### PR DESCRIPTION
What do you think about promoting snippets over other suggestions?

I think it might be useful because:
- Snippets's huge productivity booster and fast access to them is important.
- When snippets this deep in suggestions list they're almost useless because it's almost impossible to find them.
### Examples:

**Current behaviour:**
![before](https://cloud.githubusercontent.com/assets/200119/14406014/1edb8d9c-fea5-11e5-8fe9-557cca8c8298.gif)

**After changes from pull request:**
![after](https://cloud.githubusercontent.com/assets/200119/14406020/334e549e-fea5-11e5-86fc-c84af780e267.gif)

**Atom for comparison:**
![atom](https://cloud.githubusercontent.com/assets/200119/14406021/3d963728-fea5-11e5-9b83-39ef70dd3f8b.gif)
### Possibly issue in another place:

Because in empty file snippets already in the most top of suggestions:
![empty](https://cloud.githubusercontent.com/assets/200119/14406081/dd88298e-fea6-11e5-9a86-2c555d41e12d.gif)

**I've tested in:**
Code 0.10.14-insider, 0.10.11 (stable) and manual build from master branch.
OSX: 10.11.3
