### PR TITLE
Support installing deps with yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out-vscode/
 out-vscode-min/
 build/node_modules
 coverage/
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vscode-debugprotocol": "1.13.0",
     "vscode-textmate": "2.2.0",
     "winreg": "1.2.0",
-    "xterm": "git+https://github.com/Tyriar/xterm.js.git#vscode-release/1.6",
+    "xterm": "git+https://github.com/Tyriar/xterm.js.git#vscode-release",
     "yauzl": "2.3.1"
   },
   "devDependencies": {
@@ -109,8 +109,8 @@
     }
   },
   "optionalDependencies": {
+    "fsevents": "0.3.8",
     "windows-foreground-love": "0.1.0",
-    "windows-mutex": "^0.2.0",
-    "fsevents": "0.3.8"
+    "windows-mutex": "^0.2.0"
   }
 }

--- a/scripts/yarn.sh
+++ b/scripts/yarn.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
+	ROOT=$(dirname $(dirname $(realpath "$0")))
+	npm_config_arch=x64
+else
+	ROOT=$(dirname $(dirname $(readlink -f $0)))
+
+	# if [ -z $yarn_config_arch ]; then
+	# 	npm_config_arch=$(node -p process.arch)
+	# 	echo "Warning: remember to set \$yarn_config_arch to either x64 or ia32 to build the binaries for the right architecture. Picking '$yarn_config_arch'."
+	# fi
+fi
+
+ELECTRON_VERSION=$(
+	cat $ROOT/package.json |
+	grep electronVersion |
+	sed -e 's/[[:space:]]*"electronVersion":[[:space:]]*"\([0-9.]*\)"\(,\)*/\1/'
+)
+
+ELECTRON_GYP_HOME=~/.electron-gyp
+mkdir -p $ELECTRON_GYP_HOME
+
+npm_config_disturl=https://atom.io/download/atom-shell \
+npm_config_target=$ELECTRON_VERSION \
+npm_config_runtime=electron \
+HOME=$ELECTRON_GYP_HOME \
+yarn $*


### PR DESCRIPTION
There's a new package manager in town and it's really fast. Figure we could add this for some of us to use during development while we evaluate. @joaomoreno feel free to merge if you're good with it.

Notes:
- It's _really_ fast, this is the cached/second run speed:
  
  ```
  > time ./scripts/npm.sh install --arch=x64
  ...
  real    1m54.064s
  user    1m40.364s
  sys     0m10.160s
  ```
  
  ```
  > time ./scripts/yarn.sh install --arch=x64
  ...
  real    0m23.007s
  user    0m26.692s
  sys     0m3.624s
  ```
  
  The main speed gain seems to be in that native modules are built concurrently with up to 5 building at a time:
  
  ```
  [1/6] ⡀ gc-signals: node@6.7.0 | linux | x64
  [-/6] ⡀ waiting...
  [3/6] ⡀ native-keymap: node@6.7.0 | linux | x64
  [4/6] ⡀ pty.js
  [5/6] ⡀ oniguruma: node@6.7.0 | linux | x64
  ```
- It mentions in the output that npm-shrinkwrap.json is not respected:
  
  ```
  error npm-shrinkwrap.json found. This will not be updated or respected. See [TODO] for more information.
  ```
- Added `yarn.lock` to `.gitignore`, here's some info on the file: https://yarnpkg.com/en/docs/yarn-lock
- Removed `/1.6` from the xterm.js branch and filed a bug against yarn (https://github.com/yarnpkg/yarn/issues/744), this still seems to work fine on with `./scripts/npm.sh`, perhaps because the exact commit is specified in `npm-shrinkwrap.json`
- I did a quick sanity test of vscode built using yarn and it seems fine.
- Tested only Ubuntu 16.04 with command `./scripts/yarn.sh install --arch=x64`
