### PR TITLE
Fix backslash is not escaped by define key binding

### DIFF
--- a/src/vs/editor/contrib/defineKeybinding/browser/defineKeybinding.ts
+++ b/src/vs/editor/contrib/defineKeybinding/browser/defineKeybinding.ts
@@ -109,7 +109,7 @@ export class DefineKeybindingController implements editorCommon.IEditorContribut
 	private _onAccepted(keybinding: string): void {
 		let snippetText = [
 			'{',
-			'\t"key": "' + keybinding + '",',
+			'\t"key": ' + JSON.stringify(keybinding) + ',',
 			'\t"command": "${1:commandId}",',
 			'\t"when": "${2:editorTextFocus}"',
 			'}$0'


### PR DESCRIPTION
When defining keybinding using backslash key (with Define Keybinding feature), it will insert unescaped backslash:

```
"key": "shift+cmd+\",
```

This PR fixes it!