### PR TITLE
Font-weight is now numerically light. Fixes #6759

### DIFF
--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -11,6 +11,7 @@
 	padding: 0;
 	overflow: hidden;
 	font-size: 11px;
+	font-weight: 300;
 	-webkit-user-select: none;
 }
 


### PR DESCRIPTION
Also fixes #6792.

Some fonts like Helvetica Neue and San Fransisco do not match the font-family's weight for italics unless you explicitly define `font-weight` to numerically be light as well.  This fixes that.

You'll notice a **change on Windows** as a result of this, because Segoe UI was being used and not Segoe UI Light.  This change causes Segoe UI Light to appear.  (I'm actually not sure why were using a light font on Mac but not on Windows—this sort of standardizes it as a side effect). Let me know your thoughts on this.  This does not affect Ubuntu (even though it should in theory).

This is what Windows would look like
![screen shot 2016-06-27 at 5 41 39 pm](https://cloud.githubusercontent.com/assets/11839736/16400261/95e508f6-3c8e-11e6-91f0-a9fb227f4cd0.png)
