### PR TITLE
Have --verbose work on the bin command

### DIFF
--- a/src/vs/code/node/argv.ts
+++ b/src/vs/code/node/argv.ts
@@ -94,6 +94,7 @@ ${ indent }-r, --reuse-window    Force opening a file or folder in the last acti
 ${ indent }                      window.
 ${ indent }--user-data-dir <dir> Specifies the directory that user data is kept in,
 ${ indent }                      useful when running as root.
+${ indent }--verbose             Print verbose output (implies --wait).
 ${ indent }-v, --version         Print version.
 ${ indent }-w, --wait            Wait for the window to be closed before returning.
 ${ indent }--list-extensions     List the installed extensions.

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -35,14 +35,23 @@ export function main(args: string[]): TPromise<void> {
 		});
 		delete env['ATOM_SHELL_INTERNAL_RUN_AS_NODE'];
 
-		const child = spawn(process.execPath, args, {
-			detached: true,
-			stdio: 'ignore',
-			env
-		});
+		let options = {
+			detacted: true,
+			env,
+		};
+		if (!argv.verbose) {
+			options['stdio'] = 'ignore';
+		}
 
-		if (argv.wait) {
-			return new TPromise<void>(c => child.once('exit', ()=> c(null)));
+		const child = spawn(process.execPath, args, options);
+
+		if (argv.verbose) {
+			child.stdout.on('data', (data) => console.log(data.toString('utf8').trim()));
+			child.stderr.on('data', (data) => console.log(data.toString('utf8').trim()));
+		}
+
+		if (argv.wait || argv.verbose) {
+			return new TPromise<void>(c => child.once('exit', () => c(null)));
 		}
 	}
 


### PR DESCRIPTION
Fixes #6556 

---

@joaomoreno this seems to give me the electron logs too, I prefer this personally but it's inconsistent atm with `/usr/share/code/code --verbose` (see https://github.com/Microsoft/vscode/issues/6555).
