### PR TITLE
Use blankline to delimit html block in markdown colorization

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -305,7 +305,7 @@
 								</dict>
 							</array>
 							<key>while</key>
-							<string>\G(?!&lt;/\2\s*&gt;)</string>
+							<string>^(?!\s*$)</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
**Bug**
Issue #7725

Nested html is not colorized properly for markdown:

``` md
# Should Colorize

<div class="custom-class" markdown="1">
<div>
# should not colorize
  <div a="3">   
     # should not colorize
  </div>
  # should not colorize
</div>
# should not colorize
</div>

# Should Colorize
fdsafsa
```

![screen shot 2016-09-20 at 6 29 41 pm](https://cloud.githubusercontent.com/assets/12821956/18694594/37ab6a72-7f60-11e6-9b2f-a385ad4876fa.png)

**Fix**
According to the commonmark spec, general html blocks end with a blank line: http://spec.commonmark.org/0.25/#html-blocks

This change relaxes the `while` for html blocks so that we only check for blank lines, instead of trying to match the start tag (which is fragile and fails when nesting the same type of element)

![screen shot 2016-09-20 at 6 30 19 pm](https://cloud.githubusercontent.com/assets/12821956/18694606/4e191b7e-7f60-11e6-8c51-aff5ab5609f7.png)

Closes #7725
