### PR TITLE
Emmet: guaranteed applying new preferences

### DIFF
--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -35,28 +35,17 @@ export abstract class EmmetEditorAction extends EditorAction {
 
 	private updateEmmetPreferences(_emmet: any) {
 		let preferences = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		for (let key in preferences) {
-			try {
-				_emmet.preferences.set(key, preferences[key]);
-			} catch (err) {
-				_emmet.preferences.define(key, preferences[key]);
-			}
-		}
+		_emmet.loadPreferences(preferences);
+
 		let syntaxProfile = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.syntaxProfiles;
 		if (Object.keys(syntaxProfile).length !== 0) {
-			_emmet.profile.reset();
 			_emmet.loadProfiles(syntaxProfile);
 		}
 	}
 
 	private resetEmmetPreferences(_emmet: any) {
-		let preferences = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		for (let key in preferences) {
-			try {
-				_emmet.preferences.remove(key);
-			} catch (err) {
-			}
-		}
+		_emmet.preferences.reset();
+		_emmet.profile.reset();
 	}
 
 	abstract runEmmetAction(_emmet: any);

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -38,9 +38,7 @@ export abstract class EmmetEditorAction extends EditorAction {
 		_emmet.loadPreferences(preferences);
 
 		let syntaxProfile = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.syntaxProfiles;
-		if (Object.keys(syntaxProfile).length !== 0) {
-			_emmet.loadProfiles(syntaxProfile);
-		}
+		_emmet.loadProfiles(syntaxProfile);
 	}
 
 	private resetEmmetPreferences(_emmet: any) {

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -17,7 +17,7 @@ import {IConfigurationService} from 'vs/platform/configuration/common/configurat
 interface IEmmetConfiguration {
 	preferences: any;
 	syntaxProfiles: any;
-	triggerExpansionOnTab: boolean
+	triggerExpansionOnTab: boolean;
 }
 
 export abstract class EmmetEditorAction extends EditorAction {

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -15,11 +15,9 @@ import * as fileAccessor from 'vs/workbench/parts/emmet/node/fileAccessor';
 import {IConfigurationService} from 'vs/platform/configuration/common/configuration';
 
 interface IEmmetConfiguration {
-	emmet: {
-		preferences: any;
-		syntaxProfiles: any;
-		triggerExpansionOnTab: boolean
-	};
+	preferences: any;
+	syntaxProfiles: any;
+	triggerExpansionOnTab: boolean
 }
 
 export abstract class EmmetEditorAction extends EditorAction {
@@ -34,11 +32,9 @@ export abstract class EmmetEditorAction extends EditorAction {
 	}
 
 	private updateEmmetPreferences(_emmet: any) {
-		let preferences = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		_emmet.loadPreferences(preferences);
-
-		let syntaxProfile = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.syntaxProfiles;
-		_emmet.loadProfiles(syntaxProfile);
+		let emmetConfiguration = this.configurationService.getConfiguration<IEmmetConfiguration>('emmet');
+		_emmet.loadPreferences(emmetConfiguration.preferences);
+		_emmet.loadProfiles(emmetConfiguration.syntaxProfiles);
 	}
 
 	private resetEmmetPreferences(_emmet: any) {


### PR DESCRIPTION
Source: #8457 

I found a problem with cancelling settings.

Steps to Reproduce:
1. Open VS Code
2. Add to settings:
   
   ``` json
   "emmet.syntaxProfiles": {
     "html": {
       "attr_case": "upper"
     }
   }
   ```
3. Type `.test` and press <kbd>tab</kbd> to expand. Settings are applied. Result: `<div CLASS="test"></div>`
4. Delete added settings.
5. Type `.test` and press <kbd>tab</kbd> to expand, the setting doesn't apply. Result: `<div CLASS="test"></div>`

![2016-06-30_00-06-28](https://cloud.githubusercontent.com/assets/7034281/16468879/b13e7cbc-3e56-11e6-8494-672f606e09ec.gif)
#### Why is it so simple?

The method `loadPreferences` only works with the documented values. Undocumented value not supported. An example of undocumented value: `less.propertyEnd` — these values are hidden in Emmet. Because it is not needed for users.
#### Why deleted condition to apply syntax profiles?

Here it is superfluous. Just got the keys and nothing more if the editor has no settings:

``` js
loadProfiles: function(profiles) {
    profiles = utils.parseJSON(profiles);
    Object.keys(profiles).forEach(function(name) {
        profile.create(name, normalizeProfile(profiles[name]));
    });
}
```
