### PR TITLE
#14464 Preserve editor size when switching layout

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -758,7 +758,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 			this.sashTwo.setOrientation(this.layoutVertically ? Orientation.VERTICAL : Orientation.HORIZONTAL);
 
 			// Trigger layout
-			this.arrangeGroups(GroupArrangement.EVEN);
+			this.arrangeGroups(GroupArrangement.KEEP_RATIO);
 		}
 	}
 
@@ -778,27 +778,49 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 			return; // need more editors
 		}
 
-		// Minimize Others
-		if (arrangement === GroupArrangement.MINIMIZE_OTHERS) {
-			POSITIONS.forEach(position => {
-				if (this.visibleEditors[position]) {
-					if (position !== this.lastActivePosition) {
-						this.silosSize[position] = this.minSize;
-						availableSize -= this.minSize;
+		switch (arrangement) {
+			case GroupArrangement.MINIMIZE_OTHERS:
+				// Minimize Others
+				POSITIONS.forEach(position => {
+					if (this.visibleEditors[position]) {
+						if (position !== this.lastActivePosition) {
+							this.silosSize[position] = this.minSize;
+							availableSize -= this.minSize;
+						}
 					}
-				}
-			});
+				});
 
-			this.silosSize[this.lastActivePosition] = availableSize;
-		}
+				this.silosSize[this.lastActivePosition] = availableSize;
+				break;
+			case GroupArrangement.EVEN:
+				// Even Sizes
+				POSITIONS.forEach(position => {
+					if (this.visibleEditors[position]) {
+						this.silosSize[position] = availableSize / visibleEditors;
+					}
+				});
+				break;
+			case GroupArrangement.KEEP_RATIO:
+				// Minimized editors should remain minimized, others should keep their relative Sizes
+				let oldNonMinimizedTotal = 0;
+				POSITIONS.forEach(position => {
+					if (this.visibleEditors[position]) {
+						if (this.silosMinimized[position]) {
+							this.silosSize[position] = this.minSize;
+							availableSize -= this.minSize;
+						} else {
+							oldNonMinimizedTotal += this.silosSize[position];
+						}
+					}
+				});
 
-		// Even Sizes
-		else if (arrangement === GroupArrangement.EVEN) {
-			POSITIONS.forEach(position => {
-				if (this.visibleEditors[position]) {
-					this.silosSize[position] = availableSize / visibleEditors;
-				}
-			});
+				// Set size for non-minimized editors
+				const scaleFactor = availableSize / oldNonMinimizedTotal;
+				POSITIONS.forEach(position => {
+					if (this.visibleEditors[position] && !this.silosMinimized[position]) {
+						this.silosSize[position] *= scaleFactor;
+					}
+				});
 		}
 
 		// Since we triggered a change in minimized/maximized editors, we need

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -758,7 +758,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 			this.sashTwo.setOrientation(this.layoutVertically ? Orientation.VERTICAL : Orientation.HORIZONTAL);
 
 			// Trigger layout
-			this.arrangeGroups(GroupArrangement.KEEP_RATIO);
+			this.arrangeGroups();
 		}
 	}
 
@@ -766,7 +766,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 		return this.layoutVertically ? 'vertical' : 'horizontal';
 	}
 
-	public arrangeGroups(arrangement: GroupArrangement): void {
+	public arrangeGroups(arrangement?: GroupArrangement): void {
 		if (!this.dimension) {
 			return; // too early
 		}
@@ -800,7 +800,7 @@ export class EditorGroupsControl implements IEditorGroupsControl, IVerticalSashL
 					}
 				});
 				break;
-			case GroupArrangement.KEEP_RATIO:
+			default:
 				// Minimized editors should remain minimized, others should keep their relative Sizes
 				let oldNonMinimizedTotal = 0;
 				POSITIONS.forEach(position => {

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -12,8 +12,7 @@ import Event from 'vs/base/common/event';
 
 export enum GroupArrangement {
 	MINIMIZE_OTHERS,
-	EVEN,
-	KEEP_RATIO
+	EVEN
 }
 
 export type GroupOrientation = 'vertical' | 'horizontal';

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -12,7 +12,8 @@ import Event from 'vs/base/common/event';
 
 export enum GroupArrangement {
 	MINIMIZE_OTHERS,
-	EVEN
+	EVEN,
+	KEEP_RATIO
 }
 
 export type GroupOrientation = 'vertical' | 'horizontal';


### PR DESCRIPTION
Implementation of #14464 

Currently when switching from horizontal to vertical editor layout (or vice-versa), the layout is reset to all editors being evenly sized. We would like it if the editors maintained their relative size when switching layouts.

Additionally, the minimized state of any editors should be preserved so that editors that were minimized in one layout are still minimized after switching.