### PR TITLE
Added .inl file extension to C++ language

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -12,7 +12,7 @@
 		},
 		{
 			"id": "cpp",
-			"extensions": [ ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".mm", ".ino" ],
+			"extensions": [ ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".mm", ".ino", ".inl" ],
 			"aliases": [ "C++", "Cpp", "cpp"],
 			"configuration": "./cpp.configuration.json"
 		}],


### PR DESCRIPTION
`.inl` files are one convention for C++ `.h`/`.hpp` files which contain code such as definitions of inline or templates functions.

It seems [this suffix is only used for these files](http://filext.com/file-extension/INL), so there should be no problems.
