### PR TITLE
Add Specific No Result Found Messages for Implementations and Type Definition

### DIFF
--- a/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts
@@ -90,11 +90,7 @@ export class DefinitionAction extends EditorAction {
 
 			if (result.length === 0) {
 				const info = model.getWordAtPosition(pos);
-				const message = info && info.word
-					? nls.localize('noResultWord', "No definition found for '{0}'", info.word)
-					: nls.localize('generic.noResults', "No definition found");
-
-				MessageController.get(editor).showMessage(message, pos);
+				MessageController.get(editor).showMessage(this.getNoResultFoundMessage(info), pos);
 				return;
 			}
 
@@ -109,6 +105,12 @@ export class DefinitionAction extends EditorAction {
 
 	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
 		return getDefinitionsAtPosition(model, position);
+	}
+
+	protected getNoResultFoundMessage(info?: editorCommon.IWordAtPosition): string {
+		return info && info.word
+			? nls.localize('noResultWord', "No definition found for '{0}'", info.word)
+			: nls.localize('generic.noResults', "No definition found");
 	}
 
 	private _onResult(editorService: IEditorService, editor: editorCommon.ICommonCodeEditor, model: ReferencesModel) {
@@ -231,9 +233,20 @@ export class PeekDefinitionAction extends DefinitionAction {
 	}
 }
 
+export class ImplementationAction extends DefinitionAction {
+	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
+		return getImplementationsAtPosition(model, position);
+	}
+
+	protected getNoResultFoundMessage(info?: editorCommon.IWordAtPosition): string {
+		return info && info.word
+			? nls.localize('goToImplementation.noResultWord', "No implementation found for '{0}'", info.word)
+			: nls.localize('goToImplementation.generic.noResults', "No implementation found");
+	}
+}
 
 @editorAction
-export class GoToImplementationAction extends DefinitionAction {
+export class GoToImplementationAction extends ImplementationAction {
 
 	public static ID = 'editor.action.goToImplementation';
 
@@ -255,14 +268,10 @@ export class GoToImplementationAction extends DefinitionAction {
 			}
 		});
 	}
-
-	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getImplementationsAtPosition(model, position);
-	}
 }
 
 @editorAction
-export class PeekImplementationAction extends DefinitionAction {
+export class PeekImplementationAction extends ImplementationAction {
 
 	public static ID = 'editor.action.peekImplementation';
 
@@ -280,14 +289,22 @@ export class PeekImplementationAction extends DefinitionAction {
 			}
 		});
 	}
+}
 
+export class TypeDefinitionAction extends DefinitionAction {
 	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getImplementationsAtPosition(model, position);
+		return getTypeDefinitionsAtPosition(model, position);
+	}
+
+	protected getNoResultFoundMessage(info?: editorCommon.IWordAtPosition): string {
+		return info && info.word
+			? nls.localize('goToTypeDefinition.noResultWord', "No type definition found for '{0}'", info.word)
+			: nls.localize('goToTypeDefinition.generic.noResults', "No type definition found");
 	}
 }
 
 @editorAction
-export class GoToTypeDefintionAction extends DefinitionAction {
+export class GoToTypeDefintionAction extends TypeDefinitionAction {
 
 	public static ID = 'editor.action.goToTypeDefinition';
 
@@ -309,14 +326,10 @@ export class GoToTypeDefintionAction extends DefinitionAction {
 			}
 		});
 	}
-
-	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getTypeDefinitionsAtPosition(model, position);
-	}
 }
 
 @editorAction
-export class PeekTypeDefinitionAction extends DefinitionAction {
+export class PeekTypeDefinitionAction extends TypeDefinitionAction {
 
 	public static ID = 'editor.action.peekTypeDefinition';
 
@@ -333,10 +346,6 @@ export class PeekTypeDefinitionAction extends DefinitionAction {
 				primary: 0
 			}
 		});
-	}
-
-	protected getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
-		return getTypeDefinitionsAtPosition(model, position);
 	}
 }
 


### PR DESCRIPTION
fixes #21683

Adds specific messages when `go to implementation` or `go to type definition` returns no results