### PR TITLE
Fix #15765. Update textarea state even if there is no selection change in composition

### DIFF
--- a/src/vs/editor/common/controller/textAreaHandler.ts
+++ b/src/vs/editor/common/controller/textAreaHandler.ts
@@ -154,12 +154,9 @@ export class TextAreaHandler extends Disposable {
 			let typeInput = this.textAreaState.updateComposition();
 			this._onType.fire(typeInput);
 
-			// Due to isEdgeOrIE (where the textarea was not cleared initially)
+			// Due to isEdgeOrIE (where the textarea was not cleared initially) and isChrome (the textarea is not updated correctly when composition ends)
 			// we cannot assume the text at the end consists only of the composited text
-			if (Browser.isEdgeOrIE) {
-				// In Chrome v49, the text at the time of the compositionend event is not really the final text
-				// for the mac dead key input method.
-				// N.B: This can be removed in Chrome v53
+			if (Browser.isEdgeOrIE || Browser.isChrome) {
 				this.textAreaState = this.textAreaState.fromTextArea(this.textArea);
 			}
 


### PR DESCRIPTION
This PR aims to fix #15765, #16017, #16133. Previously we would update textArea's state (including value) when there is any selection change. This means, if the selection changes in composition, the textArea state is updated in time. However for those composition that don't trigger any selection change, the textArea is out of date, which leads to some words/characters duplication.

As listed issues are talking about Japanese or Accents, here I'd like to describe the behavior with another IME.

1. Switch to Chinese IME
2. Type `a` and the first selection change kicks in, we update the textArea state accordingly.
    ![screen shot 2016-11-28 at 3 01 15 pm](https://cloud.githubusercontent.com/assets/876920/20689703/9d5dddb8-b57b-11e6-821f-6b6446756f87.png)
3. Press `space` to choose the first word `啊`. There is no selection change, we forget to update the textArea state. 
![screen shot 2016-11-28 at 3 03 03 pm](https://cloud.githubusercontent.com/assets/876920/20689847/2cbc453a-b57c-11e6-9982-3eee2df335ab.png)

4. Since the textArea state is not cleaned, so next time when you press any key, let's say `enter`, the text being inserted into the editor is `啊\n`. ![ime](https://cloud.githubusercontent.com/assets/876920/20689889/5b33db1c-b57c-11e6-9895-df1abfc3c98a.gif)

From the code level, previously we were updating the textArea state for IE and Edge as the textarea is not cleared initially on those two browsers. Now we do the same thing for all compositionEnd operations as if there is no selection change in composition, the textArea is not cleared as well.
