### PR TITLE
Change TypeScript Configuration Flow For workspacesTrustedToSpecifyExecutables 

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -96,11 +96,6 @@
 					"default": false,
 					"description": "%typescript.disableAutomaticTypeAcquisition%"
 				},
-				"typescript.check.workspaceVersion": {
-					"type": "boolean",
-					"default": true,
-					"description": "%typescript.check.workspaceVersion%"
-				},
 				"typescript.check.tscVersion": {
 					"type": "boolean",
 					"default": true,

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -6,7 +6,6 @@
 	"typescript.tsdk.desc": "Specifies the folder path containing the tsserver and lib*.d.ts files to use.",
 	"typescript.tsdk_version.desc": "Specifies the version of the tsserver. Only necessary if the tsserver is not installed using npm.",
 	"typescript.disableAutomaticTypeAcquisition": "Disables automatic type acquisition. Requires TypeScript >= 2.0.6 and a restart after changing it.",
-	"typescript.check.workspaceVersion": "Check if a TypeScript version is available in the workspace.",
 	"typescript.check.tscVersion": "Check if a global install TypeScript compiler (e.g. tsc) differs from the used TypeScript language service.",
 	"typescript.tsserver.trace": "Enables tracing of messages send to the TS server.",
 	"typescript.tsserver.experimentalAutoBuild": "Enables experimental auto build. Requires 1.9 dev or 2.x tsserver version and a restart of VS Code after changing it.",

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -72,7 +72,7 @@ export function activate(context: ExtensionContext): void {
 			extensions: ['.js', '.jsx'],
 			configFile: 'jsconfig.json'
 		}
-	], context.storagePath, context.globalState);
+	], context.storagePath, context.globalState, context.workspaceState);
 
 	let client = clientHost.serviceClient;
 
@@ -334,7 +334,7 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	private languages: LanguageProvider[];
 	private languagePerId: ObjectMap<LanguageProvider>;
 
-	constructor(descriptions: LanguageDescription[], storagePath: string | undefined, globalState: Memento) {
+	constructor(descriptions: LanguageDescription[], storagePath: string | undefined, globalState: Memento, workspaceState: Memento) {
 		let handleProjectCreateOrDelete = () => {
 			this.client.execute('reloadProjects', null, false);
 			this.triggerAllDiagnostics();
@@ -349,7 +349,7 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 		watcher.onDidDelete(handleProjectCreateOrDelete);
 		watcher.onDidChange(handleProjectChange);
 
-		this.client = new TypeScriptServiceClient(this, storagePath, globalState);
+		this.client = new TypeScriptServiceClient(this, storagePath, globalState, workspaceState);
 		this.languages = [];
 		this.languagePerId = Object.create(null);
 		descriptions.forEach(description => {

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -84,6 +84,10 @@ export function activate(context: ExtensionContext): void {
 		clientHost.reloadProjects();
 	}));
 
+	context.subscriptions.push(commands.registerCommand('_typescript.onVersionStatusClicked', () => {
+		client.onVersionStatusClicked();
+	}));
+
 	window.onDidChangeActiveTextEditor(VersionStatus.showHideStatus, null, context.subscriptions);
 	client.onReady().then(() => {
 		context.subscriptions.push(ProjectStatus.create(client,

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -395,10 +395,6 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		});
 	}
 
-	private informAboutTS20(modulePath: string): Thenable<string> {
-		return Promise.resolve(modulePath);
-	}
-
 	public onVersionStatusClicked(): Thenable<string> {
 		const modulePath = this.modulePath;
 

--- a/extensions/typescript/src/utils/versionStatus.ts
+++ b/extensions/typescript/src/utils/versionStatus.ts
@@ -7,11 +7,10 @@
 
 import vscode = require('vscode');
 
-const versionBarEntry: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, Number.MIN_VALUE);
-let _enable: boolean = false;
+const versionBarEntry = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, Number.MIN_VALUE);
 
 export function showHideStatus() {
-	if (!versionBarEntry || !_enable) {
+	if (!versionBarEntry) {
 		return;
 	}
 	if (!vscode.window.activeTextEditor) {
@@ -37,14 +36,6 @@ export function disposeStatus() {
 export function setInfo(message: string, tooltip: string) {
 	versionBarEntry.text = message;
 	versionBarEntry.tooltip = tooltip;
-	let color = 'white';
-	versionBarEntry.color = color;
-	if (_enable) {
-		versionBarEntry.show();
-	}
-}
-
-export function enable(value: boolean) {
-	_enable = value;
-	showHideStatus();
+	versionBarEntry.color = 'white';
+	versionBarEntry.command = '_typescript.onVersionStatusClicked';
 }

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -224,7 +224,6 @@ const configurationValueWhitelist = [
 	'window.openFilesInNewWindow',
 	'javascript.validate.enable',
 	'editor.mouseWheelZoom',
-	'typescript.check.workspaceVersion',
 	'editor.fontWeight',
 	'editor.scrollBeyondLastLine',
 	'editor.lineNumbers',

--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -1384,7 +1384,7 @@ class UnTrustedWorkspaceSettingsRenderer extends Disposable {
 						startColumn: setting.keyRange.startColumn,
 						endLineNumber: setting.keyRange.endLineNumber,
 						endColumn: setting.keyRange.endColumn,
-						message: nls.localize('unsupportedWorkspaceSetting', "This setting must be a User Setting.")
+						message: untrustedConfiguration === 'typescript.tsdk' ? nls.localize('unsupportedTypeScriptTsdkSetting', "This setting must be a User Setting. To configure TypeScript for the workspace, open a TypeScript file and click on the TypeScript version in the status bar.") : nls.localize('unsupportedWorkspaceSetting', "This setting must be a User Setting.")
 					});
 				}
 			}


### PR DESCRIPTION
Part of #19113

This change removes the message that appears when you load a unconfigured TS workspace with a local version of typescript since #19113 breaks that flow.

The new flow makes the following changes:

* Use the bundled version of TS by default
* Always show the TS version in the status bar, even if we are using the bundled version
* When the user clicks on the status bar version, one of three things can happen:
    * If there is a local version of ts installed but the workspace is not configured, show a message about selecting the workspace or bundled version of TS.
    * If the no local version of ts is installed or the user has opted to use the bundled version explicitly, show a message about using the bundled version along with a blurb about the `typescript.tsdk` setting.
    * If the user as set `typescript.tsdk`, show a message about using the workspace version along with a blurb about the `typescript.tsdk` setting.

