### PR TITLE
Fix for WorkspaceConfigurationService.lookup does not contain value 'null' 

### DIFF
--- a/src/vs/platform/configuration/common/configuration.ts
+++ b/src/vs/platform/configuration/common/configuration.ts
@@ -87,10 +87,10 @@ export function getConfigurationValue<T>(config: any, settingPath: string, defau
 	function accessSetting(config: any, path: string[]): any {
 		let current = config;
 		for (let i = 0; i < path.length; i++) {
-			current = current[path[i]];
-			if (typeof current === 'undefined' || current === null) {
+			if (typeof current !== 'object' || current === null) {
 				return undefined;
 			}
+			current = current[path[i]];
 		}
 		return <T>current;
 	}

--- a/src/vs/platform/configuration/test/node/configurationService.test.ts
+++ b/src/vs/platform/configuration/test/node/configurationService.test.ts
@@ -203,22 +203,57 @@ suite('ConfigurationService - Node', () => {
 			const service = new ConfigurationService(new SettingsTestEnvironmentService(parseArgs(process.argv), process.execPath, testFile));
 
 			let res = service.lookup('something.missing');
-			assert.ok(!res.value);
-			assert.ok(!res.default);
-			assert.ok(!res.user);
+			assert.strictEqual(res.value, void 0);
+			assert.strictEqual(res.default, void 0);
+			assert.strictEqual(res.user, void 0);
 
 			res = service.lookup('lookup.service.testSetting');
-			assert.equal(res.default, 'isSet');
-			assert.equal(res.value, 'isSet');
-			assert.ok(!res.user);
+			assert.strictEqual(res.default, 'isSet');
+			assert.strictEqual(res.value, 'isSet');
+			assert.strictEqual(res.user, void 0);
 
 			fs.writeFileSync(testFile, '{ "lookup.service.testSetting": "bar" }');
 
 			return service.reloadConfiguration().then(() => {
 				res = service.lookup('lookup.service.testSetting');
-				assert.equal(res.default, 'isSet');
-				assert.equal(res.user, 'bar');
-				assert.equal(res.value, 'bar');
+				assert.strictEqual(res.default, 'isSet');
+				assert.strictEqual(res.user, 'bar');
+				assert.strictEqual(res.value, 'bar');
+
+				service.dispose();
+
+				cleanUp(done);
+			});
+		});
+	});
+
+	test('lookup with null', (done: () => void) => {
+		const configurationRegistry = <IConfigurationRegistry>Registry.as(ConfigurationExtensions.Configuration);
+		configurationRegistry.registerConfiguration({
+			'id': '_testNull',
+			'type': 'object',
+			'properties': {
+				'lookup.service.testNullSetting': {
+					'type': 'null',
+				}
+			}
+		});
+
+		testFile((testFile, cleanUp) => {
+			const service = new ConfigurationService(new SettingsTestEnvironmentService(parseArgs(process.argv), process.execPath, testFile));
+
+			let res = service.lookup('lookup.service.testNullSetting');
+			assert.strictEqual(res.default, null);
+			assert.strictEqual(res.value, null);
+			assert.strictEqual(res.user, void 0);
+
+			fs.writeFileSync(testFile, '{ "lookup.service.testNullSetting": null }');
+
+			return service.reloadConfiguration().then(() => {
+				res = service.lookup('lookup.service.testNullSetting');
+				assert.strictEqual(res.default, null);
+				assert.strictEqual(res.value, null);
+				assert.strictEqual(res.user, null);
 
 				service.dispose();
 


### PR DESCRIPTION
Fixes #21282 WorkspaceConfigurationService.lookup does not contain value 'null' 