### PR TITLE
Add initialValue? to QuickPickOptions

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -22,6 +22,7 @@ const $ = dom.$;
 
 export interface IInputOptions {
 	placeholder?: string;
+	initialValue?: string;
 	ariaLabel?: string;
 	type?: string;
 	validationOptions?: IInputValidationOptions;
@@ -64,6 +65,7 @@ export class InputBox extends Widget {
 	private options: IInputOptions;
 	private message: IMessage;
 	private placeholder: string;
+	private initialValue: string;
 	private ariaLabel: string;
 	private validation: IInputValidator;
 	private showValidationMessage: boolean;
@@ -83,7 +85,7 @@ export class InputBox extends Widget {
 		this.options = options || Object.create(null);
 		this.message = null;
 		this.cachedHeight = null;
-		this.placeholder = this.options.placeholder || '';
+		this.placeholder = this.options.placeholder;
 		this.ariaLabel = this.options.ariaLabel || '';
 
 		if (this.options.validationOptions) {
@@ -115,9 +117,14 @@ export class InputBox extends Widget {
 			this.input.setAttribute('aria-label', this.ariaLabel);
 		}
 
-		if (this.placeholder) {
+		// Don't allow inputValue and placeholder for aesthetic reasons
+		if (!this.initialValue && this.placeholder) {
 			this.input.setAttribute('placeholder', this.placeholder);
 			this.input.title = this.placeholder;
+		}
+
+		if (this.initialValue) {
+			this.input.setAttribute('value', this.initialValue);
 		}
 
 		this.oninput(this.input, () => this.onValueChange());

--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -41,7 +41,8 @@ export interface IQuickOpenCallbacks {
 export interface IQuickOpenOptions {
 	minItemsToShow?: number;
 	maxItemsToShow?: number;
-	inputPlaceHolder: string;
+	inputPlaceHolder?: string;
+	initialValue?: string;
 	inputAriaLabel?: string;
 	actionProvider?: IActionProvider;
 	enableAnimations?: boolean;
@@ -142,7 +143,8 @@ export class QuickOpenWidget implements IModelProvider {
 			div.div({ 'class': 'quick-open-input' }, (inputContainer) => {
 				this.inputContainer = inputContainer;
 				this.inputBox = new InputBox(inputContainer.getHTMLElement(), null, {
-					placeholder: this.options.inputPlaceHolder || '',
+					placeholder: this.options.inputPlaceHolder,
+					initialValue: this.options.initialValue,
 					ariaLabel: DEFAULT_INPUT_ARIA_LABEL
 				});
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1369,6 +1369,11 @@ declare namespace vscode {
 		ignoreFocusOut?: boolean;
 
 		/**
+		 * An initial value filled into the input box
+		 */
+		initialValue?: string;
+
+		/**
 		 * An optional function that is invoked whenever an item is selected.
 		 */
 		onDidSelectItem?: <T extends QuickPickItem>(item: T | string) => any;

--- a/src/vs/workbench/api/node/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/node/extHostQuickOpen.ts
@@ -36,7 +36,8 @@ export class ExtHostQuickOpen extends ExtHostQuickOpenShape {
 			placeHolder: options && options.placeHolder,
 			matchOnDescription: options && options.matchOnDescription,
 			matchOnDetail: options && options.matchOnDetail,
-			ignoreFocusLost: options && options.ignoreFocusOut
+			ignoreFocusLost: options && options.ignoreFocusOut,
+			initialValue: options && options.initialValue
 		});
 
 		const promise = itemsPromise.then(items => {

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -67,6 +67,7 @@ interface IInternalPickOptions {
 	matchOnDescription?: boolean;
 	matchOnDetail?: boolean;
 	ignoreFocusLost?: boolean;
+	initialValue?: string;
 	onDidType?: (value: string) => any;
 }
 

--- a/src/vs/workbench/services/quickopen/common/quickOpenService.ts
+++ b/src/vs/workbench/services/quickopen/common/quickOpenService.ts
@@ -47,7 +47,15 @@ export interface IPickOptions {
 	 */
 	matchOnDetail?: boolean;
 
+	/**
+	 * an optional flag to indicate that we ignore loss of window focus
+	 */
 	ignoreFocusLost?: boolean;
+
+	/**
+	 * an optional string that serves as the initial text fillout
+	 */
+	initialValue?: string;
 }
 
 export interface IInputOptions {
@@ -72,6 +80,9 @@ export interface IInputOptions {
 	 */
 	password?: boolean;
 
+	/**
+	 * an optional flag to indicate that we ignore loss of window focus
+	 */
 	ignoreFocusLost?: boolean;
 
 	/**


### PR DESCRIPTION
It's sometimes necessary to get a pre-filled QuickPick. In my usecase, I want to
write an extension to navigate directories, and to do this, I need the QuickPick
to be pre-filled with the current directory.

I couldn't test this, because I couldn't figure out for the life of me how to load up an extension in the dev vscode. I know about `~/.vscode-oss-dev`, but I keep running into problems with the `vscode.ts.d` (I had to hand-edit this) and `engines.vscode` settings. Surely, there's a less painful way to co-develop vscode and extensions!
