### PR TITLE
vs-seti-icon-theme: show icon for 'TODOs' files

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -826,6 +826,7 @@
 		"LICENSE": "_license",
 		"Procfile": "_heroku",
 		"TODO": "_todo",
+		"TODOs": "_todo",
 		"npm-debug.log": "_npm_ignored"
 	},
 	"languageIds": {


### PR DESCRIPTION
Update vs-seti-icon-theme to show the todo icon for files named 'TODOs' as well.
