### PR TITLE
Use No Implicit Any In TS Extension

### DIFF
--- a/extensions/typescript/src/features/formattingProvider.ts
+++ b/extensions/typescript/src/features/formattingProvider.ts
@@ -23,6 +23,8 @@ interface Configuration {
 	insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: boolean;
 	placeOpenBraceOnNewLineForFunctions: boolean;
 	placeOpenBraceOnNewLineForControlBlocks: boolean;
+
+	[key: string]: boolean;
 }
 
 namespace Configuration {

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -69,7 +69,7 @@ export interface ITypescriptServiceClient {
 
 	onProjectLanguageServiceStateChanged: Event<Proto.ProjectLanguageServiceStateEventBody>;
 
-	logTelemetry(eventName: string, properties?: { [prop: string]: string });
+	logTelemetry(eventName: string, properties?: { [prop: string]: string }): void;
 
 	experimentalAutoBuild: boolean;
 	apiVersion: API;

--- a/extensions/typescript/src/typings/ref.d.ts
+++ b/extensions/typescript/src/typings/ref.d.ts
@@ -4,6 +4,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 /// <reference path='../../../../src/vs/vscode.d.ts'/>
-/// <reference path='../../../../src/typings/mocha.d.ts'/>
 /// <reference path='../../../../extensions/declares.d.ts'/>
 /// <reference path='../../../../extensions/node.d.ts'/>

--- a/extensions/typescript/src/utils/electronForkStart.ts
+++ b/extensions/typescript/src/utils/electronForkStart.ts
@@ -14,7 +14,7 @@ var log = (function () {
 	}
 	var isFirst = true;
 	var LOG_LOCATION = 'C:\\stdFork.log';
-	return function log(str) {
+	return function log(str: any) {
 		if (isFirst) {
 			isFirst = false;
 			fs.writeFileSync(LOG_LOCATION, str + '\n');
@@ -55,13 +55,13 @@ log('ELECTRON_RUN_AS_NODE: ' + process.env['ELECTRON_RUN_AS_NODE']);
 	// handle process.stderr
 	(<any>process).__defineGetter__('stderr', function () { return stdErrStream; });
 
-	var fsWriteSyncString = function (fd, str, position, encoding) {
+	var fsWriteSyncString = function (fd: number, str: string, position: number, encoding?: string) {
 		//  fs.writeSync(fd, string[, position[, encoding]]);
 		var buf = new Buffer(str, encoding || 'utf8');
 		return fsWriteSyncBuffer(fd, buf, 0, buf.length);
 	};
 
-	var fsWriteSyncBuffer = function (fd, buffer, off, len) {
+	var fsWriteSyncBuffer = function (fd: number, buffer: Buffer, off: number, len: number) {
 		off = Math.abs(off | 0);
 		len = Math.abs(len | 0);
 
@@ -97,8 +97,8 @@ log('ELECTRON_RUN_AS_NODE: ' + process.env['ELECTRON_RUN_AS_NODE']);
 
 	// handle fs.writeSync(1, ...)
 	var originalWriteSync = fs.writeSync;
-	fs.writeSync = function (fd, data, position, encoding) {
-		if (fd !== 1 || fd !== 2) {
+	fs.writeSync = function (fd: number, data: any, position: number, encoding?: string) {
+		if (fd !== 1 && fd !== 2) {
 			return originalWriteSync.apply(fs, arguments);
 		}
 		// usage:
@@ -125,7 +125,7 @@ log('ELECTRON_RUN_AS_NODE: ' + process.env['ELECTRON_RUN_AS_NODE']);
 (function () {
 
 	// Begin listening to stdin pipe
-	var server = net.createServer(function (stream) {
+	var server = net.createServer(function (stream: any) {
 		// Stop accepting new connections, keep the existing one alive
 		server.close();
 

--- a/extensions/typescript/tsconfig.json
+++ b/extensions/typescript/tsconfig.json
@@ -7,7 +7,8 @@
 			"es2015.promise"
 		],
 		"outDir": "./out",
-		"strictNullChecks": true
+		"strictNullChecks": true,
+		"noImplicitAny": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
Use `noImplicitAny` in the TS Extension (the TS team suggests enabling this option for most code).

Just did this while verifying that ts 2.1.4 behaves as expected