### PR TITLE
Add Markdown Document Link Provider To Support Local Links

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -15,7 +15,8 @@
 	"activationEvents": [
 		"onCommand:markdown.showPreview",
 		"onCommand:markdown.showPreviewToSide",
-		"onCommand:markdown.showSource"
+		"onCommand:markdown.showSource",
+		"onLanguage:markdown"
 	],
 	"contributes": {
 		"languages": [

--- a/extensions/markdown/src/documentLinkProvider.ts
+++ b/extensions/markdown/src/documentLinkProvider.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export default class MarkdownDocumentLinkProvider implements vscode.DocumentLinkProvider {
+
+	private _cachedResult: { version: number; links: vscode.DocumentLink[] };
+	private _linkPattern = /(\[[^\]]*\]\(\s*?)(\S+?)(\s+[^\)]*)?\)/g;
+
+	public provideDocumentLinks(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.DocumentLink[] {
+		const {version} = document;
+		if (!this._cachedResult || this._cachedResult.version !== version) {
+			const links = this._computeDocumentLinks(document);
+			this._cachedResult = { version, links };
+		}
+		return this._cachedResult.links;
+	}
+
+	private _computeDocumentLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
+		const results: vscode.DocumentLink[] = [];
+		const base = path.dirname(document.uri.fsPath);
+		const text = document.getText();
+
+		this._linkPattern.lastIndex = 0;
+		let match: RegExpMatchArray | null;
+		while ((match = this._linkPattern.exec(text))) {
+			const pre = match[1];
+			const link = match[2];
+			const offset = match.index + pre.length;
+			const linkStart = document.positionAt(offset);
+			const linkEnd = document.positionAt(offset + link.length);
+			try {
+				let uri = vscode.Uri.parse(link);
+				if (!uri.scheme) {
+					// assume it must be a file
+					const file = path.join(base, link);
+					uri = vscode.Uri.file(file);
+				}
+				results.push(new vscode.DocumentLink(
+					new vscode.Range(linkStart, linkEnd),
+					uri));
+			} catch (e) {
+				// noop
+			}
+		}
+
+		return results;
+	}
+};

--- a/extensions/markdown/src/documentLinkProvider.ts
+++ b/extensions/markdown/src/documentLinkProvider.ts
@@ -31,9 +31,9 @@ export default class MarkdownDocumentLinkProvider implements vscode.DocumentLink
 					// assume it must be a file
 					let file;
 					if (uri.path[0] === '/') {
-						file = path.join(vscode.workspace.rootPath, link);
+						file = path.join(vscode.workspace.rootPath, uri.path);
 					} else {
-						file = path.join(base, link);
+						file = path.join(base, uri.path);
 					}
 					uri = vscode.Uri.file(file);
 				}

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -8,6 +8,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import DocumentLinkProvider from './documentLinkProvider';
 
 interface IPackageInfo {
 	name: string;
@@ -24,6 +25,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	let provider = new MDDocumentContentProvider(context);
 	context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('markdown', provider));
+
+	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider('markdown', new DocumentLinkProvider()));
 
 	context.subscriptions.push(vscode.commands.registerCommand('markdown.showPreview', showPreview));
 	context.subscriptions.push(vscode.commands.registerCommand('markdown.showPreviewToSide', uri => showPreview(uri, true)));


### PR DESCRIPTION
Fixes #3771

Adds a markdown document link detector to detect any type of markdown link. Currently, local links like `[abc](./xyz)` are not supported. 

This change allows navigating between markdown editor documents using these local links
