### PR TITLE
Move working file model shutdown to DoShutdown phase.

### DIFF
--- a/src/vs/workbench/parts/files/browser/textFileServices.ts
+++ b/src/vs/workbench/parts/files/browser/textFileServices.ts
@@ -234,9 +234,6 @@ export abstract class TextFileService implements ITextFileService {
 
 	public beforeShutdown(): boolean | TPromise<boolean> {
 
-		// Propagate to working files model
-		this.workingFilesModel.shutdown();
-
 		return false; // no veto
 	}
 
@@ -267,6 +264,9 @@ export abstract class TextFileService implements ITextFileService {
 		while (this.listenerToUnbind.length) {
 			this.listenerToUnbind.pop()();
 		}
+
+		// Propagate to working files model
+		this.workingFilesModel.shutdown();
 
 		this.workingFilesModel.dispose();
 


### PR DESCRIPTION
Fix #5912 . Postpone `workingFilesModel.shutdown` from `beforeShutdown` phase to `ShutDown` phase of TextFileServices, as `ShutDown` phase is used for UI state persistence.
