### PR TITLE
Enable Markdown Scroll Syncronization for Untitled Files

### DIFF
--- a/extensions/markdown/src/previewContentProvider.ts
+++ b/extensions/markdown/src/previewContentProvider.ts
@@ -30,7 +30,7 @@ export class MDDocumentContentProvider implements vscode.TextDocumentContentProv
 	}
 
 	private getMediaPath(mediaFile: string): string {
-		return this.context.asAbsolutePath(path.join('media', mediaFile));
+		return vscode.Uri.file(this.context.asAbsolutePath(path.join('media', mediaFile))).toString();
 	}
 
 	private isAbsolute(p: string): boolean {


### PR DESCRIPTION
Fixes #20070

**Bug**
Markdown scroll sync and other sync features do not work for untitled files. The root cause seems to be that the `main.js` markdown file is never loaded into the webview

**Fix**
Instead of a using a path without a scheme for `main.js`, use a `file://` path