### PR TITLE
fix flexbox height issue for parameter hint on IE and Safari

### DIFF
--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
@@ -14,7 +14,6 @@
 
 .monaco-editor .parameter-hints-widget > .wrapper {
 	max-width: 440px;
-	height: 100%;
 	display: flex;
 	flex-direction: column;
 }
@@ -56,7 +55,6 @@
 }
 
 .monaco-editor .parameter-hints-widget .docs {
-	height: 100%;
 	padding: 0 10px 0 5px;
 }
 

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
@@ -42,7 +42,6 @@
 }
 
 .monaco-editor .parameter-hints-widget.multiple .body {
-	height: 100%;
 	border-left: 1px solid rgba(204, 204, 204, 0.5);
 }
 


### PR DESCRIPTION
Fix https://github.com/Microsoft/monaco-editor/issues/282 (Safari) and https://github.com/Microsoft/monaco-editor/issues/344 (IE11). When setting flexbox item height to `100%`, browser will try to read height of its containing box, which happens to be a flexbox in our case. However browsers' behavior very when handling percentage of height in flexbox, Chrome and Edge is reasonable, Safari sometimes break, IE s***s (its partial support for flexbox).

Here I remove these two `height:100%` so browser will set its height as containing content. @joaomoreno may know if there is any catch when he adds them while implementing scrolling feature in parameter hint widget.

cc @jrieken @alexandrudima 