### PR TITLE
Open new file buffer via API

### DIFF
--- a/extensions/vscode-api-tests/src/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/workspace.test.ts
@@ -85,6 +85,21 @@ suite('workspace-namespace', () => {
 		});
 	});
 
+	test('openTextDocument, untitled without path', function () {
+		return workspace.openTextDocument().then(doc => {
+			assert.equal(doc.uri.scheme, 'untitled');
+			assert.ok(doc.isDirty);
+		});
+	});
+
+	test('openTextDocument, untitled without path but language ID', function () {
+		return workspace.openTextDocument({ language: 'xml' }).then(doc => {
+			assert.equal(doc.uri.scheme, 'untitled');
+			assert.equal(doc.languageId, 'xml');
+			assert.ok(doc.isDirty);
+		});
+	});
+
 	test('openTextDocument, untitled closes on save', function (done) {
 		const path = join(workspace.rootPath, './newfile.txt');
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3950,6 +3950,14 @@ declare module 'vscode' {
 		export function openTextDocument(fileName: string): Thenable<TextDocument>;
 
 		/**
+		 * Opens a untitled file document with an optional language.
+		 *
+		 * @param options an optional language identifier to use for the untitled file document.
+		 * @return A promise that resolves to a [document](#TextDocument).
+		 */
+		export function openTextDocument(options?: { language: string; }): Thenable<TextDocument>;
+
+		/**
 		 * Register a text document content provider.
 		 *
 		 * Only one provider can be registered per scheme.

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -119,6 +119,7 @@ export abstract class MainThreadDiagnosticsShape {
 }
 
 export abstract class MainThreadDocumentsShape {
+	$tryCreateDocument(options?: { language: string; }): TPromise<any> { throw ni(); }
 	$tryOpenDocument(uri: URI): TPromise<any> { throw ni(); }
 	$registerTextContentProvider(handle: number, scheme: string): void { throw ni(); }
 	$onVirtualDocumentChange(uri: URI, value: string): void { throw ni(); }

--- a/src/vs/workbench/api/node/extHostDocuments.ts
+++ b/src/vs/workbench/api/node/extHostDocuments.ts
@@ -107,6 +107,10 @@ export class ExtHostDocuments extends ExtHostDocumentsShape {
 		return promise;
 	}
 
+	public createDocumentData(options?: { language: string; }): TPromise<URI> {
+		return this._proxy.$tryCreateDocument(options);
+	}
+
 	public registerTextDocumentContentProvider(scheme: string, provider: vscode.TextDocumentContentProvider): vscode.Disposable {
 		if (scheme === 'file' || scheme === 'untitled') {
 			throw new Error(`scheme '${scheme}' already registered`);

--- a/src/vs/workbench/api/node/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/node/mainThreadDocuments.ts
@@ -178,6 +178,10 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 		});
 	}
 
+	$tryCreateDocument(options?: { language: string }): TPromise<URI> {
+		return this._doCreateUntitled(void 0, options ? options.language : void 0);
+	}
+
 	private _handleAsResourceInput(uri: URI): TPromise<boolean> {
 		return this._textModelResolverService.createModelReference(uri).then(ref => {
 			const result = !!ref.object;
@@ -194,19 +198,18 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 		return this._fileService.resolveFile(asFileUri).then(stats => {
 			// don't create a new file ontop of an existing file
 			return TPromise.wrapError<boolean>('file already exists on disk');
-		}, err => {
-			let input = this._untitledEditorService.createOrGet(asFileUri);
-			return input.resolve(true).then(model => {
-				if (input.getResource().toString() !== uri.toString()) {
-					throw new Error(`expected URI ${uri.toString()} BUT GOT ${input.getResource().toString()}`);
-				}
-				if (!this._modelIsSynced[uri.toString()]) {
-					throw new Error(`expected URI ${uri.toString()} to have come to LIFE`);
-				}
-				return this._proxy.$acceptModelDirty(uri.toString()); // mark as dirty
-			}).then(() => {
-				return true;
-			});
+		}, err => this._doCreateUntitled(asFileUri).then(resource => !!resource));
+	}
+
+	private _doCreateUntitled(uri?: URI, modeId?: string): TPromise<URI> {
+		let input = this._untitledEditorService.createOrGet(uri, modeId);
+		return input.resolve(true).then(model => {
+			if (!this._modelIsSynced[input.getResource().toString()]) {
+				throw new Error(`expected URI ${input.getResource().toString()} to have come to LIFE`);
+			}
+			return this._proxy.$acceptModelDirty(input.getResource().toString()); // mark as dirty
+		}).then(() => {
+			return input.getResource();
 		});
 	}
 


### PR DESCRIPTION
Second approach for some new API to fix https://github.com/Microsoft/vscode/issues/12283

This time I settled on:

`openTextDocument(options?: { language: string; }):`

This is a bit of an ugly overload to be fair, so I am open to a different API shape. The reason it works nicely is because the first overload is a `URI` and the second is a `string`. The alternative would be to introduce a method like `openUntitledTextDocument`, which also a bit ugly, but more explicit at least.