### PR TITLE
Add Markdown Preview to Editor Scroll Syncronization

### DIFF
--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -77,23 +77,17 @@
 		}
 	}
 
-	function didUpdateScrollPosition(offset) {
+	function getEditorLineNumberForPageOffset(offset) {
 		const {previous, next} = getLineElementsAtPageOffset(offset);
 		if (previous) {
-			let line = 0;
 			if (next) {
 				const betweenProgress = (offset - window.scrollY - previous.element.getBoundingClientRect().top) / (next.element.getBoundingClientRect().top - previous.element.getBoundingClientRect().top);
-				line = previous.line + betweenProgress * (next.line - previous.line);
+				return previous.line + betweenProgress * (next.line - previous.line);
 			} else {
-				line = previous.line;
+				return previous.line;
 			}
-
-			const args = [window.initialData.source, line];
-			window.parent.postMessage({
-				command: "did-click-link",
-				data: `command:_markdown.revealLine?${encodeURIComponent(JSON.stringify(args))}`
-			}, "file://");
 		}
+		return null;
 	}
 
 
@@ -153,7 +147,14 @@
 
 		document.ondblclick = (e) => {
 			const offset = e.pageY;
-			didUpdateScrollPosition(offset);
+			const line = getEditorLineNumberForPageOffset(offset);
+			if (!isNaN(line)) {
+				const args = [window.initialData.source, line];
+				window.parent.postMessage({
+					command: "did-click-link",
+					data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
+				}, "file://");
+			}
 		};
 
 		if (window.initialData.enableScrollSync) {
@@ -161,7 +162,14 @@
 				if (scrollDisabled) {
 					scrollDisabled = false;
 				} else {
-					didUpdateScrollPosition(window.scrollY);
+					const line = getEditorLineNumberForPageOffset(window.scrollY);
+					if (!isNaN(line)) {
+						const args = [window.initialData.source, line];
+						window.parent.postMessage({
+							command: "did-click-link",
+							data: `command:_markdown.revealLine?${encodeURIComponent(JSON.stringify(args))}`
+						}, "file://");
+					}
 				}
 			};
 		}

--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -83,7 +83,7 @@
 			let line = 0;
 			if (next) {
 				const betweenProgress = (offset - window.scrollY - previous.element.getBoundingClientRect().top) / (next.element.getBoundingClientRect().top - previous.element.getBoundingClientRect().top);
-				line = previous.line + Math.floor(betweenProgress * (next.line - previous.line));
+				line = previous.line + betweenProgress * (next.line - previous.line);
 			} else {
 				line = previous.line;
 			}
@@ -91,7 +91,7 @@
 			const args = [window.initialData.source, line];
 			window.parent.postMessage({
 				command: "did-click-link",
-				data: `command:_markdown.didClick?${encodeURIComponent(JSON.stringify(args))}`
+				data: `command:_markdown.revealLine?${encodeURIComponent(JSON.stringify(args))}`
 			}, "file://");
 		}
 	}
@@ -119,6 +119,7 @@
 		}
 	}
 
+	var scrollDisabled = false;
 	var pageHeight = 0;
 	var marker = new ActiveLineMarker();
 
@@ -127,6 +128,7 @@
 
 		if (window.initialData.enablePreviewSync) {
 			const initialLine = +window.initialData.line || 0;
+			scrollDisabled = true;
 			scrollToRevealSourceLine(initialLine);
 		}
 	};
@@ -144,6 +146,7 @@
 		window.addEventListener('message', event => {
 			const line = +event.data.line;
 			if (!isNaN(line)) {
+				scrollDisabled = true;
 				scrollToRevealSourceLine(line);
 			}
 		}, false);
@@ -153,10 +156,14 @@
 			didUpdateScrollPosition(offset);
 		};
 
-		/**
-		window.onscroll = () => {
-			didUpdateScrollPosition(window.scrollY);
-		};
-		*/
+		if (window.initialData.enableScrollSync) {
+			window.onscroll = () => {
+				if (scrollDisabled) {
+					scrollDisabled = false;
+				} else {
+					didUpdateScrollPosition(window.scrollY);
+				}
+			};
+		}
 	}
 }());

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -152,6 +152,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "%markdown.preview.experimentalSyncronizationEnabled.desc%"
+				},
+				"markdown.preview.synchronizePreviewScrollingToEditor": {
+					"type": "boolean",
+					"default": true,
+					"description": "%markdown.preview.synchronizePreviewScrollingToEditor.desc%"
 				}
 			}
 		}

--- a/extensions/markdown/package.nls.json
+++ b/extensions/markdown/package.nls.json
@@ -7,5 +7,6 @@
 	"markdown.preview.fontFamily.desc": "Controls the font family used in the markdown preview.",
 	"markdown.preview.fontSize.desc": "Controls the font size in pixels used in the markdown preview.",
 	"markdown.preview.lineHeight.desc": "Controls the line height used in the markdown preview. This number is relative to the font size.",
-	"markdown.preview.experimentalSyncronizationEnabled.desc": "Enable experimental syncronization between the markdown preview and the editor"
+	"markdown.preview.experimentalSyncronizationEnabled.desc": "Enable experimental syncronization between the markdown preview and the editor",
+	"markdown.preview.synchronizePreviewScrollingToEditor.desc": "When the preview is scrolled, update the view of the editor"
 }

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -55,6 +55,13 @@ export function activate(context: vscode.ExtensionContext) {
 			});
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('_markdown.didClick', (uri, line) => {
+		const sourceUri = vscode.Uri.parse(decodeURIComponent(uri));
+		return vscode.workspace.openTextDocument(sourceUri)
+			.then(document => vscode.window.showTextDocument(document))
+			.then(editor => vscode.commands.executeCommand('revealLine', { lineNumber: Math.floor(line), at: 'top' }));
+	}));
+
 	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {
 		if (isMarkdownFile(document)) {
 			const uri = getMarkdownUri(document.uri);
@@ -284,7 +291,7 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 							source: "${encodeURIComponent(sourceUri.scheme + '://' + sourceUri.path)}",
 							line: ${initialLine},
 							enablePreviewSync: ${!!markdownConfig.get('preview.experimentalSyncronizationEnabled', true)},
-							enableScrollSync: ${!!markdownConfig.get('synchronizePreviewScrollingToEditor', true)}
+							enableScrollSync: ${!!markdownConfig.get('preview.synchronizePreviewScrollingToEditor', true)}
 						};
 					</script>
 					<script src="${this.getMediaPath('main.js')}"></script>

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -612,6 +612,10 @@ export class DiffEditorWidget extends EventEmitter implements editorBrowser.IDif
 		this.modifiedEditor.revealRangeInCenterIfOutsideViewport(range);
 	}
 
+	public revealRangeAtTop(range: editorCommon.IRange): void {
+		this.modifiedEditor.revealRangeAtTop(range);
+	}
+
 	public _addAction(descriptor: editorCommon.IActionDescriptor): IAddedAction {
 		return this.modifiedEditor._addAction(descriptor);
 	}

--- a/src/vs/editor/common/commonCodeEditor.ts
+++ b/src/vs/editor/common/commonCodeEditor.ts
@@ -460,6 +460,14 @@ export abstract class CommonCodeEditor extends EventEmitter implements editorCom
 		);
 	}
 
+	public revealRangeAtTop(range: editorCommon.IRange): void {
+		this._revealRange(
+			range,
+			editorCommon.VerticalRevealType.Top,
+			true
+		);
+	}
+
 	private _revealRange(range: editorCommon.IRange, verticalType: editorCommon.VerticalRevealType, revealHorizontal: boolean): void {
 		if (!Range.isIRange(range)) {
 			throw new Error('Invalid arguments');

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -3616,6 +3616,11 @@ export interface IEditor {
 	revealRangeInCenter(range: IRange): void;
 
 	/**
+	 * Scroll vertically or horizontally as necessary and reveal a range at the top of the viewport.
+	 */
+	revealRangeAtTop(range: IRange): void;
+
+	/**
 	 * Scroll vertically or horizontally as necessary and reveal a range centered vertically only if it lies outside the viewport.
 	 */
 	revealRangeInCenterIfOutsideViewport(range: IRange): void;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3008,6 +3008,10 @@ declare module monaco.editor {
          */
         revealRangeInCenter(range: IRange): void;
         /**
+         * Scroll vertically or horizontally as necessary and reveal a range at the top of the viewport.
+         */
+        revealRangeAtTop(range: IRange): void;
+        /**
          * Scroll vertically or horizontally as necessary and reveal a range centered vertically only if it lies outside the viewport.
          */
         revealRangeInCenterIfOutsideViewport(range: IRange): void;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -651,7 +651,11 @@ declare module 'vscode' {
 		 * If the range is outside the viewport, it will be revealed in the center of the viewport.
 		 * Otherwise, it will be revealed with as little scrolling as possible.
 		 */
-		InCenterIfOutsideViewport = 2
+		InCenterIfOutsideViewport = 2,
+		/**
+		 * The range will always be revealed at the top of the viewport.
+		 */
+		AtTop = 3
 	}
 
 	/**

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -920,7 +920,8 @@ export enum TextDocumentSaveReason {
 export enum TextEditorRevealType {
 	Default = 0,
 	InCenter = 1,
-	InCenterIfOutsideViewport = 2
+	InCenterIfOutsideViewport = 2,
+	AtTop = 3
 }
 
 export enum TextEditorSelectionChangeKind {

--- a/src/vs/workbench/api/node/mainThreadEditorsTracker.ts
+++ b/src/vs/workbench/api/node/mainThreadEditorsTracker.ts
@@ -56,7 +56,8 @@ export interface IFocusTracker {
 export enum TextEditorRevealType {
 	Default = 0,
 	InCenter = 1,
-	InCenterIfOutsideViewport = 2
+	InCenterIfOutsideViewport = 2,
+	AtTop = 3
 }
 
 export interface IUndoStopOptions {
@@ -288,14 +289,22 @@ export class MainThreadTextEditor {
 			console.warn('revealRange on invisible editor');
 			return;
 		}
-		if (revealType === TextEditorRevealType.Default) {
-			this._codeEditor.revealRange(range);
-		} else if (revealType === TextEditorRevealType.InCenter) {
-			this._codeEditor.revealRangeInCenter(range);
-		} else if (revealType === TextEditorRevealType.InCenterIfOutsideViewport) {
-			this._codeEditor.revealRangeInCenterIfOutsideViewport(range);
-		} else {
-			console.warn('Unknown revealType');
+		switch (revealType) {
+			case TextEditorRevealType.Default:
+				this._codeEditor.revealRange(range);
+				break;
+			case TextEditorRevealType.InCenter:
+				this._codeEditor.revealRangeInCenter(range);
+				break;;
+			case TextEditorRevealType.InCenterIfOutsideViewport:
+				this._codeEditor.revealRangeInCenterIfOutsideViewport(range);
+				break;
+			case TextEditorRevealType.AtTop:
+				this._codeEditor.revealRangeAtTop(range);
+				break;
+			default:
+				console.warn('Unknown revealType');
+				break;
 		}
 	}
 


### PR DESCRIPTION
Part of #5047

Adds an initial implementation of scroll synrconization from the markdown preview to the editor. When the preview is scrolled, automatically scrolls the editor to reveal the same location.

![jan-22-2017 00-48-51](https://cloud.githubusercontent.com/assets/12821956/22181243/91f2077e-e03c-11e6-99f0-90c50278e75a.gif)

This required adding a new supported reveal type `AtTop` in our API. This is already supported and used internally, but not really exposed in the public apis (except for the `revealLine` command). 

The scrolling of the editor is still a little choppy. I tried revealing specific character offsets in the string, to smooth out scrolling over long lines, but it doesn't appear to be working as I expected. I'll look into this more. #18811 details some other ways this could work for truly smooth scrolling.