### PR TITLE
Fix exception on launch.json with empty configurations

### DIFF
--- a/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
+++ b/src/vs/workbench/parts/debug/node/debugConfigurationManager.ts
@@ -280,6 +280,7 @@ export class ConfigurationManager implements debug.IConfigurationManager {
 			const adapter = this.getAdapter(result.type);
 			return this.configurationResolverService.resolveInteractiveVariables(result, adapter ? adapter.variables : null);
 		}
+		return TPromise.as(null);
 	}
 
 	public openConfigFile(sideBySide: boolean): TPromise<boolean> {


### PR DESCRIPTION
Issue #15685

**Bug**

Create an empty project with a `launch.json` like this:

```
{
    "version": "0.2.0",
    "configurations": [
    ]
}
```

Try to start debugging.

See an exception message

**Fix**
Instead of returning undefined for the promise result, return a promise of null like we do in other cases. This means that we show this message instead of the exception message:

![screen shot 2016-11-17 at 5 55 23 pm](https://cloud.githubusercontent.com/assets/12821956/20415719/fe84360e-acee-11e6-943a-7ce30c0897ce.png)


closes #15685