### PR TITLE
Folding icon collides with git decorations: Create a div per linedecoration

### DIFF
--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -27,12 +27,12 @@ export class DecorationToRender {
 
 export abstract class DedupOverlay extends DynamicViewOverlay {
 
-	protected _render(visibleStartLineNumber:number, visibleEndLineNumber:number, decorations:DecorationToRender[]): string[] {
+	protected _render(visibleStartLineNumber:number, visibleEndLineNumber:number, decorations:DecorationToRender[]): string[][] {
 
-		let output: string[] = [];
+		let output: string[][] = [];
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
 			let lineIndex = lineNumber - visibleStartLineNumber;
-			output[lineIndex] = '';
+			output[lineIndex] = [];
 		}
 
 		if (decorations.length === 0) {
@@ -66,7 +66,7 @@ export abstract class DedupOverlay extends DynamicViewOverlay {
 			}
 
 			for (let i = startLineIndex; i <= prevEndLineIndex; i++) {
-				output[i] += ' ' + prevClassName;
+				output[i].push(prevClassName);
 			}
 		}
 
@@ -189,8 +189,8 @@ export class GlyphMarginOverlay extends DedupOverlay {
 				output[lineIndex] = '';
 			} else {
 				output[lineIndex] = (
-					'<div class="cgmr'
-					+ classNames
+					'<div class="cgmr '
+					+ classNames.join(' ')
 					+ common
 				);
 			}

--- a/src/vs/editor/browser/viewParts/linesDecorations/linesDecorations.ts
+++ b/src/vs/editor/browser/viewParts/linesDecorations/linesDecorations.ts
@@ -112,12 +112,11 @@ export class LinesDecorationsOverlay extends DedupOverlay {
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
 			let lineIndex = lineNumber - visibleStartLineNumber;
 			let classNames = toRender[lineIndex];
-
-			if (classNames.length === 0) {
-				output[lineIndex] = '';
-			} else {
-				output[lineIndex] = classNames.map(className => '<div class="cldr ' + className + common).join('');
+			let lineOutput = '';
+			for (let i = 0, len = classNames.length; i < len; i++) {
+				lineOutput += '<div class="cldr ' + classNames[i] + common;
 			}
+			output[lineIndex] = lineOutput;
 		}
 
 		this._renderResult = output;

--- a/src/vs/editor/browser/viewParts/linesDecorations/linesDecorations.ts
+++ b/src/vs/editor/browser/viewParts/linesDecorations/linesDecorations.ts
@@ -116,11 +116,7 @@ export class LinesDecorationsOverlay extends DedupOverlay {
 			if (classNames.length === 0) {
 				output[lineIndex] = '';
 			} else {
-				output[lineIndex] = (
-					'<div class="cldr'
-					+ classNames
-					+ common
-				);
+				output[lineIndex] = classNames.map(className => '<div class="cldr ' + className + common).join('');
 			}
 		}
 

--- a/src/vs/editor/contrib/folding/browser/folding.css
+++ b/src/vs/editor/contrib/folding/browser/folding.css
@@ -6,40 +6,31 @@
 .monaco-editor .margin-view-overlays .folding {
 	margin-left: 5px;
 	cursor: pointer;
-}
-
-.monaco-editor .margin-view-overlays .folding::after {
 	background-repeat: no-repeat;
 	background-origin: border-box;
 	background-position: 3px center;
 	background-size: 15px;
-	position: absolute;
-	top: 0;
-	left:0;
-	right: 0;
-	bottom: 0;
-	content: "";
 	opacity: 0;
 	transition: opacity 0.5s;
 }
 
-.monaco-editor .margin-view-overlays:hover .folding::after {
+.monaco-editor .margin-view-overlays:hover .folding {
 	background-image: url('arrow-expand.svg');
 	opacity: 1;
 }
 
-.monaco-editor .margin-view-overlays .folding.collapsed::after {
+.monaco-editor .margin-view-overlays .folding.collapsed {
 	background-image: url('arrow-collapse.svg');
 	opacity: 1;
 }
 
-.monaco-editor.hc-black .margin-view-overlays:hover .folding::after,
-.monaco-editor.vs-dark .margin-view-overlays:hover .folding::after {
+.monaco-editor.hc-black .margin-view-overlays:hover .folding,
+.monaco-editor.vs-dark .margin-view-overlays:hover .folding {
 	background-image: url('arrow-expand-dark.svg');
 }
 
-.monaco-editor.hc-black .margin-view-overlays .folding.collapsed::after,
-.monaco-editor.vs-dark .margin-view-overlays .folding.collapsed::after {
+.monaco-editor.hc-black .margin-view-overlays .folding.collapsed,
+.monaco-editor.vs-dark .margin-view-overlays .folding.collapsed {
 	background-image: url('arrow-collapse-dark.svg');
 }
 


### PR DESCRIPTION
Motivated by issue #9222.  Pull request also contains the changes to fix #9222.

The underlying issue is that all line decorations on the same line share the same div and that css rules on that div interfere with each other. 

The fix creates a div per decoration className. The existing code already folds multiple decorations on the same line with the same class name.
The divs are still absolutely positioned, at the same location, so there's not more horizontal space used than before.

The same change could be done on the glyph margins, but I kept the existing behaviour.

Before
![image](https://cloud.githubusercontent.com/assets/6461412/16834336/9fa6a2b4-49b3-11e6-9576-de6c8c4e6403.png)

After
![image](https://cloud.githubusercontent.com/assets/6461412/16834303/815c4944-49b3-11e6-8f56-ac3210c41d8d.png)
