### PR TITLE
Git quick open should correct invalid branch names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,4 @@
 			"command": "${workspaceRoot}\\scripts\\test.bat --coverage --run ${file}"
 		}
 	}]
-,
-"typescript.check.workspaceVersion": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,4 +24,6 @@
 			"command": "${workspaceRoot}\\scripts\\test.bat --coverage --run ${file}"
 		}
 	}]
+,
+"typescript.check.workspaceVersion": false
 }

--- a/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
+++ b/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
@@ -8,7 +8,7 @@ import { localize } from 'vs/nls';
 import { matchesContiguousSubString } from 'vs/base/common/filters';
 import { TPromise } from 'vs/base/common/winjs.base';
 import Severity from 'vs/base/common/severity';
-import { IGitService, RefType, IRef, isValidBranchName } from 'vs/workbench/parts/git/common/git';
+import { IGitService, RefType, IRef, isValidBranchName, correctBranchName } from 'vs/workbench/parts/git/common/git';
 import { ICommand, CommandQuickOpenHandler } from 'vs/workbench/browser/quickopen';
 import { Mode } from 'vs/base/parts/quickopen/common/quickOpen';
 import { QuickOpenEntry, IHighlight, IContext, QuickOpenEntryGroup } from 'vs/base/parts/quickopen/browser/quickOpenModel';
@@ -190,7 +190,10 @@ class CheckoutCommand implements ICommand {
 		if (currentHeadMatches.length > 0) {
 			entries.unshift(new CurrentHeadEntry(this.gitService, this.messageService, currentHeadMatches[0].head, currentHeadMatches[0].highlights));
 
-		} else if (exactMatches.length === 0 && isValidBranchName(input)) {
+		} else if (exactMatches.length === 0) {
+			if (!isValidBranchName(input)) {
+			input = correctBranchName(input);
+			}
 			const branchEntry = new BranchEntry(this.gitService, this.messageService, input);
 			entries.push(new QuickOpenEntryGroup(branchEntry, 'branch', checkoutEntries.length > 0 || remoteHeadEntries.length > 0));
 		}

--- a/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
+++ b/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
@@ -190,7 +190,7 @@ class CheckoutCommand implements ICommand {
 		if (currentHeadMatches.length > 0) {
 			entries.unshift(new CurrentHeadEntry(this.gitService, this.messageService, currentHeadMatches[0].head, currentHeadMatches[0].highlights));
 
-		} else if (exactMatches.length === 0) {
+		} else if (exactMatches.length === 0 && input.trim()) {
 			if (!isValidBranchName(input)) {
 			input = correctBranchName(input);
 			}

--- a/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
+++ b/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
@@ -34,7 +34,7 @@ class AbstractRefEntry extends QuickOpenEntry {
 	getDescription(): string { return ''; }
 	getAriaLabel(): string { return localize('refAriaLabel', "{0}, git", this.getLabel()); }
 
-	run(mode: Mode, context: IContext):boolean {
+	run(mode: Mode, context: IContext): boolean {
 		if (mode === Mode.PREVIEW) {
 			return false;
 		}
@@ -111,7 +111,7 @@ class BranchEntry extends QuickOpenEntry {
 	getAriaLabel(): string { return localize({ key: 'branchAriaLabel', comment: ['the branch name'] }, "{0}, git branch", this.getLabel()); }
 	getDescription(): string { return localize('createBranch', "Create branch {0}", this.name); }
 
-	run(mode: Mode, context: IContext):boolean {
+	run(mode: Mode, context: IContext): boolean {
 		if (mode === Mode.PREVIEW) {
 			return false;
 		}
@@ -192,7 +192,7 @@ class CheckoutCommand implements ICommand {
 
 		} else if (exactMatches.length === 0 && input) {
 			if (!isValidBranchName(input)) {
-			input = correctBranchName(input);
+				input = correctBranchName(input);
 			}
 			const branchEntry = new BranchEntry(this.gitService, this.messageService, input);
 			entries.push(new QuickOpenEntryGroup(branchEntry, 'branch', checkoutEntries.length > 0 || remoteHeadEntries.length > 0));
@@ -253,7 +253,7 @@ class BranchCommand implements ICommand {
 
 export class GitCommandQuickOpenHandler extends CommandQuickOpenHandler {
 
-	constructor(@IQuickOpenService quickOpenService: IQuickOpenService, @IGitService gitService: IGitService, @IMessageService messageService: IMessageService) {
+	constructor( @IQuickOpenService quickOpenService: IQuickOpenService, @IGitService gitService: IGitService, @IMessageService messageService: IMessageService) {
 		super(quickOpenService, {
 			prefix: 'git',
 			commands: [

--- a/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
+++ b/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
@@ -190,7 +190,7 @@ class CheckoutCommand implements ICommand {
 		if (currentHeadMatches.length > 0) {
 			entries.unshift(new CurrentHeadEntry(this.gitService, this.messageService, currentHeadMatches[0].head, currentHeadMatches[0].highlights));
 
-		} else if (exactMatches.length === 0 && input.trim()) {
+		} else if (exactMatches.length === 0 && input) {
 			if (!isValidBranchName(input)) {
 			input = correctBranchName(input);
 			}
@@ -218,8 +218,12 @@ class BranchCommand implements ICommand {
 	getResults(input: string): TPromise<QuickOpenEntry[]> {
 		input = input.trim();
 
-		if (!isValidBranchName(input)) {
+		if (!input) {
 			return TPromise.as([]);
+		}
+
+		if (!isValidBranchName(input)) {
+			input = correctBranchName(input);
 		}
 
 		const gitModel = this.gitService.getModel();

--- a/src/vs/workbench/parts/git/common/git.ts
+++ b/src/vs/workbench/parts/git/common/git.ts
@@ -342,9 +342,8 @@ export interface IAskpassService {
 const invalidBranchPatternName = /(^\.)|(\/\.)|(\.\.)|(~)|(\^)|(:)|(\/$)|(\.lock$)|(\.lock\/)|(\\)|(\*)|(\s)|(^\s*$)|(\.$)/g;
 
 export function isValidBranchName(value: string): boolean {
-	return !/^\.|\/\.|\.\.|~|\^|:|\/$|\.lock$|\.lock\/|\\|\*|\s|^\s*$/.test(value);
+	return !invalidBranchPatternName.test(value);
 }
-
 export function correctBranchName(branchName: string): string{
 	return branchName.replace(invalidBranchPatternName, '-');
 }

--- a/src/vs/workbench/parts/git/common/git.ts
+++ b/src/vs/workbench/parts/git/common/git.ts
@@ -339,7 +339,12 @@ export interface IAskpassService {
 }
 
 // Utils
+const invalidBranchPatternName = /(^\.)|(\/\.)|(\.\.)|(~)|(\^)|(:)|(\/$)|(\.lock$)|(\.lock\/)|(\\)|(\*)|(\s)|(^\s*$)|(\.$)/g;
 
 export function isValidBranchName(value: string): boolean {
 	return !/^\.|\/\.|\.\.|~|\^|:|\/$|\.lock$|\.lock\/|\\|\*|\s|^\s*$/.test(value);
+}
+
+export function correctBranchName(branchName: string): string{
+	return branchName.replace(invalidBranchPatternName, '-');
 }

--- a/src/vs/workbench/parts/git/common/git.ts
+++ b/src/vs/workbench/parts/git/common/git.ts
@@ -107,7 +107,7 @@ export interface IFileStatus {
 	getPathComponents(): string[];
 	getMimetype(): string;
 	getStatus(): Status;
-	getRename():string;
+	getRename(): string;
 	clone(): IFileStatus;
 	update(other: IFileStatus): void;
 }
@@ -284,13 +284,13 @@ export interface IRawGitService {
 	checkout(treeish?: string, filePaths?: string[]): TPromise<IRawStatus>;
 	clean(filePaths: string[]): TPromise<IRawStatus>;
 	undo(): TPromise<IRawStatus>;
-	reset(treeish:string, hard?: boolean): TPromise<IRawStatus>;
-	revertFiles(treeish:string, filePaths?: string[]): TPromise<IRawStatus>;
+	reset(treeish: string, hard?: boolean): TPromise<IRawStatus>;
+	revertFiles(treeish: string, filePaths?: string[]): TPromise<IRawStatus>;
 	fetch(): TPromise<IRawStatus>;
 	pull(rebase?: boolean): TPromise<IRawStatus>;
-	push(remote?: string, name?: string, options?:IPushOptions): TPromise<IRawStatus>;
+	push(remote?: string, name?: string, options?: IPushOptions): TPromise<IRawStatus>;
 	sync(): TPromise<IRawStatus>;
-	commit(message:string, amend?: boolean, stage?: boolean, signoff?: boolean): TPromise<IRawStatus>;
+	commit(message: string, amend?: boolean, stage?: boolean, signoff?: boolean): TPromise<IRawStatus>;
 	detectMimetypes(path: string, treeish?: string): TPromise<string[]>;
 	show(path: string, treeish?: string): TPromise<string>;
 	getCommitTemplate(): TPromise<string>;
@@ -313,13 +313,13 @@ export interface IGitService extends IEventEmitter {
 	checkout(treeish?: string, files?: IFileStatus[]): TPromise<IModel>;
 	clean(files: IFileStatus[]): TPromise<IModel>;
 	undo(): TPromise<IModel>;
-	reset(treeish:string, hard?: boolean): TPromise<IModel>;
-	revertFiles(treeish:string, files?: IFileStatus[]): TPromise<IModel>;
+	reset(treeish: string, hard?: boolean): TPromise<IModel>;
+	revertFiles(treeish: string, files?: IFileStatus[]): TPromise<IModel>;
 	fetch(): TPromise<IModel>;
 	pull(rebase?: boolean): TPromise<IModel>;
-	push(remote?: string, name?: string, options?:IPushOptions): TPromise<IModel>;
+	push(remote?: string, name?: string, options?: IPushOptions): TPromise<IModel>;
 	sync(): TPromise<IModel>;
-	commit(message:string, amend?: boolean, stage?: boolean, signoff?: boolean): TPromise<IModel>;
+	commit(message: string, amend?: boolean, stage?: boolean, signoff?: boolean): TPromise<IModel>;
 	detectMimetypes(path: string, treeish?: string): TPromise<string[]>;
 	buffer(path: string, treeish?: string): TPromise<string>;
 
@@ -343,6 +343,6 @@ const invalidBranchPatternName = /^\.|\/\.|\.\.|~|\^|:|\/$|\.lock$|\.lock\/|\\|\
 export function isValidBranchName(value: string): boolean {
 	return !invalidBranchPatternName.test(value);
 }
-export function correctBranchName(branchName: string): string{
+export function correctBranchName(branchName: string): string {
 	return branchName.replace(invalidBranchPatternName, '-');
 }

--- a/src/vs/workbench/parts/git/common/git.ts
+++ b/src/vs/workbench/parts/git/common/git.ts
@@ -339,8 +339,7 @@ export interface IAskpassService {
 }
 
 // Utils
-const invalidBranchPatternName = /(^\.)|(\/\.)|(\.\.)|(~)|(\^)|(:)|(\/$)|(\.lock$)|(\.lock\/)|(\\)|(\*)|(\s)|(^\s*$)|(\.$)/g;
-
+const invalidBranchPatternName = /^\.|\/\.|\.\.|~|\^|:|\/$|\.lock$|\.lock\/|\\|\*|\s|^\s*$|\.$/g;
 export function isValidBranchName(value: string): boolean {
 	return !invalidBranchPatternName.test(value);
 }


### PR DESCRIPTION
Currently whenever you try to checkout to a new branch, using the git quick open,
it will only work as long as your branch name is valid.
if your branch name is invalid you will only get "No other branches".
On this PR I am adjusting this behaviour so vscode will correct any invalid characters from the branch name, and still offer the option of creating a new branch.

Original Behaviour:
![original - invalid branch name](https://cloud.githubusercontent.com/assets/7824284/18609720/eead199c-7d11-11e6-8981-e7075b334525.png)
New Behaviour:
![after pr - invalid branch name](https://cloud.githubusercontent.com/assets/7824284/18609719/eea2cfaa-7d11-11e6-8651-c74cfd6a6d76.png)
