### PR TITLE
Fix webview internal  links 

### DIFF
--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 			'	while (node) {',
 			'		if (node.tagName === "A" && node.href) {',
 			'			let baseElement = window.document.getElementsByTagName("base")[0];',
-			'			if (baseElement && node.href.indexOf(baseElement.href) >= 0 && node.hash) {',
+			'			if (node.hash && (node.getAttribute("href") === node.hash || (baseElement && node.href.indexOf(baseElement.href) >= 0))) {',
 			'				let scrollTarget = window.document.getElementById(node.hash.substr(1, node.hash.length - 1));',
 			'				if (scrollTarget) {',
 			'					scrollTarget.scrollIntoView();',


### PR DESCRIPTION
Fixes #18486

**bug**
Click on an internal link in an extension readme. This opens `webview.html` in the editor

**Fix**
In Webview-pre, If the link being clicked has an href value (not the resolved href) equal to it's hash value, treat it as an internal link and scroll to it

The root cause of this issue is that extension readmes do not set a `baseUrl` on the webview. This change ensures that even if `baseUrl` is not set, we do the correct thing for internal links