### PR TITLE
Only resolve paths in REPL if path is relative

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -95,10 +95,11 @@ export class ReplExpressionsRenderer implements IRenderer {
 	private static FILE_LOCATION_PATTERNS: RegExp[] = [
 		// group 0: the full thing :)
 		// group 1: absolute path
-		// group 2: line number
-		// group 3: column number
+		// group 2: the root slash/drive letter, if present
+		// group 3: line number
+		// group 4: column number
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/(?:at |^|[\(<\'\"\[])(?:file:\/\/)?((?:(?:\/|[a-zA-Z]:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?):(\d+)(?::(\d+))?(?:$|[\)>\'\"\]])/
+		/(?:at |^|[\(<\'\"\[])(?:file:\/\/)?((?:(\/|[a-zA-Z]:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?):(\d+)(?::(\d+))?(?:$|[\)>\'\"\]])/
 	];
 
 	private static LINE_HEIGHT_PX = 18;
@@ -346,7 +347,8 @@ export class ReplExpressionsRenderer implements IRenderer {
 			const match = pattern.exec(text);
 			let resource: uri = null;
 			try {
-				resource = match && this.contextService.toResource(match[1]);
+				// If root slash / drive letter is present, resolve relative path
+				resource = match && (match[2] ? uri.file(match[1]) : this.contextService.toResource(match[1]));
 			} catch (e) { }
 
 			if (resource) {
@@ -363,7 +365,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 				link.textContent = text.substr(match.index, match[0].length);
 				link.title = isMacintosh ? nls.localize('fileLinkMac', "Click to follow (Cmd + click opens to the side)") : nls.localize('fileLink', "Click to follow (Ctrl + click opens to the side)");
 				linkContainer.appendChild(link);
-				link.onclick = (e) => this.onLinkClick(new StandardMouseEvent(e), resource, Number(match[2]), match[3] && Number(match[3]));
+				link.onclick = (e) => this.onLinkClick(new StandardMouseEvent(e), resource, Number(match[3]), match[4] && Number(match[4]));
 
 				let textAfterLink = text.substr(match.index + match[0].length);
 				if (textAfterLink) {


### PR DESCRIPTION
Added back the root component capture to the regexp and call `toResource` conditionally. I would appreciate it if someone could check this out and test, still have trouble building, this is untested