### PR TITLE
Fix Markdown Preview Code in Header Font Size

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -45,6 +45,16 @@ h1, h2, h3 {
 	font-weight: normal;
 }
 
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+	font-size: inherit;
+	line-height: auto;
+}
+
 a:hover {
 	color: #4080D0;
 	text-decoration: underline;


### PR DESCRIPTION
**Bug**
Issue #1121 In Markdown preview, code blocks in headers are the wrong font size.

**Fix**
Specify that code blocks in headers should inherit their font-size, instead of brining their own.

![screen shot 2016-09-13 at 3 09 19 pm](https://cloud.githubusercontent.com/assets/12821956/18493520/d67026fc-79c5-11e6-8ed9-a58415fe2aa0.png)

Closes #1121 
