### PR TITLE
Add actions to workbench registry for staging and unstaging the active file

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
@@ -28,7 +28,7 @@ import {IFileService} from 'vs/platform/files/common/files';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
 import wbar = require('vs/workbench/common/actionRegistry');
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { OpenChangeAction, OpenFileAction, SyncAction, PullAction, PushAction, PublishAction, StartGitBranchAction, StartGitCheckoutAction, InputCommitAction, UndoLastCommitAction } from './gitActions';
+import { OpenChangeAction, OpenFileAction, SyncAction, PullAction, PushAction, PublishAction, StartGitBranchAction, StartGitCheckoutAction, InputCommitAction, UndoLastCommitAction, StageAction } from './gitActions';
 import paths = require('vs/base/common/paths');
 import URI from 'vs/base/common/uri';
 
@@ -480,3 +480,4 @@ workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(StartGi
 workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(StartGitCheckoutAction, StartGitCheckoutAction.ID, StartGitCheckoutAction.LABEL), 'Git: Checkout', category);
 workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(InputCommitAction, InputCommitAction.ID, InputCommitAction.LABEL), 'Git: Commit', category);
 workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(UndoLastCommitAction, UndoLastCommitAction.ID, UndoLastCommitAction.LABEL), 'Git: Undo Last Commit', category);
+workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(StageAction, StageAction.ID, StageAction.LABEL), 'Git: Stage', category);

--- a/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
@@ -28,7 +28,7 @@ import {IFileService} from 'vs/platform/files/common/files';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
 import wbar = require('vs/workbench/common/actionRegistry');
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { OpenChangeAction, OpenFileAction, SyncAction, PullAction, PushAction, PublishAction, StartGitBranchAction, StartGitCheckoutAction, InputCommitAction, UndoLastCommitAction, StageAction } from './gitActions';
+import { OpenChangeAction, OpenFileAction, SyncAction, PullAction, PushAction, PublishAction, StartGitBranchAction, StartGitCheckoutAction, InputCommitAction, UndoLastCommitAction, StageAction, UnstageAction } from './gitActions';
 import paths = require('vs/base/common/paths');
 import URI from 'vs/base/common/uri';
 
@@ -481,3 +481,4 @@ workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(StartGi
 workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(InputCommitAction, InputCommitAction.ID, InputCommitAction.LABEL), 'Git: Commit', category);
 workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(UndoLastCommitAction, UndoLastCommitAction.ID, UndoLastCommitAction.LABEL), 'Git: Undo Last Commit', category);
 workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(StageAction, StageAction.ID, StageAction.LABEL), 'Git: Stage', category);
+workbenchActionRegistry.registerWorkbenchAction(new SyncActionDescriptor(UnstageAction, UnstageAction.ID, UnstageAction.LABEL), 'Git: Unstage', category);

--- a/src/vs/workbench/parts/git/browser/gitActions.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.ts
@@ -564,9 +564,15 @@ export abstract class BaseUnstageAction extends GitAction {
 
 export class UnstageAction extends BaseUnstageAction {
 	static ID = 'workbench.action.git.unstage';
+	static LABEL = nls.localize('unstage', "Unstage");
 
-	constructor(@IGitService gitService: IGitService, @IWorkbenchEditorService editorService: IWorkbenchEditorService) {
-		super(UnstageAction.ID, nls.localize('unstage', "Unstage"), 'git-action unstage', gitService, editorService);
+	constructor(
+		id = UnstageAction.ID,
+		label = UnstageAction.LABEL,
+		@IGitService gitService: IGitService,
+		@IWorkbenchEditorService editorService: IWorkbenchEditorService
+	) {
+		super(id, label, 'git-action unstage', gitService, editorService);
 	}
 }
 

--- a/src/vs/workbench/parts/git/browser/gitActions.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.ts
@@ -283,8 +283,13 @@ export class StageAction extends BaseStageAction {
 	static ID = 'workbench.action.git.stage';
 	static LABEL = nls.localize('stageChanges', "Stage");
 
-	constructor(@IGitService gitService: IGitService, @IWorkbenchEditorService editorService: IWorkbenchEditorService) {
-		super(StageAction.ID, StageAction.LABEL, 'git-action stage', gitService, editorService);
+	constructor(
+		id = StageAction.ID,
+		label = StageAction.LABEL,
+		@IGitService gitService: IGitService,
+		@IWorkbenchEditorService editorService: IWorkbenchEditorService
+	) {
+		super(id, label, 'git-action stage', gitService, editorService);
 	}
 }
 

--- a/src/vs/workbench/parts/git/browser/gitActions.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.ts
@@ -212,7 +212,7 @@ export class RefreshAction extends GitAction {
 }
 
 export abstract class BaseStageAction extends GitAction {
-	private editorService: IWorkbenchEditorService;
+	protected editorService: IWorkbenchEditorService;
 
 	constructor(id: string, label: string, className: string, gitService: IGitService, editorService: IWorkbenchEditorService) {
 		super(id, label, className, gitService);
@@ -490,7 +490,7 @@ export class GlobalUndoAction extends BaseUndoAction {
 
 export abstract class BaseUnstageAction extends GitAction {
 
-	private editorService: IWorkbenchEditorService;
+	protected editorService: IWorkbenchEditorService;
 
 	constructor(id: string, label: string, className: string, gitService: IGitService, editorService: IWorkbenchEditorService) {
 		super(id, label, className, gitService);


### PR DESCRIPTION
From issue: #1821 

This PR registers actions for staging and unstaging the file which currently has focus. Works for both files and diff editors. The actions can then be bound to keyboard shortcuts at the users discretion. 

Staging selection ranges is currently not part of this review but can be implemented on request.
