### PR TITLE
Ignore IntelliJ IDE directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out-monaco-editor-core/
 out-vscode/
 out-vscode-min/
 build/node_modules
+.idea/


### PR DESCRIPTION
This way we don't accidentally pull IntelliJ stuff into github.
