### PR TITLE
Fix #11284 - Resolve tokens found in settings referenced by launch.json

### DIFF
--- a/src/vs/workbench/parts/lib/node/configVariables.ts
+++ b/src/vs/workbench/parts/lib/node/configVariables.ts
@@ -25,6 +25,7 @@ export class ConfigVariables extends SystemVariables {
 	}
 
 	protected resolveString(value: string): string {
+		const originalValue = value;
 		value = super.resolveString(value);
 
 		let regexp = /\$\{config\.(.*?)\}/g;
@@ -32,9 +33,9 @@ export class ConfigVariables extends SystemVariables {
 			let config = this.configurationService.getConfiguration();
 			let newValue = new Function('_', 'try {return _.' + name + ';} catch (ex) { return "";}')(config);
 			if (Types.isString(newValue)) {
-				return newValue;
-			}
-			else {
+				// Prevent infinite recursion and also support nested references (or tokens)
+				return newValue === originalValue ? '' : this.resolveString(newValue);
+			} else {
 				return this.resolve(newValue) + '';
 			}
 		});


### PR DESCRIPTION
This fixes the issue (https://github.com/Microsoft/vscode/issues/11284):
- Launch.json can reference settings defined in settings.json via the syntax ${config.python.pythonPath}
- if a setting in setting.json such as python.pythonPath="abc", then the value received in the debugger via launch.json is "abc"
- However if the value for python.pythonPath="${workspaceRoot}/bin/python", then the value received by the debugger is "${workspaceRoot}/bin/python", when the value ${workspaceRoot} should be resolved.

Solution is to treat all values referenced by the syntax ${config...} as values that need to be resolved.
