### PR TITLE
Make markdown image dimensions configurable using a custom image renderer

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -91,27 +91,40 @@ function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}):
 
 		const renderer = new marked.Renderer();
 		renderer.image = (href: string, title: string, text: string) => {
-			let attributes = '';
-			if (title) {
-				const splitted = title.split('|');
-				title = splitted[0];
+			let dimensions = [];
+			if (href) {
+				const splitted = href.split('|').map(s => s.trim());
+				href = splitted[0];
 				const parameters = splitted[1];
 				if (parameters) {
-					const heightFromParams = new RegExp(/height=(\d+)/).exec(parameters);
-					const widthFromParams = new RegExp(/width=(\d+)/).exec(parameters);
+					const heightFromParams = /height=(\d+)/.exec(parameters);
+					const widthFromParams = /width=(\d+)/.exec(parameters);
 					const height = (heightFromParams && heightFromParams[1]);
 					const width = (widthFromParams && widthFromParams[1]);
-					const dimensions = [];
-					if (width) {
+					const widthIsFinite = isFinite(parseInt(width));
+					const heightIsFinite = isFinite(parseInt(height));
+					if (widthIsFinite) {
 						dimensions.push(`width="${width}"`);
 					}
-					if (height) {
+					if (heightIsFinite) {
 						dimensions.push(`height="${height}"`);
 					}
-					attributes = dimensions.join(' ');
 				}
 			}
-			return `<img src="${href}" alt="${text}" ${attributes}>`;
+			let attributes: string[] = [];
+			if (href) {
+				attributes.push(`src="${href}"`);
+			}
+			if (text) {
+				attributes.push(`alt="${text}"`);
+			}
+			if (title) {
+				attributes.push(`title="${title}"`);
+			}
+			if (dimensions.length) {
+				attributes = attributes.concat(dimensions);
+			}
+			return '<img ' + attributes.join(' ') + '>';
 		};
 		renderer.link = (href, title, text): string => {
 			return `<a href="#" data-href="${href}" title="${title || text}">${text}</a>`;

--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -90,6 +90,29 @@ function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}):
 		const withInnerHTML = new TPromise(c => signalInnerHTML = c);
 
 		const renderer = new marked.Renderer();
+		renderer.image = (href: string, title: string, text: string) => {
+			let attributes = '';
+			if (title) {
+				const splitted = title.split('|');
+				title = splitted[0];
+				const parameters = splitted[1];
+				if (parameters) {
+					const heightFromParams = new RegExp(/height=(\d+)/).exec(parameters);
+					const widthFromParams = new RegExp(/width=(\d+)/).exec(parameters);
+					const height = (heightFromParams && heightFromParams[1]);
+					const width = (widthFromParams && widthFromParams[1]);
+					const dimensions = [];
+					if (width) {
+						dimensions.push(`width="${width}"`);
+					}
+					if (height) {
+						dimensions.push(`height="${height}"`);
+					}
+					attributes = dimensions.join(' ');
+				}
+			}
+			return `<img src="${href}" alt="${text}" ${attributes}>`;
+		};
 		renderer.link = (href, title, text): string => {
 			return `<a href="#" data-href="${href}" title="${title || text}">${text}</a>`;
 		};

--- a/src/vs/base/test/browser/htmlContent.test.ts
+++ b/src/vs/base/test/browser/htmlContent.test.ts
@@ -155,4 +155,23 @@ suite('HtmlContent', () => {
 		assert.strictEqual(result.children.length, 0);
 		assert.strictEqual(result.innerHTML, '**bold**');
 	});
+
+	test('image width from title params', ()=> {
+		var result: HTMLElement = <any>renderHtml({
+			markdown: "![image](someimageurl 'caption|width=100')"
+		});
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" width="100"></p>`);
+	});
+	test('image height from title params', ()=> {
+		var result: HTMLElement = <any>renderHtml({
+			markdown: "![image](someimageurl 'caption|height=100')"
+		});
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" height="100"></p>`);
+	});
+	test('image width and height from title params', ()=> {
+		var result: HTMLElement = <any>renderHtml({
+			markdown: "![image](someimageurl 'caption|height=200, width=100')"
+		});
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" width="100" height="200"></p>`);
+	});
 });

--- a/src/vs/base/test/browser/htmlContent.test.ts
+++ b/src/vs/base/test/browser/htmlContent.test.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as assert from 'assert';
+import { marked } from 'vs/base/common/marked/marked';
 import { renderHtml } from 'vs/base/browser/htmlContentRenderer';
 
 suite('HtmlContent', () => {
@@ -155,23 +156,46 @@ suite('HtmlContent', () => {
 		assert.strictEqual(result.children.length, 0);
 		assert.strictEqual(result.innerHTML, '**bold**');
 	});
-
-	test('image width from title params', ()=> {
-		var result: HTMLElement = <any>renderHtml({
-			markdown: "![image](someimageurl 'caption|width=100')"
-		});
-		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" width="100"></p>`);
+	test('image rendering conforms to default', () => {
+		const renderableContent = {
+			markdown: "![image](someimageurl 'caption')"
+		};
+		const result: HTMLElement = <any>renderHtml(renderableContent);
+		const renderer = new marked.Renderer();
+		const imageFromMarked = marked(renderableContent.markdown, {
+			sanitize: true,
+			renderer
+		}).trim();
+		assert.strictEqual(result.innerHTML, imageFromMarked);
 	});
-	test('image height from title params', ()=> {
-		var result: HTMLElement = <any>renderHtml({
-			markdown: "![image](someimageurl 'caption|height=100')"
-		});
-		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" height="100"></p>`);
+	test('image rendering conforms to default without title', () => {
+		const renderableContent = {
+			markdown: "![image](someimageurl)"
+		};
+		const result: HTMLElement = <any>renderHtml(renderableContent);
+		const renderer = new marked.Renderer();
+		const imageFromMarked = marked(renderableContent.markdown, {
+			sanitize: true,
+			renderer
+		}).trim();
+		assert.strictEqual(result.innerHTML, imageFromMarked);
 	});
-	test('image width and height from title params', ()=> {
+	test('image width from title params', () => {
 		var result: HTMLElement = <any>renderHtml({
-			markdown: "![image](someimageurl 'caption|height=200, width=100')"
+			markdown: "![image](someimageurl|width=100 'caption')"
 		});
-		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" width="100" height="200"></p>`);
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100"></p>`);
+	});
+	test('image height from title params', () => {
+		var result: HTMLElement = <any>renderHtml({
+			markdown: "![image](someimageurl|height=100 'caption')"
+		});
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" height="100"></p>`);
+	});
+	test('image width and height from title params', () => {
+		var result: HTMLElement = <any>renderHtml({
+			markdown: "![image](someimageurl|height=200,width=100 'caption')"
+		});
+		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100" height="200"></p>`);
 	});
 });


### PR DESCRIPTION
In the newly introduced syntax extension the width and height of an image
can be given in the image title using following format:
`![image](someimageurl 'caption|height=200, width=100')`.
Both width and height parameters are optional, if they are not given the
width and height attributes remains unset on the image element

This resolves #14803