### PR TITLE
Fixes #6916: Remove type parameters rule from JavaScript grammar

### DIFF
--- a/extensions/javascript/syntaxes/JavaScript.tmLanguage
+++ b/extensions/javascript/syntaxes/JavaScript.tmLanguage
@@ -2026,7 +2026,7 @@
 		<key>type-parameters</key>
 		<dict>
 			<key>begin</key>
-			<string>([a-zA-Z_$][\w$]*)?(&lt;)</string>
+			<string>JAVASCRIPT_DOES_NOT_HAVE_TYPE_PARAMETERS_SO_NEVER_MATCH_PLEASE([a-zA-Z_$][\w$]*)?(&lt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This rule makes it that `<` comparator in minified code enters and never leaves the `type-parameters` state. This is not OK.
