### PR TITLE
Fix colorization of nested list.

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -522,7 +522,7 @@
 								</dict>
 							</array>
 							<key>while</key>
-							<string>(^|\G)([ ]{4}|\t)</string>
+							<string>((^|\G)([ ]{4}|\t))|(^[ \t]*$)</string>
 						</dict>
 						<dict>
 							<key>begin</key>
@@ -549,7 +549,7 @@
 								</dict>
 							</array>
 							<key>while</key>
-							<string>(^|\G)([ ]{4}|\t)</string>
+							<string>((^|\G)([ ]{4}|\t))|(^[ \t]*$)</string>
 						</dict>
 					</array>
 				</dict>

--- a/extensions/markdown/test/colorize-fixtures/test.md
+++ b/extensions/markdown/test/colorize-fixtures/test.md
@@ -29,6 +29,8 @@ Alternate Header 2
 - Another one
 + Another one
 
+    + nested list
+
 This is a paragraph, which is text surrounded by
 whitespace. Paragraphs can be on one
 line (or many), and can drone on for hours.

--- a/extensions/markdown/test/colorize-results/test_md.json
+++ b/extensions/markdown/test/colorize-results/test_md.json
@@ -1342,6 +1342,50 @@
 		}
 	},
 	{
+		"c": "    ",
+		"t": "text.html.markdown markup.list.unnumbered.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "+",
+		"t": "text.html.markdown markup.list.unnumbered.markdown markup.list.unnumbered.markdown beginning.punctuation.definition.list.markdown",
+		"r": {
+			"dark_plus": "beginning.punctuation.definition.list.markdown: #6796E6",
+			"light_plus": "beginning.punctuation.definition.list.markdown: #0451A5",
+			"dark_vs": "beginning.punctuation.definition.list.markdown: #6796E6",
+			"light_vs": "beginning.punctuation.definition.list.markdown: #0451A5",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown markup.list.unnumbered.markdown markup.list.unnumbered.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "nested list",
+		"t": "text.html.markdown markup.list.unnumbered.markdown markup.list.unnumbered.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
 		"c": "This is a paragraph, which is text surrounded by",
 		"t": "text.html.markdown meta.paragraph.markdown",
 		"r": {


### PR DESCRIPTION
Fixed colorization of nested list with unindented line.
Previously, bullets of nested list with empty line above was not colored.

This change related to #19417 which updated markdown-it version,
and after applied that, two consecutive newlines no longer terminate a list.

This PR is modified one of #19559 