### PR TITLE
Fixes mousewheel zoom in case of inline diff view

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -119,7 +119,9 @@ class VisualEditorState {
 		this._decorations = editor.deltaDecorations(this._decorations, newDecorations.decorations);
 
 		// overview ruler
-		overviewRuler.setZones(newDecorations.overviewZones);
+		if (overviewRuler) {
+			overviewRuler.setZones(newDecorations.overviewZones);
+		}
 	}
 }
 
@@ -201,6 +203,8 @@ export class DiffEditorWidget extends EventEmitter implements editorBrowser.IDif
 	private _updateDecorationsRunner:RunOnceScheduler;
 
 	private _editorWorkerService: IEditorWorkerService;
+
+	private _lastUsedFontInfo:editorCommon.FontInfo;
 
 	constructor(
 		domElement:HTMLElement,
@@ -759,6 +763,10 @@ export class DiffEditorWidget extends EventEmitter implements editorBrowser.IDif
 				if (isViewportWrapping) {
 					// oh no, you didn't!
 					this.modifiedEditor.updateOptions({ wrappingColumn: -1 });
+				}
+				if (this._lastUsedFontInfo !== this.modifiedEditor.getConfiguration().fontInfo) {
+					this._lastUsedFontInfo = this.modifiedEditor.getConfiguration().fontInfo;
+					this._onViewZonesChanged();
 				}
 			}
 		}


### PR DESCRIPTION
The problem is that the diff viewer does not updates the
font size on the view zones - e.g. deleted lines - when the
editor configuration changes.

Fixes #8778
