### PR TITLE
Detect shebang for Groovy files

### DIFF
--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -8,6 +8,7 @@
 			"id": "groovy",
 			"aliases": ["Groovy", "groovy"],
 			"extensions": [".groovy", ".gvy", ".gradle"],
+			"firstLine": "^#!.*\\bgroovy\\b",
 			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{


### PR DESCRIPTION
- Should match "#!groovy", "#!/usr/bin/env /path/to/groovy" & "#!/usr/bin/groovy" types
- Very useful for people editing Jenkinsfile configuration (which has no file extension) and hopefully others too
