### PR TITLE
Correctly duplicate files with numbers in filename

### DIFF
--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -1099,8 +1099,8 @@ export class DuplicateFileAction extends BaseFileAction {
 	private toCopyName(name: string, isFolder: boolean): string {
 
 		// file.1.txt=>file.2.txt
-		if (!isFolder && name.match(/(\d+)(\..*)$/)) {
-			return name.replace(/(\d+)(\..*)$/, (match, g1?, g2?) => { return (parseInt(g1) + 1) + g2; });
+		if (!isFolder && name.match(/(.*\.)(\d+)(\..*)$/)) {
+			return name.replace(/(.*\.)(\d+)(\..*)$/, (match, g1?, g2?, g3?) => { return g1 + (parseInt(g2) + 1) + g3; });
 		}
 
 		// file.txt=>file.1.txt


### PR DESCRIPTION
This PR fixes an issue with duplicating files with numbers in the filename. It now correctly duplicates files with numbers in filename by appending a version instead of incrementing the integer.

Before:
Duplication of "1.js" gives "2.js".

Now:
Duplication of "1.js" gives "1.1.js"

Original issue: https://github.com/Microsoft/vscode/issues/22876