### PR TITLE
Telemetry for emmet expansions

### DIFF
--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -21,6 +21,7 @@ import * as emmet from 'emmet';
 import * as path from 'path';
 import * as pfs from 'vs/base/node/pfs';
 import Severity from 'vs/base/common/severity';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 interface IEmmetConfiguration {
 	emmet: {
@@ -274,9 +275,12 @@ export class BasicEmmetEditorAction extends EmmetEditorAction {
 	}
 
 	public runEmmetAction(accessor: ServicesAccessor, ctx: EmmetActionContext) {
+		const telemetryService = accessor.get(ITelemetryService);
 		try {
 			if (!ctx.emmet.run(this.emmetActionName, ctx.editorAccessor)) {
 				this.noExpansionOccurred(ctx.editor);
+			} else if (this.emmetActionName === 'expand_abbreviation') {
+				telemetryService.publicLog('emmetActionSucceeded', { action: this.emmetActionName });
 			}
 		} catch (err) {
 			this.noExpansionOccurred(ctx.editor);


### PR DESCRIPTION
Telemetry events get logged for all commands. Emmet expansion is one of them.
But emmet expansion command can result in no expansion as well.
Therefore, adding telemetry for event when emmet expansion is successful