### PR TITLE
Sort and limit file results in search process

### DIFF
--- a/src/vs/platform/search/common/search.ts
+++ b/src/vs/platform/search/common/search.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import {PPromise} from 'vs/base/common/winjs.base';
+import {PPromise, TPromise} from 'vs/base/common/winjs.base';
 import uri from 'vs/base/common/uri';
 import glob = require('vs/base/common/glob');
 import {IFilesConfiguration} from 'vs/platform/files/common/files';
@@ -19,6 +19,7 @@ export const ISearchService = createDecorator<ISearchService>(ID);
 export interface ISearchService {
 	_serviceBrand: any;
 	search(query: ISearchQuery): PPromise<ISearchComplete, ISearchProgressItem>;
+	clearCache(cacheKey: string): TPromise<void>;
 }
 
 export interface IQueryOptions {
@@ -28,6 +29,8 @@ export interface IQueryOptions {
 	excludePattern?: glob.IExpression;
 	includePattern?: glob.IExpression;
 	maxResults?: number;
+	sortByScore?: boolean;
+	cacheKey?: string;
 	fileEncoding?: string;
 }
 
@@ -75,6 +78,19 @@ export interface ISearchComplete {
 }
 
 export interface ISearchStats {
+	fromCache: boolean;
+	resultCount: number;
+	unsortedResultTime?: number;
+	sortedResultTime?: number;
+}
+
+export interface ICachedSearchStats extends ISearchStats {
+	cacheLookupStartTime: number;
+	cacheLookupResultTime: number;
+	cacheEntryCount: number;
+}
+
+export interface IUncachedSearchStats extends ISearchStats {
 	fileWalkStartTime: number;
 	fileWalkResultTime: number;
 	directoriesWalked: number;

--- a/src/vs/workbench/parts/search/common/searchQuery.ts
+++ b/src/vs/workbench/parts/search/common/searchQuery.ts
@@ -59,6 +59,8 @@ export class QueryBuilder {
 			excludePattern: options.excludePattern,
 			includePattern: options.includePattern,
 			maxResults: options.maxResults,
+			sortByScore: options.sortByScore,
+			cacheKey: options.cacheKey,
 			fileEncoding: options.fileEncoding,
 			contentPattern: contentPattern
 		};

--- a/src/vs/workbench/parts/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/parts/search/test/common/searchModel.test.ts
@@ -14,7 +14,7 @@ import { SearchModel } from 'vs/workbench/parts/search/common/searchModel';
 import URI from 'vs/base/common/uri';
 import {IFileMatch, ILineMatch} from 'vs/platform/search/common/search';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { ISearchService, ISearchComplete, ISearchProgressItem, ISearchStats } from 'vs/platform/search/common/search';
+import { ISearchService, ISearchComplete, ISearchProgressItem, IUncachedSearchStats } from 'vs/platform/search/common/search';
 import { Range } from 'vs/editor/common/core/range';
 import { createMockModelService } from 'vs/test/utils/servicesTestUtils';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -24,7 +24,9 @@ suite('SearchModel', () => {
 	let instantiationService: TestInstantiationService;
 	let restoreStubs;
 
-	const testSearchStats: ISearchStats = {
+	const testSearchStats: IUncachedSearchStats = {
+		fromCache: false,
+		resultCount: 4,
 		fileWalkStartTime: 0,
 		fileWalkResultTime: 1,
 		directoriesWalked: 2,

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -10,20 +10,29 @@ import fs = require('fs');
 import gracefulFs = require('graceful-fs');
 gracefulFs.gracefulify(fs);
 
-import {PPromise} from 'vs/base/common/winjs.base';
+import arrays = require('vs/base/common/arrays');
+import {compareByScore} from 'vs/base/common/comparers';
+import objects = require('vs/base/common/objects');
+import paths = require('vs/base/common/paths');
+import scorer = require('vs/base/common/scorer');
+import strings = require('vs/base/common/strings');
+import {PPromise, TPromise} from 'vs/base/common/winjs.base';
 import {MAX_FILE_SIZE} from 'vs/platform/files/common/files';
 import {FileWalker, Engine as FileSearchEngine} from 'vs/workbench/services/search/node/fileSearch';
 import {Engine as TextSearchEngine} from 'vs/workbench/services/search/node/textSearch';
-import {IRawSearchService, IRawSearch, ISerializedSearchProgressItem, ISerializedSearchComplete, ISearchEngine} from './search';
+import {IRawSearchService, IRawSearch, IRawFileMatch, ISerializedFileMatch, ISerializedSearchProgressItem, ISerializedSearchComplete, ISearchEngine} from './search';
+import {ICachedSearchStats, IProgress} from 'vs/platform/search/common/search';
+
+export type IRawProgressItem<T> = T | T[] | IProgress;
 
 export class SearchService implements IRawSearchService {
 
-	private static BATCH_SIZE = 500;
+	private static BATCH_SIZE = 512;
+
+	private caches: { [cacheKey: string]: Cache; } = Object.create(null);
 
 	public fileSearch(config: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
-		let engine = new FileSearchEngine(config);
-
-		return this.doSearch(engine, SearchService.BATCH_SIZE);
+		return this.doFileSearch(FileSearchEngine, config, SearchService.BATCH_SIZE);
 	}
 
 	public textSearch(config: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
@@ -39,8 +48,194 @@ export class SearchService implements IRawSearchService {
 		return this.doSearch(engine, SearchService.BATCH_SIZE);
 	}
 
-	public doSearch(engine: ISearchEngine, batchSize?: number): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
+	public doFileSearch(EngineClass: { new (config: IRawSearch): ISearchEngine<IRawFileMatch>; }, config: IRawSearch, batchSize?: number): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
+
+		if (config.sortByScore) {
+			const cached = this.trySearchFromCache(config, batchSize);
+			if (cached) {
+				return cached;
+			}
+
+			const walkerConfig = config.maxResults ? objects.assign({}, config, { maxResults: null }) : config;
+			const engine = new EngineClass(walkerConfig);
+			return this.doSortedSearch(engine, config, batchSize);
+		}
+
+		let searchPromise;
 		return new PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>((c, e, p) => {
+			const engine = new EngineClass(config);
+			searchPromise = this.doSearch(engine, batchSize)
+				.then(c, e, progress => {
+					if (Array.isArray(progress)) {
+						p(progress.map(m => ({ path: m.absolutePath })));
+					} else if ((<IRawFileMatch>progress).absolutePath) {
+						p({ path: (<IRawFileMatch>progress).absolutePath });
+					} else {
+						p(progress);
+					}
+				});
+		}, () => searchPromise.cancel());
+	}
+
+	private doSortedSearch(engine: ISearchEngine<IRawFileMatch>, config: IRawSearch, batchSize?: number): PPromise<ISerializedSearchComplete, IRawProgressItem<IRawFileMatch>> {
+		let searchPromise;
+		return new PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>((c, e, p) => {
+			let results: IRawFileMatch[] = [];
+			let unsortedResultTime: number;
+			let sortedResultTime: number;
+			searchPromise = this.doSearch(engine, -1).then(result => {
+				const maxResults = config.maxResults;
+				result.limitHit = !!maxResults && results.length > maxResults;
+				result.stats.unsortedResultTime = unsortedResultTime || Date.now();
+				result.stats.sortedResultTime = sortedResultTime || Date.now();
+				c(result);
+			}, null, progress => {
+				try {
+					if (Array.isArray(progress)) {
+						results = progress;
+						let scorerCache;
+						if (config.cacheKey) {
+							const cache = this.getOrCreateCache(config.cacheKey);
+							cache.resultsToSearchCache[config.filePattern] = results;
+							scorerCache = cache.scorerCache;
+						} else {
+							scorerCache = Object.create(null);
+						}
+						unsortedResultTime = Date.now();
+						const sortedResults = this.sortResults(config, results, scorerCache);
+						sortedResultTime = Date.now();
+						this.sendProgress(sortedResults, p, batchSize);
+					} else {
+						p(progress);
+					}
+				} catch (err) {
+					e(err);
+				}
+			}).then(null, e);
+		}, () => searchPromise.cancel());
+	}
+
+	private getOrCreateCache(cacheKey: string): Cache {
+		const existing = this.caches[cacheKey];
+		if (existing) {
+			return existing;
+		}
+		return this.caches[cacheKey] = new Cache();
+	}
+
+	private trySearchFromCache(config: IRawSearch, batchSize?: number): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
+		const cache = config.cacheKey && this.caches[config.cacheKey];
+		if (!cache) {
+			return;
+		}
+
+		const cacheLookupStartTime = Date.now();
+		const cached = this.getResultsFromCache(cache, config.filePattern);
+		if (cached) {
+			const cacheLookupResultTime = Date.now();
+			const [results, cacheEntryCount] = cached;
+			let clippedResults;
+			if (config.sortByScore) {
+				clippedResults = this.sortResults(config, results, cache);
+			} else if (config.maxResults) {
+				clippedResults = results.slice(0, config.maxResults);
+			} else {
+				clippedResults = results;
+			}
+			const sortedResultTime = Date.now();
+			let canceled = false;
+			return new PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>((c, e, p) => {
+				process.nextTick(() => { // allow caller to register progress callback first
+					if (canceled) {
+						return;
+					}
+					this.sendProgress(clippedResults, p, batchSize);
+					const maxResults = config.maxResults;
+					const stats: ICachedSearchStats = {
+						fromCache: true,
+						cacheLookupStartTime: cacheLookupStartTime,
+						cacheLookupResultTime: cacheLookupResultTime,
+						cacheEntryCount: cacheEntryCount,
+						resultCount: results.length
+					};
+					if (config.sortByScore) {
+						stats.unsortedResultTime = cacheLookupResultTime;
+						stats.sortedResultTime = sortedResultTime;
+					}
+					c({
+						limitHit: !!maxResults && results.length > maxResults,
+						stats: stats
+					});
+				});
+			}, () => {
+				canceled = true;
+			});
+		}
+	}
+
+	private sortResults(config: IRawSearch, results: IRawFileMatch[], cache: Cache): ISerializedFileMatch[] {
+		const filePattern = config.filePattern;
+		const normalizedSearchValue = strings.stripWildcards(filePattern).toLowerCase();
+		const compare = (elementA: IRawFileMatch, elementB: IRawFileMatch) => compareByScore(elementA, elementB, FileMatchAccessor, filePattern, normalizedSearchValue, cache.scorerCache);
+		const filteredWrappers = arrays.top(results, compare, config.maxResults);
+		return filteredWrappers.map(result => ({ path: result.absolutePath }));
+	}
+
+	private sendProgress(results: ISerializedFileMatch[], progressCb: (batch: ISerializedFileMatch[]) => void, batchSize?: number) {
+		if (batchSize && batchSize > 0) {
+			for (let i = 0; i < results.length; i += batchSize) {
+				progressCb(results.slice(i, i + batchSize));
+			}
+		} else {
+			progressCb(results);
+		}
+	}
+
+	private getResultsFromCache(cache: Cache, searchValue: string): [IRawFileMatch[], number] {
+		if (paths.isAbsolute(searchValue)) {
+			return null; // bypass cache if user looks up an absolute path where matching goes directly on disk
+		}
+
+		// Find cache entries by prefix of search value
+		const hasPathSep = searchValue.indexOf(paths.nativeSep) >= 0;
+		let cachedEntries: IRawFileMatch[];
+		for (let previousSearch in cache.resultsToSearchCache) {
+
+			// If we narrow down, we might be able to reuse the cached results
+			if (strings.startsWith(searchValue, previousSearch)) {
+				if (hasPathSep && previousSearch.indexOf(paths.nativeSep) < 0) {
+					continue; // since a path character widens the search for potential more matches, require it in previous search too
+				}
+
+				cachedEntries = cache.resultsToSearchCache[previousSearch];
+				break;
+			}
+		}
+
+		if (!cachedEntries) {
+			return null;
+		}
+
+		// Pattern match on results and adjust highlights
+		let results: IRawFileMatch[] = [];
+		const normalizedSearchValue = searchValue.replace(/\\/g, '/'); // Normalize file patterns to forward slashes
+		const normalizedSearchValueLowercase = strings.stripWildcards(normalizedSearchValue).toLowerCase();
+		for (let i = 0; i < cachedEntries.length; i++) {
+			let entry = cachedEntries[i];
+
+			// Check if this entry is a match for the search value
+			if (!scorer.matches(entry.pathLabel, normalizedSearchValueLowercase)) {
+				continue;
+			}
+
+			results.push(entry);
+		}
+
+		return [results, cachedEntries.length];
+	}
+
+	private doSearch<T>(engine: ISearchEngine<T>, batchSize?: number): PPromise<ISerializedSearchComplete, IRawProgressItem<T>> {
+		return new PPromise<ISerializedSearchComplete, IRawProgressItem<T>>((c, e, p) => {
 			let batch = [];
 			engine.search((match) => {
 				if (match) {
@@ -67,5 +262,35 @@ export class SearchService implements IRawSearchService {
 				}
 			});
 		}, () => engine.cancel());
+	}
+
+	public clearCache(cacheKey: string): TPromise<void> {
+		delete this.caches[cacheKey];
+		return TPromise.as(undefined);
+	}
+}
+
+class Cache {
+
+	public resultsToSearchCache: { [searchValue: string]: IRawFileMatch[]; } = Object.create(null);
+
+	public scorerCache: { [key: string]: number } = Object.create(null);
+}
+
+interface IFileMatch extends IRawFileMatch {
+	label?: string;
+}
+
+class FileMatchAccessor {
+
+	public static getLabel(match: IFileMatch): string {
+		if (!match.label) {
+			match.label = paths.basename(match.absolutePath);
+		}
+		return match.label;
+	}
+
+	public static getResourcePath(match: IFileMatch): string {
+		return match.absolutePath;
 	}
 }

--- a/src/vs/workbench/services/search/node/search.ts
+++ b/src/vs/workbench/services/search/node/search.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { PPromise } from 'vs/base/common/winjs.base';
+import { PPromise, TPromise } from 'vs/base/common/winjs.base';
 import glob = require('vs/base/common/glob');
 import { IProgress, ILineMatch, IPatternInfo, ISearchStats } from 'vs/platform/search/common/search';
 
@@ -17,6 +17,8 @@ export interface IRawSearch {
 	includePattern?: glob.IExpression;
 	contentPattern?: IPatternInfo;
 	maxResults?: number;
+	sortByScore?: boolean;
+	cacheKey?: string;
 	maxFilesize?: number;
 	fileEncoding?: string;
 }
@@ -24,10 +26,17 @@ export interface IRawSearch {
 export interface IRawSearchService {
 	fileSearch(search: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>;
 	textSearch(search: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>;
+	clearCache(cacheKey: string): TPromise<void>;
 }
 
-export interface ISearchEngine {
-	search: (onResult: (match: ISerializedFileMatch) => void, onProgress: (progress: IProgress) => void, done: (error: Error, complete: ISerializedSearchComplete) => void) => void;
+export interface IRawFileMatch {
+	absolutePath: string;
+	pathLabel: string;
+	size: number;
+}
+
+export interface ISearchEngine<T> {
+	search: (onResult: (match: T) => void, onProgress: (progress: IProgress) => void, done: (error: Error, complete: ISerializedSearchComplete) => void) => void;
 	cancel: () => void;
 }
 

--- a/src/vs/workbench/services/search/node/searchIpc.ts
+++ b/src/vs/workbench/services/search/node/searchIpc.ts
@@ -12,6 +12,7 @@ import { IRawSearchService, IRawSearch, ISerializedSearchComplete, ISerializedSe
 export interface ISearchChannel extends IChannel {
 	call(command: 'fileSearch', search: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>;
 	call(command: 'textSearch', search: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem>;
+	call(command: 'clearCache', cacheKey: string): TPromise<void>;
 	call(command: string, arg: any): TPromise<any>;
 }
 
@@ -23,6 +24,7 @@ export class SearchChannel implements ISearchChannel {
 		switch (command) {
 			case 'fileSearch': return this.service.fileSearch(arg);
 			case 'textSearch': return this.service.textSearch(arg);
+			case 'clearCache': return this.service.clearCache(arg);
 		}
 	}
 }
@@ -37,5 +39,9 @@ export class SearchChannelClient implements IRawSearchService {
 
 	textSearch(search: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
 		return this.channel.call('textSearch', search);
+	}
+
+	public clearCache(cacheKey: string): TPromise<void> {
+		return this.channel.call('clearCache', cacheKey);
 	}
 }

--- a/src/vs/workbench/services/search/node/searchService.ts
+++ b/src/vs/workbench/services/search/node/searchService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import {PPromise} from 'vs/base/common/winjs.base';
+import {PPromise, TPromise} from 'vs/base/common/winjs.base';
 import uri from 'vs/base/common/uri';
 import glob = require('vs/base/common/glob');
 import objects = require('vs/base/common/objects');
@@ -189,6 +189,10 @@ export class SearchService implements ISearchService {
 
 		return true;
 	}
+
+	public clearCache(cacheKey: string): TPromise<void> {
+		return this.diskSearch.clearCache(cacheKey);
+	}
 }
 
 export class DiskSearch {
@@ -223,7 +227,9 @@ export class DiskSearch {
 			filePattern: query.filePattern,
 			excludePattern: query.excludePattern,
 			includePattern: query.includePattern,
-			maxResults: query.maxResults
+			maxResults: query.maxResults,
+			sortByScore: query.sortByScore,
+			cacheKey: query.cacheKey
 		};
 
 		if (query.type === QueryType.Text) {
@@ -281,5 +287,9 @@ export class DiskSearch {
 			}
 		}
 		return fileMatch;
+	}
+
+	public clearCache(cacheKey: string): TPromise<void> {
+		return this.raw.clearCache(cacheKey);
 	}
 }

--- a/src/vs/workbench/services/search/node/textSearch.ts
+++ b/src/vs/workbench/services/search/node/textSearch.ts
@@ -21,7 +21,7 @@ interface ReadLinesOptions {
 	encoding: string;
 }
 
-export class Engine implements ISearchEngine {
+export class Engine implements ISearchEngine<ISerializedFileMatch> {
 
 	private static PROGRESS_FLUSH_CHUNK_SIZE = 50; // optimization: number of files to process before emitting progress event
 
@@ -88,8 +88,8 @@ export class Engine implements ISearchEngine {
 		};
 
 		// Walk over the file system
-		this.walker.walk(this.rootFolders, this.extraFiles, (result, size) => {
-			size = size ||  1;
+		this.walker.walk(this.rootFolders, this.extraFiles, result => {
+			const size = result.size ||  1;
 			this.total += size;
 
 			// If the result is empty or we have reached the limit or we are canceled, ignore it
@@ -126,7 +126,7 @@ export class Engine implements ISearchEngine {
 					}
 
 					if (fileMatch === null) {
-						fileMatch = new FileMatch(result.path);
+						fileMatch = new FileMatch(result.absolutePath);
 					}
 
 					if (lineMatch === null) {
@@ -141,7 +141,7 @@ export class Engine implements ISearchEngine {
 			};
 
 			// Read lines buffered to support large files
-			this.readlinesAsync(result.path, perLineCallback, { bufferLength: 8096, encoding: this.fileEncoding }, doneCallback);
+			this.readlinesAsync(result.absolutePath, perLineCallback, { bufferLength: 8096, encoding: this.fileEncoding }, doneCallback);
 		}, (error, isLimitHit) => {
 			this.walkerIsDone = true;
 			this.walkerError = error;

--- a/src/vs/workbench/services/search/test/node/search.test.ts
+++ b/src/vs/workbench/services/search/test/node/search.test.ts
@@ -12,6 +12,7 @@ import {join, normalize} from 'vs/base/common/paths';
 import {LineMatch} from 'vs/platform/search/common/search';
 
 import {FileWalker, Engine as FileSearchEngine} from 'vs/workbench/services/search/node/fileSearch';
+import {IRawFileMatch} from 'vs/workbench/services/search/node/search';
 import {Engine as TextSearchEngine} from 'vs/workbench/services/search/node/textSearch';
 
 function count(lineMatches: LineMatch[]): number {
@@ -149,7 +150,7 @@ suite('Search', () => {
 		});
 
 		let count = 0;
-		let res;
+		let res: IRawFileMatch;
 		engine.search((result) => {
 			if (result) {
 				count++;
@@ -158,7 +159,7 @@ suite('Search', () => {
 		}, () => { }, (error) => {
 			assert.ok(!error);
 			assert.equal(count, 1);
-			assert.ok(path.basename(res.path) === 'site.less');
+			assert.strictEqual(path.basename(res.absolutePath), 'site.less');
 			done();
 		});
 	});
@@ -246,7 +247,7 @@ suite('Search', () => {
 		});
 
 		let count = 0;
-		let res;
+		let res: IRawFileMatch;
 		engine.search((result) => {
 			if (result) {
 				count++;
@@ -255,7 +256,7 @@ suite('Search', () => {
 		}, () => { }, (error) => {
 			assert.ok(!error);
 			assert.equal(count, 1);
-			assert.equal(path.basename(res.path), '汉语.txt');
+			assert.equal(path.basename(res.absolutePath), '汉语.txt');
 			done();
 		});
 	});
@@ -286,7 +287,7 @@ suite('Search', () => {
 		});
 
 		let count = 0;
-		let res;
+		let res: IRawFileMatch;
 		engine.search((result) => {
 			if (result) {
 				count++;
@@ -295,7 +296,7 @@ suite('Search', () => {
 		}, () => { }, (error) => {
 			assert.ok(!error);
 			assert.equal(count, 1);
-			assert.equal(path.basename(res.path), 'site.css');
+			assert.equal(path.basename(res.absolutePath), 'site.css');
 			done();
 		});
 	});
@@ -308,7 +309,7 @@ suite('Search', () => {
 		});
 
 		let count = 0;
-		let res;
+		let res: IRawFileMatch;
 		engine.search((result) => {
 			if (result) {
 				count++;
@@ -317,7 +318,7 @@ suite('Search', () => {
 		}, () => { }, (error) => {
 			assert.ok(!error);
 			assert.equal(count, 1);
-			assert.equal(path.basename(res.path), 'company.js');
+			assert.equal(path.basename(res.absolutePath), 'company.js');
 			done();
 		});
 	});
@@ -334,7 +335,7 @@ suite('Search', () => {
 		});
 
 		let count = 0;
-		let res;
+		let res: IRawFileMatch;
 		engine.search((result) => {
 			if (result) {
 				count++;
@@ -343,7 +344,7 @@ suite('Search', () => {
 		}, () => { }, (error) => {
 			assert.ok(!error);
 			assert.equal(count, 1);
-			assert.equal(path.basename(res.path), 'company.js');
+			assert.equal(path.basename(res.absolutePath), 'company.js');
 			done();
 		});
 	});
@@ -361,7 +362,7 @@ suite('Search', () => {
 		});
 
 		let count = 0;
-		let res;
+		let res: IRawFileMatch;
 		engine.search((result) => {
 			if (result) {
 				count++;
@@ -370,7 +371,7 @@ suite('Search', () => {
 		}, () => { }, (error) => {
 			assert.ok(!error);
 			assert.equal(count, 1);
-			assert.equal(path.basename(res.path), 'site.css');
+			assert.equal(path.basename(res.absolutePath), 'site.css');
 			done();
 		});
 	});

--- a/src/vs/workbench/services/search/test/node/searchService.test.ts
+++ b/src/vs/workbench/services/search/test/node/searchService.test.ts
@@ -7,31 +7,47 @@
 
 import assert = require('assert');
 
-import {IProgress} from 'vs/platform/search/common/search';
-import {ISearchEngine, ISerializedFileMatch, ISerializedSearchComplete} from 'vs/workbench/services/search/node/search';
+import {IProgress, IUncachedSearchStats} from 'vs/platform/search/common/search';
+import {ISearchEngine, IRawSearch, IRawFileMatch, ISerializedFileMatch, ISerializedSearchComplete} from 'vs/workbench/services/search/node/search';
 import {SearchService as RawSearchService} from 'vs/workbench/services/search/node/rawSearchService';
 import {DiskSearch} from 'vs/workbench/services/search/node/searchService';
 
 
-class TestSearchEngine implements ISearchEngine {
+const stats: IUncachedSearchStats = {
+	fromCache: false,
+	resultCount: 4,
+	fileWalkStartTime: 0,
+	fileWalkResultTime: 1,
+	directoriesWalked: 2,
+	filesWalked: 3
+};
 
-	constructor(private result: () => ISerializedFileMatch) {
+class TestSearchEngine implements ISearchEngine<IRawFileMatch> {
+
+	public static last: TestSearchEngine;
+
+	private isCanceled = false;
+
+	constructor(private result: () => IRawFileMatch, public config?: IRawSearch) {
+		TestSearchEngine.last = this;
 	}
 
-	public search(onResult: (match: ISerializedFileMatch) => void, onProgress: (progress: IProgress) => void, done: (error: Error, complete: ISerializedSearchComplete) => void): void {
+	public search(onResult: (match: IRawFileMatch) => void, onProgress: (progress: IProgress) => void, done: (error: Error, complete: ISerializedSearchComplete) => void): void {
 		const self = this;
 		(function next() {
 			process.nextTick(() => {
+				if (self.isCanceled) {
+					done(null, {
+						limitHit: false,
+						stats: stats
+					});
+					return;
+				}
 				const result = self.result();
 				if (!result) {
 					done(null, {
 						limitHit: false,
-						stats: {
-							fileWalkStartTime: 0,
-							fileWalkResultTime: 1,
-							directoriesWalked: 2,
-							filesWalked: 3
-						}
+						stats: stats
 					});
 				} else {
 					onResult(result);
@@ -42,24 +58,39 @@ class TestSearchEngine implements ISearchEngine {
 	}
 
 	public cancel(): void {
+		this.isCanceled = true;
 	}
 }
 
 suite('SearchService', () => {
 
+	const rawSearch: IRawSearch = {
+		rootFolders: ['/some/where'],
+		filePattern: 'a'
+	};
+
+	const rawMatch: IRawFileMatch = {
+		absolutePath: '/some/where',
+		pathLabel: 'where',
+		size: 123
+	};
+
+	const match: ISerializedFileMatch = {
+		path: '/some/where'
+	};
+
 	test('Individual results', function () {
-		const path = '/some/where';
 		let i = 5;
-		const engine = new TestSearchEngine(() => i-- && { path });
+		const Engine = TestSearchEngine.bind(null, () => i-- && rawMatch);
 		const service = new RawSearchService();
 
 		let results = 0;
-		return service.doSearch(engine)
+		return service.doFileSearch(Engine, rawSearch)
 		.then(() => {
 			assert.strictEqual(results, 5);
 		}, null, value => {
 			if (!Array.isArray(value)) {
-				assert.strictEqual((<any>value).path, path);
+				assert.deepStrictEqual(value, match);
 				results++;
 			} else {
 				assert.fail(value);
@@ -68,19 +99,18 @@ suite('SearchService', () => {
 	});
 
 	test('Batch results', function () {
-		const path = '/some/where';
 		let i = 25;
-		const engine = new TestSearchEngine(() => i-- && { path });
+		const Engine = TestSearchEngine.bind(null, () => i-- && rawMatch);
 		const service = new RawSearchService();
 
 		const results = [];
-		return service.doSearch(engine, 10)
+		return service.doFileSearch(Engine, rawSearch, 10)
 		.then(() => {
 			assert.deepStrictEqual(results, [10, 10, 5]);
 		}, null, value => {
 			if (Array.isArray(value)) {
-				value.forEach(match => {
-					assert.strictEqual(match.path, path);
+				value.forEach(m => {
+					assert.deepStrictEqual(m, match);
 				});
 				results.push(value.length);
 			} else {
@@ -92,18 +122,143 @@ suite('SearchService', () => {
 	test('Collect batched results', function () {
 		const path = '/some/where';
 		let i = 25;
-		const engine = new TestSearchEngine(() => i-- && { path });
+		const Engine = TestSearchEngine.bind(null, () => i-- && rawMatch);
 		const service = new RawSearchService();
 		const diskSearch = new DiskSearch(false);
 
 		const progressResults = [];
-		return DiskSearch.collectResults(service.doSearch(engine, 10))
+		return DiskSearch.collectResults(service.doFileSearch(Engine, rawSearch, 10))
 		.then(result => {
 			assert.strictEqual(result.results.length, 25, 'Result');
 			assert.strictEqual(progressResults.length, 25, 'Progress');
 		}, null, match => {
 			assert.strictEqual(match.resource.path, path);
 			progressResults.push(match);
+		});
+	});
+
+	test('Sorted results', function () {
+		const paths = ['bab', 'bbc', 'abb'];
+		const matches = paths.map(path => ({
+			absolutePath: `/some/where/${path}`,
+			pathLabel: path,
+			size: 3
+		}));
+		let i = 0;
+		const Engine = TestSearchEngine.bind(null, () => matches.shift());
+		const service = new RawSearchService();
+
+		const results = [];
+		return service.doFileSearch(Engine, {
+			rootFolders: ['/some/where'],
+			filePattern: 'bb',
+			sortByScore: true,
+			maxResults: 2
+		}, 1).then(() => {
+			assert.notStrictEqual(typeof TestSearchEngine.last.config.maxResults, 'number');
+			assert.deepStrictEqual(results, ['/some/where/bbc', '/some/where/bab']);
+		}, null, value => {
+			if (Array.isArray(value)) {
+				results.push(...value.map(v => v.path));
+			} else {
+				assert.fail(value);
+			}
+		});
+	});
+
+	test('Sorted result batches', function () {
+		let i = 25;
+		const Engine = TestSearchEngine.bind(null, () => i-- && rawMatch);
+		const service = new RawSearchService();
+
+		const results = [];
+		return service.doFileSearch(Engine, {
+			rootFolders: ['/some/where'],
+			filePattern: 'a',
+			sortByScore: true,
+			maxResults: 23
+		}, 10)
+		.then(() => {
+			assert.deepStrictEqual(results, [10, 10, 3]);
+		}, null, value => {
+			if (Array.isArray(value)) {
+				value.forEach(m => {
+					assert.deepStrictEqual(m, match);
+				});
+				results.push(value.length);
+			} else {
+				assert.fail(value);
+			}
+		});
+	});
+
+	test('Cached results', function () {
+		const paths = ['bcb', 'bbc', 'aab'];
+		const matches = paths.map(path => ({
+			absolutePath: `/some/where/${path}`,
+			pathLabel: path,
+			size: 3
+		}));
+		let i = 0;
+		const Engine = TestSearchEngine.bind(null, () => matches.shift());
+		const service = new RawSearchService();
+
+		const results = [];
+		return service.doFileSearch(Engine, {
+			rootFolders: ['/some/where'],
+			filePattern: 'b',
+			sortByScore: true,
+			cacheKey: 'x'
+		}, -1).then(complete => {
+			assert.strictEqual(complete.stats.fromCache, false);
+			assert.deepStrictEqual(results, ['/some/where/bcb', '/some/where/bbc', '/some/where/aab']);
+		}, null, value => {
+			if (Array.isArray(value)) {
+				results.push(...value.map(v => v.path));
+			} else {
+				assert.fail(value);
+			}
+		}).then(() => {
+			const results = [];
+			return service.doFileSearch(Engine, {
+				rootFolders: ['/some/where'],
+				filePattern: 'bc',
+				sortByScore: true,
+				cacheKey: 'x'
+			}, -1).then(complete => {
+				assert.ok(complete.stats.fromCache);
+				assert.deepStrictEqual(results, ['/some/where/bcb', '/some/where/bbc']);
+			}, null, value => {
+				if (Array.isArray(value)) {
+					results.push(...value.map(v => v.path));
+				} else {
+					assert.fail(value);
+				}
+			});
+		}).then(() => {
+			return service.clearCache('x');
+		}).then(() => {
+			matches.push({
+				absolutePath: '/some/where/bc',
+				pathLabel: 'bc',
+				size: 3
+			});
+			const results = [];
+			return service.doFileSearch(Engine, {
+				rootFolders: ['/some/where'],
+				filePattern: 'bc',
+				sortByScore: true,
+				cacheKey: 'x'
+			}, -1).then(complete => {
+				assert.strictEqual(complete.stats.fromCache, false);
+				assert.deepStrictEqual(results, ['/some/where/bc']);
+			}, null, value => {
+				if (Array.isArray(value)) {
+					results.push(...value.map(v => v.path));
+				} else {
+					assert.fail(value);
+				}
+			});
 		});
 	});
 });


### PR DESCRIPTION
Measurements on OS X show an improvement from over 11s to a little over 6s:

Before:

```
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11574,"sortedResultDuration":11684,"numberOfResultEntries":224197,"fileWalkStartDuration":308,"fileWalkResultDuration":6245,"directoriesWalked":14309,"filesWalked":234652},
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11410,"sortedResultDuration":11519,"numberOfResultEntries":224197,"fileWalkStartDuration":301,"fileWalkResultDuration":6291,"directoriesWalked":14309,"filesWalked":234652},
{"fromCache":false,"searchLength":1,"unsortedResultDuration":11159,"sortedResultDuration":11265,"numberOfResultEntries":224197,"fileWalkStartDuration":305,"fileWalkResultDuration":6282,"directoriesWalked":14309,"filesWalked":234652},
From cache:
{"fromCache":true,"searchLength":2,"unsortedResultDuration":293,"sortedResultDuration":577,"numberOfResultEntries":173864},
{"fromCache":true,"searchLength":2,"unsortedResultDuration":289,"sortedResultDuration":587,"numberOfResultEntries":173864},
{"fromCache":true,"searchLength":2,"unsortedResultDuration":295,"sortedResultDuration":576,"numberOfResultEntries":173864},
```

After:

```
{"filesfromCache":false,"searchLength":1,"sortedResultDuration":6294,"filesResultCount":224197},
{"filesfromCache":false,"searchLength":1,"sortedResultDuration":6139,"filesResultCount":224197},
{"filesfromCache":false,"searchLength":1,"sortedResultDuration":5941,"filesResultCount":224197},
From cache:
{"filesfromCache":true,"searchLength":2,"sortedResultDuration":524,"filesResultCount":173864},
{"filesfromCache":true,"searchLength":2,"sortedResultDuration":565,"filesResultCount":173864},
{"filesfromCache":true,"searchLength":2,"sortedResultDuration":478,"filesResultCount":173864},
```

The numbers from cache are included because the cache moved to the search process too, the performance impact is small, if any.

@sandy081 Would be great if you could take a quick (or if time allows longer) look.
