### PR TITLE
Fix #16432 - rejected promise not handled

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -114,8 +114,8 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		this.globalState = globalState;
 		this.pathSeparator = path.sep;
 
-		let p = new Promise<void>((resolve, reject) => {
-			this._onReady = { promise: Promise.reject<void>(null), resolve, reject };
+		const p = new Promise<void>((resolve, reject) => {
+			this._onReady = { promise: p, resolve, reject };
 		});
 		this._onReady.promise = p;
 


### PR DESCRIPTION
Fixes #16432

This error was Introducing during null check refeactoring. Before the promise was set to null inside the promise. I added a rejection because the empty  promise value should never actually be used, but it seems the rejection introduced a regression.

Fix is to use `p` inside of the promise instead.