### PR TITLE
[Clojure] Fix regexp_escaped_char rule with double slash precedence

### DIFF
--- a/extensions/clojure/syntaxes/Clojure.tmLanguage
+++ b/extensions/clojure/syntaxes/Clojure.tmLanguage
@@ -236,7 +236,7 @@
 		<key>regexp_escaped_char</key>
 		<dict>
 			<key>match</key>
-			<string>\\(\")</string>
+			<string>[^\\]\\(\")</string>
 			<key>name</key>
 			<string>string.regexp.clojure</string>
 		</dict>


### PR DESCRIPTION
Fixes #6557
