### PR TITLE
Update PHP snippets

### DIFF
--- a/extensions/php/snippets/php.json
+++ b/extensions/php/snippets/php.json
@@ -1,63 +1,75 @@
 {
-	"Class Variable": {
-		"prefix": "doc_v",
-		"body": [
-			"/**",
-			" * ${1:undocumented class variable}",
-			" *",
-			" * @var ${2:string}",
-			" **/",
-			"${3:var} $$2;$0"
-		],
-		"description": "Documented Class Variable"
-	},
-	"function __construct": {
-		"prefix": "con",
-		"body": [
-			"function __construct(${1:$${2:foo} ${3:= ${4:null}}}) {",
-			"\t${2:$this->$0 = $$0;}",
-			"}"
-		]
-	},
 	"class …": {
 		"prefix": "class",
 		"body": [
-			"/**",
-			" * $1",
-			" */",
-			"class ${2:ClassName} ${3:extends ${4:AnotherClass}}",
+			"class ${1:ClassName} ${2:extends ${3:AnotherClass}} ${4:implements ${5:Interface}}",
 			"{",
-			"\t$5",
-			"\tfunction ${6:__construct}(${7:argument})",
-			"\t{",
-			"\t\t${0:# code...}",
-			"\t}",
+			"\t$0",
 			"}",
 			""
 		],
 		"description": "Class definition"
 	},
+	"PHPDoc class …": {
+		"prefix": "doc_class",
+		"body": [
+			"/**",
+			" * ${6:undocumented class}",
+			" */",
+			"class ${1:ClassName} ${2:extends ${3:AnotherClass}} ${4:implements ${5:Interface}}",
+			"{",
+			"\t$0",
+			"}",
+			""
+		],
+		"description": "Documented Class Declaration"
+	},
+	"function __construct": {
+		"prefix": "con",
+		"body": [
+			"${1:public} function __construct(${2:${3:Type} $${4:var}${5: = ${6:null}}}) {",
+            "\t\\$this->${4:var} = $${4:var};$0",
+            "}"
+		]
+	},
+	"PHPDoc property": {
+		"prefix": "doc_v",
+		"body": [
+			"/** @var ${1:Type} $${2:var} ${3:description} */",
+			"${4:protected} $${2:var}${5: = ${6:null}};$0"
+		],
+		"description": "Documented Class Variable"
+	},
 	"PHPDoc function …": {
 		"prefix": "doc_f",
 		"body": [
 			"/**",
-			" * ${6:undocumented function summary}",
+			" * ${1:undocumented function summary}",
 			" *",
-			" * ${7:Undocumented function long description}",
+			" * ${2:Undocumented function long description}",
 			" *",
-			" * @param ${8:type} ${9:var} ${10:Description}",
+			"${3: * @param ${4:Type} $${5:var} ${6:Description}}",
+			"${7: * @return ${8:type}}",
+			"${9: * @throws ${10:conditon}}",
 			" **/",
-			"${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=''}})",
+			"${11:public }function ${12:FunctionName}(${13:${14:${4:Type} }$${5:var}${15: = ${16:null}}})",
 			"{",
 			"\t${0:# code...}",
 			"}"
 		],
 		"description": "Documented function"
 	},
+	"PHPDoc param …": {
+		"prefix": "param",
+		"body": [
+			"* @param ${1:Type} ${2:var} ${3:Description}$0"
+		],
+		"description": "Paramater documentation"
+	},
 	"function …": {
 		"prefix": "fun",
 		"body": [
-			"${1:public }function ${2:FunctionName}(${3:$${4:value}${5:=''}})",
+			"${1:public }function ${2:FunctionName}(${3:${4:${5:Type} }$${6:var}${7: = ${8:null}}})",
 			"{",
 			"\t${0:# code...}",
 			"}"
@@ -72,10 +84,7 @@
 			" */",
 			"trait ${2:TraitName}",
 			"{",
-			"\tfunction ${3:functionName}(${4:argument})",
-			"\t{",
-			"\t\t${5:# code...}",
-			"\t}",
+			"\t$0",
 			"}",
 			""
 		],
@@ -94,9 +103,27 @@
 		"body": [
 			"do {",
 			"\t${0:# code...}",
-			"} while (${1:${2:$a} <= ${3:10}});"
+			"} while (${1:$${2:a} <= ${3:10}});"
 		],
 		"description": "Do-While loop"
+	},
+		"while …": {
+		"prefix": "while",
+		"body": [
+			"while (${1:$${2:a} <= ${3:10}}) {",
+			"\t${0:# code...}",
+			"}"
+		],
+		"description": "While-loop"
+	},
+	"if …": {
+		"prefix": "if",
+		"body": [
+			"if (${1:condition}) {",
+			"\t${0:# code...}",
+			"}"
+		],
+		"description": "If block"
 	},
 	"if … else …": {
 		"prefix": "ifelse",
@@ -109,15 +136,6 @@
 			"$0"
 		],
 		"description": "If Else block"
-	},
-	"if …": {
-		"prefix": "if",
-		"body": [
-			"if (${1:condition}) {",
-			"\t${0:# code...}",
-			"}"
-		],
-		"description": "If block"
 	},
 	"$… = ( … ) ? … : …": {
 		"prefix": "if?",
@@ -178,7 +196,7 @@
 	"switch …": {
 		"prefix": "switch",
 		"body": [
-			"switch (${1:variable}) {",
+			"switch (\\$${1:variable}) {",
 			"\tcase '${2:value}':",
 			"\t\t${3:# code...}",
 			"\t\tbreak;",
@@ -193,7 +211,7 @@
 	"case …": {
 		"prefix": "case",
 		"body": [
-			"case '${1:variable}':",
+			"case '${1:value}':",
 			"\t${0:# code...}",
 			"\tbreak;"
 		],
@@ -201,12 +219,12 @@
 	},
 	"$this->…": {
 		"prefix": "this",
-		"body": "$this->$0",
+		"body": "\\$this->$0;",
 		"description": "$this->..."
 	},
 	"echo $this->…": {
 		"prefix": "ethis",
-		"body": "echo $this->$0",
+		"body": "echo \\$this->$0;",
 		"description": "Echo this"
 	},
 	"Throw Exception": {
@@ -216,14 +234,5 @@
 			"$0"
 		],
 		"description": "Throw exception"
-	},
-	"while …": {
-		"prefix": "while",
-		"body": [
-			"while (${1:$a <= 10}) {",
-			"\t${0:# code...}",
-			"}"
-		],
-		"description": "While-loop"
 	}
 }


### PR DESCRIPTION
This merge fixes syntax errors in the following snippets:

* $this->
* echo $this->
* function __construct
* do … while …
* while …
* switch …

Changed `'${1:variable}'` to `'${1:value}'` in `case` snippet to match `switch` snippet.

Add type hint and update default value for `function …` snippet.

Add type hint, `@return` and `@throw` PHPDoc elements, update default value, tab order and `@param` PHPDoc element for `PHPDoc function …` snippet.

Add accessor level and type hinting, and updated default value in `function __construct`.

Change `class …` to `PHPDoc class …` and remove constructor. Constructor removed in favor of updated `function __construct` snippet.

Remove generated function from `trait` snippet in favor of updated `function ...` and `PHPDoc function ...` snippets.

Create snippet `PHPDoc class …` that has a DocBlock.

Change name from `Class Variable` to `PHPDoc property`. Prefix remained the same.

Add `PHPDoc param …`.

Change order of snippets to group like snippets together.
