### PR TITLE
uninstall outdated extension with correct version

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -180,10 +180,14 @@ export class UninstallAction extends Action {
 
 		this.enabled = false;
 
-		return this.extensionsService.uninstall(extension)
-			.then(() => this.onSuccess(extension), err => this.onError(err, extension))
-			.then(() => this.enabled = true)
-			.then(() => null);
+		return this.extensionsService.getInstalled().then(localExtensions => {
+			const [local] = localExtensions.filter(local => extensionEquals(local, extension));
+
+			return this.extensionsService.uninstall(local)
+				.then(() => this.onSuccess(local), err => this.onError(err, local))
+				.then(() => this.enabled = true)
+				.then(() => null);
+		});
 	}
 
 	private onSuccess(extension: IExtension) {
@@ -204,7 +208,7 @@ export class UninstallAction extends Action {
 
 	private reportTelemetry(extension: IExtension, success: boolean) {
 		const data = assign(getTelemetryData(extension), { success });
-		
+
 		this.telemetryService.publicLog('extensionGallery:uninstall', data);
 	}
 }


### PR DESCRIPTION
This PR solves #4970 . It's caused by misuse of extension version number:
1. We put version number in Extension's folder name, so it's out of date.
2. Except "Show installed extensions", we'll fetch the latest extension info from VSO marketplace to generate the extension list view, so the extension version we see in the list view is actually the latest one
3. When we click Uninstall button from the extension list view, we are using the version number we fetched from VSO marketplace to locate the extension folder on disk, that's why we can't find the extension folder on disk.
