### PR TITLE
Treat `.webmanifest` files as JSON

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -28,10 +28,12 @@
 					".jshintrc",
 					".jscsrc",
 					".eslintrc",
-					".babelrc"
+					".babelrc",
+					".webmanifest"
 				],
 				"mimetypes": [
-					"application/json"
+					"application/json",
+					"application/manifest+json"
 				],
 				"configuration": "./json.configuration.json"
 			}


### PR DESCRIPTION
[Web App Manifest](https://w3c.github.io/manifest/) files (having [`webmanifest`](https://w3c.github.io/manifest/#media-type-registration) as the recommended file extension and [`application/manifest+json`](https://w3c.github.io/manifest/#media-type-registration)  as the recommended media type) [use the JSON format](https://w3c.github.io/manifest/#abstract).

See also: https://w3c.github.io/manifest/
## 

Cc: @marcoscaceres
