### PR TITLE
Simplify markdown paragraph logic

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -563,7 +563,7 @@
 						</dict>
 					</array>
 					<key>while</key>
-					<string>(^|\G)[ ]{4,}(?=\S)</string>
+					<string>(^|\G)((?=\s*[-=]{3,}\s*$)|[ ]{4,}(?=\S))</string>
 				</dict>
 				<key>fenced_code_block_css</key>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -48,10 +48,6 @@
 				</dict>
 				<dict>
 					<key>include</key>
-
-
-
-
 					<string>#fenced_code_block_css</string>
 				</dict>
 				<dict>
@@ -567,10 +563,7 @@
 						</dict>
 					</array>
 					<key>while</key>
-					<!-- seperator    [ ]{0,3}([-*_][ ]{0,2}\2){2,}[ \t]*$\n? -->
-					<!-- list         [ ]{0,3}[*+-]([ ]{1,3}|\t) -->
-					<!-- both are folded together in the expression below -->
-					<string>(^|\G)(?!\s*$|#|[ ]{0,3}((([*_][ ]{0,2}\2){2,}[ \t]*$\n?)|([*+-]([ ]{1,3}|\t)))|\s*\[.+?\]:|&gt;)</string>
+					<string>(^|\G)[ ]{4,}(?=\S)</string>
 				</dict>
 				<key>fenced_code_block_css</key>
 				<dict>
@@ -968,7 +961,6 @@
 							<string>punctuation.definition.markdown</string>
 						</dict>
 					</dict>
-
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Fixes #12946

**Bug**
Out current markdown paragraph matching logic tries to be too fancy. It's acting more like a parser instead of a tokenizer. This prevents us from correctly coloring cases where a block element immediately follows a paragraph

**Fix**
According to the [common mark spec](http://spec.commonmark.org/0.27/#paragraphs), I think we should instead try to parse each new line as a block element.

> A sequence of non-blank lines that cannot be interpreted as other kinds of blocks

The main exception is when the next line contains more than four spaces, which causes it to automatically be included in the previous paragraph instead of being a potential block element:

```md
bla
       * not a **list**
````