### PR TITLE
Emit 'running' after view is set as multi-process

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -710,10 +710,10 @@ export class DebugService implements debug.IDebugService {
 				}
 				this.extensionService.activateByEvent(`onDebug:${configuration.type}`).done(null, errors.onUnexpectedError);
 				this.inDebugMode.set(true);
-				this.setStateAndEmit(session.getId(), debug.State.Running);
 				if (this.model.getProcesses().length > 1) {
 					this.viewModel.setMultiProcessView(true);
 				}
+				this.setStateAndEmit(session.getId(), debug.State.Running);
 
 				this.telemetryService.publicLog('debugSessionStart', {
 					type: configuration.type,


### PR DESCRIPTION
Fix #19524.

I think this would have been regressed by 355c961.