### PR TITLE
Enable Strict Null Checks and Use Lib References in Markdown Extension

### DIFF
--- a/extensions/declares.d.ts
+++ b/extensions/declares.d.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/// <reference path="../src/typings/mocha.d.ts" />
 /// <reference path="../src/typings/thenable.d.ts" />
 
 // Declaring the following because the code gets compiled with es5, which lack definitions for console and timers.

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -15,7 +15,7 @@ interface IPackageInfo {
 	aiKey: string;
 }
 
-var telemetryReporter: TelemetryReporter;
+var telemetryReporter: TelemetryReporter | null;
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -89,15 +89,17 @@ function showPreview(uri?: vscode.Uri, sideBySide: boolean = false) {
 		getViewColumn(sideBySide),
 		`Preview '${path.basename(resource.fsPath)}'`);
 
-	telemetryReporter.sendTelemetryEvent('openPreview', {
-		where: sideBySide ? 'sideBySide' : 'inPlace',
-		how: (uri instanceof vscode.Uri) ? 'action' : 'pallete'
-	});
+	if (telemetryReporter) {
+		telemetryReporter.sendTelemetryEvent('openPreview', {
+			where: sideBySide ? 'sideBySide' : 'inPlace',
+			how: (uri instanceof vscode.Uri) ? 'action' : 'pallete'
+		});
+	}
 
 	return thenable;
 }
 
-function getViewColumn(sideBySide): vscode.ViewColumn {
+function getViewColumn(sideBySide: boolean): vscode.ViewColumn | undefined {
 	const active = vscode.window.activeTextEditor;
 	if (!active) {
 		return vscode.ViewColumn.One;
@@ -135,7 +137,7 @@ function showSource(mdUri: vscode.Uri) {
 	});
 }
 
-function getPackageInfo(context: vscode.ExtensionContext): IPackageInfo {
+function getPackageInfo(context: vscode.ExtensionContext): IPackageInfo | null {
 	let extensionPackage = require(context.asAbsolutePath('./package.json'));
 	if (extensionPackage) {
 		return {
@@ -169,7 +171,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		const mdnh = require('markdown-it-named-headers');
 		const md = require('markdown-it')({
 			html: true,
-			highlight: function (str, lang) {
+			highlight: (str: string, lang: string) => {
 				if (lang && hljs.getLanguage(lang)) {
 					try {
 						return `<pre class="hljs"><code><div>${hljs.highlight(lang, str, true).value}</div></code></pre>`;
@@ -181,11 +183,11 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		return md;
 	}
 
-	private getMediaPath(mediaFile): string {
+	private getMediaPath(mediaFile: string): string {
 		return this._context.asAbsolutePath(path.join('media', mediaFile));
 	}
 
-	private isAbsolute(p): boolean {
+	private isAbsolute(p: string): boolean {
 		return path.normalize(p + '/') === path.normalize(path.resolve(p) + '/');
 	}
 
@@ -213,14 +215,14 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		return href;
 	}
 
-	private computeCustomStyleSheetIncludes(uri: vscode.Uri): string[] {
+	private computeCustomStyleSheetIncludes(uri: vscode.Uri): string {
 		const styles = vscode.workspace.getConfiguration('markdown')['styles'];
 		if (styles && Array.isArray(styles) && styles.length > 0) {
 			return styles.map((style) => {
 				return `<link rel="stylesheet" href="${this.fixHref(uri, style)}" type="text/css" media="screen">`;
-			});
+			}).join('\n');
 		}
-		return [];
+		return '';
 	}
 
 	private getSettingsOverrideStyles(): string {
@@ -242,7 +244,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 	public provideTextDocumentContent(uri: vscode.Uri): Thenable<string> {
 		return vscode.workspace.openTextDocument(vscode.Uri.parse(uri.query)).then(document => {
 			const scrollBeyondLastLine = vscode.workspace.getConfiguration('editor')['scrollBeyondLastLine'];
-			const head = [].concat(
+			const head = ([] as Array<string>).concat(
 				'<!DOCTYPE html>',
 				'<html>',
 				'<head>',

--- a/extensions/markdown/src/typings/ref.d.ts
+++ b/extensions/markdown/src/typings/ref.d.ts
@@ -4,6 +4,4 @@
  *--------------------------------------------------------------------------------------------*/
 
 /// <reference path='../../../../src/vs/vscode.d.ts'/>
-/// <reference path='../../../declares.d.ts'/>
-/// <reference path='../../../lib.core.d.ts'/>
 /// <reference path='../../../node.d.ts'/>

--- a/extensions/markdown/tsconfig.json
+++ b/extensions/markdown/tsconfig.json
@@ -2,9 +2,15 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es5",
+		"lib": [
+			"es5",
+			"es2015.promise"
+		],
 		"outDir": "./out",
-		"noLib": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"noImplicitReturns": true
 	},
 	"exclude": [
 		"node_modules"


### PR DESCRIPTION
Makes a few changes to the markdown extension:

* Enables strict null checks.
* Enables no implicit any checks.
* Switch to using TS 2.0 lib files.

This change required removing the mocha declaration from the shared `declare.d.ts`. Everything seems to compile fine without it.