### PR TITLE
Improve Markdown code block tokens

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -540,7 +540,7 @@
 					<!-- seperator    [ ]{0,3}([-*_][ ]{0,2}\2){2,}[ \t]*$\n? -->
 					<!-- list         [ ]{0,3}[*+-]([ ]{1,3}|\t) -->
 					<!-- both are folded together in the expression below -->
-					<string>(^|\G)(?!\s*$|#|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
+					<string>(^|\G)(?!\s*$|#|[`~]{0,3}|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
 				</dict>
 				<key>fenced_code_block_css</key>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -48,10 +48,6 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#raw_block</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#fenced_code_block_css</string>
 				</dict>
 				<dict>
@@ -201,6 +197,14 @@
 				<dict>
 					<key>include</key>
 					<string>#fenced_code_block_csharp</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#fenced_code_block_raw</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#raw_block</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -537,31 +541,6 @@
 					<!-- list         [ ]{0,3}[*+-]([ ]{1,3}|\t) -->
 					<!-- both are folded together in the expression below -->
 					<string>(^|\G)(?!\s*$|#|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
-				</dict>
-				<key>raw_block</key>
-				<dict>
-					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*\n</string>
-					<key>name</key>
-					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.markdown</string>
-						</dict>
-					</dict>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.markdown</string>
-						</dict>
-					</dict>
 				</dict>
 				<key>fenced_code_block_css</key>
 				<dict>
@@ -1990,6 +1969,40 @@
 							<string>source.cs</string>
 						</dict>
 					</array>
+				</dict>
+				<key>fenced_code_block_raw</key>
+				<dict>
+					<key>begin</key>
+					<string>(^|\G)\s*([`~]{3,})\s*\n</string>
+					<key>name</key>
+					<string>markup.fenced_code.block.markdown</string>
+					<key>end</key>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
+				</dict>
+				<key>raw_block</key>
+				<dict>
+					<key>begin</key>
+					<string>(^|\G)([ ]{4}|\t)</string>
+					<key>name</key>
+					<string>markup.raw.block.markdown</string>
+					<key>while</key>
+					<string>(^|\G)([ ]{4}|\t)</string>
 				</dict>
 				<key>separator</key>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -204,10 +204,6 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#fenced_code_block_raw</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#link-def</string>
 				</dict>
 				<dict>
@@ -545,20 +541,36 @@
 				<key>raw_block</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)([ ]{4}|\t)</string>
+					<string>(^|\G)\s*([`~]{3,})\s*\n</string>
 					<key>name</key>
-					<string>markup.raw.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)([ ]{4}|\t)</string>
+					<string>markup.fenced_code.block.markdown</string>
+					<key>end</key>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 				</dict>
 				<key>fenced_code_block_css</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(css|css.erb)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(css|css.erb)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -591,11 +603,11 @@
 				<key>fenced_code_block_basic</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -628,11 +640,11 @@
 				<key>fenced_code_block_ini</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(ini|conf)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(ini|conf)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -665,11 +677,11 @@
 				<key>fenced_code_block_java</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(java|bsh)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(java|bsh)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -702,11 +714,11 @@
 				<key>fenced_code_block_lua</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(lua)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(lua)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -739,11 +751,11 @@
 				<key>fenced_code_block_makefile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -776,11 +788,11 @@
 				<key>fenced_code_block_perl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -813,11 +825,11 @@
 				<key>fenced_code_block_r</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(R|r|s|S|Rprofile)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(R|r|s|S|Rprofile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -850,11 +862,11 @@
 				<key>fenced_code_block_ruby</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -899,11 +911,11 @@
 					scenarios, and also appears to be consistent with the approach that GitHub takes.
 					</string>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -946,11 +958,11 @@
 				<key>fenced_code_block_sql</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(sql|ddl|dml)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(sql|ddl|dml)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -983,11 +995,11 @@
 				<key>fenced_code_block_vs_net</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(vb)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(vb)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1020,11 +1032,11 @@
 				<key>fenced_code_block_xml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1057,11 +1069,11 @@
 				<key>fenced_code_block_xsl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(xsl|xslt)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(xsl|xslt)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1094,11 +1106,11 @@
 				<key>fenced_code_block_yaml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(yaml|yml)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(yaml|yml)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1131,11 +1143,11 @@
 				<key>fenced_code_block_dosbatch</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(bat|batch)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(bat|batch)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1168,11 +1180,11 @@
 				<key>fenced_code_block_clojure</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(clj|cljs|clojure)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(clj|cljs|clojure)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1205,11 +1217,11 @@
 				<key>fenced_code_block_coffee</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(coffee|Cakefile|coffee.erb)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(coffee|Cakefile|coffee.erb)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1242,11 +1254,11 @@
 				<key>fenced_code_block_c</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(c|h)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(c|h)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1279,11 +1291,11 @@
 				<key>fenced_code_block_diff</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(patch|diff|rej)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(patch|diff|rej)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1316,11 +1328,11 @@
 				<key>fenced_code_block_dockerfile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(dockerfile|Dockerfile)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(dockerfile|Dockerfile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1353,11 +1365,11 @@
 				<key>fenced_code_block_git_commit</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1390,11 +1402,11 @@
 				<key>fenced_code_block_git_rebase</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(git-rebase-todo)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(git-rebase-todo)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1427,11 +1439,11 @@
 				<key>fenced_code_block_groovy</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(groovy|gvy)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(groovy|gvy)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1464,11 +1476,11 @@
 				<key>fenced_code_block_jade</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(jade)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(jade)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1501,11 +1513,11 @@
 				<key>fenced_code_block_js</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(js|jsx|javascript)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(js|jsx|javascript)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1538,11 +1550,11 @@
 				<key>fenced_code_block_js_regexp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(regexp)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(regexp)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1575,11 +1587,11 @@
 				<key>fenced_code_block_json</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1612,11 +1624,11 @@
 				<key>fenced_code_block_less</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(less)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(less)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1649,11 +1661,11 @@
 				<key>fenced_code_block_objc</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(objectivec|mm|objc|obj-c|m|h)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(objectivec|mm|objc|obj-c|m|h)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1686,11 +1698,11 @@
 				<key>fenced_code_block_perl6</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(perl6|p6|pl6|pm6|nqp)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(perl6|p6|pl6|pm6|nqp)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1723,11 +1735,11 @@
 				<key>fenced_code_block_powershell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(powershell|ps1|psm1|psd1)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(powershell|ps1|psm1|psd1)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1760,11 +1772,11 @@
 				<key>fenced_code_block_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1797,11 +1809,11 @@
 				<key>fenced_code_block_regexp_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(re)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(re)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1834,11 +1846,11 @@
 				<key>fenced_code_block_shell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1871,11 +1883,11 @@
 				<key>fenced_code_block_ts</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(typescript|ts)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(typescript|ts)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1908,11 +1920,11 @@
 				<key>fenced_code_block_tsx</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(tsx)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(tsx)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1945,11 +1957,11 @@
 				<key>fenced_code_block_csharp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*(cs|csharp|c#)\n</string>
+					<string>(^|\G)\s*([`~]{3,})\s*(cs|csharp|c#)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<string>(^|\G)\s*([`~]{3,})\n</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1978,31 +1990,6 @@
 							<string>source.cs</string>
 						</dict>
 					</array>
-				</dict>
-				<key>fenced_code_block_raw</key>
-				<dict>
-					<key>begin</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\s*\n</string>
-					<key>name</key>
-					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.markdown</string>
-						</dict>
-					</dict>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.markdown</string>
-						</dict>
-					</dict>
 				</dict>
 				<key>separator</key>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -204,6 +204,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#fenced_code_block_raw</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#link-def</string>
 				</dict>
 				<dict>
@@ -550,11 +554,32 @@
 				<key>fenced_code_block_css</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(css|css.erb)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(css|css.erb)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -566,11 +591,32 @@
 				<key>fenced_code_block_basic</key>
 				<dict>
 					<key>begin</key>
-						<string>(^|\G)\s*(([`~]){3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -582,11 +628,32 @@
 				<key>fenced_code_block_ini</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(ini|conf)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(ini|conf)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -598,11 +665,32 @@
 				<key>fenced_code_block_java</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(java|bsh)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(java|bsh)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -614,11 +702,32 @@
 				<key>fenced_code_block_lua</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(lua)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(lua)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -630,11 +739,32 @@
 				<key>fenced_code_block_makefile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -646,11 +776,32 @@
 				<key>fenced_code_block_perl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -662,11 +813,32 @@
 				<key>fenced_code_block_r</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(R|r|s|S|Rprofile)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(R|r|s|S|Rprofile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -678,11 +850,32 @@
 				<key>fenced_code_block_ruby</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -706,11 +899,32 @@
 					scenarios, and also appears to be consistent with the approach that GitHub takes.
 					</string>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -732,11 +946,32 @@
 				<key>fenced_code_block_sql</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(sql|ddl|dml)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(sql|ddl|dml)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -748,11 +983,32 @@
 				<key>fenced_code_block_vs_net</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(vb)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(vb)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -764,11 +1020,32 @@
 				<key>fenced_code_block_xml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -780,11 +1057,32 @@
 				<key>fenced_code_block_xsl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(xsl|xslt)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(xsl|xslt)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -796,11 +1094,32 @@
 				<key>fenced_code_block_yaml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(yaml|yml)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(yaml|yml)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -812,11 +1131,32 @@
 				<key>fenced_code_block_dosbatch</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(bat|batch)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(bat|batch)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -828,11 +1168,32 @@
 				<key>fenced_code_block_clojure</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(clj|cljs|clojure)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(clj|cljs|clojure)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -844,11 +1205,32 @@
 				<key>fenced_code_block_coffee</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(coffee|Cakefile|coffee.erb)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(coffee|Cakefile|coffee.erb)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -860,11 +1242,32 @@
 				<key>fenced_code_block_c</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(c|h)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(c|h)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -876,11 +1279,32 @@
 				<key>fenced_code_block_diff</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(patch|diff|rej)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(patch|diff|rej)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -892,11 +1316,32 @@
 				<key>fenced_code_block_dockerfile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(dockerfile|Dockerfile)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(dockerfile|Dockerfile)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -908,11 +1353,32 @@
 				<key>fenced_code_block_git_commit</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(COMMIT_EDITMSG|MERGE_MSG)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -924,11 +1390,32 @@
 				<key>fenced_code_block_git_rebase</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(git-rebase-todo)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(git-rebase-todo)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -940,11 +1427,32 @@
 				<key>fenced_code_block_groovy</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(groovy|gvy)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(groovy|gvy)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -956,11 +1464,32 @@
 				<key>fenced_code_block_jade</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(jade)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(jade)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -972,11 +1501,32 @@
 				<key>fenced_code_block_js</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(js|jsx|javascript)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(js|jsx|javascript)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -988,11 +1538,32 @@
 				<key>fenced_code_block_js_regexp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(regexp)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(regexp)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1004,11 +1575,32 @@
 				<key>fenced_code_block_json</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1020,11 +1612,32 @@
 				<key>fenced_code_block_less</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(less)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(less)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1036,11 +1649,32 @@
 				<key>fenced_code_block_objc</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(objectivec|mm|objc|obj-c|m|h)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(objectivec|mm|objc|obj-c|m|h)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1052,11 +1686,32 @@
 				<key>fenced_code_block_perl6</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(perl6|p6|pl6|pm6|nqp)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(perl6|p6|pl6|pm6|nqp)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1068,11 +1723,32 @@
 				<key>fenced_code_block_powershell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(powershell|ps1|psm1|psd1)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(powershell|ps1|psm1|psd1)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1084,11 +1760,32 @@
 				<key>fenced_code_block_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1100,11 +1797,32 @@
 				<key>fenced_code_block_regexp_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(re)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(re)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1116,11 +1834,32 @@
 				<key>fenced_code_block_shell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1132,11 +1871,32 @@
 				<key>fenced_code_block_ts</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(typescript|ts)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(typescript|ts)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1148,11 +1908,32 @@
 				<key>fenced_code_block_tsx</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(tsx)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(tsx)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1164,11 +1945,32 @@
 				<key>fenced_code_block_csharp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*(([`~]){3,})\s*(cs|csharp|c#)(\s+.*)?$</string>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*(cs|csharp|c#)\n</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
-					<key>while</key>
-					<string>(^|\G)(?!\s*\2\3*\s*$)</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -1176,6 +1978,31 @@
 							<string>source.cs</string>
 						</dict>
 					</array>
+				</dict>
+				<key>fenced_code_block_raw</key>
+				<dict>
+					<key>begin</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\s*\n</string>
+					<key>name</key>
+					<string>markup.fenced_code.block.markdown</string>
+					<key>end</key>
+					<string>(^|\G)\s{0,3}([`~]{3,})\n</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
 				</dict>
 				<key>separator</key>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -48,6 +48,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+
+
+
+
 					<string>#fenced_code_block_css</string>
 				</dict>
 				<dict>
@@ -200,7 +204,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#fenced_code_block_raw</string>
+					<string>#fenced_code_block_unknown</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -540,338 +544,482 @@
 					<!-- seperator    [ ]{0,3}([-*_][ ]{0,2}\2){2,}[ \t]*$\n? -->
 					<!-- list         [ ]{0,3}[*+-]([ ]{1,3}|\t) -->
 					<!-- both are folded together in the expression below -->
-					<string>(^|\G)(?!\s*$|#|[`~]{0,3}|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
+					<string>(^|\G)(?!\s*$|#|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
 				</dict>
+
+
+
+
+
+
+
+
+
 				<key>fenced_code_block_css</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(css|css.erb)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((css|css.erb)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.css</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.css</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_basic</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(html|htm|shtml|xhtml|inc|tmpl|tpl)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((html|htm|shtml|xhtml|inc|tmpl|tpl)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>text.html.basic</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>text.html.basic</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_ini</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(ini|conf)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((ini|conf)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.ini</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.ini</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_java</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(java|bsh)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((java|bsh)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.java</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.java</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_lua</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(lua)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((lua)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.lua</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.lua</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_makefile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(Makefile|makefile|GNUmakefile|OCamlMakefile)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((Makefile|makefile|GNUmakefile|OCamlMakefile)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.makefile</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.makefile</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_perl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(perl|pl|pm|pod|t|PL|psgi|vcl)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((perl|pl|pm|pod|t|PL|psgi|vcl)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.perl</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.perl</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_r</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(R|r|s|S|Rprofile)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((R|r|s|S|Rprofile)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.r</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.r</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_ruby</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((ruby|rb|rbx|rjs|Rakefile|rake|cgi|fcgi|gemspec|irbrc|Capfile|ru|prawn|Cheffile|Gemfile|Guardfile|Hobofile|Vagrantfile|Appraisals|Rantfile|Berksfile|Berksfile.lock|Thorfile|Puppetfile)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.ruby</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.ruby</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
@@ -890,1065 +1038,1539 @@
 					scenarios, and also appears to be consistent with the approach that GitHub takes.
 					</string>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(php|php3|php4|php5|phpt|phtml|aw|ctp)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((php|php3|php4|php5|phpt|phtml|aw|ctp)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>comment</key>
-							<string>
-							Left to its own devices, the PHP grammar will match HTML as a combination of operators
-							and constants. Therefore, HTML must take precedence over PHP in order to get proper
-							syntax highlighting.
-							</string>
-							<key>include</key>
-							<string>text.html.basic</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>text.html.php#language</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>comment</key>
+									<string>
+
+
+									Left to its own devices, the PHP grammar will match HTML as a combination of operators
+									and constants. Therefore, HTML must take precedence over PHP in order to get proper
+									syntax highlighting.
+									</string>
+									<key>include</key>
+									<string>text.html.basic</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>text.html.php#language</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_sql</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(sql|ddl|dml)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((sql|ddl|dml)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.sql</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.sql</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_vs_net</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(vb)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((vb)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.asp.vb.net</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.asp.vb.net</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_xml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((xml|xsd|tld|jsp|pt|cpt|dtml|rss|opml)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>text.xml</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>text.xml</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_xsl</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(xsl|xslt)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((xsl|xslt)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>text.xml.xsl</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>text.xml.xsl</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_yaml</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(yaml|yml)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((yaml|yml)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.yaml</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.yaml</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_dosbatch</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(bat|batch)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((bat|batch)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.dosbatch</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.dosbatch</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_clojure</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(clj|cljs|clojure)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((clj|cljs|clojure)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.clojure</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.clojure</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_coffee</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(coffee|Cakefile|coffee.erb)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((coffee|Cakefile|coffee.erb)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.coffee</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.coffee</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_c</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(c|h)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((c|h)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.c</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.c</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_diff</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(patch|diff|rej)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((patch|diff|rej)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.diff</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.diff</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_dockerfile</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(dockerfile|Dockerfile)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((dockerfile|Dockerfile)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.dockerfile</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.dockerfile</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_git_commit</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(COMMIT_EDITMSG|MERGE_MSG)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((COMMIT_EDITMSG|MERGE_MSG)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>text.git-commit</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>text.git-commit</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_git_rebase</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(git-rebase-todo)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((git-rebase-todo)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>text.git-rebase</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>text.git-rebase</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_groovy</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(groovy|gvy)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((groovy|gvy)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.groovy</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.groovy</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_jade</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(jade)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((jade)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>text.jade</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>text.jade</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_js</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(js|jsx|javascript)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((js|jsx|javascript)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.js</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.js</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_js_regexp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(regexp)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((regexp)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.js.regexp</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.js.regexp</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_json</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((json|sublime-settings|sublime-menu|sublime-keymap|sublime-mousemap|sublime-theme|sublime-build|sublime-project|sublime-completions)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.json</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.json</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_less</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(less)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((less)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.css.less</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.css.less</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_objc</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(objectivec|mm|objc|obj-c|m|h)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((objectivec|mm|objc|obj-c|m|h)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.objc</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.objc</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_perl6</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(perl6|p6|pl6|pm6|nqp)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((perl6|p6|pl6|pm6|nqp)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.perl.6</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.perl.6</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_powershell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(powershell|ps1|psm1|psd1)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((powershell|ps1|psm1|psd1)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.powershell</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.powershell</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((python|py|py3|rpy|pyw|cpy|SConstruct|Sconstruct|sconstruct|SConscript|gyp|gypi)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.python</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.python</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_regexp_python</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(re)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((re)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.regexp.python</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.regexp.python</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_shell</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((shell|sh|bash|zsh|bashrc|bash_profile|bash_login|profile|bash_logout|.textmate_init)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.shell</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.shell</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_ts</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(typescript|ts)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((typescript|ts)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.ts</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.ts</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_tsx</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(tsx)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((tsx)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
-						<key>3</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
 						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
+
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>source.tsx</string>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.tsx</string>
+								</dict>
+							</array>
 						</dict>
 					</array>
 				</dict>
 				<key>fenced_code_block_csharp</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*(cs|csharp|c#)\n</string>
+					<string>(^|\G)(\s*)([`~]{3,})\s*((cs|csharp|c#)(\s+.*)?$)</string>
 					<key>name</key>
 					<string>markup.fenced_code.block.markdown</string>
 					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>
 						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>fenced_code.block.language.attributes</string>
+						</dict>
+					</dict>
+					<key>endCaptures</key>
+					<dict>
 						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+					</dict>
+
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string>(^|\G)(\s*)(.*)</string>
+							<key>while</key>
+							<string>(^|\G)(?!\s*([`~]{3,})\s*$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>source.cs</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<key>fenced_code_block_unknown</key>
+				<dict>
+					<key>name</key>
+					<string>markup.fenced_code.block.markdown</string>
+					<key>begin</key>
+					<string>(^|\G)(\s*)([`~]{3,})\s*(.*)?$</string>
+					<key>end</key>
+					<string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.markdown</string>
+						</dict>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>fenced_code.block.language</string>
@@ -1956,39 +2578,7 @@
 					</dict>
 					<key>endCaptures</key>
 					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.markdown</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>source.cs</string>
-						</dict>
-					</array>
-				</dict>
-				<key>fenced_code_block_raw</key>
-				<dict>
-					<key>begin</key>
-					<string>(^|\G)\s*([`~]{3,})\s*\n</string>
-					<key>name</key>
-					<string>markup.fenced_code.block.markdown</string>
-					<key>end</key>
-					<string>(^|\G)\s*([`~]{3,})\n</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.markdown</string>
-						</dict>
-					</dict>
-					<key>endCaptures</key>
-					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.markdown</string>

--- a/extensions/markdown/test/colorize-results/test_md.json
+++ b/extensions/markdown/test/colorize-results/test_md.json
@@ -1827,7 +1827,7 @@
 	},
 	{
 		"c": "~~~",
-		"t": "markdown.meta.paragraph",
+		"t": "block.definition.fenced_code.markdown.markup.punctuation",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1838,7 +1838,7 @@
 	},
 	{
 		"c": "// Markdown extra adds un-indented code blocks too",
-		"t": "markdown.meta.paragraph",
+		"t": "block.fenced_code.markdown.markup",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1848,74 +1848,8 @@
 		}
 	},
 	{
-		"c": "if (this",
-		"t": "markdown.meta.paragraph",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "_",
-		"t": "definition.italic.markdown.markup.meta.paragraph.punctuation",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.italic rgb(212, 212, 212)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.italic rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.italic rgb(212, 212, 212)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.italic rgb(0, 0, 0)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.italic rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "is",
-		"t": "italic.markdown.markup.meta.paragraph",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.italic rgb(212, 212, 212)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.italic rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.italic rgb(212, 212, 212)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.italic rgb(0, 0, 0)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.italic rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "_",
-		"t": "definition.italic.markdown.markup.meta.paragraph.punctuation",
-		"r": {
-			"dark_plus": ".vs-dark.vscode-theme-defaults-themes-dark_plus-json .token.markup.italic rgb(212, 212, 212)",
-			"light_plus": ".vs.vscode-theme-defaults-themes-light_plus-json .token.markup.italic rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark.vscode-theme-defaults-themes-dark_vs-json .token.markup.italic rgb(212, 212, 212)",
-			"light_vs": ".vs.vscode-theme-defaults-themes-light_vs-json .token.markup.italic rgb(0, 0, 0)",
-			"hc_black": ".hc-black.vscode-theme-defaults-themes-hc_black-json .token.markup.italic rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "more_code == true ",
-		"t": "markdown.meta.paragraph",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": "&&",
-		"t": "markdown.meta.other.paragraph.valid-ampersand",
-		"r": {
-			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
-			"light_plus": ".vs .token rgb(0, 0, 0)",
-			"dark_vs": ".vs-dark .token rgb(212, 212, 212)",
-			"light_vs": ".vs .token rgb(0, 0, 0)",
-			"hc_black": ".hc-black .token rgb(255, 255, 255)"
-		}
-	},
-	{
-		"c": " !indented) {",
-		"t": "markdown.meta.paragraph",
+		"c": "if (this_is_more_code == true && !indented) {",
+		"t": "block.fenced_code.markdown.markup",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1926,7 +1860,7 @@
 	},
 	{
 		"c": "    // tild wrapped code blocks, also not indented",
-		"t": "markdown.meta.paragraph",
+		"t": "block.fenced_code.markdown.markup",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1937,7 +1871,7 @@
 	},
 	{
 		"c": "}",
-		"t": "markdown.meta.paragraph",
+		"t": "block.fenced_code.markdown.markup",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",
@@ -1948,7 +1882,7 @@
 	},
 	{
 		"c": "~~~",
-		"t": "markdown.meta.paragraph",
+		"t": "block.definition.fenced_code.markdown.markup.punctuation",
 		"r": {
 			"dark_plus": ".vs-dark .token rgb(212, 212, 212)",
 			"light_plus": ".vs .token rgb(0, 0, 0)",


### PR DESCRIPTION
Code blocks without a language weren't tokenized. Code blocks didn't have their ending ``` punctuation tokenized. Both fixed.

Code blocks used to only have one token. Now each block has the following tokens available for syntax highlighters:
- Starting and ending ``` punctuations
- Code block's language setting
- Code snippet