### PR TITLE
TypeScript first line matching added.

### DIFF
--- a/extensions/typescript/syntaxes/TypeScript.tmLanguage.json
+++ b/extensions/typescript/syntaxes/TypeScript.tmLanguage.json
@@ -3,6 +3,7 @@
 		"ts"
 	],
 	"name": "TypeScript",
+	"firstLineMatch": "#!/.*\bnode",
 	"patterns": [
 		{
 			"include": "#expression"

--- a/extensions/typescript/syntaxes/TypeScriptReact.tmLanguage.json
+++ b/extensions/typescript/syntaxes/TypeScriptReact.tmLanguage.json
@@ -3,6 +3,7 @@
 		"tsx"
 	],
 	"name": "TypeScriptReact",
+	"firstLineMatch": "#!/.*\bnode",
 	"patterns": [
 		{
 			"include": "#expression"


### PR DESCRIPTION
As when you write node CLI software you have to include the UNIX header `!# /bin/..` now TypeScript had no such support for that. Made a pull request for that in the [TypeScript.tmLanguage](https://github.com/Microsoft/TypeScript-TmLanguage/pull/225) repository but it seems that it's somehow out of maintenance and no one noticed it (also I see that my additions have syntax issues...) so I made a same change here with correct syntax and stuff.

As always hope it have helped.
Have so much fun!
Pouya
