### PR TITLE
Disable backups when extensions are being debugged

### DIFF
--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -351,8 +351,9 @@ export class WindowsManager implements IWindowsMainService {
 		let configuration: IWindowConfiguration;
 		let openInNewWindow = openConfig.preferNewWindow || openConfig.forceNewWindow;
 
-		// Restore any existing backup workspaces on the first initial startup
-		if (openConfig.initialStartup) {
+		// Restore any existing backup workspaces on the first initial startup, provided an
+		// extension development path is not being launch.
+		if (openConfig.initialStartup && !openConfig.cli.extensionDevelopmentPath) {
 			const workspacesWithBackups = this.backupService.getWorkspaceBackupPaths();
 			workspacesWithBackups.forEach(workspacePath => {
 				if (!fs.existsSync(workspacePath)) {
@@ -478,7 +479,9 @@ export class WindowsManager implements IWindowsMainService {
 		}
 
 		// Register new paths for backup
-		this.backupService.pushWorkspaceBackupPathsSync(iPathsToOpen.filter(p => p.workspacePath).map(p => Uri.file(p.workspacePath)));
+		if (!openConfig.cli.extensionDevelopmentPath) {
+			this.backupService.pushWorkspaceBackupPathsSync(iPathsToOpen.filter(p => p.workspacePath).map(p => Uri.file(p.workspacePath)));
+		}
 
 		// Emit events
 		iPathsToOpen.forEach(iPath => this._onPathOpen.fire(iPath));

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -353,7 +353,7 @@ export class WindowsManager implements IWindowsMainService {
 
 		// Restore any existing backup workspaces on the first initial startup, provided an
 		// extension development path is not being launch.
-		if (openConfig.initialStartup && !openConfig.cli.extensionDevelopmentPath) {
+		if (openConfig.initialStartup && !this.environmentService.isExtensionDevelopment) {
 			const workspacesWithBackups = this.backupService.getWorkspaceBackupPaths();
 			workspacesWithBackups.forEach(workspacePath => {
 				if (!fs.existsSync(workspacePath)) {
@@ -380,7 +380,7 @@ export class WindowsManager implements IWindowsMainService {
 				openFilesInNewWindow = true;
 			} else {
 				openFilesInNewWindow = openConfig.preferNewWindow;
-				if (openFilesInNewWindow && !openConfig.cli.extensionDevelopmentPath) { // can be overriden via settings (not for PDE though!)
+				if (openFilesInNewWindow && !this.environmentService.isExtensionDevelopment) { // can be overriden via settings (not for PDE though!)
 					const windowConfig = this.configurationService.getConfiguration<IWindowSettings>('window');
 					if (windowConfig && !windowConfig.openFilesInNewWindow) {
 						openFilesInNewWindow = false; // do not open in new window if user configured this explicitly
@@ -479,7 +479,7 @@ export class WindowsManager implements IWindowsMainService {
 		}
 
 		// Register new paths for backup
-		if (!openConfig.cli.extensionDevelopmentPath) {
+		if (!this.environmentService.isExtensionDevelopment) {
 			this.backupService.pushWorkspaceBackupPathsSync(iPathsToOpen.filter(p => p.workspacePath).map(p => Uri.file(p.workspacePath)));
 		}
 

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -51,6 +51,7 @@ export interface IEnvironmentService {
 	appSettingsPath: string;
 	appKeybindingsPath: string;
 
+	isBackupEnabled: boolean;
 	backupHome: string;
 	backupWorkspacesPath: string;
 

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -51,10 +51,10 @@ export interface IEnvironmentService {
 	appSettingsPath: string;
 	appKeybindingsPath: string;
 
-	isBackupEnabled: boolean;
 	backupHome: string;
 	backupWorkspacesPath: string;
 
+	isExtensionDevelopment: boolean;
 	disableExtensions: boolean;
 	extensionsPath: string;
 	extensionDevelopmentPath: string;

--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -80,7 +80,7 @@ export class EnvironmentService implements IEnvironmentService {
 	get appKeybindingsPath(): string { return path.join(this.appSettingsHome, 'keybindings.json'); }
 
 	@memoize
-	get isBackupEnabled(): boolean { return !this._args.extensionDevelopmentPath; }
+	get isExtensionDevelopment(): boolean { return !!this._args.extensionDevelopmentPath; }
 
 	@memoize
 	get backupHome(): string { return path.join(this.userDataPath, 'Backups'); }

--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -80,6 +80,9 @@ export class EnvironmentService implements IEnvironmentService {
 	get appKeybindingsPath(): string { return path.join(this.appSettingsHome, 'keybindings.json'); }
 
 	@memoize
+	get isBackupEnabled(): boolean { return !this._args.extensionDevelopmentPath; }
+
+	@memoize
 	get backupHome(): string { return path.join(this.userDataPath, 'Backups'); }
 
 	@memoize

--- a/src/vs/workbench/services/backup/node/backupFileService.ts
+++ b/src/vs/workbench/services/backup/node/backupFileService.ts
@@ -32,7 +32,7 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public getWorkspaceBackupPaths(): TPromise<string[]> {
-		if (!this.environmentService.isBackupEnabled) {
+		if (this.environmentService.isExtensionDevelopment) {
 			return TPromise.as([]);
 		}
 
@@ -51,7 +51,7 @@ export class BackupFileService implements IBackupFileService {
 
 	public getBackupResource(resource: Uri): Uri {
 		// Hot exit is disabled for empty workspaces
-		if (!this.currentWorkspace || !this.environmentService.isBackupEnabled) {
+		if (!this.currentWorkspace || this.environmentService.isExtensionDevelopment) {
 			return null;
 		}
 
@@ -67,7 +67,7 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public backupResource(resource: Uri, content: string): TPromise<void> {
-		if (!this.environmentService.isBackupEnabled) {
+		if (this.environmentService.isExtensionDevelopment) {
 			return TPromise.as(void 0);
 		}
 
@@ -82,7 +82,7 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public discardResourceBackup(resource: Uri): TPromise<void> {
-		if (!this.environmentService.isBackupEnabled) {
+		if (this.environmentService.isExtensionDevelopment) {
 			return TPromise.as(void 0);
 		}
 
@@ -97,7 +97,7 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public discardAllWorkspaceBackups(): TPromise<void> {
-		if (!this.environmentService.isBackupEnabled) {
+		if (this.environmentService.isExtensionDevelopment) {
 			return TPromise.as(void 0);
 		}
 

--- a/src/vs/workbench/services/backup/node/backupFileService.ts
+++ b/src/vs/workbench/services/backup/node/backupFileService.ts
@@ -24,7 +24,7 @@ export class BackupFileService implements IBackupFileService {
 
 	constructor(
 		private currentWorkspace: Uri,
-		@IEnvironmentService environmentService: IEnvironmentService,
+		@IEnvironmentService private environmentService: IEnvironmentService,
 		@IFileService private fileService: IFileService
 	) {
 		this.backupHome = environmentService.backupHome;
@@ -32,6 +32,10 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public getWorkspaceBackupPaths(): TPromise<string[]> {
+		if (!this.environmentService.isBackupEnabled) {
+			return TPromise.as([]);
+		}
+
 		return this.loadWorkspaces().then(workspacesJsonContent => {
 			return workspacesJsonContent.folderWorkspaces;
 		});
@@ -47,7 +51,7 @@ export class BackupFileService implements IBackupFileService {
 
 	public getBackupResource(resource: Uri): Uri {
 		// Hot exit is disabled for empty workspaces
-		if (!this.currentWorkspace) {
+		if (!this.currentWorkspace || !this.environmentService.isBackupEnabled) {
 			return null;
 		}
 
@@ -63,6 +67,10 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public backupResource(resource: Uri, content: string): TPromise<void> {
+		if (!this.environmentService.isBackupEnabled) {
+			return TPromise.as(void 0);
+		}
+
 		const backupResource = this.getBackupResource(resource);
 
 		// Hot exit is disabled for empty workspaces
@@ -74,6 +82,10 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public discardResourceBackup(resource: Uri): TPromise<void> {
+		if (!this.environmentService.isBackupEnabled) {
+			return TPromise.as(void 0);
+		}
+
 		const backupResource = this.getBackupResource(resource);
 
 		// Hot exit is disabled for empty workspaces
@@ -85,6 +97,10 @@ export class BackupFileService implements IBackupFileService {
 	}
 
 	public discardAllWorkspaceBackups(): TPromise<void> {
+		if (!this.environmentService.isBackupEnabled) {
+			return TPromise.as(void 0);
+		}
+
 		return this.fileService.del(Uri.file(this.getWorkspaceBackupDirectory()));
 	}
 

--- a/src/vs/workbench/services/backup/node/backupModelService.ts
+++ b/src/vs/workbench/services/backup/node/backupModelService.ts
@@ -35,7 +35,7 @@ export class BackupModelService implements IBackupModelService {
 	}
 
 	private registerListeners() {
-		if (this.environmentService.isBackupEnabled) {
+		if (this.environmentService.isExtensionDevelopment) {
 			return;
 		}
 

--- a/src/vs/workbench/services/backup/node/backupModelService.ts
+++ b/src/vs/workbench/services/backup/node/backupModelService.ts
@@ -12,6 +12,7 @@ import { ITextFileService, TextFileModelChangeEvent } from 'vs/workbench/service
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 
 export class BackupModelService implements IBackupModelService {
 
@@ -25,7 +26,8 @@ export class BackupModelService implements IBackupModelService {
 		@IFileService private fileService: IFileService,
 		@ITextFileService private textFileService: ITextFileService,
 		@IUntitledEditorService private untitledEditorService: IUntitledEditorService,
-		@IWorkspaceContextService private contextService: IWorkspaceContextService
+		@IWorkspaceContextService private contextService: IWorkspaceContextService,
+		@IEnvironmentService private environmentService: IEnvironmentService
 	) {
 		this.toDispose = [];
 
@@ -33,6 +35,10 @@ export class BackupModelService implements IBackupModelService {
 	}
 
 	private registerListeners() {
+		if (this.environmentService.isBackupEnabled) {
+			return;
+		}
+
 		// Listen for text file model changes
 		this.toDispose.push(this.textFileService.models.onModelContentChanged((e) => this.onTextFileModelChanged(e)));
 		this.toDispose.push(this.textFileService.models.onModelSaved((e) => this.discardBackup(e.resource)));

--- a/src/vs/workbench/services/backup/node/backupService.ts
+++ b/src/vs/workbench/services/backup/node/backupService.ts
@@ -125,7 +125,7 @@ export class BackupService implements IBackupService {
 	public get isHotExitEnabled(): boolean {
 		// If hot exit is enabled then save the dirty files in the workspace and then exit
 		// Hot exit is currently disabled for empty workspaces (#13733).
-		return this.environmentService.isBackupEnabled && this.configuredHotExit && !!this.contextService.getWorkspace();
+		return !this.environmentService.isExtensionDevelopment && this.configuredHotExit && !!this.contextService.getWorkspace();
 	}
 
 	public backupBeforeShutdown(dirtyToBackup: Uri[], textFileEditorModelManager: ITextFileEditorModelManager, quitRequested: boolean): TPromise<IBackupResult> {
@@ -148,7 +148,7 @@ export class BackupService implements IBackupService {
 	}
 
 	public cleanupBackupsBeforeShutdown(): TPromise<void> {
-		if (!this.environmentService.isBackupEnabled) {
+		if (this.environmentService.isExtensionDevelopment) {
 			return TPromise.as(void 0);
 		}
 

--- a/src/vs/workbench/services/backup/node/backupService.ts
+++ b/src/vs/workbench/services/backup/node/backupService.ts
@@ -15,6 +15,7 @@ import { IFileService, IFilesConfiguration } from 'vs/platform/files/common/file
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { TPromise } from 'vs/base/common/winjs.base';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 
 export class BackupService implements IBackupService {
 
@@ -34,7 +35,8 @@ export class BackupService implements IBackupService {
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IFileService private fileService: IFileService,
 		@IUntitledEditorService private untitledEditorService: IUntitledEditorService,
-		@IWorkspaceContextService private contextService: IWorkspaceContextService
+		@IWorkspaceContextService private contextService: IWorkspaceContextService,
+		@IEnvironmentService private environmentService: IEnvironmentService
 	) {
 		this.toDispose = [];
 		this.backupPromises = [];
@@ -123,10 +125,14 @@ export class BackupService implements IBackupService {
 	public get isHotExitEnabled(): boolean {
 		// If hot exit is enabled then save the dirty files in the workspace and then exit
 		// Hot exit is currently disabled for empty workspaces (#13733).
-		return this.configuredHotExit && !!this.contextService.getWorkspace();
+		return this.environmentService.isBackupEnabled && this.configuredHotExit && !!this.contextService.getWorkspace();
 	}
 
 	public backupBeforeShutdown(dirtyToBackup: Uri[], textFileEditorModelManager: ITextFileEditorModelManager, quitRequested: boolean): TPromise<IBackupResult> {
+		if (!this.isHotExitEnabled) {
+			return TPromise.as({ didBackup: false });
+		}
+
 		return this.backupFileService.getWorkspaceBackupPaths().then(workspaceBackupPaths => {
 			// When quit is requested skip the confirm callback and attempt to backup all workspaces.
 			// When quit is not requested the confirm callback should be shown when the window being
@@ -142,9 +148,13 @@ export class BackupService implements IBackupService {
 	}
 
 	public cleanupBackupsBeforeShutdown(): TPromise<void> {
+		if (!this.environmentService.isBackupEnabled) {
+			return TPromise.as(void 0);
+		}
+
 		const workspace = this.contextService.getWorkspace();
 		if (!workspace) {
-			return TPromise.as(null); // no backups to cleanup
+			return TPromise.as(void 0); // no backups to cleanup
 		}
 
 		return this.backupFileService.discardAllWorkspaceBackups();


### PR DESCRIPTION
Fixes #15571

---

@bpasero let me know if you see issues with this approach. Another way is to make the backup services `@optional` and only register them if backups are enabled.