### PR TITLE
Support CompletionItemKind.Method

### DIFF
--- a/src/vs/editor/browser/standalone/standaloneLanguages.ts
+++ b/src/vs/editor/browser/standalone/standaloneLanguages.ts
@@ -353,6 +353,7 @@ interface ISuggestion2 extends modes.ISuggestion {
 }
 function convertKind(kind: CompletionItemKind): modes.SuggestionType {
 	switch (kind) {
+		case CompletionItemKind.Method: return 'method';
 		case CompletionItemKind.Function: return 'function';
 		case CompletionItemKind.Constructor: return 'constructor';
 		case CompletionItemKind.Field: return 'field';

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -240,6 +240,7 @@ export const CompletionItemKind = {
 
 	from(kind: types.CompletionItemKind): modes.SuggestionType {
 		switch (kind) {
+			case types.CompletionItemKind.Method: return 'method';
 			case types.CompletionItemKind.Function: return 'function';
 			case types.CompletionItemKind.Constructor: return 'constructor';
 			case types.CompletionItemKind.Field: return 'field';


### PR DESCRIPTION
Previously, if a registered completion provider returned items with
`CompletionItemKind.Method`, they would display in the list as properties,
due to not being converted to the corresponding `SuggestionType`.
