### PR TITLE
Check window.autoDetectHighContrast on window load

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -478,7 +478,7 @@ export class VSCodeWindow implements IVSCodeWindow {
 		windowConfiguration.fullscreen = this._win.isFullScreen();
 
 		// Set Accessibility Config
-		windowConfiguration.highContrast = platform.isWindows && systemPreferences.isInvertedColorScheme();
+		windowConfiguration.highContrast = platform.isWindows && systemPreferences.isInvertedColorScheme() && (!windowConfig || windowConfig.autoDetectHighContrast);
 		windowConfiguration.accessibilitySupport = app.isAccessibilitySupportEnabled();
 
 		// Perf Counters


### PR DESCRIPTION
Complete the fix of #17279. Previous PR #17394 only affected the case when switching Windows theme with VSCode.

This PR ensures VSCode won't start in High Contrast theme if `windows.autoDetectHighContrast` is `false`.