### PR TITLE
Add TS Code Action Provider

### DIFF
--- a/extensions/typescript/src/features/codeActionProvider.ts
+++ b/extensions/typescript/src/features/codeActionProvider.ts
@@ -19,22 +19,6 @@ interface Source {
 	version: number;
 }
 
-const actionToEdit = (source: Source, action: Proto.CodeAction) => {
-	const workspaceEdit = new WorkspaceEdit();
-	action.changes.forEach(change => {
-		change.textChanges.forEach(textChange => {
-			workspaceEdit.replace(this.client.asUrl(change.fileName),
-				new Range(textChange.start.line - 1, textChange.start.offset - 1, textChange.end.line - 1, textChange.end.offset - 1),
-				textChange.newText);
-		});
-	});
-	return {
-		title: action.description,
-		command: this.commandId,
-		args: [source, workspaceEdit]
-	};
-};
-
 export default class TypeScriptCodeActionProvider implements CodeActionProvider {
 	private client: ITypescriptServiceClient;
 	private commandId: string;
@@ -80,7 +64,7 @@ export default class TypeScriptCodeActionProvider implements CodeActionProvider 
 				}, token);
 			})
 			.then(response => response.body)
-			.then(codeActions => codeActions.map(action => actionToEdit(source, action)));
+			.then(codeActions => codeActions.map(action => this.actionToEdit(source, action)));
 	}
 
 	private getSupportedCodeActions(context: CodeActionContext): Thenable<number[]> {
@@ -90,6 +74,24 @@ export default class TypeScriptCodeActionProvider implements CodeActionProvider 
 					.map(diagnostic => +diagnostic.code)
 					.filter(code => supportedActions[code]);
 			});
+	}
+
+	private actionToEdit(source: Source, action: Proto.CodeAction): Command {
+		const workspaceEdit = new WorkspaceEdit();
+		action.changes.forEach(change => {
+			change.textChanges.forEach(textChange => {
+				workspaceEdit.replace(this.client.asUrl(change.fileName),
+					new Range(
+						textChange.start.line - 1, textChange.start.offset - 1,
+						textChange.end.line - 1, textChange.end.offset - 1),
+					textChange.newText);
+			});
+		});
+		return {
+			title: action.description,
+			command: this.commandId,
+			arguments: [source, workspaceEdit]
+		};
 	}
 
 	private onCodeAction(source: Source, workspaceEdit: WorkspaceEdit) {

--- a/extensions/typescript/src/features/codeActionProvider.ts
+++ b/extensions/typescript/src/features/codeActionProvider.ts
@@ -29,7 +29,7 @@ export default class TypeScriptCodeActionProvider implements CodeActionProvider 
 		this.client = client;
 		this.commandId = `typescript.codeActions.${modeId}`;
 		this.supportedCodeActions = client.execute('getSupportedCodeFixes', null, undefined)
-			.then(response => response.body)
+			.then(response => response.body || [])
 			.then(codes => {
 				return codes.map(code => +code).filter(code => !isNaN(code));
 			})
@@ -45,7 +45,7 @@ export default class TypeScriptCodeActionProvider implements CodeActionProvider 
 	public provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): Thenable<Command[]> {
 		const file = this.client.asAbsolutePath(document.uri);
 		if (!file) {
-			return Promise.resolve<Command[]>(null);
+			return Promise.resolve(null);
 		}
 
 		const source: Source = {
@@ -63,7 +63,7 @@ export default class TypeScriptCodeActionProvider implements CodeActionProvider 
 					errorCodes: supportedActions
 				}, token);
 			})
-			.then(response => response.body)
+			.then(response => response.body || [])
 			.then(codeActions => codeActions.map(action => this.actionToEdit(source, action)));
 	}
 

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -165,7 +165,9 @@ class LanguageProvider {
 			languages.registerRenameProvider(selector, renameProvider);
 			languages.registerOnTypeFormattingEditProvider(selector, this.formattingProvider, ';', '}', '\n');
 			languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(client, modeId));
-			languages.registerCodeActionsProvider(selector, new CodeActionProvider(client, modeId));
+			if (client.apiVersion.has211Features()) {
+				languages.registerCodeActionsProvider(selector, new CodeActionProvider(client, modeId));
+			}
 			languages.setLanguageConfiguration(modeId, {
 				indentationRules: {
 					// ^(.*\*/)?\s*\}.*$

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -431,7 +431,7 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 			let range = new Range(start.line - 1, start.offset - 1, end.line - 1, end.offset - 1);
 			let converted = new Diagnostic(range, text);
 			converted.source = source;
-			converted.code = diagnostic.code;
+			converted.code = '' + diagnostic.code;
 			result.push(converted);
 		}
 		return result;

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -34,6 +34,7 @@ import FormattingProvider from './features/formattingProvider';
 import BufferSyncSupport from './features/bufferSyncSupport';
 import CompletionItemProvider from './features/completionItemProvider';
 import WorkspaceSymbolProvider from './features/workspaceSymbolProvider';
+import CodeActionProvider from './features/codeActionProvider';
 
 import * as VersionStatus from './utils/versionStatus';
 import * as ProjectStatus from './utils/projectStatus';
@@ -164,6 +165,7 @@ class LanguageProvider {
 			languages.registerRenameProvider(selector, renameProvider);
 			languages.registerOnTypeFormattingEditProvider(selector, this.formattingProvider, ';', '}', '\n');
 			languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(client, modeId));
+			languages.registerCodeActionsProvider(selector, new CodeActionProvider(client, modeId));
 			languages.setLanguageConfiguration(modeId, {
 				indentationRules: {
 					// ^(.*\*/)?\s*\}.*$
@@ -427,6 +429,7 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 			let range = new Range(start.line - 1, start.offset - 1, end.line - 1, end.offset - 1);
 			let converted = new Diagnostic(range, text);
 			converted.source = source;
+			converted.code = diagnostic.code;
 			result.push(converted);
 		}
 		return result;

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -165,7 +165,7 @@ class LanguageProvider {
 			languages.registerRenameProvider(selector, renameProvider);
 			languages.registerOnTypeFormattingEditProvider(selector, this.formattingProvider, ';', '}', '\n');
 			languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider(client, modeId));
-			if (client.apiVersion.has211Features()) {
+			if (client.apiVersion.has213Features()) {
 				languages.registerCodeActionsProvider(selector, new CodeActionProvider(client, modeId));
 			}
 			languages.setLanguageConfiguration(modeId, {

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -97,6 +97,8 @@ export interface ITypescriptServiceClient {
 	execute(command: 'reload', args: Proto.ReloadRequestArgs, expectedResult: boolean, token?: CancellationToken): Promise<any>;
 	execute(command: 'compilerOptionsForInferredProjects', args: Proto.SetCompilerOptionsForInferredProjectsArgs, token?: CancellationToken): Promise<any>;
 	execute(command: 'navtree', args: Proto.FileRequestArgs, token?: CancellationToken): Promise<Proto.NavTreeResponse>;
+	execute(command: 'getCodeFixes', args: Proto.CodeFixRequestArgs, token?: CancellationToken): Promise<Proto.GetCodeFixesResponse>;
+	execute(command: 'getSupportedCodeFixes', args: null, token?: CancellationToken): Promise<Proto.GetSupportedCodeFixesResponse>;
 	// execute(command: 'compileOnSaveAffectedFileList', args: Proto.CompileOnSaveEmitFileRequestArgs, token?: CancellationToken): Promise<Proto.CompileOnSaveAffectedFileListResponse>;
 	// execute(command: 'compileOnSaveEmitFile', args: Proto.CompileOnSaveEmitFileRequestArgs, token?: CancellationToken): Promise<any>;
 	execute(command: string, args: any, expectedResult: boolean | CancellationToken, token?: CancellationToken): Promise<any>;

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -670,6 +670,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 						case 'typingsInstalled':
 							let typingsInstalledPayload: Proto.TypingsInstalledTelemetryEventPayload = (telemetryData.payload as Proto.TypingsInstalledTelemetryEventPayload);
 							properties['installedPackages'] = typingsInstalledPayload.installedPackages;
+
 							if (is.defined(typingsInstalledPayload.installSuccess)) {
 								properties['installSuccess'] = typingsInstalledPayload.installSuccess.toString();
 							}


### PR DESCRIPTION
With #16295, TS now supplies code actions for automatically fixing a limited set of errors. This change creates a new CodeActionProvider for the TypeScript extension. 

Fixes #16542