### PR TITLE
Fixed `code.sh` to start VS Code under Cygwin.

### DIFF
--- a/resources/win32/bin/code.sh
+++ b/resources/win32/bin/code.sh
@@ -6,6 +6,10 @@
 NAME="@@NAME@@"
 VSCODE_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
 ELECTRON="$VSCODE_PATH/$NAME.exe"
-CLI="$VSCODE_PATH/resources/app/out/cli.js"
+if [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
+	CLI=$(cygpath -m "$VSCODE_PATH/resources/app/out/cli.js")
+else
+	CLI="$VSCODE_PATH/resources/app/out/cli.js"
+fi
 ELECTRON_NO_ATTACH_CONSOLE=1 ATOM_SHELL_INTERNAL_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
 exit $?


### PR DESCRIPTION
- VSCode Version: 1.4.0
- OS Version: Microsoft Windows [Version 6.3.9600]
- Cygwin Version: CYGWIN_NT-6.3

Steps to Reproduce:
1. Run `code` from Cygwin Terminal

Error Reported:

```
module.js:341
    throw err;
    ^

Error: Cannot find module 'C:\cygdrive\c\Program Files (x86)\Microsoft VS Code\resources\app\out\cli.js'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:154:18)
    at node.js:416:3
```

Fix attached in the following PR.
