### PR TITLE
Stop TS From Spamming Crash Messages

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -643,7 +643,9 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 			let startService = true;
 			if (this.numberRestarts > 5) {
 				let prompt: Thenable<MyMessageItem | undefined> | undefined = undefined;
+				this.numberRestarts = 0;
 				if (diff < 60 * 1000 /* 1 Minutes */) {
+					this.lastStart = Date.now();
 					prompt = window.showWarningMessage<MyMessageItem>(
 						localize('serverDied', 'The TypeScript language service died unexpectedly 5 times in the last 5 Minutes.'),
 						{
@@ -651,7 +653,8 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 							id: MessageAction.reportIssue,
 							isCloseAffordance: true
 						});
-				} else if (diff < 2 * 1000 /* 2 seconds */) {
+				} else if (diff < 10 * 1000 /* 10 seconds */) {
+					this.lastStart = Date.now();
 					startService = false;
 					prompt = window.showErrorMessage<MyMessageItem>(
 						localize('serverDiedAfterStart', 'The TypeScript language service died 5 times right after it got started. The service will not be restarted.'),

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -129,6 +129,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		this.storagePath = storagePath;
 		this.globalState = globalState;
 		this.pathSeparator = path.sep;
+		this.lastStart = Date.now();
 
 		var p = new Promise<void>((resolve, reject) => {
 			this._onReady = { promise: p, resolve, reject };


### PR DESCRIPTION
**Bug**
When the tsserver crashes repeatedly, it can end up spamming users with constant alerts. This is not too helpful

**Fix**
A number of small fixes:

* Set lastStart on boot to handle cases where tsserver crashes right away without ever starting successfully 
* Lengthen 5 crash timeout to 10 seconds from 2 seconds. 5 crashes in 10 seconds == no attempted restart
* Reset the last started time when we have any number of crashes in the row. This resets the crash windows.
* Fix any crash after the fifth retriggering the same alert. I believe the intent was that we should show these errors every five crashes, not on any crash after the fifth one