### PR TITLE
Adding extra file extensions/names to ini and shell script extensions

### DIFF
--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "ini",
-			"extensions": [ ".ini", ".properties", ".gitconfig" ],
+			"extensions": [ ".desktop", ".ini", ".properties", ".gitconfig" ],
 			"filenames": ["config", ".gitattributes", ".gitconfig", "gitconfig", ".editorconfig"],
 			"aliases": [ "Ini", "ini" ],
 			"configuration": "./ini.configuration.json"

--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -7,7 +7,8 @@
 		"languages": [{
 			"id": "shellscript",
 			"aliases": ["Shell Script (Bash)", "shellscript", "bash", "sh", "zsh"],
-			"extensions": [".sh", ".bash", ".bashrc", ".bash_profile", ".bash_login", ".profile", ".bash_logout", ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv"],
+			"extensions": [".sh", ".bash", ".bashrc", ".bash_profile", ".bash_login", ".ebuild", ".install", ".profile", ".bash_logout", ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv"],
+			"filenames": ["PKGBUILD"],
 			"firstLine": "^#!.*\\b(bash|zsh|sh|tcsh)|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-",
 			"configuration": "./shellscript.configuration.json",
 			"mimetypes": ["text/x-shellscript"]


### PR DESCRIPTION
Hi,

In this pull request I am making the following changes:
- INI extension: adding file extension support for `.desktop` files. 
- Shell script extension: adding file name support for PKGBUILD (a file used on Arch Linux and related distributions to build packages). Adding file extension support for `.ebuild` (used on Gentoo Linux and related distributions for package building) and `.install` (used by Arch Linux, referred to by PKGBUILDs).

Thanks for your time,
Brenton
