### PR TITLE
Fixed typo - fourth instead if forth

### DIFF
--- a/src/vs/platform/instantiation/common/instantiation.ts
+++ b/src/vs/platform/instantiation/common/instantiation.ts
@@ -41,23 +41,23 @@ export interface IConstructorSignature3<A1, A2, A3, T> {
 }
 
 export interface IConstructorSignature4<A1, A2, A3, A4, T> {
-	new (first: A1, second: A2, third: A3, forth: A4, ...services: { _serviceBrand: any; }[]): T;
+	new (first: A1, second: A2, third: A3, fourth: A4, ...services: { _serviceBrand: any; }[]): T;
 }
 
 export interface IConstructorSignature5<A1, A2, A3, A4, A5, T> {
-	new (first: A1, second: A2, third: A3, forth: A4, fifth: A5, ...services: { _serviceBrand: any; }[]): T;
+	new (first: A1, second: A2, third: A3, fourth: A4, fifth: A5, ...services: { _serviceBrand: any; }[]): T;
 }
 
 export interface IConstructorSignature6<A1, A2, A3, A4, A5, A6, T> {
-	new (first: A1, second: A2, third: A3, forth: A4, fifth: A5, sixth: A6, ...services: { _serviceBrand: any; }[]): T;
+	new (first: A1, second: A2, third: A3, fourth: A4, fifth: A5, sixth: A6, ...services: { _serviceBrand: any; }[]): T;
 }
 
 export interface IConstructorSignature7<A1, A2, A3, A4, A5, A6, A7, T> {
-	new (first: A1, second: A2, third: A3, forth: A4, fifth: A5, sixth: A6, seventh: A7, ...services: { _serviceBrand: any; }[]): T;
+	new (first: A1, second: A2, third: A3, fourth: A4, fifth: A5, sixth: A6, seventh: A7, ...services: { _serviceBrand: any; }[]): T;
 }
 
 export interface IConstructorSignature8<A1, A2, A3, A4, A5, A6, A7, A8, T> {
-	new (first: A1, second: A2, third: A3, forth: A4, fifth: A5, sixth: A6, seventh: A7, eigth: A8, ...services: { _serviceBrand: any; }[]): T;
+	new (first: A1, second: A2, third: A3, fourth: A4, fifth: A5, sixth: A6, seventh: A7, eigth: A8, ...services: { _serviceBrand: any; }[]): T;
 }
 
 export interface ServicesAccessor {
@@ -81,23 +81,23 @@ export interface IFunctionSignature3<A1, A2, A3, R> {
 }
 
 export interface IFunctionSignature4<A1, A2, A3, A4, R> {
-	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, forth: A4): R;
+	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, fourth: A4): R;
 }
 
 export interface IFunctionSignature5<A1, A2, A3, A4, A5, R> {
-	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, forth: A4, fifth: A5): R;
+	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, fourth: A4, fifth: A5): R;
 }
 
 export interface IFunctionSignature6<A1, A2, A3, A4, A5, A6, R> {
-	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, forth: A4, fifth: A5, sixth: A6): R;
+	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, fourth: A4, fifth: A5, sixth: A6): R;
 }
 
 export interface IFunctionSignature7<A1, A2, A3, A4, A5, A6, A7, R> {
-	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, forth: A4, fifth: A5, sixth: A6, seventh: A7): R;
+	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, fourth: A4, fifth: A5, sixth: A6, seventh: A7): R;
 }
 
 export interface IFunctionSignature8<A1, A2, A3, A4, A5, A6, A7, A8, R> {
-	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, forth: A4, fifth: A5, sixth: A6, seventh: A7, eigth: A8): R;
+	(accessor: ServicesAccessor, first: A1, second: A2, third: A3, fourth: A4, fifth: A5, sixth: A6, seventh: A7, eigth: A8): R;
 }
 
 export const IInstantiationService = createDecorator<IInstantiationService>('instantiationService');

--- a/src/vs/workbench/test/node/api/extHostApiCommands.test.ts
+++ b/src/vs/workbench/test/node/api/extHostApiCommands.test.ts
@@ -306,7 +306,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 				let values = list.items;
 				assert.ok(Array.isArray(values));
 				assert.equal(values.length, 4);
-				let [first, second, third, forth] = values;
+				let [first, second, third, fourth] = values;
 				assert.equal(first.label, 'item1');
 				assert.equal(first.textEdit.newText, 'item1');
 				assert.equal(first.textEdit.range.start.line, 0);
@@ -328,14 +328,14 @@ suite('ExtHostLanguageFeatureCommands', function () {
 				assert.equal(third.textEdit.range.end.line, 0);
 				assert.equal(third.textEdit.range.end.character, 6);
 
-				assert.equal(forth.label, 'item4');
-				assert.equal(forth.textEdit, undefined);
-				assert.equal(forth.range.start.line, 0);
-				assert.equal(forth.range.start.character, 1);
-				assert.equal(forth.range.end.line, 0);
-				assert.equal(forth.range.end.character, 4);
-				assert.ok(forth.insertText instanceof types.SnippetString);
-				assert.equal((<types.SnippetString>forth.insertText).value, 'foo$0bar');
+				assert.equal(fourth.label, 'item4');
+				assert.equal(fourth.textEdit, undefined);
+				assert.equal(fourth.range.start.line, 0);
+				assert.equal(fourth.range.start.character, 1);
+				assert.equal(fourth.range.end.line, 0);
+				assert.equal(fourth.range.end.character, 4);
+				assert.ok(fourth.insertText instanceof types.SnippetString);
+				assert.equal((<types.SnippetString>fourth.insertText).value, 'foo$0bar');
 			});
 		});
 	});


### PR DESCRIPTION
Hi, I was looking for something in the source and stumbled on this typo.