### PR TITLE
Fixes #10386: Seeding search text only if search string is empty or manual selection is involved

### DIFF
--- a/src/vs/editor/contrib/find/common/findController.ts
+++ b/src/vs/editor/contrib/find/common/findController.ts
@@ -256,9 +256,11 @@ export class StartFindAction extends EditorAction {
 	public run(accessor:ServicesAccessor, editor:editorCommon.ICommonCodeEditor): void {
 		let controller = CommonFindController.get(editor);
 		if (controller) {
+			let isSearchStringEmpty = controller.getState().searchString.length === 0;
+			let isManualSelection = !editor.getSelection().isEmpty();
 			controller.start({
 				forceRevealReplace: false,
-				seedSearchStringFromSelection: true,
+				seedSearchStringFromSelection: (isSearchStringEmpty || isManualSelection),
 				shouldFocus: FindStartFocusAction.FocusFindInput,
 				shouldAnimate: true
 			});
@@ -417,9 +419,11 @@ export class StartFindReplaceAction extends EditorAction {
 
 		let controller = CommonFindController.get(editor);
 		if (controller) {
+			let isSearchStringEmpty = controller.getState().searchString.length === 0;
+			let isManualSelection = !editor.getSelection().isEmpty();
 			controller.start({
 				forceRevealReplace: true,
-				seedSearchStringFromSelection: true,
+				seedSearchStringFromSelection: (isSearchStringEmpty || isManualSelection),
 				shouldFocus: FindStartFocusAction.FocusReplaceInput,
 				shouldAnimate: true
 			});


### PR DESCRIPTION
Fixes #10386 
Incorporating feedback from @alexandrudima
Now search string override happens only if
1. Search string is empty.
or
2. User has manually selected the text.
