### PR TITLE
Fixes Webview reload Flickering

### DIFF
--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -144,11 +144,13 @@
 
 	window.onload = () => {
 		if (window.initialData.scrollPreviewWithEditorSelection) {
-			const initialLine = +window.initialData.line || 0;
-			setTimeout(() => {
-				scrollDisabled = true;
-				scrollToRevealSourceLine(initialLine);
-			}, 0);
+			const initialLine = +window.initialData.line;
+			if (!isNaN(initialLine)) {
+				setTimeout(() => {
+					scrollDisabled = true;
+					scrollToRevealSourceLine(initialLine);
+				}, 0);
+			}
 		}
 	};
 


### PR DESCRIPTION
Fixes #19351

**Bug**
When refreshing a webview, a slight flicker can sometime be seen. This is especially noticable when using the markdown preview.

**Fix**
Instead of replacing the content of the iframe for refresh, create a new iframe with the new content and do a swap to update. 