### PR TITLE
Second prototype of markdown extensions API

### DIFF
--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -33,8 +33,6 @@ export class MarkdownEngine {
 
 	private plugins: Array<(md: any) => any> = [];
 
-	constructor() { }
-
 	public addPlugin(factory: (md: any) => any): void {
 		if (this.md) {
 			this.usePlugin(factory);


### PR DESCRIPTION
This implements the new proposal for markdown extensions: https://github.com/mjbvz/vscode-markdown-emoji#api-proposal-take-two-not-yet-implemented

This new API is a mix between the two original concepts: it uses declarative contributions for styles for the preview and an exported API that the markdown extension invokes to add markdown it plugins  