### PR TITLE
Emmet: add support for toggle comment

### DIFF
--- a/src/vs/workbench/parts/emmet/node/actions/toggleComment.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/toggleComment.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import nls = require('vs/nls');
+import {BasicEmmetEditorAction} from 'vs/workbench/parts/emmet/node/emmetActions';
+
+import {CommonEditorRegistry, EditorActionDescriptor} from 'vs/editor/common/editorCommonExtensions';
+import {IEditorActionDescriptorData, ICommonCodeEditor} from 'vs/editor/common/editorCommon';
+import {IConfigurationService} from 'vs/platform/configuration/common/configuration';
+
+class ToggleCommentAction extends BasicEmmetEditorAction {
+
+	static ID = 'editor.emmet.action.toggleComment';
+
+	constructor(descriptor: IEditorActionDescriptorData, editor: ICommonCodeEditor, @IConfigurationService configurationService: IConfigurationService) {
+		super(descriptor, editor, configurationService, 'toggle_comment');
+	}
+}
+
+CommonEditorRegistry.registerEditorAction(new EditorActionDescriptor(ToggleCommentAction,
+	ToggleCommentAction.ID,
+	nls.localize('toggleComment', "Emmet: Toggle Comment"), void 0, 'Emmet: Toggle Comment'));

--- a/src/vs/workbench/parts/emmet/node/emmet.contribution.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.contribution.ts
@@ -16,6 +16,7 @@ import './actions/matchingPair';
 import './actions/wrapWithAbbreviation';
 import './actions/editPoints';
 import './actions/selectItem';
+import './actions/toggleComment';
 import './actions/splitJoinTag';
 import './actions/removeTag';
 import './actions/mergeLines';


### PR DESCRIPTION
Source: #8452

Sorry, i thought that this feature is implemented by default as and snippets.

Documentation: [click](http://docs.emmet.io/actions/toggle-comment/)
Demo:
![2016-06-29_11-50-04](https://cloud.githubusercontent.com/assets/7034281/16446365/dc5ffaa4-3def-11e6-9d41-661bce994ac2.gif)
