### PR TITLE
Text upper and lower case commands as CoreCommand:

### DIFF
--- a/src/vs/editor/common/config/config.ts
+++ b/src/vs/editor/common/config/config.ts
@@ -494,6 +494,29 @@ registerCommand(new CoreCommand({
 	}
 }));
 
+
+registerCommand(new CoreCommand({
+	id: H.TextUpperCase,
+	precondition: ContextKeyExpr.and(EditorContextKeys.Writable, EditorContextKeys.HasNonEmptySelection),
+	kbOpts: {
+		weight: CORE_WEIGHT,
+		// kbExpr: EditorContextKeys.TextFocus,
+		kbExpr: null,
+		primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_U
+	}
+}));
+registerCommand(new CoreCommand({
+	id: H.TextLowerCase,
+	precondition: ContextKeyExpr.and(EditorContextKeys.Writable, EditorContextKeys.HasNonEmptySelection),
+	kbOpts: {
+		weight: CORE_WEIGHT,
+		// kbExpr: EditorContextKeys.TextFocus,
+		kbExpr: null,
+		primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_L
+	}
+}));
+
+
 registerCoreAPICommand(H.RevealLine, D.RevealLine);
 
 registerCommand(new CoreCommand({

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -1009,6 +1009,9 @@ export class Cursor extends EventEmitter {
 		this._handlers[H.ScrollPageUp] = (ctx) => this._scrollUp(true, ctx);
 		this._handlers[H.ScrollPageDown] = (ctx) => this._scrollDown(true, ctx);
 
+		this._handlers[H.TextUpperCase] = (ctx) => this._textUpperCase(ctx);
+		this._handlers[H.TextLowerCase] = (ctx) => this._textLowerCase(ctx);
+
 		this._handlers[H.DeleteLeft] = (ctx) => this._deleteLeft(ctx);
 
 		this._handlers[H.DeleteWordLeft] = (ctx) => this._deleteWordLeft(true, WordNavigationType.WordStart, ctx);
@@ -1539,6 +1542,28 @@ export class Cursor extends EventEmitter {
 		ctx.eventData = <editorCommon.EditorScrollArguments>{ to: editorCommon.EditorScrollDirection.Down, value: 1 };
 		ctx.eventData.by = isPaged ? editorCommon.EditorScrollByUnit.Page : editorCommon.EditorScrollByUnit.WrappedLine;
 		return this._editorScroll(ctx);
+	}
+
+	private _textUpperCase(ctx: IMultipleCursorOperationContext): boolean {
+		if (this.configuration.editor.readOnly || this.model.hasEditableRange()) {
+			return false;
+		}
+
+		const toUpperCase = true;
+		return this._invokeForAllSorted(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => {
+			return OneCursorOp.changeCase(oneCursor, toUpperCase, oneCtx)
+		});
+	}
+
+	private _textLowerCase(ctx: IMultipleCursorOperationContext): boolean {
+		if (this.configuration.editor.readOnly || this.model.hasEditableRange()) {
+			return false;
+		}
+
+		const toUpperCase = false;
+		return this._invokeForAllSorted(ctx, (cursorIndex: number, oneCursor: OneCursor, oneCtx: IOneCursorOperationContext) => {
+			return OneCursorOp.changeCase(oneCursor, toUpperCase, oneCtx)
+		});
 	}
 
 	private _distributePasteToCursors(ctx: IMultipleCursorOperationContext): string[] {

--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -6,7 +6,7 @@
 
 import { onUnexpectedError, illegalArgument } from 'vs/base/common/errors';
 import * as strings from 'vs/base/common/strings';
-import { ReplaceCommand, ReplaceCommandWithOffsetCursorState, ReplaceCommandWithoutChangingPosition } from 'vs/editor/common/commands/replaceCommand';
+import { ReplaceCommand, ReplaceCommandWithOffsetCursorState, ReplaceCommandWithoutChangingPosition, ReplaceCommandThatPreservesSelection } from 'vs/editor/common/commands/replaceCommand';
 import { ShiftCommand } from 'vs/editor/common/commands/shiftCommand';
 import { SurroundSelectionCommand } from 'vs/editor/common/commands/surroundSelectionCommand';
 import { CursorMoveHelper, ICursorMoveHelperModel, IMoveResult, IColumnSelectResult, IViewColumnSelectResult } from 'vs/editor/common/controller/cursorMoveHelper';
@@ -1808,6 +1808,23 @@ export class OneCursorOp {
 		}
 		ctx.executeCommand = new ReplaceCommand(selection, text);
 		return true;
+	}
+
+	public static changeCase(cursor: OneCursor, toUpperCase: boolean, ctx: IOneCursorOperationContext): boolean {
+		let selection: Selection = cursor.getSelection();
+		if (selection.isEmpty()) {
+			return false;
+		}
+
+		let selectionText = cursor.model.getValueInRange(selection);
+		if (selectionText) {
+			ctx.shouldPushStackElementBefore = true;
+			let replacementText = toUpperCase ? selectionText.toUpperCase() : selectionText.toLowerCase();
+			ctx.executeCommand = new ReplaceCommandThatPreservesSelection(selection, replacementText, selection);
+			return true;
+		}
+
+		return false;
 	}
 
 	// -------------------- END type interceptors & co.

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -4575,6 +4575,9 @@ export var Handler = {
 	ScrollPageUp: 'scrollPageUp',
 	ScrollPageDown: 'scrollPageDown',
 
+	TextUpperCase: 'textUpperCase',
+	TextLowerCase: 'textLowerCase',
+
 	RevealLine: 'revealLine'
 };
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3384,6 +3384,8 @@ declare module monaco.editor {
         ScrollLineDown: string;
         ScrollPageUp: string;
         ScrollPageDown: string;
+        TextUpperCase: string;
+        TextLowerCase: string;
         RevealLine: string;
     };
 


### PR DESCRIPTION
- uppercase is alt+shift+u.
- lowercase is alt+shift+l.

---

Hi,

Please tell me if this is correct way to go about doing this.
More than happy to hear suggestions...

Reference issue: https://github.com/Microsoft/vscode/issues/8340.
