### PR TITLE
Show warning for a long commit message

### DIFF
--- a/src/vs/workbench/parts/git/browser/views/changes/changesView.ts
+++ b/src/vs/workbench/parts/git/browser/views/changes/changesView.ts
@@ -52,6 +52,7 @@ export class ChangesView extends EventEmitter.EventEmitter implements GitView.IV
 	private static COMMIT_KEYBINDING = Platform.isMacintosh ? 'Cmd+Enter' : 'Ctrl+Enter';
 	private static NEED_MESSAGE = nls.localize('needMessage', "Please provide a commit message. You can always press **{0}** to commit changes. If there are any staged changes, only those will be committed; otherwise, all changes will.", ChangesView.COMMIT_KEYBINDING);
 	private static NOTHING_TO_COMMIT = nls.localize('nothingToCommit', "Once there are some changes to commit, type in the commit message and either press **{0}** to commit changes. If there are any staged changes, only those will be committed; otherwise, all changes will.", ChangesView.COMMIT_KEYBINDING);
+	private static LONG_COMMIT = nls.localize('longCommit', "Great commit summaries are 50 characters or less. Place extra information in next lines.");
 
 	private instantiationService: IInstantiationService;
 	private editorService: IWorkbenchEditorService;
@@ -132,7 +133,15 @@ export class ChangesView extends EventEmitter.EventEmitter implements GitView.IV
 			placeholder: nls.localize('commitMessage', "Message (press {0} to commit)", ChangesView.COMMIT_KEYBINDING),
 			validationOptions: {
 				showMessage: true,
-				validation: (): InputBox.IMessage => null
+				validation: (value): InputBox.IMessage => {
+					if (Strings.trim(value.split('\n')[0]).length > 50) {
+						return {
+							content: ChangesView.LONG_COMMIT,
+							type: InputBox.MessageType.WARNING
+						};
+					}
+					return null;
+				}
 			},
 			ariaLabel: nls.localize('commitMessageAriaLabel', "Git: Type commit message and press {0} to commit", ChangesView.COMMIT_KEYBINDING),
 			flexibleHeight: true


### PR DESCRIPTION
fixes #7138
50 characters limit is hardcoded, should it be a configurable setting?
