### PR TITLE
Emmet tweaks: remove extra languages from conditions

### DIFF
--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -166,7 +166,7 @@ export class EditorAccessor implements emmet.Editor {
 			return syntax;
 		}
 		let languages = languageGrammar.split('.');
-		let thisLanguage = languages[languages.length-1];
+		let thisLanguage = languages[languages.length - 1];
 		if (syntax !== thisLanguage || languages.length < 2) {
 			return syntax;
 		}

--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -139,7 +139,7 @@ export class EditorAccessor implements emmet.Editor {
 			return syntax;
 		}
 
-		if (/\b(razor|handlebars|erb|php|hbs|ejs|twig)\b/.test(syntax)) { // treat like html
+		if (/\b(razor|handlebars)\b/.test(syntax)) { // treat like html
 			return 'html';
 		}
 		if (/\b(typescriptreact|javascriptreact)\b/.test(syntax)) { // treat tsx like jsx

--- a/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
+++ b/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
@@ -56,7 +56,7 @@ suite('Emmet', () => {
 			});
 
 			// syntaxes mapped to html, hard coded
-			let html = ['razor', 'handlebars', 'erb', 'php', 'hbs', 'ejs', 'twig'];  // twig??
+			let html = ['razor', 'handlebars'];
 			html.forEach(each => {
 				testIsEnabled(each, null);
 			});
@@ -97,7 +97,7 @@ suite('Emmet', () => {
 			});
 
 			// syntaxes mapped to html, hard coded
-			let html = ['razor', 'handlebars', 'erb', 'php', 'hbs', 'ejs', 'twig'];  // twig??
+			let html = ['razor', 'handlebars'];
 			html.forEach(each => {
 				testSyntax(each, null, 'html');
 			});


### PR DESCRIPTION
Source: #9500 

The following languages can be removed from the condition:
- [`twig`](https://github.com/Bajdzis/vscode-twig-pack/blob/master/package.json#L68) by TwigPack extension and [`twig`](https://github.com/whatwedo/vscode-twig/blob/master/package.json#L52) by Twig extension
- [`ejs`](https://github.com/Rayraegah/ejs-visual-studio/blob/master/package.json#L22) by .ejs extension
- [`erb`](https://github.com/craigmaslowski/vscode-erb/blob/master/package.json#L21) by erb extension
- [`php`](https://github.com/Microsoft/vscode/blob/master/extensions/php/package.json#L21) by vscode extension
- `hbs` === `handlebars` (We work with identifiers)

The following languages cannot be removed because it does not have `scopeNames`:
- [`razor`](https://github.com/Microsoft/vscode/blob/master/src/vs/languages/razor/common/razor.contribution.ts)
- [`handlebars`](https://github.com/Microsoft/vscode/blob/master/src/vs/languages/handlebars/common/handlebars.contribution.ts)
