### PR TITLE
Bgashler1/watermark tweeks

### DIFF
--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -11,18 +11,31 @@
 	position: absolute;
 	width: 100%;
 	top: calc(50% + 55px);
-	animation: watermarkfadein 2s;
-	animation-delay: 1s;
-	animation-fill-mode: forwards;
-	opacity: 0;
 }
 
 @keyframes watermarkfadein {
-	from {
+	0% {
 		opacity: 0;
 	}
-	to {
+	33% {
+		opacity: 0;
+	}
+	100% {
 		opacity: 1;
+	}
+}
+
+@media (min-height: 501px) {
+	.monaco-workbench > .part.editor > .watermark {
+		animation: watermarkfadein 2s;
+		opacity: 1;
+		transition: opacity 2s;
+	}
+}
+
+@media (max-height: 500px) {
+	.monaco-workbench > .part.editor > .watermark {
+		opacity: 0;
 	}
 }
 

--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.monaco-workbench .part.editor.empty.watermark-tips {
+	background-position-y: calc(50% - 100px);
+}
+
 .monaco-workbench > .part.editor > .watermark {
 	position: absolute;
 	width: 100%;
-	bottom: 10%;
+	top: calc(50% + 55px);
 }
 
 .monaco-workbench > .part.editor > .watermark dl {

--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -33,21 +33,16 @@
 .monaco-workbench > .part.editor > .watermark dt,
 .monaco-workbench > .part.editor > .watermark dd {
 	margin-bottom: 17px;
-	font-weight: 300;
 }
 
-.monaco-workbench > .part.editor > .watermark dt {
+.monaco-workbench > .part.editor > .watermark dt,
+.monaco-workbench > .part.editor > .watermark dl {
 	color: rgba(0,0,0,.68);
 }
-.monaco-workbench > .part.editor > .watermark dl {
-	color: rgba(0,0,0,.9);
-}
 
-.vs-dark .monaco-workbench > .part.editor > .watermark dt {
-	color: rgba(255,255,255,.6);
-}
+.vs-dark .monaco-workbench > .part.editor > .watermark dt,
 .vs-dark .monaco-workbench > .part.editor > .watermark dl {
-	color: #fff;
+	color: rgba(255,255,255,.6);
 }
 
 .hc-black .monaco-workbench > .part.editor > .watermark dt {

--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -5,6 +5,7 @@
 
 .monaco-workbench .part.editor.empty.watermark-tips {
 	background-position-y: calc(50% - 100px);
+	transition: background-position-y 1s;
 }
 
 .monaco-workbench > .part.editor > .watermark {
@@ -29,13 +30,16 @@
 	.monaco-workbench > .part.editor > .watermark {
 		animation: watermarkfadein 2s;
 		opacity: 1;
-		transition: opacity 2s;
+		transition: opacity 1s;
 	}
 }
 
 @media (max-height: 500px) {
 	.monaco-workbench > .part.editor > .watermark {
 		opacity: 0;
+	}
+	.monaco-workbench .part.editor.empty.watermark-tips {
+		background-position-y: 50%;
 	}
 }
 

--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -25,6 +25,7 @@
 	width: 49%;
 	margin: 0 1% 0 0;
 	text-align: right;
+	font-weight: bold;
 }
 
 .monaco-workbench > .part.editor > .watermark dd {

--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -11,6 +11,19 @@
 	position: absolute;
 	width: 100%;
 	top: calc(50% + 55px);
+	animation: watermarkfadein 2s;
+	animation-delay: 1s;
+	animation-fill-mode: forwards;
+	opacity: 0;
+}
+
+@keyframes watermarkfadein {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }
 
 .monaco-workbench > .part.editor > .watermark dl {

--- a/src/vs/workbench/parts/watermark/watermark.ts
+++ b/src/vs/workbench/parts/watermark/watermark.ts
@@ -50,8 +50,8 @@ export function create(container: Builder, keybindingService: IKeybindingService
 					entry.ids
 						.map(id => keybindingService.lookupKeybindings(id)
 							.map(k => keybindingService.getLabelFor(k))
-							.join(', ') || UNBOUND)
-						.join(' / ')
+							.join(' or ') || UNBOUND)
+						.join(' or ')
 				));
 			}));
 	}

--- a/src/vs/workbench/parts/watermark/watermark.ts
+++ b/src/vs/workbench/parts/watermark/watermark.ts
@@ -41,6 +41,7 @@ export function create(container: Builder, keybindingService: IKeybindingService
 			'class': 'watermark',
 		});
 	function update() {
+		container.addClass('watermark-tips');
 		$(div).clearChildren()
 			.element('dl', {
 			}, dl => entries.map(entry => {


### PR DESCRIPTION
Smoothly responsive to window height.  Never interferes with branding logo.  Vertically aligned to middle with branding logo.

Darkest possible text while still meeting minimum accessibility compliance.

Initial fade in added to speak to the user "hey, this is not an editor"

![sep-26-2016 18-43-35](https://cloud.githubusercontent.com/assets/11839736/18857481/2d70033e-8419-11e6-9884-5b14fbb84afb.gif)

![screen shot 2016-09-26 at 6 37 31 pm](https://cloud.githubusercontent.com/assets/11839736/18857438/bdaa776e-8418-11e6-9016-4f3bc6d42099.png)
![screen shot 2016-09-26 at 6 37 40 pm](https://cloud.githubusercontent.com/assets/11839736/18857439/bdbd90f6-8418-11e6-80d7-f255f48ac43a.png)
