### PR TITLE
Allow Expanding Suggestions with Mulitline details

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -45,6 +45,14 @@ function matchesColor(text: string) {
 	return text && text.match(colorRegExp) ? text : null;
 }
 
+function canExpandCompletionItem(item: ICompletionItem) {
+	const suggestion = item.suggestion;
+	if (suggestion.documentation) {
+		return true;
+	}
+	return (suggestion.detail || '').indexOf('\n') >= 0;
+}
+
 class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 
 	private triggerKeybindingLabel: string;
@@ -111,7 +119,7 @@ class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 		const data = <ISuggestionTemplateData>templateData;
 		const suggestion = (<ICompletionItem>element).suggestion;
 
-		if (suggestion.documentation) {
+		if (canExpandCompletionItem(element)) {
 			data.root.setAttribute('aria-label', nls.localize('suggestionWithDetailsAriaLabel', "{0}, suggestion, has details", suggestion.label));
 		} else {
 			data.root.setAttribute('aria-label', nls.localize('suggestionAriaLabel', "{0}, suggestion", suggestion.label));
@@ -133,7 +141,7 @@ class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 
 		data.documentation.textContent = suggestion.documentation || '';
 
-		if (suggestion.documentation) {
+		if (canExpandCompletionItem(element)) {
 			show(data.documentationDetails);
 			data.documentationDetails.onmousedown = e => {
 				e.stopPropagation();
@@ -408,7 +416,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 	}
 
 	private _getSuggestionAriaAlertLabel(item: ICompletionItem): string {
-		if (item.suggestion.documentation) {
+		if (canExpandCompletionItem(item)) {
 			return nls.localize('ariaCurrentSuggestionWithDetails', "{0}, suggestion, has details", item.suggestion.label);
 		} else {
 			return nls.localize('ariaCurrentSuggestion', "{0}, suggestion", item.suggestion.label);
@@ -674,7 +682,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 
 		const item = this.list.getFocusedElements()[0];
 
-		if (!item || !item.suggestion.documentation) {
+		if (!item || !canExpandCompletionItem(item)) {
 			return;
 		}
 
@@ -778,7 +786,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 	getHeight(element: ICompletionItem): number {
 		const focus = this.list.getFocusedElements()[0];
 
-		if (element.suggestion.documentation && element === focus) {
+		if (canExpandCompletionItem(element) && element === focus) {
 			return this.focusHeight;
 		}
 


### PR DESCRIPTION
Fixes #18490

**Bug**
For completion items with no `documentation` but a long `detail` string, we currently do not allow expansion.

**Fix**
Allow expanding the item if it either has a documentation string or has new line characters in its detail string.