### PR TITLE
TypeScript should use double quotes for string in import snippet.

### DIFF
--- a/extensions/typescript/snippets/typescript.json
+++ b/extensions/typescript/snippets/typescript.json
@@ -50,7 +50,7 @@
 	"Import external module.": {
 		"prefix": "import statement",
 		"body": [
-			"import { $0 } from '${1:module}';"
+			"import { $0 } from \"${1:module}\";"
 		],
 		"description": "Import external module."
 	},


### PR DESCRIPTION
From style guide: https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines #22231 