### PR TITLE
Upgrade minimatch in npm-shinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -274,9 +274,9 @@
       }
     },
     "minimatch": {
-      "version": "0.2.14",
-      "from": "minimatch@>=0.2.12 <0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+      "version": "2.0.10",
+      "from": "minimatch@>=2.0.10 <3.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
     },
     "ms": {
       "version": "0.7.1",


### PR DESCRIPTION
Upgrade minimatchn in npm-shinkwrap.json to 2.0.10 the same  package.json.
Latest [minimatch](https://github.com/isaacs/minimatch) is 3.0.0 that doesn't package browser version.
So I still have not tried the 3.0.0.
