### PR TITLE
Show message when detected encoding of file is non UTF

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -257,6 +257,11 @@
       "from": "isobject@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
     },
+    "jschardet": {
+      "version": "1.4.1",
+      "from": "jschardet@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.1.tgz"
+    },
     "kind-of": {
       "version": "3.0.4",
       "from": "kind-of@>=3.0.2 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "http-proxy-agent": "0.2.7",
     "https-proxy-agent": "0.3.6",
     "iconv-lite": "0.4.13",
+    "jschardet": "^1.4.1",
     "minimist": "1.2.0",
     "native-keymap": "0.2.0",
     "pty.js": "https://github.com/Tyriar/pty.js/tarball/fffbf86eb9e8051b5b2be4ba9c7b07faa018ce8d",

--- a/src/typings/jschardet.d.ts
+++ b/src/typings/jschardet.d.ts
@@ -1,0 +1,21 @@
+declare module 'jschardet' {
+	export interface IDetectedMap {
+		encoding: string,
+		confidence: number
+	}
+	export interface JsCharDetConstants {
+		_debug: boolean,
+		MINIMUM_THRESHOLD: number
+	}
+	export function detect(buffer: NodeBuffer): IDetectedMap;
+	export const Constants: JsCharDetConstants;
+
+	export class UniversalDetector {
+		constructor();
+		result: IDetectedMap;
+		done: boolean;
+		reset(): void;
+		feed(buffer: NodeBuffer): void;
+		close(): IDetectedMap;
+	}
+}


### PR DESCRIPTION
This related to #5388, #10013.

![screenshot](https://cloud.githubusercontent.com/assets/3643499/19026740/5f60efc0-8964-11e6-9626-de4744bae0ef.gif)
1. Always open file with user preference.
2. If detected non utf encoding, show guess encoding via jschardet.
3. When press 'Reopen', reopen with guess encoding.
