### PR TITLE
update-grammer.js to change grammar name #2867

### DIFF
--- a/extensions/python/build/update-grammars.js
+++ b/extensions/python/build/update-grammars.js
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+var updateGrammar = require('../../../build/npm/update-grammar');
+
+function fixGrammarName(grammar) {
+	grammar.name = 'Python';
+}
+function fixRexExpGrammarName(grammar) {
+	grammar.name = 'PythonRegExp';
+}
+var pyGrammarRepo = 'MagicStack/MagicPython';
+updateGrammar.update(pyGrammarRepo, 'grammars/MagicPython.tmLanguage', './syntaxes/MagicPython.tmLanguage.json', fixGrammarName);
+updateGrammar.update(pyGrammarRepo, 'grammars/MagicRegExp.tmLanguage', './syntaxes/MagicRegExp.tmLanguage.json', fixRexExpGrammarName);

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -25,6 +25,6 @@
 	"scripts": {
 		"compile": "gulp compile-extension:python",
 		"watch": "gulp watch-extension:python",
-		"update-grammar": "node ../../build/npm/update-grammar.js MagicStack/MagicPython grammars/MagicPython.tmLanguage ./syntaxes/MagicPython.tmLanguage.json grammars/MagicRegExp.tmLanguage ./syntaxes/MagicRegExp.tmLanguage.json"
+		"update-grammar": "node ./build/update-grammars.js"
 	}
 }

--- a/extensions/python/syntaxes/MagicPython.tmLanguage.json
+++ b/extensions/python/syntaxes/MagicPython.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-	"name": "MagicPython",
+	"name": "Python",
 	"scopeName": "source.python",
 	"fileTypes": [
 		"py",

--- a/extensions/python/syntaxes/MagicRegExp.tmLanguage.json
+++ b/extensions/python/syntaxes/MagicRegExp.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-	"name": "MagicRegExp",
+	"name": "PythonRegExp",
 	"scopeName": "source.regexp.python",
 	"fileTypes": [
 		"re"


### PR DESCRIPTION
Ensure name of language file is [changed from MagicPython to Python](https://github.com/Microsoft/vscode/issues/2867#issuecomment-241491423) 
Fixes Microsoft/vscode/issues/2867
