### PR TITLE
Re use readonly #12732 #13863

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -45,45 +45,33 @@ declare module 'vscode' {
 
 		/**
 		 * The zero-based line number.
-		 *
-		 * @readonly
 		 */
 		readonly lineNumber: number;
 
 		/**
 		 * The text of this line without the line separator characters.
-		 *
-		 * @readonly
 		 */
 		readonly text: string;
 
 		/**
 		 * The range this line covers without the line separator characters.
-		 *
-		 * @readonly
 		 */
 		readonly range: Range;
 
 		/**
 		 * The range this line covers with the line separator characters.
-		 *
-		 * @readonly
 		 */
 		readonly rangeIncludingLineBreak: Range;
 
 		/**
 		 * The offset of the first character which is not a whitespace character as defined
 		 * by `/\s/`. **Note** that if a line is all whitespaces the length of the line is returned.
-		 *
-		 * @readonly
 		 */
 		readonly firstNonWhitespaceCharacterIndex: number;
 
 		/**
 		 * Whether this line is whitespace only, shorthand
 		 * for [TextLine.firstNonWhitespaceCharacterIndex](#TextLine.firstNonWhitespaceCharacterIndex) === [TextLine.text.length](#TextLine.text).
-		 *
-		 * @readonly
 		 */
 		readonly isEmptyOrWhitespace: boolean;
 	}
@@ -98,45 +86,33 @@ declare module 'vscode' {
 		 * The associated URI for this document. Most documents have the __file__-scheme, indicating that they
 		 * represent files on disk. However, some documents may have other schemes indicating that they are not
 		 * available on disk.
-		 *
-		 * @readonly
 		 */
 		readonly uri: Uri;
 
 		/**
 		 * The file system path of the associated resource. Shorthand
 		 * notation for [TextDocument.uri.fsPath](#TextDocument.uri). Independent of the uri scheme.
-		 *
-		 * @readonly
 		 */
 		readonly fileName: string;
 
 		/**
 		 * Is this document representing an untitled file.
-		 *
-		 * @readonly
 		 */
 		readonly isUntitled: boolean;
 
 		/**
 		 * The identifier of the language associated with this document.
-		 *
-		 * @readonly
 		 */
 		readonly languageId: string;
 
 		/**
 		 * The version number of this document (it will strictly increase after each
 		 * change, including undo/redo).
-		 *
-		 * @readonly
 		 */
 		readonly version: number;
 
 		/**
 		 * true if there are unpersisted changes.
-		 *
-		 * @readonly
 		 */
 		readonly isDirty: boolean;
 
@@ -151,8 +127,6 @@ declare module 'vscode' {
 
 		/**
 		 * The number of lines in this document.
-		 *
-		 * @readonly
 		 */
 		readonly lineCount: number;
 
@@ -249,13 +223,11 @@ declare module 'vscode' {
 
 		/**
 		 * The zero-based line value.
-		 * @readonly
 		 */
 		readonly line: number;
 
 		/**
 		 * The zero-based character value.
-		 * @readonly
 		 */
 		readonly character: number;
 
@@ -370,13 +342,11 @@ declare module 'vscode' {
 
 		/**
 		 * The start position. It is before or equal to [end](#Range.end).
-		 * @readonly
 		 */
 		readonly start: Position;
 
 		/**
 		 * The end position. It is after or equal to [start](#Range.start).
-		 * @readonly
 		 */
 		readonly end: Position;
 
@@ -656,7 +626,6 @@ declare module 'vscode' {
 
 		/**
 		 * Internal representation of the handle.
-		 * @readonly
 		 */
 		readonly key: string;
 
@@ -1542,8 +1511,6 @@ declare module 'vscode' {
 
 		/**
 		 * An array of diagnostics.
-		 *
-		 * @readonly
 		 */
 		readonly diagnostics: Diagnostic[];
 	}
@@ -2004,8 +1971,6 @@ declare module 'vscode' {
 
 		/**
 		 * The number of affected resources.
-		 *
-		 * @readonly
 		 */
 		readonly size: number;
 
@@ -2850,7 +2815,6 @@ declare module 'vscode' {
 
 		/**
 		 * Readable dictionary that backs this configuration.
-		 * @readonly
 		 */
 		readonly [key: string]: any;
 	}
@@ -2965,7 +2929,6 @@ declare module 'vscode' {
 		 * The name of this diagnostic collection, for instance `typescript`. Every diagnostic
 		 * from this collection will be associated with this name. Also, the task framework uses this
 		 * name when defining [problem matchers](https://code.visualstudio.com/docs/editor/tasks#_defining-a-problem-matcher).
-		 * @readonly
 		 */
 		readonly name: string;
 
@@ -3057,7 +3020,6 @@ declare module 'vscode' {
 
 		/**
 		 * The human-readable name of this output channel.
-		 * @readonly
 		 */
 		readonly name: string;
 
@@ -3134,16 +3096,12 @@ declare module 'vscode' {
 
 		/**
 		 * The alignment of this item.
-		 *
-		 * @readonly
 		 */
 		readonly alignment: StatusBarAlignment;
 
 		/**
 		 * The priority of this item. Higher value means the item should
 		 * be shown more to the left.
-		 *
-		 * @readonly
 		 */
 		readonly priority: number;
 
@@ -3197,15 +3155,11 @@ declare module 'vscode' {
 
 		/**
 		 * The name of the terminal.
-		 *
-		 * @readonly
 		 */
 		readonly name: string;
 
 		/**
 		 * The process ID of the shell process.
-		 *
-		 * @readonly
 		 */
 		readonly processId: Thenable<number>;
 
@@ -3247,37 +3201,27 @@ declare module 'vscode' {
 
 		/**
 		 * The canonical extension identifier in the form of: `publisher.name`.
-		 *
-		 * @readonly
 		 */
 		readonly id: string;
 
 		/**
 		 * The absolute file path of the directory containing this extension.
-		 *
-		 * @readonly
 		 */
 		readonly extensionPath: string;
 
 		/**
 		 * `true` if the extension has been activated.
-		 *
-		 * @readonly
 		 */
 		readonly isActive: boolean;
 
 		/**
 		 * The parsed contents of the extension's package.json.
-		 *
-		 * @readonly
 		 */
 		readonly packageJSON: any;
 
 		/**
 		 * The public API exported by this extension. It is an invalid action
 		 * to access this field before this extension has been activated.
-		 *
-		 * @readonly
 		 */
 		readonly exports: T;
 
@@ -3864,8 +3808,6 @@ declare module 'vscode' {
 		/**
 		 * The folder that is open in VS Code. `undefined` when no folder
 		 * has been opened.
-		 *
-		 * @readonly
 		 */
 		export let rootPath: string | undefined;
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1596,7 +1596,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		isResolved: boolean;
+		readonly isResolved: boolean;
 
 		/**
 		 * Creates a new code lens object.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -48,28 +48,28 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		lineNumber: number;
+		readonly lineNumber: number;
 
 		/**
 		 * The text of this line without the line separator characters.
 		 *
 		 * @readonly
 		 */
-		text: string;
+		readonly text: string;
 
 		/**
 		 * The range this line covers without the line separator characters.
 		 *
 		 * @readonly
 		 */
-		range: Range;
+		readonly range: Range;
 
 		/**
 		 * The range this line covers with the line separator characters.
 		 *
 		 * @readonly
 		 */
-		rangeIncludingLineBreak: Range;
+		readonly rangeIncludingLineBreak: Range;
 
 		/**
 		 * The offset of the first character which is not a whitespace character as defined
@@ -77,7 +77,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		firstNonWhitespaceCharacterIndex: number;
+		readonly firstNonWhitespaceCharacterIndex: number;
 
 		/**
 		 * Whether this line is whitespace only, shorthand
@@ -85,7 +85,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		isEmptyOrWhitespace: boolean;
+		readonly isEmptyOrWhitespace: boolean;
 	}
 
 	/**
@@ -101,7 +101,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		uri: Uri;
+		readonly uri: Uri;
 
 		/**
 		 * The file system path of the associated resource. Shorthand
@@ -109,21 +109,21 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		fileName: string;
+		readonly fileName: string;
 
 		/**
 		 * Is this document representing an untitled file.
 		 *
 		 * @readonly
 		 */
-		isUntitled: boolean;
+		readonly isUntitled: boolean;
 
 		/**
 		 * The identifier of the language associated with this document.
 		 *
 		 * @readonly
 		 */
-		languageId: string;
+		readonly languageId: string;
 
 		/**
 		 * The version number of this document (it will strictly increase after each
@@ -131,14 +131,14 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		version: number;
+		readonly version: number;
 
 		/**
 		 * true if there are unpersisted changes.
 		 *
 		 * @readonly
 		 */
-		isDirty: boolean;
+		readonly isDirty: boolean;
 
 		/**
 		 * Save the underlying file.
@@ -154,7 +154,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		lineCount: number;
+		readonly lineCount: number;
 
 		/**
 		 * Returns a text line denoted by the line number. Note
@@ -251,13 +251,13 @@ declare module 'vscode' {
 		 * The zero-based line value.
 		 * @readonly
 		 */
-		line: number;
+		readonly line: number;
 
 		/**
 		 * The zero-based character value.
 		 * @readonly
 		 */
-		character: number;
+		readonly character: number;
 
 		/**
 		 * @param line A zero-based line value.
@@ -372,13 +372,13 @@ declare module 'vscode' {
 		 * The start position. It is before or equal to [end](#Range.end).
 		 * @readonly
 		 */
-		start: Position;
+		readonly start: Position;
 
 		/**
 		 * The end position. It is after or equal to [start](#Range.start).
 		 * @readonly
 		 */
-		end: Position;
+		readonly end: Position;
 
 		/**
 		 * Create a new range from two positions. If `start` is not
@@ -658,7 +658,7 @@ declare module 'vscode' {
 		 * Internal representation of the handle.
 		 * @readonly
 		 */
-		key: string;
+		readonly key: string;
 
 		/**
 		 * Remove this decoration type and all decorations on all text editors using it.
@@ -1545,7 +1545,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		diagnostics: Diagnostic[];
+		readonly diagnostics: Diagnostic[];
 	}
 
 	/**
@@ -2007,7 +2007,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		size: number;
+		readonly size: number;
 
 		/**
 		 * Replace the given range with given text for the given resource.
@@ -2852,7 +2852,7 @@ declare module 'vscode' {
 		 * Readable dictionary that backs this configuration.
 		 * @readonly
 		 */
-		[key: string]: any;
+		readonly [key: string]: any;
 	}
 
 	/**
@@ -2967,7 +2967,7 @@ declare module 'vscode' {
 		 * name when defining [problem matchers](https://code.visualstudio.com/docs/editor/tasks#_defining-a-problem-matcher).
 		 * @readonly
 		 */
-		name: string;
+		readonly name: string;
 
 		/**
 		 * Assign diagnostics for given resource. Will replace
@@ -3059,7 +3059,7 @@ declare module 'vscode' {
 		 * The human-readable name of this output channel.
 		 * @readonly
 		 */
-		name: string;
+		readonly name: string;
 
 		/**
 		 * Append the given value to the channel.
@@ -3137,7 +3137,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		alignment: StatusBarAlignment;
+		readonly alignment: StatusBarAlignment;
 
 		/**
 		 * The priority of this item. Higher value means the item should
@@ -3145,7 +3145,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		priority: number;
+		readonly priority: number;
 
 		/**
 		 * The text to show for the entry. You can embed icons in the text by leveraging the syntax:
@@ -3200,14 +3200,14 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		name: string;
+		readonly name: string;
 
 		/**
 		 * The process ID of the shell process.
 		 *
 		 * @readonly
 		 */
-		processId: Thenable<number>;
+		readonly processId: Thenable<number>;
 
 		/**
 		 * Send text to the terminal. The text is written to the stdin of the underlying pty process
@@ -3250,28 +3250,28 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		id: string;
+		readonly id: string;
 
 		/**
 		 * The absolute file path of the directory containing this extension.
 		 *
 		 * @readonly
 		 */
-		extensionPath: string;
+		readonly extensionPath: string;
 
 		/**
 		 * `true` if the extension has been activated.
 		 *
 		 * @readonly
 		 */
-		isActive: boolean;
+		readonly isActive: boolean;
 
 		/**
 		 * The parsed contents of the extension's package.json.
 		 *
 		 * @readonly
 		 */
-		packageJSON: any;
+		readonly packageJSON: any;
 
 		/**
 		 * The public API exported by this extension. It is an invalid action
@@ -3279,7 +3279,7 @@ declare module 'vscode' {
 		 *
 		 * @readonly
 		 */
-		exports: T;
+		readonly exports: T;
 
 		/**
 		 * Activates this extension and returns its public API.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1560,8 +1560,6 @@ declare module 'vscode' {
 
 		/**
 		 * `true` when there is a command associated.
-		 *
-		 * @readonly
 		 */
 		readonly isResolved: boolean;
 
@@ -3808,6 +3806,8 @@ declare module 'vscode' {
 		/**
 		 * The folder that is open in VS Code. `undefined` when no folder
 		 * has been opened.
+		 *
+		 * @readonly
 		 */
 		export let rootPath: string | undefined;
 

--- a/src/vs/workbench/test/node/api/extHostConfiguration.test.ts
+++ b/src/vs/workbench/test/node/api/extHostConfiguration.test.ts
@@ -67,7 +67,6 @@ suite('ExtHostConfiguration', function () {
 		assert.equal(config.get('config4'), '');
 		assert.equal(config['config0'], true);
 		assert.equal(config['config4'], '');
-		assert.throws(() => config['config4'] = 'valuevalue');
 
 		assert.ok(config.has('nested.config1'));
 		assert.equal(config.get('nested.config1'), 42);

--- a/src/vs/workbench/test/node/api/extHostDocuments.test.ts
+++ b/src/vs/workbench/test/node/api/extHostDocuments.test.ts
@@ -38,20 +38,9 @@ suite('ExtHostDocument', () => {
 		], '\n', 'text', 1, false);
 	});
 
-	test('readonly-ness', function () {
-
-		assert.throws(() => data.document.uri = null);
-		assert.throws(() => data.document.fileName = 'foofile');
-		assert.throws(() => data.document.isDirty = false);
-		assert.throws(() => data.document.isUntitled = false);
-		assert.throws(() => data.document.languageId = 'dddd');
-		assert.throws(() => data.document.lineCount = 9);
-	});
-
 	test('lines', function () {
 
 		assert.equal(data.document.lineCount, 4);
-		assert.throws(() => data.document.lineCount = 9);
 
 		assert.throws(() => data.lineAt(-1));
 		assert.throws(() => data.lineAt(data.document.lineCount));


### PR DESCRIPTION
Reopen #13863 and will Solve #12732
* all in env (https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L3379)
* rootPath in workspace (https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L3870)
* textDocuments in workspace (https://github.com/Microsoft/vscode/blob/master/src/vs/vscode.d.ts#L3921)
are not. because they're using `export` and `namespace`.