### PR TITLE
Fix spanish menu typo

### DIFF
--- a/i18n/esn/src/vs/code/electron-main/menus.i18n.json
+++ b/i18n/esn/src/vs/code/electron-main/menus.i18n.json
@@ -101,7 +101,7 @@
 	"miUserVoice": "&&Buscar solicitudes de características",
 	"miViewDebug": "&&Depurar",
 	"miViewExplorer": "&&Explorador",
-	"miViewExtensions": "E& &xtensiones",
+	"miViewExtensions": "E&&xtensiones",
 	"miViewGit": "&&GIT",
 	"miViewSearch": "&&Buscar",
 	"miZoomIn": "&&Ampliar",


### PR DESCRIPTION
Fixed a small typo where the spanish word for "Extensions" had a space in between.
