### PR TITLE
dupe module

### DIFF
--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -5,10 +5,13 @@
 
 const cp = require('child_process');
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf');
 
-function npmInstall(location) {
+function npmInstallSync(location) {
 	const result = cp.spawnSync(npm, ['install'], {
-		cwd: location ,
+		cwd: location,
 		stdio: 'inherit'
 	});
 
@@ -17,7 +20,7 @@ function npmInstall(location) {
 	}
 }
 
-npmInstall('extensions'); // node modules shared by all extensions
+npmInstallSync('extensions'); // node modules shared by all extensions
 
 const extensions = [
 	'vscode-api-tests',
@@ -33,4 +36,42 @@ const extensions = [
 	'html'
 ];
 
-extensions.forEach(extension => npmInstall(`extensions/${extension}`));
+extensions.forEach(extension => npmInstallSync(`extensions/${extension}`));
+
+function rmDuplicateModulesSync() {
+
+	function fetchModuleIds(basepath) {
+		const result = new Map();
+		for (const candidate of fs.readdirSync(path.join(basepath, 'node_modules'))) {
+			try {
+				let raw = fs.readFileSync(path.join(basepath, 'node_modules', candidate, 'package.json'));
+				let data = JSON.parse(raw);
+				result.set(data._id, path.join(basepath, 'node_modules', candidate));
+			} catch (e) {
+				if (e.code !== 'ENOENT') {
+					throw e;
+				}
+			}
+		}
+		return result;
+	}
+
+	const duplicates = new Set();
+	const baseModules = fetchModuleIds('');
+
+	for (const extension of extensions) {
+		const extensionModules = fetchModuleIds(`extensions/${extension}`);
+		for (let [key, value] of extensionModules) {
+			if (baseModules.has(key)) {
+				duplicates.add(value);
+			}
+		}
+	}
+
+	for (let duplicate of duplicates) {
+		console.log(`REMOVING duplicate module '${duplicate}'`);
+		rimraf.sync(path.join(process.cwd(), duplicate));
+	}
+}
+
+rmDuplicateModulesSync();


### PR DESCRIPTION
After running `npm install` for the extensions-folder check for identical (name & version) modules in the *parent folder* and remove dupes.