### PR TITLE
Suggestion widget: Fix overflowing text problem (fixes #20679)

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/suggest.css
@@ -172,7 +172,8 @@
 }
 
 .monaco-editor .suggest-widget .details > .header > .title {
-	flex: 2;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .monaco-editor .suggest-widget .details > .header > .go-back {


### PR DESCRIPTION
**Bug**
https://github.com/Microsoft/vscode/issues/20679

**Fix**
If the title is too long to fit to the widget, use ellipsis. Screenshot: 
<img width="454" alt="screen shot 2017-02-18 at 13 41 24" src="https://cloud.githubusercontent.com/assets/3121257/23093013/7d1f4c08-f5e0-11e6-9616-ae090c24c296.png">
