### PR TITLE
Fix task schema suppressTaskName and echoCommand defaultValue.

### DIFF
--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1214,8 +1214,8 @@ let schema : IJSONSchema =
 					},
 					'suppressTaskName': {
 						'type': 'boolean',
-						'description': nls.localize('JsonSchema.suppressTaskName', 'Controls whether the task name is added as an argument to the command. Default is false.'),
-						'default': true
+						'description': nls.localize('JsonSchema.suppressTaskName', 'Controls whether the task name should be suppressed as an argument to the command. Only valid when there is a tasks property. Default is false.'),
+						'default': false
 					},
 					'taskSelector': {
 						'type': 'string',
@@ -1253,8 +1253,8 @@ let schema : IJSONSchema =
 					},
 					'suppressTaskName': {
 						'type': 'boolean',
-						'description': nls.localize('JsonSchema.tasks.suppressTaskName', 'Controls whether the task name is added as an argument to the command. If omitted the globally defined value is used.'),
-						'default': true
+						'description': nls.localize('JsonSchema.tasks.suppressTaskName', 'Controls whether the task name should be suppressed as an argument to the command. If omitted the globally defined value is used.'),
+						'default': false
 					},
 					'showOutput': {
 						'$ref': '#/definitions/showOutputType',

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1210,7 +1210,7 @@ let schema : IJSONSchema =
 					'echoCommand': {
 						'type': 'boolean',
 						'description': nls.localize('JsonSchema.echoCommand', 'Controls whether the executed command is echoed to the output. Default is false.'),
-						'default': true
+						'default': false
 					},
 					'suppressTaskName': {
 						'type': 'boolean',
@@ -1263,7 +1263,7 @@ let schema : IJSONSchema =
 					'echoCommand': {
 						'type': 'boolean',
 						'description': nls.localize('JsonSchema.echoCommand', 'Controls whether the executed command is echoed to the output. Default is false.'),
-						'default': true
+						'default': false
 					},
 					'isWatching': {
 						'type': 'boolean',

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1210,12 +1210,12 @@ let schema : IJSONSchema =
 					'echoCommand': {
 						'type': 'boolean',
 						'description': nls.localize('JsonSchema.echoCommand', 'Controls whether the executed command is echoed to the output. Default is false.'),
-						'default': false
+						'default': true
 					},
 					'suppressTaskName': {
 						'type': 'boolean',
 						'description': nls.localize('JsonSchema.suppressTaskName', 'Controls whether the task name should be suppressed as an argument to the command. Only valid when there is a tasks property. Default is false.'),
-						'default': false
+						'default': true
 					},
 					'taskSelector': {
 						'type': 'string',
@@ -1254,7 +1254,7 @@ let schema : IJSONSchema =
 					'suppressTaskName': {
 						'type': 'boolean',
 						'description': nls.localize('JsonSchema.tasks.suppressTaskName', 'Controls whether the task name should be suppressed as an argument to the command. If omitted the globally defined value is used.'),
-						'default': false
+						'default': true
 					},
 					'showOutput': {
 						'$ref': '#/definitions/showOutputType',
@@ -1263,7 +1263,7 @@ let schema : IJSONSchema =
 					'echoCommand': {
 						'type': 'boolean',
 						'description': nls.localize('JsonSchema.echoCommand', 'Controls whether the executed command is echoed to the output. Default is false.'),
-						'default': false
+						'default': true
 					},
 					'isWatching': {
 						'type': 'boolean',


### PR DESCRIPTION
`suppressTaskName` description  is confusing.

If `tasks.json` there is no tasks. `suppressTaskName` is always `true`. see:
https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/tasks/node/processRunnerConfiguration.ts#L453

If `tasks.json` there is tasks. `suppressTaskName` default use global value is `false`. see:
https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/tasks/node/processRunnerConfiguration.ts#L326

So I change the schema description to `only valid when there is a tasks property.`

In addition, `echoCommand` and `suppressTaskName` default value in schema is incorrect.

![4](https://cloud.githubusercontent.com/assets/7069719/16833106/53132e7c-49e0-11e6-9a30-dc9349de8726.png)
