### PR TITLE
Fix German Translation of "Tabs"

### DIFF
--- a/i18n/deu/src/vs/editor/contrib/indentation/common/indentation.i18n.json
+++ b/i18n/deu/src/vs/editor/contrib/indentation/common/indentation.i18n.json
@@ -9,7 +9,7 @@
 	"indentUsingSpaces": "Einzug mithilfe von Leerzeichen",
 	"indentUsingTabs": "Einzug mithilfe von Tabstopps",
 	"indentationToSpaces": "Einzug in Leerzeichen konvertieren",
-	"indentationToTabs": "Einzug in Registerkarten konvertieren",
+	"indentationToTabs": "Einzug in Tabstopps konvertieren",
 	"selectTabWidth": "Tabulatorgröße für aktuelle Datei auswählen",
 	"toggleRenderWhitespace": "Rendern von Leerzeichen umschalten"
 }


### PR DESCRIPTION
It's "Tabstopp" which is already used in line 10, and not "Registerkarte", which is a valid translation, but semantically different (browser tab vs. indentation tab).
