### PR TITLE
Fix Autolink Syntax Highlighting in Markdown

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -355,7 +355,7 @@
 						</dict>
 						<dict>
 							<key>begin</key>
-							<string>(^|\G)\s*(?=(&lt;[a-zA-Z0-9\-].*&gt;|&lt;/[a-zA-Z0-9\-]&gt;)\s*$)</string>
+							<string>(^|\G)\s*(?=(&lt;[a-zA-Z0-9\-](/?&gt;|\s.*?&gt;)|&lt;/[a-zA-Z0-9\-]&gt;)\s*$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>


### PR DESCRIPTION
Fixes #18197

**Bug**
Autolinks that start a line in markdown are currently parsed as as html content

**Fix**
Restrict the html element matcher a little more so that we don't match tags html tags that look like `<scheme:...>`