### PR TITLE
Headings outline for markdown

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -13,6 +13,7 @@
 		"Languages"
 	],
 	"activationEvents": [
+		"onLanguage:markdown",
 		"onCommand:markdown.showPreview",
 		"onCommand:markdown.showPreviewToSide",
 		"onCommand:markdown.showSource"


### PR DESCRIPTION
Adds a DocumentSymbolProvider for markdown that lists headings. Should make navigation is large documents easier. 

![screen shot 2016-10-05 at 11 04 07](https://cloud.githubusercontent.com/assets/1794099/19107248/a37a4f48-8aeb-11e6-8dc4-ab2fda977c7f.png)
