### PR TITLE
Add Markdown Preview Right Click Copy Context Menu

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -68,6 +68,7 @@ const vscodeResources = [
 	'out-build/vs/workbench/parts/html/browser/webview.html',
 	'out-build/vs/workbench/parts/html/browser/webview-pre.js',
 	'out-build/vs/**/markdown.css',
+	'out-build/vs/**/markdown.js',
 	'out-build/vs/workbench/parts/tasks/**/*.json',
 	'out-build/vs/workbench/parts/terminal/electron-browser/terminalProcess.js',
 	'out-build/vs/workbench/services/files/**/*.exe',

--- a/extensions/markdown/media/markdown.js
+++ b/extensions/markdown/media/markdown.js
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+"use strict";
+
+var remote = window.parent.require('electron').remote;
+var Menu = remote.Menu;
+var MenuItem = remote.MenuItem;
+
+var menu = new Menu();
+menu.append(new MenuItem({
+	label: 'Copy', click: function () {
+		document.execCommand('copy');
+	}
+}));
+
+window.addEventListener('contextmenu', function () {
+	menu.popup(remote.getCurrentWindow());
+	return false;
+}, false);

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -235,7 +235,8 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 				this.computeCustomStyleSheetIncludes(uri),
 				`<base href="${document.uri.toString(true)}">`,
 				'</head>',
-				'<body>'
+				'<body>',
+				`<script src="${this.getMediaPath('markdown.js')}"></script>`,
 			).join('\n');
 			const body = this._renderer.render(this.getDocumentContentForPreview(document));
 


### PR DESCRIPTION
Issue #12034

**Bug**
There are no right click context menus in the markdown preview. Copying text using command-c still works, but you cannot access the copy context menu.

**Fix**
Add some JS to handle right clicks in the markdown preview. Show an electron menu on click and provide an option to copy text using builtin logic.

![nov-22-2016 17-37-54](https://cloud.githubusercontent.com/assets/12821956/20548681/53469a4e-b0da-11e6-9d66-a756274fe208.gif)

closes #12034