### PR TITLE
Emmet: Encode\Decode action & preferences

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -78,9 +78,9 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "emmet": {
-      "version": "1.3.1",
-      "from": "emmet@1.3.1",
-      "resolved": "https://registry.npmjs.org/emmet/-/emmet-1.3.1.tgz"
+      "version": "1.6.0",
+      "from": "emmet@1.6.0",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-1.6.0.tgz"
     },
     "expand-brackets": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ansi-regex": "^2.0.0",
     "applicationinsights": "0.15.6",
     "chokidar": "1.0.5",
-    "emmet": "1.3.1",
+    "emmet": "1.6.0",
     "getmac": "1.0.7",
     "graceful-fs": "4.1.2",
     "http-proxy-agent": "0.2.7",

--- a/src/vs/base/node/request.ts
+++ b/src/vs/base/node/request.ts
@@ -123,3 +123,20 @@ export function json<T>(opts: IRequestOptions): TPromise<T> {
 		pair.res.on('error', e);
 	}));
 }
+
+export function buffer(opts: IRequestOptions): TPromise<Buffer> {
+	return request(opts).then(pair => new Promise((c, e) => {
+		if (!((pair.res.statusCode >= 200 && pair.res.statusCode < 300) || pair.res.statusCode === 1223)) {
+			return e('Server returned ' + pair.res.statusCode);
+		}
+
+		if (pair.res.statusCode === 204) {
+			return c(null);
+		}
+
+		let buffer: Buffer[] = [];
+		pair.res.on('data', d => buffer.push(d));
+		pair.res.on('end', () => c(Buffer.concat(buffer)));
+		pair.res.on('error', e);
+	}));
+}

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -30,7 +30,7 @@ export interface IFileService {
 	resolveFile(resource: URI, options?: IResolveFileOptions): winjs.TPromise<IFileStat>;
 
 	/**
-	 *Finds out if a file identified by the resource exists.
+	 * Finds out if a file identified by the resource exists.
 	 */
 	existsFile(resource: URI): winjs.TPromise<boolean>;
 

--- a/src/vs/workbench/parts/emmet/node/actions/base64.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/base64.ts
@@ -130,7 +130,7 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 		}
 
 		if (!isValidFilePath) {
-			const message = nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", input);
+			const message = nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file name. Please choose a different name.", input);
 			this.messageService.show(Severity.Error, message);
 			return false;
 		}

--- a/src/vs/workbench/parts/emmet/node/actions/base64.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/base64.ts
@@ -39,12 +39,7 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 	}
 
 	private createPath(parent: string, fileName: string): string {
-		// TO DO replace with IFileService
-		var stat = fs.statSync(parent);
-		if (stat && !stat.isDirectory()) {
-			parent = dirname(parent);
-		}
-		return join(parent, fileName);
+		return join(dirname(parent), fileName);
 	};
 
 	public runEmmetAction(_emmet: typeof emmet) {

--- a/src/vs/workbench/parts/emmet/node/actions/base64.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/base64.ts
@@ -31,7 +31,7 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 
 	constructor(descriptor: IEditorActionDescriptorData, editor: ICommonCodeEditor,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IWorkspaceContextService private workspaceContext: IWorkspaceContextService,
+		@IWorkspaceContextService private contextService: IWorkspaceContextService,
 		@IQuickOpenService private quickOpenService: IQuickOpenService,
 		@IMessageService private messageService: IMessageService,
 		@IFileService private fileService: IFileService) {
@@ -54,7 +54,7 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 			return;
 		}
 
-		if (!this.workspaceContext.getWorkspace()) {
+		if (!this.contextService.getWorkspace()) {
 			const message = nls.localize('noWorkspace', "Decoding a data:URL image is only available inside a workspace folder.");
 			this.messageService.show(Severity.Info, message);
 			return;

--- a/src/vs/workbench/parts/emmet/node/actions/base64.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/base64.ts
@@ -9,7 +9,6 @@ import nls = require('vs/nls');
 
 import * as emmet from 'emmet';
 import {fileExists} from 'vs/base/node/pfs';
-import fs = require('fs');
 import {dirname, join, normalize, isValidBasename, isEqualOrParent} from 'vs/base/common/paths';
 
 import {EmmetEditorAction} from 'vs/workbench/parts/emmet/node/emmetActions';

--- a/src/vs/workbench/parts/emmet/node/actions/base64.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/base64.ts
@@ -81,7 +81,7 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 					return;
 				}
 
-				const message = nls.localize('warnEscalation', "File **{0}** already exists.  Do you want to overwrite the existing file?", this.imageFilePath);
+				const message = nls.localize('warnEscalation', "File **{0}** already exists. Do you want to overwrite the existing file?", this.imageFilePath);
 				const actions = [
 					new Action('cancel', nls.localize('cancel', "Cancel"), '', true),
 					new Action('ok', nls.localize('ok', "OK"), '', true, () => {

--- a/src/vs/workbench/parts/emmet/node/actions/base64.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/base64.ts
@@ -75,12 +75,13 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 				const fullpath = this.createPath(this.editorAccessor.getFilePath(), path);
 				return fileExists(fullpath);
 			})
-			.then(status => {
-				if (!status) {
+			.then(fileExist => {
+				if (!fileExist) {
 					this.encodeDecode(_emmet, this.imageFilePath);
 					return;
 				}
 
+				// If a file with the same name and location specified by path exists, give the user a choice
 				const message = nls.localize('warnEscalation', "File **{0}** already exists. Do you want to overwrite the existing file?", this.imageFilePath);
 				const actions = [
 					new Action('cancel', nls.localize('cancel', "Cancel"), '', true),
@@ -94,10 +95,18 @@ class EncodeDecodeDataUrlAction extends EmmetEditorAction {
 	}
 
 	public encodeDecode(_emmet: any, filepath?: string) {
-		this.editorAccessor.prompt = (): string => {
-			return filepath;
-		};
-
+		/*
+		 * This function implements a standard method *prompt*.
+		 *
+		 * Link to the original source code:
+		 * https://github.com/emmetio/emmet/blob/afafbd27efa48e386513bfabf65756a10f4929ef/lib/action/base64.js#L78-L83
+		 *
+		 * Unfortunately, Emmet gets the path from the user using the *prompt*
+		 * method, and does not allow pass the path explicitly. It is therefore
+		 * necessary to replace the method so as to have the possibility
+		 * to return the path already obtained by us.
+		 */
+		this.editorAccessor.prompt = (): string => filepath;
 		if (!_emmet.run('encode_decode_data_url', this.editorAccessor)) {
 			this.noExpansionOccurred();
 		}

--- a/src/vs/workbench/parts/emmet/node/actions/updateImageSize.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/updateImageSize.ts
@@ -6,18 +6,40 @@
 'use strict';
 
 import nls = require('vs/nls');
-import {BasicEmmetEditorAction} from 'vs/workbench/parts/emmet/node/emmetActions';
+import {EmmetEditorAction} from 'vs/workbench/parts/emmet/node/emmetActions';
+import * as emmet from 'emmet';
+
+import {FileAccessor} from 'vs/workbench/parts/emmet/node/fileAccessor';
 
 import {CommonEditorRegistry, EditorActionDescriptor} from 'vs/editor/common/editorCommonExtensions';
 import {IEditorActionDescriptorData, ICommonCodeEditor} from 'vs/editor/common/editorCommon';
 import {IConfigurationService} from 'vs/platform/configuration/common/configuration';
+import {IMessageService} from 'vs/platform/message/common/message';
+import {IFileService} from 'vs/platform/files/common/files';
 
-class UpdateImageSizeAction extends BasicEmmetEditorAction {
+class UpdateImageSizeAction extends EmmetEditorAction {
 
 	static ID = 'editor.emmet.action.updateImageSize';
 
-	constructor(descriptor: IEditorActionDescriptorData, editor: ICommonCodeEditor, @IConfigurationService configurationService: IConfigurationService) {
-		super(descriptor, editor, configurationService, 'update_image_size');
+	protected fileAccessor: FileAccessor = null;
+
+	constructor(descriptor: IEditorActionDescriptorData, editor: ICommonCodeEditor,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IMessageService private messageService: IMessageService,
+		@IFileService private fileService: IFileService) {
+		super(descriptor, editor, configurationService);
+	}
+
+	public runEmmetAction(_emmet: typeof emmet) {
+		// Create layer for working with files only when it is needed
+		this.fileAccessor = new FileAccessor(this.messageService, this.fileService);
+
+		// Setting layer Emmet for working with files
+		_emmet.file(this.fileAccessor.listOfMethods);
+
+		if (!_emmet.run('update_image_size', this.editorAccessor)) {
+			this.noExpansionOccurred();
+		}
 	}
 }
 

--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -17,7 +17,7 @@ export class EditorAccessor implements emmet.Editor {
 	editor: ICommonCodeEditor;
 	private _hasMadeEdits: boolean;
 
-	emmetSupportedModes = ['html', 'razor', 'css', 'less', 'sass', 'scss', 'stylus', 'xml', 'xsl', 'jade', 'handlebars', 'ejs', 'hbs', 'jsx', 'tsx', 'erb', 'php', 'twig'];
+	emmetSupportedModes = ['html', 'razor', 'css', 'less', 'sass', 'scss', 'stylus', 'xml', 'xsl', 'jade', 'handlebars', 'ejs', 'hbs', 'jsx', 'tsx', 'erb', 'php', 'twig', 'svg'];
 
 	constructor(editor: ICommonCodeEditor) {
 		this.editor = editor;
@@ -127,6 +127,10 @@ export class EditorAccessor implements emmet.Editor {
 		}
 		if (syntax === 'sass-indented') { // map sass-indented to sass
 			return 'sass';
+		}
+		let filename = this.getFilePath();
+		if (/\.svg$/.test(filename)) {
+			return 'svg';
 		}
 		return syntax;
 	}

--- a/src/vs/workbench/parts/emmet/node/emmet.contribution.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.contribution.ts
@@ -24,7 +24,7 @@ import './actions/updateImageSize';
 import './actions/evaluateMath';
 import './actions/incrementDecrement';
 import './actions/reflectCssValue';
-// import './actions/base64'; // disabled - we will revisit the implementation
+import './actions/base64';
 import './actions/updateTag';
 
 // Configuration: emmet

--- a/src/vs/workbench/parts/emmet/node/emmet.d.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.d.ts
@@ -11,9 +11,7 @@ declare module 'emmet' {
 	}
 
 	export interface Preferences {
-		set(key:string, value: string);
-		define(key:string, value: string);
-		remove(key:string);
+		reset();
 	}
 
 	export interface Profiles {
@@ -150,5 +148,18 @@ declare module 'emmet' {
 
 	export var profile: Profiles;
 
-	export function loadProfiles(profiles: any);
+	/**
+	 * Extends the standard set of methods for working with files
+	 */
+	export function file(io: File): void;
+
+	/**
+	 * Loads preferences from JSON object
+	 */
+	export function loadPreferences(preferences: any): void;
+
+	/**
+	 * Loads named profiles from JSON object
+	 */
+	export function loadProfiles(profiles: any): void;
 }

--- a/src/vs/workbench/parts/emmet/node/emmet.d.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.d.ts
@@ -18,6 +18,44 @@ declare module 'emmet' {
 		reset();
 	}
 
+	export interface File {
+		/**
+		 * Locate <code>file_name</code> file that relates to <code>editor_file</code>.
+		 * File name may be absolute or relative path
+		 *
+		 * @param {String} parent
+		 * @param {String} filename
+		 * @return {String} Returns null if <code>filename</code> cannot be located
+		 */
+		locateFile(parent: string, filename: string): string;
+
+		/**
+		 * Creates absolute path by concatenating <code>parent</code> and <code>filename</code>.
+		 * If <code>parent</code> points to file, its parent directory is used
+		 *
+		 * @param {String} parent
+		 * @param {String} filename
+		 * @return {String}
+		 */
+		createPath(parent: string, filename: string): string;
+
+		/**
+		 * Reads binary file content and return it
+		 *
+		 * @param {String} path File's relative or absolute path
+		 * @return {String}
+		 */
+		read(path: string, callback: (err: Error, content: string) => void): void;
+
+		/**
+		 * Saves <code>content</code> as <code>file</code>
+		 *
+		 * @param {String} file File's absolute path
+		 * @param {String} content File content
+		 */
+		save(file: string, content: string): void;
+	}
+
 	export interface Editor {
 		/**
 		 * Returns character indexes of selected text: object with <code>start</code>

--- a/src/vs/workbench/parts/emmet/node/emmet.d.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.d.ts
@@ -27,7 +27,7 @@ declare module 'emmet' {
 		 * @param {String} filename
 		 * @return {String} Returns null if <code>filename</code> cannot be located
 		 */
-		locateFile(parent: string, filename: string): string;
+		locateFile(parent: string, filename: string, callback: any): void;
 
 		/**
 		 * Creates absolute path by concatenating <code>parent</code> and <code>filename</code>.
@@ -37,7 +37,7 @@ declare module 'emmet' {
 		 * @param {String} filename
 		 * @return {String}
 		 */
-		createPath(parent: string, filename: string): string;
+		createPath(parent: string, filename: string, callback: any): void;
 
 		/**
 		 * Reads binary file content and return it
@@ -45,7 +45,7 @@ declare module 'emmet' {
 		 * @param {String} path File's relative or absolute path
 		 * @return {String}
 		 */
-		read(path: string, callback: (err: Error, content: string) => void): void;
+		read(path: string, callback: any): void;
 
 		/**
 		 * Saves <code>content</code> as <code>file</code>
@@ -53,7 +53,7 @@ declare module 'emmet' {
 		 * @param {String} file File's absolute path
 		 * @param {String} content File content
 		 */
-		save(file: string, content: string): void;
+		save(file: string, content: string, callback: any): void;
 	}
 
 	export interface Editor {

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -34,27 +34,14 @@ export abstract class EmmetEditorAction extends EditorAction {
 	}
 
 	private updateEmmetPreferences(_emmet: typeof emmet) {
-		let preferences = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		for (let key in preferences) {
-			try {
-				_emmet.preferences.set(key, preferences[key]);
-			} catch (err) {
-				_emmet.preferences.define(key, preferences[key]);
-			}
-		}
-		let syntaxProfile = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.syntaxProfiles;
-		_emmet.profile.reset();
-		_emmet.loadProfiles(syntaxProfile);
+		let emmetPreferences = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet;
+		_emmet.loadPreferences(emmetPreferences.preferences);
+		_emmet.loadProfiles(emmetPreferences.syntaxProfiles);
 	}
 
 	private resetEmmetPreferences(_emmet: typeof emmet) {
-		let preferences = this.configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		for (let key in preferences) {
-			try {
-				_emmet.preferences.remove(key);
-			} catch (err) {
-			}
-		}
+		_emmet.preferences.reset();
+		_emmet.profile.reset();
 	}
 
 	abstract runEmmetAction(_emmet: typeof emmet);

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -53,7 +53,7 @@ export abstract class EmmetEditorAction extends EditorAction {
 	public run(): TPromise<boolean> {
 		if (!this.editorAccessor.isEmmetEnabledMode()) {
 			this.noExpansionOccurred();
-			return ;
+			return;
 		}
 
 		return this._withEmmet().then((_emmet) => {
@@ -73,7 +73,7 @@ export abstract class EmmetEditorAction extends EditorAction {
 		});
 	}
 
-	private _withEmmetPreferences(_emmet:typeof emmet, callback:() => void): void {
+	private _withEmmetPreferences(_emmet: typeof emmet, callback: () => void): void {
 		try {
 			this.updateEmmetPreferences(_emmet);
 			callback();

--- a/src/vs/workbench/parts/emmet/node/fileAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/fileAccessor.ts
@@ -1,0 +1,93 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import nls = require('vs/nls');
+
+import {buffer} from 'vs/base/node/request';
+import {join, dirname} from 'vs/base/common/paths';
+import URI from 'vs/base/common/uri';
+
+import {IMessageService, Severity} from 'vs/platform/message/common/message';
+import {IFileService} from 'vs/platform/files/common/files';
+
+import emmet = require('emmet');
+
+function isURL(path: string): boolean {
+	return /^https?:\/\//.test(path);
+}
+
+export function getFullPath(parent: string, filename: string): string {
+	return join(dirname(parent), filename);
+}
+
+export class FileAccessor implements emmet.File {
+
+	messageService: IMessageService;
+	fileService: IFileService;
+
+	constructor(messageService: IMessageService, fileService: IFileService) {
+		this.messageService = messageService;
+		this.fileService = fileService;
+	}
+
+	public createPath(parent: string, filename: string, callback: any): void {
+		callback(null, getFullPath(parent, filename));
+	}
+
+	public locateFile(parent: string, filename: string, callback: any): void {
+		if (isURL(filename)) {
+			return callback(filename);
+		}
+
+		const filepath = getFullPath(parent, filename);
+		const fileUri = URI.file(filepath);
+		this.fileService.existsFile(fileUri).then(fileExist => {
+			if (!fileExist) {
+				const message = nls.localize('fileNotExist', "File does not exist: **{0}**", filename);
+				this.messageService.show(Severity.Warning, message);
+				return;
+			}
+
+			callback(filepath);
+		});
+	}
+
+	public read(path: string, callback: any): void {
+		if (isURL(path)) {
+			buffer({ url: path }).then(buf => callback(null, buf.toString('binary')), err => {
+				const errCode = err.code ? err.code : err;
+				const message = nls.localize('requestError', "Request error: **{0}**", errCode);
+				this.messageService.show(Severity.Error, message);
+			});
+		} else {
+			const pathUri = URI.file(path);
+			this.fileService.resolveContent(pathUri, { encoding: 'binary' }).then(content => {
+				callback(null, content.value);
+			}, err => {
+				this.messageService.show(Severity.Error, err);
+			});
+		}
+	}
+
+	public save(file: string, content: string, callback: any): void {
+		const fileUri = URI.file(file);
+		this.fileService.updateContent(fileUri, content, { encoding: 'binary' }).then(() => {
+			callback(null);
+		}, err => {
+			this.messageService.show(Severity.Error, err);
+		});
+	}
+
+	public get listOfMethods() {
+		return {
+			locateFile: this.locateFile.bind(this),
+			createPath: this.createPath.bind(this),
+			read: this.read.bind(this),
+			save: this.save.bind(this)
+		};
+	}
+}

--- a/src/vs/workbench/parts/emmet/node/fileAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/fileAccessor.ts
@@ -59,8 +59,8 @@ export class FileAccessor implements emmet.File {
 	public read(path: string, callback: any): void {
 		if (isURL(path)) {
 			buffer({ url: path }).then(buf => callback(null, buf.toString('binary')), err => {
-				const errCode = err.code ? err.code : err;
-				const message = nls.localize('requestError', "Request error: **{0}**", errCode);
+				const errMessage = err.code ? err.code : err;
+				const message = nls.localize('requestError', "Request error: **{0}**", errMessage);
 				this.messageService.show(Severity.Error, message);
 			});
 		} else {


### PR DESCRIPTION
As I promised before, here’s a detailed description of what’s happening in the code.
## Description

I contacted with the developer of Emmet (@sergeche) and made a bit of changes for creating an ability of using asynchronous API, and handle any errors, such as _file does not exist_, _reading errors_, _write errors_ etc. 

This PR close following issues and PR:  #8569, #8324, #8586, #8542, which were created before.
## Changelog

There’s a main changes that this PR make:
1. Update Emmet to **1.6.0** version. Changelog for Emmet in addition to the asynchronous API:
   1. Added a meta tag for Edge [commit](https://github.com/emmetio/emmet/commit/6026cec2ec60e9ea3229a02b2d044b93f02d9790)
   2. Resolved [#428](https://github.com/emmetio/emmet/issues/428) [commit](https://github.com/emmetio/emmet/commit/c4a4cf495407c7a0da597f4f77df72421eb60eaf)
   3. Fixed annoying issue with locating CSS rule [commit](https://github.com/emmetio/emmet/commit/4b440ae9be9f9ec33a93d84a216fd9ac1cb1ec36)
   4. Added code snippets for SVG [commit](https://github.com/emmetio/emmet/commit/6efa2234cd3a72a9bd1232fa79783a878d556107)
   5. Added `meta:redirect` snippet [commit](https://github.com/emmetio/emmet/commit/4b02f62d61be7b44a30d583f73e39e8785ceb78b)
   6. Added more boolean attributes for `profile.booleanAttributes` [commit](https://github.com/emmetio/emmet/commit/96996d46d1e3735be81a95781969adcc2e95495d)
   7. Switched to extenal _Can I Use_ database [commit](https://github.com/emmetio/emmet/commit/7aa7e4a69a341cf545878e53974e469062b35d64)
2. Support of **SVG**, based on open file extension is added.  (see 1.4).
3. The process of set/reset settings and snippets for Emmet has been simplify. We don’t have to support undocumented features of Emmet, which don’t have any sense for the end user. 
4. The checking for the case when user specify the path, which open out of the current directory. 
5. Added function `buffer` in the file `src/vs/base/node/request.ts`, since the function `text` returns a string. This function returns the buffer.
6. Added layer between Emmet and methods Editor for work with the file system (**FileAccessor**).
7. **FileAccessor** is enabled only for actions `Encode\Decode` and `Update Image Size`.
8. The emulator of **prompt** function, which used in file `base64` for transmit path to the Emmet, has been delete (it is not necessary in version 1.6.0).
9. The action **Encode\Decode** is again enabled.
## Why the `base64` has a lot of code?

For user comfortable it’s necessary to process several situations: 
1. Decoding a data:URL image is only available inside a workspace folder.
2. Checking the validity of path:
   1. The path must be inside of open directory.
   2. The filename must consist valid symbols. 
3. If the file with specified name is already exist, it’s necessary to provide the user a choice (overwrite)
## Automated tests

I try to create automatic tests for this command, but got an editor error. The log is below. The source code for the test: [Gist](https://gist.github.com/mrmlnc/1dcb04bb7f0b4358dd60de8464ae3d96).

Despite of error, `console.log` in the test (inside the test file) file displays the correct result. I can’t find a reason of this. 

<details>
  <summary>

Error log: `Cannot read property 'getStartPosition' of null`</summary>



``` shell
    WARNING: Promise with no error callback:58
  { exception:
    TypeError: Cannot read property 'getStartPosition' of null
        at EditorAccessor.getSyntax (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\editorAccessor.js:93:54)
        at Object.outputInfo (C:\projects\vscode-master\node_modules\emmet\lib\utils\editor.js:57:37)
        at Object.expandAbbreviationAction (C:\projects\vscode-master\node_modules\emmet\lib\action\expandAbbreviation.js:106:27)
        at Object.run (C:\projects\vscode-master\node_modules\emmet\lib\action\main.js:150:21)
        at Object.run (C:\projects\vscode-master\node_modules\emmet\lib\emmet.js:81:23)
        at ExpandAbbreviationAction.BasicEmmetEditorAction.runEmmetAction (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:82:25)
        at C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:51:27
        at ExpandAbbreviationAction.EmmetEditorAction._withEmmetPreferences (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:65:17)
        at C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:49:23
        at Object.notifySuccess [as _notify] (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1170:59)
        at Object.state_success_notify.enter (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:852:30)
        at Promise_ctor._Base.Class.define._run (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1068:29)
        at Promise_ctor._Base.Class.define._completed (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1036:18)
        at Module._invokeFactory (C:\projects\vscode-master\out\vs\loader.js:755:52)
        at Module._complete (C:\projects\vscode-master\out\vs\loader.js:776:34)
        at Module.resolveDependency (C:\projects\vscode-master\out\vs\loader.js:831:22)
        at ModuleManager._onModuleComplete (C:\projects\vscode-master\out\vs\loader.js:1190:39)
        at ModuleManager._resolve (C:\projects\vscode-master\out\vs\loader.js:1525:22)
        at ModuleManager.defineModule (C:\projects\vscode-master\out\vs\loader.js:1027:18)
        at ModuleManager._onLoad (C:\projects\vscode-master\out\vs\loader.js:1113:34)
        at Object.callback (C:\projects\vscode-master\out\vs\loader.js:1488:31)
        at OnlyOnceScriptLoader.triggerCallback (C:\projects\vscode-master\out\vs\loader.js:1559:36)
        at C:\projects\vscode-master\out\vs\loader.js:1553:80
        at NodeScriptLoader.load (C:\projects\vscode-master\out\vs\loader.js:1727:17)
        at OnlyOnceScriptLoader.load (C:\projects\vscode-master\out\vs\loader.js:1553:37)
        at loadNextPath (C:\projects\vscode-master\out\vs\loader.js:1483:41)
        at Object.errorback (C:\projects\vscode-master\out\vs\loader.js:1491:25)
        at OnlyOnceScriptLoader.triggerErrorback (C:\projects\vscode-master\out\vs\loader.js:1566:36)
        at C:\projects\vscode-master\out\vs\loader.js:1553:141
        at ReadFileContext.callback (C:\projects\vscode-master\out\vs\loader.js:1733:25)
        at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:359:13),
    error: null,
    promise:
    { _creator: null,
      _nextState: null,
      _state:
        { name: 'error',
          enter: [Function],
          cancel: [Function: _],
          done: null,
          then: null,
          _completed: [Function: _],
          _error: [Function: _],
          _notify: [Function: notifyError],
          _progress: [Function: _],
          _setCompleteValue: [Function: _],
          _setErrorValue: [Function: _] },
      _value:
        TypeError: Cannot read property 'getStartPosition' of null
            at EditorAccessor.getSyntax (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\editorAccessor.js:93:54)
            at Object.outputInfo (C:\projects\vscode-master\node_modules\emmet\lib\utils\editor.js:57:37)
            at Object.expandAbbreviationAction (C:\projects\vscode-master\node_modules\emmet\lib\action\expandAbbreviation.js:106:27)
            at Object.run (C:\projects\vscode-master\node_modules\emmet\lib\action\main.js:150:21)
            at Object.run (C:\projects\vscode-master\node_modules\emmet\lib\emmet.js:81:23)
            at ExpandAbbreviationAction.BasicEmmetEditorAction.runEmmetAction (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:82:25)
            at C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:51:27
            at ExpandAbbreviationAction.EmmetEditorAction._withEmmetPreferences (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:65:17)
            at C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:49:23
            at Object.notifySuccess [as _notify] (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1170:59)
            at Object.state_success_notify.enter (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:852:30)
            at Promise_ctor._Base.Class.define._run (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1068:29)
            at Promise_ctor._Base.Class.define._completed (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1036:18)
            at Module._invokeFactory (C:\projects\vscode-master\out\vs\loader.js:755:52)
            at Module._complete (C:\projects\vscode-master\out\vs\loader.js:776:34)
            at Module.resolveDependency (C:\projects\vscode-master\out\vs\loader.js:831:22)
            at ModuleManager._onModuleComplete (C:\projects\vscode-master\out\vs\loader.js:1190:39)
            at ModuleManager._resolve (C:\projects\vscode-master\out\vs\loader.js:1525:22)
            at ModuleManager.defineModule (C:\projects\vscode-master\out\vs\loader.js:1027:18)
            at ModuleManager._onLoad (C:\projects\vscode-master\out\vs\loader.js:1113:34)
            at Object.callback (C:\projects\vscode-master\out\vs\loader.js:1488:31)
            at OnlyOnceScriptLoader.triggerCallback (C:\projects\vscode-master\out\vs\loader.js:1559:36)
            at C:\projects\vscode-master\out\vs\loader.js:1553:80
            at NodeScriptLoader.load (C:\projects\vscode-master\out\vs\loader.js:1727:17)
            at OnlyOnceScriptLoader.load (C:\projects\vscode-master\out\vs\loader.js:1553:37)
            at loadNextPath (C:\projects\vscode-master\out\vs\loader.js:1483:41)
            at Object.errorback (C:\projects\vscode-master\out\vs\loader.js:1491:25)
            at OnlyOnceScriptLoader.triggerErrorback (C:\projects\vscode-master\out\vs\loader.js:1566:36)
            at C:\projects\vscode-master\out\vs\loader.js:1553:141
            at ReadFileContext.callback (C:\projects\vscode-master\out\vs\loader.js:1733:25)
            at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:359:13),
      _isException: true,
      _errorId: 58,
      done: [Function: ErrorPromise_done],
      then: [Function: ErrorPromise_then] },
    handler: undefined,
    id: 58,
    parent: undefined }
  TypeError: Cannot read property 'getStartPosition' of null
      at EditorAccessor.getSyntax (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\editorAccessor.js:93:54)
      at Object.outputInfo (C:\projects\vscode-master\node_modules\emmet\lib\utils\editor.js:57:37)
      at Object.expandAbbreviationAction (C:\projects\vscode-master\node_modules\emmet\lib\action\expandAbbreviation.js:106:27)
      at Object.run (C:\projects\vscode-master\node_modules\emmet\lib\action\main.js:150:21)
      at Object.run (C:\projects\vscode-master\node_modules\emmet\lib\emmet.js:81:23)
      at ExpandAbbreviationAction.BasicEmmetEditorAction.runEmmetAction (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:82:25)
      at C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:51:27
      at ExpandAbbreviationAction.EmmetEditorAction._withEmmetPreferences (C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:65:17)
      at C:\projects\vscode-master\out\vs\workbench\parts\emmet\node\emmetActions.js:49:23
      at Object.notifySuccess [as _notify] (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1170:59)
      at Object.state_success_notify.enter (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:852:30)
      at Promise_ctor._Base.Class.define._run (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1068:29)
      at Promise_ctor._Base.Class.define._completed (C:\projects\vscode-master\out\vs\base\common\winjs.base.raw.js:1036:18)
      at Module._invokeFactory (C:\projects\vscode-master\out\vs\loader.js:755:52)
      at Module._complete (C:\projects\vscode-master\out\vs\loader.js:776:34)
      at Module.resolveDependency (C:\projects\vscode-master\out\vs\loader.js:831:22)
      at ModuleManager._onModuleComplete (C:\projects\vscode-master\out\vs\loader.js:1190:39)
      at ModuleManager._resolve (C:\projects\vscode-master\out\vs\loader.js:1525:22)
      at ModuleManager.defineModule (C:\projects\vscode-master\out\vs\loader.js:1027:18)
      at ModuleManager._onLoad (C:\projects\vscode-master\out\vs\loader.js:1113:34)
      at Object.callback (C:\projects\vscode-master\out\vs\loader.js:1488:31)
      at OnlyOnceScriptLoader.triggerCallback (C:\projects\vscode-master\out\vs\loader.js:1559:36)
      at C:\projects\vscode-master\out\vs\loader.js:1553:80
      at NodeScriptLoader.load (C:\projects\vscode-master\out\vs\loader.js:1727:17)
      at OnlyOnceScriptLoader.load (C:\projects\vscode-master\out\vs\loader.js:1553:37)
      at loadNextPath (C:\projects\vscode-master\out\vs\loader.js:1483:41)
      at Object.errorback (C:\projects\vscode-master\out\vs\loader.js:1491:25)
      at OnlyOnceScriptLoader.triggerErrorback (C:\projects\vscode-master\out\vs\loader.js:1566:36)
      at C:\projects\vscode-master\out\vs\loader.js:1553:141
      at ReadFileContext.callback (C:\projects\vscode-master\out\vs\loader.js:1733:25)
      at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:359:13)
  ....................
  Cannot read property 'getStartPosition' of null
  Error: oops
      at ErrorHandler.unexpectedErrorHandler (C:\projects\vscode-master\test\all.js:184:12)
      at ErrorHandler.onUnexpectedError (C:\projects\vscode-master\out\vs\base\common\errors.js:42:18)
      at Object.onUnexpectedError (C:\projects\vscode-master\out\vs\base\common\errors.js:56:34)
      at C:\projects\vscode-master\out\vs\base\common\winjs.base.js:41:18
      at Array.forEach (native)
      at Timeout._onTimeout (C:\projects\vscode-master\out\vs\base\common\winjs.base.js:38:25)
      at tryOnTimeout (timers.js:224:11)
      at Timer.listOnTimeout (timers.js:198:5)
  .

    1803 passing (18s)
    2 failing

    1) Basic Emmet actions expandAbbreviationTest:
      Error: timeout of 10000ms exceeded. Ensure the done() callback is being called in this test.
        at Timeout.<anonymous> (C:\projects\vscode-master\node_modules\mocha\lib\runnable.js:226:19)

    2) Errors should not have unexpected errors in tests:

        AssertionError: false == true
        + expected - actual

        -false
        +true

        at Context.<anonymous> (C:\projects\vscode-master\test\all.js:175:13)
        at callFn (C:\projects\vscode-master\node_modules\mocha\lib\runnable.js:326:21)
        at Test.Runnable.run (C:\projects\vscode-master\node_modules\mocha\lib\runnable.js:319:7)
        at Runner.runTest (C:\projects\vscode-master\node_modules\mocha\lib\runner.js:422:10)
        at C:\projects\vscode-master\node_modules\mocha\lib\runner.js:528:12
        at next (C:\projects\vscode-master\node_modules\mocha\lib\runner.js:342:14)
        at C:\projects\vscode-master\node_modules\mocha\lib\runner.js:352:7
        at next (C:\projects\vscode-master\node_modules\mocha\lib\runner.js:284:14)
        at Immediate._onImmediate (C:\projects\vscode-master\node_modules\mocha\lib\runner.js:320:5)



  npm ERR! Test failed.  See above for more details.
```

</details>

I also wrote the basic tests for `FileAccessor`, but i didn’t include them in this PR. They are available in [Gist](https://gist.github.com/mrmlnc/40c7b11ad4219fc578cc88437acbeab5). 

This tests are useful after little changes of a class `FileAccessor`:
1. In the `locateFile` method should return `this.fileService.existsFile`.
2. In the `read` method should return `buffer` и `this.fileService.resolveContent`.
3. In the `save` method should return `this.fileService.updateContent`.

Because of automatic tests don’t work, I wrote the instructions for manual testing.
## Manual tests

<details>
  <summary>

1. Check for encoding and decoding for files from network and disks.</summary>


1. Open the directory and create a CSS file.
2. Insert the following code into the newly created file:
   
   ``` css
   .test {
       background-image: url(https://avatars3.githubusercontent.com/u/7034281?v=3&s=40);
   }
   ```
3. Run `Encode\Decode` command. The correct result: `background-image: url(data:application/octet-stream;base64,/9j/2wCEAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSE…);`
4. Run `Encode/Decode` command in the same file.
5. Write the name `test.png`. File must be saved, and property looks following: `background-image: url (test.png);`.
6. Rerun `Encode\Decode` command. The correct result: as in **item 3** above.
   </details>

<details>
  <summary>

2. Check of processing cancellation of decode and display a simple errors.</summary>


1. Repeat the first three steps described above (1.1 - 1.3).
2. Run `Encode\Decode` command and press <kbd>Escape</kbd> key. Nothing's going to happen.
3. Run `Encode\Decode` and write the following text: `../../test.png`. You should see:
   
   ![image](https://cloud.githubusercontent.com/assets/7034281/16635342/9c068482-43da-11e6-9da2-82ccd203d4f8.png)
4. Run `Encode\Decode` and write the following text: `test:::image.png`. You should see:
   
   ![image](https://cloud.githubusercontent.com/assets/7034281/16635476/4ee6eb6e-43db-11e6-8110-632ecd60a49c.png)
   </details>

<details>
  <summary>

3. Checking display of warnings.</summary>


1. Repeat the first six steps described above (1.1 - 1.5).
2. Change image url on `https://avatars2.githubusercontent.com/u/172399?v=3&s=60`.
3. Run `Encode\Decode` action and write `test.png`. You should see:
   
   ![image](https://cloud.githubusercontent.com/assets/7034281/16635713/4084b65e-43dc-11e6-9ec9-a8653e5d567e.png)
4. Agree to overwrite.
5. Open the file `test.png`. You should see avatar @egamma.
   </details>

<details>
  <summary>

4. Checking display warnings about missing files.</summary>


1. Open the directory and create a CSS file.
2. Insert the following code into the newly created file:
   
   ``` css
   .test {
       background-image: url(https://www.canonium.com/fileNotExist.svg);
   }
   ```
3. Run `Encode\Decode` action. You should see:
   
   ![image](https://cloud.githubusercontent.com/assets/7034281/16636090/9b6c534a-43de-11e6-8f46-f4c536b9fa12.png)
4. Replace the path in `background-image` property to a new value: `fileNotExist.png`.
5. Run `Encode\Decode` action. You should see:
   
   ![image](https://cloud.githubusercontent.com/assets/7034281/16635913/8e8f4b10-43dd-11e6-9b72-516f06758aae.png)
   </details>
