### PR TITLE
Fix `import statement` snippet for typescriptreact

### DIFF
--- a/extensions/typescript/snippets/typescriptreact.json
+++ b/extensions/typescript/snippets/typescriptreact.json
@@ -64,7 +64,7 @@
 	"Import external module.": {
 		"prefix": "import statement",
 		"body": [
-			"import ${name} = require('$0');"
+			"import { $0 } from '${module}';"
 		],
 		"description": "Import external module."
 	},


### PR DESCRIPTION
The mix of `import` and `require` makes no sense. This should be the same snippet as in [typescript.json](https://github.com/Microsoft/vscode/blob/master/extensions/typescript/snippets/typescript.json#L67).
