### PR TITLE
Fix package.json Auto complete

### DIFF
--- a/extensions/javascript/src/features/packageJSONContribution.ts
+++ b/extensions/javascript/src/features/packageJSONContribution.ts
@@ -67,7 +67,7 @@ export class PackageJSONContribution implements IJSONContribution {
 										let name = keys[0];
 										let insertText = new SnippetString().appendText(JSON.stringify(name));
 										if (addValue) {
-											insertText.appendText(': ').appendPlaceholder('*');
+											insertText.appendText(': "').appendPlaceholder('').appendText('"');
 											if (!isLast) {
 												insertText.appendText(',');
 											}
@@ -99,7 +99,7 @@ export class PackageJSONContribution implements IJSONContribution {
 				this.mostDependedOn.forEach((name) => {
 					let insertText = new SnippetString().appendText(JSON.stringify(name));
 					if (addValue) {
-						insertText.appendText(': ').appendPlaceholder('*');
+						insertText.appendText(': "').appendPlaceholder('').appendText('"');
 						if (!isLast) {
 							insertText.appendText(',');
 						}


### PR DESCRIPTION
Fixes #17342

**Bug**
I believe that 739d8ca77f6215a5a385587e6e6c7d66fdbe15c6 introduced a regression for package.json auto complete where we end up inserting the text `*` when completing dependency versions

**Fix**
Insert `""` instead of star to match previous behavior better