### PR TITLE
Use :: as a comment for batch language

### DIFF
--- a/extensions/bat/language-configuration.json
+++ b/extensions/bat/language-configuration.json
@@ -1,6 +1,6 @@
 {
 	"comments": {
-		"lineComment": "REM"
+		"lineComment": "::"
 	},
 	"brackets": [
 		["{", "}"],


### PR DESCRIPTION
`REM` stands for 'remark' what is a comment but in a different sense. A syntax for a comment in a meaning of an annotation that does nothing other just comment a code is double colon `::`