### PR TITLE
Fix Webview scroll position Preserving

### DIFF
--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -135,13 +135,13 @@ document.addEventListener("DOMContentLoaded", function (event) {
 
 		// workaround for https://github.com/Microsoft/vscode/issues/12865
 		// check new scrollTop and reset if neccessary
-		setTimeout(function () {
+		newFrame.contentWindow.addEventListener('DOMContentLoaded', function () {
 			if (newFrame.contentDocument.body && scrollTop !== newFrame.contentDocument.body.scrollTop) {
 				newFrame.contentDocument.body.scrollTop = scrollTop;
 			}
 			document.body.removeChild(frame);
 			newFrame.style.display = 'block';
-		}, 0);
+		});
 
 		ipcRenderer.sendToHost('did-set-content', stats);
 	});


### PR DESCRIPTION
**Bug**
A regression since 1.9 caused the scroll preserve behavior of webviews to stop working in certain cases. There appears to be a race condition where `newFrame.contentDocument.body` does not exist when the scroll preserve code is called

**Fix**
Instead of using a timeout, update the scroll position when `DOMContentLoaded` is fired from the webview window

Fixes #21491