### PR TITLE
Standardize cursor movement with home and end keys

### DIFF
--- a/src/vs/editor/common/controller/cursorMoveOperations.ts
+++ b/src/vs/editor/common/controller/cursorMoveOperations.ts
@@ -242,13 +242,14 @@ export class MoveOperations {
 	}
 
 	public static moveToBeginningOfLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleMoveOperationResult {
-
-		let lineNumber = cursor.selection.startLineNumber;
+		let lineNumber = cursor.position.lineNumber;
 		let minColumn = model.getLineMinColumn(lineNumber);
 		let firstNonBlankColumn = model.getLineFirstNonWhitespaceColumn(lineNumber) || minColumn;
 
 		let column: number;
-		if (cursor.selection.startColumn === firstNonBlankColumn) {
+
+		let relevantColumnNumber = cursor.position.column;
+		if (relevantColumnNumber === firstNonBlankColumn) {
 			column = minColumn;
 		} else {
 			column = firstNonBlankColumn;
@@ -258,10 +259,8 @@ export class MoveOperations {
 	}
 
 	public static moveToEndOfLine(config: CursorConfiguration, model: ICursorSimpleModel, cursor: SingleCursorState, inSelectionMode: boolean): SingleMoveOperationResult {
-
-		let lineNumber = cursor.selection.endLineNumber;
+		let lineNumber = cursor.position.lineNumber;
 		let maxColumn = model.getLineMaxColumn(lineNumber);
-
 		return SingleMoveOperationResult.fromMove(cursor, inSelectionMode, lineNumber, maxColumn, 0, true, CursorChangeReason.Explicit);
 	}
 

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -491,7 +491,7 @@ suite('Editor Controller - Cursor', () => {
 		moveTo(thisCursor, 1, 8);
 		moveTo(thisCursor, 3, 9, true);
 		moveToBeginningOfLine(thisCursor, false);
-		assertCursor(thisCursor, new Selection(1, 6, 1, 6));
+		assertCursor(thisCursor, new Selection(3, 5, 3, 5));
 	});
 
 	test('move to beginning of line with selection multiline backward', () => {
@@ -519,7 +519,14 @@ suite('Editor Controller - Cursor', () => {
 		moveTo(thisCursor, 1, 8);
 		moveTo(thisCursor, 3, 9, true);
 		moveToBeginningOfLine(thisCursor, false);
-		assertCursor(thisCursor, new Selection(1, 6, 1, 6));
+		assertCursor(thisCursor, new Selection(3, 5, 3, 5));
+	});
+
+	test('issue #17011: Shift+home/end now go to the end of the selection start\'s line, not the selection\'s end', () => {
+		moveTo(thisCursor, 1, 8);
+		moveTo(thisCursor, 3, 9, true);
+		moveToBeginningOfLine(thisCursor, true);
+		assertCursor(thisCursor, new Selection(1, 8, 3, 5));
 	});
 
 	// --------- move to end of line
@@ -566,7 +573,7 @@ suite('Editor Controller - Cursor', () => {
 		moveTo(thisCursor, 3, 9);
 		moveTo(thisCursor, 1, 1, true);
 		moveToEndOfLine(thisCursor, false);
-		assertCursor(thisCursor, new Selection(3, 17, 3, 17));
+		assertCursor(thisCursor, new Selection(1, 21, 1, 21));
 	});
 
 	test('move to end of line with selection single line forward', () => {


### PR DESCRIPTION
In order to fix the linked issue some preexisting behaviours had to
be modified. The resulting overall behaviour now fits better to standard
implementations.

Editors taken into account:
Chrome dev tools
Windows notepad
Atom
Intellij IDEA

This fixes #17011