### PR TITLE
Fix missing 'set' command that was causing a useless error.

### DIFF
--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -16,7 +16,7 @@ set CODE=".build\electron\%NAMESHORT%"
 for /f "tokens=2 delims=:," %%a in ('findstr /R /C:"\"electronVersion\":.*" package.json') do set DESIREDVERSION=%%~a
 set DESIREDVERSION=%DESIREDVERSION: "=%
 set DESIREDVERSION=v%DESIREDVERSION:"=%
-if exist .\.build\electron\version (set /p INSTALLEDVERSION=<.\.build\electron\version) else (INSTALLEDVERSION="")
+if exist .\.build\electron\version (set /p INSTALLEDVERSION=<.\.build\electron\version) else (set INSTALLEDVERSION="")
 
 :: Get electron
 if not exist %CODE% node .\node_modules\gulp\bin\gulp.js electron


### PR DESCRIPTION
Was following the instructions for the first time to set up my local environment for contributing to VSCode and I noticed when I ran .\scripts\code.bat as instructed that the script emitted an error about INSTALLEDVERSION being unknown. At first I thought I had mis-configured something but looking at the code.bat file there is an obvious omission of a 'set' command. Simple fix.