### PR TITLE
Add workbench.action.focusActiveEditorGroup to commandsToSkipShell

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -25,7 +25,7 @@ import { ToggleTabFocusModeAction } from 'vs/editor/contrib/toggleTabFocusMode/c
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import debugActions = require('vs/workbench/parts/debug/browser/debugActions');
 import { KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { OpenNextRecentlyUsedEditorInGroupAction, OpenPreviousRecentlyUsedEditorInGroupAction } from 'vs/workbench/browser/parts/editor/editorActions';
+import { OpenNextRecentlyUsedEditorInGroupAction, OpenPreviousRecentlyUsedEditorInGroupAction, FocusActiveGroupAction } from 'vs/workbench/browser/parts/editor/editorActions';
 import { DefaultConfig } from 'vs/editor/common/config/defaultConfig';
 
 let configurationRegistry = <IConfigurationRegistry>Registry.as(Extensions.Configuration);
@@ -137,6 +137,7 @@ configurationRegistry.registerConfiguration({
 			},
 			'default': [
 				ToggleTabFocusModeAction.ID,
+				FocusActiveGroupAction.ID,
 				GlobalQuickOpenAction.ID,
 				ShowAllCommandsAction.ID,
 				CreateNewTerminalAction.ID,

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -171,6 +171,7 @@ configurationRegistry.registerConfiguration({
 				debugActions.RunAction.ID,
 				debugActions.RestartAction.ID,
 				debugActions.ContinueAction.ID,
+				debugActions.PauseAction.ID,
 				OpenNextRecentlyUsedEditorInGroupAction.ID,
 				OpenPreviousRecentlyUsedEditorInGroupAction.ID
 


### PR DESCRIPTION
This change adds the `workbench.action.focusActiveEditorGroup` command to
the default value array of the `terminal.integrated.commandsToSkipShell`
setting so that it is available for key bindings when the user is inside
of the integrated terminal.

Resolves #21393.

/cc @Tyriar