### PR TITLE
Sort the installed extension list

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -223,6 +223,7 @@ export class ExtensionsViewlet extends Viewlet implements IExtensionsViewlet {
 		if (!value) {
 			// Show installed extensions
 			return this.extensionsWorkbenchService.queryLocal()
+				.then(result => result.sort((e1, e2) => e1.displayName.localeCompare(e2.displayName)))
 				.then(result => result.filter(e => e.type === LocalExtensionType.User))
 				.then(result => new PagedModel(result));
 		}


### PR DESCRIPTION
According to #12910. This PR will sort the installed extensions by its name in ascending order.
