### PR TITLE
Get keycode from 'key' when IME enabled.

### DIFF
--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -154,6 +154,10 @@ interface INormalizedKeyCode {
 }
 
 export function lookupKeyCode(e:KeyboardEvent): KeyCode {
+	// when IME enabled
+	if (e.keyCode === 229) {
+		return KeyCodeUtils.fromString(e.key.toUpperCase());
+	}
 	return KEY_CODE_MAP[e.keyCode] || KeyCode.Unknown;
 }
 


### PR DESCRIPTION
Fixes #10183.

When IME enabled, KeyboardEvent.keyCode is set 229 always.
So, case of inputting keybindings, get keycode via KeyboardEvent.key.
