### PR TITLE
Variable Substitution Relative Path

### DIFF
--- a/extensions/vscode-colorize-tests/.vscode/tasks.json
+++ b/extensions/vscode-colorize-tests/.vscode/tasks.json
@@ -1,7 +1,7 @@
 // Available variables which can be used inside of strings.
 // ${workspaceRoot}: the root folder of the team
 // ${file}: the current opened file
-// ${relFile}: the current opened file relative to cwd
+// ${relativeFile}: the current opened file relative to cwd
 // ${fileBasename}: the current opened file's basename
 // ${fileDirname}: the current opened file's dirname
 // ${fileExtname}: the current opened file's extension

--- a/extensions/vscode-colorize-tests/.vscode/tasks.json
+++ b/extensions/vscode-colorize-tests/.vscode/tasks.json
@@ -1,6 +1,7 @@
 // Available variables which can be used inside of strings.
 // ${workspaceRoot}: the root folder of the team
 // ${file}: the current opened file
+// ${relFile}: the current opened file relative to cwd
 // ${fileBasename}: the current opened file's basename
 // ${fileDirname}: the current opened file's dirname
 // ${fileExtname}: the current opened file's extension

--- a/src/vs/workbench/parts/lib/node/systemVariables.ts
+++ b/src/vs/workbench/parts/lib/node/systemVariables.ts
@@ -48,6 +48,10 @@ export class SystemVariables extends AbstractSystemVariables {
 		return this.getFilePath();
 	}
 
+	public get relFile(): string {
+		return Paths.relative(this.cwd, this.file);
+	}
+
 	public get fileBasename(): string {
 		return Paths.basename(this.getFilePath());
 	}

--- a/src/vs/workbench/parts/lib/node/systemVariables.ts
+++ b/src/vs/workbench/parts/lib/node/systemVariables.ts
@@ -49,7 +49,7 @@ export class SystemVariables extends AbstractSystemVariables {
 	}
 
 	public get relativeFile(): string {
-		return Paths.relative(this.workspaceRoot, this.file);
+		return (this.workspaceRoot) ? Paths.relative(this.workspaceRoot, this.file) : this.file;
 	}
 
 	public get fileBasename(): string {

--- a/src/vs/workbench/parts/lib/node/systemVariables.ts
+++ b/src/vs/workbench/parts/lib/node/systemVariables.ts
@@ -48,7 +48,7 @@ export class SystemVariables extends AbstractSystemVariables {
 		return this.getFilePath();
 	}
 
-	public get relFile(): string {
+	public get relativeFile(): string {
 		return Paths.relative(this.workspaceRoot, this.file);
 	}
 

--- a/src/vs/workbench/parts/lib/node/systemVariables.ts
+++ b/src/vs/workbench/parts/lib/node/systemVariables.ts
@@ -49,7 +49,7 @@ export class SystemVariables extends AbstractSystemVariables {
 	}
 
 	public get relFile(): string {
-		return Paths.relative(this.cwd, this.file);
+		return Paths.relative(this.workspaceRoot, this.file);
 	}
 
 	public get fileBasename(): string {


### PR DESCRIPTION
adding 'relFile' to support substituting the path to the current open file realtive to cwd

Issue: https://github.com/Microsoft/vscode/issues/7000
