### PR TITLE
Array.concat

### DIFF
--- a/extensions/typescript/server/typescript/lib/lib.d.ts
+++ b/extensions/typescript/server/typescript/lib/lib.d.ts
@@ -1027,7 +1027,7 @@ interface Array<T> {
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat<U extends T[]>(...items: U[]): T[];
+    concat<U extends T[]>(...items: (U | U[])[]): T[];
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.


### PR DESCRIPTION
it can actually take both items and arrays

EcmaScript Language Specefication says:
http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.concat

When the concat method is called with zero or more arguments, it returns an array containing the array elements of the object followed by the array elements of each argument in order.
