### PR TITLE
fixes issue with array iterator

### DIFF
--- a/src/vs/base/common/iterator.ts
+++ b/src/vs/base/common/iterator.ts
@@ -7,6 +7,7 @@
 
 export interface IIterator<T> {
 	next(): T;
+	hasNext(): boolean;
 }
 
 export class ArrayIterator<T> implements IIterator<T> {
@@ -32,6 +33,17 @@ export class ArrayIterator<T> implements IIterator<T> {
 
 		return this.items[this.index];
 	}
+
+	public hasNext(): boolean {
+		var newIndex = Math.min(this.index + 1, this.end);
+
+		if (newIndex === this.end) {
+			return false;
+		}
+		else {
+			return true;
+		}
+	}
 }
 
 export class MappedIterator<T, R> implements IIterator<R> {
@@ -41,6 +53,8 @@ export class MappedIterator<T, R> implements IIterator<R> {
 	}
 
 	next() { return this.fn(this.iterator.next()); }
+
+	hasNext() { return this.iterator.hasNext(); }
 }
 
 export interface INavigator<T> extends IIterator<T> {

--- a/src/vs/base/common/iterator.ts
+++ b/src/vs/base/common/iterator.ts
@@ -7,7 +7,7 @@
 
 export interface IIterator<T> {
 	next(): T;
-	hasNext(): boolean;
+	hasNext?(): boolean;
 }
 
 export class ArrayIterator<T> implements IIterator<T> {

--- a/src/vs/base/parts/tree/browser/treeViewModel.ts
+++ b/src/vs/base/parts/tree/browser/treeViewModel.ts
@@ -96,7 +96,8 @@ export class HeightMap extends EventEmitter {
 		var i: number;
 		var sizeDiff = 0;
 
-		while (itemId = iterator.next()) {
+		while (iterator.hasNext()) {
+			itemId = iterator.next();
 			i = this.indexes[itemId];
 			viewItem = this.heightMap[i];
 


### PR DESCRIPTION
I have spent the last 2 days digging into this issue.  But it seems if you initialize an element for the treemodel to an empty string `''` there is an issue with the array iterator where the call `itemId = iterator.next()` does actually not return anything when it is supposed to return an item, the last entry in the array.
