### PR TITLE
tsconfig : make the module resolution explicit

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "amd",
+		"moduleResolution": "classic",
 		"noImplicitAny": false,
 		"removeComments": false,
 		"preserveConstEnums": true,


### PR DESCRIPTION
Parent: https://github.com/microsoft/vscode-internalbacklog/issues/7918

## Goal

Define the API and capability shape for passing lightweight context into speech-to-text providers without requiring every provider to implement a realtime backend.

## Current Baseline

VS Code proposed `SpeechToTextOptions` already includes optional `context`, `language`, and `phraseHints`, and the workbench speech service forwards options through the provider boundary.

`vscode-speech` is the current provider baseline. It uses `@vscode/node-speech`, packaged STT/TTS assets, language-pack discovery, and a static phrase list in the en-US transcriber model. In the provider implementation checked here, STT model selection uses `options.language`; dynamic `context` and `phraseHints` are still provider work, not something to assume is already honored.

## Tasks

- Confirm the final shape and documentation for `context`, `language`, and `phraseHints` in generic `SpeechToTextOptions`.
- Document expected provider behavior when optional context/hints are unsupported or ignored.
- Add provider capability detection if needed for optional context-aware recognition.
- Decide which richer fields belong in a chat/agent-specific voice layer rather than the generic speech provider API.
- Keep existing local/offline speech providers working as fallback behavior.

## Reference

This issue is about the provider contract and capability model. Implementation follow-ups are tracked separately for feeding chat vocabulary, measuring accuracy, and prototyping realtime transcription.
