### PR TITLE
Map TS  type completion items to CompletionItemKind.class

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -65,6 +65,7 @@ class MyCompletionItem extends CompletionItem {
 			case PConst.Kind.externalModuleName:
 				return CompletionItemKind.Module;
 			case PConst.Kind.class:
+			case PConst.Kind.type:
 				return CompletionItemKind.Class;
 			case PConst.Kind.interface:
 				return CompletionItemKind.Interface;


### PR DESCRIPTION
**Bug**
`type` completions currently use the default CompletionItemKind in the completion item provider.

**Fix**
Use `CompletionItemKind.class` instead. This seems to be the best fit for types.