### PR TITLE
Callback parameter for TestEditorService() is optional

### DIFF
--- a/src/vs/workbench/test/common/editor/rangeDecorations.test.ts
+++ b/src/vs/workbench/test/common/editor/rangeDecorations.test.ts
@@ -40,7 +40,7 @@ suite('Editor - Range decorations', () => {
 
 	setup(() => {
 		instantiationService = <TestInstantiationService>workbenchInstantiationService();
-		editorService = <WorkbenchEditorService.IWorkbenchEditorService>instantiationService.stub(WorkbenchEditorService.IWorkbenchEditorService, new TestEditorService(function () { }));
+		editorService = <WorkbenchEditorService.IWorkbenchEditorService>instantiationService.stub(WorkbenchEditorService.IWorkbenchEditorService, new TestEditorService());
 		modeService = instantiationService.stub(IModeService, ModeServiceImpl);
 		modelService = <IModelService>instantiationService.stub(IModelService, stubModelService(instantiationService));
 		text = 'LINE1' + '\n' + 'LINE2' + '\n' + 'LINE3' + '\n' + 'LINE4' + '\r\n' + 'LINE5';

--- a/src/vs/workbench/test/common/editor/stringEditorInput.test.ts
+++ b/src/vs/workbench/test/common/editor/stringEditorInput.test.ts
@@ -27,7 +27,7 @@ suite('Workbench - StringEditorInput', () => {
 
 	setup(() => {
 		instantiationService = new TestInstantiationService();
-		editorService = <WorkbenchEditorService.IWorkbenchEditorService>instantiationService.stub(WorkbenchEditorService.IWorkbenchEditorService, new TestEditorService(function () { }));
+		editorService = <WorkbenchEditorService.IWorkbenchEditorService>instantiationService.stub(WorkbenchEditorService.IWorkbenchEditorService, new TestEditorService());
 		modeService = instantiationService.stub(IModeService, ModeServiceImpl);
 		modelService = <IModelService>instantiationService.stub(IModelService, stubModelService(instantiationService));
 	});

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -189,7 +189,7 @@ export function workbenchInstantiationService(): IInstantiationService {
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());
 	instantiationService.stub(IUntitledEditorService, instantiationService.createInstance(UntitledEditorService));
 	instantiationService.stub(IStorageService, new TestStorageService());
-	instantiationService.stub(IWorkbenchEditorService, new TestEditorService(function () { }));
+	instantiationService.stub(IWorkbenchEditorService, new TestEditorService());
 	instantiationService.stub(IPartService, new TestPartService());
 	instantiationService.stub(IEditorGroupService, new TestEditorGroupService());
 	instantiationService.stub(IModeService, ModeServiceImpl);


### PR DESCRIPTION
Since the `callback` property is assigned an empty function in the constructor of TestEditorService, we shouldn't have to pass one in every time.