### PR TITLE
Split up and rename Markdown Scroll Sync Settings

### DIFF
--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -120,7 +120,7 @@
 	window.onload = () => {
 		pageHeight = document.body.getBoundingClientRect().height;
 
-		if (window.initialData.enablePreviewSync) {
+		if (window.initialData.scrollPreviewWithEditorSelection) {
 			const initialLine = +window.initialData.line || 0;
 			scrollDisabled = true;
 			scrollToRevealSourceLine(initialLine);
@@ -135,7 +135,7 @@
 		pageHeight = newPageHeight;
 	}, true);
 
-	if (window.initialData.enablePreviewSync) {
+	if (window.initialData.scrollPreviewWithEditorSelection) {
 
 		window.addEventListener('message', event => {
 			const line = +event.data.line;
@@ -157,7 +157,7 @@
 			}
 		};
 
-		if (window.initialData.enableScrollSync) {
+		if (window.initialData.scrollEditorWithPreview) {
 			window.onscroll = () => {
 				if (scrollDisabled) {
 					scrollDisabled = false;

--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -15,12 +15,12 @@ body.scrollBeyondLastLine {
 	margin-bottom: calc(100vh - 22px);
 }
 
-.code-line {
+body.showEditorSelection .code-line {
 	position: relative;
 }
 
-.code-active-line:before,
-.code-line:hover:before {
+body.showEditorSelection .code-active-line:before,
+body.showEditorSelection .code-line:hover:before {
 	content: "";
 	display: block;
 	position: absolute;
@@ -29,11 +29,11 @@ body.scrollBeyondLastLine {
 	height: 100%;
 }
 
-.code-active-line:before {
+body.showEditorSelection .code-active-line:before {
 	border-left: 3px solid rgba(0, 122, 204, 0.5);
 }
 
-.code-line:hover:before {
+body.showEditorSelection .code-line:hover:before {
 	border-left: 3px solid #4080D0;
 }
 

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -148,15 +148,20 @@
 					"default": 1.6,
 					"description": "%markdown.preview.lineHeight.desc%"
 				},
-				"markdown.preview.experimentalSyncronizationEnabled": {
+				"markdown.preview.scrollPreviewWithEditorSelection": {
 					"type": "boolean",
 					"default": true,
-					"description": "%markdown.preview.experimentalSyncronizationEnabled.desc%"
+					"description": "%markdown.preview.scrollPreviewWithEditorSelection.desc%"
 				},
-				"markdown.preview.synchronizePreviewScrollingToEditor": {
+				"markdown.preview.markEditorSelection": {
 					"type": "boolean",
 					"default": true,
-					"description": "%markdown.preview.synchronizePreviewScrollingToEditor.desc%"
+					"description": "%markdown.preview.markEditorSelection.desc%"
+				},
+				"markdown.preview.scrollEditorWithPreview": {
+					"type": "boolean",
+					"default": true,
+					"description": "%markdown.preview.scrollEditorWithPreview.desc%"
 				}
 			}
 		}

--- a/extensions/markdown/package.nls.json
+++ b/extensions/markdown/package.nls.json
@@ -7,6 +7,7 @@
 	"markdown.preview.fontFamily.desc": "Controls the font family used in the markdown preview.",
 	"markdown.preview.fontSize.desc": "Controls the font size in pixels used in the markdown preview.",
 	"markdown.preview.lineHeight.desc": "Controls the line height used in the markdown preview. This number is relative to the font size.",
-	"markdown.preview.experimentalSyncronizationEnabled.desc": "Enable experimental syncronization between the markdown preview and the editor",
-	"markdown.preview.synchronizePreviewScrollingToEditor.desc": "When the preview is scrolled, update the view of the editor"
+	"markdown.preview.scrollPreviewWithEditorSelection.desc": "Scrolls the markdown preview to reveal the currently selected line from the editor.",
+	"markdown.preview.scrollEditorWithPreview.desc": "When the markdown preview is scrolled, update the view of the editor.",
+	"markdown.preview.markEditorSelection.desc": "Mark the current editor selection in the markdown preview."
 }

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -284,14 +284,14 @@ class MDDocumentContentProvider implements vscode.TextDocumentContentProvider {
 					${this.computeCustomStyleSheetIncludes(uri)}
 					<base href="${document.uri.toString(true)}">
 				</head>
-				<body class="${scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${wordWrap ? 'wordWrap' : ''}">
+				<body class="${scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${wordWrap ? 'wordWrap' : ''} ${!!markdownConfig.get('preview.markEditorSelection') ? 'showEditorSelection' : ''}">
 					${body}
 					<script>
 						window.initialData = {
 							source: "${encodeURIComponent(sourceUri.scheme + '://' + sourceUri.path)}",
 							line: ${initialLine},
-							enablePreviewSync: ${!!markdownConfig.get('preview.experimentalSyncronizationEnabled', true)},
-							enableScrollSync: ${!!markdownConfig.get('preview.synchronizePreviewScrollingToEditor', true)}
+							scrollPreviewWithEditorSelection: ${!!markdownConfig.get('preview.scrollPreviewWithEditorSelection', true)},
+							scrollEditorWithPreview: ${!!markdownConfig.get('preview.scrollEditorWithPreview', true)}
 						};
 					</script>
 					<script src="${this.getMediaPath('main.js')}"></script>


### PR DESCRIPTION
Splits the markdown scroll sync settings to be more granular and clarify setting names