### PR TITLE
Create IContext type, dynamic `getValue`

### DIFF
--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -88,7 +88,7 @@ export abstract class ContextKeyExpr {
 
 	public abstract getType(): ContextKeyExprType;
 	public abstract equals(other: ContextKeyExpr): boolean;
-	public abstract evaluate(context: any): boolean;
+	public abstract evaluate(context: IContext): boolean;
 	public abstract normalize(): ContextKeyExpr;
 	public abstract serialize(): string;
 	public abstract keys(): string[];
@@ -139,8 +139,8 @@ export class ContextKeyDefinedExpr implements ContextKeyExpr {
 		return false;
 	}
 
-	public evaluate(context: any): boolean {
-		return (!!context[this.key]);
+	public evaluate(context: IContext): boolean {
+		return (!!context.getValue(this.key));
 	}
 
 	public normalize(): ContextKeyExpr {
@@ -187,10 +187,10 @@ export class ContextKeyEqualsExpr implements ContextKeyExpr {
 		return false;
 	}
 
-	public evaluate(context: any): boolean {
+	public evaluate(context: IContext): boolean {
 		/* tslint:disable:triple-equals */
 		// Intentional ==
-		return (context[this.key] == this.value);
+		return (context.getValue(this.key) == this.value);
 		/* tslint:enable:triple-equals */
 	}
 
@@ -248,10 +248,10 @@ export class ContextKeyNotEqualsExpr implements ContextKeyExpr {
 		return false;
 	}
 
-	public evaluate(context: any): boolean {
+	public evaluate(context: IContext): boolean {
 		/* tslint:disable:triple-equals */
 		// Intentional !=
-		return (context[this.key] != this.value);
+		return (context.getValue(this.key) != this.value);
 		/* tslint:enable:triple-equals */
 	}
 
@@ -303,8 +303,8 @@ export class ContextKeyNotExpr implements ContextKeyExpr {
 		return false;
 	}
 
-	public evaluate(context: any): boolean {
-		return (!context[this.key]);
+	public evaluate(context: IContext): boolean {
+		return (!context.getValue(this.key));
 	}
 
 	public normalize(): ContextKeyExpr {
@@ -346,7 +346,7 @@ export class ContextKeyAndExpr implements ContextKeyExpr {
 		return false;
 	}
 
-	public evaluate(context: any): boolean {
+	public evaluate(context: IContext): boolean {
 		for (let i = 0, len = this.expr.length; i < len; i++) {
 			if (!this.expr[i].evaluate(context)) {
 				return false;
@@ -441,6 +441,10 @@ export class RawContextKey<T> extends ContextKeyDefinedExpr {
 	}
 }
 
+export interface IContext {
+	getValue<T>(key: string): T;
+}
+
 export interface IContextKey<T> {
 	set(value: T): void;
 	reset(): void;
@@ -467,7 +471,7 @@ export interface IContextKeyService {
 	getContextKeyValue<T>(key: string): T;
 
 	createScoped(target?: IContextKeyServiceTarget): IContextKeyService;
-	getContextValue(target: IContextKeyServiceTarget): any;
+	getContext(target: IContextKeyServiceTarget): IContext;
 }
 
 export const SET_CONTEXT_COMMAND_ID = 'setContext';

--- a/src/vs/platform/contextkey/test/common/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/common/contextkey.test.ts
@@ -7,6 +7,8 @@
 import * as assert from 'assert';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
+const createContext = ctx => ({ getValue: key => ctx[key] });
+
 suite('ContextKeyExpr', () => {
 	test('ContextKeyExpr.equals', function () {
 		let a = ContextKeyExpr.and(
@@ -48,11 +50,11 @@ suite('ContextKeyExpr', () => {
 
 	test('evaluate', function () {
 		/* tslint:disable:triple-equals */
-		let context = {
+		let context = createContext({
 			'a': true,
 			'b': false,
 			'c': '5'
-		};
+		});
 		function testExpression(expr: string, expected: boolean): void {
 			let rules = ContextKeyExpr.deserialize(expr);
 			assert.equal(rules.evaluate(context), expected, expr);

--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -230,7 +230,7 @@ export abstract class AbstractKeybindingService implements IKeybindingService {
 			return null;
 		}
 
-		const contextValue = this._contextKeyService.getContextValue(target);
+		const contextValue = this._contextKeyService.getContext(target);
 		const currentChord = this._currentChord ? this._currentChord.keypress : null;
 		const keypress = keybinding.value.toString();
 		return this._getResolver().resolve(contextValue, currentChord, keypress);
@@ -244,7 +244,7 @@ export abstract class AbstractKeybindingService implements IKeybindingService {
 			return shouldPreventDefault;
 		}
 
-		const contextValue = this._contextKeyService.getContextValue(target);
+		const contextValue = this._contextKeyService.getContext(target);
 		const currentChord = this._currentChord ? this._currentChord.keypress : null;
 		const keypress = keybinding.value.toString();
 		const keypressLabel = this._createResolvedKeybinding(keybinding).getLabel();

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr, IContext } from 'vs/platform/contextkey/common/contextkey';
 import { NormalizedKeybindingItem } from 'vs/platform/keybinding/common/normalizedKeybindingItem';
 
 export interface IResolveResult {
@@ -227,7 +227,7 @@ export class KeybindingResolver {
 		return items[items.length - 1];
 	}
 
-	public resolve(context: any, currentChord: string, keypress: string): IResolveResult {
+	public resolve(context: IContext, currentChord: string, keypress: string): IResolveResult {
 		let lookupMap: NormalizedKeybindingItem[] = null;
 
 		if (currentChord !== null) {
@@ -278,7 +278,7 @@ export class KeybindingResolver {
 		};
 	}
 
-	private _findCommand(context: any, matches: NormalizedKeybindingItem[]): NormalizedKeybindingItem {
+	private _findCommand(context: IContext, matches: NormalizedKeybindingItem[]): NormalizedKeybindingItem {
 		for (let i = matches.length - 1; i >= 0; i--) {
 			let k = matches[i];
 
@@ -292,7 +292,7 @@ export class KeybindingResolver {
 		return null;
 	}
 
-	public static contextMatchesRules(context: any, rules: ContextKeyExpr): boolean {
+	public static contextMatchesRules(context: IContext, rules: ContextKeyExpr): boolean {
 		if (!rules) {
 			return true;
 		}

--- a/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
+++ b/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
@@ -11,12 +11,14 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import Severity from 'vs/base/common/severity';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { KeybindingResolver } from 'vs/platform/keybinding/common/keybindingResolver';
-import { ContextKeyExpr, IContextKeyService, IContextKeyServiceTarget } from 'vs/platform/contextkey/common/contextkey';
+import { IContext, ContextKeyExpr, IContextKeyService, IContextKeyServiceTarget } from 'vs/platform/contextkey/common/contextkey';
 import { IStatusbarService } from 'vs/platform/statusbar/common/statusbar';
 import { IMessageService } from 'vs/platform/message/common/message';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { NormalizedKeybindingItem } from 'vs/platform/keybinding/common/normalizedKeybindingItem';
 import { OS } from 'vs/base/common/platform';
+
+const createContext = ctx => ({ getValue: key => ctx[key] });
 
 suite('AbstractKeybindingService', () => {
 
@@ -48,7 +50,7 @@ suite('AbstractKeybindingService', () => {
 	}
 
 	let createTestKeybindingService: (items: NormalizedKeybindingItem[], contextValue?: any) => TestKeybindingService = null;
-	let currentContextValue: any = null;
+	let currentContextValue: IContext = null;
 	let executeCommandCalls: { commandId: string; args: any[]; }[] = null;
 	let showMessageCalls: { sev: Severity, message: any; }[] = null;
 	let statusMessageCalls: string[] = null;
@@ -70,7 +72,7 @@ suite('AbstractKeybindingService', () => {
 				contextMatchesRules: undefined,
 				getContextKeyValue: undefined,
 				createScoped: undefined,
-				getContextValue: (target: IContextKeyServiceTarget): any => {
+				getContext: (target: IContextKeyServiceTarget): any => {
 					return currentContextValue;
 				}
 			};
@@ -248,9 +250,9 @@ suite('AbstractKeybindingService', () => {
 
 
 		// send Ctrl/Cmd + K
-		currentContextValue = {
+		currentContextValue = createContext({
 			key1: true
-		};
+		});
 		let shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_K));
 		assert.equal(shouldPreventDefault, true);
 		assert.deepEqual(executeCommandCalls, [{
@@ -266,7 +268,7 @@ suite('AbstractKeybindingService', () => {
 		statusMessageCallsDisposed = [];
 
 		// send Ctrl/Cmd + K
-		currentContextValue = {};
+		currentContextValue = createContext({});
 		shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_K));
 		assert.equal(shouldPreventDefault, true);
 		assert.deepEqual(executeCommandCalls, []);
@@ -281,7 +283,7 @@ suite('AbstractKeybindingService', () => {
 		statusMessageCallsDisposed = [];
 
 		// send Ctrl/Cmd + X
-		currentContextValue = {};
+		currentContextValue = createContext({});
 		shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_X));
 		assert.equal(shouldPreventDefault, true);
 		assert.deepEqual(executeCommandCalls, [{
@@ -310,7 +312,7 @@ suite('AbstractKeybindingService', () => {
 
 
 		// send Ctrl/Cmd + K
-		currentContextValue = {};
+		currentContextValue = createContext({});
 		let shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_K));
 		assert.equal(shouldPreventDefault, true);
 		assert.deepEqual(executeCommandCalls, [{
@@ -326,9 +328,9 @@ suite('AbstractKeybindingService', () => {
 		statusMessageCallsDisposed = [];
 
 		// send Ctrl/Cmd + K
-		currentContextValue = {
+		currentContextValue = createContext({
 			key1: true
-		};
+		});
 		shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_K));
 		assert.equal(shouldPreventDefault, true);
 		assert.deepEqual(executeCommandCalls, [{
@@ -344,9 +346,9 @@ suite('AbstractKeybindingService', () => {
 		statusMessageCallsDisposed = [];
 
 		// send Ctrl/Cmd + X
-		currentContextValue = {
+		currentContextValue = createContext({
 			key1: true
-		};
+		});
 		shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_X));
 		assert.equal(shouldPreventDefault, false);
 		assert.deepEqual(executeCommandCalls, []);
@@ -368,7 +370,7 @@ suite('AbstractKeybindingService', () => {
 		]);
 
 		// send Ctrl/Cmd + K
-		currentContextValue = {};
+		currentContextValue = createContext({});
 		let shouldPreventDefault = kbService.dispatch(new SimpleKeybinding(KeyMod.CtrlCmd | KeyCode.KEY_K));
 		assert.equal(shouldPreventDefault, false);
 		assert.deepEqual(executeCommandCalls, [{

--- a/src/vs/platform/keybinding/test/common/mockKeybindingService.ts
+++ b/src/vs/platform/keybinding/test/common/mockKeybindingService.ts
@@ -53,7 +53,7 @@ export class MockKeybindingService implements IContextKeyService {
 	public getContextKeyValue(key: string) {
 		return;
 	}
-	public getContextValue(domNode: HTMLElement): any {
+	public getContext(domNode: HTMLElement): any {
 		return null;
 	}
 	public createScoped(domNode: HTMLElement): IContextKeyService {


### PR DESCRIPTION
This PR changes `context: any` to `context: IContext` with the following interface:

```ts
export interface IContext {
	getValue<T>(key: string): T;
}
```

As I use the `Menu` infrastructure, I discovered that every time I call `getActions()` on it, a context evaluation happened. This envolves calling [`contextMatchRules`](https://github.com/Microsoft/vscode/blob/5cbb1b0d8e7659f1538286d2d3c1ef4eba4221ed/src/vs/platform/contextkey/browser/contextKeyService.ts#L171) which creates an object containing the whole context at that given point in time.

I found this while implementing multi-select in the SCM viewlet, which happens to use Menus extensively, where creating all these contexts all the time flared up the CPU profiler quite a lot:

![image](https://cloud.githubusercontent.com/assets/22350/23921704/eaf23182-08ff-11e7-88c4-707c1899a39f.png)

In this profile, I'm multi selecting rows in the SCM viewlet, which makes them refresh, which makes them re-render. Re-rendering these causes `getActions` to get called, creating all those contexts, which happens to be taking up most of the CPU time. Each of those is a single click, blocking the UI thread for ~250ms.

By creating an `IContext` type, I introduce a `getValue` method, which simply avoids creating static contexts all the time. Plus it gets rid of a few `any` types.

After the PR, the profile looks like this:

![image](https://cloud.githubusercontent.com/assets/22350/23922096/5ef16246-0901-11e7-9e9d-c31ab28d9d96.png)

Each of the multi-selections takes now ~50ms. Further optimization needs to happen on the list/renderer side.

---

Another alternative which I have explored is to use ES6 Proxy objects for contexts which would let us have dynamic _getters_. This is cool 🏄 but barely usable in browsers in which the editor has to be compatible. We can still do it for Electron, although it would just be unnecessary voodoo, imo.

---

I realise that making the context values accessible via a `getValue` method might not be ideal, or even against the whole point, because we might want to keep the context static. But we seem to be paying a high price for that choice. This PR aims to open up that conversation, as it is my opinion that we need to improve performance in this area.