### PR TITLE
Added .dsql and .psql filetypes

### DIFF
--- a/extensions/sql/syntaxes/SQL.plist
+++ b/extensions/sql/syntaxes/SQL.plist
@@ -7,6 +7,8 @@
 		<string>sql</string>
 		<string>ddl</string>
 		<string>dml</string>
+		<string>dsql</string>
+		<string>psql</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~S</string>


### PR DESCRIPTION
.psql - It appears this is used by PostgreSQL
.dsql - this is used by Microsoft's very own SQL Studio Tools when working with APS/PDW
