### PR TITLE
Rename TypeDefinitionProvider to TypeImplementationProvider

### DIFF
--- a/extensions/typescript/src/features/typeImplementationProvider.ts
+++ b/extensions/typescript/src/features/typeImplementationProvider.ts
@@ -5,18 +5,18 @@
 
 'use strict';
 
-import { TypeDefinitionProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
+import { TypeImplementationProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
 
 import { ITypescriptServiceClient } from '../typescriptService';
 import DefinitionProviderBase from './definitionProviderBase';
 
-export default class TypeScriptTypeDefinitionProvider extends DefinitionProviderBase implements TypeDefinitionProvider {
+export default class TypeScriptTypeImplementationProvider extends DefinitionProviderBase implements TypeImplementationProvider {
 
 	constructor(client: ITypescriptServiceClient) {
 		super(client);
 	}
 
-	public provideTypeDefinition(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | null> {
+	public provideTypeImplementation(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | null> {
 		return this.getSymbolLocations('implementation', document, position, token);
 	}
 }

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -25,7 +25,7 @@ import { ITypescriptServiceClientHost } from './typescriptService';
 
 import HoverProvider from './features/hoverProvider';
 import DefinitionProvider from './features/definitionProvider';
-import TypeDefinitionProvider from './features/TypeDefinitionProvider';
+import TypeImplementationProvider from './features/TypeImplementationProvider';
 import DocumentHighlightProvider from './features/documentHighlightProvider';
 import ReferenceProvider from './features/referenceProvider';
 import DocumentSymbolProvider from './features/documentSymbolProvider';
@@ -149,7 +149,7 @@ class LanguageProvider {
 
 		let hoverProvider = new HoverProvider(client);
 		let definitionProvider = new DefinitionProvider(client);
-		let typeDefinitionProvider = new TypeDefinitionProvider(client);
+		let typeImplementationProvider = new TypeImplementationProvider(client);
 		let documentHighlightProvider = new DocumentHighlightProvider(client);
 		let referenceProvider = new ReferenceProvider(client);
 		let documentSymbolProvider = new DocumentSymbolProvider(client);
@@ -174,7 +174,7 @@ class LanguageProvider {
 			languages.registerDefinitionProvider(selector, definitionProvider);
 			if (client.apiVersion.has220Features()) {
 				// TODO: TS 2.1.5 returns incorrect results for implementation locations.
-				languages.registerTypeDefinitionProvider(selector, typeDefinitionProvider);
+				languages.registerTypeImplementationProvider(selector, typeImplementationProvider);
 			}
 			languages.registerDocumentHighlightProvider(selector, documentHighlightProvider);
 			languages.registerReferenceProvider(selector, referenceProvider);

--- a/src/vs/editor/browser/standalone/standaloneLanguages.ts
+++ b/src/vs/editor/browser/standalone/standaloneLanguages.ts
@@ -275,7 +275,7 @@ export function registerDefinitionProvider(languageId: string, provider: modes.D
 }
 
 /**
- * Register a type definition provider (used by e.g. go to implementation).
+ * Register a type implementation provider (used by e.g. go to implementation).
  */
 export function registerTypeImplementationProvider(languageId: string, provider: modes.TypeImplementationProvider): IDisposable {
 	return modes.TypeImplementationProviderRegistry.register(languageId, provider);

--- a/src/vs/editor/browser/standalone/standaloneLanguages.ts
+++ b/src/vs/editor/browser/standalone/standaloneLanguages.ts
@@ -277,8 +277,8 @@ export function registerDefinitionProvider(languageId: string, provider: modes.D
 /**
  * Register a type definition provider (used by e.g. go to implementation).
  */
-export function registerTypeDefinitionProvider(languageId: string, provider: modes.TypeDefinitionProvider): IDisposable {
-	return modes.TypeDefinitionProviderRegistry.register(languageId, provider);
+export function registerTypeImplementationProvider(languageId: string, provider: modes.TypeImplementationProvider): IDisposable {
+	return modes.TypeImplementationProviderRegistry.register(languageId, provider);
 }
 
 /**
@@ -681,7 +681,7 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		registerDocumentSymbolProvider: registerDocumentSymbolProvider,
 		registerDocumentHighlightProvider: registerDocumentHighlightProvider,
 		registerDefinitionProvider: registerDefinitionProvider,
-		registerTypeDefinitionProvider: registerTypeDefinitionProvider,
+		registerTypeImplementationProvider: registerTypeImplementationProvider,
 		registerCodeLensProvider: registerCodeLensProvider,
 		registerCodeActionProvider: registerCodeActionProvider,
 		registerDocumentFormattingEditProvider: registerDocumentFormattingEditProvider,

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -3096,7 +3096,7 @@ export namespace ModeContextKeys {
 	/**
 	 * @internal
 	 */
-	export const hasTypeDefinitionProvider = new RawContextKey<boolean>('editorHasTypeDefinitionProvider', undefined);
+	export const hasTypeImplementationProvider = new RawContextKey<boolean>('editorHasTypeImplementationProvider', undefined);
 	/**
 	 * @internal
 	 */

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -435,11 +435,11 @@ export interface DefinitionProvider {
  * The type definition provider interface defines the contract between extensions and
  * the go to implementation feature.
  */
-export interface TypeDefinitionProvider {
+export interface TypeImplementationProvider {
 	/**
 	 * Provide the implementation of the symbol at the given position and document.
 	 */
-	provideTypeDefinition(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideTypeImplementation(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
 }
 
 /**
@@ -752,7 +752,7 @@ export const DefinitionProviderRegistry = new LanguageFeatureRegistry<Definition
 /**
  * @internal
  */
-export const TypeDefinitionProviderRegistry = new LanguageFeatureRegistry<TypeDefinitionProvider>();
+export const TypeImplementationProviderRegistry = new LanguageFeatureRegistry<TypeImplementationProvider>();
 
 /**
  * @internal

--- a/src/vs/editor/common/modes/editorModeContext.ts
+++ b/src/vs/editor/common/modes/editorModeContext.ts
@@ -20,7 +20,7 @@ export class EditorModeContext {
 	private _hasCodeActionsProvider: IContextKey<boolean>;
 	private _hasCodeLensProvider: IContextKey<boolean>;
 	private _hasDefinitionProvider: IContextKey<boolean>;
-	private _hasTypeDefinitionProvider: IContextKey<boolean>;
+	private _hasTypeImplementationProvider: IContextKey<boolean>;
 	private _hasHoverProvider: IContextKey<boolean>;
 	private _hasDocumentHighlightProvider: IContextKey<boolean>;
 	private _hasDocumentSymbolProvider: IContextKey<boolean>;
@@ -42,7 +42,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider = ModeContextKeys.hasCodeActionsProvider.bindTo(contextKeyService);
 		this._hasCodeLensProvider = ModeContextKeys.hasCodeLensProvider.bindTo(contextKeyService);
 		this._hasDefinitionProvider = ModeContextKeys.hasDefinitionProvider.bindTo(contextKeyService);
-		this._hasTypeDefinitionProvider = ModeContextKeys.hasTypeDefinitionProvider.bindTo(contextKeyService);
+		this._hasTypeImplementationProvider = ModeContextKeys.hasTypeImplementationProvider.bindTo(contextKeyService);
 		this._hasHoverProvider = ModeContextKeys.hasHoverProvider.bindTo(contextKeyService);
 		this._hasDocumentHighlightProvider = ModeContextKeys.hasDocumentHighlightProvider.bindTo(contextKeyService);
 		this._hasDocumentSymbolProvider = ModeContextKeys.hasDocumentSymbolProvider.bindTo(contextKeyService);
@@ -62,7 +62,7 @@ export class EditorModeContext {
 		modes.CodeActionProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.CodeLensProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DefinitionProviderRegistry.onDidChange(this._update, this, this._disposables);
-		modes.TypeDefinitionProviderRegistry.onDidChange(this._update, this, this._disposables);
+		modes.TypeImplementationProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.HoverProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DocumentHighlightProviderRegistry.onDidChange(this._update, this, this._disposables);
 		modes.DocumentSymbolProviderRegistry.onDidChange(this._update, this, this._disposables);
@@ -85,7 +85,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider.reset();
 		this._hasCodeLensProvider.reset();
 		this._hasDefinitionProvider.reset();
-		this._hasTypeDefinitionProvider.reset();
+		this._hasTypeImplementationProvider.reset();
 		this._hasHoverProvider.reset();
 		this._hasDocumentHighlightProvider.reset();
 		this._hasDocumentSymbolProvider.reset();
@@ -108,7 +108,7 @@ export class EditorModeContext {
 		this._hasCodeActionsProvider.set(modes.CodeActionProviderRegistry.has(model));
 		this._hasCodeLensProvider.set(modes.CodeLensProviderRegistry.has(model));
 		this._hasDefinitionProvider.set(modes.DefinitionProviderRegistry.has(model));
-		this._hasTypeDefinitionProvider.set(modes.TypeDefinitionProviderRegistry.has(model));
+		this._hasTypeImplementationProvider.set(modes.TypeImplementationProviderRegistry.has(model));
 		this._hasHoverProvider.set(modes.HoverProviderRegistry.has(model));
 		this._hasDocumentHighlightProvider.set(modes.DocumentHighlightProviderRegistry.has(model));
 		this._hasDocumentSymbolProvider.set(modes.DocumentSymbolProviderRegistry.has(model));

--- a/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
@@ -26,7 +26,7 @@ import { editorAction, IActionOptions, ServicesAccessor, EditorAction } from 'vs
 import { Location, DefinitionProviderRegistry } from 'vs/editor/common/modes';
 import { ICodeEditor, IEditorMouseEvent, IMouseTarget } from 'vs/editor/browser/editorBrowser';
 import { editorContribution } from 'vs/editor/browser/editorBrowserExtensions';
-import { getDeclarationsAtPosition, getTypeDefinitionAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
+import { getDeclarationsAtPosition, getTypeImplementationAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
 import { ReferencesController } from 'vs/editor/contrib/referenceSearch/browser/referencesController';
 import { ReferencesModel } from 'vs/editor/contrib/referenceSearch/browser/referencesModel';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -241,7 +241,7 @@ export class GoToImplementationAction extends DefinitionAction {
 			label: nls.localize('actions.goToImplementation.label', "Go to Implementation"),
 			alias: 'Go to Implementation',
 			precondition: ContextKeyExpr.and(
-				ModeContextKeys.hasTypeDefinitionProvider,
+				ModeContextKeys.hasTypeImplementationProvider,
 				ModeContextKeys.isInEmbeddedEditor.toNegated()),
 			kbOpts: {
 				kbExpr: EditorContextKeys.TextFocus,
@@ -255,7 +255,7 @@ export class GoToImplementationAction extends DefinitionAction {
 	}
 
 	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getTypeDefinitionAtPosition(model, position);
+		return getTypeImplementationAtPosition(model, position);
 	}
 }
 
@@ -270,7 +270,7 @@ export class PeekImplementationAction extends DefinitionAction {
 			label: nls.localize('actions.peekImplementation.label', "Peek Implementation"),
 			alias: 'Peek Implementation',
 			precondition: ContextKeyExpr.and(
-				ModeContextKeys.hasTypeDefinitionProvider,
+				ModeContextKeys.hasTypeImplementationProvider,
 				ModeContextKeys.isInEmbeddedEditor.toNegated()),
 			kbOpts: {
 				kbExpr: EditorContextKeys.TextFocus,
@@ -284,7 +284,7 @@ export class PeekImplementationAction extends DefinitionAction {
 	}
 
 	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getTypeDefinitionAtPosition(model, position);
+		return getTypeImplementationAtPosition(model, position);
 	}
 }
 

--- a/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/common/goToDeclaration.ts
@@ -9,7 +9,7 @@ import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
-import { DefinitionProviderRegistry, TypeDefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, TypeImplementationProviderRegistry, Location } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
 
@@ -44,14 +44,14 @@ export function getDeclarationsAtPosition(model: IReadOnlyModel, position: Posit
 	return outputResults(promises);
 }
 
-export function getTypeDefinitionAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+export function getTypeImplementationAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
 
-	const provider = TypeDefinitionProviderRegistry.ordered(model);
+	const provider = TypeImplementationProviderRegistry.ordered(model);
 
 	// get results
 	const promises = provider.map((provider, idx) => {
 		return asWinJsPromise((token) => {
-			return provider.provideTypeDefinition(model, position, token);
+			return provider.provideTypeImplementation(model, position, token);
 		}).then(result => {
 			return result;
 		}, err => {
@@ -62,4 +62,4 @@ export function getTypeDefinitionAtPosition(model: IReadOnlyModel, position: Pos
 }
 
 CommonEditorRegistry.registerDefaultLanguageCommand('_executeDefinitionProvider', getDeclarationsAtPosition);
-CommonEditorRegistry.registerDefaultLanguageCommand('_executeTypeDefinitionProvider', getTypeDefinitionAtPosition);
+CommonEditorRegistry.registerDefaultLanguageCommand('_executeTypeImplementationProvider', getTypeImplementationAtPosition);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3939,7 +3939,7 @@ declare module monaco.languages {
     /**
      * Register a type definition provider (used by e.g. go to implementation).
      */
-    export function registerTypeDefinitionProvider(languageId: string, provider: TypeDefinitionProvider): IDisposable;
+    export function registerTypeImplementationProvider(languageId: string, provider: TypeImplementationProvider): IDisposable;
 
     /**
      * Register a code lens provider (used by e.g. inline code lenses).
@@ -4557,11 +4557,11 @@ declare module monaco.languages {
      * The type definition provider interface defines the contract between extensions and
      * the go to implementation feature.
      */
-    export interface TypeDefinitionProvider {
+    export interface TypeImplementationProvider {
         /**
          * Provide the implementation of the symbol at the given position and document.
          */
-        provideTypeDefinition(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+        provideTypeImplementation(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
     }
 
     /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3937,7 +3937,7 @@ declare module monaco.languages {
     export function registerDefinitionProvider(languageId: string, provider: DefinitionProvider): IDisposable;
 
     /**
-     * Register a type definition provider (used by e.g. go to implementation).
+     * Register a type implementation provider (used by e.g. go to implementation).
      */
     export function registerTypeImplementationProvider(languageId: string, provider: TypeImplementationProvider): IDisposable;
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1646,7 +1646,7 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * The type definition provider interface defines the contract between extensions and
+	 * The type implemenetation provider interface defines the contract between extensions and
 	 * the go to implementation feature.
 	 */
 	export interface TypeImplementationProvider {
@@ -4155,7 +4155,7 @@ declare module 'vscode' {
 		export function registerDefinitionProvider(selector: DocumentSelector, provider: DefinitionProvider): Disposable;
 
 		/**
-		 * Register an type definition provider.
+		 * Register an type implementation provider.
 		 *
 		 * Multiple providers can be registered for a language. In that case providers are sorted
 		 * by their [score](#languages.match) and the best-matching provider is used.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1649,7 +1649,7 @@ declare module 'vscode' {
 	 * The type definition provider interface defines the contract between extensions and
 	 * the go to implementation feature.
 	 */
-	export interface TypeDefinitionProvider {
+	export interface TypeImplementationProvider {
 
 		/**
 		 * Provide the implementations of the symbol at the given position and document.
@@ -1660,7 +1660,7 @@ declare module 'vscode' {
 		 * @return A definition or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideTypeDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+		provideTypeImplementation(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
 	}
 
 	/**
@@ -4164,7 +4164,7 @@ declare module 'vscode' {
 		 * @param provider An implementation provider.
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
-		export function registerTypeDefinitionProvider(selector: DocumentSelector, provider: TypeDefinitionProvider): Disposable;
+		export function registerTypeImplementationProvider(selector: DocumentSelector, provider: TypeImplementationProvider): Disposable;
 
 		/**
 		 * Register a hover provider.

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -211,8 +211,8 @@ export function createApiFactory(initData: IInitData, threadService: IThreadServ
 			registerDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.DefinitionProvider): vscode.Disposable {
 				return languageFeatures.registerDefinitionProvider(selector, provider);
 			},
-			registerTypeDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.TypeDefinitionProvider): vscode.Disposable {
-				return languageFeatures.registerTypeDefinitionProvider(selector, provider);
+			registerTypeImplementationProvider(selector: vscode.DocumentSelector, provider: vscode.TypeImplementationProvider): vscode.Disposable {
+				return languageFeatures.registerTypeImplementationProvider(selector, provider);
 			},
 			registerHoverProvider(selector: vscode.DocumentSelector, provider: vscode.HoverProvider): vscode.Disposable {
 				return languageFeatures.registerHoverProvider(selector, provider);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -361,7 +361,7 @@ export abstract class ExtHostLanguageFeaturesShape {
 	$provideCodeLenses(handle: number, resource: URI): TPromise<modes.ICodeLensSymbol[]> { throw ni(); }
 	$resolveCodeLens(handle: number, resource: URI, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol> { throw ni(); }
 	$provideDefinition(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
-	$provideTypeDefinition(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
+	$provideTypeImplementation(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
 	$provideHover(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Hover> { throw ni(); }
 	$provideDocumentHighlights(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.DocumentHighlight[]> { throw ni(); }
 	$provideReferences(handle: number, resource: URI, position: editorCommon.IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]> { throw ni(); }

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -46,7 +46,7 @@ export class ExtHostApiCommands {
 			],
 			returns: 'A promise that resolves to an array of Location-instances.'
 		});
-		this._register('vscode.executeTypeDefinitionProvider', this._executeTypeDefinitionProvider, {
+		this._register('vscode.executeTypeImplementationProvider', this._executeTypeImplementationProvider, {
 			description: 'Execute all implementation providers.',
 			args: [
 				{ name: 'uri', description: 'Uri of a text document', constraint: URI },
@@ -273,12 +273,12 @@ export class ExtHostApiCommands {
 		});
 	}
 
-	private _executeTypeDefinitionProvider(resource: URI, position: types.Position): Thenable<types.Location[]> {
+	private _executeTypeImplementationProvider(resource: URI, position: types.Position): Thenable<types.Location[]> {
 		const args = {
 			resource,
 			position: position && typeConverters.fromPosition(position)
 		};
-		return this._commands.executeCommand<modes.Location[]>('_executeTypeDefinitionProvider', args).then(value => {
+		return this._commands.executeCommand<modes.Location[]>('_executeTypeImplementationProvider', args).then(value => {
 			if (Array.isArray(value)) {
 				return value.map(typeConverters.location.to);
 			}

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -125,17 +125,17 @@ class DefinitionAdapter {
 class ImplementationAdapter {
 
 	private _documents: ExtHostDocuments;
-	private _provider: vscode.TypeDefinitionProvider;
+	private _provider: vscode.TypeImplementationProvider;
 
-	constructor(documents: ExtHostDocuments, provider: vscode.TypeDefinitionProvider) {
+	constructor(documents: ExtHostDocuments, provider: vscode.TypeImplementationProvider) {
 		this._documents = documents;
 		this._provider = provider;
 	}
 
-	provideTypeDefinition(resource: URI, position: IPosition): TPromise<modes.Definition> {
+	provideTypeImplementation(resource: URI, position: IPosition): TPromise<modes.Definition> {
 		let doc = this._documents.getDocumentData(resource).document;
 		let pos = TypeConverters.toPosition(position);
-		return asWinJsPromise(token => this._provider.provideTypeDefinition(doc, pos, token)).then(value => {
+		return asWinJsPromise(token => this._provider.provideTypeImplementation(doc, pos, token)).then(value => {
 			if (Array.isArray(value)) {
 				return value.map(TypeConverters.location.from);
 			} else if (value) {
@@ -736,15 +736,15 @@ export class ExtHostLanguageFeatures extends ExtHostLanguageFeaturesShape {
 		return this._withAdapter(handle, DefinitionAdapter, adapter => adapter.provideDefinition(resource, position));
 	}
 
-	registerTypeDefinitionProvider(selector: vscode.DocumentSelector, provider: vscode.TypeDefinitionProvider): vscode.Disposable {
+	registerTypeImplementationProvider(selector: vscode.DocumentSelector, provider: vscode.TypeImplementationProvider): vscode.Disposable {
 		const handle = this._nextHandle();
 		this._adapter.set(handle, new ImplementationAdapter(this._documents, provider));
 		this._proxy.$registerImplementationSupport(handle, selector);
 		return this._createDisposable(handle);
 	}
 
-	$provideTypeDefinition(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition> {
-		return this._withAdapter(handle, ImplementationAdapter, adapter => adapter.provideTypeDefinition(resource, position));
+	$provideTypeImplementation(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition> {
+		return this._withAdapter(handle, ImplementationAdapter, adapter => adapter.provideTypeImplementation(resource, position));
 	}
 
 	// --- extra info

--- a/src/vs/workbench/api/node/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/mainThreadLanguageFeatures.ts
@@ -103,9 +103,9 @@ export class MainThreadLanguageFeatures extends MainThreadLanguageFeaturesShape 
 	}
 
 	$registerImplementationSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> {
-		this._registrations[handle] = modes.TypeDefinitionProviderRegistry.register(selector, <modes.TypeDefinitionProvider>{
-			provideTypeDefinition: (model, position, token): Thenable<modes.Definition> => {
-				return wireCancellationToken(token, this._proxy.$provideTypeDefinition(handle, model.uri, position));
+		this._registrations[handle] = modes.TypeImplementationProviderRegistry.register(selector, <modes.TypeImplementationProvider>{
+			provideTypeImplementation: (model, position, token): Thenable<modes.Definition> => {
+				return wireCancellationToken(token, this._proxy.$provideTypeImplementation(handle, model.uri, position));
 			}
 		});
 		return undefined;

--- a/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
@@ -27,7 +27,7 @@ import { ExtHostDocuments } from 'vs/workbench/api/node/extHostDocuments';
 import { getDocumentSymbols } from 'vs/editor/contrib/quickOpen/common/quickOpen';
 import { DocumentSymbolProviderRegistry, DocumentHighlightKind } from 'vs/editor/common/modes';
 import { getCodeLensData } from 'vs/editor/contrib/codelens/common/codelens';
-import { getDeclarationsAtPosition, getTypeDefinitionAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
+import { getDeclarationsAtPosition, getTypeImplementationAtPosition } from 'vs/editor/contrib/goToDeclaration/common/goToDeclaration';
 import { getHover } from 'vs/editor/contrib/hover/common/hover';
 import { getOccurrencesAtPosition } from 'vs/editor/contrib/wordHighlighter/common/wordHighlighter';
 import { provideReferences } from 'vs/editor/contrib/referenceSearch/common/referenceSearch';
@@ -354,16 +354,16 @@ suite('ExtHostLanguageFeatures', function () {
 
 	// --- type definition
 
-	test('TypeDefinition, data conversion', function () {
+	test('TypeImplementation, data conversion', function () {
 
-		disposables.push(extHost.registerTypeDefinitionProvider(defaultSelector, <vscode.TypeDefinitionProvider>{
-			provideTypeDefinition(): any {
+		disposables.push(extHost.registerTypeImplementationProvider(defaultSelector, <vscode.TypeImplementationProvider>{
+			provideTypeImplementation(): any {
 				return [new types.Location(model.uri, new types.Range(1, 2, 3, 4))];
 			}
 		}));
 
 		return threadService.sync().then(() => {
-			return getTypeDefinitionAtPosition(model, new EditorPosition(1, 1)).then(value => {
+			return getTypeImplementationAtPosition(model, new EditorPosition(1, 1)).then(value => {
 				assert.equal(value.length, 1);
 				let [entry] = value;
 				assert.deepEqual(entry.range, { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 });

--- a/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts
@@ -352,7 +352,7 @@ suite('ExtHostLanguageFeatures', function () {
 		});
 	});
 
-	// --- type definition
+	// --- type implementation
 
 	test('TypeImplementation, data conversion', function () {
 


### PR DESCRIPTION
Fixes #19099


**bug**
In #18346, I originally called the new `go to implementation` provider api `ImplementationProvider` which was a terrible name, so we then decided to rename the API to `TypeDefinitionProvider`. At the time, I didn't realize that a `type definition` was actually its own, unrelated concept.

**Fix**
Rename `TypeDefinitionProvider` to `TypeImplementationProvider` to make it clear what the purpose and use of this API is.