### PR TITLE
Hot Exit: Opens the same file twice in two separate windows

### DIFF
--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -373,7 +373,7 @@ export class WindowsManager implements IWindowsMainService {
 			openFolderInNewWindow = (windowConfig.openFoldersInNewWindow === 'on');
 		}
 
-		// Handle files to open/diff or to create when we dont open a folder
+		// Handle files to open/diff or to create when we dont open a folder and we do not restore any folder/untitled from hot-exit
 		if (!foldersToOpen.length && !foldersToRestore.length && !emptyToRestore.length && (filesToOpen.length > 0 || filesToCreate.length > 0 || filesToDiff.length > 0)) {
 
 			// let the user settings override how files are open in a new window or same window unless we are forced (not for extension development though)

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -374,7 +374,7 @@ export class WindowsManager implements IWindowsMainService {
 		}
 
 		// Handle files to open/diff or to create when we dont open a folder
-		if (!foldersToOpen.length && (filesToOpen.length > 0 || filesToCreate.length > 0 || filesToDiff.length > 0)) {
+		if (!foldersToOpen.length && !foldersToRestore.length && !emptyToRestore.length && (filesToOpen.length > 0 || filesToCreate.length > 0 || filesToDiff.length > 0)) {
 
 			// let the user settings override how files are open in a new window or same window unless we are forced (not for extension development though)
 			let openFilesInNewWindow: boolean;
@@ -471,9 +471,14 @@ export class WindowsManager implements IWindowsMainService {
 		// Handle empty
 		if (emptyToRestore.length > 0) {
 			emptyToRestore.forEach(emptyWorkspaceBackupFolder => {
-				const configuration = this.toConfiguration(openConfig);
+				const configuration = this.toConfiguration(openConfig, void 0, filesToOpen, filesToCreate, filesToDiff);
 				const browserWindow = this.openInBrowserWindow(configuration, true /* new window */, null, emptyWorkspaceBackupFolder);
 				usedWindows.push(browserWindow);
+
+				// Reset these because we handled them
+				filesToOpen = [];
+				filesToCreate = [];
+				filesToDiff = [];
 
 				openFolderInNewWindow = true; // any other folders to open must open in new window then
 			});


### PR DESCRIPTION
For: https://github.com/Microsoft/vscode/issues/16820

We have logic that decides on startup if files should open inside a separate window or new window. When we know that we open a window with a folder we always open files in that window. However we are not doing so when we know that we open a window with a folder that contains hot-exit files or an untitled window with hot-exit files.

This fix will prefer a folder with dirty files (or untitled window with dirty files to restore) to open the files in in order to fix https://github.com/Microsoft/vscode/issues/16820