### PR TITLE
14945 - Updates regex for CoffeeScript block comment syntax highlighting

### DIFF
--- a/extensions/coffeescript/syntaxes/coffeescript.json
+++ b/extensions/coffeescript/syntaxes/coffeescript.json
@@ -170,7 +170,7 @@
 			]
 		},
 		{
-			"begin": "(?<!#)###(?!#)",
+			"begin": "(?<!#)[\\s]*###(?!#)",
 			"captures": {
 				"0": {
 					"name": "punctuation.definition.comment.coffee"


### PR DESCRIPTION
#14945

This regex edit fixes the syntax highlighting for CoffeeScript block comments.

cc: @aeschli 