### PR TITLE
Format complex command descriptions for better generated Markdown.

### DIFF
--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -4342,19 +4342,19 @@ export var CommandDescription = {
 			{
 				name: 'Cursor move argument object',
 				description: `Property-value pairs that can be passed through this argument:
-				  * 'to': A mandatory logical position value providing where to move the cursor.
-				    \`\`\`
-				    'left', 'right', 'up', 'down'
-				    'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter'
-				    'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter',
-				    'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside'
-				    \`\`\`
-				  * 'by': Unit to move. Default is computed based on 'to' value.
-				    \`\`\`
-				    'line', 'wrappedLine', 'character', 'halfLine'
-				    \`\`\`
-				  * 'value': Number of units to move. Default is '1'.
-				  * 'select': If 'true' makes the selection. Default is 'false'.
+					* 'to': A mandatory logical position value providing where to move the cursor.
+						\`\`\`
+						'left', 'right', 'up', 'down'
+						'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter'
+						'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter',
+						'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside'
+						\`\`\`
+					* 'by': Unit to move. Default is computed based on 'to' value.
+						\`\`\`
+						'line', 'wrappedLine', 'character', 'halfLine'
+						\`\`\`
+					* 'value': Number of units to move. Default is '1'.
+					* 'select': If 'true' makes the selection. Default is 'false'.
 				`,
 				constraint: isCursorMoveArgs
 			}
@@ -4366,16 +4366,16 @@ export var CommandDescription = {
 			{
 				name: 'Editor scroll argument object',
 				description: `Property-value pairs that can be passed through this argument:
-				  * 'to': A mandatory direction value.
-				    \`\`\`
-				    'up', 'down'
-				    \`\`\`
-				  * 'by': Unit to move. Default is computed based on 'to' value.
-				    \`\`\`
-				    'line', 'wrappedLine', 'page', 'halfPage'
-				    \`\`\`
-				  * 'value': Number of units to move. Default is '1'.
-				  * 'revealCursor': If 'true' reveals the cursor if it is outside view port.
+					* 'to': A mandatory direction value.
+						\`\`\`
+						'up', 'down'
+						\`\`\`
+					* 'by': Unit to move. Default is computed based on 'to' value.
+						\`\`\`
+						'line', 'wrappedLine', 'page', 'halfPage'
+						\`\`\`
+					* 'value': Number of units to move. Default is '1'.
+					* 'revealCursor': If 'true' reveals the cursor if it is outside view port.
 				`,
 				constraint: isEditorScrollArgs
 			}
@@ -4387,11 +4387,11 @@ export var CommandDescription = {
 			{
 				name: 'Reveal line argument object',
 				description: `Property-value pairs that can be passed through this argument:
-				  * 'lineNumber': A mandatory line number value.
-				  * 'at': Logical position at which line has to be revealed .
-				  \`\`\`
-				  'top', 'center', 'bottom'
-				  \`\`\`
+					* 'lineNumber': A mandatory line number value.
+					* 'at': Logical position at which line has to be revealed .
+						\`\`\`
+						'top', 'center', 'bottom'
+						\`\`\`
 				`,
 				constraint: isRevealLineArgs
 			}

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -4342,18 +4342,19 @@ export var CommandDescription = {
 			{
 				name: 'Cursor move argument object',
 				description: `Property-value pairs that can be passed through this argument:
-					'to': A mandatory logical position value providing where to move the cursor.
-					\`\`\`
-						'left', 'right', 'up', 'down',
-						'wrappedLineStart', 'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineColumnCenter', 'wrappedLineEnd' ,'wrappedLineLastNonWhitespaceCharacter',
-						'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside'
-					\`\`\`
-					'by': Unit to move. Default is computed based on 'to' value.
-					\`\`\`
-						'line', 'wrappedLine', 'character', 'halfLine'
-					\`\`\`
-					'value': Number of units to move. Default is '1'.
-					'select': If 'true' makes the selection. Default is 'false'.
+				  * 'to': A mandatory logical position value providing where to move the cursor.
+				    \`\`\`
+				    'left', 'right', 'up', 'down'
+				    'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter'
+				    'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter',
+				    'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside'
+				    \`\`\`
+				  * 'by': Unit to move. Default is computed based on 'to' value.
+				    \`\`\`
+				    'line', 'wrappedLine', 'character', 'halfLine'
+				    \`\`\`
+				  * 'value': Number of units to move. Default is '1'.
+				  * 'select': If 'true' makes the selection. Default is 'false'.
 				`,
 				constraint: isCursorMoveArgs
 			}
@@ -4365,16 +4366,16 @@ export var CommandDescription = {
 			{
 				name: 'Editor scroll argument object',
 				description: `Property-value pairs that can be passed through this argument:
-					'to': A mandatory direction value.
-					\`\`\`
-						'up', 'down'
-					\`\`\`
-					'by': Unit to move. Default is computed based on 'to' value.
-					\`\`\`
-						'line', 'wrappedLine', 'page', 'halfPage'
-					\`\`\`
-					'value': Number of units to move. Default is '1'.
-					'revealCursor': If 'true' reveals the cursor if it is outside view port.
+				  * 'to': A mandatory direction value.
+				    \`\`\`
+				    'up', 'down'
+				    \`\`\`
+				  * 'by': Unit to move. Default is computed based on 'to' value.
+				    \`\`\`
+				    'line', 'wrappedLine', 'page', 'halfPage'
+				    \`\`\`
+				  * 'value': Number of units to move. Default is '1'.
+				  * 'revealCursor': If 'true' reveals the cursor if it is outside view port.
 				`,
 				constraint: isEditorScrollArgs
 			}
@@ -4386,11 +4387,11 @@ export var CommandDescription = {
 			{
 				name: 'Reveal line argument object',
 				description: `Property-value pairs that can be passed through this argument:
-					'lineNumber': A mandatory line number value.
-					'at': Logical position at which line has to be revealed .
-					\`\`\`
-						'top', 'center', 'bottom'
-					\`\`\`
+				  * 'lineNumber': A mandatory line number value.
+				  * 'at': Logical position at which line has to be revealed .
+				  \`\`\`
+				  'top', 'center', 'bottom'
+				  \`\`\`
 				`,
 				constraint: isRevealLineArgs
 			}

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -560,7 +560,7 @@ class UnfoldAction extends FoldingAction<FoldingArguments> {
 					{
 						name: 'Unfold editor argument',
 						description: `Property-value pairs that can be passed through this argument:
-							'level': Number of levels to unfold
+						  * 'level': Number of levels to unfold
 						`,
 						constraint: foldingArgumentsConstraint
 					}
@@ -614,8 +614,8 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 					{
 						name: 'Fold editor argument',
 						description: `Property-value pairs that can be passed through this argument:
-							'levels': Number of levels to fold
-							'up': If 'true' folds given number of levels up otherwise folds down
+						  * 'levels': Number of levels to fold
+						  * 'up': If 'true' folds given number of levels up otherwise folds down
 						`,
 						constraint: foldingArgumentsConstraint
 					}

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -560,7 +560,7 @@ class UnfoldAction extends FoldingAction<FoldingArguments> {
 					{
 						name: 'Unfold editor argument',
 						description: `Property-value pairs that can be passed through this argument:
-						  * 'level': Number of levels to unfold
+							* 'level': Number of levels to unfold
 						`,
 						constraint: foldingArgumentsConstraint
 					}
@@ -614,8 +614,8 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 					{
 						name: 'Fold editor argument',
 						description: `Property-value pairs that can be passed through this argument:
-						  * 'levels': Number of levels to fold
-						  * 'up': If 'true' folds given number of levels up otherwise folds down
+							* 'levels': Number of levels to fold
+							* 'up': If 'true' folds given number of levels up otherwise folds down
 						`,
 						constraint: foldingArgumentsConstraint
 					}

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -114,7 +114,7 @@ class ExtHostApiCommands {
 			returns: 'A promise that resolves to an array of Command-instances.'
 		});
 		this._register('vscode.executeCodeLensProvider', this._executeCodeLensProvider, {
-			description: 'Execute code lens provider.',
+			description: 'Execute CodeLens provider.',
 			args: [
 				{ name: 'uri', description: 'Uri of a text document', constraint: URI }
 			],

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -59,11 +59,10 @@ function registerActiveEditorMoveCommand() {
 			args: [
 				{
 					name: nls.localize('editorCommand.activeEditorMove.arg.name', "Active editor move argument"),
-					description: nls.localize('editorCommand.activeEditorMove.arg.description', `
-						Argument Properties:
-						'to': String value providing where to move.
-						'by': String value providing the unit for move. By tab or by group.
-						'value': Number value providing how many positions or an absolute position to move.
+					description: nls.localize('editorCommand.activeEditorMove.arg.description', `Argument Properties:
+					  * 'to': String value providing where to move.
+					  * 'by': String value providing the unit for move. By tab or by group.
+					  * 'value': Number value providing how many positions or an absolute position to move.
 					`),
 					constraint: isActiveEditorMoveArg
 				}

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -60,9 +60,9 @@ function registerActiveEditorMoveCommand() {
 				{
 					name: nls.localize('editorCommand.activeEditorMove.arg.name', "Active editor move argument"),
 					description: nls.localize('editorCommand.activeEditorMove.arg.description', `Argument Properties:
-					  * 'to': String value providing where to move.
-					  * 'by': String value providing the unit for move. By tab or by group.
-					  * 'value': Number value providing how many positions or an absolute position to move.
+						* 'to': String value providing where to move.
+						* 'by': String value providing the unit for move. By tab or by group.
+						* 'value': Number value providing how many positions or an absolute position to move.
 					`),
 					constraint: isActiveEditorMoveArg
 				}


### PR DESCRIPTION
The last couple of releases I had been manually reformatting the generated API complex commands topic (vscode-api-commands.md). 
This PR Markdown'ifies the command descriptions (use spaces not tabs for indentation, add bullet points).
