### PR TITLE
Emmet: show error when the path is located outside the current workspace

### DIFF
--- a/src/vs/workbench/parts/emmet/node/fileAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/fileAccessor.ts
@@ -5,17 +5,11 @@
 
 'use strict';
 
-import fs = require('fs');
 import {dirname, join} from 'vs/base/common/paths';
 import {mkdirp, writeFile} from 'vs/base/node/pfs';
 
 export function createPath(parent: string, fileName: string): string {
-	var stat = fs.statSync(parent);
-	if (stat && !stat.isDirectory()) {
-		parent = dirname(parent);
-	}
-
-	return join(parent, fileName);
+	return join(dirname(parent), fileName);
 };
 
 export function save(file: string, content: string): any {


### PR DESCRIPTION
Source: #8569
#### Description

Just show error when the path is located outside the current workspace.

![image](https://cloud.githubusercontent.com/assets/7034281/16498683/8f0ff68e-3f05-11e6-8bc0-2237f7f35ce3.png)
#### About `createPath` function

It's not necessary to check. The function `createPath` only used in [base64.js](https://github.com/emmetio/emmet/blob/3a946a2ca2c4b0e5878547dab9911e04edc1bd64/lib/action/base64.js#L84) action:

``` js
var absPath = file.createPath(editor.getFilePath(), filePath);
```

The method (`editor.getFilePath()`) always returns the real path to the **file**.

``` ts
public getFilePath(): string {
    return this.editor.getModel().uri.fsPath;
}
```
