### PR TITLE
onInitialize() should check if params.initializationOptions is null

### DIFF
--- a/extensions/json/server/src/jsonServerMain.ts
+++ b/extensions/json/server/src/jsonServerMain.ts
@@ -56,7 +56,9 @@ const filesAssociationContribution = new FileAssociationContribution();
 let workspaceRoot: URI;
 connection.onInitialize((params: InitializeParams): InitializeResult => {
 	workspaceRoot = URI.parse(params.rootPath);
-	filesAssociationContribution.setLanguageIds(params.initializationOptions.languageIds);
+	if (params.initializationOptions) {
+		filesAssociationContribution.setLanguageIds(params.initializationOptions.languageIds);
+	}
 	return {
 		capabilities: {
 			// Tell the client that the server works in FULL text document sync mode


### PR DESCRIPTION
`InitializeParams.initializationOptions` is optional. See:
https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize-request

Also it has just been added to the official protocol:
https://github.com/Microsoft/language-server-protocol/issues/55

Therefore most (if not all) of the clients, other than VSCode, do not
currently include the `initializationOptions` in the Initialize Request.

In order to be reusable the JSON language server should check if the
`initializationOptions` are available before trying to use them.
