### PR TITLE
Fix #19550

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -107,7 +107,7 @@ export class ReplExpressionsRenderer implements IRenderer {
 	}
 
 	public getHeight(tree: ITree, element: any): number {
-		if (element instanceof Variable) {
+		if (element instanceof Variable && (element.hasChildren || (element.name !== null))) {
 			return ReplExpressionsRenderer.LINE_HEIGHT_PX;
 		}
 		if (element instanceof Expression && element.hasChildren) {


### PR DESCRIPTION
Related to #17333, probably regressed by https://github.com/Microsoft/vscode/commit/ed900e4399a27e18d9f93ae57dc9bc6097f280ee

Need `console.log('a\nb')` to be rendered as multiline, but `console.log({ 'a\nb': 'c\nd' })` to not be. So here, only skip the string height measurement if the variable has children (is an object/array) or has a name (is a prop of an object/array).

This is a hack, I think the newlines in the preview need to be escaped somewhere since they aren't now, and the property values need to go through here after being escaped, which much happen elsewhere.