### PR TITLE
Fix TS/JS Implicit Project Too Large Exclude Action

### DIFF
--- a/extensions/typescript/src/utils/projectStatus.ts
+++ b/extensions/typescript/src/utils/projectStatus.ts
@@ -8,7 +8,7 @@
 import * as vscode from 'vscode';
 import { ITypescriptServiceClient } from '../typescriptService';
 import { loadMessageBundle } from 'vscode-nls';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 
 const localize = loadMessageBundle();
 const selector = ['javascript', 'javascriptreact'];
@@ -77,7 +77,6 @@ export function create(client: ITypescriptServiceClient, isOpen: (path: string) 
 				}
 
 				if (fileNames.length > fileLimit) {
-
 					let largeRoots = computeLargeRoots(configFileName, fileNames).map(f => `'/${f}/'`).join(', ');
 
 					currentHint = {
@@ -91,7 +90,14 @@ export function create(client: ITypescriptServiceClient, isOpen: (path: string) 
 								projectHinted[configFileName] = true;
 								item.hide();
 
-								return vscode.workspace.openTextDocument(configFileName)
+								let configFileUri: vscode.Uri;
+								if (dirname(configFileName).indexOf(vscode.workspace.rootPath) === 0) {
+									configFileUri = vscode.Uri.file(configFileName);
+								} else {
+									configFileUri = vscode.Uri.parse('untitled://' + join(vscode.workspace.rootPath, 'jsconfig.json'));
+								}
+
+								return vscode.workspace.openTextDocument(configFileUri)
 									.then(vscode.window.showTextDocument);
 							}
 						}]


### PR DESCRIPTION
Issue #15610

**bug**
For implicit js/ts projects that trigger the large project warning in vscode, the fix/action we currently suggest tries to open a jsconfig.json file in `/dev/null/...`. 

**Fix**
In cases where the `jsconfig.json` file returned by tsserver is not under the root worspace, create an empty `jsconfig.json` at the root of the project instead.



Closes #15610