### PR TITLE
Disable emmet in markdown by default

### DIFF
--- a/src/vs/workbench/parts/emmet/node/emmet.contribution.ts
+++ b/src/vs/workbench/parts/emmet/node/emmet.contribution.ts
@@ -52,7 +52,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'emmet.excludeLanguages': {
 			'type': 'array',
-			'default': [],
+			'default': ['markdown'],
 			'description': nls.localize('emmetExclude', "An array of languages where emmet abbreviations should not be expanded.")
 		},
 	}


### PR DESCRIPTION
Fixes #16569

This disables emmet expansion inside of markdown files by default. Users can enable these expansion again by adding `"emmet.excludeLanguages": []` to their user settings.