### PR TITLE
Add error handling for when emmet cannot be loaded and update commit hash for emmet

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -90,7 +90,7 @@
     "emmet": {
       "version": "1.3.1",
       "from": "ramya-rao-a/emmet#vscode",
-      "resolved": "git+https://github.com/ramya-rao-a/emmet.git#1d75a37a8c75795e103dae72b897eb0790c523ae"
+      "resolved": "git+https://github.com/ramya-rao-a/emmet.git#c8eb99f46c6734a37beadfd826c98a7a44d3e141"
     },
     "expand-brackets": {
       "version": "0.1.5",

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -92,6 +92,8 @@ class LazyEmmet {
 		return this._loadEmmet().then((_emmet: typeof emmet) => {
 			this._messageService = messageService;
 			this._withEmmetPreferences(configurationService, _emmet, callback);
+		}, (e) => {
+			callback(null);
 		});
 	}
 
@@ -241,6 +243,10 @@ export abstract class EmmetEditorAction extends EditorAction {
 			}
 
 			return LazyEmmet.withConfiguredEmmet(configurationService, messageService, workspaceRoot, (_emmet) => {
+				if (!_emmet) {
+					this.noExpansionOccurred(editor);
+					return undefined;
+				}
 				editorAccessor.onBeforeEmmetAction();
 				instantiationService.invokeFunction((accessor) => {
 					this.runEmmetAction(accessor, new EmmetActionContext(editor, _emmet, editorAccessor));


### PR DESCRIPTION
Fixes #20209 
The patched emmet that we were using had an unintended commit that adds a dependency on `caniuse-db` which could not be found.

For some reason, this is not an issue while building VS Code from source. Either that or I might have had an old version of `caniuse-db` lying around.