### PR TITLE
correct boundary for embedded languages in HTML

### DIFF
--- a/extensions/html/syntaxes/html.json
+++ b/extensions/html/syntaxes/html.json
@@ -152,12 +152,12 @@
 				}
 			},
 			"end": "(</)((?i:style))(>)(?:\\s*\\n)?",
-			"contentName": "source.css.embedded.html",
 			"patterns": [
 				{
 					"include": "#tag-stuff"
 				},
 				{
+					"contentName": "source.css.embedded.html",
 					"begin": "(>)",
 					"beginCaptures": {
 						"1": {
@@ -192,12 +192,12 @@
 					"name": "punctuation.definition.tag.html"
 				}
 			},
-			"contentName": "source.js.embedded.html",
 			"patterns": [
 				{
 					"include": "#tag-stuff"
 				},
 				{
+					"contentName": "source.js.embedded.html",
 					"begin": "(?<!</(?:script|SCRIPT))(>)",
 					"captures": {
 						"1": {


### PR DESCRIPTION
Treat tags `<script>` `<style>` as HTML instead of part of the embedded languages.

![grammar](https://cloud.githubusercontent.com/assets/876920/22944053/5dc5bfe8-f2a4-11e6-864b-e941233de897.gif)
