### PR TITLE
Cannot read property 'uri' of null fix

### DIFF
--- a/src/vs/editor/browser/standalone/standaloneEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneEditor.ts
@@ -155,7 +155,9 @@ export function setModelLanguage(model:IModel, language:string): void {
  * Set the markers for a model.
  */
 export function setModelMarkers(model:IModel, owner:string, markers: IMarkerData[]): void {
-	StaticServices.markerService.get().changeOne(owner, model.uri, markers);
+	if (model) {
+		StaticServices.markerService.get().changeOne(owner, model.uri, markers);
+	}
 }
 
 /**


### PR DESCRIPTION
There is a case that throw **TypeError: Cannot read property 'uri' of null** when I try to construct and remove the monaco editor in short amount of time in an web app. The **setModelMarkers** is in call stack already while the model is already removed.
