### PR TITLE
Count lines in getHeightForString - fix #10980

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -101,6 +101,8 @@ export class ReplExpressionsRenderer implements tree.IRenderer {
 		/((\/|[a-zA-Z]:\\)[^\(\)<>\'\"\[\]]+):(\d+):(\d+)/
 	];
 
+	private static LINE_HEIGHT_PX = 18;
+
 	private width: number;
 	private characterWidth: number;
 
@@ -116,14 +118,20 @@ export class ReplExpressionsRenderer implements tree.IRenderer {
 
 	private getHeightForString(s: string): number {
 		if (!s || !s.length || !this.width || this.width <= 0 || !this.characterWidth || this.characterWidth <= 0) {
-			return 18;
-		}
-		let realLength = 0;
-		for (let i = 0; i < s.length; i++) {
-			realLength += strings.isFullWidthCharacter(s.charCodeAt(i)) ? 2 : 1;
+			return ReplExpressionsRenderer.LINE_HEIGHT_PX;
 		}
 
-		return 18 * Math.ceil(realLength * this.characterWidth / this.width);
+		const lines = s.split(/\r\n|\r|\n/g);
+		const numLines = lines.reduce((length: number, line: string) => {
+			let lineLength = 0;
+			for (let i = 0; i < line.length; i++) {
+				lineLength = strings.isFullWidthCharacter(s.charCodeAt(i)) ? 2 : 1;
+			}
+
+			return length + Math.floor(lineLength * this.characterWidth / this.width);
+		}, lines.length);
+
+		return ReplExpressionsRenderer.LINE_HEIGHT_PX * numLines;
 	}
 
 	public setWidth(fullWidth: number, characterWidth: number): void {


### PR DESCRIPTION
FYI @isidorn -

Looks like for output, there's one item per line created in debugModel, but for the input, there's only one item, so we need to count lines to calculate height.
