### PR TITLE
Exclude Definition From TS code lens

### DIFF
--- a/extensions/typescript/src/features/referencesCodeLensProvider.ts
+++ b/extensions/typescript/src/features/referencesCodeLensProvider.ts
@@ -70,15 +70,19 @@ export default class TypeScriptReferencesCodeLensProvider implements CodeLensPro
 		};
 		return this.client.execute('references', args, token).then(response => {
 			if (response && response.body) {
-				const referenceCount = Math.max(0, response.body.refs.length - 1);
-				const locations = response.body.refs.map(reference =>
-					new Location(Uri.file(reference.file),
-						new Range(
-							new Position(reference.start.line - 1, reference.start.offset - 1),
-							new Position(reference.end.line - 1, reference.end.offset - 1))));
+				// Exclude original definition from references
+				const locations = response.body.refs
+					.filter(reference =>
+						reference.start.line !== codeLens.range.start.line + 1
+						&& reference.start.offset !== codeLens.range.start.character + 1)
+					.map(reference =>
+						new Location(Uri.file(reference.file),
+							new Range(
+								new Position(reference.start.line - 1, reference.start.offset - 1),
+								new Position(reference.end.line - 1, reference.end.offset - 1))));
 
 				codeLens.command = {
-					title: referenceCount + ' ' + (referenceCount === 1 ? localize('oneReferenceLabel', 'reference') : localize('manyReferenceLabel', 'references')),
+					title: locations.length + ' ' + (locations.length === 1 ? localize('oneReferenceLabel', 'reference') : localize('manyReferenceLabel', 'references')),
 					command: 'editor.action.showReferences',
 					arguments: [codeLens.document, codeLens.range.start, locations]
 				};


### PR DESCRIPTION
Fixes #18335

Removes the definition itself from the list of references shown in the TS code lens