### PR TITLE
Fix feedback form styles in high contrast theme

### DIFF
--- a/src/vs/workbench/parts/feedback/browser/media/feedback.css
+++ b/src/vs/workbench/parts/feedback/browser/media/feedback.css
@@ -298,8 +298,10 @@
 }
 
 /* High Contrast Theming */
-.monaco-shell .hc-black .feedback-form {
-	background-color: #0C141F;
+.monaco-shell.hc-black .feedback-form {
+	background-color: #000;
+	outline: 2px solid #6fc3df;
+	outline-offset: -2px;
 }
 
 .monaco-shell.hc-black .feedback-form h2 {
@@ -315,7 +317,7 @@
 
 .monaco-shell.hc-black .feedback-form .content .contactus {
 	padding: 10px;
-	border: solid 1px #B4BABF;
+	border: solid 1px #6FC3DF;
 	background-color: #0C141F;
 	float: right;
 }


### PR DESCRIPTION
Fixes #6441 

---

@bgashler1 push if this looks good - should the text area background be blue?

![image](https://cloud.githubusercontent.com/assets/2193314/15346484/73e0b50c-1c6d-11e6-9ce3-5b183d7bdfcc.png)
