### PR TITLE
Modification to the VS code startup batch file for #7619

### DIFF
--- a/resources/win32/bin/code.cmd
+++ b/resources/win32/bin/code.cmd
@@ -2,5 +2,9 @@
 setlocal
 set VSCODE_DEV=
 set ATOM_SHELL_INTERNAL_RUN_AS_NODE=1
+if "%*" == "" (
+start "" "%~dp0..\@@NAME@@.exe" "%~dp0..\resources\\app\\out\\cli.js" %*
+) else (
 call "%~dp0..\@@NAME@@.exe" "%~dp0..\resources\\app\\out\\cli.js" %*
+)
 endlocal


### PR DESCRIPTION
This as another attempt (previously #10162) at handling issue #7619 . This attempt handles situations involving  the `--wait` and `--verbose` arguments. In this revision the batch script will only use the `start` command when the arguments are empty. I have tested this by building and installing code-oss on my system and trying various scenarios:
- `code-oss` from a command prompt opens a new GUI window and does not block the command window it was launched from.
- `code-oss --wait` and `code-oss --verbose` block the command prompt while still opening the GUI window.
- Running `code-oss` from Windows 10 search (I had to enter the full path) launches the VS code GUI and only briefly flashes the console window.
- Running `code-oss --verbose` from Windows 10 search (I had to enter the full path) launches the VS code GUI and leaves a console open in the background with information written to it.
- I am not yet sure if `code-oss file.txt` works as my build is not complete but given that `CALL` would be used in that case I expect it to be fine.
