### PR TITLE
More robust deprecation warning for launch.json (Fixes #21946)

### DIFF
--- a/src/vs/workbench/parts/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/parts/debug/node/debugAdapter.ts
@@ -227,7 +227,7 @@ export class Adapter {
 			};
 			Object.keys(attributes.properties).forEach(name => {
 				// Use schema allOf property to get independent error reporting #21113
-				attributes.properties[name].pattern = attributes.properties[name].pattern || '^(?!\\$\\{(env|config|command)\\.)';
+				attributes.properties[name].pattern = attributes.properties[name].pattern || '^(?!\\s*\\$\\{(env|config|command)\\.)';
 				attributes.properties[name].patternErrorMessage = attributes.properties[name].patternErrorMessage ||
 					nls.localize('deprecatedVariables', "'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead.");
 			});

--- a/src/vs/workbench/parts/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/parts/debug/node/debugAdapter.ts
@@ -227,7 +227,7 @@ export class Adapter {
 			};
 			Object.keys(attributes.properties).forEach(name => {
 				// Use schema allOf property to get independent error reporting #21113
-				attributes.properties[name].pattern = attributes.properties[name].pattern || '^(?!\\s*\\$\\{(env|config|command)\\.)';
+				attributes.properties[name].pattern = attributes.properties[name].pattern || '^(?!.*\\$\\{(env|config|command)\\.)';
 				attributes.properties[name].patternErrorMessage = attributes.properties[name].patternErrorMessage ||
 					nls.localize('deprecatedVariables', "'env.', 'config.' and 'command.' are deprecated, use 'env:', 'config:' and 'command:' instead.");
 			});


### PR DESCRIPTION
As described in #21946, `"${workspaceRoot}/${command.AskForProgramName}",` and
`" ${command.AskForProgramName}",` should trigger a deprecation warning, but the regular expression used was only checking if the `${command.` part was at the start of the string. I changed it to ignore any characters that come before the `${command.` part.

This seems to fix the problem for me. Hopefully I'm not missing anything.

<img width="562" alt="debug" src="https://cloud.githubusercontent.com/assets/1572318/23702045/f08527ac-043c-11e7-82d4-781f9c5e042a.png">