### PR TITLE
add gitignore for .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out-vscode/
 out-vscode-min/
 build/node_modules
 coverage/
+.vscode


### PR DESCRIPTION
this ensures users who work with vscode to develop vscode :package:  don't accidentally add the .vscode folder into their commits.
