### PR TITLE
[Typo] Change signifikant -> significant in problem matcher

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -62,12 +62,12 @@ export interface ProblemPattern {
 
 	loop?: boolean;
 
-	mostSignifikant?: boolean;
+	mostSignificant?: boolean;
 
 	[key: string]: any;
 }
 
-export let problemPatternProperties = ['file', 'message', 'location', 'line', 'column', 'endLine', 'endColumn', 'code', 'severity', 'loop', 'mostSignifikant'];
+export let problemPatternProperties = ['file', 'message', 'location', 'line', 'column', 'endLine', 'endColumn', 'code', 'severity', 'loop', 'mostSignificant'];
 
 export interface WatchingPattern {
 	regexp: RegExp;

--- a/src/vs/workbench/parts/tasks/test/node/configuration.test.ts
+++ b/src/vs/workbench/parts/tasks/test/node/configuration.test.ts
@@ -230,8 +230,8 @@ class PatternBuilder {
 		return this;
 	}
 
-	public mostSignifikant(value: boolean): PatternBuilder {
-		this.result.mostSignifikant = value;
+	public mostSignificant(value: boolean): PatternBuilder {
+		this.result.mostSignificant = value;
 		return this;
 	}
 }
@@ -1007,6 +1007,6 @@ suite('Tasks Configuration parsing tests', () => {
 		assert.strictEqual(actual.code, expected.code);
 		assert.strictEqual(actual.severity, expected.severity);
 		assert.strictEqual(actual.loop, expected.loop);
-		assert.strictEqual(actual.mostSignifikant, expected.mostSignifikant);
+		assert.strictEqual(actual.mostSignificant, expected.mostSignificant);
 	}
 });


### PR DESCRIPTION
Hello there, I was looking at adding support for the problem matcher object format [to Danger](https://github.com/danger/danger-js/issues/18) and spotted a typo inside the source. 