### PR TITLE
Remove incorrect ANSI escape code for LF

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -531,14 +531,12 @@ export function lcut(text: string, n: number): string {
 // Escape codes
 // http://en.wikipedia.org/wiki/ANSI_escape_code
 const EL = /\x1B\x5B[12]?K/g; // Erase in line
-const LF = /\xA/g; // line feed
 const COLOR_START = /\x1b\[\d+m/g; // Color
 const COLOR_END = /\x1b\[0?m/g; // Color
 
 export function removeAnsiEscapeCodes(str: string): string {
 	if (str) {
 		str = str.replace(EL, '');
-		str = str.replace(LF, '\n');
 		str = str.replace(COLOR_START, '');
 		str = str.replace(COLOR_END, '');
 	}


### PR DESCRIPTION
ANSI technically doesn't have an escape code for LF, since it just uses the 0x0A character. The regex `\xA` is incorrect (it should be `\x0A`) and is being treated as the two-character sequence `"xA"`. But then once we've fixed that, replacing 0x0A with \n in `removeAnsiEscapeCodes` is a no-op. Better to just remove the `str.replace(LF, '\n')` call.

Fixes #12608.
