### PR TITLE
Add outline support for Markdown files

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -13,6 +13,7 @@
 		"Languages"
 	],
 	"activationEvents": [
+		"onLanguage:markdown",
 		"onCommand:markdown.showPreview",
 		"onCommand:markdown.showPreviewToSide",
 		"onCommand:markdown.showSource"

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -320,7 +320,6 @@ class MDDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 		const headings = tokens.filter(token => token.type === 'heading_open');
 
 		const symbols = headings.map(heading => {
-			console.log(heading);
 			const lineNumber = heading.map[0];
 			const line = document.lineAt(lineNumber + offset);
 			const location = new vscode.Location(document.uri, line.range);

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -338,7 +338,13 @@ class MDDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
 			const lineNumber = heading.map[0];
 			const line = document.lineAt(lineNumber + offset);
 			const location = new vscode.Location(document.uri, line.range);
-			const text = line.text.replace(/^\s*#+\s*/, '');
+
+			// # Header        => 'Header'
+			// ## Header ##    => 'Header'
+			// ## Header ####  => 'Header'
+			// Header ##       => 'Header ##'
+			// =========
+			const text = line.text.replace(/^\s*(#)+\s*(.*?)\s*\1*$/, '$2');
 
 			return new vscode.SymbolInformation(text, vscode.SymbolKind.Module, '', location);
 		});


### PR DESCRIPTION
This PR adds outline support for Markdown files.

- Introduces a `MDDocumentSymbolProvider` which is able to provide symbols based on the same `markdown-it` parser.
- Optimizes the Front Matter regex to `/^---\s*(.|\s)*?---\s*/`.
- First attempt was #13238
- Fixes #3493