### PR TITLE
Fix colorization of html prefixed by spaces in markdown files

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -283,7 +283,7 @@
 					<array>
 						<dict>
 							<key>begin</key>
-							<string>(?i)(^|\G)(?=&lt;(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del).*&lt;/\2\s*&gt;\s*$)</string>
+							<string>(?i)(^|\G)\s*(?=&lt;(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del).*&lt;/\2\s*&gt;\s*$)</string>
 							<key>end</key>
 							<string>$</string>
 							<key>patterns</key>
@@ -296,7 +296,7 @@
 						</dict>
 						<dict>
 							<key>begin</key>
-							<string>(?i)(^|\G)(?=&lt;(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del))</string>
+							<string>(?i)(^|\G)\s*(?=&lt;(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del))</string>
 							<key>patterns</key>
 							<array>
 								<dict>


### PR DESCRIPTION
Issue #12289

**Bug**
Html tags prefixed by 1 to 4 spaces are not colorized properly in markdown files

**Fix**
Consume optional leading whitespace when matching html tags instead of only starting from previous match location

<img width="229" alt="screen shot 2016-09-19 at 4 13 47 pm" src="https://cloud.githubusercontent.com/assets/12821956/18652037/111374ae-7e84-11e6-9688-be48a445baae.png">

closes #12289
