### PR TITLE
Workaround for #16909

### DIFF
--- a/extensions/typescript/src/features/documentHighlightProvider.ts
+++ b/extensions/typescript/src/features/documentHighlightProvider.ts
@@ -42,7 +42,7 @@ export default class TypeScriptDocumentHighlightProvider implements DocumentHigh
 					// Check to see if contents around first occurrence are string delimiters
 					const contents = resource.getText(new Range(firstOccurrence.start.line - 1, firstOccurrence.start.offset - 1 - 1, firstOccurrence.end.line - 1, firstOccurrence.end.offset - 1 + 1));
 					const stringDelimiters = ['"', '\'', '`'];
-					if (contents && contents.length && stringDelimiters.indexOf(contents[0]) >= 0 && contents[0] === contents[contents.length - 1]) {
+					if (contents && contents.length > 2 && stringDelimiters.indexOf(contents[0]) >= 0 && contents[0] === contents[contents.length - 1]) {
 						return [];
 					}
 				}

--- a/extensions/typescript/src/features/documentHighlightProvider.ts
+++ b/extensions/typescript/src/features/documentHighlightProvider.ts
@@ -38,7 +38,7 @@ export default class TypeScriptDocumentHighlightProvider implements DocumentHigh
 				// Workaround for https://github.com/Microsoft/TypeScript/issues/12780
 				// Don't highlight string occurrences
 				const firstOccurrence = data[0];
-				if (firstOccurrence.start.offset > 1) {
+				if (this.client.apiVersion.has213Features() && firstOccurrence.start.offset > 1) {
 					// Check to see if contents around first occurrence are string delimiters
 					const contents = resource.getText(new Range(firstOccurrence.start.line - 1, firstOccurrence.start.offset - 1 - 1, firstOccurrence.end.line - 1, firstOccurrence.end.offset - 1 + 1));
 					const stringDelimiters = ['"', '\'', '`'];

--- a/extensions/typescript/src/features/documentHighlightProvider.ts
+++ b/extensions/typescript/src/features/documentHighlightProvider.ts
@@ -34,7 +34,18 @@ export default class TypeScriptDocumentHighlightProvider implements DocumentHigh
 		}
 		return this.client.execute('occurrences', args, token).then((response): DocumentHighlight[] => {
 			let data = response.body;
-			if (data) {
+			if (data && data.length) {
+				// Workaround for https://github.com/Microsoft/TypeScript/issues/12780
+				// Don't highlight strings
+				const firstOccurrence = data[0];
+				if (firstOccurrence.start.offset > 1) {
+					// Check to see if contents around first occurrence are string delimiters
+					const contents = resource.getText(new Range(firstOccurrence.start.line - 1, firstOccurrence.start.offset - 1 - 1, firstOccurrence.end.line - 1, firstOccurrence.end.offset - 1 + 1));
+					const stringDelimiters = ['"', '\'', '`'];
+					if (contents && contents.length && stringDelimiters.indexOf(contents[0]) >= 0 && contents[0] === contents[contents.length - 1]) {
+						return [];
+					}
+				}
 				return data.map((item) => {
 					return new DocumentHighlight(new Range(item.start.line - 1, item.start.offset - 1, item.end.line - 1, item.end.offset - 1),
 						item.isWriteAccess ? DocumentHighlightKind.Write : DocumentHighlightKind.Read);

--- a/extensions/typescript/src/features/documentHighlightProvider.ts
+++ b/extensions/typescript/src/features/documentHighlightProvider.ts
@@ -36,7 +36,7 @@ export default class TypeScriptDocumentHighlightProvider implements DocumentHigh
 			let data = response.body;
 			if (data && data.length) {
 				// Workaround for https://github.com/Microsoft/TypeScript/issues/12780
-				// Don't highlight strings
+				// Don't highlight string occurrences
 				const firstOccurrence = data[0];
 				if (firstOccurrence.start.offset > 1) {
 					// Check to see if contents around first occurrence are string delimiters


### PR DESCRIPTION
Fixes #16909

Workaround TS2.1+ returning strings in the `occurrences` response we use for highlighting symbol occurrences in a document

The workaround is to look at the text surrounding the first occurrence to see if it is a string literal.