### PR TITLE
Added missing "rem" unit

### DIFF
--- a/extensions/less/syntaxes/LESS.tmLanguage
+++ b/extensions/less/syntaxes/LESS.tmLanguage
@@ -164,7 +164,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;=[\d])(px|pt|cm|mm|in|em|ex|pc)\b|%</string>
+			<string>(?&lt;=[\d])(px|pt|cm|mm|in|em|rem|ex|pc)\b|%</string>
 			<key>name</key>
 			<string>keyword.other.unit.css</string>
 		</dict>


### PR DESCRIPTION
Less language support had no `rem` support, so I simply added. It's a very very minor change. 
