### PR TITLE
Convert from 1- to 0-based indexing for TypeScript completion spans

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -23,8 +23,10 @@ class MyCompletionItem extends CompletionItem {
 		this.sortText = entry.sortText;
 		this.kind = MyCompletionItem.convertKind(entry.kind);
 		if (entry.replacementSpan) {
-			let span = entry.replacementSpan;
-			this.textEdit = TextEdit.replace(new Range(span.start.line, span.start.offset, span.end.line, span.end.offset), entry.name);
+			let span: protocol.TextSpan = entry.replacementSpan;
+			// The indexing for the range returned by the server uses 1-based indexing.
+			// We convert to 0-based indexing.
+			this.textEdit = TextEdit.replace(new Range(span.start.line - 1, span.start.offset - 1, span.end.line - 1, span.end.offset - 1), entry.name);
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where module and triple slash completions had an off-by-one error with the indexing of text spans. Corresponding issues in the TypeScript repo are:

https://github.com/Microsoft/TypeScript/issues/12165
https://github.com/Microsoft/TypeScript/issues/11462