### PR TITLE
Add typescript and javascript format.insertSpaceBeforeFunctionParenthesis

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -164,6 +164,11 @@
           "default": true,
           "description": "%format.insertSpaceAfterFunctionKeywordForAnonymousFunctions%"
         },
+        "typescript.format.insertSpaceBeforeFunctionParenthesis": {
+          "type": "boolean",
+          "default": false,
+          "description": "%format.insertSpaceBeforeFunctionParenthesis%"
+        },
         "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": {
           "type": "boolean",
           "default": false,

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -234,6 +234,11 @@
           "default": true,
           "description": "%format.insertSpaceAfterFunctionKeywordForAnonymousFunctions%"
         },
+        "javascript.format.insertSpaceBeforeFunctionParenthesis": {
+          "type": "boolean",
+          "default": false,
+          "description": "%format.insertSpaceBeforeFunctionParenthesis%"
+        },
         "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": {
           "type": "boolean",
           "default": false,

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -17,6 +17,7 @@
 	"format.insertSpaceBeforeAndAfterBinaryOperators": "Defines space handling after a binary operator.",
 	"format.insertSpaceAfterKeywordsInControlFlowStatements": "Defines space handling after keywords in a control flow statement.",
 	"format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": "Defines space handling after function keyword for anonymous functions.",
+	"format.insertSpaceBeforeFunctionParenthesis": "Defines space handling before function argument parentheses.",
 	"format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": "Defines space handling after opening and before closing non empty parenthesis.",
 	"format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": "Defines space handling after opening and before closing non empty brackets.",
 	"format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": "Defines space handling after opening and before closing template string braces. Requires TypeScript >= 2.0.6.",

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -17,7 +17,7 @@
 	"format.insertSpaceBeforeAndAfterBinaryOperators": "Defines space handling after a binary operator.",
 	"format.insertSpaceAfterKeywordsInControlFlowStatements": "Defines space handling after keywords in a control flow statement.",
 	"format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": "Defines space handling after function keyword for anonymous functions.",
-	"format.insertSpaceBeforeFunctionParenthesis": "Defines space handling before function argument parentheses.",
+	"format.insertSpaceBeforeFunctionParenthesis": "Defines space handling before function argument parentheses. Requires TypeScript >= 2.1.5.",
 	"format.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": "Defines space handling after opening and before closing non empty parenthesis.",
 	"format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": "Defines space handling after opening and before closing non empty brackets.",
 	"format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": "Defines space handling after opening and before closing template string braces. Requires TypeScript >= 2.0.6.",

--- a/extensions/typescript/src/features/formattingProvider.ts
+++ b/extensions/typescript/src/features/formattingProvider.ts
@@ -21,6 +21,7 @@ interface Configuration {
 	insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: boolean;
 	insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
 	insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: boolean;
+	insertSpaceBeforeFunctionParenthesis: boolean;
 	placeOpenBraceOnNewLineForFunctions: boolean;
 	placeOpenBraceOnNewLineForControlBlocks: boolean;
 
@@ -33,6 +34,7 @@ namespace Configuration {
 	export const insertSpaceBeforeAndAfterBinaryOperators: string = 'insertSpaceBeforeAndAfterBinaryOperators';
 	export const insertSpaceAfterKeywordsInControlFlowStatements: string = 'insertSpaceAfterKeywordsInControlFlowStatements';
 	export const insertSpaceAfterFunctionKeywordForAnonymousFunctions: string = 'insertSpaceAfterFunctionKeywordForAnonymousFunctions';
+	export const insertSpaceBeforeFunctionParenthesis: string = 'insertSpaceBeforeFunctionParenthesis';
 	export const insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: string = 'insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis';
 	export const insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: string = 'insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets';
 	export const insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: string = 'insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces';
@@ -59,6 +61,7 @@ namespace Configuration {
 		result.insertSpaceBeforeAndAfterBinaryOperators = true;
 		result.insertSpaceAfterKeywordsInControlFlowStatements = true;
 		result.insertSpaceAfterFunctionKeywordForAnonymousFunctions = false;
+		result.insertSpaceBeforeFunctionParenthesis = false;
 		result.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis = false;
 		result.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets = false;
 		result.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces = false;
@@ -213,6 +216,7 @@ export default class TypeScriptFormattingProvider implements DocumentRangeFormat
 			insertSpaceBeforeAndAfterBinaryOperators: this.config.insertSpaceBeforeAndAfterBinaryOperators,
 			insertSpaceAfterKeywordsInControlFlowStatements: this.config.insertSpaceAfterKeywordsInControlFlowStatements,
 			insertSpaceAfterFunctionKeywordForAnonymousFunctions: this.config.insertSpaceAfterFunctionKeywordForAnonymousFunctions,
+			insertSpaceBeforeFunctionParenthesis: this.config.insertSpaceBeforeFunctionParenthesis,
 			insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: this.config.insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis,
 			insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: this.config.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets,
 			insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: this.config.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces,

--- a/tsfmt.json
+++ b/tsfmt.json
@@ -11,6 +11,7 @@
 	"insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis": false,
 	"insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,
 	"insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+	"insertSpaceBeforeFunctionParenthesis": false,
 	"placeOpenBraceOnNewLineForFunctions": false,
 	"placeOpenBraceOnNewLineForControlBlocks": false
 }


### PR DESCRIPTION
[Original Issue](https://github.com/Microsoft/vscode/issues/15386)

This issue was closed and hasn't been reopened since the feature 
[has been implemented in TypeScript](https://github.com/Microsoft/TypeScript/issues/12234).

Figured I would try my hand at completing it. I'm too busy at the moment to get a local build working, so I figured I'd just do the changes it looks like are necessary and then make a PR. If it's broken it can be rejected, and in that case I'll apologise for wasting your time. >.>

If you have time and this doesn't provide everything necessary, let me know. I'll try make a local build and update the request with a working version if that's the case.