### PR TITLE
Make indentation of API reference samples consistent

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1123,15 +1123,16 @@ declare module 'vscode' {
 		/**
 		 * Derive a new Uri from this Uri.
 		 *
+		 * ```ts
+		 * let file = Uri.parse('before:some/file/path');
+		 * let other = file.with({ scheme: 'after' });
+		 * assert.ok(other.toString() === 'after:some/file/path');
+		 * ```
+		 *
 		 * @param change An object that describes a change to this Uri. To unset components use `null` or
 		 *  the empty string.
 		 * @return A new Uri that reflects the given change. Will return `this` Uri if the change
 		 *  is not changing anything.
-		 * @sample ```
-			let file = Uri.parse('before:some/file/path');
-			let other = file.with({ scheme: 'after' });
-			assert.ok(other.toString() === 'after:some/file/path');
-		 * ```
 		 */
 		with(change: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): Uri;
 
@@ -1510,26 +1511,26 @@ declare module 'vscode' {
 	 * The snippets below are all valid implementions of the [`HoverProvider`](#HoverProvider):
 	 *
 	 * ```ts
-	 *	let a: HoverProvider = {
-	 *		provideHover(doc, pos, token): ProviderResult<Hover> {
-	 *			return new Hover('Hello World');
-	 *		}
-	 *	}
+	 * let a: HoverProvider = {
+	 * 	provideHover(doc, pos, token): ProviderResult<Hover> {
+	 * 		return new Hover('Hello World');
+	 * 	}
+	 * }
 	 *
-	 *	let b: HoverProvider = {
-	 *		provideHover(doc, pos, token): ProviderResult<Hover> {
-	 *			return new Promise(resolve => {
-	 * 				resolve(new Hover('Hello World'));
-	 *			});
-	 *		}
-	 *	}
+	 * let b: HoverProvider = {
+	 * 	provideHover(doc, pos, token): ProviderResult<Hover> {
+	 * 		return new Promise(resolve => {
+	 * 			resolve(new Hover('Hello World'));
+	 * 	 	});
+	 * 	}
+	 * }
 	 *
-	 *	let c: HoverProvider = {
-	 *		provideHover(doc, pos, token): ProviderResult<Hover> {
-	 *			return; // undefined
-	 *		}
-	 *	}
-	 *```
+	 * let c: HoverProvider = {
+	 * 	provideHover(doc, pos, token): ProviderResult<Hover> {
+	 * 		return; // undefined
+	 * 	}
+	 * }
+	 * ```
 	 */
 	export type ProviderResult<T> = T | undefined | null | Thenable<T | undefined | null>
 
@@ -2773,7 +2774,7 @@ declare module 'vscode' {
 	 * part of the section identifier. The following snippets shows how to retrieve all configurations
 	 * from `launch.json`:
 	 *
-	 * ```
+	 * ```ts
 	 * // launch.json configuration
 	 * const config = workspace.getConfiguration('launch');
 	 *
@@ -3422,17 +3423,18 @@ declare module 'vscode' {
 	 * register a command handler with the identfier `extension.sayHello`.
 	 * ```javascript
 	 * commands.registerCommand('extension.sayHello', () => {
-	 * 		window.showInformationMessage('Hello World!');
+	 * 	window.showInformationMessage('Hello World!');
 	 * });
 	 * ```
 	 * Second, bind the command identfier to a title under which it will show in the palette (`package.json`).
 	 * ```json
 	 * {
-	 * "contributes": {
-	 * 	"commands": [{
-	 * 		"command": "extension.sayHello",
-	 * 		"title": "Hello World"
-	 * 	}]
+	 * 	"contributes": {
+	 * 		"commands": [{
+	 * 			"command": "extension.sayHello",
+	 * 			"title": "Hello World"
+	 * 		}]
+	 * 	}
 	 * }
 	 * ```
 	 */
@@ -3805,11 +3807,11 @@ declare module 'vscode' {
 		 *
 		 * ```ts
 		 * workspace.onWillSaveTextDocument(event => {
-			// async, will *throw* an error
-		 	setTimeout(() => event.waitUntil(promise));
-
-		 	// sync, OK
-		 *	event.waitUntil(promise);
+		 * 	// async, will *throw* an error
+		 * 	setTimeout(() => event.waitUntil(promise));
+		 *
+		 * 	// sync, OK
+		 * 	event.waitUntil(promise);
 		 * })
 		 * ```
 		 *
@@ -4015,9 +4017,9 @@ declare module 'vscode' {
 	 *
 	 * ```javascript
 	 * languages.registerHoverProvider('javascript', {
-	 * 		provideHover(document, position, token) {
-	 * 			return new Hover('I am a hover!');
-	 * 		}
+	 * 	provideHover(document, position, token) {
+	 * 		return new Hover('I am a hover!');
+	 * 	}
 	 * });
 	 * ```
 	 *
@@ -4293,16 +4295,16 @@ declare module 'vscode' {
 	 *
 	 * ```javascript
 	 * export function activate(context: vscode.ExtensionContext) {
-	 * 		let api = {
-	 * 			sum(a, b) {
-	 * 				return a + b;
-	 * 			},
-	 * 			mul(a, b) {
-	 * 				return a * b;
-	 * 			}
-	 * 		};
-	 * 		// 'export' public api-surface
-	 *		return api;
+	 * 	let api = {
+	 * 		sum(a, b) {
+	 * 			return a + b;
+	 * 		},
+	 * 		mul(a, b) {
+	 * 			return a * b;
+	 * 		}
+	 * 	};
+	 * 	// 'export' public api-surface
+	 * 	return api;
 	 * }
 	 * ```
 	 * When depending on the API of another extension add an `extensionDependency`-entry


### PR DESCRIPTION
Fixes #17356 

---

I ensured `<indent><space>*<space>` was consistently in front of all the code blocks.