### PR TITLE
C# needs to be written using HTML codes or escaped

### DIFF
--- a/wiki/project-management/roadmap.md
+++ b/wiki/project-management/roadmap.md
@@ -37,6 +37,6 @@ As of March 31st we will have completed the engineering work for our “1.0” r
 * Improved Intellisense in JavaScript, migrate to [Salsa](https://github.com/Microsoft/TypeScript/issues/4789)
 * Improve the support for JSX (Salsa enables this)
 
-### C#
+### C&#35;
 * Move into a separate extension
 * Debugging support (collaboration with the CoreCLR team) :heart:


### PR DESCRIPTION
The hash sign in the C# title needs to be written using HTML codes or escaped because as it stands now, people may think you're going to add debugging support for C or something weird. :)
