### PR TITLE
Default for git.autofetch should be set to false to prevent blacklisting

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
+++ b/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
@@ -199,7 +199,7 @@ export function registerContributions(): void {
 			'git.autofetch': {
 				type: 'boolean',
 				description: nls.localize('gitAutoFetch', "Whether auto fetching is enabled."),
-				default: true
+				default: false
 			},
 			'git.enableLongCommitWarning': {
 				type: 'boolean',


### PR DESCRIPTION
With a default to `true`, it keeps fetching the remote repo, which sometimes results in a blacklist of the IP address.

This just happened to me with ovh hosting.