### PR TITLE
Fixed keybinding json for backslash

### DIFF
--- a/src/vs/editor/contrib/defineKeybinding/browser/defineKeybinding.ts
+++ b/src/vs/editor/contrib/defineKeybinding/browser/defineKeybinding.ts
@@ -107,6 +107,11 @@ export class DefineKeybindingController implements editorCommon.IEditorContribut
 	}
 
 	private _onAccepted(keybinding: string): void {
+		let regexp = new RegExp(/\\/g);
+		let backslash = regexp.test(keybinding);
+		if (backslash) {
+			keybinding = keybinding.slice(0, -1) + '\\\\';
+		}
 		let snippetText = [
 			'{',
 			'\t"key": ' + JSON.stringify(keybinding) + ',',


### PR DESCRIPTION
Hello, this is a possible solution for issue #21657 

Short description:
Check with regex whether backslash is found, if so add double backslash otherwise keybindings JSON will be invalid