### PR TITLE
Fix dom.getRelativeTop

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -655,7 +655,7 @@ export function getRelativeTop(element: HTMLElement, parent: HTMLElement): numbe
 
 	let elementPosition = getTopLeftOffset(element);
 	let parentPosition = getTopLeftOffset(parent);
-	return parentPosition.top - elementPosition.top;
+	return elementPosition.top - parentPosition.top;
 }
 
 export function getLargestChildWidth(parent: HTMLElement, children: HTMLElement[]): number {


### PR DESCRIPTION
I use `Builder.getPositionRelativeTo` return a wrong`top` value. I found that it's because at
https://github.com/Microsoft/vscode/blob/master/src/vs/base/browser/dom.ts#L658
