### PR TITLE
Fix sensitivity not always being applied.

### DIFF
--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -240,12 +240,12 @@ export class ScrollableElement extends Widget {
 			let deltaX = e.deltaX * this._options.mouseWheelScrollSensitivity;
 
 			if (this._options.flipAxes) {
-				deltaY = e.deltaX;
-				deltaX = e.deltaY;
+				deltaY = deltaX;
+				deltaX = deltaY;
 			}
 
 			if (this._options.scrollYToX && !deltaX) {
-				deltaX = e.deltaY;
+				deltaX = deltaY;
 				deltaY = 0;
 			}
 


### PR DESCRIPTION
Minor change to allow scroll sensitivity to be taken into account when options `flipAxes` or `scrollYToX` are being used.
