### PR TITLE
Unstage selected ranges

### DIFF
--- a/src/vs/workbench/parts/git/common/stageRanges.ts
+++ b/src/vs/workbench/parts/git/common/stageRanges.ts
@@ -48,6 +48,17 @@ export function stageRanges(diff:editorbrowser.IDiffEditor): string {
 	return applyChangesToModel(diff.getModel().original, diff.getModel().modified, changes);
 }
 
+export function unstageRanges(diff:editorbrowser.IDiffEditor): string {
+	var selections = diff.getSelections();
+	var changes = getSelectedChanges(diff.getLineChanges(), selections);
+
+	changes.forEach((change) => {
+		[change.originalStartLineNumber, change.originalEndLineNumber, change.modifiedStartLineNumber, change.modifiedEndLineNumber] = [change.modifiedStartLineNumber, change.modifiedEndLineNumber, change.originalStartLineNumber, change.originalEndLineNumber];
+	});
+
+	return applyChangesToModel(diff.getModel().modified, diff.getModel().original, changes);
+}
+
 /**
  * Returns an intersection between a change and a selection.
  * Returns null if intersection does not exist.


### PR DESCRIPTION
Part of feature #6516. Since we allow users to stage selected lines, it would be better if users can unstage changes they don't want anymore.

This PR only contains the code change, we need to involve Localization team to handle `nls.localize('unstageSelectedLines', "Unstage Selected Lines")` as well, right? @isidorn 

![image](https://cloud.githubusercontent.com/assets/876920/15557574/e1989ea4-2288-11e6-81c9-8b4cd6f084d0.png)
