### PR TITLE
Explain change to terminal API coming in v1.6

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3003,7 +3003,9 @@ declare namespace vscode {
 
 		/**
 		 * Send text to the terminal. The text is written to the stdin of the underlying pty process
-		 * (shell) of the terminal.
+		 * (shell) of the terminal. Note that this will currently force the terminal panel to the
+		 * foreground, this is changing in v1.6 such that it will require an explicit call to
+		 * [Terminal.show](#Terminal.show) in order to show the terminal panel.
 		 *
 		 * @param text The text to send.
 		 * @param addNewLine Whether to add a new line to the text being sent, this is normally
@@ -3490,7 +3492,9 @@ declare namespace vscode {
 		export function createStatusBarItem(alignment?: StatusBarAlignment, priority?: number): StatusBarItem;
 
 		/**
-		 * Creates a [Terminal](#Terminal).
+		 * Creates a [Terminal](#Terminal). Note that this will currently force the terminal panel
+		 * to the foreground, this is changing in v1.6 such that it will require an explicit call to
+		 * [Terminal.show](#Terminal.show) in order to show the terminal panel.
 		 *
 		 * @param name Optional human-readable string which will be used to represent the terminal in the UI.
 		 * @return A new Terminal.


### PR DESCRIPTION
Part of #11384 

---

If this looks good I'll merge this and cherry pick to `release/1.5`. Given that `Terminal.sendText` also forces the panel to the foreground currently, I don't think there's much point doing the `createTerminal` workaround (call hide right after) since they will almost always be used one after the other, plus that would force hide the terminal panel if it was already opened.
