### PR TITLE
Support HTML comments in Markdown

### DIFF
--- a/extensions/markdown/language-configuration.json
+++ b/extensions/markdown/language-configuration.json
@@ -1,11 +1,9 @@
 {
 	"comments": {
-		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
 		"blockComment": [
-			"/*",
-			"*/"
+			"<!--",
+			"-->"
 		]
 	},
 	// symbols used as brackets


### PR DESCRIPTION
Hi :raising_hand_man: 

This PR do:
- Remove Java comment syntax, because is not valid in Markdown
- Add HTML block comments supported by Markdown
