### PR TITLE
reimplement spread operator for node 4

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -210,12 +210,12 @@ function packageTask(platform, arch, opts) {
 			'!extensions/typescript/bin/**',
 			'!extensions/vscode-api-tests/**',
 			'!extensions/vscode-colorize-tests/**',
-			...builtInExtensions.map(e => `!extensions/${ e.name }/**`)
 		];
+		builtInExtensions.map(extensionsList.push(e => `!extensions/${ e.name }/**`));
 
 		const extensions = gulp.src(extensionsList, { base: '.' });
 
-		const marketplaceExtensions = es.merge(...builtInExtensions.map(extension => {
+		const marketplaceExtensions = es.merge.apply(undefined, builtInExtensions.map(extension => {
 			return ext.src(extension.name, extension.version)
 				.pipe(rename(p => p.dirname = `extensions/${ extension.name }/${ p.dirname }`));
 		}));


### PR DESCRIPTION
This reimplements the spread operator for node 4.  As of now node 4
is the stable LTS release, and so it is the version which is supplied
on many distributions.  This change reimplements the gulpfile to not
use spread operator to make vscode working on systems using node 4.
