### PR TITLE
Fix #1798 -  Disable UndoLastCommit when no commits

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitActions.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.ts
@@ -1152,6 +1152,25 @@ export class UndoLastCommitAction extends GitAction {
 		super(UndoLastCommitAction.ID, UndoLastCommitAction.LABEL, 'git-action undo-last-commit', gitService);
 	}
 
+	protected isEnabled():boolean {
+		if (!super.isEnabled()) {
+			return false;
+		}
+
+		if (!this.gitService.isIdle()) {
+			return false;
+		}
+
+		var model = this.gitService.getModel();
+		var HEAD = model.getHEAD();
+
+		if (!HEAD || !HEAD.commit ) {
+			return false;
+		}
+
+		return true;
+	}
+
 	public run():Promise {
 		return this.gitService.reset('HEAD~');
 	}


### PR DESCRIPTION
This makes `Undo Last Commit` action in Git Integration if there are no commits (usually just after `git init`)

Unfortunately UndoLastCommit will also fail if there is only one commit (`HEAD~` is not defined in such case). But it looks like that currently git integration doesn't provide information about HEAD parent (or commit list, or anything like that) so it would require more "deep" changes.

CC: @joaomoreno as assignee to #1798 
