### PR TITLE
Fix #17645.

### DIFF
--- a/src/vs/editor/common/controller/cursorTypeOperations.ts
+++ b/src/vs/editor/common/controller/cursorTypeOperations.ts
@@ -391,9 +391,10 @@ export class TypeOperations {
 		}
 
 		if (electricAction.matchOpenBracket) {
+			let endColumn = (lineTokens.getLineContent() + ch).lastIndexOf(electricAction.matchOpenBracket) + 1;
 			let match = model.findMatchingBracketUp(electricAction.matchOpenBracket, {
 				lineNumber: position.lineNumber,
-				column: position.column
+				column: endColumn
 			});
 
 			if (match) {

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -2957,6 +2957,23 @@ suite('ElectricCharacter', () => {
 		mode.dispose();
 	});
 
+	test('is no-op if pairs are all matched before', () => {
+		let mode = new ElectricCharMode();
+		usingCursor({
+			text: [
+				'foo(() => {',
+				'  ( 1 + 2 ) ',
+				'})'
+			],
+			languageIdentifier: mode.getLanguageIdentifier()
+		}, (model, cursor) => {
+			moveTo(cursor, 2, 13);
+			cursorCommand(cursor, H.Type, { text: '*' }, 'keyboard');
+			assert.deepEqual(model.getLineContent(2), '  ( 1 + 2 ) *');
+		});
+		mode.dispose();
+	});
+
 	test('appends text', () => {
 		let mode = new ElectricCharMode();
 		usingCursor({


### PR DESCRIPTION
Make endOffset correct when searching for matching pair. Details about the bug are put in https://github.com/Microsoft/vscode/issues/17645#issuecomment-273583417