### PR TITLE
Add Syntax Highlighting for C# Fenced Code Blocks in Markdown Files

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -196,6 +196,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#fenced_code_block_csharp</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#link-def</string>
 				</dict>
 				<dict>
@@ -1107,6 +1111,22 @@
 						<dict>
 							<key>include</key>
 							<string>source.tsx</string>
+						</dict>
+					</array>
+				</dict>
+				<key>fenced_code_block_csharp</key>
+				<dict>
+					<key>begin</key>
+					<string>(^|\G)\s*([`~]{3,})\s*(cs|csharp|c#)\s*$</string>
+					<key>name</key>
+					<string>markup.fenced_code.block.markdown</string>
+					<key>end</key>
+					<string>(^|\G)(\2)\n</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>source.cs</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
Adds c# to the list of language highlighted in markdown fenced code blocks. You must have a c# language extension install for this to work.

![screen shot 2016-09-19 at 11 55 44 am](https://cloud.githubusercontent.com/assets/12821956/18644905/ff847bb2-7e5f-11e6-9652-d7bafef4e42a.png)

Closes #7003
