### PR TITLE
Support Emmet for Sass and Stylus

### DIFF
--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -19,7 +19,7 @@ export class EditorAccessor implements emmet.Editor {
 
 	lineStarts: number[] = null;
 
-	emmetSupportedModes = ['html', 'razor', 'css', 'less', 'scss', 'xml', 'xsl', 'jade', 'handlebars', 'ejs', 'hbs', 'jsx', 'tsx', 'erb', 'php', 'twig'];
+	emmetSupportedModes = ['html', 'razor', 'css', 'less', 'sass', 'scss', 'stylus', 'xml', 'xsl', 'jade', 'handlebars', 'ejs', 'hbs', 'jsx', 'tsx', 'erb', 'php', 'twig'];
 
 	constructor(editor: ICommonCodeEditor) {
 		this.editor = editor;
@@ -121,8 +121,8 @@ export class EditorAccessor implements emmet.Editor {
 		if (/\b(typescriptreact|javascriptreact)\b/.test(syntax)) { // treat like tsx like jsx
 			return 'jsx';
 		}
-		if (syntax === 'stylus') { // map stylus to css
-			return 'css';
+		if (syntax === 'sass-indented') { // map sass-indented to sass
+			return 'sass';
 		}
 		return syntax;
 	}


### PR DESCRIPTION
Support Emmet for Sass and Stylus.

Source: https://github.com/mrmlnc/vscode-emmet-fix/issues/1 (by @egamma) and https://github.com/Microsoft/vscode/issues/7312#issuecomment-227064046 (by @aeschli)

**Sass:**
![2016-06-20_14-29-36](https://cloud.githubusercontent.com/assets/7034281/16192720/956b257c-36f3-11e6-917d-002964ca0ff5.gif)

**Stylus:**
![2016-06-20_14-30-14](https://cloud.githubusercontent.com/assets/7034281/16192733/a8a3ab00-36f3-11e6-94a8-8b0cc64e338d.gif)

**More tests:**
- [CSS](https://cloud.githubusercontent.com/assets/7034281/16192748/c5e29bae-36f3-11e6-8c8e-722ada4fef91.gif)
- [SCSS](https://cloud.githubusercontent.com/assets/7034281/16192760/d62425e6-36f3-11e6-8f91-c518887fd58c.gif)
- [LESS](https://cloud.githubusercontent.com/assets/7034281/16192775/e589e796-36f3-11e6-9b07-25d0b4eb70cb.gif)
- [HTML](https://cloud.githubusercontent.com/assets/7034281/16192795/fdc139f4-36f3-11e6-8d16-ba1b2f655012.gif)
