### PR TITLE
Fix #1939 - Show tag name instead of commit in GitStatusbar

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitWidgets.ts
+++ b/src/vs/workbench/parts/git/browser/gitWidgets.ts
@@ -24,7 +24,7 @@ interface IState {
 	isSyncing: boolean;
 	HEAD: IBranch;
 	remotes: IRemote[];
-	ps1: string;
+	label: string;
 }
 
 const DisablementDelay = 500;
@@ -73,7 +73,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 			isSyncing: false,
 			HEAD: null,
 			remotes: [],
-			ps1: ''
+			label: ''
 		};
 	}
 
@@ -100,6 +100,9 @@ export class GitStatusbarItem implements IStatusbarItem {
 
 	private onGitServiceChange(): void {
 		const model = this.gitService.getModel();
+		const ps1 = model.getPS1();
+		const tags = model.getRefs().filter(iref => iref.commit.substr(0,8) === ps1);
+		const name = tags.length > 0 ? tags[0].name : model.getPS1();
 
 		this.setState({
 			serviceState: this.gitService.getState(),
@@ -107,7 +110,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 			isSyncing: this.gitService.getRunningOperations().some(op => op.id === ServiceOperations.SYNC),
 			HEAD: model.getHEAD(),
 			remotes: model.getRemotes(),
-			ps1: model.getPS1()
+			label: name
 		});
 	}
 
@@ -136,14 +139,14 @@ export class GitStatusbarItem implements IStatusbarItem {
 			}
 
 			if (!HEAD) {
-				textContent = state.ps1;
+				textContent = state.label;
 			} else if (!HEAD.name) {
-				textContent = state.ps1;
+				textContent = state.label;
 				className += ' headless';
 			} else if (!HEAD.commit || !HEAD.upstream || (!HEAD.ahead && !HEAD.behind)) {
-				textContent = state.ps1;
+				textContent = state.label;
 			} else {
-				textContent = state.ps1;
+				textContent = state.label;
 				aheadBehindLabel = strings.format('{0}↓ {1}↑', HEAD.behind, HEAD.ahead);
 			}
 		}

--- a/src/vs/workbench/parts/git/browser/gitWidgets.ts
+++ b/src/vs/workbench/parts/git/browser/gitWidgets.ts
@@ -24,7 +24,7 @@ interface IState {
 	isSyncing: boolean;
 	HEAD: IBranch;
 	remotes: IRemote[];
-	label: string;
+	ps1: string;
 }
 
 const DisablementDelay = 500;
@@ -73,7 +73,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 			isSyncing: false,
 			HEAD: null,
 			remotes: [],
-			label: ''
+			ps1: ''
 		};
 	}
 
@@ -100,9 +100,6 @@ export class GitStatusbarItem implements IStatusbarItem {
 
 	private onGitServiceChange(): void {
 		const model = this.gitService.getModel();
-		const ps1 = model.getPS1();
-		const tags = model.getRefs().filter(iref => iref.commit.substr(0,8) === ps1);
-		const name = tags.length > 0 ? tags[0].name : model.getPS1();
 
 		this.setState({
 			serviceState: this.gitService.getState(),
@@ -110,7 +107,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 			isSyncing: this.gitService.getRunningOperations().some(op => op.id === ServiceOperations.SYNC),
 			HEAD: model.getHEAD(),
 			remotes: model.getRemotes(),
-			label: name
+			ps1: model.getPS1()
 		});
 	}
 
@@ -139,14 +136,14 @@ export class GitStatusbarItem implements IStatusbarItem {
 			}
 
 			if (!HEAD) {
-				textContent = state.label;
+				textContent = state.ps1;
 			} else if (!HEAD.name) {
-				textContent = state.label;
+				textContent = state.ps1;
 				className += ' headless';
 			} else if (!HEAD.commit || !HEAD.upstream || (!HEAD.ahead && !HEAD.behind)) {
-				textContent = state.label;
+				textContent = state.ps1;
 			} else {
-				textContent = state.label;
+				textContent = state.ps1;
 				aheadBehindLabel = strings.format('{0}↓ {1}↑', HEAD.behind, HEAD.ahead);
 			}
 		}

--- a/src/vs/workbench/parts/git/common/gitModel.ts
+++ b/src/vs/workbench/parts/git/common/gitModel.ts
@@ -391,8 +391,9 @@ export class Model extends EventEmitter implements IModel {
 		if (!this.HEAD) {
 			return '';
 		}
-
-		var label = this.HEAD.name || this.HEAD.commit.substr(0, 8);
+		var head = this.HEAD.name || this.HEAD.commit.substr(0, 8);
+		const tags = this.getRefs().filter(iref => iref.commit === this.HEAD.commit);
+		const label = tags.length > 0 ? tags[0].name : head;
 		var statusSummary = this.getStatus().getSummary();
 
 		return format('{0}{1}{2}{3}',


### PR DESCRIPTION
If there exist tag with same `ps1` as checkout commit show tag name, otherwise use `ps1` as before

CC @joaomoreno, issue #1939
