### PR TITLE
Implement reference streaming

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -394,7 +394,7 @@ export interface ReferenceProvider {
 	/**
 	 * Provide a set of project-wide references for the given position and document.
 	 */
-	provideReferences(model: editorCommon.IReadOnlyModel, position: Position, context: ReferenceContext, token: CancellationToken): Location[] | Thenable<Location[]>;
+	provideReferences(model: editorCommon.IReadOnlyModel, position: Position, context: ReferenceContext, token: CancellationToken, progress: (locations: Location[]) => void): Location[] | Thenable<Location[]>;
 }
 
 /**

--- a/src/vs/editor/contrib/referenceSearch/browser/referencesModel.ts
+++ b/src/vs/editor/contrib/referenceSearch/browser/referencesModel.ts
@@ -10,7 +10,6 @@ import { basename, dirname } from 'vs/base/common/paths';
 import { IDisposable, dispose, IReference } from 'vs/base/common/lifecycle';
 import * as strings from 'vs/base/common/strings';
 import URI from 'vs/base/common/uri';
-import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Range } from 'vs/editor/common/core/range';
 import { IPosition, IRange } from 'vs/editor/common/editorCommon';
@@ -26,7 +25,15 @@ export class OneReference {
 		private _range: IRange,
 		private _eventBus: EventEmitter
 	) {
-		this._id = defaultGenerator.nextId();
+		this._id = this._generateStableId();
+	}
+
+	private _generateStableId(): string {
+		return this.uri.toString() + ":" + this._toString(this.range);
+	}
+
+	private _toString(range: IRange): string {
+		return [range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn].join(":");
 	}
 
 	public get id(): string {

--- a/src/vs/editor/contrib/referenceSearch/common/referenceSearch.ts
+++ b/src/vs/editor/contrib/referenceSearch/common/referenceSearch.ts
@@ -13,12 +13,12 @@ import { Location, ReferenceProviderRegistry } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
 
-export function provideReferences(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+export function provideReferences(model: IReadOnlyModel, position: Position, progress: (locations: Location[]) => void): TPromise<Location[]> {
 
 	// collect references from all providers
 	const promises = ReferenceProviderRegistry.ordered(model).map(provider => {
 		return asWinJsPromise((token) => {
-			return provider.provideReferences(model, position, { includeDeclaration: true }, token);
+			return provider.provideReferences(model, position, { includeDeclaration: true }, token, progress);
 		}).then(result => {
 			if (Array.isArray(result)) {
 				return <Location[]>result;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4577,7 +4577,7 @@ declare module monaco.languages {
         /**
          * Provide a set of project-wide references for the given position and document.
          */
-        provideReferences(model: editor.IReadOnlyModel, position: Position, context: ReferenceContext, token: CancellationToken): Location[] | Thenable<Location[]>;
+        provideReferences(model: editor.IReadOnlyModel, position: Position, context: ReferenceContext, token: CancellationToken, progress: (locations: Location[]) => void): Location[] | Thenable<Location[]>;
     }
 
     /**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1183,6 +1183,9 @@ declare module 'vscode' {
 		dispose(): void;
 	}
 
+	// TODO(nick): document and use everywhere
+	export type ProgressCallback<T> = (value: T) => void;
+
 	/**
 	 * Represents a type which can release resources, such
 	 * as event listening or a timer.
@@ -1973,10 +1976,15 @@ declare module 'vscode' {
 		 * @param position The position at which the command was invoked.
 		 * @param context
 		 * @param token A cancellation token.
+		 * @param progress A callback that the implementation MAY call to send intermediate results.
+		 * This allows the UI to start showing these results to the user.
+		 * Calls to `progress` should only include results that have not been passed to previous calls to `progress`.
+		 * Calls to `progress` after the call to `provideReferences` has resolved will be ignored.
+		 * The order of data sent via `progress` does not matter. The results will be sorted before being displayed to the user.
 		 * @return An array of locations or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideReferences(document: TextDocument, position: Position, context: ReferenceContext, token: CancellationToken): ProviderResult<Location[]>;
+		provideReferences(document: TextDocument, position: Position, context: ReferenceContext, token: CancellationToken, progress: ProgressCallback<Location[]>): ProviderResult<Location[]>;
 	}
 
 	/**

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -160,6 +160,15 @@ export abstract class MainThreadLanguageFeaturesShape {
 	$registerHoverProvider(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerDocumentHighlightProvider(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerReferenceSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
+	/**
+	 * While the main thread is waiting for a call to ExtHostLanguageFeaturesShape.$provideReferences to resolve,
+	 * the extension may call this method to notify the main thread of intermediate results.
+	 * This function is an implementation detail since it is not possible to serialize callbacks (functions) over the
+	 * communication channel between the extension host and the main thread.
+	 *
+	 * vscode.d.ts exposes a higher level API with a progress callback.
+	 */
+	$notifyProvideReferencesProgress(handle: number, progressHandle: number, locations: modes.Location[]): TPromise<any> { throw ni(); }
 	$registerQuickFixSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerDocumentFormattingSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
 	$registerRangeFormattingSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> { throw ni(); }
@@ -367,7 +376,7 @@ export abstract class ExtHostLanguageFeaturesShape {
 	$provideTypeDefinition(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Definition> { throw ni(); }
 	$provideHover(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.Hover> { throw ni(); }
 	$provideDocumentHighlights(handle: number, resource: URI, position: editorCommon.IPosition): TPromise<modes.DocumentHighlight[]> { throw ni(); }
-	$provideReferences(handle: number, resource: URI, position: editorCommon.IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]> { throw ni(); }
+	$provideReferences(handle: number, progressHandle: number, resource: URI, position: editorCommon.IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]> { throw ni(); }
 	$provideCodeActions(handle: number, resource: URI, range: editorCommon.IRange): TPromise<modes.CodeAction[]> { throw ni(); }
 	$provideDocumentFormattingEdits(handle: number, resource: URI, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]> { throw ni(); }
 	$provideDocumentRangeFormattingEdits(handle: number, resource: URI, range: editorCommon.IRange, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]> { throw ni(); }

--- a/src/vs/workbench/api/node/mainThreadHandlerRegistry.ts
+++ b/src/vs/workbench/api/node/mainThreadHandlerRegistry.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+/**
+ * MainThreadHandlerRegistry maintains a collection of objects by handle.
+ */
+export class MainThreadHandlerRegistry<T> {
+
+	private _nextChildHandle: number = 0;
+	private _registrations: { [handle: number]: { [childHandle: number]: T }; } = Object.create(null);
+
+	/**
+	 * registerChild registers a child object of handle.
+	 * It returns the new handle assigned to the child.
+	 */
+	registerChild(handle: number, child: T): number {
+		const childHandle = this._nextChildHandle;
+		this._nextChildHandle++;
+		if (!this._registrations[handle]) {
+			this._registrations[handle] = Object.create(null);
+		}
+		this._registrations[handle][childHandle] = child;
+		return childHandle;
+	}
+
+	/**
+	 * getChild returns the object associated with handle and childHandle, if it exists.
+	 */
+	getChild(handle: number, childHandle: number): T | undefined {
+		if (!this._registrations[handle]) {
+			return undefined;
+		}
+		return this._registrations[handle][childHandle];
+	}
+
+	/**
+	 * unregister unregisters all child objects of handle.
+	 */
+	unregister(handle: number): void {
+		delete this._registrations[handle];
+	}
+
+	/**
+	 * unregisterChild unregisters the object associated with handle and childHandle.
+	 */
+	unregisterChild(handle: number, childHandle: number): void {
+		if (this._registrations[handle]) {
+			delete this._registrations[handle][childHandle];
+		}
+	}
+}


### PR DESCRIPTION
This PR implements the necessary changes in vscode to support streaming the response for "Find all references" requests as described in #20010 (please read this issue for complete context).

Streaming results makes reference requests more responsive for large repos since the user does not have to wait for all results to start seeing some results. If the user interacts with the reference results before they have finished streaming in, their position and state will be preserved.

Before merging:
- [ ] Use ProgressCallback
- [ ] Fix CI errors
    ```
    src/vs/editor/contrib/referenceSearch/browser/referencesModel.ts:32:32:Unexternalized string found: ":"
    src/vs/editor/contrib/referenceSearch/browser/referencesModel.ts:36:96:Unexternalized string found: ":"
    /home/travis/build/Microsoft/vscode/src/vs/workbench/test/node/api/extHostLanguageFeatures.test.ts(592,11): Supplied parameters do not match any signature of call target.
    ```