### PR TITLE
[Objective-C grammar] Xcode’s snippets-markup

### DIFF
--- a/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
+++ b/extensions/objective-c/syntaxes/objective-c.tmLanguage.json
@@ -219,6 +219,10 @@
 			"name": "support.variable.foundation"
 		},
 		{
+			"match": "(<#\\().*?(\\)#>)\\b",
+			"name": "support.snippet.xcode"
+		},
+		{
 			"captures": {
 				"1": {
 					"name": "punctuation.whitespace.support.function.cocoa.leopard"


### PR DESCRIPTION
Added Xcode snippet/hint-markup to grammar.

Screenshot from the Xcode:
![screen shot 2017-03-03 at 03 31 57](https://cloud.githubusercontent.com/assets/888526/23533439/d95294bc-ffc2-11e6-8804-38401cdc3615.png)
There originally `[self setDetailViewController:<#(DetailViewController *)#>]` .