### PR TITLE
Fixed a problem when a comment is in an attribute.

### DIFF
--- a/extensions/rust/syntaxes/rust.json
+++ b/extensions/rust/syntaxes/rust.json
@@ -216,6 +216,12 @@
       "patterns": [
         {
           "include": "#string_literal"
+        },
+        {
+          "include": "#block_comment"
+        },
+        {
+          "include": "#line_comment"
         }
       ]
     },


### PR DESCRIPTION
Rust allows both a block comment and a line comment in an attribute.
[Playground](https://is.gd/8YgB3Z)
Closes https://github.com/KalitaAlexey/vscode-rust/issues/51