### PR TITLE
Update default project.json TFMs

### DIFF
--- a/extensions/json/server/src/jsoncontributions/projectJSONContribution.ts
+++ b/extensions/json/server/src/jsoncontributions/projectJSONContribution.ts
@@ -110,8 +110,8 @@ export class ProjectJSONContribution implements IJSONWorkerContribution {
 				'version': '{{1.0.0-*}}',
 				'dependencies': {},
 				'frameworks': {
-					'dnx451': {},
-					'dnxcore50': {}
+					'net461': {},
+					'netcoreapp1.0': {}
 				}
 			};
 			result.add({ kind: CompletionItemKind.Class, label: localize('json.project.default', 'Default project.json'), insertText: JSON.stringify(defaultValue, null, '\t'), documentation: '' });

--- a/src/vs/languages/json/common/contributions/projectJSONContribution.ts
+++ b/src/vs/languages/json/common/contributions/projectJSONContribution.ts
@@ -34,8 +34,8 @@ export class ProjectJSONContribution implements JSONWorker.IJSONWorkerContributi
 				'version': '{{1.0.0-*}}',
 				'dependencies': {},
 				'frameworks': {
-					'dnx451': {},
-					'dnxcore50': {}
+					'net461': {},
+					'netcoreapp1.0': {}
 				}
 			};
 			result.add({ type: 'snippet', label: nls.localize('json.project.default', 'Default project.json'), codeSnippet: JSON.stringify(defaultValue, null, '\t'), documentationLabel: '' });


### PR DESCRIPTION
When manually creating a new `project.json` file, opening IntelliSense, and selecting **Default project.json**, the default `project.json` file is created with old DNX target framework monikers. Since DNX is dead, this PR updates the default `project.json` to use the same TFMs used by the ASP.NET Core project templates in VS 2015. 
