### PR TITLE
Reset skip flag to false to fix skipping rest of string

### DIFF
--- a/src/vs/base/common/paths.ts
+++ b/src/vs/base/common/paths.ts
@@ -136,6 +136,7 @@ export function normalize(path: string, toOSPath?: boolean): string {
 				res += part;
 			}
 			start = end + 1;
+			skip = false;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a regression introduced in ef537b0aabb7933184340418b64284cdcd162320.

Please review, @jrieken.
