### PR TITLE
Fix link parsing for non-ASCII characters

### DIFF
--- a/src/vs/editor/common/modes/linkComputer.ts
+++ b/src/vs/editor/common/modes/linkComputer.ts
@@ -28,40 +28,65 @@ enum CharacterClass {
 	CannotEndIn = 2
 }
 
-var getCharacterClasses = (function() {
-	var FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"';
-	var CANNOT_END_WITH_CHARACTERS = '.,;';
-	var _cachedResult: CharacterClass[] = null;
-
-	var set = (str:string, toWhat:CharacterClass): void => {
-		for (var i = 0, len = str.length; i < len; i++) {
-			_cachedResult[str.charCodeAt(i)] = toWhat;
-		}
-	};
-
-	return function(): CharacterClass[] {
-		if (_cachedResult === null) {
-			// Initialize cachedResult for ASCII characters
-			_cachedResult = [];
-			for (var i = 0; i < 128; i++) {
-				_cachedResult[i] = CharacterClass.None;
-			}
-
-			// Fill in cachedResult
-			set(FORCE_TERMINATION_CHARACTERS, CharacterClass.ForceTermination);
-			set(CANNOT_END_WITH_CHARACTERS, CharacterClass.CannotEndIn);
-		}
-
-		return _cachedResult;
-	};
-})();
-
 let _openParens = '('.charCodeAt(0);
 let _closeParens = ')'.charCodeAt(0);
 let _openSquareBracket = '['.charCodeAt(0);
 let _closeSquareBracket = ']'.charCodeAt(0);
 let _openCurlyBracket = '{'.charCodeAt(0);
 let _closeCurlyBracket = '}'.charCodeAt(0);
+
+class CharacterClassifier {
+
+	/**
+	 * Maintain a compact (fully initialized ASCII map for quickly classifying ASCII characters - used more often in code).
+	 */
+	private _asciiMap: CharacterClass[];
+
+	/**
+	 * The entire map (sparse array).
+	 */
+	private _map: CharacterClass[];
+
+	constructor() {
+		var FORCE_TERMINATION_CHARACTERS = ' \t<>\'\"、。｡､，．：；？！＠＃＄％＆＊‘“〈《「『【〔（［｛｢｣｝］）〕】』」》〉”’｀～…';
+		var CANNOT_END_WITH_CHARACTERS = '.,;';
+
+		this._asciiMap = [];
+		for (let i = 0; i < 256; i++) {
+			this._asciiMap[i] = CharacterClass.None;
+		}
+
+		this._map = [];
+
+		for (let i = 0; i < FORCE_TERMINATION_CHARACTERS.length; i++) {
+			this._set(FORCE_TERMINATION_CHARACTERS.charCodeAt(i), CharacterClass.ForceTermination);
+		}
+
+		for (let i = 0; i < CANNOT_END_WITH_CHARACTERS.length; i++) {
+			this._set(CANNOT_END_WITH_CHARACTERS.charCodeAt(i), CharacterClass.CannotEndIn);
+		}
+	}
+
+	private _set(charCode:number, charClass:CharacterClass): void {
+		if (charCode < 256) {
+			this._asciiMap[charCode] = charClass;
+		}
+		this._map[charCode] = charClass;
+	}
+
+	public classify(charCode:number): CharacterClass {
+		if (charCode < 256) {
+			return this._asciiMap[charCode];
+		}
+
+		let charClass = this._map[charCode];
+		if (charClass) {
+			return charClass;
+		}
+
+		return CharacterClass.None;
+	}
+}
 
 class LinkComputer {
 
@@ -87,8 +112,6 @@ class LinkComputer {
 			j:number,
 			lastIncludedCharIndex:number,
 			len:number,
-			characterClasses = getCharacterClasses(),
-			characterClassesLength = characterClasses.length,
 			linkBeginIndex:number,
 			state:number,
 			ch:string,
@@ -97,7 +120,8 @@ class LinkComputer {
 			resetStateMachine:boolean,
 			hasOpenParens:boolean,
 			hasOpenSquareBracket:boolean,
-			hasOpenCurlyBracket:boolean;
+			hasOpenCurlyBracket:boolean,
+			characterClassifier:CharacterClassifier = new CharacterClassifier();
 
 		for (i = 1, lineCount = model.getLineCount(); i <= lineCount; i++) {
 			line = model.getLineContent(i);
@@ -139,7 +163,7 @@ class LinkComputer {
 							chClass = (hasOpenCurlyBracket ? CharacterClass.None : CharacterClass.ForceTermination);
 							break;
 						default:
-							chClass = (chCode < characterClassesLength ? characterClasses[chCode] : CharacterClass.ForceTermination);
+							chClass = characterClassifier.classify(chCode);
 					}
 
 					// Check if character terminates link
@@ -149,7 +173,7 @@ class LinkComputer {
 						lastIncludedCharIndex = j - 1;
 						do {
 							chCode = line.charCodeAt(lastIncludedCharIndex);
-							chClass = (chCode < characterClassesLength ? characterClasses[chCode] : CharacterClass.None);
+							chClass = characterClassifier.classify(chCode);
 							if (chClass !== CharacterClass.CannotEndIn) {
 								break;
 							}
@@ -160,7 +184,7 @@ class LinkComputer {
 						resetStateMachine = true;
 					}
 				} else if (state === END_STATE) {
-					chClass = (chCode < characterClassesLength ? characterClasses[chCode] : CharacterClass.None);
+					chClass = characterClassifier.classify(chCode);
 
 					// Check if character terminates link
 					if (chClass === CharacterClass.ForceTermination) {

--- a/src/vs/editor/common/modes/linkComputer.ts
+++ b/src/vs/editor/common/modes/linkComputer.ts
@@ -33,14 +33,6 @@ var getCharacterClasses = (function() {
 	var CANNOT_END_WITH_CHARACTERS = '.,;';
 	var _cachedResult: CharacterClass[] = null;
 
-	var findLargestCharCode = (str:string):number => {
-		var r = 0;
-		for (var i = 0, len = str.length; i < len; i++) {
-			r = Math.max(r, str.charCodeAt(i));
-		}
-		return r;
-	};
-
 	var set = (str:string, toWhat:CharacterClass): void => {
 		for (var i = 0, len = str.length; i < len; i++) {
 			_cachedResult[str.charCodeAt(i)] = toWhat;
@@ -49,15 +41,9 @@ var getCharacterClasses = (function() {
 
 	return function(): CharacterClass[] {
 		if (_cachedResult === null) {
-			// Find cachedResult size
-			var largestCharCode = Math.max(
-				findLargestCharCode(FORCE_TERMINATION_CHARACTERS),
-				findLargestCharCode(CANNOT_END_WITH_CHARACTERS)
-			);
-
-			// Initialize cachedResult
+			// Initialize cachedResult for ASCII characters
 			_cachedResult = [];
-			for (var i = 0; i < largestCharCode; i++) {
+			for (var i = 0; i < 128; i++) {
 				_cachedResult[i] = CharacterClass.None;
 			}
 
@@ -153,7 +139,7 @@ class LinkComputer {
 							chClass = (hasOpenCurlyBracket ? CharacterClass.None : CharacterClass.ForceTermination);
 							break;
 						default:
-							chClass = (chCode < characterClassesLength ? characterClasses[chCode] : CharacterClass.None);
+							chClass = (chCode < characterClassesLength ? characterClasses[chCode] : CharacterClass.ForceTermination);
 					}
 
 					// Check if character terminates link

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -150,6 +150,10 @@ suite('Editor Modes - Link Computer', () => {
 			'For instructions, see http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx.</value>',
 			'                      http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx         '
 		);
+		assertLink(
+			'請參閱 http://go.microsoft.com/fwlink/?LinkId=761051。',
+			'    http://go.microsoft.com/fwlink/?LinkId=761051 '
+		);
 
 		// foo bar (see http://www.w3schools.com/tags/att_iframe_sandbox.asp)
 	});

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -151,8 +151,16 @@ suite('Editor Modes - Link Computer', () => {
 			'                      http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx         '
 		);
 		assertLink(
+			'x = "https://en.wikipedia.org/wiki/Zürich";',
+			'     https://en.wikipedia.org/wiki/Zürich  '
+		);
+		assertLink(
 			'請參閱 http://go.microsoft.com/fwlink/?LinkId=761051。',
 			'    http://go.microsoft.com/fwlink/?LinkId=761051 '
+		);
+		assertLink(
+			'（請參閱 http://go.microsoft.com/fwlink/?LinkId=761051）',
+			'     http://go.microsoft.com/fwlink/?LinkId=761051 '
 		);
 
 		// foo bar (see http://www.w3schools.com/tags/att_iframe_sandbox.asp)


### PR DESCRIPTION
Fix #5268 

Changes in `src/vs/editor/common/modes/linkComputer.ts` basically let `_cachedResult` caches for all 128 ASCII characters. In the bottom switch clause of state machine, non-ASCII characters will be matched as `CharacterClass.ForceTermination` to solve the URL parsing issue when non-ASCII characters embedded (e.g. Chinese).

A test case for such scenario is also provided.
