### PR TITLE
Make text edits more minimal

### DIFF
--- a/src/vs/base/common/diff/diff.ts
+++ b/src/vs/base/common/diff/diff.ts
@@ -6,6 +6,20 @@
 
 import {DiffChange} from 'vs/base/common/diff/diffChange';
 
+
+function createStringSequence(a: string): ISequence {
+
+	return {
+		getLength() { return a.length; },
+		getElementHash(pos: number) { return a[pos]; }
+	};
+}
+
+export function stringDiff(original: string, modified: string): IDiffChange[] {
+	return new LcsDiff(createStringSequence(original), createStringSequence(modified)).ComputeDiff();
+}
+
+
 export interface ISequence {
 	getLength(): number;
 	getElementHash(index:number): string;

--- a/src/vs/editor/contrib/format/common/formatActions.ts
+++ b/src/vs/editor/contrib/format/common/formatActions.ts
@@ -198,17 +198,8 @@ export class FormatAction extends EditorAction {
 	}
 
 	public apply(editor: editorCommon.ICommonCodeEditor, editorSelection: Selection, value: editorCommon.ISingleEditOperation[]): void {
-		var state: editorCommon.IEditorViewState = null;
-
-		if (editorSelection.isEmpty()) {
-			state = editor.saveViewState();
-		}
-		var command = new EditOperationsCommand(value, editorSelection);
+		const command = new EditOperationsCommand(value, editorSelection);
 		editor.executeCommand(this.id, command);
-
-		if (state) {
-			editor.restoreViewState(state);
-		}
 	}
 }
 

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -6,6 +6,7 @@
 
 import URI from 'vs/base/common/uri';
 import {TPromise} from 'vs/base/common/winjs.base';
+import {ISequence, LcsDiff, IDiffChange} from 'vs/base/common/diff/diff';
 import {IDisposable, dispose} from 'vs/base/common/lifecycle';
 import {IThreadService} from 'vs/workbench/services/thread/common/threadService';
 import * as vscode from 'vscode';
@@ -324,6 +325,18 @@ class QuickFixAdapter {
 	}
 }
 
+function createStringSequence(a: string): ISequence {
+
+	return {
+		getLength() { return a.length; },
+		getElementHash(pos: number) { return a[pos]; }
+	};
+}
+
+function stringDiff(a: string, b: string): IDiffChange[] {
+	return new LcsDiff(createStringSequence(a), createStringSequence(b)).ComputeDiff();
+}
+
 class DocumentFormattingAdapter {
 
 	private _documents: ExtHostDocuments;
@@ -336,13 +349,45 @@ class DocumentFormattingAdapter {
 
 	provideDocumentFormattingEdits(resource: URI, options: modes.FormattingOptions): TPromise<ISingleEditOperation[]> {
 
-		let doc = this._documents.getDocumentData(resource).document;
+		const {document, version} = this._documents.getDocumentData(resource);
 
-		return asWinJsPromise(token => this._provider.provideDocumentFormattingEdits(doc, <any>options, token)).then(value => {
+		return asWinJsPromise(token => this._provider.provideDocumentFormattingEdits(document, <any>options, token)).then(value => {
+
 			if (Array.isArray(value)) {
+				value = DocumentFormattingAdapter.minimizeTextEdits(document, version, value);
 				return value.map(TypeConverters.TextEdit.from);
 			}
 		});
+	}
+
+	// todo@joh find a better place for this
+	// todo@joh reuse in other places
+	static minimizeTextEdits(document: vscode.TextDocument, beforeVersion: number, edits: vscode.TextEdit[]): vscode.TextEdit[] {
+		if (document.version !== beforeVersion) {
+			return edits;
+		}
+
+		const result: vscode.TextEdit[] = [];
+
+		for (let i = 0; i < edits.length; i++) {
+			const original = document.getText(edits[i].range);
+			const modified = edits[i].newText;
+			const changes = stringDiff(original, modified);
+
+			if (changes.length <= 1) {
+				result.push(edits[i]);
+				continue;
+			}
+
+			for (let j = 0; j < changes.length; j++) {
+				const {originalStart, originalLength, modifiedStart, modifiedLength} = changes[j];
+				const range = new Range(<any> document.positionAt(originalStart), <any> document.positionAt(originalStart + originalLength));
+				const newText = modified.substr(modifiedStart, modifiedLength);
+				result.push({ range, newText });
+			}
+		}
+
+		return result;
 	}
 }
 

--- a/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
@@ -861,7 +861,7 @@ suite('ExtHostLanguageFeatures', function() {
 	test('Format Doc, data conversion', function() {
 		disposables.push(extHost.registerDocumentFormattingEditProvider(defaultSelector, <vscode.DocumentFormattingEditProvider>{
 			provideDocumentFormattingEdits(): any {
-				return [new types.TextEdit(new types.Range(0, 0, 1, 1), 'testing')];
+				return [new types.TextEdit(new types.Range(0, 0, 0, 0), 'testing')];
 			}
 		}));
 
@@ -870,7 +870,7 @@ suite('ExtHostLanguageFeatures', function() {
 				assert.equal(value.length, 1);
 				let [first] = value;
 				assert.equal(first.text, 'testing');
-				assert.deepEqual(first.range, { startLineNumber: 1, startColumn: 1, endLineNumber: 2, endColumn: 2 });
+				assert.deepEqual(first.range, { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 });
 			});
 		});
 	});

--- a/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
@@ -890,7 +890,7 @@ suite('ExtHostLanguageFeatures', function() {
 	test('Format Range, data conversion', function() {
 		disposables.push(extHost.registerDocumentRangeFormattingEditProvider(defaultSelector, <vscode.DocumentRangeFormattingEditProvider>{
 			provideDocumentRangeFormattingEdits(): any {
-				return [new types.TextEdit(new types.Range(0, 0, 1, 1), 'testing')];
+				return [new types.TextEdit(new types.Range(0, 0, 0, 0), 'testing')];
 			}
 		}));
 
@@ -899,7 +899,7 @@ suite('ExtHostLanguageFeatures', function() {
 				assert.equal(value.length, 1);
 				let [first] = value;
 				assert.equal(first.text, 'testing');
-				assert.deepEqual(first.range, { startLineNumber: 1, startColumn: 1, endLineNumber: 2, endColumn: 2 });
+				assert.deepEqual(first.range, { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 });
 			});
 		});
 	});
@@ -907,7 +907,7 @@ suite('ExtHostLanguageFeatures', function() {
 	test('Format Range, + format_doc', function() {
 		disposables.push(extHost.registerDocumentRangeFormattingEditProvider(defaultSelector, <vscode.DocumentRangeFormattingEditProvider>{
 			provideDocumentRangeFormattingEdits(): any {
-				return [new types.TextEdit(new types.Range(0, 0, 1, 1), 'range')];
+				return [new types.TextEdit(new types.Range(0, 0, 0, 0), 'range')];
 			}
 		}));
 		disposables.push(extHost.registerDocumentFormattingEditProvider(defaultSelector, <vscode.DocumentFormattingEditProvider>{


### PR DESCRIPTION
Often extension writers use tools to format code that produce non minimal text edits which is bad for the editor - multiple cursor will collapse, decoration might vanish, unnecessary events happen etc, etc. With this PR we look at text edits returned by extensions and try to make them more minimal
