### PR TITLE
Fix #17346. Clear reference decorations when switching models.

### DIFF
--- a/src/vs/editor/contrib/referenceSearch/browser/referencesWidget.ts
+++ b/src/vs/editor/contrib/referenceSearch/browser/referencesWidget.ts
@@ -63,8 +63,6 @@ class DecorationsManager implements IDisposable {
 	}
 
 	private _onModelChanged(): void {
-
-		this.removeDecorations();
 		this._callOnModelChange = dispose(this._callOnModelChange);
 
 		var model = this.editor.getModel();
@@ -733,6 +731,7 @@ export class ReferenceWidget extends PeekViewWidget {
 			const model = ref.object;
 			if (model) {
 				this._previewModelReference = ref;
+				this._decorationsManager.removeDecorations();
 				this._preview.setModel(model.textEditorModel);
 				var sel = Range.lift(reference.range).collapseToStart();
 				this._preview.setSelection(sel);


### PR DESCRIPTION
As decorations are bind to the model, when `_onModelChanged` kicks in, the model is the new one while `_decorationSet` is still holding the decorations in old model. That's the root cause of #17346.

Here we manually clear the decorations for references before `setModel`.