### PR TITLE
Fix TypeScript Verbose Logging not Printing Out Argument Values

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -709,7 +709,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		}
 		let data: string | undefined = undefined;
 		if (this.trace === Trace.Verbose && request.arguments) {
-			data = `Arguments: ${JSON.stringify(request.arguments, [], 4)}`;
+			data = `Arguments: ${JSON.stringify(request.arguments, null, 4)}`;
 		}
 		this.logTrace(`Sending request: ${request.command} (${request.seq}). Response expected: ${responseExpected ? 'yes' : 'no'}. Current queue length: ${this.requestQueue.length}`, data);
 	}
@@ -720,7 +720,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		}
 		let data: string | undefined = undefined;
 		if (this.trace === Trace.Verbose && response.body) {
-			data = `Result: ${JSON.stringify(response.body, [], 4)}`;
+			data = `Result: ${JSON.stringify(response.body, null, 4)}`;
 		}
 		this.logTrace(`Response received: ${response.command} (${response.request_seq}). Request took ${Date.now() - startTime} ms. Success: ${response.success} ${!response.success ? '. Message: ' + response.message : ''}`, data);
 	}
@@ -731,7 +731,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		}
 		let data: string | undefined = undefined;
 		if (this.trace === Trace.Verbose && event.body) {
-			data = `Data: ${JSON.stringify(event.body, [], 4)}`;
+			data = `Data: ${JSON.stringify(event.body, null, 4)}`;
 		}
 		this.logTrace(`Event received: ${event.event} (${event.seq}).`, data);
 	}


### PR DESCRIPTION
Fixes #17488

**Bug**
In the calls to `JSON.stringify`, we are currently passing in `[]` as a whitelist. This results in no argument values being printed.

**Fix**
Pass in null instead so that we print all argument values