### PR TITLE
typography fix for better legibility

### DIFF
--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -14,6 +14,12 @@
 	-webkit-user-select: none;
 }
 
+@media (min-resolution: 192dpi) {
+	.monaco-shell {
+		-webkit-font-smoothing: antialiased;
+	}
+}
+
 /* Font Families (with CJK support) */
 
 .monaco-shell { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif; }


### PR DESCRIPTION
Enhance the legibility on high DPI screens.  Applied to light, dark, and high-contrast.  

Light
<img width="388" alt="screen shot 2016-12-11 at 2 05 40 am" src="https://cloud.githubusercontent.com/assets/10452/21079437/865b22ae-bf46-11e6-84cf-6c14a37e505c.png">
<img width="382" alt="screen shot 2016-12-11 at 2 05 56 am" src="https://cloud.githubusercontent.com/assets/10452/21079436/83ca9fa6-bf46-11e6-8f40-a327cf84ee5d.png">

Dark
<img width="384" alt="screen shot 2016-12-11 at 2 04 53 am" src="https://cloud.githubusercontent.com/assets/10452/21079439/8b96a216-bf46-11e6-9108-2731de4c2174.png">
<img width="381" alt="screen shot 2016-12-11 at 2 05 16 am" src="https://cloud.githubusercontent.com/assets/10452/21079440/8d646e16-bf46-11e6-8d88-140acd87ed28.png">

High-Contrast
<img width="387" alt="screen shot 2016-12-11 at 2 06 32 am" src="https://cloud.githubusercontent.com/assets/10452/21079444/90e067ac-bf46-11e6-885d-da61adf72ce4.png">
<img width="387" alt="screen shot 2016-12-11 at 2 06 20 am" src="https://cloud.githubusercontent.com/assets/10452/21079445/930b514a-bf46-11e6-9a2b-a5cbe804a2c6.png">


Sadly, Ive not been able to test on [Windows nor a Linux device](https://github.com/Microsoft/vscode/issues/9152#issuecomment-265847011).

refs #9152 