### PR TITLE
Show Markdown Preview Menu Button For any File Opened as Markdown

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -73,7 +73,7 @@
 		"menus": {
 			"editor/title": [
 				{
-					"when": "resourceLangId == markdown",
+					"when": "editorLangId == markdown",
 					"command": "markdown.showPreview",
 					"alt": "markdown.showPreviewToSide",
 					"group": "navigation"
@@ -86,7 +86,7 @@
 			],
 			"explorer/context": [
 				{
-					"when": "resourceLangId == markdown",
+					"when": "editorLangId == markdown",
 					"command": "markdown.showPreview",
 					"group": "navigation"
 				}


### PR DESCRIPTION
Issue #7638

**Bug**
Open a `.txt` file containing markdown in VSCode. Select the editor language as `markdown` and the highlighing kicks in, but there is no preview button for the file.

**Fix**
Base display of the markdown preview button on `resourceScheme` instead of `resourceLangId`.

![example](https://cloud.githubusercontent.com/assets/12821956/18760051/30daecc2-80b4-11e6-9b62-aa24ad5fb67e.gif)

Closes #7638
