### PR TITLE
Remove dependency on window.event in ListView

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -233,16 +233,20 @@ export class ListView<T> implements IDisposable {
 		let domNode = this.domNode;
 
 		if (MouseEventTypes.indexOf(type) > -1) {
-			handler = e => this.fireScopedEvent(userHandler, this.getItemIndexFromMouseEvent(e));
+			handler = e => this.fireScopedEvent(e, userHandler, this.getItemIndexFromMouseEvent(e));
 		} else if (type === TouchEventType.Tap) {
 			domNode = this.rowsContainer;
-			handler = e => this.fireScopedEvent(userHandler, this.getItemIndexFromGestureEvent(e));
+			handler = e => this.fireScopedEvent(e, userHandler, this.getItemIndexFromGestureEvent(e));
 		}
 
 		return DOM.addDisposableListener(domNode, type, handler, useCapture);
 	}
 
-	private fireScopedEvent(handler: (event: any) => void, index: number) {
+	private fireScopedEvent(
+		event: any,
+		handler: (event: any) => void,
+		index: number
+	) {
 		if (index < 0) {
 			return;
 		}
@@ -255,11 +259,11 @@ export class ListView<T> implements IDisposable {
 		this.render(e.scrollTop, e.height);
 	}
 
-	private onTouchChange(e: GestureEvent): void {
+	private onTouchChange(event: GestureEvent): void {
 		event.preventDefault();
 		event.stopPropagation();
 
-		this.scrollTop -= e.translationY;
+		this.scrollTop -= event.translationY;
 	}
 
 	// Util


### PR DESCRIPTION
Fixes Microsoft/monaco-editor#371.

The `event` property of Window is [nonstandard] and isn't supported by Firefox,
breaking some of ListView's event-handling behavior.

I checked for places where VSCode depends on `window.event` by removing it from
`lib.d.ts` and building from scratch; the references in ListView were the only
ones I found in `src/vs/base/browser`. There are also some references in
non-browser parts of the codebase, but I assume that's fine since they work in
Electron.

[nonstandard]: https://developer.mozilla.org/en-US/docs/Web/API/Window/event