### PR TITLE
Smarter search batching

### DIFF
--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -389,7 +389,7 @@ class BatchedCollector<T> {
 		if (this.maxBatchSize > 0) {
 			this.batch.push(item);
 			this.batchSize += size;
-			if (this.batchSize > this.maxBatchSize) {
+			if (this.batchSize >= this.maxBatchSize) {
 				this.flush();
 			} else {
 				if (!this.timeoutHandle && this.totalNumberCompleted < this.batchOnlyAfter) {

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -27,13 +27,12 @@ export type IRawProgressItem<T> = T | T[] | IProgress;
 
 export class SearchService implements IRawSearchService {
 
-	private static FILE_SEARCH_BATCH_SIZE = 512;
-	private static TEXT_SEARCH_BATCH_SIZE = 300;
+	private static BATCH_SIZE = 512;
 
 	private caches: { [cacheKey: string]: Cache; } = Object.create(null);
 
 	public fileSearch(config: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
-		return this.doFileSearch(FileSearchEngine, config, SearchService.FILE_SEARCH_BATCH_SIZE);
+		return this.doFileSearch(FileSearchEngine, config, SearchService.BATCH_SIZE);
 	}
 
 	public textSearch(config: IRawSearch): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
@@ -46,7 +45,7 @@ export class SearchService implements IRawSearchService {
 			maxFilesize: MAX_FILE_SIZE
 		}));
 
-		return this.doSearchWithBatchTimeout(engine, SearchService.TEXT_SEARCH_BATCH_SIZE);
+		return this.doSearchWithBatchTimeout(engine, SearchService.BATCH_SIZE);
 	}
 
 	public doFileSearch(EngineClass: { new (config: IRawSearch): ISearchEngine<IRawFileMatch>; }, config: IRawSearch, batchSize?: number): PPromise<ISerializedSearchComplete, ISerializedSearchProgressItem> {
@@ -371,7 +370,7 @@ interface CacheStats {
 /**
  * Collects a batch of items that each have a size. When the cumulative size of the batch reaches 'maxBatchSize', it calls the callback.
  * If the batch isn't filled within 'timeout' ms, the callback is also called.
- * And after 'batchOnlyAfter' ms, the timeout is ignored, and the callback is called only when the batch is full.
+ * And after 'batchOnlyAfter' items, the timeout is ignored, and the callback is called only when the batch is full.
  */
 class BatchedCollector<T> {
 	private totalNumberCompleted = 0;

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -404,11 +404,13 @@ class BatchedCollector<T> {
 	}
 
 	flush(): void {
-		this.totalNumberCompleted += this.batchSize;
-		this.cb(this.batch);
-		this.batch = [];
-		this.batchSize = 0;
-		clearTimeout(this.timeoutHandle);
-		this.timeoutHandle = 0;
+		if (this.batchSize) {
+			this.totalNumberCompleted += this.batchSize;
+			this.cb(this.batch);
+			this.batch = [];
+			this.batchSize = 0;
+			clearTimeout(this.timeoutHandle);
+			this.timeoutHandle = 0;
+		}
 	}
 }

--- a/src/vs/workbench/services/search/node/search.ts
+++ b/src/vs/workbench/services/search/node/search.ts
@@ -49,6 +49,7 @@ export interface ISerializedSearchComplete {
 export interface ISerializedFileMatch {
 	path: string;
 	lineMatches?: ILineMatch[];
+	numMatches?: number;
 }
 
 // Type of the possible values for progress calls from the engine

--- a/src/vs/workbench/services/search/node/worker/searchWorker.ts
+++ b/src/vs/workbench/services/search/node/worker/searchWorker.ts
@@ -284,14 +284,17 @@ export class FileMatch implements ISerializedFileMatch {
 
 	serialize(): ISerializedFileMatch {
 		let lineMatches: ILineMatch[] = [];
+		let numMatches = 0;
 
 		for (let i = 0; i < this.lineMatches.length; i++) {
+			numMatches += this.lineMatches[i].offsetAndLengths.length;
 			lineMatches.push(this.lineMatches[i].serialize());
 		}
 
 		return {
 			path: this.path,
-			lineMatches
+			lineMatches,
+			numMatches
 		};
 	}
 }


### PR DESCRIPTION
If the search process batch isn't filled in 2 seconds, it's sent to the frontend anyway. After 50 results are returned, it reverts to the original batching behavior. Also fixed to batch by actual number of results, instead of 'number of files with matches' which it ended up doing before.

Fixes #16284