### PR TITLE
Make more descriptive appdata summary field

### DIFF
--- a/resources/linux/code.appdata.xml
+++ b/resources/linux/code.appdata.xml
@@ -5,7 +5,7 @@
 	<project_license>@@LICENSE@@</project_license>
 	<name>@@NAME_LONG@@</name>
 	<url type="homepage">https://code.visualstudio.com</url>
-	<summary>Code editing. Redefined.</summary>
+	<summary>Visual Studio Code. Code editing. Redefined.</summary>
 	<description>
 		<p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle. See https://code.visualstudio.com/docs/setup/linux for installation instructions and FAQ.</p>
 	</description>


### PR DESCRIPTION
This is a small change in the AppData XML file to make the description include “Visual Studio Code”, which makes it much easier for users to find out the application when browsing e.g. with GNOME Software when a repository containing VSCode is configured. 

Related issue: #22964

---

I am sending this in behalf of @ltilve who has asked me to report the issue and provide the patch on his behalf, as I have already signed the CLA. I hope that's okay.