### PR TITLE
Update Dockerfile highlighting to support 'ARG'

### DIFF
--- a/extensions/docker/syntaxes/Dockerfile.tmLanguage
+++ b/extensions/docker/syntaxes/Dockerfile.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -25,7 +25,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(?:(ONBUILD)\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY|LABEL|STOPSIGNAL)\s</string>
+			<string>^\s*(?:(ONBUILD)\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY|LABEL|STOPSIGNAL|ARG)\s</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
Upstream [changes](https://github.com/docker/docker/commit/8d7459140701006fb8e3a0550872ce55c43bcec0) from the Dockerfile tmLanguage within Docker's repo:
- Added highlighting for [ARG](https://docs.docker.com/engine/reference/builder/#arg) instructions within a Dockerfile 
- Aligned doctype declaration with Apple's spec (see Apple's [info.plst](http://opensource.apple.com/source/IOUSBFamily/IOUSBFamily-208.4.5/pbxbuild.data/IOUSBHIDDriver.build/Info.plist))
