### PR TITLE
Add cs to the list of C# aliases

### DIFF
--- a/src/vs/editor/standalone-languages/all.ts
+++ b/src/vs/editor/standalone-languages/all.ts
@@ -39,7 +39,7 @@ MonacoEditorLanguages.push({
 MonacoEditorLanguages.push({
 	id: 'csharp',
 	extensions: [ '.cs', '.csx' ],
-	aliases: [ 'C#', 'csharp' ],
+	aliases: [ 'C#', 'cs', 'csharp' ],
 	defModule: 'vs/editor/standalone-languages/csharp'
 });
 MonacoEditorLanguages.push({


### PR DESCRIPTION
This adds `cs` to the list of C# aliases, which means it'll be syntax highlighted in markdown when writing something like

```cs
Console.WriteLine("Hello, world!");
```

Should fix #7003.

cc: @aeschli
