### PR TITLE
fix for "screen cheese with long error messages"

### DIFF
--- a/src/vs/workbench/parts/markers/browser/media/markers.css
+++ b/src/vs/workbench/parts/markers/browser/media/markers.css
@@ -96,12 +96,10 @@
 }
 
 .markers-panel .icon {
-	float: left;
-	display: block;
-	width: 16px;
 	height: 22px;
-	margin-right: 4px;
-	margin-left: 4px;
+    margin-right: 4px;
+    margin-left: 4px;
+    flex: 0 0 16px;
 }
 
 .markers-panel .icon.warning {

--- a/src/vs/workbench/parts/markers/browser/media/markers.css
+++ b/src/vs/workbench/parts/markers/browser/media/markers.css
@@ -97,9 +97,9 @@
 
 .markers-panel .icon {
 	height: 22px;
-    margin-right: 4px;
-    margin-left: 4px;
-    flex: 0 0 16px;
+	margin-right: 4px;
+	margin-left: 4px;
+	flex: 0 0 16px;
 }
 
 .markers-panel .icon.warning {


### PR DESCRIPTION
Since the parent element has been set to display: flex, it's children does not uses some of the css properties.
Those has been removed and subtsituted with the flex css property.

fixes #8357
