### PR TITLE
git clone nvm with --depth 1, to make clone faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
 
 before_install:
   - git submodule update --init --recursive
-  - git clone https://github.com/creationix/nvm.git ./.nvm
+  - git clone --depth 1 https://github.com/creationix/nvm.git ./.nvm
   - source ./.nvm/nvm.sh
   - nvm install 6.6.0
   - nvm use 6.6.0


### PR DESCRIPTION
nvm git repo has 1500+ commits, there's no need to clone the full repo.
So add `--depth 1` when git clone to make it faster