### PR TITLE
Fix endLine parameter in problem matchers

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -233,7 +233,7 @@ class AbstractLineMatcher implements ILineMatcher {
 				severity: this.getSeverity(data),
 				startLineNumber: location.startLineNumber,
 				startColumn: location.startColumn,
-				endLineNumber: location.startLineNumber,
+				endLineNumber: location.endLineNumber,
 				endColumn: location.endColumn,
 				message: data.message
 			};


### PR DESCRIPTION
If the endLine parameter in a problem matcher is different from startLine then only the first character is underlined in the editor. 

Example compiler message:
`main.rs:1:1: 3:2 warning: function is never used: foo, #[warn(dead_code)] on by default`

With the regex:
`"^(.+?):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(\\w+):\\s+(.+)$"`

Results in:
![screen shot 2016-06-21 at 6 14 54 pm](https://cloud.githubusercontent.com/assets/5770094/16248321/7c6df362-37dc-11e6-8e40-0860c09e2614.png)

marker.endLineNumber is being incorrectly set to location.startLineNumber in getMarkerMatch
