### PR TITLE
Fix C# in markdown header

### DIFF
--- a/wiki/project-management/roadmap.md
+++ b/wiki/project-management/roadmap.md
@@ -37,6 +37,6 @@ As of March 31st we will have completed the engineering work for our “1.0” r
 * Improved Intellisense in JavaScript, migrate to [Salsa](https://github.com/Microsoft/TypeScript/issues/4789)
 * Improve the support for JSX (Salsa enables this)
 
-<h3>C#</h3>
+### C&#35;
 * Move into a separate extension
 * Debugging support (collaboration with the CoreCLR team) :heart:

--- a/wiki/project-management/roadmap.md
+++ b/wiki/project-management/roadmap.md
@@ -37,6 +37,6 @@ As of March 31st we will have completed the engineering work for our “1.0” r
 * Improved Intellisense in JavaScript, migrate to [Salsa](https://github.com/Microsoft/TypeScript/issues/4789)
 * Improve the support for JSX (Salsa enables this)
 
-### C#
+<h3>C#</h3>
 * Move into a separate extension
 * Debugging support (collaboration with the CoreCLR team) :heart:


### PR DESCRIPTION
Example

``` markdown
### C#
```
### C

Proposed fix

``` markdown
<h3>C#</h3>
```

<h3>C#</h3>
