### PR TITLE
quickopen and quickoutline will now show the field icon for field symbols

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -494,6 +494,8 @@ export namespace SymbolKind {
 				return 'function';
 			case SymbolKind.Constructor:
 				return 'constructor';
+			case SymbolKind.Field:
+				return 'field';
 			case SymbolKind.Variable:
 				return 'variable';
 			case SymbolKind.Class:
@@ -541,6 +543,8 @@ export namespace SymbolKind {
 				return SymbolKind.Function;
 			case 'constructor':
 				return SymbolKind.Constructor;
+			case 'field':
+				return SymbolKind.Field;
 			case 'variable':
 				return SymbolKind.Variable;
 			case 'class':

--- a/src/vs/editor/contrib/quickOpen/browser/quickOutline.css
+++ b/src/vs/editor/contrib/quickOpen/browser/quickOutline.css
@@ -16,6 +16,7 @@
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.method,
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.function,
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.constructor		{ background-position: 0 -4px; }
+.quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.field,
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.variable 			{ background-position: -22px -4px; }
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.class 				{ background-position: -43px -3px; }
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.interface 			{ background-position: -63px -4px; }
@@ -28,6 +29,7 @@
 .vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.method,
 .vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.function,
 .vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.constructor 	{ background-position: 0 -24px; }
+.vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.field,
 .vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.variable 		{ background-position: -22px -24px; }
 .vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.class 		{ background-position: -43px -23px; }
 .vs-dark .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.interface 	{ background-position: -63px -24px; }

--- a/src/vs/workbench/parts/quickopen/browser/gotoSymbolHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/gotoSymbolHandler.ts
@@ -454,7 +454,7 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 
 			// Add
 			const icon = SymbolKind.from(element.kind);
-			results.push(new SymbolEntry(i, label, SymbolKind.from(element.kind), description, icon, element.location.range, null, this.editorService, this));
+			results.push(new SymbolEntry(i, label, icon, description, icon, element.location.range, null, this.editorService, this));
 		}
 
 		return results;

--- a/src/vs/workbench/parts/quickopen/browser/media/gotoSymbolHandler.css
+++ b/src/vs/workbench/parts/quickopen/browser/media/gotoSymbolHandler.css
@@ -17,6 +17,7 @@
 .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.method,
 .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.function,
 .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.constructor,
+.monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.field,
 .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.variable,
 .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.class,
 .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.interface,
@@ -41,6 +42,7 @@
 .vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.method,
 .vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.function,
 .vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.constructor		{ background-position: 0 -4px; }
+.vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.field,
 .vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.variable 		{ background-position: -22px -4px; }
 .vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.class 			{ background-position: -43px -3px; }
 .vs .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.interface 		{ background-position: -63px -4px; }
@@ -65,6 +67,8 @@
 .hc-black .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.method,
 .hc-black .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.function,
 .hc-black .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.constructor 	{ background-position: 0 -24px; }
+.vs-dark .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.field,
+.hc-black .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.field,
 .vs-dark .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.variable,
 .hc-black .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.variable 		{ background-position: -22px -24px; }
 .vs-dark .monaco-workbench .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon.class,


### PR DESCRIPTION
This addresses https://github.com/Microsoft/vscode/issues/21315.

I noticed a few issues:
1) `SymbolKind.to` and `SymbolKind.from` didn't map `SymbolKind.Field` to anything so `SymbolKind.Property` was used by default
2) There were no classes for field icons except for one high contract mapping that field icons shared with variable icons. I could see that the icon used for variables in that location matched `Field_16x.svg`, so I operated under the assumption that in the other locations that variable icon classes were defined, field icon classes should be created to point to the same icon