### PR TITLE
ProtoType Go To Implementation For TypeScript

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -30,7 +30,8 @@
 		"onLanguage:typescript",
 		"onLanguage:typescriptreact",
 		"onCommand:typescript.reloadProjects",
-		"onCommand:javascript.reloadProjects"
+		"onCommand:javascript.reloadProjects",
+		"onCommand:typescript.goToImplementation"
 	],
 	"main": "./out/typescriptMain",
 	"contributes": {
@@ -259,6 +260,10 @@
 			{
 				"command": "javascript.reloadProjects",
 				"title": "%javascript.reloadProjects.title%"
+			},
+			{
+				"command": "typescript.goToImplementation",
+				"title": "%javascript.goToImplementation.title%"
 			}
 		],
 		"breakpoints": [

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -1,6 +1,7 @@
 {
 	"typescript.reloadProjects.title": "Reload TypeScript Project",
 	"javascript.reloadProjects.title": "Reload JavaScript Project",
+	"javascript.goToImplementation.title": "TypeScript Go To Implementation",
 	"configuration.typescript": "TypeScript",
 	"typescript.useCodeSnippetsOnMethodSuggest.dec": "Complete functions with their parameter signature.",
 	"typescript.tsdk.desc": "Specifies the folder path containing the tsserver and lib*.d.ts files to use.",

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -85,6 +85,7 @@ export interface ITypescriptServiceClient {
 	execute(commant: 'completionEntryDetails', args: Proto.CompletionDetailsRequestArgs, token?: CancellationToken): Promise<Proto.CompletionDetailsResponse>;
 	execute(commant: 'signatureHelp', args: Proto.SignatureHelpRequestArgs, token?: CancellationToken): Promise<Proto.SignatureHelpResponse>;
 	execute(command: 'definition', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DefinitionResponse>;
+	execute(command: 'implementation', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ImplementationResponse>;
 	execute(command: 'references', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ReferencesResponse>;
 	execute(command: 'navto', args: Proto.NavtoRequestArgs, token?: CancellationToken): Promise<Proto.NavtoResponse>;
 	execute(command: 'navbar', args: Proto.FileRequestArgs, token?: CancellationToken): Promise<Proto.NavBarResponse>;


### PR DESCRIPTION
For #10806

Initial prototype of using the TypeScript Go To Implementation Feature. Adds a go to implementation command for js and ts documents.

This has a few issues at the moment:

* We likely would want to expose `go to implementation` for other languages. Therefore, it would make sense to standardize an api for this based on the existing `DefinitionProvider` api.
* The location values that typescript returns are not correct some of the time. I'll double check that this is not a bug on our side, but the feature needs some more testing and polish before we can ship it.