### PR TITLE
[jade/pug] Correct highlighting when including CSS/JS

### DIFF
--- a/extensions/jade/syntaxes/Jade.json
+++ b/extensions/jade/syntaxes/Jade.json
@@ -45,7 +45,7 @@
 			]
 		},
 		{
-			"begin": "^(\\s*)(script)(?=[.#(\\s])((?![^\\n]*type=)|(?=[^\\n]*(text|application)/javascript))",
+			"begin": "^(\\s*)(script)((\\.$)|(?=[.#(].*\\.$))",
 			"beginCaptures": {
 				"2": {
 					"name": "entity.name.tag.script.jade"
@@ -84,7 +84,7 @@
 			"begin": "^(\\s*)(style)((\\.$)|(?=[.#(].*\\.$))",
 			"beginCaptures": {
 				"2": {
-					"name": "entity.name.tag.script.jade"
+					"name": "entity.name.tag.style.jade"
 				}
 			},
 			"comment": "Style tag with CSS code.",


### PR DESCRIPTION
Hello, @aeschli,

This PR is fix for https://github.com/devongovett/atom-jade/pull/72 that reproduced in VS Code.

**Before fix:**

![code - oss_2016-09-09_14-25-22](https://cloud.githubusercontent.com/assets/7034281/18385781/44489ac0-769b-11e6-92e8-44068da4faea.png)

**After fix:**

![code - oss_2016-09-09_14-25-53](https://cloud.githubusercontent.com/assets/7034281/18385786/4a6468b2-769b-11e6-8c29-bb90347e7f85.png)
