### PR TITLE
Add 'vscode' as a keyword in the .desktop file

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -10,6 +10,7 @@ StartupWMClass=@@NAME_SHORT@@
 Categories=Utility;TextEditor;Development;IDE;
 MimeType=text/plain;
 Actions=new-window;
+Keywords=vscode;
 
 [Desktop Action new-window]
 Name=New Window


### PR DESCRIPTION
I find myself always typing vscode when searching for vs code in gnome 3, however being that there is no word vscode in the desktop file the search always comes up empty, and I realise that i have to type in code not vscode.
This small addition makes it searchable using term vscode.
