### PR TITLE
upgrade telemetry package used by git extension

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -589,7 +589,7 @@
     }
   },
   "dependencies": {
-    "vscode-extension-telemetry": "0.0.5",
+    "vscode-extension-telemetry": "^0.0.6",
     "vscode-nls": "^2.0.1"
   },
   "devDependencies": {

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -23,6 +23,7 @@ const localize = nls.config()();
 async function init(context: ExtensionContext, disposables: Disposable[]): Promise<void> {
 	const { name, version, aiKey } = require(context.asAbsolutePath('./package.json')) as { name: string, version: string, aiKey: string };
 	const telemetryReporter: TelemetryReporter = new TelemetryReporter(name, version, aiKey);
+	disposables.push(telemetryReporter);
 
 	const outputChannel = window.createOutputChannel('Git');
 	disposables.push(outputChannel);

--- a/extensions/git/src/typings/vscode-extension-telemetry.d.ts
+++ b/extensions/git/src/typings/vscode-extension-telemetry.d.ts
@@ -1,6 +1,0 @@
-declare module 'vscode-extension-telemetry' {
-	export default class TelemetryReporter {
-		constructor(extensionId: string, extensionVersion: string, key: string);
-		sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
-	}
-}


### PR DESCRIPTION
Upgrade to new version of vscode-extension-telemetry. See https://github.com/Microsoft/vscode-extension-telemetry/pull/5 for details.