### PR TITLE
Bgashler1/issue/13529/no animation watermark

### DIFF
--- a/src/vs/workbench/parts/watermark/browser/watermark.css
+++ b/src/vs/workbench/parts/watermark/browser/watermark.css
@@ -52,7 +52,7 @@
 	.monaco-workbench > .part.editor.empty > .watermark {
 		opacity: 0;
 	}
-	.monaco-workbench .part.editor.empty {
+	.monaco-workbench .part.editor.empty.has-watermark {
 		background-position-y: 50%;
 	}
 }

--- a/src/vs/workbench/parts/watermark/browser/watermark.css
+++ b/src/vs/workbench/parts/watermark/browser/watermark.css
@@ -5,7 +5,6 @@
 
 .monaco-workbench .part.editor.empty.has-watermark {
 	background-position-y: calc(50% - 100px);
-	transition: background-position-y 1s;
 }
 
 .monaco-workbench > .part.editor > .watermark {
@@ -28,29 +27,15 @@
 	border-spacing: 13px 17px;
 }
 
-@keyframes watermarkfadein {
-	0% {
-		opacity: 0;
-	}
-	33% {
-		opacity: 0;
-	}
-	100% {
-		opacity: 1;
-	}
-}
-
 @media (min-height: 501px) {
 	.monaco-workbench > .part.editor.empty > .watermark {
-		animation: watermarkfadein 2s;
-		opacity: 1;
-		transition: opacity 1s;
+		display: block;
 	}
 }
 
 @media (max-height: 500px) {
 	.monaco-workbench > .part.editor.empty > .watermark {
-		opacity: 0;
+		display: none;
 	}
 	.monaco-workbench .part.editor.empty.has-watermark {
 		background-position-y: 50%;


### PR DESCRIPTION
![oct-24-2016 15-57-05](https://cloud.githubusercontent.com/assets/11839736/19666966/8b5f2840-9a02-11e6-95f7-384248dc2e65.gif)

Fixes #13529

Removes all animations/transitions from the watermark.  Everything is instantaneous and snappy (including when you close editors, open a new window, and when you resize).

fyi @chrmarti 
