### PR TITLE
proposal to fix issue 21600

### DIFF
--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -24,7 +24,7 @@ export class HistoryNavigator<T> implements INavigator<T> {
 	}
 
 	public addIfNotPresent(t: T) {
-		if(!this._history.contains(t)) {
+		if (!this._history.contains(t)) {
 			this.add(t);
 		}
 	}

--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -23,6 +23,12 @@ export class HistoryNavigator<T> implements INavigator<T> {
 		this._onChange();
 	}
 
+	public addIfNotPresent(t: T) {
+		if(!this._history.contains(t)) {
+			this.add(t);
+		}
+	}
+
 	public next(): T {
 		if (this._navigator.next()) {
 			return this._navigator.current();
@@ -67,4 +73,5 @@ export class HistoryNavigator<T> implements INavigator<T> {
 			this._history = new ArraySet<T>(data.slice(data.length - this._limit));
 		}
 	}
+
 }

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -174,6 +174,7 @@ export class SearchWidget extends Widget {
 		if (this.searchInput.getValue().length === 0) {
 			previous = this.searchHistory.current();
 		} else {
+			this.searchHistory.addIfNotPresent(this.searchInput.getValue());
 			previous = this.searchHistory.previous();
 		}
 		if (previous) {

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -140,7 +140,7 @@ export class SearchWidget extends Widget {
 		}
 	}
 
-	public setHasBeenCleared(cleared : boolean): void {
+	public setHasBeenCleared(cleared: boolean): void {
 		this.hasBeenCleared = cleared;
 	}
 
@@ -179,11 +179,10 @@ export class SearchWidget extends Widget {
 
 	public showPreviousSearchTerm() {
 		let previous;
-		if(this.hasBeenCleared){
+		if (this.hasBeenCleared) {
 			this.setHasBeenCleared(false);
-			 previous = this.searchHistory.current();
-
-		}else{
+			previous = this.searchHistory.current();
+		} else {
 		 	previous = this.searchHistory.previous();
 		}
 		if (previous) {

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -108,9 +108,12 @@ export class SearchWidget extends Widget {
 	private _onReplaceAll = this._register(new Emitter<void>());
 	public onReplaceAll: Event<void> = this._onReplaceAll.event;
 
+	private hasBeenCleared: boolean;
+
 	constructor(container: Builder, private contextViewService: IContextViewService, options: ISearchWidgetOptions = Object.create(null),
 		private keyBindingService: IContextKeyService, private keyBindingService2: IKeybindingService, private instantiationService: IInstantiationService) {
 		super();
+		this.setHasBeenCleared(false);
 		this.searchHistory = new HistoryNavigator<string>();
 		this.replaceActive = Constants.ReplaceActiveKey.bindTo(this.keyBindingService);
 		this.searchInputBoxFocussed = Constants.SearchInputBoxFocussedKey.bindTo(this.keyBindingService);
@@ -137,12 +140,17 @@ export class SearchWidget extends Widget {
 		}
 	}
 
+	public setHasBeenCleared(cleared : boolean): void {
+		this.hasBeenCleared = cleared;
+	}
+
 	public setWidth(width: number) {
 		this.searchInput.setWidth(width - 2);
 		this.replaceInput.width = width - 28;
 	}
 
 	public clear() {
+		this.setHasBeenCleared(true);
 		this.searchInput.clear();
 		this.replaceInput.value = '';
 		this.setReplaceAllActionState(false);
@@ -170,7 +178,14 @@ export class SearchWidget extends Widget {
 	}
 
 	public showPreviousSearchTerm() {
-		let previous = this.searchHistory.previous();
+		let previous;
+		if(this.hasBeenCleared){
+			this.setHasBeenCleared(false);
+			 previous = this.searchHistory.current();
+
+		}else{
+		 	previous = this.searchHistory.previous();
+		}
 		if (previous) {
 			this.searchInput.setValue(previous);
 		}

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -183,7 +183,7 @@ export class SearchWidget extends Widget {
 			this.setHasBeenCleared(false);
 			previous = this.searchHistory.current();
 		} else {
-		 	previous = this.searchHistory.previous();
+			previous = this.searchHistory.previous();
 		}
 		if (previous) {
 			this.searchInput.setValue(previous);

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -108,12 +108,9 @@ export class SearchWidget extends Widget {
 	private _onReplaceAll = this._register(new Emitter<void>());
 	public onReplaceAll: Event<void> = this._onReplaceAll.event;
 
-	private hasBeenCleared: boolean;
-
 	constructor(container: Builder, private contextViewService: IContextViewService, options: ISearchWidgetOptions = Object.create(null),
 		private keyBindingService: IContextKeyService, private keyBindingService2: IKeybindingService, private instantiationService: IInstantiationService) {
 		super();
-		this.setHasBeenCleared(false);
 		this.searchHistory = new HistoryNavigator<string>();
 		this.replaceActive = Constants.ReplaceActiveKey.bindTo(this.keyBindingService);
 		this.searchInputBoxFocussed = Constants.SearchInputBoxFocussedKey.bindTo(this.keyBindingService);
@@ -140,17 +137,12 @@ export class SearchWidget extends Widget {
 		}
 	}
 
-	public setHasBeenCleared(cleared: boolean): void {
-		this.hasBeenCleared = cleared;
-	}
-
 	public setWidth(width: number) {
 		this.searchInput.setWidth(width - 2);
 		this.replaceInput.width = width - 28;
 	}
 
 	public clear() {
-		this.setHasBeenCleared(true);
 		this.searchInput.clear();
 		this.replaceInput.value = '';
 		this.setReplaceAllActionState(false);
@@ -179,8 +171,7 @@ export class SearchWidget extends Widget {
 
 	public showPreviousSearchTerm() {
 		let previous;
-		if (this.hasBeenCleared) {
-			this.setHasBeenCleared(false);
+		if (this.searchInput.getValue().length === 0) {
 			previous = this.searchHistory.current();
 		} else {
 			previous = this.searchHistory.previous();


### PR DESCRIPTION
Hello, I got a proposal to resolve #21600. 

The `showPreviousSearchTerm` function tried to get the previous search term, but since `clear()` does not add a value to the `searchHistory` the `showPreviousSearchTerm` returned the one last search term.

This is my first pull request, so please let me know if anything is wrong.

Hope it helps!