### PR TITLE
Fix terminal color key lookup.

### DIFF
--- a/src/vs/workbench/services/themes/electron-browser/stylesContributions.ts
+++ b/src/vs/workbench/services/themes/electron-browser/stylesContributions.ts
@@ -93,7 +93,8 @@ for (let key in ansiColorMap) {
 
 function updateTerminalStyles(theme: ITheme, collector: ICssStyleCollector) {
 	for (let key in ansiColorMap) {
-		const color = theme.getColor(keyPrefix + key);
+		let id = keyPrefix + key[0].toUpperCase() + key.substr(1);
+		const color = theme.getColor(id);
 		if (color) {
 			const index = ansiColorMap[key];
 			const rgba = color.transparent(0.996);


### PR DESCRIPTION
This is a small fix for terminal ansi color support in themes. Subwords in the key should be capitalized in `updateTerminalStyles` similar to the loop above.