### PR TITLE
workspaces can't override settings for executables

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -261,32 +261,6 @@ function getDefaultValue(type: string | string[]): any {
 const configurationRegistry = new ConfigurationRegistry();
 Registry.add(Extensions.Configuration, configurationRegistry);
 
-export interface ISecurityConfiguration {
-	security: {
-		workspacesTrustedToSpecifyExecutables: { [path: string]: boolean }
-	};
-}
-
-configurationRegistry.registerConfiguration({
-	'id': 'Security',
-	'order': 5,
-	'title': nls.localize('securityConfigurationTitle', "Security"),
-	'type': 'object',
-	'properties': {
-		'security.workspacesTrustedToSpecifyExecutables': {
-			'type': 'object',
-			'description': nls.localize('security.workspacesTrustedToSpecifyExecutables', "Controls which workspaces are trusted to specify executables in their settings. This option can only be configured in the user settings."),
-			'default': {},
-			defaultSnippets: [{ body: '${1:workspace_path} : ${2:true}' }],
-			'additionalProperties': {
-				'type': 'boolean',
-				'description': nls.localize('exclude.boolean', "Path to a workspaces. Set to true or false to trust or distrust a workspace."),
-			}
-		}
-	}
-
-});
-
 const configurationExtPoint = ExtensionsRegistry.registerExtensionPoint<IConfigurationNode>('configuration', [], {
 	description: nls.localize('vscode.extension.contributes.configuration', 'Contributes configuration settings.'),
 	type: 'object',

--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -1384,7 +1384,7 @@ class UnTrustedWorkspaceSettingsRenderer extends Disposable {
 						startColumn: setting.keyRange.startColumn,
 						endLineNumber: setting.keyRange.endLineNumber,
 						endColumn: setting.keyRange.endColumn,
-						message: nls.localize('untrustedWorkspaceWithExectuables', "`{0}` specifies an executable. It is ignored because the workspace is untrusted. To mark a workspace as trusted, open the User settings and add workspace folder to `security.workspacesTrustedToSpecifyExecutables`", setting.key)
+						message: nls.localize('unsupportedWorkspaceSetting', "This setting must be a User Setting.")
 					});
 				}
 			}

--- a/src/vs/workbench/services/configuration/node/configurationService.ts
+++ b/src/vs/workbench/services/configuration/node/configurationService.ts
@@ -25,8 +25,7 @@ import { IWorkspaceConfigurationValues, IWorkspaceConfigurationService, IWorkspa
 import { FileChangeType, FileChangesEvent } from 'vs/platform/files/common/files';
 import Event, { Emitter } from 'vs/base/common/event';
 import { Registry } from 'vs/platform/platform';
-import { IConfigurationRegistry, IConfigurationNode, Extensions, ISecurityConfiguration } from 'vs/platform/configuration/common/configurationRegistry';
-import baseplatform = require('vs/base/common/platform');
+import { IConfigurationRegistry, IConfigurationNode, Extensions } from 'vs/platform/configuration/common/configurationRegistry';
 
 
 interface IStat {
@@ -49,37 +48,11 @@ export class WorkspaceTrust implements IWorkspaceTrust {
 
 	constructor(private contextService: IWorkspaceContextService, private baseConfigurationService: BaseConfigurationService<any>) { }
 
-	private getWorkspaceTrustKey(): string {
-		const workspace = this.contextService.getWorkspace();
-		if (workspace) {
-			const path = workspace.resource.fsPath;
-			if (baseplatform.isWindows && path.length > 2) {
-				if (path.charAt(1) === ':') {
-					return path.charAt(0).toLocaleUpperCase().concat(path.substr(1));
-				}
-			}
-			return path;
-		}
-		return null;
-	}
-
 	public isTrusted(): boolean {
-		const workspaceTrustKey = this.getWorkspaceTrustKey();
-		if (workspaceTrustKey) {
-			const securityConfiguration = this.baseConfigurationService.getConfiguration<ISecurityConfiguration>();
-			const whiteList = securityConfiguration.security.workspacesTrustedToSpecifyExecutables;
-			return whiteList && whiteList[workspaceTrustKey];
-		}
 		return false;
 	}
 
 	public isExplicitlyUntrusted(): boolean {
-		const workspaceTrustKey = this.getWorkspaceTrustKey();
-		if (workspaceTrustKey) {
-			const securityConfiguration = this.baseConfigurationService.getConfiguration<ISecurityConfiguration>();
-			const whiteList = securityConfiguration.security.workspacesTrustedToSpecifyExecutables;
-			return whiteList && whiteList.hasOwnProperty(workspaceTrustKey) && !whiteList[workspaceTrustKey];
-		}
 		return false;
 	}
 


### PR DESCRIPTION
Removes the ability for workspaces to override settings that specify executables, i.e. marked with 'isExecutable'.