### PR TITLE
Check if adapter is null and let it print errors

### DIFF
--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -297,9 +297,12 @@ export class ConfigurationManager implements debug.IConfigurationManager {
 
 		const factory: { (): TPromise<any> }[] = Object.keys(interactiveVariablesToSubstitutes).map(interactiveVariable => {
 			return () => {
-				const commandId = this.adapter.variables ? this.adapter.variables[interactiveVariable] : null;
+				var commandId = null;
+				if (this.adapter != null) {
+					commandId = this.adapter.variables ? this.adapter.variables[interactiveVariable] : null;
+				}
 				if (!commandId) {
-					return TPromise.wrapError(nls.localize('interactiveVariableNotFound', "Adapter {0} does not contribute variable {1} that is specified in launch configuration.", this.adapter.type, interactiveVariable));
+					return TPromise.wrapError(nls.localize('interactiveVariableNotFound', "Adapter {0} does not contribute variable {1} that is specified in launch configuration.", this.adapter != null ? this.adapter.type : null, interactiveVariable));
 				} else {
 					return this.commandService.executeCommand<string>(commandId, this.configuration).then(result => {
 						if (!result) {

--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -298,11 +298,11 @@ export class ConfigurationManager implements debug.IConfigurationManager {
 		const factory: { (): TPromise<any> }[] = Object.keys(interactiveVariablesToSubstitutes).map(interactiveVariable => {
 			return () => {
 				var commandId = null;
-				if (this.adapter != null) {
+				if (this.adapter !== null) {
 					commandId = this.adapter.variables ? this.adapter.variables[interactiveVariable] : null;
 				}
 				if (!commandId) {
-					return TPromise.wrapError(nls.localize('interactiveVariableNotFound', "Adapter {0} does not contribute variable {1} that is specified in launch configuration.", this.adapter != null ? this.adapter.type : null, interactiveVariable));
+					return TPromise.wrapError(nls.localize('interactiveVariableNotFound', "Adapter {0} does not contribute variable {1} that is specified in launch configuration.", this.adapter !== null ? this.adapter.type : null, interactiveVariable));
 				} else {
 					return this.commandService.executeCommand<string>(commandId, this.configuration).then(result => {
 						if (!result) {

--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -297,7 +297,7 @@ export class ConfigurationManager implements debug.IConfigurationManager {
 
 		const factory: { (): TPromise<any> }[] = Object.keys(interactiveVariablesToSubstitutes).map(interactiveVariable => {
 			return () => {
-				var commandId = null;
+				let commandId = null;
 				if (this.adapter !== null) {
 					commandId = this.adapter.variables ? this.adapter.variables[interactiveVariable] : null;
 				}


### PR DESCRIPTION
I had entire sections in the package.json missing and the errors I was getting were not helpful at all, it just said "e.adapter.variables undefined". Well it's undefined because the adapter is null!
If we work around that null we can get actually helpful messages here.
