### PR TITLE
Send Script Kind based on languageId for js and ts files

### DIFF
--- a/extensions/typescript/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript/src/features/bufferSyncSupport.ts
@@ -5,7 +5,6 @@
 'use strict';
 
 import * as cp from 'child_process';
-import * as path from 'path';
 import * as fs from 'fs';
 
 import { workspace, window, TextDocument, TextDocumentChangeEvent, TextDocumentContentChangeEvent, Disposable, MessageItem } from 'vscode';
@@ -48,15 +47,11 @@ class SyncedBuffer {
 			fileContent: this.document.getText(),
 		};
 		if (this.client.apiVersion.has203Features()) {
-			// we have no extension. So check the mode and
-			// set the script kind accordningly.
-			const ext = path.extname(this.filepath);
-			if (ext === '') {
-				const scriptKind = Mode2ScriptKind[this.document.languageId];
-				if (scriptKind) {
-					args.scriptKindName = scriptKind;
-				}
+			const scriptKind = Mode2ScriptKind[this.document.languageId];
+			if (scriptKind) {
+				args.scriptKindName = scriptKind;
 			}
+
 		}
 		this.client.execute('open', args, false);
 	}


### PR DESCRIPTION
http://stackoverflow.com/questions/42139118/is-error-checking-in-vs-code-exclusively-tied-to-the-file-extension

**bug**
When using custom file associations for js/ts files, we do not always open the files against TypeScript with the  correct language mode.

**Fix**
Always send `scriptKind` to Typescript based on the languageId of the file