### PR TITLE
Adding Docker 1.12 instructions to its grammar

### DIFF
--- a/extensions/docker/syntaxes/Dockerfile.tmLanguage
+++ b/extensions/docker/syntaxes/Dockerfile.tmLanguage
@@ -25,7 +25,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(?:(ONBUILD)\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY|LABEL|STOPSIGNAL|ARG)\s</string>
+			<string>^\s*(?:(ONBUILD)\s+)?(ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|MAINTAINER|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\s</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
This simply updates the Docker grammar to include the `HEALTHCHECK` and `SHELL` commands which were introduced to Docker 1.12, and were added to the [grammar file](https://github.com/docker/docker/blob/4cb71f80823af345d063cf0ad657e73ce9caa75f/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage) that VS Code's copy is based on.

*Note that the alpha-sorting of the command names represents the majority of the code churn, and was done in order to sync with the aforementioned grammar in the Docker GitHub repo.*
