### PR TITLE
make renderMarkedString properly handle language='markdown'

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -21,8 +21,13 @@ export interface RenderOptions {
 }
 
 export function renderMarkedString(markedString: MarkedString, options: RenderOptions = {}): Node {
-	const htmlContentElement = typeof markedString === 'string' ? { markdown: markedString } : { code: markedString };
-	return renderHtml(htmlContentElement, options);
+	if (typeof markedString === 'string') {
+		return renderHtml({ markdown: markedString }, options);
+	}
+	if (markedString.language === 'markdown') {
+		return renderHtml({ markdown: markedString.value }, options);
+	}
+	return renderHtml({ code: markedString }, options);
 }
 
 /**


### PR DESCRIPTION
The [Language Server Protocol spec](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#hover-request) doesn't say a language server can't return a `MarkedString` like `{language: 'markdown', value: '<some markdown>'}`. In fact, https://github.com/sourcegraph/go-langserver is a language server that currently returns `MarkedString` like that.

This change makes `renderMarkedString` properly handle rendering the special case above as markdown, *not* as some markdown code block. A string value for `MarkedString` will still be interpreted as markdown according to the spec.