### PR TITLE
Fix removal of /usr/bin link when upgrading package

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -43,7 +43,9 @@ sudo ln -s /usr/share/@@NAME@@/bin/@@NAME@@ /usr/bin/@@NAME@@
 #fi
 
 %postun
-sudo rm -f /usr/bin/@@NAME@@
+if [ $1 = 0 ]; then
+  rm -f /usr/bin/@@NAME@@
+fi
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
This should be fix for #5840 (but I've not tested it)
