### PR TITLE
Upgrade telemetry package used by TS and markdown extensions.

### DIFF
--- a/extensions/markdown/npm-shrinkwrap.json
+++ b/extensions/markdown/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "dependencies": {
     "applicationinsights": {
-      "version": "0.15.6",
-      "from": "applicationinsights@0.15.6",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.6.tgz"
+      "version": "0.18.0",
+      "from": "applicationinsights@0.18.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz"
     },
     "argparse": {
       "version": "1.0.9",
@@ -58,14 +58,14 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz"
     },
     "vscode-extension-telemetry": {
-      "version": "0.0.5",
-      "from": "vscode-extension-telemetry@>=0.0.5 <0.0.6",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.5.tgz"
+      "version": "0.0.6",
+      "from": "vscode-extension-telemetry@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.6.tgz"
     },
     "winreg": {
-      "version": "0.0.13",
-      "from": "winreg@0.0.13",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.13.tgz"
+      "version": "1.2.3",
+      "from": "winreg@1.2.3",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.3.tgz"
     }
   }
 }

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -177,7 +177,7 @@
 		"highlight.js": "^9.3.0",
 		"markdown-it": "^8.2.2",
 		"markdown-it-named-headers": "0.0.4",
-		"vscode-extension-telemetry": "^0.0.5"
+		"vscode-extension-telemetry": "^0.0.6"
 	},
 	"devDependencies": {
 		"@types/node": "^7.0.4"

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -30,6 +30,9 @@ var telemetryReporter: TelemetryReporter | null;
 export function activate(context: vscode.ExtensionContext) {
 	const packageInfo = getPackageInfo();
 	telemetryReporter = packageInfo && new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+	if (telemetryReporter) {
+		context.subscriptions.push(telemetryReporter);
+	}
 
 	const engine = new MarkdownEngine();
 

--- a/extensions/markdown/src/typings/vscode-extension-telemetry.d.ts
+++ b/extensions/markdown/src/typings/vscode-extension-telemetry.d.ts
@@ -1,6 +1,0 @@
-declare module 'vscode-extension-telemetry' {
-	export default class TelemetryReporter {
-		constructor(extensionId: string, extensionVersion: string, key: string);
-		sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
-	}
-}

--- a/extensions/typescript/npm-shrinkwrap.json
+++ b/extensions/typescript/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.10.1",
   "dependencies": {
     "applicationinsights": {
-      "version": "0.15.6",
-      "from": "applicationinsights@0.15.6",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.15.6.tgz"
+      "version": "0.18.0",
+      "from": "applicationinsights@0.18.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz"
     },
     "semver": {
       "version": "4.3.6",
@@ -13,14 +13,14 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
     },
     "typescript": {
-      "version": "typescript@2.2.1-insiders.20170217",
+      "version": "2.2.1-insiders.20170217",
       "from": "typescript@typescript@2.2.1-insiders.20170217",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.2.1-insiders.20170217.tgz"
     },
     "vscode-extension-telemetry": {
-      "version": "0.0.5",
-      "from": "vscode-extension-telemetry@>=0.0.5 <0.0.6",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.5.tgz"
+      "version": "0.0.6",
+      "from": "vscode-extension-telemetry@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.6.tgz"
     },
     "vscode-nls": {
       "version": "2.0.1",
@@ -28,9 +28,9 @@
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-2.0.1.tgz"
     },
     "winreg": {
-      "version": "0.0.13",
-      "from": "winreg@0.0.13",
-      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.13.tgz"
+      "version": "1.2.3",
+      "from": "winreg@1.2.3",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.3.tgz"
     }
   }
 }

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "semver": "4.3.6",
-    "vscode-extension-telemetry": "^0.0.5",
+    "vscode-extension-telemetry": "^0.0.6",
     "vscode-nls": "^2.0.1",
     "typescript": "typescript@2.2.1-insiders.20170217"
   },

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -408,7 +408,7 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 		configFileWatcher.onDidDelete(handleProjectCreateOrDelete, this, this.disposables);
 		configFileWatcher.onDidChange(handleProjectChange, this, this.disposables);
 
-		this.client = new TypeScriptServiceClient(this, storagePath, globalState, workspaceState);
+		this.client = new TypeScriptServiceClient(this, storagePath, globalState, workspaceState, this.disposables);
 		this.languages = [];
 		this.languagePerId = Object.create(null);
 		for (const description of descriptions) {

--- a/extensions/typescript/src/typings/vscode-extension-telemetry.d.ts
+++ b/extensions/typescript/src/typings/vscode-extension-telemetry.d.ts
@@ -1,6 +1,0 @@
-declare module 'vscode-extension-telemetry' {
-	export default class TelemetryReporter {
-		constructor(extensionId: string, extensionVersion: string, key: string);
-		sendTelemetryEvent(eventName: string, properties?: { [key: string]: string }, measures?: { [key: string]: number }): void;
-	}
-}


### PR DESCRIPTION
Upgrade to latest version of the `vscode-extension-telemetry` package. See https://github.com/Microsoft/vscode-extension-telemetry/pull/5 for details.