### PR TITLE
menubar add extension menu

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -18,7 +18,7 @@ export let IActionsService = createDecorator<IActionsService>('actionsService');
 
 export interface IActionsService {
 	serviceId: ServiceIdentifier<any>;
-	getActions(): Actions.IAction[];
+	getActions(extensionId?: string): Actions.IAction[];
 }
 
 export class SyncActionDescriptor {


### PR DESCRIPTION
![1](https://cloud.githubusercontent.com/assets/7069719/14929697/5e4848f2-0e91-11e6-8641-f683860decda.png)

We love extension menu in Atom. 

Extension Menu can find which actions provided in installed extensions quickly.
