### PR TITLE
Remove TSC Mismatch Warning

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -100,11 +100,6 @@
           "default": false,
           "description": "%typescript.disableAutomaticTypeAcquisition%"
         },
-        "typescript.check.tscVersion": {
-          "type": "boolean",
-          "default": true,
-          "description": "%typescript.check.tscVersion%"
-        },
         "typescript.referencesCodeLens.enabled": {
           "type": "boolean",
           "default": false,

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -6,7 +6,6 @@
 	"typescript.tsdk.desc": "Specifies the folder path containing the tsserver and lib*.d.ts files to use.",
 	"typescript.tsdk_version.desc": "Specifies the version of the tsserver. Only necessary if the tsserver is not installed using npm.",
 	"typescript.disableAutomaticTypeAcquisition": "Disables automatic type acquisition. Requires TypeScript >= 2.0.6 and a restart after changing it.",
-	"typescript.check.tscVersion": "Check if a global install TypeScript compiler (e.g. tsc) differs from the used TypeScript language service.",
 	"typescript.tsserver.log": "Enables logging of the TS server to a file.",
 	"typescript.tsserver.trace": "Enables tracing of messages sent to the TS server.",
 	"typescript.tsserver.experimentalAutoBuild": "Enables experimental auto build. Requires 1.9 dev or 2.x tsserver version and a restart of VS Code after changing it.",

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -79,7 +79,6 @@ export interface ITypescriptServiceClient {
 
 	experimentalAutoBuild: boolean;
 	apiVersion: API;
-	checkGlobalTSCVersion: boolean;
 
 	execute(command: 'configure', args: Proto.ConfigureRequestArguments, token?: CancellationToken): Promise<Proto.ConfigureResponse>;
 	execute(command: 'open', args: Proto.OpenRequestArgs, expectedResult: boolean, token?: CancellationToken): Promise<any>;


### PR DESCRIPTION
Fixes #23054
Fixes #20666

**Bug**
The global tsc version mismatch warning message is no longer very helpful and provides a poor initial experinace for TS users. The messaging has also been a source of confusion. More often than not, no user action is required and the proper solution is the suppress the warning. 

**Fix**
After talking with @chrisdias, we feel that the TS version number in the status bar (along with documentation) provides enough context for users to see why their `tsc` compiler compiler errors may not match the errors that are shown in the editor. This change removes the global tsc version warning