### PR TITLE
Option to exclude items from Git branch checkout list #13506

### DIFF
--- a/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
+++ b/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
@@ -139,14 +139,14 @@ class CheckoutCommand implements ICommand {
 
 		const checkoutType = this.gitService.checkoutType;
 		const includeTags = checkoutType === 'all' || checkoutType === 'tags';
-		const inclueRemotes = checkoutType === 'all' || checkoutType === 'remote';
+		const includeRemotes = checkoutType === 'all' || checkoutType === 'remote';
 
 		const gitModel = this.gitService.getModel();
 		const currentHead = gitModel.getHEAD();
 		const refs = gitModel.getRefs();
 		const heads = refs.filter(ref => ref.type === RefType.Head);
 		const tags = includeTags ? refs.filter(ref => ref.type === RefType.Tag) : [];
-		const remoteHeads = inclueRemotes ? refs.filter(ref => ref.type === RefType.RemoteHead) : [];
+		const remoteHeads = includeRemotes ? refs.filter(ref => ref.type === RefType.RemoteHead) : [];
 
 		const headMatches = heads
 			.map(head => ({ head, highlights: matchesContiguousSubString(input, head.name) }))

--- a/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
+++ b/src/vs/workbench/parts/git/browser/gitQuickOpen.ts
@@ -137,12 +137,16 @@ class CheckoutCommand implements ICommand {
 	getResults(input: string): TPromise<QuickOpenEntry[]> {
 		input = input.trim();
 
+		const checkoutType = this.gitService.checkoutType;
+		const includeTags = checkoutType === 'all' || checkoutType === 'tags';
+		const inclueRemotes = checkoutType === 'all' || checkoutType === 'remote';
+
 		const gitModel = this.gitService.getModel();
 		const currentHead = gitModel.getHEAD();
 		const refs = gitModel.getRefs();
 		const heads = refs.filter(ref => ref.type === RefType.Head);
-		const tags = refs.filter(ref => ref.type === RefType.Tag);
-		const remoteHeads = refs.filter(ref => ref.type === RefType.RemoteHead);
+		const tags = includeTags ? refs.filter(ref => ref.type === RefType.Tag) : [];
+		const remoteHeads = inclueRemotes ? refs.filter(ref => ref.type === RefType.RemoteHead) : [];
 
 		const headMatches = heads
 			.map(head => ({ head, highlights: matchesContiguousSubString(input, head.name) }))

--- a/src/vs/workbench/parts/git/browser/gitServices.ts
+++ b/src/vs/workbench/parts/git/browser/gitServices.ts
@@ -418,6 +418,10 @@ export class GitService extends EventEmitter
 			this.transition(ServiceState.OK);
 		}
 	}
+	get checkoutType(): string {
+		const { checkoutType } = this.configurationService.getConfiguration<IGitConfiguration>('git');
+		return checkoutType;
+	}
 
 	get onOutput(): Event<string> { return this.raw.onOutput; }
 

--- a/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
+++ b/src/vs/workbench/parts/git/browser/gitWorkbenchContributions.ts
@@ -221,6 +221,12 @@ export function registerContributions(): void {
 				enum: ['all', 'tracked', 'off'],
 				default: 'all',
 				description: nls.localize('countBadge', "Controls the git badge counter."),
+			},
+			'git.checkoutType': {
+				type: 'string',
+				enum: ['all', 'local', 'tags', 'remote'],
+				default: 'all',
+				description: nls.localize('checkoutType', "Controls what type of branches are listed."),
 			}
 		}
 	});

--- a/src/vs/workbench/parts/git/common/git.ts
+++ b/src/vs/workbench/parts/git/common/git.ts
@@ -242,6 +242,7 @@ export interface IGitConfiguration {
 	allowLargeRepositories: boolean;
 	confirmSync: boolean;
 	countBadge: string;
+	checkoutType: string;
 }
 
 // Service interfaces
@@ -305,6 +306,7 @@ export const IGitService = createDecorator<IGitService>(GIT_SERVICE_ID);
 export interface IGitService extends IEventEmitter {
 	_serviceBrand: any;
 	allowHugeRepositories: boolean;
+	checkoutType: string;
 	onOutput: Event<string>;
 	status(): TPromise<IModel>;
 	init(): TPromise<IModel>;


### PR DESCRIPTION
Here are my proposed changes to solve issue #13506.. This is an implementation of what @joaomoreno proposed in the ticket.. I've added a setting named `checkoutType` which controls what is listed inside the quick open panel for the git checkout command (`all` is as it is today, `local` is only local branches, `tags` is local branches and tagged commits, `remote` is local branches and remote branches... Happy to change names/descriptions of anything :) ).

I believe these are the minimal amount of changes to do this. Poking around, I could see a couple other ways you'd do it, either getting the config service into the `CheckoutCommand` (which seemed like a large refactor) or using the setting as a filter on the `GitService` for what's exposed as `model`/`head`/`refs` (which also seemed like a large refactor and could change other consumers).. If one of those are the desired approach, I think that my changes should be abandoned and someone else would have to take over that effort (as I'm not familiar enough with the larger application).

There's still some things I'm unsure of. For example, we could branch inside the `CheckoutCommand`'s `getResult` method instead of using empty arrays for `tags`/`remoteHeads` (I just thought it added an unnecessary level of complexity). Another example is maybe using a private `_checkoutType` on the `GitService` and set it as part of the `onDidUpdateConfiguration` handler (this would be more similar to `allowHugeRepositories`, but since there isn't an override I don't know that it's necessary (and very possible I'm misunderstanding some intents here).. It's also very possible there's other completely different things I overlooked/you guys would know more about.

I looked for tests related to either the `CheckoutCommand` or the git settings and had trouble finding anything that I could base things on. If you had any suggestions or places to look at for similar tests, I'd be happy to take a stab at automating something. I did run all local tests and linting and they passed and reported nothing (respectively).

I did test this locally with this repo to ensure that 1) The setting existed/had the description and options I expected 2) The drop down respected the settings I picked (and that it updated without restarting) 3) I could still switch branches

Thanks for the great product!

Edit: reread this this morning and noticed I had some bad English in some places.. Also signed the CLA (and got confirmation from it), but the bot hasn't updated this. Is there anything else I should do for that? I wasn't expecting one line for the address, so maybe I messed it up.