### PR TITLE
Assume Jsx For Implicit TS Projects

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -464,6 +464,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 				allowSyntheticDefaultImports: true,
 				allowNonTsExtensions: true,
 				allowJs: true,
+				jsx: 'Preserve'
 			};
 			let args: Proto.SetCompilerOptionsForInferredProjectsArgs = {
 				options: compilerOptions


### PR DESCRIPTION
Issue #15814

**Bug**
1. Open a tsx file on its own.
2. See a error about passing `--jsx` to tsc.

**Fix**
For implicit projects, assume `"jsx": "preserve"`. I believe `preserve` is a safer assumption than `"jsx": "react"`, which will generate an error if `React` is not defined.

Closes #15814