### PR TITLE
Fix sending message to terminated worker

### DIFF
--- a/src/vs/base/common/worker/workerClient.ts
+++ b/src/vs/base/common/worker/workerClient.ts
@@ -227,7 +227,9 @@ export class WorkerClient {
 	}
 
 	private _postMessage(msg:any): void {
-		this._worker.postMessage(stringify(msg));
+		if (this._worker) {
+			this._worker.postMessage(stringify(msg));
+		}
 	}
 
 	private _onSerializedMessage(msg:string): void {

--- a/src/vs/base/worker/defaultWorkerFactory.ts
+++ b/src/vs/base/worker/defaultWorkerFactory.ts
@@ -41,7 +41,9 @@ class WebWorker implements IWorker {
 	}
 
 	public postMessage(msg:string): void {
-		this.worker.postMessage(msg);
+		if (this.worker) {
+			this.worker.postMessage(msg);
+		}
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
The problem appears if you create multiple editors/models and then change the typescript compilation settings. This will dispose (terminate) the worker as first action. then it will dispose all existing models which will try to send messages for "acceptRemovedModel" to the worker(s) but as they are already terminated this will result in error.

I'm not sure if it is a better if the worker is terminated to reject the postMessage request immediately since this will again result in error.
