### PR TITLE
[Proxy] Use the same service for exploring extensions and for installing them

### DIFF
--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -79,8 +79,7 @@ import { ThemeService } from 'vs/workbench/services/themes/electron-browser/them
 import { getDelayedChannel } from 'vs/base/parts/ipc/common/ipc';
 import { connect as connectNet } from 'vs/base/parts/ipc/node/ipc.net';
 import { Client as ElectronIPCClient } from 'vs/base/parts/ipc/electron-browser/ipc.electron-browser';
-import { IExtensionManagementChannel, ExtensionManagementChannelClient } from 'vs/platform/extensionManagement/common/extensionManagementIpc';
-import { IExtensionManagementService, IExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IExtensionManagementService, IExtensionEnablementService, IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionEnablementService';
 import { UpdateChannelClient } from 'vs/platform/update/common/updateIpc';
 import { IUpdateService } from 'vs/platform/update/common/update';
@@ -92,6 +91,8 @@ import { ReloadWindowAction } from 'vs/workbench/electron-browser/actions';
 import { ExtensionHostProcessWorker } from 'vs/workbench/electron-browser/extensionHost';
 import { ITimerService } from 'vs/workbench/services/timer/common/timerService';
 import { remote } from 'electron';
+import { ExtensionManagementService } from 'vs/platform/extensionManagement/node/extensionManagementService';
+import { ExtensionGalleryService } from 'vs/platform/extensionManagement/node/extensionGalleryService';
 import 'vs/platform/opener/browser/opener.contribution';
 
 /**
@@ -321,8 +322,9 @@ export class WorkbenchShell {
 		serviceCollection.set(ILifecycleService, lifecycleService);
 		disposables.add(lifecycleTelemetry(this.telemetryService, lifecycleService));
 
-		const extensionManagementChannel = getDelayedChannel<IExtensionManagementChannel>(sharedProcess.then(c => c.getChannel('extensions')));
-		serviceCollection.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementChannelClient, extensionManagementChannel));
+		serviceCollection.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
+		serviceCollection.set(IExtensionGalleryService, new SyncDescriptor(ExtensionGalleryService));
+		serviceCollection.set(IRequestService, new SyncDescriptor(RequestService));
 
 		const extensionEnablementService = instantiationService.createInstance(ExtensionEnablementService);
 		serviceCollection.set(IExtensionEnablementService, extensionEnablementService);
@@ -344,8 +346,6 @@ export class WorkbenchShell {
 
 		this.contextViewService = instantiationService.createInstance(ContextViewService, this.container);
 		serviceCollection.set(IContextViewService, this.contextViewService);
-
-		serviceCollection.set(IRequestService, new SyncDescriptor(RequestService));
 
 		serviceCollection.set(IMarkerService, new SyncDescriptor(MarkerService));
 


### PR DESCRIPTION
Hi,

This is in relation to https://github.com/Microsoft/vscode/issues/17574, https://github.com/Microsoft/vscode/issues/17397, https://github.com/Microsoft/vscode/issues/17360.

Like I said in those issues, I remarked that looking for extensions on the marketplace and installing them don't use the same "piece of code". And indeed, listing extensions and their properties is done by the main process which has access to ExtensionManagementService. The latter doesn't seem to care about the config "http.proxy", but can nonetheless use the default system proxy. So far, so good.

However, when "install" is pressed on the screen, the IExtensionManagementService is resolved as ExtensionManagementChannelClient which will call via ipc the Shared process which will finally call ExtensionManagementService. What's astonishing is that the same piece of code now cares about "http.proxy" and when it's not set, it cannot use the default system proxy.

**TL;DR**
This PR aims at fixing the issues with http proxy or otherwise be a starting point 😁 
To test that the behaviours of searchs & installs are different you can add the following user setting: 

```json
{
    "http.proxy": "http://dummy.proxy:8080"
}
```

What do you think? Is the fix proposed here the right thing to do or does it hide another bug?
