### PR TITLE
menu bar extensions

### DIFF
--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -18,8 +18,10 @@ export interface ResourceFilter {
 	pattern?: string;
 }
 
+export type Where = 'editor/primary' | 'editor/secondary' | 'context';
+
 export interface Context {
-	where: 'editor/primary' | 'editor/secondary';
+	where: Where;
 	when: string | string[] | ResourceFilter | ResourceFilter[];
 }
 
@@ -69,8 +71,8 @@ namespace validation {
 		if (!context) {
 			return true;
 		}
-		if (context.where !== 'editor/primary' && context.where !== 'editor/secondary') {
-			rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`"));
+		if (context.where !== 'editor/primary' && context.where !== 'editor/secondary' && context.where !== 'context/explorer') {
+			rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`, or `context/explorer`"));
 			return false;
 		}
 		if (typeof context.when !== 'object' && typeof context.when !== 'string' && !Array.isArray(context.when)) {

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -18,7 +18,7 @@ export interface ResourceFilter {
 }
 
 export interface Context {
-	path: 'editor/primary' | 'editor/secondary';
+	where: 'editor/primary' | 'editor/secondary';
 	when: string | string[] | ResourceFilter | ResourceFilter[];
 }
 
@@ -41,8 +41,8 @@ function isValidContext(context: Context, rejects: string[]): boolean {
 	if (!context) {
 		return true;
 	}
-	if (context.path !== 'editor/primary' && context.path !== 'editor/secondary') {
-		rejects.push(localize('requireenumtype', "property `path` is mandatory and must be one of `editor/primary`, `editor/secondary`"));
+	if (context.where !== 'editor/primary' && context.where !== 'editor/secondary') {
+		rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`"));
 		return false;
 	}
 	if (typeof context.when !== 'object' && typeof context.when !== 'string' && !Array.isArray(context.when)) {
@@ -103,7 +103,7 @@ const filterType: IJSONSchema = {
 const contextType: IJSONSchema = {
 	type: 'object',
 	properties: {
-		path: {
+		where: {
 			description: localize('vscode.extension.contributes.commandType.context.path', ""),
 			enum: [
 				'editor/primary',

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -42,7 +42,7 @@ function isValidContext(context: Context, rejects: string[]): boolean {
 		rejects.push(localize('requireenumtype', "property `path` is mandatory and must be one of `editor/primary`, `editor/secondary`"));
 		return false;
 	}
-	if (typeof context.when !== 'object') {
+	if (typeof context.when !== 'object' && typeof context.when !== 'string' && !Array.isArray(context.when)) {
 		rejects.push(localize('requirefilter', "property `when` is mandatory and must be like `{language, scheme, pattern}`"));
 		return false;
 	}
@@ -79,7 +79,46 @@ function isValidCommand(candidate: Command, rejects: string[]): boolean {
 	return true;
 }
 
-let commandType: IJSONSchema = {
+const filterType: IJSONSchema = {
+	type: 'object',
+	properties: {
+		language: {
+			description: localize('vscode.extension.contributes.filterType.language', ""),
+			type: 'string'
+		},
+		scheme: {
+			description: localize('vscode.extension.contributes.filterType.scheme', ""),
+			type: 'string'
+		},
+		pattern: {
+			description: localize('vscode.extension.contributes.filterType.pattern', ""),
+			type: 'string'
+		}
+	}
+};
+
+const contextType: IJSONSchema = {
+	type: 'object',
+	properties: {
+		path: {
+			description: localize('vscode.extension.contributes.commandType.context.path', ""),
+			enum: [
+				'editor/primary',
+				'editor/secondary'
+			]
+		},
+		when: {
+			anyOf: [
+				'string',
+				filterType,
+				{ type: 'array', items: 'string' },
+				{ type: 'array', items: filterType },
+			]
+		}
+	}
+};
+
+const commandType: IJSONSchema = {
 	type: 'object',
 	properties: {
 		command: {
@@ -93,6 +132,13 @@ let commandType: IJSONSchema = {
 		category: {
 			description: localize('vscode.extension.contributes.commandType.category', '(Optional) category string by the command is grouped in the UI'),
 			type: 'string'
+		},
+		context: {
+			description: localize('vscode.extension.contributes.commandType.context', '(Optional) '),
+			oneOf: [
+				contextType,
+				{ type: 'array', items: contextType }
+			]
 		}
 	}
 };

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import {localize} from 'vs/nls';
+import {Action} from 'vs/base/common/actions';
 import {IJSONSchema} from 'vs/base/common/jsonSchema';
 import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
@@ -189,18 +190,17 @@ ExtensionsRegistry.registerExtensionPoint<Command | Command[]>('commands', {
 });
 
 
-export function run(command: Command, extensionService: IExtensionService, keybindingService: IKeybindingService) {
-	return createCommandRunner(command, extensionService, keybindingService)();
-}
-
-export function createCommandRunner(command: Command, extensionService: IExtensionService, keybindingService: IKeybindingService) {
+export function createAction(command: Command, extensionService: IExtensionService, keybindingService: IKeybindingService): Action {
 
 	const activationEvent = `onCommand:${command.command}`;
 
-	return (...args: any[]) => {
-		// action that (1) activates the extension and (2) dispatches the command
-		return extensionService.activateByEvent(activationEvent).then(() => {
-			return keybindingService.executeCommand(command.command);
-		});
-	};
+	return new Action(command.command, command.title,
+		void 0, true,
+		(...args: any[]) => {
+			// action that (1) activates the extension and (2) dispatches the command
+			return extensionService.activateByEvent(activationEvent).then(() => {
+				return keybindingService.executeCommand(command.command);
+			});
+		}
+	);
 }

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -273,7 +273,7 @@ export class CommandAction extends Action {
 		const activationEvent = `onCommand:${command.command}`;
 		this._actionCallback = (...args: any[]) => {
 			return extensionService.activateByEvent(activationEvent).then(() => {
-				return keybindingService.executeCommand(command.command);
+				return keybindingService.executeCommand(command.command, ...args);
 			});
 		};
 	}

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -71,8 +71,8 @@ namespace validation {
 		if (!context) {
 			return true;
 		}
-		if (context.where !== 'editor/primary' && context.where !== 'editor/secondary' && context.where !== 'context/explorer') {
-			rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`, or `context/explorer`"));
+		if (context.where !== 'editor/primary' && context.where !== 'editor/secondary' && context.where !== 'explorer/context') {
+			rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`, or `explorer/context`"));
 			return false;
 		}
 		if (typeof context.when !== 'object' && typeof context.when !== 'string' && !Array.isArray(context.when)) {

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -6,8 +6,9 @@
 
 import {localize} from 'vs/nls';
 import {Action} from 'vs/base/common/actions';
+import {join} from 'vs/base/common/paths';
 import {IJSONSchema} from 'vs/base/common/jsonSchema';
-import {IExtensionService} from 'vs/platform/extensions/common/extensions';
+import {IExtensionService, IExtensionDescription} from 'vs/platform/extensions/common/extensions';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
 import {IExtensionMessageCollector, ExtensionsRegistry} from 'vs/platform/extensions/common/extensionsRegistry';
 
@@ -22,136 +23,215 @@ export interface Context {
 	when: string | string[] | ResourceFilter | ResourceFilter[];
 }
 
+export interface ThemableIcon {
+	dark: string;
+	light: string;
+}
+
+
 export interface Command {
 	command: string;
 	title: string;
 	category?: string;
+	icon?: string | ThemableIcon;
 	context?: Context | Context[];
+}
+
+function isThemableIcon(thing: any): thing is ThemableIcon {
+	return typeof thing === 'object' && thing && typeof (<ThemableIcon>thing).dark === 'string' && typeof (<ThemableIcon>thing).light === 'string';
 }
 
 function isCommands(thing: Command | Command[]): thing is Command[] {
 	return Array.isArray(thing);
 }
-
 function isContexts(thing: Context | Context[]): thing is Context[] {
 	return Array.isArray(thing);
 }
 
-function isValidContext(context: Context, rejects: string[]): boolean {
-	if (!context) {
-		return true;
-	}
-	if (context.where !== 'editor/primary' && context.where !== 'editor/secondary') {
-		rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`"));
-		return false;
-	}
-	if (typeof context.when !== 'object' && typeof context.when !== 'string' && !Array.isArray(context.when)) {
-		rejects.push(localize('requirefilter', "property `when` is mandatory and must be like `{language, scheme, pattern}`"));
-		return false;
-	}
-	return true;
-}
+namespace validation {
 
-function isValidCommand(candidate: Command, rejects: string[]): boolean {
-	if (!candidate) {
-		rejects.push(localize('nonempty', "expected non-empty value."));
+
+	function isValidIcon(icon: string | ThemableIcon, reject: string[]): boolean {
+		if (typeof icon === 'undefined') {
+			return true;
+		}
+		if (typeof icon === 'string') {
+			return true;
+		}
+		if (typeof icon === 'object' && typeof (<ThemableIcon>icon).dark === 'string' && typeof (<ThemableIcon>icon).light === 'string') {
+			return true;
+		}
+		reject.push(localize('opticon', "property `icon` can be omitted or must be either a string or a literal like `{dark, light}`"));
 		return false;
 	}
-	if (typeof candidate.command !== 'string') {
-		rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'command'));
-		return false;
-	}
-	if (typeof candidate.title !== 'string') {
-		rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'title'));
-		return false;
-	}
-	if (candidate.category && typeof candidate.category !== 'string') {
-		rejects.push(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'category'));
-		return false;
-	}
-	if (candidate.context) {
-		let {context} = candidate;
-		if (isContexts(context)) {
-			if (!context.every(context => isValidContext(context, rejects))) {
-				return false;
-			}
-		} else if (!isValidContext(context, rejects)) {
+
+	function isValidContext(context: Context, rejects: string[]): boolean {
+		if (!context) {
+			return true;
+		}
+		if (context.where !== 'editor/primary' && context.where !== 'editor/secondary') {
+			rejects.push(localize('requireenumtype', "property `where` is mandatory and must be one of `editor/primary`, `editor/secondary`"));
 			return false;
 		}
+		if (typeof context.when !== 'object' && typeof context.when !== 'string' && !Array.isArray(context.when)) {
+			rejects.push(localize('requirefilter', "property `when` is mandatory and must be like `{language, scheme, pattern}`"));
+			return false;
+		}
+		return true;
 	}
-	return true;
+
+	export function isValidCommand(candidate: Command, rejects: string[]): boolean {
+		if (!candidate) {
+			rejects.push(localize('nonempty', "expected non-empty value."));
+			return false;
+		}
+		if (typeof candidate.command !== 'string') {
+			rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'command'));
+			return false;
+		}
+		if (typeof candidate.title !== 'string') {
+			rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'title'));
+			return false;
+		}
+		if (candidate.category && typeof candidate.category !== 'string') {
+			rejects.push(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'category'));
+			return false;
+		}
+		if (!isValidIcon(candidate.icon, rejects)) {
+			return false;
+		}
+		if (candidate.context) {
+			let {context} = candidate;
+			if (isContexts(context)) {
+				if (!context.every(context => isValidContext(context, rejects))) {
+					return false;
+				}
+			} else if (!isValidContext(context, rejects)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 }
 
-const filterType: IJSONSchema = {
-	type: 'object',
-	properties: {
-		language: {
-			description: localize('vscode.extension.contributes.filterType.language', ""),
-			type: 'string'
-		},
-		scheme: {
-			description: localize('vscode.extension.contributes.filterType.scheme', ""),
-			type: 'string'
-		},
-		pattern: {
-			description: localize('vscode.extension.contributes.filterType.pattern', ""),
-			type: 'string'
-		}
-	}
-};
 
-const contextType: IJSONSchema = {
-	type: 'object',
-	properties: {
-		where: {
-			description: localize('vscode.extension.contributes.commandType.context.path', ""),
-			enum: [
-				'editor/primary',
-				'editor/secondary'
-			]
-		},
-		when: {
-			anyOf: [
-				'string',
-				filterType,
-				{ type: 'array', items: 'string' },
-				{ type: 'array', items: filterType },
-			]
-		}
-	}
-};
+namespace schema {
 
-const commandType: IJSONSchema = {
-	type: 'object',
-	properties: {
-		command: {
-			description: localize('vscode.extension.contributes.commandType.command', 'Identifier of the command to execute'),
-			type: 'string'
-		},
-		title: {
-			description: localize('vscode.extension.contributes.commandType.title', 'Title by which the command is represented in the UI'),
-			type: 'string'
-		},
-		category: {
-			description: localize('vscode.extension.contributes.commandType.category', '(Optional) category string by the command is grouped in the UI'),
-			type: 'string'
-		},
-		context: {
-			description: localize('vscode.extension.contributes.commandType.context', '(Optional) '),
-			oneOf: [
-				contextType,
-				{ type: 'array', items: contextType }
-			]
+	const filterType: IJSONSchema = {
+		type: 'object',
+		properties: {
+			language: {
+				description: localize('vscode.extension.contributes.filterType.language', ""),
+				type: 'string'
+			},
+			scheme: {
+				description: localize('vscode.extension.contributes.filterType.scheme', ""),
+				type: 'string'
+			},
+			pattern: {
+				description: localize('vscode.extension.contributes.filterType.pattern', ""),
+				type: 'string'
+			}
 		}
-	}
-};
+	};
 
-function handleCommand(command: Command, collector: IExtensionMessageCollector): void {
+	const contextType: IJSONSchema = {
+		type: 'object',
+		properties: {
+			where: {
+				description: localize('vscode.extension.contributes.commandType.context.where', "Menus and tool bars to which commands can be added, e.g. `editor title actions` or `explorer context menu`"),
+				enum: [
+					'editor/primary',
+					'editor/secondary'
+				]
+			},
+			when: {
+				description: localize('vscode.extension.contributes.commandType.context.when', "Condition that must be met in order to show the command. Can be a language identifier, a glob-pattern, an uri scheme, or a combination of them."),
+				anyOf: [
+					'string',
+					filterType,
+					{ type: 'array', items: 'string' },
+					{ type: 'array', items: filterType },
+				]
+			}
+		}
+	};
+
+	const commandType: IJSONSchema = {
+		type: 'object',
+		properties: {
+			command: {
+				description: localize('vscode.extension.contributes.commandType.command', 'Identifier of the command to execute'),
+				type: 'string'
+			},
+			title: {
+				description: localize('vscode.extension.contributes.commandType.title', 'Title by which the command is represented in the UI'),
+				type: 'string'
+			},
+			category: {
+				description: localize('vscode.extension.contributes.commandType.category', '(Optional) Category string by the command is grouped in the UI'),
+				type: 'string'
+			},
+			icon: {
+				description: localize('vscode.extension.contributes.commandType.icon', '(Optional) Icon which is used to represent the command in the UI. Either a file path or a themable configuration'),
+				oneOf: [
+					'string',
+					{
+						type: 'object',
+						properties: {
+							light: {
+								description: localize('vscode.extension.contributes.commandType.icon.light', 'Icon path when a light theme is used'),
+								type: 'string'
+							},
+							dark: {
+								description: localize('vscode.extension.contributes.commandType.icon.dark', 'Icon path when a dark theme is used'),
+								type: 'string'
+							}
+						}
+					}
+				]
+			},
+			context: {
+				description: localize('vscode.extension.contributes.commandType.context', '(Optional) Define places where the command should show in addition to the Command palette'),
+				oneOf: [
+					contextType,
+					{ type: 'array', items: contextType }
+				]
+			}
+		}
+	};
+
+	export const commandContribution: IJSONSchema = {
+		description: localize('vscode.extension.contributes.commands', "Contributes commands to the command palette."),
+		oneOf: [
+			commandType,
+			{
+				type: 'array',
+				items: commandType
+			}
+		]
+	};
+}
+
+export const commands: Command[] = [];
+
+function handleCommand(command: Command, collector: IExtensionMessageCollector, description: IExtensionDescription): void {
 
 	let rejects: string[] = [];
 
-	if (isValidCommand(command, rejects)) {
-		// keep command
+	if (validation.isValidCommand(command, rejects)) {
+
+		// make icon paths absolute
+		let {icon} = command;
+		if (typeof icon === 'string') {
+			command.icon = join(description.extensionFolderPath, icon);
+		} else if(isThemableIcon(icon)) {
+			icon.dark = join(description.extensionFolderPath, icon.dark);
+			icon.light = join(description.extensionFolderPath, icon.light);
+		}
+
+		// store command globally
 		commands.push(command);
 
 	} else if (rejects.length > 0) {
@@ -163,44 +243,36 @@ function handleCommand(command: Command, collector: IExtensionMessageCollector):
 	}
 }
 
-export const commands: Command[] = [];
-
-ExtensionsRegistry.registerExtensionPoint<Command | Command[]>('commands', {
-	description: localize('vscode.extension.contributes.commands', "Contributes commands to the command palette."),
-	oneOf: [
-		commandType,
-		{
-			type: 'array',
-			items: commandType
-		}
-	]
-}).setHandler(extensions => {
+ExtensionsRegistry.registerExtensionPoint<Command | Command[]>('commands', schema.commandContribution).setHandler(extensions => {
 	for (let extension of extensions) {
-		const {value, collector} = extension;
+		const {value, collector, description} = extension;
 		if (isCommands(value)) {
 			for (let command of value) {
-				handleCommand(command, collector);
+				handleCommand(command, collector, description);
 			}
 		} else {
-			handleCommand(value, collector);
+			handleCommand(value, collector, description);
 		}
 	}
 
 	Object.freeze(commands);
 });
 
+export class CommandAction extends Action {
 
-export function createAction(command: Command, extensionService: IExtensionService, keybindingService: IKeybindingService): Action {
+	constructor(
+		public command: Command,
+		@IExtensionService extensionService: IExtensionService,
+		@IKeybindingService keybindingService: IKeybindingService
+	) {
+		super(command.command, command.title);
 
-	const activationEvent = `onCommand:${command.command}`;
-
-	return new Action(command.command, command.title,
-		void 0, true,
-		(...args: any[]) => {
-			// action that (1) activates the extension and (2) dispatches the command
+		// callback that (1) activates the extension and (2) dispatches the command
+		const activationEvent = `onCommand:${command.command}`;
+		this._actionCallback = (...args: any[]) => {
 			return extensionService.activateByEvent(activationEvent).then(() => {
 				return keybindingService.executeCommand(command.command);
 			});
-		}
-	);
+		};
+	}
 }

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -18,7 +18,7 @@ export interface ResourceFilter {
 	pattern?: string;
 }
 
-export type Where = 'editor/primary' | 'editor/secondary' | 'context';
+export type Where = 'editor/primary' | 'editor/secondary' | 'explorer/context';
 
 export interface Context {
 	where: Where;

--- a/src/vs/platform/actions/common/commandsExtensionPoint.ts
+++ b/src/vs/platform/actions/common/commandsExtensionPoint.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import {localize} from 'vs/nls';
+import {IJSONSchema} from 'vs/base/common/jsonSchema';
+import {IExtensionMessageCollector, ExtensionsRegistry} from 'vs/platform/extensions/common/extensionsRegistry';
+
+export interface Command {
+	command: string;
+	title: string;
+	category?: string;
+}
+
+function isCommands(thing: Command | Command[]): thing is Command[] {
+	return Array.isArray(thing);
+}
+
+function isValidCommand(candidate: Command, rejects: string[]): boolean {
+	if (!candidate) {
+		rejects.push(localize('nonempty', "expected non-empty value."));
+		return false;
+	}
+	if (typeof candidate.command !== 'string') {
+		rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'command'));
+		return false;
+	}
+	if (typeof candidate.title !== 'string') {
+		rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'title'));
+		return false;
+	}
+	if (candidate.category && typeof candidate.category !== 'string') {
+		rejects.push(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'category'));
+		return false;
+	}
+	return true;
+}
+
+let commandType: IJSONSchema = {
+	type: 'object',
+	properties: {
+		command: {
+			description: localize('vscode.extension.contributes.commandType.command', 'Identifier of the command to execute'),
+			type: 'string'
+		},
+		title: {
+			description: localize('vscode.extension.contributes.commandType.title', 'Title by which the command is represented in the UI'),
+			type: 'string'
+		},
+		category: {
+			description: localize('vscode.extension.contributes.commandType.category', '(Optional) category string by the command is grouped in the UI'),
+			type: 'string'
+		}
+	}
+};
+
+function handleCommand(command: Command, collector: IExtensionMessageCollector): void {
+
+	let rejects: string[] = [];
+
+	if (isValidCommand(command, rejects)) {
+		// keep command
+		commands.push(command);
+
+	} else if (rejects.length > 0) {
+		collector.error(localize(
+			'error',
+			"Invalid `contributes.commands`: {0}",
+			rejects.join('\n')
+		));
+	}
+}
+
+export const commands: Command[] = [];
+
+ExtensionsRegistry.registerExtensionPoint<Command | Command[]>('commands', {
+	description: localize('vscode.extension.contributes.commands', "Contributes commands to the command palette."),
+	oneOf: [
+		commandType,
+		{
+			type: 'array',
+			items: commandType
+		}
+	]
+}).setHandler(extensions => {
+	for (let extension of extensions) {
+		const {value, collector} = extension;
+		if (isCommands(value)) {
+			for (let command of value) {
+				handleCommand(command, collector);
+			}
+		} else {
+			handleCommand(value, collector);
+		}
+	}
+
+	Object.freeze(commands);
+});

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -7,7 +7,8 @@
 
 import {Registry} from 'vs/platform/platform';
 import URI from 'vs/base/common/uri';
-import {IAction} from 'vs/base/common/actions';
+import {IAction, Action} from 'vs/base/common/actions';
+import {BaseActionItem, ActionItem} from 'vs/base/browser/ui/actionbar/actionbar';
 import {Scope, IActionBarRegistry, Extensions, ActionBarContributor} from 'vs/workbench/browser/actionBarRegistry';
 import {IActionsService} from 'vs/platform/actions/common/actions';
 import {IModeService} from 'vs/editor/common/services/modeService';
@@ -60,7 +61,9 @@ class Contributor extends ActionBarContributor {
 	}
 
 	private _getResource(context: any): URI {
-		return getUntitledOrFileResource(context.input, true);
+		if (context.input  !== void 0 && context.editor  !== void 0 && context.position !== void 0 ) {
+			return getUntitledOrFileResource(context.input, true);
+		}
 	}
 
 	private _getCommandIds(resource: URI, path: string): string[] {
@@ -83,6 +86,18 @@ class Contributor extends ActionBarContributor {
 			const language = this._modeService.getModeIdByFilenameOrFirstLine(resource.fsPath);
 			return matches(context.when, resource, language);
 		}
+	}
+
+	public getActionItem(context: any, action: Action): BaseActionItem {
+		const uri = this._getResource(context);
+		return new CommandItem(uri, action);
+	}
+}
+
+class CommandItem extends ActionItem {
+
+	constructor(context: any, action: IAction) {
+		super(context, action, { icon: !!action.class, label: !action.class });
 	}
 }
 

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -15,7 +15,7 @@ import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IThemeService} from 'vs/workbench/services/themes/common/themeService';
 import {isLightTheme} from 'vs/platform/theme/common/themes';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
-import {commands, Context, Where, CommandAction} from '../common/commandsExtensionPoint';
+import {commands, Command, Context, Where, CommandAction} from '../common/commandsExtensionPoint';
 import matches from 'vs/editor/common/modes/languageSelector';
 import {getUntitledOrFileResource} from 'vs/workbench/common/editor';
 
@@ -64,10 +64,10 @@ abstract class BaseActionBarContributor extends ActionBarContributor {
 			const {context} = command;
 			if (Array.isArray(context)) {
 				if (context.some(context => this._matches(context, resource, where))) {
-					result.push(new CommandAction(command, this._extensionService, this._keybindingsService));
+					result.push(this._createAction(command, resource));
 				}
 			} else if (context && this._matches(context, resource, where)) {
-				result.push(new CommandAction(command, this._extensionService, this._keybindingsService));
+				result.push(this._createAction(command, resource));
 			}
 		}
 		return result;
@@ -86,6 +86,17 @@ abstract class BaseActionBarContributor extends ActionBarContributor {
 			const uri = this._getResource(context);
 			return new CommandItem(uri, action, this._themeService);
 		}
+	}
+
+	private _createAction(command: Command, context: URI): CommandAction {
+		return new class extends CommandAction {
+			run() {
+				// TODO@joh,ben This is a workaround for the actionbar
+				// overwriting the context of the action item
+				return super.run(context);
+			}
+
+		}(command, this._extensionService, this._keybindingsService);
 	}
 }
 

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -104,7 +104,7 @@ class EditorContributor extends BaseActionBarContributor {
 class ContextMenuContributor extends BaseActionBarContributor {
 
 	protected _wheres(): { primary: Where; secondary: Where } {
-		return { secondary: 'context', primary: undefined };
+		return { secondary: 'explorer/context', primary: undefined };
 	}
 
 	protected _getResource(context: any): URI {

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -80,8 +80,10 @@ class Contributor extends ActionBarContributor {
 	}
 
 	public getActionItem(context: any, action: Action): BaseActionItem {
-		const uri = this._getResource(context);
-		return new CommandItem(uri, action);
+		if (this.hasActions(context)) {
+			const uri = this._getResource(context);
+			return new CommandItem(uri, action);
+		}
 	}
 }
 

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -43,10 +43,10 @@ class Contributor extends ActionBarContributor {
 		return this._getActions(context, 'editor/secondary');
 	}
 
-	private _getActions(context: any, path: string): IAction[]{
+	private _getActions(context: any, where: string): IAction[]{
 		const uri = this._getResource(context);
 		if (uri) {
-			return this._getCommandActions(uri, path);
+			return this._getCommandActions(uri, where);
 		}
 		return [];
 	}
@@ -57,26 +57,27 @@ class Contributor extends ActionBarContributor {
 		}
 	}
 
-	private _getCommandActions(resource: URI, path: string): IAction[] {
+	private _getCommandActions(resource: URI, where: string): IAction[] {
 		const result: IAction[] = [];
 		for (let command of commands) {
 			const {context} = command;
 			if (Array.isArray(context)) {
-				if (context.some(context => this._matches(context, resource, path))) {
+				if (context.some(context => this._matches(context, resource, where))) {
 					result.push(createAction(command, this._extensionService, this._keybindingsService));
 				}
-			} else if (context && this._matches(context, resource, path)) {
+			} else if (context && this._matches(context, resource, where)) {
 				result.push(createAction(command, this._extensionService, this._keybindingsService));
 			}
 		}
 		return result;
 	}
 
-	private _matches(context: Context, resource: URI, path: string): boolean {
-		if (context.path === path) {
-			const language = this._modeService.getModeIdByFilenameOrFirstLine(resource.fsPath);
-			return matches(context.when, resource, language);
+	private _matches(context: Context, resource: URI, where: string): boolean {
+		if (context.where !== where) {
+			return false;
 		}
+		const language = this._modeService.getModeIdByFilenameOrFirstLine(resource.fsPath);
+		return matches(context.when, resource, language);
 	}
 
 	public getActionItem(context: any, action: Action): BaseActionItem {

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import {Registry} from 'vs/platform/platform';
+import URI from 'vs/base/common/uri';
+import {IAction} from 'vs/base/common/actions';
+import {Scope, IActionBarRegistry, Extensions, ActionBarContributor} from 'vs/workbench/browser/actionBarRegistry';
+import {IActionsService} from 'vs/platform/actions/common/actions';
+import {IModeService} from 'vs/editor/common/services/modeService';
+import {commands, Context} from '../common/commandsExtensionPoint';
+import matches from 'vs/editor/common/modes/languageSelector';
+import {getUntitledOrFileResource} from 'vs/workbench/common/editor';
+
+class Contributor extends ActionBarContributor {
+
+	constructor(
+		@IModeService private _modeService: IModeService,
+		@IActionsService private _actionsService: IActionsService
+	) {
+		super();
+	}
+
+	public hasActions(context: any): boolean {
+		return this.getActions(context).length > 0;
+	}
+
+	public getActions(context: any): IAction[] {
+		return this._getActions(context, 'editor/primary');
+	}
+
+	public hasSecondaryActions(context: any): boolean {
+		return this.getSecondaryActions(context).length > 0;
+	}
+
+	public getSecondaryActions(context: any): IAction[] {
+		return this._getActions(context, 'editor/secondary');
+	}
+
+	private _getActions(context: any, path: string): IAction[]{
+		const uri = this._getResource(context);
+		if (!uri) {
+			return [];
+		}
+		const ids = this._getCommandIds(uri, path);
+		const actions: { [id: string]: IAction } = Object.create(null);
+		const result: IAction[] = [];
+		for (let action of this._actionsService.getActions()) {
+			actions[action.id] = action;
+		}
+		for (let id of ids) {
+			if (actions[id]) {
+				result.push(actions[id]);
+			}
+		}
+		return result;
+	}
+
+	private _getResource(context: any): URI {
+		return getUntitledOrFileResource(context.input, true);
+	}
+
+	private _getCommandIds(resource: URI, path: string): string[] {
+		const result: string[] = [];
+		for (let command of commands) {
+			const {context} = command;
+			if (Array.isArray(context)) {
+				if (context.some(context => this._matches(context, resource, path))) {
+					result.push(command.command);
+				}
+			} else if (context && this._matches(context, resource, path)) {
+				result.push(command.command);
+			}
+		}
+		return result;
+	}
+
+	private _matches(context: Context, resource: URI, path: string): boolean {
+		if (context.path === path) {
+			const language = this._modeService.getModeIdByFilenameOrFirstLine(resource.fsPath);
+			return matches(context.when, resource, language);
+		}
+	}
+}
+
+Registry.as<IActionBarRegistry>(Extensions.Actionbar).registerActionBarContributor(Scope.EDITOR, Contributor);

--- a/src/vs/platform/actions/workbench/actionBarContributions.ts
+++ b/src/vs/platform/actions/workbench/actionBarContributions.ts
@@ -12,8 +12,10 @@ import {BaseActionItem, ActionItem} from 'vs/base/browser/ui/actionbar/actionbar
 import {Scope, IActionBarRegistry, Extensions, ActionBarContributor} from 'vs/workbench/browser/actionBarRegistry';
 import {IModeService} from 'vs/editor/common/services/modeService';
 import {IExtensionService} from 'vs/platform/extensions/common/extensions';
+import {IThemeService} from 'vs/workbench/services/themes/common/themeService';
+import {isLightTheme} from 'vs/platform/theme/common/themes';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
-import {commands, Context, createAction} from '../common/commandsExtensionPoint';
+import {commands, Context, CommandAction} from '../common/commandsExtensionPoint';
 import matches from 'vs/editor/common/modes/languageSelector';
 import {getUntitledOrFileResource} from 'vs/workbench/common/editor';
 
@@ -22,7 +24,8 @@ class Contributor extends ActionBarContributor {
 	constructor(
 		@IModeService private _modeService: IModeService,
 		@IExtensionService private _extensionService: IExtensionService,
-		@IKeybindingService private _keybindingsService: IKeybindingService
+		@IKeybindingService private _keybindingsService: IKeybindingService,
+		@IThemeService private _themeService: IThemeService
 	) {
 		super();
 	}
@@ -63,10 +66,10 @@ class Contributor extends ActionBarContributor {
 			const {context} = command;
 			if (Array.isArray(context)) {
 				if (context.some(context => this._matches(context, resource, where))) {
-					result.push(createAction(command, this._extensionService, this._keybindingsService));
+					result.push(new CommandAction(command, this._extensionService, this._keybindingsService));
 				}
 			} else if (context && this._matches(context, resource, where)) {
-				result.push(createAction(command, this._extensionService, this._keybindingsService));
+				result.push(new CommandAction(command, this._extensionService, this._keybindingsService));
 			}
 		}
 		return result;
@@ -81,17 +84,50 @@ class Contributor extends ActionBarContributor {
 	}
 
 	public getActionItem(context: any, action: Action): BaseActionItem {
-		if (this.hasActions(context)) {
+		if (action instanceof CommandAction) {
 			const uri = this._getResource(context);
-			return new CommandItem(uri, action);
+			return new CommandItem(uri, action, this._themeService);
 		}
 	}
 }
 
 class CommandItem extends ActionItem {
 
-	constructor(context: any, action: IAction) {
-		super(context, action, { icon: !!action.class, label: !action.class });
+	constructor(
+		context: any,
+		action: CommandAction,
+		@IThemeService private _themeService: IThemeService
+	) {
+		super(context, action, { icon: Boolean(action.command.icon), label: !Boolean(action.command.icon) });
+
+		if (typeof action.command.icon === 'object') {
+			this._themeService.onDidThemeChange(this._updateIcon, this, this.callOnDispose);
+		}
+	}
+
+	_updateClass(): void {
+		super._updateClass();
+		this._updateIcon();
+	}
+
+	private _updateIcon(): void {
+		const element = this.$e.getHTMLElement();
+
+		const {command: {icon}} = <CommandAction>this._action;
+		let iconUri: string;
+
+		if (element.classList.contains('icon')) {
+			if (!icon) {
+				return;
+			} else if (typeof icon === 'string') {
+				iconUri = icon;
+			} else {
+				iconUri = isLightTheme(this._themeService.getTheme())
+					? icon.light
+					: icon.dark;
+			}
+			element.style.backgroundImage = `url("${iconUri}")`;
+		}
 	}
 }
 

--- a/src/vs/platform/actions/workbench/actionsService.ts
+++ b/src/vs/platform/actions/workbench/actionsService.ts
@@ -5,11 +5,11 @@
 'use strict';
 
 import {localize} from 'vs/nls';
-import {Action, IAction} from 'vs/base/common/actions';
+import {IAction} from 'vs/base/common/actions';
 import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
 import {IActionsService} from '../common/actions';
-import {commands, createCommandRunner} from '../common/commandsExtensionPoint';
+import {commands, createAction} from '../common/commandsExtensionPoint';
 import 'vs/platform/actions/workbench/actionBarContributions';
 
 export default class ActionsService implements IActionsService {
@@ -31,13 +31,11 @@ export default class ActionsService implements IActionsService {
 			this._extensionsActions = [];
 			for (let command of commands) {
 
-				const runner = createCommandRunner(command, this._extensionService, this._keybindingsService);
-				const label = command.category
+				const action = createAction(command, this._extensionService, this._keybindingsService);
+				action.order = Number.MAX_VALUE;
+				action.label = command.category
 					? localize('category.label', "{0}: {1}", command.category, command.title)
 					: command.title;
-
-				const action = new Action(command.command, label, undefined, true, runner);
-				action.order = Number.MAX_VALUE;
 
 				this._extensionsActions.push(action);
 			}

--- a/src/vs/platform/actions/workbench/actionsService.ts
+++ b/src/vs/platform/actions/workbench/actionsService.ts
@@ -6,79 +6,16 @@
 
 import {localize} from 'vs/nls';
 import {Action, IAction} from 'vs/base/common/actions';
-import {IJSONSchema} from 'vs/base/common/jsonSchema';
 import {IExtensionService} from 'vs/platform/extensions/common/extensions';
-import {IExtensionMessageCollector, ExtensionsRegistry} from 'vs/platform/extensions/common/extensionsRegistry';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
 import {IActionsService} from '../common/actions';
-
-interface Commands {
-	commands: Command | Command[];
-}
-
-interface Command {
-	command: string;
-	title: string;
-	category?: string;
-}
-
-function isCommands(thing: Command | Command[]): thing is Command[] {
-	return Array.isArray(thing);
-}
-
-function isValidCommand(candidate: Command, rejects: string[]): boolean {
-	if (!candidate) {
-		rejects.push(localize('nonempty', "expected non-empty value."));
-		return false;
-	}
-	if (typeof candidate.command !== 'string') {
-		rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'command'));
-		return false;
-	}
-	if (typeof candidate.title !== 'string') {
-		rejects.push(localize('requirestring', "property `{0}` is mandatory and must be of type `string`", 'title'));
-		return false;
-	}
-	if (candidate.category && typeof candidate.category !== 'string') {
-		rejects.push(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'category'));
-		return false;
-	}
-	return true;
-}
-
-let commandType: IJSONSchema = {
-	type: 'object',
-	properties: {
-		command: {
-			description: localize('vscode.extension.contributes.commandType.command', 'Identifier of the command to execute'),
-			type: 'string'
-		},
-		title: {
-			description: localize('vscode.extension.contributes.commandType.title', 'Title by which the command is represented in the UI.'),
-			type: 'string'
-		},
-		category: {
-			description: localize('vscode.extension.contributes.commandType.category', '(Optional) category string by the command is grouped in the UI'),
-			type: 'string'
-		}
-	}
-};
-let commandsExtPoint = ExtensionsRegistry.registerExtensionPoint<Command | Command[]>('commands', {
-	description: localize('vscode.extension.contributes.commands', "Contributes commands to the command palette."),
-	oneOf: [
-		commandType,
-		{
-			type: 'array',
-			items: commandType
-		}
-	]
-});
+import {commands} from '../common/commandsExtensionPoint';
 
 export default class ActionsService implements IActionsService {
 
 	private _extensionService: IExtensionService;
 	private _keybindingsService: IKeybindingService;
-	private _extensionsActions: IAction[] = [];
+	private _extensionsActions: IAction[];
 
 	serviceId: any;
 
@@ -88,53 +25,25 @@ export default class ActionsService implements IActionsService {
 	) {
 		this._extensionService = extensionService;
 		this._keybindingsService = keybindingsService;
-		commandsExtPoint.setHandler((extensions) => {
-			for (let d of extensions) {
-				this._onDescription(d.value, d.collector);
-			}
-		});
-	}
-
-	private _onDescription(commands: Command | Command[], collector: IExtensionMessageCollector): void {
-		if (isCommands(commands)) {
-			for (let command of commands) {
-				this._handleCommand(command, collector);
-			}
-		} else {
-			this._handleCommand(commands, collector);
-		}
-	}
-
-	private _handleCommand(command: Command, collector: IExtensionMessageCollector): void {
-
-		let rejects: string[] = [];
-
-		if (isValidCommand(command, rejects)) {
-			// make sure this extension is activated by this command
-			let activationEvent = `onCommand:${command.command}`;
-
-			// action that (1) activates the extension and dispatches the command
-			let label = command.category ? localize('category.label', "{0}: {1}", command.category, command.title) : command.title;
-			let action = new Action(command.command, label, undefined, true, () => {
-				return this._extensionService.activateByEvent(activationEvent).then(() => {
-					return this._keybindingsService.executeCommand(command.command);
-				});
-			});
-			this._extensionsActions.push(action);
-		}
-
-		if (rejects.length > 0) {
-			collector.error(localize(
-				'error',
-				"Invalid `contributes.{0}`: {1}",
-				commandsExtPoint.name,
-				rejects.join('\n')
-			));
-		}
-
 	}
 
 	getActions(): IAction[] {
+
+		if (!this._extensionsActions) {
+			this._extensionsActions = [];
+			for (let command of commands) {
+				// make sure this extension is activated by this command
+				const activationEvent = `onCommand:${command.command}`;
+
+				// action that (1) activates the extension and dispatches the command
+				const label = command.category ? localize('category.label', "{0}: {1}", command.category, command.title) : command.title;
+				const action = new Action(command.command, label, undefined, true, () => this._extensionService.activateByEvent(activationEvent)
+					.then(() => this._keybindingsService.executeCommand(command.command)));
+
+				this._extensionsActions.push(action);
+			}
+		}
+
 		return this._extensionsActions.slice(0);
 	}
 }

--- a/src/vs/platform/actions/workbench/actionsService.ts
+++ b/src/vs/platform/actions/workbench/actionsService.ts
@@ -10,7 +10,7 @@ import {IJSONSchema} from 'vs/base/common/jsonSchema';
 import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IExtensionMessageCollector, ExtensionsRegistry} from 'vs/platform/extensions/common/extensionsRegistry';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
-import {IActionsService} from './actions';
+import {IActionsService} from '../common/actions';
 
 interface Commands {
 	commands: Command | Command[];

--- a/src/vs/platform/actions/workbench/actionsService.ts
+++ b/src/vs/platform/actions/workbench/actionsService.ts
@@ -34,9 +34,13 @@ export default class ActionsService implements IActionsService {
 				const activationEvent = `onCommand:${command.command}`;
 
 				// action that (1) activates the extension and dispatches the command
-				const label = command.category ? localize('category.label', "{0}: {1}", command.category, command.title) : command.title;
-				const action = new Action(command.command, label, undefined, true, () => this._extensionService.activateByEvent(activationEvent)
+				const action = new Action(command.command, undefined, undefined, true, () => this._extensionService.activateByEvent(activationEvent)
 					.then(() => this._keybindingsService.executeCommand(command.command)));
+
+				action.label = command.category
+					? localize('category.label', "{0}: {1}", command.category, command.title)
+					: command.title;
+				action.order = Number.MAX_VALUE;
 
 				this._extensionsActions.push(action);
 			}

--- a/src/vs/platform/actions/workbench/actionsService.ts
+++ b/src/vs/platform/actions/workbench/actionsService.ts
@@ -10,21 +10,19 @@ import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
 import {IActionsService} from '../common/actions';
 import {commands} from '../common/commandsExtensionPoint';
+import 'vs/platform/actions/workbench/actionBarContributions';
 
 export default class ActionsService implements IActionsService {
 
-	private _extensionService: IExtensionService;
-	private _keybindingsService: IKeybindingService;
-	private _extensionsActions: IAction[];
-
 	serviceId: any;
 
+	private _extensionsActions: IAction[];
+
 	constructor(
-		@IExtensionService extensionService: IExtensionService,
-		@IKeybindingService keybindingsService: IKeybindingService
+		@IExtensionService private _extensionService: IExtensionService,
+		@IKeybindingService private _keybindingsService: IKeybindingService
 	) {
-		this._extensionService = extensionService;
-		this._keybindingsService = keybindingsService;
+		this._extensionService.onReady().then(() => this._extensionsActions = null);
 	}
 
 	getActions(): IAction[] {

--- a/src/vs/platform/actions/workbench/actionsService.ts
+++ b/src/vs/platform/actions/workbench/actionsService.ts
@@ -9,7 +9,7 @@ import {IAction} from 'vs/base/common/actions';
 import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
 import {IActionsService} from '../common/actions';
-import {commands, createAction} from '../common/commandsExtensionPoint';
+import {commands, CommandAction} from '../common/commandsExtensionPoint';
 import 'vs/platform/actions/workbench/actionBarContributions';
 
 export default class ActionsService implements IActionsService {
@@ -31,7 +31,7 @@ export default class ActionsService implements IActionsService {
 			this._extensionsActions = [];
 			for (let command of commands) {
 
-				const action = createAction(command, this._extensionService, this._keybindingsService);
+				const action = new CommandAction(command, this._extensionService, this._keybindingsService);
 				action.order = Number.MAX_VALUE;
 				action.label = command.category
 					? localize('category.label', "{0}: {1}", command.category, command.title)

--- a/src/vs/workbench/browser/actionBarRegistry.ts
+++ b/src/vs/workbench/browser/actionBarRegistry.ts
@@ -198,8 +198,13 @@ export function prepareActions(actions: IAction[]): IAction[] {
 	actions = actions.sort((first: Action, second: Action) => {
 		let firstOrder = first.order;
 		let secondOrder = second.order;
-
-		return firstOrder < secondOrder ? -1 : 1;
+		if (firstOrder < secondOrder) {
+			return -1;
+		} else if (firstOrder > secondOrder) {
+			return 1;
+		} else {
+			return 0;
+		}
 	});
 
 	// Clean up leading separators

--- a/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
@@ -51,6 +51,11 @@
 .monaco-workbench > .part.editor > .content > .one-editor-container > .title .group-actions .action-label {
 	display: block;
 	height: 35px;
+	line-height: 35px;
+}
+
+.monaco-workbench > .part.editor > .content > .one-editor-container > .title .title-actions .action-label.icon,
+.monaco-workbench > .part.editor > .content > .one-editor-container > .title .group-actions .action-label.icon {
 	width: 28px;
 	background-size: 16px;
 	background-position: center center;

--- a/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
@@ -52,11 +52,7 @@
 	display: block;
 	height: 35px;
 	line-height: 35px;
-}
-
-.monaco-workbench > .part.editor > .content > .one-editor-container > .title .title-actions .action-label.icon,
-.monaco-workbench > .part.editor > .content > .one-editor-container > .title .group-actions .action-label.icon {
-	width: 28px;
+	min-width: 28px;
 	background-size: 16px;
 	background-position: center center;
 	background-repeat: no-repeat;

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditorControl.ts
@@ -26,6 +26,7 @@ import {ITelemetryService} from 'vs/platform/telemetry/common/telemetry';
 import {IConfigurationService} from 'vs/platform/configuration/common/configuration';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
 import {IKeybindingService} from 'vs/platform/keybinding/common/keybindingService';
+import {IExtensionService} from 'vs/platform/extensions/common/extensions';
 import {IDisposable, dispose} from 'vs/base/common/lifecycle';
 import {TabsTitleControl} from 'vs/workbench/browser/parts/editor/tabsTitleControl';
 import {NoTabsTitleControl} from 'vs/workbench/browser/parts/editor/noTabsTitleControl';
@@ -124,6 +125,7 @@ export class SideBySideEditorControl implements ISideBySideEditorControl, IVerti
 		@IEventService private eventService: IEventService,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IKeybindingService private keybindingService: IKeybindingService,
+		@IExtensionService private extensionService: IExtensionService,
 		@IInstantiationService private instantiationService: IInstantiationService
 	) {
 		this.stacks = editorGroupService.getStacksModel();
@@ -154,6 +156,7 @@ export class SideBySideEditorControl implements ISideBySideEditorControl, IVerti
 	private registerListeners(): void {
 		this.toDispose.push(this.stacks.onModelChanged(e => this.onStacksChanged(e)));
 		this.toDispose.push(this.configurationService.onDidUpdateConfiguration(e => this.onConfigurationUpdated(e.config)));
+		this.extensionService.onReady().then(() => POSITIONS.forEach(position => this.titleAreaControl[position].refresh()));
 	}
 
 	private onConfigurationUpdated(configuration: IWorkbenchEditorConfiguration): void {

--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -67,7 +67,7 @@ import {IThreadService} from 'vs/platform/thread/common/thread';
 import {MainThreadService} from 'vs/platform/thread/common/mainThreadService';
 import {IStatusbarService} from 'vs/platform/statusbar/common/statusbar';
 import {IActionsService} from 'vs/platform/actions/common/actions';
-import ActionsService from 'vs/platform/actions/common/actionsService';
+import ActionsService from 'vs/platform/actions/workbench/actionsService';
 import {IContextMenuService} from 'vs/platform/contextview/browser/contextView';
 
 interface WorkbenchParams {


### PR DESCRIPTION
The PR is the start to implement #3192 by allowing extensions to add primary and secondary actions to the editor action bar. The approach we take will also allow to add action in other places, like viewlets or context menus. 

The current thinking goes like this: In the `commands` contribution point will get an additional `context` property (better name to be found) that allows to define _where_ to show the command under _what_ condition.

``` json
{
    "command": "v.sayHello",
    "title": "Hello World",
    "icon": "./media/Preview.svg",
    "context": {
        "where": "editor/primary",
        "when": "typescript"
    }
}
```

The sample above makes the command show up in the primary editor tool bar when it shows a typescript file. The `path` will be a finite enumeration of locations, like `editor/primary`, `editor/secondary`, `explorer/primary` etc. The `when` condition is the trustworthy [DocumentSelector](https://github.com/Microsoft/vscode/blob/joh/menus/src/vs/vscode.d.ts#L1431) always being applied on an Uri.

The **big** concern is UI scalability wrt the amount of actions/menu entries accumulating over time. I don't think being restrictive is the right approach but we should give users the change to customise menus like we allow to customise keybindings. Customisation from extensions should be treated as _proposed_ customisation which the user accepts or denies. Analog to keybindings, there should be a file like `menus.json` which allows to manually change the menu layout.
