### PR TITLE
[css] Fixed slightly misleading description of all CSS margin properties

### DIFF
--- a/src/vs/languages/css/common/services/browsers.js
+++ b/src/vs/languages/css/common/services/browsers.js
@@ -3978,7 +3978,7 @@ exports.data ={
 			},
 			{
 				"name": "margin",
-				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top. The value may not be negative.",
+				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top.",
 				"restriction": "length, percentage",
 				"values": [
 					{
@@ -4010,7 +4010,7 @@ exports.data ={
 			},
 			{
 				"name": "margin-bottom",
-				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top. The value may not be negative.",
+				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top.",
 				"restriction": "length, percentage",
 				"values": [
 					{
@@ -4042,7 +4042,7 @@ exports.data ={
 			},
 			{
 				"name": "margin-left",
-				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top. The value may not be negative.",
+				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top.",
 				"restriction": "length, percentage",
 				"values": [
 					{
@@ -4052,7 +4052,7 @@ exports.data ={
 			},
 			{
 				"name": "margin-right",
-				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top. The value may not be negative.",
+				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top.",
 				"restriction": "length, percentage",
 				"values": [
 					{
@@ -4062,7 +4062,7 @@ exports.data ={
 			},
 			{
 				"name": "margin-top",
-				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top. The value may not be negative.",
+				"desc": "Shorthand property to set values the thickness of the margin area. If left is omitted, it is the same as right. If bottom is omitted it is the same as top, if right is omitted it is the same as top.",
 				"restriction": "length, percentage",
 				"values": [
 					{


### PR DESCRIPTION
Negative values are allowed in the following CSS properties:

```
margin
margin-top
margin-right
margin-bottom
margin-left
```

[See this relevant W3C document](https://www.w3.org/TR/CSS2/box.html#margin-properties)

> "Negative values for margin properties are allowed"

I believe it is slightly misleading to state that '"The values may not be negative" when negative values are accepted and valid CSS.
