### PR TITLE
Fixed: Markdown syntax highlighting to support alternative header styles

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -28,6 +28,10 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#separator</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#heading</string>
 				</dict>
 				<dict>
@@ -202,11 +206,6 @@
 					<key>include</key>
 					<string>#paragraph</string>
 				</dict>
-				<dict>
-					<key>include</key>
-					<string>#separator</string>
-				</dict>
-
 			</array>
 			<key>repository</key>
 			<dict>
@@ -413,10 +412,6 @@
 							<key>include</key>
 							<string>text.html.basic</string>
 						</dict>
-						<dict>
-							<key>include</key>
-							<string>#heading-setext</string>
-						</dict>
 					</array>
 					<key>while</key>
 					<string>(^|\G)(?!\s*$|#|[ ]{0,3}([-*_][ ]{2,}){3,}[ \t]*$\n?|&gt;|[ ]{0,3}[*+-]|[ ]{0,3}[0-9]+\.)</string>
@@ -508,7 +503,7 @@
 					<!-- seperator    [ ]{0,3}([-*_][ ]{0,2}\2){2,}[ \t]*$\n? -->
 					<!-- list         [ ]{0,3}[*+-]([ ]{1,3}|\t) -->
 					<!-- both are folded together in the expression below -->
-					<string>(^|\G)(?!\s*$|#|[ ]{0,3}((([-*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
+					<string>(^|\G)(?!\s*$|#|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
 				</dict>
 				<key>raw_block</key>
 				<dict>
@@ -1114,7 +1109,7 @@
 				<key>separator</key>
 				<dict>
 					<key>match</key>
-					<string>(^|\G)[ ]{0,3}([-*_])([ ]{0,2}\2){2,}[ \t]*$\n?</string>
+					<string>(^|\G)[ ]{0,3}([*-_])([ ]{0,2}\2){2,}[ \t]*$\n?</string>
 					<key>name</key>
 					<string>meta.separator.markdown</string>
 				</dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -28,10 +28,6 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#separator</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#heading</string>
 				</dict>
 				<dict>
@@ -206,6 +202,11 @@
 					<key>include</key>
 					<string>#paragraph</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#separator</string>
+				</dict>
+
 			</array>
 			<key>repository</key>
 			<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -412,6 +412,10 @@
 							<key>include</key>
 							<string>text.html.basic</string>
 						</dict>
+						<dict>
+							<key>include</key>
+							<string>#heading-setext</string>
+						</dict>
 					</array>
 					<key>while</key>
 					<string>(^|\G)(?!\s*$|#|[ ]{0,3}([-*_][ ]{2,}){3,}[ \t]*$\n?|&gt;|[ ]{0,3}[*+-]|[ ]{0,3}[0-9]+\.)</string>

--- a/extensions/markdown/test/colorize-fixtures/test.md
+++ b/extensions/markdown/test/colorize-fixtures/test.md
@@ -4,6 +4,12 @@
 ## Markdown plus h2 with a custom ID ##   {#id-goes-here}
 [Link back to H2](#id-goes-here)
 
+### Alternate heading styles:
+Alternate Header 1
+==========================
+Alternate Header 2
+--------------------------
+
 <!-- html madness -->
 <div class="custom-class" markdown="1">
   <div>

--- a/extensions/markdown/test/colorize-fixtures/test.md
+++ b/extensions/markdown/test/colorize-fixtures/test.md
@@ -6,9 +6,9 @@
 
 ### Alternate heading styles:
 Alternate Header 1
-==========================
+==================
 Alternate Header 2
---------------------------
+------------------
 
 <!-- html madness -->
 <div class="custom-class" markdown="1">

--- a/extensions/markdown/test/colorize-results/test_md.json
+++ b/extensions/markdown/test/colorize-results/test_md.json
@@ -242,6 +242,83 @@
 		}
 	},
 	{
+		"c": "###",
+		"t": "${1/(#)(#)?(#)?(#)?(#)?(#)?/${6:?6:${5:?5:${4:?4:${3:?3:${2:?2:1}}}}}/}.definition.heading.markdown.markup.punctuation",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.heading rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.heading rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.heading rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.heading rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.heading rgb(103, 150, 230)"
+		}
+	},
+	{
+		"c": " ",
+		"t": "${1/(#)(#)?(#)?(#)?(#)?(#)?/${6:?6:${5:?5:${4:?4:${3:?3:${2:?2:1}}}}}/}.heading.markdown.markup",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.heading rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.heading rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.heading rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.heading rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.heading rgb(103, 150, 230)"
+		}
+	},
+	{
+		"c": "Alternate heading styles:",
+		"t": "${1/(#)(#)?(#)?(#)?(#)?(#)?/${6:?6:${5:?5:${4:?4:${3:?3:${2:?2:1}}}}}/}.entity.heading.markdown.markup.name.section",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.heading rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.heading rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.heading rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.heading rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.heading rgb(103, 150, 230)"
+		}
+	},
+	{
+		"c": "Alternate Header 1",
+		"t": "markdown.meta.paragraph",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": "==================",
+		"t": "1.heading.markdown.markup.meta.paragraph.setext",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.heading rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.heading rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.heading rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.heading rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.heading rgb(103, 150, 230)"
+		}
+	},
+	{
+		"c": "Alternate Header 2",
+		"t": "markdown.meta.paragraph",
+		"r": {
+			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
+			"light_plus": ".vs .token rgb(0, 0, 0)",
+			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
+			"light_vs": ".vs .token rgb(0, 0, 0)",
+			"hc_black": ".hc-black .token rgb(255, 255, 255)"
+		}
+	},
+	{
+		"c": "------------------",
+		"t": "2.heading.markdown.markup.meta.paragraph.setext",
+		"r": {
+			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.heading rgb(86, 156, 214)",
+			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.heading rgb(128, 0, 0)",
+			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.heading rgb(86, 156, 214)",
+			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.heading rgb(128, 0, 0)",
+			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.heading rgb(103, 150, 230)"
+		}
+	},
+	{
 		"c": "<!--",
 		"t": "block.comment.definition.html.markdown.meta.paragraph.punctuation",
 		"r": {


### PR DESCRIPTION
Fixes #9784.

The paragraph TM rule was excluding heading-setext alt heading 2 rule, because of a conflict with the separator rule.

Also added tests to verify the behaviour. 
