### PR TITLE
upgrade telemetry package used by json and html extensions

### DIFF
--- a/extensions/html/client/src/htmlMain.ts
+++ b/extensions/html/client/src/htmlMain.ts
@@ -29,6 +29,7 @@ export function activate(context: ExtensionContext) {
 
 	let packageInfo = getPackageInfo(context);
 	let telemetryReporter: TelemetryReporter = packageInfo && new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+	context.subscriptions.push(telemetryReporter);
 
 	// The server is implemented in node
 	let serverModule = context.asAbsolutePath(path.join('server', 'out', 'htmlServerMain.js'));

--- a/extensions/html/client/src/typings/vscode-extension-telemetry.d.ts
+++ b/extensions/html/client/src/typings/vscode-extension-telemetry.d.ts
@@ -1,6 +1,0 @@
-declare module 'vscode-extension-telemetry' {
-	export default class TelemetryReporter {
-		constructor(extensionId: string, extensionVersion: string, key: string);
-		sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
-	}
-}

--- a/extensions/html/npm-shrinkwrap.json
+++ b/extensions/html/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "dependencies": {
     "applicationinsights": {
-      "version": "0.15.6",
-      "from": "applicationinsights@0.15.6",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.6.tgz"
+      "version": "0.18.0",
+      "from": "applicationinsights@0.18.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz"
     },
     "vscode-extension-telemetry": {
-      "version": "0.0.5",
-      "from": "vscode-extension-telemetry@>=0.0.5 <0.0.6",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.5.tgz"
+      "version": "0.0.6",
+      "from": "vscode-extension-telemetry@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.6.tgz"
     },
     "vscode-jsonrpc": {
       "version": "3.1.0-alpha.1",
@@ -33,9 +33,9 @@
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.2.tgz"
     },
     "winreg": {
-      "version": "0.0.13",
-      "from": "winreg@0.0.13",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.13.tgz"
+      "version": "1.2.3",
+      "from": "winreg@1.2.3",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.3.tgz"
     }
   }
 }

--- a/extensions/html/package.json
+++ b/extensions/html/package.json
@@ -189,7 +189,7 @@
     }
   },
   "dependencies": {
-    "vscode-extension-telemetry": "0.0.5",
+    "vscode-extension-telemetry": "^0.0.6",
     "vscode-languageclient": "^3.1.0-alpha.1",
     "vscode-languageserver-types": "^3.0.3",
     "vscode-nls": "^2.0.2"

--- a/extensions/json/client/src/jsonMain.ts
+++ b/extensions/json/client/src/jsonMain.ts
@@ -35,6 +35,7 @@ export function activate(context: ExtensionContext) {
 
 	let packageInfo = getPackageInfo(context);
 	let telemetryReporter: TelemetryReporter = packageInfo && new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+	context.subscriptions.push(telemetryReporter);
 
 	// The server is implemented in node
 	let serverModule = context.asAbsolutePath(path.join('server', 'out', 'jsonServerMain.js'));
@@ -99,7 +100,7 @@ function getSchemaAssociation(context: ExtensionContext): ISchemaAssociations {
 			let jsonValidation = packageJSON.contributes.jsonValidation;
 			if (Array.isArray(jsonValidation)) {
 				jsonValidation.forEach(jv => {
-					let {fileMatch, url} = jv;
+					let { fileMatch, url } = jv;
 					if (fileMatch && url) {
 						if (url[0] === '.' && url[1] === '/') {
 							url = Uri.file(path.join(extension.extensionPath, url)).toString();

--- a/extensions/json/client/src/typings/vscode-extension-telemetry.d.ts
+++ b/extensions/json/client/src/typings/vscode-extension-telemetry.d.ts
@@ -1,6 +1,0 @@
-declare module 'vscode-extension-telemetry' {
-	export default class TelemetryReporter {
-		constructor(extensionId: string, extensionVersion: string, key: string);
-		sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
-	}
-}

--- a/extensions/json/npm-shrinkwrap.json
+++ b/extensions/json/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "dependencies": {
     "applicationinsights": {
-      "version": "0.15.6",
-      "from": "applicationinsights@0.15.6",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.6.tgz"
+      "version": "0.18.0",
+      "from": "applicationinsights@0.18.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz"
     },
     "vscode-extension-telemetry": {
-      "version": "0.0.5",
-      "from": "vscode-extension-telemetry@>=0.0.5 <0.0.6",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.5.tgz"
+      "version": "0.0.6",
+      "from": "vscode-extension-telemetry@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.6.tgz"
     },
     "vscode-jsonrpc": {
       "version": "3.1.0-alpha.1",
@@ -33,9 +33,9 @@
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.2.tgz"
     },
     "winreg": {
-      "version": "0.0.13",
-      "from": "winreg@0.0.13",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.13.tgz"
+      "version": "1.2.3",
+      "from": "winreg@1.2.3",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.3.tgz"
     }
   }
 }

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -112,7 +112,7 @@
     }
   },
   "dependencies": {
-    "vscode-extension-telemetry": "^0.0.5",
+    "vscode-extension-telemetry": "^0.0.6",
     "vscode-languageclient": "^3.1.0-alpha.1",
     "vscode-nls": "^2.0.2"
   },


### PR DESCRIPTION
Upgrade to latest version of the `vscode-extension-telemetry` package. See https://github.com/Microsoft/vscode-extension-telemetry/pull/5 for details.