### PR TITLE
Adjust function focusLast, "end key" now goes to last result(resolves #21096).

### DIFF
--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -1234,10 +1234,11 @@ export class TreeModel extends Events.EventEmitter {
 	public focusLast(eventPayload?: any): void {
 		var nav = this.getNavigator(this.input);
 		var item = nav.last();
-		while (item.hasChildren()) {
-			item = item.lastChild;
-		}
+
 		if (item) {
+			while (item.hasChildren()) {
+				item = item.lastChild;
+			}
 			this.setFocus(item, eventPayload);
 		}
 	}

--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -1234,7 +1234,9 @@ export class TreeModel extends Events.EventEmitter {
 	public focusLast(eventPayload?: any): void {
 		var nav = this.getNavigator(this.input);
 		var item = nav.last();
-
+		while (item.hasChildren()) {
+			item = item.lastChild;
+		}
 		if (item) {
 			this.setFocus(item, eventPayload);
 		}


### PR DESCRIPTION
Goodmorning,

To resolve #21096 , I adjusted the function `focusLast` in `src\vs\base\parts\tree\browser\treeImpl.ts`.
The problem was that only the last element was retrieved, but never checked if that element has any children, so in case the last element is a folder it would focus the folder instead of the files it contains.
Note that I created a while loop to check for children, since multiple folders could be nested.

Since I'm not familiar with the `treeImpl.ts`, please let me know if anything needs to be adjusted.