### PR TITLE
Fix markdown preview anchor links

### DIFF
--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -90,7 +90,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 			'			if (baseElement && node.href.indexOf(baseElement.href) >= 0 && node.hash) {',
 			'				let scrollTarget = window.document.getElementById(node.hash.substr(1, node.hash.length - 1));',
 			'				if (scrollTarget) {',
-			'					scrollgetTarget().scrollIntoView();',
+			'					scrollTarget.scrollIntoView();',
 			'				}',
 			'			} else {',
 			'				window.parent.postMessage({ command: "did-click-link", data: node.href }, "file://");',


### PR DESCRIPTION
**Bug**
In the markdown preview, clicking on a anchor link causes the editor to go blank. This effects our release notes.

**Fix**
Fix the webview pre script which was accidentally changed when it was extracted in 0cef61f4f4d8a73a00f8da28bdf9b7af0a11e4ef


Fixes #16337

FYI @gregvanl 