### PR TITLE
Monitor Typings Acqusition Events in TS Completion Item Provider

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -8,10 +8,14 @@
 import { CompletionItem, TextDocument, Position, CompletionItemKind, CompletionItemProvider, CancellationToken, WorkspaceConfiguration, TextEdit, Range, SnippetString, workspace } from 'vscode';
 
 import { ITypescriptServiceClient } from '../typescriptService';
+import TypingsStatus from '../utils/typingsStatus';
 
 import * as PConst from '../protocol.const';
 import { CompletionEntry, CompletionsRequestArgs, CompletionDetailsRequestArgs, CompletionEntryDetails, FileLocationRequestArgs } from '../protocol';
 import * as Previewer from './previewer';
+
+import * as nls from 'vscode-nls';
+let localize = nls.loadMessageBundle();
 
 class MyCompletionItem extends CompletionItem {
 
@@ -79,10 +83,12 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 	public sortBy = [{ type: 'reference', partSeparator: '/' }];
 
 	private client: ITypescriptServiceClient;
+	private typingsStatus: TypingsStatus;
 	private config: Configuration;
 
-	constructor(client: ITypescriptServiceClient) {
+	constructor(client: ITypescriptServiceClient, typingsStatus: TypingsStatus) {
 		this.client = client;
+		this.typingsStatus = typingsStatus;
 		this.config = { useCodeSnippetsOnMethodSuggest: false };
 	}
 
@@ -93,6 +99,13 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 	}
 
 	public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
+		if (this.typingsStatus.isAcquiringTypings) {
+			return Promise.reject({
+				label: localize('acquiringTypingsLabel', 'Acquiring typings...'),
+				detail: localize('acquiringTypingsDetail', 'Acquiring typings definitions for IntelliSense.')
+			});
+		}
+
 		let filepath = this.client.asAbsolutePath(document.uri);
 		if (!filepath) {
 			return Promise.resolve<CompletionItem[]>([]);

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -35,9 +35,10 @@ import BufferSyncSupport from './features/bufferSyncSupport';
 import CompletionItemProvider from './features/completionItemProvider';
 import WorkspaceSymbolProvider from './features/workspaceSymbolProvider';
 
-import * as VersionStatus from './utils/versionStatus';
-import * as ProjectStatus from './utils/projectStatus';
 import * as BuildStatus from './utils/buildStatus';
+import * as ProjectStatus from './utils/projectStatus';
+import TypingsStatus from './utils/typingsStatus';
+import * as VersionStatus from './utils/versionStatus';
 
 interface LanguageDescription {
 	id: string;
@@ -104,6 +105,7 @@ class LanguageProvider {
 	private completionItemProvider: CompletionItemProvider;
 	private formattingProvider: FormattingProvider;
 	private formattingProviderRegistration: Disposable | null;
+	private typingsStatus: TypingsStatus;
 
 	private _validate: boolean;
 
@@ -121,6 +123,7 @@ class LanguageProvider {
 		this.syntaxDiagnostics = Object.create(null);
 		this.currentDiagnostics = languages.createDiagnosticCollection(description.id);
 
+		this.typingsStatus = new TypingsStatus(client);
 
 		workspace.onDidChangeConfiguration(this.configurationChanged, this);
 		this.configurationChanged();
@@ -136,7 +139,7 @@ class LanguageProvider {
 	private registerProviders(client: TypeScriptServiceClient): void {
 		let config = workspace.getConfiguration(this.id);
 
-		this.completionItemProvider = new CompletionItemProvider(client);
+		this.completionItemProvider = new CompletionItemProvider(client, this.typingsStatus);
 		this.completionItemProvider.updateConfiguration(config);
 
 		let hoverProvider = new HoverProvider(client);

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -68,6 +68,8 @@ export interface ITypescriptServiceClient {
 	error(message: string, data?: any): void;
 
 	onProjectLanguageServiceStateChanged: Event<Proto.ProjectLanguageServiceStateEventBody>;
+	onDidBeginInstallTypings: Event<Proto.BeginInstallTypesEventBody>;
+	onDidEndInstallTypings: Event<Proto.EndInstallTypesEventBody>;
 
 	logTelemetry(eventName: string, properties?: { [prop: string]: string }): void;
 

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -103,6 +103,8 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 	private pendingResponses: number;
 	private callbacks: CallbackMap;
 	private _onProjectLanguageServiceStateChanged = new EventEmitter<Proto.ProjectLanguageServiceStateEventBody>();
+	private _onDidBeginInstallTypings = new EventEmitter<Proto.BeginInstallTypesEventBody>();
+	private _onDidEndInstallTypings = new EventEmitter<Proto.EndInstallTypesEventBody>();
 
 	private _packageInfo: IPackageInfo | null;
 	private _apiVersion: API;
@@ -151,6 +153,14 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 
 	get onProjectLanguageServiceStateChanged(): Event<Proto.ProjectLanguageServiceStateEventBody> {
 		return this._onProjectLanguageServiceStateChanged.event;
+	}
+
+	get onDidBeginInstallTypings(): Event<Proto.BeginInstallTypesEventBody> {
+		return this._onDidBeginInstallTypings.event;
+	}
+
+	get onDidEndInstallTypings(): Event<Proto.EndInstallTypesEventBody> {
+		return this._onDidEndInstallTypings.event;
 	}
 
 	private get output(): OutputChannel {
@@ -693,6 +703,16 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 					const data = (event as Proto.ProjectLanguageServiceStateEvent).body;
 					if (data) {
 						this._onProjectLanguageServiceStateChanged.fire(data);
+					}
+				} else if (event.event === 'beginInstallTypes') {
+					const data = (event as Proto.BeginInstallTypesEvent).body;
+					if (data) {
+						this._onDidBeginInstallTypings.fire(data);
+					}
+				} else if (event.event === 'endInstallTypes') {
+					const data = (event as Proto.EndInstallTypesEvent).body;
+					if (data) {
+						this._onDidEndInstallTypings.fire(data);
 					}
 				}
 			} else {

--- a/extensions/typescript/src/utils/typingsStatus.ts
+++ b/extensions/typescript/src/utils/typingsStatus.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import * as vscode from 'vscode';
+import { ITypescriptServiceClient } from '../typescriptService';
+
+const typingsInstallTimeout = 30 * 1000;
+
+export default class TypingsStatus extends vscode.Disposable {
+	private _acquiringTypings: Map<NodeJS.Timer> = Object.create({});
+	private _client: ITypescriptServiceClient;
+	private _subscriptions: vscode.Disposable[] = [];
+
+	constructor(client: ITypescriptServiceClient) {
+		super(() => this.dispose());
+		this._client = client;
+
+		this._subscriptions.push(
+			this._client.onDidBeginInstallTypings(event => this.onBeginInstallTypings(event.eventId)));
+
+		this._subscriptions.push(
+			this._client.onDidEndInstallTypings(event => this.onEndInstallTypings(event.eventId)));
+	}
+
+	public dispose(): void {
+		this._subscriptions.forEach(x => x.dispose());
+
+		for (const eventId of Object.keys(this._acquiringTypings)) {
+			clearTimeout(this._acquiringTypings[eventId]);
+		}
+	}
+
+	public get isAcquiringTypings(): boolean {
+		return Object.keys(this._acquiringTypings).length > 0;
+	}
+
+	private onBeginInstallTypings(eventId: number): void {
+		if (this._acquiringTypings[eventId]) {
+			return;
+		}
+		this._acquiringTypings[eventId] = setTimeout(() => {
+			this.onEndInstallTypings(eventId);
+		}, typingsInstallTimeout);
+	}
+
+	private onEndInstallTypings(eventId: number): void {
+		const timer = this._acquiringTypings[eventId];
+		if (timer) {
+			clearTimeout(timer);
+		}
+		delete this._acquiringTypings[eventId];
+	}
+}


### PR DESCRIPTION
Part of #15209 

Monitors the status of typings acqusition from TS. If we are acquiring typings, in the TypeScript completion item provider, return an error result that informs the user that the results are incomplete.

Typings acqusition is currently capped at 30 seconds per typings install event so that we don't block intellisense forever if something goes wrong.