### PR TITLE
Update TS extension to target es6

### DIFF
--- a/extensions/typescript/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript/src/features/bufferSyncSupport.ts
@@ -21,7 +21,7 @@ interface IDiagnosticRequestor {
 	requestDiagnostic(filepath: string): void;
 }
 
-const Mode2ScriptKind: Map<'TS' | 'JS' | 'TSX' | 'JSX'> = {
+const Mode2ScriptKind: ObjectMap<'TS' | 'JS' | 'TSX' | 'JSX'> = {
 	'typescript': 'TS',
 	'typescriptreact': 'TSX',
 	'javascript': 'JS',
@@ -106,11 +106,11 @@ export default class BufferSyncSupport {
 	private client: ITypescriptServiceClient;
 
 	private _validate: boolean;
-	private modeIds: Map<boolean>;
-	private extensions: Map<boolean>;
+	private modeIds: ObjectMap<boolean>;
+	private extensions: ObjectMap<boolean>;
 	private diagnostics: Diagnostics;
 	private disposables: Disposable[] = [];
-	private syncedBuffers: Map<SyncedBuffer>;
+	private syncedBuffers: ObjectMap<SyncedBuffer>;
 
 	private projectValidationRequested: boolean;
 
@@ -119,7 +119,7 @@ export default class BufferSyncSupport {
 	private emitQueue: LinkedMap<string>;
 	private checkGlobalTSCVersion: boolean;
 
-	constructor(client: ITypescriptServiceClient, modeIds: string[], diagnostics: Diagnostics, extensions: Map<boolean>, validate: boolean = true) {
+	constructor(client: ITypescriptServiceClient, modeIds: string[], diagnostics: Diagnostics, extensions: ObjectMap<boolean>, validate: boolean = true) {
 		this.client = client;
 		this.modeIds = Object.create(null);
 		modeIds.forEach(modeId => this.modeIds[modeId] = true);

--- a/extensions/typescript/src/features/documentSymbolProvider.ts
+++ b/extensions/typescript/src/features/documentSymbolProvider.ts
@@ -51,7 +51,7 @@ export default class TypeScriptDocumentSymbolProvider implements DocumentSymbolP
 			return Promise.resolve<SymbolInformation[]>([]);
 		}
 
-		function convertNavBar(indent: number, foldingMap: Map<SymbolInformation>, bucket: SymbolInformation[], item: Proto.NavigationBarItem, containerLabel?: string): void {
+		function convertNavBar(indent: number, foldingMap: ObjectMap<SymbolInformation>, bucket: SymbolInformation[], item: Proto.NavigationBarItem, containerLabel?: string): void {
 			let realIndent = indent + item.indent;
 			let key = `${realIndent}|${item.text}`;
 			if (realIndent !== 0 && !foldingMap[key]) {
@@ -102,7 +102,7 @@ export default class TypeScriptDocumentSymbolProvider implements DocumentSymbolP
 			return this.client.execute('navbar', args, token).then((response) => {
 				let result: SymbolInformation[] = [];
 				if (response.body) {
-					let foldingMap: Map<SymbolInformation> = Object.create(null);
+					let foldingMap: ObjectMap<SymbolInformation> = Object.create(null);
 					response.body.forEach(item => convertNavBar(0, foldingMap, result, item));
 				}
 				return result;

--- a/extensions/typescript/src/features/linkedMap.ts
+++ b/extensions/typescript/src/features/linkedMap.ts
@@ -12,7 +12,7 @@ interface Item<T> {
 
 export default class LinkedMap<T> {
 
-	private map: Map<Item<T>>;
+	private map: ObjectMap<Item<T>>;
 	private head: Item<T> | undefined;
 	private tail: Item<T> | undefined;
 	private _length: number;

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -96,8 +96,8 @@ const validateSetting = 'validate.enable';
 class LanguageProvider {
 
 	private description: LanguageDescription;
-	private extensions: Map<boolean>;
-	private syntaxDiagnostics: Map<Diagnostic[]>;
+	private extensions: ObjectMap<boolean>;
+	private syntaxDiagnostics: ObjectMap<Diagnostic[]>;
 	private currentDiagnostics: DiagnosticCollection;
 	private bufferSyncSupport: BufferSyncSupport;
 
@@ -285,7 +285,7 @@ class LanguageProvider {
 class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	private client: TypeScriptServiceClient;
 	private languages: LanguageProvider[];
-	private languagePerId: Map<LanguageProvider>;
+	private languagePerId: ObjectMap<LanguageProvider>;
 
 	constructor(descriptions: LanguageDescription[], storagePath: string, globalState: Memento) {
 		let handleProjectCreateOrDelete = () => {

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -114,7 +114,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		this.globalState = globalState;
 		this.pathSeparator = path.sep;
 
-		const p = new Promise<void>((resolve, reject) => {
+		var p = new Promise<void>((resolve, reject) => {
 			this._onReady = { promise: p, resolve, reject };
 		});
 		this._onReady.promise = p;
@@ -665,7 +665,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 					this.host.configFileDiagnosticsReceived(event as Proto.ConfigFileDiagnosticEvent);
 				} else if (event.event === 'telemetry') {
 					let telemetryData = (event as Proto.TelemetryEvent).body;
-					let properties: Map<string> = Object.create(null);
+					let properties: ObjectMap<string> = Object.create(null);
 					switch (telemetryData.telemetryEventName) {
 						case 'typingsInstalled':
 							let typingsInstalledPayload: Proto.TypingsInstalledTelemetryEventPayload = (telemetryData.payload as Proto.TypingsInstalledTelemetryEventPayload);

--- a/extensions/typescript/src/typings/collections.d.ts
+++ b/extensions/typescript/src/typings/collections.d.ts
@@ -3,6 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-interface Map<V> {
+interface ObjectMap<V> {
 	[key: string]: V;
 }

--- a/extensions/typescript/tsconfig.json
+++ b/extensions/typescript/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es6",
 		"module": "commonjs",
 		"lib": [
-			"es5",
+			"es6",
 			"es2015.promise"
 		],
 		"outDir": "./out",


### PR DESCRIPTION
Updates the TypeScript extension to target ES6. The main change here was renaming `Map` to `ObjectMap` so that our type does not collide with the builtin es6 `Map` type definition.