### PR TITLE
Show selected line count in the editor status bar

### DIFF
--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -1645,6 +1645,13 @@ export interface ITextModel {
 	getLineCount(): number;
 
 	/**
+	 * Get the number of lines in a certain range.
+	 * @param range The range to be checked.
+	 * @return Number of lines.
+	 */
+	getLineCountInRange(range: IRange, eol?: EndOfLinePreference): number;
+
+	/**
 	 * Get the text for a certain line.
 	 */
 	getLineContent(lineNumber: number): string;

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -478,6 +478,17 @@ export class TextModel extends OrderGuaranteeEventEmitter implements editorCommo
 		return this._lines.length;
 	}
 
+	public getLineCountInRange(rawRange: editorCommon.IRange, eol: editorCommon.EndOfLinePreference = editorCommon.EndOfLinePreference.TextDefined): number {
+		this._assertNotDisposed();
+		var range = this.validateRange(rawRange);
+
+		if (range.isEmpty()) {
+			return 1;
+		}
+
+		return (range.endLineNumber - range.startLineNumber) + 1;
+	}
+
 	public getLineContent(lineNumber: number): string {
 		this._assertNotDisposed();
 		if (lineNumber < 1 || lineNumber > this.getLineCount()) {

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -791,6 +791,20 @@ suite('TextModel.mightContainRTL', () => {
 
 });
 
+suite('TextModel.getLineCountInRange', () => {
+	test('getLineCountInRange', () => {
+		// Use range with 5 lines in total.
+		var m = new TextModel([], TextModel.toRawText('aaa\r\nbbb\r\nccc\r\nddd\r\neee', TextModel.DEFAULT_CREATION_OPTIONS));
+		assert.equal(m.getLineCountInRange(new Range(1, 1, 1, 1)), 1, 'Collapsed range in first line');
+		assert.equal(m.getLineCountInRange(new Range(1, 1, 1, 3)), 1, 'First line selection');
+		assert.equal(m.getLineCountInRange(new Range(1, 1, 2, 1)), 2, 'Two lines selected');
+		assert.equal(m.getLineCountInRange(new Range(2, 3, 4, 1)), 3, 'Three lines edge case');
+		assert.equal(m.getLineCountInRange(new Range(1, 1, 5, 1)), 5, 'Range across all the lines');
+		assert.equal(m.getLineCountInRange(new Range(2, 1, 1, 1)), 2, 'Backward range from second line to the first');
+		assert.equal(m.getLineCountInRange(new Range(1, 1, 1000, 1000)), 5, 'Overflowing range');
+	});
+});
+
 suite('TextModel.getLineIndentGuide', () => {
 	function assertIndentGuides(lines: [number, string][]): void {
 		let text = lines.map(l => l[1]).join('\n');

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1934,6 +1934,12 @@ declare module monaco.editor {
          */
         getLineCount(): number;
         /**
+         * Get the number of lines in a certain range.
+         * @param range The range to be checked.
+         * @return Number of lines.
+         */
+        getLineCountInRange(range: IRange, eol?: EndOfLinePreference): number;
+        /**
          * Get the text for a certain line.
          */
         getLineContent(lineNumber: number): string;

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -88,6 +88,7 @@ function toEditorWithEncodingSupport(input: IEditorInput): IEncodingSupport {
 interface IEditorSelectionStatus {
 	selections?: Selection[];
 	charactersSelected?: number;
+	linesSelected?: number;
 }
 
 class StateChange {
@@ -224,7 +225,7 @@ class State {
 	}
 }
 
-const nlsSingleSelectionRange = nls.localize('singleSelectionRange', "Ln {0}, Col {1} ({2} selected)");
+const nlsSingleSelectionRange = nls.localize('singleSelectionRange', "Ln {0}, Col {1} ({3} lines, {2} characters selected)");
 const nlsSingleSelection = nls.localize('singleSelection', "Ln {0}, Col {1}");
 const nlsMultiSelectionRange = nls.localize('multiSelectionRange', "{0} selections ({1} characters selected)");
 const nlsMultiSelection = nls.localize('multiSelection', "{0} selections");
@@ -419,7 +420,7 @@ export class EditorStatus implements IStatusbarItem {
 
 		if (info.selections.length === 1) {
 			if (info.charactersSelected) {
-				return strings.format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected);
+				return strings.format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected, info.linesSelected);
 			}
 
 			return strings.format(nlsSingleSelection, info.selections[0].positionLineNumber, info.selections[0].positionColumn);
@@ -584,10 +585,12 @@ export class EditorStatus implements IStatusbarItem {
 
 			// Compute selection length
 			info.charactersSelected = 0;
+			info.linesSelected = 0;
 			const textModel = getTextModel(editorWidget);
 			if (textModel) {
 				info.selections.forEach(selection => {
 					info.charactersSelected += textModel.getValueLengthInRange(selection);
+					info.linesSelected += textModel.getLineCountInRange(selection);
 				});
 			}
 


### PR DESCRIPTION
This pull request adds selected lines count in case of non-collapsed selection.

![This is how it does looks like](https://cloud.githubusercontent.com/assets/5353898/21575506/1d462566-cf0e-11e6-9c72-e3fb93614a5b.png)

It fixes #932 and #15344 (which is a dup of former one).

## Remarks

### Multiple selections

I did not add lines selected information in case of multiple selection on purpose. Reason for this is that you might have a selection like that (bracket marks range):

```
a[aaaa
b]b[b]b[b
c]cccc
```

In that case we effectively have 3 lines selected, however with the simplified implementation that just adds TextModel.getLineCountInRange() for each range, it would give us 5 lines (2 + 1 + 2).

So instead of showing possibly buggy value, I decided not to show it at all.

If you'll like the feature, I can implement more clever way to count unique lines for multiple selection, just let me know.

### nlsSingleSelectionRange default string adjusted

You will note that I've also added "characters" part in case of single selection range.

```const nlsSingleSelectionRange = nls.localize('singleSelectionRange', "Ln {0}, Col {1} ({3} lines, {2} characters selected)");```

### `monaco.d.ts`

While adding method ITextModel it looks like it got automatically added to `monaco.d.ts`, because I don't recall adding it there. Just worth to mention, as I'm not super familiar with Code internals.