### PR TITLE
Rename lineHighlight to rangeHighlight

### DIFF
--- a/src/vs/editor/browser/widget/media/editor.css
+++ b/src/vs/editor/browser/widget/media/editor.css
@@ -112,11 +112,11 @@
 	top: 0;
 }
 
-/* -------------------- Highlight a line -------------------- */
+/* -------------------- Highlight a range -------------------- */
 
-.monaco-editor.vs		.lineHighlight { background: rgba(253, 255, 0, 0.2); }
-.monaco-editor.vs-dark	.lineHighlight { background: rgba(243, 240, 245, 0.2); }
-.monaco-editor.hc-black	.lineHighlight { background: rgba(243, 240, 245, 0.2); }
+.monaco-editor.vs		.rangeHighlight { background: rgba(253, 255, 0, 0.2); }
+.monaco-editor.vs-dark	.rangeHighlight { background: rgba(243, 240, 245, 0.2); }
+.monaco-editor.hc-black	.rangeHighlight { background: rgba(243, 240, 245, 0.2); }
 
 /* -------------------- Squigglies -------------------- */
 

--- a/src/vs/editor/contrib/find/common/findDecorations.ts
+++ b/src/vs/editor/contrib/find/common/findDecorations.ts
@@ -14,7 +14,7 @@ export class FindDecorations implements IDisposable {
 	private _editor:editorCommon.ICommonCodeEditor;
 	private _decorations:string[];
 	private _findScopeDecorationId:string;
-	private _lineHighlightDecorationId:string;
+	private _rangeHighlightDecorationId:string;
 	private _highlightedDecorationId:string;
 	private _startPosition:Position;
 
@@ -22,7 +22,7 @@ export class FindDecorations implements IDisposable {
 		this._editor = editor;
 		this._decorations = [];
 		this._findScopeDecorationId = null;
-		this._lineHighlightDecorationId = null;
+		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
 		this._startPosition = this._editor.getPosition();
 	}
@@ -33,7 +33,7 @@ export class FindDecorations implements IDisposable {
 		this._editor = null;
 		this._decorations = [];
 		this._findScopeDecorationId = null;
-		this._lineHighlightDecorationId = null;
+		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
 		this._startPosition = null;
 	}
@@ -41,7 +41,7 @@ export class FindDecorations implements IDisposable {
 	public reset(): void {
 		this._decorations = [];
 		this._findScopeDecorationId = null;
-		this._lineHighlightDecorationId = null;
+		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
 	}
 
@@ -99,13 +99,13 @@ export class FindDecorations implements IDisposable {
 					this._highlightedDecorationId = newCurrentDecorationId;
 					changeAccessor.changeDecorationOptions(this._highlightedDecorationId, FindDecorations.createFindMatchDecorationOptions(true));
 				}
-				if (this._lineHighlightDecorationId !== null) {
-					changeAccessor.removeDecoration(this._lineHighlightDecorationId);
-					this._lineHighlightDecorationId = null;
+				if (this._rangeHighlightDecorationId !== null) {
+					changeAccessor.removeDecoration(this._rangeHighlightDecorationId);
+					this._rangeHighlightDecorationId = null;
 				}
 				if (newCurrentDecorationId !== null) {
 					let rng = this._editor.getModel().getDecorationRange(newCurrentDecorationId);
-					this._lineHighlightDecorationId = changeAccessor.addDecoration(rng, FindDecorations.createLineHighlightDecoration());
+					this._rangeHighlightDecorationId = changeAccessor.addDecoration(rng, FindDecorations.createRangeHighlightDecoration());
 				}
 			});
 		}
@@ -134,7 +134,7 @@ export class FindDecorations implements IDisposable {
 			this._findScopeDecorationId = null;
 		}
 		this._decorations = tmpDecorations;
-		this._lineHighlightDecorationId = null;
+		this._rangeHighlightDecorationId = null;
 		this._highlightedDecorationId = null;
 	}
 
@@ -144,8 +144,8 @@ export class FindDecorations implements IDisposable {
 		if (this._findScopeDecorationId) {
 			result.push(this._findScopeDecorationId);
 		}
-		if (this._lineHighlightDecorationId) {
-			result.push(this._lineHighlightDecorationId);
+		if (this._rangeHighlightDecorationId) {
+			result.push(this._rangeHighlightDecorationId);
 		}
 		return result;
 	}
@@ -162,10 +162,10 @@ export class FindDecorations implements IDisposable {
 		};
 	}
 
-	private static createLineHighlightDecoration(): editorCommon.IModelDecorationOptions {
+	private static createRangeHighlightDecoration(): editorCommon.IModelDecorationOptions {
 		return {
 			stickiness: editorCommon.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-			className: 'lineHighlight',
+			className: 'rangeHighlight',
 			isWholeLine: true
 		};
 	}

--- a/src/vs/editor/contrib/quickOpen/browser/editorQuickOpen.ts
+++ b/src/vs/editor/contrib/quickOpen/browser/editorQuickOpen.ts
@@ -29,7 +29,7 @@ export class QuickOpenController implements editorCommon.IEditorContribution {
 
 	private editor:ICodeEditor;
 	private widget:QuickOpenEditorWidget;
-	private lineHighlightDecorationId:string;
+	private rangeHighlightDecorationId:string;
 	private lastKnownEditorSelection:Selection;
 
 	constructor(editor:ICodeEditor) {
@@ -93,31 +93,31 @@ export class QuickOpenController implements editorCommon.IEditorContribution {
 	public decorateLine(range:editorCommon.IRange, editor:ICodeEditor):void {
 		editor.changeDecorations((changeAccessor:editorCommon.IModelDecorationsChangeAccessor)=>{
 			var oldDecorations: string[] = [];
-			if (this.lineHighlightDecorationId) {
-				oldDecorations.push(this.lineHighlightDecorationId);
-				this.lineHighlightDecorationId = null;
+			if (this.rangeHighlightDecorationId) {
+				oldDecorations.push(this.rangeHighlightDecorationId);
+				this.rangeHighlightDecorationId = null;
 			}
 
 			var newDecorations: editorCommon.IModelDeltaDecoration[] = [
 				{
 					range: range,
 					options: {
-						className: 'lineHighlight',
+						className: 'rangeHighlight',
 						isWholeLine: true
 					}
 				}
 			];
 
 			var decorations = changeAccessor.deltaDecorations(oldDecorations, newDecorations);
-			this.lineHighlightDecorationId = decorations[0];
+			this.rangeHighlightDecorationId = decorations[0];
 		});
 	}
 
 	public clearDecorations():void {
-		if (this.lineHighlightDecorationId) {
+		if (this.rangeHighlightDecorationId) {
 			this.editor.changeDecorations((changeAccessor:editorCommon.IModelDecorationsChangeAccessor)=>{
-				changeAccessor.deltaDecorations([this.lineHighlightDecorationId], []);
-				this.lineHighlightDecorationId = null;
+				changeAccessor.deltaDecorations([this.rangeHighlightDecorationId], []);
+				this.rangeHighlightDecorationId = null;
 			});
 		}
 	}

--- a/src/vs/workbench/parts/quickopen/browser/gotoLineHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/gotoLineHandler.ts
@@ -161,13 +161,13 @@ class GotoLineEntry extends EditorQuickOpenEntry {
 }
 
 interface IEditorLineDecoration {
-	lineHighlightId: string;
+	rangeHighlightId: string;
 	lineDecorationId: string;
 	position: Position;
 }
 
 export class GotoLineHandler extends QuickOpenHandler {
-	private lineHighlightDecorationId: IEditorLineDecoration;
+	private rangeHighlightDecorationId: IEditorLineDecoration;
 	private lastKnownEditorViewState: IEditorViewState;
 
 	constructor( @IWorkbenchEditorService private editorService: IWorkbenchEditorService) {
@@ -200,18 +200,18 @@ export class GotoLineHandler extends QuickOpenHandler {
 		editor.changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 			let deleteDecorations: string[] = [];
 
-			if (this.lineHighlightDecorationId) {
-				deleteDecorations.push(this.lineHighlightDecorationId.lineDecorationId);
-				deleteDecorations.push(this.lineHighlightDecorationId.lineHighlightId);
-				this.lineHighlightDecorationId = null;
+			if (this.rangeHighlightDecorationId) {
+				deleteDecorations.push(this.rangeHighlightDecorationId.lineDecorationId);
+				deleteDecorations.push(this.rangeHighlightDecorationId.rangeHighlightId);
+				this.rangeHighlightDecorationId = null;
 			}
 
 			let newDecorations: IModelDeltaDecoration[] = [
-				// lineHighlight at index 0
+				// rangeHighlight at index 0
 				{
 					range: range,
 					options: {
-						className: 'lineHighlight',
+						className: 'rangeHighlight',
 						isWholeLine: true
 					}
 				},
@@ -230,11 +230,11 @@ export class GotoLineHandler extends QuickOpenHandler {
 			];
 
 			let decorations = changeAccessor.deltaDecorations(deleteDecorations, newDecorations);
-			let lineHighlightId = decorations[0];
+			let rangeHighlightId = decorations[0];
 			let lineDecorationId = decorations[1];
 
-			this.lineHighlightDecorationId = {
-				lineHighlightId: lineHighlightId,
+			this.rangeHighlightDecorationId = {
+				rangeHighlightId: rangeHighlightId,
 				lineDecorationId: lineDecorationId,
 				position: position
 			};
@@ -242,20 +242,20 @@ export class GotoLineHandler extends QuickOpenHandler {
 	}
 
 	public clearDecorations(): void {
-		if (this.lineHighlightDecorationId) {
+		if (this.rangeHighlightDecorationId) {
 			this.editorService.getVisibleEditors().forEach((editor) => {
-				if (editor.position === this.lineHighlightDecorationId.position) {
+				if (editor.position === this.rangeHighlightDecorationId.position) {
 					let editorControl = <IEditor>editor.getControl();
 					editorControl.changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 						changeAccessor.deltaDecorations([
-							this.lineHighlightDecorationId.lineDecorationId,
-							this.lineHighlightDecorationId.lineHighlightId
+							this.rangeHighlightDecorationId.lineDecorationId,
+							this.rangeHighlightDecorationId.rangeHighlightId
 						], []);
 					});
 				}
 			});
 
-			this.lineHighlightDecorationId = null;
+			this.rangeHighlightDecorationId = null;
 		}
 	}
 

--- a/src/vs/workbench/parts/quickopen/browser/gotoSymbolHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/gotoSymbolHandler.ts
@@ -363,14 +363,14 @@ interface Outline {
 }
 
 interface IEditorLineDecoration {
-	lineHighlightId: string;
+	rangeHighlightId: string;
 	lineDecorationId: string;
 	position: Position;
 }
 
 export class GotoSymbolHandler extends QuickOpenHandler {
 	private outlineToModelCache: { [modelId: string]: OutlineModel; };
-	private lineHighlightDecorationId: IEditorLineDecoration;
+	private rangeHighlightDecorationId: IEditorLineDecoration;
 	private lastKnownEditorViewState: IEditorViewState;
 	private activeOutlineRequest: TPromise<OutlineModel>;
 
@@ -509,19 +509,19 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 		editor.changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 			let deleteDecorations: string[] = [];
 
-			if (this.lineHighlightDecorationId) {
-				deleteDecorations.push(this.lineHighlightDecorationId.lineDecorationId);
-				deleteDecorations.push(this.lineHighlightDecorationId.lineHighlightId);
-				this.lineHighlightDecorationId = null;
+			if (this.rangeHighlightDecorationId) {
+				deleteDecorations.push(this.rangeHighlightDecorationId.lineDecorationId);
+				deleteDecorations.push(this.rangeHighlightDecorationId.rangeHighlightId);
+				this.rangeHighlightDecorationId = null;
 			}
 
 			let newDecorations: IModelDeltaDecoration[] = [
 
-				// lineHighlight at index 0
+				// rangeHighlight at index 0
 				{
 					range: fullRange,
 					options: {
-						className: 'lineHighlight',
+						className: 'rangeHighlight',
 						isWholeLine: true
 					}
 				},
@@ -541,11 +541,11 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 			];
 
 			let decorations = changeAccessor.deltaDecorations(deleteDecorations, newDecorations);
-			let lineHighlightId = decorations[0];
+			let rangeHighlightId = decorations[0];
 			let lineDecorationId = decorations[1];
 
-			this.lineHighlightDecorationId = {
-				lineHighlightId: lineHighlightId,
+			this.rangeHighlightDecorationId = {
+				rangeHighlightId: rangeHighlightId,
 				lineDecorationId: lineDecorationId,
 				position: position
 			};
@@ -553,20 +553,20 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 	}
 
 	public clearDecorations(): void {
-		if (this.lineHighlightDecorationId) {
+		if (this.rangeHighlightDecorationId) {
 			this.editorService.getVisibleEditors().forEach((editor) => {
-				if (editor.position === this.lineHighlightDecorationId.position) {
+				if (editor.position === this.rangeHighlightDecorationId.position) {
 					let editorControl = <IEditor>editor.getControl();
 					editorControl.changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 						changeAccessor.deltaDecorations([
-							this.lineHighlightDecorationId.lineDecorationId,
-							this.lineHighlightDecorationId.lineHighlightId
+							this.rangeHighlightDecorationId.lineDecorationId,
+							this.rangeHighlightDecorationId.rangeHighlightId
 						], []);
 					});
 				}
 			});
 
-			this.lineHighlightDecorationId = null;
+			this.rangeHighlightDecorationId = null;
 		}
 	}
 


### PR DESCRIPTION
In editor we have following feature using lineHighlight decoration 
### Find

Decorating for line (s) containing find matches
### Go to symbol

Decorating line (s) of selected symbol
### Go to line

Decorating requested line

TM themes already use this key for highlighting current line. In order to expose this as tm theme setting, we need a unique and proper key. Looking at the above usages we can call this rangeHighlight.

This PR is to rename lineHighlight to rangeHighlight
