### PR TITLE
Fix debounceEvent

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -199,8 +199,9 @@ export function debounceEvent<I, O>(event: Event<I>, merger: (last: O, event: I)
 				output = merger(output, cur);
 				clearTimeout(handle);
 				handle = setTimeout(() => {
-					emitter.fire(output);
+					let _output = output;
 					output = undefined;
+					emitter.fire(_output);
 				}, delay);
 			});
 		},

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -178,7 +178,7 @@ suite('Event',function(){
 		}
 	});
 
-	test('Debounce Event', function () {
+	test('Debounce Event', function (done: () => void) {
 		let doc = new Samples.Document3();
 
 		let onDocDidChange = debounceEvent(doc.onDidChange, (prev: string[], cur) => {
@@ -190,13 +190,17 @@ suite('Event',function(){
 			return prev;
 		}, 10);
 
+		let count = 0;
+
 		onDocDidChange(keys => {
+			count++;
 			assert.ok(keys, 'was not expecting keys.');
-			if (keys.length === 3) {
+			if (count === 1) {
 				doc.setText('4');
 				assert.deepEqual(keys, ['1', '2', '3']);
-			} else {
+			} else if (count === 2){
 				assert.deepEqual(keys, ['4']);
+				done();
 			}
 		});
 

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as assert from 'assert';
-import Event, {Emitter, fromEventEmitter, EventBufferer} from 'vs/base/common/event';
+import Event, {Emitter, fromEventEmitter, debounceEvent, EventBufferer} from 'vs/base/common/event';
 import {IDisposable} from 'vs/base/common/lifecycle';
 import {EventEmitter} from 'vs/base/common/eventEmitter';
 import Errors = require('vs/base/common/errors');
@@ -176,6 +176,33 @@ suite('Event',function(){
 		} finally {
 			Errors.setUnexpectedErrorHandler(origErrorHandler);
 		}
+	});
+
+	test('Debounce Event', function () {
+		let doc = new Samples.Document3();
+
+		let onDocDidChange = debounceEvent(doc.onDidChange, (prev: string[], cur) => {
+			if (!prev) {
+				prev = [cur];
+			} else if (prev.indexOf(cur) < 0) {
+				prev.push(cur);
+			}
+			return prev;
+		}, 10);
+
+		onDocDidChange(keys => {
+			assert.ok(keys, 'was not expecting keys.');
+			if (keys.length === 3) {
+				doc.setText('4');
+				assert.deepEqual(keys, ['1', '2', '3']);
+			} else {
+				assert.deepEqual(keys, ['4']);
+			}
+		});
+
+		doc.setText('1');
+		doc.setText('2');
+		doc.setText('3');
 	});
 });
 


### PR DESCRIPTION
`debounceEvent` is abnormal sometimes. 

**Steps to Reproduce**:

Here is my test case:

```
test('Debounce Event', function () {
    let doc = new Samples.Document3();

    let onDocDidChange = debounceEvent(doc.onDidChange, (prev: string[], cur) => {
        if (!prev) {
            prev = [cur];
        } else if (prev.indexOf(cur) < 0) {
            prev.push(cur);
        }
        return prev;
    }, 10);

    onDocDidChange(keys => {
        assert.ok(keys, 'was not expecting keys.');
        if (keys.length === 3) {
            doc.setText('4');
            assert.deepEqual(keys, ['1', '2', '3']);
        } else {
            assert.deepEqual(keys, ['4']);
        }
    });

    doc.setText('1');
    doc.setText('2');
    doc.setText('3');
}); 
```
1. Insert test code to [`event.test.ts`](https://github.com/Microsoft/vscode/blob/master/src/vs/base/test/common/event.test.ts).
2. run `scripts\test`.

Here is error:
`was not expecting keys.`

**Reason**:
Some code is changing `output` during `emitter.fire`

**Solution**:
Reset `output` before `emitter.fire`
