### PR TITLE
fix Korean(and Chinese, Japanese) IME behavior (#4541)

### DIFF
--- a/src/vs/base/browser/compositionEvent.ts
+++ b/src/vs/base/browser/compositionEvent.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+export interface ICompositionEvent {
+	data: string;
+	locale: string;
+}

--- a/src/vs/editor/common/controller/textAreaHandler.ts
+++ b/src/vs/editor/common/controller/textAreaHandler.ts
@@ -12,6 +12,7 @@ import {IClipboardEvent, IKeyboardEventWrapper, ISimpleModel, ITextAreaWrapper, 
 import {Position} from 'vs/editor/common/core/position';
 import {Range} from 'vs/editor/common/core/range';
 import {EndOfLinePreference, IEditorPosition, IEditorRange} from 'vs/editor/common/editorCommon';
+import {ICompositionEvent} from 'vs/base/browser/compositionEvent';
 
 enum ReadFromTextArea {
 	Type,
@@ -56,8 +57,11 @@ export class TextAreaHandler extends Disposable {
 	private _onCompositionStart = this._register(new Emitter<ICompositionStartData>());
 	public onCompositionStart: Event<ICompositionStartData> = this._onCompositionStart.event;
 
-	private _onCompositionEnd = this._register(new Emitter<void>());
-	public onCompositionEnd: Event<void> = this._onCompositionEnd.event;
+	private _onCompositionUpdate = this._register(new Emitter<ICompositionEvent>());
+	public onCompositionUpdate: Event<ICompositionEvent> = this._onCompositionUpdate.event;
+
+	private _onCompositionEnd = this._register(new Emitter<ICompositionEvent>());
+	public onCompositionEnd: Event<ICompositionEvent> = this._onCompositionEnd.event;
 
 	private Browser:IBrowser;
 	private textArea:ITextAreaWrapper;
@@ -108,8 +112,8 @@ export class TextAreaHandler extends Disposable {
 
 		this.textareaIsShownAtCursor = false;
 
-		this._register(this.textArea.onCompositionStart(() => {
-			let timeSinceLastCompositionEnd = (new Date().getTime()) - this.lastCompositionEndTime;
+		this._register(this.textArea.onCompositionStart((e) => {
+
 			if (this.textareaIsShownAtCursor) {
 				return;
 			}
@@ -117,7 +121,7 @@ export class TextAreaHandler extends Disposable {
 			this.textareaIsShownAtCursor = true;
 
 			// In IE we cannot set .value when handling 'compositionstart' because the entire composition will get canceled.
-			let shouldEmptyTextArea = (timeSinceLastCompositionEnd >= 100);
+			let shouldEmptyTextArea = true;
 			if (shouldEmptyTextArea) {
 				if (!this.Browser.isIE11orEarlier) {
 					this.setTextAreaState('compositionstart', this.textAreaState.toEmpty());
@@ -136,11 +140,24 @@ export class TextAreaHandler extends Disposable {
 				showAtLineNumber = this.cursorPosition.lineNumber;
 				showAtColumn = this.cursorPosition.column;
 			}
-
 			this._onCompositionStart.fire({
 				showAtLineNumber: showAtLineNumber,
 				showAtColumn: showAtColumn
 			});
+		}));
+
+		this._register(this.textArea.onCompositionUpdate((e) => {
+			this.textAreaState = this.textAreaState.fromText(e.data);
+			let typeInput = this.textAreaState.updateComposition();
+			if (this._nextCommand === ReadFromTextArea.Type) {
+				if (typeInput.text !== '') {
+					this._onType.fire(typeInput);
+				}
+			} else {
+				this.executePaste(typeInput.text);
+				this._nextCommand = ReadFromTextArea.Type;
+			}
+			this._onCompositionUpdate.fire(e);
 		}));
 
 		let readFromTextArea = () => {
@@ -157,9 +174,11 @@ export class TextAreaHandler extends Disposable {
 			}
 		};
 
-		this._register(this.textArea.onCompositionEnd(() => {
-			// console.log('onCompositionEnd: ' + this.textArea.getValue());
-			// readFromTextArea();
+		this._register(this.textArea.onCompositionEnd((e) => {
+			// console.log('onCompositionEnd: ' + e.data);
+			this.textAreaState = this.textAreaState.fromText(e.data);
+			let typeInput = this.textAreaState.updateComposition();
+			this._onType.fire(typeInput);
 
 			this.lastCompositionEndTime = (new Date()).getTime();
 			if (!this.textareaIsShownAtCursor) {
@@ -236,6 +255,10 @@ export class TextAreaHandler extends Disposable {
 		this.selection = primary;
 		this.selections = [primary].concat(secondary);
 		this._writePlaceholderAndSelectTextArea('selection changed');
+	}
+
+	public getCursorPosition(): IEditorPosition {
+		return this.cursorPosition;
 	}
 
 	public setCursorPosition(primary: IEditorPosition): void {

--- a/src/vs/editor/common/controller/textAreaState.ts
+++ b/src/vs/editor/common/controller/textAreaState.ts
@@ -8,6 +8,7 @@ import Event from 'vs/base/common/event';
 import {commonPrefixLength, commonSuffixLength} from 'vs/base/common/strings';
 import {Range} from 'vs/editor/common/core/range';
 import {EndOfLinePreference, IEditorPosition, IEditorRange, IRange} from 'vs/editor/common/editorCommon';
+import {ICompositionEvent} from 'vs/base/browser/compositionEvent';
 
 export interface IClipboardEvent {
 	canUseTextData(): boolean;
@@ -26,8 +27,9 @@ export interface ITextAreaWrapper {
 	onKeyDown: Event<IKeyboardEventWrapper>;
 	onKeyUp: Event<IKeyboardEventWrapper>;
 	onKeyPress: Event<IKeyboardEventWrapper>;
-	onCompositionStart: Event<void>;
-	onCompositionEnd: Event<void>;
+	onCompositionStart: Event<ICompositionEvent>;
+	onCompositionUpdate: Event<ICompositionEvent>;
+	onCompositionEnd: Event<ICompositionEvent>;
 	onInput: Event<void>;
 	onCut: Event<IClipboardEvent>;
 	onCopy: Event<IClipboardEvent>;
@@ -104,6 +106,21 @@ export abstract class TextAreaState {
 	public abstract fromEditorSelection(model:ISimpleModel, selection:IEditorRange);
 
 	public abstract fromText(text:string): TextAreaState;
+
+	public updateComposition(): ITypeData {
+		if (!this.previousState) {
+			// This is the EMPTY state
+			return {
+				text: '',
+				replaceCharCnt: 0
+			};
+		}
+
+		return {
+			text: this.value,
+			replaceCharCnt: this.previousState.selectionEnd - this.previousState.selectionStart
+		};
+	}
 
 	public abstract resetSelection(): TextAreaState;
 

--- a/src/vs/editor/test/common/mocks/mockTextAreaWrapper.ts
+++ b/src/vs/editor/test/common/mocks/mockTextAreaWrapper.ts
@@ -7,6 +7,7 @@
 import Event, {Emitter} from 'vs/base/common/event';
 import {Disposable} from 'vs/base/common/lifecycle';
 import {IClipboardEvent, IKeyboardEventWrapper, ITextAreaWrapper} from 'vs/editor/common/controller/textAreaState';
+import {ICompositionEvent} from 'vs/base/browser/compositionEvent';
 
 export class MockTextAreaWrapper extends Disposable implements ITextAreaWrapper {
 
@@ -19,11 +20,14 @@ export class MockTextAreaWrapper extends Disposable implements ITextAreaWrapper 
 	private _onKeyPress = this._register(new Emitter<IKeyboardEventWrapper>());
 	public onKeyPress: Event<IKeyboardEventWrapper> = this._onKeyPress.event;
 
-	private _onCompositionStart = this._register(new Emitter<void>());
-	public onCompositionStart: Event<void> = this._onCompositionStart.event;
+	private _onCompositionStart = this._register(new Emitter<ICompositionEvent>());
+	public onCompositionStart: Event<ICompositionEvent> = this._onCompositionStart.event;
 
-	private _onCompositionEnd = this._register(new Emitter<void>());
-	public onCompositionEnd: Event<void> = this._onCompositionEnd.event;
+	private _onCompositionUpdate = this._register(new Emitter<ICompositionEvent>());
+	public onCompositionUpdate: Event<ICompositionEvent> = this._onCompositionUpdate.event;
+
+	private _onCompositionEnd = this._register(new Emitter<ICompositionEvent>());
+	public onCompositionEnd: Event<ICompositionEvent> = this._onCompositionEnd.event;
 
 	private _onInput = this._register(new Emitter<void>());
 	public onInput: Event<void> = this._onInput.event;


### PR DESCRIPTION
Hello, this PR is for issue #4541 - Korean characters problem
- fix displaying Korean letters twice during composition
- show composition letters between the text not over the text

Doing so, I added ICompositionEvent that has 'data' field. On 'compositionupdate' events, textarea is changed by composition data.

To show composition letters between the text, the visibleRange is calculated every compositionupdate event with composition word. It can be expensive.

I changed the variable shouldEmptyTextArea to be always true because I think textarea should be empty when composition starts but I didn't test with other browsers (How?).

Symptom (VSCode v1.0, type 'dkssudgktpdy')
![animation1](https://cloud.githubusercontent.com/assets/3759882/14712510/60204442-0818-11e6-8619-1bfae520c0ce.gif)

Expected (there are two cursors.. it must be fix either)
![animation2](https://cloud.githubusercontent.com/assets/3759882/14712512/6021ba2a-0818-11e6-8eaa-b5530be103d2.gif)

And When I composite letters between the text, the letters are displayed over the text. But Korean IME doesn't act like that.  (type 'gksrmf')
![animation3](https://cloud.githubusercontent.com/assets/3759882/14712511/6020be68-0818-11e6-8753-643345f8f414.gif)

Expected
![animation4](https://cloud.githubusercontent.com/assets/3759882/14712513/60223d2e-0818-11e6-8753-fd57da33db7c.gif)

It is confused that Japanese IME usually show composition letters over the text (in the notepad) but when I tested with Microsoft Word, the composition letters are occupied between the text. (type 'sensei')
![animation5](https://cloud.githubusercontent.com/assets/3759882/14712515/6029c1f2-0818-11e6-9bc1-8364dfe631d6.gif)

After change
![animation6](https://cloud.githubusercontent.com/assets/3759882/14712514/60299632-0818-11e6-9f2b-a6ecd01d1ddf.gif)

But It's same as Microsoft Word
![animation7](https://cloud.githubusercontent.com/assets/3759882/14712517/604f38ce-0818-11e6-9699-72b8d58292cb.gif)
