### PR TITLE
Improve markdown preview to editor mapping

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -15,11 +15,21 @@ body.scrollBeyondLastLine {
 	margin-bottom: calc(100vh - 22px);
 }
 
-.code-active-line {
+.code-line {
 	position: relative;
 }
 
 .code-active-line:before {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 0;
+	left: -12px;
+	height: 100%;
+	border-left: 3px solid rgba(0, 122, 204, 0.5);
+}
+
+.code-line:hover:before {
 	content: "";
 	display: block;
 	position: absolute;

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -32,7 +32,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('_markdown.didClick', (uri, line) => {
 		return vscode.workspace.openTextDocument(vscode.Uri.parse(decodeURIComponent(uri)))
 			.then(document => vscode.window.showTextDocument(document))
-			.then(editor => vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'center' }));
+			.then(editor => vscode.commands.executeCommand('revealLine', { lineNumber: line, at: 'top' }));
 	}));
 
 	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {


### PR DESCRIPTION
Two changes:

* Adds a hover indicator for elements with directly corresponding lines in the markdown preview.
* Improves the mapping from pixel positions in the markdown preview to line numbers. We now use the same logic as the editor to preview mapping to round to lines that don't exactly match an element