### PR TITLE
Treat podfile as ruby

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -9,7 +9,7 @@
 		"languages": [{
 			"id": "ruby",
 			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".rake", ".ru" ],
-			"filenames": [ "rakefile", "gemfile", "guardfile" ],
+			"filenames": [ "rakefile", "gemfile", "guardfile", "podfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"firstLine": "^#!/.*\\bruby\\b",
 			"configuration": "./language-configuration.json"


### PR DESCRIPTION
Treat cocoapods `podfile` as ruby for syntax highlighting and other language features