### PR TITLE
Fixes #7366 Remove leaked breakpoint after stopping with run-to-cursor

### DIFF
--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -257,11 +257,6 @@ export interface IRawDebugSession {
 
 	custom(request: string, args: any): TPromise<DebugProtocol.Response>;
 
-	/**
-	 * Allows to register on each debug session stop event.
-	 */
-	onDidStop: Event<DebugProtocol.StoppedEvent>;
-
 	onDidEvent: Event<DebugProtocol.Event>;
 }
 

--- a/src/vs/workbench/parts/debug/electron-browser/debugActions.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugActions.ts
@@ -557,11 +557,13 @@ export class RunToCursorAction extends EditorAction {
 		const lineNumber = this.editor.getPosition().lineNumber;
 		const uri = this.editor.getModel().uri;
 
-		const oneTimeListener = this.debugService.getActiveSession().onDidStop(() => {
-			const toRemove = this.debugService.getModel().getBreakpoints()
-				.filter(bp => bp.lineNumber === lineNumber && bp.source.uri.toString() === uri.toString()).pop();
-			this.debugService.removeBreakpoints(toRemove.getId());
-			oneTimeListener.dispose();
+		const oneTimeListener = this.debugService.getActiveSession().onDidEvent(event => {
+			if (event.event === 'stopped' || event.event === 'exit') {
+				const toRemove = this.debugService.getModel().getBreakpoints()
+					.filter(bp => bp.lineNumber === lineNumber && bp.source.uri.toString() === uri.toString()).pop();
+				this.debugService.removeBreakpoints(toRemove.getId());
+				oneTimeListener.dispose();
+			}
 		});
 
 		return this.debugService.addBreakpoints([{ uri, lineNumber }]).then(() => {

--- a/src/vs/workbench/parts/debug/test/common/mockDebugService.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebugService.ts
@@ -135,10 +135,6 @@ class MockRawSession implements debug.IRawDebugSession {
 		};
 	}
 
-	public get onDidStop(): Event<DebugProtocol.StoppedEvent> {
-		return null;
-	}
-
 	public get onDidEvent(): Event<DebugProtocol.Event> {
 		return null;
 	}


### PR DESCRIPTION
Add a listener for the `exit` event as well to remove the generated breakpoint in `RunToCursorAction`.

@isidorn @weinand 
