### PR TITLE
Don't translate Markdown.category 

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -45,7 +45,7 @@
 			{
 				"command": "markdown.showPreview",
 				"title": "%markdown.preview.title%",
-				"category": "%markdown.category%",
+				"category": "Markdown",
 				"icon": {
 					"light": "./media/Preview.svg",
 					"dark": "./media/Preview_inverse.svg"
@@ -54,7 +54,7 @@
 			{
 				"command": "markdown.showPreviewToSide",
 				"title": "%markdown.previewSide.title%",
-				"category": "%markdown.category%",
+				"category": "Markdown",
 				"icon": {
 					"light": "./media/PreviewOnRightPane_16x.svg",
 					"dark": "./media/PreviewOnRightPane_16x_dark.svg"
@@ -63,7 +63,7 @@
 			{
 				"command": "markdown.showSource",
 				"title": "%markdown.showSource.title%",
-				"category": "%markdown.category%",
+				"category": "Markdown",
 				"icon": {
 					"light": "./media/ViewSource.svg",
 					"dark": "./media/ViewSource_inverse.svg"

--- a/extensions/markdown/package.nls.json
+++ b/extensions/markdown/package.nls.json
@@ -1,5 +1,4 @@
 {
-	"markdown.category" : "Markdown",
 	"markdown.preview.title" : "Open Preview",
 	"markdown.previewSide.title" : "Open Preview to the Side",
 	"markdown.showSource.title" : "Show Source"


### PR DESCRIPTION
**Bug**
The `Markdown.category` should not be translated.

**Fix**
Inline translation

Closes #16087 