### PR TITLE
Fixed named headers for markdown preview

### DIFF
--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -181,16 +181,25 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 			}
 		}).use(mdnh, {});
 
-		function addLineNumberRenderer(tokens: any, idx: number, options: any, env: any, self: any) {
-			const token = tokens[idx];
-			if (token.level === 0 && token.map && token.map.length) {
-				token.attrSet('data-line', token.map[0]);
-			}
-			return self.renderToken(tokens, idx, options, env, self);
+		function createLineNumberRenderer(ruleName: string) {
+			const original = md.renderer.rules[ruleName];
+			return (tokens: any, idx: number, options: any, env: any, self: any) => {
+				const token = tokens[idx];
+				if (token.level === 0 && token.map && token.map.length) {
+					token.attrSet('data-line', token.map[0]);
+					token.attrJoin('class', 'code-line');
+				}
+				if (original) {
+					return original(tokens, idx, options, env, self);
+				} else {
+					return self.renderToken(tokens, idx, options, env, self);
+				}
+			};
 		}
 
-		md.renderer.rules.paragraph_open = addLineNumberRenderer;
-		md.renderer.rules.heading_open = addLineNumberRenderer;
+		md.renderer.rules.paragraph_open = createLineNumberRenderer('paragraph_open');
+		md.renderer.rules.heading_open = createLineNumberRenderer('heading_open');
+		md.renderer.rules.image = createLineNumberRenderer('image');
 
 		return md;
 	}


### PR DESCRIPTION
**Bug**
Named headers are not being generated in the markdown preview. Root cause seems to be my changed that added line number data to some elements.

**Fix**
In the custom line number render, make sure we play nice with other markdown-it extensions.

FYI @gregvanl 