### PR TITLE
Proposal fix 22401: Search in settings editor is showing invalid results for search term

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -79,7 +79,7 @@ function _matchesPrefix(ignoreCase: boolean, word: string, wordToMatchAgainst: s
 		}
 
 		if (ignoreCase) {
-			if (isAlphanumeric(wordChar) && isAlphanumeric(wordToMatchAgainstChar)) {
+			if (isAsciiLetter(wordChar) && isAsciiLetter(wordToMatchAgainstChar)) {
 				const diff = wordChar - wordToMatchAgainstChar;
 				if (diff === 32 || diff === -32) {
 					// ascii -> equalIgnoreCase
@@ -155,7 +155,11 @@ function isWhitespace(code: number): boolean {
 }
 
 function isAlphanumeric(code: number): boolean {
-	return isLower(code) || isUpper(code);
+	return isLower(code) || isUpper(code) || isNumber(code);
+}
+
+function isAsciiLetter(code: number): boolean {
+	return (code >= CharCode.a && code <= CharCode.z) || (code >= CharCode.A && code <= CharCode.Z);
 }
 
 function join(head: IMatch, tail: IMatch[]): IMatch[] {

--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -155,7 +155,7 @@ function isWhitespace(code: number): boolean {
 }
 
 function isAlphanumeric(code: number): boolean {
-	return isLower(code) || isUpper(code) || isNumber(code);
+	return isLower(code) || isUpper(code);
 }
 
 function join(head: IMatch, tail: IMatch[]): IMatch[] {


### PR DESCRIPTION
Related issue: #22401 

The error was related to what I described in the issue comment:

The problem is in the _matchesPrefix method in `base\common\filter.ts`

```typescript
	const wordChar = word.charCodeAt(i);
	const wordToMatchAgainstChar = wordToMatchAgainst.charCodeAt(i)
```
"4"=52 and for "T"= 84

If the difference between them are 32 or -32 (uppercase==lowercase), it is a match. But the method was checking for Alphanumeric characters instead of AsciiLetter.

`base\common\strings.ts` is an example where this is also used.









