### PR TITLE
Make high contrast detection configurable

### DIFF
--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -93,4 +93,5 @@ export interface IWindowSettings {
 	fullScreenZenMode: boolean;
 	zoomLevel: number;
 	titleBarStyle: 'native' | 'custom';
+	autoDetectHighContrast: boolean;
 }

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -203,6 +203,14 @@ let properties: { [path: string]: IJSONSchema; } = {
 	}
 };
 
+if (platform.isWindows) {
+	properties['window.autoDetectHighContrast'] = {
+		'type': 'boolean',
+		'default': true,
+		'description': nls.localize('autoDetectHighContrast', "If enabled, will automatically change to high contrast theme if Windows is using a high contrast theme.")
+	}
+}
+
 if (platform.isMacintosh) {
 	properties['window.titleBarStyle'] = {
 		'type': 'string',

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -207,8 +207,8 @@ if (platform.isWindows) {
 	properties['window.autoDetectHighContrast'] = {
 		'type': 'boolean',
 		'default': true,
-		'description': nls.localize('autoDetectHighContrast', "If enabled, will automatically change to high contrast theme if Windows is using a high contrast theme.")
-	}
+		'description': nls.localize('autoDetectHighContrast', "If enabled, will automatically change to high contrast theme if Windows is using a high contrast theme, and to dark theme when switching away from a Windows high contrast theme."),
+	};
 }
 
 if (platform.isMacintosh) {

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -259,7 +259,7 @@ export class ElectronWindow {
 		// High Contrast Events
 		ipc.on('vscode:enterHighContrast', (event) => {
 			const windowConfig = this.configurationService.getConfiguration<IWindowSettings>('window');
-			if (windowConfig.autoDetectHighContrast) {
+			if (windowConfig && windowConfig.autoDetectHighContrast) {
 				this.partService.joinCreation().then(() => {
 					this.themeService.setColorTheme(VS_HC_THEME, false);
 				});
@@ -268,7 +268,7 @@ export class ElectronWindow {
 
 		ipc.on('vscode:leaveHighContrast', (event) => {
 			const windowConfig = this.configurationService.getConfiguration<IWindowSettings>('window');
-			if (windowConfig.autoDetectHighContrast) {
+			if (windowConfig && windowConfig.autoDetectHighContrast) {
 				this.partService.joinCreation().then(() => {
 					this.themeService.setColorTheme(VS_DARK_THEME, false);
 				});

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -26,7 +26,7 @@ import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/edi
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IMessageService } from 'vs/platform/message/common/message';
 import { IWorkspaceConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
-import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
+import { IWindowsService, IWindowService, IWindowSettings } from 'vs/platform/windows/common/windows';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IWindowIPCService } from 'vs/workbench/services/window/electron-browser/windowService';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -258,15 +258,21 @@ export class ElectronWindow {
 
 		// High Contrast Events
 		ipc.on('vscode:enterHighContrast', (event) => {
-			this.partService.joinCreation().then(() => {
-				this.themeService.setColorTheme(VS_HC_THEME, false);
-			});
+			const windowConfig = this.configurationService.getConfiguration<IWindowSettings>('window');
+			if (windowConfig.autoDetectHighContrast) {
+				this.partService.joinCreation().then(() => {
+					this.themeService.setColorTheme(VS_HC_THEME, false);
+				});
+			}
 		});
 
 		ipc.on('vscode:leaveHighContrast', (event) => {
-			this.partService.joinCreation().then(() => {
-				this.themeService.setColorTheme(VS_DARK_THEME, false);
-			});
+			const windowConfig = this.configurationService.getConfiguration<IWindowSettings>('window');
+			if (windowConfig.autoDetectHighContrast) {
+				this.partService.joinCreation().then(() => {
+					this.themeService.setColorTheme(VS_DARK_THEME, false);
+				});
+			}
 		});
 
 		// Configuration changes


### PR DESCRIPTION
Add a new option 'window.autoDetectHighContrast', defaults to true. If false, VS Code theme will ignore Windows High Contrast theme.

Fixes #17279 