### PR TITLE
Maintain Markdown Preview Scroll Position on Window Resize

### DIFF
--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -5,86 +5,16 @@
 
 'use strict';
 
-var height;
-
-function updateScrollPosition(line) {
-	const lines = document.getElementsByClassName('code-line');
-	let previous = null;
-	let next = null;
-	for (const element of lines) {
-		const lineNumber = +element.getAttribute('data-line');
-		if (lineNumber === line) {
-			previous = { line: lineNumber, element: element  };
-			break;
-		} else if (lineNumber < line) {
-			previous = { line: lineNumber, element: element };
-		} else {
-			next = { line: lineNumber, element: element };
-			break;
-		}
-	}
-
-	if (previous) {
-		if (next) {
-			const betweenOffset = (line - previous.line) / (next.line - previous.line);
-			const d = betweenOffset * ((window.scrollY + next.element.getBoundingClientRect().top) - (window.scrollY + previous.element.getBoundingClientRect().top));
-			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top + d);
-
-		} else {
-			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top);
-		}
-	}
-}
-
-function didUpdateScrollPosition(offset) {
-	const lines = document.getElementsByClassName('code-line');
-	let nearest = lines[0];
-	for (let i = lines.length - 1; i >= 0; --i) {
-		const lineElement = lines[i];
-		if (offset <= window.scrollY + lineElement.getBoundingClientRect().top + lineElement.getBoundingClientRect().height) {
-			nearest = lineElement;
-		} else {
-			break;
-		}
-	}
-
-	if (nearest) {
-		const line = +nearest.getAttribute('data-line');
-		const args = [window.initialData.source, line];
-		window.parent.postMessage({
-			command: "did-click-link",
-			data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
-		}, "file://");
-	}
-}
-
-window.addEventListener('message', event => {
-	const line = +event.data.line;
-	if (!isNaN(line)) {
-		updateScrollPosition(line);
-	}
-}, false);
+let pageHeight = 0;
 
 window.onload = () => {
-	const initialLine = +window.initialData.line || 0;
-	updateScrollPosition(initialLine);
-	height = window.document.body.getBoundingClientRect().height;
+	pageHeight = document.body.getBoundingClientRect().height;
 };
 
-document.onclick = (e) => {
-	const offset = e.pageY;
-	didUpdateScrollPosition(offset);
-};
-
-
-window.onscroll = () => {
-	didUpdateScrollPosition(window.scrollY);
-};
-
-/*
-window.addEventListener('resize', (e) => {
+window.addEventListener('resize', () => {
 	const currentOffset = window.scrollY;
-	const dHeight = window.document.body.getBoundingClientRect().height / height;
+	const newPageHeight = document.body.getBoundingClientRect().height;
+	const dHeight = newPageHeight / pageHeight;
 	window.scrollTo(0, currentOffset * dHeight);
-	height = window.document.body.getBoundingClientRect().height ;
-}, true);*/
+	pageHeight = newPageHeight;
+}, true);

--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+var height;
+
+function updateScrollPosition(line) {
+	const lines = document.getElementsByClassName('code-line');
+	let previous = null;
+	let next = null;
+	for (const element of lines) {
+		const lineNumber = +element.getAttribute('data-line');
+		if (lineNumber === line) {
+			previous = { line: lineNumber, element: element  };
+			break;
+		} else if (lineNumber < line) {
+			previous = { line: lineNumber, element: element };
+		} else {
+			next = { line: lineNumber, element: element };
+			break;
+		}
+	}
+
+	if (previous) {
+		if (next) {
+			const betweenOffset = (line - previous.line) / (next.line - previous.line);
+			const d = betweenOffset * ((window.scrollY + next.element.getBoundingClientRect().top) - (window.scrollY + previous.element.getBoundingClientRect().top));
+			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top + d);
+
+		} else {
+			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top);
+		}
+	}
+}
+
+function didUpdateScrollPosition(offset) {
+	const lines = document.getElementsByClassName('code-line');
+	let nearest = lines[0];
+	for (let i = lines.length - 1; i >= 0; --i) {
+		const lineElement = lines[i];
+		if (offset <= window.scrollY + lineElement.getBoundingClientRect().top + lineElement.getBoundingClientRect().height) {
+			nearest = lineElement;
+		} else {
+			break;
+		}
+	}
+
+	if (nearest) {
+		const line = +nearest.getAttribute('data-line');
+		const args = [window.initialData.source, line];
+		window.parent.postMessage({
+			command: "did-click-link",
+			data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
+		}, "file://");
+	}
+}
+
+window.addEventListener('message', event => {
+	const line = +event.data.line;
+	if (!isNaN(line)) {
+		updateScrollPosition(line);
+	}
+}, false);
+
+window.onload = () => {
+	const initialLine = +window.initialData.line || 0;
+	updateScrollPosition(initialLine);
+	height = window.document.body.getBoundingClientRect().height;
+};
+
+document.onclick = (e) => {
+	const offset = e.pageY;
+	didUpdateScrollPosition(offset);
+};
+
+
+window.onscroll = () => {
+	didUpdateScrollPosition(window.scrollY);
+};
+
+/*
+window.addEventListener('resize', (e) => {
+	const currentOffset = window.scrollY;
+	const dHeight = window.document.body.getBoundingClientRect().height / height;
+	window.scrollTo(0, currentOffset * dHeight);
+	height = window.document.body.getBoundingClientRect().height ;
+}, true);*/


### PR DESCRIPTION
**Bug**
Currently, when resizing an editor with a markdown preview, the preview shifts all around.

![jan-18-2017 14-46-26](https://cloud.githubusercontent.com/assets/12821956/22086291/f399bbbe-dd8c-11e6-84e7-55c5b2b2366a.gif)

**Fix**
Add some custom js to handle this better. The js maintains the relative offset when resizing the window.

![jan-18-2017 14-49-52](https://cloud.githubusercontent.com/assets/12821956/22086396/655963bc-dd8d-11e6-80fb-73016d59ea18.gif)

This simple solution isn't perfect because page reflows can cause the elements to shift around relative on the page. I find it better than the current behavior though, and will investigate further improvements with the scrolling sync work.
