### PR TITLE
Make cmd+k clear terminal on Mac

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -97,12 +97,13 @@
 				"command": "markdown.showPreview",
 				"key": "shift+ctrl+v",
 				"mac": "shift+cmd+v",
-				"when": "!terminalFocus"
+				"when": "editorFocus"
 			},
 			{
 				"command": "markdown.showPreviewToSide",
 				"key": "ctrl+k v",
-				"mac": "cmd+k v"
+				"mac": "cmd+k v",
+				"when": "editorFocus"
 			}
 		],
 		"snippets": [

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -296,7 +296,7 @@ export class KeybindingResolver {
 	}
 
 	public resolve(context: any, currentChord: number, keypress: number): IResolveResult {
-		// console.log('resolve: ' + Keybinding.toLabel(keypress));
+		// console.log('resolve: ' + Keybinding.toUserSettingsLabel(keypress));
 		let lookupMap: ICommandEntry[] = null;
 
 		if (currentChord !== 0) {
@@ -411,7 +411,7 @@ export class IOSupport {
 		} else {
 			out.write(`${quotedSerializeCommand} `);
 		}
-		//		out.write(String(item.weight));
+		// out.write(String(item.weight1 + '-' + item.weight2));
 		out.write('}');
 	}
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -22,6 +22,7 @@ import { TerminalService } from 'vs/workbench/parts/terminal/electron-browser/te
 import { ToggleTabFocusModeAction } from 'vs/editor/contrib/toggleTabFocusMode/common/toggleTabFocusMode';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import debugActions = require('vs/workbench/parts/debug/browser/debugActions');
+import { KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
 let configurationRegistry = <IConfigurationRegistry>Registry.as(Extensions.Configuration);
 configurationRegistry.registerConfiguration({
@@ -200,4 +201,6 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(ScrollToTopTermi
 	primary: KeyMod.CtrlCmd | KeyCode.Home,
 	linux: { primary: KeyMod.Shift | KeyCode.Home }
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Scroll to Top', category);
-actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(ClearTerminalAction, ClearTerminalAction.ID, ClearTerminalAction.LABEL), 'Terminal: Clear', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(ClearTerminalAction, ClearTerminalAction.ID, ClearTerminalAction.LABEL, {
+	primary: KeyMod.CtrlCmd | KeyCode.KEY_K
+}, KEYBINDING_CONTEXT_TERMINAL_FOCUS, KeybindingsRegistry.WEIGHT.workbenchContrib(1)), 'Terminal: Clear', category);


### PR DESCRIPTION
Fixes #12585

---

@mjbvz please review the markdown keybindings change. This makes the keybindings only work when the editor is focused. This could be considered a regression if people rely on the fact that it's a global command (eg. if panel is focused), but it kind of makes sense to keep it to the editorFocus context as it's an action on the active editor.