### PR TITLE
Add User Setting for Highlight.js Theme used in Markdown Preview

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -90,6 +90,7 @@ code {
 	font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
 	font-size: 14px;
 	line-height: 19px;
+	background: inherit;
 }
 
 .mac code {
@@ -101,6 +102,10 @@ code > div {
 	padding: 16px;
 	border-radius: 3px;
 	overflow: auto;
+}
+
+pre.hljs {
+	background-color: inherit;
 }
 
 /** Theming */

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -120,6 +120,11 @@
 					"type": ["array"],
 					"default": [],
 					"description": "A list of URLs or local paths to CSS style sheets to use from the markdown preview. Relative paths are interpreted relative to the folder open in the explorer. If there is no open folder, they are interpreted relative to the location of the markdown file. All '\\' need to be written as '\\\\'."
+				},
+				"markdown.highlightStyle": {
+					"type": ["string"],
+					"default": "",
+					"description": "Name of the highlight.js style used for syntax highlighting in the markdown preview."
 				}
 			}
 		}

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -164,6 +164,7 @@ class MDDocumentContentProvider implements TextDocumentContentProvider {
 		this._context = context;
 		this._waiting = false;
 		this._renderer = this.createRenderer();
+		this._alertedForMissingTheme = '';
 	}
 
 	private createRenderer(): IRenderer {


### PR DESCRIPTION
Issue #9136

Just submitting a PR for some work from last month. This allows users to specify which highlight.js theme they would like to use for the markdown preview. These themes are bundled in highlight.js and we already ship them.

![example-lg](https://cloud.githubusercontent.com/assets/12821956/19699682/244bb996-9aa9-11e6-8fb2-abf8686f6e50.gif)

Not all of the highlight themes work well with all vscode color themes, but I think letting users choose which theme to use is a worthwhile customization to expose.

closes #9136
