### PR TITLE
Relax Language First Line Match

### DIFF
--- a/src/vs/base/common/mime.ts
+++ b/src/vs/base/common/mime.ts
@@ -202,9 +202,8 @@ function guessMimeTypeByFirstline(firstLine: string): string {
 				continue;
 			}
 
-			// Make sure the entire line matches, not just a subpart.
 			let matches = firstLine.match(association.firstline);
-			if (matches && matches.length > 0 && matches[0].length === firstLine.length) {
+			if (matches && matches.length > 0) {
 				return association.mime;
 			}
 		}

--- a/src/vs/base/test/common/mime.test.ts
+++ b/src/vs/base/test/common/mime.test.ts
@@ -37,7 +37,7 @@ suite('Mime', () => {
 		guess = guessMimeTypes('Randomfile.noregistration', 'RegexesAreNice');
 		assert.deepEqual(guess, ['text/nice-regex', 'text/plain']);
 
-		guess = guessMimeTypes('Randomfile.noregistration', 'RegexesAreNiceee');
+		guess = guessMimeTypes('Randomfile.noregistration', 'RegexesAreNotNice');
 		assert.deepEqual(guess, ['application/unknown']);
 
 		guess = guessMimeTypes('Codefile', 'RegexesAreNice');


### PR DESCRIPTION
Fixes #21533

**Bug**
The first line pattern for a language currently requires the entire line to match. This does is different from how tools such as textmate use firstLineMatch

**Fix**
Relax this restriction so that any match is used, even if it only matches part of the line