### PR TITLE
Prototype Using Commit Characters for JS and TS Completions

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -256,11 +256,6 @@
 				}
 			}
 		},
-		"keybindings": {
-			"key": ".",
-			"command": "^acceptSelectedSuggestion",
-			"when": "editorTextFocus && suggestWidgetVisible && editorLangId == 'typescript' && suggestionSupportsAcceptOnKey"
-		},
 		"commands": [
 			{
 				"command": "typescript.reloadProjects",

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -18,16 +18,15 @@ import * as nls from 'vscode-nls';
 let localize = nls.loadMessageBundle();
 
 class MyCompletionItem extends CompletionItem {
-
-	document: TextDocument;
-	position: Position;
-
-	constructor(position: Position, document: TextDocument, entry: CompletionEntry) {
+	constructor(
+		public position: Position,
+		public document: TextDocument,
+		entry: CompletionEntry
+	) {
 		super(entry.name);
 		this.sortText = entry.sortText;
 		this.kind = MyCompletionItem.convertKind(entry.kind);
 		this.position = position;
-		this.document = document;
 		this.commitCharacters = MyCompletionItem.getCommitCharacters(entry.kind);
 		if (entry.replacementSpan) {
 			let span: protocol.TextSpan = entry.replacementSpan;
@@ -89,14 +88,10 @@ class MyCompletionItem extends CompletionItem {
 
 	private static getCommitCharacters(kind: string): string[] | undefined {
 		switch (kind) {
-			case PConst.Kind.primitiveType:
-			case PConst.Kind.keyword:
+			case PConst.Kind.externalModuleName:
 			case PConst.Kind.file:
 			case PConst.Kind.directory:
-			case PConst.Kind.script:
-			case PConst.Kind.warning:
-			case PConst.Kind.externalModuleName:
-				return undefined;
+				return ['/', '"', '\''];
 
 			case PConst.Kind.alias:
 			case PConst.Kind.variable:
@@ -111,7 +106,6 @@ class MyCompletionItem extends CompletionItem {
 			case PConst.Kind.module:
 			case PConst.Kind.class:
 			case PConst.Kind.interface:
-			case PConst.Kind.type:
 			case PConst.Kind.function:
 			case PConst.Kind.memberFunction:
 				return ['.'];
@@ -130,10 +124,6 @@ namespace Configuration {
 }
 
 export default class TypeScriptCompletionItemProvider implements CompletionItemProvider {
-
-	public triggerCharacters = ['.'];
-	public excludeTokens = ['string', 'comment', 'numeric'];
-	public sortBy = [{ type: 'reference', partSeparator: '/' }];
 
 	private client: ITypescriptServiceClient;
 	private typingsStatus: TypingsStatus;

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -28,6 +28,7 @@ class MyCompletionItem extends CompletionItem {
 		this.kind = MyCompletionItem.convertKind(entry.kind);
 		this.position = position;
 		this.document = document;
+		this.commitCharacters = MyCompletionItem.getCommitCharacters(entry.kind);
 		if (entry.replacementSpan) {
 			let span: protocol.TextSpan = entry.replacementSpan;
 			// The indexing for the range returned by the server uses 1-based indexing.
@@ -84,6 +85,39 @@ class MyCompletionItem extends CompletionItem {
 		}
 
 		return CompletionItemKind.Property;
+	}
+
+	private static getCommitCharacters(kind: string): string[] | undefined {
+		switch (kind) {
+			case PConst.Kind.primitiveType:
+			case PConst.Kind.keyword:
+			case PConst.Kind.file:
+			case PConst.Kind.directory:
+			case PConst.Kind.script:
+			case PConst.Kind.warning:
+			case PConst.Kind.externalModuleName:
+				return undefined;
+
+			case PConst.Kind.alias:
+			case PConst.Kind.variable:
+			case PConst.Kind.localVariable:
+			case PConst.Kind.memberVariable:
+			case PConst.Kind.memberGetAccessor:
+			case PConst.Kind.memberSetAccessor:
+			case PConst.Kind.constructSignature:
+			case PConst.Kind.callSignature:
+			case PConst.Kind.indexSignature:
+			case PConst.Kind.enum:
+			case PConst.Kind.module:
+			case PConst.Kind.class:
+			case PConst.Kind.interface:
+			case PConst.Kind.type:
+			case PConst.Kind.function:
+			case PConst.Kind.memberFunction:
+				return ['.'];
+		}
+
+		return undefined;
 	}
 }
 

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -27,7 +27,7 @@ class MyCompletionItem extends CompletionItem {
 		this.sortText = entry.sortText;
 		this.kind = MyCompletionItem.convertKind(entry.kind);
 		this.position = position;
-		this.commitCharacters = MyCompletionItem.getCommitCharacters(entry.kind);
+		this.commitCharacters = MyCompletionItem.getCommitCharacters(document, entry.kind);
 		if (entry.replacementSpan) {
 			let span: protocol.TextSpan = entry.replacementSpan;
 			// The indexing for the range returned by the server uses 1-based indexing.
@@ -86,7 +86,7 @@ class MyCompletionItem extends CompletionItem {
 		return CompletionItemKind.Property;
 	}
 
-	private static getCommitCharacters(kind: string): string[] | undefined {
+	private static getCommitCharacters(document: TextDocument, kind: string): string[] | undefined {
 		switch (kind) {
 			case PConst.Kind.externalModuleName:
 			case PConst.Kind.file:
@@ -108,6 +108,9 @@ class MyCompletionItem extends CompletionItem {
 			case PConst.Kind.interface:
 			case PConst.Kind.function:
 			case PConst.Kind.memberFunction:
+				if (!document || (document.languageId !== 'typescript' && document.languageId !== 'typescriptreact')) {
+					return undefined;
+				}
 				return ['.'];
 		}
 
@@ -125,11 +128,12 @@ namespace Configuration {
 
 export default class TypeScriptCompletionItemProvider implements CompletionItemProvider {
 
-	private client: ITypescriptServiceClient;
-	private typingsStatus: TypingsStatus;
 	private config: Configuration;
 
-	constructor(client: ITypescriptServiceClient, typingsStatus: TypingsStatus) {
+	constructor(
+		private client: ITypescriptServiceClient,
+		private typingsStatus: TypingsStatus
+	) {
 		this.client = client;
 		this.typingsStatus = typingsStatus;
 		this.config = { useCodeSnippetsOnMethodSuggest: false };

--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -89,6 +89,8 @@ class MyCompletionItem extends CompletionItem {
 	private static getCommitCharacters(document: TextDocument, kind: string): string[] | undefined {
 		switch (kind) {
 			case PConst.Kind.externalModuleName:
+				return ['"', '\''];
+
 			case PConst.Kind.file:
 			case PConst.Kind.directory:
 				return ['/', '"', '\''];


### PR DESCRIPTION
Part of #7326

Adds a prototype for using specific characters to complete TS/JS completion items automatically.

Work to do:

- [ ] Add setting to disable this (and only apply in TS files perhaps to match existing behavior)
- [ ] Get this to play nicely with `typescript.useCodeSnippetsOnMethodSuggest` (not a regression actually)
- [x] Improve completions for paths and module names
