### PR TITLE
Unescape Markdown Escapes inside of a link

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -9,7 +9,7 @@ import DOM = require('vs/base/browser/dom');
 import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { escape } from 'vs/base/common/strings';
 import { TPromise } from 'vs/base/common/winjs.base';
-import { IHTMLContentElement, MarkedString } from 'vs/base/common/htmlContent';
+import { IHTMLContentElement, MarkedString, removeMarkdownEscapes } from 'vs/base/common/htmlContent';
 import { marked } from 'vs/base/common/marked/marked';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 
@@ -127,6 +127,9 @@ function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}):
 			return '<img ' + attributes.join(' ') + '>';
 		};
 		renderer.link = (href, title, text): string => {
+			// Remove markdown escapes in href and title. Workaround for https://github.com/chjj/marked/issues/829
+			title = removeMarkdownEscapes(title);
+			href = removeMarkdownEscapes(href);
 			return `<a href="#" data-href="${href}" title="${title || text}">${text}</a>`;
 		};
 		renderer.paragraph = (text): string => {

--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -127,7 +127,7 @@ function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}):
 			return '<img ' + attributes.join(' ') + '>';
 		};
 		renderer.link = (href, title, text): string => {
-			// Remove markdown escapes in href and title. Workaround for https://github.com/chjj/marked/issues/829
+			// Remove markdown escapes. Workaround for https://github.com/chjj/marked/issues/829
 			if (href === text) { // raw link case
 				text = removeMarkdownEscapes(text);
 			}

--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -128,6 +128,9 @@ function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}):
 		};
 		renderer.link = (href, title, text): string => {
 			// Remove markdown escapes in href and title. Workaround for https://github.com/chjj/marked/issues/829
+			if (href === text) { // raw link case
+				text = removeMarkdownEscapes(text);
+			}
 			title = removeMarkdownEscapes(title);
 			href = removeMarkdownEscapes(href);
 			return `<a href="#" data-href="${href}" title="${title || text}">${text}</a>`;

--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -71,6 +71,12 @@ export function textToMarkedString(text: string): MarkedString {
 	return text.replace(/[\\`*_{}[\]()#+\-.!]/g, '\\$&'); // escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
 }
 
+export function removeMarkdownEscapes(text: string): string {
+	if (!text) {
+		return text;
+	}
+	return text.replace(/\\([\\`*_{}[\]()#+\-.!])/g, '$1');
+}
 
 export interface IHTMLContentElement {
 	/**


### PR DESCRIPTION
Fixes #14968

**Bug**
Due to a bug in marked (https://github.com/chjj/marked/issues/829), markdown escapes inside of links are currently not rendered properly. As shown in #14968, this can also can effect regular text that contains characters that are escaped when we convert the text to markdown text.

**Fix**
For links, remove markdown escapes before rendering them.