### PR TITLE
Next/Prev Group circles through existing groups

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -16,7 +16,6 @@ import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/edi
 import { IQuickOpenService } from 'vs/platform/quickOpen/common/quickOpen';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { Position, IEditor, Direction, IResourceInput, IEditorInput } from 'vs/platform/editor/common/editor';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IEditorGroupService, GroupArrangement } from 'vs/workbench/services/group/common/groupService';
@@ -351,15 +350,17 @@ export class FocusPreviousGroup extends Action {
 			return TPromise.as(true);
 		}
 
+		const stacks = this.editorGroupService.getStacksModel();
+		const groupCount = stacks.groups.length;
 
-		// Find the next position to the left/top
-		let nextPosition: Position = Position.ONE;
-		if (activeEditor.position === Position.THREE) {
-			nextPosition = Position.TWO;
+		// Nowhere to switch if the only group
+		if (groupCount === 1) {
+			return TPromise.as(true);
 		}
 
-		// Focus next position if provided
-		this.editorGroupService.focusGroup(nextPosition);
+		// Nevigate to the previous group or to the last group if the first group is active
+		const newPositionIndex = (activeEditor.position + groupCount - 1) % groupCount;
+		this.editorGroupService.focusGroup(<Position>newPositionIndex);
 
 		return TPromise.as(true);
 	}
@@ -370,39 +371,34 @@ export class FocusNextGroup extends Action {
 	public static ID = 'workbench.action.focusNextGroup';
 	public static LABEL = nls.localize('focusNextGroup', "Focus Next Group");
 
-	private navigateActions: Action[];
-
 	constructor(
 		id: string,
 		label: string,
-		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IEditorGroupService private editorGroupService: IEditorGroupService,
+		@IWorkbenchEditorService private editorService: IWorkbenchEditorService
 	) {
 		super(id, label);
-
-		this.navigateActions = [];
-		this.navigateActions[Position.ONE] = instantiationService.createInstance(FocusFirstGroupAction, FocusFirstGroupAction.ID, FocusFirstGroupAction.LABEL);
-		this.navigateActions[Position.TWO] = instantiationService.createInstance(FocusSecondGroupAction, FocusSecondGroupAction.ID, FocusSecondGroupAction.LABEL);
-		this.navigateActions[Position.THREE] = instantiationService.createInstance(FocusThirdGroupAction, FocusThirdGroupAction.ID, FocusThirdGroupAction.LABEL);
 	}
 
 	public run(event?: any): TPromise<any> {
 
-		// Find the next position to the right/bottom to use
-		let nextPosition: Position;
 		const activeEditor = this.editorService.getActiveEditor();
+
 		if (!activeEditor) {
-			nextPosition = Position.ONE;
-		} else if (activeEditor.position === Position.ONE) {
-			nextPosition = Position.TWO;
-		} else if (activeEditor.position === Position.TWO) {
-			nextPosition = Position.THREE;
+			return TPromise.as(true);
 		}
 
-		// Run the action for the target next position
-		if (typeof nextPosition === 'number' && this.navigateActions[nextPosition]) {
-			return this.navigateActions[nextPosition].run(event);
+		const stacks = this.editorGroupService.getStacksModel();
+		const groupCount = stacks.groups.length;
+
+		// Nowhere to switch if the only group
+		if (groupCount === 1) {
+			return TPromise.as(true);
 		}
+
+		// Nevigate to the next group or to the first group if the last group is active
+		const newPositionIndex = (activeEditor.position + 1) % groupCount;
+		this.editorGroupService.focusGroup(<Position>newPositionIndex);
 
 		return TPromise.as(true);
 	}


### PR DESCRIPTION
Proposal for #12833.

Next/Prev Group actions circle through existing groups without creating new ones. Similar to behavior in Sublime and Atom.
Fixes the issue when the user is at the last group and NextGroup action does nothing. Same for first group and PreviousGroup action.