### PR TITLE
Send telemetry only to vortex

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "code-oss-dev",
   "version": "1.11.0",
   "electronVersion": "1.4.6",
-  "distro": "64f6f295b56a3512bf34dfb643f770160fd33ee8",
+  "distro": "d6bc6b7ee7481530a5495a6a58c9e7dd06fa4af2",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/src/vs/code/electron-browser/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcessMain.ts
@@ -63,10 +63,6 @@ function main(server: Server, initData: ISharedProcessInitData): void {
 	instantiationService.invokeFunction(accessor => {
 		const appenders: AppInsightsAppender[] = [];
 
-		if (product.aiConfig && product.aiConfig.key) {
-			appenders.push(new AppInsightsAppender(eventPrefix, null, product.aiConfig.key));
-		}
-
 		if (product.aiConfig && product.aiConfig.asimovKey) {
 			appenders.push(new AppInsightsAppender(eventPrefix, null, product.aiConfig.asimovKey));
 		}

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -173,10 +173,6 @@ export function main(argv: ParsedArgs): TPromise<void> {
 			if (isBuilt && !extensionDevelopmentPath && product.enableTelemetry) {
 				const appenders: AppInsightsAppender[] = [];
 
-				if (product.aiConfig && product.aiConfig.key) {
-					appenders.push(new AppInsightsAppender(eventPrefix, null, product.aiConfig.key));
-				}
-
 				if (product.aiConfig && product.aiConfig.asimovKey) {
 					appenders.push(new AppInsightsAppender(eventPrefix, null, product.aiConfig.asimovKey));
 				}

--- a/src/vs/platform/node/product.ts
+++ b/src/vs/platform/node/product.ts
@@ -32,7 +32,6 @@ export interface IProductConfiguration {
 	welcomePage: string;
 	enableTelemetry: boolean;
 	aiConfig: {
-		key: string;
 		asimovKey: string;
 	};
 	sendASmile: {


### PR DESCRIPTION
@kieferrm As discussed last week, we don't need to send telemetry events to AI channel anymore