### PR TITLE
Emmet tweaks: simplify set/reset Emmet preferences and syntax profiles

### DIFF
--- a/src/vs/workbench/parts/emmet/node/emmet.d.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.d.ts
@@ -11,9 +11,7 @@ declare module 'emmet' {
 	}
 
 	export interface Preferences {
-		set(key:string, value: string);
-		define(key:string, value: string);
-		remove(key:string);
+		reset();
 	}
 
 	export interface Profiles {
@@ -150,5 +148,13 @@ declare module 'emmet' {
 
 	export const profile: Profiles;
 
-	export function loadProfiles(profiles: any);
+	/**
+	 * Loads preferences from JSON object
+	 */
+	export function loadPreferences(preferences: any): void;
+
+	/**
+	 * Loads named profiles from JSON object
+	 */
+	export function loadProfiles(profiles: any): void;
 }

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -89,27 +89,14 @@ class LazyEmmet {
 	}
 
 	private updateEmmetPreferences(configurationService: IConfigurationService, _emmet: typeof emmet) {
-		let preferences = configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		for (let key in preferences) {
-			try {
-				_emmet.preferences.set(key, preferences[key]);
-			} catch (err) {
-				_emmet.preferences.define(key, preferences[key]);
-			}
-		}
-		let syntaxProfiles = configurationService.getConfiguration<IEmmetConfiguration>().emmet.syntaxProfiles;
-		_emmet.profile.reset();
-		_emmet.loadProfiles(syntaxProfiles);
+		let emmetPreferences = configurationService.getConfiguration<IEmmetConfiguration>().emmet;
+		_emmet.loadPreferences(emmetPreferences.preferences);
+		_emmet.loadProfiles(emmetPreferences.syntaxProfiles);
 	}
 
 	private resetEmmetPreferences(configurationService: IConfigurationService, _emmet: typeof emmet) {
-		let preferences = configurationService.getConfiguration<IEmmetConfiguration>().emmet.preferences;
-		for (let key in preferences) {
-			try {
-				_emmet.preferences.remove(key);
-			} catch (err) {
-			}
-		}
+		_emmet.preferences.reset();
+		_emmet.profile.reset();
 	}
 
 	private _withEmmetPreferences(configurationService: IConfigurationService, _emmet: typeof emmet, callback: (_emmet: typeof emmet) => void): void {


### PR DESCRIPTION
Source: #9500 and #9002

The process of set/reset preferences and syntax profiles for Emmet has been simplify. We don’t have to support undocumented features of Emmet, which don’t have any sense for the end user.

Just use Emmet API.
