### PR TITLE
extensions: Ensure make uses tab instead of space.

### DIFF
--- a/extensions/make/make.configuration.json
+++ b/extensions/make/make.configuration.json
@@ -1,4 +1,5 @@
 {
+	"insertSpaces": false,
 	"comments": {
 		"lineComment": "#"
 	},


### PR DESCRIPTION
This change addresses the following issues:

https://github.com/Microsoft/vscode/issues/6447
https://github.com/Microsoft/vscode/issues/4815

It was not clear to me how to write an automated test for this change. All testing was done manually. When editing a Makefile, now the default is to use tabs instead of spaces. Switching to another file/type, and then back to the Makefile does not alter this behavior. Quitting and restarting the editor also does not alter this behavior. If an automated test is required, please point me to an example so that I can replicate it. 
