### PR TITLE
Add command to post a message to an html preview document

### DIFF
--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -183,6 +183,26 @@ export class ExtHostApiCommands {
 				]
 			});
 
+		this._register('vscode.htmlPreview.postMessage', (uri: URI, message: any) => {
+			return this._commands.executeCommand('_workbench.htmlPreview.postMessage', uri, message);
+		}, {
+				description: `
+				Posts a message to a visible html preview.
+
+				The message is posted to the html preview as a \`message\` event:
+				~~~js
+				window.addEventListener('message', event => {
+					console.log(event.data);
+					...
+				}, false);
+				~~~
+			`,
+				args: [
+					{ name: 'uri', description: 'Uri of the resource to preview.', constraint: value => value instanceof URI || typeof value === 'string' },
+					{ name: 'message', description: 'Message contents' }
+				]
+			});
+
 		this._register('vscode.openFolder', (uri?: URI, forceNewWindow?: boolean) => {
 			if (!uri) {
 				return this._commands.executeCommand('_files.openFolderPicker', forceNewWindow);

--- a/src/vs/workbench/parts/html/browser/html.contribution.ts
+++ b/src/vs/workbench/parts/html/browser/html.contribution.ts
@@ -100,3 +100,16 @@ CommandsRegistry.registerCommand('_workbench.previewHtml', function (accessor: S
 		.openEditor(input, { pinned: true }, position)
 		.then(editor => true);
 });
+
+CommandsRegistry.registerCommand('_workbench.htmlPreview.postMessage', (accessor: ServicesAccessor, resource: URI | string, message: any) => {
+	const uri = resource instanceof URI ? resource : URI.parse(resource);
+	const activePreview = accessor.get(IWorkbenchEditorService).getVisibleEditors()
+		.filter(c => c instanceof HtmlPreviewPart)
+		.map(e => e as HtmlPreviewPart)
+		.filter(e => e.model.uri.scheme == uri.scheme && e.model.uri.path === uri.path);
+	if (activePreview.length) {
+		activePreview[0].sendMessage(message);
+		return true;
+	}
+	return false;
+});

--- a/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
@@ -21,6 +21,8 @@ import { HtmlInput } from 'vs/workbench/parts/html/common/htmlInput';
 import { IThemeService } from 'vs/workbench/services/themes/common/themeService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ITextModelResolverService, ITextEditorModel } from 'vs/editor/common/services/resolverService';
+import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
+
 import Webview from './webview';
 
 /**
@@ -40,7 +42,7 @@ export class HtmlPreviewPart extends BaseEditor {
 	private _baseUrl: URI;
 
 	private _modelRef: IReference<ITextEditorModel>;
-	private get _model(): IModel { return this._modelRef.object.textEditorModel; }
+	public get model(): IModel { return this._modelRef.object.textEditorModel; }
 	private _modelChangeSubscription = EmptyDisposable;
 	private _themeChangeSubscription = EmptyDisposable;
 
@@ -117,14 +119,14 @@ export class HtmlPreviewPart extends BaseEditor {
 			this.webview.style(this._themeService.getColorTheme());
 
 			if (this._hasValidModel()) {
-				this._modelChangeSubscription = this._model.onDidChangeContent(() => this.webview.contents = this._model.getLinesContent());
-				this.webview.contents = this._model.getLinesContent();
+				this._modelChangeSubscription = this.model.onDidChangeContent(() => this.webview.contents = this.model.getLinesContent());
+				this.webview.contents = this.model.getLinesContent();
 			}
 		}
 	}
 
 	private _hasValidModel(): boolean {
-		return this._modelRef && this._model && !this._model.isDisposed();
+		return this._modelRef && this.model && !this.model.isDisposed();
 	}
 
 	public layout(dimension: Dimension): void {
@@ -142,6 +144,10 @@ export class HtmlPreviewPart extends BaseEditor {
 		dispose(this._modelRef);
 		this._modelRef = undefined;
 		super.clearInput();
+	}
+
+	public sendMessage(data: any): void {
+		this.webview.sendMessage(data);
 	}
 
 	public setInput(input: EditorInput, options?: EditorOptions): TPromise<void> {
@@ -168,13 +174,13 @@ export class HtmlPreviewPart extends BaseEditor {
 					this._modelRef = ref;
 				}
 
-				if (!this._model) {
+				if (!this.model) {
 					return TPromise.wrapError<void>(localize('html.voidInput', "Invalid editor input."));
 				}
 
-				this._modelChangeSubscription = this._model.onDidChangeContent(() => this.webview.contents = this._model.getLinesContent());
+				this._modelChangeSubscription = this.model.onDidChangeContent(() => this.webview.contents = this.model.getLinesContent());
 				this.webview.baseUrl = resourceUri.toString(true);
-				this.webview.contents = this._model.getLinesContent();
+				this.webview.contents = this.model.getLinesContent();
 			});
 		});
 	}

--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -131,7 +131,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
 	// Forward message to the embedded iframe
 	ipcRenderer.on('message', function (event, data) {
 		const target = getTarget();
-		console.log(data);
 		target.contentWindow.postMessage(data, 'file://');
 	});
 

--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -128,6 +128,13 @@ document.addEventListener("DOMContentLoaded", function (event) {
 		ipcRenderer.sendToHost('did-set-content', stats);
 	});
 
+	// Forward message to the embedded iframe
+	ipcRenderer.on('message', function (event, data) {
+		const target = getTarget();
+		console.log(data);
+		target.contentWindow.postMessage(data, 'file://');
+	});
+
 	// forward messages from the embedded iframe
 	window.onmessage = function (message) {
 		ipcRenderer.sendToHost(message.data.command, message.data.data);

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -157,6 +157,10 @@ export default class Webview {
 		this._send('focus');
 	}
 
+	public sendMessage(data: any): void {
+		this._send('message', data);
+	}
+
 	style(themeId: string): void {
 		const {color, backgroundColor, fontFamily, fontWeight, fontSize} = window.getComputedStyle(this._styleElement);
 


### PR DESCRIPTION
**Bug**
There is currently no easy way to communicate from the editor to an html preview document after the preview has been created.

**Fix**
Adds a command called `vscode.htmlPreview.postMessage` to post a message to a visible html preview. This message will only be posted if the target preview is visible (meaning this is mainly for side by side editor use cases).

Inside the preview, the event is recieved using the standard dom event:

```js
window.addEventListener('message', event => {
	console.log(event.data);
	...
}, false);
```