### PR TITLE
Add gnupg and apt to depends

### DIFF
--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -1,7 +1,7 @@
 Package: @@NAME@@
 Version: @@VERSION@@
 Section: devel
-Depends: libnotify4, libnss3
+Depends: libnotify4, libnss3, gnupg, apt
 Priority: optional
 Architecture: @@ARCHITECTURE@@
 Maintainer: Microsoft Corporation <vscode-linux@microsoft.com>


### PR DESCRIPTION
The postinst template uses tools from those packages.

Normally they are installed in most systems. However, this is not guaranteed. Lets make it guaranteed.