### PR TITLE
Proof of Concept: User color theme overrides

### DIFF
--- a/src/vs/workbench/services/themes/common/themeService.ts
+++ b/src/vs/workbench/services/themes/common/themeService.ts
@@ -16,6 +16,9 @@ export const VS_DARK_THEME = 'vs-dark';
 export const VS_HC_THEME = 'hc-black';
 
 export const COLOR_THEME_SETTING = 'workbench.colorTheme';
+export const COLOR_THEME_OVERRIDE_SETTING = 'workbench.colorThemeOverrides';
+export const COLOR_THEME_OVERRIDE_SETTING_LIGHT = COLOR_THEME_OVERRIDE_SETTING + '.light';
+export const COLOR_THEME_OVERRIDE_SETTING_DARK = COLOR_THEME_OVERRIDE_SETTING + '.dark';
 export const ICON_THEME_SETTING = 'workbench.iconTheme';
 
 export interface IColorTheme {


### PR DESCRIPTION
This is a proof of concept implementation of user color theme overrides.

It exposes a configuration setting that would allow user overrides for all themes, or only for light or dark themes as seen in the gifs below.

This is  PR that would satisfy my use case as described in [this comment](https://github.com/Microsoft/vscode/issues/11556#issuecomment-283976552) while having minimal impact on the performance and complexity of the theme service, but I understand that it might not fit with the vision of the team. If that is the case, I am happy to hear feedback and see what type of contribution would be accepted.

![vscodethemeoverrides1](https://cloud.githubusercontent.com/assets/2957173/23581026/14c245ec-010d-11e7-904b-f93fdf258682.gif)
![vscodethemeoverrides2](https://cloud.githubusercontent.com/assets/2957173/23581030/1f0acd26-010d-11e7-8302-9f6cbb8e682c.gif)
