### PR TITLE
Fix Markdown Scroll Sync For Windows Path Casing

### DIFF
--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -44,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand('_markdown.revealLine', (uri, line) => {
 		const sourceUri = vscode.Uri.parse(decodeURIComponent(uri));
 		vscode.window.visibleTextEditors
-			.filter(editor => editor.document.uri.path === sourceUri.path)
+			.filter(editor => isMarkdownFile(editor.document) && editor.document.uri.fsPath === sourceUri.fsPath)
 			.forEach(editor => {
 				const sourceLine = Math.floor(line);
 				const text = editor.document.getText(new vscode.Range(sourceLine, 0, sourceLine + 1, 0));
@@ -82,10 +82,10 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 			}
 		};
-		if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.uri.path === args.path) {
+		if (vscode.window.activeTextEditor && isMarkdownFile(vscode.window.activeTextEditor.document) && vscode.window.activeTextEditor.document.uri.fsPath === args.fsPath) {
 			return tryRevealLine(vscode.window.activeTextEditor);
 		} else {
-			const resource = vscode.Uri.file(args.path);
+			const resource = vscode.Uri.file(args.fsPath);
 			vscode.workspace.openTextDocument(resource)
 				.then(vscode.window.showTextDocument)
 				.then(tryRevealLine, _ => vscode.commands.executeCommand('vscode.open', resource));

--- a/extensions/markdown/src/previewContentProvider.ts
+++ b/extensions/markdown/src/previewContentProvider.ts
@@ -117,7 +117,7 @@ export class MDDocumentContentProvider implements vscode.TextDocumentContentProv
 					${body}
 					<script>
 						window.initialData = {
-							source: "${encodeURIComponent(sourceUri.scheme + '://' + sourceUri.path)}",
+							source: "${encodeURIComponent(sourceUri.toString(true))}",
 							line: ${initialLine},
 							scrollPreviewWithEditorSelection: ${!!markdownConfig.get('preview.scrollPreviewWithEditorSelection', true)},
 							scrollEditorWithPreview: ${!!markdownConfig.get('preview.scrollEditorWithPreview', true)},

--- a/src/vs/workbench/parts/html/browser/html.contribution.ts
+++ b/src/vs/workbench/parts/html/browser/html.contribution.ts
@@ -106,7 +106,7 @@ CommandsRegistry.registerCommand('_workbench.htmlPreview.postMessage', (accessor
 	const activePreviews = accessor.get(IWorkbenchEditorService).getVisibleEditors()
 		.filter(c => c instanceof HtmlPreviewPart)
 		.map(e => e as HtmlPreviewPart)
-		.filter(e => e.model.uri.scheme === uri.scheme && e.model.uri.path === uri.path);
+		.filter(e => e.model.uri.scheme === uri.scheme && e.model.uri.fsPath === uri.fsPath);
 	for (const preview of activePreviews) {
 		preview.sendMessage(message);
 	}


### PR DESCRIPTION
**Bug**
Scroll sync not working for some users on windows

**Fix**
Root cause seems to be that windows drive/path cases can sometimes differ between preview and editor document. Adds a equality check based on `fsPath` as well

Fixes #20000 
Fixes #19966
Fixes #19898
Fixes #19802