### PR TITLE
Fix Fenced Code Syntax Highlighting in Markdown Leaking

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -528,8 +528,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(css|css.erb)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -544,8 +544,8 @@
 						<string>(^|\G)\s*([`~]{3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -560,8 +560,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(ini|conf)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -576,8 +576,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(java|bsh)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -592,8 +592,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(lua)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -608,8 +608,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -624,8 +624,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -640,8 +640,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(R|r|s|S|Rprofile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -656,8 +656,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -672,8 +672,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -688,8 +688,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(sql|ddl|dml)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -704,8 +704,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(vb)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -720,8 +720,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -736,8 +736,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(xsl|xslt)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -752,8 +752,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(yaml|yml)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -768,8 +768,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(bat|batch)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -784,8 +784,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(clj|cljs|clojure)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -800,8 +800,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(coffee|Cakefile|coffee.erb)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -816,8 +816,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(c|h)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -832,8 +832,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(patch|diff|rej)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -848,8 +848,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(dockerfile|Dockerfile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -864,8 +864,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -880,8 +880,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(git-rebase-todo)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -896,8 +896,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(groovy|gvy)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -912,8 +912,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(jade)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -928,8 +928,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(js|jsx|javascript)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -944,8 +944,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(regexp)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -960,8 +960,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -976,8 +976,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(less)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -992,8 +992,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(objectivec|mm|objc|obj-c|m|h)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1008,8 +1008,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(perl6|p6|pl6|pm6|nqp)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1024,8 +1024,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(powershell|ps1|psm1|psd1)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1040,8 +1040,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1056,8 +1056,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(re)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1072,8 +1072,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1088,8 +1088,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(typescript|ts)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1104,8 +1104,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(tsx)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)[ ]{0,3}(\2)\s*\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1120,8 +1120,8 @@
 					<string>(^|\G)\s*([`~]{3,})\s*(cs|csharp|c#)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)(\2)\n</string>
+					<key>while</key>
+					<string>(^|\G)(?!\s*\2\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -525,11 +525,11 @@
 				<key>fenced_code_block_css</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(css|css.erb)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(css|css.erb)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -541,11 +541,11 @@
 				<key>fenced_code_block_basic</key>
 				<dict>
 					<key>begin</key>
-						<string>(^|\G)\s*([`~]{3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\s*$</string>
+						<string>(^|\G)\s*(([`~]){3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -557,11 +557,11 @@
 				<key>fenced_code_block_ini</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(ini|conf)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(ini|conf)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -573,11 +573,11 @@
 				<key>fenced_code_block_java</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(java|bsh)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(java|bsh)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -589,11 +589,11 @@
 				<key>fenced_code_block_lua</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(lua)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(lua)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -605,11 +605,11 @@
 				<key>fenced_code_block_makefile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -621,11 +621,11 @@
 				<key>fenced_code_block_perl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -637,11 +637,11 @@
 				<key>fenced_code_block_r</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(R|r|s|S|Rprofile)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(R|r|s|S|Rprofile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -653,11 +653,11 @@
 				<key>fenced_code_block_ruby</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -669,11 +669,11 @@
 				<key>fenced_code_block_php</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -685,11 +685,11 @@
 				<key>fenced_code_block_sql</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(sql|ddl|dml)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(sql|ddl|dml)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -701,11 +701,11 @@
 				<key>fenced_code_block_vs_net</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(vb)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(vb)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -717,11 +717,11 @@
 				<key>fenced_code_block_xml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -733,11 +733,11 @@
 				<key>fenced_code_block_xsl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(xsl|xslt)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(xsl|xslt)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -749,11 +749,11 @@
 				<key>fenced_code_block_yaml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(yaml|yml)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(yaml|yml)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -765,11 +765,11 @@
 				<key>fenced_code_block_dosbatch</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(bat|batch)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(bat|batch)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -781,11 +781,11 @@
 				<key>fenced_code_block_clojure</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(clj|cljs|clojure)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(clj|cljs|clojure)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -797,11 +797,11 @@
 				<key>fenced_code_block_coffee</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(coffee|Cakefile|coffee.erb)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(coffee|Cakefile|coffee.erb)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -813,11 +813,11 @@
 				<key>fenced_code_block_c</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(c|h)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(c|h)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -829,11 +829,11 @@
 				<key>fenced_code_block_diff</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(patch|diff|rej)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(patch|diff|rej)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -845,11 +845,11 @@
 				<key>fenced_code_block_dockerfile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(dockerfile|Dockerfile)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(dockerfile|Dockerfile)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -861,11 +861,11 @@
 				<key>fenced_code_block_git_commit</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -877,11 +877,11 @@
 				<key>fenced_code_block_git_rebase</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(git-rebase-todo)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(git-rebase-todo)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -893,11 +893,11 @@
 				<key>fenced_code_block_groovy</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(groovy|gvy)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(groovy|gvy)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -909,11 +909,11 @@
 				<key>fenced_code_block_jade</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(jade)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(jade)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -925,11 +925,11 @@
 				<key>fenced_code_block_js</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(js|jsx|javascript)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(js|jsx|javascript)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -941,11 +941,11 @@
 				<key>fenced_code_block_js_regexp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(regexp)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(regexp)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -957,11 +957,11 @@
 				<key>fenced_code_block_json</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -973,11 +973,11 @@
 				<key>fenced_code_block_less</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(less)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(less)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -989,11 +989,11 @@
 				<key>fenced_code_block_objc</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(objectivec|mm|objc|obj-c|m|h)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(objectivec|mm|objc|obj-c|m|h)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1005,11 +1005,11 @@
 				<key>fenced_code_block_perl6</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(perl6|p6|pl6|pm6|nqp)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(perl6|p6|pl6|pm6|nqp)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1021,11 +1021,11 @@
 				<key>fenced_code_block_powershell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(powershell|ps1|psm1|psd1)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(powershell|ps1|psm1|psd1)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1037,11 +1037,11 @@
 				<key>fenced_code_block_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1053,11 +1053,11 @@
 				<key>fenced_code_block_regexp_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(re)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(re)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1069,11 +1069,11 @@
 				<key>fenced_code_block_shell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1085,11 +1085,11 @@
 				<key>fenced_code_block_ts</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(typescript|ts)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(typescript|ts)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1101,11 +1101,11 @@
 				<key>fenced_code_block_tsx</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(tsx)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(tsx)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1117,11 +1117,11 @@
 				<key>fenced_code_block_csharp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(cs|csharp|c#)\s*$</string>
+					<string>(^|\G)\s*(([`~]){3,})\s*(cs|csharp|c#)\s*$</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>while</key>
-					<string>(^|\G)(?!\s*\2\s*$)</string>
+					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
### Bug

This builds on #14488  to fix a number of issues where syntax  highlighting leaks outside of code blocks in markdown files. A simple repo currently is this markdown:

``````
**a**

```js
(
```

**a**
``````

Which is incorrectly colored as:

<img width="154" alt="screen shot 2016-10-27 at 1 41 58 pm" src="https://cloud.githubusercontent.com/assets/12821956/19784601/31a71600-9c4b-11e6-8782-f5039c45eb1a.png">

### Fix

Leverage the updated while rule logic from  #14488 to break out of language syntax highlighting when the end of a code block is detected:

<img width="169" alt="screen shot 2016-10-27 at 1 42 53 pm" src="https://cloud.githubusercontent.com/assets/12821956/19784638/5d51d448-9c4b-11e6-9122-5c22812f5959.png">

Also includes work to fix fenced code blocks where the size of the trailing fence is larger than the size of the starting fence:

``````
```js
1;
`````
``````

And cases such as:

``````
```js
1;
                 `````
``````

Possibly fixed issues include #9457, #8903, #8259, #13149, and others

This is not something we'd want to take into the current months release. I'd like to get some usage in insiders builds and target next month's release.
