### PR TITLE
Update to VSCode-Textmate 2.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -410,9 +410,9 @@
       "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.13.0.tgz"
     },
     "vscode-textmate": {
-      "version": "2.2.0",
-      "from": "vscode-textmate@2.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-2.2.0.tgz"
+      "version": "2.3.0",
+      "from": "vscode-textmate@2.3.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-2.3.0.tgz"
     },
     "windows-foreground-love": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "pty.js": "https://github.com/Tyriar/pty.js/tarball/c75c2dcb6dcad83b0cb3ef2ae42d0448fb912642",
     "semver": "4.3.6",
     "vscode-debugprotocol": "1.13.0",
-    "vscode-textmate": "2.2.0",
+    "vscode-textmate": "2.3.0",
     "winreg": "1.2.0",
     "xterm": "git+https://github.com/Tyriar/xterm.js.git#vscode-release/1.7",
     "yauzl": "2.3.1"


### PR DESCRIPTION
Bumps vscode-textmate to 2.3 in order to pick up this work for the markdown grammar: https://github.com/Microsoft/vscode-textmate/pull/26

Ran colorization tests but none seemed to need updating after this change.

Closes #14294
