### PR TITLE
Extract markdown setting strings  for localization

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -120,12 +120,12 @@
 				"markdown.styles": {
 					"type": ["array"],
 					"default": [],
-					"description": "A list of URLs or local paths to CSS style sheets to use from the markdown preview. Relative paths are interpreted relative to the folder open in the explorer. If there is no open folder, they are interpreted relative to the location of the markdown file. All '\\' need to be written as '\\\\'."
+					"description": "%markdown.styles.dec%"
 				},
 				"markdown.previewFrontMatter": {
 					"type": ["string"],
 					"default": "hide",
-					"description": "Sets how YAML front matter should be rendered in the markdown preview. 'hide' removes the front matter. Otherwise, the front matter is treated as markdown content"
+					"description": "%markdown.previewFrontMatter.dec%"
 				}
 			}
 		}

--- a/extensions/markdown/package.nls.json
+++ b/extensions/markdown/package.nls.json
@@ -1,5 +1,7 @@
 {
 	"markdown.preview.title" : "Open Preview",
 	"markdown.previewSide.title" : "Open Preview to the Side",
-	"markdown.showSource.title" : "Show Source"
+	"markdown.showSource.title" : "Show Source",
+	"markdown.styles.dec": "A list of URLs or local paths to CSS style sheets to use from the markdown preview. Relative paths are interpreted relative to the folder open in the explorer. If there is no open folder, they are interpreted relative to the location of the markdown file. All '\\' need to be written as '\\\\'.",
+	"markdown.previewFrontMatter.dec": "Sets how YAML front matter should be rendered in the markdown preview. 'hide' removes the front matter. Otherwise, the front matter is treated as markdown content"
 }


### PR DESCRIPTION
Extracting markdown settings description strings so that they can be localized as part of  #13102