### PR TITLE
#9003 Provide temporary option to disable the built-in PHP completion provider

### DIFF
--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -39,6 +39,11 @@
 			"type": "object",
 			"order": 20,
 			"properties": {
+				"php.builtInCompletions.enable": {
+					"type": "boolean",
+					"default": true,
+					"description": "%configuration.builtInCompletions.enable%"
+				},
 				"php.validate.enable": {
 					"type": "boolean",
 					"default": true,

--- a/extensions/php/package.nls.json
+++ b/extensions/php/package.nls.json
@@ -1,6 +1,7 @@
 ﻿{
-	"configuration.validate.enable": "Whether php validation is enabled or not.",
-	"configuration.validate.executablePath": "Points to the php executable.",
+	"configuration.builtInCompletions.enable": "Enable/disable built-in PHP completions.",
+	"configuration.validate.enable": "Enable/disable built-in PHP validation.",
+	"configuration.validate.executablePath": "Points to the PHP executable.",
 	"configuration.validate.run": "Whether the linter is run on save or on type.",
 	"configuration.title": "PHP"
 }

--- a/extensions/php/src/features/completionItemProvider.ts
+++ b/extensions/php/src/features/completionItemProvider.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Position, Range, TextEdit } from 'vscode';
+import { CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken, TextDocument, Position, Range, TextEdit, workspace } from 'vscode';
 import phpGlobals = require('./phpGlobals');
 
 export default class PHPCompletionItemProvider implements CompletionItemProvider {
@@ -14,6 +14,12 @@ export default class PHPCompletionItemProvider implements CompletionItemProvider
 
 	public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Promise<CompletionItem[]> {
 		let result: CompletionItem[] = [];
+
+		let shouldProvideCompletionItems = workspace.getConfiguration('php').get<boolean>('builtInCompletions.enable', true);
+		if (!shouldProvideCompletionItems) {
+			return Promise.resolve(result);
+		}
+
 		var range = document.getWordRangeAtPosition(position);
 		var prefix = range ? document.getText(range) : '';
 		if (!range) {

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -211,7 +211,6 @@ const configurationValueWhitelist = [
 	'editor.snippetSuggestions',
 	'editor.selectionHighlight',
 	'editor.glyphMargin',
-	'php.validate.run',
 	'editor.wordSeparators',
 	'editor.mouseWheelScrollSensitivity',
 	'editor.suggestOnTriggerCharacters',
@@ -224,7 +223,9 @@ const configurationValueWhitelist = [
 	'editor.trimAutoWhitespace',
 	'editor.folding',
 	'workbench.editor.enablePreviewFromQuickOpen',
+	'php.builtInCompletions.enable',
 	'php.validate.enable',
+	'php.validate.run',
 	'editor.parameterHints',
 ];
 


### PR DESCRIPTION
This option enables extension authors providing PHP support to prevent needless duplication in the completions list. We can remove it when we extract this functionality to a separate extension.

close #9003