### PR TITLE
Introduce a backup file model inside IBackupFileService

### DIFF
--- a/src/vs/test/utils/servicesTestUtils.ts
+++ b/src/vs/test/utils/servicesTestUtils.ts
@@ -668,6 +668,16 @@ export class TestBackupFileService implements IBackupFileService {
 		return TPromise.as(false);
 	}
 
+	public loadBackupResource(resource: URI): TPromise<URI> {
+		return this.hasBackup(resource).then(hasBackup => {
+			if (hasBackup) {
+				return this.getBackupResource(resource);
+			}
+
+			return void 0;
+		});
+	}
+
 	public registerResourceForBackup(resource: URI): TPromise<void> {
 		return TPromise.as(void 0);
 	}

--- a/src/vs/workbench/common/editor/untitledEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledEditorModel.ts
@@ -158,9 +158,9 @@ export class UntitledEditorModel extends StringEditorModel implements IEncodingS
 	public load(): TPromise<EditorModel> {
 
 		// Check for backups first
-		return this.backupFileService.hasBackup(this.resource).then(hasBackup => {
-			if (hasBackup) {
-				return this.textFileService.resolveTextContent(this.backupFileService.getBackupResource(this.resource), BACKUP_FILE_RESOLVE_OPTIONS).then(rawTextContent => rawTextContent.value.lines.join('\n'));
+		return this.backupFileService.loadBackupResource(this.resource).then(backupResource => {
+			if (backupResource) {
+				return this.textFileService.resolveTextContent(backupResource, BACKUP_FILE_RESOLVE_OPTIONS).then(rawTextContent => rawTextContent.value.lines.join('\n'));
 			}
 
 			return null;

--- a/src/vs/workbench/parts/backup/common/backupModelTracker.ts
+++ b/src/vs/workbench/parts/backup/common/backupModelTracker.ts
@@ -56,7 +56,7 @@ export class BackupModelTracker implements IWorkbenchContribution {
 		} else if (event.kind === StateChange.CONTENT_CHANGE) {
 			if (this.backupService.isHotExitEnabled) {
 				const model = this.textFileService.models.get(event.resource);
-				this.backupFileService.backupResource(model.getResource(), model.getValue());
+				this.backupFileService.backupResource(model.getResource(), model.getValue(), model.getVersionId());
 			}
 		}
 	}
@@ -65,7 +65,7 @@ export class BackupModelTracker implements IWorkbenchContribution {
 		if (this.backupService.isHotExitEnabled) {
 			const input = this.untitledEditorService.get(resource);
 			if (input.isDirty()) {
-				input.resolve().then(model => this.backupFileService.backupResource(resource, model.getValue()));
+				input.resolve().then(model => this.backupFileService.backupResource(resource, model.getValue(), model.getVersionId()));
 			} else {
 				this.discardBackup(resource);
 			}

--- a/src/vs/workbench/parts/backup/common/backupRestorer.ts
+++ b/src/vs/workbench/parts/backup/common/backupRestorer.ts
@@ -55,8 +55,8 @@ export class BackupRestorer implements IWorkbenchContribution {
 				});
 
 				TPromise.join(Object.keys(fileResources).map(resource => {
-					return this.backupFileService.hasBackup(URI.parse(resource)).then(hasBackup => {
-						if (hasBackup) {
+					return this.backupFileService.loadBackupResource(URI.parse(resource)).then(backupResource => {
+						if (backupResource) {
 							return fileResources[resource].resolve();
 						}
 					});

--- a/src/vs/workbench/services/backup/common/backup.ts
+++ b/src/vs/workbench/services/backup/common/backup.ts
@@ -40,28 +40,21 @@ export interface IBackupFileService {
 	_serviceBrand: any;
 
 	/**
-	 * Gets whether a text file has a backup to restore.
-	 *
-	 * @param resource The resource to check.
-	 * @returns Whether the file has a backup.
-	 */
-	hasBackup(resource: Uri): TPromise<boolean>;
-
-	/**
-	 * Gets the backup resource for a particular resource within the current workspace.
+	 * Loads the backup resource for a particular resource within the current workspace.
 	 *
 	 * @param resource The resource that is backed up.
-	 * @return The backup resource.
+	 * @return The backup resource if any.
 	 */
-	getBackupResource(resource: Uri): Uri;
+	loadBackupResource(resource: Uri): TPromise<Uri>;
 
 	/**
 	 * Backs up a resource.
 	 *
 	 * @param resource The resource to back up.
-	 * @param content THe content of the resource.
+	 * @param content The content of the resource.
+	 * @param versionId The version id of the resource to backup.
 	 */
-	backupResource(resource: Uri, content: string): TPromise<void>;
+	backupResource(resource: Uri, content: string, versionId?: number): TPromise<void>;
 
 	/**
 	 * Discards the backup associated with a resource if it exists..

--- a/src/vs/workbench/services/backup/node/backupFileService.ts
+++ b/src/vs/workbench/services/backup/node/backupFileService.ts
@@ -14,12 +14,74 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IFileService } from 'vs/platform/files/common/files';
 import { TPromise } from 'vs/base/common/winjs.base';
 
+export interface IBackupsFileModel {
+	resolve(backupRoot: string): TPromise<IBackupsFileModel>;
+
+	add(resource: Uri, versionId?: number): void;
+	has(resource: Uri, versionId?: number): boolean;
+	remove(resource: Uri): void;
+	clear(): void;
+}
+
+// TODO@daniel this should resolve the backups with their file names once we have the metadata in place
+export class BackupsFileModel implements IBackupsFileModel {
+	private cache: { [resource: string]: number /* version ID */ } = Object.create(null);
+
+	resolve(backupRoot: string): TPromise<IBackupsFileModel> {
+		return pfs.readDirsInDir(backupRoot).then(backupSchemas => {
+
+			// For all supported schemas
+			return TPromise.join(backupSchemas.map(backupSchema => {
+
+				// Read backup directory for backups
+				const backupSchemaPath = path.join(backupRoot, backupSchema);
+				return pfs.readdir(backupSchemaPath).then(backupHashes => {
+
+					// Remember known backups in our caches
+					backupHashes.forEach(backupHash => {
+						const backupResource = Uri.file(path.join(backupSchemaPath, backupHash));
+						this.add(backupResource);
+					});
+				});
+			}));
+		}).then(() => this, error => this);
+	}
+
+	add(resource: Uri, versionId = 0): void {
+		this.cache[resource.toString()] = versionId;
+	}
+
+	has(resource: Uri, versionId?: number): boolean {
+		const cachedVersionId = this.cache[resource.toString()];
+		if (typeof cachedVersionId !== 'number') {
+			return false; // unknown resource
+		}
+
+		if (typeof versionId === 'number') {
+			return versionId === cachedVersionId; // if we are asked with a specific version ID, make sure to test for it
+		}
+
+		return true;
+	}
+
+	remove(resource: Uri): void {
+		delete this.cache[resource.toString()];
+	}
+
+	clear(): void {
+		this.cache = Object.create(null);
+	}
+}
+
 export class BackupFileService implements IBackupFileService {
 
 	public _serviceBrand: any;
 
 	protected backupHome: string;
 	protected workspacesJsonPath: string;
+
+	private backupWorkspacePath: string;
+	private ready: TPromise<IBackupsFileModel>;
 
 	constructor(
 		private currentWorkspace: Uri,
@@ -28,10 +90,27 @@ export class BackupFileService implements IBackupFileService {
 	) {
 		this.backupHome = environmentService.backupHome;
 		this.workspacesJsonPath = environmentService.backupWorkspacesPath;
+
+		if (this.currentWorkspace) {
+			const workspaceHash = crypto.createHash('md5').update(this.currentWorkspace.fsPath).digest('hex');
+			this.backupWorkspacePath = path.join(this.backupHome, workspaceHash);
+		}
+
+		this.ready = this.init();
 	}
 
 	private get backupEnabled(): boolean {
 		return this.currentWorkspace && !this.environmentService.isExtensionDevelopment; // Hot exit is disabled for empty workspaces and when doing extension development
+	}
+
+	private init(): TPromise<IBackupsFileModel> {
+		const model = new BackupsFileModel();
+
+		if (!this.backupEnabled) {
+			return TPromise.as(model);
+		}
+
+		return model.resolve(this.backupWorkspacePath);
 	}
 
 	public hasBackup(resource: Uri): TPromise<boolean> {
@@ -40,42 +119,36 @@ export class BackupFileService implements IBackupFileService {
 			return TPromise.as(false);
 		}
 
-		return pfs.exists(backupResource.fsPath);
+		return this.ready.then(model => model.has(backupResource));
 	}
 
-	private getBackupHash(resource: Uri): string {
-		if (!this.backupEnabled) {
-			return null;
-		}
+	public loadBackupResource(resource: Uri): TPromise<Uri> {
+		return this.hasBackup(resource).then(hasBackup => {
+			if (hasBackup) {
+				return this.getBackupResource(resource);
+			}
 
-		// Only hash the file path if the file is not untitled
-		return resource.scheme === 'untitled' ? resource.fsPath : crypto.createHash('md5').update(resource.fsPath).digest('hex');
+			return void 0;
+		});
 	}
 
-	public getBackupResource(resource: Uri): Uri {
-		const backupHash = this.getBackupHash(resource);
-		if (!backupHash) {
-			return null;
-		}
-
-		const backupPath = path.join(this.getWorkspaceBackupDirectory(), resource.scheme, backupHash);
-
-		return Uri.file(backupPath);
-	}
-
-	private getWorkspaceBackupDirectory(): string {
-		const workspaceHash = crypto.createHash('md5').update(this.currentWorkspace.fsPath).digest('hex');
-
-		return path.join(this.backupHome, workspaceHash);
-	}
-
-	public backupResource(resource: Uri, content: string): TPromise<void> {
+	public backupResource(resource: Uri, content: string, versionId?: number): TPromise<void> {
 		const backupResource = this.getBackupResource(resource);
 		if (!backupResource) {
 			return TPromise.as(void 0);
 		}
 
-		return this.fileService.updateContent(backupResource, content, BACKUP_FILE_UPDATE_OPTIONS).then(() => void 0);
+		return this.ready.then(model => {
+			if (model.has(backupResource, versionId)) {
+				return TPromise.as(void 0); // return early if backup version id matches requested one
+			}
+
+			return this.fileService.updateContent(backupResource, content, BACKUP_FILE_UPDATE_OPTIONS).then(() => {
+				model.add(backupResource, versionId);
+
+				return void 0;
+			});
+		});
 	}
 
 	public discardResourceBackup(resource: Uri): TPromise<void> {
@@ -84,7 +157,11 @@ export class BackupFileService implements IBackupFileService {
 			return TPromise.as(void 0);
 		}
 
-		return this.fileService.del(backupResource);
+		return this.ready.then(model => {
+			model.remove(backupResource);
+
+			return this.fileService.del(backupResource);
+		});
 	}
 
 	public discardAllWorkspaceBackups(): TPromise<void> {
@@ -92,6 +169,22 @@ export class BackupFileService implements IBackupFileService {
 			return TPromise.as(void 0);
 		}
 
-		return this.fileService.del(Uri.file(this.getWorkspaceBackupDirectory()));
+		return this.ready.then(model => {
+			model.clear();
+
+			return this.fileService.del(Uri.file(this.backupWorkspacePath));
+		});
+	}
+
+	public getBackupResource(resource: Uri): Uri {
+		if (!this.backupEnabled) {
+			return null;
+		}
+
+		// Only hash the file path if the file is not untitled
+		const backupName = resource.scheme === 'untitled' ? resource.fsPath : crypto.createHash('md5').update(resource.fsPath).digest('hex');
+		const backupPath = path.join(this.backupWorkspacePath, resource.scheme, backupName);
+
+		return Uri.file(backupPath);
 	}
 }

--- a/src/vs/workbench/services/backup/node/backupService.ts
+++ b/src/vs/workbench/services/backup/node/backupService.ts
@@ -73,7 +73,7 @@ export class BackupService implements IBackupService {
 	private doBackupAll(dirtyFileModels: ITextFileEditorModel[], untitledResources: Uri[]): TPromise<void> {
 		// Handle file resources first
 		return TPromise.join(dirtyFileModels.map(model => {
-			return this.backupFileService.backupResource(model.getResource(), model.getValue());
+			return this.backupFileService.backupResource(model.getResource(), model.getValue(), model.getVersionId());
 		})).then(results => {
 			// Handle untitled resources
 			const untitledModelPromises = untitledResources.map(untitledResource => this.untitledEditorService.get(untitledResource))
@@ -82,7 +82,7 @@ export class BackupService implements IBackupService {
 
 			return TPromise.join(untitledModelPromises).then(untitledModels => {
 				const untitledBackupPromises = untitledModels.map(model => {
-					return this.backupFileService.backupResource(model.getResource(), model.getValue());
+					return this.backupFileService.backupResource(model.getResource(), model.getValue(), model.getVersionId());
 				});
 				return TPromise.join(untitledBackupPromises).then(() => void 0);
 			});

--- a/src/vs/workbench/services/backup/test/backupFileService.test.ts
+++ b/src/vs/workbench/services/backup/test/backupFileService.test.ts
@@ -14,7 +14,7 @@ import path = require('path');
 import extfs = require('vs/base/node/extfs');
 import pfs = require('vs/base/node/pfs');
 import Uri from 'vs/base/common/uri';
-import { BackupFileService, BackupsFileModel } from 'vs/workbench/services/backup/node/backupFileService';
+import { BackupFileService, BackupFilesModel } from 'vs/workbench/services/backup/node/backupFileService';
 import { FileService } from 'vs/workbench/services/files/node/fileService';
 import { EnvironmentService } from 'vs/platform/environment/node/environmentService';
 import { parseArgs } from 'vs/platform/environment/node/argv';
@@ -37,6 +37,10 @@ class TestBackupFileService extends BackupFileService {
 
 		super(workspace, testEnvironmentService, fileService);
 	}
+
+	public getBackupResource(resource: Uri): Uri {
+		return super.getBackupResource(resource);
+	}
 }
 
 suite('BackupFileService', () => {
@@ -53,7 +57,7 @@ suite('BackupFileService', () => {
 	const barBackupPath = path.join(workspaceBackupPath, 'file', crypto.createHash('md5').update(barFile.fsPath).digest('hex'));
 	const untitledBackupPath = path.join(workspaceBackupPath, 'untitled', untitledFile.fsPath);
 
-	let service: BackupFileService;
+	let service: TestBackupFileService;
 
 	setup(done => {
 		service = new TestBackupFileService(workspaceResource, backupHome, workspacesJsonPath);
@@ -166,8 +170,8 @@ suite('BackupFileService', () => {
 		});
 	});
 
-	test('BackupsFileModel - simple', () => {
-		const model = new BackupsFileModel();
+	test('BackupFilesModel - simple', () => {
+		const model = new BackupFilesModel();
 
 		const resource1 = Uri.file('test.html');
 
@@ -213,11 +217,11 @@ suite('BackupFileService', () => {
 		assert.equal(model.has(resource4), true);
 	});
 
-	test('BackupsFileModel - resolve', (done) => {
+	test('BackupFilesModel - resolve', (done) => {
 		pfs.mkdirp(path.dirname(fooBackupPath)).then(() => {
 			fs.writeFileSync(fooBackupPath, 'foo');
 
-			const model = new BackupsFileModel();
+			const model = new BackupFilesModel();
 
 			model.resolve(workspaceBackupPath).then(model => {
 				assert.equal(model.has(Uri.file(fooBackupPath)), true);

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -289,13 +289,12 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 			else {
 				diag('load() - created text editor model', this.resource, new Date());
 
-				return this.backupFileService.hasBackup(this.resource).then(backupExists => {
+				return this.backupFileService.loadBackupResource(this.resource).then(backupResource => {
 					let resolveBackupPromise: TPromise<IRawText>;
 
 					// Try get restore content, if there is an issue fallback silently to the original file's content
-					if (backupExists) {
-						const restoreResource = this.backupFileService.getBackupResource(this.resource);
-						resolveBackupPromise = this.textFileService.resolveTextContent(restoreResource, BACKUP_FILE_RESOLVE_OPTIONS).then(backup => backup.value, error => content.value);
+					if (backupResource) {
+						resolveBackupPromise = this.textFileService.resolveTextContent(backupResource, BACKUP_FILE_RESOLVE_OPTIONS).then(backup => backup.value, error => content.value);
 					} else {
 						resolveBackupPromise = TPromise.as(content.value);
 					}
@@ -304,7 +303,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 						return this.createTextEditorModel(fileContent, content.resource).then(() => {
 							this.createTextEditorModelPromise = null;
 
-							if (backupExists) {
+							if (backupResource) {
 								this.makeDirty();
 							} else {
 								this.setDirty(false); // Ensure we are not tracking a stale state


### PR DESCRIPTION
This PR introduces a `BackupsFileModel` to `BackupFileService`. It resolves all backups that exist for a workspace on startup and keeps itself updated when changes to backups are made. Thus it avoids the constant disk lookup when resolving files or untitled models (https://github.com/Microsoft/vscode/issues/15653)

In addition to that, it associates the `versionId` of the model with the resource that was backed up and thus allows to avoid backing up content of a model that is already backed up (https://github.com/Microsoft/vscode/issues/14075).

**Fixes**:
* Avoid checking for backups on each resolve() of file/untitled (https://github.com/Microsoft/vscode/issues/15653)
* Hot Exit: backup all ignores existing backups? (https://github.com/Microsoft/vscode/issues/14075)

@Tyriar I would think that the `BackupsFileModel` is also the right place of reading the meta data of the backups for https://github.com/Microsoft/vscode/issues/15718 to keep everything in one place. Once that is in, `IBackupFileService` should get a method that returns the paths of file and untitled resources that contain backups.