### PR TITLE
markdown-it-named-header custom slugify for non-latin characters

### DIFF
--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -44,7 +44,15 @@ export class MarkdownEngine {
 					}
 					return `<pre class="hljs"><code><div>${this.engine.utils.escapeHtml(str)}</div></code></pre>`;
 				}
-			}).use(mdnh, {});
+			}).use(mdnh, {
+				slugify: function (header: string) {
+            		return encodeURI(header.trim()
+ 							.toLowerCase()
+							.replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~]/g, '') //remove symbol
+							.replace(/\s+/g, '-')) // Replace spaces with hyphens
+							.replace(/\-+$/, ''); // Replace trailing hyphen
+					}
+			});
 
 			for (const renderName of ['paragraph_open', 'heading_open', 'image', 'code_block', 'blockquote_open', 'list_item_open']) {
 				this.addLineNumberRenderer(this.md, renderName);

--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -48,9 +48,9 @@ export class MarkdownEngine {
 				slugify: function (header: string) {
             		return encodeURI(header.trim()
  							.toLowerCase()
-							.replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~]/g, '') //remove symbol
-							.replace(/\s+/g, '-')) // Replace spaces with hyphens
-							.replace(/\-+$/, ''); // Replace trailing hyphen
+							.replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~]/g, '')
+							.replace(/\s+/g, '-')
+							.replace(/\-+$/, ''));
 					}
 			});
 


### PR DESCRIPTION
Issues: non-latin characters (such as japanese) and Markdown preview anchor #20626

**PROBLEM:**

I want to realize an in-page link by using an anchor in Markdown Preview, but it does not work with non-latin characters.
If the header is written in non-latin characters (such as Japanese), it is judged to be an invalid character, so the value of the id attribute is empty.
