### PR TITLE
Addresses #3690 high-contrast less hacky in editor

### DIFF
--- a/src/vs/editor/browser/widget/media/editor.css
+++ b/src/vs/editor/browser/widget/media/editor.css
@@ -21,6 +21,7 @@
 	position: relative;
 	overflow: visible;
 	-webkit-text-size-adjust: 100%;
+	-ms-high-contrast-adjust: none;
 }
 .monaco-editor.enable-ligatures {
 	-webkit-font-feature-settings: "liga" on, "calt" on;


### PR DESCRIPTION
This pertains to the Monaco editor running in Windows high-contrast mode.

Windows removes all background images in high contrast mode unless a rule like this applied.
