### PR TITLE
Add Command to Go To / Create project configuration for an active js or ts file

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -34,6 +34,7 @@
     "onCommand:typescript.reloadProjects",
     "onCommand:javascript.reloadProjects",
     "onCommand:typescript.selectTypeScriptVersion",
+    "onCommand:javascript.goToProjectConfig",
     "onCommand:typescript.goToProjectConfig"
   ],
   "main": "./out/typescriptMain",
@@ -258,19 +259,28 @@
     "commands": [
       {
         "command": "typescript.reloadProjects",
-        "title": "%typescript.reloadProjects.title%"
+        "title": "%typescript.reloadProjects.title%",
+        "category": "TypeScript"
       },
       {
         "command": "javascript.reloadProjects",
-        "title": "%javascript.reloadProjects.title%"
+        "title": "%javascript.reloadProjects.title%",
+        "category": "JavaScript"
       },
       {
         "command": "typescript.selectTypeScriptVersion",
-        "title": "%typescript.selectTypeScriptVersion.title%"
+        "title": "%typescript.selectTypeScriptVersion.title%",
+        "category": "TypeScript"
       },
       {
         "command": "typescript.goToProjectConfig",
-        "title": "%typescript.goToProjectConfig.title%"
+        "title": "%typescript.goToProjectConfig.title%",
+        "category": "TypeScript"
+      },
+       {
+        "command": "javascript.goToProjectConfig",
+        "title": "%javascript.goToProjectConfig.title%",
+        "category": "JavaScript"
       }
     ],
     "breakpoints": [

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -33,7 +33,8 @@
     "onLanguage:jsx-tags",
     "onCommand:typescript.reloadProjects",
     "onCommand:javascript.reloadProjects",
-    "onCommand:typescript.selectTypeScriptVersion"
+    "onCommand:typescript.selectTypeScriptVersion",
+    "onCommand:typescript.goToProjectConfig"
   ],
   "main": "./out/typescriptMain",
   "enableProposedApi": true,
@@ -266,6 +267,10 @@
       {
         "command": "typescript.selectTypeScriptVersion",
         "title": "%typescript.selectTypeScriptVersion.title%"
+      },
+      {
+        "command": "typescript.goToProjectConfig",
+        "title": "%typescript.goToProjectConfig.title%"
       }
     ],
     "breakpoints": [

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -24,6 +24,7 @@
 	"format.placeOpenBraceOnNewLineForFunctions": "Defines whether an open brace is put onto a new line for functions or not.",
 	"format.placeOpenBraceOnNewLineForControlBlocks": "Defines whether an open brace is put onto a new line for control blocks or not.",
 	"javascript.validate.enable": "Enable/disable JavaScript validation.",
+	"typescript.goToProjectConfig.title": "Go to project configuration",
 	"typescript.referencesCodeLens.enabled": "Enable/disable the references code lens.",
-	"typescript.selectTypeScriptVersion.title": "Select TypeScript version."
+	"typescript.selectTypeScriptVersion.title": "Select TypeScript version"
 }

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -1,6 +1,6 @@
 {
-	"typescript.reloadProjects.title": "Reload TypeScript Project",
-	"javascript.reloadProjects.title": "Reload JavaScript Project",
+	"typescript.reloadProjects.title": "Reload Project",
+	"javascript.reloadProjects.title": "Reload Project",
 	"configuration.typescript": "TypeScript",
 	"typescript.useCodeSnippetsOnMethodSuggest.dec": "Complete functions with their parameter signature.",
 	"typescript.tsdk.desc": "Specifies the folder path containing the tsserver and lib*.d.ts files to use.",
@@ -24,7 +24,8 @@
 	"format.placeOpenBraceOnNewLineForFunctions": "Defines whether an open brace is put onto a new line for functions or not.",
 	"format.placeOpenBraceOnNewLineForControlBlocks": "Defines whether an open brace is put onto a new line for control blocks or not.",
 	"javascript.validate.enable": "Enable/disable JavaScript validation.",
-	"typescript.goToProjectConfig.title": "Go to project configuration",
+	"typescript.goToProjectConfig.title": "Go to Project Configuration",
+	"javascript.goToProjectConfig.title": "Go to Project Configuration",
 	"typescript.referencesCodeLens.enabled": "Enable/disable the references code lens.",
-	"typescript.selectTypeScriptVersion.title": "Select TypeScript version"
+	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version"
 }

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -103,7 +103,7 @@ export function activate(context: ExtensionContext): void {
 	const goToProjectConfig = (isTypeScript: boolean) => {
 		const editor = window.activeTextEditor;
 		if (editor) {
-			clientHost.goToProjectConfig(isTypeScript, editor.document.uri);
+			clientHost.goToProjectConfig(isTypeScript, editor.document.uri, editor.document.languageId);
 		}
 	};
 	context.subscriptions.push(commands.registerCommand('typescript.goToProjectConfig', goToProjectConfig.bind(null, true)));
@@ -398,7 +398,11 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 		return !!this.findLanguage(file);
 	}
 
-	public goToProjectConfig(isTypeScriptProject: boolean, resource: Uri): Thenable<TextEditor> | undefined {
+	public goToProjectConfig(
+		isTypeScriptProject: boolean,
+		resource: Uri,
+		languageId: string
+	): Thenable<TextEditor> | undefined {
 		const rootPath = workspace.rootPath;
 		if (!rootPath) {
 			window.showInformationMessage(
@@ -409,7 +413,8 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 		}
 
 		const file = this.client.normalizePath(resource);
-		if (!file) {
+		// TODO: TSServer errors when 'projectInfo' is invoked on a non js/ts file
+		if (!file || !this.languagePerId[languageId]) {
 			window.showWarningMessage(
 				localize(
 					'typescript.projectConfigUnsupportedFile',


### PR DESCRIPTION
Part of #20356

Adds a new command that opens the `jsconfig` or `tsconfig` project configuration file for the currently active javascript or typescript file. If the file is not part of a project, displays a quick pick that allows users to learn more and create a config file at the root of their project