### PR TITLE
#16770 Delimit compound shortcuts with commas

### DIFF
--- a/src/vs/base/common/keybinding.ts
+++ b/src/vs/base/common/keybinding.ts
@@ -114,10 +114,10 @@ export class KeybindingLabels {
 
 		let chord: number = 0;
 
-		let firstSpaceIdx = input.indexOf(' ');
-		if (firstSpaceIdx > 0) {
-			key = input.substring(0, firstSpaceIdx);
-			chord = KeybindingLabels.fromUserSettingsLabel(input.substring(firstSpaceIdx), Platform);
+		let firstSeparatorIdx = input.indexOf(', ');
+		if (firstSeparatorIdx > 0) {
+			key = input.substring(0, firstSeparatorIdx);
+			chord = KeybindingLabels.fromUserSettingsLabel(input.substring(firstSeparatorIdx + 1), Platform);
 		} else {
 			key = input;
 		}

--- a/src/vs/base/common/keybinding.ts
+++ b/src/vs/base/common/keybinding.ts
@@ -369,7 +369,7 @@ function _asString(keybinding: number, labelProvider: IKeyBindingLabelProvider, 
 	var actualResult = result.join(labelProvider.modifierSeparator);
 
 	if (BinaryKeybindings.hasChord(keybinding)) {
-		return actualResult + ' ' + _asString(BinaryKeybindings.extractChordPart(keybinding), labelProvider, Platform);
+		return actualResult + ', ' + _asString(BinaryKeybindings.extractChordPart(keybinding), labelProvider, Platform);
 	}
 
 	return actualResult;
@@ -433,7 +433,7 @@ function _asHTML(keybinding: number, labelProvider: IKeyBindingLabelProvider, Pl
 		chordTo = _asHTML(BinaryKeybindings.extractChordPart(keybinding), labelProvider, Platform, true);
 		result.push({
 			tagName: 'span',
-			text: ' '
+			text: ', '
 		});
 		result = result.concat(chordTo);
 	}

--- a/src/vs/editor/contrib/quickOpen/browser/quickCommand.ts
+++ b/src/vs/editor/contrib/quickOpen/browser/quickCommand.ts
@@ -116,12 +116,12 @@ export class QuickCommandAction extends BaseEditorQuickOpenAction {
 		for (let i = 0; i < actions.length; i++) {
 			let action = actions[i];
 
-			let keys = keybindingService.lookupKeybindings(action.id).map(k => keybindingService.getLabelFor(k));
+			let [keybind] = keybindingService.lookupKeybindings(action.id);
 
 			if (action.label) {
 				let highlights = matchesFuzzy(searchValue, action.label);
 				if (highlights) {
-					entries.push(new EditorActionCommandEntry(keys.length > 0 ? keys.join(', ') : '', highlights, action, editor));
+					entries.push(new EditorActionCommandEntry(keybind ? keybindingService.getLabelFor(keybind) : '', highlights, action, editor));
 				}
 			}
 		}

--- a/src/vs/platform/keybinding/test/common/keybindingIO.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingIO.test.ts
@@ -72,8 +72,8 @@ suite('Keybinding IO', () => {
 		testRoundtrip(KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyMod.WinCtrl | KeyCode.KEY_A, 'ctrl+shift+alt+win+a', 'ctrl+shift+alt+cmd+a', 'ctrl+shift+alt+meta+a');
 
 		// chords
-		testRoundtrip(KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_A, KeyMod.CtrlCmd | KeyCode.KEY_A), 'ctrl+a ctrl+a', 'cmd+a cmd+a', 'ctrl+a ctrl+a');
-		testRoundtrip(KeyChord(KeyMod.CtrlCmd | KeyCode.UpArrow, KeyMod.CtrlCmd | KeyCode.UpArrow), 'ctrl+up ctrl+up', 'cmd+up cmd+up', 'ctrl+up ctrl+up');
+		testRoundtrip(KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_A, KeyMod.CtrlCmd | KeyCode.KEY_A), 'ctrl+a, ctrl+a', 'cmd+a, cmd+a', 'ctrl+a, ctrl+a');
+		testRoundtrip(KeyChord(KeyMod.CtrlCmd | KeyCode.UpArrow, KeyMod.CtrlCmd | KeyCode.UpArrow), 'ctrl+up, ctrl+up', 'cmd+up, cmd+up', 'ctrl+up, ctrl+up');
 
 		// OEM keys
 		testRoundtrip(KeyCode.US_SEMICOLON, ';', ';', ';');

--- a/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
@@ -294,9 +294,9 @@ export class CommandsHandler extends QuickOpenHandler {
 
 		for (let i = 0; i < actionDescriptors.length; i++) {
 			const actionDescriptor = actionDescriptors[i];
-			const keys = this.keybindingService.lookupKeybindings(actionDescriptor.id);
-			const keyLabel = keys.map(k => this.keybindingService.getLabelFor(k));
-			const keyAriaLabel = keys.map(k => this.keybindingService.getAriaLabelFor(k));
+			const [keybind] = this.keybindingService.lookupKeybindings(actionDescriptor.id);
+			const keyLabel = keybind ? this.keybindingService.getLabelFor(keybind) : '';
+			const keyAriaLabel = keybind ? this.keybindingService.getAriaLabelFor(keybind) : '';
 
 			if (actionDescriptor.label) {
 
@@ -312,7 +312,7 @@ export class CommandsHandler extends QuickOpenHandler {
 				const labelHighlights = wordFilter(searchValue, label);
 				const aliasHighlights = alias ? wordFilter(searchValue, alias) : null;
 				if (labelHighlights || aliasHighlights) {
-					entries.push(this.instantiationService.createInstance(CommandEntry, keyLabel.length > 0 ? keyLabel.join(', ') : '', keyAriaLabel.length > 0 ? keyAriaLabel.join(', ') : '', label, alias, labelHighlights, aliasHighlights, actionDescriptor));
+					entries.push(this.instantiationService.createInstance(CommandEntry, keyLabel, keyAriaLabel, label, alias, labelHighlights, aliasHighlights, actionDescriptor));
 				}
 			}
 		}
@@ -326,9 +326,9 @@ export class CommandsHandler extends QuickOpenHandler {
 		for (let i = 0; i < actions.length; i++) {
 			const action = actions[i];
 
-			const keys = this.keybindingService.lookupKeybindings(action.id);
-			const keyLabel = keys.map(k => this.keybindingService.getLabelFor(k));
-			const keyAriaLabel = keys.map(k => this.keybindingService.getAriaLabelFor(k));
+			const [keybind] = this.keybindingService.lookupKeybindings(action.id);
+			const keyLabel = keybind ? this.keybindingService.getLabelFor(keybind) : '';
+			const keyAriaLabel = keybind ? this.keybindingService.getAriaLabelFor(keybind) : '';
 			const label = action.label;
 
 			if (label) {
@@ -338,7 +338,7 @@ export class CommandsHandler extends QuickOpenHandler {
 				const labelHighlights = wordFilter(searchValue, label);
 				const aliasHighlights = alias ? wordFilter(searchValue, alias) : null;
 				if (labelHighlights || aliasHighlights) {
-					entries.push(this.instantiationService.createInstance(EditorActionCommandEntry, keyLabel.length > 0 ? keyLabel.join(', ') : '', keyAriaLabel.length > 0 ? keyAriaLabel.join(', ') : '', label, alias, labelHighlights, aliasHighlights, action));
+					entries.push(this.instantiationService.createInstance(EditorActionCommandEntry, keyLabel, keyAriaLabel, label, alias, labelHighlights, aliasHighlights, action));
 				}
 			}
 		}
@@ -350,12 +350,12 @@ export class CommandsHandler extends QuickOpenHandler {
 		const entries: ActionCommandEntry[] = [];
 
 		for (let action of actions) {
-			const keys = this.keybindingService.lookupKeybindings(action.id);
-			const keyLabel = keys.map(k => this.keybindingService.getLabelFor(k));
-			const keyAriaLabel = keys.map(k => this.keybindingService.getAriaLabelFor(k));
+			const [keybind] = this.keybindingService.lookupKeybindings(action.id);
+			const keyLabel = keybind ? this.keybindingService.getLabelFor(keybind) : '';
+			const keyAriaLabel = keybind ? this.keybindingService.getAriaLabelFor(keybind) : '';
 			const highlights = wordFilter(searchValue, action.label);
 			if (highlights) {
-				entries.push(this.instantiationService.createInstance(ActionCommandEntry, keyLabel.join(', '), keyAriaLabel.join(', '), action.label, null, highlights, null, action));
+				entries.push(this.instantiationService.createInstance(ActionCommandEntry, keyLabel, keyAriaLabel, action.label, null, highlights, null, action));
 			}
 		}
 


### PR DESCRIPTION
Implements #16770

Changes the display of compound keyboard shortcuts to separate various parts of a chord with a comma, instead of just a space.

To prevent confusion for commands that have multiple keyboard shortcuts, the command palette will now only show the first keyboard shortcut, instead of all of them.

*Note*: I made a change to `quickCommand.ts` because it was also concatenating the keyboard shortcuts with a space, however that class doesn't seem to actually be used anywhere.