### PR TITLE
Exception message text to be selectable

### DIFF
--- a/src/vs/workbench/parts/debug/browser/media/exceptionWidget.css
+++ b/src/vs/workbench/parts/debug/browser/media/exceptionWidget.css
@@ -5,6 +5,12 @@
 
 .monaco-editor .zone-widget .zone-widget-container.exception-widget {
 	padding: 6px 10px;
+	-webkit-user-select: text;
+	-ms-user-select: text;
+	-khtml-user-select: text;
+	-moz-user-select: text;
+	-o-user-select: text;
+	user-select: text;
 }
 
 .monaco-editor .zone-widget .zone-widget-container.exception-widget .title {


### PR DESCRIPTION
Fixes #21083.

Context menu still has to be added. Keyboard shortcut for copying works fine.