### PR TITLE
Update Go grammar to atom/language-go@11ad31e7 (2016-12-30)

### DIFF
--- a/extensions/go/syntaxes/go.json
+++ b/extensions/go/syntaxes/go.json
@@ -9,26 +9,7 @@
 	"foldingStopMarker": "(}|\\))\\s*$",
 	"patterns": [
 		{
-			"comment": "Block comments",
-			"begin": "/\\*",
-			"end": "\\*/",
-			"captures": {
-				"0": {
-					"name": "punctuation.definition.comment.go"
-				}
-			},
-			"name": "comment.block.go"
-		},
-		{
-			"comment": "Line comments",
-			"begin": "//",
-			"beginCaptures": {
-				"0": {
-					"name": "punctuation.definition.comment.go"
-				}
-			},
-			"end": "$",
-			"name": "comment.line.double-slash.go"
+			"include": "#comments"
 		},
 		{
 			"comment": "Interpreted string literals",
@@ -219,6 +200,9 @@
 							"name": "punctuation.definition.string.end.go"
 						}
 					}
+				},
+				{
+					"include": "#comments"
 				}
 			],
 			"end": "\\)",
@@ -348,6 +332,30 @@
 				{
 					"match": "\\[|\\]",
 					"name": "punctuation.other.bracket.square.go"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"begin": "/\\*",
+					"end": "\\*/",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.go"
+						}
+					},
+					"name": "comment.block.go"
+				},
+				{
+					"begin": "//",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.go"
+						}
+					},
+					"end": "$",
+					"name": "comment.line.double-slash.go"
 				}
 			]
 		},


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-go/issues/872