### PR TITLE
Travis builds post coverage info to coveralls.io and add README badge.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out-monaco-editor-core/
 out-vscode/
 out-vscode-min/
 build/node_modules
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,8 @@ script:
   - gulp electron
   - gulp compile
   - gulp optimize-vscode
-  - ./scripts/test.sh
+  - ./scripts/test.sh --coverage
   - ./scripts/test-integration.sh
+
+after_success:
+  - cat coverage/lcov.info | node_modules/.bin/coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Visual Studio Code - Open Source
 
-[![Build Status](https://travis-ci.org/Microsoft/vscode.svg?branch=master)](https://travis-ci.org/Microsoft/vscode) [![Build status](https://ci.appveyor.com/api/projects/status/vuhlhg80tj3e2a0l?svg=true)](https://ci.appveyor.com/project/VSCode/vscode)
+[![Build Status](https://travis-ci.org/Microsoft/vscode.svg?branch=master)](https://travis-ci.org/Microsoft/vscode)
+[![Build status](https://ci.appveyor.com/api/projects/status/vuhlhg80tj3e2a0l?svg=true)](https://ci.appveyor.com/project/VSCode/vscode)
+[![Coverage Status](https://img.shields.io/coveralls/Microsoft/vscode/master.svg)](https://coveralls.io/github/Microsoft/vscode?branch=master)
 
 [VS Code](https://code.visualstudio.com) is a new type of tool that combines the simplicity of
 a code editor with what developers need for their core edit-build-debug cycle. Code

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "azure-storage": "^0.3.1",
     "clean-css": "3.4.6",
     "clone": "^1.0.2",
+    "coveralls": "^2.11.11",
     "debounce": "^1.0.0",
     "documentdb": "^1.5.1",
     "event-stream": "^3.1.7",

--- a/test/all.js
+++ b/test/all.js
@@ -107,8 +107,8 @@ function main() {
 			var collector = new istanbul.Collector();
 			collector.add(global.__coverage__);
 
-			var reporter = new istanbul.Reporter(null, path.join(path.dirname(path.dirname(__dirname)), 'Code-Coverage'));
-			reporter.add('html');
+			var reporter = new istanbul.Reporter();
+			reporter.addAll(['lcov', 'html']);
 			reporter.write(collector, true, function () {});
 		});
 	}


### PR DESCRIPTION
Seems vscode already has istanbul instrumentation enabled in tests. It would be nice to see the coverage info as a badge in the REPO readme.

You'll need to add the following environment vars in travis.

COVERALLS_REPO_TOKEN = XXXX (Generate from https://coveralls.io/repos/118314/regenerate_token)
COVERALLS_GIT_COMMIT = HEAD
