### PR TITLE
Git sync info

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -12,7 +12,6 @@
 	color: white;
 	font-size: 12px;
 	padding: 0 10px;
-	overflow: hidden;
 }
 
 .monaco-workbench.no-workspace > .part.statusbar {

--- a/src/vs/workbench/parts/git/browser/gitWidgets.ts
+++ b/src/vs/workbench/parts/git/browser/gitWidgets.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import nls = require('vs/nls');
-import strings = require('vs/base/common/strings');
 import { Delayer } from 'vs/base/common/async';
 import { $, append, show, hide, toggleClass } from 'vs/base/browser/dom';
 import { IAction } from 'vs/base/common/actions';
@@ -39,6 +38,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 	private branchElement: HTMLElement;
 	private publishElement: HTMLElement;
 	private syncElement: HTMLElement;
+	private syncInfo: HTMLElement;
 	private syncLabelElement: HTMLElement;
 	private disablementDelayer: Delayer<void>;
 
@@ -86,10 +86,14 @@ export class GitStatusbarItem implements IStatusbarItem {
 		this.publishElement.title = nls.localize('publishBranch', "Publish Branch");
 		this.publishElement.onclick = () => this.onPublishClick();
 
-		this.syncElement = append(this.element, $('a.git-statusbar-sync-item'));
+		const syncContainer = append(this.element, $('span.git-statusbar-sync'));
+
+		this.syncElement = append(syncContainer, $('a.git-statusbar-sync-item'));
 		this.syncElement.title = nls.localize('syncBranch', "Synchronize Changes");
 		this.syncElement.onclick = () => this.onSyncClick();
 		append(this.syncElement, $('span.octicon.octicon-sync'));
+
+		this.syncInfo = append(syncContainer, $('.git-statusbar-sync-info'));
 
 		this.syncLabelElement = append(this.syncElement, $('span.ahead-behind'));
 
@@ -118,6 +122,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 		let className = 'git-statusbar-branch-item';
 		let textContent: string;
 		let aheadBehindLabel = '';
+		let aheadBehindInfoLabel = '';
 		let title = '';
 		let onclick: () => void = null;
 
@@ -144,7 +149,8 @@ export class GitStatusbarItem implements IStatusbarItem {
 				textContent = state.ps1;
 			} else {
 				textContent = state.ps1;
-				aheadBehindLabel = strings.format('{0}↓ {1}↑', HEAD.behind, HEAD.ahead);
+				aheadBehindLabel = `${ HEAD.behind }↓ ${ HEAD.ahead }↑`;
+				aheadBehindInfoLabel = nls.localize('commits', "Push {0} commits and pull {1} commits", HEAD.ahead, HEAD.behind);
 			}
 		}
 
@@ -153,6 +159,7 @@ export class GitStatusbarItem implements IStatusbarItem {
 		this.branchElement.textContent = textContent;
 		this.branchElement.onclick = onclick;
 		this.syncLabelElement.textContent = aheadBehindLabel;
+		this.syncInfo.textContent = aheadBehindInfoLabel;
 
 		if (isGitDisabled) {
 			hide(this.branchElement);

--- a/src/vs/workbench/parts/git/browser/media/git.contribution.css
+++ b/src/vs/workbench/parts/git/browser/media/git.contribution.css
@@ -122,7 +122,7 @@
 
 /* Status bar */
 
-.monaco-shell .git-statusbar-group > a {
+.monaco-shell .git-statusbar-group a {
 	padding: 0 5px;
 }
 
@@ -140,7 +140,13 @@
 	font-size: 14px;
 }
 
-.monaco-shell .git-statusbar-group > .git-statusbar-sync-item:not(.empty) > span.octicon {
+.monaco-shell .git-statusbar-group > .git-statusbar-sync {
+	position: relative;
+	height: 100%;
+	display: inline-block;
+}
+
+.monaco-shell .git-statusbar-group > .git-statusbar-sync > .git-statusbar-sync-item:not(.empty) > span.octicon {
 	margin-right: 6px;
 }
 
@@ -149,12 +155,12 @@
 	to { transform: rotate(1080deg); }
 }
 
-.monaco-shell .git-statusbar-group > .git-statusbar-sync-item.syncing > .octicon {
+.monaco-shell .git-statusbar-group > .git-statusbar-sync > .git-statusbar-sync-item.syncing > .octicon {
 	animation: 2s ease-in-out infinite spin;
 }
 
-.monaco-shell .git-statusbar-group > .git-statusbar-sync-item.disabled > .ahead-behind,
-.monaco-shell .git-statusbar-group > .git-statusbar-sync-item.busy > .ahead-behind {
+.monaco-shell .git-statusbar-group > .git-statusbar-sync > .git-statusbar-sync-item.disabled > .ahead-behind,
+.monaco-shell .git-statusbar-group > .git-statusbar-sync > .git-statusbar-sync-item.busy > .ahead-behind {
 	cursor: default;
 }
 
@@ -178,4 +184,28 @@
 
 .monaco-shell .git-statusbar-group > .git-statusbar-branch-item.headless {
 	font-style: italic;
+}
+
+.monaco-shell .git-statusbar-group > .git-statusbar-sync > .git-statusbar-sync-info {
+	display: none;
+	position: absolute;
+	bottom: 22px;
+	left: 0;
+	color: #6C6C6C;
+	border: 1px solid #CCC;
+	border-bottom: none;
+	background-color: #F3F3F3;
+	padding: 4px 6px 3px 6px;
+	width: 120px;
+}
+
+.monaco-shell .git-statusbar-group > .git-statusbar-sync:hover > .git-statusbar-sync-info:not(:empty) {
+	display: block;
+}
+
+
+.vs-dark .monaco-workbench .git-statusbar-group > .git-statusbar-sync > .git-statusbar-sync-info {
+	color: #bbbbbb;
+	background-color: #2D2D30;
+	border-color: #555;
 }


### PR DESCRIPTION
Proposed alternative to #13313, fixes #8655

@chrmarti @bgashler1 This is what I meant.

![image](https://cloud.githubusercontent.com/assets/22350/19195175/b8566dae-8cb0-11e6-8a2a-7c6dee83372e.png)

The tooltip shows instantly, so you can't miss it. We can even render anything in there... like the actual commit IDs and messages in- and outgoing.
