### PR TITLE
Use File Icon for TS Path Completions

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -57,6 +57,9 @@ class MyCompletionItem extends CompletionItem {
 			case PConst.Kind.interface:
 				return CompletionItemKind.Interface;
 			case PConst.Kind.warning:
+			case PConst.Kind.directory:
+			case PConst.Kind.file:
+			case PConst.Kind.script:
 				return CompletionItemKind.File;
 		}
 


### PR DESCRIPTION
Part of #17331

Updates path completions for directories and files to use a file icon instead of the generic icon they currently use.