### PR TITLE
#55: Improve result sorting performance

### DIFF
--- a/src/vs/base/common/arrays.ts
+++ b/src/vs/base/common/arrays.ts
@@ -79,6 +79,29 @@ export function findFirst<T>(array: T[], p: (x: T) => boolean): number {
 	return low;
 }
 
+/**
+ * Returns the top N elements from the array.
+ *
+ * Faster than sorting the entire array when the array is a lot larger than N.
+ *
+ * @param array The unsorted array.
+ * @param compare A sort function for the elements.
+ * @param n The number of elements to return.
+ * @return The first n elemnts from array when sorted with compare.
+ */
+export function top<T>(array: T[], compare: (a: T, b: T) => number, n: number) {
+	const result = array.slice(0, n).sort(compare);
+	for (let i = n, m = array.length; i < m; i++) {
+		const element = array[i];
+		if (compare(element, result[n - 1]) < 0) {
+			result.pop();
+			const j = findFirst(result, e => compare(element, e) < 0);
+			result.splice(j, 0, element);
+		}
+	}
+	return result;
+}
+
 export function merge<T>(arrays: T[][], hashFn?: (element: T) => string): T[] {
 	const result = new Array<T>();
 	if (!hashFn) {

--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -57,8 +57,8 @@ export function compareByPrefix(one: string, other: string, lookFor: string): nu
 	let elementBName = other.toLowerCase();
 
 	// Sort prefix matches over non prefix matches
-	let elementAPrefixMatch = elementAName.indexOf(lookFor) === 0;
-	let elementBPrefixMatch = elementBName.indexOf(lookFor) === 0;
+	let elementAPrefixMatch = strings.startsWith(elementAName, lookFor);
+	let elementBPrefixMatch = strings.startsWith(elementBName, lookFor);
 	if (elementAPrefixMatch !== elementBPrefixMatch) {
 		return elementAPrefixMatch ? -1 : 1;
 	}

--- a/src/vs/base/test/common/arrays.test.ts
+++ b/src/vs/base/test/common/arrays.test.ts
@@ -60,5 +60,17 @@ suite('Arrays', () => {
 		assert.deepEqual(arrays.distinct(['32', 'constructor', 'proto', 'proto', 'constructor'], compare), ['32', 'constructor', 'proto']);
 		assert.deepEqual(arrays.distinct(['32', '4', '5', '32', '4', '5', '32', '4', '5', '5'], compare), ['32', '4', '5']);
 	});
+
+	test('top', function () {
+		const cmp = (a, b) => a - b;
+
+		assert.deepEqual(arrays.top([], cmp, 1), []);
+		assert.deepEqual(arrays.top([1], cmp, 0), []);
+		assert.deepEqual(arrays.top([1, 2], cmp, 1), [1]);
+		assert.deepEqual(arrays.top([2, 1], cmp, 1), [1]);
+		assert.deepEqual(arrays.top([1, 3, 2], cmp, 2), [1, 2]);
+		assert.deepEqual(arrays.top([3, 2, 1], cmp, 3), [1, 2, 3]);
+		assert.deepEqual(arrays.top([4, 6, 2, 7, 8, 3, 5, 1], cmp, 3), [1, 2, 3]);
+	});
 });
 


### PR DESCRIPTION
A good improvement, time to sort is (sortedResultDuration - unsortedResultDuration) below.

Before:

```
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11682,"sortedResultDuration":22670,"numberOfResultEntries":224197},
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11451,"sortedResultDuration":22369,"numberOfResultEntries":224197},
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11915,"sortedResultDuration":23141,"numberOfResultEntries":224197},
```

After:

```
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11325,"sortedResultDuration":11429,"numberOfResultEntries":224197},
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11526,"sortedResultDuration":11636,"numberOfResultEntries":224197},
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11270,"sortedResultDuration":11376,"numberOfResultEntries":224197},
```
