### PR TITLE
Minor case change in README Github -> GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 ## Feedback
 
 * Ask a question on [Stack Overflow](http://stackoverflow.com/questions/tagged/vscode).
-* Request a new feature on [Github](CONTRIBUTING.md).
+* Request a new feature on [GitHub](CONTRIBUTING.md).
 * Vote for [popular feature requests](https://github.com/Microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc).
 * File a bug in [GitHub Issues](https://github.com/Microsoft/vscode/issues).
 * [Tweet](https://twitter.com/code) us with other feedback.


### PR DESCRIPTION
Makes it consistent with the rest of the README.
