### PR TITLE
Add missing Sublime/Atom commands

### DIFF
--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -463,10 +463,6 @@ export class JoinLinesAction extends EditorAction {
 
 				let lineTextWithoutIndent = lineText.substr(firstNonWhitespaceIdx - 1);
 
-				if (lineTextWithoutIndent.charAt(0) === ')') {
-					insertSpace = false;
-				}
-
 				trimmedLinesContent += (insertSpace ? ' ' : '') + lineTextWithoutIndent;
 
 				if (insertSpace) {

--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -524,7 +524,7 @@ export class TransposeAction extends EditorAction {
 
 		for (let i = 0, len = selections.length; i < len; i++) {
 			let selection = selections[i];
-			if (selection.isEmpty) {
+			if (selection.isEmpty()) {
 				let cursor = selection.getStartPosition();
 				if (cursor.column > model.getLineContent(cursor.lineNumber).length) {
 					return;
@@ -564,18 +564,19 @@ export class UpperCaseAction extends EditorAction {
 
 		for (let i = 0, len = selections.length; i < len; i++) {
 			let selection = selections[i];
-			if (selection.isEmpty) {
+			if (selection.isEmpty()) {
 				let cursor = selection.getStartPosition();
 				let word = model.getWordAtPosition(cursor);
 				let wordRange = new Range(cursor.lineNumber, word.startColumn, cursor.lineNumber, word.endColumn);
 
 				if (wordRange !== undefined) {
 					let text = model.getValueInRange(wordRange);
-					commands.push(new ReplaceCommand(wordRange, text.toLocaleUpperCase()));
+					commands.push(new ReplaceCommandThatPreservesSelection(wordRange, text.toLocaleUpperCase(),
+						new Selection(cursor.lineNumber, cursor.column, cursor.lineNumber, cursor.column)));
 				}
 			} else {
 				let text = model.getValueInRange(selection);
-				commands.push(new ReplaceCommand(selection, text.toLocaleUpperCase()));
+				commands.push(new ReplaceCommandThatPreservesSelection(selection, text.toLocaleUpperCase(), selection));
 			}
 		}
 
@@ -601,18 +602,19 @@ export class LowerCaseAction extends EditorAction {
 
 		for (let i = 0, len = selections.length; i < len; i++) {
 			let selection = selections[i];
-			if (selection.isEmpty) {
+			if (selection.isEmpty()) {
 				let cursor = selection.getStartPosition();
 				let word = model.getWordAtPosition(cursor);
 				let wordRange = new Range(cursor.lineNumber, word.startColumn, cursor.lineNumber, word.endColumn);
 
 				if (wordRange !== undefined) {
 					let text = model.getValueInRange(wordRange);
-					commands.push(new ReplaceCommand(wordRange, text.toLocaleLowerCase()));
+					commands.push(new ReplaceCommandThatPreservesSelection(wordRange, text.toLocaleLowerCase(),
+						new Selection(cursor.lineNumber, cursor.column, cursor.lineNumber, cursor.column)));
 				}
 			} else {
 				let text = model.getValueInRange(selection);
-				commands.push(new ReplaceCommand(selection, text.toLocaleLowerCase()));
+				commands.push(new ReplaceCommandThatPreservesSelection(selection, text.toLocaleLowerCase(), selection));
 			}
 		}
 

--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -547,7 +547,7 @@ export class TransposeAction extends EditorAction {
 }
 
 @editorAction
-class UpperCaseAction extends EditorAction {
+export class UpperCaseAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToUppercase',
@@ -562,7 +562,8 @@ class UpperCaseAction extends EditorAction {
 		let model = editor.getModel();
 		let commands: ICommand[] = [];
 
-		selections.forEach((selection) => {
+		for (let i = 0, len = selections.length; i < len; i++) {
+			let selection = selections[i];
 			if (selection.isEmpty) {
 				let cursor = selection.getStartPosition();
 				let word = model.getWordAtPosition(cursor);
@@ -576,14 +577,14 @@ class UpperCaseAction extends EditorAction {
 				let text = model.getValueInRange(selection);
 				commands.push(new ReplaceCommand(selection, text.toLocaleUpperCase()));
 			}
-		});
+		}
 
 		editor.executeCommands(this.id, commands);
 	}
 }
 
 @editorAction
-class LowerCaseAction extends EditorAction {
+export class LowerCaseAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToLowercase',
@@ -598,7 +599,8 @@ class LowerCaseAction extends EditorAction {
 		let model = editor.getModel();
 		let commands: ICommand[] = [];
 
-		selections.forEach((selection) => {
+		for (let i = 0, len = selections.length; i < len; i++) {
+			let selection = selections[i];
 			if (selection.isEmpty) {
 				let cursor = selection.getStartPosition();
 				let word = model.getWordAtPosition(cursor);
@@ -612,7 +614,7 @@ class LowerCaseAction extends EditorAction {
 				let text = model.getValueInRange(selection);
 				commands.push(new ReplaceCommand(selection, text.toLocaleLowerCase()));
 			}
-		});
+		}
 
 		editor.executeCommands(this.id, commands);
 	}

--- a/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
@@ -116,7 +116,9 @@ suite('Editor Contrib - Line Operations', () => {
 	test('transpose', function () {
 		withMockCodeEditor(
 			[
-				'hello world'
+				'hello world',
+				'',
+				'   '
 			], {}, (editor, cursor) => {
 				let model = editor.getModel();
 				let transposeAction = new TransposeAction();
@@ -135,6 +137,16 @@ suite('Editor Contrib - Line Operations', () => {
 				transposeAction.run(null, editor);
 				assert.equal(model.getLineContent(1), 'hell oworld', '005');
 				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 12, 1, 12).toString(), '006');
+
+				editor.setSelection(new Selection(2, 1, 2, 1));
+				transposeAction.run(null, editor);
+				assert.equal(model.getLineContent(2), '', '007');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 1, 2, 1).toString(), '008');
+
+				editor.setSelection(new Selection(3, 2, 3, 2));
+				transposeAction.run(null, editor);
+				assert.equal(model.getLineContent(3), '   ', '009');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(3, 3, 3, 3).toString(), '010');
 			}
 		);
 	});
@@ -178,6 +190,37 @@ suite('Editor Contrib - Line Operations', () => {
 				lowercaseAction.run(null, editor);
 				assert.equal(model.getLineContent(2), 'öçşğü', '011');
 				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 1, 2, 6).toString(), '012');
+			}
+		);
+
+		withMockCodeEditor(
+			[
+				'',
+				'   '
+			], {}, (editor, cursor) => {
+				let model = editor.getModel();
+				let uppercaseAction = new UpperCaseAction();
+				let lowercaseAction = new LowerCaseAction();
+
+				editor.setSelection(new Selection(1, 1, 1, 1));
+				uppercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(1), '', '001');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 1, 1, 1).toString(), '002');
+
+				editor.setSelection(new Selection(1, 1, 1, 1));
+				lowercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(1), '', '003');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 1, 1, 1).toString(), '004');
+
+				editor.setSelection(new Selection(2, 2, 2, 2));
+				uppercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(2), '   ', '005');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 2, 2, 2).toString(), '006');
+
+				editor.setSelection(new Selection(2, 2, 2, 2));
+				lowercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(2), '   ', '007');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 2, 2, 2).toString(), '008');
 			}
 		);
 	});

--- a/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
@@ -7,7 +7,7 @@
 import * as assert from 'assert';
 import { Selection } from 'vs/editor/common/core/selection';
 import { withMockCodeEditor } from 'vs/editor/test/common/mocks/mockCodeEditor';
-import { DeleteAllLeftAction } from 'vs/editor/contrib/linesOperations/common/linesOperations';
+import { DeleteAllLeftAction, JoinLinesAction } from 'vs/editor/contrib/linesOperations/common/linesOperations';
 
 suite('Editor Contrib - Line Operations', () => {
 	test('delete all left', function () {
@@ -65,6 +65,51 @@ suite('Editor Contrib - Line Operations', () => {
 				editor.setSelections([new Selection(5, 3, 6, 3), new Selection(6, 5, 7, 5), new Selection(7, 7, 7, 7)]);
 				deleteAllLeftAction.run(null, editor);
 				assert.equal(model.getLineContent(5), 'horlworld', '005');
+			});
+	});
+
+	test('Join lines', function () {
+		withMockCodeEditor(
+			[
+				'hello',
+				'world',
+				'hello ',
+				'world',
+				'hello		',
+				'	world',
+				'hello   ',
+				'	world',
+				'',
+				'',
+				'hello world'
+			], {}, (editor, cursor) => {
+				let model = editor.getModel();
+				let joinLinesAction = new JoinLinesAction();
+
+				editor.setSelection(new Selection(1, 2, 1, 2));
+				joinLinesAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'hello world', '001');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 6, 1, 6).toString(), '002');
+
+				editor.setSelection(new Selection(2, 2, 2, 2));
+				joinLinesAction.run(null, editor);
+				assert.equal(model.getLineContent(2), 'hello world', '003');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 7, 2, 7).toString(), '004');
+
+				editor.setSelection(new Selection(3, 2, 3, 2));
+				joinLinesAction.run(null, editor);
+				assert.equal(model.getLineContent(3), 'hello world', '005');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(3, 7, 3, 7).toString(), '006');
+
+				editor.setSelection(new Selection(4, 2, 5, 3));
+				joinLinesAction.run(null, editor);
+				assert.equal(model.getLineContent(4), 'hello world', '007');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(4, 2, 4, 8).toString(), '008');
+
+				editor.setSelection(new Selection(5, 1, 7, 3));
+				joinLinesAction.run(null, editor);
+				assert.equal(model.getLineContent(5), 'hello world', '009');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(5, 1, 5, 3).toString(), '010');
 			});
 	});
 });

--- a/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
@@ -112,4 +112,73 @@ suite('Editor Contrib - Line Operations', () => {
 				assert.deepEqual(editor.getSelection().toString(), new Selection(5, 1, 5, 3).toString(), '010');
 			});
 	});
+
+	test('transpose', function () {
+		withMockCodeEditor(
+			[
+				'hello world'
+			], {}, (editor, cursor) => {
+				let model = editor.getModel();
+				let transposeAction = new TransposeAction();
+
+				editor.setSelection(new Selection(1, 1, 1, 1));
+				transposeAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'hello world', '001');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 2, 1, 2).toString(), '002');
+
+				editor.setSelection(new Selection(1, 6, 1, 6));
+				transposeAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'hell oworld', '003');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 7, 1, 7).toString(), '004');
+
+				editor.setSelection(new Selection(1, 12, 1, 12));
+				transposeAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'hell oworld', '005');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 12, 1, 12).toString(), '006');
+			}
+		);
+	});
+
+	test('toggle case', function () {
+		withMockCodeEditor(
+			[
+				'hello world',
+				'öçşğü'
+			], {}, (editor, cursor) => {
+				let model = editor.getModel();
+				let uppercaseAction = new UpperCaseAction();
+				let lowercaseAction = new LowerCaseAction();
+
+				editor.setSelection(new Selection(1, 1, 1, 12));
+				uppercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'HELLO WORLD', '001');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 1, 1, 12).toString(), '002');
+
+				editor.setSelection(new Selection(1, 1, 1, 12));
+				lowercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'hello world', '003');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 1, 1, 12).toString(), '004');
+
+				editor.setSelection(new Selection(1, 3, 1, 3));
+				uppercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'HELLO world', '005');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 3, 1, 3).toString(), '006');
+
+				editor.setSelection(new Selection(1, 4, 1, 4));
+				lowercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(1), 'hello world', '007');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(1, 4, 1, 4).toString(), '008');
+
+				editor.setSelection(new Selection(2, 1, 2, 6));
+				uppercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(2), 'ÖÇŞĞÜ', '009');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 1, 2, 6).toString(), '010');
+
+				editor.setSelection(new Selection(2, 1, 2, 6));
+				lowercaseAction.run(null, editor);
+				assert.equal(model.getLineContent(2), 'öçşğü', '011');
+				assert.deepEqual(editor.getSelection().toString(), new Selection(2, 1, 2, 6).toString(), '012');
+			}
+		);
+	});
 });

--- a/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
@@ -7,7 +7,7 @@
 import * as assert from 'assert';
 import { Selection } from 'vs/editor/common/core/selection';
 import { withMockCodeEditor } from 'vs/editor/test/common/mocks/mockCodeEditor';
-import { DeleteAllLeftAction, JoinLinesAction } from 'vs/editor/contrib/linesOperations/common/linesOperations';
+import { DeleteAllLeftAction, JoinLinesAction, TransposeAction, UpperCaseAction, LowerCaseAction } from 'vs/editor/contrib/linesOperations/common/linesOperations';
 
 suite('Editor Contrib - Line Operations', () => {
 	test('delete all left', function () {


### PR DESCRIPTION
Add missing commands from Sublime/Atom per #3776 .

TODO: 
- [x] Join lines
- [x] Transpose
- [x] Upper/Lower case
- [x] Paste and format
- [x] Test cases

Discussed with Kai and Alex, our `contrib` part of code is used as internal extension so it's Okay to put these missing commands into our code base. However while implementing them in core, I found that there is one new issue: key bindings conflicts. Will have a discuss with Alex and @waderyan on Monday.