### PR TITLE
Include newline when expanding line selection

### DIFF
--- a/src/vs/editor/common/controller/oneCursor.ts
+++ b/src/vs/editor/common/controller/oneCursor.ts
@@ -790,23 +790,22 @@ export class OneCursorOp {
 		let viewSel = cursor.viewState.selection;
 
 		let viewStartLineNumber = viewSel.startLineNumber;
-		let viewStartColumn = viewSel.startColumn;
 		let viewEndLineNumber = viewSel.endLineNumber;
 		let viewEndColumn = viewSel.endColumn;
 
-		let viewEndMaxColumn = cursor.viewModel.getLineMaxColumn(viewEndLineNumber);
-		if (viewStartColumn !== 1 || viewEndColumn !== viewEndMaxColumn) {
-			viewStartColumn = 1;
-			viewEndColumn = viewEndMaxColumn;
-		} else {
-			// Expand selection with one more line down
-			let moveResult = MoveOperations.down(cursor.config, cursor.viewModel, viewEndLineNumber, viewEndColumn, 0, 1, true);
-			viewEndLineNumber = moveResult.lineNumber;
+		let moveResult = MoveOperations.down(cursor.config, cursor.viewModel, viewEndLineNumber, viewEndColumn, 0, 1, true);
+		viewEndLineNumber = moveResult.lineNumber;
+
+		// If we reach the last line of the document, select until the end of line too
+		if (cursor.viewModel.getLineCount() === viewSel.endLineNumber) {
 			viewEndColumn = cursor.viewModel.getLineMaxColumn(viewEndLineNumber);
+		} else {
+			viewEndColumn = 1;
 		}
 
-		cursor.moveViewPosition(false, viewStartLineNumber, viewStartColumn, 0, true);
+		cursor.moveViewPosition(false, viewStartLineNumber, 1, 0, true);
 		cursor.moveViewPosition(true, viewEndLineNumber, viewEndColumn, 0, true);
+
 		return true;
 	}
 

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -671,33 +671,33 @@ suite('Editor Controller - Cursor', () => {
 		// let LINE1 = '    \tMy First Line\t ';
 		moveTo(thisCursor, 1, 1);
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 1, LINE1.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 2, 1));
 
 		moveTo(thisCursor, 1, 2);
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 1, LINE1.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 2, 1));
 
 		moveTo(thisCursor, 1, 5);
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 1, LINE1.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 2, 1));
 
 		moveTo(thisCursor, 1, 19);
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 1, LINE1.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 2, 1));
 
 		moveTo(thisCursor, 1, 20);
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 1, LINE1.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 2, 1));
 
 		moveTo(thisCursor, 1, 21);
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 1, LINE1.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 2, 1));
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 2, LINE2.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 3, 1));
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 3, LINE3.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 4, 1));
 		cursorCommand(thisCursor, H.ExpandLineSelection);
-		assertCursor(thisCursor, new Selection(1, 1, 4, LINE4.length + 1));
+		assertCursor(thisCursor, new Selection(1, 1, 5, 1));
 		cursorCommand(thisCursor, H.ExpandLineSelection);
 		assertCursor(thisCursor, new Selection(1, 1, 5, LINE5.length + 1));
 		cursorCommand(thisCursor, H.ExpandLineSelection);


### PR DESCRIPTION
Fixes Microsoft/vscode#14485

A note for future reference: This PR leaves the current behaviour when selecting wrapped long lines intact / in the same state it is currently implemented (it handles wrapped lines as if they are real lines). 

Although I disagree with the current implementation – selecting a line should select the whole real line, because otherwise you semantically cut a real line in half – the way moving up/down in the editor treats those wrapped lines as real lines anyway, so the implementation is at least consistent.

If the day comes where this movement behaviour is changed, `expandLineSelection` should be changed as well to stay consistent.