### PR TITLE
Add option to follow the last valid active path for untitled editors outside of a workspace

### DIFF
--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -505,6 +505,11 @@ export const HotExitConfiguration = {
 	ON_EXIT_AND_WINDOW_CLOSE: 'onExitAndWindowClose'
 };
 
+export const FollowSavePathConfiguration = {
+	ON: 'on',
+	OFF: 'off'
+};
+
 export const CONTENT_CHANGE_EVENT_BUFFER_DELAY = 1000;
 
 export interface IFilesConfiguration {
@@ -518,6 +523,7 @@ export interface IFilesConfiguration {
 		autoSaveDelay: number;
 		eol: string;
 		hotExit: string;
+		followSavePath: string;
 	};
 }
 

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -16,7 +16,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'v
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actionRegistry';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { IEditorRegistry, Extensions as EditorExtensions, IEditorInputFactory, EditorInput, IFileEditorInput } from 'vs/workbench/common/editor';
-import { AutoSaveConfiguration, HotExitConfiguration, SUPPORTED_ENCODINGS, IFilesConfiguration } from 'vs/platform/files/common/files';
+import { AutoSaveConfiguration, HotExitConfiguration, FollowSavePathConfiguration, SUPPORTED_ENCODINGS, IFilesConfiguration } from 'vs/platform/files/common/files';
 import { EditorDescriptor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { FILE_EDITOR_INPUT_ID, VIEWLET_ID } from 'vs/workbench/parts/files/common/files';
 import { FileEditorTracker } from 'vs/workbench/parts/files/common/editors/fileEditorTracker';
@@ -267,6 +267,16 @@ configurationRegistry.registerConfiguration({
 				nls.localize('hotExit.onExitAndWindowClose', 'Hot exit will be triggered when the application is closed, that is when the last window is closed on Windows/Linux or when the workbench.action.quit command is triggered (command pallete, keybinding, menu), and also for any window with a folder opened regardless of whether it\'s the last window. All windows without folders opened will be restored upon next launch. To restore folder windows as they were before shutdown set "window.reopenFolders" to "all".')
 			],
 			'description': nls.localize('hotExit', "Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.", HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE)
+		},
+		'files.followSavePath': {
+			'type': 'string',
+			'enum': [FollowSavePathConfiguration.ON, FollowSavePathConfiguration.OFF],
+			'default': FollowSavePathConfiguration.OFF,
+			'enumDescriptions': [
+				nls.localize('followSavePath.on', 'Untitled files will follow the last active valid path.'),
+				nls.localize('followSavePath.off', 'Untitled files will not follow the last active valid path.')
+			],
+			'description': nls.localize('followSavePath', "Controls whether untitled files are saved in the last active valid folder outside of workspace.")
 		}
 	}
 });


### PR DESCRIPTION
This PR adds an option to store the last active valid path when switching editors to use the path directory as the base directory for saving untitled editors when creating new files outside of a workspace. This is a feature that Sublime Text provides out of the box and I made a huge habit of (ab)using it so I figured I might as well give it a try to implement it in vscode.

If such feature either already exists and I missed it or is unwanted then feel free to ignore it.

Assuming the following three editor tabs open and the feature option set to ON:
1) /home/user/dir1/a.txt
2) /home/user/dir2/b.txt
3) Untitled-1

The feature will provide the following behavior:
* If we switch to tab 1), then 3), and then attempt to save the untitled editor, the file dialog will use /home/user/dir1/ as the base directory.
* If we switch to tab 2), then 3), and then attempt to save the untitled editor, the file dialog will use /home/user/dir2/ as the base directory.
* And so on...

The feature needs to be enabled explicitly and the old behavior is retained by default.