### PR TITLE
fix: dispose the this.documentListener

### DIFF
--- a/extensions/php/src/features/validationProvider.ts
+++ b/extensions/php/src/features/validationProvider.ts
@@ -120,6 +120,10 @@ export default class PHPValidationProvider {
 	public dispose(): void {
 		this.diagnosticCollection.clear();
 		this.diagnosticCollection.dispose();
+		if (this.documentListener) {
+			this.documentListener.dispose();
+			this.documentListener = null;
+		}
 	}
 
 	private loadConfiguration(): void {


### PR DESCRIPTION
I'm not sure if I should submit a PR on master or elsewhere.

I'm fixing this issue :

```
Uncaught Exception:  Error: illegal state - object is disposed
Error: illegal state - object is disposed
    at r.e._checkDisposed (/usr/share/code/resources/app/out/vs/workbench/node/extensionHostProcess.js:10:25284)
    at r.e.set (/usr/share/code/resources/app/out/vs/workbench/node/extensionHostProcess.js:10:23310)
    at Socket.<anonymous> (/usr/share/code/resources/app/extensions/php/out/features/validationProvider.js:189:52)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Case to reproduce this error : `extensionService.deactivate('vscode.php')`