### PR TITLE
Add API to force quit with the ability to revert changes silently

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -515,10 +515,15 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		}
 	}
 
-	public closeEditor(position: Position, input: EditorInput): TPromise<void> {
+	public closeEditor(position: Position, input: EditorInput, force?: boolean): TPromise<void> {
 		const group = this.stacks.groupAt(position);
 		if (!group) {
 			return TPromise.as<void>(null);
+		}
+
+		// Revert editor and close when forced
+		if (force) {
+			return group.activeEditor.revert().then(ok => this.doCloseEditor(group, input));
 		}
 
 		// Check for dirty and veto

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -59,6 +59,29 @@ export class CloseEditorAction extends Action {
 	}
 }
 
+export class ForceCloseEditorAction extends Action {
+
+	public static ID = 'workbench.action.forceCloseActiveEditor';
+	public static LABEL = nls.localize('forceCloseActiveEditor', "Force Close Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IWorkbenchEditorService private editorService: IWorkbenchEditorService
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<any> {
+		const activeEditor = this.editorService.getActiveEditor();
+		if (activeEditor) {
+			return this.editorService.closeEditor(activeEditor.position, activeEditor.input, true);
+		}
+
+		return TPromise.as(false);
+	}
+}
+
 export class CloseWindowAction extends Action {
 
 	public static ID = 'workbench.action.closeWindow';

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -13,7 +13,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'v
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actionRegistry';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
-import { CloseEditorAction, KeybindingsReferenceAction, OpenDocumentationUrlAction, OpenIntroductoryVideosUrlAction, ReportIssueAction, ReportPerformanceIssueAction, ZoomResetAction, ZoomOutAction, ZoomInAction, ToggleFullScreenAction, ToggleMenuBarAction, CloseFolderAction, CloseWindowAction, SwitchWindow, NewWindowAction, CloseMessagesAction } from 'vs/workbench/electron-browser/actions';
+import { CloseEditorAction, ForceCloseEditorAction, KeybindingsReferenceAction, OpenDocumentationUrlAction, OpenIntroductoryVideosUrlAction, ReportIssueAction, ReportPerformanceIssueAction, ZoomResetAction, ZoomOutAction, ZoomInAction, ToggleFullScreenAction, ToggleMenuBarAction, CloseFolderAction, CloseWindowAction, SwitchWindow, NewWindowAction, CloseMessagesAction } from 'vs/workbench/electron-browser/actions';
 import { MessagesVisibleContext } from 'vs/workbench/electron-browser/workbench';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { registerCommands } from 'vs/workbench/electron-browser/commands';
@@ -62,6 +62,7 @@ workbenchActionsRegistry.registerWorkbenchAction(
 );
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(CloseMessagesAction, CloseMessagesAction.ID, CloseMessagesAction.LABEL, { primary: KeyCode.Escape, secondary: [KeyMod.Shift | KeyCode.Escape] }, MessagesVisibleContext), 'Close Notification Messages');
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(CloseEditorAction, CloseEditorAction.ID, CloseEditorAction.LABEL, { primary: KeyMod.CtrlCmd | KeyCode.KEY_W, win: { primary: KeyMod.CtrlCmd | KeyCode.F4, secondary: [KeyMod.CtrlCmd | KeyCode.KEY_W] } }), 'View: Close Editor', viewCategory);
+workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ForceCloseEditorAction, ForceCloseEditorAction.ID, ForceCloseEditorAction.LABEL, undefined), 'View: Force Close Editor', viewCategory);
 workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ToggleFullScreenAction, ToggleFullScreenAction.ID, ToggleFullScreenAction.LABEL, { primary: KeyCode.F11, mac: { primary: KeyMod.CtrlCmd | KeyMod.WinCtrl | KeyCode.KEY_F } }), 'View: Toggle Full Screen', viewCategory);
 if (isWindows || isLinux) {
 	workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ToggleMenuBarAction, ToggleMenuBarAction.ID, ToggleMenuBarAction.LABEL), 'View: Toggle Menu Bar', viewCategory);

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -28,7 +28,7 @@ export interface IEditorPart {
 	openEditor(input?: IEditorInput, options?: IEditorOptions | ITextEditorOptions, position?: Position): TPromise<BaseEditor>;
 	openEditors(editors: { input: IEditorInput, position: Position, options?: IEditorOptions | ITextEditorOptions }[]): TPromise<BaseEditor[]>;
 	replaceEditors(editors: { toReplace: IEditorInput, replaceWith: IEditorInput, options?: IEditorOptions | ITextEditorOptions }[], position?: Position): TPromise<BaseEditor[]>;
-	closeEditor(position: Position, input: IEditorInput): TPromise<void>;
+	closeEditor(position: Position, input: IEditorInput, force?: boolean): TPromise<void>;
 	closeEditors(position: Position, except?: IEditorInput, direction?: Direction): TPromise<void>;
 	closeAllEditors(except?: Position): TPromise<void>;
 	getActiveEditor(): BaseEditor;
@@ -184,8 +184,8 @@ export class WorkbenchEditorService implements IWorkbenchEditorService {
 		});
 	}
 
-	public closeEditor(position: Position, input: IEditorInput): TPromise<void> {
-		return this.editorPart.closeEditor(position, input);
+	public closeEditor(position: Position, input: IEditorInput, force: boolean = false): TPromise<void> {
+		return this.editorPart.closeEditor(position, input, force);
 	}
 
 	public closeEditors(position: Position, except?: IEditorInput, direction?: Direction): TPromise<void> {

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -71,7 +71,7 @@ export interface IWorkbenchEditorService extends IEditorService {
 	/**
 	 * Closes the editor at the provided position.
 	 */
-	closeEditor(position: Position, input: IEditorInput): TPromise<void>;
+	closeEditor(position: Position, input: IEditorInput, force?: boolean): TPromise<void>;
 
 	/**
 	 * Closes editors of a specific group at the provided position. If the optional editor is provided to exclude, it


### PR DESCRIPTION
Fix #21536
Adds "workbench.action.forceCloseActiveEditor" to externalAPI