### PR TITLE
Render MarkedString according to language server spec

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -6,12 +6,17 @@
 'use strict';
 
 import DOM = require('vs/base/browser/dom');
+import { onUnexpectedError } from 'vs/base/common/errors';
 import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { escape } from 'vs/base/common/strings';
+import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IHTMLContentElement, MarkedString } from 'vs/base/common/htmlContent';
 import { marked } from 'vs/base/common/marked/marked';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
+import { tokenizeToString } from 'vs/editor/common/modes/textToHtmlTokenizer';
+import { IModeService } from 'vs/editor/common/services/modeService';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 export type RenderableContent = string | IHTMLContentElement | IHTMLContentElement[];
 
@@ -20,9 +25,33 @@ export interface RenderOptions {
 	codeBlockRenderer?: (modeId: string, value: string) => string | TPromise<string>;
 }
 
-export function renderMarkedString(markedString: MarkedString, options: RenderOptions = {}): Node {
+export function renderMarkedString(modeService: IModeService, openerService: IOpenerService, markedString: MarkedString): Node {
 	const htmlContentElement = typeof markedString === 'string' ? { markdown: markedString } : { code: markedString };
-	return renderHtml(htmlContentElement, options);
+
+	return renderHtml(htmlContentElement, {
+		actionCallback: (content) => {
+			openerService.open(URI.parse(content)).then(void 0, onUnexpectedError);
+		},
+		codeBlockRenderer: (languageAlias, value): string | TPromise<string> => {
+			// According to the language server spec (https://github.com/Microsoft/language-server-protocol)
+			// A MarkedString is rendered as:
+			// - CASE 1: markdown if it is represented as a string
+			// - CASE 2: markdown code block of the given langauge if it is represented as a pair of a language and a value
+			//
+			// Because this function is only responsible for rendering code blocks, we only need to worry about handling
+			// CASE 2 here. We follow the spec exactly because in some cases (e.g. PHP), we want the content to be
+			// rendered using less strict rules than the official grammar (as we sometimes do in markdown.)
+			//
+			// Also note that we render the codeblock using TextMate grammar rather than using highlight.js as we do in the
+			// markdown preview. This is because we want renderings to be as consistent with the editor as possible.
+			value = '```' + languageAlias + '\n' + value + '\n ```';
+			const modeId = 'markdown';
+
+			return modeService.getOrCreateMode(modeId).then(_ => {
+				return `<div class="code">${tokenizeToString(value, modeId, true)}</div>`;
+			});
+		}
+	});
 }
 
 /**

--- a/src/vs/editor/contrib/hover/browser/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/modesContentHover.ts
@@ -6,8 +6,6 @@
 
 import 'vs/css!vs/base/browser/ui/progressbar/progressbar';
 import * as nls from 'vs/nls';
-import URI from 'vs/base/common/uri';
-import { onUnexpectedError } from 'vs/base/common/errors';
 import { $ } from 'vs/base/browser/dom';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { renderMarkedString } from 'vs/base/browser/htmlContentRenderer';
@@ -17,7 +15,6 @@ import { Range } from 'vs/editor/common/core/range';
 import { Position } from 'vs/editor/common/core/position';
 import { IRange } from 'vs/editor/common/editorCommon';
 import { HoverProviderRegistry, Hover } from 'vs/editor/common/modes';
-import { tokenizeToString } from 'vs/editor/common/modes/textToHtmlTokenizer';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { getHover } from '../common/hover';
 import { HoverOperation, IHoverComputer } from './hoverOperation';
@@ -245,24 +242,7 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 			msg.contents
 				.filter(contents => !!contents)
 				.forEach(contents => {
-					const renderedContents = renderMarkedString(contents, {
-						actionCallback: (content) => {
-							this._openerService.open(URI.parse(content)).then(void 0, onUnexpectedError);
-						},
-						codeBlockRenderer: (languageAlias, value): string | TPromise<string> => {
-							// In markdown,
-							// it is possible that we stumble upon language aliases (e.g.js instead of javascript)
-							// it is possible no alias is given in which case we fall back to the current editor lang
-							const modeId = languageAlias
-								? this._modeService.getModeIdForLanguageName(languageAlias)
-								: this._editor.getModel().getModeId();
-
-							return this._modeService.getOrCreateMode(modeId).then(_ => {
-								return `<div class="code">${tokenizeToString(value, modeId)}</div>`;
-							});
-						}
-					});
-
+					const renderedContents = renderMarkedString(this._modeService, this._openerService, contents);
 					fragment.appendChild($('div.hover-row', null, renderedContents));
 				});
 		});

--- a/src/vs/editor/contrib/hover/browser/modesGlyphHover.ts
+++ b/src/vs/editor/contrib/hover/browser/modesGlyphHover.ts
@@ -11,11 +11,7 @@ import { GlyphHoverWidget } from './hoverWidgets';
 import { $ } from 'vs/base/browser/dom';
 import { renderMarkedString } from 'vs/base/browser/htmlContentRenderer';
 import { IOpenerService, NullOpenerService } from 'vs/platform/opener/common/opener';
-import URI from 'vs/base/common/uri';
-import { onUnexpectedError } from 'vs/base/common/errors';
-import { TPromise } from 'vs/base/common/winjs.base';
 import { IModeService } from 'vs/editor/common/services/modeService';
-import { tokenizeToString } from 'vs/editor/common/modes/textToHtmlTokenizer';
 
 export interface IHoverMessage {
 	value?: string;
@@ -154,17 +150,7 @@ export class ModesGlyphHoverWidget extends GlyphHoverWidget {
 		const fragment = document.createDocumentFragment();
 
 		messages.forEach((msg) => {
-			const renderedContents = renderMarkedString(msg.value, {
-				actionCallback: content => this.openerService.open(URI.parse(content)).then(undefined, onUnexpectedError),
-				codeBlockRenderer: (languageAlias, value): string | TPromise<string> => {
-					// In markdown, it is possible that we stumble upon language aliases (e.g. js instead of javascript)
-					const modeId = this.modeService.getModeIdForLanguageName(languageAlias);
-					return this.modeService.getOrCreateMode(modeId).then(_ => {
-						return `<div class="code">${tokenizeToString(value, modeId)}</div>`;
-					});
-				}
-			});
-
+			const renderedContents = renderMarkedString(this.modeService, this.openerService, msg.value);
 			fragment.appendChild($('div.hover-row', null, renderedContents));
 		});
 


### PR DESCRIPTION
- surround content with backticks + language alias before tokenizing, then render using markdown TextMate grammar
- remove marked string rendering code duplication

forked from #16006, related to #3746

close #14166 (requires #16502 to get PHP syntax highlighting, also note that this does not address the debug eval issue alluded to in that thread. will address that separately, likely using a similar approach.)

cc @jrieken, @dbaeumer, @alexandrudima, @mjbvz 