### PR TITLE
Improve Markdown Syntax Highlighting of Nested Lists

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -455,7 +455,7 @@
 								</dict>
 							</array>
 							<key>while</key>
-							<string>\G([ ]{4}|\t|$)</string>
+							<string>(^|\G)([ ]{4}|\t)</string>
 						</dict>
 						<dict>
 							<key>begin</key>
@@ -482,7 +482,7 @@
 								</dict>
 							</array>
 							<key>while</key>
-							<string>\G([ ]{4}|\t|$)</string>
+							<string>(^|\G)([ ]{4}|\t)</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
**Bug**
Indented lists in markdown stop highlighting after four indents, even if they are nested.

For this markdown:

```
* a
    * text **bold**
    * text **bold**
* text **bold**
    * text **bold**
    * text **bold**
        * text **bold**
            * text **bold**

                * code **bold**
            * text **bold**
    * text **bold**

    * text **bold**

    * text **bold**

    code **bold**
```

The colorization currently is:

<img width="439" alt="screen shot 2016-10-27 at 6 36 45 pm" src="https://cloud.githubusercontent.com/assets/12821956/19791274/68576596-9c74-11e6-98c6-3ca141508063.png">

**Fix**
Allow lists to also match the start of the line instead of the anchor point in their while clause.

Here's the new colorization:

<img width="412" alt="screen shot 2016-10-27 at 6 36 34 pm" src="https://cloud.githubusercontent.com/assets/12821956/19791277/7134e90e-9c74-11e6-9813-2be74d655129.png">

The new colorization is mostly correct, except that we cannot handle single blank lines without any whitespace between list elements. This is shown in the last element of the list not being properly highlighted.
