### PR TITLE
Fix extract when fileName is a directory

### DIFF
--- a/src/vs/base/node/zip.ts
+++ b/src/vs/base/node/zip.ts
@@ -38,6 +38,11 @@ function extractEntry(stream: Readable, fileName: string, mode: number, targetPa
 	const dirName = path.dirname(fileName);
 	const targetDirName = path.join(targetPath, dirName);
 	const targetFileName = path.join(targetPath, fileName);
+	
+	// directory file names end with '/'
+	if (/\/$/.test(fileName)) {
+        return mkdirp(targetFileName);
+    }
 
 	return mkdirp(targetDirName).then(() => new Promise((c, e) => {
 		let istream = createWriteStream(targetFileName, { mode });


### PR DESCRIPTION
See https://github.com/thejoshwolfe/yauzl/blob/master/README.md

```
  zipfile.on("entry", function(entry) {
    if (/\/$/.test(entry.fileName)) {
      // directory file names end with '/'
      mkdirp(entry.fileName, function(err) {
        if (err) throw err;
        zipfile.readEntry();
      });
    } else {
      ......
    }
  };
```

If `entry.fileName` is a directory name, extracting will be failed.

Here is a test file.
https://github.com/f111fei/test-files/raw/master/test.zip

The case has `4` entries.

```
/
/1/
/1/2/
/1/2/README.md
```
