### PR TITLE
Fix did not removed css class dropfeedback

### DIFF
--- a/src/vs/workbench/browser/parts/editor/sideBySideEditorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditorControl.ts
@@ -984,20 +984,27 @@ export class SideBySideEditorControl implements ISideBySideEditorControl, IVerti
 			if (e.target === node) {
 				DOM.EventHelper.stop(e, true);
 				onDrop(e, Position.LEFT);
+			} else {
+				DOM.removeClass(node, 'dropfeedback');
 			}
 		}));
 
 		// Drag over
 		this.toDispose.push(DOM.addDisposableListener(node, DOM.EventType.DRAG_OVER, (e: DragEvent) => {
-			DOM.addClass(node, 'dropfeedback');
+			if (e.target === node) {
+				DOM.addClass(node, 'dropfeedback');
+			}
 
 			const target = <HTMLElement>e.target;
 			if (target) {
 				if (overlay && target.id !== overlayId) {
 					destroyOverlay(); // somehow we managed to move the mouse quickly out of the current overlay, so destroy it
 				}
-
 				createOverlay(target);
+
+				if (overlay) {
+					DOM.addClass(node, 'dropfeedback');
+				}
 			}
 		}));
 


### PR DESCRIPTION
The editor content did not remove css class `dropfeedback` sometimes.

Steps to Reproduce:
1. Drag a file into `Tab` or `Tabs Container` or `Title ActionBar`
2. Close All Files

![1](https://cloud.githubusercontent.com/assets/7069719/16574843/d8fd59cc-42b5-11e6-9053-2ef8299a6dab.gif)
