### PR TITLE
Log where an editor action was triggered from

### DIFF
--- a/src/vs/editor/common/editorAction.ts
+++ b/src/vs/editor/common/editorAction.ts
@@ -53,7 +53,7 @@ export class InternalEditorAction extends AbstractInternalEditorAction implement
 		}
 
 		return this._instantiationService.invokeFunction((accessor) => {
-			return TPromise.as(this._actual.runEditorCommand(accessor, this._editor, null));
+			return TPromise.as(this._actual.runEditorCommand(accessor, this._editor, { from: 'wrapper' }));
 		});
 	}
 }

--- a/src/vs/editor/common/editorCommonExtensions.ts
+++ b/src/vs/editor/common/editorCommonExtensions.ts
@@ -62,12 +62,12 @@ export abstract class EditorAction extends ConfigEditorCommand {
 	}
 
 	public runEditorCommand(accessor: ServicesAccessor, editor: editorCommon.ICommonCodeEditor, args: any): void | TPromise<void> {
-		this.reportTelemetry(accessor);
+		this.reportTelemetry(accessor, args);
 		return this.run(accessor, editor);
 	}
 
-	protected reportTelemetry(accessor: ServicesAccessor) {
-		accessor.get(ITelemetryService).publicLog('editorActionInvoked', { name: this.label, id: this.id });
+	protected reportTelemetry(accessor: ServicesAccessor, args: any) {
+		accessor.get(ITelemetryService).publicLog('editorActionInvoked', { name: this.label, id: this.id, from: args && args.from || 'unknown' });
 	}
 
 	public abstract run(accessor: ServicesAccessor, editor: editorCommon.ICommonCodeEditor): void | TPromise<void>;

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -505,7 +505,7 @@ abstract class FoldingAction<T> extends EditorAction {
 		if (!foldingController) {
 			return;
 		}
-		this.reportTelemetry(accessor);
+		this.reportTelemetry(accessor, args);
 		this.invoke(foldingController, editor, args);
 	}
 

--- a/src/vs/platform/keybinding/browser/keybindingServiceImpl.ts
+++ b/src/vs/platform/keybinding/browser/keybindingServiceImpl.ts
@@ -10,6 +10,7 @@ import { IHTMLContentElement } from 'vs/base/common/htmlContent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Keybinding } from 'vs/base/common/keybinding';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
+import * as objects from 'vs/base/common/objects';
 import Severity from 'vs/base/common/severity';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
 import * as dom from 'vs/base/browser/dom';
@@ -182,7 +183,7 @@ export abstract class KeybindingService implements IKeybindingService {
 				e.preventDefault();
 			}
 			let commandId = resolveResult.commandId.replace(/^\^/, '');
-			this._commandService.executeCommand(commandId, resolveResult.commandArgs || {}).done(undefined, err => {
+			this._commandService.executeCommand(commandId, objects.assign({ from: 'keybinding' }, resolveResult.commandArgs || {})).done(undefined, err => {
 				this._messageService.show(Severity.Warning, err);
 			});
 		}

--- a/src/vs/workbench/common/actionRegistry.ts
+++ b/src/vs/workbench/common/actionRegistry.ts
@@ -169,7 +169,7 @@ export function triggerAndDisposeAction(instantitationService: IInstantiationSer
 	}
 
 	if (telemetryService) {
-		telemetryService.publicLog('workbenchActionExecuted', { id: actionInstance.id, from: args && args.from || 'keybinding' });
+		telemetryService.publicLog('workbenchActionExecuted', { id: actionInstance.id, from: args && args.from || 'unknown' });
 	}
 
 	// run action when workbench is created


### PR DESCRIPTION
For evaluating #15156

@bpasero I would like to add a 'from' to the editor actions telemetry, the same way we have that for workbench actions. Could you take a look? I might be missing things since the data flows past a lot of code.