### PR TITLE
Implements current line highlighting with modes 'line', 'gutter' and 'all'

### DIFF
--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -25,6 +25,7 @@ import { ContentViewOverlays, MarginViewOverlays } from 'vs/editor/browser/view/
 import { LayoutProvider } from 'vs/editor/browser/viewLayout/layoutProvider';
 import { ViewContentWidgets } from 'vs/editor/browser/viewParts/contentWidgets/contentWidgets';
 import { CurrentLineHighlightOverlay } from 'vs/editor/browser/viewParts/currentLineHighlight/currentLineHighlight';
+import { CurrentLineMarginHighlightOverlay } from 'vs/editor/browser/viewParts/currentLineMarginHighlight/currentLineMarginHighlight';
 import { DecorationsOverlay } from 'vs/editor/browser/viewParts/decorations/decorations';
 import { GlyphMarginOverlay } from 'vs/editor/browser/viewParts/glyphMargin/glyphMargin';
 import { LineNumbersOverlay } from 'vs/editor/browser/viewParts/lineNumbers/lineNumbers';
@@ -236,6 +237,7 @@ export class View extends ViewEventHandler implements editorBrowser.IView, IDisp
 
 		let marginViewOverlays = new MarginViewOverlays(this._context, this.layoutProvider);
 		this.viewParts.push(marginViewOverlays);
+		marginViewOverlays.addDynamicOverlay(new CurrentLineMarginHighlightOverlay(this._context, this.layoutProvider));
 		marginViewOverlays.addDynamicOverlay(new GlyphMarginOverlay(this._context));
 		marginViewOverlays.addDynamicOverlay(new LinesDecorationsOverlay(this._context));
 		marginViewOverlays.addDynamicOverlay(new LineNumbersOverlay(this._context));

--- a/src/vs/editor/browser/viewParts/currentLineMarginHighlight/currentLineMarginHighlight.css
+++ b/src/vs/editor/browser/viewParts/currentLineMarginHighlight/currentLineMarginHighlight.css
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.monaco-editor .current-line {
+	display: block;
+	position: absolute;
+	left: 0;
+	top: 0;
+	box-sizing: border-box;
+}
+
+.monaco-editor.vs .current-line {
+	border: 2px solid #eee;
+}
+
+.monaco-editor.vs-dark .current-line {
+	border: 2px solid #282828;
+}
+
+.monaco-editor.hc-black .current-line {
+	border: 2px solid #f38518;
+}

--- a/src/vs/editor/browser/viewParts/currentLineMarginHighlight/currentLineMarginHighlight.ts
+++ b/src/vs/editor/browser/viewParts/currentLineMarginHighlight/currentLineMarginHighlight.ts
@@ -5,39 +5,33 @@
 
 'use strict';
 
-import 'vs/css!./currentLineHighlight';
+import 'vs/css!./currentLineMarginHighlight';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { DynamicViewOverlay } from 'vs/editor/browser/view/dynamicViewOverlay';
 import { ViewContext } from 'vs/editor/common/view/viewContext';
 import { IRenderingContext } from 'vs/editor/common/view/renderingContext';
 import { ILayoutProvider } from 'vs/editor/browser/viewLayout/layoutProvider';
 
-export class CurrentLineHighlightOverlay extends DynamicViewOverlay {
+export class CurrentLineMarginHighlightOverlay extends DynamicViewOverlay {
 	private _context: ViewContext;
 	private _lineHeight: number;
-	private _readOnly: boolean;
 	private _renderLineHighlight: 'none' | 'gutter' | 'line' | 'all';
 	private _layoutProvider: ILayoutProvider;
-	private _selectionIsEmpty: boolean;
 	private _primaryCursorIsInEditableRange: boolean;
 	private _primaryCursorLineNumber: number;
-	private _scrollWidth: number;
-	private _contentWidth: number;
+	private _contentLeft: number;
 
 	constructor(context: ViewContext, layoutProvider: ILayoutProvider) {
 		super();
 		this._context = context;
 		this._lineHeight = this._context.configuration.editor.lineHeight;
-		this._readOnly = this._context.configuration.editor.readOnly;
 		this._renderLineHighlight = this._context.configuration.editor.viewInfo.renderLineHighlight;
 
 		this._layoutProvider = layoutProvider;
 
-		this._selectionIsEmpty = true;
 		this._primaryCursorIsInEditableRange = true;
 		this._primaryCursorLineNumber = 1;
-		this._scrollWidth = this._layoutProvider.getScrollWidth();
-		this._contentWidth = this._context.configuration.editor.layoutInfo.contentWidth;
+		this._contentLeft = this._context.configuration.editor.layoutInfo.contentLeft;
 
 		this._context.addEventHandler(this);
 	}
@@ -51,9 +45,7 @@ export class CurrentLineHighlightOverlay extends DynamicViewOverlay {
 
 	public onModelFlushed(): boolean {
 		this._primaryCursorIsInEditableRange = true;
-		this._selectionIsEmpty = true;
 		this._primaryCursorLineNumber = 1;
-		this._scrollWidth = this._layoutProvider.getScrollWidth();
 		return true;
 	}
 	public onModelLinesDeleted(e: editorCommon.IViewLinesDeletedEvent): boolean {
@@ -74,35 +66,20 @@ export class CurrentLineHighlightOverlay extends DynamicViewOverlay {
 		}
 		return hasChanged;
 	}
-	public onCursorSelectionChanged(e: editorCommon.IViewCursorSelectionChangedEvent): boolean {
-		let isEmpty = e.selection.isEmpty();
-		if (this._selectionIsEmpty !== isEmpty) {
-			this._selectionIsEmpty = isEmpty;
-			return true;
-		}
-		return false;
-	}
 	public onConfigurationChanged(e: editorCommon.IConfigurationChangedEvent): boolean {
 		if (e.lineHeight) {
 			this._lineHeight = this._context.configuration.editor.lineHeight;
-		}
-		if (e.readOnly) {
-			this._readOnly = this._context.configuration.editor.readOnly;
 		}
 		if (e.viewInfo.renderLineHighlight) {
 			this._renderLineHighlight = this._context.configuration.editor.viewInfo.renderLineHighlight;
 		}
 		if (e.layoutInfo) {
-			this._contentWidth = this._context.configuration.editor.layoutInfo.contentWidth;
+			this._contentLeft = this._context.configuration.editor.layoutInfo.contentLeft;
 		}
 		return true;
 	}
 	public onLayoutChanged(layoutInfo: editorCommon.EditorLayoutInfo): boolean {
 		return true;
-	}
-	public onScrollChanged(e: editorCommon.IScrollEvent): boolean {
-		this._scrollWidth = e.scrollWidth;
-		return e.scrollWidthChanged;
 	}
 	public onZonesChanged(): boolean {
 		return true;
@@ -110,10 +87,6 @@ export class CurrentLineHighlightOverlay extends DynamicViewOverlay {
 	// --- end event handlers
 
 	public prepareRender(ctx: IRenderingContext): void {
-		if (!this.shouldRender()) {
-			throw new Error('I did not ask to render!');
-		}
-		this._scrollWidth = ctx.scrollWidth;
 	}
 
 	public render(startLineNumber: number, lineNumber: number): string {
@@ -121,7 +94,7 @@ export class CurrentLineHighlightOverlay extends DynamicViewOverlay {
 			if (this._shouldShowCurrentLine()) {
 				return (
 					'<div class="current-line" style="width:'
-					+ String(Math.max(this._scrollWidth, this._contentWidth))
+					+ String(this._contentLeft)
 					+ 'px; height:'
 					+ String(this._lineHeight)
 					+ 'px;"></div>'
@@ -134,8 +107,6 @@ export class CurrentLineHighlightOverlay extends DynamicViewOverlay {
 	}
 
 	private _shouldShowCurrentLine(): boolean {
-		return (this._renderLineHighlight === 'line' || this._renderLineHighlight === 'all') &&
-			this._selectionIsEmpty &&
-			this._primaryCursorIsInEditableRange;
+		return (this._renderLineHighlight === 'gutter' || this._renderLineHighlight === 'all') && this._primaryCursorIsInEditableRange;
 	}
 }

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -270,6 +270,14 @@ class InternalEditorOptionsHelper {
 			renderWhitespace = 'none';
 		}
 
+		let renderLineHighlight = opts.renderLineHighlight;
+		// Compatibility with old true or false values
+		if (<any>renderLineHighlight === true) {
+			renderLineHighlight = 'line';
+		} else if (<any>renderLineHighlight === false) {
+			renderLineHighlight = 'none';
+		}
+
 		let viewInfo = new editorCommon.InternalEditorViewOptions({
 			theme: opts.theme,
 			canUseTranslate3d: canUseTranslate3d,
@@ -294,7 +302,7 @@ class InternalEditorOptionsHelper {
 			renderWhitespace: renderWhitespace,
 			renderControlCharacters: toBoolean(opts.renderControlCharacters),
 			renderIndentGuides: toBoolean(opts.renderIndentGuides),
-			renderLineHighlight: toBoolean(opts.renderLineHighlight),
+			renderLineHighlight: renderLineHighlight,
 			scrollbar: scrollbar,
 			fixedOverflowWidgets: toBoolean(opts.fixedOverflowWidgets)
 		});
@@ -845,9 +853,10 @@ let editorConfiguration: IConfigurationNode = {
 			description: nls.localize('renderIndentGuides', "Controls whether the editor should render indent guides")
 		},
 		'editor.renderLineHighlight': {
-			'type': 'boolean',
+			'type': 'string',
+			'enum': ['none', 'gutter', 'line', 'all'],
 			default: DefaultConfig.editor.renderLineHighlight,
-			description: nls.localize('renderLineHighlight', "Controls whether the editor should render the current line highlight")
+			description: nls.localize('renderLineHighlight', "Controls how the editor should render the current line highlight, posibilties are 'none', 'gutter', 'line', and 'all'.")
 		},
 		'editor.codeLens': {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/defaultConfig.ts
+++ b/src/vs/editor/common/config/defaultConfig.ts
@@ -98,7 +98,7 @@ class ConfigClass implements IConfiguration {
 			renderWhitespace: 'none',
 			renderControlCharacters: false,
 			renderIndentGuides: false,
-			renderLineHighlight: true,
+			renderLineHighlight: 'all',
 			useTabStops: true,
 
 			fontFamily: (

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -465,9 +465,9 @@ export interface IEditorOptions {
 	renderIndentGuides?: boolean;
 	/**
 	 * Enable rendering of current line highlight.
-	 * Defaults to true.
+	 * Defaults to all.
 	 */
-	renderLineHighlight?: boolean;
+	renderLineHighlight?: 'none' | 'gutter' | 'line' | 'all';
 	/**
 	 * Inserting and deleting whitespace follows tab stops.
 	 */
@@ -668,7 +668,7 @@ export class InternalEditorViewOptions {
 	readonly renderWhitespace: 'none' | 'boundary' | 'all';
 	readonly renderControlCharacters: boolean;
 	readonly renderIndentGuides: boolean;
-	readonly renderLineHighlight: boolean;
+	readonly renderLineHighlight: 'none' | 'gutter' | 'line' | 'all';
 	readonly scrollbar: InternalEditorScrollbarOptions;
 	readonly fixedOverflowWidgets: boolean;
 
@@ -699,7 +699,7 @@ export class InternalEditorViewOptions {
 		renderWhitespace: 'none' | 'boundary' | 'all';
 		renderControlCharacters: boolean;
 		renderIndentGuides: boolean;
-		renderLineHighlight: boolean;
+		renderLineHighlight: 'none' | 'gutter' | 'line' | 'all';
 		scrollbar: InternalEditorScrollbarOptions;
 		fixedOverflowWidgets: boolean;
 	}) {
@@ -726,7 +726,7 @@ export class InternalEditorViewOptions {
 		this.renderWhitespace = source.renderWhitespace;
 		this.renderControlCharacters = Boolean(source.renderControlCharacters);
 		this.renderIndentGuides = Boolean(source.renderIndentGuides);
-		this.renderLineHighlight = Boolean(source.renderLineHighlight);
+		this.renderLineHighlight = source.renderLineHighlight;
 		this.scrollbar = source.scrollbar.clone();
 		this.fixedOverflowWidgets = Boolean(source.fixedOverflowWidgets);
 	}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1321,9 +1321,9 @@ declare module monaco.editor {
         renderIndentGuides?: boolean;
         /**
          * Enable rendering of current line highlight.
-         * Defaults to true.
+         * Defaults to all.
          */
-        renderLineHighlight?: boolean;
+        renderLineHighlight?: 'none' | 'gutter' | 'line' | 'all';
         /**
          * Inserting and deleting whitespace follows tab stops.
          */
@@ -1423,7 +1423,7 @@ declare module monaco.editor {
         readonly renderWhitespace: 'none' | 'boundary' | 'all';
         readonly renderControlCharacters: boolean;
         readonly renderIndentGuides: boolean;
-        readonly renderLineHighlight: boolean;
+        readonly renderLineHighlight: 'none' | 'gutter' | 'line' | 'all';
         readonly scrollbar: InternalEditorScrollbarOptions;
         readonly fixedOverflowWidgets: boolean;
     }

--- a/src/vs/workbench/parts/debug/electron-browser/repl.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/repl.ts
@@ -269,7 +269,7 @@ export class Repl extends Panel implements IPrivateReplService {
 			lineDecorationsWidth: 0,
 			scrollBeyondLastLine: false,
 			theme: this.themeService.getColorTheme(),
-			renderLineHighlight: false,
+			renderLineHighlight: 'none',
 			fixedOverflowWidgets: true,
 			acceptSuggestionOnEnter: false
 		};

--- a/src/vs/workbench/parts/output/browser/outputPanel.ts
+++ b/src/vs/workbench/parts/output/browser/outputPanel.ts
@@ -90,7 +90,7 @@ export class OutputPanel extends StringEditor {
 		options.rulers = [];
 		options.folding = false;
 		options.scrollBeyondLastLine = false;
-		options.renderLineHighlight = false;
+		options.renderLineHighlight = 'none';
 
 		const channel = this.outputService.getActiveChannel();
 		options.ariaLabel = channel ? nls.localize('outputPanelWithInputAriaLabel', "{0}, Output panel", channel.label) : nls.localize('outputPanelAriaLabel', "Output panel");


### PR DESCRIPTION
Implement feature request #14273. Previously we only highlight current line or not but here we allow users to decide where they want to show the hint, gutter, line, both or none.

`"editor.renderLineHighlight": "gutter"` will be like

<img width="1319" alt="screen shot 2016-11-16 at 6 40 43 pm" src="https://cloud.githubusercontent.com/assets/876920/20374334/caa5fed4-ac2c-11e6-8385-7a46f54c5182.png">

It helps mitigate #3803 , cc @bgashler1 

Right now I'm just using the same background color in gutter as highlighted current line but it can be different. The good part of using the same color for both line and gutter is that current line highlight color is a TM setting, we don't need to introduce a new concept.