### PR TITLE
Consume languageServiceEnabled Events from TS

### DIFF
--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -99,6 +99,7 @@ class LanguageProvider {
 	private extensions: Map<boolean>;
 	private syntaxDiagnostics: Map<Diagnostic[]>;
 	private currentDiagnostics: DiagnosticCollection;
+	private languageServiceEnabled: boolean;
 	private bufferSyncSupport: BufferSyncSupport;
 
 	private completionItemProvider: CompletionItemProvider;
@@ -120,7 +121,7 @@ class LanguageProvider {
 		}, this.extensions);
 		this.syntaxDiagnostics = Object.create(null);
 		this.currentDiagnostics = languages.createDiagnosticCollection(description.id);
-
+		this.languageServiceEnabled = true;
 
 		workspace.onDidChangeConfiguration(this.configurationChanged, this);
 		this.configurationChanged();

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -99,7 +99,6 @@ class LanguageProvider {
 	private extensions: Map<boolean>;
 	private syntaxDiagnostics: Map<Diagnostic[]>;
 	private currentDiagnostics: DiagnosticCollection;
-	private languageServiceEnabled: boolean;
 	private bufferSyncSupport: BufferSyncSupport;
 
 	private completionItemProvider: CompletionItemProvider;
@@ -121,7 +120,7 @@ class LanguageProvider {
 		}, this.extensions);
 		this.syntaxDiagnostics = Object.create(null);
 		this.currentDiagnostics = languages.createDiagnosticCollection(description.id);
-		this.languageServiceEnabled = true;
+
 
 		workspace.onDidChangeConfiguration(this.configurationChanged, this);
 		this.configurationChanged();

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CancellationToken, Uri } from 'vscode';
+import { CancellationToken, Uri, Event } from 'vscode';
 import * as Proto from './protocol';
 import * as semver from 'semver';
 
@@ -54,12 +54,15 @@ export class API {
 		return semver.gte(this._version, '2.0.8');
 	}
 
-	public has220Features(): boolean {
-		return semver.gte(this._version, '2.2.0');
+	public has213Features(): boolean {
+		return semver.gte(this._version, '2.1.3');
 	}
 }
 
-export type ProjectStatusChanagedCallback = (string, boolean) => void;
+export interface ProjectStatusChanaged {
+	projectName: string;
+	enabled: boolean;
+}
 
 export interface ITypescriptServiceClient {
 	asAbsolutePath(resource: Uri): string | null;
@@ -69,7 +72,7 @@ export interface ITypescriptServiceClient {
 	warn(message: string, data?: any): void;
 	error(message: string, data?: any): void;
 
-	onProjectLanguageServiceStateChanged(callback: ProjectStatusChanagedCallback);
+	onProjectLanguageServiceStateChanged: Event<Proto.ProjectLanguageServiceStateEventBody>;
 
 	logTelemetry(eventName: string, properties?: { [prop: string]: string });
 

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -55,6 +55,8 @@ export class API {
 	}
 }
 
+export type ProjectStatusChanagedCallback = (string, boolean) => void;
+
 export interface ITypescriptServiceClient {
 	asAbsolutePath(resource: Uri): string | null;
 	asUrl(filepath: string): Uri;
@@ -62,6 +64,8 @@ export interface ITypescriptServiceClient {
 	info(message: string, data?: any): void;
 	warn(message: string, data?: any): void;
 	error(message: string, data?: any): void;
+
+	onProjectLanguageServiceStateChanged(callback: ProjectStatusChanagedCallback);
 
 	logTelemetry(eventName: string, properties?: { [prop: string]: string });
 

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -53,6 +53,10 @@ export class API {
 	public has208Features(): boolean {
 		return semver.gte(this._version, '2.0.8');
 	}
+
+	public has220Features(): boolean {
+		return semver.gte(this._version, '2.2.0');
+	}
 }
 
 export type ProjectStatusChanagedCallback = (string, boolean) => void;

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -59,11 +59,6 @@ export class API {
 	}
 }
 
-export interface ProjectStatusChanaged {
-	projectName: string;
-	enabled: boolean;
-}
-
 export interface ITypescriptServiceClient {
 	asAbsolutePath(resource: Uri): string | null;
 	asUrl(filepath: string): Uri;

--- a/extensions/typescript/src/utils/projectStatus.ts
+++ b/extensions/typescript/src/utils/projectStatus.ts
@@ -26,8 +26,7 @@ interface ProjectHintedMap {
 	[k: string]: boolean;
 }
 
-const fileLimit = 1; // TODO
-
+const fileLimit = 500;
 
 class ExcludeHintItem {
 	private _item: vscode.StatusBarItem;
@@ -174,6 +173,8 @@ function computeLargeRoots(configFileName: string, fileNames: string[]): string[
 
 	let roots: { [first: string]: number } = Object.create(null);
 	let dir = dirname(configFileName);
+
+	// console.log(dir, fileNames);
 
 	for (let fileName of fileNames) {
 		if (fileName.indexOf(dir) === 0) {

--- a/extensions/typescript/src/utils/projectStatus.ts
+++ b/extensions/typescript/src/utils/projectStatus.ts
@@ -8,7 +8,7 @@
 import * as vscode from 'vscode';
 import { ITypescriptServiceClient } from '../typescriptService';
 import { loadMessageBundle } from 'vscode-nls';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 
 const localize = loadMessageBundle();
 const selector = ['javascript', 'javascriptreact'];
@@ -22,36 +22,69 @@ interface Hint {
 	options: Option[];
 }
 
-const fileLimit = 500;
+interface ProjectHintedMap {
+	[k: string]: boolean;
+}
 
-export function create(client: ITypescriptServiceClient, isOpen: (path: string) => Promise<boolean>, memento: vscode.Memento) {
+const fileLimit = 1; // TODO
 
+
+class ExcludeHintItem {
+	private _item: vscode.StatusBarItem;
+	private _client: ITypescriptServiceClient;
+	private _currentHint: Hint;
+
+	constructor(client: ITypescriptServiceClient) {
+		this._client = client;
+		this._item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, Number.MIN_VALUE);
+		this._item.command = 'js.projectStatus.command';
+	}
+
+	public getCurrentHint(): Hint {
+		return this._currentHint;
+	}
+
+	public hide() {
+		this._item.hide();
+	}
+
+	public show(configFileName: string, largeRoots: string, onExecute: () => void) {
+		this._currentHint = {
+			message: largeRoots.length > 0
+				? localize('hintExclude', "For better performance exclude folders with many files, like: {0}", largeRoots)
+				: localize('hintExclude.generic', "For better performance exclude folders with many files."),
+			options: [{
+				title: localize('open', "Configure Excludes"),
+				execute: () => {
+					this._client.logTelemetry('js.hintProjectExcludes.accepted');
+					onExecute();
+					this._item.hide();
+
+					return vscode.workspace.openTextDocument(configFileName)
+						.then(vscode.window.showTextDocument);
+				}
+			}]
+		};
+		this._item.tooltip = this._currentHint.message;
+		this._item.text = localize('large.label', "Configure Excludes");
+		this._item.tooltip = localize('hintExclude.tooltip', "For better performance exclude folders with many files.");
+		this._item.color = '#A5DF3B';
+		this._item.show();
+		this._client.logTelemetry('js.hintProjectExcludes');
+	}
+}
+
+function createLargeProjectMonitorForProject(item: ExcludeHintItem, client: ITypescriptServiceClient, isOpen: (path: string) => Promise<boolean>, memento: vscode.Memento): vscode.Disposable[] {
 	const toDispose: vscode.Disposable[] = [];
-	const projectHinted: { [k: string]: boolean } = Object.create(null);
+	const projectHinted: ProjectHintedMap = Object.create(null);
 
 	const projectHintIgnoreList = memento.get<string[]>('projectHintIgnoreList', []);
 	for (let path of projectHintIgnoreList) {
-		if (!path) {
+		if (path === null) {
 			path = 'undefined';
 		}
 		projectHinted[path] = true;
 	}
-
-	let currentHint: Hint;
-	let item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, Number.MIN_VALUE);
-	item.command = 'js.projectStatus.command';
-	toDispose.push(vscode.commands.registerCommand('js.projectStatus.command', () => {
-		let {message, options} = currentHint;
-		return vscode.window.showInformationMessage(message, ...options).then(selection => {
-			if (selection) {
-				return selection.execute();
-			}
-		});
-	}));
-
-	toDispose.push(vscode.workspace.onDidChangeTextDocument(e => {
-		delete projectHinted[e.document.fileName];
-	}));
 
 	function onEditor(editor: vscode.TextEditor | undefined): void {
 		if (!editor
@@ -66,7 +99,6 @@ export function create(client: ITypescriptServiceClient, isOpen: (path: string) 
 		if (!file) {
 			return;
 		}
-
 		isOpen(file).then(value => {
 			if (!value) {
 				return;
@@ -78,44 +110,15 @@ export function create(client: ITypescriptServiceClient, isOpen: (path: string) 
 				}
 				let {configFileName, fileNames} = res.body;
 
-				if (projectHinted[configFileName] === true) {
+				if (projectHinted[configFileName] === true || !fileNames) {
 					return;
 				}
 
-				if (fileNames && fileNames.length > fileLimit) {
+				if (fileNames.length > fileLimit || res.body.languageServiceDisabled) {
 					let largeRoots = computeLargeRoots(configFileName, fileNames).map(f => `'/${f}/'`).join(', ');
-
-					currentHint = {
-						message: largeRoots.length > 0
-							? localize('hintExclude', "For better performance exclude folders with many files, like: {0}", largeRoots)
-							: localize('hintExclude.generic', "For better performance exclude folders with many files."),
-						options: [{
-							title: localize('open', "Configure Excludes"),
-							execute: () => {
-								client.logTelemetry('js.hintProjectExcludes.accepted');
-								projectHinted[configFileName] = true;
-								item.hide();
-
-								let configFileUri: vscode.Uri;
-								let rootPath = vscode.workspace.rootPath;
-								if (rootPath && dirname(configFileName).indexOf('' + rootPath) === 0) {
-									configFileUri = vscode.Uri.file(configFileName);
-								} else {
-									configFileUri = vscode.Uri.parse('untitled://' + join(rootPath, 'jsconfig.json'));
-								}
-
-								return vscode.workspace.openTextDocument(configFileUri)
-									.then(vscode.window.showTextDocument);
-							}
-						}]
-					};
-					item.tooltip = currentHint.message;
-					item.text = localize('large.label', "Configure Excludes");
-					item.tooltip = localize('hintExclude.tooltip', "For better performance exclude folders with many files.");
-					item.color = '#A5DF3B';
-					item.show();
-					client.logTelemetry('js.hintProjectExcludes');
-
+					item.show(configFileName, largeRoots, () => {
+						projectHinted[configFileName] = true;
+					});
 				} else {
 					item.hide();
 				}
@@ -125,8 +128,50 @@ export function create(client: ITypescriptServiceClient, isOpen: (path: string) 
 		});
 	}
 
+	toDispose.push(vscode.workspace.onDidChangeTextDocument(e => {
+		delete projectHinted[e.document.fileName];
+	}));
+
 	toDispose.push(vscode.window.onDidChangeActiveTextEditor(onEditor));
 	onEditor(vscode.window.activeTextEditor);
+
+	return toDispose;
+}
+
+function createLargeProjectMonitorFromTypeScript(item: ExcludeHintItem, client: ITypescriptServiceClient): vscode.Disposable[] {
+	client.onProjectLanguageServiceStateChanged((projectName, languageServiceEnabled) => {
+		if (languageServiceEnabled) {
+			item.hide();
+			return;
+		}
+		client.execute('projectInfo', { file: vscode.workspace.rootPath, needFileNameList: true }).then(res => {
+			let {configFileName, fileNames} = res.body;
+
+			let largeRoots = computeLargeRoots(configFileName, fileNames).map(f => `'/${f}/'`).join(', ');
+			item.show('', largeRoots, () => { });
+		});
+	});
+	return [];
+}
+
+export function create(client: ITypescriptServiceClient, isOpen: (path: string) => Promise<boolean>, memento: vscode.Memento) {
+	const toDispose: vscode.Disposable[] = [];
+
+	let item = new ExcludeHintItem(client);
+	toDispose.push(vscode.commands.registerCommand('js.projectStatus.command', () => {
+		let {message, options} = item.getCurrentHint();
+		return vscode.window.showInformationMessage(message, ...options).then(selection => {
+			if (selection) {
+				return selection.execute();
+			}
+		});
+	}));
+
+	if (client.apiVersion.has1xFeatures) {
+		toDispose.push(...createLargeProjectMonitorFromTypeScript(item, client));
+	} else {
+		toDispose.push(...createLargeProjectMonitorForProject(item, client, isOpen, memento));
+	}
 
 	return vscode.Disposable.from(...toDispose);
 }

--- a/extensions/typescript/src/utils/projectStatus.ts
+++ b/extensions/typescript/src/utils/projectStatus.ts
@@ -138,20 +138,14 @@ function createLargeProjectMonitorForProject(item: ExcludeHintItem, client: ITyp
 	return toDispose;
 }
 
-function createLargeProjectMonitorFromTypeScript(item: ExcludeHintItem, client: ITypescriptServiceClient): vscode.Disposable[] {
-	client.onProjectLanguageServiceStateChanged((projectName, languageServiceEnabled) => {
+function createLargeProjectMonitorFromTypeScript(item: ExcludeHintItem, client: ITypescriptServiceClient) {
+	client.onProjectLanguageServiceStateChanged((projectName: string, languageServiceEnabled) => {
 		if (languageServiceEnabled) {
 			item.hide();
-			return;
+		} else {
+			item.show(projectName, '', () => { });
 		}
-		client.execute('projectInfo', { file: vscode.workspace.rootPath, needFileNameList: true }).then(res => {
-			let {configFileName, fileNames} = res.body;
-
-			let largeRoots = computeLargeRoots(configFileName, fileNames).map(f => `'/${f}/'`).join(', ');
-			item.show('', largeRoots, () => { });
-		});
 	});
-	return [];
 }
 
 export function create(client: ITypescriptServiceClient, isOpen: (path: string) => Promise<boolean>, memento: vscode.Memento) {
@@ -167,8 +161,8 @@ export function create(client: ITypescriptServiceClient, isOpen: (path: string) 
 		});
 	}));
 
-	if (client.apiVersion.has1xFeatures) {
-		toDispose.push(...createLargeProjectMonitorFromTypeScript(item, client));
+	if (client.apiVersion.has220Features) {
+		createLargeProjectMonitorFromTypeScript(item, client);
 	} else {
 		toDispose.push(...createLargeProjectMonitorForProject(item, client, isOpen, memento));
 	}


### PR DESCRIPTION
fixes #15208

**Bug**
We currently use our own logic to determine if a TS project contains too many files. The actual TS server may use different criteria for determining this.

**Fix**
For TS 2.1.3+, listen for languageServiceEnabled events from the TS server instead.