### PR TITLE
Isidorn/tabs in editor group service

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -7,9 +7,8 @@ import * as nls from 'vs/nls';
 import * as types from 'vs/base/common/types';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
-import { IWorkbenchEditorConfiguration, ActiveEditorMoveArguments, ActiveEditorMovePositioning, ActiveEditorMovePositioningBy, EditorCommands } from 'vs/workbench/common/editor';
+import { ActiveEditorMoveArguments, ActiveEditorMovePositioning, ActiveEditorMovePositioningBy, EditorCommands } from 'vs/workbench/common/editor';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IEditor, Position, POSITIONS } from 'vs/platform/editor/common/editor';
 import { EditorContextKeys } from 'vs/editor/common/editorCommon';
@@ -72,8 +71,7 @@ function registerActiveEditorMoveCommand(): void {
 }
 
 function moveActiveEditor(args: ActiveEditorMoveArguments = {}, accessor: ServicesAccessor): void {
-	const config = <IWorkbenchEditorConfiguration>accessor.get(IConfigurationService).getConfiguration();
-	const tabsShown = config.workbench && config.workbench.editor && config.workbench.editor.showTabs;
+	const tabsShown = accessor.get(IEditorGroupService).areTabsShown();
 	args.to = args.to || ActiveEditorMovePositioning.RIGHT;
 	args.by = tabsShown ? args.by || ActiveEditorMovePositioningBy.TAB : ActiveEditorMovePositioningBy.GROUP;
 	args.value = types.isUndefined(args.value) ? 1 : args.value;

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -71,9 +71,9 @@ function registerActiveEditorMoveCommand(): void {
 }
 
 function moveActiveEditor(args: ActiveEditorMoveArguments = {}, accessor: ServicesAccessor): void {
-	const tabsShown = accessor.get(IEditorGroupService).areTabsShown();
+	const showTabs = accessor.get(IEditorGroupService).getTabOptions().showTabs;
 	args.to = args.to || ActiveEditorMovePositioning.RIGHT;
-	args.by = tabsShown ? args.by || ActiveEditorMovePositioningBy.TAB : ActiveEditorMovePositioningBy.GROUP;
+	args.by = showTabs ? args.by || ActiveEditorMovePositioningBy.TAB : ActiveEditorMovePositioningBy.GROUP;
 	args.value = types.isUndefined(args.value) ? 1 : args.value;
 
 	const activeEditor = accessor.get(IWorkbenchEditorService).getActiveEditor();

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -166,7 +166,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 		this.toDispose.push(this.onStacksChangeScheduler);
 		this.stacksChangedBuffer = [];
 
-		this.onConfigurationUpdated(this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>());
+		this.updateTabOptions(this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>());
 
 		const editorGroupOrientation = groupOrientation || 'vertical';
 		this.layoutVertically = (editorGroupOrientation !== 'horizontal');
@@ -210,19 +210,19 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 
 	private registerListeners(): void {
 		this.toDispose.push(this.stacks.onModelChanged(e => this.onStacksChanged(e)));
-		this.toDispose.push(this.configurationService.onDidUpdateConfiguration(e => this.onConfigurationUpdated(e.config, true)));
+		this.toDispose.push(this.configurationService.onDidUpdateConfiguration(e => this.updateTabOptions(e.config, true)));
+		this.toDispose.push(this.editorGroupService.onShowTabsChanged(() => this.updateTabOptions(this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>(), true)));
 		this.extensionService.onReady().then(() => this.onExtensionsReady());
 	}
 
-	private onConfigurationUpdated(config: IWorkbenchEditorConfiguration, refresh?: boolean): void {
+	private updateTabOptions(config: IWorkbenchEditorConfiguration, refresh?: boolean): void {
 		const showTabCloseButton = this.showTabCloseButton;
 
+		this.showTabs = this.editorGroupService.areTabsShown();
 		if (config.workbench && config.workbench.editor) {
-			this.showTabs = config.workbench.editor.showTabs;
 			this.showTabCloseButton = config.workbench.editor.showTabCloseButton;
 			this.showIcons = config.workbench.editor.showIcons;
 		} else {
-			this.showTabs = true;
 			this.showTabCloseButton = true;
 			this.showIcons = false;
 		}

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -20,7 +20,7 @@ import { RunOnceScheduler } from 'vs/base/common/async';
 import { isMacintosh } from 'vs/base/common/platform';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { Position, POSITIONS } from 'vs/platform/editor/common/editor';
-import { IEditorGroupService, GroupArrangement, GroupOrientation } from 'vs/workbench/services/group/common/groupService';
+import { IEditorGroupService, ITabOptions, GroupArrangement, GroupOrientation } from 'vs/workbench/services/group/common/groupService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -31,7 +31,7 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { TabsTitleControl } from 'vs/workbench/browser/parts/editor/tabsTitleControl';
 import { TitleControl, ITitleAreaControl } from 'vs/workbench/browser/parts/editor/titleControl';
 import { NoTabsTitleControl } from 'vs/workbench/browser/parts/editor/noTabsTitleControl';
-import { IEditorStacksModel, IStacksModelChangeEvent, IWorkbenchEditorConfiguration, IEditorGroup, EditorOptions, TextEditorOptions, IEditorIdentifier } from 'vs/workbench/common/editor';
+import { IEditorStacksModel, IStacksModelChangeEvent, IEditorGroup, EditorOptions, TextEditorOptions, IEditorIdentifier } from 'vs/workbench/common/editor';
 import { extractResources } from 'vs/base/browser/dnd';
 import { IWindowService } from 'vs/platform/windows/common/windows';
 import { getCodeEditor } from 'vs/editor/common/services/codeEditorService';
@@ -106,9 +106,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 
 	private layoutVertically: boolean;
 
-	private showTabs: boolean;
-	private showTabCloseButton: boolean;
-	private showIcons: boolean;
+	private tabOptions: ITabOptions;
 
 	private silos: Builder[];
 	private silosSize: number[];
@@ -166,7 +164,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 		this.toDispose.push(this.onStacksChangeScheduler);
 		this.stacksChangedBuffer = [];
 
-		this.updateTabOptions(this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>());
+		this.updateTabOptions(this.editorGroupService.getTabOptions());
 
 		const editorGroupOrientation = groupOrientation || 'vertical';
 		this.layoutVertically = (editorGroupOrientation !== 'horizontal');
@@ -210,22 +208,13 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 
 	private registerListeners(): void {
 		this.toDispose.push(this.stacks.onModelChanged(e => this.onStacksChanged(e)));
-		this.toDispose.push(this.configurationService.onDidUpdateConfiguration(e => this.updateTabOptions(e.config, true)));
-		this.toDispose.push(this.editorGroupService.onShowTabsChanged(() => this.updateTabOptions(this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>(), true)));
+		this.toDispose.push(this.editorGroupService.onTabOptionsChanged(options => this.updateTabOptions(options, true)));
 		this.extensionService.onReady().then(() => this.onExtensionsReady());
 	}
 
-	private updateTabOptions(config: IWorkbenchEditorConfiguration, refresh?: boolean): void {
-		const showTabCloseButton = this.showTabCloseButton;
-
-		this.showTabs = this.editorGroupService.areTabsShown();
-		if (config.workbench && config.workbench.editor) {
-			this.showTabCloseButton = config.workbench.editor.showTabCloseButton;
-			this.showIcons = config.workbench.editor.showIcons;
-		} else {
-			this.showTabCloseButton = true;
-			this.showIcons = false;
-		}
+	private updateTabOptions(tabOptions: ITabOptions, refresh?: boolean): void {
+		const showTabCloseButton = this.tabOptions ? this.tabOptions.showTabCloseButton : false;
+		this.tabOptions = tabOptions;
 
 		if (!refresh) {
 			return; // return early if no refresh is needed
@@ -237,14 +226,14 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 
 			// TItle Container
 			const titleContainer = $(titleControl.getContainer());
-			if (this.showTabs) {
+			if (this.tabOptions.showTabs) {
 				titleContainer.addClass('tabs');
 			} else {
 				titleContainer.removeClass('tabs');
 			}
 
 			const showingIcons = titleContainer.hasClass('show-file-icons');
-			if (this.showIcons) {
+			if (this.tabOptions.showIcons) {
 				titleContainer.addClass('show-file-icons');
 			} else {
 				titleContainer.removeClass('show-file-icons');
@@ -255,14 +244,14 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 				const usingTabs = (titleControl instanceof TabsTitleControl);
 
 				// Recreate title when tabs change
-				if (usingTabs !== this.showTabs) {
+				if (usingTabs !== this.tabOptions.showTabs) {
 					titleControl.dispose();
 					titleContainer.empty();
 					this.createTitleControl(this.stacks.groupAt(position), this.silos[position], titleContainer, this.getInstantiationService(position));
 				}
 
 				// Refresh title when icons change
-				else if (showingIcons !== this.showIcons || showTabCloseButton !== this.showTabCloseButton) {
+				else if (showingIcons !== this.tabOptions.showIcons || showTabCloseButton !== this.tabOptions.showTabCloseButton) {
 					titleControl.refresh();
 				}
 			}
@@ -894,10 +883,10 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 
 			// Title containers
 			const titleContainer = $(container).div({ 'class': 'title' });
-			if (this.showTabs) {
+			if (this.tabOptions.showTabs) {
 				titleContainer.addClass('tabs');
 			}
-			if (this.showIcons) {
+			if (this.tabOptions.showIcons) {
 				titleContainer.addClass('show-file-icons');
 			}
 			this.hookTitleDragListener(titleContainer);
@@ -1091,7 +1080,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 				if ($this.layoutVertically) {
 					overlay.style({ left: '0', width: '100%' });
 				} else {
-					overlay.style({ top: $this.showTabs ? `${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : 0, height: $this.showTabs ? `calc(100% - ${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : '100%' });
+					overlay.style({ top: $this.tabOptions.showTabs ? `${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : 0, height: $this.tabOptions.showTabs ? `calc(100% - ${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : '100%' });
 				}
 			}
 
@@ -1114,8 +1103,8 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 				containers.forEach((container, index) => {
 					if (container && DOM.isAncestor(target, container.getHTMLElement())) {
 						overlay = $('div').style({
-							top: $this.showTabs ? `${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : 0,
-							height: $this.showTabs ? `calc(100% - ${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : '100%'
+							top: $this.tabOptions.showTabs ? `${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : 0,
+							height: $this.tabOptions.showTabs ? `calc(100% - ${EditorGroupsControl.EDITOR_TITLE_HEIGHT}px` : '100%'
 						}).id(overlayId);
 
 						overlay.appendTo(container);
@@ -1202,7 +1191,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 	}
 
 	private createTitleControl(context: IEditorGroup, silo: Builder, container: Builder, instantiationService: IInstantiationService): void {
-		const titleAreaControl = instantiationService.createInstance<ITitleAreaControl>(this.showTabs ? TabsTitleControl : NoTabsTitleControl);
+		const titleAreaControl = instantiationService.createInstance<ITitleAreaControl>(this.tabOptions.showTabs ? TabsTitleControl : NoTabsTitleControl);
 		titleAreaControl.create(container.getHTMLElement());
 		titleAreaControl.setContext(context);
 		titleAreaControl.refresh(true /* instant */);

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -15,6 +15,7 @@ import strings = require('vs/base/common/strings');
 import arrays = require('vs/base/common/arrays');
 import types = require('vs/base/common/types');
 import errors = require('vs/base/common/errors');
+import * as objects from 'vs/base/common/objects';
 import { getCodeEditor } from 'vs/editor/common/services/codeEditorService';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { Scope as MementoScope } from 'vs/workbench/common/memento';
@@ -23,7 +24,7 @@ import { BaseEditor, EditorDescriptor } from 'vs/workbench/browser/parts/editor/
 import { IEditorRegistry, Extensions as EditorExtensions, EditorInput, EditorOptions, ConfirmResult, IWorkbenchEditorConfiguration, IEditorDescriptor, TextEditorOptions, SideBySideEditorInput } from 'vs/workbench/common/editor';
 import { EditorGroupsControl, Rochade, IEditorGroupsControl, ProgressState } from 'vs/workbench/browser/parts/editor/editorGroupsControl';
 import { WorkbenchProgressService } from 'vs/workbench/services/progress/browser/progressService';
-import { IEditorGroupService, GroupOrientation, GroupArrangement } from 'vs/workbench/services/group/common/groupService';
+import { IEditorGroupService, GroupOrientation, GroupArrangement, ITabOptions } from 'vs/workbench/services/group/common/groupService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IEditorPart } from 'vs/workbench/services/editor/browser/editorService';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
@@ -83,14 +84,13 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 	private editorGroupsControl: IEditorGroupsControl;
 	private memento: any;
 	private stacks: EditorStacksModel;
-	private previewEditors: boolean;
-	private showTabs: boolean;
+	private tabOptions: ITabOptions;
 
 	private _onEditorsChanged: Emitter<void>;
 	private _onEditorsMoved: Emitter<void>;
 	private _onEditorOpenFail: Emitter<EditorInput>;
 	private _onGroupOrientationChanged: Emitter<void>;
-	private _onShowTabsChanged: Emitter<void>;
+	private _onTabOptionsChanged: Emitter<ITabOptions>;
 
 	// The following data structures are partitioned into array of Position as provided by Services.POSITION array
 	private visibleEditors: BaseEditor[];
@@ -116,7 +116,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		this._onEditorsMoved = new Emitter<void>();
 		this._onEditorOpenFail = new Emitter<EditorInput>();
 		this._onGroupOrientationChanged = new Emitter<void>();
-		this._onShowTabsChanged = new Emitter<void>();
+		this._onTabOptionsChanged = new Emitter<ITabOptions>();
 
 		this.visibleEditors = [];
 
@@ -134,11 +134,21 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		const config = configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
 		if (config && config.workbench && config.workbench.editor) {
 			const editorConfig = config.workbench.editor;
-
-			this.previewEditors = editorConfig.enablePreview;
-			this.showTabs = editorConfig.showTabs;
+			this.tabOptions = {
+				previewEditors: editorConfig.enablePreview,
+				showIcons: editorConfig.showIcons,
+				showTabs: editorConfig.showTabs,
+				showTabCloseButton: editorConfig.showTabCloseButton
+			};
 
 			this.telemetryService.publicLog('workbenchEditorConfiguration', editorConfig);
+		} else {
+			this.tabOptions = {
+				previewEditors: true,
+				showIcons: false,
+				showTabs: true,
+				showTabCloseButton: true
+			};
 		}
 
 		this.registerListeners();
@@ -158,7 +168,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 
 			// Pin all preview editors of the user chose to disable preview
 			const newPreviewEditors = editorConfig.enablePreview;
-			if (this.previewEditors !== newPreviewEditors && !newPreviewEditors) {
+			if (this.tabOptions.previewEditors !== newPreviewEditors && !newPreviewEditors) {
 				this.stacks.groups.forEach(group => {
 					if (group.previewEditor) {
 						this.pinEditor(group, group.previewEditor);
@@ -166,7 +176,17 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				});
 			}
 
-			this.previewEditors = newPreviewEditors;
+			const oldTabOptions = objects.clone(this.tabOptions);
+			this.tabOptions = {
+				previewEditors: newPreviewEditors,
+				showIcons: editorConfig.showIcons,
+				showTabCloseButton: editorConfig.showTabCloseButton,
+				showTabs: editorConfig.showTabs
+			};
+
+			if (!objects.equals(oldTabOptions, this.tabOptions)) {
+				this._onTabOptionsChanged.fire(this.tabOptions);
+			}
 		}
 	}
 
@@ -205,17 +225,12 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		return this._onGroupOrientationChanged.event;
 	}
 
-	public get onShowTabsChanged(): Event<void> {
-		return this._onShowTabsChanged.event;
+	public get onTabOptionsChanged(): Event<ITabOptions> {
+		return this._onTabOptionsChanged.event;
 	}
 
-	public areTabsShown(): boolean {
-		return this.showTabs;
-	}
-
-	public setShowTabs(value: boolean) {
-		this.showTabs = value;
-		this._onShowTabsChanged.fire();
+	public getTabOptions(): ITabOptions {
+		return this.tabOptions;
 	}
 
 	public openEditor(input: EditorInput, options?: EditorOptions, sideBySide?: boolean): TPromise<BaseEditor>;
@@ -263,7 +278,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		// while the UI is not yet ready. Clients have to deal with this fact and we have to make sure that the
 		// stacks model gets updated if any of the UI updating fails with an error.
 		const group = this.ensureGroup(position, !options || !options.preserveFocus);
-		const pinned = !this.previewEditors || (options && (options.pinned || typeof options.index === 'number')) || input.isDirty();
+		const pinned = !this.tabOptions.previewEditors || (options && (options.pinned || typeof options.index === 'number')) || input.isDirty();
 		const active = (group.count === 0) || !options || !options.inactive;
 		group.openEditor(input, { active, pinned, index: options && options.index });
 

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -85,6 +85,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 	private memento: any;
 	private stacks: EditorStacksModel;
 	private tabOptions: ITabOptions;
+	private doNotFireTabOptionsChanged: boolean;
 
 	private _onEditorsChanged: Emitter<void>;
 	private _onEditorsMoved: Emitter<void>;
@@ -184,7 +185,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				showTabs: editorConfig.showTabs
 			};
 
-			if (!objects.equals(oldTabOptions, this.tabOptions)) {
+			if (!this.doNotFireTabOptionsChanged && !objects.equals(oldTabOptions, this.tabOptions)) {
 				this._onTabOptionsChanged.fire(this.tabOptions);
 			}
 		}
@@ -207,6 +208,15 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 
 	private onEditorClosed(event: GroupEvent): void {
 		this.telemetryService.publicLog('editorClosed', event.editor.getTelemetryDescriptor());
+	}
+
+	public hideTabs(hidden: boolean): void {
+		this.doNotFireTabOptionsChanged = hidden;
+		if (hidden) {
+			this._onTabOptionsChanged.fire({ showTabs: false });
+		} else {
+			this._onTabOptionsChanged.fire(this.tabOptions);
+		}
 	}
 
 	public get onEditorsChanged(): Event<void> {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -84,11 +84,13 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 	private memento: any;
 	private stacks: EditorStacksModel;
 	private previewEditors: boolean;
+	private showTabs: boolean;
 
 	private _onEditorsChanged: Emitter<void>;
 	private _onEditorsMoved: Emitter<void>;
 	private _onEditorOpenFail: Emitter<EditorInput>;
 	private _onGroupOrientationChanged: Emitter<void>;
+	private _onShowTabsChanged: Emitter<void>;
 
 	// The following data structures are partitioned into array of Position as provided by Services.POSITION array
 	private visibleEditors: BaseEditor[];
@@ -114,6 +116,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		this._onEditorsMoved = new Emitter<void>();
 		this._onEditorOpenFail = new Emitter<EditorInput>();
 		this._onGroupOrientationChanged = new Emitter<void>();
+		this._onShowTabsChanged = new Emitter<void>();
 
 		this.visibleEditors = [];
 
@@ -133,6 +136,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 			const editorConfig = config.workbench.editor;
 
 			this.previewEditors = editorConfig.enablePreview;
+			this.showTabs = editorConfig.showTabs;
 
 			this.telemetryService.publicLog('workbenchEditorConfiguration', editorConfig);
 		}
@@ -199,6 +203,19 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 
 	public get onGroupOrientationChanged(): Event<void> {
 		return this._onGroupOrientationChanged.event;
+	}
+
+	public get onShowTabsChanged(): Event<void> {
+		return this._onShowTabsChanged.event;
+	}
+
+	public areTabsShown(): boolean {
+		return this.showTabs;
+	}
+
+	public setShowTabs(value: boolean) {
+		this.showTabs = value;
+		this._onShowTabsChanged.fire();
 	}
 
 	public openEditor(input: EditorInput, options?: EditorOptions, sideBySide?: boolean): TPromise<BaseEditor>;

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -362,7 +362,7 @@ export class TabsTitleControl extends TitleControl {
 		tabContainer.setAttribute('role', 'presentation'); // cannot use role "tab" here due to https://github.com/Microsoft/vscode/issues/8659
 		DOM.addClass(tabContainer, 'tab monaco-editor-background');
 
-		if (!this.showTabCloseButton) {
+		if (!this.tabOptions.showTabCloseButton) {
 			DOM.addClass(tabContainer, 'no-close-button');
 		} else {
 			DOM.removeClass(tabContainer, 'no-close-button');

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -111,7 +111,7 @@ export abstract class TitleControl implements ITitleAreaControl {
 		this.stacks = editorGroupService.getStacksModel();
 		this.mapActionsToEditors = Object.create(null);
 
-		this.onConfigurationUpdated(configurationService.getConfiguration<IWorkbenchEditorConfiguration>());
+		this.updateTabOptions(configurationService.getConfiguration<IWorkbenchEditorConfiguration>());
 
 		this.scheduler = new RunOnceScheduler(() => this.onSchedule(), 0);
 		this.toDispose.push(this.scheduler);
@@ -142,7 +142,8 @@ export abstract class TitleControl implements ITitleAreaControl {
 	}
 
 	private registerListeners(): void {
-		this.toDispose.push(this.configurationService.onDidUpdateConfiguration(e => this.onConfigurationUpdated(e.config)));
+		this.toDispose.push(this.configurationService.onDidUpdateConfiguration(e => this.updateTabOptions(e.config)));
+		this.toDispose.push(this.editorGroupService.onShowTabsChanged(() => this.updateTabOptions(this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>())));
 		this.toDispose.push(this.stacks.onModelChanged(e => this.onStacksChanged(e)));
 	}
 
@@ -152,9 +153,9 @@ export abstract class TitleControl implements ITitleAreaControl {
 		}
 	}
 
-	private onConfigurationUpdated(config: IWorkbenchEditorConfiguration): void {
+	private updateTabOptions(config: IWorkbenchEditorConfiguration): void {
 		this.previewEditors = config.workbench && config.workbench.editor && config.workbench.editor.enablePreview;
-		this.showTabs = config.workbench && config.workbench.editor && config.workbench.editor.showTabs;
+		this.showTabs = this.editorGroupService.areTabsShown();
 		this.showTabCloseButton = config.workbench && config.workbench.editor && config.workbench.editor.showTabCloseButton;
 	}
 

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -1070,6 +1070,7 @@ export class Workbench implements IPartService {
 			this.setSideBarHidden(true, true);
 			this.setActivityBarHidden(true, true);
 			this.setStatusBarHidden(true, true);
+			this.editorPart.setShowTabs(false);
 		} else {
 			if (this.zenMode.wasPanelVisible) {
 				this.setPanelHidden(false, true);

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -133,7 +133,6 @@ export class Workbench implements IPartService {
 	private static sidebarPositionConfigurationKey = 'workbench.sideBar.location';
 	private static statusbarVisibleConfigurationKey = 'workbench.statusBar.visible';
 	private static activityBarVisibleConfigurationKey = 'workbench.activityBar.visible';
-	private static showTabsConfigurationKey = 'workbench.editor.showTabs';
 
 	private _onTitleBarVisibilityChange: Emitter<void>;
 
@@ -881,11 +880,6 @@ export class Workbench implements IPartService {
 			if (newActivityBarHiddenValue !== this.activityBarHidden) {
 				this.setActivityBarHidden(newActivityBarHiddenValue, skipLayout);
 			}
-
-			const showTabsValue = this.configurationService.lookup<boolean>(Workbench.showTabsConfigurationKey).value;
-			if (showTabsValue !== this.editorPart.areTabsShown()) {
-				this.editorPart.setShowTabs(showTabsValue);
-			}
 		}
 	}
 
@@ -1070,7 +1064,6 @@ export class Workbench implements IPartService {
 			this.setSideBarHidden(true, true);
 			this.setActivityBarHidden(true, true);
 			this.setStatusBarHidden(true, true);
-			this.editorPart.setShowTabs(false);
 		} else {
 			if (this.zenMode.wasPanelVisible) {
 				this.setPanelHidden(false, true);

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -1064,6 +1064,7 @@ export class Workbench implements IPartService {
 			this.setSideBarHidden(true, true);
 			this.setActivityBarHidden(true, true);
 			this.setStatusBarHidden(true, true);
+			this.editorPart.hideTabs(true);
 		} else {
 			if (this.zenMode.wasPanelVisible) {
 				this.setPanelHidden(false, true);
@@ -1073,6 +1074,7 @@ export class Workbench implements IPartService {
 			}
 			// Status bar and activity bar visibility come from settings -> update their visibility.
 			this.onDidUpdateConfiguration(true);
+			this.editorPart.hideTabs(false);
 			const activeEditor = this.editorPart.getActiveEditor();
 			if (activeEditor) {
 				activeEditor.focus();

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -133,6 +133,7 @@ export class Workbench implements IPartService {
 	private static sidebarPositionConfigurationKey = 'workbench.sideBar.location';
 	private static statusbarVisibleConfigurationKey = 'workbench.statusBar.visible';
 	private static activityBarVisibleConfigurationKey = 'workbench.activityBar.visible';
+	private static showTabsConfigurationKey = 'workbench.editor.showTabs';
 
 	private _onTitleBarVisibilityChange: Emitter<void>;
 
@@ -879,6 +880,11 @@ export class Workbench implements IPartService {
 			const newActivityBarHiddenValue = !this.configurationService.lookup<boolean>(Workbench.activityBarVisibleConfigurationKey).value;
 			if (newActivityBarHiddenValue !== this.activityBarHidden) {
 				this.setActivityBarHidden(newActivityBarHiddenValue, skipLayout);
+			}
+
+			const showTabsValue = this.configurationService.lookup<boolean>(Workbench.showTabsConfigurationKey).value;
+			if (showTabsValue !== this.editorPart.areTabsShown()) {
+				this.editorPart.setShowTabs(showTabsValue);
 			}
 		}
 	}

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -47,6 +47,11 @@ export interface IEditorGroupService {
 	onGroupOrientationChanged: Event<void>;
 
 	/**
+	 * Emitted when tabs visibility was changed.
+	 */
+	onShowTabsChanged: Event<void>;
+
+	/**
 	 * Keyboard focus the editor group at the provided position.
 	 */
 	focusGroup(group: IEditorGroup): void;
@@ -102,4 +107,9 @@ export interface IEditorGroupService {
 	 * Provides access to the editor stacks model
 	 */
 	getStacksModel(): IEditorStacksModel;
+
+	/**
+	 * Returns true if tabs are shown, false otherwise.
+	 */
+	areTabsShown(): boolean;
 }

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -19,6 +19,13 @@ export type GroupOrientation = 'vertical' | 'horizontal';
 
 export const IEditorGroupService = createDecorator<IEditorGroupService>('editorGroupService');
 
+export interface ITabOptions {
+	showTabs?: boolean;
+	showTabCloseButton?: boolean;
+	showIcons?: boolean;
+	previewEditors?: boolean;
+};
+
 /**
  * The editor service allows to open editors and work on the active
  * editor input and models.
@@ -47,9 +54,9 @@ export interface IEditorGroupService {
 	onGroupOrientationChanged: Event<void>;
 
 	/**
-	 * Emitted when tabs visibility was changed.
+	 * Emitted when tab options changed.
 	 */
-	onShowTabsChanged: Event<void>;
+	onTabOptionsChanged: Event<ITabOptions>;
 
 	/**
 	 * Keyboard focus the editor group at the provided position.
@@ -111,5 +118,5 @@ export interface IEditorGroupService {
 	/**
 	 * Returns true if tabs are shown, false otherwise.
 	 */
-	areTabsShown(): boolean;
+	getTabOptions(): ITabOptions;
 }

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -31,7 +31,7 @@ import { ILifecycleService, ShutdownEvent, ShutdownReason } from 'vs/platform/li
 import { EditorStacksModel } from 'vs/workbench/common/editor/editorStacksModel';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
-import { IEditorGroupService, GroupArrangement, GroupOrientation } from 'vs/workbench/services/group/common/groupService';
+import { IEditorGroupService, GroupArrangement, GroupOrientation, ITabOptions } from 'vs/workbench/services/group/common/groupService';
 import { TextFileService } from 'vs/workbench/services/textfile/common/textFileService';
 import { FileOperationEvent, IFileService, IResolveContentOptions, IFileOperationResult, IFileStat, IImportResult, FileChangesEvent, IResolveFileOptions, IContent, IUpdateContentOptions, IStreamContent } from 'vs/platform/files/common/files';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -336,14 +336,14 @@ export class TestEditorGroupService implements IEditorGroupService {
 	private _onEditorOpenFail: Emitter<IEditorInput>;
 	private _onEditorsMoved: Emitter<void>;
 	private _onGroupOrientationChanged: Emitter<void>;
-	private _onShowTabsChanged: Emitter<void>;
+	private _onTabOptionsChanged: Emitter<ITabOptions>;
 
 	constructor(callback?: (method: string) => void) {
 		this._onEditorsMoved = new Emitter<void>();
 		this._onEditorsChanged = new Emitter<void>();
 		this._onGroupOrientationChanged = new Emitter<void>();
 		this._onEditorOpenFail = new Emitter<IEditorInput>();
-		this._onShowTabsChanged = new Emitter<void>();
+		this._onTabOptionsChanged = new Emitter<ITabOptions>();
 
 		let services = new ServiceCollection();
 
@@ -379,8 +379,8 @@ export class TestEditorGroupService implements IEditorGroupService {
 		return this._onGroupOrientationChanged.event;
 	}
 
-	public get onShowTabsChanged(): Event<void> {
-		return this._onShowTabsChanged.event;
+	public get onTabOptionsChanged(): Event<ITabOptions> {
+		return this._onTabOptionsChanged.event;
 	}
 
 	public focusGroup(group: IEditorGroup): void;
@@ -432,8 +432,8 @@ export class TestEditorGroupService implements IEditorGroupService {
 		return this.stacksModel;
 	}
 
-	public areTabsShown(): boolean {
-		return true;
+	public getTabOptions(): ITabOptions {
+		return {};
 	}
 }
 

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -336,12 +336,14 @@ export class TestEditorGroupService implements IEditorGroupService {
 	private _onEditorOpenFail: Emitter<IEditorInput>;
 	private _onEditorsMoved: Emitter<void>;
 	private _onGroupOrientationChanged: Emitter<void>;
+	private _onShowTabsChanged: Emitter<void>;
 
 	constructor(callback?: (method: string) => void) {
 		this._onEditorsMoved = new Emitter<void>();
 		this._onEditorsChanged = new Emitter<void>();
 		this._onGroupOrientationChanged = new Emitter<void>();
 		this._onEditorOpenFail = new Emitter<IEditorInput>();
+		this._onShowTabsChanged = new Emitter<void>();
 
 		let services = new ServiceCollection();
 
@@ -375,6 +377,10 @@ export class TestEditorGroupService implements IEditorGroupService {
 
 	public get onGroupOrientationChanged(): Event<void> {
 		return this._onGroupOrientationChanged.event;
+	}
+
+	public get onShowTabsChanged(): Event<void> {
+		return this._onShowTabsChanged.event;
 	}
 
 	public focusGroup(group: IEditorGroup): void;
@@ -424,6 +430,10 @@ export class TestEditorGroupService implements IEditorGroupService {
 
 	public getStacksModel(): EditorStacksModel {
 		return this.stacksModel;
+	}
+
+	public areTabsShown(): boolean {
+		return true;
 	}
 }
 


### PR DESCRIPTION
Tested it out and works nicely. Things which are not very nice and would like to get feedback:

- Naming of methods in `groupService.ts`, notice that the setting is named `showTabs` so I was trying to be consistent with that
- Currently the `editorGroupService` does not react on `showTabs` changed in the configuration - the `PartService` does that and lets the `editorGroupService` know. The alternative would be the `editorGroupService` does this but then needs to check the part service if zen mode is active (which would require an additional method in part service)

Fixes #17207