### PR TITLE
Markdown plugins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,12 +15,5 @@
 		"extensions/**/out/**": true
 	},
 	"tslint.enable": true,
-	"tslint.rulesDirectory": "build/lib/tslint",
-	"markdown.styles": [ "file:///home/breeden/git/KaTeX/build/katex.min.css" ],
-	"markdown.plugins": [
-		{
-            "name": "markdown-it-katex",
-            "options": { "throwOnError": false }
-        }
-	]
+	"tslint.rulesDirectory": "build/lib/tslint"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,12 @@
 		"extensions/**/out/**": true
 	},
 	"tslint.enable": true,
-	"tslint.rulesDirectory": "build/lib/tslint"
+	"tslint.rulesDirectory": "build/lib/tslint",
+	"markdown.styles": [ "file:///home/breeden/git/KaTeX/build/katex.min.css" ],
+	"markdown.plugins": [
+		{
+            "name": "markdown-it-katex",
+            "options": { "throwOnError": false }
+        }
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,5 @@
 		"extensions/**/out/**": true
 	},
 	"tslint.enable": true,
-	"tslint.rulesDirectory": "build/lib/tslint",
-	"markdown.plugins": [
-		{
-			"name": "markdown-it-katex",
-		}
-	]
+	"tslint.rulesDirectory": "build/lib/tslint"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,10 @@
 		"extensions/**/out/**": true
 	},
 	"tslint.enable": true,
-	"tslint.rulesDirectory": "build/lib/tslint"
+	"tslint.rulesDirectory": "build/lib/tslint",
+	"markdown.plugins": [
+		{
+			"name": "markdown-it-katex",
+		}
+	]
 }

--- a/extensions/markdown/README.md
+++ b/extensions/markdown/README.md
@@ -1,0 +1,29 @@
+## Using Markdown-it Plugins
+
+To use a `markdown-it` plugin, goto the directory containing the `markdown-it` extension.  This will
+be found in the `extensions` folder in your vscode installation.  Install the `markdown-it` plugin
+as a node module.  For example, to install the `KaTeX` markdown-it extension you would simply type:
+
+``` sh
+npm install markdown-it-katex
+```
+
+Next, add the plugin into your [settings configuration](https://code.visualstudio.com/docs/customization/userandworkspace)
+under the `"markdown.plugs"` namespace.  This setting should contain a list for each `markdown-it` extension you wish
+to install.  The list should contain an object describing the name of the module, a list of styles that your extentsion
+may require, and options that you wish to pass to your extension.  For example, while installing the `markdown-it-katex`
+extension we would include this in your settings configuration:
+
+``` json
+    "markdown.plugins": [
+        {
+            "name": "markdown-it-katex",
+            "styles": [
+                "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css"
+            ],
+            "options": { "throwOnError": false }
+        }
+    ]
+```
+
+And that's all there is to it.  Enjoy!

--- a/extensions/markdown/README.md
+++ b/extensions/markdown/README.md
@@ -26,4 +26,5 @@ extension we would include this in your settings configuration:
     ]
 ```
 
-And that's all there is to it.  Enjoy!
+The `styles` field can contain a filename or a URL.  If the field is a file, file must be placed in the `/media` folder of
+the vscode markdown extension. And that's all there is to it.  Enjoy!

--- a/extensions/markdown/README.md
+++ b/extensions/markdown/README.md
@@ -1,30 +1,35 @@
 ## Using Markdown-it Plugins
 
-To use a `markdown-it` plugin, goto the directory containing the `markdown-it` extension.  This will
-be found in the `extensions` folder in your vscode installation.  Install the `markdown-it` plugin
-as a node module.  For example, to install the `KaTeX` markdown-it extension you would simply type:
+To use a markdown-it plugin for markdown preview rendering, you will need to provide the name
+and settings for each plugin in your "markdown.plugins" workspace configuration.  An example
+configuration is shown here:
+
+``` json
+	"markdown.styles": [ "file:///Path/To/katex.min.css" ],
+	"markdown.plugins": [
+	    {
+	        "name": "markdown-it-katex",
+	        "options": { "throwOnError": false }
+	    }
+	]
+```
+
+This configuration will tell the markdown extension to load the plugin "markdown-it-katex" with the options
+`{ "throwOnError": false }`.  This particular plugin requires additional styling to work properly, so you can
+place the references for these stylesheets in your "markdown.styles" workspace configuration.  The stylesheet
+in the "markdown.styles" may be either a URL, a `file:///...` or simply a filename like `styles.css` which
+then should be placed in the root directory of your workspace.
+
+Before the markdown extension can load markdown-it plugin properly, you must install the node package.  You
+can do this anywhere where the markdown extension can find your plugin.  So you can for instance install
+the package locally in the `extensions/markdown` folder using with
 
 ``` sh
 npm install markdown-it-katex
 ```
 
-Next, add the plugin into your [settings configuration](https://code.visualstudio.com/docs/customization/userandworkspace)
-under the `"markdown.plugs"` namespace.  This setting should contain a list for each `markdown-it` extension you wish
-to install.  The list should contain an object describing the name of the module, a list of styles that your extentsion
-may require, and options that you wish to pass to your extension.  For example, while installing the `markdown-it-katex`
-extension we would include this in your settings configuration:
+or globally with
 
-``` json
-    "markdown.plugins": [
-        {
-            "name": "markdown-it-katex",
-            "styles": [
-                "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css"
-            ],
-            "options": { "throwOnError": false }
-        }
-    ]
+``` sh
+npm install -g markdown-it-katex
 ```
-
-The `styles` field can contain a filename or a URL.  If the field is a file, file must be placed in the `/media` folder of
-the vscode markdown extension. And that's all there is to it.  Enjoy!

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -100,6 +100,11 @@
 					"type": "array",
 					"default" : null,
 					"description": "A list of URLs or local paths to CSS style sheets to use from the markdown preview."
+				},
+				"markdown.plugins": {
+					"type": "array",
+					"default": null,
+					"description": "A list of Objects describing plugins to load for the markdown preview. See README.md for more details."
 				}
 			}
 		}

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -30,6 +30,21 @@ export function activate(context: ExtensionContext) {
 		}
 	}).use(mdnh, {});
 
+	// Load user-defined packages
+	const userPlugins = <Array<Object>>vscode.workspace.getConfiguration("markdown")['plugins'];
+	if (userPlugins && Array.isArray(userPlugins)) {
+		userPlugins.forEach(value => {
+			if (!value.name) { return; }
+			try {
+				let plugin = require(value.name);
+				md.use(plugin, value.options ? value.options : {});
+				vscode.window.showInformationMessage("Loaded Markdown plugin '${value.name}'");
+			} catch (e) {
+				vscode.window.showErrorMessage("Unable to find Markdown plugin '${value.name}'. Is it installed?");
+				return;
+			}
+		});
+	}
 
 	let provider = new MDDocumentContentProvider(context);
 	let registration = vscode.workspace.registerTextDocumentContentProvider('markdown', provider);

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -9,21 +9,28 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { ExtensionContext, TextDocumentContentProvider, EventEmitter, Event, Uri, ViewColumn } from "vscode";
 
-const hljs = require('highlight.js');
-const mdnh = require('markdown-it-named-headers');
-const md = require('markdown-it')({
-	html: true,
-	highlight: function (str, lang) {
-		if (lang && hljs.getLanguage(lang)) {
-			try {
-				return `<pre class="hljs"><code><div>${hljs.highlight(lang, str, true).value}</div></code></pre>`;
-			} catch (error) { }
-		}
-		return `<pre class="hljs"><code><div>${md.utils.escapeHtml(str)}</div></code></pre>`;
-	}
-}).use(mdnh, {});
+let md;
 
 export function activate(context: ExtensionContext) {
+	// Upon activation, load markdown module with default
+	// plugins, and then load any user-defined plugins.
+	// Note: user-defined plugins may override default plugins.
+
+	const hljs = require('highlight.js');
+	const mdnh = require('markdown-it-named-headers');
+	md = require('markdown-it')({
+		html: true,
+		highlight: function (str, lang) {
+			if (lang && hljs.getLanguage(lang)) {
+				try {
+					return `<pre class="hljs"><code><div>${hljs.highlight(lang, str, true).value}</div></code></pre>`;
+				} catch (error) { }
+			}
+			return `<pre class="hljs"><code><div>${md.utils.escapeHtml(str)}</div></code></pre>`;
+		}
+	}).use(mdnh, {});
+
+
 	let provider = new MDDocumentContentProvider(context);
 	let registration = vscode.workspace.registerTextDocumentContentProvider('markdown', provider);
 

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -30,9 +30,9 @@ export function activate(context: ExtensionContext) {
 		}
 	}).use(mdnh, {});
 
-	// Load user-defined packages
+	// Load user defined plugins
 	const userPlugins = <Array<Object>>vscode.workspace.getConfiguration('markdown')['plugins'];
-	if (userPlugins && Array.isArray(userPlugins)) {
+	if (userPlugins instanceof Array) {
 		userPlugins.forEach(value => {
 			if (!value.name) { return; }
 			try {
@@ -174,7 +174,7 @@ class MDDocumentContentProvider implements TextDocumentContentProvider {
 
 	private computeCustomStyleSheetIncludes(uri: Uri): string[] {
 		const styles = vscode.workspace.getConfiguration('markdown')['styles'];
-		if (styles && Array.isArray(styles)) {
+		if (styles instanceof Array) {
 			return styles.map((style) => {
 				return `<link rel="stylesheet" href="${this.fixHref(uri, style)}" type="text/css" media="screen">`;
 			});
@@ -183,7 +183,7 @@ class MDDocumentContentProvider implements TextDocumentContentProvider {
 	}
 
 	private computePluginStyleSheetIncludes() {
-		if (userStyles && Array.isArray(userStyles)) {
+		if (userStyles instanceof Array) {
 			return userStyles.map((style) => {
 				if (Uri.parse(style).scheme) {
 					return `<link rel="stylesheet" type="text/css" href="${style}" type="text/css" media="screen">`;

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -85,8 +85,8 @@ export function activate(context: ExtensionContext) {
 }
 
 function isMarkdownFile(document: vscode.TextDocument) {
-	return document.languageId === 'markdown'
-		&& document.uri.scheme !== 'markdown'; // prevent processing of own documents
+    return document.languageId === 'markdown'
+        && document.uri.scheme !== 'markdown'; // prevent processing of own documents
 }
 
 function getMarkdownUri(uri: Uri) {
@@ -114,23 +114,23 @@ function showPreview(resource?: Uri, sideBySide: boolean = false) {
 }
 
 function getViewColumn(sideBySide): ViewColumn {
-	const active = vscode.window.activeTextEditor;
-	if (!active) {
-		return ViewColumn.One;
-	}
+    const active = vscode.window.activeTextEditor;
+    if (!active) {
+        return ViewColumn.One;
+    }
 
-	if (!sideBySide) {
-		return active.viewColumn;
-	}
+    if (!sideBySide) {
+        return active.viewColumn;
+    }
 
-	switch (active.viewColumn) {
-		case ViewColumn.One:
-			return ViewColumn.Two;
-		case ViewColumn.Two:
-			return ViewColumn.Three;
-	}
+    switch (active.viewColumn) {
+        case ViewColumn.One:
+            return ViewColumn.Two;
+        case ViewColumn.Two:
+            return ViewColumn.Three;
+    }
 
-	return active.viewColumn;
+    return active.viewColumn;
 }
 
 function showSource(mdUri: Uri) {
@@ -148,92 +148,92 @@ function showSource(mdUri: Uri) {
 }
 
 class MDDocumentContentProvider implements TextDocumentContentProvider {
-	private _context: ExtensionContext;
-	private _onDidChange = new EventEmitter<Uri>();
-	private _waiting : boolean;
+    private _context: ExtensionContext;
+    private _onDidChange = new EventEmitter<Uri>();
+    private _waiting : boolean;
 
-	constructor(context: ExtensionContext) {
-		this._context = context;
-		this._waiting = false;
-	}
+    constructor(context: ExtensionContext) {
+        this._context = context;
+        this._waiting = false;
+    }
 
-	private getMediaPath(mediaFile) {
-		return this._context.asAbsolutePath(path.join('media', mediaFile));
-	}
+    private getMediaPath(mediaFile) {
+        return this._context.asAbsolutePath(path.join('media', mediaFile));
+    }
 
-	private fixHref(resource: Uri, href: string) {
-		if (href) {
-			// Return early if href is already a URL
-			if (Uri.parse(href).scheme) {
-				return href;
-			}
-			// Otherwise convert to a file URI by joining the href with the resource location
-			return Uri.file(path.join(path.dirname(resource.fsPath), href)).toString();
-		}
-		return href;
-	}
+    private fixHref(resource: Uri, href: string) {
+        if (href) {
+            // Return early if href is already a URL
+            if (Uri.parse(href).scheme) {
+                return href;
+            }
+            // Otherwise convert to a file URI by joining the href with the resource location
+            return Uri.file(path.join(path.dirname(resource.fsPath), href)).toString();
+        }
+        return href;
+    }
 
-	private computeCustomStyleSheetIncludes(uri: Uri): string[] {
-		const styles = vscode.workspace.getConfiguration('markdown')['styles'];
-		if (styles && Array.isArray(styles)) {
-			return styles.map((style) => {
-				return `<link rel="stylesheet" href="${this.fixHref(uri, style)}" type="text/css" media="screen">`;
-			});
-		}
-		return [];
-	}
+    private computeCustomStyleSheetIncludes(uri: Uri): string[] {
+        const styles = vscode.workspace.getConfiguration('markdown')['styles'];
+        if (styles && Array.isArray(styles)) {
+            return styles.map((style) => {
+                return `<link rel="stylesheet" href="${this.fixHref(uri, style)}" type="text/css" media="screen">`;
+            });
+        }
+        return [];
+    }
 
-	private computePluginStyleSheetIncludes() {
-		if (userStyles && Array.isArray(userStyles)) {
-			return userStyles.map((style) => {
-				if (Uri.parse(style).scheme) {
-					return `<link rel="stylesheet" type="text/css" href="${style}" type="text/css" media="screen">`;
+    private computePluginStyleSheetIncludes() {
+        if (userStyles && Array.isArray(userStyles)) {
+            return userStyles.map((style) => {
+                if (Uri.parse(style).scheme) {
+                    return `<link rel="stylesheet" type="text/css" href="${style}" type="text/css" media="screen">`;
 
-				} else {
-					return `<link rel="stylehseet" type="text/css" href="${this.getMediaPath(style)}">`;
-				}
-			});
-		}
-	}
+                } else {
+                    return `<link rel="stylehseet" type="text/css" href="${this.getMediaPath(style)}">`;
+                }
+            });
+        }
+    }
 
-	public provideTextDocumentContent(uri: Uri): Thenable<string> {
+    public provideTextDocumentContent(uri: Uri): Thenable<string> {
 
-		return vscode.workspace.openTextDocument(Uri.parse(uri.query)).then(document => {
-			const head = [].concat(
-				'<!DOCTYPE html>',
-				'<html>',
-				'<head>',
-				'<meta http-equiv="Content-type" content="text/html;charset=UTF-8">',
-				`<link rel="stylesheet" type="text/css" href="${this.getMediaPath('markdown.css')}" >`,
-				`<link rel="stylesheet" type="text/css" href="${this.getMediaPath('tomorrow.css')}" >`,
-				this.computeCustomStyleSheetIncludes(uri),
-				this.computePluginStyleSheetIncludes(),
-				'</head>',
-				'<body>'
-			).join('\n');
+        return vscode.workspace.openTextDocument(Uri.parse(uri.query)).then(document => {
+            const head = [].concat(
+                '<!DOCTYPE html>',
+                '<html>',
+                '<head>',
+                '<meta http-equiv="Content-type" content="text/html;charset=UTF-8">',
+                `<link rel="stylesheet" type="text/css" href="${this.getMediaPath('markdown.css')}" >`,
+                `<link rel="stylesheet" type="text/css" href="${this.getMediaPath('tomorrow.css')}" >`,
+                this.computeCustomStyleSheetIncludes(uri),
+                this.computePluginStyleSheetIncludes(),
+                '</head>',
+                '<body>'
+            ).join('\n');
 
-			const body = md.render(document.getText());
+            const body = md.render(document.getText());
 
-			const tail = [
-				'</body>',
-				'</html>'
-			].join('\n');
+            const tail = [
+                '</body>',
+                '</html>'
+            ].join('\n');
 
-			return head + body + tail;
-		});
-	}
+            return head + body + tail;
+        });
+    }
 
-	get onDidChange(): Event<Uri> {
-		return this._onDidChange.event;
-	}
+    get onDidChange(): Event<Uri> {
+        return this._onDidChange.event;
+    }
 
-	public update(uri: Uri) {
-		if (!this._waiting) {
-			this._waiting = true;
-			setTimeout(() => {
-				this._waiting = false;
-				this._onDidChange.fire(uri);
-			}, 300);
-		}
-	}
+    public update(uri: Uri) {
+        if (!this._waiting) {
+            this._waiting = true;
+            setTimeout(() => {
+                this._waiting = false;
+                this._onDidChange.fire(uri);
+            }, 300);
+        }
+    }
 }

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: ExtensionContext) {
 	}).use(mdnh, {});
 
 	// Load user-defined packages
-	const userPlugins = <Array<Object>>vscode.workspace.getConfiguration("markdown")['plugins'];
+	const userPlugins = <Array<Object>>vscode.workspace.getConfiguration('markdown')['plugins'];
 	if (userPlugins && Array.isArray(userPlugins)) {
 		userPlugins.forEach(value => {
 			if (!value.name) { return; }

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -188,10 +188,10 @@ class MDDocumentContentProvider implements TextDocumentContentProvider {
 
 	public update(uri: Uri) {
 		if (!this._waiting) {
+			this._onDidChange.fire(uri);
 			this._waiting = true;
 			setTimeout(() => {
 				this._waiting = false;
-				this._onDidChange.fire(uri);
 			}, 300);
 		}
 	}

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -16,8 +16,6 @@ export function activate(context: ExtensionContext) {
 	// Upon activation, load markdown module with default
 	// plugins, and then load any user-defined plugins.
 	// Note: user-defined plugins may override default plugins.
-	vscode.window.showInformationMessage("Markdown Loaded! :D")
-
 	const hljs = require('highlight.js');
 	const mdnh = require('markdown-it-named-headers');
 	md = require('markdown-it')({
@@ -54,6 +52,7 @@ export function activate(context: ExtensionContext) {
 	let provider = new MDDocumentContentProvider(context);
 	let registration = vscode.workspace.registerTextDocumentContentProvider('markdown', provider);
 
+
 	let d1 = vscode.commands.registerCommand('markdown.showPreview', showPreview);
 	let d2 = vscode.commands.registerCommand('markdown.showPreviewToSide', uri => showPreview(uri, true));
 	let d3 = vscode.commands.registerCommand('markdown.showSource', showSource);
@@ -85,8 +84,8 @@ export function activate(context: ExtensionContext) {
 }
 
 function isMarkdownFile(document: vscode.TextDocument) {
-    return document.languageId === 'markdown'
-        && document.uri.scheme !== 'markdown'; // prevent processing of own documents
+	return document.languageId === 'markdown'
+		&& document.uri.scheme !== 'markdown'; // prevent processing of own documents
 }
 
 function getMarkdownUri(uri: Uri) {
@@ -114,23 +113,23 @@ function showPreview(resource?: Uri, sideBySide: boolean = false) {
 }
 
 function getViewColumn(sideBySide): ViewColumn {
-    const active = vscode.window.activeTextEditor;
-    if (!active) {
-        return ViewColumn.One;
-    }
+	const active = vscode.window.activeTextEditor;
+	if (!active) {
+		return ViewColumn.One;
+	}
 
-    if (!sideBySide) {
-        return active.viewColumn;
-    }
+	if (!sideBySide) {
+		return active.viewColumn;
+	}
 
-    switch (active.viewColumn) {
-        case ViewColumn.One:
-            return ViewColumn.Two;
-        case ViewColumn.Two:
-            return ViewColumn.Three;
-    }
+	switch (active.viewColumn) {
+		case ViewColumn.One:
+			return ViewColumn.Two;
+		case ViewColumn.Two:
+			return ViewColumn.Three;
+	}
 
-    return active.viewColumn;
+	return active.viewColumn;
 }
 
 function showSource(mdUri: Uri) {
@@ -148,92 +147,92 @@ function showSource(mdUri: Uri) {
 }
 
 class MDDocumentContentProvider implements TextDocumentContentProvider {
-    private _context: ExtensionContext;
-    private _onDidChange = new EventEmitter<Uri>();
-    private _waiting : boolean;
+	private _context: ExtensionContext;
+	private _onDidChange = new EventEmitter<Uri>();
+	private _waiting : boolean;
 
-    constructor(context: ExtensionContext) {
-        this._context = context;
-        this._waiting = false;
-    }
+	constructor(context: ExtensionContext) {
+		this._context = context;
+		this._waiting = false;
+	}
 
-    private getMediaPath(mediaFile) {
-        return this._context.asAbsolutePath(path.join('media', mediaFile));
-    }
+	private getMediaPath(mediaFile) {
+		return this._context.asAbsolutePath(path.join('media', mediaFile));
+	}
 
-    private fixHref(resource: Uri, href: string) {
-        if (href) {
-            // Return early if href is already a URL
-            if (Uri.parse(href).scheme) {
-                return href;
-            }
-            // Otherwise convert to a file URI by joining the href with the resource location
-            return Uri.file(path.join(path.dirname(resource.fsPath), href)).toString();
-        }
-        return href;
-    }
+	private fixHref(resource: Uri, href: string) {
+		if (href) {
+			// Return early if href is already a URL
+			if (Uri.parse(href).scheme) {
+				return href;
+			}
+			// Otherwise convert to a file URI by joining the href with the resource location
+			return Uri.file(path.join(path.dirname(resource.fsPath), href)).toString();
+		}
+		return href;
+	}
 
-    private computeCustomStyleSheetIncludes(uri: Uri): string[] {
-        const styles = vscode.workspace.getConfiguration('markdown')['styles'];
-        if (styles && Array.isArray(styles)) {
-            return styles.map((style) => {
-                return `<link rel="stylesheet" href="${this.fixHref(uri, style)}" type="text/css" media="screen">`;
-            });
-        }
-        return [];
-    }
+	private computeCustomStyleSheetIncludes(uri: Uri): string[] {
+		const styles = vscode.workspace.getConfiguration('markdown')['styles'];
+		if (styles && Array.isArray(styles)) {
+			return styles.map((style) => {
+				return `<link rel="stylesheet" href="${this.fixHref(uri, style)}" type="text/css" media="screen">`;
+			});
+		}
+		return [];
+	}
 
-    private computePluginStyleSheetIncludes() {
-        if (userStyles && Array.isArray(userStyles)) {
-            return userStyles.map((style) => {
-                if (Uri.parse(style).scheme) {
-                    return `<link rel="stylesheet" type="text/css" href="${style}" type="text/css" media="screen">`;
+	private computePluginStyleSheetIncludes() {
+		if (userStyles && Array.isArray(userStyles)) {
+			return userStyles.map((style) => {
+				if (Uri.parse(style).scheme) {
+					return `<link rel="stylesheet" type="text/css" href="${style}" type="text/css" media="screen">`;
 
-                } else {
-                    return `<link rel="stylehseet" type="text/css" href="${this.getMediaPath(style)}">`;
-                }
-            });
-        }
-    }
+				} else {
+					return `<link rel="stylehseet" type="text/css" href="${this.getMediaPath(style)}">`;
+				}
+			});
+		}
+	}
 
-    public provideTextDocumentContent(uri: Uri): Thenable<string> {
+	public provideTextDocumentContent(uri: Uri): Thenable<string> {
 
-        return vscode.workspace.openTextDocument(Uri.parse(uri.query)).then(document => {
-            const head = [].concat(
-                '<!DOCTYPE html>',
-                '<html>',
-                '<head>',
-                '<meta http-equiv="Content-type" content="text/html;charset=UTF-8">',
-                `<link rel="stylesheet" type="text/css" href="${this.getMediaPath('markdown.css')}" >`,
-                `<link rel="stylesheet" type="text/css" href="${this.getMediaPath('tomorrow.css')}" >`,
-                this.computeCustomStyleSheetIncludes(uri),
-                this.computePluginStyleSheetIncludes(),
-                '</head>',
-                '<body>'
-            ).join('\n');
+		return vscode.workspace.openTextDocument(Uri.parse(uri.query)).then(document => {
+			const head = [].concat(
+				'<!DOCTYPE html>',
+				'<html>',
+				'<head>',
+				'<meta http-equiv="Content-type" content="text/html;charset=UTF-8">',
+				`<link rel="stylesheet" type="text/css" href="${this.getMediaPath('markdown.css')}" >`,
+				`<link rel="stylesheet" type="text/css" href="${this.getMediaPath('tomorrow.css')}" >`,
+				this.computeCustomStyleSheetIncludes(uri),
+				this.computePluginStyleSheetIncludes(),
+				'</head>',
+				'<body>'
+			).join('\n');
 
-            const body = md.render(document.getText());
+			const body = md.render(document.getText());
 
-            const tail = [
-                '</body>',
-                '</html>'
-            ].join('\n');
+			const tail = [
+				'</body>',
+				'</html>'
+			].join('\n');
 
-            return head + body + tail;
-        });
-    }
+			return head + body + tail;
+		});
+	}
 
-    get onDidChange(): Event<Uri> {
-        return this._onDidChange.event;
-    }
+	get onDidChange(): Event<Uri> {
+		return this._onDidChange.event;
+	}
 
-    public update(uri: Uri) {
-        if (!this._waiting) {
-            this._waiting = true;
-            setTimeout(() => {
-                this._waiting = false;
-                this._onDidChange.fire(uri);
-            }, 300);
-        }
-    }
+	public update(uri: Uri) {
+		if (!this._waiting) {
+			this._waiting = true;
+			setTimeout(() => {
+				this._waiting = false;
+				this._onDidChange.fire(uri);
+			}, 300);
+		}
+	}
 }


### PR DESCRIPTION
A strategy for allowing users to install markdown-it plugins was discussed in #7656.  This is an attempt to implement the ideas discussed there.  I feel that the README describes the implementation well, so I'll just post it here.  I would like to incorporate a few tests maybe, are there any ideas?  So far, it seems to be working.
## Using Markdown-it Plugins

To use a `markdown-it` plugin, goto the directory containing the `markdown-it` extension.  This will be found in the `extensions` folder in your vscode installation.  Install the `markdown-it` plugin as a node module.  For example, to install the `KaTeX` markdown-it extension you would simply type:

``` sh
npm install markdown-it-katex
```

Next, add the plugin into your [settings configuration](https://code.visualstudio.com/docs/customization/userandworkspace) under the `"markdown.plugs"` namespace.  This setting should contain a list for each `markdown-it` extension you wish to install.  The list should contain an object describing the name of the module, a list of styles that your extension may require, and options that you wish to pass to your extension.  For example, while installing the `markdown-it-katex` extension we would include this in your settings configuration:

``` json
    "markdown.plugins": [
        {
            "name": "markdown-it-katex",
            "styles": [
                "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css"
            ],
            "options": { "throwOnError": false }
        }
    ]
```

The `styles` field can contain a filename or a URL.  If the field is a file, file must be placed in the `/media` folder of the vscode markdown extension. And that's all there is to it.  Enjoy!
