### PR TITLE
Use Module Symbol for TS/JS Module Name Completions

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -61,6 +61,7 @@ class MyCompletionItem extends CompletionItem {
 			case PConst.Kind.enum:
 				return CompletionItemKind.Enum;
 			case PConst.Kind.module:
+			case PConst.Kind.externalModuleName:
 				return CompletionItemKind.Module;
 			case PConst.Kind.class:
 				return CompletionItemKind.Class;

--- a/extensions/typescript/src/protocol.const.ts
+++ b/extensions/typescript/src/protocol.const.ts
@@ -36,6 +36,7 @@ export class Kind {
 	public static warning: string = 'warning';
 	public static directory: string = 'directory';
 	public static file: string = 'file';
+	public static externalModuleName = 'external module name';
 }
 
 export class KindModifier {


### PR DESCRIPTION
Adds support for the `external module name` type of completion that typescript returns.

<img width="490" alt="screen shot 2016-12-19 at 1 27 36 pm" src="https://cloud.githubusercontent.com/assets/12821956/21329704/efe54b56-c5ee-11e6-8e58-68f98866aa56.png">
