### PR TITLE
Add .babelrc to json mimetype

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -27,7 +27,8 @@
 					".bowerrc",
 					".jshintrc",
 					".jscsrc",
-					".eslintrc"
+					".eslintrc",
+					".babelrc"
 				],
 				"mimetypes": [
 					"application/json"

--- a/src/vs/languages/json/common/json.contribution.ts
+++ b/src/vs/languages/json/common/json.contribution.ts
@@ -11,7 +11,7 @@ import {ModesRegistry} from 'vs/editor/common/modes/modesRegistry';
 
 ModesRegistry.registerCompatMode({
 	id: 'json',
-	extensions: ['.json', '.bowerrc', '.jshintrc', '.jscsrc', '.eslintrc'],
+	extensions: ['.json', '.bowerrc', '.jshintrc', '.jscsrc', '.eslintrc', '.babelrc'],
 	aliases: ['JSON', 'json'],
 	mimetypes: ['application/json'],
 	moduleId: 'vs/languages/json/common/json',


### PR DESCRIPTION
The `.babelrc` configuration file is used for babel to transpile future JavaScript features to older ES versions. [1] It is a json file and can be embedded in `package.json`. More commonly people store babel settings in it's own `.babelrc` file.

This PR applies the json mime type to files ending with babelrc to fix syntax highlighting.

[1] [Babel-Docs](https://babeljs.io/docs/usage/babelrc/)
