### PR TITLE
Show move file to trash keybinding in context menu - resolves #5603

### DIFF
--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -2362,7 +2362,7 @@ export function keybindingForAction(id: string): Keybinding {
 			return new Keybinding(KeyMod.CtrlCmd | KeyCode.KEY_S);
 		case DeleteFileAction.ID:
 		case MoveFileToTrashAction.ID:
-			return new Keybinding(KeyCode.Delete);
+			return new Keybinding(isMacintosh ? KeyMod.CtrlCmd | KeyCode.Backspace : KeyCode.Delete);
 		case CopyFileAction.ID:
 			return new Keybinding(KeyMod.CtrlCmd | KeyCode.KEY_C);
 		case PasteFileAction.ID:


### PR DESCRIPTION
Adds the keybinding to the context menu in the file explorer. I'm not sure though that changing this has any effect somewhere else. But it looked like this line in `fileActions.ts` was not in sync with the keybindings defined in [explorerViewer.ts](https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/files/browser/views/explorerViewer.ts#L385-L391).

<img width="275" alt="screen shot 2016-04-21 at 19 51 43" src="https://cloud.githubusercontent.com/assets/1913805/14719084/86585456-07fa-11e6-9b01-c426a57ca6c4.png">

// @bpasero
