### PR TITLE
Repl links fix

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -98,7 +98,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 		// group 3: line number
 		// group 4: column number
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/((\/|[a-zA-Z]:\\)?[^\(\)<>\'\"\[\]:]+):(\d+)(?::(\d+))?/
+		/(?:file:\/\/)?((\/|[a-zA-Z]:\\)?[^\(\)<>\'\"\[\]:]+):(\d+)(?::(\d+))?/
 	];
 
 	private static LINE_HEIGHT_PX = 18;

--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -98,7 +98,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 		// group 3: line number
 		// group 4: column number
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/((\/|[a-zA-Z]:\\)?[^\(\)<>\'\"\[\]]+):(\d+):(\d+)/
+		/((\/|[a-zA-Z]:\\)?[^\(\)<>\'\"\[\]:]+):(\d+)(?::(\d+))?/
 	];
 
 	private static LINE_HEIGHT_PX = 18;
@@ -362,7 +362,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 				link.textContent = text.substr(match.index, match[0].length);
 				link.title = isMacintosh ? nls.localize('fileLinkMac', "Click to follow (Cmd + click opens to the side)") : nls.localize('fileLink', "Click to follow (Ctrl + click opens to the side)");
 				linkContainer.appendChild(link);
-				link.onclick = (e) => this.onLinkClick(new StandardMouseEvent(e), resource, Number(match[3]), Number(match[4]));
+				link.onclick = (e) => this.onLinkClick(new StandardMouseEvent(e), resource, Number(match[3]), match[4] && Number(match[4]));
 
 				let textAfterLink = text.substr(match.index + match[0].length);
 				if (textAfterLink) {
@@ -378,7 +378,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 		return linkContainer || text;
 	}
 
-	private onLinkClick(event: IMouseEvent, resource: uri, line: number, column: number): void {
+	private onLinkClick(event: IMouseEvent, resource: uri, line: number, column: number = 0): void {
 		const selection = window.getSelection();
 		if (selection.type === 'Range') {
 			return; // do not navigate when user is selecting

--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -98,7 +98,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 		// group 3: line number
 		// group 4: column number
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/((\/|[a-zA-Z]:\\)[^\(\)<>\'\"\[\]]+):(\d+):(\d+)/
+		/((\/|[a-zA-Z]:\\)?[^\(\)<>\'\"\[\]]+):(\d+):(\d+)/
 	];
 
 	private static LINE_HEIGHT_PX = 18;


### PR DESCRIPTION
@isidorn Fixes for #13370 

I got a bunch of errors trying to build VS Code. I will look into this and try to test this later but I wanted to share my commits anyway.

- "root" capture group is now optional to allow relative paths
- "column" capture group is now optional to allow paths without columns (will default to 0)
- colon was added to the path blacklist so the line doesn't get detected as part of the path and the column as line
- optional `file://` prefix was added so the a whole file URI is underlined and not just the path part