### PR TITLE
Remove comma from not allowed characters in capture group

### DIFF
--- a/extensions/yaml/syntaxes/YAML.plist
+++ b/extensions/yaml/syntaxes/YAML.plist
@@ -144,7 +144,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?:(?:(-\s*)?(\w+\s*(:)))|(-))\s*(?:((")[^"]*("))|((')[^']*('))|([^,{}&amp;#\[\]]+))\s*</string>
+			<string>(?:(?:(-\s*)?(\w+\s*(:)))|(-))\s*(?:((")[^"]*("))|((')[^']*('))|([^{}&amp;#\[\]]+))\s*</string>
 			<key>name</key>
 			<string>string.unquoted.yaml</string>
 		</dict>


### PR DESCRIPTION
Fix the comma break in syntax highlight, e.g., fields: 

``` yaml
publisher_id.`split(., 1, 1)`
```

currently the highlight will break at first comma
