### PR TITLE
Log errors from feature providers as external

### DIFF
--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -68,6 +68,11 @@ export class ErrorHandler {
 		this.unexpectedErrorHandler(e);
 		this.emit(e);
 	}
+
+	// For external errors, we don't want the listeners to be called
+	public onUnexpectedExternalError(e: any): void {
+		this.unexpectedErrorHandler(e);
+	}
 }
 
 export let errorHandler = new ErrorHandler();
@@ -81,6 +86,14 @@ export function onUnexpectedError(e: any): void {
 	// ignore errors from cancelled promises
 	if (!isPromiseCanceledError(e)) {
 		errorHandler.onUnexpectedError(e);
+	}
+}
+
+export function onUnexpectedExternalError(e: any): void {
+
+	// ignore errors from cancelled promises
+	if (!isPromiseCanceledError(e)) {
+		errorHandler.onUnexpectedExternalError(e);
 	}
 }
 

--- a/src/vs/editor/contrib/codelens/common/codelens.ts
+++ b/src/vs/editor/contrib/codelens/common/codelens.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { illegalArgument, onUnexpectedError } from 'vs/base/common/errors';
+import { illegalArgument, onUnexpectedExternalError } from 'vs/base/common/errors';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IModel } from 'vs/editor/common/editorCommon';
@@ -30,7 +30,7 @@ export function getCodeLensData(model: IModel): TPromise<ICodeLensData[]> {
 				symbols.push({ symbol, provider });
 			}
 		}
-	}, onUnexpectedError));
+	}, onUnexpectedExternalError));
 
 	return TPromise.join(promises).then(() => {
 		return symbols.sort((a, b) => {

--- a/src/vs/editor/contrib/format/common/format.ts
+++ b/src/vs/editor/contrib/format/common/format.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { illegalArgument } from 'vs/base/common/errors';
+import { illegalArgument, onUnexpectedExternalError } from 'vs/base/common/errors';
 import URI from 'vs/base/common/uri';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -31,9 +31,7 @@ export function getDocumentRangeFormattingEdits(model: IReadOnlyModel, range: Ra
 			return () => {
 				return asWinJsPromise(token => provider.provideDocumentRangeFormattingEdits(model, range, options, token)).then(value => {
 					result = value;
-				}, err => {
-					// ignore
-				});
+				}, onUnexpectedExternalError);
 			};
 		}
 	})).then(() => result);
@@ -53,9 +51,7 @@ export function getDocumentFormattingEdits(model: IReadOnlyModel, options: Forma
 			return () => {
 				return asWinJsPromise(token => provider.provideDocumentFormattingEdits(model, options, token)).then(value => {
 					result = value;
-				}, err => {
-					// ignore
-				});
+				}, onUnexpectedExternalError);
 			};
 		}
 	})).then(() => result);
@@ -72,7 +68,7 @@ export function getOnTypeFormattingEdits(model: IReadOnlyModel, position: Positi
 
 	return asWinJsPromise((token) => {
 		return support.provideOnTypeFormattingEdits(model, position, ch, options, token);
-	});
+	}).then(r => r, onUnexpectedExternalError);
 }
 
 CommonEditorRegistry.registerLanguageCommand('_executeFormatRangeProvider', function (accessor, args) {

--- a/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
@@ -24,7 +24,7 @@ export function getDeclarationsAtPosition(model: IReadOnlyModel, position: Posit
 		}).then(result => {
 			return result;
 		}, err => {
-			onUnexpectedError(err);
+			onUnexpectedExternalError(err);
 		});
 	});
 

--- a/src/vs/editor/contrib/hover/common/hover.ts
+++ b/src/vs/editor/contrib/hover/common/hover.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import { coalesce } from 'vs/base/common/arrays';
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
@@ -31,7 +31,7 @@ export function getHover(model: IReadOnlyModel, position: Position): TPromise<Ho
 				}
 			}
 		}, err => {
-			onUnexpectedError(err);
+			onUnexpectedExternalError(err);
 		});
 	});
 

--- a/src/vs/editor/contrib/links/common/links.ts
+++ b/src/vs/editor/contrib/links/common/links.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Range } from 'vs/editor/common/core/range';
@@ -69,7 +69,7 @@ export function getLinks(model: IReadOnlyModel): TPromise<Link[]> {
 				const newLinks = result.map(link => new Link(link, provider));
 				links = union(links, newLinks);
 			}
-		}, onUnexpectedError);
+		}, onUnexpectedExternalError);
 	});
 
 	return TPromise.join(promises).then(() => {

--- a/src/vs/editor/contrib/parameterHints/common/parameterHints.ts
+++ b/src/vs/editor/contrib/parameterHints/common/parameterHints.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import { TPromise } from 'vs/base/common/winjs.base';
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
 import { SignatureHelp, SignatureHelpProviderRegistry } from 'vs/editor/common/modes';
@@ -33,7 +33,7 @@ export function provideSignatureHelp(model: IReadOnlyModel, position: Position):
 
 		return asWinJsPromise(token => support.provideSignatureHelp(model, position, token)).then(thisResult => {
 			result = thisResult;
-		}, onUnexpectedError);
+		}, onUnexpectedExternalError);
 
 	})).then(() => result);
 }

--- a/src/vs/editor/contrib/quickFix/common/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/common/quickFix.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { illegalArgument, onUnexpectedError } from 'vs/base/common/errors';
+import { illegalArgument, onUnexpectedExternalError } from 'vs/base/common/errors';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Range } from 'vs/editor/common/core/range';
@@ -24,7 +24,7 @@ export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<Co
 				allResults.push(...result);
 			}
 		}, err => {
-			onUnexpectedError(err);
+			onUnexpectedExternalError(err);
 		});
 	});
 

--- a/src/vs/editor/contrib/quickOpen/common/quickOpen.ts
+++ b/src/vs/editor/contrib/quickOpen/common/quickOpen.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { illegalArgument, onUnexpectedError } from 'vs/base/common/errors';
+import { illegalArgument, onUnexpectedExternalError } from 'vs/base/common/errors';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Range } from 'vs/editor/common/core/range';
@@ -32,7 +32,7 @@ export function getDocumentSymbols(model: IModel): TPromise<IOutline> {
 				entries.push(...result);
 			}
 		}, err => {
-			onUnexpectedError(err);
+			onUnexpectedExternalError(err);
 		});
 	});
 

--- a/src/vs/editor/contrib/referenceSearch/common/referenceSearch.ts
+++ b/src/vs/editor/contrib/referenceSearch/common/referenceSearch.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
@@ -24,7 +24,7 @@ export function provideReferences(model: IReadOnlyModel, position: Position): TP
 				return <Location[]>result;
 			}
 		}, err => {
-			onUnexpectedError(err);
+			onUnexpectedExternalError(err);
 		});
 	});
 

--- a/src/vs/editor/contrib/rename/common/rename.ts
+++ b/src/vs/editor/contrib/rename/common/rename.ts
@@ -7,7 +7,7 @@
 
 import { localize } from 'vs/nls';
 import { sequence, asWinJsPromise } from 'vs/base/common/async';
-import { illegalArgument } from 'vs/base/common/errors';
+import { illegalArgument, onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
@@ -34,7 +34,7 @@ export function rename(model: IReadOnlyModel, position: Position, newName: strin
 					} else {
 						rejects.push(result.rejectReason);
 					}
-				});
+				}, onUnexpectedExternalError);
 			}
 		};
 	});

--- a/src/vs/editor/contrib/rename/common/rename.ts
+++ b/src/vs/editor/contrib/rename/common/rename.ts
@@ -34,7 +34,10 @@ export function rename(model: IReadOnlyModel, position: Position, newName: strin
 					} else {
 						rejects.push(result.rejectReason);
 					}
-				}, onUnexpectedExternalError);
+				}, err => {
+					onUnexpectedExternalError(err);
+					return TPromise.wrapError<WorkspaceEdit>('provider failed');
+				});
 			}
 		};
 	});

--- a/src/vs/editor/contrib/suggest/common/suggest.ts
+++ b/src/vs/editor/contrib/suggest/common/suggest.ts
@@ -8,7 +8,7 @@ import { sequence, asWinJsPromise } from 'vs/base/common/async';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
 import { compare } from 'vs/base/common/strings';
 import { assign } from 'vs/base/common/objects';
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IModel, IPosition } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
@@ -106,7 +106,7 @@ export function provideSuggestionItems(model: IModel, position: Position, snippe
 						hasResult = true;
 					}
 
-				}, onUnexpectedError);
+				}, onUnexpectedExternalError);
 			}));
 		};
 	});

--- a/src/vs/editor/contrib/wordHighlighter/common/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/common/wordHighlighter.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import { sequence, asWinJsPromise } from 'vs/base/common/async';
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Range } from 'vs/editor/common/core/range';
 import * as editorCommon from 'vs/editor/common/editorCommon';
@@ -33,7 +33,7 @@ export function getOccurrencesAtPosition(model: editorCommon.IReadOnlyModel, pos
 						return data;
 					}
 				}, err => {
-					onUnexpectedError(err);
+					onUnexpectedExternalError(err);
 				});
 			}
 		};


### PR DESCRIPTION
Fixes #15374

When promises from language feature providers are rejected, we currently call `onUnexpectedError` which ends up calling error telemetry service that logs the error as a telemetry event.
There are 2 reasons why we wouldn't want this

- It is noise when we triage the error telemetry events because these errors are external as far as the core product is concerned.
- It may contain PII.