### PR TITLE
Only apply TS Dot Accept Suggestion if Previous Character is a valid identifier

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -261,8 +261,8 @@
 				"title": "%javascript.reloadProjects.title%"
 			},
 			{
-				"command": "typescript.tryAcceptSelectedSuggestion",
-				"title": "try accept select suggestion"
+				"command": "typescript.tryAcceptSelectedSuggestionOnDot",
+				"title": "%typescript.tryAcceptSelectedSuggestionOnDot.title%"
 			}
 		],
 		"breakpoints": [

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -248,7 +248,7 @@
 		},
 		"keybindings": {
 			"key": ".",
-			"command": "^acceptSelectedSuggestion",
+			"command": "typescript.tryAcceptSelectedSuggestionOnDot",
 			"when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'typescript' && suggestionSupportsAcceptOnKey"
 		},
 		"commands": [
@@ -259,6 +259,10 @@
 			{
 				"command": "javascript.reloadProjects",
 				"title": "%javascript.reloadProjects.title%"
+			},
+			{
+				"command": "typescript.tryAcceptSelectedSuggestion",
+				"title": "try accept select suggestion"
 			}
 		],
 		"breakpoints": [

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -12,6 +12,7 @@
 	"typescript.tsserver.experimentalAutoBuild": "Enables experimental auto build. Requires 1.9 dev or 2.x tsserver version and a restart of VS Code after changing it.",
 	"typescript.validate.enable": "Enable/disable TypeScript validation.",
 	"typescript.format.enable": "Enable/disable default TypeScript formatter.",
+	"typescript.tryAcceptSelectedSuggestionOnDot": "Accept current suggestion when a dot is typed",
 	"javascript.format.enable": "Enable/disable default JavaScript formatter.",
 	"format.insertSpaceAfterCommaDelimiter": "Defines space handling after a comma delimiter.",
 	"format.insertSpaceAfterSemicolonInForStatements": " Defines space handling after a semicolon in a for statement.",

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -9,7 +9,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { env, languages, commands, workspace, window, Uri, ExtensionContext, Memento, IndentAction, Diagnostic, DiagnosticCollection, Range, DocumentFilter, Disposable } from 'vscode';
+import { env, languages, commands, workspace, window, Uri, ExtensionContext, Memento, IndentAction, Diagnostic, DiagnosticCollection, Range, DocumentFilter, Disposable, Position } from 'vscode';
 
 // This must be the first statement otherwise modules might got loaded with
 // the wrong locale.
@@ -80,6 +80,18 @@ export function activate(context: ExtensionContext): void {
 
 	context.subscriptions.push(commands.registerCommand('javascript.reloadProjects', () => {
 		clientHost.reloadProjects();
+	}));
+
+	context.subscriptions.push(commands.registerCommand('typescript.tryAcceptSelectedSuggestionOnDot', () => {
+		// When typing a dot, make sure the character before the dot is a valid indentifier character.
+		const editor = window.activeTextEditor;
+		if (editor && editor.selection && editor.selection.start.character >= 1) {
+			const preText = editor.document.getText(new Range(new Position(editor.selection.start.line, 0), new Position(editor.selection.start.line, editor.selection.start.character - 1)));
+			if (preText.match(/[a-z_$]\s*$/ig)) {
+				return commands.executeCommand('acceptSelectedSuggestion');
+			}
+		}
+		return commands.executeCommand('type', { text: '.' });
 	}));
 
 	window.onDidChangeActiveTextEditor(VersionStatus.showHideStatus, null, context.subscriptions);


### PR DESCRIPTION
Fixes #17825
Fixes #17770
Fixes #17584

**Bug**
When typing two or more `.` in a row, we end up unexpectedly accepting suggestions in TS files. This is caused by the custom keybinding that ts registers for `.`.

**Fix**
Only accept the suggestion on `.` if the previous character is a valid identifier character. This is accomplished by registering a new command in TS. 

I'm not too happy with this workaround, but wasn't able to find a better way to do this. Let me know if you have any suggested improvements.