### PR TITLE
[emmet] Support for more languages

### DIFF
--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -145,9 +145,6 @@ export class EditorAccessor implements emmet.Editor {
 			return syntax;
 		}
 
-		if (/\b(razor|handlebars)\b/.test(syntax)) { // treat like html
-			return 'html';
-		}
 		if (/\b(typescriptreact|javascriptreact)\b/.test(syntax)) { // treat tsx like jsx
 			return 'jsx';
 		}

--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -172,8 +172,7 @@ export class EditorAccessor implements emmet.Editor {
 			return syntax;
 		}
 		let languages = languageGrammar.split('.');
-		let thisLanguage = languages[languages.length - 1];
-		if (syntax !== thisLanguage || languages.length < 2) {
+		if (languages.length < 2) {
 			return syntax;
 		}
 		for (let i = 1; i < languages.length; i++) {

--- a/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
+++ b/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
@@ -60,18 +60,14 @@ suite('Emmet', () => {
 				testIsEnabled(each, null);
 			});
 
-			// syntaxes mapped to html, hard coded
-			let html = ['razor', 'handlebars'];
-			html.forEach(each => {
-				testIsEnabled(each, null);
-			});
-
+			// mapped syntaxes
 			testIsEnabled('typescriptreact', null);
 			testIsEnabled('javascriptreact', null);
 			testIsEnabled('sass-indented', null);
 
 			// syntaxes mapped using the scope name of the grammar
 			testIsEnabled('markdown', 'text.html.markdown');
+			testIsEnabled('handlebars', 'text.html.handlebars');
 			testIsEnabled('nunjucks', 'text.html.nunjucks');
 			testIsEnabled('laravel-blade', 'text.html.php.laravel-blade');
 
@@ -116,19 +112,14 @@ suite('Emmet', () => {
 				testSyntax(each, null, each);
 			});
 
-			// syntaxes mapped to html, hard coded
-			let html = ['razor', 'handlebars'];
-			html.forEach(each => {
-				testSyntax(each, null, 'html');
-			});
-
+			// mapped syntaxes
 			testSyntax('typescriptreact', null, 'jsx');
 			testSyntax('javascriptreact', null, 'jsx');
-
 			testSyntax('sass-indented', null, 'sass');
 
 			// syntaxes mapped using the scope name of the grammar
 			testSyntax('markdown', 'text.html.markdown', 'html');
+			testSyntax('handlebars', 'text.html.handlebars', 'html');
 			testSyntax('nunjucks', 'text.html.nunjucks', 'html');
 			testSyntax('laravel-blade', 'text.html.php.laravel-blade', 'html');
 

--- a/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
+++ b/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
@@ -71,6 +71,10 @@ suite('Emmet', () => {
 			testIsEnabled('nunjucks', 'text.html.nunjucks');
 			testIsEnabled('laravel-blade', 'text.html.php.laravel-blade');
 
+			// languages that have different Language Id and scopeName
+			testIsEnabled('razer', 'text.html.cshtml');
+			testIsEnabled('HTML (Eex)', 'text.html.elixir');
+
 			// not enabled syntaxes
 			testIsEnabled('java', 'source.java', false);
 			testIsEnabled('javascript', 'source.js', false);
@@ -122,6 +126,10 @@ suite('Emmet', () => {
 			testSyntax('handlebars', 'text.html.handlebars', 'html');
 			testSyntax('nunjucks', 'text.html.nunjucks', 'html');
 			testSyntax('laravel-blade', 'text.html.php.laravel-blade', 'html');
+
+			// languages that have different Language Id and scopeName
+			testSyntax('razer', 'text.html.cshtml', 'html');
+			testSyntax('HTML (Eex)', 'text.html.elixir', 'html');
 
 			// user define mapping
 			testSyntax('java', 'source.java', 'html', {

--- a/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
+++ b/src/vs/workbench/parts/emmet/test/common/editorAccessor.test.ts
@@ -72,7 +72,7 @@ suite('Emmet', () => {
 			testIsEnabled('laravel-blade', 'text.html.php.laravel-blade');
 
 			// languages that have different Language Id and scopeName
-			testIsEnabled('razer', 'text.html.cshtml');
+			testIsEnabled('razor', 'text.html.cshtml');
 			testIsEnabled('HTML (Eex)', 'text.html.elixir');
 
 			// not enabled syntaxes
@@ -128,7 +128,7 @@ suite('Emmet', () => {
 			testSyntax('laravel-blade', 'text.html.php.laravel-blade', 'html');
 
 			// languages that have different Language Id and scopeName
-			testSyntax('razer', 'text.html.cshtml', 'html');
+			testSyntax('razor', 'text.html.cshtml', 'html');
 			testSyntax('HTML (Eex)', 'text.html.elixir', 'html');
 
 			// user define mapping


### PR DESCRIPTION
Source: https://github.com/Microsoft/vscode/issues/11329#issuecomment-247836884 and https://github.com/Microsoft/vscode/issues/11329#issuecomment-247863509
1. Remove hard code mapping for Handlebars (see [click](https://github.com/Microsoft/vscode/blob/master/extensions/handlebars/package.json#L21)) & Razor (see [click](https://github.com/Microsoft/vscode/blob/master/extensions/razor/package.json#L21)) after https://github.com/Microsoft/vscode/pull/12039.
2. Remove old tests for Handlebars & Razor.
3. Remove extra `syntax !== thisLanguage` condition.
4. Add tests for languages that have different Language Id and scopeName. 
