### PR TITLE
Addition of USE EXEC OPENQUERY syntax

### DIFF
--- a/extensions/sql/syntaxes/SQL.plist
+++ b/extensions/sql/syntaxes/SQL.plist
@@ -239,7 +239,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\bvalues\b)</string>
+			<string>(?i:\b(values|use|exec|openquery)\b)</string>
 			<key>name</key>
 			<string>keyword.other.DML.II.sql</string>
 		</dict>


### PR DESCRIPTION
USE is used to select a database in SQL Server when a database is connected to.
EXEC and OPENQUERY are both used to get data on other servers.

I have grouped this with the VALUES keyword as EXEC/OPENQUERY are dealing with similar data.
I have also added USE into this dictionart as I felt it is cleaner than adding into dictionary keyword.other.DML.sql but let me know if you disagree.
