### PR TITLE
Remove unnecessary calculation

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -164,7 +164,7 @@ export function startsWith(haystack: string, needle: string): boolean {
 export function endsWith(haystack: string, needle: string): boolean {
 	let diff = haystack.length - needle.length;
 	if (diff > 0) {
-		return haystack.lastIndexOf(needle) === haystack.length - needle.length;
+		return haystack.lastIndexOf(needle) === diff;
 	} else if (diff === 0) {
 		return haystack === needle;
 	} else {


### PR DESCRIPTION
Remove unnecessary calculation in `endsWith`
