### PR TITLE
Activate TS Extension When Workspace Contains TSConfig or JSConfig file

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -30,7 +30,9 @@
 		"onLanguage:typescript",
 		"onLanguage:typescriptreact",
 		"onCommand:typescript.reloadProjects",
-		"onCommand:javascript.reloadProjects"
+		"onCommand:javascript.reloadProjects",
+		"workspaceContains:jsconfig.json",
+		"workspaceContains:tsconfig.json"
 	],
 	"main": "./out/typescriptMain",
 	"contributes": {


### PR DESCRIPTION
For #17393

Makes the TS extension activate when the top level folder opened contains a jsconfig or tsconfig file