### PR TITLE
Update copyright year to 2016

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -97,7 +97,7 @@ var config = {
 	version: packageJson.electronVersion,
 	productAppName: product.nameLong,
 	companyName: 'Microsoft Corporation',
-	copyright: 'Copyright (C) 2015 Microsoft. All rights reserved',
+	copyright: 'Copyright (C) 2016 Microsoft. All rights reserved',
 	darwinIcon: 'resources/darwin/code.icns',
 	darwinBundleIdentifier: product.darwinBundleIdentifier,
 	darwinApplicationCategoryType: 'public.app-category.developer-tools',


### PR DESCRIPTION
The copyright in the about window still shows 2015:

> Copyright (C) 2015 Microsoft. All rights reserved
