### PR TITLE
Modification to the VS code startup batch file for #7619

### DIFF
--- a/resources/win32/bin/code.cmd
+++ b/resources/win32/bin/code.cmd
@@ -2,5 +2,5 @@
 setlocal
 set VSCODE_DEV=
 set ATOM_SHELL_INTERNAL_RUN_AS_NODE=1
-call "%~dp0..\@@NAME@@.exe" "%~dp0..\resources\\app\\out\\cli.js" %*
+start "" "%~dp0..\@@NAME@@.exe" "%~dp0..\resources\\app\\out\\cli.js" %*
 endlocal


### PR DESCRIPTION
This PR is a possible fix for #7619 . It is a simple change to the VS Code batch file. I can't seem to build a proper installer to fully test this change but my code-oss build was able to still launch from the modified batch file. Because my build does not open files I was able to make the same change to the batch file for the real VS Code and was able to open files and directories from the command line using the batch file and running the batch file from the start menu did not leave a blank command window open.
