### PR TITLE
Remove .pp from Ruby extension list. Issue #5366

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "ruby",
-			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".pp", ".rake", ".ru" ],
+			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".rake", ".ru" ],
 			"filenames": [ "rakefile", "gemfile", "guardfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"configuration": "./ruby.configuration.json"


### PR DESCRIPTION
The *.pp file extension as it pertains it Ruby is actually
a file type used to denote a Puppet Manifest written in the Puppet
DSL (which itself is written in Ruby). The affected setting was
overriding VSCode Puppet extensions that are expecting the .pp
extension to be detected as file type Puppet.
