### PR TITLE
Remove color from italics in markdown in default theme

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -115,8 +115,7 @@
 		{
 			"scope": "markup.italic",
 			"settings": {
-				"fontStyle": "italic",
-				"foreground": "#569cd6"
+				"fontStyle": "italic"
 			}
 		},
 		{

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -106,8 +106,7 @@
 		{
 			"scope": "markup.italic",
 			"settings": {
-				"fontStyle": "italic",
-				"foreground": "#000080"
+				"fontStyle": "italic"
 			}
 		},
 		{


### PR DESCRIPTION
Fixes #10984 

---

Dark+

![image](https://cloud.githubusercontent.com/assets/2193314/17990630/561df052-6aec-11e6-8e97-dbeb9b4b6ee6.png)

Light+

![image](https://cloud.githubusercontent.com/assets/2193314/17990639/6131fd30-6aec-11e6-8508-645672766b61.png)
