### PR TITLE
Add syntax highlighting for JS/TS template string interpolation (Monokai built-in theme)

### DIFF
--- a/extensions/theme-monokai/themes/Monokai.tmTheme
+++ b/extensions/theme-monokai/themes/Monokai.tmTheme
@@ -72,7 +72,7 @@
 			<key>name</key>
 			<string>Template Definition</string>
 			<key>scope</key>
-			<string>punctuation.definition.template-expression.begin.ts, punctuation.definition.template-expression.end.ts, punctuation.definition.template-expression.begin.js, punctuation.definition.template-expression.end.js</string>
+			<string>punctuation.definition.template-expression</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>

--- a/extensions/theme-monokai/themes/Monokai.tmTheme
+++ b/extensions/theme-monokai/themes/Monokai.tmTheme
@@ -70,6 +70,28 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Template Definition</string>
+			<key>scope</key>
+			<string>template.definition</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#F92672</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Template Variable</string>
+			<key>scope</key>
+			<string>template.variable</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#66D9EF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>Number</string>
 			<key>scope</key>
 			<string>constant.numeric</string>

--- a/extensions/theme-monokai/themes/Monokai.tmTheme
+++ b/extensions/theme-monokai/themes/Monokai.tmTheme
@@ -72,7 +72,7 @@
 			<key>name</key>
 			<string>Template Definition</string>
 			<key>scope</key>
-			<string>template.definition</string>
+			<string>punctuation.definition.template-expression.begin.ts, punctuation.definition.template-expression.end.ts, punctuation.definition.template-expression.begin.js, punctuation.definition.template-expression.end.js</string>
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>


### PR DESCRIPTION
The built-in Monokai theme makes interpolated template strings difficult to read. This PR adds highlighting to improve accessibility.

before:
![before](https://cloud.githubusercontent.com/assets/232225/21492059/d16ace7a-cbc6-11e6-9a73-485187ebeabc.png)

after:
![after](https://cloud.githubusercontent.com/assets/232225/21492061/d3a81b48-cbc6-11e6-93c9-9b59b373643c.png)



