### PR TITLE
fixed #6009

### DIFF
--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -147,7 +147,7 @@ export class ItemRegistry extends Events.EventEmitter {
 	}
 
 	public isRegistered(id: string): boolean {
-		return this.items.hasOwnProperty(id);
+		return this.items[id] !== null;
 	}
 
 	public getItem(id: string): Item {

--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -147,7 +147,8 @@ export class ItemRegistry extends Events.EventEmitter {
 	}
 
 	public isRegistered(id: string): boolean {
-		return this.items[id] !== null;
+		const result = this.items[id];
+		return result ? true : false;
 	}
 
 	public getItem(id: string): Item {


### PR DESCRIPTION
This will fix #6009 and #4575(These contents are the same).
`this.items` is array, not object.
So, `hasOwnProperty` is not available.
