### PR TITLE
Improve REPL link highlight regexp

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -94,11 +94,10 @@ export class ReplExpressionsRenderer implements IRenderer {
 	private static FILE_LOCATION_PATTERNS: RegExp[] = [
 		// group 0: the full thing :)
 		// group 1: absolute path
-		// group 2: drive letter on windows with trailing backslash or leading slash on mac/linux
-		// group 3: line number
-		// group 4: column number
+		// group 2: line number
+		// group 3: column number
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/(?:file:\/\/)?((\/|[a-zA-Z]:\\)?[^\(\)<>\'\"\[\]:]+):(\d+)(?::(\d+))?/
+		/(?:at |^|[\(<\'\"\[])(?:file:\/\/)?((?:(?:\/|[a-zA-Z]:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?):(\d+)(?::(\d+))?(?:$|[\)>\'\"\]])/
 	];
 
 	private static LINE_HEIGHT_PX = 18;
@@ -362,7 +361,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 				link.textContent = text.substr(match.index, match[0].length);
 				link.title = isMacintosh ? nls.localize('fileLinkMac', "Click to follow (Cmd + click opens to the side)") : nls.localize('fileLink', "Click to follow (Ctrl + click opens to the side)");
 				linkContainer.appendChild(link);
-				link.onclick = (e) => this.onLinkClick(new StandardMouseEvent(e), resource, Number(match[3]), match[4] && Number(match[4]));
+				link.onclick = (e) => this.onLinkClick(new StandardMouseEvent(e), resource, Number(match[2]), match[3] && Number(match[3]));
 
 				let textAfterLink = text.substr(match.index + match[0].length);
 				if (textAfterLink) {


### PR DESCRIPTION
Fixes the issues I discovered after #15174 was merged.

#15174 added the ability to match relative paths by making the "root" path component optional. Unfortunately, since paths can contain spaces, that meant there was no leading "terminator" for the path anymore, so all whitespace and "at" before a relative path matched too:

![bug](https://cloud.githubusercontent.com/assets/10532611/20221907/8efaca9c-a833-11e6-92c6-1040f0de7f53.png)

This is resolved by requiring terminators at the start and end, which are line start/end, `at `, brackets or quotes.

The capture group that previously captured the "root" path component is not captured anymore (it was not used) and can now either be a unix root slash, a window drive letter component OR the beginning of a relative path, which cannot contain spaces.

## Known issues:
Cannot match a relative path where the first component contains a space, like this:
```
     at what ever\test.js:20
```
Seems impossible to me without using look-around assertions.

Relative paths still cannot be opened, need to be resolved to absolute, don't know how.

https://regex101.com/r/xkAp3A/1