### PR TITLE
# ## Pound Hash signs should not be marked as comments in SQL

### DIFF
--- a/extensions/sql/syntaxes/SQL.plist
+++ b/extensions/sql/syntaxes/SQL.plist
@@ -411,7 +411,7 @@
 						</dict>
 					</array>
 				</dict>
-				<dict>
+				<!-- <dict>
 					<key>begin</key>
 					<string>(^[ \t]+)?(?=#)</string>
 					<key>beginCaptures</key>
@@ -443,7 +443,7 @@
 							<string>comment.line.number-sign.sql</string>
 						</dict>
 					</array>
-				</dict>
+				</dict> -->
 				<dict>
 					<key>begin</key>
 					<string>/\*</string>


### PR DESCRIPTION
MySQL uses # as comments along with the standard SQL '--' at the beginning. However, # is not standard SQL and therefore when using SQL Server/Oracle, etc. things marked with # are still shown as comment in the code even if they aren't comments. SQL Server specifically uses # ## to denote temporary tables.

Therefore, until someone figures out how to write a mysql exception to the syntax highlighting, I would suggest we suppress this code.
