### PR TITLE
Implement Feature Request from 9213

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -272,6 +272,7 @@ class InternalEditorOptionsHelper {
 		return new editorCommon.InternalEditorOptions({
 			lineHeight: fontInfo.lineHeight, // todo -> duplicated in styling
 			readOnly: readOnly,
+			externalEditor: String(opts.externalEditor),
 			wordSeparators: String(opts.wordSeparators),
 			autoClosingBrackets: toBoolean(opts.autoClosingBrackets),
 			useTabStops: toBoolean(opts.useTabStops),
@@ -614,6 +615,11 @@ let editorConfiguration:IConfigurationNode = {
 			},
 			'default': DefaultConfig.editor.rulers,
 			'description': nls.localize('rulers', "Columns at which to show vertical rulers")
+		},
+		'editor.externalEditor' : {
+			'type': 'string',
+			'default': DefaultConfig.editor.externalEditor,
+			'description': nls.localize('externalEditor', "External editor to be used for opening files.")
 		},
 		'editor.wordSeparators' : {
 			'type': 'string',

--- a/src/vs/editor/common/config/defaultConfig.ts
+++ b/src/vs/editor/common/config/defaultConfig.ts
@@ -37,6 +37,7 @@ class ConfigClass implements IConfiguration {
 		this.editor = {
 			experimentalScreenReader: true,
 			rulers: [],
+			externalEditor: null,
 			wordSeparators: USUAL_WORD_SEPARATORS,
 			selectionClipboard: true,
 			ariaLabel: nls.localize('editorViewAccessibleLabel', "Editor content"),

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -190,6 +190,10 @@ export interface IEditorOptions {
 	 */
 	rulers?: number[];
 	/**
+	 * External editor to be used for opening files.
+	 */
+	externalEditor?: string;
+	/**
 	 * A string containing the word separators used when doing word navigation.
 	 * Defaults to `~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?
 	 */
@@ -907,6 +911,7 @@ export class InternalEditorOptions {
 	lineHeight:number; // todo: move to fontInfo
 
 	readOnly:boolean;
+	externalEditor:string;
 	// ---- cursor options
 	wordSeparators: string;
 	autoClosingBrackets:boolean;
@@ -925,6 +930,7 @@ export class InternalEditorOptions {
 	constructor(source: {
 		lineHeight:number;
 		readOnly:boolean;
+		externalEditor:string;
 		wordSeparators: string;
 		autoClosingBrackets:boolean;
 		useTabStops: boolean;
@@ -937,6 +943,7 @@ export class InternalEditorOptions {
 	}) {
 		this.lineHeight = source.lineHeight|0;
 		this.readOnly = Boolean(source.readOnly);
+		this.externalEditor = String(source.externalEditor);
 		this.wordSeparators = String(source.wordSeparators);
 		this.autoClosingBrackets = Boolean(source.autoClosingBrackets);
 		this.useTabStops = Boolean(source.useTabStops);
@@ -955,6 +962,7 @@ export class InternalEditorOptions {
 		return (
 			this.lineHeight === other.lineHeight
 			&& this.readOnly === other.readOnly
+			&& this.externalEditor === other.externalEditor
 			&& this.wordSeparators === other.wordSeparators
 			&& this.autoClosingBrackets === other.autoClosingBrackets
 			&& this.useTabStops === other.useTabStops
@@ -974,6 +982,7 @@ export class InternalEditorOptions {
 		return {
 			lineHeight: (this.lineHeight !== newOpts.lineHeight),
 			readOnly: (this.readOnly !== newOpts.readOnly),
+			externalEditor: (this.externalEditor !== newOpts.externalEditor),
 			wordSeparators: (this.wordSeparators !== newOpts.wordSeparators),
 			autoClosingBrackets: (this.autoClosingBrackets !== newOpts.autoClosingBrackets),
 			useTabStops: (this.useTabStops !== newOpts.useTabStops),
@@ -1000,6 +1009,7 @@ export class InternalEditorOptions {
 export interface IConfigurationChangedEvent {
 	lineHeight: boolean;
 	readOnly: boolean;
+	externalEditor: boolean;
 	wordSeparators: boolean;
 	autoClosingBrackets: boolean;
 	useTabStops: boolean;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1045,6 +1045,10 @@ declare module monaco.editor {
          */
         rulers?: number[];
         /**
+         * External editor to be used for opening files.
+         */
+        externalEditor?: string;
+        /**
          * A string containing the word separators used when doing word navigation.
          * Defaults to `~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?
          */
@@ -1437,6 +1441,7 @@ declare module monaco.editor {
         _internalEditorOptionsBrand: void;
         lineHeight: number;
         readOnly: boolean;
+        externalEditor: string;
         wordSeparators: string;
         autoClosingBrackets: boolean;
         useTabStops: boolean;
@@ -1454,6 +1459,7 @@ declare module monaco.editor {
     export interface IConfigurationChangedEvent {
         lineHeight: boolean;
         readOnly: boolean;
+        externalEditor: boolean;
         wordSeparators: boolean;
         autoClosingBrackets: boolean;
         useTabStops: boolean;

--- a/src/vs/workbench/parts/files/electron-browser/files.electron.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/files.electron.contribution.ts
@@ -17,7 +17,7 @@ import {IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions} from
 import {GlobalNewUntitledFileAction, SaveFileAsAction} from 'vs/workbench/parts/files/browser/fileActions';
 import {FileTracker} from 'vs/workbench/parts/files/electron-browser/electronFileTracker';
 import {TextFileService} from 'vs/workbench/parts/files/electron-browser/textFileServices';
-import {OpenFolderAction, OPEN_FOLDER_ID, OPEN_FOLDER_LABEL, OpenFileAction, OPEN_FILE_ID, OPEN_FILE_LABEL, OpenFileFolderAction, OPEN_FILE_FOLDER_ID, OPEN_FILE_FOLDER_LABEL, ShowOpenedFileInNewWindow, GlobalRevealInOSAction, GlobalCopyPathAction, CopyPathAction, RevealInOSAction} from 'vs/workbench/parts/files/electron-browser/electronFileActions';
+import {OpenFolderAction, OPEN_FOLDER_ID, OPEN_FOLDER_LABEL, OpenFileAction, OPEN_FILE_ID, OPEN_FILE_LABEL, OpenFileFolderAction, OPEN_FILE_FOLDER_ID, OPEN_FILE_FOLDER_LABEL, ShowOpenedFileInNewWindow, GlobalRevealInOSAction, GlobalCopyPathAction, CopyPathAction, RevealInOSAction, EditInExternalEditor} from 'vs/workbench/parts/files/electron-browser/electronFileActions';
 import {IInstantiationService} from 'vs/platform/instantiation/common/instantiation';
 import {registerSingleton} from 'vs/platform/instantiation/common/extensions';
 import {KeyMod, KeyCode} from 'vs/base/common/keyCodes';
@@ -47,6 +47,9 @@ class FileViewerActionContributor extends ActionBarContributor {
 
 			// Copy Path
 			actions.push(this.instantiationService.createInstance(CopyPathAction, resource));
+
+			// Edit In External Editor
+			actions.push(this.instantiationService.createInstance(EditInExternalEditor, resource));
 		}
 
 		return actions;


### PR DESCRIPTION
Added a new context menu entry 'Edit in External Editor' to the file
explorer which allows a person to open any file (not just the active
file) in an external program (configurable through a config key called
'externalEditor').

Implements #9213 
