### PR TITLE
Remove extraneous "..." that breaks gulpfile

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -214,7 +214,7 @@ function packageTask(platform, arch, opts) {
 			'!extensions/vscode-colorize-tests/**'
 		], { base: '.' });
 
-		const marketplaceExtensions = es.merge(...builtInExtensions.map(extension => {
+		const marketplaceExtensions = es.merge(builtInExtensions.map(extension => {
 			return ext.src(extension.name, extension.version)
 				.pipe(rename(p => p.dirname = `extensions/${ extension.name }/${ p.dirname }`));
 		}));


### PR DESCRIPTION
Not sure if I'm missing something but the "..." in the gulpfile breaks gulp for me. Removing it seems to allow me to build as normal.
