### PR TITLE
Fix #14729 - Don't escape newlines in console eval results. They are still escaped elsewhere.

### DIFF
--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -422,7 +422,7 @@ export interface IDebugService {
 	/**
 	 * Adds a new log to the repl. Either a string value or a dictionary (used to inspect complex objects printed to the repl).
 	 */
-	logToRepl(value: string | { [key: string]: any }, severity?: severity): void;
+	logToRepl(value: string | { [key: string]: any }, session: ISession, severity?: severity): void;
 
 	/**
 	 * Appends new output to the repl.

--- a/src/vs/workbench/parts/debug/common/debugModel.ts
+++ b/src/vs/workbench/parts/debug/common/debugModel.ts
@@ -24,7 +24,7 @@ const MAX_REPL_LENGTH = 10000;
 const UNKNOWN_SOURCE_LABEL = nls.localize('unknownSource', "Unknown Source");
 
 function massageValue(value: string): string {
-	return value ? value.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t') : value;
+	return value ? value.replace(/\r\n|\r|\n/g, '↵').replace(/\t/g, '\\t') : value;
 }
 
 export class OutputElement implements debug.ITreeElement {
@@ -170,7 +170,7 @@ export abstract class ExpressionContainer implements debug.IExpressionContainer 
 	}
 
 	public set value(value: string) {
-		this._value = massageValue(value);
+		this._value = value;
 		this.valueChanged = ExpressionContainer.allValues[this.getId()] &&
 			ExpressionContainer.allValues[this.getId()] !== Expression.DEFAULT_VALUE && ExpressionContainer.allValues[this.getId()] !== value;
 		ExpressionContainer.allValues[this.getId()] = value;
@@ -213,14 +213,15 @@ export class Expression extends ExpressionContainer implements debug.IExpression
 		}).then(response => {
 			this.available = !!(response && response.body);
 			if (response && response.body) {
-				this.value = response.body.result;
+				// Take repl responses verbatim - others get massaged.
+				this.value = context === 'repl' ? response.body.result : massageValue(response.body.result);
 				this.reference = response.body.variablesReference;
 				this.namedVariables = response.body.namedVariables;
 				this.indexedVariables = response.body.indexedVariables;
 				this.type = response.body.type;
 			}
 		}, err => {
-			this.value = err.message;
+			this.value = massageValue(err.message);
 			this.available = false;
 			this.reference = 0;
 		});
@@ -286,7 +287,7 @@ export class Variable extends ExpressionContainer implements debug.IExpression {
 			variablesReference: (<ExpressionContainer>this.parent).reference
 		}).then(response => {
 			if (response && response.body) {
-				this.value = response.body.value;
+				this.value = massageValue(response.body.value);
 				this.type = response.body.type || this.type;
 				this.reference = response.body.variablesReference;
 				this.namedVariables = response.body.namedVariables;

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -195,12 +195,12 @@ export class DebugService implements debug.IDebugService {
 
 					// flush any existing simple values logged
 					if (simpleVals.length) {
-						this.logToRepl(simpleVals.join(' '), sev);
+						this.logToRepl(simpleVals.join(' '), session, sev);
 						simpleVals = [];
 					}
 
 					// show object
-					this.logToRepl(a, sev);
+					this.logToRepl(a, session, sev);
 				}
 
 				// string: watch out for % replacement directive
@@ -229,7 +229,7 @@ export class DebugService implements debug.IDebugService {
 
 			// flush simple values
 			if (simpleVals.length) {
-				this.logToRepl(simpleVals.join(' '), sev);
+				this.logToRepl(simpleVals.join(' '), session, sev);
 			}
 		}
 	}
@@ -515,8 +515,8 @@ export class DebugService implements debug.IDebugService {
 			.then(() => this.focusStackFrameAndEvaluate(this.viewModel.focusedStackFrame));
 	}
 
-	public logToRepl(value: string | { [key: string]: any }, severity?: severity): void {
-		this.model.logToRepl(value, severity);
+	public logToRepl(value: string | { [key: string]: any }, session: debug.ISession, severity?: severity): void {
+		this.model.logToRepl(value, session, severity);
 	}
 
 	public appendReplOutput(value: string, severity?: severity): void {

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -63,7 +63,7 @@ export class MockDebugService implements debug.IDebugService {
 
 	public removeReplExpressions(): void { }
 
-	public logToRepl(value: string | { [key: string]: any }, severity?: severity): void { }
+	public logToRepl(value: string | { [key: string]: any }, session: debug.ISession, severity?: severity): void { }
 
 	public appendReplOutput(value: string, severity?: severity): void { }
 
@@ -101,6 +101,9 @@ export class MockDebugService implements debug.IDebugService {
 export class MockSession implements debug.ISession {
 	public readyForBreakpoints = true;
 	public emittedStopped = true;
+
+	constructor(private opts: { capabilities?: DebugProtocol.Capabilities } = {}) {
+	}
 
 	public getId() {
 		return 'mockrawsession';
@@ -141,7 +144,7 @@ export class MockSession implements debug.ISession {
 	public get configuration(): { type: string, capabilities: DebugProtocol.Capabilities } {
 		return {
 			type: 'mock',
-			capabilities: {}
+			capabilities: this.opts.capabilities || {}
 		};
 	}
 

--- a/src/vs/workbench/parts/debug/test/node/debugModel.test.ts
+++ b/src/vs/workbench/parts/debug/test/node/debugModel.test.ts
@@ -331,10 +331,10 @@ suite('Debug - Model', () => {
 	// Repl output
 
 	test('repl output', () => {
-		model.logToRepl('first line', severity.Error);
-		model.logToRepl('second line', severity.Warning);
-		model.logToRepl('second line', severity.Warning);
-		model.logToRepl('second line', severity.Error);
+		model.logToRepl('first line', rawSession, severity.Error);
+		model.logToRepl('second line', rawSession, severity.Warning);
+		model.logToRepl('second line', rawSession, severity.Warning);
+		model.logToRepl('second line', rawSession, severity.Error);
 
 		let elements = <debugmodel.ValueOutputElement[]>model.getReplElements();
 		assert.equal(elements.length, 3);
@@ -354,7 +354,7 @@ suite('Debug - Model', () => {
 		assert.equal(elements[3].severity, severity.Error);
 
 		const keyValueObject = { 'key1': 2, 'key2': 'value' };
-		model.logToRepl(keyValueObject);
+		model.logToRepl(keyValueObject, rawSession);
 		const element = <debugmodel.KeyValueOutputElement>model.getReplElements()[4];
 		assert.equal(element.value, 'Object');
 		assert.deepEqual(element.valueObj, keyValueObject);


### PR DESCRIPTION
One possibility... my comment on the issue

> at first I wanted to skip massageValue for eval results in the console, but it seems like strings in an object preview like ["a\nb"] should stay on one line. We could leave the logic up to the debug adapter like you say, but other debugger authors are assuming that their strings will be escaped for them. Is that too big of a breaking change?

Also, we could do massageValue only when an object is returned, i.e. when the eval result has a variablesReference, so that object previews with newlines will remain escaped, but that seems too inconsistent.