### PR TITLE
Extra letter-spacing only on OSX (fixes #13017)

### DIFF
--- a/src/vs/workbench/parts/watermark/watermark.css
+++ b/src/vs/workbench/parts/watermark/watermark.css
@@ -68,6 +68,9 @@
 .monaco-workbench > .part.editor > .watermark dd > .shortcuts {
 	padding-left: 0.5em;
 	padding-right: 0.5em;
+}
+
+.monaco-workbench.mac > .part.editor > .watermark dd > .shortcuts {
 	letter-spacing: 0.15em;
 }
 


### PR DESCRIPTION
fixes #13017
