### PR TITLE
TypeScript References Code Lens Provider

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -99,6 +99,11 @@
 					"default": true,
 					"description": "%typescript.check.tscVersion%"
 				},
+				"typescript.referencesCodeLens.enabled": {
+					"type": "boolean",
+					"default": false,
+					"description": "%typescript.referencesCodeLens.enabled%"
+				},
 				"typescript.tsserver.trace": {
 					"type": "string",
 					"enum": [

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -24,5 +24,6 @@
 	"format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": "Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.",
 	"format.placeOpenBraceOnNewLineForFunctions": "Defines whether an open brace is put onto a new line for functions or not.",
 	"format.placeOpenBraceOnNewLineForControlBlocks": "Defines whether an open brace is put onto a new line for control blocks or not.",
-	"javascript.validate.enable": "Enable/disable JavaScript validation."
+	"javascript.validate.enable": "Enable/disable JavaScript validation.",
+	"typescript.referencesCodeLens.enabled": "Enable/disable the references code lens"
 }

--- a/extensions/typescript/src/features/referencesCodeLensProvider.ts
+++ b/extensions/typescript/src/features/referencesCodeLensProvider.ts
@@ -1,0 +1,144 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { CodeLensProvider, CodeLens, CancellationToken, TextDocument, Range, Uri, Location, Position, workspace, WorkspaceConfiguration } from 'vscode';
+import * as Proto from '../protocol';
+import * as PConst from '../protocol.const';
+
+import { ITypescriptServiceClient } from '../typescriptService';
+
+import * as nls from 'vscode-nls';
+let localize = nls.loadMessageBundle();
+
+
+class ReferencesCodeLens extends CodeLens {
+	public document: Uri;
+	public file: string;
+
+	constructor(document: Uri, file: string, range: Range) {
+		super(range);
+		this.document = document;
+		this.file = file;
+	}
+}
+
+export default class TypeScriptReferencesCodeLensProvider implements CodeLensProvider {
+	private client: ITypescriptServiceClient;
+	private enabled = false;
+
+	constructor(client: ITypescriptServiceClient) {
+		this.client = client;
+	}
+
+	public updateConfiguration(config: WorkspaceConfiguration): void {
+		let typeScriptConfig = workspace.getConfiguration('typescript');
+		this.enabled = typeScriptConfig.get('referencesCodeLens.enabled', false);
+	}
+
+	provideCodeLenses(document: TextDocument, token: CancellationToken): Promise<CodeLens[]> {
+		if (!this.enabled) {
+			return Promise.resolve([]);
+		}
+
+		const filepath = this.client.asAbsolutePath(document.uri);
+		if (!filepath) {
+			return Promise.resolve([]);
+		}
+		return this.client.execute('navtree', { file: filepath }, token).then(response => {
+			const tree = response.body;
+			const referenceableSpans: Range[] = [];
+			if (tree && tree.childItems) {
+				tree.childItems.forEach(item => this.extractReferenceableSymbols(document, item, referenceableSpans));
+			}
+			return Promise.resolve(referenceableSpans.map(span => new ReferencesCodeLens(document.uri, filepath, span)));
+		});
+	}
+
+	resolveCodeLens(inputCodeLens: CodeLens, token: CancellationToken): Promise<CodeLens> {
+		const codeLens = inputCodeLens as ReferencesCodeLens;
+		if (!codeLens.document) {
+			return Promise.reject<CodeLens>(codeLens);
+		}
+		const args: Proto.FileLocationRequestArgs = {
+			file: codeLens.file,
+			line: codeLens.range.start.line + 1,
+			offset: codeLens.range.start.character + 1
+		};
+		return this.client.execute('references', args, token).then(response => {
+			if (response && response.body) {
+				const referenceCount = Math.max(0, response.body.refs.length - 1);
+				const locations = response.body.refs.map(reference =>
+					new Location(Uri.file(reference.file),
+						new Range(
+							new Position(reference.start.line - 1, reference.start.offset - 1),
+							new Position(reference.end.line - 1, reference.end.offset - 1))));
+
+				codeLens.command = {
+					title: referenceCount + ' ' + (referenceCount === 1 ? localize('oneReferenceLabel', 'reference') : localize('manyReferenceLabel', 'references')),
+					command: 'editor.action.showReferences',
+					arguments: [codeLens.document, codeLens.range.start, locations]
+				};
+				return Promise.resolve(codeLens);
+			}
+			return Promise.reject(codeLens);
+		}).catch(() => {
+			codeLens.command = {
+				title: localize('referenceErrorLabel', 'Could not determine references'),
+				command: ''
+			};
+			return Promise.resolve(codeLens);
+		});
+	}
+
+	private extractReferenceableSymbols(document: TextDocument, item: Proto.NavigationTree, results: Range[]) {
+		if (!item) {
+			return;
+		}
+
+		const span = item.spans && item.spans[0];
+		if (span) {
+			const range = new Range(
+				new Position(span.start.line - 1, span.start.offset - 1),
+				new Position(span.end.line - 1, span.end.offset - 1));
+
+			// TODO: TS currently requires the position for 'references 'to be inside of the identifer
+			// Massage the range to make sure this is the case
+			const text = document.getText(range);
+
+			switch (item.kind) {
+				case PConst.Kind.const:
+				case PConst.Kind.let:
+				case PConst.Kind.variable:
+				case PConst.Kind.function:
+					// Only show references for exported variables
+					if (!item.kindModifiers.match(/\bexport\b/)) {
+						break;
+					}
+				// fallthrough
+
+				case PConst.Kind.memberFunction:
+				case PConst.Kind.memberVariable:
+				case PConst.Kind.memberGetAccessor:
+				case PConst.Kind.memberSetAccessor:
+				case PConst.Kind.constructorImplementation:
+				case PConst.Kind.class:
+				case PConst.Kind.interface:
+				case PConst.Kind.type:
+				case PConst.Kind.enum:
+					const identifierMatch = new RegExp(`^(.*?(\\b|\\W))${item.text}`, 'g');
+					const match = identifierMatch.exec(text);
+					const start = match ? match.index + match[1].length : 0;
+					results.push(new Range(
+						new Position(range.start.line, range.start.character + start),
+						new Position(range.start.line, range.start.character + start + item.text.length)));
+					break;
+			}
+		}
+
+		(item.childItems || []).forEach(item => this.extractReferenceableSymbols(document, item, results));
+	}
+};


### PR DESCRIPTION
Fixes #18054

Adds an initial references code lens provider implementation for JS and TS

![screen shot 2017-01-05 at 6 22 28 pm](https://cloud.githubusercontent.com/assets/12821956/21705346/42bdab38-d374-11e6-8746-851ea6147a87.png)

Remaining work and issues:

- [x] Add setting to disable this references code lens provider.
- [x] Add some gating for TS version
- [x] Support properties as well as methods
- [x] Support access modifiers and getters and setters (added workaround, but I believe we also need a fix on TS side: https://github.com/Microsoft/TypeScript/issues/13309)
- [x] Support classes and interfaces
- [x] Support `export const ...`
- [x] Support `export function`
- [ ] Fix `public construtor() {...}` - (needs TS: https://github.com/Microsoft/TypeScript/issues/13330)
- [ ] Default exports (needs TS: https://github.com/Microsoft/TypeScript/issues/11551)

We also need to investigate the perf impact of the code lens further. It will be opt in to start with