### PR TITLE
Enable PHP syntax highlighting without <?php, also fix markdown + PHP code fence issues

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -668,6 +668,18 @@
 				</dict>
 				<key>fenced_code_block_php</key>
 				<dict>
+					<key>comment</key>
+					<string>
+					In fenced PHP code blocks, we match a "fuzzy" version of the PHP language.
+					This is because code blocks may be an incomplete PHP script that lacks a script
+					section start tag, and we still want to provide syntax highlighting, rather
+					than adhering to the actual grammar, where everything not prepended by a
+					start tag would be ignored. Additionally, we want to provide highlighting
+					for potential non-PHP languages (in particular HTML).
+
+					There are certainly plenty of edge cases here, but this seems to cover most popular
+					scenarios, and also appears to be consistent with the approach that GitHub takes.
+					</string>
 					<key>begin</key>
 					<string>(^|\G)\s*([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\s*$</string>
 					<key>name</key>
@@ -677,8 +689,18 @@
 					<key>patterns</key>
 					<array>
 						<dict>
+							<key>comment</key>
+							<string>
+							Left to its own devices, the PHP grammar will match HTML as a combination of operators
+							and constants. Therefore, HTML must take precedence over PHP in order to get proper
+							syntax highlighting.
+							</string>
 							<key>include</key>
-							<string>text.html.php</string>
+							<string>text.html.basic</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>text.html.php.language</string>
 						</dict>
 					</array>
 				</dict>

--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -20,6 +20,7 @@
 			// For reference by services requiring PHP syntax highlighting for partial
 			// code missing script start/end tags.
 			"id": "phplanguage",
+			"aliases": [ null ], // unsupported: prevents language from appearing in Language Mode list
 			"mimetypes": ["application/x-php-language"],
 			"configuration": "./language-configuration.json"
 		}],

--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"publisher": "vscode",
 	"engines": { "vscode": "0.10.x" },
-	"activationEvents": ["onLanguage:php"],
+	"activationEvents": ["onLanguage:php", "onLanguage:phplanguage"],
 	"main": "./out/phpMain",
 	"dependencies": {
 		"vscode-nls": "^1.0.4"
@@ -14,6 +14,13 @@
 			"extensions": [ ".php", ".php4", ".php5", ".phtml", ".ctp" ],
 			"aliases": [ "PHP", "php" ],
 			"mimetypes": ["application/x-php"],
+			"configuration": "./language-configuration.json"
+		},
+		{
+			// For reference by services requiring PHP syntax highlighting for partial
+			// code missing script start/end tags.
+			"id": "phplanguage",
+			"mimetypes": ["application/x-php-language"],
 			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{
@@ -29,6 +36,11 @@
 				"source.json": "json",
 				"source.css": "css"
 			}
+		},
+		{
+			"language": "phplanguage",
+			"scopeName": "text.html.php.language",
+			"path": "./syntaxes/phplanguage.json"
 		}],
 		"snippets": [{
 			"language": "php",

--- a/extensions/php/syntaxes/phplanguage.json
+++ b/extensions/php/syntaxes/phplanguage.json
@@ -1,0 +1,10 @@
+{
+  "scopeName" : "text.html.php.language",
+  "comment": "Grammar for PHP code without script-section start/end tags.",
+  "name": "PhpLanguage",
+  "patterns" : [
+    {
+      "include": "text.html.php#language"
+    }
+  ]
+}

--- a/src/vs/editor/common/services/modeServiceImpl.ts
+++ b/src/vs/editor/common/services/modeServiceImpl.ts
@@ -119,7 +119,7 @@ function isValidLanguageExtensionPoint(value: ILanguageExtensionPoint, collector
 		collector.error(nls.localize('opt.configuration', "property `{0}` can be omitted and must be of type `string`", 'configuration'));
 		return false;
 	}
-	if (!isUndefinedOrStringArray(value.aliases)) {
+	if (!isUndefinedOrStringArray(value.aliases) && value.aliases[0] !== null) {
 		collector.error(nls.localize('opt.aliases', "property `{0}` can be omitted and must be of type `string[]`", 'aliases'));
 		return false;
 	}


### PR DESCRIPTION
* Provide a new language (phplanguage) for reference by services requiring PHP syntax highlighting for code without script/start end tags. 
* Add workaround to prevent phplanguage from appearing in Language Mode list 
* fix markdown + PHP fenced code blocks
  * previously PHP wasn't working at all because we don't appear to properly support injections. This issue was addressed by pointing to a specific repository key (#languages).
  * ensure "fuzzy" syntax highlighting for PHP/HTML code so that script start tags are not required

close #14166, close #3746