### PR TITLE
fix: remove unnecessary spacing in German i18n menu

### DIFF
--- a/i18n/deu/src/vs/code/electron-main/menus.i18n.json
+++ b/i18n/deu/src/vs/code/electron-main/menus.i18n.json
@@ -101,7 +101,7 @@
 	"miSelectAll": "&&Alles auswählen",
 	"miSelectColorTheme": "&&Farbdesign",
 	"miSelectHighlights": "Alle V&&orkommen auswählen",
-	"miSelectIconTheme": "Datei- &&Symboldesign",
+	"miSelectIconTheme": "Datei-&&Symboldesign",
 	"miShowActivityBar": "&&Aktivitätsleiste anzeigen",
 	"miShowEmmetCommands": "E&&mmet...",
 	"miShowStatusbar": "&&Statusleiste anzeigen",


### PR DESCRIPTION
Fix German menu looks and spelling in VSCode.