### PR TITLE
Allow spaces before markdown heading

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -256,7 +256,7 @@
 				<key>heading</key>
 				<dict>
 					<key>begin</key>
-					<string>(?:^|\G)(#{1,6})\s*(?=[\S[^#]])</string>
+					<string>(?:^|\G)[ ]{0,3}(#{1,6})\s*(?=[\S[^#]])</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Fixes #11480