### PR TITLE
Fix #14135 - Allow files with merge status to be staged

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
+++ b/src/vs/workbench/parts/git/browser/gitActions.contribution.ts
@@ -39,7 +39,8 @@ function getStatus(gitService: IGitService, contextService: IWorkspaceContextSer
 	const repositoryRelativePath = paths.normalize(paths.relative(repositoryRoot, input.getResource().fsPath));
 
 	return statusModel.getWorkingTreeStatus().find(repositoryRelativePath) ||
-		statusModel.getIndexStatus().find(repositoryRelativePath);
+		statusModel.getIndexStatus().find(repositoryRelativePath) ||
+		statusModel.getMergeStatus().find(repositoryRelativePath);
 }
 
 class OpenInDiffAction extends baseeditor.EditorInputAction {


### PR DESCRIPTION
Allows files with merge status to be staged using `workbench.action.git.stage`.
Fixes #14135.