### PR TITLE
Prototyping Markdown Preview Synchronization With Editors

### DIFF
--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -7,7 +7,67 @@
 
 let pageHeight = 0;
 
+function updateScrollPosition(line) {
+	const lines = document.getElementsByClassName('code-line');
+	let previous = null;
+	let next = null;
+	for (const element of lines) {
+		const lineNumber = +element.getAttribute('data-line');
+		if (lineNumber === line) {
+			previous = { line: lineNumber, element: element  };
+			break;
+		} else if (lineNumber < line) {
+			previous = { line: lineNumber, element: element };
+		} else {
+			next = { line: lineNumber, element: element };
+			break;
+		}
+	}
+
+	if (previous) {
+		if (next) {
+			const betweenOffset = (line - previous.line) / (next.line - previous.line);
+			const d = betweenOffset * (next.element.getBoundingClientRect().top - previous.element.getBoundingClientRect().top);
+			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top + d);
+		} else {
+			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top);
+		}
+	}
+}
+
+function didUpdateScrollPosition(offset) {
+	const lines = document.getElementsByClassName('code-line');
+	let nearest = lines[0];
+	for (let i = lines.length - 1; i >= 0; --i) {
+		const lineElement = lines[i];
+		if (offset <= window.scrollY + lineElement.getBoundingClientRect().top + lineElement.getBoundingClientRect().height) {
+			nearest = lineElement;
+		} else {
+			break;
+		}
+	}
+
+	if (nearest) {
+		const line = +nearest.getAttribute('data-line');
+		const args = [window.initialData.source, line];
+		window.parent.postMessage({
+			command: "did-click-link",
+			data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
+		}, "file://");
+	}
+}
+
+window.addEventListener('message', event => {
+	const line = +event.data.line;
+	if (!isNaN(line)) {
+		updateScrollPosition(line);
+	}
+}, false);
+
+
 window.onload = () => {
+	const initialLine = +window.initialData.line || 0;
+	updateScrollPosition(initialLine);
 	pageHeight = document.body.getBoundingClientRect().height;
 };
 
@@ -18,3 +78,13 @@ window.addEventListener('resize', () => {
 	window.scrollTo(0, currentOffset * dHeight);
 	pageHeight = newPageHeight;
 }, true);
+
+document.onclick = (e) => {
+	const offset = e.pageY;
+	didUpdateScrollPosition(offset);
+};
+
+/*
+window.onscroll = () => {
+	didUpdateScrollPosition(window.scrollY);
+};*/

--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -5,87 +5,114 @@
 
 'use strict';
 
-var pageHeight = 0;
+(function () {
+	var pageHeight = 0;
 
-function updateScrollPosition(line) {
-	const lines = document.getElementsByClassName('code-line');
-	let previous = null;
-	let next = null;
-	for (const element of lines) {
-		const lineNumber = +element.getAttribute('data-line');
-		if (lineNumber === line) {
-			previous = { line: lineNumber, element: element  };
-			break;
-		} else if (lineNumber < line) {
-			previous = { line: lineNumber, element: element };
-		} else {
-			next = { line: lineNumber, element: element };
-			break;
+	/**
+	 * Find the elements around line.
+	 *
+	 * If an exact match, returns a single element. If the line is between elements,
+	 * returns the element before and the element after the given line.
+	 */
+	function getElementsAroundSourceLine(targetLine) {
+		const lines = document.getElementsByClassName('code-line');
+		let before = null;
+		for (const element of lines) {
+			const lineNumber = +element.getAttribute('data-line');
+			if (isNaN(lineNumber)) {
+				continue;
+			}
+			const entry = { line: lineNumber, element: element };
+			if (lineNumber === targetLine) {
+				return { before: entry, after: null };
+			} else if (lineNumber > targetLine) {
+				return { before, after: entry };
+			}
+			before = entry;
+		}
+		return { before };
+	}
+
+	function getSourceRevealAddedOffset() {
+		return -(window.innerHeight * 1 / 5);
+	}
+
+	/**
+	 * Attempt to reveal the element for a source line in the editor.
+	 */
+	function scrollToRevealSourceLine(line) {
+		const {before, after} = getElementsAroundSourceLine(line);
+		if (before) {
+			let scrollTo = 0;
+			if (after) {
+				// Between two elements. Go to percentage offset between them.
+				const betweenProgress = (line - before.line) / (after.line - before.line);
+				const elementOffset = after.element.getBoundingClientRect().top - before.element.getBoundingClientRect().top;
+				scrollTo = before.element.getBoundingClientRect().top + betweenProgress * elementOffset;
+			} else {
+				scrollTo = before.element.getBoundingClientRect().top;
+			}
+			window.scroll(0, window.scrollY + scrollTo + getSourceRevealAddedOffset());
 		}
 	}
 
-	if (previous) {
-		if (next) {
-			const betweenOffset = (line - previous.line) / (next.line - previous.line);
-			const d = betweenOffset * (next.element.getBoundingClientRect().top - previous.element.getBoundingClientRect().top);
-			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top + d);
-		} else {
-			window.scroll(0, window.scrollY + previous.element.getBoundingClientRect().top);
+	function didUpdateScrollPosition(offset) {
+		const lines = document.getElementsByClassName('code-line');
+		let nearest = lines[0];
+		for (let i = lines.length - 1; i >= 0; --i) {
+			const lineElement = lines[i];
+			if (offset <= window.scrollY + lineElement.getBoundingClientRect().top + lineElement.getBoundingClientRect().height) {
+				nearest = lineElement;
+			} else {
+				break;
+			}
+		}
+
+		if (nearest) {
+			const line = +nearest.getAttribute('data-line');
+			const args = [window.initialData.source, line];
+			window.parent.postMessage({
+				command: "did-click-link",
+				data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
+			}, "file://");
 		}
 	}
-}
 
-function didUpdateScrollPosition(offset) {
-	const lines = document.getElementsByClassName('code-line');
-	let nearest = lines[0];
-	for (let i = lines.length - 1; i >= 0; --i) {
-		const lineElement = lines[i];
-		if (offset <= window.scrollY + lineElement.getBoundingClientRect().top + lineElement.getBoundingClientRect().height) {
-			nearest = lineElement;
-		} else {
-			break;
+	window.onload = () => {
+		pageHeight = document.body.getBoundingClientRect().height;
+
+		if (window.initialData.enablePreviewSync) {
+			const initialLine = +window.initialData.line || 0;
+			scrollToRevealSourceLine(initialLine);
 		}
+	};
+
+	window.addEventListener('resize', () => {
+		const currentOffset = window.scrollY;
+		const newPageHeight = document.body.getBoundingClientRect().height;
+		const dHeight = newPageHeight / pageHeight;
+		window.scrollTo(0, currentOffset * dHeight);
+		pageHeight = newPageHeight;
+	}, true);
+
+	if (window.initialData.enablePreviewSync) {
+
+		window.addEventListener('message', event => {
+			const line = +event.data.line;
+			if (!isNaN(line)) {
+				scrollToRevealSourceLine(line);
+			}
+		}, false);
+
+		document.ondblclick = (e) => {
+			const offset = e.pageY;
+			didUpdateScrollPosition(offset);
+		};
+
+		/*
+		window.onscroll = () => {
+			didUpdateScrollPosition(window.scrollY);
+		};
+		*/
 	}
-
-	if (nearest) {
-		const line = +nearest.getAttribute('data-line');
-		const args = [window.initialData.source, line];
-		window.parent.postMessage({
-			command: "did-click-link",
-			data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
-		}, "file://");
-	}
-}
-
-window.addEventListener('message', event => {
-	const line = +event.data.line;
-	if (!isNaN(line)) {
-		updateScrollPosition(line);
-	}
-}, false);
-
-
-window.onload = () => {
-	const initialLine = +window.initialData.line || 0;
-	updateScrollPosition(initialLine);
-	pageHeight = document.body.getBoundingClientRect().height;
-};
-
-window.addEventListener('resize', () => {
-	const currentOffset = window.scrollY;
-	const newPageHeight = document.body.getBoundingClientRect().height;
-	const dHeight = newPageHeight / pageHeight;
-	window.scrollTo(0, currentOffset * dHeight);
-	pageHeight = newPageHeight;
-}, true);
-
-document.onclick = (e) => {
-	const offset = e.pageY;
-	didUpdateScrollPosition(offset);
-};
-
-/*
-window.onscroll = () => {
-	didUpdateScrollPosition(window.scrollY);
-};
-*/
+}());

--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-let pageHeight = 0;
+var pageHeight = 0;
 
 function updateScrollPosition(line) {
 	const lines = document.getElementsByClassName('code-line');
@@ -87,4 +87,5 @@ document.onclick = (e) => {
 /*
 window.onscroll = () => {
 	didUpdateScrollPosition(window.scrollY);
-};*/
+};
+*/

--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -6,8 +6,6 @@
 'use strict';
 
 (function () {
-	var pageHeight = 0;
-
 	/**
 	 * Find the elements around line.
 	 *
@@ -42,6 +40,7 @@
 	 */
 	function scrollToRevealSourceLine(line) {
 		const {before, after} = getElementsAroundSourceLine(line);
+		marker.update(before && before.element);
 		if (before) {
 			let scrollTo = 0;
 			if (after) {
@@ -77,6 +76,32 @@
 			}, "file://");
 		}
 	}
+
+
+	class ActiveLineMarker {
+		update(before) {
+			this._unmarkActiveElement(this._current);
+			this._markActiveElement(before);
+			this._current = before;
+		}
+
+		_unmarkActiveElement(element) {
+			if (!element) {
+				return;
+			}
+			element.className = element.className.replace(/\bcode-active-line\b/g);
+		}
+
+		_markActiveElement(element) {
+			if (!element) {
+				return;
+			}
+			element.className += ' code-active-line';
+		}
+	}
+
+	var pageHeight = 0;
+	var marker = new ActiveLineMarker();
 
 	window.onload = () => {
 		pageHeight = document.body.getBoundingClientRect().height;

--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -15,6 +15,20 @@ body.scrollBeyondLastLine {
 	margin-bottom: calc(100vh - 22px);
 }
 
+.code-active-line {
+	position: relative;
+}
+
+.code-active-line:before {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 0;
+	left: -12px;
+	height: 100%;
+	border-left: 3px solid #4080D0;
+}
+
 img {
 	max-width: 100%;
 	max-height: 100%;

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -145,6 +145,11 @@
 					"type": "number",
 					"default": 1.6,
 					"description": "%markdown.preview.lineHeight.desc%"
+				},
+				"markdown.experimental.preview.syncronization": {
+					"type": "boolean",
+					"default": false,
+					"description": "EXPERIMENTAL - Syncronization between markdown preview and editor"
 				}
 			}
 		}

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -146,10 +146,10 @@
 					"default": 1.6,
 					"description": "%markdown.preview.lineHeight.desc%"
 				},
-				"markdown.preview.experimentalSyncronization": {
+				"markdown.preview.experimentalSyncronizationEnabled": {
 					"type": "boolean",
 					"default": true,
-					"description": "EXPERIMENTAL - Syncronization between markdown preview and editor"
+					"description": "%markdown.preview.experimentalSyncronizationEnabled.desc%"
 				}
 			}
 		}

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -146,9 +146,9 @@
 					"default": 1.6,
 					"description": "%markdown.preview.lineHeight.desc%"
 				},
-				"markdown.experimental.preview.syncronization": {
+				"markdown.preview.experimentalSyncronization": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"description": "EXPERIMENTAL - Syncronization between markdown preview and editor"
 				}
 			}

--- a/extensions/markdown/package.nls.json
+++ b/extensions/markdown/package.nls.json
@@ -6,5 +6,6 @@
 	"markdown.previewFrontMatter.dec": "Sets how YAML front matter should be rendered in the markdown preview. 'hide' removes the front matter. Otherwise, the front matter is treated as markdown content.",
 	"markdown.preview.fontFamily.desc": "Controls the font family used in the markdown preview.",
 	"markdown.preview.fontSize.desc": "Controls the font size in pixels used in the markdown preview.",
-	"markdown.preview.lineHeight.desc": "Controls the line height used in the markdown preview. This number is relative to the font size."
+	"markdown.preview.lineHeight.desc": "Controls the line height used in the markdown preview. This number is relative to the font size.",
+	"markdown.preview.experimentalSyncronizationEnabled.desc": "Enable experimental syncronization between the markdown preview and the editor"
 }

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -30,14 +30,9 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('markdown.showSource', showSource));
 
 	context.subscriptions.push(vscode.commands.registerCommand('_markdown.didClick', (uri, line) => {
-		const documentUri = decodeURIComponent(uri);
-		const target = vscode.workspace.textDocuments.filter(x => x.uri.toString() === documentUri);
-		if (!target.length) {
-			return;
-		}
-		vscode.window.showTextDocument(target[0]).then(() => {
-			return vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'top' });
-		});
+		return vscode.workspace.openTextDocument(vscode.Uri.parse(decodeURIComponent(uri)))
+			.then(document => vscode.window.showTextDocument(document))
+			.then(editor => vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'top' }));
 	}));
 
 	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {
@@ -65,7 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(event => {
 		if (isMarkdownFile(event.textEditor.document)) {
-			vscode.commands.executeCommand('vscode.htmlPreview.postMessage',
+			vscode.commands.executeCommand('_workbench.htmlPreview.postMessage',
 				getMarkdownUri(event.textEditor.document.uri),
 				{
 					line: event.selections[0].start.line
@@ -283,7 +278,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		return vscode.workspace.openTextDocument(sourceUri).then(document => {
 			const scrollBeyondLastLine = vscode.workspace.getConfiguration('editor')['scrollBeyondLastLine'];
 			const wordWrap = vscode.workspace.getConfiguration('editor')['wordWrap'];
-			const enablePreviewSync = vscode.workspace.getConfiguration('markdown').get('experimental.preview.syncronization', false);
+			const enablePreviewSync = vscode.workspace.getConfiguration('markdown').get('preview.experimentalSyncronization', true);
 
 			let initialLine = 0;
 			const editor = vscode.window.activeTextEditor;

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -269,14 +269,13 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 			return '';
 		}
 		const {fontFamily, fontSize, lineHeight} = previewSettings;
-		return [
-			'<style>',
-			'body {',
-			fontFamily ? `font-family: ${fontFamily};` : '',
-			+fontSize > 0 ? `font-size: ${fontSize}px;` : '',
-			+lineHeight > 0 ? `line-height: ${lineHeight};` : '',
-			'}',
-			'</style>'].join('\n');
+		return `<style>
+			body {
+				${fontFamily ? `font-family: ${fontFamily};` : ''}
+				${+fontSize > 0 ? `font-size: ${fontSize}px;` : ''}
+				${+lineHeight > 0 ? `line-height: ${lineHeight};` : ''}
+			}
+		</style>`;
 	}
 
 	public provideTextDocumentContent(uri: vscode.Uri): Thenable<string> {
@@ -284,6 +283,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		return vscode.workspace.openTextDocument(sourceUri).then(document => {
 			const scrollBeyondLastLine = vscode.workspace.getConfiguration('editor')['scrollBeyondLastLine'];
 			const wordWrap = vscode.workspace.getConfiguration('editor')['wordWrap'];
+			const enablePreviewSync = vscode.workspace.getConfiguration('markdown')['experimental.preview.syncronization'];
 
 			let initialLine = 0;
 			const editor = vscode.window.activeTextEditor;
@@ -306,7 +306,8 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 					<script>
 						window.initialData = {
 							source: "${encodeURIComponent(sourceUri.scheme + '://' + sourceUri.path)}",
-							line: ${initialLine}
+							line: ${initialLine},
+							enablePreviewSync: ${!!enablePreviewSync}
 						};
 					</script>
 					<script src="${this.getMediaPath('main.js')}"></script>

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -278,7 +278,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		return vscode.workspace.openTextDocument(sourceUri).then(document => {
 			const scrollBeyondLastLine = vscode.workspace.getConfiguration('editor')['scrollBeyondLastLine'];
 			const wordWrap = vscode.workspace.getConfiguration('editor')['wordWrap'];
-			const enablePreviewSync = vscode.workspace.getConfiguration('markdown').get('preview.experimentalSyncronization', true);
+			const enablePreviewSync = vscode.workspace.getConfiguration('markdown').get('preview.experimentalSyncronizationEnabled', true);
 
 			let initialLine = 0;
 			const editor = vscode.window.activeTextEditor;

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -283,7 +283,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 		return vscode.workspace.openTextDocument(sourceUri).then(document => {
 			const scrollBeyondLastLine = vscode.workspace.getConfiguration('editor')['scrollBeyondLastLine'];
 			const wordWrap = vscode.workspace.getConfiguration('editor')['wordWrap'];
-			const enablePreviewSync = vscode.workspace.getConfiguration('markdown')['experimental.preview.syncronization'];
+			const enablePreviewSync = vscode.workspace.getConfiguration('markdown').get('experimental.preview.syncronization', false);
 
 			let initialLine = 0;
 			const editor = vscode.window.activeTextEditor;

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('_markdown.didClick', (uri, line) => {
 		return vscode.workspace.openTextDocument(vscode.Uri.parse(decodeURIComponent(uri)))
 			.then(document => vscode.window.showTextDocument(document))
-			.then(editor => vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'top' }));
+			.then(editor => vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'center' }));
 	}));
 
 	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -191,6 +191,26 @@ export class ExtHostApiCommands {
 				]
 			});
 
+		this._register('vscode.htmlPreview.postMessage', (uri: URI, message: any) => {
+			return this._commands.executeCommand('_workbench.htmlPreview.postMessage', uri, message);
+		}, {
+				description: `
+				Posts a message to a visible html preview.
+
+				The message is posted to the html preview as a \`message\` event:
+				~~~js
+				window.addEventListener('message', event => {
+					console.log(event.data);
+					...
+				}, false);
+				~~~
+			`,
+				args: [
+					{ name: 'uri', description: 'Uri of the resource to preview.', constraint: value => value instanceof URI || typeof value === 'string' },
+					{ name: 'message', description: 'Message contents' }
+				]
+			});
+
 		this._register('vscode.openFolder', (uri?: URI, forceNewWindow?: boolean) => {
 			if (!uri) {
 				return this._commands.executeCommand('_files.openFolderPicker', forceNewWindow);

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -191,26 +191,6 @@ export class ExtHostApiCommands {
 				]
 			});
 
-		this._register('vscode.htmlPreview.postMessage', (uri: URI, message: any) => {
-			return this._commands.executeCommand('_workbench.htmlPreview.postMessage', uri, message);
-		}, {
-				description: `
-				Posts a message to a visible html preview.
-
-				The message is posted to the html preview as a \`message\` event:
-				~~~js
-				window.addEventListener('message', event => {
-					console.log(event.data);
-					...
-				}, false);
-				~~~
-			`,
-				args: [
-					{ name: 'uri', description: 'Uri of the resource to preview.', constraint: value => value instanceof URI || typeof value === 'string' },
-					{ name: 'message', description: 'Message contents' }
-				]
-			});
-
 		this._register('vscode.openFolder', (uri?: URI, forceNewWindow?: boolean) => {
 			if (!uri) {
 				return this._commands.executeCommand('_files.openFolderPicker', forceNewWindow);

--- a/src/vs/workbench/parts/html/browser/html.contribution.ts
+++ b/src/vs/workbench/parts/html/browser/html.contribution.ts
@@ -103,13 +103,12 @@ CommandsRegistry.registerCommand('_workbench.previewHtml', function (accessor: S
 
 CommandsRegistry.registerCommand('_workbench.htmlPreview.postMessage', (accessor: ServicesAccessor, resource: URI | string, message: any) => {
 	const uri = resource instanceof URI ? resource : URI.parse(resource);
-	const activePreview = accessor.get(IWorkbenchEditorService).getVisibleEditors()
+	const activePreviews = accessor.get(IWorkbenchEditorService).getVisibleEditors()
 		.filter(c => c instanceof HtmlPreviewPart)
 		.map(e => e as HtmlPreviewPart)
-		.filter(e => e.model.uri.scheme == uri.scheme && e.model.uri.path === uri.path);
-	if (activePreview.length) {
-		activePreview[0].sendMessage(message);
-		return true;
+		.filter(e => e.model.uri.scheme === uri.scheme && e.model.uri.path === uri.path);
+	for (const preview of activePreviews) {
+		preview.sendMessage(message);
 	}
-	return false;
+	return activePreviews.length > 0;
 });

--- a/src/vs/workbench/parts/html/browser/html.contribution.ts
+++ b/src/vs/workbench/parts/html/browser/html.contribution.ts
@@ -100,3 +100,16 @@ CommandsRegistry.registerCommand('_workbench.previewHtml', function (accessor: S
 		.openEditor(input, { pinned: true }, position)
 		.then(editor => true);
 });
+
+CommandsRegistry.registerCommand('_workbench.htmlPreview.postMessage', (accessor: ServicesAccessor, resource: URI | string, message: any) => {
+	const uri = resource instanceof URI ? resource : URI.parse(resource);
+	const activePreview = accessor.get(IWorkbenchEditorService).getVisibleEditors()
+		.filter(c => c instanceof HtmlPreviewPart)
+		.map(e => e as HtmlPreviewPart)
+		.filter(e => e.model.uri.scheme == uri.scheme && e.model.uri.path === uri.path);
+	if (activePreview.length) {
+		activePreview[0].sendMessage(message);
+		return true;
+	}
+	return false;
+});

--- a/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
@@ -21,6 +21,8 @@ import { HtmlInput } from 'vs/workbench/parts/html/common/htmlInput';
 import { IThemeService } from 'vs/workbench/services/themes/common/themeService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ITextModelResolverService, ITextEditorModel } from 'vs/editor/common/services/resolverService';
+import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
+
 import Webview from './webview';
 
 /**
@@ -40,7 +42,7 @@ export class HtmlPreviewPart extends BaseEditor {
 	private _baseUrl: URI;
 
 	private _modelRef: IReference<ITextEditorModel>;
-	private get _model(): IModel { return this._modelRef.object.textEditorModel; }
+	public get model(): IModel { return this._modelRef.object.textEditorModel; }
 	private _modelChangeSubscription = EmptyDisposable;
 	private _themeChangeSubscription = EmptyDisposable;
 
@@ -117,14 +119,14 @@ export class HtmlPreviewPart extends BaseEditor {
 			this.webview.style(this._themeService.getColorTheme());
 
 			if (this._hasValidModel()) {
-				this._modelChangeSubscription = this._model.onDidChangeContent(() => this.webview.contents = this._model.getLinesContent());
-				this.webview.contents = this._model.getLinesContent();
+				this._modelChangeSubscription = this.model.onDidChangeContent(() => this.webview.contents = this.model.getLinesContent());
+				this.webview.contents = this.model.getLinesContent();
 			}
 		}
 	}
 
 	private _hasValidModel(): boolean {
-		return this._modelRef && this._model && !this._model.isDisposed();
+		return this._modelRef && this.model && !this.model.isDisposed();
 	}
 
 	public layout(dimension: Dimension): void {
@@ -142,6 +144,10 @@ export class HtmlPreviewPart extends BaseEditor {
 		dispose(this._modelRef);
 		this._modelRef = undefined;
 		super.clearInput();
+	}
+
+	public sendMessage(data: any): void {
+		this.webview.sendMessage(data);
 	}
 
 	public setInput(input: EditorInput, options?: EditorOptions): TPromise<void> {
@@ -168,13 +174,13 @@ export class HtmlPreviewPart extends BaseEditor {
 					this._modelRef = ref;
 				}
 
-				if (!this._model) {
+				if (!this.model) {
 					return TPromise.wrapError<void>(localize('html.voidInput', "Invalid editor input."));
 				}
 
-				this._modelChangeSubscription = this._model.onDidChangeContent(() => this.webview.contents = this._model.getLinesContent());
+				this._modelChangeSubscription = this.model.onDidChangeContent(() => this.webview.contents = this.model.getLinesContent());
 				this.webview.baseUrl = resourceUri.toString(true);
-				this.webview.contents = this._model.getLinesContent();
+				this.webview.contents = this.model.getLinesContent();
 			});
 		});
 	}

--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -131,7 +131,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
 	// Forward message to the embedded iframe
 	ipcRenderer.on('message', function (event, data) {
 		const target = getTarget();
-		console.log(data);
 		target.contentWindow.postMessage(data, 'file://');
 	});
 

--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -128,6 +128,13 @@ document.addEventListener("DOMContentLoaded", function (event) {
 		ipcRenderer.sendToHost('did-set-content', stats);
 	});
 
+	// Forward message to the embedded iframe
+	ipcRenderer.on('message', function (event, data) {
+		const target = getTarget();
+		console.log(data);
+		target.contentWindow.postMessage(data, 'file://');
+	});
+
 	// forward messages from the embedded iframe
 	window.onmessage = function (message) {
 		ipcRenderer.sendToHost(message.data.command, message.data.data);

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -158,6 +158,10 @@ export default class Webview {
 		this._send('focus');
 	}
 
+	public sendMessage(data: any): void {
+		this._send('message', data);
+	}
+
 	style(theme: IColorTheme): void {
 		let themeId = theme.id;
 		const {color, backgroundColor, fontFamily, fontWeight, fontSize} = window.getComputedStyle(this._styleElement);


### PR DESCRIPTION
Builds on #18422 to implement basic synchronization between markdown editor and its preview. Adds the following:

* When opening the md preview for the first time, automatically scrolls to view the current selected line from the markdown editor.
* When changing the selection in the markdown editor, updates the markdown preview scroll to reveal this element.
* When double clicking an element on the markdown preview page, opens an editor and reveals this line.
* Indicator in preview to show currently selected line

Functionality can be disabled using `markdown.preview.experimentalSyncronizationEnabled`