### PR TITLE
Fix #9922: Roll back PowerShell syntax definition

### DIFF
--- a/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
+++ b/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
@@ -14,175 +14,25 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>(--%)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.powershell</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Stop Parsing</string>
-			<key>end</key>
-			<string>$</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#lineComment</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(.)</string>
-					<key>name</key>
-					<string>support.other.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#illegalBacktick</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#lineComment</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#blockComment</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#stringDoubleQuoted</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#stringSingleQuoted</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#stringDoubleQuotedHeredoc</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#stringSingleQuotedHeredoc</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#switch</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#scriptBlock</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#subExpression</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#arrayDeclaration</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#redirection</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#numericConstant</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#operators</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#type</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#function</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#enum</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#class</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#reservedWords</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#controlWords</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#commands</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#executableFiles</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#illegalVariable</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#variable</string>
-		</dict>
-	</array>
-	<key>repository</key>
-	<dict>
-		<key>arrayDeclaration</key>
-		<dict>
-			<key>begin</key>
-			<string>(\@?\()</string>
+			<string>&lt;#</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.powershell</string>
+					<string>punctuation.start.definition.comment.block.powershell</string>
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\))((\.[\w"']+)*)</string>
+			<string>#&gt;</string>
 			<key>endCaptures</key>
 			<dict>
-				<key>1</key>
+				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.attribute-name.powershell</string>
+					<string>punctuation.end.definition.comment.block.powershell</string>
 				</dict>
 			</dict>
-			<key>name</key>
-			<string>meta.array.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
-		<key>blockComment</key>
-		<dict>
-			<key>begin</key>
-			<string>(&lt;#)</string>
-			<key>end</key>
-			<string>(#&gt;)</string>
 			<key>name</key>
 			<string>comment.block.powershell</string>
 			<key>patterns</key>
@@ -193,575 +43,173 @@
 				</dict>
 			</array>
 		</dict>
-		<key>class</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!\w|-)(?i:(class))\s+(\w+)(?:\s*(:)\s*(\w+))?\s*\{</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.powershell</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.function.powershell</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.powershell</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.powershell</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>Class</string>
+			<string>(?&lt;![\\-])#</string>
 			<key>end</key>
-			<string>\}</string>
+			<string>$</string>
 			<key>name</key>
-			<string>meta.class.powershell</string>
+			<string>comment.line.number-sign.powershell</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#classReservedWords</string>
+					<string>#commentEmbeddedDocs</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>[2-6]&gt;&amp;1|&gt;&gt;|&gt;|&lt;&lt;|&lt;|&gt;|&gt;\||[1-6]&gt;|[1-6]&gt;&gt;</string>
+			<key>name</key>
+			<string>keyword.operator.redirection.powershell</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#commands</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#variable</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#interpolatedStringContent</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#function</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#attribute</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#type</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!(?&lt;!`)")"</string>
+			<key>end</key>
+			<string>"(?!")</string>
+			<key>name</key>
+			<string>string.quoted.double.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#variableNoProperty</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#classBaseKeyword</string>
+					<string>#doubleQuotedStringEscapes</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#interpolation</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>`\s*$</string>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Needed to parse stuff correctly in 'argument mode'. (See about_parsing.)</string>
+			<key>include</key>
+			<string>#doubleQuotedStringEscapes</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!')'</string>
+			<key>end</key>
+			<string>'(?!')</string>
+			<key>name</key>
+			<string>string.quoted.single.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>''</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>\@"(?=$)</string>
+			<key>end</key>
+			<string>^"@</string>
+			<key>name</key>
+			<string>string.quoted.double.heredoc.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#variableNoProperty</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#doubleQuotedStringEscapes</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#interpolation</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>\@'(?=$)</string>
+			<key>end</key>
+			<string>^'@</string>
+			<key>name</key>
+			<string>string.quoted.single.heredoc.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>''</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#numericConstant</string>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>@\(</string>
+			<key>captures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\)</string>
+			<key>name</key>
+			<string>meta.group.array-expression.powershell</string>
+			<key>patterns</key>
+			<array>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
-		<key>classBaseKeyword</key>
 		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.powershell</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.class.powershell</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>The base keyword used in classes.</string>
-			<key>match</key>
-			<string>(:)\s*(?i:(base))\s*(?=\()</string>
-		</dict>
-		<key>classReservedWords</key>
-		<dict>
-			<key>comment</key>
-			<string>Reserved words for classes.</string>
-			<key>match</key>
-			<string>\b(?i:(hidden|static))\b</string>
-			<key>name</key>
-			<string>keyword.other.powershell</string>
-		</dict>
-		<key>commandParameter</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>comment</key>
-					<string>-Parameter value</string>
-					<key>match</key>
-					<string>\s(-\w+)(:)?</string>
-					<key>name</key>
-					<string>variable.parameter.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<key>commands</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>(?&lt;!\\)\b((?i:(Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write))-(\w+))\b(?!\.|\\)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Generic function match based on Verb-Noun pair using list of approved verbs.</string>
-					<key>end</key>
-					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.powershell</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.command.powershell</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#scriptblock</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#commandParameter</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#lineComment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#redirection</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#numericConstant</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#operators</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#variable</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringDoubleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringSingleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#arrayDeclaration</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalBacktick</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalVariable</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(?&lt;!\\)\b(?i:foreach-object|tee-object|where-object|sort-object)\b(?!\.|\\)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Built-in commands that don't adhere to the approved verbs standard.</string>
-					<key>end</key>
-					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.powershell</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.command.powershell</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#scriptblock</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#commandParameter</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#lineComment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#redirection</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#numericConstant</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#operators</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#variable</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringDoubleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringSingleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#arrayDeclaration</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalBacktick</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalVariable</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(?&lt;!\\|\[)\b(?i:ac|asnp|cat|cd|cfs|chdir|clc|clear|clhy|cli|clp|cls|clv|cnsn|compare|copy|cp|cpi|cpp|curl|cvpa|dbp|del|diff|dir|dnsn|ebp|echo|epal|epcsv|epsn|erase|etsn|exsn|fc|fhx|fl|ft|fw|gal|gbp|gc|gcb|gci|gcm|gcs|gdr|ghy|gi|gjb|gl|gm|gmo|gp|gps|gpv|group|gsn|gsnp|gsv|gu|gv|gwmi|h|history|icm|iex|ihy|ii|ipal|ipcsv|ipmo|ipsn|irm|ise|iwmi|iwr|kill|lp|ls|man|md|measure|mi|mount|move|mp|mv|nal|ndr|ni|nmo|npssc|nsn|nv|ogv|oh|popd|ps|pushd|r|rbp|rcjb|rcsn|rd|rdr|ren|ri|rjb|rm|rmdir|rmo|rni|rnp|rp|rsn|rsnp|rujb|rv|rvpa|rwmi|sajb|sal|saps|sasv|sbp|sc|scb|select|set|shcm|si|sl|sleep|sls|sort|sp|spjb|spps|spsv|start|sujb|sv|swmi|tee|trcm|type|wget|wjb|write)\b(?!\.|\\|\])</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Built-in aliases</string>
-					<key>end</key>
-					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.powershell</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.command.powershell</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#scriptblock</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#commandParameter</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#lineComment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#redirection</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#numericConstant</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#operators</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#variable</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringDoubleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringSingleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#arrayDeclaration</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalBacktick</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalVariable</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(\b(([A-Za-z0-9\-_\.]+).(?i:ps1))\b)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>support.function.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>External script</string>
-					<key>end</key>
-					<string>((?=\))|(?=\})|(?&lt;!`)\n|(?&lt;!`)\r|(\|))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.powershell</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.command.powershell</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#scriptblock</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#commandParameter</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#lineComment</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#redirection</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#numericConstant</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#operators</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#variable</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringDoubleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#stringSingleQuoted</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#arrayDeclaration</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalBacktick</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#illegalVariable</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
-		</dict>
-		<key>commentEmbeddedDocs</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY|ROLE)\b)</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(?i:(\.)(PARAMETER|FORWARDHELPTARGETNAME|FORWARDHELPCATEGORY|REMOTEHELPRUNSPACE|EXTERNALHELP)\s+(.+))</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Requires -Version</string>
-					<key>match</key>
-					<string>(?i:(requires))\s(-(?i:version)\s\d+(\.\d+)?)</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Requires -PSSnapin</string>
-					<key>match</key>
-					<string>(?i:(requires))\s(-(?i:pssnapin)\s\w+(\s*-(?i:version)\s\d+(\.\d+)?)?)</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Requires -Modules</string>
-					<key>match</key>
-					<string>(?i:(requires))\s(-(?i:modules)\s.*)</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Requires -ShellId</string>
-					<key>match</key>
-					<string>(?i:(requires))\s(-(?i:shellid)\s.*)</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.documentation.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.string.documentation.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Requires -RunAsAdministrator</string>
-					<key>match</key>
-					<string>(?i:(requires))\s(-(?i:runasadministrator))</string>
-					<key>name</key>
-					<string>comment.documentation.embedded.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<key>controlWords</key>
-		<dict>
-			<key>match</key>
-			<string>(\b(?&lt;!-|\$)(?i:begin|process|exit|break|return|catch|finally|for|continue|foreach|throw|from|trap|try|do|if|until|in|using|else|elseif|while|end|where)\b(?!-|\.))</string>
-			<key>name</key>
-			<string>keyword.control.powershell</string>
-		</dict>
-		<key>defaultKeyword</key>
-		<dict>
+			<key>begin</key>
+			<string>\$\(</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>
@@ -771,11 +219,37 @@
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Default is a reserved word when used in Switch statements. This is kind of a work-around - it will highlight only inside scriptblocks.</string>
-			<key>match</key>
-			<string>(?i:(default))\s*(?=\{)</string>
+			<string>TODO: move to repo; make recursive.</string>
+			<key>end</key>
+			<string>\)</string>
+			<key>name</key>
+			<string>meta.group.complex.subexpression.powershell</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
 		</dict>
-		<key>enum</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-([ci]?[lg][te]|eq|ne)</string>
+			<key>name</key>
+			<string>keyword.operator.logical.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?i:[a-z][a-z0-9]+-?[a-z][a-z0-9]+)(?i:\.(?i:exe|cmd|bat|ps1))</string>
+			<key>name</key>
+			<string>support.function.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|using|var|where(?!=-object)|while)|%|\?)(?!\w)</string>
+			<key>name</key>
+			<string>keyword.control.powershell</string>
+		</dict>
 		<dict>
 			<key>captures</key>
 			<dict>
@@ -793,21 +267,262 @@
 			<key>comment</key>
 			<string>capture should be entity.name.type, but it doesn't provide a good color in the default schema.</string>
 			<key>match</key>
-			<string>(?&lt;!\w|-)(?i:(enum))\s+(\w+)\s+</string>
+			<string>(?&lt;!\w)((?i:class)|%|\?)(?:\s)+((?:\p{L}|\d|_|-|)+)\b</string>
 		</dict>
-		<key>executableFiles</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-(?i:is(?:not)?|as)\b</string>
+			<key>name</key>
+			<string>keyword.operator.comparison.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-(?i:[ic]?(?:eq|ne|[gl][te]|(?:not)?(?:like|match|contains|in)|replace))(?!\p{L})</string>
+			<key>name</key>
+			<string>keyword.operator.comparison.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-(?i:join|split)(?!\p{L})|!</string>
+			<key>name</key>
+			<string>keyword.operator.unary.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-(?i:and|or|not|xor)(?!\p{L})|!</string>
+			<key>name</key>
+			<string>keyword.operator.logical.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-(?i:band|bor|bnot|bxor)(?!\p{L})</string>
+			<key>name</key>
+			<string>keyword.operator.bitwise.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;!\w)-(?i:f)(?!\p{L})</string>
+			<key>name</key>
+			<string>keyword.operator.string-format.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>[+%*/-]?=|[+/*%-]</string>
+			<key>name</key>
+			<string>keyword.operator.assignment.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\|{2}|&amp;{2}|;</string>
+			<key>name</key>
+			<string>keyword.other.statement-separator.powershell</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>&amp;|(?&lt;!\w)\.(?= )|`|,|\|</string>
+			<key>name</key>
+			<string>keyword.operator.other.powershell</string>
+		</dict>
 		<dict>
 			<key>comment</key>
-			<string>Executable files, like exe, com, cmd and bat</string>
+			<string>This is very imprecise, is there a syntax for 'must come after...' </string>
 			<key>match</key>
-			<string>(\b(([A-Za-z0-9\-_\.]+).(?i:exe|com|cmd|bat))\b)</string>
+			<string>(?&lt;!\s|^)\.\.(?=\d|\(|\$)</string>
 			<key>name</key>
-			<string>support.function.powershell</string>
+			<string>keyword.operator.range.powershell</string>
+		</dict>
+	</array>
+	<key>repository</key>
+	<dict>
+		<key>attribute</key>
+		<dict>
+			<key>begin</key>
+			<string>\[(\p{L}|\.|``\d+)+(?=\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag</string>
+				</dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\]</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\(</string>
+					<key>end</key>
+					<string>\)</string>
+					<key>name</key>
+					<string>entity.other.attribute-name</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>entity.other.attribute.parameter.powershell</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>constant.language.powershell</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>variable.other.powershell</string>
+								</dict>
+							</dict>
+							<key>comment</key>
+							<string>really we should match the known attributes first</string>
+							<key>match</key>
+							<string>(\w+)\s*=?([^"']*?|'[^']*?'|"[^"]*?")?(?=,|\))</string>
+							<key>name</key>
+							<string>entity.other.attribute-name.powershell</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#variable</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>commands</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Verb-Noun pattern:</string>
+					<key>match</key>
+					<string>(?:(\p{L}|\d|_|-|\\|\:)*\\)?\b(?i:Add|Approve|Assert|Backup|Block|Checkpoint|Clear|Close|Compare|Complete|Compress|Confirm|Connect|Convert|ConvertFrom|ConvertTo|Copy|Debug|Deny|Disable|Disconnect|Dismount|Edit|Enable|Enter|Exit|Expand|Export|Find|Format|Get|Grant|Group|Hide|Import|Initialize|Install|Invoke|Join|Limit|Lock|Measure|Merge|Mount|Move|New|Open|Optimize|Out|Ping|Pop|Protect|Publish|Push|Read|Receive|Redo|Register|Remove|Rename|Repair|Request|Reset|Resize|Resolve|Restart|Restore|Resume|Revoke|Save|Search|Select|Send|Set|Show|Skip|Split|Start|Step|Stop|Submit|Suspend|Switch|Sync|Test|Trace|Unblock|Undo|Uninstall|Unlock|Unprotect|Unpublish|Unregister|Update|Use|Wait|Watch|Write)\-.+?(?:\.(?i:exe|cmd|bat|ps1))?\b</string>
+					<key>name</key>
+					<string>support.function.powershell</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Builtin cmdlets with reserved verbs</string>
+					<key>match</key>
+					<string>(?&lt;!\w)(?i:foreach-object)(?!\w)</string>
+					<key>name</key>
+					<string>support.function.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>commentEmbeddedDocs</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?i:\s*(\.)(SYNOPSIS|DESCRIPTION|EXAMPLE|INPUTS|OUTPUTS|NOTES|LINK|COMPONENT|FUNCTIONALITY))</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?i:\s*(\.)(PARAMETER|FORWARDHELPTARGETNAME|FORWARDHELPCATEGORY|REMOTEHELPRUNSPACE|EXTERNALHELP)\s+([a-z0-9-_]+))</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.string.documentation.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.documentation.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.double.heredoc.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?i:requires\s+-(Version\s+\d(.\d+)?|Assembly\s+(.*)|Module\s+(.*)|PsSnapIn\s+(.*)|ShellId\s+(.*)))</string>
+					<key>name</key>
+					<string>comment.documentation.embedded.powershell</string>
+				</dict>
+			</array>
+		</dict>
+		<key>doubleQuotedStringEscapes</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>`[0abnfrvt"'$`]</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>""</string>
+					<key>name</key>
+					<string>constant.character.escape.powershell</string>
+				</dict>
+			</array>
 		</dict>
 		<key>function</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;!\S)(?i)(function|filter|workflow|configuration)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
+			<string>(?&lt;!\S)(?i)(function|filter|configuration|workflow)\s+(?:(global|local|script|private):)?((?:\p{L}|\d|_|-|\.)+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -833,61 +548,84 @@
 			</dict>
 			<key>end</key>
 			<string>\{|\(</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#lineComment</string>
-				</dict>
-			</array>
 		</dict>
-		<key>hashTable</key>
+		<key>interpolatedStringContent</key>
 		<dict>
 			<key>begin</key>
-			<string>(@\{)</string>
+			<string>\(</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>interpolated.simple.source.powershell</string>
 			<key>end</key>
-			<string>(\})</string>
-			<key>name</key>
-			<string>meta.hashtable.powershell</string>
+			<string>\)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</dict>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#interpolation</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#interpolatedStringContent</string>
+				</dict>
 			</array>
 		</dict>
-		<key>illegalBacktick</key>
-		<dict>
-			<key>comment</key>
-			<string>Any characters (other than new line) after a back-tick, is illegal in PowerShell.</string>
-			<key>match</key>
-			<string>(`(?!$))</string>
-			<key>name</key>
-			<string>invalid.illegal.powershell</string>
-		</dict>
-		<key>illegalVariable</key>
-		<dict>
-			<key>match</key>
-			<string>\$\w+:\s</string>
-			<key>name</key>
-			<string>invalid.illegal.powershell</string>
-		</dict>
-		<key>lineComment</key>
+		<key>interpolation</key>
 		<dict>
 			<key>begin</key>
-			<string>(^#|\s#)</string>
-			<key>comment</key>
-			<string>Line comment - must start with new line or at least one whitespace character before the '#'.</string>
+			<string>(\$)\(</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>interpolated.complex.source.powershell</string>
 			<key>end</key>
-			<string>$</string>
-			<key>name</key>
-			<string>comment.line.number-sign.powershell</string>
+			<string>\)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.powershell</string>
+				</dict>
+			</dict>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#commentEmbeddedDocs</string>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#interpolation</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#interpolatedStringContent</string>
 				</dict>
 			</array>
 		</dict>
@@ -896,192 +634,71 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>comment</key>
-					<string>Real [(+|-)] digits . digits [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.math.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
 					<key>match</key>
-					<string>(?&lt;!\w)([-+]?)\d+\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
-					<key>name</key>
-					<string>constant.numeric.real.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Real [(+|-)] . digits [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
-					<key>match</key>
-					<string>(?&lt;!\.|\d|\w)([-+]?)\.\d+(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
-					<key>name</key>
-					<string>constant.numeric.real.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Real [(+|-)] digits . [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
-					<key>match</key>
-					<string>(?&lt;!\w)([-+]?)(?&lt;!\d)\d+\.(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d|\.)</string>
-					<key>name</key>
-					<string>constant.numeric.real.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Integer [(+|-)] digits [(d|l)] [(kb|mb|gb|tb|pb)]</string>
-					<key>match</key>
-					<string>(?&lt;!\w|\w\.)([-+]?)\d+(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
-					<key>name</key>
-					<string>constant.numeric.integer.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Real [(+|-)] digits [e [(+|-)] digits] [(d|l)] [(kb|mb|gb|tb|pb)]</string>
-					<key>match</key>
-					<string>(?&lt;!\w|\.)([-+]?)(?&lt;!\d)\d+(?i:e(\+|-){0,1}\d+){0,1}(?i:d|l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d|\.)</string>
-					<key>name</key>
-					<string>constant.numeric.real.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Hexadecimal 0x 0-f [l] [kb|mb|gb|tb|pb]</string>
-					<key>match</key>
-					<string>(?&lt;!\w|\d)([-+]?)(?i:0x)(?i:[0-9a-f])+(?i:l){0,1}(?i:kb|mb|gb|tb|pb){0,1}(?!\w|\d)</string>
+					<string>(?&lt;!\w)(?i:(0x)([a-f0-9]+)((?i:L)?(?i:[kmgtp]b)?))(?!\w)</string>
 					<key>name</key>
 					<string>constant.numeric.hexadecimal.powershell</string>
 				</dict>
-			</array>
-		</dict>
-		<key>operators</key>
-		<dict>
-			<key>patterns</key>
-			<array>
 				<dict>
-					<key>comment</key>
-					<string>Comparison</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.math.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+					</dict>
 					<key>match</key>
-					<string>(?&lt;=\d|\s|^)-(?i:as|is|isnot|in|notin|join|((c|i)?(eq|ne|gt|lt|ge|le|like|notlike|split|replace|contains|notcontains|match|notmatch))|shl|shr)\b(?!\.|\\)</string>
+					<string>(?&lt;!\w)(?i:(\d*\.?\d+)(?:((?i:E)[+-]?)(\d+))?((?i:[DL])?)((?i:[kmgtp]b)?))(?!\w)</string>
 					<key>name</key>
-					<string>keyword.operator.comparison.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Bitwise</string>
-					<key>match</key>
-					<string>(?&lt;=\d|\s|^)-(?i:band|bor|bxor|bnot|shr|shl)\b</string>
-					<key>name</key>
-					<string>keyword.operator.bitwise.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Logical</string>
-					<key>match</key>
-					<string>(?&lt;=\d|\s|^)-(?i:and|or|xor)\b</string>
-					<key>name</key>
-					<string>keyword.operator.logical.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Format</string>
-					<key>match</key>
-					<string>(?&lt;=\d|\s|^)-(?i:f)\b</string>
-					<key>name</key>
-					<string>keyword.operator.format.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Assignment</string>
-					<key>match</key>
-					<string>(=|-=|\+=|\*=|/=|%=)</string>
-					<key>name</key>
-					<string>keyword.operator.assignment.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Logical NOT</string>
-					<key>match</key>
-					<string>(?&lt;=\d|\s|^)((?i:-not)|!)</string>
-					<key>name</key>
-					<string>keyword.operator.unary.logical-not.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Multiplicative</string>
-					<key>match</key>
-					<string>([*/%])(?!\.)</string>
-					<key>name</key>
-					<string>keyword.operator.multiplicative.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Unary Plus</string>
-					<key>match</key>
-					<string>([+](?=\$|\(|"))</string>
-					<key>name</key>
-					<string>keyword.operator.unary-plus.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Unary Minus</string>
-					<key>match</key>
-					<string>([-](?=\$|\(|"))</string>
-					<key>name</key>
-					<string>keyword.operator.unary-minus.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Additive</string>
-					<key>match</key>
-					<string>([+-])(?!\{|\p{L}|@)</string>
-					<key>name</key>
-					<string>keyword.operator.additive.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Range</string>
-					<key>match</key>
-					<string>(\.\.)</string>
-					<key>name</key>
-					<string>keyword.operator.range.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Command invocation (Call)</string>
-					<key>match</key>
-					<string>(&amp;|\|)</string>
-					<key>name</key>
-					<string>keyword.operator.other.powershell</string>
+					<string>constant.numeric.scientific.powershell</string>
 				</dict>
 			</array>
 		</dict>
-		<key>redirection</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>comment</key>
-					<string>Merging redirection</string>
-					<key>match</key>
-					<string>(?&lt;=\s|^)([2-6\*]?&gt;&amp;1)</string>
-					<key>name</key>
-					<string>keyword.operator.redirection.powershell</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>File redirection</string>
-					<key>match</key>
-					<string>(?&lt;=\s|^)(([1-6\*]?&gt;{1,2})|(&lt;))</string>
-					<key>name</key>
-					<string>keyword.operator.redirection.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<key>reservedWords</key>
-		<dict>
-			<key>match</key>
-			<string>(\b(?&lt;!-|\$)(?i:configuration|node|enum|filter|sequence|class|data|define|function|dynamicparam|inlinescript|var|parallel|param|workflow)\b(?!-|\.))</string>
-			<key>name</key>
-			<string>keyword.other.powershell</string>
-		</dict>
-		<key>scriptBlock</key>
+		<key>scriptblock</key>
 		<dict>
 			<key>begin</key>
-			<string>(\{)</string>
+			<string>\{</string>
 			<key>end</key>
-			<string>(\})</string>
+			<string>\}</string>
 			<key>name</key>
 			<string>meta.scriptblock.powershell</string>
 			<key>patterns</key>
@@ -1089,216 +706,6 @@
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#defaultKeyword</string>
-				</dict>
-			</array>
-		</dict>
-		<key>stringDoubleQuoted</key>
-		<dict>
-			<key>begin</key>
-			<string>((?&lt;!\")\")</string>
-			<key>end</key>
-			<string>(\"(?!\"))</string>
-			<key>name</key>
-			<string>string.quoted.double.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#illegalVariable</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#stringEscapeChars</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#variableWithoutPropertyHighlighting</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#subExpression</string>
-				</dict>
-			</array>
-		</dict>
-		<key>stringDoubleQuotedHeredoc</key>
-		<dict>
-			<key>begin</key>
-			<string>(\@"\s*$)</string>
-			<key>end</key>
-			<string>^"\@</string>
-			<key>name</key>
-			<string>string.quoted.double.heredoc.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#illegalVariable</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#stringEscapeChars</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#variableWithoutPropertyHighlighting</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#subExpression</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#scriptBlock</string>
-				</dict>
-			</array>
-		</dict>
-		<key>stringEscapeChars</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>(`[0abfnrtv"'$`])</string>
-					<key>name</key>
-					<string>constant.character.escape.powershell</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>("")</string>
-					<key>name</key>
-					<string>constant.character.escape.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<key>stringSingleQuoted</key>
-		<dict>
-			<key>begin</key>
-			<string>((?&lt;!')')</string>
-			<key>end</key>
-			<string>('(?!'))</string>
-			<key>name</key>
-			<string>string.quoted.single.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#stringSingleQuotedDouble</string>
-				</dict>
-			</array>
-		</dict>
-		<key>stringSingleQuotedDouble</key>
-		<dict>
-			<key>match</key>
-			<string>('')</string>
-			<key>name</key>
-			<string>constant.character.escape.powershell</string>
-		</dict>
-		<key>stringSingleQuotedHeredoc</key>
-		<dict>
-			<key>begin</key>
-			<string>(\@'\s*$)</string>
-			<key>end</key>
-			<string>^'\@</string>
-			<key>name</key>
-			<string>string.quoted.single.heredoc.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#stringSingleQuotedDouble</string>
-				</dict>
-			</array>
-		</dict>
-		<key>subExpression</key>
-		<dict>
-			<key>begin</key>
-			<string>(\$\()</string>
-			<key>captures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(\))</string>
-			<key>name</key>
-			<string>meta.subexpression.powershell</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(.)</string>
-					<key>name</key>
-					<string>source.powershell</string>
-				</dict>
-			</array>
-		</dict>
-		<key>switch</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.powershell</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>switch [-regex|-wildcard|-exact][-casesensitive] -file filename</string>
-					<key>match</key>
-					<string>\b(?i:(switch))\b\s+(?i:(-regex|-wildcard|-exact){0,1})\s*(?i:(-casesensitive){0,1})\s*(?i:(-file))\s+</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>switch [-regex|-wildcard|-exact][-casesensitive] (&lt;value&gt;)</string>
-					<key>match</key>
-					<string>\b(?i:(switch))\b\s+(?i:(-regex|-wildcard|-exact){0,1})\s*(?i:(-casesensitive){0,1})\s*</string>
 				</dict>
 			</array>
 		</dict>
@@ -1311,81 +718,32 @@
 				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.powershell</string>
+					<string>entity.other.attribute-name</string>
 				</dict>
 			</dict>
 			<key>comment</key>
-			<string>Type []</string>
+			<string>name should be entity.name.type but default schema doesn't have a good color for it</string>
 			<key>end</key>
-			<string>(\])(::[\w]+)*((\.[\w"']+)*)</string>
+			<string>\]</string>
 			<key>endCaptures</key>
 			<dict>
-				<key>1</key>
+				<key>0</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.powershell</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>meta.method.powershell</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.attribute-name.powershell</string>
+					<string>entity.other.attribute-name</string>
 				</dict>
 			</dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>\(</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>Parenthesis ()</string>
-					<key>end</key>
-					<string>\)</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-						<dict>
-							<key>comment</key>
-							<string>Reserved words within [( )]</string>
-							<key>match</key>
-							<string>\b(?i)(mandatory|valuefrompipeline|valuefrompipelinebypropertyname|valuefromremainingarguments|position|parametersetname|defaultparametersetname|supportsshouldprocess|positionalbinding|helpuri|confirmimpact|helpmessage)\b</string>
-							<key>name</key>
-							<string>entity.other.attribute-name.powershell</string>
-						</dict>
-					</array>
+					<key>match</key>
+					<string>(\p{L}|\.|``\d+)+?</string>
+					<key>name</key>
+					<string>entity.other.attribute-name</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>(.(`){0,2}(\d){0,2})</string>
-					<key>name</key>
-					<string>entity.name.type</string>
 				</dict>
 			</array>
 		</dict>
@@ -1394,12 +752,23 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.powershell</string>
+						</dict>
+					</dict>
 					<key>comment</key>
-					<string>Invalid variable name</string>
+					<string>These are special constants.</string>
 					<key>match</key>
-					<string>(\$)(\w+-\w+)\b</string>
-					<key>name</key>
-					<string>invalid.illegal.powershell</string>
+					<string>(\$)(?i:(False|Null|True))\b</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1407,23 +776,98 @@
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>constant.language.powershell</string>
+							<string>keyword.other.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>constant.language.powershell</string>
+							<string>support.constant.variable.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>entity.other.attribute-name.powershell</string>
+							<string>entity.name.function.invocation.powershell</string>
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Automatic variables - read-only.</string>
+					<string>These are the other built-in constants.</string>
 					<key>match</key>
-					<string>(\$)(?i:(_|args|consolefilename|error|event|eventsubscriber|executioncontext|false|foreach|home|host|input|lastexitcode|matches|myinvocation|nestedpromptlevel|null|pid|psboundparameters|pscmdlet|psculture|psdebugcontext|pshome|psitem|psscriptroot|psuiculture|psversiontable|pwd|sender|shellid|sourceargs|sourceeventargs|switch|this|true))\b((\.[\w"'\- @#]+)*)</string>
+					<string>(\$)(?i:(Error|ExecutionContext|Host|Home|PID|PsHome|PsVersionTable|ShellID))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.automatic.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Automatic variables are not constants, but they are read-only. In monokai (default) color schema support.variable doesn't have color, so we use constant.</string>
+					<key>match</key>
+					<string>(\$)(?i:(\$|\^|\?|_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Style preference variables as language variables so that they stand out.</string>
+					<key>match</key>
+					<string>(\$)(?i:(ConfirmPreference|DebugPreference|ErrorActionPreference|ErrorView|FormatEnumerationLimit|MaximumAliasCount|MaximumDriveCount|MaximumErrorCount|MaximumFunctionCount|MaximumHistoryCount|MaximumVariableCount|OFS|OutputEncoding|ProgressPreference|PsCulture|PSDebugContext|PSDefaultParameterValues|PSEmailServer|PSItem|PSModuleAutoloadingPreference|PSSenderInfo|PSSessionApplicationName|PSSessionConfigurationName|PSSessionOption|VerbosePreference|WarningPreference|WhatIfPreference))((?:\.(?:\p{L}|\d|_)+)*\b)?\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.scope.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.normal.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1446,18 +890,16 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
+							<string>keyword.other.powershell</string>
 						</dict>
 						<key>5</key>
 						<dict>
 							<key>name</key>
-							<string>entity.other.attribute-name.powershell</string>
+							<string>entity.name.function.invocation.powershell</string>
 						</dict>
 					</dict>
-					<key>comment</key>
-					<string>$var, $local:var</string>
 					<key>match</key>
-					<string>(\$)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(\w+)(:\w+)?((\.[\w"'\- @#]+)*)</string>
+					<string>(?i:(\$\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\}))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1470,33 +912,21 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.powershell</string>
+							<string>support.variable.drive.powershell</string>
 						</dict>
 						<key>3</key>
 						<dict>
 							<key>name</key>
-							<string>storage.modifier.scope.powershell</string>
+							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>6</key>
-						<dict>
-							<key>name</key>
-							<string>entity.other.attribute-name.powershell</string>
+							<string>entity.name.function.invocation.powershell</string>
 						</dict>
 					</dict>
-					<key>comment</key>
-					<string>${var}, ${script:var}</string>
 					<key>match</key>
-					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+?)(\})((\.[\w"'\- @#]+)*)</string>
+					<string>(?i:(\$)((?:\p{L}|\d|_)+:)?((?:\p{L}|\d|_)+))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1509,35 +939,40 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>support.variable.drive.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>variable.other.readwrite.powershell</string>
 						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
 					</dict>
-					<key>comment</key>
-					<string>Splatting</string>
 					<key>match</key>
-					<string>(@)(\w+)</string>
+					<string>(?i:(\$\{)((?:\p{L}|\d|_)+:)?([^}]*[^}`])(\}))((?:\.(?:\p{L}|\d|_)+)*\b)?</string>
 				</dict>
 			</array>
 		</dict>
-		<key>variableWithoutPropertyHighlighting</key>
+		<key>variableNoProperty</key>
 		<dict>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>comment</key>
-					<string>Invalid variable name</string>
-					<key>match</key>
-					<string>(\$)(\w+-\w+)\b</string>
-					<key>name</key>
-					<string>invalid.illegal.powershell</string>
-				</dict>
-				<dict>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
-							<string>constant.language.powershell</string>
+							<string>keyword.other.powershell</string>
 						</dict>
 						<key>2</key>
 						<dict>
@@ -1546,9 +981,108 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>Automatic variables - read-only.</string>
+					<string>These are special constants.</string>
 					<key>match</key>
-					<string>(\$)(?i:(_|args|consolefilename|error|event|eventsubscriber|executioncontext|false|foreach|home|host|input|lastexitcode|matches|myinvocation|nestedpromptlevel|null|pid|psboundparameters|pscmdlet|psculture|psdebugcontext|pshome|psitem|psscriptroot|psuiculture|psversiontable|pwd|sender|shellid|sourceargs|sourceeventargs|switch|this|true))\b</string>
+					<string>(\$)(?i:(False|Null|True))\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>support.constant.variable.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>These are the other built-in constants.</string>
+					<key>match</key>
+					<string>(\$)(?i:(Error|ExecutionContext|Host|Home|PID|PsHome|PsVersionTable|ShellID))\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>support.variable.automatic.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Automatic variables are not constants, but they are read-only...</string>
+					<key>match</key>
+					<string>(\$)(?i:(\$|\^|\?|_|Args|ConsoleFileName|Event|EventArgs|EventSubscriber|ForEach|Input|LastExitCode|Matches|MyInvocation|NestedPromptLevel|Profile|PSBoundParameters|PsCmdlet|PsCulture|PSDebugContext|PSItem|PSCommandPath|PSScriptRoot|PsUICulture|Pwd|Sender|SourceArgs|SourceEventArgs|StackTrace|Switch|This))\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Style preference variables as language variables so that they stand out.</string>
+					<key>match</key>
+					<string>(\$)(?i:(ConfirmPreference|DebugPreference|ErrorActionPreference|ErrorView|FormatEnumerationLimit|MaximumAliasCount|MaximumDriveCount|MaximumErrorCount|MaximumFunctionCount|MaximumHistoryCount|MaximumVariableCount|OFS|OutputEncoding|ProgressPreference|PsCulture|PSDebugContext|PSDefaultParameterValues|PSEmailServer|PSItem|PSModuleAutoloadingPreference|PSSenderInfo|PSSessionApplicationName|PSSessionConfigurationName|PSSessionOption|VerbosePreference|WarningPreference|WhatIfPreference))\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.scope.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.normal.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?i:(\$)(global|local|private|script|using|workflow):((?:\p{L}|\d|_)+))</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1571,47 +1105,16 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>$var, $local:var</string>
-					<key>match</key>
-					<string>(\$)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(\w+)(:\w+)?</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
 							<string>keyword.other.powershell</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.powershell</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.scope.powershell</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.readwrite.powershell</string>
 						</dict>
 						<key>5</key>
 						<dict>
 							<key>name</key>
-							<string>keyword.other.powershell</string>
+							<string>entity.name.function.invocation.powershell</string>
 						</dict>
 					</dict>
-					<key>comment</key>
-					<string>${var}, ${script:var}</string>
 					<key>match</key>
-					<string>(\$)(\{)((?i:global|local|script|private|using|env|function|alias|cert|variable|hkcu|hklm|wsman):)?(.+?)(\})</string>
+					<string>(?i:(\$\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\}))</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1624,13 +1127,53 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>support.variable.drive.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
 							<string>variable.other.readwrite.powershell</string>
 						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
 					</dict>
-					<key>comment</key>
-					<string>Splatting</string>
 					<key>match</key>
-					<string>(@)(\w+)</string>
+					<string>(?i:(\$)((?:\p{L}|\d|_)+:)?((?:\p{L}|\d|_)+))</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>support.variable.drive.powershell</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.readwrite.powershell</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.powershell</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.invocation.powershell</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?i:(\$\{)((?:\p{L}|\d|_)+:)?([^}]*[^}`])(\}))</string>
 				</dict>
 			</array>
 		</dict>

--- a/extensions/powershell/test/colorize-results/test_ps1.json
+++ b/extensions/powershell/test/colorize-results/test_ps1.json
@@ -44,7 +44,7 @@
 		}
 	},
 	{
-		"c": "() ",
+		"c": "() {",
 		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
@@ -55,19 +55,8 @@
 		}
 	},
 	{
-		"c": "{",
-		"t": "meta.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -78,7 +67,7 @@
 	},
 	{
 		"c": "try",
-		"t": "control.keyword.meta.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -89,7 +78,7 @@
 	},
 	{
 		"c": " {",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -100,7 +89,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -111,7 +100,7 @@
 	},
 	{
 		"c": "$",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -122,7 +111,7 @@
 	},
 	{
 		"c": "identity",
-		"t": "meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -133,7 +122,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -144,7 +133,7 @@
 	},
 	{
 		"c": "=",
-		"t": "assignment.keyword.meta.operator.powershell.scriptblock",
+		"t": "assignment.keyword.operator.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -155,7 +144,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -165,41 +154,19 @@
 		}
 	},
 	{
-		"c": "[",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"c": "[Security.Principal.WindowsIdentity]",
+		"t": "attribute-name.entity.other",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": "Security.Principal.WindowsIdentity",
-		"t": "entity.meta.name.powershell.scriptblock.type",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.type rgb(78, 201, 176)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.type rgb(38, 127, 153)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "]",
-		"t": "keyword.meta.other.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
 		"c": "::GetCurrent",
-		"t": "meta.method.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -210,7 +177,7 @@
 	},
 	{
 		"c": "()",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -221,7 +188,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -232,7 +199,7 @@
 	},
 	{
 		"c": "$",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -243,7 +210,7 @@
 	},
 	{
 		"c": "principal",
-		"t": "meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -254,7 +221,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -265,7 +232,7 @@
 	},
 	{
 		"c": "=",
-		"t": "assignment.keyword.meta.operator.powershell.scriptblock",
+		"t": "assignment.keyword.operator.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -276,7 +243,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -287,7 +254,7 @@
 	},
 	{
 		"c": "New-Object",
-		"t": "command.function.meta.powershell.scriptblock.support",
+		"t": "function.powershell.support",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -297,8 +264,8 @@
 		}
 	},
 	{
-		"c": " Security.Principal.WindowsPrincipal",
-		"t": "command.meta.powershell.scriptblock",
+		"c": " Security.Principal.WindowsPrincipal ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -308,19 +275,19 @@
 		}
 	},
 	{
-		"c": " -ArgumentList",
-		"t": "command.meta.parameter.powershell.scriptblock.variable",
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
 		}
 	},
 	{
-		"c": " ",
-		"t": "command.meta.powershell.scriptblock",
+		"c": "ArgumentList ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -331,7 +298,7 @@
 	},
 	{
 		"c": "$",
-		"t": "command.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -342,7 +309,7 @@
 	},
 	{
 		"c": "identity",
-		"t": "command.meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -353,7 +320,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -364,7 +331,7 @@
 	},
 	{
 		"c": "return",
-		"t": "control.keyword.meta.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -375,7 +342,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -386,7 +353,7 @@
 	},
 	{
 		"c": "$",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -397,7 +364,7 @@
 	},
 	{
 		"c": "principal",
-		"t": "meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -408,7 +375,40 @@
 	},
 	{
 		"c": ".IsInRole",
-		"t": "attribute-name.entity.meta.other.powershell.scriptblock",
+		"t": "entity.function.invocation.name.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.function rgb(220, 220, 170)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.function rgb(121, 94, 38)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.name.function rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": "(",
+		"t": "keyword.other.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": " ",
+		"t": "interpolated.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": "[Security.Principal.WindowsBuiltInRole]",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
@@ -418,74 +418,8 @@
 		}
 	},
 	{
-		"c": "(",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": " ",
-		"t": "array.meta.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "[",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": "Security.Principal.WindowsBuiltInRole",
-		"t": "array.entity.meta.name.powershell.scriptblock.type",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.type rgb(78, 201, 176)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.type rgb(38, 127, 153)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "]",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": "::Administrator",
-		"t": "array.meta.method.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": " ",
-		"t": "array.meta.powershell.scriptblock",
+		"c": "::Administrator ",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -496,7 +430,7 @@
 	},
 	{
 		"c": ")",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -507,7 +441,7 @@
 	},
 	{
 		"c": "    } ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -518,7 +452,7 @@
 	},
 	{
 		"c": "catch",
-		"t": "control.keyword.meta.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -529,7 +463,7 @@
 	},
 	{
 		"c": " {",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -540,7 +474,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -551,7 +485,7 @@
 	},
 	{
 		"c": "throw",
-		"t": "control.keyword.meta.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -562,7 +496,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -573,7 +507,7 @@
 	},
 	{
 		"c": "\"Failed to determine if the current user has elevated privileges. The error was: '{0}'.\"",
-		"t": "double.meta.powershell.quoted.scriptblock.string",
+		"t": "double.powershell.quoted.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -584,7 +518,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -595,7 +529,7 @@
 	},
 	{
 		"c": "-f",
-		"t": "format.keyword.meta.operator.powershell.scriptblock",
+		"t": "keyword.operator.powershell.string-format",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -606,7 +540,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -616,19 +550,30 @@
 		}
 	},
 	{
-		"c": "$_",
-		"t": "constant.language.meta.powershell.scriptblock",
+		"c": "$",
+		"t": "keyword.other.powershell",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.language rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.language rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.constant.language rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.constant.language rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.constant.language rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": "_",
+		"t": "automatic.constant.powershell.support",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
 		"c": "    }",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -639,7 +584,7 @@
 	},
 	{
 		"c": "}",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -694,7 +639,7 @@
 	},
 	{
 		"c": "{",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -705,7 +650,7 @@
 	},
 	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -716,18 +661,18 @@
 	},
 	{
 		"c": "param",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.control rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.control rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.control rgb(86, 156, 214)"
 		}
 	},
 	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -738,7 +683,7 @@
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -749,7 +694,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -759,41 +704,30 @@
 		}
 	},
 	{
-		"c": "[",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"c": "[Parameter",
+		"t": "entity.interpolated.name.powershell.simple.source.tag",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": "Parameter",
-		"t": "array.entity.meta.name.powershell.scriptblock.type",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.type rgb(78, 201, 176)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.type rgb(38, 127, 153)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.tag rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.tag rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.name.tag rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.name.tag rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.name.tag rgb(86, 156, 214)"
 		}
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
 		"c": "Mandatory",
-		"t": "array.attribute-name.entity.meta.other.powershell.scriptblock",
+		"t": "attribute.attribute-name.constant.entity.interpolated.language.other.parameter.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
@@ -804,51 +738,62 @@
 	},
 	{
 		"c": "=",
-		"t": "array.assignment.keyword.meta.operator.powershell.scriptblock",
+		"t": "attribute.attribute-name.entity.interpolated.other.parameter.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
 		"c": "1",
-		"t": "array.constant.integer.meta.numeric.powershell.scriptblock",
+		"t": "attribute.attribute-name.entity.interpolated.other.parameter.powershell.simple.source.variable",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.numeric rgb(181, 206, 168)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.numeric rgb(9, 136, 90)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.constant.numeric rgb(181, 206, 168)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.constant.numeric rgb(9, 136, 90)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.constant.numeric rgb(181, 206, 168)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
-		"c": ")][",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"c": ")",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
-		"c": "string",
-		"t": "array.entity.meta.name.powershell.scriptblock.type",
+		"c": "]",
+		"t": "entity.interpolated.name.powershell.simple.source.tag",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.type rgb(78, 201, 176)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.type rgb(38, 127, 153)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.tag rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.tag rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.name.tag rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.name.tag rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.name.tag rgb(86, 156, 214)"
 		}
 	},
 	{
-		"c": "]$",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"c": "[string]",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
+		}
+	},
+	{
+		"c": "$",
+		"t": "interpolated.keyword.other.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -859,7 +804,7 @@
 	},
 	{
 		"c": "Command",
-		"t": "array.meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "interpolated.other.powershell.readwrite.simple.source.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -870,7 +815,7 @@
 	},
 	{
 		"c": "    ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -881,7 +826,7 @@
 	},
 	{
 		"c": ")",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -892,7 +837,7 @@
 	},
 	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -903,7 +848,7 @@
 	},
 	{
 		"c": "foreach",
-		"t": "control.keyword.meta.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -914,7 +859,7 @@
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -924,19 +869,30 @@
 		}
 	},
 	{
-		"c": "$_",
-		"t": "array.constant.language.meta.powershell.scriptblock",
+		"c": "$",
+		"t": "interpolated.keyword.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.language rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.language rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.constant.language rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.constant.language rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.constant.language rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": "_",
+		"t": "automatic.constant.interpolated.powershell.simple.source.support",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
 		"c": " ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -947,7 +903,7 @@
 	},
 	{
 		"c": "in",
-		"t": "array.control.keyword.meta.powershell.scriptblock",
+		"t": "control.interpolated.keyword.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -958,7 +914,7 @@
 	},
 	{
 		"c": " cmd ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -969,7 +925,7 @@
 	},
 	{
 		"c": "/",
-		"t": "array.keyword.meta.multiplicative.operator.powershell.scriptblock",
+		"t": "assignment.interpolated.keyword.operator.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -980,7 +936,7 @@
 	},
 	{
 		"c": "c ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -991,7 +947,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "array.double.meta.powershell.quoted.scriptblock.string",
+		"t": "double.interpolated.powershell.quoted.simple.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1002,7 +958,7 @@
 	},
 	{
 		"c": "$",
-		"t": "array.double.keyword.meta.other.powershell.quoted.scriptblock.string",
+		"t": "double.interpolated.keyword.other.powershell.quoted.simple.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1013,7 +969,7 @@
 	},
 	{
 		"c": "Command",
-		"t": "array.double.meta.other.powershell.quoted.readwrite.scriptblock.string.variable",
+		"t": "double.interpolated.other.powershell.quoted.readwrite.simple.source.string.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -1024,7 +980,7 @@
 	},
 	{
 		"c": "  2>&1 & set\"",
-		"t": "array.double.meta.powershell.quoted.scriptblock.string",
+		"t": "double.interpolated.powershell.quoted.simple.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1035,7 +991,7 @@
 	},
 	{
 		"c": ")",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1046,7 +1002,7 @@
 	},
 	{
 		"c": " {",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1057,7 +1013,7 @@
 	},
 	{
 		"c": "        ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1068,7 +1024,7 @@
 	},
 	{
 		"c": "if",
-		"t": "control.keyword.meta.powershell.scriptblock",
+		"t": "control.keyword.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.control rgb(197, 134, 192)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.control rgb(175, 0, 219)",
@@ -1079,7 +1035,7 @@
 	},
 	{
 		"c": " ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1090,7 +1046,7 @@
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1100,19 +1056,30 @@
 		}
 	},
 	{
-		"c": "$_",
-		"t": "array.constant.language.meta.powershell.scriptblock",
+		"c": "$",
+		"t": "interpolated.keyword.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.language rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.language rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.constant.language rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.constant.language rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.constant.language rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": "_",
+		"t": "automatic.constant.interpolated.powershell.simple.source.support",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
 		"c": " ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1123,7 +1090,7 @@
 	},
 	{
 		"c": "-match",
-		"t": "array.comparison.keyword.meta.operator.powershell.scriptblock",
+		"t": "comparison.interpolated.keyword.operator.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -1134,7 +1101,7 @@
 	},
 	{
 		"c": " ",
-		"t": "array.meta.powershell.scriptblock",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1145,7 +1112,7 @@
 	},
 	{
 		"c": "'^([^=]+)=(.*)'",
-		"t": "array.meta.powershell.quoted.scriptblock.single.string",
+		"t": "interpolated.powershell.quoted.simple.single.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1156,7 +1123,7 @@
 	},
 	{
 		"c": ")",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1167,7 +1134,7 @@
 	},
 	{
 		"c": " {",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1178,7 +1145,7 @@
 	},
 	{
 		"c": "            ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1188,41 +1155,19 @@
 		}
 	},
 	{
-		"c": "[",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"c": "[System.Environment]",
+		"t": "attribute-name.entity.other",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": "System.Environment",
-		"t": "entity.meta.name.powershell.scriptblock.type",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.name.type rgb(78, 201, 176)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.name.type rgb(38, 127, 153)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "]",
-		"t": "keyword.meta.other.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
 		"c": "::SetEnvironmentVariable",
-		"t": "meta.method.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1233,7 +1178,7 @@
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1243,30 +1188,41 @@
 		}
 	},
 	{
-		"c": "$matches",
-		"t": "array.constant.language.meta.powershell.scriptblock",
+		"c": "$",
+		"t": "interpolated.keyword.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.language rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.language rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.constant.language rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.constant.language rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.constant.language rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": "matches",
+		"t": "automatic.constant.interpolated.powershell.simple.source.support",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
 		"c": "[",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
 		"c": "1",
-		"t": "array.constant.integer.meta.numeric.powershell.scriptblock",
+		"t": "constant.interpolated.numeric.powershell.scientific.simple.source.support",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.numeric rgb(181, 206, 168)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.numeric rgb(9, 136, 90)",
@@ -1277,18 +1233,29 @@
 	},
 	{
 		"c": "]",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
 		}
 	},
 	{
-		"c": ", ",
-		"t": "array.meta.powershell.scriptblock",
+		"c": ",",
+		"t": "interpolated.keyword.operator.other.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": " ",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1298,19 +1265,8 @@
 		}
 	},
 	{
-		"c": "$matches",
-		"t": "array.constant.language.meta.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.language rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.language rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.constant.language rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.constant.language rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.constant.language rgb(86, 156, 214)"
-		}
-	},
-	{
-		"c": "[",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"c": "$",
+		"t": "interpolated.keyword.other.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1320,8 +1276,30 @@
 		}
 	},
 	{
+		"c": "matches",
+		"t": "automatic.constant.interpolated.powershell.simple.source.support",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": "[",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
+		}
+	},
+	{
 		"c": "2",
-		"t": "array.constant.integer.meta.numeric.powershell.scriptblock",
+		"t": "constant.interpolated.numeric.powershell.scientific.simple.source.support",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.constant.numeric rgb(181, 206, 168)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.constant.numeric rgb(9, 136, 90)",
@@ -1331,8 +1309,19 @@
 		}
 	},
 	{
-		"c": "])",
-		"t": "array.keyword.meta.other.powershell.scriptblock",
+		"c": "]",
+		"t": "attribute-name.entity.interpolated.other.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.entity.other.attribute-name rgb(156, 220, 254)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.entity.other.attribute-name rgb(255, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.entity.other.attribute-name rgb(156, 220, 254)"
+		}
+	},
+	{
+		"c": ")",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1343,7 +1332,7 @@
 	},
 	{
 		"c": "        }",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1354,7 +1343,7 @@
 	},
 	{
 		"c": "    }",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1365,7 +1354,7 @@
 	},
 	{
 		"c": "}",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1376,7 +1365,7 @@
 	},
 	{
 		"c": "Write-Host",
-		"t": "command.function.meta.powershell.support",
+		"t": "function.powershell.support",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1386,19 +1375,30 @@
 		}
 	},
 	{
-		"c": " -Object",
-		"t": "command.meta.parameter.powershell.variable",
+		"c": " ",
+		"t": "",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
 			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
 			"light_vs": ".vs .token rgb(0, 0, 0)",
 			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
-		"c": " ",
-		"t": "command.meta.powershell",
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": "Object ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1409,7 +1409,7 @@
 	},
 	{
 		"c": "'Initializing Azure PowerShell environment...'",
-		"t": "command.meta.powershell.quoted.single.string",
+		"t": "powershell.quoted.single.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1420,13 +1420,13 @@
 	},
 	{
 		"c": ";",
-		"t": "command.meta.powershell",
+		"t": "keyword.other.powershell.statement-separator",
 		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
 		}
 	},
 	{
@@ -1464,7 +1464,7 @@
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1475,18 +1475,18 @@
 	},
 	{
 		"c": "!",
-		"t": "array.meta.powershell",
+		"t": "interpolated.keyword.operator.powershell.simple.source.unary",
 		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
 		}
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell",
+		"t": "interpolated.keyword.other.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1497,7 +1497,7 @@
 	},
 	{
 		"c": "Test-IsAdmin",
-		"t": "array.command.function.meta.powershell.support",
+		"t": "function.interpolated.powershell.simple.source.support",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1507,8 +1507,19 @@
 		}
 	},
 	{
-		"c": "))",
-		"t": "array.keyword.meta.other.powershell",
+		"c": ")",
+		"t": "interpolated.keyword.other.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": ")",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1519,7 +1530,7 @@
 	},
 	{
 		"c": "{",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1530,7 +1541,7 @@
 	},
 	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1541,7 +1552,7 @@
 	},
 	{
 		"c": "Write-Host",
-		"t": "command.function.meta.powershell.scriptblock.support",
+		"t": "function.powershell.support",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1551,19 +1562,30 @@
 		}
 	},
 	{
-		"c": " -Object",
-		"t": "command.meta.parameter.powershell.scriptblock.variable",
+		"c": " ",
+		"t": "",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
 			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
 			"light_vs": ".vs .token rgb(0, 0, 0)",
 			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
-		"c": " ",
-		"t": "command.meta.powershell.scriptblock",
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": "Object ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1574,7 +1596,7 @@
 	},
 	{
 		"c": "'Please launch command under administrator account. It is needed for environment setting up and unit test.'",
-		"t": "command.meta.powershell.quoted.scriptblock.single.string",
+		"t": "powershell.quoted.single.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1584,19 +1606,8 @@
 		}
 	},
 	{
-		"c": " -ForegroundColor",
-		"t": "command.meta.parameter.powershell.scriptblock.variable",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": " Red;",
-		"t": "command.meta.powershell.scriptblock",
+		"c": " ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1606,8 +1617,41 @@
 		}
 	},
 	{
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": "ForegroundColor Red",
+		"t": "",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": ";",
+		"t": "keyword.other.powershell.statement-separator",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
 		"c": "}",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1629,13 +1673,13 @@
 	},
 	{
 		"c": "env:",
-		"t": "modifier.powershell.scope.storage",
+		"t": "drive.powershell.support.variable",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.storage.modifier rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.storage.modifier rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.storage.modifier rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
@@ -1684,7 +1728,7 @@
 	},
 	{
 		"c": "Split-Path",
-		"t": "command.function.meta.powershell.support",
+		"t": "function.powershell.support",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1694,19 +1738,52 @@
 		}
 	},
 	{
-		"c": " -Parent -Path",
-		"t": "command.meta.parameter.powershell.variable",
+		"c": " ",
+		"t": "",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
 			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
 			"light_vs": ".vs .token rgb(0, 0, 0)",
 			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
-		"c": " ",
-		"t": "command.meta.powershell",
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": "Parent ",
+		"t": "",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": "Path ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1717,7 +1794,7 @@
 	},
 	{
 		"c": "$",
-		"t": "command.keyword.meta.other.powershell",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1728,18 +1805,18 @@
 	},
 	{
 		"c": "env:",
-		"t": "command.meta.modifier.powershell.scope.storage",
+		"t": "drive.powershell.support.variable",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.storage.modifier rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.storage.modifier rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.storage.modifier rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
 		"c": "AzurePSRoot",
-		"t": "command.meta.other.powershell.readwrite.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -1750,13 +1827,13 @@
 	},
 	{
 		"c": ";",
-		"t": "command.meta.powershell",
+		"t": "keyword.other.powershell.statement-separator",
 		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
 		}
 	},
 	{
@@ -1783,7 +1860,7 @@
 	},
 	{
 		"c": "(",
-		"t": "array.keyword.meta.other.powershell",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1794,7 +1871,7 @@
 	},
 	{
 		"c": "Test-Path",
-		"t": "array.command.function.meta.powershell.support",
+		"t": "function.interpolated.powershell.simple.source.support",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1804,19 +1881,30 @@
 		}
 	},
 	{
-		"c": " -Path",
-		"t": "array.command.meta.parameter.powershell.variable",
+		"c": " ",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
 			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
 			"light_vs": ".vs .token rgb(0, 0, 0)",
 			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
-		"c": " ",
-		"t": "array.command.meta.powershell",
+		"c": "-",
+		"t": "assignment.interpolated.keyword.operator.powershell.simple.source",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": "Path ",
+		"t": "interpolated.powershell.simple.source",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1827,7 +1915,7 @@
 	},
 	{
 		"c": "\"",
-		"t": "array.command.double.meta.powershell.quoted.string",
+		"t": "double.interpolated.powershell.quoted.simple.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1838,7 +1926,7 @@
 	},
 	{
 		"c": "$",
-		"t": "array.command.double.keyword.meta.other.powershell.quoted.string",
+		"t": "double.interpolated.keyword.other.powershell.quoted.simple.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1849,18 +1937,18 @@
 	},
 	{
 		"c": "env:",
-		"t": "array.command.double.meta.modifier.powershell.quoted.scope.storage.string",
+		"t": "double.drive.interpolated.powershell.quoted.simple.source.string.support.variable",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.storage.modifier rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.storage.modifier rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.storage.modifier rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.string rgb(206, 145, 120)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.string rgb(163, 21, 21)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.string rgb(206, 145, 120)"
 		}
 	},
 	{
 		"c": "ADXSDKProgramFiles",
-		"t": "array.command.double.meta.other.powershell.quoted.readwrite.string.variable",
+		"t": "double.interpolated.other.powershell.quoted.readwrite.simple.source.string.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -1871,7 +1959,7 @@
 	},
 	{
 		"c": "\\Microsoft Visual Studio 12.0\"",
-		"t": "array.command.double.meta.powershell.quoted.string",
+		"t": "double.interpolated.powershell.quoted.simple.source.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1882,7 +1970,7 @@
 	},
 	{
 		"c": ")",
-		"t": "array.keyword.meta.other.powershell",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1892,7 +1980,7 @@
 		}
 	},
 	{
-		"c": " ",
+		"c": " {",
 		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
@@ -1903,19 +1991,8 @@
 		}
 	},
 	{
-		"c": "{",
-		"t": "meta.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1926,7 +2003,7 @@
 	},
 	{
 		"c": "$",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -1937,7 +2014,7 @@
 	},
 	{
 		"c": "vsVersion",
-		"t": "meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -1948,7 +2025,7 @@
 	},
 	{
 		"c": "=",
-		"t": "assignment.keyword.meta.operator.powershell.scriptblock",
+		"t": "assignment.keyword.operator.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -1959,7 +2036,7 @@
 	},
 	{
 		"c": "\"12.0\"",
-		"t": "double.meta.powershell.quoted.scriptblock.string",
+		"t": "double.powershell.quoted.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -1969,18 +2046,7 @@
 		}
 	},
 	{
-		"c": "}",
-		"t": "meta.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": " ",
+		"c": "} ",
 		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
@@ -2002,7 +2068,7 @@
 		}
 	},
 	{
-		"c": " ",
+		"c": " {",
 		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
@@ -2013,19 +2079,8 @@
 		}
 	},
 	{
-		"c": "{",
-		"t": "meta.powershell.scriptblock",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
 		"c": "    ",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -2036,7 +2091,7 @@
 	},
 	{
 		"c": "$",
-		"t": "keyword.meta.other.powershell.scriptblock",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -2047,7 +2102,7 @@
 	},
 	{
 		"c": "vsVersion",
-		"t": "meta.other.powershell.readwrite.scriptblock.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -2058,7 +2113,7 @@
 	},
 	{
 		"c": "=",
-		"t": "assignment.keyword.meta.operator.powershell.scriptblock",
+		"t": "assignment.keyword.operator.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -2069,7 +2124,7 @@
 	},
 	{
 		"c": "\"11.0\"",
-		"t": "double.meta.powershell.quoted.scriptblock.string",
+		"t": "double.powershell.quoted.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.string rgb(163, 21, 21)",
@@ -2080,7 +2135,7 @@
 	},
 	{
 		"c": "}",
-		"t": "meta.powershell.scriptblock",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -2168,7 +2223,7 @@
 	},
 	{
 		"c": "-f",
-		"t": "format.keyword.operator.powershell",
+		"t": "keyword.operator.powershell.string-format",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
@@ -2201,13 +2256,13 @@
 	},
 	{
 		"c": "env:",
-		"t": "modifier.powershell.scope.storage",
+		"t": "drive.powershell.support.variable",
 		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.storage.modifier rgb(0, 0, 255)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.storage.modifier rgb(86, 156, 214)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.storage.modifier rgb(0, 0, 255)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.storage.modifier rgb(86, 156, 214)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
 		}
 	},
 	{
@@ -2222,7 +2277,18 @@
 		}
 	},
 	{
-		"c": ", ",
+		"c": ",",
+		"t": "keyword.operator.other.powershell",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
+		}
+	},
+	{
+		"c": " ",
 		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
@@ -2256,6 +2322,28 @@
 	},
 	{
 		"c": ";",
+		"t": "keyword.other.powershell.statement-separator",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
+		}
+	},
+	{
+		"c": "Invoke-Environment",
+		"t": "function.powershell.support",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": " ",
 		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
@@ -2266,30 +2354,19 @@
 		}
 	},
 	{
-		"c": "Invoke-Environment",
-		"t": "command.function.meta.powershell.support",
+		"c": "-",
+		"t": "assignment.keyword.operator.powershell",
 		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword.operator rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword.operator rgb(212, 212, 212)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword.operator rgb(0, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword.operator rgb(212, 212, 212)"
 		}
 	},
 	{
-		"c": " -Command",
-		"t": "command.meta.parameter.powershell.variable",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable.parameter rgb(156, 220, 254)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable.parameter rgb(0, 16, 128)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": " ",
-		"t": "command.meta.powershell",
+		"c": "Command ",
+		"t": "",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -2300,7 +2377,7 @@
 	},
 	{
 		"c": "$",
-		"t": "command.keyword.meta.other.powershell",
+		"t": "keyword.other.powershell",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
@@ -2311,7 +2388,7 @@
 	},
 	{
 		"c": "setVSEnv",
-		"t": "command.meta.other.powershell.readwrite.variable",
+		"t": "other.powershell.readwrite.variable",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.variable rgb(156, 220, 254)",
 			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.variable rgb(0, 16, 128)",
@@ -2322,13 +2399,13 @@
 	},
 	{
 		"c": ";",
-		"t": "command.meta.powershell",
+		"t": "keyword.other.powershell.statement-separator",
 		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.keyword rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.keyword rgb(0, 0, 255)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.keyword rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.keyword rgb(0, 0, 255)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.keyword rgb(86, 156, 214)"
 		}
 	}
 ]


### PR DESCRIPTION
This change rolls back the PowerShell syntax definition file to a previous state before a major refactoring which introduced a lot of new issues.  Once these issues are fixed we will move back to the new definition.
