### PR TITLE
Use createQueuedSender for all IPC

### DIFF
--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -55,6 +55,12 @@ export interface IIPCOptions {
 	 * Allows to assign a debug port for debugging the application and breaking it on the first line.
 	 */
 	debugBrk?: number;
+
+	/**
+	 * Enables our createQueuedSender helper for this Client. Uses a queue when the internal Node.js queue is
+	 * full of messages - see notes on that method.
+	 */
+	useQueue?: boolean;
 }
 
 export class Client implements IChannelClient, IDisposable {
@@ -153,8 +159,8 @@ export class Client implements IChannelClient, IDisposable {
 				}
 			});
 
-			const queuedSender = createQueuedSender(this.child);
-			const send = r => this.child && this.child.connected && queuedSender.send(r);
+			const sender = this.options.useQueue ? createQueuedSender(this.child) : this.child;
+			const send = r => this.child && this.child.connected && sender.send(r);
 			const onMessage = onMessageEmitter.event;
 			const protocol = { send, onMessage };
 

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -10,6 +10,7 @@ import { Delayer } from 'vs/base/common/async';
 import { clone, assign } from 'vs/base/common/objects';
 import { Emitter } from 'vs/base/common/event';
 import { fromEventEmitter } from 'vs/base/node/event';
+import { createQueuedSender } from 'vs/base/node/processes';
 import { ChannelServer as IPCServer, ChannelClient as IPCClient, IChannelClient, IChannel } from 'vs/base/parts/ipc/common/ipc';
 
 export class Server extends IPCServer {
@@ -152,7 +153,8 @@ export class Client implements IChannelClient, IDisposable {
 				}
 			});
 
-			const send = r => this.child && this.child.connected && this.child.send(r);
+			const queuedSender = createQueuedSender(this.child);
+			const send = r => this.child && this.child.connected && queuedSender.send(r);
 			const onMessage = onMessageEmitter.event;
 			const protocol = { send, onMessage };
 

--- a/src/vs/workbench/services/search/node/textSearchWorkerProvider.ts
+++ b/src/vs/workbench/services/search/node/textSearchWorkerProvider.ts
@@ -40,7 +40,8 @@ export class TextSearchWorkerProvider implements ITextSearchWorkerProvider {
 					AMD_ENTRYPOINT: 'vs/workbench/services/search/node/worker/searchWorkerApp',
 					PIPE_LOGGING: 'true',
 					VERBOSE_LOGGING: process.env.VERBOSE_LOGGING
-				}
+				},
+				useQueue: true
 			});
 
 		const channel = ipc.getNextTickChannel(client.getChannel<ISearchWorkerChannel>('searchWorker'));


### PR DESCRIPTION
Is this ok, or is there a reason why we don't use this for all IPC channels? I'm seeing this problem with search on Windows. https://github.com/nodejs/node/issues/7657

I can add an option somewhere to limit it to the search worker processes if needed.