### PR TITLE
Fix show in IE11

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -965,7 +965,7 @@ export function emmet<T extends HTMLElement>(description: string): T {
 
 export function show(...elements: HTMLElement[]): void {
 	for (let element of elements) {
-		element.style.display = null;
+		element.style.display = '';
 	}
 }
 


### PR DESCRIPTION
Setting `element.style.display` to `null` in IE11 has no effect.
So if the suggest widget was hidden for some reason, and then
shown again, it just stayed hidden.

This issue also prevented the "No suggestions" message from displaying.

Fixes: https://github.com/Microsoft/monaco-editor/issues/96
