### PR TITLE
Add Go To Implementation Api

### DIFF
--- a/extensions/typescript/src/features/definitionProviderBase.ts
+++ b/extensions/typescript/src/features/definitionProviderBase.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { TextDocument, Position, Range, CancellationToken, Location } from 'vscode';
+
+import * as Proto from '../protocol';
+import { ITypescriptServiceClient } from '../typescriptService';
+
+export default class TypeScriptDefinitionProviderBase {
+
+	private client: ITypescriptServiceClient;
+
+	public tokens: string[] = [];
+
+	constructor(client: ITypescriptServiceClient) {
+		this.client = client;
+	}
+
+	protected getSymbolLocations(definitionType: 'definition' | 'implementation', document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Location[] | null> {
+		const filepath = this.client.asAbsolutePath(document.uri);
+		if (!filepath) {
+			return Promise.resolve(null);
+		}
+		let args: Proto.FileLocationRequestArgs = {
+			file: filepath,
+			line: position.line + 1,
+			offset: position.character + 1
+		};
+		if (!args.file) {
+			return Promise.resolve(null);
+		}
+		return this.client.execute(definitionType, args, token).then(response => {
+			let locations: Proto.FileSpan[] = (response && response.body) || [];
+			if (!locations || locations.length === 0) {
+				return [];
+			}
+			return locations.map(location => {
+				let resource = this.client.asUrl(location.file);
+				if (resource === null) {
+					return null;
+				} else {
+					return new Location(resource, new Range(location.start.line - 1, location.start.offset - 1, location.end.line - 1, location.end.offset - 1));
+				}
+			}).filter(x => x !== null) as Location[];
+		}, (error) => {
+			this.client.error(`'${definitionType}' request failed with error.`, error);
+			return [];
+		});
+	}
+}

--- a/extensions/typescript/src/features/implementationProvider.ts
+++ b/extensions/typescript/src/features/implementationProvider.ts
@@ -5,18 +5,18 @@
 
 'use strict';
 
-import { DefinitionProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
+import { ImplementationProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
 
 import { ITypescriptServiceClient } from '../typescriptService';
 import DefinitionProviderBase from './definitionProviderBase';
 
-export default class TypeScriptDefinitionProvider extends DefinitionProviderBase implements DefinitionProvider {
+export default class TypeScriptImplementationProvider extends DefinitionProviderBase implements ImplementationProvider {
 
 	constructor(client: ITypescriptServiceClient) {
 		super(client);
 	}
 
-	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | null> {
-		return this.getSymbolLocations('definition', document, position, token);
+	public provideImplementation(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | null> {
+		return this.getSymbolLocations('implementation', document, position, token);
 	}
 }

--- a/extensions/typescript/src/features/typeDefinitionProvider.ts
+++ b/extensions/typescript/src/features/typeDefinitionProvider.ts
@@ -5,18 +5,18 @@
 
 'use strict';
 
-import { ImplementationProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
+import { TypeDefinitionProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
 
 import { ITypescriptServiceClient } from '../typescriptService';
 import DefinitionProviderBase from './definitionProviderBase';
 
-export default class TypeScriptImplementationProvider extends DefinitionProviderBase implements ImplementationProvider {
+export default class TypeScriptTypeDefinitionProvider extends DefinitionProviderBase implements TypeDefinitionProvider {
 
 	constructor(client: ITypescriptServiceClient) {
 		super(client);
 	}
 
-	public provideImplementation(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | null> {
+	public provideTypeDefinition(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | null> {
 		return this.getSymbolLocations('implementation', document, position, token);
 	}
 }

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -25,7 +25,7 @@ import { ITypescriptServiceClientHost } from './typescriptService';
 
 import HoverProvider from './features/hoverProvider';
 import DefinitionProvider from './features/definitionProvider';
-import ImplementationProvider from './features/implementationProvider';
+import TypeDefinitionProvider from './features/TypeDefinitionProvider';
 import DocumentHighlightProvider from './features/documentHighlightProvider';
 import ReferenceProvider from './features/referenceProvider';
 import DocumentSymbolProvider from './features/documentSymbolProvider';
@@ -160,7 +160,7 @@ class LanguageProvider {
 
 		let hoverProvider = new HoverProvider(client);
 		let definitionProvider = new DefinitionProvider(client);
-		let implementationProvider = new ImplementationProvider(client);
+		let typeDefinitionProvider = new TypeDefinitionProvider(client);
 		let documentHighlightProvider = new DocumentHighlightProvider(client);
 		let referenceProvider = new ReferenceProvider(client);
 		let documentSymbolProvider = new DocumentSymbolProvider(client);
@@ -183,7 +183,7 @@ class LanguageProvider {
 			languages.registerCompletionItemProvider(selector, this.completionItemProvider, '.');
 			languages.registerHoverProvider(selector, hoverProvider);
 			languages.registerDefinitionProvider(selector, definitionProvider);
-			languages.registerImplementationProvider(selector, implementationProvider);
+			languages.registerTypeDefinitionProvider(selector, typeDefinitionProvider);
 			languages.registerDocumentHighlightProvider(selector, documentHighlightProvider);
 			languages.registerReferenceProvider(selector, referenceProvider);
 			languages.registerDocumentSymbolProvider(selector, documentSymbolProvider);

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -25,6 +25,7 @@ import { ITypescriptServiceClientHost } from './typescriptService';
 
 import HoverProvider from './features/hoverProvider';
 import DefinitionProvider from './features/definitionProvider';
+import ImplementationProvider from './features/implementationProvider';
 import DocumentHighlightProvider from './features/documentHighlightProvider';
 import ReferenceProvider from './features/referenceProvider';
 import DocumentSymbolProvider from './features/documentSymbolProvider';
@@ -159,6 +160,7 @@ class LanguageProvider {
 
 		let hoverProvider = new HoverProvider(client);
 		let definitionProvider = new DefinitionProvider(client);
+		let implementationProvider = new ImplementationProvider(client);
 		let documentHighlightProvider = new DocumentHighlightProvider(client);
 		let referenceProvider = new ReferenceProvider(client);
 		let documentSymbolProvider = new DocumentSymbolProvider(client);
@@ -181,6 +183,7 @@ class LanguageProvider {
 			languages.registerCompletionItemProvider(selector, this.completionItemProvider, '.');
 			languages.registerHoverProvider(selector, hoverProvider);
 			languages.registerDefinitionProvider(selector, definitionProvider);
+			languages.registerImplementationProvider(selector, implementationProvider);
 			languages.registerDocumentHighlightProvider(selector, documentHighlightProvider);
 			languages.registerReferenceProvider(selector, referenceProvider);
 			languages.registerDocumentSymbolProvider(selector, documentSymbolProvider);

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -87,6 +87,7 @@ export interface ITypescriptServiceClient {
 	execute(commant: 'completionEntryDetails', args: Proto.CompletionDetailsRequestArgs, token?: CancellationToken): Promise<Proto.CompletionDetailsResponse>;
 	execute(commant: 'signatureHelp', args: Proto.SignatureHelpRequestArgs, token?: CancellationToken): Promise<Proto.SignatureHelpResponse>;
 	execute(command: 'definition', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DefinitionResponse>;
+	execute(command: 'implementation', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ImplementationResponse>;
 	execute(command: 'references', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ReferencesResponse>;
 	execute(command: 'navto', args: Proto.NavtoRequestArgs, token?: CancellationToken): Promise<Proto.NavtoResponse>;
 	execute(command: 'navbar', args: Proto.FileRequestArgs, token?: CancellationToken): Promise<Proto.NavBarResponse>;

--- a/src/vs/editor/browser/standalone/standaloneLanguages.ts
+++ b/src/vs/editor/browser/standalone/standaloneLanguages.ts
@@ -277,6 +277,13 @@ export function registerDefinitionProvider(languageId: string, provider: modes.D
 }
 
 /**
+ * Register a implementation provider (used by e.g. go to implementation).
+ */
+export function registerImplementationProvider(languageId: string, provider: modes.ImplementationProvider): IDisposable {
+	return modes.ImplementationProviderRegistry.register(languageId, provider);
+}
+
+/**
  * Register a code lens provider (used by e.g. inline code lenses).
  */
 export function registerCodeLensProvider(languageId: string, provider: modes.CodeLensProvider): IDisposable {
@@ -633,6 +640,7 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		registerDocumentSymbolProvider: registerDocumentSymbolProvider,
 		registerDocumentHighlightProvider: registerDocumentHighlightProvider,
 		registerDefinitionProvider: registerDefinitionProvider,
+		registerImplementationProvider: registerImplementationProvider,
 		registerCodeLensProvider: registerCodeLensProvider,
 		registerCodeActionProvider: registerCodeActionProvider,
 		registerDocumentFormattingEditProvider: registerDocumentFormattingEditProvider,

--- a/src/vs/editor/browser/standalone/standaloneLanguages.ts
+++ b/src/vs/editor/browser/standalone/standaloneLanguages.ts
@@ -279,8 +279,8 @@ export function registerDefinitionProvider(languageId: string, provider: modes.D
 /**
  * Register a implementation provider (used by e.g. go to implementation).
  */
-export function registerImplementationProvider(languageId: string, provider: modes.ImplementationProvider): IDisposable {
-	return modes.ImplementationProviderRegistry.register(languageId, provider);
+export function registerTypeDefinitionProvider(languageId: string, provider: modes.TypeDefinitionProvider): IDisposable {
+	return modes.TypeDefinitionProviderRegistry.register(languageId, provider);
 }
 
 /**
@@ -640,7 +640,7 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		registerDocumentSymbolProvider: registerDocumentSymbolProvider,
 		registerDocumentHighlightProvider: registerDocumentHighlightProvider,
 		registerDefinitionProvider: registerDefinitionProvider,
-		registerImplementationProvider: registerImplementationProvider,
+		registerTypeDefinitionProvider: registerTypeDefinitionProvider,
 		registerCodeLensProvider: registerCodeLensProvider,
 		registerCodeActionProvider: registerCodeActionProvider,
 		registerDocumentFormattingEditProvider: registerDocumentFormattingEditProvider,

--- a/src/vs/editor/browser/standalone/standaloneLanguages.ts
+++ b/src/vs/editor/browser/standalone/standaloneLanguages.ts
@@ -277,7 +277,7 @@ export function registerDefinitionProvider(languageId: string, provider: modes.D
 }
 
 /**
- * Register a implementation provider (used by e.g. go to implementation).
+ * Register a type definition provider (used by e.g. go to implementation).
  */
 export function registerTypeDefinitionProvider(languageId: string, provider: modes.TypeDefinitionProvider): IDisposable {
 	return modes.TypeDefinitionProviderRegistry.register(languageId, provider);

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -3048,7 +3048,7 @@ export namespace ModeContextKeys {
 	/**
 	 * @internal
 	 */
-	export const hasImplementationProvider = new RawContextKey<boolean>('editorHasImplementationProvider', undefined);
+	export const hasTypeDefinitionProvider = new RawContextKey<boolean>('editorHasTypeDefinitionProvider', undefined);
 	/**
 	 * @internal
 	 */

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -3048,6 +3048,10 @@ export namespace ModeContextKeys {
 	/**
 	 * @internal
 	 */
+	export const hasImplementationProvider = new RawContextKey<boolean>('editorHasImplementationProvider', undefined);
+	/**
+	 * @internal
+	 */
 	export const hasHoverProvider = new RawContextKey<boolean>('editorHasHoverProvider', undefined);
 	/**
 	 * @internal

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -431,8 +431,8 @@ export interface DefinitionProvider {
 }
 
 /**
- * The implementation provider interface defines the contract between extensions and
- * the go to implementation and peek implementation features.
+ * The type definition provider interface defines the contract between extensions and
+ * the go to implementation feature.
  */
 export interface TypeDefinitionProvider {
 	/**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -417,6 +417,7 @@ export interface Location {
  * defined.
  */
 export type Definition = Location | Location[];
+
 /**
  * The definition provider interface defines the contract between extensions and
  * the [go to definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
@@ -429,6 +430,16 @@ export interface DefinitionProvider {
 	provideDefinition(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
 }
 
+/**
+ * The implementation provider interface defines the contract between extensions and
+ * the go to implementation and peek implementation features.
+ */
+export interface ImplementationProvider {
+	/**
+	 * Provide the implementation of the symbol at the given position and document.
+	 */
+	provideImplementation(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+}
 
 /**
  * A symbol kind.
@@ -736,6 +747,11 @@ export const DocumentHighlightProviderRegistry = new LanguageFeatureRegistry<Doc
  * @internal
  */
 export const DefinitionProviderRegistry = new LanguageFeatureRegistry<DefinitionProvider>();
+
+/**
+ * @internal
+ */
+export const ImplementationProviderRegistry = new LanguageFeatureRegistry<ImplementationProvider>();
 
 /**
  * @internal

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -434,11 +434,11 @@ export interface DefinitionProvider {
  * The implementation provider interface defines the contract between extensions and
  * the go to implementation and peek implementation features.
  */
-export interface ImplementationProvider {
+export interface TypeDefinitionProvider {
 	/**
 	 * Provide the implementation of the symbol at the given position and document.
 	 */
-	provideImplementation(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideTypeDefinition(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
 }
 
 /**
@@ -751,7 +751,7 @@ export const DefinitionProviderRegistry = new LanguageFeatureRegistry<Definition
 /**
  * @internal
  */
-export const ImplementationProviderRegistry = new LanguageFeatureRegistry<ImplementationProvider>();
+export const TypeDefinitionProviderRegistry = new LanguageFeatureRegistry<TypeDefinitionProvider>();
 
 /**
  * @internal

--- a/src/vs/editor/common/modes/editorModeContext.ts
+++ b/src/vs/editor/common/modes/editorModeContext.ts
@@ -19,7 +19,7 @@ export class EditorModeContext {
 	private _hasCodeActionsProvider: IContextKey<boolean>;
 	private _hasCodeLensProvider: IContextKey<boolean>;
 	private _hasDefinitionProvider: IContextKey<boolean>;
-	private _hasImplementationProvider: IContextKey<boolean>;
+	private _hasTypeDefinitionProvider: IContextKey<boolean>;
 	private _hasHoverProvider: IContextKey<boolean>;
 	private _hasDocumentHighlightProvider: IContextKey<boolean>;
 	private _hasDocumentSymbolProvider: IContextKey<boolean>;
@@ -40,7 +40,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider = ModeContextKeys.hasCodeActionsProvider.bindTo(contextKeyService);
 		this._hasCodeLensProvider = ModeContextKeys.hasCodeLensProvider.bindTo(contextKeyService);
 		this._hasDefinitionProvider = ModeContextKeys.hasDefinitionProvider.bindTo(contextKeyService);
-		this._hasImplementationProvider = ModeContextKeys.hasImplementationProvider.bindTo(contextKeyService);
+		this._hasTypeDefinitionProvider = ModeContextKeys.hasTypeDefinitionProvider.bindTo(contextKeyService);
 		this._hasHoverProvider = ModeContextKeys.hasHoverProvider.bindTo(contextKeyService);
 		this._hasDocumentHighlightProvider = ModeContextKeys.hasDocumentHighlightProvider.bindTo(contextKeyService);
 		this._hasDocumentSymbolProvider = ModeContextKeys.hasDocumentSymbolProvider.bindTo(contextKeyService);
@@ -59,7 +59,7 @@ export class EditorModeContext {
 		modes.CodeActionProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.CodeLensProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DefinitionProviderRegistry.onDidChange(this._update, this, this._disposables);
-		modes.ImplementationProviderRegistry.onDidChange(this._update, this, this._disposables);
+		modes.TypeDefinitionProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.HoverProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DocumentHighlightProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DocumentSymbolProviderRegistry.onDidChange(this._update, this, this._disposables);
@@ -82,7 +82,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider.reset();
 		this._hasCodeLensProvider.reset();
 		this._hasDefinitionProvider.reset();
-		this._hasImplementationProvider.reset();
+		this._hasTypeDefinitionProvider.reset();
 		this._hasHoverProvider.reset();
 		this._hasDocumentHighlightProvider.reset();
 		this._hasDocumentSymbolProvider.reset();
@@ -104,7 +104,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider.set(modes.CodeActionProviderRegistry.has(model));
 		this._hasCodeLensProvider.set(modes.CodeLensProviderRegistry.has(model));
 		this._hasDefinitionProvider.set(modes.DefinitionProviderRegistry.has(model));
-		this._hasImplementationProvider.set(modes.ImplementationProviderRegistry.has(model));
+		this._hasTypeDefinitionProvider.set(modes.TypeDefinitionProviderRegistry.has(model));
 		this._hasHoverProvider.set(modes.HoverProviderRegistry.has(model));
 		this._hasDocumentHighlightProvider.set(modes.DocumentHighlightProviderRegistry.has(model));
 		this._hasDocumentSymbolProvider.set(modes.DocumentSymbolProviderRegistry.has(model));

--- a/src/vs/editor/common/modes/editorModeContext.ts
+++ b/src/vs/editor/common/modes/editorModeContext.ts
@@ -19,6 +19,7 @@ export class EditorModeContext {
 	private _hasCodeActionsProvider: IContextKey<boolean>;
 	private _hasCodeLensProvider: IContextKey<boolean>;
 	private _hasDefinitionProvider: IContextKey<boolean>;
+	private _hasImplementationProvider: IContextKey<boolean>;
 	private _hasHoverProvider: IContextKey<boolean>;
 	private _hasDocumentHighlightProvider: IContextKey<boolean>;
 	private _hasDocumentSymbolProvider: IContextKey<boolean>;
@@ -39,6 +40,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider = ModeContextKeys.hasCodeActionsProvider.bindTo(contextKeyService);
 		this._hasCodeLensProvider = ModeContextKeys.hasCodeLensProvider.bindTo(contextKeyService);
 		this._hasDefinitionProvider = ModeContextKeys.hasDefinitionProvider.bindTo(contextKeyService);
+		this._hasImplementationProvider = ModeContextKeys.hasImplementationProvider.bindTo(contextKeyService);
 		this._hasHoverProvider = ModeContextKeys.hasHoverProvider.bindTo(contextKeyService);
 		this._hasDocumentHighlightProvider = ModeContextKeys.hasDocumentHighlightProvider.bindTo(contextKeyService);
 		this._hasDocumentSymbolProvider = ModeContextKeys.hasDocumentSymbolProvider.bindTo(contextKeyService);
@@ -57,6 +59,7 @@ export class EditorModeContext {
 		modes.CodeActionProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.CodeLensProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DefinitionProviderRegistry.onDidChange(this._update, this, this._disposables);
+		modes.ImplementationProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.HoverProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DocumentHighlightProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DocumentSymbolProviderRegistry.onDidChange(this._update, this, this._disposables);
@@ -79,6 +82,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider.reset();
 		this._hasCodeLensProvider.reset();
 		this._hasDefinitionProvider.reset();
+		this._hasImplementationProvider.reset();
 		this._hasHoverProvider.reset();
 		this._hasDocumentHighlightProvider.reset();
 		this._hasDocumentSymbolProvider.reset();
@@ -100,6 +104,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider.set(modes.CodeActionProviderRegistry.has(model));
 		this._hasCodeLensProvider.set(modes.CodeLensProviderRegistry.has(model));
 		this._hasDefinitionProvider.set(modes.DefinitionProviderRegistry.has(model));
+		this._hasImplementationProvider.set(modes.ImplementationProviderRegistry.has(model));
 		this._hasHoverProvider.set(modes.HoverProviderRegistry.has(model));
 		this._hasDocumentHighlightProvider.set(modes.DocumentHighlightProviderRegistry.has(model));
 		this._hasDocumentSymbolProvider.set(modes.DocumentSymbolProviderRegistry.has(model));

--- a/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
@@ -26,7 +26,7 @@ import { editorAction, IActionOptions, ServicesAccessor, EditorAction } from 'vs
 import { Location, DefinitionProviderRegistry } from 'vs/editor/common/modes';
 import { ICodeEditor, IEditorMouseEvent, IMouseTarget } from 'vs/editor/browser/editorBrowser';
 import { editorContribution } from 'vs/editor/browser/editorBrowserExtensions';
-import { getDeclarationsAtPosition, getImplementationAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
+import { getDeclarationsAtPosition, getTypeDefinitionAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
 import { ReferencesController } from 'vs/editor/contrib/referenceSearch/browser/referencesController';
 import { ReferencesModel } from 'vs/editor/contrib/referenceSearch/browser/referencesModel';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -233,7 +233,7 @@ export class GoToImplementationAction extends DefinitionAction {
 			id: GoToImplementationAction.ID,
 			label: nls.localize('actions.goToImplementation.label', "Go to Implementation"),
 			alias: 'Go to Implementation',
-			precondition: ModeContextKeys.hasImplementationProvider,
+			precondition: ModeContextKeys.hasTypeDefinitionProvider,
 			kbOpts: {
 				kbExpr: EditorContextKeys.TextFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.F12
@@ -246,7 +246,7 @@ export class GoToImplementationAction extends DefinitionAction {
 	}
 
 	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getImplementationAtPosition(model, position);
+		return getTypeDefinitionAtPosition(model, position);
 	}
 }
 

--- a/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
@@ -26,13 +26,14 @@ import { editorAction, IActionOptions, ServicesAccessor, EditorAction } from 'vs
 import { Location, DefinitionProviderRegistry } from 'vs/editor/common/modes';
 import { ICodeEditor, IEditorMouseEvent, IMouseTarget } from 'vs/editor/browser/editorBrowser';
 import { editorContribution } from 'vs/editor/browser/editorBrowserExtensions';
-import { getDeclarationsAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
+import { getDeclarationsAtPosition, getImplementationAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
 import { ReferencesController } from 'vs/editor/contrib/referenceSearch/browser/referencesController';
 import { ReferencesModel } from 'vs/editor/contrib/referenceSearch/browser/referencesModel';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { PeekContext } from 'vs/editor/contrib/zoneWidget/browser/peekViewWidget';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ITextModelResolverService } from 'vs/editor/common/services/resolverService';
+import * as corePosition from 'vs/editor/common/core/position';
 
 import ModeContextKeys = editorCommon.ModeContextKeys;
 import EditorContextKeys = editorCommon.EditorContextKeys;
@@ -64,7 +65,7 @@ export class DefinitionAction extends EditorAction {
 		let model = editor.getModel();
 		let pos = editor.getPosition();
 
-		return getDeclarationsAtPosition(model, pos).then(references => {
+		return this.getDeclarationsAtPosition(model, pos).then(references => {
 
 			if (!references) {
 				return;
@@ -102,6 +103,10 @@ export class DefinitionAction extends EditorAction {
 			messageService.show(Severity.Error, err);
 			return false;
 		});
+	}
+
+	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
+		return getDeclarationsAtPosition(model, position);
 	}
 
 	private _onResult(editorService: IEditorService, editor: editorCommon.ICommonCodeEditor, model: ReferencesModel) {
@@ -216,6 +221,35 @@ export class PeekDefinitionAction extends DefinitionAction {
 		});
 	}
 }
+
+
+@editorAction
+export class GoToImplementationAction extends DefinitionAction {
+
+	public static ID = 'editor.action.goToImplementation';
+
+	constructor() {
+		super(new DefinitionActionConfig(), {
+			id: GoToImplementationAction.ID,
+			label: nls.localize('actions.goToImplementation.label', "Go to Implementation"),
+			alias: 'Go to Implementation',
+			precondition: ModeContextKeys.hasImplementationProvider,
+			kbOpts: {
+				kbExpr: EditorContextKeys.TextFocus,
+				primary: KeyMod.CtrlCmd | KeyCode.F12
+			},
+			menuOpts: {
+				group: 'navigation',
+				order: 1.3
+			}
+		});
+	}
+
+	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
+		return getImplementationAtPosition(model, position);
+	}
+}
+
 
 // --- Editor Contribution to goto definition using the mouse and a modifier key
 

--- a/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
@@ -9,9 +9,23 @@ import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
-import { DefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, ImplementationProviderRegistry, Location } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
+
+function outputResults(promises: TPromise<Location[]>[]) {
+	return TPromise.join(promises).then(allReferences => {
+		let result: Location[] = [];
+		for (let references of allReferences) {
+			if (Array.isArray(references)) {
+				result.push(...references);
+			} else if (references) {
+				result.push(references);
+			}
+		}
+		return result;
+	});
+}
 
 export function getDeclarationsAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
 
@@ -27,18 +41,25 @@ export function getDeclarationsAtPosition(model: IReadOnlyModel, position: Posit
 			onUnexpectedExternalError(err);
 		});
 	});
+	return outputResults(promises);
+}
 
-	return TPromise.join(promises).then(allReferences => {
-		let result: Location[] = [];
-		for (let references of allReferences) {
-			if (Array.isArray(references)) {
-				result.push(...references);
-			} else if (references) {
-				result.push(references);
-			}
-		}
-		return result;
+export function getImplementationAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+
+	const provider = ImplementationProviderRegistry.ordered(model);
+
+	// get results
+	const promises = provider.map((provider, idx) => {
+		return asWinJsPromise((token) => {
+			return provider.provideImplementation(model, position, token);
+		}).then(result => {
+			return result;
+		}, err => {
+			onUnexpectedExternalError(err);
+		});
 	});
+	return outputResults(promises);
 }
 
 CommonEditorRegistry.registerDefaultLanguageCommand('_executeDefinitionProvider', getDeclarationsAtPosition);
+CommonEditorRegistry.registerDefaultLanguageCommand('_executeImplementationProvider', getImplementationAtPosition);

--- a/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
@@ -9,7 +9,7 @@ import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
-import { DefinitionProviderRegistry, ImplementationProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, TypeDefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
 
@@ -44,14 +44,14 @@ export function getDeclarationsAtPosition(model: IReadOnlyModel, position: Posit
 	return outputResults(promises);
 }
 
-export function getImplementationAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+export function getTypeDefinitionAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
 
-	const provider = ImplementationProviderRegistry.ordered(model);
+	const provider = TypeDefinitionProviderRegistry.ordered(model);
 
 	// get results
 	const promises = provider.map((provider, idx) => {
 		return asWinJsPromise((token) => {
-			return provider.provideImplementation(model, position, token);
+			return provider.provideTypeDefinition(model, position, token);
 		}).then(result => {
 			return result;
 		}, err => {
@@ -62,4 +62,4 @@ export function getImplementationAtPosition(model: IReadOnlyModel, position: Pos
 }
 
 CommonEditorRegistry.registerDefaultLanguageCommand('_executeDefinitionProvider', getDeclarationsAtPosition);
-CommonEditorRegistry.registerDefaultLanguageCommand('_executeImplementationProvider', getImplementationAtPosition);
+CommonEditorRegistry.registerDefaultLanguageCommand('_executeTypeDefinitionProvider', getTypeDefinitionAtPosition);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3943,7 +3943,7 @@ declare module monaco.languages {
     /**
      * Register a implementation provider (used by e.g. go to implementation).
      */
-    export function registerImplementationProvider(languageId: string, provider: ImplementationProvider): IDisposable;
+    export function registerTypeDefinitionProvider(languageId: string, provider: TypeDefinitionProvider): IDisposable;
 
     /**
      * Register a code lens provider (used by e.g. inline code lenses).
@@ -4528,11 +4528,11 @@ declare module monaco.languages {
      * The implementation provider interface defines the contract between extensions and
      * the go to implementation and peek implementation features.
      */
-    export interface ImplementationProvider {
+    export interface TypeDefinitionProvider {
         /**
          * Provide the implementation of the symbol at the given position and document.
          */
-        provideImplementation(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+        provideTypeDefinition(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
     }
 
     /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3941,6 +3941,11 @@ declare module monaco.languages {
     export function registerDefinitionProvider(languageId: string, provider: DefinitionProvider): IDisposable;
 
     /**
+     * Register a implementation provider (used by e.g. go to implementation).
+     */
+    export function registerImplementationProvider(languageId: string, provider: ImplementationProvider): IDisposable;
+
+    /**
      * Register a code lens provider (used by e.g. inline code lenses).
      */
     export function registerCodeLensProvider(languageId: string, provider: CodeLensProvider): IDisposable;
@@ -4517,6 +4522,17 @@ declare module monaco.languages {
          * Provide the definition of the symbol at the given position and document.
          */
         provideDefinition(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+    }
+
+    /**
+     * The implementation provider interface defines the contract between extensions and
+     * the go to implementation and peek implementation features.
+     */
+    export interface ImplementationProvider {
+        /**
+         * Provide the implementation of the symbol at the given position and document.
+         */
+        provideImplementation(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
     }
 
     /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3941,7 +3941,7 @@ declare module monaco.languages {
     export function registerDefinitionProvider(languageId: string, provider: DefinitionProvider): IDisposable;
 
     /**
-     * Register a implementation provider (used by e.g. go to implementation).
+     * Register a type definition provider (used by e.g. go to implementation).
      */
     export function registerTypeDefinitionProvider(languageId: string, provider: TypeDefinitionProvider): IDisposable;
 
@@ -4525,8 +4525,8 @@ declare module monaco.languages {
     }
 
     /**
-     * The implementation provider interface defines the contract between extensions and
-     * the go to implementation and peek implementation features.
+     * The type definition provider interface defines the contract between extensions and
+     * the go to implementation feature.
      */
     export interface TypeDefinitionProvider {
         /**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1633,10 +1633,10 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * The implementation provider interface defines the contract between extensions and
+	 * The type definition provider interface defines the contract between extensions and
 	 * the go to implementation feature.
 	 */
-	export interface ImplementationProvider {
+	export interface TypeDefinitionProvider {
 
 		/**
 		 * Provide the implementations of the symbol at the given position and document.
@@ -1647,7 +1647,7 @@ declare module 'vscode' {
 		 * @return A definition or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideImplementation(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+		provideTypeDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
 	}
 
 	/**
@@ -4104,7 +4104,7 @@ declare module 'vscode' {
 		 * @param provider An implementation provider.
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
-		export function registerImplementationProvider(selector: DocumentSelector, provider: ImplementationProvider): Disposable;
+		export function registerTypeDefinitionProvider(selector: DocumentSelector, provider: TypeDefinitionProvider): Disposable;
 
 		/**
 		 * Register a hover provider.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4095,7 +4095,7 @@ declare module 'vscode' {
 		export function registerDefinitionProvider(selector: DocumentSelector, provider: DefinitionProvider): Disposable;
 
 		/**
-		 * Register an implementation provider.
+		 * Register an type definition provider.
 		 *
 		 * Multiple providers can be registered for a language. In that case providers are sorted
 		 * by their [score](#languages.match) and the best-matching provider is used.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1633,6 +1633,24 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * The implementation provider interface defines the contract between extensions and
+	 * the go to implementation feature.
+	 */
+	export interface ImplementationProvider {
+
+		/**
+		 * Provide the implementations of the symbol at the given position and document.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @return A definition or a thenable that resolves to such. The lack of a result can be
+		 * signaled by returning `undefined` or `null`.
+		 */
+		provideImplementation(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+	}
+
+	/**
 	 * MarkedString can be used to render human readable text. It is either a markdown string
 	 * or a code-block that provides a language and a code snippet. Note that
 	 * markdown strings will be sanitized - that means html will be escaped.
@@ -4075,6 +4093,18 @@ declare module 'vscode' {
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
 		export function registerDefinitionProvider(selector: DocumentSelector, provider: DefinitionProvider): Disposable;
+
+		/**
+		 * Register an implementation provider.
+		 *
+		 * Multiple providers can be registered for a language. In that case providers are sorted
+		 * by their [score](#languages.match) and the best-matching provider is used.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider An implementation provider.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+		export function registerImplementationProvider(selector: DocumentSelector, provider: ImplementationProvider): Disposable;
 
 		/**
 		 * Register a hover provider.

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -180,6 +180,9 @@ export function createApiFactory(initData: IInitData, threadService: IThreadServ
 			registerDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.DefinitionProvider): vscode.Disposable {
 				return languageFeatures.registerDefinitionProvider(selector, provider);
 			},
+			registerImplementationProvider(selector: vscode.DocumentSelector, provider: vscode.ImplementationProvider): vscode.Disposable {
+				return languageFeatures.registerImplementationProvider(selector, provider);
+			},
 			registerHoverProvider(selector: vscode.DocumentSelector, provider: vscode.HoverProvider): vscode.Disposable {
 				return languageFeatures.registerHoverProvider(selector, provider);
 			},

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -180,8 +180,8 @@ export function createApiFactory(initData: IInitData, threadService: IThreadServ
 			registerDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.DefinitionProvider): vscode.Disposable {
 				return languageFeatures.registerDefinitionProvider(selector, provider);
 			},
-			registerImplementationProvider(selector: vscode.DocumentSelector, provider: vscode.ImplementationProvider): vscode.Disposable {
-				return languageFeatures.registerImplementationProvider(selector, provider);
+			registerTypeDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.TypeDefinitionProvider): vscode.Disposable {
+				return languageFeatures.registerTypeDefinitionProvider(selector, provider);
 			},
 			registerHoverProvider(selector: vscode.DocumentSelector, provider: vscode.HoverProvider): vscode.Disposable {
 				return languageFeatures.registerHoverProvider(selector, provider);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -330,7 +330,7 @@ export abstract class ExtHostLanguageFeaturesShape {
 	$provideCodeLenses(handle: number, resource: URI): TPromise<modes.ICodeLensSymbol[]> { throw ni(); }
 	$resolveCodeLens(handle: number, resource: URI, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol> { throw ni(); }
 	$provideDefinition(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
-	$provideImplementation(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
+	$provideTypeDefinition(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
 	$provideHover(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Hover> { throw ni(); }
 	$provideDocumentHighlights(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.DocumentHighlight[]> { throw ni(); }
 	$provideReferences(handle: number, resource: URI, position: editorCommon.IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]> { throw ni(); }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -153,6 +153,7 @@ export abstract class MainThreadLanguageFeaturesShape {
 	$registerCodeLensSupport(handle: number, selector: vscode.DocumentSelector, eventHandle: number): TPromise<any> { throw ni(); }
 	$emitCodeLensEvent(eventHandle: number, event?: any): TPromise<any> { throw ni(); }
 	$registerDeclaractionSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
+	$registerImplementationSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerHoverProvider(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerDocumentHighlightProvider(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerReferenceSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
@@ -329,6 +330,7 @@ export abstract class ExtHostLanguageFeaturesShape {
 	$provideCodeLenses(handle: number, resource: URI): TPromise<modes.ICodeLensSymbol[]> { throw ni(); }
 	$resolveCodeLens(handle: number, resource: URI, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol> { throw ni(); }
 	$provideDefinition(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
+	$provideImplementation(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
 	$provideHover(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Hover> { throw ni(); }
 	$provideDocumentHighlights(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.DocumentHighlight[]> { throw ni(); }
 	$provideReferences(handle: number, resource: URI, position: editorCommon.IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]> { throw ni(); }

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -46,6 +46,14 @@ export class ExtHostApiCommands {
 			],
 			returns: 'A promise that resolves to an array of Location-instances.'
 		});
+		this._register('vscode.executeImplementationProvider', this._executeImplementationProvider, {
+			description: 'Execute all implementation providers.',
+			args: [
+				{ name: 'uri', description: 'Uri of a text document', constraint: URI },
+				{ name: 'position', description: 'Position of a symbol', constraint: types.Position }
+			],
+			returns: 'A promise that resolves to an array of Location-instance.'
+		});
 		this._register('vscode.executeHoverProvider', this._executeHoverProvider, {
 			description: 'Execute all hover provider.',
 			args: [
@@ -259,6 +267,18 @@ export class ExtHostApiCommands {
 			position: position && typeConverters.fromPosition(position)
 		};
 		return this._commands.executeCommand<modes.Location[]>('_executeDefinitionProvider', args).then(value => {
+			if (Array.isArray(value)) {
+				return value.map(typeConverters.location.to);
+			}
+		});
+	}
+
+	private _executeImplementationProvider(resource: URI, position: types.Position): Thenable<types.Location[]> {
+		const args = {
+			resource,
+			position: position && typeConverters.fromPosition(position)
+		};
+		return this._commands.executeCommand<modes.Location[]>('_executeImplementationProvider', args).then(value => {
 			if (Array.isArray(value)) {
 				return value.map(typeConverters.location.to);
 			}

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -46,7 +46,7 @@ export class ExtHostApiCommands {
 			],
 			returns: 'A promise that resolves to an array of Location-instances.'
 		});
-		this._register('vscode.executeImplementationProvider', this._executeImplementationProvider, {
+		this._register('vscode.executeTypeDefinitionProvider', this._executeTypeDefinitionProvider, {
 			description: 'Execute all implementation providers.',
 			args: [
 				{ name: 'uri', description: 'Uri of a text document', constraint: URI },
@@ -273,12 +273,12 @@ export class ExtHostApiCommands {
 		});
 	}
 
-	private _executeImplementationProvider(resource: URI, position: types.Position): Thenable<types.Location[]> {
+	private _executeTypeDefinitionProvider(resource: URI, position: types.Position): Thenable<types.Location[]> {
 		const args = {
 			resource,
 			position: position && typeConverters.fromPosition(position)
 		};
-		return this._commands.executeCommand<modes.Location[]>('_executeImplementationProvider', args).then(value => {
+		return this._commands.executeCommand<modes.Location[]>('_executeTypeDefinitionProvider', args).then(value => {
 			if (Array.isArray(value)) {
 				return value.map(typeConverters.location.to);
 			}

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -122,6 +122,29 @@ class DefinitionAdapter {
 	}
 }
 
+class ImplementationAdapter {
+
+	private _documents: ExtHostDocuments;
+	private _provider: vscode.ImplementationProvider;
+
+	constructor(documents: ExtHostDocuments, provider: vscode.ImplementationProvider) {
+		this._documents = documents;
+		this._provider = provider;
+	}
+
+	provideImplementation(resource: URI, position: IPosition): TPromise<modes.Definition> {
+		let doc = this._documents.getDocumentData(resource).document;
+		let pos = TypeConverters.toPosition(position);
+		return asWinJsPromise(token => this._provider.provideImplementation(doc, pos, token)).then(value => {
+			if (Array.isArray(value)) {
+				return value.map(TypeConverters.location.from);
+			} else if (value) {
+				return TypeConverters.location.from(value);
+			}
+		});
+	}
+}
+
 class HoverAdapter {
 
 	private _documents: ExtHostDocuments;
@@ -613,7 +636,7 @@ class LinkProviderAdapter {
 type Adapter = OutlineAdapter | CodeLensAdapter | DefinitionAdapter | HoverAdapter
 	| DocumentHighlightAdapter | ReferenceAdapter | QuickFixAdapter | DocumentFormattingAdapter
 	| RangeFormattingAdapter | OnTypeFormattingAdapter | NavigateTypeAdapter | RenameAdapter
-	| SuggestAdapter | SignatureHelpAdapter | LinkProviderAdapter;
+	| SuggestAdapter | SignatureHelpAdapter | LinkProviderAdapter | ImplementationAdapter;
 
 export class ExtHostLanguageFeatures extends ExtHostLanguageFeaturesShape {
 
@@ -710,6 +733,17 @@ export class ExtHostLanguageFeatures extends ExtHostLanguageFeaturesShape {
 
 	$provideDefinition(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition> {
 		return this._withAdapter(handle, DefinitionAdapter, adapter => adapter.provideDefinition(resource, position));
+	}
+
+	registerImplementationProvider(selector: vscode.DocumentSelector, provider: vscode.ImplementationProvider): vscode.Disposable {
+		const handle = this._nextHandle();
+		this._adapter.set(handle, new ImplementationAdapter(this._documents, provider));
+		this._proxy.$registerImplementationSupport(handle, selector);
+		return this._createDisposable(handle);
+	}
+
+	$provideImplementation(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition> {
+		return this._withAdapter(handle, ImplementationAdapter, adapter => adapter.provideImplementation(resource, position));
 	}
 
 	// --- extra info

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -125,17 +125,17 @@ class DefinitionAdapter {
 class ImplementationAdapter {
 
 	private _documents: ExtHostDocuments;
-	private _provider: vscode.ImplementationProvider;
+	private _provider: vscode.TypeDefinitionProvider;
 
-	constructor(documents: ExtHostDocuments, provider: vscode.ImplementationProvider) {
+	constructor(documents: ExtHostDocuments, provider: vscode.TypeDefinitionProvider) {
 		this._documents = documents;
 		this._provider = provider;
 	}
 
-	provideImplementation(resource: URI, position: IPosition): TPromise<modes.Definition> {
+	provideTypeDefinition(resource: URI, position: IPosition): TPromise<modes.Definition> {
 		let doc = this._documents.getDocumentData(resource).document;
 		let pos = TypeConverters.toPosition(position);
-		return asWinJsPromise(token => this._provider.provideImplementation(doc, pos, token)).then(value => {
+		return asWinJsPromise(token => this._provider.provideTypeDefinition(doc, pos, token)).then(value => {
 			if (Array.isArray(value)) {
 				return value.map(TypeConverters.location.from);
 			} else if (value) {
@@ -735,15 +735,15 @@ export class ExtHostLanguageFeatures extends ExtHostLanguageFeaturesShape {
 		return this._withAdapter(handle, DefinitionAdapter, adapter => adapter.provideDefinition(resource, position));
 	}
 
-	registerImplementationProvider(selector: vscode.DocumentSelector, provider: vscode.ImplementationProvider): vscode.Disposable {
+	registerTypeDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.TypeDefinitionProvider): vscode.Disposable {
 		const handle = this._nextHandle();
 		this._adapter.set(handle, new ImplementationAdapter(this._documents, provider));
 		this._proxy.$registerImplementationSupport(handle, selector);
 		return this._createDisposable(handle);
 	}
 
-	$provideImplementation(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition> {
-		return this._withAdapter(handle, ImplementationAdapter, adapter => adapter.provideImplementation(resource, position));
+	$provideTypeDefinition(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition> {
+		return this._withAdapter(handle, ImplementationAdapter, adapter => adapter.provideTypeDefinition(resource, position));
 	}
 
 	// --- extra info

--- a/src/vs/workbench/api/node/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/mainThreadLanguageFeatures.ts
@@ -103,9 +103,9 @@ export class MainThreadLanguageFeatures extends MainThreadLanguageFeaturesShape 
 	}
 
 	$registerImplementationSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> {
-		this._registrations[handle] = modes.ImplementationProviderRegistry.register(selector, <modes.ImplementationProvider>{
-			provideImplementation: (model, position, token): Thenable<modes.Definition> => {
-				return wireCancellationToken(token, this._proxy.$provideImplementation(handle, model.uri, position));
+		this._registrations[handle] = modes.TypeDefinitionProviderRegistry.register(selector, <modes.TypeDefinitionProvider>{
+			provideTypeDefinition: (model, position, token): Thenable<modes.Definition> => {
+				return wireCancellationToken(token, this._proxy.$provideTypeDefinition(handle, model.uri, position));
 			}
 		});
 		return undefined;

--- a/src/vs/workbench/api/node/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/mainThreadLanguageFeatures.ts
@@ -102,6 +102,15 @@ export class MainThreadLanguageFeatures extends MainThreadLanguageFeaturesShape 
 		return undefined;
 	}
 
+	$registerImplementationSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> {
+		this._registrations[handle] = modes.ImplementationProviderRegistry.register(selector, <modes.ImplementationProvider>{
+			provideImplementation: (model, position, token): Thenable<modes.Definition> => {
+				return wireCancellationToken(token, this._proxy.$provideImplementation(handle, model.uri, position));
+			}
+		});
+		return undefined;
+	}
+
 	// --- extra info
 
 	$registerHoverProvider(handle: number, selector: vscode.DocumentSelector): TPromise<any> {

--- a/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
@@ -27,7 +27,7 @@ import { ExtHostDocuments } from 'vs/workbench/api/node/extHostDocuments';
 import { getDocumentSymbols } from 'vs/editor/contrib/quickOpen/common/quickOpen';
 import { DocumentSymbolProviderRegistry, DocumentHighlightKind } from 'vs/editor/common/modes';
 import { getCodeLensData } from 'vs/editor/contrib/codelens/common/codelens';
-import { getDeclarationsAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
+import { getDeclarationsAtPosition, getTypeDefinitionAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
 import { getHover } from 'vs/editor/contrib/hover/common/hover';
 import { getOccurrencesAtPosition } from 'vs/editor/contrib/wordHighlighter/common/wordHighlighter';
 import { provideReferences } from 'vs/editor/contrib/referenceSearch/common/referenceSearch';
@@ -347,6 +347,26 @@ suite('ExtHostLanguageFeatures', function () {
 
 			return getDeclarationsAtPosition(model, new EditorPosition(1, 1)).then(value => {
 				assert.equal(value.length, 1);
+			});
+		});
+	});
+
+	// --- type definition
+
+	test('TypeDefinition, data conversion', function () {
+
+		disposables.push(extHost.registerTypeDefinitionProvider(defaultSelector, <vscode.TypeDefinitionProvider>{
+			provideTypeDefinition(): any {
+				return [new types.Location(model.uri, new types.Range(1, 2, 3, 4))];
+			}
+		}));
+
+		return threadService.sync().then(() => {
+			return getTypeDefinitionAtPosition(model, new EditorPosition(1, 1)).then(value => {
+				assert.equal(value.length, 1);
+				let [entry] = value;
+				assert.deepEqual(entry.range, { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 });
+				assert.equal(entry.uri.toString(), model.uri.toString());
 			});
 		});
 	});


### PR DESCRIPTION
Fixes #10806

Adds a new API for supporting  `go to implementation` type commands in languages. Implements an example for TS

The current approach added a new public interface called `ImplementationProvider` (a suggestions for a better name would be appreciated). This resulted in some duplicate code that I will try to clean up further. An alternate design would be to extend the `DefintionProvider` with an optional `provideImplemtnation` method. This would allow reusing our existing internal interfaces without as much duplication, but we may want to keep the two concepts separate. Please let me know if you have any thoughts one way or the other.