### PR TITLE
Fixes #18990, #21693 - Shutdown terminal pty process more gracefully

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalProcess.js
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalProcess.js
@@ -48,6 +48,7 @@ ptyProcess.on('data', function (data) {
 });
 
 ptyProcess.on('exit', function (exitCode) {
+	ptyProcess.kill();
 	process.exit(exitCode);
 });
 


### PR DESCRIPTION
This should terminate the integrated terminal process more gracefully before VS Code's exit. This should fix #18990 and other potential issues like #21693.

Fixes #18990 
Fixes #21693