### PR TITLE
Emmet tweaks: clean-up editorAccessor tests

### DIFF
--- a/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
+++ b/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
@@ -40,7 +40,6 @@ class MockGrammarContributions implements IGrammarContributions {
 	}
 }
 
-
 export interface IGrammarContributions {
 	getGrammar(mode: string): string;
 }

--- a/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
+++ b/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
@@ -1,3 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
 import {EditorAccessor, IGrammarContributions} from 'vs/workbench/parts/emmet/node/editorAccessor';
 import {withMockCodeEditor} from 'vs/editor/test/common/mocks/mockCodeEditor';
 import {MockMode} from 'vs/editor/test/common/mocks/mockMode';


### PR DESCRIPTION
Source: #9500

I think, that all tests are correct after #11001.
