### PR TITLE
Hexadecimal integer match capitalized prefix `0x`

### DIFF
--- a/extensions/go/syntaxes/go.json
+++ b/extensions/go/syntaxes/go.json
@@ -153,7 +153,7 @@
 		},
 		{
 			"comment": "Integers",
-			"match": "\\b((0x[0-9a-fA-F]+)|(0[0-7]+i?)|(\\d+([Ee]\\d+)?i?)|(\\d+[Ee][-+]\\d+i?))\\b",
+			"match": "\\b((0[xX][0-9a-fA-F]+)|(0[0-7]+i?)|(\\d+([Ee]\\d+)?i?)|(\\d+[Ee][-+]\\d+i?))\\b",
 			"name": "constant.numeric.integer.go"
 		},
 		{


### PR DESCRIPTION
The idea arose from the fact that I couldn't see `0XFF` highlighted as an integer when `0xFF` obviously did. 
As said in the [Golang's language specification](https://golang.org/ref/spec#Integer_literals), an hexadecimal integer literal should match either `0x` or `0X` as prefix i.e. `0[xX]` regexp.

This is a Pull Request to fix the Go's parser in VS Code.