### PR TITLE
Fixes #10386, preventing start find action overwriting find input text

### DIFF
--- a/src/vs/editor/contrib/find/common/findController.ts
+++ b/src/vs/editor/contrib/find/common/findController.ts
@@ -257,7 +257,7 @@ export class StartFindAction extends EditorAction {
 		let controller = CommonFindController.get(editor);
 		controller.start({
 			forceRevealReplace: false,
-			seedSearchStringFromSelection: true,
+			seedSearchStringFromSelection: (controller.getState().searchString.length === 0),
 			shouldFocus: FindStartFocusAction.FocusFindInput,
 			shouldAnimate: true
 		});
@@ -413,7 +413,7 @@ export class StartFindReplaceAction extends EditorAction {
 		let controller = CommonFindController.get(editor);
 		controller.start({
 			forceRevealReplace: true,
-			seedSearchStringFromSelection: true,
+			seedSearchStringFromSelection: (controller.getState().searchString.length === 0),
 			shouldFocus: FindStartFocusAction.FocusReplaceInput,
 			shouldAnimate: true
 		});


### PR DESCRIPTION
Preventing find & replace input from updating the search text, once populated.
