### PR TITLE
Fixing sorting of directory and filenames with numbers

### DIFF
--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -7,8 +7,10 @@
 import scorer = require('vs/base/common/scorer');
 import strings = require('vs/base/common/strings');
 
+const FileNameComparer = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
 export function compareFileNames(one: string, other: string): number {
-	return (one || '').localeCompare((other || ''), undefined, { numeric: true, sensitivity: 'base' });
+	return FileNameComparer.compare(one || '', other || '');
 }
 
 export function compareAnything(one: string, other: string, lookFor: string): number {

--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -7,27 +7,8 @@
 import scorer = require('vs/base/common/scorer');
 import strings = require('vs/base/common/strings');
 
-const FileNameMatch = /^([^.]*)(\.(.*))?$/;
-
 export function compareFileNames(one: string, other: string): number {
-	let oneMatch = FileNameMatch.exec(one.toLowerCase());
-	let otherMatch = FileNameMatch.exec(other.toLowerCase());
-
-	let oneName = oneMatch[1] || '';
-	let oneExtension = oneMatch[3] || '';
-
-	let otherName = otherMatch[1] || '';
-	let otherExtension = otherMatch[3] || '';
-
-	if (oneName !== otherName) {
-		return oneName < otherName ? -1 : 1;
-	}
-
-	if (oneExtension === otherExtension) {
-		return 0;
-	}
-
-	return oneExtension < otherExtension ? -1 : 1;
+	return (one || '').localeCompare((other || ''), undefined, { numeric: true, sensitivity: 'base' });
 }
 
 export function compareAnything(one: string, other: string, lookFor: string): number {

--- a/src/vs/base/test/common/comparers.test.ts
+++ b/src/vs/base/test/common/comparers.test.ts
@@ -12,10 +12,16 @@ suite('Comparers', () => {
 
 	test('compareFileNames', () => {
 
+		assert(compareFileNames(null, null) === 0, 'null should be equal');
+		assert(compareFileNames(null, 'abc') < 0, 'null should be come before real values');
 		assert(compareFileNames('', '') === 0, 'empty should be equal');
 		assert(compareFileNames('abc', 'abc') === 0, 'equal names should be equal');
 		assert(compareFileNames('.abc', '.abc') === 0, 'equal full names should be equal');
-		assert(compareFileNames('.env', '.env.example') < 0);
-		assert(compareFileNames('.env.example', '.gitattributes') < 0);
+		assert(compareFileNames('.env', '.env.example') < 0, 'filenames with extensions should come after those without');
+		assert(compareFileNames('.env.example', '.gitattributes') < 0, 'filenames starting with dots and with extensions should still sort properly');
+		assert(compareFileNames('1', '1') === 0, 'numerically equal full names should be equal');
+		assert(compareFileNames('abc1.txt', 'abc1.txt') === 0, 'equal filenames with numbers should be equal');
+		assert(compareFileNames('abc1.txt', 'abc2.txt') < 0, 'filenames with numbers should be in numerical order, not alphabetical order');
+		assert(compareFileNames('abc2.txt', 'abc10.txt') < 0, 'filenames with numbers should be in numerical order even when they are multiple digits long');
 	});
 });

--- a/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
@@ -652,10 +652,6 @@ export class FileSorter implements ISorter {
 			return 1;
 		}
 
-		if (statA.isDirectory && statB.isDirectory) {
-			return statA.name.toLowerCase().localeCompare(statB.name.toLowerCase());
-		}
-
 		if (statA instanceof NewStatPlaceholder) {
 			return -1;
 		}


### PR DESCRIPTION
These changes replace the existing regex-based sorting of filenames and directory names with a call to the [`String.prototype.localeCompare()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) function which supports this natively via the `numeric` option.

Also added some unit test cases for filenames with numbers.

CC: @bpasero

Fixes #17495 