### PR TITLE
Add a few niceties for making Flatpak builds of VSCode

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -215,8 +215,13 @@ function buildFlatpak(arch) {
 	];
 	const buildOptions = {
 		arch: flatpakArch,
-		bundlePath: manifest.appId + '-' + flatpakArch + '.flatpak',
 	};
+	// If requested, use the configured path for the OSTree repository.
+	if (process.env.FLATPAK_REPO) {
+		buildOptions.repoDir = process.env.FLATPAK_REPO;
+	} else {
+		buildOptions.bundlePath = manifest.appId + '-' + flatpakArch + '.flatpak';
+	}
 	// Setup PGP signing if requested.
 	if (process.env.GPG_KEY_ID !== undefined) {
 		buildOptions.gpgSign = process.env.GPG_KEY_ID;

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -215,6 +215,7 @@ function buildFlatpak(arch) {
 	];
 	const buildOptions = {
 		arch: flatpakArch,
+		subject: product.nameLong + ' ' + packageJson.version + '.' + linuxPackageRevision,
 	};
 	// If requested, use the configured path for the OSTree repository.
 	if (process.env.FLATPAK_REPO) {

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -217,6 +217,13 @@ function buildFlatpak(arch) {
 		arch: flatpakArch,
 		bundlePath: manifest.appId + '-' + flatpakArch + '.flatpak',
 	};
+	// Setup PGP signing if requested.
+	if (process.env.GPG_KEY_ID !== undefined) {
+		buildOptions.gpgSign = process.env.GPG_KEY_ID;
+		if (process.env.GPG_HOMEDIR) {
+			buildOptions.gpgHomedir = process.env.GPG_HOME_DIR;
+		}
+	}
 	return function (cb) {
 		require('flatpak-bundler').bundle(manifest, buildOptions, cb);
 	}


### PR DESCRIPTION
This adds the following:

* Support signing built Flatpak builds using GnuPG.
* Support exporting Flatpak builds to a repository, which can be used for distributing the application *and* updates.
* When exporting to a repository, set the subject of the commit message for the repository to contain the built version.

## Rationale

Flatpak includes support for fetching applications from a repository (which may contain multiple applications and runtimes), and updates pushed to the repository are automatically picked by application managers like [GNOME Software](https://wiki.gnome.org/Apps/Software) or when using the `flatpak update` command. 

## More Info

Additional reasons why one would want to prefer a repository over serving a bunch of `.flatpak` files:

* Under the hood repositories are managed by [OSTree](https://github.com/ostreedev/ostree), which uses a [Git-like model to store data](https://ostree.readthedocs.io/en/latest/manual/repo/): each file is stored as blob, which gets hashed, and stored indexed by its hash —thus deduplicating data—, which makes repositories quite space efficient. If one is going to host multiple versions of Flatpak apps, a significative amount of disk space can be saved server-side.
* Repositories can be server over plain HTTP(S) as well — nothing special is needed server-side.
* When the `flatpak-builder` tool (called under the hood by the `flatpak-bundler` JS module) is building a `.flatpak` single-file bundle, it will first commit the built files into a temporary OSTree repository and then export that single commit to the `.flatpak` file. Using `$FLATPAK_REPO` just skips the latter.
* Installation is not made more complex for users. They can still download and just double-click to open a `.flatpakref` file in GNOME Software, which will have the application installed *and* the repository configured in one go. This is nice to ensure the users will get updates (see “Referring to repositories” in the [Flatpak documentation](http://flatpak.org/developer.html#Distributing_Applications) for details).

---

This is a follow-up to PR #16169 and a complement to issue #7112. 