### PR TITLE
Debug: Allow click to show getter property value

### DIFF
--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -356,6 +356,11 @@ export interface IDebugService {
 	appendReplOutput(value: string, severity?: severity): void;
 
 	/**
+	 * Get the value for the variable against the debug adapter.
+	 */
+	getVariable(variable: IExpression): TPromise<void>;
+
+	/**
 	 * Sets the value for the variable against the debug adapter.
 	 */
 	setVariable(variable: IExpression, value: string): TPromise<void>;

--- a/src/vs/workbench/parts/debug/common/debugModel.ts
+++ b/src/vs/workbench/parts/debug/common/debugModel.ts
@@ -290,7 +290,7 @@ export abstract class ExpressionContainer implements debug.IExpressionContainer 
 			filter
 		}).then(response => {
 			return arrays.distinct(response.body.variables.filter(v => !!v), v => v.name).map(
-				v => new Variable(this, v.variablesReference, v.name, v.value, v.namedVariables, v.indexedVariables, v.type)
+				v => new Variable(this, v.variablesReference, v.name, v.value, v.namedVariables, v.indexedVariables, v.type, undefined, undefined, v.unsolved)
 			);
 		}, (e: Error) => [new Variable(this, 0, null, e.message, 0, 0, null, false)]);
 	}
@@ -326,6 +326,9 @@ export class Variable extends ExpressionContainer implements debug.IExpression {
 	// Used to show the error message coming from the adapter when setting the value #7807
 	public errorMessage: string;
 
+	// Used to determine whether the variable has resolved
+	public resolved: boolean;
+
 	constructor(
 		public parent: debug.IExpressionContainer,
 		reference: number,
@@ -335,10 +338,12 @@ export class Variable extends ExpressionContainer implements debug.IExpression {
 		indexedVariables: number,
 		public type: string = null,
 		public available = true,
-		chunkIndex = 0
+		chunkIndex = 0,
+		unsolved?: boolean
 	) {
 		super(reference, `variable:${ parent.getId() }:${ name }`, true, namedVariables, indexedVariables, chunkIndex);
 		this.value = massageValue(value);
+		this.resolved = !unsolved;
 	}
 }
 

--- a/src/vs/workbench/parts/debug/common/debugProtocol.d.ts
+++ b/src/vs/workbench/parts/debug/common/debugProtocol.d.ts
@@ -538,6 +538,29 @@ declare module DebugProtocol {
 		};
 	}
 
+	/** getVariable request; value of command field is "getVariable".
+		Get the variable with the given name in the variable container.
+	*/
+	export interface GetVariableRequest extends Request {
+		arguments: GetVariableArguments;
+	}
+	/** Arguments for "getVariable" request. */
+	export interface GetVariableArguments {
+		/** The reference of the variable container. */
+		variablesReference: number;
+		/** The name of the variable. */
+		name: string;
+	}
+	/** Response to "getVariable" request. */
+	export interface GetVariableResponse extends Response {
+		body: {
+			/** the value of the variable. */
+			value: string;
+			/** The reference of the variable. */
+			variablesReference: number;
+		};
+	}
+
 	/** setVariable request; value of command field is "setVariable".
 		Set the variable with the given name in the variable container to a new value.
 	*/
@@ -931,6 +954,8 @@ declare module DebugProtocol {
 		/** The number of indexed child variables in this scope.
 			The client can use this optional information to present the children in a paged UI and fetch them in chunks. */
 		indexedVariables?: number;
+		/** If unsolved is true, the variable need use `getVariable` function to get correct value */
+		unsolved?: boolean;
 	}
 
 	/** Properties of a breakpoint passed to the setBreakpoints request.

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -490,6 +490,27 @@ export class DebugService implements debug.IDebugService {
 		this.model.removeReplExpressions();
 	}
 
+	public getVariable(variable: debug.IExpression): TPromise<any> {
+		if (!this.session || !(variable instanceof model.Variable)) {
+			return TPromise.as(null);
+		}
+
+		return this.session.getVariable({
+			name: variable.name,
+			variablesReference: (<model.Variable>variable).parent.reference
+		}).then(response => {
+			variable.value = response.body.value;
+			variable.reference = response.body.variablesReference;
+			(<model.Variable>variable).resolved = true;
+			return void 0;
+		}, err => {
+			// On error we show the errorMessage.
+			(<model.Variable>variable).value = err.message;
+			(<model.Variable>variable).resolved = true;
+			return void 0;
+		});
+	}
+
 	public setVariable(variable: debug.IExpression, value: string): TPromise<any> {
 		if (!this.session || !(variable instanceof model.Variable)) {
 			return TPromise.as(null);

--- a/src/vs/workbench/parts/debug/node/rawDebugSession.ts
+++ b/src/vs/workbench/parts/debug/node/rawDebugSession.ts
@@ -264,6 +264,10 @@ export class RawDebugSession extends v8.V8Protocol implements debug.IRawDebugSes
 		return this.send('pause', args);
 	}
 
+	public getVariable(args: DebugProtocol.GetVariableArguments): TPromise<DebugProtocol.GetVariableResponse> {
+		return this.send('getVariable', args);
+	}
+
 	public setVariable(args: DebugProtocol.SetVariableArguments): TPromise<DebugProtocol.SetVariableResponse> {
 		return this.send('setVariable', args);
 	}

--- a/src/vs/workbench/parts/debug/test/common/mockDebugService.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebugService.ts
@@ -127,6 +127,10 @@ export class MockDebugService implements debug.IDebugService {
 		return TPromise.as(null);
 	}
 
+	public getVariable(variable: debug.IExpression): TPromise<any> {
+		return TPromise.as(null);
+	}
+
 	public setVariable(variable: debug.IExpression, value: string): TPromise<any> {
 		return TPromise.as(null);
 	}


### PR DESCRIPTION
When I use chrome debugger, I find variables can't show the getter property value.  The PR to resolve the problem.

Before:
![qq 20160729214752](https://cloud.githubusercontent.com/assets/7069719/17250850/c9c741da-55d8-11e6-888e-e3a1ce5d8672.png)

After:
![2](https://cloud.githubusercontent.com/assets/7069719/17250870/d9d15458-55d8-11e6-9fe2-6986c7a6ccfe.gif)
## How to implemented

Add a protocal command called `getVariable` to `DebugProtocol`. the command can get the variable`s value. See:
https://github.com/f111fei/vscode/blob/70007f9c238c89c5a3e8508b3ed8359f164312d5/src/vs/workbench/parts/debug/common/debugProtocol.d.ts#L541

Add a property called `unsolved` to `DebugProtocol.Variable` .  If `unsolved` is true, the variable need use `getVariable` function to get correct value. See:
https://github.com/f111fei/vscode/blob/70007f9c238c89c5a3e8508b3ed8359f164312d5/src/vs/workbench/parts/debug/common/debugProtocol.d.ts#L957

When click the unsolved variable, the `debugService.getVariable` to update the variable and render.

Last, implement the `getVariable` command in `vscode-chrome-debug-core`. I push the PR about the implement, See: https://github.com/Microsoft/vscode-chrome-debug-core/pull/75

Moreover, we need to update `debugProtocol.d.ts`. See:  https://github.com/Microsoft/vscode-debugadapter-node/pull/49
