### PR TITLE
Improve Markdown Preview Code Block Styling

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -149,7 +149,8 @@ body.wordWrap pre {
 	line-height: 18px;
 }
 
-code > div {
+pre:not(.hljs),
+pre.hljs code > div {
 	padding: 16px;
 	border-radius: 3px;
 	overflow: auto;
@@ -157,15 +158,18 @@ code > div {
 
 /** Theming */
 
-.vscode-light {
+.vscode-light,
+.vscode-light pre code {
 	color: rgb(30, 30, 30);
 }
 
-.vscode-dark {
+.vscode-dark,
+.vscode-dark pre code {
 	color: #DDD;
 }
 
-.vscode-high-contrast {
+.vscode-high-contrast,
+.vscode-high-contrast pre code {
 	color: white;
 }
 
@@ -177,14 +181,17 @@ code > div {
 	color: #D7BA7D;
 }
 
+.vscode-light pre:not(.hljs),
 .vscode-light code > div {
 	background-color: rgba(220, 220, 220, 0.4);
 }
 
+.vscode-dark pre:not(.hljs),
 .vscode-dark code > div {
 	background-color: rgba(10, 10, 10, 0.4);
 }
 
+.vscode-high-contrast pre:not(.hljs),
 .vscode-high-contrast code > div {
 	background-color: rgb(0, 0, 0);
 }


### PR DESCRIPTION
Fixes #7776

**Bug**
Indented code blocks in the markdown preview are not very good looking

**Fix**
Use default text color for indented code blocks and add a background


# Before
<img width="1247" alt="screen shot 2017-02-06 at 5 21 18 pm" src="https://cloud.githubusercontent.com/assets/12821956/22673731/b7d0e34c-ec90-11e6-95fb-b8203501fade.png">
<img width="1255" alt="screen shot 2017-02-06 at 5 21 06 pm" src="https://cloud.githubusercontent.com/assets/12821956/22673730/b7b359e4-ec90-11e6-8402-49cf34fb6e23.png">

# After 
<img width="1243" alt="screen shot 2017-02-06 at 5 17 16 pm" src="https://cloud.githubusercontent.com/assets/12821956/22673697/945abc94-ec90-11e6-97b5-dd0f683656b4.png">
<img width="1232" alt="screen shot 2017-02-06 at 5 17 26 pm" src="https://cloud.githubusercontent.com/assets/12821956/22673698/94798886-ec90-11e6-9c84-624f62e155b0.png">




