### PR TITLE
linux argument startup fix

### DIFF
--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -4,7 +4,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 # If root, ensure that --user-data-dir is specified
-ARGS=$@
 if [ "$(id -u)" = "0" ]; then
 	while test $# -gt 0
 	do
@@ -34,5 +33,5 @@ fi
 
 ELECTRON="$VSCODE_PATH/@@NAME@@"
 CLI="$VSCODE_PATH/resources/app/out/cli.js"
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" $ARGS
+ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
 exit $?


### PR DESCRIPTION
You shouldn't put the the script's arguments in a variable without keeping them as a list because the arguments were merged and then splitted with whitespace. This results in a total mashup of tabs. 

See Issue https://github.com/Microsoft/vscode/issues/17852