### PR TITLE
Fixed typo in jsdoc of function tail

### DIFF
--- a/src/vs/base/common/arrays.ts
+++ b/src/vs/base/common/arrays.ts
@@ -7,7 +7,7 @@
 /**
  * Returns the last element of an array.
  * @param array The array.
- * @param n Which element from the end (default ist zero).
+ * @param n Which element from the end (default is zero).
  */
 export function tail<T>(array: T[], n: number = 0): T {
 	return array[array.length - (1 + n)];


### PR DESCRIPTION
When scanning the code base I came across this small typo.

Furthermore I noticed that some parameters tags were missing from other functions, for instance the `insert` function. I can also add those if that is desired