### PR TITLE
Fix Slow  Markdown Front matter stripping regexp

### DIFF
--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -21,7 +21,7 @@ interface MarkdownIt {
 	utils: any;
 }
 
-const FrontMatterRegex = /^---\s*(.|\s)*?---\s*/;
+const FrontMatterRegex = /^---\s*[^]*?---\s*/;
 
 export class MarkdownEngine {
 	private md: MarkdownIt;
@@ -59,7 +59,6 @@ export class MarkdownEngine {
 	private stripFrontmatter(text: string): { text: string, offset: number } {
 		let offset = 0;
 		const frontMatterMatch = FrontMatterRegex.exec(text);
-
 		if (frontMatterMatch) {
 			const frontMatter = frontMatterMatch[0];
 


### PR DESCRIPTION
**Bug**
For long/not-terminated frontmatter in a markdown file, we can currently hang the process while trying match it using a regular expression

**Fix**
Use a more efficent regexp to identify the front matter