### PR TITLE
Add a global action to add a new file in the explorer - resolves #5547

### DIFF
--- a/src/vs/workbench/parts/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.contribution.ts
@@ -10,7 +10,7 @@ import {Action, IAction} from 'vs/base/common/actions';
 import {ActionItem, BaseActionItem, Separator} from 'vs/base/browser/ui/actionbar/actionbar';
 import {Scope, IActionBarRegistry, Extensions as ActionBarExtensions, ActionBarContributor} from 'vs/workbench/browser/actionBarRegistry';
 import {IEditorInputActionContext, IEditorInputAction, EditorInputActionContributor} from 'vs/workbench/browser/parts/editor/baseEditor';
-import {AddToWorkingFiles, FocusWorkingFiles, FocusFilesExplorer, OpenPreviousWorkingFile, OpenNextWorkingFile, CloseAllFilesAction, CloseFileAction, CloseOtherFilesAction, GlobalCompareResourcesAction, GlobalNewFolderAction, RevertFileAction, SaveFilesAction, SaveAllAction, SaveFileAction, keybindingForAction, MoveFileToTrashAction, TriggerRenameFileAction, PasteFileAction, CopyFileAction, SelectResourceForCompareAction, CompareResourcesAction, NewFolderAction, NewFileAction, OpenToSideAction, ShowActiveFileInExplorer} from 'vs/workbench/parts/files/browser/fileActions';
+import {AddToWorkingFiles, FocusWorkingFiles, FocusFilesExplorer, OpenPreviousWorkingFile, OpenNextWorkingFile, CloseAllFilesAction, CloseFileAction, CloseOtherFilesAction, GlobalCompareResourcesAction, GlobalNewFileAction, GlobalNewFolderAction, RevertFileAction, SaveFilesAction, SaveAllAction, SaveFileAction, keybindingForAction, MoveFileToTrashAction, TriggerRenameFileAction, PasteFileAction, CopyFileAction, SelectResourceForCompareAction, CompareResourcesAction, NewFolderAction, NewFileAction, OpenToSideAction, ShowActiveFileInExplorer} from 'vs/workbench/parts/files/browser/fileActions';
 import {RevertLocalChangesAction, AcceptLocalChangesAction, ConflictResolutionDiffEditorInput} from 'vs/workbench/parts/files/browser/saveErrorHandler';
 import {SyncActionDescriptor} from 'vs/platform/actions/common/actions';
 import {IWorkbenchActionRegistry, Extensions as ActionExtensions} from 'vs/workbench/common/actionRegistry';
@@ -166,6 +166,7 @@ registry.registerWorkbenchAction(new SyncActionDescriptor(SaveFileAction, SaveFi
 registry.registerWorkbenchAction(new SyncActionDescriptor(SaveAllAction, SaveAllAction.ID, SaveAllAction.LABEL), category, ['save', 'all', 'files']);
 registry.registerWorkbenchAction(new SyncActionDescriptor(SaveFilesAction, SaveFilesAction.ID, null /* only for programmatic trigger */));
 registry.registerWorkbenchAction(new SyncActionDescriptor(RevertFileAction, RevertFileAction.ID, RevertFileAction.LABEL), category, ['revert', 'file']);
+registry.registerWorkbenchAction(new SyncActionDescriptor(GlobalNewFileAction, GlobalNewFileAction.ID, GlobalNewFileAction.LABEL), category, ['new', 'file']);
 registry.registerWorkbenchAction(new SyncActionDescriptor(GlobalNewFolderAction, GlobalNewFolderAction.ID, GlobalNewFolderAction.LABEL), category, ['new', 'folder']);
 registry.registerWorkbenchAction(new SyncActionDescriptor(GlobalCompareResourcesAction, GlobalCompareResourcesAction.ID, GlobalCompareResourcesAction.LABEL), category, ['compare', 'files']);
 registry.registerWorkbenchAction(new SyncActionDescriptor(CloseFileAction, CloseFileAction.ID, CloseFileAction.LABEL, { primary: KeyMod.chord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_W) }), category, ['close', 'file']);

--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -560,7 +560,7 @@ export abstract class BaseGlobalNewAction extends Action {
 }
 
 /* Create new file from anywhere: Open untitled */
-export class GlobalNewFileAction extends Action {
+export class GlobalNewUntitledFileAction extends Action {
 	public static ID = 'workbench.action.files.newUntitledFile';
 	public static LABEL = nls.localize('newFile', "New File");
 
@@ -582,6 +582,16 @@ export class GlobalNewFileAction extends Action {
 		this.textFileService.getWorkingFilesModel().addEntry(input.getResource());
 
 		return this.editorService.openEditor(input);
+	}
+}
+
+/* Create new file from anywhere */
+export class GlobalNewFileAction extends BaseGlobalNewAction {
+	public static ID = 'workbench.action.files.newFile';
+	public static LABEL = nls.localize('newFile', "New File");
+
+	protected getAction(): IConstructorSignature2<ITree, IFileStat, Action> {
+		return NewFileAction;
 	}
 }
 
@@ -2337,7 +2347,7 @@ export class ShowActiveFileInExplorer extends Action {
 
 export function keybindingForAction(id: string): Keybinding {
 	switch (id) {
-		case GlobalNewFileAction.ID:
+		case GlobalNewUntitledFileAction.ID:
 			return new Keybinding(KeyMod.CtrlCmd | KeyCode.KEY_N);
 		case TriggerRenameFileAction.ID:
 			return new Keybinding(isMacintosh ? KeyCode.Enter : KeyCode.F2);

--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -562,7 +562,7 @@ export abstract class BaseGlobalNewAction extends Action {
 /* Create new file from anywhere: Open untitled */
 export class GlobalNewUntitledFileAction extends Action {
 	public static ID = 'workbench.action.files.newUntitledFile';
-	public static LABEL = nls.localize('newFile', "New File");
+	public static LABEL = nls.localize('newUntitledFile', "New Untitled File");
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/parts/files/electron-browser/files.electron.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/files.electron.contribution.ts
@@ -57,7 +57,7 @@ const category = nls.localize('filesCategory', "Files");
 
 let workbenchActionsRegistry = <IWorkbenchActionRegistry>Registry.as(ActionExtensions.WorkbenchActions);
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(SaveFileAsAction, SaveFileAsAction.ID, SaveFileAsAction.LABEL, { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_S }), category, ['save', 'as']);
-workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalNewUntitledFileAction, GlobalNewUntitledFileAction.ID, GlobalNewUntitledFileAction.LABEL, { primary: KeyMod.CtrlCmd | KeyCode.KEY_N }), category, ['new', 'file']);
+workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalNewUntitledFileAction, GlobalNewUntitledFileAction.ID, GlobalNewUntitledFileAction.LABEL, { primary: KeyMod.CtrlCmd | KeyCode.KEY_N }), category, ['new', 'untitled', 'file']);
 
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalCopyPathAction, GlobalCopyPathAction.ID, GlobalCopyPathAction.LABEL, { primary: KeyMod.chord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_P) }), category, ['copy', 'path']);
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalRevealInOSAction, GlobalRevealInOSAction.ID, GlobalRevealInOSAction.LABEL, { primary: KeyMod.chord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_R) }), category, ['reveal', 'file']);

--- a/src/vs/workbench/parts/files/electron-browser/files.electron.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/files.electron.contribution.ts
@@ -14,7 +14,7 @@ import {SyncActionDescriptor} from 'vs/platform/actions/common/actions';
 import env = require('vs/base/common/platform');
 import {ITextFileService, asFileResource} from 'vs/workbench/parts/files/common/files';
 import {IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions} from 'vs/workbench/common/contributions';
-import {GlobalNewFileAction, SaveFileAsAction} from 'vs/workbench/parts/files/browser/fileActions';
+import {GlobalNewUntitledFileAction, SaveFileAsAction} from 'vs/workbench/parts/files/browser/fileActions';
 import {FileTracker} from 'vs/workbench/parts/files/electron-browser/electronFileTracker';
 import {TextFileService} from 'vs/workbench/parts/files/electron-browser/textFileServices';
 import {OpenFolderAction, OPEN_FOLDER_ID, OPEN_FOLDER_LABEL, OpenFileAction, OPEN_FILE_ID, OPEN_FILE_LABEL, OpenFileFolderAction, OPEN_FILE_FOLDER_ID, OPEN_FILE_FOLDER_LABEL, ShowOpenedFileInNewWindow, GlobalRevealInOSAction, GlobalCopyPathAction, CopyPathAction, RevealInOSAction} from 'vs/workbench/parts/files/electron-browser/electronFileActions';
@@ -57,7 +57,7 @@ const category = nls.localize('filesCategory', "Files");
 
 let workbenchActionsRegistry = <IWorkbenchActionRegistry>Registry.as(ActionExtensions.WorkbenchActions);
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(SaveFileAsAction, SaveFileAsAction.ID, SaveFileAsAction.LABEL, { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_S }), category, ['save', 'as']);
-workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalNewFileAction, GlobalNewFileAction.ID, GlobalNewFileAction.LABEL, { primary: KeyMod.CtrlCmd | KeyCode.KEY_N }), category, ['new', 'file']);
+workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalNewUntitledFileAction, GlobalNewUntitledFileAction.ID, GlobalNewUntitledFileAction.LABEL, { primary: KeyMod.CtrlCmd | KeyCode.KEY_N }), category, ['new', 'file']);
 
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalCopyPathAction, GlobalCopyPathAction.ID, GlobalCopyPathAction.LABEL, { primary: KeyMod.chord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_P) }), category, ['copy', 'path']);
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(GlobalRevealInOSAction, GlobalRevealInOSAction.ID, GlobalRevealInOSAction.LABEL, { primary: KeyMod.chord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_R) }), category, ['reveal', 'file']);


### PR DESCRIPTION
Adds the possibility of binding a keyboard shortcut to a `Create new file` action. Resolves #5547 

@bpasero I believe this should do the trick :)
