### PR TITLE
quick open files in background

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -166,12 +166,12 @@ export class QuickOpenWidget implements IModelProvider {
 					}
 
 					// Select element on Enter
-					else if (keyboardEvent.keyCode === KeyCode.Enter) {
+					else if (keyboardEvent.keyCode === KeyCode.Enter || keyboardEvent.keyCode === KeyCode.RightArrow) {
 						DOM.EventHelper.stop(e, true);
 
 						const focus = this.tree.getFocus();
 						if (focus) {
-							this.elementSelected(focus, e);
+							this.elementSelected(focus, keyboardEvent);
 						}
 					}
 
@@ -406,8 +406,20 @@ export class QuickOpenWidget implements IModelProvider {
 
 		// Trigger open of element on selection
 		if (this.isVisible()) {
-			const context: IEntryRunContext = { event, keymods: this.extractKeyMods(event), quickNavigateConfiguration: this.quickNavigateConfiguration };
-			hide = this.model.runner.run(value, Mode.OPEN, context);
+			let eventForContext = event;
+			let mode = Mode.OPEN;
+
+			if (event instanceof StandardKeyboardEvent) {
+				eventForContext = event.browserEvent;
+
+				if (event.keyCode === KeyCode.RightArrow) {
+					mode = Mode.OPEN_IN_BACKGROUND;
+				}
+			}
+
+			const context: IEntryRunContext = { event: eventForContext, keymods: this.extractKeyMods(eventForContext), quickNavigateConfiguration: this.quickNavigateConfiguration };
+
+			hide = this.model.runner.run(value, mode, context);
 		}
 
 		// add telemetry when an item is accepted, logging the index of the item in the list and the length of the list

--- a/src/vs/base/parts/quickopen/common/quickOpen.ts
+++ b/src/vs/base/parts/quickopen/common/quickOpen.ts
@@ -43,7 +43,8 @@ export interface IAutoFocus {
 
 export enum Mode {
 	PREVIEW,
-	OPEN
+	OPEN,
+	OPEN_IN_BACKGROUND
 }
 
 export interface IEntryRunContext {

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -1116,7 +1116,7 @@ export class EditorHistoryEntry extends EditorQuickOpenEntry {
 			return true;
 		}
 
-		return false;
+		return super.run(mode, context);
 	}
 }
 

--- a/src/vs/workbench/parts/search/browser/openSymbolHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openSymbolHandler.ts
@@ -79,7 +79,8 @@ class SymbolEntry extends EditorQuickOpenEntry {
 			.then(_ => super.run(mode, context))
 			.done(undefined, onUnexpectedError);
 
-		return true;
+		// hide if OPEN
+		return mode === Mode.OPEN;
 	}
 
 	public getInput(): IResourceInput | EditorInput {


### PR DESCRIPTION
- allows one to continually open files while keeping quick open widget focused
- uses the right modifier key to open in background
- can open in split view if using the cmd trigger key

refs #13711 
