### PR TITLE
The whole file name is used when dealing with filename associations

### DIFF
--- a/src/vs/workbench/browser/labels.ts
+++ b/src/vs/workbench/browser/labels.ts
@@ -194,7 +194,7 @@ export function getIconClasses(modelService: IModelService, modeService: IModeSe
 		else {
 
 			// Name
-			const name = dotSegments[0]; // file.txt => "file", .dockerfile => "", file.some.txt => "file"
+			const name = dotSegments.join('.'); // get the whole name
 			if (name) {
 				classes.push(`${cssEscape(name.toLowerCase())}-name-file-icon`);
 			}

--- a/src/vs/workbench/services/themes/electron-browser/themeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/themeService.ts
@@ -546,9 +546,7 @@ function _processIconThemeDocument(id: string, iconThemeDocumentPath: string, ic
 				for (let fileName in fileNames) {
 					let selectors = [];
 					let segments = fileName.toLowerCase().split('.');
-					if (segments[0]) {
-						selectors.push(`.${escapeCSS(segments[0])}-name-file-icon`);
-					}
+					selectors.push(`.${escapeCSS(fileName.toLowerCase())}-name-file-icon`);
 					for (let i = 1; i < segments.length; i++) {
 						selectors.push(`.${escapeCSS(segments.slice(i).join('.'))}-ext-file-icon`);
 					}


### PR DESCRIPTION
Fixes #17864

I've changed the behavior of the filename associations so they use the whole filename (including the extension(s)) instead of using just the name, which was causing the effects explained in #17864 and [vscode-icons #557](https://github.com/robertohuertasm/vscode-icons/issues/557).