### PR TITLE
Disable Autoclosing Quotes in Python Strings and Comments

### DIFF
--- a/extensions/python/language-configuration.json
+++ b/extensions/python/language-configuration.json
@@ -9,11 +9,11 @@
 		["(", ")"]
 	],
 	"autoClosingPairs": [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"],
-		["\"", "\""],
-		["'", "'"]
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],


### PR DESCRIPTION
Fixes #8539

**Bug**
In python file, typing `'` in a string or comment results in `''` due to auto closing pairs.

**fix**
Apply same fix that we use for Typescript to disable this behavior in strings and comments https://github.com/Microsoft/vscode/blob/master/extensions/typescript/language-configuration.json
