### PR TITLE
Git: Ignore untracked files in change count badge

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
+++ b/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
@@ -26,6 +26,7 @@ import output = require('vs/workbench/parts/output/common/output');
 import {SyncActionDescriptor} from 'vs/platform/actions/common/actions';
 import {EditorBrowserRegistry} from 'vs/editor/browser/editorBrowserExtensions';
 import confregistry = require('vs/platform/configuration/common/configurationRegistry');
+import {IConfigurationService} from 'vs/platform/configuration/common/configuration';
 import quickopen = require('vs/workbench/browser/quickopen');
 import editorcontrib = require('vs/workbench/parts/git/browser/gitEditorContributions');
 import {IActivityService, ProgressBadge, NumberBadge} from 'vs/workbench/services/activity/common/activityService';
@@ -52,6 +53,7 @@ export class StatusUpdater implements ext.IWorkbenchContribution
 	private eventService: IEventService;
 	private activityService:IActivityService;
 	private messageService:IMessageService;
+	private configurationService:IConfigurationService;
 	private progressBadgeDelayer: async.Delayer<void>;
 	private toDispose: lifecycle.IDisposable[];
 
@@ -59,12 +61,14 @@ export class StatusUpdater implements ext.IWorkbenchContribution
 		@IGitService gitService: IGitService,
 		@IEventService eventService: IEventService,
 		@IActivityService activityService: IActivityService,
-		@IMessageService messageService: IMessageService
+		@IMessageService messageService: IMessageService,
+		@IConfigurationService configurationService: IConfigurationService
 	) {
 		this.gitService = gitService;
 		this.eventService = eventService;
 		this.activityService = activityService;
 		this.messageService = messageService;
+		this.configurationService = configurationService;
 
 		this.progressBadgeDelayer = new async.Delayer<void>(200);
 
@@ -86,9 +90,21 @@ export class StatusUpdater implements ext.IWorkbenchContribution
 	}
 
 	private showChangesBadge(): void {
-		var count = this.gitService.getModel().getStatus().getGroups().map((g1: git.IStatusGroup) => {
-			return g1.all().length;
-		}).reduce((a, b) => a + b, 0);
+		const config = this.configurationService.getConfiguration<git.IGitConfiguration>('git');
+
+		// only use the filter version of the map callback if filtering by file status is really necessary
+		var mapper = (g1: git.IStatusGroup) => {
+				return g1.all().filter((f1: git.IFileStatus) => {
+					return f1.getStatus() !== git.Status.UNTRACKED;
+				}).length;
+			};
+
+		// no need to filter by file status if we count both tracked and untracked files
+		if (config.countUntracked) {
+			mapper = (g1: git.IStatusGroup) => g1.all().length;
+		}
+
+		var count = this.gitService.getModel().getStatus().getGroups().map(mapper).reduce((a, b) => a + b, 0);
 
 		var badge = new NumberBadge(count, (num)=>{ return nls.localize('gitPendingChangesBadge', '{0} pending changes', num); });
 

--- a/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
+++ b/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
@@ -563,6 +563,11 @@ export function registerContributions(): void {
 				type: 'boolean',
 				description: nls.localize('confirmSync', "Confirm before synchronizing git repositories."),
 				default: false
+			},
+			'git.countUntracked': {
+				type: 'boolean',
+				description: nls.localize('countUntracked', "Count untracked files in the changes badge."),
+				default: true
 			}
 		}
 	});

--- a/src/vs/workbench/parts/git/common/git.ts
+++ b/src/vs/workbench/parts/git/common/git.ts
@@ -235,6 +235,7 @@ export interface IGitConfiguration {
 	enableLongCommitWarning: boolean;
 	allowLargeRepositories: boolean;
 	confirmSync: boolean;
+	countUntracked: boolean;
 }
 
 // Service interfaces


### PR DESCRIPTION
This PR implements @avih's the feature-request from issue #10268.
### What has changed?
- new configuration setting `git.countUntracked`, default is `false`
- the blue 'change count badge' on the git icon in the main sidebar ignores untracked files if `git.countUntracked` is `true`
### New Configuration Setting

The new setting does not affect the default behaviour of the change count badge as it is off by default, meaning both tracked and untracked files are counted. Untracked files are only ignored if `git.countUntracked` is set to `true` in the user or workspace preferences.
### Other Changes to `gitWorkbenchContribution.ts`
- import `IConfigurationService` in order to read the `countUntracked` config
- in `StatusUpdater`: add private member `configurationService`
- in `StatusUpdater.showChangesBadge()`: use a different callback for `map` depending on `countUntracked`
### In Action

![git-ignore-untracked 1](https://cloud.githubusercontent.com/assets/2205595/17605304/1732cf70-601a-11e6-8cc0-e43133f9faaa.gif)
