### PR TITLE
Use Word Based Completion Range by Default in TS

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -34,10 +34,12 @@ class MyCompletionItem extends CompletionItem {
 			// We convert to 0-based indexing.
 			this.textEdit = TextEdit.replace(new Range(span.start.line - 1, span.start.offset - 1, span.end.line - 1, span.end.offset - 1), entry.name);
 		} else {
+			// Try getting longer, prefix based range for completions that span words
+			const wordRange = document.getWordRangeAtPosition(position);
 			const text = document.getText(new Range(position.line, Math.max(0, position.character - entry.name.length), position.line, position.character)).toLowerCase();
 			const entryName = entry.name.toLowerCase();
 			for (let i = entryName.length; i >= 0; --i) {
-				if (text.endsWith(entryName.substr(0, i))) {
+				if (text.endsWith(entryName.substr(0, i)) && (!wordRange || wordRange.start.character > position.character - i)) {
 					this.range = new Range(position.line, Math.max(0, position.character - i), position.line, position.character);
 					break;
 				}


### PR DESCRIPTION
Fixes #17906

**bug**
To support completion items that span multiple words, I added extra logic in 1.9 insiders to use the word prefix to compute the completion range. This introduced a few regressions for completions that do start with the replacement.

**fix**
Use the old, word based range logic by default. Use the prefix completion if it is longer.