### PR TITLE
Fixed $fileBasenameNoExtension

### DIFF
--- a/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
@@ -66,8 +66,8 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 	}
 
 	private get fileBasenameNoExtension(): string {
-		const basename = this.fileBasename;
-		return basename.slice(0, basename.length - paths.extname(basename).length);
+		const basename = this.fileBasename();
+		return basename.slice(0, basename.length - paths.extname(basename).length - 1);
 	}
 
 	private get fileDirname(): string {

--- a/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
@@ -66,7 +66,7 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 	}
 
 	private get fileBasenameNoExtension(): string {
-		const basename = this.fileBasename();
+		const basename = this.fileBasename;
 		return basename.slice(0, basename.length - paths.extname(basename).length - 1);
 	}
 


### PR DESCRIPTION
The newly added variable for tasks.json, $fileBasenameNoExtension, is not working... 
TRY to close #15937 

NOTE: as you may find in travis messages, the major issue is not the returned string length (that I fixed), but relate to registerTextDocumentContentProvider or sth else

I'm really a rookie to this domain, please help to diagnose