### PR TITLE
Addition of GO INTO T-SQL syntax

### DIFF
--- a/extensions/sql/syntaxes/SQL.plist
+++ b/extensions/sql/syntaxes/SQL.plist
@@ -239,7 +239,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(values|use|exec|openquery)\b)</string>
+			<string>(?i:\b(values|use|go|into|exec|openquery)\b)</string>
 			<key>name</key>
 			<string>keyword.other.DML.II.sql</string>
 		</dict>


### PR DESCRIPTION
GO is used as a separator of batches of statemements in SQL Server which uses T-SQL
SELECT ... INTO is used as a CTAS (Create Table AS) of sorts in T-SQL.
