### PR TITLE
Update to VSCode-Textmate 2.3.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -410,9 +410,9 @@
       "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.14.0.tgz"
     },
     "vscode-textmate": {
-      "version": "2.3.0",
-      "from": "vscode-textmate@2.3.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-2.3.0.tgz"
+      "version": "2.3.1",
+      "from": "vscode-textmate@2.3.1",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-2.3.1.tgz"
     },
     "windows-foreground-love": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pty.js": "https://github.com/Tyriar/pty.js/tarball/c75c2dcb6dcad83b0cb3ef2ae42d0448fb912642",
     "semver": "4.3.6",
     "vscode-debugprotocol": "1.14.0",
-    "vscode-textmate": "2.3.0",
+    "vscode-textmate": "2.3.1",
     "winreg": "1.2.0",
     "xterm": "git+https://github.com/Tyriar/xterm.js.git#vscode-release/1.7",
     "yauzl": "2.3.1"


### PR DESCRIPTION
This bumps the vscode-textmate version to pick up this work: https://github.com/Microsoft/vscode-textmate/pull/30

Taking in this change allows us to take in fixes such as #14626, and also addresses some existing edge cases in the markdown grammar