### PR TITLE
Fix Markdown TOC Provider for Invalid References

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -191,7 +191,7 @@
 	},
 	"dependencies": {
 		"highlight.js": "^9.3.0",
-		"markdown-it": "^8.2.2",
+		"markdown-it": "^8.3.1",
 		"markdown-it-named-headers": "0.0.4",
 		"vscode-extension-telemetry": "^0.0.6",
 		"vscode-nls": "^2.0.2"

--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -17,7 +17,7 @@ export interface IToken {
 interface MarkdownIt {
 	render(text: string): string;
 
-	parse(text: string): IToken[];
+	parse(text: string, env: any): IToken[];
 
 	utils: any;
 }
@@ -83,9 +83,10 @@ export class MarkdownEngine {
 		return this.engine.render(text);
 	}
 
-	public parse(source: string): IToken[] {
+	public parse(document: vscode.Uri, source: string): IToken[] {
 		const {text, offset} = this.stripFrontmatter(source);
-		return this.engine.parse(text).map(token => {
+		this.currentDocument = document;
+		return this.engine.parse(text, {}).map(token => {
 			if (token.map) {
 				token.map[0] += offset;
 			}

--- a/extensions/markdown/src/tableOfContentsProvider.ts
+++ b/extensions/markdown/src/tableOfContentsProvider.ts
@@ -46,7 +46,7 @@ export class TableOfContentsProvider {
 
 	private buildToc(document: vscode.TextDocument): any {
 		const toc: TocEntry[] = [];
-		const tokens: IToken[] = this.engine.parse(this.document.getText());
+		const tokens: IToken[] = this.engine.parse(document.uri, document.getText());
 
 		for (const heading of tokens.filter(token => token.type === 'heading_open')) {
 			const lineNumber = heading.map[0];


### PR DESCRIPTION
Fixes #22494

**Bug**
References without a definition can cause the markdown table of contents provider to break

**Fix**
Pass in an empty environment to markdown-it `parse` to prevent the null dereference on invalid links. Also picks up new markdown it version and fixes a potential case where `currentDocument` is undefined