### PR TITLE
Refactor to fix compile error with noImplicitAny

### DIFF
--- a/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
+++ b/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
@@ -15,8 +15,13 @@ import DOM = require('vs/base/browser/dom');
 import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
 import { BoundedLinkedMap } from 'vs/base/common/map';
 
+
+interface MapExtToMediaMimes {
+	[index: string]: string;
+}
+
 // Known media mimes that we can handle
-const mapExtToMediaMimes = {
+const mapExtToMediaMimes: MapExtToMediaMimes = {
 	'.bmp': 'image/bmp',
 	'.gif': 'image/gif',
 	'.jpg': 'image/jpg',

--- a/src/vs/base/common/diagnostics.ts
+++ b/src/vs/base/common/diagnostics.ts
@@ -18,7 +18,7 @@ if (!globals.Monaco) {
 globals.Monaco.Diagnostics = {};
 
 var switches = globals.Monaco.Diagnostics;
-var map = {};
+var map = new Map<string, Function[]>();
 var data: any[] = [];
 
 function fifo(array: any[], size: number) {
@@ -41,9 +41,9 @@ export function register(what: string, fn: Function): (...args: any[]) => void {
 	switches[what] = flag;
 
 	// register function
-	var tracers = map[what] || [];
+	var tracers = map.get(what) || [];
 	tracers.push(fn);
-	map[what] = tracers;
+	map.set(what, tracers);
 
 	var result = function (...args: any[]) {
 

--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -58,12 +58,12 @@ function markedStringEqual(a: MarkedString, b: MarkedString): boolean {
 	if (!a || !b) {
 		return false;
 	}
-	if (typeof a === 'string') {
-		return typeof b === 'string' && a === b;
+	if (typeof a === 'string' || typeof b === 'string') {
+		return typeof a === 'string' && typeof b === 'string' && a === b;
 	}
 	return (
-		a['language'] === b['language']
-		&& a['value'] === b['value']
+		a.language === b.language
+		&& a.value === b.value
 	);
 }
 

--- a/src/vs/base/common/json.ts
+++ b/src/vs/base/common/json.ts
@@ -972,7 +972,7 @@ export function getNodeValue(node: Node): any {
 	if (node.type === 'array') {
 		return node.children.map(getNodeValue);
 	} else if (node.type === 'object') {
-		let obj = {};
+		let obj: any = {};
 		for (let prop of node.children) {
 			obj[prop.children[0].value] = getNodeValue(prop.children[1]);
 		}

--- a/src/vs/base/common/map.ts
+++ b/src/vs/base/common/map.ts
@@ -305,7 +305,7 @@ export class LRUCache<T> extends BoundedLinkedMap<T> {
 
 class Node<E> {
 	element?: E;
-	readonly children = new Map<string, E>();
+	readonly children = new Map<string, Node<E>>();
 }
 
 /**
@@ -330,7 +330,7 @@ export class TrieMap<E> {
 		// find insertion node
 		let node = this._root;
 		for (; i < parts.length; i++) {
-			let child = node.children[parts[i]];
+			let child = node.children.get(parts[i]);
 			if (child) {
 				node = child;
 				continue;
@@ -342,7 +342,7 @@ export class TrieMap<E> {
 		let newNode: Node<E>;
 		for (; i < parts.length; i++) {
 			newNode = new Node<E>();
-			node.children[parts[i]] = newNode;
+			node.children.set(parts[i], newNode);
 			node = newNode;
 		}
 
@@ -355,7 +355,7 @@ export class TrieMap<E> {
 		let { children } = this._root;
 		let node: Node<E>;
 		for (const part of parts) {
-			node = children[part];
+			node = children.get(part);
 			if (!node) {
 				return undefined;
 			}
@@ -371,7 +371,7 @@ export class TrieMap<E> {
 		let lastNode: Node<E>;
 		let { children } = this._root;
 		for (const part of parts) {
-			const node = children[part];
+			const node = children.get(part);
 			if (!node) {
 				break;
 			}
@@ -395,7 +395,7 @@ export class TrieMap<E> {
 		let { children } = this._root;
 		let node: Node<E>;
 		for (const part of parts) {
-			node = children[part];
+			node = children.get(part);
 			if (!node) {
 				return undefined;
 			}

--- a/src/vs/editor/browser/standalone/standaloneServices.ts
+++ b/src/vs/editor/browser/standalone/standaloneServices.ts
@@ -47,6 +47,7 @@ export interface IEditorContextViewService extends IContextViewService {
 }
 
 export interface IEditorOverrideServices {
+	[index: string]: any;
 }
 
 export module StaticServices {

--- a/src/vs/editor/contrib/referenceSearch/browser/referencesWidget.ts
+++ b/src/vs/editor/contrib/referenceSearch/browser/referencesWidget.ts
@@ -139,7 +139,7 @@ class DecorationsManager implements IDisposable {
 
 		this._editor.changeDecorations((accessor) => {
 			for (let i = 0, len = toRemove.length; i < len; i++) {
-				delete this._decorations[toRemove[i]];
+				this._decorations.delete(toRemove[i]);
 			}
 			accessor.deltaDecorations(toRemove, []);
 		});

--- a/src/vs/editor/electron-browser/textMate/TMSyntax.ts
+++ b/src/vs/editor/electron-browser/textMate/TMSyntax.ts
@@ -146,7 +146,7 @@ export class MainProcessTextMateSyntax implements ITextMateService {
 
 		this._modeService.onDidCreateMode((mode) => {
 			let modeId = mode.getId();
-			if (this._languageToScope[modeId]) {
+			if (this._languageToScope.has(modeId)) {
 				this.registerDefinition(modeId);
 			}
 		});
@@ -234,7 +234,7 @@ export class MainProcessTextMateSyntax implements ITextMateService {
 
 		let modeId = syntax.language;
 		if (modeId) {
-			this._languageToScope[modeId] = syntax.scopeName;
+			this._languageToScope.set(modeId, syntax.scopeName);
 		}
 	}
 
@@ -257,7 +257,7 @@ export class MainProcessTextMateSyntax implements ITextMateService {
 	}
 
 	private _createGrammar(modeId: string): TPromise<ICreateGrammarResult> {
-		let scopeName = this._languageToScope[modeId];
+		let scopeName = this._languageToScope.get(modeId);
 		let languageRegistration = this._scopeRegistry.getLanguageRegistration(scopeName);
 		if (!languageRegistration) {
 			// No TM grammar defined

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -972,6 +972,7 @@ declare module monaco.editor {
     }
 
     export interface IEditorOverrideServices {
+        [index: string]: any;
     }
 
     /**

--- a/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
@@ -150,7 +150,7 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 
 	private resolveConfigVariable(value: string, originalValue: string): string {
 		const replacer = (match: string, name: string) => {
-			let config = this.configurationService.getConfiguration();
+			let config = this.configurationService.getConfiguration<any>();
 			let newValue: any;
 			try {
 				const keys: string[] = name.split('.');

--- a/src/vs/workbench/services/themes/electron-browser/themeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/themeService.ts
@@ -462,7 +462,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 
 	private findThemeData(themeId: string, defaultId?: string): TPromise<ColorThemeData> {
 		return this.getColorThemes().then(allThemes => {
-			let defaultTheme = void 0;
+			let defaultTheme: IColorTheme = void 0;
 			for (let t of allThemes) {
 				if (t.id === themeId) {
 					return t;
@@ -477,7 +477,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 
 	private findThemeDataBySettingsId(settingsId: string, defaultId: string): TPromise<ColorThemeData> {
 		return this.getColorThemes().then(allThemes => {
-			let defaultTheme = void 0;
+			let defaultTheme: IColorTheme = void 0;
 			for (let t of allThemes) {
 				if (t.settingsId === settingsId) {
 					return t;
@@ -591,10 +591,10 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 		});
 	}
 
-	private themeExtensionsActivated = {};
+	private themeExtensionsActivated = new Map<string, boolean>();
 	private sendTelemetry(themeId: string, themeData: ExtensionData, themeType: string) {
 		let key = themeType + themeData.extensionId;
-		if (!this.themeExtensionsActivated[key]) {
+		if (!this.themeExtensionsActivated.get(key)) {
 			this.telemetryService.publicLog('activatePlugin', {
 				id: themeData.extensionId,
 				name: themeData.extensionName,
@@ -602,7 +602,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 				publisherDisplayName: themeData.extensionPublisher,
 				themeId: themeId
 			});
-			this.themeExtensionsActivated[key] = true;
+			this.themeExtensionsActivated.set(key, true);
 		}
 	}
 


### PR DESCRIPTION
Some refactorings

- Introduced index signature.
- Fixed to use ES6 Map properly.
- Fixed type signature.
- Fixed to use `foo.bar` instead of `foo[bar]`

All of these changes fix compile errors which occur if `noImplicitAny` in `tsconfig.json` is set to `true`.