### PR TITLE
Allow MarkedString in CompletionItem details and documentation

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -235,8 +235,8 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 				return item;
 			}
 			const detail = details[0];
-			item.documentation = Previewer.plain(detail.documentation);
-			item.detail = Previewer.plain(detail.displayParts);
+			item.documentation = [Previewer.plain(detail.documentation)];
+			item.detail = [{ language: 'typescript', value: Previewer.plain(detail.displayParts) }];
 
 			if (detail && this.config.useCodeSnippetsOnMethodSuggest && (item.kind === CompletionItemKind.Function || item.kind === CompletionItemKind.Method)) {
 				return this.isValidFunctionCompletionContext(filepath, item.position).then(shouldCompleteFunction => {

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -208,8 +208,8 @@ export interface ISuggestion {
 	label: string;
 	insertText: string;
 	type: SuggestionType;
-	detail?: string;
-	documentation?: string;
+	detail?: string | MarkedString[];
+	documentation?: string | MarkedString[];
 	filterText?: string;
 	sortText?: string;
 	noAutoAccept?: boolean;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2410,12 +2410,12 @@ declare module 'vscode' {
 		 * A human-readable string with additional information
 		 * about this item, like type or symbol information.
 		 */
-		detail?: string;
+		detail?: string | MarkedString[];
 
 		/**
 		 * A human-readable string that represents a doc-comment.
 		 */
-		documentation?: string;
+		documentation?: string | MarkedString[];
 
 		/**
 		 * A string that should be used when comparing this item

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -848,8 +848,8 @@ export class CompletionItem {
 
 	label: string;
 	kind: CompletionItemKind;
-	detail: string;
-	documentation: string;
+	detail: string | vscode.MarkedString[];
+	documentation: string | vscode.MarkedString[];
 	sortText: string;
 	filterText: string;
 	insertText: string | SnippetString;


### PR DESCRIPTION
part of #11877

This allows marked strings to be used in the `detail` and `documentation` field of completion items. I've tried to preseve the existing behavior as much as possible with this change. The new rendering will only be applied when an array of marked strings is passed in

<img width="549" alt="screen shot 2017-02-02 at 6 23 23 pm" src="https://cloud.githubusercontent.com/assets/12821956/22577230/3b6615d4-e975-11e6-8e0a-9c5c7defb972.png">
