### PR TITLE
removed ocaml extensions

### DIFF
--- a/extensions/fsharp/package.json
+++ b/extensions/fsharp/package.json
@@ -6,7 +6,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "fsharp",
-			"extensions": [ ".fs", ".fsi", ".ml", ".mli", ".fsx", ".fsscript" ],
+			"extensions": [ ".fs", ".fsi", ".fsx", ".fsscript" ],
 			"aliases": [ "F#", "FSharp", "fsharp" ],
 			"configuration": "./language-configuration.json"
 		}],


### PR DESCRIPTION
These file extensions are for OCaml and should not be associated with F#
