### PR TITLE
Add New Context For When an Html Preview Is Focused

### DIFF
--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -185,6 +185,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 			const token = tokens[idx];
 			if (token.level === 0 && token.map && token.map.length) {
 				token.attrSet('data-line', token.map[0]);
+				token.attrJoin('class', 'line');
 			}
 			return self.renderToken(tokens, idx, options, env, self);
 		}

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -185,7 +185,6 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 			const token = tokens[idx];
 			if (token.level === 0 && token.map && token.map.length) {
 				token.attrSet('data-line', token.map[0]);
-				token.attrJoin('class', 'line');
 			}
 			return self.renderToken(tokens, idx, options, env, self);
 		}

--- a/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
@@ -14,6 +14,7 @@ import { empty as EmptyDisposable, IDisposable, dispose, IReference } from 'vs/b
 import { EditorOptions, EditorInput } from 'vs/workbench/common/editor';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { Position } from 'vs/platform/editor/common/editor';
+import { RawContextKey, ContextKeyExpr, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { BaseTextEditorModel } from 'vs/workbench/common/editor/textEditorModel';
@@ -22,6 +23,13 @@ import { IThemeService } from 'vs/workbench/services/themes/common/themeService'
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ITextModelResolverService, ITextEditorModel } from 'vs/editor/common/services/resolverService';
 import Webview from './webview';
+
+// --- Register Context Keys
+
+/**  A context key that is set when an html preview has focus. */
+export const KEYBINDING_CONTEXT_HTML_PREVIEW_FOCUS = new RawContextKey<boolean>('htmlPreviewFocus', undefined);
+/**  A context key that is set when an html preview does not have focus. */
+export const KEYBINDING_CONTEXT_HTML_PREVIEW_NOT_FOCUSED: ContextKeyExpr = KEYBINDING_CONTEXT_HTML_PREVIEW_FOCUS.toNegated();
 
 /**
  * An implementation of editor for showing HTML content in an IFrame by leveraging the HTML input.
@@ -43,13 +51,15 @@ export class HtmlPreviewPart extends BaseEditor {
 	private get _model(): IModel { return this._modelRef.object.textEditorModel; }
 	private _modelChangeSubscription = EmptyDisposable;
 	private _themeChangeSubscription = EmptyDisposable;
+	private _htmlPreviewFocusContexKey: IContextKey<boolean>;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
 		@ITextModelResolverService textModelResolverService: ITextModelResolverService,
 		@IThemeService themeService: IThemeService,
 		@IOpenerService openerService: IOpenerService,
-		@IWorkspaceContextService contextService: IWorkspaceContextService
+		@IWorkspaceContextService contextService: IWorkspaceContextService,
+		@IContextKeyService private _contextKeyService: IContextKeyService
 	) {
 		super(HtmlPreviewPart.ID, telemetryService);
 
@@ -57,6 +67,8 @@ export class HtmlPreviewPart extends BaseEditor {
 		this._themeService = themeService;
 		this._openerService = openerService;
 		this._baseUrl = contextService.toResource('/');
+
+		this._htmlPreviewFocusContexKey = KEYBINDING_CONTEXT_HTML_PREVIEW_FOCUS.bindTo(this._contextKeyService);
 	}
 
 	dispose(): void {
@@ -80,7 +92,7 @@ export class HtmlPreviewPart extends BaseEditor {
 
 	private get webview(): Webview {
 		if (!this._webview) {
-			this._webview = new Webview(this._container, document.querySelector('.monaco-editor-background'), { nodeintegration: true });
+			this._webview = new Webview(this._container, document.querySelector('.monaco-editor-background'), { nodeintegration: true }, this._htmlPreviewFocusContexKey);
 			this._webview.baseUrl = this._baseUrl && this._baseUrl.toString(true);
 
 			this._webviewDisposables = [

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -12,6 +12,7 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import Event, { Emitter } from 'vs/base/common/event';
 import { addDisposableListener, addClass } from 'vs/base/browser/dom';
 import { isLightTheme, isDarkTheme } from 'vs/platform/theme/common/themes';
+import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { MenuRegistry } from 'vs/platform/actions/common/actions';
 
@@ -60,7 +61,12 @@ export default class Webview {
 	private _onDidClickLink = new Emitter<URI>();
 	private _onDidLoadContent = new Emitter<{ stats: any }>();
 
-	constructor(parent: HTMLElement, private _styleElement: Element, options: WebviewOptions) {
+	constructor(
+		parent: HTMLElement,
+		private _styleElement: Element,
+		options: WebviewOptions,
+		private htmlPreviewFocusContexKey?: IContextKey<boolean>
+	) {
 		this._webview = <any>document.createElement('webview');
 
 		this._webview.style.width = '100%';
@@ -107,6 +113,16 @@ export default class Webview {
 					let [stats] = event.args;
 					this._onDidLoadContent.fire({ stats });
 					return;
+				}
+			}),
+			addDisposableListener(this._webview, 'focus', (event: KeyboardEvent) => {
+				if (this.htmlPreviewFocusContexKey) {
+					this.htmlPreviewFocusContexKey.set(true);
+				}
+			}),
+			addDisposableListener(this._webview, 'blur', (event: KeyboardEvent) => {
+				if (this.htmlPreviewFocusContexKey) {
+					this.htmlPreviewFocusContexKey.reset();
 				}
 			})
 		];


### PR DESCRIPTION
Adds a new context called `htmlPreviewFocus` that is active when an HtmlPreview editor is focused. This will be required to support features such as #2187: adding search to the webview, which I imagine being implemented similarly to `StartSearchDefaultSettingsCommand`