### PR TITLE
Added new commands to allow finer-grain line navigation

### DIFF
--- a/src/vs/editor/common/config/config.ts
+++ b/src/vs/editor/common/config/config.ts
@@ -205,18 +205,38 @@ registerCoreCommand(H.CursorHome, {
 	primary: KeyCode.Home,
 	mac: { primary: KeyCode.Home, secondary: [KeyMod.CtrlCmd | KeyCode.LeftArrow, KeyMod.WinCtrl | KeyCode.KEY_A] }
 });
+registerCoreDispatchCommand2(H.CursorHomeVisualThenLogical);
+registerCoreDispatchCommand2(H.CursorHomeLogicalThenVisual);
+registerCoreDispatchCommand2(H.CursorHomeVisualOnly);
+registerCoreDispatchCommand2(H.CursorHomeLogicalOnly);
+
 registerCoreCommand(H.CursorHomeSelect, {
 	primary: KeyMod.Shift | KeyCode.Home,
 	mac: { primary: KeyMod.Shift | KeyCode.Home, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.LeftArrow] }
 });
+registerCoreDispatchCommand2(H.CursorHomeVisualThenLogicalSelect);
+registerCoreDispatchCommand2(H.CursorHomeLogicalThenVisualSelect);
+registerCoreDispatchCommand2(H.CursorHomeVisualOnlySelect);
+registerCoreDispatchCommand2(H.CursorHomeLogicalOnlySelect);
+
 registerCoreCommand(H.CursorEnd, {
 	primary: KeyCode.End,
 	mac: { primary: KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyCode.RightArrow, KeyMod.WinCtrl | KeyCode.KEY_E] }
 });
+registerCoreDispatchCommand2(H.CursorEndVisualThenLogical);
+registerCoreDispatchCommand2(H.CursorEndLogicalThenVisual);
+registerCoreDispatchCommand2(H.CursorEndVisualOnly);
+registerCoreDispatchCommand2(H.CursorEndLogicalOnly);
+
 registerCoreCommand(H.CursorEndSelect, {
 	primary: KeyMod.Shift | KeyCode.End,
 	mac: { primary: KeyMod.Shift | KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.RightArrow] }
 });
+registerCoreDispatchCommand2(H.CursorEndVisualThenLogicalSelect);
+registerCoreDispatchCommand2(H.CursorEndLogicalThenVisualSelect);
+registerCoreDispatchCommand2(H.CursorEndVisualOnlySelect);
+registerCoreDispatchCommand2(H.CursorEndLogicalOnlySelect);
+
 registerCoreCommand(H.ExpandLineSelection, {
 	primary: KeyMod.CtrlCmd | KeyCode.KEY_I
 });

--- a/src/vs/editor/common/controller/cursorMoveHelper.ts
+++ b/src/vs/editor/common/controller/cursorMoveHelper.ts
@@ -193,6 +193,14 @@ export class CursorMoveHelper {
 		};
 	}
 
+	public getColumnAtBeginningOfVisualLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return model.getLineFirstNonWhitespaceColumn(lineNumber) || 1;
+	}
+
+	public getColumnAtBeginningOfLogicalLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return model.getLineMinColumn(lineNumber);
+	}
+
 	public getColumnAtBeginningOfLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
 		var firstNonBlankColumn = model.getLineFirstNonWhitespaceColumn(lineNumber) || 1;
 		var minColumn = model.getLineMinColumn(lineNumber);
@@ -204,6 +212,15 @@ export class CursorMoveHelper {
 		}
 
 		return column;
+	}
+
+	public getColumnAtEndOfVisualLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		var maxColumn = model.getLineMaxColumn(lineNumber);
+		return model.getLineLastNonWhitespaceColumn(lineNumber) || maxColumn;
+	}
+
+	public getColumnAtEndOfLogicalLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return model.getLineMaxColumn(lineNumber);
 	}
 
 	public getColumnAtEndOfLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {

--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -108,6 +108,38 @@ export enum WordNavigationType {
 	WordEnd = 1
 }
 
+/**
+ * Navigation mode when jumping to the beginning or at the end of a line.
+ * Remark: This is usually what happens when you press the 'Home' or the 'End' key.
+ * Terminology:
+ * - logical beginning/end of line: boundaries of a line, including the white-spaces.
+ * - visual beginning/end of line: boundaries of a line, excluding the white-spaces.
+ * Example:
+ * "        alice and bob alice and bob       "
+ *  |       |                         |      |
+ *  ^-------|-- logical boundaries ---|------^
+ *          |                         |
+ *          ^--- visual boundaries ---^
+ */
+export enum LineNavigationType {
+	/**
+	 * First jumps to the visual boundary, then to the logical one, and so forth.
+	 */
+	VisualThenLogical = 0,
+	/**
+	 * First jumps to the logical boundary, then to the visual one, and so forth.
+	 */
+	LogicalThenVisual = 1,
+	/**
+	 * Always jumps to the visual boundary.
+	 */
+	VisualOnly = 2,
+	/**
+	 * Always jumps to the logical boundary.
+	 */
+	LogicalOnly = 3
+}
+
 const CH_REGULAR = CharacterClass.Regular;
 const CH_WHITESPACE = CharacterClass.Whitespace;
 const CH_WORD_SEPARATOR = CharacterClass.WordSeparator;
@@ -530,8 +562,20 @@ export class OneCursor {
 	public getPositionDown(lineNumber:number, column:number, leftoverVisibleColumns:number, count:number, allowMoveOnLastLine:boolean): IMoveResult {
 		return this.helper.getPositionDown(this.model, lineNumber, column, leftoverVisibleColumns, count, allowMoveOnLastLine);
 	}
+	public getColumnAtBeginningOfVisualLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtBeginningOfVisualLine(this.model, lineNumber, column);
+	}
+	public getColumnAtBeginningOfLogicalLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtBeginningOfLogicalLine(this.model, lineNumber, column);
+	}
 	public getColumnAtBeginningOfLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtBeginningOfLine(this.model, lineNumber, column);
+	}
+	public getColumnAtEndOfVisualLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtEndOfVisualLine(this.model, lineNumber, column);
+	}
+	public getColumnAtEndOfLogicalLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtEndOfLogicalLine(this.model, lineNumber, column);
 	}
 	public getColumnAtEndOfLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtEndOfLine(this.model, lineNumber, column);
@@ -565,8 +609,20 @@ export class OneCursor {
 	public getViewPositionDown(lineNumber:number, column:number, leftoverVisibleColumns:number, count:number, allowMoveOnLastLine:boolean): IMoveResult {
 		return this.helper.getPositionDown(this.viewModelHelper.viewModel, lineNumber, column, leftoverVisibleColumns, count, allowMoveOnLastLine);
 	}
+	public getColumnAtBeginningOfVisualViewLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtBeginningOfVisualLine(this.viewModelHelper.viewModel, lineNumber, column);
+	}
+	public getColumnAtBeginningOfLogicalViewLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtBeginningOfLogicalLine(this.viewModelHelper.viewModel, lineNumber, column);
+	}
 	public getColumnAtBeginningOfViewLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtBeginningOfLine(this.viewModelHelper.viewModel, lineNumber, column);
+	}
+	public getColumnAtEndOfVisualViewLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtEndOfVisualLine(this.viewModelHelper.viewModel, lineNumber, column);
+	}
+	public getColumnAtEndOfLogicalViewLine(lineNumber:number, column:number): number {
+		return this.helper.getColumnAtEndOfLogicalLine(this.viewModelHelper.viewModel, lineNumber, column);
 	}
 	public getColumnAtEndOfViewLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtEndOfLine(this.viewModelHelper.viewModel, lineNumber, column);
@@ -900,23 +956,64 @@ export class OneCursorOp {
 		return true;
 	}
 
-	public static moveToBeginningOfLine(cursor:OneCursor, inSelectionMode: boolean, ctx: IOneCursorOperationContext): boolean {
+	public static moveToBeginningOfLine(cursor:OneCursor, inSelectionMode: boolean, lineNavigationType: LineNavigationType, ctx: IOneCursorOperationContext): boolean {
 		let validatedViewPosition = cursor.getValidViewPosition();
 		let viewLineNumber = validatedViewPosition.lineNumber;
 		let viewColumn = validatedViewPosition.column;
 
-		viewColumn = cursor.getColumnAtBeginningOfViewLine(viewLineNumber, viewColumn);
+		var firstNonBlankColumn = cursor.getColumnAtBeginningOfVisualViewLine(viewLineNumber, viewColumn);
+		var minColumn = cursor.getColumnAtBeginningOfLogicalViewLine(viewLineNumber, viewColumn);
+
+		if (lineNavigationType === LineNavigationType.VisualThenLogical) {
+			if (viewColumn !== minColumn && viewColumn <= firstNonBlankColumn) {
+				viewColumn = minColumn;
+			} else {
+				viewColumn = firstNonBlankColumn;
+			}
+		} else if (lineNavigationType === LineNavigationType.LogicalThenVisual) {
+			if (viewColumn !== minColumn) {
+				viewColumn = minColumn;
+			} else {
+				viewColumn = firstNonBlankColumn;
+			}
+		} else if (lineNavigationType === LineNavigationType.LogicalOnly) {
+			viewColumn = minColumn;
+		} else if (lineNavigationType === LineNavigationType.VisualOnly) {
+			viewColumn = firstNonBlankColumn;
+		}
+
 		ctx.cursorPositionChangeReason = editorCommon.CursorChangeReason.Explicit;
 		cursor.moveViewPosition(inSelectionMode, viewLineNumber, viewColumn, 0, true);
 		return true;
 	}
 
-	public static moveToEndOfLine(cursor:OneCursor, inSelectionMode: boolean, ctx: IOneCursorOperationContext): boolean {
+	public static moveToEndOfLine(cursor:OneCursor, inSelectionMode: boolean, lineNavigationType: LineNavigationType, ctx: IOneCursorOperationContext): boolean {
 		let validatedViewPosition = cursor.getValidViewPosition();
 		let viewLineNumber = validatedViewPosition.lineNumber;
 		let viewColumn = validatedViewPosition.column;
 
-		viewColumn = cursor.getColumnAtEndOfViewLine(viewLineNumber, viewColumn);
+		let maxColumn = cursor.getColumnAtEndOfLogicalViewLine(viewLineNumber, viewColumn);
+		let lastNonBlankColumn = cursor.getColumnAtEndOfVisualViewLine(viewLineNumber, viewColumn);
+
+		if (lineNavigationType === LineNavigationType.VisualThenLogical) {
+
+			if (viewColumn !== maxColumn && viewColumn >= lastNonBlankColumn) {
+				viewColumn = maxColumn;
+			} else {
+				viewColumn = lastNonBlankColumn;
+			}
+		} else if (lineNavigationType === LineNavigationType.LogicalThenVisual) {
+			if (viewColumn !== maxColumn) {
+				viewColumn = maxColumn;
+			} else {
+				viewColumn = lastNonBlankColumn;
+			}
+		} else if (lineNavigationType === LineNavigationType.LogicalOnly) {
+			viewColumn = maxColumn;
+		} else if (lineNavigationType === LineNavigationType.VisualOnly) {
+			viewColumn = lastNonBlankColumn;
+		}
+
 		ctx.cursorPositionChangeReason = editorCommon.CursorChangeReason.Explicit;
 		cursor.moveViewPosition(inSelectionMode, viewLineNumber, viewColumn, 0, true);
 		return true;
@@ -2023,8 +2120,24 @@ class CursorHelper {
 		return this.moveHelper.getPositionDown(model, lineNumber, column, leftoverVisibleColumns, count, allowMoveOnLastLine);
 	}
 
+	public getColumnAtBeginningOfVisualLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return this.moveHelper.getColumnAtBeginningOfVisualLine(model, lineNumber, column);
+	}
+
+	public getColumnAtBeginningOfLogicalLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return this.moveHelper.getColumnAtBeginningOfLogicalLine(model, lineNumber, column);
+	}
+
 	public getColumnAtBeginningOfLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
 		return this.moveHelper.getColumnAtBeginningOfLine(model, lineNumber, column);
+	}
+
+	public getColumnAtEndOfVisualLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return this.moveHelper.getColumnAtEndOfVisualLine(model, lineNumber, column);
+	}
+
+	public getColumnAtEndOfLogicalLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {
+		return this.moveHelper.getColumnAtEndOfLogicalLine(model, lineNumber, column);
 	}
 
 	public getColumnAtEndOfLine(model:ICursorMoveHelperModel, lineNumber:number, column:number): number {

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -3827,11 +3827,31 @@ export var Handler = {
 	CursorPageDown:				'cursorPageDown',
 	CursorPageDownSelect:		'cursorPageDownSelect',
 
-	CursorHome:					'cursorHome',
-	CursorHomeSelect:			'cursorHomeSelect',
+	CursorHome:					 'cursorHome',
+	CursorHomeSelect:            'cursorHomeSelect',
+
+	CursorHomeVisualThenLogical: 'cursorHomeVisualThenLogical',
+	CursorHomeLogicalThenVisual: 'cursorHomeLogicalThenVisual',
+	CursorHomeVisualOnly:        'cursorHomeVisualOnly',
+	CursorHomeLogicalOnly:       'cursorHomeLogicalOnly',
+
+	CursorHomeVisualThenLogicalSelect: 'cursorHomeVisualThenLogicalSelect',
+	CursorHomeLogicalThenVisualSelect: 'cursorHomeLogicalThenVisualSelect',
+	CursorHomeVisualOnlySelect:        'cursorHomeVisualOnlySelect',
+	CursorHomeLogicalOnlySelect:       'cursorHomeLogicalOnlySelect',
 
 	CursorEnd:					'cursorEnd',
 	CursorEndSelect:			'cursorEndSelect',
+
+	CursorEndVisualThenLogical:	'cursorEndVisualThenLogical',
+	CursorEndLogicalThenVisual:	'cursorEndLogicalThenVisual',
+	CursorEndVisualOnly:		'cursorEndVisualOnly',
+	CursorEndLogicalOnly:		'cursorEndLogicalOnly',
+
+	CursorEndVisualThenLogicalSelect:	'cursorEndVisualThenLogicalSelect',
+	CursorEndLogicalThenVisualSelect:	'cursorEndLogicalThenVisualSelect',
+	CursorEndVisualOnlySelect:			'cursorEndVisualOnlySelect',
+	CursorEndLogicalOnlySelect:			'cursorEndLogicalOnlySelect',
 
 	ExpandLineSelection:		'expandLineSelection',
 

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -78,12 +78,36 @@ function moveUp(cursor: Cursor, linesCount: number, inSelectionMode: boolean = f
 	}
 }
 
-function moveToBeginningOfLine(cursor: Cursor, inSelectionMode: boolean = false) {
-	cursorCommand(cursor, inSelectionMode ? H.CursorHomeSelect : H.CursorHome);
+function moveToBeginningOfLineVisualThenLogical(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorHomeVisualThenLogicalSelect : H.CursorHomeVisualThenLogical);
 }
 
-function moveToEndOfLine(cursor: Cursor, inSelectionMode: boolean = false) {
-	cursorCommand(cursor, inSelectionMode ?  H.CursorEndSelect : H.CursorEnd);
+function moveToBeginningOfLineLogicalThenVisual(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorHomeLogicalThenVisualSelect : H.CursorHomeLogicalThenVisual);
+}
+
+function moveToBeginningOfLineVisualOnly(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorHomeVisualOnlySelect : H.CursorHomeVisualOnly);
+}
+
+function moveToBeginningOfLineLogicalOnly(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorHomeLogicalOnlySelect : H.CursorHomeLogicalOnly);
+}
+
+function moveToEndOfLineVisualThenLogical(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorEndVisualThenLogicalSelect : H.CursorEndVisualThenLogical);
+}
+
+function moveToEndOfLineLogicalThenVisual(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorEndLogicalThenVisualSelect : H.CursorEndLogicalThenVisual);
+}
+
+function moveToEndOfLineVisualOnly(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorEndVisualOnlySelect : H.CursorEndVisualOnly);
+}
+
+function moveToEndOfLineLogicalOnly(cursor: Cursor, inSelectionMode: boolean = false) {
+	cursorCommand(cursor, inSelectionMode ? H.CursorEndLogicalOnlySelect : H.CursorEndLogicalOnly);
 }
 
 function moveToBeginningOfBuffer(cursor: Cursor, inSelectionMode: boolean = false) {
@@ -458,9 +482,9 @@ suite('Editor Controller - Cursor', () => {
 	});
 
 	test('move up and down with end of lines starting from a long one', () => {
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length - 1);
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length + 1);
 		moveDown(thisCursor, 1);
 		cursorEqual(thisCursor, 2, LINE2.length + 1);
@@ -476,67 +500,253 @@ suite('Editor Controller - Cursor', () => {
 
 	// --------- move to beginning of line
 
-	test('move to beginning of line', () => {
-		moveToBeginningOfLine(thisCursor);
+	test('move to beginning of line (visual then logical)', () => {
+		moveToBeginningOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, 6);
-		moveToBeginningOfLine(thisCursor);
+		moveToBeginningOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, 1);
 	});
 
-	test('move to beginning of line from within line', () => {
+	test('move to beginning of line (logical then visual)', () => {
+		moveToBeginningOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to beginning of line (visual only)', () => {
+		moveToBeginningOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+		moveToBeginningOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to beginning of line (logical only)', () => {
+		moveToBeginningOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+		moveToBeginningOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to beginning of line from within line (visual then logical)', () => {
 		moveTo(thisCursor, 1, 8);
-		moveToBeginningOfLine(thisCursor);
+		moveToBeginningOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, 6);
-		moveToBeginningOfLine(thisCursor);
+		moveToBeginningOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, 1);
 	});
 
-	test('move to beginning of line from whitespace at beginning of line', () => {
+	test('move to beginning of line from within line (logical then visual)', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to beginning of line from within line (visual only)', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToBeginningOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+		moveToBeginningOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to beginning of line from within line (logical only)', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToBeginningOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+		moveToBeginningOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to beginning of line from whitespace at beginning of line (visual then logical)', () => {
 		moveTo(thisCursor, 1, 2);
-		moveToBeginningOfLine(thisCursor);
+		moveToBeginningOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, 1);
-		moveToBeginningOfLine(thisCursor);
+		moveToBeginningOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, 6);
 	});
 
-	test('move to beginning of line from within line selection', () => {
+	test('move to beginning of line from whitespace at beginning of line (logical then visual)', () => {
+		moveTo(thisCursor, 1, 2);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to beginning of line from whitespace at beginning of line (visual only)', () => {
+		moveTo(thisCursor, 1, 2);
+		moveToBeginningOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+		moveToBeginningOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to beginning of line from whitespace at beginning of line (logical only)', () => {
+		moveTo(thisCursor, 1, 2);
+		moveToBeginningOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+		moveToBeginningOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to beginning of line from within line selection (visual then logical)', () => {
 		moveTo(thisCursor, 1, 8);
-		moveToBeginningOfLine(thisCursor, true);
+		moveToBeginningOfLineVisualThenLogical(thisCursor, true);
 		cursorEqual(thisCursor, 1, 6, 1, 8);
-		moveToBeginningOfLine(thisCursor, true);
+		moveToBeginningOfLineVisualThenLogical(thisCursor, true);
+		cursorEqual(thisCursor, 1, 1, 1, 8);
+	});
+
+	test('move to beginning of line from within line selection (logical then visual)', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor, true);
+		cursorEqual(thisCursor, 1, 1, 1, 8);
+		moveToBeginningOfLineLogicalThenVisual(thisCursor, true);
+		cursorEqual(thisCursor, 1, 6, 1, 8);
+	});
+
+	test('move to beginning of line from within line selection (visual only)', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToBeginningOfLineVisualOnly(thisCursor, true);
+		cursorEqual(thisCursor, 1, 6, 1, 8);
+		moveToBeginningOfLineVisualOnly(thisCursor, true);
+		cursorEqual(thisCursor, 1, 6, 1, 8);
+	});
+
+	test('move to beginning of line from within line selection (logical only)', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToBeginningOfLineLogicalOnly(thisCursor, true);
+		cursorEqual(thisCursor, 1, 1, 1, 8);
+		moveToBeginningOfLineLogicalOnly(thisCursor, true);
 		cursorEqual(thisCursor, 1, 1, 1, 8);
 	});
 
 	// --------- move to end of line
 
-	test('move to end of line', () => {
-		moveToEndOfLine(thisCursor);
+	test('move to end of line (visual then logical)', () => {
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length - 1);
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length + 1);
 	});
 
-	test('move to end of line from within line', () => {
+	test('move to end of line (logical then visual)', () => {
+		moveToEndOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+		moveToEndOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to end of line (visual only)', () => {
+		moveToEndOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+		moveToEndOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to end of line (logical only)', () => {
+		moveToEndOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+		moveToEndOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+	});
+
+	test('move to end of line from within line (visual then logical)', () => {
 		moveTo(thisCursor, 1, 6);
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length - 1);
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length + 1);
 	});
 
-	test('move to end of line from whitespace at end of line', () => {
+	test('move to end of line from within line (logical then visual)', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToEndOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+		moveToEndOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to end of line from within line (visual only)', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToEndOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+		moveToEndOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to end of line from within line (logical only)', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToEndOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+		moveToEndOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+	});
+
+	test('move to end of line from whitespace at end of line (visual then logical)', () => {
 		moveTo(thisCursor, 1, 20);
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length + 1);
-		moveToEndOfLine(thisCursor);
+		moveToEndOfLineVisualThenLogical(thisCursor);
 		cursorEqual(thisCursor, 1, LINE1.length - 1);
 	});
 
-	test('move to end of line from within line selection', () => {
+	test('move to end of line from whitespace at end of line (logical then visual)', () => {
+		moveTo(thisCursor, 1, 20);
+		moveToEndOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+		moveToEndOfLineLogicalThenVisual(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to end of line from whitespace at end of line (visual only)', () => {
+		moveTo(thisCursor, 1, 20);
+		moveToEndOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+		moveToEndOfLineVisualOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to end of line from whitespace at end of line (logical only)', () => {
+		moveTo(thisCursor, 1, 20);
+		moveToEndOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+		moveToEndOfLineLogicalOnly(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+	});
+
+	test('move to end of line from within line selection (visual then logical)', () => {
 		moveTo(thisCursor, 1, 6);
-		moveToEndOfLine(thisCursor, true);
+		moveToEndOfLineVisualThenLogical(thisCursor, true);
 		cursorEqual(thisCursor, 1, LINE1.length - 1, 1, 6);
-		moveToEndOfLine(thisCursor, true);
+		moveToEndOfLineVisualThenLogical(thisCursor, true);
+		cursorEqual(thisCursor, 1, LINE1.length + 1, 1, 6);
+	});
+
+	test('move to end of line from within line selection (logical then visual)', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToEndOfLineLogicalThenVisual(thisCursor, true);
+		cursorEqual(thisCursor, 1, LINE1.length + 1, 1, 6);
+		moveToEndOfLineLogicalThenVisual(thisCursor, true);
+		cursorEqual(thisCursor, 1, LINE1.length - 1, 1, 6);
+	});
+
+	test('move to end of line from within line selection (visual only)', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToEndOfLineVisualOnly(thisCursor, true);
+		cursorEqual(thisCursor, 1, LINE1.length - 1, 1, 6);
+		moveToEndOfLineVisualOnly(thisCursor, true);
+		cursorEqual(thisCursor, 1, LINE1.length - 1, 1, 6);
+	});
+
+	test('move to end of line from within line selection (logical only)', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToEndOfLineLogicalOnly(thisCursor, true);
+		cursorEqual(thisCursor, 1, LINE1.length + 1, 1, 6);
+		moveToEndOfLineLogicalOnly(thisCursor, true);
 		cursorEqual(thisCursor, 1, LINE1.length + 1, 1, 6);
 	});
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2832,10 +2832,33 @@ declare module monaco.editor {
         CursorPageUpSelect: string;
         CursorPageDown: string;
         CursorPageDownSelect: string;
+
         CursorHome: string;
         CursorHomeSelect: string;
+
+        CursorHomeVisualThenLogical: string; // more descriptive alias for 'CursorHome'
+        CursorHomeLogicalThenVisual: string;
+        CursorHomeVisualOnly: string;
+        CursorHomeLogicalOnly: string;
+
+        CursorHomeVisualThenLogicalSelect: string; // more descriptive alias for 'CursorHomeSelect'
+        CursorHomeLogicalThenVisualSelect: string;
+        CursorHomeVisualOnlySelect: string;
+        CursorHomeLogicalOnlySelect: string;
+
         CursorEnd: string;
         CursorEndSelect: string;
+
+        CursorEndVisualThenLogical: string; // more descriptive alias for 'CursorEnd'
+        CursorEndLogicalThenVisual: string;
+        CursorEndVisualOnly: string;
+        CursorEndLogicalOnly: string;
+
+        CursorEndVisualThenLogicalSelect: string; // more descriptive alias for 'CursorEndSelect'
+        CursorEndLogicalThenVisualSelect: string;
+        CursorEndVisualOnlySelect: string;
+        CursorEndLogicalOnlySelect: string;
+
         ExpandLineSelection: string;
         CursorTop: string;
         CursorTopSelect: string;


### PR DESCRIPTION
This PR propose a change to allow more behaviors for the line navigation feature, through new keyboard shortcut commands.
# The problem

Now pressing `Home` and `End` keys makes the cursor move to the first/last non white space character first, then to the real beginning/end of line, and so forth. This makes VSCode behave like WebStorm for example, however I would like to be able to make it behave like Visual Studio.
- WebStorn:
  - `Home` goes to the first non white space character, then goes to the very beginning of the line
  - `End` goes to the last non white space character, then goes to the very end of the line
- Visual Studio:
  - `Home` goes to the first non white space character, then goes to the very beginning of the line (same as WebStorm)
  - `End` just go to the the very end of the line

Until then, I could not find the way to setup VSCode and make it behave like Visual Studio, that's why I propose a change.
# The proposal

First, I believe a bit a terminology is required in order to be sure that we are all on the same page.
If the vocabulary I use is not correct, please let me know.
## Terminology

What I call the **visual** boundaries of a line, is the line not including the white space characters, so simply said, the **visual** boundaries of a line go from the first 'visible' character to the last 'visible' character.

The **logical** boundaries of a line is the whole line, including all the characters from the beginning to the first line separator character, including white spaces.

Example:

```
"        alice and bob alice and bob       "
 |       |                         |      |
 ^-------|-- logical boundaries ---|------^
         |                         |
         ^--- visual boundaries ---^
```
## New cursor commands

To be able to change the line navigation behavior, and still let other people configure it the way they want, I added new cursor commands. Existing ones are `CursorHome` and `CursorEnd` (along with their `*Select` related command).

For the ones interested, they can be found through the menu `File` / `Preferences` / `Keyboard Shortcuts`, then this way:

```
{ "key": "end",                   "command": "cursorEnd",
                                     "when": "editorTextFocus" },
{ "key": "home",                  "command": "cursorHome",
                                     "when": "editorTextFocus" },
```

I added the following new commands:

`Cursor*VisualThenLogical`
`Cursor*LogicalThenVisual`
`Cursor*VisualOnly`
`Cursor*LogicalOnly`

where '*' is `Home` and `End`, and of course their `*Select` related commands, making a total of 16 new commands.

Note that `CursorHomeVisualThenLogical` is simply an alias to existing `CursorHome`, and the same goes for `CursorEndVisualThenLogical` aliasing `CursorEnd`, since this is the default behavior of VSCode.

The new commands appear in the list at the bottom of the keyboard shortcuts configuration file as _other available commands_.
## Unit tests

I added new unit tests (all passing) for each combination of commands and contexts.
Those are in the file `cursor.test.ts`.
## Linting

When I ran the `tslint` command, some reports appeared, but none concerning the change I made, so should be fine.
## Combination of cases

I've tested the change, and it works in all line navigation modes, including all combination or selection, wrapped lines and multi cursor contexts.
## monaco editor

I had to modify `monaco.d.ts` in order to add new handlers, however I'm not sure if I'm supposed to do that, neither if I'm supposed to do it that way. I tried to find the code I needed to change in the monacor-editor related GitHub repositories, but I could not find what I was looking for.
## Visual Studio like setup

```
{ "key": "end",           "command": "cursorEndLogicalOnly",
                             "when": "editorTextFocus" },
{ "key": "shift+end",     "command": "cursorEndLogicalOnlySelect",
                             "when": "editorTextFocus" },
{ "key": "home",          "command": "cursorHomeVisualThenLogical",
                             "when": "editorTextFocus" },
{ "key": "shift+home",    "command": "cursorHomeVisualThenLogicalSelect",
                             "when": "editorTextFocus" }
```

Do not forget to set the `*Select` version, or you may experience asymmetries.
