### PR TITLE
Fix Terminal.show preserveFocus parameter

### DIFF
--- a/src/vs/workbench/api/node/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/node/mainThreadTerminalService.ts
@@ -26,6 +26,10 @@ export class MainThreadTerminalService extends MainThreadTerminalServiceShape {
 	public $show(terminalId: number, preserveFocus: boolean): void {
 		this._terminalService.show(!preserveFocus).then((terminalPanel) => {
 			this._terminalService.setActiveTerminalById(terminalId);
+			if (!preserveFocus) {
+				// If the panel was already showing an explicit focus call is necessary here.
+				terminalPanel.focus();
+			}
 		});
 	}
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.ts
@@ -87,5 +87,6 @@ export interface ITerminalService {
 
 export interface ITerminalPanel {
 	closeTerminalById(terminalId: number): TPromise<void>;
+	focus(): void;
 	sendTextToActiveTerminal(text: string, addNewLine: boolean): void;
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -69,7 +69,6 @@ export class TerminalService implements ITerminalService {
 		return this.show(false).then((terminalPanel) => {
 			this.activeTerminalIndex = index;
 			terminalPanel.setActiveTerminal(this.activeTerminalIndex);
-			terminalPanel.focus();
 			this._onActiveInstanceChanged.fire();
 		});
 	}


### PR DESCRIPTION
Fixes #11325 

---

Verified that all calls into `setActiveTerminal` come from a `TerminalService.show(focus: boolean)` call which require an explicit indicator so this minimal change should be fine. Manually verified the following cases:
- API
  - Creating terminal via API (focus)
  - Hide terminal then `show(false)` via API (focus)
  - Hide terminal then `show(true)` via API (no focus)
  - Hide terminal then `show(true)` (no focus) then `show(false)` (focus)
- Regular commands
  - Create first terminal (focus)
  - Create second terminal (focus)
  - Focus next/previous terminal (focus)
