### PR TITLE
Call AllowSetForegroundWindow before sending IPC

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -268,6 +268,7 @@ function packageTask(platform, arch, opts) {
 			.pipe(util.cleanNodeModule('oniguruma', ['binding.gyp', 'build/**', 'src/**', 'deps/**'], ['**/*.node']))
 			.pipe(util.cleanNodeModule('windows-mutex', ['binding.gyp', 'build/**', 'src/**'], ['**/*.node']))
 			.pipe(util.cleanNodeModule('native-keymap', ['binding.gyp', 'build/**', 'src/**', 'deps/**'], ['**/*.node']))
+			.pipe(util.cleanNodeModule('windows-foreground-love', ['binding.gyp', 'build/**', 'src/**'], ['**/*.node']))
 			.pipe(util.cleanNodeModule('gc-signals', ['binding.gyp', 'build/**', 'src/**', 'deps/**'], ['**/*.node', 'src/index.js']))
 			.pipe(util.cleanNodeModule('pty.js', ['binding.gyp', 'build/**', 'src/**', 'deps/**'], ['build/Release/**']));
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -414,6 +414,11 @@
       "from": "vscode-textmate@2.2.0",
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-2.2.0.tgz"
     },
+    "windows-foreground-love": {
+      "version": "0.1.0",
+      "from": "windows-foreground-love@0.1.0",
+      "resolved": "https://registry.npmjs.org/windows-foreground-love/-/windows-foreground-love-0.1.0.tgz"
+    },
     "windows-mutex": {
       "version": "0.2.0",
       "from": "windows-mutex@>=0.2.0 <0.3.0",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     }
   },
   "optionalDependencies": {
+    "windows-foreground-love": "0.1.0",
     "windows-mutex": "^0.2.0",
     "fsevents": "0.3.8"
   }

--- a/src/typings/windows-foreground-love.d.ts
+++ b/src/typings/windows-foreground-love.d.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'windows-foreground-love' {
+
+	export function allowSetForegroundWindow(pid?: number): boolean;
+
+}

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -25,7 +25,6 @@ import { AskpassChannel } from 'vs/workbench/parts/git/common/gitIpc';
 import { GitAskpassService } from 'vs/workbench/parts/git/electron-main/askpassService';
 import { spawnSharedProcess } from 'vs/code/node/sharedProcess';
 import { Mutex } from 'windows-mutex';
-import { allowSetForegroundWindow } from 'windows-foreground-love';
 import { LaunchService, ILaunchChannel, LaunchChannel, LaunchChannelClient } from './launch';
 import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
@@ -305,7 +304,12 @@ function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 						promise = service.getMainProcessId()
 							.then(processId => {
 								logService.log('Sending some foreground love to the running instance:', processId);
-								allowSetForegroundWindow(processId);
+								try {
+									const { allowSetForegroundWindow } = <any>require.__$__nodeRequire('windows-foreground-love');
+									allowSetForegroundWindow(processId);
+								} catch (e) {
+									// noop
+								}
 							});
 					}
 


### PR DESCRIPTION
Call `AllowSetForegroundWindow` before sending IPC to the running instance on Windows (Fixes #929)

When a second instance of vscode is started on Windows, it now performs these actions:
1. (New) Get PID of the original instance via IPC.
2. (New) Call `AllowSetForegroundWindow` to allow the original instance to use `SetForegroundWindow`. (https://blogs.msdn.microsoft.com/oldnewthing/20090220-00/?p=19083)
3. Send the `start` IPC to the original instance and exit.

I created a `windows-foreground-love` npm package to wrap the `AllowSetForegroundWindow` API.
