### PR TITLE
Prototype of Implementations Code Lens Provider for TypeScript

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -111,6 +111,11 @@
           "default": false,
           "description": "%typescript.referencesCodeLens.enabled%"
         },
+        "typescript.implementationsCodeLens.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "%typescript.implementationsCodeLens.enabled%"
+        },
         "typescript.tsserver.trace": {
           "type": "string",
           "enum": [

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -27,5 +27,6 @@
 	"typescript.goToProjectConfig.title": "Go to Project Configuration",
 	"javascript.goToProjectConfig.title": "Go to Project Configuration",
 	"typescript.referencesCodeLens.enabled": "Enable/disable references CodeLens.",
+	"typescript.implementationsCodeLens.enabled": "Enable/disable implementations CodeLens.",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version"
 }

--- a/extensions/typescript/src/features/baseCodeLensProvider.ts
+++ b/extensions/typescript/src/features/baseCodeLensProvider.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { CodeLensProvider, CodeLens, CancellationToken, TextDocument, Range, Uri, Position } from 'vscode';
+import * as Proto from '../protocol';
+
+import { ITypescriptServiceClient } from '../typescriptService';
+
+export class ReferencesCodeLens extends CodeLens {
+	constructor(
+		public document: Uri,
+		public file: string,
+		range: Range
+	) {
+		super(range);
+	}
+}
+
+export abstract class TypeScriptBaseCodeLensProvider implements CodeLensProvider {
+	public constructor(
+		protected client: ITypescriptServiceClient
+	) { }
+
+	provideCodeLenses(document: TextDocument, token: CancellationToken): Promise<CodeLens[]> {
+		const filepath = this.client.normalizePath(document.uri);
+		if (!filepath) {
+			return Promise.resolve([]);
+		}
+		return this.client.execute('navtree', { file: filepath }, token).then(response => {
+			if (!response) {
+				return [];
+			}
+			const tree = response.body;
+			const referenceableSpans: Range[] = [];
+			if (tree && tree.childItems) {
+				tree.childItems.forEach(item => this.walkNavTree(document, item, referenceableSpans));
+			}
+			return referenceableSpans.map(span => new ReferencesCodeLens(document.uri, filepath, span));
+		});
+	}
+
+	protected abstract extractSymbol(
+		document: TextDocument,
+		item: Proto.NavigationTree
+	): Range | null;
+
+	private walkNavTree(
+		document: TextDocument,
+		item: Proto.NavigationTree,
+		results: Range[]
+	): void {
+		if (!item) {
+			return;
+		}
+
+		const range = this.extractSymbol(document, item);
+		if (range) {
+			results.push(range);
+		}
+
+		(item.childItems || []).forEach(item => this.walkNavTree(document, item, results));
+	}
+
+
+	/**
+	 * TODO: TS currently requires the position for 'references 'to be inside of the identifer
+	 * Massage the range to make sure this is the case
+	 */
+	protected getSymbolRange(document: TextDocument, item: Proto.NavigationTree): Range | null {
+		if (!item) {
+			return null;
+		}
+
+		const span = item.spans && item.spans[0];
+		if (!span) {
+			return null;
+		}
+
+		const range = new Range(
+			span.start.line - 1, span.start.offset - 1,
+			span.end.line - 1, span.end.offset - 1);
+
+		const text = document.getText(range);
+
+		const identifierMatch = new RegExp(`^(.*?(\\b|\\W))${(item.text || '').replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')}\\b`, 'gm');
+		const match = identifierMatch.exec(text);
+		const prefixLength = match ? match.index + match[1].length : 0;
+		const startOffset = document.offsetAt(new Position(range.start.line, range.start.character)) + prefixLength;
+		return new Range(
+			document.positionAt(startOffset),
+			document.positionAt(startOffset + item.text.length));
+	}
+};

--- a/extensions/typescript/src/features/baseCodeLensProvider.ts
+++ b/extensions/typescript/src/features/baseCodeLensProvider.ts
@@ -37,7 +37,7 @@ export abstract class TypeScriptBaseCodeLensProvider implements CodeLensProvider
 			const tree = response.body;
 			const referenceableSpans: Range[] = [];
 			if (tree && tree.childItems) {
-				tree.childItems.forEach(item => this.walkNavTree(document, item, referenceableSpans));
+				tree.childItems.forEach(item => this.walkNavTree(document, item, null, referenceableSpans));
 			}
 			return referenceableSpans.map(span => new ReferencesCodeLens(document.uri, filepath, span));
 		});
@@ -45,26 +45,27 @@ export abstract class TypeScriptBaseCodeLensProvider implements CodeLensProvider
 
 	protected abstract extractSymbol(
 		document: TextDocument,
-		item: Proto.NavigationTree
+		item: Proto.NavigationTree,
+		parent: Proto.NavigationTree | null
 	): Range | null;
 
 	private walkNavTree(
 		document: TextDocument,
 		item: Proto.NavigationTree,
+		parent: Proto.NavigationTree | null,
 		results: Range[]
 	): void {
 		if (!item) {
 			return;
 		}
 
-		const range = this.extractSymbol(document, item);
+		const range = this.extractSymbol(document, item, parent);
 		if (range) {
 			results.push(range);
 		}
 
-		(item.childItems || []).forEach(item => this.walkNavTree(document, item, results));
+		(item.childItems || []).forEach(child => this.walkNavTree(document, child, item, results));
 	}
-
 
 	/**
 	 * TODO: TS currently requires the position for 'references 'to be inside of the identifer
@@ -94,4 +95,4 @@ export abstract class TypeScriptBaseCodeLensProvider implements CodeLensProvider
 			document.positionAt(startOffset),
 			document.positionAt(startOffset + item.text.length));
 	}
-};
+}

--- a/extensions/typescript/src/features/implementationsCodeLensProvider.ts
+++ b/extensions/typescript/src/features/implementationsCodeLensProvider.ts
@@ -15,7 +15,7 @@ import { ITypescriptServiceClient } from '../typescriptService';
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
-export default class TypeScriptReferencesCodeLensProvider extends TypeScriptBaseCodeLensProvider {
+export default class TypeScriptImplementationsCodeLensProvider extends TypeScriptBaseCodeLensProvider {
 	private enabled = false;
 
 	private onDidChangeCodeLensesEmitter = new EventEmitter<void>();
@@ -53,33 +53,33 @@ export default class TypeScriptReferencesCodeLensProvider extends TypeScriptBase
 			line: codeLens.range.start.line + 1,
 			offset: codeLens.range.start.character + 1
 		};
-		return this.client.execute('references', args, token).then(response => {
+		return this.client.execute('implementation', args, token).then(response => {
 			if (!response || !response.body) {
 				throw codeLens;
 			}
 
-			const locations = response.body.refs
+			const locations = response.body
 				.map(reference =>
 					new Location(this.client.asUrl(reference.file),
 						new Range(
 							reference.start.line - 1, reference.start.offset - 1,
 							reference.end.line - 1, reference.end.offset - 1)))
+				// Exclude original from implementations
 				.filter(location =>
-					// Exclude original definition from references
 					!(location.uri.fsPath === codeLens.document.fsPath &&
-						location.range.start.isEqual(codeLens.range.start)));
+						location.range.start.line === codeLens.range.start.line));
 
 			codeLens.command = {
 				title: locations.length === 1
-					? localize('oneReferenceLabel', '1 reference')
-					: localize('manyReferenceLabel', '{0} references', locations.length),
+					? localize('oneImplementationLabel', '1 implementation')
+					: localize('manyImplementationLabel', '{0} implementations', locations.length),
 				command: 'editor.action.showReferences',
 				arguments: [codeLens.document, codeLens.range.start, locations]
 			};
 			return codeLens;
 		}).catch(() => {
 			codeLens.command = {
-				title: localize('referenceErrorLabel', 'Could not determine references'),
+				title: localize('implementationsErrorLabel', 'Could not determine implementations'),
 				command: ''
 			};
 			return codeLens;
@@ -91,33 +91,19 @@ export default class TypeScriptReferencesCodeLensProvider extends TypeScriptBase
 		item: Proto.NavigationTree
 	): Range | null {
 		switch (item.kind) {
-			case PConst.Kind.const:
-			case PConst.Kind.let:
-			case PConst.Kind.variable:
-			case PConst.Kind.function:
-				// Only show references for exported variables
-				if (!item.kindModifiers.match(/\bexport\b/)) {
-					break;
-				}
-			// fallthrough
+			case PConst.Kind.interface:
+				return super.getSymbolRange(document, item);
 
 			case PConst.Kind.class:
-				if (item.text === '<class>') {
-					break;
-				}
-			// fallthrough
-
 			case PConst.Kind.memberFunction:
 			case PConst.Kind.memberVariable:
 			case PConst.Kind.memberGetAccessor:
 			case PConst.Kind.memberSetAccessor:
-			case PConst.Kind.constructorImplementation:
-			case PConst.Kind.interface:
-			case PConst.Kind.type:
-			case PConst.Kind.enum:
-				return super.getSymbolRange(document, item);
+				if (item.kindModifiers.match(/\babstract\b/g)) {
+					return super.getSymbolRange(document, item);
+				}
+				break;
 		}
-
 		return null;
 	}
 }

--- a/extensions/typescript/src/features/implementationsCodeLensProvider.ts
+++ b/extensions/typescript/src/features/implementationsCodeLensProvider.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CodeLens, CancellationToken, TextDocument, Range, Location, workspace, EventEmitter, Event } from 'vscode';
+import { CodeLens, CancellationToken, TextDocument, Range, Location } from 'vscode';
 import * as Proto from '../protocol';
 import * as PConst from '../protocol.const';
 
@@ -16,34 +16,10 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 export default class TypeScriptImplementationsCodeLensProvider extends TypeScriptBaseCodeLensProvider {
-	private enabled = false;
-
-	private onDidChangeCodeLensesEmitter = new EventEmitter<void>();
-
 	public constructor(
 		client: ITypescriptServiceClient
 	) {
-		super(client);
-	}
-
-	public get onDidChangeCodeLenses(): Event<void> {
-		return this.onDidChangeCodeLensesEmitter.event;
-	}
-
-	public updateConfiguration(): void {
-		const typeScriptConfig = workspace.getConfiguration('typescript');
-		const wasEnabled = this.enabled;
-		this.enabled = typeScriptConfig.get('referencesCodeLens.enabled', false);
-		if (wasEnabled !== this.enabled) {
-			this.onDidChangeCodeLensesEmitter.fire();
-		}
-	}
-
-	provideCodeLenses(document: TextDocument, token: CancellationToken): Promise<CodeLens[]> {
-		if (!this.enabled) {
-			return Promise.resolve([]);
-		}
-		return super.provideCodeLenses(document, token);
+		super(client, 'implementationsCodeLens.enabled');
 	}
 
 	resolveCodeLens(inputCodeLens: CodeLens, token: CancellationToken): Promise<CodeLens> {

--- a/extensions/typescript/src/features/implementationsCodeLensProvider.ts
+++ b/extensions/typescript/src/features/implementationsCodeLensProvider.ts
@@ -88,8 +88,20 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 
 	protected extractSymbol(
 		document: TextDocument,
-		item: Proto.NavigationTree
+		item: Proto.NavigationTree,
+		parent: Proto.NavigationTree | null
 	): Range | null {
+		// Handle children of interfaces
+		if (parent && parent.kind === PConst.Kind.interface) {
+			switch (item.kind) {
+				case PConst.Kind.memberFunction:
+				case PConst.Kind.memberVariable:
+				case PConst.Kind.memberGetAccessor:
+				case PConst.Kind.memberSetAccessor:
+					return super.getSymbolRange(document, item);
+			}
+		}
+
 		switch (item.kind) {
 			case PConst.Kind.interface:
 				return super.getSymbolRange(document, item);

--- a/extensions/typescript/src/features/referencesCodeLensProvider.ts
+++ b/extensions/typescript/src/features/referencesCodeLensProvider.ts
@@ -88,7 +88,8 @@ export default class TypeScriptReferencesCodeLensProvider extends TypeScriptBase
 
 	protected extractSymbol(
 		document: TextDocument,
-		item: Proto.NavigationTree
+		item: Proto.NavigationTree,
+		_parent: Proto.NavigationTree | null
 	): Range | null {
 		switch (item.kind) {
 			case PConst.Kind.const:

--- a/extensions/typescript/src/features/referencesCodeLensProvider.ts
+++ b/extensions/typescript/src/features/referencesCodeLensProvider.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CodeLens, CancellationToken, TextDocument, Range, Location, workspace, EventEmitter, Event } from 'vscode';
+import { CodeLens, CancellationToken, TextDocument, Range, Location } from 'vscode';
 import * as Proto from '../protocol';
 import * as PConst from '../protocol.const';
 
@@ -16,34 +16,10 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 export default class TypeScriptReferencesCodeLensProvider extends TypeScriptBaseCodeLensProvider {
-	private enabled = false;
-
-	private onDidChangeCodeLensesEmitter = new EventEmitter<void>();
-
 	public constructor(
 		client: ITypescriptServiceClient
 	) {
-		super(client);
-	}
-
-	public get onDidChangeCodeLenses(): Event<void> {
-		return this.onDidChangeCodeLensesEmitter.event;
-	}
-
-	public updateConfiguration(): void {
-		const typeScriptConfig = workspace.getConfiguration('typescript');
-		const wasEnabled = this.enabled;
-		this.enabled = typeScriptConfig.get('referencesCodeLens.enabled', false);
-		if (wasEnabled !== this.enabled) {
-			this.onDidChangeCodeLensesEmitter.fire();
-		}
-	}
-
-	provideCodeLenses(document: TextDocument, token: CancellationToken): Promise<CodeLens[]> {
-		if (!this.enabled) {
-			return Promise.resolve([]);
-		}
-		return super.provideCodeLenses(document, token);
+		super(client, 'referencesCodeLens.enabled');
 	}
 
 	resolveCodeLens(inputCodeLens: CodeLens, token: CancellationToken): Promise<CodeLens> {

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -40,6 +40,7 @@ import WorkspaceSymbolProvider from './features/workspaceSymbolProvider';
 import CodeActionProvider from './features/codeActionProvider';
 import ReferenceCodeLensProvider from './features/referencesCodeLensProvider';
 import JsDocCompletionHelper from './features/jsDocCompletionProvider';
+import ImplementationCodeLensProvider from './features/implementationsCodeLensProvider';
 
 import * as BuildStatus from './utils/buildStatus';
 import * as ProjectStatus from './utils/projectStatus';
@@ -218,6 +219,10 @@ class LanguageProvider {
 			this.referenceCodeLensProvider = new ReferenceCodeLensProvider(client);
 			this.referenceCodeLensProvider.updateConfiguration();
 			this.disposables.push(languages.registerCodeLensProvider(selector, this.referenceCodeLensProvider));
+
+			const implementationCodeLens = new ImplementationCodeLensProvider(client);
+			implementationCodeLens.updateConfiguration();
+			this.disposables.push(languages.registerCodeLensProvider(selector, implementationCodeLens));
 		}
 
 		if (client.apiVersion.has213Features()) {


### PR DESCRIPTION
Fixes #20832

Adds a prototype code lens that shows the number of implementations for interfaces and abstract classes. This shares a lot of code with the references code lens provider, so I extracted most of the common stuff into a base class.

Currently, implementation counts are only shown on abstract classes, abstract methods, and interfaces

<img width="450" alt="screen shot 2017-02-16 at 11 08 05 pm" src="https://cloud.githubusercontent.com/assets/12821956/23055902/501c8fa2-f49d-11e6-9879-cdb752fc107c.png">


**Todo**
- [x] Show on interface members.
- [x] Add setting to toggle this on and off
- [ ] Think about the expected behavior. Should this also show up for inheritance / overriden methods
- [x] Remove more duplicate code