### PR TITLE
Don't start ts server with enable telemetry if user has disabled telemetry

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -440,7 +440,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 							args.push('--disableAutomaticTypingAcquisition');
 						}
 					}
-					if (this.apiVersion.has208Features()) {
+					if (this.apiVersion.has208Features() && workspace.getConfiguration().get<boolean>('telemetry.enableTelemetry', true)) {
 						args.push('--enableTelemetry');
 					}
 					electron.fork(modulePath, args, options, (err: any, childProcess: cp.ChildProcess) => {


### PR DESCRIPTION
@dbaeumer / @mhegazy - Does the TS upload and telemetry data on its own when `tsserver` is run using `--enableTelemtry`. I know that vscode receives telemetry events from `tsserver`, but we do not actually upload them on our side if the user has disabled telemetry.


#19693
