### PR TITLE
Create new conf files with right indent settings (fixes #5550)

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -590,3 +590,11 @@ export function appendWithLimit(first: string, second: string, maxLength: number
 export function safeBtoa(str: string): string {
 	return btoa(encodeURIComponent(str)); // we use encodeURIComponent because btoa fails for non Latin 1 values
 }
+
+export function repeat(s:string, count: number): string {
+	var result = '';
+	for (var i = 0; i < count; i++) {
+		result += s;
+	}
+	return result;
+}

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -150,4 +150,11 @@ suite('Strings', () => {
 		assert.strictEqual(strings.appendWithLimit('ab', 'cdefgh', 4), '...efgh');
 		assert.strictEqual(strings.appendWithLimit('abcdef', 'ghijk', 7), '...efghijk');
 	});
+
+	test('repeat', () => {
+		assert.strictEqual(strings.repeat(' ', 4), '    ');
+		assert.strictEqual(strings.repeat(' ', 1), ' ');
+		assert.strictEqual(strings.repeat(' ', 0), '');
+		assert.strictEqual(strings.repeat('abc', 2), 'abcabc');
+	});
 });

--- a/src/vs/languages/json/common/features/jsonFormatter.ts
+++ b/src/vs/languages/json/common/features/jsonFormatter.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import strings = require('vs/base/common/strings');
 import Json = require('vs/base/common/json');
 import EditorCommon = require('vs/editor/common/editorCommon');
 import Modes = require('vs/editor/common/modes');
@@ -28,7 +29,7 @@ export function format(model: EditorCommon.IMirrorModel, range: EditorCommon.IRa
 	var indentLevel = 0;
 	var indentValue: string;
 	if (options.insertSpaces) {
-		indentValue = repeat(' ', options.tabSize);
+		indentValue = strings.repeat(' ', options.tabSize);
 	} else {
 		indentValue = '\t';
 	}
@@ -36,7 +37,7 @@ export function format(model: EditorCommon.IMirrorModel, range: EditorCommon.IRa
 	var scanner = Json.createScanner(value, false);
 
 	function newLineAndIndent(): string {
-		return model.getEOL() + repeat(indentValue, initialIndentLevel + indentLevel);
+		return model.getEOL() + strings.repeat(indentValue, initialIndentLevel + indentLevel);
 	}
 	function scanNext(): Json.SyntaxKind {
 		var token = scanner.scan();
@@ -57,7 +58,7 @@ export function format(model: EditorCommon.IMirrorModel, range: EditorCommon.IRa
 	var firstToken = scanNext();
 	if (firstToken !== Json.SyntaxKind.EOF) {
 		var firstTokenStart = model.getPositionFromOffset(scanner.getTokenOffset() + rangeOffset);
-		var initialIndent = repeat(indentValue, initialIndentLevel);
+		var initialIndent = strings.repeat(indentValue, initialIndentLevel);
 		addEdit(initialIndent, { startLineNumber: range.startLineNumber, startColumn: range.startColumn, endLineNumber: firstTokenStart.lineNumber, endColumn: firstTokenStart.column });
 	}
 
@@ -124,14 +125,6 @@ export function format(model: EditorCommon.IMirrorModel, range: EditorCommon.IRa
 		firstToken = secondToken;
 	}
 	return editOperations;
-}
-
-function repeat(s:string, count: number): string {
-	var result = '';
-	for (var i = 0; i < count; i++) {
-		result += s;
-	}
-	return result;
 }
 
 function computeIndentLevel(line: string, options: Modes.IFormattingOptions): number {

--- a/src/vs/platform/configuration/common/model.ts
+++ b/src/vs/platform/configuration/common/model.ts
@@ -167,7 +167,7 @@ export function getDefaultValues(): any {
 }
 
 
-export function getDefaultValuesContent(): string {
+export function getDefaultValuesContent(indent: string): string {
 	let lastEntry = -1;
 	let result: string[] = [];
 	result.push('{');
@@ -177,9 +177,9 @@ export function getDefaultValuesContent(): string {
 		if (config.title) {
 			if (isTop) {
 				result.push('');
-				result.push('\t//-------- ' + config.title + ' --------');
+				result.push(indent + '//-------- ' + config.title + ' --------');
 			} else {
-				result.push('\t// ' + config.title);
+				result.push(indent + '// ' + config.title);
 			}
 			result.push('');
 		}
@@ -192,12 +192,12 @@ export function getDefaultValuesContent(): string {
 					defaultValue = getDefaultValue(prop.type);
 				}
 				if (prop.description) {
-					result.push('\t// ' + prop.description);
+					result.push(indent + '// ' + prop.description);
 				}
 
-				let valueString = JSON.stringify(defaultValue, null, '\t');
+				let valueString = JSON.stringify(defaultValue, null, indent);
 				if (valueString && (typeof defaultValue === 'object')) {
-					valueString = addIndent(valueString);
+					valueString = addIndent(valueString, indent);
 				}
 
 				if (lastEntry !== -1) {
@@ -205,7 +205,7 @@ export function getDefaultValuesContent(): string {
 				}
 				lastEntry = result.length;
 
-				result.push('\t' + JSON.stringify(key) + ': ' + valueString);
+				result.push(indent + JSON.stringify(key) + ': ' + valueString);
 				result.push('');
 			});
 		}
@@ -216,8 +216,8 @@ export function getDefaultValuesContent(): string {
 	return result.join('\n');
 }
 
-function addIndent(str: string): string {
-	return str.split('\n').join('\n\t');
+function addIndent(str: string, indent: string): string {
+	return str.split('\n').join('\n' + indent);
 }
 
 function getDefaultValue(type: string | string[]): any {

--- a/src/vs/workbench/browser/actions/openSettings.ts
+++ b/src/vs/workbench/browser/actions/openSettings.ts
@@ -10,6 +10,7 @@ import URI from 'vs/base/common/uri';
 import labels = require('vs/base/common/labels');
 import {Registry} from 'vs/platform/platform';
 import {Action} from 'vs/base/common/actions';
+import strings = require('vs/base/common/strings');
 import {IWorkbenchActionRegistry, Extensions} from 'vs/workbench/common/actionRegistry';
 import {StringEditorInput} from 'vs/workbench/common/editor/stringEditorInput';
 import {getDefaultValuesContent} from 'vs/platform/configuration/common/model';
@@ -85,7 +86,7 @@ export class BaseOpenSettingsAction extends BaseTwoEditorsAction {
 	}
 
 	protected open(emptySettingsContents: string, settingsResource: URI): TPromise<IEditor> {
-		return this.openTwoEditors(DefaultSettingsInput.getInstance(this.instantiationService), settingsResource, emptySettingsContents);
+		return this.openTwoEditors(DefaultSettingsInput.getInstance(this.instantiationService, this.configurationService), settingsResource, emptySettingsContents);
 	}
 }
 
@@ -190,9 +191,10 @@ export class OpenWorkspaceSettingsAction extends BaseOpenSettingsAction {
 class DefaultSettingsInput extends StringEditorInput {
 	private static INSTANCE: DefaultSettingsInput;
 
-	public static getInstance(instantiationService: IInstantiationService): DefaultSettingsInput {
+	public static getInstance(instantiationService: IInstantiationService, configurationService: IConfigurationService): DefaultSettingsInput {
 		if (!DefaultSettingsInput.INSTANCE) {
-			let defaults = getDefaultValuesContent();
+			let editorConfig = configurationService.getConfiguration<any>();
+			let defaults = getDefaultValuesContent(editorConfig.insertSpaces ? strings.repeat(' ', editorConfig.tabSize) : '\t');
 
 			let defaultsHeader = '// ' + nls.localize('defaultSettingsHeader', "Overwrite settings by placing them into your settings file.");
 			DefaultSettingsInput.INSTANCE = instantiationService.createInstance(DefaultSettingsInput, nls.localize('defaultName', "Default Settings"), null, defaultsHeader + '\n' + defaults, 'application/json', false);

--- a/src/vs/workbench/browser/actions/openSettings.ts
+++ b/src/vs/workbench/browser/actions/openSettings.ts
@@ -194,7 +194,7 @@ class DefaultSettingsInput extends StringEditorInput {
 	public static getInstance(instantiationService: IInstantiationService, configurationService: IConfigurationService): DefaultSettingsInput {
 		if (!DefaultSettingsInput.INSTANCE) {
 			let editorConfig = configurationService.getConfiguration<any>();
-			let defaults = getDefaultValuesContent(editorConfig.insertSpaces ? strings.repeat(' ', editorConfig.tabSize) : '\t');
+			let defaults = getDefaultValuesContent(editorConfig.editor.insertSpaces ? strings.repeat(' ', editorConfig.editor.tabSize) : '\t');
 
 			let defaultsHeader = '// ' + nls.localize('defaultSettingsHeader', "Overwrite settings by placing them into your settings file.");
 			DefaultSettingsInput.INSTANCE = instantiationService.createInstance(DefaultSettingsInput, nls.localize('defaultName', "Default Settings"), null, defaultsHeader + '\n' + defaults, 'application/json', false);

--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -295,7 +295,7 @@ export class ConfigurationManager implements debug.IConfigurationManager {
 						configurations: adapter.initialConfigurations ? adapter.initialConfigurations : []
 					},
 					null,
-					editorConfig.insertSpaces ? strings.repeat(' ', editorConfig.tabSize) : '\t');
+					editorConfig.editor.insertSpaces ? strings.repeat(' ', editorConfig.editor.tabSize) : '\t');
 			});
 		});
 	}

--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -287,12 +287,16 @@ export class ConfigurationManager implements debug.IConfigurationManager {
 				return null;
 			}
 
-			return this.massageInitialConfigurations(adapter).then(() =>
-				JSON.stringify({
-					version: '0.2.0',
-					configurations: adapter.initialConfigurations ? adapter.initialConfigurations : []
-				}, null, '\t')
-			);
+			return this.massageInitialConfigurations(adapter).then(() => {
+				let editorConfig = this.configurationService.getConfiguration<any>();
+				return JSON.stringify(
+					{
+						version: '0.2.0',
+						configurations: adapter.initialConfigurations ? adapter.initialConfigurations : []
+					},
+					null,
+					editorConfig.insertSpaces ? strings.repeat(' ', editorConfig.tabSize) : '\t');
+			});
 		});
 	}
 

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -24,6 +24,7 @@ import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { match } from 'vs/base/common/glob';
 import { setTimeout } from 'vs/base/common/platform';
 import { TerminateResponse } from 'vs/base/common/processes';
+import * as strings from 'vs/base/common/strings';
 
 import { Registry } from 'vs/platform/platform';
 import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
@@ -239,6 +240,10 @@ class ConfigureTaskRunnerAction extends Action {
 					contentPromise = TPromise.as(selection.content);
 				}
 				return contentPromise.then(content => {
+					let editorConfig = this.configurationService.getConfiguration<any>();
+					if (editorConfig.insertSpaces) {
+						content = content.replace(/(\n)(\t+)/g, (_, s1, s2) => s1 + strings.repeat(' ', s2.length * editorConfig.tabSize));
+					}
 					return this.fileService.createFile(this.contextService.toResource('.vscode/tasks.json'), content);
 				});
 			});

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -241,8 +241,8 @@ class ConfigureTaskRunnerAction extends Action {
 				}
 				return contentPromise.then(content => {
 					let editorConfig = this.configurationService.getConfiguration<any>();
-					if (editorConfig.insertSpaces) {
-						content = content.replace(/(\n)(\t+)/g, (_, s1, s2) => s1 + strings.repeat(' ', s2.length * editorConfig.tabSize));
+					if (editorConfig.editor.insertSpaces) {
+						content = content.replace(/(\n)(\t+)/g, (_, s1, s2) => s1 + strings.repeat(' ', s2.length * editorConfig.editor.tabSize));
 					}
 					return this.fileService.createFile(this.contextService.toResource('.vscode/tasks.json'), content);
 				});


### PR DESCRIPTION
If you are prefer to use spaces instead of tabs - in most cases you
don't want to see tabs anywhere (copy paste issues with other files).

This fixes several workflows:
- Creating new Debug file
- Creating new Tasks file
- Showing global settings (this one is cached, so it shows for the first
  time only right indentation, if you will change it will show old
  indentation till restart)
