### PR TITLE
Add hot exit educational message

### DIFF
--- a/src/vs/test/utils/servicesTestUtils.ts
+++ b/src/vs/test/utils/servicesTestUtils.ts
@@ -164,6 +164,8 @@ export class TestTextFileService extends TextFileService {
 	public confirmSave(resources?: URI[]): ConfirmResult {
 		return this.confirmResult;
 	}
+
+	public showHotExitMessage(): void { }
 }
 
 export function workbenchInstantiationService(): IInstantiationService {

--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -90,6 +90,8 @@ export abstract class TextFileService implements ITextFileService {
 
 	abstract confirmSave(resources?: URI[]): ConfirmResult;
 
+	abstract showHotExitMessage(): void;
+
 	public get onAutoSaveConfigurationChange(): Event<IAutoSaveConfiguration> {
 		return this._onAutoSaveConfigurationChange.event;
 	}
@@ -135,6 +137,8 @@ export abstract class TextFileService implements ITextFileService {
 
 					// If hot exit is enabled, backup dirty files and allow to exit without confirmation
 					if (this.backupService.isHotExitEnabled) {
+						this.showHotExitMessage();
+
 						return this.backupService.backupBeforeShutdown(dirty, this.models, reason).then(result => {
 							if (result.didBackup) {
 								return this.noVeto({ cleanUpBackups: false }); // no veto and no backup cleanup (since backup was successful)

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -325,6 +325,12 @@ export interface ITextFileService extends IDisposable {
 	confirmSave(resources?: URI[]): ConfirmResult;
 
 	/**
+	 * Brings up an informational message about how exit now being enabled by default. This message
+	 * is temporary and will eventually be removed.
+	 */
+	showHotExitMessage(): void;
+
+	/**
 	 * Convinient fast access to the current auto save mode.
 	 */
 	getAutoSaveMode(): AutoSaveMode;

--- a/src/vs/workbench/services/textfile/electron-browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/electron-browser/textFileService.ts
@@ -30,6 +30,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IBackupModelService } from 'vs/workbench/services/backup/common/backup';
 import { IMessageService } from 'vs/platform/message/common/message';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 
 export class TextFileService extends AbstractTextFileService {
 
@@ -49,7 +50,8 @@ export class TextFileService extends AbstractTextFileService {
 		@IModelService private modelService: IModelService,
 		@IEnvironmentService private environmentService: IEnvironmentService,
 		@IBackupModelService backupService: IBackupModelService,
-		@IMessageService messageService: IMessageService
+		@IMessageService messageService: IMessageService,
+		@IStorageService private storageService: IStorageService
 	) {
 		super(lifecycleService, contextService, configurationService, telemetryService, editorGroupService, fileService, untitledEditorService, instantiationService, backupService, messageService);
 	}
@@ -135,6 +137,23 @@ export class TextFileService extends AbstractTextFileService {
 		const choice = this.windowService.getWindow().showMessageBox(opts);
 
 		return buttons[choice].result;
+	}
+
+	public showHotExitMessage(): void {
+		const key = 'hotExit/hasShownMessage';
+		const hasShownMessage = !!this.storageService.get(key, StorageScope.GLOBAL);
+		if (!hasShownMessage) {
+			this.storageService.store(key, true, StorageScope.GLOBAL);
+			const opts: Electron.ShowMessageBoxOptions = {
+				title: product.nameLong,
+				message: nls.localize('hotExitEducationalMessage', "Hot exit is now enabled by default"),
+				type: 'info',
+				detail: nls.localize('hotExitEducationalDetail', "Hot exit remembers any unsaved changed between sessions, so you don't have to save your files before you exit. You can disable this feature in the settings."),
+				buttons: [nls.localize('ok', "OK")],
+				noLink: true
+			};
+			this.windowService.getWindow().showMessageBox(opts);
+		}
 	}
 
 	private mnemonicLabel(label: string): string {


### PR DESCRIPTION
Fixes #16491 

---

@bpasero I put everything inside of electron-browser/textFileService.ts so it's all in one place and because it's probably only going to stick around for a few versions.

![image](https://cloud.githubusercontent.com/assets/2193314/21023873/3b66640e-bd37-11e6-8b79-2d3488b358ce.png)
