### PR TITLE
Gutter icon background size limited

### DIFF
--- a/src/vs/editor/browser/services/codeEditorServiceImpl.ts
+++ b/src/vs/editor/browser/services/codeEditorServiceImpl.ts
@@ -16,9 +16,9 @@ export class CodeEditorServiceImpl extends AbstractCodeEditorService {
 	private _styleSheet: HTMLStyleElement;
 	private _decorationRenderOptions: {[key:string]:DecorationRenderOptions};
 
-	constructor() {
+	constructor(styleSheet = dom.createStyleSheet()) {
 		super();
-		this._styleSheet = dom.createStyleSheet();
+		this._styleSheet = styleSheet;
 		this._decorationRenderOptions = Object.create(null);
 	}
 
@@ -129,6 +129,7 @@ class DecorationRenderOptions implements IModelDecorationOptions {
 		letterSpacing: 'letter-spacing:{0};',
 
 		gutterIconPath: 'background:url(\'{0}\') center center no-repeat;',
+		gutterIconSize: 'background-size:{0};',
 	};
 
 	/**
@@ -209,7 +210,10 @@ class DecorationRenderOptions implements IModelDecorationOptions {
 		let cssTextArr = [];
 
 		if (typeof opts.gutterIconPath !== 'undefined') {
-			cssTextArr.push(strings.format(this._CSS_MAP.gutterIconPath, URI.file(opts.gutterIconPath).toString()));
+			cssTextArr.push(strings.format(this._CSS_MAP.gutterIconPath, URI.parse(opts.gutterIconPath).toString()));
+			if (typeof opts.gutterIconSize !== 'undefined') {
+				cssTextArr.push(strings.format(this._CSS_MAP.gutterIconSize, opts.gutterIconSize));
+			}
 		}
 
 		return cssTextArr.join('');

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -3192,6 +3192,7 @@ export interface IThemeDecorationRenderOptions {
 	letterSpacing?: string;
 
 	gutterIconPath?: string;
+	gutterIconSize?: string;
 
 	overviewRulerColor?: string;
 }

--- a/src/vs/editor/test/browser/services/decorationRenderOptions.test.ts
+++ b/src/vs/editor/test/browser/services/decorationRenderOptions.test.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as assert from 'assert';
+import * as dom from 'vs/base/browser/dom';
+import {CodeEditorServiceImpl} from 'vs/editor/browser/services/codeEditorServiceImpl';
+import {IDecorationRenderOptions, IModelDecorationOptions, IModelDecorationOverviewRulerOptions, IThemeDecorationRenderOptions, OverviewRulerLane} from 'vs/editor/common/editorCommon';
+
+suite('Browser Services - EditorLayoutProvider', () => {
+	var options: IDecorationRenderOptions = {
+		gutterIconPath: 'https://github.com/Microsoft/vscode/blob/master/resources/linux/code.png',
+		gutterIconSize: 'contain',
+		backgroundColor: 'red',
+		borderColor: 'yellow'
+	};
+	test('register and resolve decoration type', () => {
+		var s = new CodeEditorServiceImpl();
+		s.registerDecorationType('example', options);
+		assert.notEqual(s.resolveDecorationType('example'), undefined);
+	});
+	test('remove decoration type', () => {
+		var s = new CodeEditorServiceImpl();
+		s.registerDecorationType('example', options);
+		assert.notEqual(s.resolveDecorationType('example'), undefined);
+		s.removeDecorationType('example');
+		assert.throws(() => s.resolveDecorationType('example'));
+	});
+	test('css properties', () => {
+		var styleSheet = dom.createStyleSheet();
+		var s = new CodeEditorServiceImpl(styleSheet);
+		s.registerDecorationType('example', options);
+		var sheet = styleSheet.sheet.toString();
+		assert(sheet.indexOf('background: url(\'https://github.com/Microsoft/vscode/blob/master/resources/linux/code.png\') center center no-repeat;') > 0);
+		assert(sheet.indexOf('background-size: contain;') > 0);
+		assert(sheet.indexOf('border-color: yellow;') > 0);
+		assert(sheet.indexOf('background-color: red;') > 0);
+	});
+});

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -694,6 +694,13 @@ declare namespace vscode {
 		gutterIconPath?: string;
 
 		/**
+		 * Specifies the size of the gutter icon.
+		 * Available values are 'auto', 'contain', 'cover' and any percentage value.
+		 * For further information: https://msdn.microsoft.com/en-us/library/jj127316(v=vs.85).aspx
+		 */
+		gutterIconSize?: string;
+
+		/**
 		 * The color of the decoration in the overview ruler. Use rgba() and define transparent colors to play well with other decorations.
 		 */
 		overviewRulerColor?: string;


### PR DESCRIPTION
To be able to show images with arbitrary size on the gutter margin,
the css property 'background-size' has been added.
