### PR TITLE
Fix bug in decorationRenderHelper

### DIFF
--- a/src/vs/editor/browser/services/codeEditorServiceImpl.ts
+++ b/src/vs/editor/browser/services/codeEditorServiceImpl.ts
@@ -310,7 +310,7 @@ class DecorationRenderHelper {
 				cssTextArr.push(strings.format(this._CSS_MAP.contentIconPath, opts.contentIconPath.toString(true).replace(/'/g, '%27')));
 			}
 			if (typeof opts.contentText !== 'undefined') {
-				let escaped = opts.contentText.replace(/\"/g, '\\\"');
+				const escaped = opts.contentText.replace(/'/g, '\\\'');
 				cssTextArr.push(strings.format(this._CSS_MAP.contentText, escaped));
 			}
 			DecorationRenderHelper.collectCSSText(opts, ['textDecoration', 'color', 'backgroundColor', 'margin'], cssTextArr);


### PR DESCRIPTION
getCSSTextForModelDecorationContentClassName will not escape ' in contentText since its escaping " rather than '

_CSS_MAPcontentText: 'content:\'{0}\';' uses single apostrophe so we need to escape ' rather than "

This is a bug that was always present and breaks inlineValueDebugging feature I am working on #16129