### PR TITLE
Introduce a move command for the editor

### DIFF
--- a/src/vs/editor/browser/standalone/standaloneEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneEditor.ts
@@ -434,6 +434,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		// vars
 		EditorType: editorCommon.EditorType,
 		Handler: editorCommon.Handler,
+		ViewPosition: editorCommon.ViewPosition,
 
 		// consts
 		KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS: editorCommon.KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS,

--- a/src/vs/editor/browser/standalone/standaloneEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneEditor.ts
@@ -433,8 +433,8 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 
 		// vars
 		EditorType: editorCommon.EditorType,
+		CursorMoveViewPosition: editorCommon.CursorMoveViewPosition,
 		Handler: editorCommon.Handler,
-		ViewPosition: editorCommon.ViewPosition,
 
 		// consts
 		KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS: editorCommon.KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS,

--- a/src/vs/editor/common/config/config.ts
+++ b/src/vs/editor/common/config/config.ts
@@ -154,6 +154,9 @@ function getWordNavigationKB(shift:boolean, key:KeyCode): number {
 // Control+Command+d => noop
 // Control+Command+shift+d => noop
 
+// Register cursor commands
+registerCoreCommand(H.CursorMove, { primary: null });
+
 registerCoreCommand(H.CursorLeft, {
 	primary: KeyCode.LeftArrow,
 	mac: { primary: KeyCode.LeftArrow, secondary: [KeyMod.WinCtrl | KeyCode.KEY_B] }

--- a/src/vs/editor/common/config/config.ts
+++ b/src/vs/editor/common/config/config.ts
@@ -9,10 +9,12 @@ import {IEditorService} from 'vs/platform/editor/common/editor';
 import {ServicesAccessor} from 'vs/platform/instantiation/common/instantiation';
 import {IKeybindings, KbExpr} from 'vs/platform/keybinding/common/keybinding';
 import {ICommandDescriptor, KeybindingsRegistry} from 'vs/platform/keybinding/common/keybindingsRegistry';
+import {ICommandHandlerDescription} from 'vs/platform/commands/common/commands';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import {ICodeEditorService} from 'vs/editor/common/services/codeEditorService';
 
 const H = editorCommon.Handler;
+const D = editorCommon.CommandDescription;
 
 export function findFocusedEditor(commandId: string, accessor: ServicesAccessor, complain: boolean): editorCommon.ICommonCodeEditor {
 	let editor = accessor.get(ICodeEditorService).getFocusedCodeEditor();
@@ -54,17 +56,18 @@ function triggerEditorHandler(handlerId: string, accessor: ServicesAccessor, arg
 	});
 }
 
-function registerCoreCommand(handlerId: string, kb: IKeybindings, weight: number = KeybindingsRegistry.WEIGHT.editorCore(), when?: KbExpr): void {
+function registerCoreCommand(handlerId: string, kb: IKeybindings, weight?: number, when?: KbExpr, description?: ICommandHandlerDescription): void {
 	let desc: ICommandDescriptor = {
 		id: handlerId,
 		handler: triggerEditorHandler.bind(null, handlerId),
-		weight: weight,
+		weight: weight ? weight : KeybindingsRegistry.WEIGHT.editorCore(),
 		when: (when ? when : KbExpr.has(editorCommon.KEYBINDING_CONTEXT_EDITOR_TEXT_FOCUS)),
 		primary: kb.primary,
 		secondary: kb.secondary,
 		win: kb.win,
 		mac: kb.mac,
-		linux: kb.linux
+		linux: kb.linux,
+		description: description
 	};
 	KeybindingsRegistry.registerCommandDesc(desc);
 }
@@ -155,7 +158,7 @@ function getWordNavigationKB(shift:boolean, key:KeyCode): number {
 // Control+Command+shift+d => noop
 
 // Register cursor commands
-registerCoreCommand(H.CursorMove, { primary: null });
+registerCoreCommand(H.CursorMove, { primary: null }, null, null, D.CursorMove);
 
 registerCoreCommand(H.CursorLeft, {
 	primary: KeyCode.LeftArrow,

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -944,6 +944,7 @@ export class Cursor extends EventEmitter {
 
 		this._handlers[H.JumpToBracket] =				(ctx) => this._jumpToBracket(ctx);
 
+		this._handlers[H.CursorMove] = 					(ctx) => this._move(false, ctx);
 		this._handlers[H.MoveTo] = 						(ctx) => this._moveTo(false, ctx);
 		this._handlers[H.MoveToSelect] = 				(ctx) => this._moveTo(true, ctx);
 		this._handlers[H.ColumnSelect] = 				(ctx) => this._columnSelectMouse(ctx);
@@ -1092,7 +1093,8 @@ export class Cursor extends EventEmitter {
 				postOperationRunnable: null,
 				shouldPushStackElementBefore: false,
 				shouldPushStackElementAfter: false,
-				requestScrollDeltaLines: 0
+				requestScrollDeltaLines: 0,
+				eventData: ctx.eventData
 			};
 
 			result = callable(i, cursors[i], context) || result;
@@ -1124,6 +1126,10 @@ export class Cursor extends EventEmitter {
 	private _moveTo(inSelectionMode:boolean, ctx: IMultipleCursorOperationContext): boolean {
 		this.cursors.killSecondaryCursors();
 		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.moveTo(oneCursor, inSelectionMode, ctx.eventData.position, ctx.eventData.viewPosition, ctx.eventSource, oneCtx));
+	}
+
+	private _move(inSelectionMode:boolean, ctx: IMultipleCursorOperationContext): boolean {
+		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.move(oneCursor, inSelectionMode, ctx.eventData.viewPosition, ctx.eventSource, oneCtx));
 	}
 
 	private _columnSelectToLineNumber: number = 0;

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -944,7 +944,7 @@ export class Cursor extends EventEmitter {
 
 		this._handlers[H.JumpToBracket] =				(ctx) => this._jumpToBracket(ctx);
 
-		this._handlers[H.CursorMove] = 					(ctx) => this._move(false, ctx);
+		this._handlers[H.CursorMove] = 					(ctx) => this._cursorMove(ctx);
 		this._handlers[H.MoveTo] = 						(ctx) => this._moveTo(false, ctx);
 		this._handlers[H.MoveToSelect] = 				(ctx) => this._moveTo(true, ctx);
 		this._handlers[H.ColumnSelect] = 				(ctx) => this._columnSelectMouse(ctx);
@@ -1093,8 +1093,7 @@ export class Cursor extends EventEmitter {
 				postOperationRunnable: null,
 				shouldPushStackElementBefore: false,
 				shouldPushStackElementAfter: false,
-				requestScrollDeltaLines: 0,
-				eventData: ctx.eventData
+				requestScrollDeltaLines: 0
 			};
 
 			result = callable(i, cursors[i], context) || result;
@@ -1128,8 +1127,8 @@ export class Cursor extends EventEmitter {
 		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.moveTo(oneCursor, inSelectionMode, ctx.eventData.position, ctx.eventData.viewPosition, ctx.eventSource, oneCtx));
 	}
 
-	private _move(inSelectionMode:boolean, ctx: IMultipleCursorOperationContext): boolean {
-		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.move(oneCursor, inSelectionMode, ctx.eventData.to, ctx.eventSource, oneCtx));
+	private _cursorMove(ctx: IMultipleCursorOperationContext): boolean {
+		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.move(oneCursor, !!ctx.eventData.inSelectionMode, ctx.eventData.to, ctx.eventSource, oneCtx));
 	}
 
 	private _columnSelectToLineNumber: number = 0;

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -1129,7 +1129,7 @@ export class Cursor extends EventEmitter {
 	}
 
 	private _move(inSelectionMode:boolean, ctx: IMultipleCursorOperationContext): boolean {
-		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.move(oneCursor, inSelectionMode, ctx.eventData.viewPosition, ctx.eventSource, oneCtx));
+		return this._invokeForAll(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => OneCursorOp.move(oneCursor, inSelectionMode, ctx.eventData.to, ctx.eventSource, oneCtx));
 	}
 
 	private _columnSelectToLineNumber: number = 0;

--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -6,6 +6,7 @@
 
 import {onUnexpectedError} from 'vs/base/common/errors';
 import * as strings from 'vs/base/common/strings';
+import types = require('vs/base/common/types');
 import {ReplaceCommand, ReplaceCommandWithOffsetCursorState, ReplaceCommandWithoutChangingPosition} from 'vs/editor/common/commands/replaceCommand';
 import {ShiftCommand} from 'vs/editor/common/commands/shiftCommand';
 import {SurroundSelectionCommand} from 'vs/editor/common/commands/surroundSelectionCommand';
@@ -23,6 +24,7 @@ export interface IPostOperationRunnable {
 
 export interface IOneCursorOperationContext {
 	cursorPositionChangeReason: editorCommon.CursorChangeReason;
+	eventData: any;
 	shouldReveal: boolean;
 	shouldRevealVerticalInCenter: boolean;
 	shouldRevealHorizontal: boolean;
@@ -530,9 +532,6 @@ export class OneCursor {
 	public getPositionDown(lineNumber:number, column:number, leftoverVisibleColumns:number, count:number, allowMoveOnLastLine:boolean): IMoveResult {
 		return this.helper.getPositionDown(this.model, lineNumber, column, leftoverVisibleColumns, count, allowMoveOnLastLine);
 	}
-	public getColumnAtBeginningOfLine(lineNumber:number, column:number): number {
-		return this.helper.getColumnAtBeginningOfLine(this.model, lineNumber, column);
-	}
 	public getColumnAtEndOfLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtEndOfLine(this.model, lineNumber, column);
 	}
@@ -567,6 +566,12 @@ export class OneCursor {
 	}
 	public getColumnAtBeginningOfViewLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtBeginningOfLine(this.viewModelHelper.viewModel, lineNumber, column);
+	}
+	public getViewLineMinColumn(lineNumber:number): number {
+		return this.viewModelHelper.viewModel.getLineMinColumn(lineNumber);
+	}
+	public getViewLineFirstNonWhiteSpaceColumn(lineNumber:number): number {
+		return this.viewModelHelper.viewModel.getLineFirstNonWhitespaceColumn(lineNumber);
 	}
 	public getColumnAtEndOfViewLine(lineNumber:number, column:number): number {
 		return this.helper.getColumnAtEndOfLine(this.viewModelHelper.viewModel, lineNumber, column);
@@ -613,7 +618,6 @@ export class OneCursorOp {
 	}
 
 	public static moveTo(cursor:OneCursor, inSelectionMode: boolean, position: editorCommon.IPosition, viewPosition:editorCommon.IPosition, eventSource: string, ctx: IOneCursorOperationContext): boolean {
-
 		let validatedPosition = cursor.model.validatePosition(position);
 		let validatedViewPosition: editorCommon.IPosition;
 		if (viewPosition) {
@@ -622,6 +626,21 @@ export class OneCursorOp {
 			validatedViewPosition = cursor.convertModelPositionToViewPosition(validatedPosition.lineNumber, validatedPosition.column);
 		}
 
+		return this.move(cursor, inSelectionMode, validatedViewPosition, eventSource, ctx);
+	}
+
+	public static move(cursor:OneCursor, inSelectionMode: boolean, to:editorCommon.IPosition | string, eventSource: string, ctx: IOneCursorOperationContext): boolean {
+		if (types.isString(to)) {
+			switch (to) {
+				case editorCommon.ViewPosition.FirstCharacterOfLine:
+					return this.moveToFirstColumnOfLine(cursor, inSelectionMode, ctx);
+				case editorCommon.ViewPosition.FirstNonWhiteSpaceCharacterOfLine:
+					return this.moveToFirstNonWhiteSpaceColumnOfLine(cursor, inSelectionMode, ctx);
+			}
+			return false;
+		}
+
+		let viewPosition: editorCommon.IPosition= <editorCommon.IPosition>to;
 		let reason = (eventSource === 'mouse' ? editorCommon.CursorChangeReason.Explicit : editorCommon.CursorChangeReason.NotSet);
 		if (eventSource === 'api') {
 			ctx.shouldRevealVerticalInCenter = true;
@@ -630,7 +649,7 @@ export class OneCursorOp {
 		if (reason) {
 			ctx.cursorPositionChangeReason = reason;
 		}
-		cursor.moveViewPosition(inSelectionMode, validatedViewPosition.lineNumber, validatedViewPosition.column, 0, false);
+		cursor.moveViewPosition(inSelectionMode, viewPosition.lineNumber, viewPosition.column, 0, false);
 		return true;
 	}
 
@@ -906,6 +925,26 @@ export class OneCursorOp {
 		let viewColumn = validatedViewPosition.column;
 
 		viewColumn = cursor.getColumnAtBeginningOfViewLine(viewLineNumber, viewColumn);
+		ctx.cursorPositionChangeReason = editorCommon.CursorChangeReason.Explicit;
+		cursor.moveViewPosition(inSelectionMode, viewLineNumber, viewColumn, 0, true);
+		return true;
+	}
+
+	public static moveToFirstColumnOfLine(cursor:OneCursor, inSelectionMode: boolean, ctx: IOneCursorOperationContext): boolean {
+		let validatedViewPosition = cursor.getValidViewPosition();
+		let viewLineNumber = validatedViewPosition.lineNumber;
+		let viewColumn = cursor.getViewLineMinColumn(viewLineNumber);
+
+		ctx.cursorPositionChangeReason = editorCommon.CursorChangeReason.Explicit;
+		cursor.moveViewPosition(inSelectionMode, viewLineNumber, viewColumn, 0, true);
+		return true;
+	}
+
+	public static moveToFirstNonWhiteSpaceColumnOfLine(cursor:OneCursor, inSelectionMode: boolean, ctx: IOneCursorOperationContext): boolean {
+		let validatedViewPosition = cursor.getValidViewPosition();
+		let viewLineNumber = validatedViewPosition.lineNumber;
+		let viewColumn = cursor.getViewLineFirstNonWhiteSpaceColumn(viewLineNumber);
+
 		ctx.cursorPositionChangeReason = editorCommon.CursorChangeReason.Explicit;
 		cursor.moveViewPosition(inSelectionMode, viewLineNumber, viewColumn, 0, true);
 		return true;

--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -6,7 +6,7 @@
 
 import {onUnexpectedError, illegalArgument} from 'vs/base/common/errors';
 import * as strings from 'vs/base/common/strings';
-import types = require('vs/base/common/types');
+import * as types from 'vs/base/common/types';
 import {ReplaceCommand, ReplaceCommandWithOffsetCursorState, ReplaceCommandWithoutChangingPosition} from 'vs/editor/common/commands/replaceCommand';
 import {ShiftCommand} from 'vs/editor/common/commands/shiftCommand';
 import {SurroundSelectionCommand} from 'vs/editor/common/commands/surroundSelectionCommand';
@@ -24,7 +24,6 @@ export interface IPostOperationRunnable {
 
 export interface IOneCursorOperationContext {
 	cursorPositionChangeReason: editorCommon.CursorChangeReason;
-	eventData: any;
 	shouldReveal: boolean;
 	shouldRevealVerticalInCenter: boolean;
 	shouldRevealHorizontal: boolean;
@@ -635,16 +634,16 @@ export class OneCursorOp {
 		return this.move(cursor, inSelectionMode, validatedViewPosition, eventSource, ctx);
 	}
 
-	public static move(cursor:OneCursor, inSelectionMode: boolean, to:editorCommon.IPosition | string, eventSource: string, ctx: IOneCursorOperationContext): boolean {
+	public static move(cursor: OneCursor, inSelectionMode: boolean, to: editorCommon.IPosition | string, eventSource: string, ctx: IOneCursorOperationContext): boolean {
 		if (!to) {
 			illegalArgument('to');
 		}
 
 		if (types.isString(to)) {
-			return this._move(cursor, inSelectionMode, to, ctx);
+			return this.moveToLogicalViewPosition(cursor, inSelectionMode, to, ctx);
 		}
 
-		let viewPosition: editorCommon.IPosition= <editorCommon.IPosition>to;
+		let viewPosition: editorCommon.IPosition = <editorCommon.IPosition>to;
 		let reason = (eventSource === 'mouse' ? editorCommon.CursorChangeReason.Explicit : editorCommon.CursorChangeReason.NotSet);
 		if (eventSource === 'api') {
 			ctx.shouldRevealVerticalInCenter = true;
@@ -656,24 +655,24 @@ export class OneCursorOp {
 		return true;
 	}
 
-	private static _move(cursor:OneCursor, inSelectionMode: boolean, viewPosition:string, ctx: IOneCursorOperationContext): boolean {
+	private static moveToLogicalViewPosition(cursor: OneCursor, inSelectionMode: boolean, cursorMoveViewPosition: string, ctx: IOneCursorOperationContext): boolean {
 		let validatedViewPosition = cursor.getValidViewPosition();
 		let viewLineNumber = validatedViewPosition.lineNumber;
 		let viewColumn;
-		switch (viewPosition) {
-			case editorCommon.ViewPosition.LineStart:
+		switch (cursorMoveViewPosition) {
+			case editorCommon.CursorMoveViewPosition.LineStart:
 				viewColumn = cursor.getViewLineMinColumn(viewLineNumber);
 				break;
-			case editorCommon.ViewPosition.LineFirstNonWhitespaceCharacter:
+			case editorCommon.CursorMoveViewPosition.LineFirstNonWhitespaceCharacter:
 				viewColumn = cursor.getViewLineFirstNonWhiteSpaceColumn(viewLineNumber);
 				break;
-			case editorCommon.ViewPosition.LineCenter:
+			case editorCommon.CursorMoveViewPosition.LineColumnCenter:
 				viewColumn = cursor.getViewLineCenterColumn(viewLineNumber);
 				break;
-			case editorCommon.ViewPosition.LineEnd:
+			case editorCommon.CursorMoveViewPosition.LineEnd:
 				viewColumn = cursor.getViewLineMaxColumn(viewLineNumber);
 				break;
-			case editorCommon.ViewPosition.LineLastNonWhitespaceCharacter:
+			case editorCommon.CursorMoveViewPosition.LineLastNonWhitespaceCharacter:
 				viewColumn = cursor.getViewLineLastNonWhiteSpaceColumn(viewLineNumber);
 				break;
 			default:

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import nls = require('vs/nls');
+import * as nls from 'vs/nls';
 import {IAction} from 'vs/base/common/actions';
 import {IEventEmitter, BulkListenerCallback} from 'vs/base/common/eventEmitter';
 import {MarkedString} from 'vs/base/common/htmlContent';
-import types = require('vs/base/common/types');
+import * as types from 'vs/base/common/types';
 import URI from 'vs/base/common/uri';
 import {TPromise} from 'vs/base/common/winjs.base';
 import {IInstantiationService, IConstructorSignature1, IConstructorSignature2} from 'vs/platform/instantiation/common/instantiation';
@@ -4167,12 +4167,12 @@ export var EventType = {
 };
 
 /**
- * Positions on the view
+ * Logical positions in the view for cursor move command.
  */
-export const ViewPosition = {
+export const CursorMoveViewPosition = {
 	LineStart: 'lineStart',
 	LineFirstNonWhitespaceCharacter: 'lineFirstNonWhitespaceCharacter',
-	LineCenter: 'lineCenter',
+	LineColumnCenter: 'lineColumnCenter',
 	LineEnd: 'lineEnd',
 	LineLastNonWhitespaceCharacter: 'lineLastNonWhitespaceCharacter'
 };
@@ -4185,9 +4185,9 @@ export var CommandDescription= {
 		description: nls.localize('editorCommand.cursorMove.description', "Move cursor to a logical position in the view"),
 		args: [
 			{
-				name: 'Logical position argument',
-				description: nls.localize('editorCommand.cursorMove.arg.description', "A logical position in the view"),
-				constraint: (arg) => types.isObject(arg) && types.isString(arg.to)
+				name: nls.localize('editorCommand.cursorMove.arg.name', "Cursor move argument"),
+				description: nls.localize('editorCommand.cursorMove.arg.description', "Argument containing mandatory 'to' value and an optional 'inSelectionMode' value. Value of 'to' has to be a defined value in `CursorMoveViewPosition`."),
+				constraint: (arg) => types.isObject(arg) && types.isString(arg.to) && (types.isUndefined(arg.inSelectionMode) || types.isBoolean(arg.inSelectionMode))
 			}
 		]
 	}

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -4164,6 +4164,14 @@ export var EventType = {
 };
 
 /**
+ * Positions on the view
+ */
+export const ViewPosition = {
+	FirstCharacterOfLine: 'firstCharacterOfLine',
+	FirstNonWhiteSpaceCharacterOfLine: 'firstNonWhiteSpaceCharacterOfLine'
+};
+
+/**
  * Built-in commands.
  */
 export var Handler = {
@@ -4221,6 +4229,8 @@ export var Handler = {
 	CursorColumnSelectPageUp:	'cursorColumnSelectPageUp',
 	CursorColumnSelectDown:		'cursorColumnSelectDown',
 	CursorColumnSelectPageDown:	'cursorColumnSelectPageDown',
+
+	CursorMove:					'cursorMove',
 
 	AddCursorDown:				'addCursorDown',
 	AddCursorUp:				'addCursorUp',

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import nls = require('vs/nls');
 import {IAction} from 'vs/base/common/actions';
 import {IEventEmitter, BulkListenerCallback} from 'vs/base/common/eventEmitter';
 import {MarkedString} from 'vs/base/common/htmlContent';
+import types = require('vs/base/common/types');
 import URI from 'vs/base/common/uri';
 import {TPromise} from 'vs/base/common/winjs.base';
 import {IInstantiationService, IConstructorSignature1, IConstructorSignature2} from 'vs/platform/instantiation/common/instantiation';
@@ -19,6 +21,7 @@ import {Range} from 'vs/editor/common/core/range';
 import {Selection} from 'vs/editor/common/core/selection';
 import {ModeTransition} from 'vs/editor/common/core/modeTransition';
 import {IndentRange} from 'vs/editor/common/model/indentRanges';
+import {ICommandHandlerDescription} from 'vs/platform/commands/common/commands';
 
 /**
  * @internal
@@ -4167,8 +4170,27 @@ export var EventType = {
  * Positions on the view
  */
 export const ViewPosition = {
-	FirstCharacterOfLine: 'firstCharacterOfLine',
-	FirstNonWhiteSpaceCharacterOfLine: 'firstNonWhiteSpaceCharacterOfLine'
+	LineStart: 'lineStart',
+	LineFirstNonWhitespaceCharacter: 'lineFirstNonWhitespaceCharacter',
+	LineCenter: 'lineCenter',
+	LineEnd: 'lineEnd',
+	LineLastNonWhitespaceCharacter: 'lineLastNonWhitespaceCharacter'
+};
+
+/**
+ * @internal
+ */
+export var CommandDescription= {
+	CursorMove: <ICommandHandlerDescription>{
+		description: nls.localize('editorCommand.cursorMove.description', "Move cursor to a logical position in the view"),
+		args: [
+			{
+				name: 'Logical position argument',
+				description: nls.localize('editorCommand.cursorMove.arg.description', "A logical position in the view"),
+				constraint: (arg) => types.isObject(arg) && types.isString(arg.to)
+			}
+		]
+	}
 };
 
 /**

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -36,12 +36,28 @@ function move(cursor: Cursor, args: any) {
 	cursorCommand(cursor, H.CursorMove, args);
 }
 
-function moveToFirstCharacterOfLine(cursor: Cursor) {
-	move(cursor, {viewPosition: ViewPosition.FirstCharacterOfLine});
+function moveToLineStart(cursor: Cursor) {
+	move(cursor, {to: ViewPosition.LineStart});
 }
 
-function moveToFirstNonWhiteSpaceCharacterOfLine(cursor: Cursor) {
-	move(cursor, {viewPosition: ViewPosition.FirstNonWhiteSpaceCharacterOfLine});
+function moveToLineFirstNonWhiteSpaceCharacter(cursor: Cursor) {
+	move(cursor, {to: ViewPosition.LineFirstNonWhitespaceCharacter});
+}
+
+function moveToLineCenter(cursor: Cursor) {
+	move(cursor, {to: ViewPosition.LineCenter});
+}
+
+function moveToLineEnd(cursor: Cursor) {
+	move(cursor, {to: ViewPosition.LineEnd});
+}
+
+function moveToLineLastNonWhiteSpaceCharacter(cursor: Cursor) {
+	move(cursor, {to: ViewPosition.LineLastNonWhitespaceCharacter});
+}
+
+function moveToPosition(cursor: Cursor, lineNumber: number, column: number) {
+	move(cursor, {to: new Position(lineNumber, column)});
 }
 
 function moveTo(cursor: Cursor, lineNumber: number, column: number, inSelectionMode: boolean = false) {
@@ -209,38 +225,103 @@ suite('Editor Controller - Cursor', () => {
 
 	test('move to first character of line from middle', () => {
 		moveTo(thisCursor, 1, 8);
-		moveToFirstCharacterOfLine(thisCursor);
+		moveToLineStart(thisCursor);
 		cursorEqual(thisCursor, 1, 1);
 	});
 
 	test('move to first character of line from first non white space character', () => {
 		moveTo(thisCursor, 1, 6);
-		moveToFirstCharacterOfLine(thisCursor);
+		moveToLineStart(thisCursor);
 		cursorEqual(thisCursor, 1, 1);
 	});
 
 	test('move to first character of line from first character', () => {
 		moveTo(thisCursor, 1, 1);
-		moveToFirstCharacterOfLine(thisCursor);
+		moveToLineStart(thisCursor);
 		cursorEqual(thisCursor, 1, 1);
 	});
 
 	test('move to first non white space character of line from middle', () => {
 		moveTo(thisCursor, 1, 8);
-		moveToFirstNonWhiteSpaceCharacterOfLine(thisCursor);
+		moveToLineFirstNonWhiteSpaceCharacter(thisCursor);
 		cursorEqual(thisCursor, 1, 6);
 	});
 
 	test('move to first non white space character of line from first non white space character', () => {
 		moveTo(thisCursor, 1, 6);
-		moveToFirstNonWhiteSpaceCharacterOfLine(thisCursor);
+		moveToLineFirstNonWhiteSpaceCharacter(thisCursor);
 		cursorEqual(thisCursor, 1, 6);
 	});
 
 	test('move to first non white space character of line from first character', () => {
 		moveTo(thisCursor, 1, 1);
-		moveToFirstNonWhiteSpaceCharacterOfLine(thisCursor);
+		moveToLineFirstNonWhiteSpaceCharacter(thisCursor);
 		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to end of line from middle', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToLineEnd(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+	});
+
+	test('move to end of line from last non white space character', () => {
+		moveTo(thisCursor, 1, LINE1.length - 1);
+		moveToLineEnd(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+	});
+
+	test('move to end of line from line end', () => {
+		moveTo(thisCursor, 1, LINE1.length + 1);
+		moveToLineEnd(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length + 1);
+	});
+
+	test('move to last non white space character from middle', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToLineLastNonWhiteSpaceCharacter(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to last non white space character from last non white space character', () => {
+		moveTo(thisCursor, 1, LINE1.length - 1);
+		moveToLineLastNonWhiteSpaceCharacter(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to last non white space character from line end', () => {
+		moveTo(thisCursor, 1, LINE1.length + 1);
+		moveToLineLastNonWhiteSpaceCharacter(thisCursor);
+		cursorEqual(thisCursor, 1, LINE1.length - 1);
+	});
+
+	test('move to center of line not from center', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToLineCenter(thisCursor);
+		cursorEqual(thisCursor, 1, 11);
+	});
+
+	test('move to center of line from center', () => {
+		moveTo(thisCursor, 1, 11);
+		moveToLineCenter(thisCursor);
+		cursorEqual(thisCursor, 1, 11);
+	});
+
+	test('move to center of line from start', () => {
+		moveToLineStart(thisCursor);
+		moveToLineCenter(thisCursor);
+		cursorEqual(thisCursor, 1, 11);
+	});
+
+	test('move to center of line from end', () => {
+		moveToLineEnd(thisCursor);
+		moveToLineCenter(thisCursor);
+		cursorEqual(thisCursor, 1, 11);
+	});
+
+	test('move to position', () => {
+		moveToPosition(thisCursor, 3, 10);
+		cursorEqual(thisCursor, 3, 10);
 	});
 
 	test('move', () => {

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -13,7 +13,7 @@ import {Selection} from 'vs/editor/common/core/selection';
 import {
 	EndOfLinePreference, EventType, Handler, IPosition, ISelection, IEditorOptions,
 	DefaultEndOfLine, ITextModelCreationOptions, ICommand,
-	ITokenizedModel, IEditOperationBuilder, ICursorStateComputerData
+	ITokenizedModel, IEditOperationBuilder, ICursorStateComputerData, ViewPosition
 } from 'vs/editor/common/editorCommon';
 import {Model} from 'vs/editor/common/model/model';
 import {IMode, IndentAction} from 'vs/editor/common/modes';
@@ -28,6 +28,20 @@ let H = Handler;
 
 function cursorCommand(cursor: Cursor, command: string, extraData?: any, overwriteSource?: string) {
 	cursor.trigger(overwriteSource || 'tests', command, extraData);
+}
+
+// Move command
+
+function move(cursor: Cursor, args: any) {
+	cursorCommand(cursor, H.CursorMove, args);
+}
+
+function moveToFirstCharacterOfLine(cursor: Cursor) {
+	move(cursor, {viewPosition: ViewPosition.FirstCharacterOfLine});
+}
+
+function moveToFirstNonWhiteSpaceCharacterOfLine(cursor: Cursor) {
+	move(cursor, {viewPosition: ViewPosition.FirstNonWhiteSpaceCharacterOfLine});
 }
 
 function moveTo(cursor: Cursor, lineNumber: number, column: number, inSelectionMode: boolean = false) {
@@ -189,6 +203,44 @@ suite('Editor Controller - Cursor', () => {
 	test('no move', () => {
 		moveTo(thisCursor, 1, 1);
 		cursorEqual(thisCursor, 1, 1);
+	});
+
+	// --------- move to first character of line
+
+	test('move to first character of line from middle', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToFirstCharacterOfLine(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to first character of line from first non white space character', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToFirstCharacterOfLine(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to first character of line from first character', () => {
+		moveTo(thisCursor, 1, 1);
+		moveToFirstCharacterOfLine(thisCursor);
+		cursorEqual(thisCursor, 1, 1);
+	});
+
+	test('move to first non white space character of line from middle', () => {
+		moveTo(thisCursor, 1, 8);
+		moveToFirstNonWhiteSpaceCharacterOfLine(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to first non white space character of line from first non white space character', () => {
+		moveTo(thisCursor, 1, 6);
+		moveToFirstNonWhiteSpaceCharacterOfLine(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
+	});
+
+	test('move to first non white space character of line from first character', () => {
+		moveTo(thisCursor, 1, 1);
+		moveToFirstNonWhiteSpaceCharacterOfLine(thisCursor);
+		cursorEqual(thisCursor, 1, 6);
 	});
 
 	test('move', () => {

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -13,7 +13,7 @@ import {Selection} from 'vs/editor/common/core/selection';
 import {
 	EndOfLinePreference, EventType, Handler, IPosition, ISelection, IEditorOptions,
 	DefaultEndOfLine, ITextModelCreationOptions, ICommand,
-	ITokenizedModel, IEditOperationBuilder, ICursorStateComputerData, ViewPosition
+	ITokenizedModel, IEditOperationBuilder, ICursorStateComputerData, CursorMoveViewPosition
 } from 'vs/editor/common/editorCommon';
 import {Model} from 'vs/editor/common/model/model';
 import {IMode, IndentAction} from 'vs/editor/common/modes';
@@ -37,23 +37,23 @@ function move(cursor: Cursor, args: any) {
 }
 
 function moveToLineStart(cursor: Cursor) {
-	move(cursor, {to: ViewPosition.LineStart});
+	move(cursor, {to: CursorMoveViewPosition.LineStart});
 }
 
 function moveToLineFirstNonWhiteSpaceCharacter(cursor: Cursor) {
-	move(cursor, {to: ViewPosition.LineFirstNonWhitespaceCharacter});
+	move(cursor, {to: CursorMoveViewPosition.LineFirstNonWhitespaceCharacter});
 }
 
 function moveToLineCenter(cursor: Cursor) {
-	move(cursor, {to: ViewPosition.LineCenter});
+	move(cursor, {to: CursorMoveViewPosition.LineColumnCenter});
 }
 
 function moveToLineEnd(cursor: Cursor) {
-	move(cursor, {to: ViewPosition.LineEnd});
+	move(cursor, {to: CursorMoveViewPosition.LineEnd});
 }
 
 function moveToLineLastNonWhiteSpaceCharacter(cursor: Cursor) {
-	move(cursor, {to: ViewPosition.LineLastNonWhitespaceCharacter});
+	move(cursor, {to: CursorMoveViewPosition.LineLastNonWhitespaceCharacter});
 }
 
 function moveToPosition(cursor: Cursor, lineNumber: number, column: number) {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3185,6 +3185,14 @@ declare module monaco.editor {
     };
 
     /**
+     * Positions on the view
+     */
+    export const ViewPosition: {
+        FirstCharacterOfLine: string;
+        FirstNonWhiteSpaceCharacterOfLine: string;
+    };
+
+    /**
      * Built-in commands.
      */
     export var Handler: {
@@ -3229,6 +3237,7 @@ declare module monaco.editor {
         CursorColumnSelectPageUp: string;
         CursorColumnSelectDown: string;
         CursorColumnSelectPageDown: string;
+        CursorMove: string;
         AddCursorDown: string;
         AddCursorUp: string;
         CursorUndo: string;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3188,8 +3188,11 @@ declare module monaco.editor {
      * Positions on the view
      */
     export const ViewPosition: {
-        FirstCharacterOfLine: string;
-        FirstNonWhiteSpaceCharacterOfLine: string;
+        LineStart: string;
+        LineFirstNonWhitespaceCharacter: string;
+        LineCenter: string;
+        LineEnd: string;
+        LineLastNonWhitespaceCharacter: string;
     };
 
     /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3185,12 +3185,12 @@ declare module monaco.editor {
     };
 
     /**
-     * Positions on the view
+     * Logical positions in the view for cursor move command.
      */
-    export const ViewPosition: {
+    export const CursorMoveViewPosition: {
         LineStart: string;
         LineFirstNonWhitespaceCharacter: string;
-        LineCenter: string;
+        LineColumnCenter: string;
         LineEnd: string;
         LineLastNonWhitespaceCharacter: string;
     };


### PR DESCRIPTION
PR for #9143 

Introduce a move command for placing cursor at a logical view position in the editor.

Usage:
- Command Id: `cursorMove`
- Arguments: `{to: $viewPosition}`

Allowed view positions:
- `lineStart`: Places the cursor at the start of the current line in the view.
- `lineFirstNonWhitespaceCharacter`: Places the cursor at the first non white space character of the current line in the view.
- `lineEnd`: Places the cursor at the end of the current line in the view.
- `lineLastNonWhitespaceCharacter`: Places the cursor at the last non white space character of the current line in the view.
- `lineCenter`: Places the cursor at the center of the line in the view.
