### PR TITLE
Add ability to open untitled document with initial content

### DIFF
--- a/extensions/vscode-api-tests/src/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/workspace.test.ts
@@ -100,6 +100,15 @@ suite('workspace-namespace', () => {
 		});
 	});
 
+	test('openTextDocument, untitled without path but language ID and contents', function () {
+		return workspace.openTextDocument({ language: 'html', contents: '<h1>Hello world!</h1>' }).then(doc => {
+			assert.equal(doc.uri.scheme, 'untitled');
+			assert.equal(doc.languageId, 'html');
+			assert.ok(doc.isDirty);
+			assert.equal(doc.getText(), '<h1>Hello world!</h1>');
+		});
+	});
+
 	test('openTextDocument, untitled closes on save', function (done) {
 		const path = join(workspace.rootPath || '', './newfile.txt');
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4085,7 +4085,7 @@ declare module 'vscode' {
 		 * @param options Options to control how the document will be created.
 		 * @return A promise that resolves to a [document](#TextDocument).
 		 */
-		export function openTextDocument(options?: { language: string; }): Thenable<TextDocument>;
+		export function openTextDocument(options?: { language?: string; contents?: string; }): Thenable<TextDocument>;
 
 		/**
 		 * Register a text document content provider.

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -366,10 +366,10 @@ export function createApiFactory(initData: IInitData, threadService: IThreadServ
 			set textDocuments(value) {
 				throw errors.readonly();
 			},
-			openTextDocument(uriOrFileNameOrOptions?: vscode.Uri | string | { language: string; }) {
+			openTextDocument(uriOrFileNameOrOptions?: vscode.Uri | string | { language?: string; contents?: string; }) {
 				let uriPromise: TPromise<URI>;
 
-				let options = uriOrFileNameOrOptions as { language: string; };
+				let options = uriOrFileNameOrOptions as { language?: string; contents?: string; };
 				if (!options || typeof options.language === 'string') {
 					uriPromise = extHostDocuments.createDocumentData(options);
 				} else if (typeof uriOrFileNameOrOptions === 'string') {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -120,7 +120,7 @@ export abstract class MainThreadDiagnosticsShape {
 }
 
 export abstract class MainThreadDocumentsShape {
-	$tryCreateDocument(options?: { language: string; }): TPromise<any> { throw ni(); }
+	$tryCreateDocument(options?: { language?: string; contents?: string; }): TPromise<any> { throw ni(); }
 	$tryOpenDocument(uri: URI): TPromise<any> { throw ni(); }
 	$registerTextContentProvider(handle: number, scheme: string): void { throw ni(); }
 	$onVirtualDocumentChange(uri: URI, value: ITextSource): void { throw ni(); }

--- a/src/vs/workbench/api/node/extHostDocuments.ts
+++ b/src/vs/workbench/api/node/extHostDocuments.ts
@@ -109,7 +109,7 @@ export class ExtHostDocuments extends ExtHostDocumentsShape {
 		return promise;
 	}
 
-	public createDocumentData(options?: { language: string; }): TPromise<URI> {
+	public createDocumentData(options?: { language?: string; contents?: string }): TPromise<URI> {
 		return this._proxy.$tryCreateDocument(options);
 	}
 

--- a/src/vs/workbench/api/node/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/node/mainThreadDocuments.ts
@@ -181,8 +181,8 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 		});
 	}
 
-	$tryCreateDocument(options?: { language: string }): TPromise<URI> {
-		return this._doCreateUntitled(void 0, options ? options.language : void 0);
+	$tryCreateDocument(options?: { language?: string, contents?: string }): TPromise<URI> {
+		return this._doCreateUntitled(void 0, options ? options.language : void 0, options ? options.contents : void 0);
 	}
 
 	private _handleAsResourceInput(uri: URI): TPromise<boolean> {
@@ -204,8 +204,8 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 		}, err => this._doCreateUntitled(asFileUri).then(resource => !!resource));
 	}
 
-	private _doCreateUntitled(uri?: URI, modeId?: string): TPromise<URI> {
-		let input = this._untitledEditorService.createOrGet(uri, modeId);
+	private _doCreateUntitled(uri?: URI, modeId?: string, initialValue?: string): TPromise<URI> {
+		let input = this._untitledEditorService.createOrGet(uri, modeId, initialValue);
 		return input.resolve(true).then(model => {
 			if (!this._modelIsSynced[input.getResource().toString()]) {
 				throw new Error(`expected URI ${input.getResource().toString()} to have come to LIFE`);

--- a/src/vs/workbench/common/editor/untitledEditorInput.ts
+++ b/src/vs/workbench/common/editor/untitledEditorInput.ts
@@ -29,6 +29,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 
 	private resource: URI;
 	private _hasAssociatedFilePath: boolean;
+	private _initialValue: string;
 	private modeId: string;
 	private cachedModel: UntitledEditorModel;
 	private modelResolve: TPromise<UntitledEditorModel>;
@@ -42,6 +43,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 		resource: URI,
 		hasAssociatedFilePath: boolean,
 		modeId: string,
+		initialValue: string,
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@IWorkspaceContextService private contextService: IWorkspaceContextService,
 		@ITextFileService private textFileService: ITextFileService
@@ -49,6 +51,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 		super();
 
 		this.resource = resource;
+		this._initialValue = initialValue;
 		this._hasAssociatedFilePath = hasAssociatedFilePath;
 		this.modeId = modeId;
 		this.toUnbind = [];
@@ -166,7 +169,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 	}
 
 	private createModel(): UntitledEditorModel {
-		const model = this.instantiationService.createInstance(UntitledEditorModel, this.modeId, this.resource, this.hasAssociatedFilePath);
+		const model = this.instantiationService.createInstance(UntitledEditorModel, this.modeId, this.resource, this.hasAssociatedFilePath, this._initialValue);
 
 		// re-emit some events from the model
 		this.toUnbind.push(model.onDidChangeContent(() => this._onDidModelChangeContent.fire()));

--- a/src/vs/workbench/common/editor/untitledEditorInput.ts
+++ b/src/vs/workbench/common/editor/untitledEditorInput.ts
@@ -29,7 +29,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 
 	private resource: URI;
 	private _hasAssociatedFilePath: boolean;
-	private _initialValue: string;
+	private initialValue: string;
 	private modeId: string;
 	private cachedModel: UntitledEditorModel;
 	private modelResolve: TPromise<UntitledEditorModel>;
@@ -51,7 +51,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 		super();
 
 		this.resource = resource;
-		this._initialValue = initialValue;
+		this.initialValue = initialValue;
 		this._hasAssociatedFilePath = hasAssociatedFilePath;
 		this.modeId = modeId;
 		this.toUnbind = [];
@@ -169,7 +169,7 @@ export class UntitledEditorInput extends EditorInput implements IEncodingSupport
 	}
 
 	private createModel(): UntitledEditorModel {
-		const model = this.instantiationService.createInstance(UntitledEditorModel, this.modeId, this.resource, this.hasAssociatedFilePath, this._initialValue);
+		const model = this.instantiationService.createInstance(UntitledEditorModel, this.modeId, this.resource, this.hasAssociatedFilePath, this.initialValue);
 
 		// re-emit some events from the model
 		this.toUnbind.push(model.onDidChangeContent(() => this._onDidModelChangeContent.fire()));

--- a/src/vs/workbench/common/editor/untitledEditorModel.ts
+++ b/src/vs/workbench/common/editor/untitledEditorModel.ts
@@ -41,11 +41,13 @@ export class UntitledEditorModel extends BaseTextEditorModel implements IEncodin
 	private preferredEncoding: string;
 
 	private hasAssociatedFilePath: boolean;
+	private initialValue: string;
 
 	constructor(
 		private modeId: string,
 		private resource: URI,
 		hasAssociatedFilePath: boolean,
+		initialValue: string,
 		@IModeService modeService: IModeService,
 		@IModelService modelService: IModelService,
 		@IBackupFileService private backupFileService: IBackupFileService,
@@ -55,6 +57,7 @@ export class UntitledEditorModel extends BaseTextEditorModel implements IEncodin
 		super(modelService, modeService);
 
 		this.hasAssociatedFilePath = hasAssociatedFilePath;
+		this.initialValue = initialValue;
 		this.dirty = false;
 		this.versionId = 0;
 
@@ -171,7 +174,7 @@ export class UntitledEditorModel extends BaseTextEditorModel implements IEncodin
 			// untitled associated to file path are dirty right away as well as untitled with content
 			this.setDirty(this.hasAssociatedFilePath || !!backupContent);
 
-			return this.doLoad(backupContent || '').then(model => {
+			return this.doLoad(backupContent || this.initialValue || '').then(model => {
 				const configuration = this.configurationService.getConfiguration<IFilesConfiguration>();
 
 				// Encoding

--- a/src/vs/workbench/services/untitled/common/untitledEditorService.ts
+++ b/src/vs/workbench/services/untitled/common/untitledEditorService.ts
@@ -68,7 +68,7 @@ export interface IUntitledEditorService {
 	 * It is valid to pass in a file resource. In that case the path will be used as identifier.
 	 * The use case is to be able to create a new file with a specific path with VSCode.
 	 */
-	createOrGet(resource?: URI, modeId?: string): UntitledEditorInput;
+	createOrGet(resource?: URI, modeId?: string, initialValue?: string): UntitledEditorInput;
 
 	/**
 	 * A check to find out if a untitled resource has a file path associated or not.
@@ -154,7 +154,7 @@ export class UntitledEditorService implements IUntitledEditorService {
 			.map((i) => i.getResource());
 	}
 
-	public createOrGet(resource?: URI, modeId?: string): UntitledEditorInput {
+	public createOrGet(resource?: URI, modeId?: string, initialValue?: string): UntitledEditorInput {
 		let hasAssociatedFilePath = false;
 		if (resource) {
 			hasAssociatedFilePath = (resource.scheme === 'file');
@@ -171,10 +171,10 @@ export class UntitledEditorService implements IUntitledEditorService {
 		}
 
 		// Create new otherwise
-		return this.doCreate(resource, hasAssociatedFilePath, modeId);
+		return this.doCreate(resource, hasAssociatedFilePath, modeId, initialValue);
 	}
 
-	private doCreate(resource?: URI, hasAssociatedFilePath?: boolean, modeId?: string): UntitledEditorInput {
+	private doCreate(resource?: URI, hasAssociatedFilePath?: boolean, modeId?: string, initialValue?: string): UntitledEditorInput {
 		if (!resource) {
 
 			// Create new taking a resource URI that is not already taken
@@ -185,7 +185,7 @@ export class UntitledEditorService implements IUntitledEditorService {
 			} while (Object.keys(UntitledEditorService.CACHE).indexOf(resource.toString()) >= 0);
 		}
 
-		const input = this.instantiationService.createInstance(UntitledEditorInput, resource, hasAssociatedFilePath, modeId);
+		const input = this.instantiationService.createInstance(UntitledEditorInput, resource, hasAssociatedFilePath, modeId, initialValue);
 
 		const contentListener = input.onDidModelChangeContent(() => {
 			this._onDidChangeContent.fire(resource);


### PR DESCRIPTION
Addresses #21413 by passing file contents down to the `UntitledEditorModel`.

I checked that it worked locally and I added a test case, but I've had issues getting tests to run as reported in #22019.