### PR TITLE
[Terminal] Run entire text if selection is empty

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -116,9 +116,10 @@ export class TerminalService implements ITerminalService {
 	public runSelectedText(): TPromise<any> {
 		return this.showAndGetTerminalPanel().then((terminalPanel) => {
 			let editor = this.codeEditorService.getFocusedCodeEditor();
-			let selection = editor.getModel().getValueInRange(editor.getSelection(), os.EOL === '\n' ? EndOfLinePreference.LF : EndOfLinePreference.CRLF);
+			let selection = editor.getSelection();
+			let text = selection.isEmpty() ? editor.getValue() : editor.getModel().getValueInRange(selection, os.EOL === '\n' ? EndOfLinePreference.LF : EndOfLinePreference.CRLF);
 			// Add a new line if one doesn't already exist so the text is executed
-			let text = selection + (selection.substr(selection.length - os.EOL.length) === os.EOL ? '' : os.EOL);
+			text = text + (text.substr(text.length - os.EOL.length) === os.EOL ? '' : os.EOL);
 			this.terminalProcesses[this.activeTerminalIndex].process.send({
 				event: 'input',
 				data: text


### PR DESCRIPTION
Since VS Code already has great built-in support for the terminal, it would be good to merge the function of this [Terminal extension](https://marketplace.visualstudio.com/items?itemName=formulahendry.terminal) now. 
VS Code has support to run the selected text in terminal and another common scenario would be: when user open a file (maybe a bash or cmd file), he wants to run the entire file in terminal. 
Therefore, it would be useful that user could run the entire text of current active text editor conveniently. To make this, I suggest we support to run the entire text when the selection is empty. Simple and effective.
