### PR TITLE
Fix colorization for markdown indented paragraphs

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -485,7 +485,7 @@
 				<key>paragraph</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)(?=\S)</string>
+					<string>(^|\G)[ ]{0,3}(?=\S)</string>
 					<key>name</key>
 					<string>meta.paragraph.markdown</string>
 					<key>patterns</key>


### PR DESCRIPTION
Issue #8264

**Bug**
Indented paragraphs are not highlighted in markdown files. Up to three spaces are allowed before the first non space character (4 or more spaces turn it into a code block).

**Fix**
Add rule to consume optional spaces before paragrpah start.

closes #8264
