### PR TITLE
Correct docs for Hover.range

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -292,9 +292,7 @@ export interface Hover {
 	contents: MarkedString[];
 
 	/**
-	 * The range to which this hover applies. When missing, the
-	 * editor will use the range at the current position or the
-	 * current position itself.
+	 * The range to which this hover applies.
 	 */
 	range: editorCommon.IRange;
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4163,9 +4163,7 @@ declare module monaco.languages {
          */
         contents: MarkedString[];
         /**
-         * The range to which this hover applies. When missing, the
-         * editor will use the range at the current position or the
-         * current position itself.
+         * The range to which this hover applies.
          */
         range: IRange;
     }

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1617,9 +1617,7 @@ declare namespace vscode {
 		contents: MarkedString[];
 
 		/**
-		 * The range to which this hover applies. When missing, the
-		 * editor will use the range at the current position or the
-		 * current position itself.
+		 * The range to which this hover applies.
 		 */
 		range: Range;
 


### PR DESCRIPTION
Hover items without a range set are ignored.
