### PR TITLE
Update Quick Fix Lightbulb once a Fix has been Applied

### DIFF
--- a/src/vs/editor/contrib/quickFix/common/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/common/quickFixModel.ts
@@ -50,7 +50,7 @@ export class QuickFixOracle {
 		const {uri} = this._editor.getModel();
 		for (const resource of resources) {
 			if (resource.toString() === uri.toString()) {
-				this._onCursorChange();
+				this._updateRange(this._rangeAtPosition());
 				return;
 			}
 		}
@@ -59,14 +59,18 @@ export class QuickFixOracle {
 	private _onCursorChange(): void {
 		const range = this._rangeAtPosition();
 		if (!Range.equalsRange(this._currentRange, range)) {
-			this._currentRange = range;
-			this._signalChange({
-				type: 'auto',
-				range,
-				position: this._editor.getPosition(),
-				fixes: range && getCodeActions(this._editor.getModel(), this._editor.getModel().validateRange(range))
-			});
+			this._updateRange(range);
 		}
+	}
+
+	private _updateRange(range: IRange): void {
+		this._currentRange = range;
+		this._signalChange({
+			type: 'auto',
+			range,
+			position: this._editor.getPosition(),
+			fixes: range && getCodeActions(this._editor.getModel(), this._editor.getModel().validateRange(range))
+		});
 	}
 
 	private _rangeAtPosition(): IRange {


### PR DESCRIPTION
Fixes #21060

**Bug**
The quick fix lightbulb widget does not get updated after a quick fix is applied. This seems to happen when the quick fix does not touch the span containing the lightbulb widget itself.

**Fix**
The root cause seems to be that the quick fix model does not broadcast an update event when a quick fix is applied. To workaround this, force an update when the markers are updated even if the range for the current cursor remains the same.
