### PR TITLE
Fixed #14311 by adding preserveFocus parameter to vscode.previewHtml

### DIFF
--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -161,12 +161,12 @@ export class ExtHostApiCommands {
 			],
 			returns: 'A promise that resolves to an array of DocumentLink-instances.'
 		});
-
-		this._register('vscode.previewHtml', (uri: URI, position?: vscode.ViewColumn, label?: string) => {
+		this._register('vscode.previewHtml', (uri: URI, position?: vscode.ViewColumn, label?: string, preserveFocus?: boolean) => {
 			return this._commands.executeCommand('_workbench.previewHtml',
 				uri,
 				typeof position === 'number' && typeConverters.fromViewColumn(position),
-				label);
+				label,
+				preserveFocus);
 		}, {
 				description: `
 					Render the html of the resource in an editor view.
@@ -187,7 +187,8 @@ export class ExtHostApiCommands {
 				args: [
 					{ name: 'uri', description: 'Uri of the resource to preview.', constraint: value => value instanceof URI || typeof value === 'string' },
 					{ name: 'column', description: '(optional) Column in which to preview.', constraint: value => typeof value === 'undefined' || (typeof value === 'number' && typeof types.ViewColumn[value] === 'string') },
-					{ name: 'label', description: '(optional) An human readable string that is used as title for the preview.', constraint: v => typeof v === 'string' || typeof v === 'undefined' }
+					{ name: 'label', description: '(optional) An human readable string that is used as title for the preview.', constraint: v => typeof v === 'string' || typeof v === 'undefined' },
+					{ name: 'preserveFocus', description: '(optional) When `true` the preview will not take focus.', constraint: value => typeof value === 'boolean' || typeof value === 'undefined' }
 				]
 			});
 

--- a/src/vs/workbench/parts/html/browser/html.contribution.ts
+++ b/src/vs/workbench/parts/html/browser/html.contribution.ts
@@ -72,7 +72,7 @@ CommandsRegistry.registerCommand('_workbench.htmlZone', function (accessor: Serv
 
 });
 
-CommandsRegistry.registerCommand('_workbench.previewHtml', function (accessor: ServicesAccessor, resource: URI | string, position?: EditorPosition, label?: string) {
+CommandsRegistry.registerCommand('_workbench.previewHtml', function (accessor: ServicesAccessor, resource: URI | string, position?: EditorPosition, label?: string, preserveFocus?: boolean) {
 
 	const uri = resource instanceof URI ? resource : URI.parse(resource);
 	label = label || uri.fsPath;
@@ -97,7 +97,7 @@ CommandsRegistry.registerCommand('_workbench.previewHtml', function (accessor: S
 	}
 
 	return accessor.get(IWorkbenchEditorService)
-		.openEditor(input, { pinned: true }, position)
+		.openEditor(input, { pinned: true, preserveFocus: preserveFocus }, position)
 		.then(editor => true);
 });
 


### PR DESCRIPTION
The command now matches the behavior of window.showTextDocument with regards to focus - taking it by default with an optional `preserveFocus` parameter that will not take focus when set to true.

![issue14311](https://cloud.githubusercontent.com/assets/2957173/23827770/b21d7786-06bb-11e7-9ecb-71bc69f38ca3.gif)
