### PR TITLE
Introduce new vscode.newUntitled API command (fixes #17917)

### DIFF
--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -234,6 +234,17 @@ export class ExtHostApiCommands {
 					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' }
 				]
 			});
+
+		this._register('vscode.newUntitled', (contents: string, path: string, language: string) => {
+			return this._commands.executeCommand('_workbench.newUntitled', [contents, path, language]);
+		}, {
+				description: 'Creates a new untitled file and opens it in the editor. The optional arguments allow to define the contents, path and language of the untitled document.',
+				args: [
+					{ name: 'contents', description: '(optional) Contents of the untitled document', constraint: v => v === void 0 || typeof v === 'string' },
+					{ name: 'path', description: '(optional) File path of the untitled document', constraint: v => v === void 0 || typeof v === 'string' },
+					{ name: 'language', description: '(optional) Identifier of the language to use for the untitled document', constraint: v => v === void 0 || typeof v === 'string' }
+				]
+			});
 	}
 
 	// --- command impl

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -15,11 +15,13 @@ import nls = require('vs/nls');
 import product from 'vs/platform/node/product';
 import pkg from 'vs/platform/node/package';
 import errors = require('vs/base/common/errors');
+import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorModel';
 import { IMessageService, Severity } from 'vs/platform/message/common/message';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IConfigurationEditingService, ConfigurationTarget } from 'vs/workbench/services/configuration/common/configurationEditing';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { IExtensionManagementService, LocalExtensionType, ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IWorkspaceConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
@@ -762,4 +764,19 @@ CommandsRegistry.registerCommand('_workbench.open', function (accessor: Services
 	return editorService.openEditor({ resource }, column).then(() => {
 		return void 0;
 	});
+});
+
+CommandsRegistry.registerCommand('_workbench.newUntitled', function (accessor: ServicesAccessor, args: [string, string, string]) {
+	const untitledEditorService = accessor.get(IUntitledEditorService);
+	const editorService = accessor.get(IWorkbenchEditorService);
+	const [value, path, modeId] = args;
+
+	const input = untitledEditorService.createOrGet(path ? URI.file(path) : void 0, modeId);
+
+	let valuePromise = TPromise.as(void 0);
+	if (value) {
+		valuePromise = input.resolve().then(model => (model as UntitledEditorModel).textEditorModel.setValue(value));
+	}
+
+	return valuePromise.then(() => editorService.openEditor(input, { pinned: true })).then(() => void 0); // untitled are always pinned
 });


### PR DESCRIPTION
Motivation is to allow extensions to open untitled documents with a specific language. Today they can only do this by associating a file path to the untitled document with the extension of choice but that has the down side of making the untitled file save to that path which may not be desired.

Since there are likely more use cases for handling untitled files, I decided to add 2 more arguments to control the untitled file: the initial contents and the associated file path of the untitled file.

Fixes #17917