### PR TITLE
Support for TSServer Request Cancelation

### DIFF
--- a/extensions/typescript/src/utils/electron.ts
+++ b/extensions/typescript/src/utils/electron.ts
@@ -17,7 +17,7 @@ export interface IForkOptions {
 	execArgv?: string[];
 }
 
-function makeRandomHexString(length: number): string {
+export function makeRandomHexString(length: number): string {
 	let chars = ['0', '1', '2', '3', '4', '5', '6', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
 	let result = '';
 	for (let i = 0; i < length; i++) {
@@ -28,14 +28,19 @@ function makeRandomHexString(length: number): string {
 }
 
 function generatePipeName(): string {
-	var randomName = 'vscode-' + makeRandomHexString(40);
+	return getPipeName(makeRandomHexString(40));
+}
+
+export function getPipeName(name: string): string {
+	const fullName = 'vscode-' + name;
 	if (process.platform === 'win32') {
-		return '\\\\.\\pipe\\' + randomName + '-sock';
+		return '\\\\.\\pipe\\' + fullName + '-sock';
 	}
 
 	// Mac/Unix: use socket file
-	return path.join(os.tmpdir(), randomName + '.sock');
+	return path.join(os.tmpdir(), fullName + '.sock');
 }
+
 
 function generatePatchedEnv(env: any, stdInPipeName: string, stdOutPipeName: string, stdErrPipeName: string): any {
 	// Set the two unique pipe names and the electron flag as process env


### PR DESCRIPTION
#18053

Adds support for canceling ongoing TSServer requests using per request cancelation. This PR is a WIP currently.

@vladima and @mhegazy can you take a quick look at the PR to see if it looks correct. I keep getting error from the TSServer that look like this:

```
shell.ts:468 Error processing request. Mismatched request id, expected undefined, actual 4
Error: Mismatched request id, expected undefined, actual 4
    at Object.resetRequest (/Users/matb/projects/vscode/extensions/node_modules/typescript/lib/cancellationToken.js:57:27)
    at IOSession.Session.resetCurrentRequest (/Users/matb/projects/vscode/extensions/node_modules/typescript/lib/tsserver.js:73291:40)
    at IOSession.Session.executeWithRequestId (/Users/matb/projects/vscode/extensions/node_modules/typescript/lib/tsserver.js:73299:26)
    at IOSession.Session.executeCommand (/Users/matb/projects/vscode/extensions/node_modules/typescript/lib/tsserver.js:73305:33)
    at IOSession.Session.onMessage (/Users/matb/projects/vscode/extensions/node_modules/typescript/lib/tsserver.js:73325:35)
    at Interface.<anonymous> (/Users/matb/projects/vscode/extensions/node_modules/typescript/lib/tsserver.js:74477:27)
    at emitOne (events.js:96:13)
    at Interface.emit (events.js:188:7)
    at Interface._onLine (readline.js:232:10)
    at Interface.<anonymous> (readline.js:365:12)
``` 

It seems the expected request is never set. I think there is a bug on this line with `currentRequestId = currentRequestId`: https://github.com/Microsoft/TypeScript/blob/6117ed77087b5d84774ee545bd3cad3d059caa75/src/server/cancellationToken/cancellationToken.ts#L51

Here's a PR with a fix: https://github.com/Microsoft/TypeScript/pull/14594

 

 