### PR TITLE
Use old-style icons for terminal and panel

### DIFF
--- a/src/vs/workbench/browser/parts/panel/media/hide-inverse.svg
+++ b/src/vs/workbench/browser/parts/panel/media/hide-inverse.svg
@@ -5,5 +5,5 @@
 <style type="text/css">
 	.st0{fill:#C5C5C5;}
 </style>
-<path id="iconBg" class="st0" d="M8,11.3L2.1,5.4l0.7-0.7L8,9.9l5.1-5.1l0.7,0.7C13.9,5.4,8,11.3,8,11.3z"/>
+<path id="iconBg" class="st0" d="M8,12.2L1.3,7.4l1.5-2L8,9.1l5.3-3.8l1.5,2C14.7,7.4,8,12.2,8,12.2z"/>
 </svg>

--- a/src/vs/workbench/browser/parts/panel/media/hide.svg
+++ b/src/vs/workbench/browser/parts/panel/media/hide.svg
@@ -5,5 +5,5 @@
 <style type="text/css">
 	.st0{fill:#424242;}
 </style>
-<path id="iconBg" class="st0" d="M8,11.3L2.1,5.4l0.7-0.7L8,9.9l5.1-5.1l0.7,0.7C13.9,5.4,8,11.3,8,11.3z"/>
+<path id="iconBg" class="st0" d="M8,12.2L1.3,7.4l1.5-2L8,9.1l5.3-3.8l1.5,2C14.7,7.4,8,12.2,8,12.2z"/>
 </svg>

--- a/src/vs/workbench/parts/terminal/electron-browser/media/kill-inverse.svg
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/kill-inverse.svg
@@ -5,6 +5,6 @@
 <style type="text/css">
 	.st0{fill:#C5C5C5;}
 </style>
-<path id="iconBg" class="st0" d="M6,12H5V6h1V12z M8,6H7v6h1V6z M10,6H9v6h1V6z M13,3v1h-1v10c0,0.6-0.4,1-1,1H4c-0.6,0-1-0.4-1-1V4
-	H2V3h3V2c0-0.6,0.4-1,1-1h3c0.6,0,1,0.4,1,1v1H13z M6,3h3V2H6V3z M11,4H4v10h7V4z"/>
+<path class="st0" d="M10,3V2c0-0.6-0.4-1-1-1H6C5.4,1,5,1.4,5,2v1H2v1h1v10c0,0.6,0.4,1,1,1h7c0.6,0,1-0.4,1-1V4h1V3H10z M6,12H5V6
+	h1V12z M6,2h3v1H6V2z M8,12H7V6h1V12z M10,12H9V6h1V12z"/>
 </svg>

--- a/src/vs/workbench/parts/terminal/electron-browser/media/kill.svg
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/kill.svg
@@ -5,6 +5,6 @@
 <style type="text/css">
 	.st0{fill:#424242;}
 </style>
-<path id="iconBg" class="st0" d="M6,12H5V6h1V12z M8,6H7v6h1V6z M10,6H9v6h1V6z M13,3v1h-1v10c0,0.6-0.4,1-1,1H4c-0.6,0-1-0.4-1-1V4
-	H2V3h3V2c0-0.6,0.4-1,1-1h3c0.6,0,1,0.4,1,1v1H13z M6,3h3V2H6V3z M11,4H4v10h7V4z"/>
+<path class="st0" d="M10,3V2c0-0.6-0.4-1-1-1H6C5.4,1,5,1.4,5,2v1H2v1h1v10c0,0.6,0.4,1,1,1h7c0.6,0,1-0.4,1-1V4h1V3H10z M6,12H5V6
+	h1V12z M6,2h3v1H6V2z M8,12H7V6h1V12z M10,12H9V6h1V12z"/>
 </svg>

--- a/src/vs/workbench/parts/terminal/electron-browser/media/new-inverse.svg
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/new-inverse.svg
@@ -5,5 +5,5 @@
 <style type="text/css">
 	.st0{fill:#C5C5C5;}
 </style>
-<path class="st0" d="M15,8H9v6H8V8H2V7h6V1h1v6h6V8z"/>
+<path id="iconBg" class="st0" d="M10,6h5v4h-5v5H6v-5H1V6h5V1h4V6z"/>
 </svg>

--- a/src/vs/workbench/parts/terminal/electron-browser/media/new-inverse.svg
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/new-inverse.svg
@@ -5,5 +5,6 @@
 <style type="text/css">
 	.st0{fill:#C5C5C5;}
 </style>
-<path id="iconBg" class="st0" d="M10,6h5v4h-5v5H6v-5H1V6h5V1h4V6z"/>
+<rect x="7" y="3" class="st0" width="3" height="11"/>
+<rect x="3" y="7" class="st0" width="11" height="3"/>
 </svg>

--- a/src/vs/workbench/parts/terminal/electron-browser/media/new.svg
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/new.svg
@@ -5,5 +5,5 @@
 <style type="text/css">
 	.st0{fill:#424242;}
 </style>
-<path class="st0" d="M15,8H9v6H8V8H2V7h6V1h1v6h6V8z"/>
+<path id="iconBg" class="st0" d="M10,6h5v4h-5v5H6v-5H1V6h5V1h4V6z"/>
 </svg>

--- a/src/vs/workbench/parts/terminal/electron-browser/media/new.svg
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/new.svg
@@ -5,5 +5,6 @@
 <style type="text/css">
 	.st0{fill:#424242;}
 </style>
-<path id="iconBg" class="st0" d="M10,6h5v4h-5v5H6v-5H1V6h5V1h4V6z"/>
+<rect x="7" y="3" class="st0" width="3" height="11"/>
+<rect x="3" y="7" class="st0" width="11" height="3"/>
 </svg>


### PR DESCRIPTION
Fixes #8525 

---

@bgashler1 merge if this look right. They look really fat/big to me, may just be because I'm used to the thin style now.

![image](https://cloud.githubusercontent.com/assets/2193314/16479440/16c5b5d4-3e55-11e6-9ad8-460ecb0e40b3.png)

![image](https://cloud.githubusercontent.com/assets/2193314/16479421/01a2090a-3e55-11e6-8a36-ee349150030c.png)
