### PR TITLE
Display language identifier in Language Mode drop down

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -662,9 +662,12 @@ export class ChangeModeAction extends Action {
 
 		// All languages are valid picks
 		const picks: IPickOpenEntry[] = languages.sort().map((lang, index) => {
-			return {
+			const languageModeId = this.modeService.getModeIdForLanguageName(lang.toLowerCase());
+			const configureLabel = nls.localize('configuredLanguage', "Configured Language");
+
+			return <IPickOpenEntry>{
 				label: lang,
-				description: currentModeId === lang ? nls.localize('configuredLanguage', "Configured Language") : void 0
+				description: currentModeId === lang ? `${languageModeId} (${configureLabel})` : languageModeId
 			};
 		});
 		picks[0].separator = { border: true, label: nls.localize('languagesPicks', "languages") };


### PR DESCRIPTION
Source: #11977

> @mrmlnc happy to review a PR if you wanna give it a shot 👍

@bpasero, I'm not sure about the output format for language identifiers. It seems to me that the `Configured Language` label visually lost.

![code - oss_2016-09-14_18-23-12](https://cloud.githubusercontent.com/assets/7034281/18518642/84251c9c-7aa9-11e6-8060-714647ba9230.png)
