### PR TITLE
c++keywords: nullptr -> constant

### DIFF
--- a/extensions/cpp/syntaxes/c++.json
+++ b/extensions/cpp/syntaxes/c++.json
@@ -54,7 +54,7 @@
 		},
 		{
 			"match": "\\bnullptr\\b",
-			"name": "variable.language.cpp"
+			"name": "constant.language.cpp"
 		},
 		{
 			"match": "\\btemplate\\b\\s*",


### PR DESCRIPTION

> const void* pa = NULL;
> const void* pb = nullptr;

'NULL' will parse as constant, well 'nullptr' not.
I think is a mistake, and fix it.