### PR TITLE
Fix markdown highlighting for fenced code block close with space prefix

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -525,7 +525,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -541,7 +541,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -557,7 +557,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -573,7 +573,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -589,7 +589,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -605,7 +605,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -621,7 +621,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -637,7 +637,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -653,7 +653,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -669,7 +669,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -685,7 +685,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -701,7 +701,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -717,7 +717,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -733,7 +733,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -749,7 +749,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -765,7 +765,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -781,7 +781,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -797,7 +797,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -813,7 +813,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -829,7 +829,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -845,7 +845,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -861,7 +861,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -877,7 +877,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -893,7 +893,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -909,7 +909,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -925,7 +925,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -941,7 +941,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -957,7 +957,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -973,7 +973,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -989,7 +989,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1005,7 +1005,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1021,7 +1021,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1037,7 +1037,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1053,7 +1053,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1069,7 +1069,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1085,7 +1085,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1101,7 +1101,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -525,7 +525,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -541,7 +541,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -557,7 +557,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -573,7 +573,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -589,7 +589,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -605,7 +605,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -621,7 +621,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -637,7 +637,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -653,7 +653,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -669,7 +669,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -685,7 +685,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -701,7 +701,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -717,7 +717,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -733,7 +733,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -749,7 +749,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -765,7 +765,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -781,7 +781,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -797,7 +797,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -813,7 +813,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -829,7 +829,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -845,7 +845,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -861,7 +861,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -877,7 +877,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -893,7 +893,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -909,7 +909,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -925,7 +925,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -941,7 +941,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -957,7 +957,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -973,7 +973,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -989,7 +989,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1005,7 +1005,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1021,7 +1021,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1037,7 +1037,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1053,7 +1053,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1069,7 +1069,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1085,7 +1085,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1101,7 +1101,7 @@
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\n</string>
+					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Issue #8636

**Bug**
Fenced code block closing tags break colorization if they are prefixed with spaces like so:

``````
*a*

```json
{}
  ```

*b*
``````

 According to the commonmark spec, up to three spaces are allowed: http://spec.commonmark.org/0.25/#fenced-code-blocks

**Fix**
Update defintion of fenced code block closing tag to support up to three spaces before and any number of spaces after.

Closes #8636
