### PR TITLE
Fixes 7369: report RunToCursorAction as not supported when session not stopped

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugActions.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugActions.ts
@@ -585,6 +585,10 @@ export class RunToCursorAction extends EditorAction {
 		// breakpoint must not be on position (no need for this action).
 		return bps.length === 0;
 	}
+
+	public isSupported(): boolean {
+		return super.isSupported() && this.debugService.state === debug.State.Stopped;
+	}
 }
 
 export class AddWatchExpressionAction extends AbstractDebugAction {


### PR DESCRIPTION
Fixes #7369: report `RunToCursorAction` as not supported when session not stopped

Other `DebugAction`s report as not enabled when VSCode is not in the correct state
for the action to run. However, `RunToCursorAction` inherits from `EditorAction`
which relies on an `IEnablementState` to report whether it's enabled, and it's
very specific to `EditorAction`s.

@isidorn
