### PR TITLE
 Add selectAllMatches command in column selection mode.

### DIFF
--- a/src/vs/editor/contrib/find/common/findController.ts
+++ b/src/vs/editor/contrib/find/common/findController.ts
@@ -223,7 +223,7 @@ export class CommonFindController extends Disposable implements editorCommon.IEd
 
 	public selectAllMatches(): boolean {
 		if (this._model) {
-			this._model.selectAll();
+			this._model.selectAllMatches();
 			this.closeFindWidget();
 			return true;
 		}

--- a/src/vs/editor/contrib/find/common/findController.ts
+++ b/src/vs/editor/contrib/find/common/findController.ts
@@ -220,6 +220,15 @@ export class CommonFindController extends Disposable implements editorCommon.IEd
 		}
 		return false;
 	}
+
+	public selectAllMatches(): boolean {
+		if (this._model) {
+			this._model.selectAll();
+			this.closeFindWidget();
+			return true;
+		}
+		return false;
+	}
 }
 
 export class StartFindAction extends EditorAction {
@@ -721,4 +730,7 @@ registerFindCommand(FIND_IDS.ReplaceOneAction, x => x.replace(), {
 });
 registerFindCommand(FIND_IDS.ReplaceAllAction, x => x.replaceAll(), {
 	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter
+});
+registerFindCommand(FIND_IDS.SelectAllMatchesAction, x => x.selectAllMatches(), {
+	primary: KeyMod.Alt | KeyCode.Enter
 });

--- a/src/vs/editor/contrib/find/common/findModel.ts
+++ b/src/vs/editor/contrib/find/common/findModel.ts
@@ -352,7 +352,7 @@ export class FindModelBoundToEditorModel {
 		this.research(false);
 	}
 
-	public selectAll(): void {
+	public selectAllMatches(): void {
 		if (!this._hasMatches()) {
 			return;
 		}

--- a/src/vs/editor/contrib/find/common/findModel.ts
+++ b/src/vs/editor/contrib/find/common/findModel.ts
@@ -14,6 +14,7 @@ import * as editorCommon from 'vs/editor/common/editorCommon';
 import {FindDecorations} from './findDecorations';
 import {FindReplaceState, FindReplaceStateChangedEvent} from './findState';
 import {ReplaceAllCommand} from './replaceAllCommand';
+import {SelectAllMatchesCommand} from './selectAllMatchesCommand';
 
 export const FIND_IDS = {
 	StartFindAction: 'actions.find',
@@ -29,7 +30,8 @@ export const FIND_IDS = {
 	ToggleWholeWordCommand: 'toggleFindWholeWord',
 	ToggleRegexCommand: 'toggleFindRegex',
 	ReplaceOneAction: 'editor.action.replaceOne',
-	ReplaceAllAction: 'editor.action.replaceAll'
+	ReplaceAllAction: 'editor.action.replaceAll',
+	SelectAllMatchesAction: 'editor.action.selectAllMatches'
 };
 
 export const MATCHES_LIMIT = 999;
@@ -348,6 +350,20 @@ export class FindModelBoundToEditorModel {
 		this._executeEditorCommand('replaceAll', command);
 
 		this.research(false);
+	}
+
+	public selectAll(): void {
+		if (!this._hasMatches()) {
+			return;
+		}
+
+		let findScope = this._decorations.getFindScope();
+
+		// Get all the ranges (even more than the highlighted ones)
+		let ranges = this._findMatches(findScope, Number.MAX_VALUE);
+
+		let command = new SelectAllMatchesCommand(this._editor, ranges);
+		this._executeEditorCommand('selectAllMatches', command);
 	}
 
 	private _executeEditorCommand(source:string, command:editorCommon.ICommand): void {

--- a/src/vs/editor/contrib/find/common/selectAllMatchesCommand.ts
+++ b/src/vs/editor/contrib/find/common/selectAllMatchesCommand.ts
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import {Selection} from 'vs/editor/common/core/selection';
+import {ISelection} from 'vs/editor/common/editorCommon';
+import * as editorCommon from 'vs/editor/common/editorCommon';
+
+export class SelectAllMatchesCommand implements editorCommon.ICommand {
+
+	private _editor:editorCommon.ICommonCodeEditor;
+	private _ranges: editorCommon.IEditorRange[];
+
+	constructor(editor:editorCommon.ICommonCodeEditor, ranges: editorCommon.IEditorRange[]) {
+		this._editor = editor;
+		this._ranges = ranges;
+	}
+
+	public getEditOperations(model:editorCommon.ITokenizedModel, builder:editorCommon.IEditOperationBuilder): void {
+		if (this._ranges.length > 0) {
+			// Collect all select operations
+			let newSelections = new Array<ISelection>();
+			for (var i = 0; i < this._ranges.length; i++) {
+				newSelections.push({
+						selectionStartLineNumber: this._ranges[i].startLineNumber,
+						selectionStartColumn: this._ranges[i].startColumn,
+						positionLineNumber: this._ranges[i].startLineNumber,
+						positionColumn: this._ranges[i].endColumn
+				});
+			}
+
+			this._editor.setSelections(newSelections);
+		}
+	}
+
+	public computeCursorState(model:editorCommon.ITokenizedModel, helper: editorCommon.ICursorStateComputerData): editorCommon.IEditorSelection {
+		var inverseEditOperations = helper.getInverseEditOperations();
+		var srcRange = inverseEditOperations[inverseEditOperations.length - 1].range;
+		return Selection.createSelection(
+			srcRange.endLineNumber,
+			srcRange.endColumn,
+			srcRange.endLineNumber,
+			srcRange.endColumn
+		);
+	}
+}


### PR DESCRIPTION
![vs_ml](https://cloud.githubusercontent.com/assets/6732524/14766916/01868528-0a4c-11e6-9a94-81a8340a0ccb.gif)
Operation flow:
1.   Ctrl+F                   -->  Open find widegt.
2.   Alt+R                    -->  Turn on regex mode.
3.   Input search text   -->  Regex text or normal text.
4.   **Alt+Enter              -->  Select all matches.**
5.   Left arrow             -->  Ajust cursors.(Ignore this step if you don't want to edit the selected text.)
6.   Edit text                -->  Do what you want.(Ignore this step if you don't want to edit the selected text.)
7.   Shift+Home          -->  Select modified text.(Ignore this step if you don't want to edit the selected text.)
8.   Ctrl+C                   -->  Copy selected text. 
9.   Ctrl+N                   -->  Open a new tab.
10 .Ctrl+V                   -->  Paste.

Compared to sublime:
![sb_ml](https://cloud.githubusercontent.com/assets/6732524/14766918/05547ab6-0a4c-11e6-8cf6-d2da2e0b6403.gif)
