### PR TITLE
Allow markdown preview to scroll past content

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -8,6 +8,9 @@ body {
 	font-size: 14px;
 	padding-left: 12px;
 	line-height: 22px;
+}
+
+body.scrollBeyondLastLine {
 	margin-bottom: calc(100vh - 22px);
 }
 

--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -8,6 +8,7 @@ body {
 	font-size: 14px;
 	padding-left: 12px;
 	line-height: 22px;
+	margin-bottom: calc(100vh - 22px);
 }
 
 img {

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -225,6 +225,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 
 	public provideTextDocumentContent(uri: vscode.Uri): Thenable<string> {
 		return vscode.workspace.openTextDocument(vscode.Uri.parse(uri.query)).then(document => {
+			const scrollBeyondLastLine = vscode.workspace.getConfiguration('editor')['scrollBeyondLastLine'];
 			const head = [].concat(
 				'<!DOCTYPE html>',
 				'<html>',
@@ -235,7 +236,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 				this.computeCustomStyleSheetIncludes(uri),
 				`<base href="${document.uri.toString(true)}">`,
 				'</head>',
-				'<body>'
+				`<body class="${scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''}">`
 			).join('\n');
 			const body = this._renderer.render(this.getDocumentContentForPreview(document));
 


### PR DESCRIPTION
Issue #15795

Allows the markdown preview to scroll past its contents, like we do with the markdown editor.

![nov-22-2016 13-00-26](https://cloud.githubusercontent.com/assets/12821956/20541802/878af7f4-b0b3-11e6-9866-75474675a3e6.gif)

Closes #15795