### PR TITLE
Fix markdown view sync for frontmatter

### DIFF
--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -249,16 +249,28 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 			const wordWrap = vscode.workspace.getConfiguration('editor')['wordWrap'];
 			const enablePreviewSync = vscode.workspace.getConfiguration('markdown').get('preview.experimentalSyncronizationEnabled', true);
 
+			const previewFrontMatter = vscode.workspace.getConfiguration('markdown')['previewFrontMatter'];
+			const text = document.getText();
+			let contents;
+			let lineOffset = 0;
+			if (previewFrontMatter === 'hide') {
+				const frontMatter = text.match(FrontMatterRegex);
+				if (frontMatter) {
+					lineOffset = (frontMatter[0].match(/\n/g) || []).length;
+				}
+				contents = text.replace(FrontMatterRegex, '');
+			} else {
+				contents = text;
+			}
+
 			let initialLine = 0;
 			const editor = vscode.window.activeTextEditor;
 			if (editor && editor.document.uri.path === sourceUri.path) {
 				initialLine = editor.selection.start.line;
 			}
 
-			const previewFrontMatter = vscode.workspace.getConfiguration('markdown')['previewFrontMatter'];
-			const text = document.getText();
-			const contents = previewFrontMatter === 'hide' ? text.replace(FrontMatterRegex, '') : text;
-			const body = this.engine.render(sourceUri, contents);
+
+			const body = this.engine.render(sourceUri, lineOffset, contents);
 
 			return `<!DOCTYPE html>
 				<html>

--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -24,6 +24,8 @@ interface MarkdownIt {
 export class MarkdownEngine {
 	private md: MarkdownIt;
 
+	private firstLine: number;
+
 	private currentDocument: vscode.Uri;
 
 	private get engine(): MarkdownIt {
@@ -53,8 +55,9 @@ export class MarkdownEngine {
 		return this.md;
 	}
 
-	public render(document: vscode.Uri, text: string): string {
+	public render(document: vscode.Uri, firstLine: number, text: string): string {
 		this.currentDocument = document;
+		this.firstLine = firstLine;
 		return this.engine.render(text);
 	}
 
@@ -67,7 +70,7 @@ export class MarkdownEngine {
 		md.renderer.rules[ruleName] = (tokens: any, idx: number, options: any, env: any, self: any) => {
 			const token = tokens[idx];
 			if (token.level === 0 && token.map && token.map.length) {
-				token.attrSet('data-line', token.map[0]);
+				token.attrSet('data-line', this.firstLine + token.map[0]);
 				token.attrJoin('class', 'code-line');
 			}
 			if (original) {


### PR DESCRIPTION
Fixes #18946

**Bug**
The markdown preview and editor syncronization is currently thrown off by yaml frontmatter. All the line numbers generated are off by the size of the frontmatter

**Fix**
For the generated line numbers, add an initial line offset to account for the size of the remove frontmatter.
