### PR TITLE
Emmet: canceling wrap shouldn't add tab to the active editor

### DIFF
--- a/src/vs/workbench/parts/emmet/node/actions/updateTag.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/updateTag.ts
@@ -34,7 +34,7 @@ class UpdateTagAction extends EmmetEditorAction {
 	}
 
 	private wrapAbbreviation(_emmet: any, tag) {
-		if (!_emmet.run('update_tag', this.editorAccessor, tag)) {
+		if (tag && !_emmet.run('update_tag', this.editorAccessor, tag)) {
 			this.editorAccessor.noExpansionOccurred();
 		}
 	}

--- a/src/vs/workbench/parts/emmet/node/actions/wrapWithAbbreviation.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/wrapWithAbbreviation.ts
@@ -34,7 +34,7 @@ class WrapWithAbbreviationAction extends EmmetEditorAction {
 	}
 
 	private wrapAbbreviation(_emmet: any, abbreviation) {
-		if (!_emmet.run('wrap_with_abbreviation', this.editorAccessor, abbreviation)) {
+		if (abbreviation && !_emmet.run('wrap_with_abbreviation', this.editorAccessor, abbreviation)) {
 			this.editorAccessor.noExpansionOccurred();
 		}
 	}

--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -23,9 +23,11 @@ export class EditorAccessor implements emmet.Editor {
 		this.editor = editor;
 	}
 
-	public noExpansionOccurred(): void {
-		// return the tab key handling back to the editor
-		this.editor.trigger('emmet', Handler.Tab, {});
+	public noExpansionOccurred(actionId?: string): void {
+		// return the tab key handling back to the editor only for Expand Abbreviation command
+		if (actionId === 'editor.emmet.action.expandAbbreviation') {
+			this.editor.trigger('emmet', Handler.Tab, {});
+		}
 	}
 
 	public isEmmetEnabledMode(): boolean {

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -68,7 +68,7 @@ export abstract class EmmetEditorAction extends EditorAction {
 
 				try {
 					if (!this.editorAccessor.isEmmetEnabledMode()) {
-						this.editorAccessor.noExpansionOccurred();
+						this.editorAccessor.noExpansionOccurred(this.id);
 						return;
 					}
 					this.updateEmmetPreferences(_emmet);


### PR DESCRIPTION
Source: #8450

Before:
![2016-06-29_12-48-01](https://cloud.githubusercontent.com/assets/7034281/16448007/e561c6a2-3df7-11e6-80fc-926ba48b929f.gif)

After
![2016-06-29_12-49-03](https://cloud.githubusercontent.com/assets/7034281/16448033/0d1bb8ce-3df8-11e6-8d28-351b70955c74.gif)
