### PR TITLE
Open vscode://file/path/to/project/ URLs properly on Windows - fixes #20290

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -8,7 +8,7 @@
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { assign } from 'vs/base/common/objects';
-import { URI } from 'vs/base/common/uri';
+import URI from 'vs/base/common/uri';
 import { IWindowsService } from 'vs/platform/windows/common/windows';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { shell, crashReporter, app } from 'electron';

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -274,11 +274,14 @@ export class WindowsService implements IWindowsService, IDisposable {
 	private parseURIForOpen(uri: URI): string {
 		if (uri.authority === 'file') {
 			let path = uri.path.substr(1);
-			if (path.slice(0, path.indexOf('/')).length === 1) { // add a colon if the uri.path contains a valid drive letter.
+			let drive = path.slice(0, path.indexOf('/'));
+			if (drive.length === 1) { // add a colon if the uri.path contains a valid drive letter.
 				path = path.slice(0, path.indexOf('/')) + ':' + path.slice(path.indexOf('/'));
 				return path;
 			}
-
+			if (drive.length === 2 && drive.indexOf(':')) { // path has a colon already
+				return path;
+			}
 			return uri.path;
 		}
 		return uri.path;

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -274,7 +274,7 @@ export class WindowsService implements IWindowsService, IDisposable {
 	private parseURIForOpen(uri: URI): string {
 		if (uri.authority === 'file') {
 			let path = uri.path.substr(1);
-			if (path.slice(0, path.indexOf('/')).length === 1) {
+			if (path.slice(0, path.indexOf('/')).length === 1) { // add a colon if the uri.path contains a valid drive letter.
 				path = path.slice(0, path.indexOf('/')) + ':' + path.slice(path.indexOf('/'));
 			}
 			else {

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -276,12 +276,10 @@ export class WindowsService implements IWindowsService, IDisposable {
 			let path = uri.path.substr(1);
 			if (path.slice(0, path.indexOf('/')).length === 1) { // add a colon if the uri.path contains a valid drive letter.
 				path = path.slice(0, path.indexOf('/')) + ':' + path.slice(path.indexOf('/'));
-			}
-			else {
-				path = path;
+				return path;
 			}
 
-			return path;
+			return uri.path;
 		}
 		return uri.path;
 	}

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -272,9 +272,15 @@ export class WindowsService implements IWindowsService, IDisposable {
 	}
 
 	private parseURIForOpen(uri: URI): string {
-		if (uri.authority === 'file') {
-			let path = uri.path.substr(1);
-			let drive = path.slice(0, path.indexOf('/'));
+		/**
+		 * opening vscode://file/drive/path/to/project passes a POSIX-style path on Windows.
+		 * i.e vscode://file/c/path/to/project gives a path of /c/path/to/project
+		 * let's strip the root slash and ensure the drive letter is something Windows
+		 * can understand.
+		 */
+		if (uri.authority === 'file' && process.platform === 'win32') {
+			let path = uri.path.substr(1); // strip the root slash
+			let drive = path.slice(0, path.indexOf('/')); // find the drive letter
 			if (drive.length === 1) { // add a colon if the uri.path contains a valid drive letter.
 				path = path.slice(0, path.indexOf('/')) + ':' + path.slice(path.indexOf('/'));
 				return path;
@@ -284,6 +290,8 @@ export class WindowsService implements IWindowsService, IDisposable {
 			}
 			return uri.path;
 		}
+
+		// *NIX platforms can process this path natively.
 		return uri.path;
 	}
 


### PR DESCRIPTION
Opening vscode://file/c/path/to/project/or/file.txt will no longer fail on Windows.

Tested using multiple drive letters and file/folder paths.