### PR TITLE
Fixes #9482: AutoClosePair between tags

### DIFF
--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -1324,7 +1324,7 @@ export class OneCursorOp {
 		let lineText = cursor.model.getLineContent(position.lineNumber);
 		let beforeCharacter = lineText[position.column - 1];
 
-		// Only consider auto closing the pair if a space follows or if another autoclosed pair follows
+		// Only consider auto closing the pair if a space follows or if another autoclosed pair follows or a '<' follows
 		if (beforeCharacter) {
 			let isBeforeCloseBrace = false;
 			for (let closeBrace in cursor.modeConfiguration.autoClosingPairsClose) {
@@ -1333,7 +1333,7 @@ export class OneCursorOp {
 					break;
 				}
 			}
-			if ( !isBeforeCloseBrace && !/\s/.test(beforeCharacter)) {
+			if ( !isBeforeCloseBrace && !/\s|</.test(beforeCharacter)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Fix #9482 
This is a very common scenario when users use Emmet or [Auto Close Tag Extension](https://marketplace.visualstudio.com/items?itemName=formulahendry.auto-close-tag). The cursor is just before the `<`.
## Before Fix:

![beforeFix](https://msdnshared.blob.core.windows.net/media/2016/07/beforeFix.gif)
## After Fix:

![afterFix](https://msdnshared.blob.core.windows.net/media/2016/07/afterFix.gif)
## VS IDE behavior:

![beforeFix](https://msdnshared.blob.core.windows.net/media/2016/07/AutoClosePair.gif)
