### PR TITLE
themes.dark+: Highlight keyword operators

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus.json
+++ b/extensions/theme-defaults/themes/dark_plus.json
@@ -49,6 +49,13 @@
 			}
 		},
 		{
+			"name": "Operator keywords",
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#C586C0"
+			}
+		},
+		{
 			"name": "Variable and parameter name",
 			"scope": [
 				"variable.parameter",


### PR DESCRIPTION
This PR makes operators scoped as `keyword.operator` be highlighted with the same style as `keyword.control`.

Before:

<img width="103" alt="screen shot 2016-11-29 at 12 07 39 am" src="https://cloud.githubusercontent.com/assets/239003/20697547/09f70c14-b5c8-11e6-9ee8-18257df53e23.png">

After:

<img width="108" alt="screen shot 2016-11-29 at 12 08 39 am" src="https://cloud.githubusercontent.com/assets/239003/20697552/0e724984-b5c8-11e6-8c78-2fc5a0c55c6c.png">

See also https://github.com/MagicStack/MagicPython/issues/69.

The issue was originally reported to MagicPython, but I believe that this PR will solve many similar problems for other language highlighters, since `keyword.operator` is the standard scope for operators in ST, Atom and TextMate.