### PR TITLE
Added support for home/end key in IntelliSense

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -390,6 +390,16 @@ export class List<T> implements IDisposable {
 		}
 	}
 
+	focusLast(): void {
+		if (this.length === 0) { return; }
+		this.setFocus([this.length - 1]);
+	}
+
+	focusFirst(): void {
+		if (this.length === 0) { return; }
+		this.setFocus([0]);
+	}
+
 	getFocus(): number[] {
 		return this.focus.get();
 	}

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -199,6 +199,12 @@ export class SuggestController implements IEditorContribution {
 		}
 	}
 
+	selectLastSuggestion(): void {
+		if (this.widget) {
+			this.widget.selectLast();
+		}
+	}
+
 	selectPrevSuggestion(): void {
 		if (this.widget) {
 			this.widget.selectPrevious();
@@ -208,6 +214,12 @@ export class SuggestController implements IEditorContribution {
 	selectPrevPageSuggestion(): void {
 		if (this.widget) {
 			this.widget.selectPreviousPage();
+		}
+	}
+
+	selectFirstSuggestion(): void {
+		if (this.widget) {
+			this.widget.selectFirst();
 		}
 	}
 
@@ -311,6 +323,17 @@ CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
 }));
 
 CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
+	id: 'selectLastSuggestion',
+	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
+	handler: c => c.selectLastSuggestion(),
+	kbOpts: {
+		weight: weight,
+		kbExpr: EditorContextKeys.TextFocus,
+		primary: KeyCode.End
+	}
+}));
+
+CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
 	id: 'selectPrevSuggestion',
 	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
 	handler: c => c.selectPrevSuggestion(),
@@ -332,6 +355,17 @@ CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
 		kbExpr: EditorContextKeys.TextFocus,
 		primary: KeyCode.PageUp,
 		secondary: [KeyMod.Alt | KeyCode.PageUp]
+	}
+}));
+
+CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
+	id: 'selectFirstSuggestion',
+	precondition: ContextKeyExpr.and(SuggestContext.Visible, SuggestContext.MultipleSuggestions),
+	handler: c => c.selectFirstSuggestion(),
+	kbOpts: {
+		weight: weight,
+		kbExpr: EditorContextKeys.TextFocus,
+		primary: KeyCode.Home
 	}
 }));
 

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -634,6 +634,22 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		}
 	}
 
+	selectLast(): boolean {
+		switch (this.state) {
+			case State.Hidden:
+				return false;
+			case State.Details:
+				// Not worried about details just yet...
+				// this.details.pageDown();
+				return true;
+			case State.Loading:
+				return !this.isAuto;
+			default:
+				this.list.focusLast();
+				return true;
+		}
+	}
+
 	selectPreviousPage(): boolean {
 		switch (this.state) {
 			case State.Hidden:
@@ -662,6 +678,22 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 			default:
 				this.list.focusPrevious(1, true);
 				return false;
+		}
+	}
+
+	selectFirst(): boolean {
+		switch (this.state) {
+			case State.Hidden:
+				return false;
+			case State.Details:
+				// Not worried about details just yet...
+				// this.details.pageUp();
+				return true;
+			case State.Loading:
+				return !this.isAuto;
+			default:
+				this.list.focusFirst();
+				return true;
 		}
 	}
 

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -265,6 +265,14 @@ class SuggestionDetails {
 		this.body.scrollTop -= much;
 	}
 
+	scrollTop(): void {
+		this.body.scrollTop = 0;
+	}
+
+	scrollBottom(): void {
+		this.body.scrollTop = this.body.scrollHeight;
+	}
+
 	pageDown(): void {
 		this.scrollDown(80);
 	}
@@ -639,8 +647,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 			case State.Hidden:
 				return false;
 			case State.Details:
-				// Not worried about details just yet...
-				// this.details.pageDown();
+				this.details.scrollBottom();
 				return true;
 			case State.Loading:
 				return !this.isAuto;
@@ -686,8 +693,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 			case State.Hidden:
 				return false;
 			case State.Details:
-				// Not worried about details just yet...
-				// this.details.pageUp();
+				this.details.scrollTop();
 				return true;
 			case State.Loading:
 				return !this.isAuto;


### PR DESCRIPTION
This PR adds a support for `home` / `end` keys in IntelliSense. I had basically the very same expectaction / feeling as given in #18656.

Everything is pretty straight-forward except:

* I wasn't able to locate tests for `suggestWidget`, `listWidget`, am I missing something?
* I don't really know how to trigger details view (from end user perspective) so **I couldn't test it**. Please make sure to check it or provide me an example steps on how to trigger it.
* I know nothing about Mac hotkeys, so the default mapping included only home and end key which are present on Windows / Linux.