### PR TITLE
Add an AppData XML data file to Linux builds

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -57,6 +57,12 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(rename('usr/share/applications/' + product.applicationName + '.desktop'));
 
+		const appdata = gulp.src('resources/linux/code.appdata.xml', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(replace('@@LICENSE@@', product.licenseName))
+			.pipe(rename('usr/share/appdata/' + product.applicationName + '.appdata.xml'));
+
 		const icon = gulp.src('resources/linux/code.png', { base: '.' })
 			.pipe(rename('usr/share/pixmaps/' + product.applicationName + '.png'));
 
@@ -92,7 +98,7 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(rename('DEBIAN/postinst'));
 
-		const all = es.merge(control, postinst, postrm, prerm, desktop, icon, code);
+		const all = es.merge(control, postinst, postrm, prerm, desktop, appdata, icon, code);
 
 		return all.pipe(vfs.dest(destination));
 	};
@@ -127,6 +133,12 @@ function prepareRpmPackage(arch) {
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(rename('BUILD/usr/share/applications/' + product.applicationName + '.desktop'));
 
+		const appdata = gulp.src('resources/linux/code.appdata.xml', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(replace('@@LICENSE@@', product.licenseName))
+			.pipe(rename('usr/share/appdata/' + product.applicationName + '.appdata.xml'));
+
 		const icon = gulp.src('resources/linux/code.png', { base: '.' })
 			.pipe(rename('BUILD/usr/share/pixmaps/' + product.applicationName + '.png'));
 
@@ -148,7 +160,7 @@ function prepareRpmPackage(arch) {
 		const specIcon = gulp.src('resources/linux/rpm/code.xpm', { base: '.' })
 			.pipe(rename('SOURCES/' + product.applicationName + '.xpm'));
 
-		const all = es.merge(code, desktop, icon, spec, specIcon);
+		const all = es.merge(code, desktop, appdata, icon, spec, specIcon);
 
 		return all.pipe(vfs.dest(getRpmBuildPath(rpmArch)));
 	};
@@ -194,6 +206,12 @@ function prepareFlatpak(arch) {
 			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(rename('share/applications/' + flatpakManifest.appId + '.desktop')));
+
+		all.push(gulp.src('resources/linux/code.appdata.xml', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME@@', flatpakManifest.appId))
+			.pipe(replace('@@LICENSE@@', product.licenseName))
+			.pipe(rename('share/appdata/' + flatpakManifest.appId + '.appdata.xml')));
 
 		all.push(gulp.src(binaryDir + '/**/*', { base:binaryDir })
 			.pipe(rename(function (p) {

--- a/resources/linux/code.appdata.xml
+++ b/resources/linux/code.appdata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+	<id>@@NAME@@.desktop</id>
+	<metadata_license>@@LICENSE@@</metadata_license>
+	<project_license>@@LICENSE@@</project_license>
+	<name>@@NAME_LONG@@</name>
+	<url type="homepage">https://code.visualstudio.com</url>
+	<summary>Code editor for developers supporting integration with existing tools</summary>
+	<description>
+		<p>
+			Visual Studio Code is a lightweight but powerful source code editor which
+			runs on your desktop and is available for Windows, Mac and Linux. It comes
+			with built-in support for JavaScript, TypeScript and Node.js and has a rich
+			ecosystem of extensions for other languages (such as C++, C#, Python, PHP)
+			and runtimes. 
+		</p>
+		<p>
+			The editor includes built-in support for the Git distributed version control
+			system, intelligent code completion, support for highlighting and completing
+			many programming languages, and and integrated debugging interface. Additional
+			functionality is provided by optional extensions.
+		</p>
+	</description>
+	<screenshots>
+		<screenshot type="default">
+			<image>https://code.visualstudio.com/home/home-screenshot-linux-lg.png</image>
+			<caption>Editing TypeScript and searching for extensions</caption>
+		</screenshot>
+	</screenshots>
+</component>


### PR DESCRIPTION
The [AppData](https://people.freedesktop.org/~hughsient/appdata/) files provide descriptive data about an application, and is typically used in application managers to display additional information to the user. Having an AppData file is especially important for some graphical application installers: without one, an application manager may not event show an entry for the application. This happens for example in GNOME Software.

For the sake of completeness, this commit not only adds the AppData file to the Flatpak build, but also to the Linux .deb and .rpm packages.

---

This is follow-up to PR #16169 and a complement to issue #7112. 