### PR TITLE
Remove bold font style in the Solarized themes

### DIFF
--- a/extensions/theme-solarized-dark/themes/Solarized-dark.tmTheme
+++ b/extensions/theme-solarized-dark/themes/Solarized-dark.tmTheme
@@ -98,8 +98,6 @@
 			<string>storage</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string>bold</string>
 				<key>foreground</key>
 				<string>#93A1A1</string>
 			</dict>

--- a/extensions/theme-solarized-light/themes/Solarized-light.tmTheme
+++ b/extensions/theme-solarized-light/themes/Solarized-light.tmTheme
@@ -96,8 +96,6 @@
 			<string>storage</string>
 			<key>settings</key>
 			<dict>
-				<key>fontStyle</key>
-				<string>bold</string>
 				<key>foreground</key>
 				<string>#073642</string>
 			</dict>


### PR DESCRIPTION
The effect is very annoying in Go code like this:

``` go
var x map[string]string
```

The default color is enough to emphasize the types.

Before:

![lbe](https://cloud.githubusercontent.com/assets/180453/15552630/9d604d80-22bb-11e6-9feb-f5aabdda632c.png)

![dbe](https://cloud.githubusercontent.com/assets/180453/15552639/a7ae4d00-22bb-11e6-9db6-ffed9917e2ea.png)

After:

![laf](https://cloud.githubusercontent.com/assets/180453/15552656/baec7afe-22bb-11e6-888c-649d606d58db.png)

![daf](https://cloud.githubusercontent.com/assets/180453/15552664/bffa2abe-22bb-11e6-8eba-33fd083ecfb4.png)
