### PR TITLE
Fix explorer selection state when drag ends

### DIFF
--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -1353,7 +1353,7 @@ export class TreeView extends HeightMap {
 
 		var viewItem = this.getItemAround(event.target);
 
-		if (!viewItem || (event.posx === 0 && event.posy === 0)) {
+		if (!viewItem || (event.posx === 0 && event.posy === 0 && event.browserEvent.type === DOM.EventType.DRAG_LEAVE)) {
 			// dragging outside of tree
 
 			if (this.currentDropTarget) {

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -1353,7 +1353,7 @@ export class TreeView extends HeightMap {
 
 		var viewItem = this.getItemAround(event.target);
 
-		if (!viewItem) {
+		if (!viewItem || (event.posx === 0 && event.posy === 0)) {
 			// dragging outside of tree
 
 			if (this.currentDropTarget) {


### PR DESCRIPTION
Fixes #2367

When a file is dragged onto tree view from desktop and escape key is pressed, the `dragend` event does not fire.

This fix relies on the property that such an event has a position of (0 , 0).