### PR TITLE
Update markdown-it version

### DIFF
--- a/extensions/markdown/npm-shrinkwrap.json
+++ b/extensions/markdown/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.6.tgz"
     },
     "argparse": {
-      "version": "1.0.7",
+      "version": "1.0.9",
       "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
     },
     "entities": {
       "version": "1.1.1",
@@ -23,14 +23,14 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.5.0.tgz"
     },
     "linkify-it": {
-      "version": "1.2.4",
-      "from": "linkify-it@>=1.2.2 <1.3.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz"
+      "version": "2.0.3",
+      "from": "linkify-it@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz"
     },
     "markdown-it": {
-      "version": "6.1.1",
-      "from": "markdown-it@>=6.0.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.1.1.tgz"
+      "version": "8.2.2",
+      "from": "markdown-it@8.2.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.2.2.tgz"
     },
     "markdown-it-named-headers": {
       "version": "0.0.4",
@@ -53,9 +53,9 @@
       "resolved": "https://registry.npmjs.org/string/-/string-3.3.1.tgz"
     },
     "uc.micro": {
-      "version": "1.0.2",
-      "from": "uc.micro@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.2.tgz"
+      "version": "1.0.3",
+      "from": "uc.micro@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz"
     },
     "vscode-extension-telemetry": {
       "version": "0.0.5",

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -175,7 +175,7 @@
 	},
 	"dependencies": {
 		"highlight.js": "^9.3.0",
-		"markdown-it": "^6.0.1",
+		"markdown-it": "^8.2.2",
 		"markdown-it-named-headers": "0.0.4",
 		"vscode-extension-telemetry": "^0.0.5"
 	}


### PR DESCRIPTION
Update the version of markdown-it in markdown extension from 6.0.1 to 8.2.2.