### PR TITLE
Using Cmd+Scroll to zoom on a mac

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -182,7 +182,7 @@ export class MouseHandler extends ViewEventHandler implements IDisposable {
 				return;
 			}
 			let e = new StandardMouseWheelEvent(browserEvent);
-			if (e.browserEvent.ctrlKey) {
+			if (e.browserEvent.ctrlKey || e.browserEvent.metaKey) {
 				let zoomLevel:number = EditorZoom.getZoomLevel();
 				let delta = e.deltaY > 0 ? 1 : -1;
 				EditorZoom.setZoomLevel(zoomLevel + delta);


### PR DESCRIPTION
Issue Microsoft/monaco-editor#201

Bug
Cmd + Scroll doesn't work on a mac. Only Ctrl+Scroll. 
Most mac users would be used to using Cmd instead of Ctrl. 

Fix
Zoom on both Ctrl+Scroll and Cmd+Scroll (metaKey). 

closes Microsoft/monaco-editor#201
