### PR TITLE
fixes glibc dep issue on rhel 6

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -8,7 +8,7 @@ Packager: Visual Studio Code Team <vscode-linux@microsoft.com>
 License:  MIT
 URL:      https://code.visualstudio.com/
 Icon:     @@NAME@@.xpm
-Requires: glibc >= 2.15
+Requires: glibc >= 2.12
 AutoReq:  0
 
 %description


### PR DESCRIPTION
resolves #9487.

The RPM for RHEL 6.7 x64 does not work as it fails dependency checks. The spec file for the rpm specifies glibc >= 2.15 while 2.12 is the latest thats available in RHEL 6.
