### PR TITLE
Fix error markers and problems links in untitled js and ts files

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -698,7 +698,9 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 	}
 
 	public asUrl(filepath: string): Uri {
-		if (filepath.startsWith(TypeScriptServiceClient.WALK_THROUGH_SNIPPET_SCHEME_COLON)) {
+		if (filepath.startsWith(TypeScriptServiceClient.WALK_THROUGH_SNIPPET_SCHEME_COLON)
+			|| (filepath.startsWith('untitled:') && this._apiVersion.has213Features())
+		) {
 			return Uri.parse(filepath);
 		}
 		return Uri.file(filepath);


### PR DESCRIPTION
Fixes #19856

**Bug**
No error/warning markers shown in untitled js and ts files. 

Clicking on problem in problem view tried to jump to non-existent file

**Fix**
Add logic to handle files with an `untitled` scheme correctly