### PR TITLE
Fix Detected Link Style For Links With Underscores

### DIFF
--- a/src/vs/editor/contrib/links/browser/links.css
+++ b/src/vs/editor/contrib/links/browser/links.css
@@ -2,18 +2,16 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-.monaco-editor .detected-link {
-	text-decoration: underline;
+.monaco-editor .detected-link,
+.monaco-editor .detected-link-active {
+	border-bottom: 1px solid;
+	border-color: currentColor;
+	text-decoration: none !important;
 }
 
 .monaco-editor .detected-link-active {
-	text-decoration: underline;
 	cursor: pointer;
 	color: blue !important;
-}
-
-.monaco-editor.vs-dark .detected-link {
-	border-color: #1C5DAF;
 }
 
 .monaco-editor.vs-dark .detected-link-active {


### PR DESCRIPTION
Fixes #12226

**Bug**
Current styling hides underscores in detected links

**Fix**
Instead of using `text-decoration: underline`, use `border-bottom` to offset the underline a bit further from the text:


![screen shot 2017-01-31 at 2 25 57 pm](https://cloud.githubusercontent.com/assets/12821956/22487266/9345d57e-e7c1-11e6-8a8c-ca9136a53e66.png)

![screen shot 2017-01-31 at 2 26 04 pm](https://cloud.githubusercontent.com/assets/12821956/22487265/9328bfca-e7c1-11e6-8b3b-6f121842b270.png)