### PR TITLE
Avoid multiple updates when file search is cached

### DIFF
--- a/src/vs/workbench/browser/quickopen.ts
+++ b/src/vs/workbench/browser/quickopen.ts
@@ -33,7 +33,7 @@ export class QuickOpenHandler {
 	 * As such, returning the same model instance across multiple searches will yield best
 	 * results in terms of performance when many items are shown.
 	 */
-	public getResults(searchValue: string): TPromise<IModel<any>> {
+	public getResults(searchValue: string): TPromise<IModel<any>> | QuickOpenHandlerResult {
 		return TPromise.as(null);
 	}
 
@@ -98,6 +98,14 @@ export class QuickOpenHandler {
 		}
 		return nls.localize('noResultsFound2', "No results found");
 	}
+}
+
+export interface QuickOpenHandlerResult {
+
+	shortResponseTime: boolean;
+
+	promisedModel: TPromise<IModel<any>>;
+
 }
 
 export interface QuickOpenHandlerHelpEntry {

--- a/src/vs/workbench/test/browser/parts/quickOpen/quickopen.perf.test.ts
+++ b/src/vs/workbench/test/browser/parts/quickOpen/quickopen.perf.test.ts
@@ -17,7 +17,7 @@ import {IUntitledEditorService, UntitledEditorService} from 'vs/workbench/servic
 import {IWorkbenchEditorService} from 'vs/workbench/services/editor/common/editorService';
 import * as minimist from 'minimist';
 import * as path from 'path';
-import {QuickOpenHandler, IQuickOpenRegistry, Extensions} from 'vs/workbench/browser/quickopen';
+import {QuickOpenHandler, QuickOpenHandlerResult, IQuickOpenRegistry, Extensions} from 'vs/workbench/browser/quickopen';
 import {Registry} from 'vs/platform/platform';
 import {SearchService} from 'vs/workbench/services/search/node/searchService';
 import {ServiceCollection} from 'vs/platform/instantiation/common/serviceCollection';
@@ -26,6 +26,7 @@ import {IEnvironmentService} from 'vs/platform/environment/common/environment';
 import * as Timer from 'vs/base/common/timer';
 import {TPromise} from 'vs/base/common/winjs.base';
 import URI from 'vs/base/common/uri';
+import {IModel} from 'vs/base/parts/quickopen/common/quickOpen';
 
 declare var __dirname: string;
 
@@ -65,7 +66,9 @@ suite('QuickOpen performance', () => {
 			return instantiationService.createInstance(descriptors[0])
 				.then((handler: QuickOpenHandler) => {
 					handler.onOpen();
-					return handler.getResults('a').then(result => {
+					const result = handler.getResults('a');
+					const promise = (<QuickOpenHandlerResult>result).promisedModel || <TPromise<IModel<any>>>result;
+					return promise.then(result => {
 						const uncachedEvent = popEvent();
 						assert.strictEqual(uncachedEvent.data.symbols.fromCache, false, 'symbols.fromCache');
 						assert.strictEqual(uncachedEvent.data.files.fromCache, true, 'files.fromCache');
@@ -74,7 +77,9 @@ suite('QuickOpen performance', () => {
 						}
 						return uncachedEvent;
 					}).then(uncachedEvent => {
-						return handler.getResults('ab').then(result => {
+						const result = handler.getResults('ab');
+						const promise = (<QuickOpenHandlerResult>result).promisedModel || <TPromise<IModel<any>>>result;
+						return promise.then(result => {
 							const cachedEvent = popEvent();
 							assert.ok(cachedEvent.data.symbols.fromCache, 'symbolsFromCache');
 							assert.ok(cachedEvent.data.files.fromCache, 'filesFromCache');


### PR DESCRIPTION
@bpasero this is a possible fix for the flickering of QuickOpen. It seems to be a noticeable improvement, but I'm not sure what you had in mind as a long term fix.

As I'm heading out soon, I don't want to push this without your approval. Please feel free to ignore or merge.
