### PR TITLE
On mac ctrl-n should behave exactly like DownArrow

### DIFF
--- a/src/vs/base/common/keyCodes.ts
+++ b/src/vs/base/common/keyCodes.ts
@@ -492,10 +492,12 @@ export class CommonKeybindings {
 	public static CTRLCMD_BACKSPACE: number = KeyMod.CtrlCmd | KeyCode.Backspace;
 
 	public static UP_ARROW: number = KeyCode.UpArrow;
+	public static WINCTRL_P: number = KeyMod.WinCtrl | KeyCode.KEY_P;
 	public static SHIFT_UP_ARROW: number = KeyMod.Shift | KeyCode.UpArrow;
 	public static CTRLCMD_UP_ARROW: number = KeyMod.CtrlCmd | KeyCode.UpArrow;
 
 	public static DOWN_ARROW: number = KeyCode.DownArrow;
+	public static WINCTRL_N: number = KeyMod.WinCtrl | KeyCode.KEY_N;
 	public static SHIFT_DOWN_ARROW: number = KeyMod.Shift | KeyCode.DownArrow;
 	public static CTRLCMD_DOWN_ARROW: number = KeyMod.CtrlCmd | KeyCode.DownArrow;
 

--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -25,7 +25,7 @@ import {StandardKeyboardEvent} from 'vs/base/browser/keyboardEvent';
 import {DefaultController, ClickBehavior} from 'vs/base/parts/tree/browser/treeDefaults';
 import DOM = require('vs/base/browser/dom');
 import {IActionProvider} from 'vs/base/parts/tree/browser/actionsRenderer';
-import {KeyCode, KeyMod} from 'vs/base/common/keyCodes';
+import {KeyCode, KeyMod, CommonKeybindings} from 'vs/base/common/keyCodes';
 import {IDisposable, dispose} from 'vs/base/common/lifecycle';
 import {ScrollbarVisibility} from 'vs/base/browser/ui/scrollbar/scrollableElementOptions';
 
@@ -155,6 +155,15 @@ export class QuickOpenWidget implements IModelProvider {
 				DOM.addDisposableListener(this.inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 					let keyboardEvent: StandardKeyboardEvent = new StandardKeyboardEvent(e);
 
+					if (platform.isMacintosh) {
+						if (keyboardEvent.equals(CommonKeybindings.WINCTRL_N)) {
+							keyboardEvent.keyCode = KeyCode.DownArrow;
+						}
+						else if (keyboardEvent.equals(CommonKeybindings.WINCTRL_P)) {
+							keyboardEvent.keyCode = KeyCode.UpArrow;
+						}
+					}
+
 					// Do not handle Tab: It is used to navigate between elements without mouse
 					if (keyboardEvent.keyCode === KeyCode.Tab) {
 						return;
@@ -225,6 +234,15 @@ export class QuickOpenWidget implements IModelProvider {
 					// Only handle when in quick navigation mode
 					if (!this.quickNavigateConfiguration) {
 						return;
+					}
+
+					if (platform.isMacintosh) {
+						if (keyboardEvent.equals(CommonKeybindings.WINCTRL_N)) {
+							keyboardEvent.keyCode = KeyCode.DownArrow;
+						}
+						else if (keyboardEvent.equals(CommonKeybindings.WINCTRL_P)) {
+							keyboardEvent.keyCode = KeyCode.UpArrow;
+						}
 					}
 
 					// Support keyboard navigation in quick navigation mode

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
@@ -113,7 +113,8 @@ KeybindingsRegistry.registerCommandDesc({
 	weight,
 	when: KbExpr.and(KbExpr.has(KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS), KbExpr.has(Context.Visible), KbExpr.has(Context.MultipleSignatures)),
 	primary: KeyCode.UpArrow,
-	secondary: [KeyMod.Alt | KeyCode.UpArrow]
+	secondary: [KeyMod.Alt | KeyCode.UpArrow],
+	mac: { primary: KeyCode.UpArrow, secondary: [KeyMod.Alt | KeyCode.UpArrow, KeyMod.WinCtrl | KeyCode.KEY_P] }
 });
 
 KeybindingsRegistry.registerCommandDesc({
@@ -122,5 +123,6 @@ KeybindingsRegistry.registerCommandDesc({
 	weight,
 	when: KbExpr.and(KbExpr.has(KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS), KbExpr.has(Context.Visible), KbExpr.has(Context.MultipleSignatures)),
 	primary: KeyCode.DownArrow,
-	secondary: [KeyMod.Alt | KeyCode.DownArrow]
+	secondary: [KeyMod.Alt | KeyCode.DownArrow],
+	mac: { primary: KeyCode.DownArrow, secondary: [KeyMod.Alt | KeyCode.DownArrow, KeyMod.WinCtrl | KeyCode.KEY_N] }
 });

--- a/src/vs/editor/contrib/quickFix/browser/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/browser/quickFix.ts
@@ -153,7 +153,7 @@ CommonEditorRegistry.registerEditorCommand('closeQuickFixWidget', weight, { prim
 	var controller = QuickFixController.getQuickFixController(editor);
 	controller.closeWidget();
 });
-CommonEditorRegistry.registerEditorCommand('selectNextQuickFix', weight, { primary: KeyCode.DownArrow }, false, CONTEXT_QUICK_FIX_WIDGET_VISIBLE,(ctx, editor, args) => {
+CommonEditorRegistry.registerEditorCommand('selectNextQuickFix', weight, { primary: KeyCode.DownArrow , mac: { primary: KeyCode.DownArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_N] } }, false, CONTEXT_QUICK_FIX_WIDGET_VISIBLE,(ctx, editor, args) => {
 	var controller = QuickFixController.getQuickFixController(editor);
 	controller.selectNextSuggestion();
 });
@@ -161,7 +161,7 @@ CommonEditorRegistry.registerEditorCommand('selectNextPageQuickFix', weight, { p
 	var controller = QuickFixController.getQuickFixController(editor);
 	controller.selectNextPageSuggestion();
 });
-CommonEditorRegistry.registerEditorCommand('selectPrevQuickFix', weight, { primary: KeyCode.UpArrow }, false, CONTEXT_QUICK_FIX_WIDGET_VISIBLE,(ctx, editor, args) => {
+CommonEditorRegistry.registerEditorCommand('selectPrevQuickFix', weight, { primary: KeyCode.UpArrow , mac: { primary: KeyCode.UpArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_P] }}, false, CONTEXT_QUICK_FIX_WIDGET_VISIBLE,(ctx, editor, args) => {
 	var controller = QuickFixController.getQuickFixController(editor);
 	controller.selectPrevSuggestion();
 });

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -252,7 +252,8 @@ KeybindingsRegistry.registerCommandDesc({
 	weight,
 	when: KbExpr.and(KbExpr.has(KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS), KbExpr.has(SuggestContext.Visible), KbExpr.has(SuggestContext.MultipleSuggestions)),
 	primary: KeyCode.DownArrow,
-	secondary: [KeyMod.Alt | KeyCode.DownArrow]
+	secondary: [KeyMod.Alt | KeyCode.DownArrow],
+	mac: { primary: KeyCode.DownArrow, secondary: [KeyMod.Alt | KeyCode.DownArrow, KeyMod.WinCtrl | KeyCode.KEY_N] }
 });
 
 KeybindingsRegistry.registerCommandDesc({
@@ -270,7 +271,8 @@ KeybindingsRegistry.registerCommandDesc({
 	weight,
 	when: KbExpr.and(KbExpr.has(KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS), KbExpr.has(SuggestContext.Visible), KbExpr.has(SuggestContext.MultipleSuggestions)),
 	primary: KeyCode.UpArrow,
-	secondary: [KeyMod.Alt | KeyCode.UpArrow]
+	secondary: [KeyMod.Alt | KeyCode.UpArrow],
+	mac: { primary: KeyCode.UpArrow, secondary: [KeyMod.Alt | KeyCode.UpArrow, KeyMod.WinCtrl | KeyCode.KEY_P] }
 });
 
 KeybindingsRegistry.registerCommandDesc({


### PR DESCRIPTION
The same is true for ctrl-p and UpArrow. This fixes that
