### PR TITLE
Highlight Markdown Image Starting ! Punctuator

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -1434,8 +1434,7 @@
 					</dict>
 					<key>match</key>
 					<string>(?x:
-						\!							# Images start with !
-						(\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])
+						(\!\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])
 													# Match the link text.
 						([ ])?						# Space not allowed
 						(\()						# Opening paren for url
@@ -1487,7 +1486,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\!(\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])[ ]?(\[)(.*?)(\])</string>
+					<string>(\!\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])[ ]?(\[)(.*?)(\])</string>
 					<key>name</key>
 					<string>meta.image.reference.markdown</string>
 				</dict>

--- a/extensions/markdown/test/colorize-results/test_md.json
+++ b/extensions/markdown/test/colorize-results/test_md.json
@@ -2046,18 +2046,7 @@
 		}
 	},
 	{
-		"c": "!",
-		"t": "image.inline.markdown.meta.paragraph",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "[",
+		"c": "![",
 		"t": "begin.definition.image.inline.markdown.meta.paragraph.punctuation.string",
 		"r": {
 			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.string rgb(206, 145, 120)",


### PR DESCRIPTION
Issue #12835

Adds colorization for the `!` that defines a markdown image link. The `!` is colored the same as the `[` after it.

![screen shot 2016-09-27 at 4 08 24 pm](https://cloud.githubusercontent.com/assets/12821956/18895194/a4f2f598-84cc-11e6-92b1-c1a40461f925.png)

Closes #12835
