### PR TITLE
Fix 17584

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -198,7 +198,6 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 					const preText = document.getText(new Range(
 						new Position(position.line, 0),
 						new Position(position.line, position.character - 1)));
-					console.log(preText, preText.match(/[a-z_$]\s*$/ig));
 					enableDotCompletions = preText.match(/[a-z_$]\s*$/ig) !== null;
 				}
 


### PR DESCRIPTION
Fixes #17584

Uses commit characters to ensure we only enable dot completions when the previous character is a valid identifier.

This is a workaround for https://github.com/Microsoft/TypeScript/issues/13456