### PR TITLE
add problem matcher for Haxe compiler messages

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -1155,3 +1155,10 @@ registry.add('go', {
 	filePrefix: '${cwd}',
 	pattern: defaultPattern('go')
 });
+
+registry.add('haxe', {
+	owner: 'haxe',
+	applyTo: ApplyToKind.allDocuments,
+	fileLocation: FileLocationKind.Relative,
+	pattern: defaultPattern('haxe')
+});

--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -501,6 +501,14 @@ _defaultPatterns['go'] = {
 	column: 6,
 	message: 7
 };
+_defaultPatterns['haxe'] = {
+	regexp: /^\s*(.+):(\d+): (?:lines \d+-\d+|character(?:s \d+-| )(\d+)) : (?:(Warning) : )?(.*)$/,
+	file: 1,
+	line: 2,
+	column: 3,
+	severity: 4,
+	message: 5
+};
 
 export function defaultPattern(name: 'msCompile'): ProblemPattern;
 export function defaultPattern(name: 'tsc'): ProblemPattern;
@@ -511,6 +519,7 @@ export function defaultPattern(name: 'lessCompile'): ProblemPattern;
 export function defaultPattern(name: 'jshint'): ProblemPattern;
 export function defaultPattern(name: 'gulp-tsc'): ProblemPattern;
 export function defaultPattern(name: 'go'): ProblemPattern;
+export function defaultPattern(name: 'haxe'): ProblemPattern;
 export function defaultPattern(name: 'jshint-stylish'): ProblemPattern[];
 export function defaultPattern(name: string): ProblemPattern | ProblemPattern[];
 export function defaultPattern(name: string): ProblemPattern | ProblemPattern[] {

--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -502,12 +502,14 @@ _defaultPatterns['go'] = {
 	message: 7
 };
 _defaultPatterns['haxe'] = {
-	regexp: /^\s*(.+):(\d+): (?:lines \d+-\d+|character(?:s \d+-| )(\d+)) : (?:(Warning) : )?(.*)$/,
+	regexp: /^(.+):(\d+): (?:lines \d+-(\d+)|character(?:s (\d+)-| )(\d+)) : (?:(Warning) : )?(.*)$/,
 	file: 1,
 	line: 2,
-	column: 3,
-	severity: 4,
-	message: 5
+	endLine: 3,
+	column: 4,
+	endColumn: 5,
+	severity: 6,
+	message: 7
 };
 
 export function defaultPattern(name: 'msCompile'): ProblemPattern;


### PR DESCRIPTION
As language extensions currently can't contribute problem matchers (and #492 is in the backlog), I thought maybe we could just have a problem matcher for Haxe bundled right in the VS Code. It's simple enough, hence the PR.
