### PR TITLE
Add .zsh-theme to shellscript extensions

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -10,7 +10,7 @@
 		"languages": [{
 			"id": "shellscript",
 			"aliases": ["Shell Script (Bash)", "shellscript", "bash", "sh", "zsh"],
-			"extensions": [".sh", ".bash", ".bashrc", ".bash_aliases", ".bash_profile", ".bash_login", ".ebuild", ".install", ".profile", ".bash_logout", ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv"],
+			"extensions": [".sh", ".bash", ".bashrc", ".bash_aliases", ".bash_profile", ".bash_login", ".ebuild", ".install", ".profile", ".bash_logout", ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv", ".zsh-theme"],
 			"filenames": ["PKGBUILD"],
 			"firstLine": "^#!.*\\b(bash|zsh|sh|tcsh).*|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-",
 			"configuration": "./language-configuration.json",


### PR DESCRIPTION
The `.zsh-theme` extension is used for oh-my-zsh theme files.