### PR TITLE
Add ellipsis to path in quick open

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
@@ -595,8 +595,17 @@ class Renderer implements IRenderer<QuickOpenEntry> {
 			data.detail.set(entry.getDetail(), detailHighlights);
 
 			// Description
-			data.description.set(entry.getDescription(), descriptionHighlights || []);
-			data.description.element.title = entry.getDescription();
+			const description = entry.getDescription();
+			let halfIndex = Math.floor(description.length / 2);
+			// direction is rtl on the string so we are trying not to split with a
+			// special char on the right
+			if (['-', '/'].indexOf(description[halfIndex]) > 0) {
+				halfIndex++;
+			}
+			data.description.set(description, descriptionHighlights || []);
+			data.description.element.title = description;
+			data.description.element.dataset.contentStart = description.substring(0, halfIndex);
+			data.description.element.dataset.contentEnd = description.substring(halfIndex);
 		}
 	}
 

--- a/src/vs/base/parts/quickopen/browser/quickopen.css
+++ b/src/vs/base/parts/quickopen/browser/quickopen.css
@@ -83,10 +83,32 @@
 .quick-open-widget .quick-open-tree .quick-open-entry-description {
 	opacity: 0.7;
 	margin-left: 0.5em;
+	margin-right: 3.2em;
 	font-size: 0.9em;
 	overflow: hidden;
 	flex: 1;
 	text-overflow: ellipsis;
+}
+.quick-open-widget .quick-open-tree .quick-open-entry-description .monaco-highlighted-label > span {
+	display: none;
+}
+.quick-open-widget .quick-open-tree .quick-open-entry-description .monaco-highlighted-label:before,
+.quick-open-widget .quick-open-tree .quick-open-entry-description .monaco-highlighted-label:after {
+	display: inline-block;
+	max-width: 50%;
+	overflow: hidden;
+	white-space: pre;
+	vertical-align: middle;
+}
+.quick-open-widget .quick-open-tree .quick-open-entry-description .monaco-highlighted-label:before {
+	content: attr(data-content-start);
+	text-overflow: ellipsis;
+}
+.quick-open-widget .quick-open-tree .quick-open-entry-description .monaco-highlighted-label:after {
+	content: attr(data-content-end);
+	text-overflow: clip;
+	text-overflow: '';
+	direction: rtl;
 }
 
 .quick-open-widget .quick-open-tree .results-group {


### PR DESCRIPTION
Addresses https://github.com/Microsoft/vscode/issues/18259
Alternative solution https://github.com/Microsoft/vscode/pull/18742

Based on feedback from @bpasero 
Attempting to:
1. don't increase line height
1. solve without using js to monitor quick-open width
1. put the ellipsis `...` in the middle of the string

Notes:
- I did leave a little extra padding on the right side so that the path isn't covered by the split icon.
- Style wise it looks a little funny to me that the paths don't begin at the same column...
- The css selector is getting kind of long

![screen shot 2017-02-03 at 4 39 19 pm](https://cloud.githubusercontent.com/assets/604015/22609478/5757a630-ea2f-11e6-92f2-1310c147a8f0.png)

