### PR TITLE
Fix to retain and pass args in linux cli

### DIFF
--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -4,6 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 # If root, ensure that --user-data-dir is specified
+ARGS=$@
 if [ "$(id -u)" = "0" ]; then
 	while test $# -gt 0
 	do
@@ -33,5 +34,5 @@ fi
 
 ELECTRON="$VSCODE_PATH/@@NAME@@"
 CLI="$VSCODE_PATH/resources/app/out/cli.js"
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" $ARGS
 exit $?


### PR DESCRIPTION
The --user-data-dir check routine shifts and removes the args. This edit is to retain the original arguments and pass to executable when finally called.
See issue #15435