### PR TITLE
Expose diff editors in the API

### DIFF
--- a/extensions/git/src/staging.ts
+++ b/extensions/git/src/staging.ts
@@ -5,9 +5,9 @@
 
 'use strict';
 
-import { TextDocument, Range, LineChange } from 'vscode';
+import { TextDocument, Range, LineChange2 } from 'vscode';
 
-export function applyChanges(original: TextDocument, modified: TextDocument, diffs: LineChange[]): string {
+export function applyChanges(original: TextDocument, modified: TextDocument, diffs: LineChange2[]): string {
 	const result: string[] = [];
 	let currentLine = 0;
 

--- a/src/vs/editor/browser/standalone/standaloneCodeEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneCodeEditor.ts
@@ -280,14 +280,15 @@ export class StandaloneDiffEditor extends DiffEditorWidget implements IStandalon
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextViewService contextViewService: IContextViewService,
 		@IStandaloneThemeService standaloneColorService: IStandaloneThemeService,
-		@IEditorWorkerService editorWorkerService: IEditorWorkerService
+		@IEditorWorkerService editorWorkerService: IEditorWorkerService,
+		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		options = options || {};
 		if (typeof options.theme === 'string') {
 			options.theme = standaloneColorService.setTheme(options.theme);
 		}
 
-		super(domElement, options, editorWorkerService, contextKeyService, instantiationService);
+		super(domElement, options, editorWorkerService, contextKeyService, instantiationService, codeEditorService);
 
 		if (keybindingService instanceof StandaloneKeybindingService) {
 			this._standaloneKeybindingService = keybindingService;

--- a/src/vs/editor/browser/standalone/standaloneEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneEditor.ts
@@ -124,7 +124,8 @@ export function createDiffEditor(domElement: HTMLElement, options?: IDiffEditorC
 			services.get(IKeybindingService),
 			services.get(IContextViewService),
 			services.get(IStandaloneThemeService),
-			services.get(IEditorWorkerService)
+			services.get(IEditorWorkerService),
+			services.get(ICodeEditorService)
 		);
 	});
 }

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -15,6 +15,7 @@ import { FastDomNode, createFastDomNode } from 'vs/base/browser/fastDomNode';
 import { ISashEvent, IVerticalSashLayoutProvider, Sash } from 'vs/base/browser/ui/sash/sash';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ICodeEditorService } from 'vs/editor/common/services/codeEditorService';
 import { DefaultConfig } from 'vs/editor/common/config/defaultConfig';
 import { Range } from 'vs/editor/common/core/range';
 import * as editorCommon from 'vs/editor/common/editorCommon';
@@ -204,16 +205,19 @@ export class DiffEditorWidget extends EventEmitter implements editorBrowser.IDif
 
 	private _editorWorkerService: IEditorWorkerService;
 	protected _contextKeyService: IContextKeyService;
+	private _codeEditorService: ICodeEditorService;
 
 	constructor(
 		domElement: HTMLElement,
 		options: editorCommon.IDiffEditorOptions,
 		@IEditorWorkerService editorWorkerService: IEditorWorkerService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		super();
 		this._editorWorkerService = editorWorkerService;
+		this._codeEditorService = codeEditorService;
 		this._contextKeyService = contextKeyService.createScoped(domElement);
 		this._contextKeyService.createKey('isInDiffEditor', true);
 
@@ -314,6 +318,8 @@ export class DiffEditorWidget extends EventEmitter implements editorBrowser.IDif
 		} else {
 			this._setStrategy(new DiffEdtorWidgetInline(this._createDataSource(), this._enableSplitViewResizing));
 		}
+
+		this._codeEditorService.addDiffEditor(this);
 	}
 
 	public get ignoreTrimWhitespace(): boolean {
@@ -392,6 +398,8 @@ export class DiffEditorWidget extends EventEmitter implements editorBrowser.IDif
 	}
 
 	public dispose(): void {
+		this._codeEditorService.removeDiffEditor(this);
+
 		this._toDispose = dispose(this._toDispose);
 
 		window.clearInterval(this._measureDomElementToken);

--- a/src/vs/editor/common/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/common/services/abstractCodeEditorService.ts
@@ -5,51 +5,85 @@
 'use strict';
 
 import Event, { Emitter } from 'vs/base/common/event';
-import { ICommonCodeEditor, IDecorationRenderOptions, IModelDecorationOptions } from 'vs/editor/common/editorCommon';
+import { ICommonCodeEditor, ICommonDiffEditor, IDecorationRenderOptions, IModelDecorationOptions } from 'vs/editor/common/editorCommon';
 import { ICodeEditorService } from 'vs/editor/common/services/codeEditorService';
 
 export abstract class AbstractCodeEditorService implements ICodeEditorService {
-	public _serviceBrand: any;
+
+	_serviceBrand: any;
+
 	private _onCodeEditorAdd: Emitter<ICommonCodeEditor>;
 	private _onCodeEditorRemove: Emitter<ICommonCodeEditor>;
-	private _codeEditors: {
-		[editorId: string]: ICommonCodeEditor;
-	};
+	private _codeEditors: { [editorId: string]: ICommonCodeEditor; };
+
+	private _onDiffEditorAdd: Emitter<ICommonDiffEditor>;
+	private _onDiffEditorRemove: Emitter<ICommonDiffEditor>;
+	private _diffEditors: { [editorId: string]: ICommonDiffEditor; };
 
 	constructor() {
 		this._codeEditors = Object.create(null);
+		this._diffEditors = Object.create(null);
 		this._onCodeEditorAdd = new Emitter<ICommonCodeEditor>();
 		this._onCodeEditorRemove = new Emitter<ICommonCodeEditor>();
+		this._onDiffEditorAdd = new Emitter<ICommonDiffEditor>();
+		this._onDiffEditorRemove = new Emitter<ICommonDiffEditor>();
 	}
 
-	public addCodeEditor(editor: ICommonCodeEditor): void {
+	addCodeEditor(editor: ICommonCodeEditor): void {
 		this._codeEditors[editor.getId()] = editor;
 		this._onCodeEditorAdd.fire(editor);
 	}
 
-	public get onCodeEditorAdd(): Event<ICommonCodeEditor> {
+	get onCodeEditorAdd(): Event<ICommonCodeEditor> {
 		return this._onCodeEditorAdd.event;
 	}
 
-	public removeCodeEditor(editor: ICommonCodeEditor): void {
+	removeCodeEditor(editor: ICommonCodeEditor): void {
 		if (delete this._codeEditors[editor.getId()]) {
 			this._onCodeEditorRemove.fire(editor);
 		}
 	}
 
-	public get onCodeEditorRemove(): Event<ICommonCodeEditor> {
+	get onCodeEditorRemove(): Event<ICommonCodeEditor> {
 		return this._onCodeEditorRemove.event;
 	}
 
-	public getCodeEditor(editorId: string): ICommonCodeEditor {
+	getCodeEditor(editorId: string): ICommonCodeEditor {
 		return this._codeEditors[editorId] || null;
 	}
 
-	public listCodeEditors(): ICommonCodeEditor[] {
+	listCodeEditors(): ICommonCodeEditor[] {
 		return Object.keys(this._codeEditors).map(id => this._codeEditors[id]);
 	}
 
-	public getFocusedCodeEditor(): ICommonCodeEditor {
+	addDiffEditor(editor: ICommonDiffEditor): void {
+		this._diffEditors[editor.getId()] = editor;
+		this._onDiffEditorAdd.fire(editor);
+	}
+
+	get onDiffEditorAdd(): Event<ICommonDiffEditor> {
+		return this._onDiffEditorAdd.event;
+	}
+
+	removeDiffEditor(editor: ICommonDiffEditor): void {
+		if (delete this._diffEditors[editor.getId()]) {
+			this._onDiffEditorRemove.fire(editor);
+		}
+	}
+
+	get onDiffEditorRemove(): Event<ICommonDiffEditor> {
+		return this._onDiffEditorRemove.event;
+	}
+
+	getDiffEditor(editorId: string): ICommonDiffEditor {
+		return this._diffEditors[editorId] || null;
+	}
+
+	listDiffEditors(): ICommonDiffEditor[] {
+		return Object.keys(this._diffEditors).map(id => this._diffEditors[id]);
+	}
+
+	getFocusedCodeEditor(): ICommonCodeEditor {
 		let editorWithWidgetFocus: ICommonCodeEditor = null;
 
 		let editors = this.listCodeEditors();
@@ -69,7 +103,7 @@ export abstract class AbstractCodeEditorService implements ICodeEditorService {
 		return editorWithWidgetFocus;
 	}
 
-	public abstract registerDecorationType(key: string, options: IDecorationRenderOptions, parentTypeKey?: string): void;
-	public abstract removeDecorationType(key: string): void;
-	public abstract resolveDecorationOptions(decorationTypeKey: string, writable: boolean): IModelDecorationOptions;
+	abstract registerDecorationType(key: string, options: IDecorationRenderOptions, parentTypeKey?: string): void;
+	abstract removeDecorationType(key: string): void;
+	abstract resolveDecorationOptions(decorationTypeKey: string, writable: boolean): IModelDecorationOptions;
 }

--- a/src/vs/editor/common/services/codeEditorService.ts
+++ b/src/vs/editor/common/services/codeEditorService.ts
@@ -14,15 +14,21 @@ export var ICodeEditorService = createDecorator<ICodeEditorService>('codeEditorS
 export interface ICodeEditorService {
 	_serviceBrand: any;
 
-	addCodeEditor(editor: ICommonCodeEditor): void;
 	onCodeEditorAdd: Event<ICommonCodeEditor>;
-
-	removeCodeEditor(editor: ICommonCodeEditor): void;
 	onCodeEditorRemove: Event<ICommonCodeEditor>;
 
-	getCodeEditor(editorId: string): ICommonCodeEditor;
+	onDiffEditorAdd: Event<ICommonDiffEditor>;
+	onDiffEditorRemove: Event<ICommonDiffEditor>;
 
+	addCodeEditor(editor: ICommonCodeEditor): void;
+	removeCodeEditor(editor: ICommonCodeEditor): void;
+	getCodeEditor(editorId: string): ICommonCodeEditor;
 	listCodeEditors(): ICommonCodeEditor[];
+
+	addDiffEditor(editor: ICommonDiffEditor): void;
+	removeDiffEditor(editor: ICommonDiffEditor): void;
+	getDiffEditor(editorId: string): ICommonDiffEditor;
+	listDiffEditors(): ICommonDiffEditor[];
 
 	/**
 	 * Returns the current focused code editor (if the focus is in the editor or in an editor widget) or null.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -945,6 +945,12 @@ declare module 'vscode' {
 		viewColumn?: ViewColumn;
 
 		/**
+		 * The diff information for this text editor. Will be `udnefined` in case
+		 * this editor isn't inside a diff editor.
+		 */
+		readonly diffInformation?: DiffInformation;
+
+		/**
 		 * Perform an edit on the document associated with this text editor.
 		 *
 		 * The given callback-function is invoked with an [edit-builder](#TextEditorEdit) which must
@@ -1006,6 +1012,43 @@ declare module 'vscode' {
 		 * This method shows unexpected behavior and will be removed in the next major update.
 		 */
 		hide(): void;
+	}
+
+	/**
+	 * Represents a contiguous set of line changes in a diff.
+	 */
+	export interface LineChange {
+
+		/**
+		 * The range of lines in the left-hand side [text editor](#TextEditor).
+		 */
+		readonly left: Range;
+
+		/**
+		 * The range of lines in the right-hand side [text editor](#TextEditor).
+		 */
+		readonly right: Range;
+	}
+
+	/**
+	 * Represents the diff information between two [text editors](#TextEditor).
+	 */
+	export interface DiffInformation {
+
+		/**
+		 * The left-hand side [text editor](#TextEditor) of this diff.
+		 */
+		readonly left: TextEditor;
+
+		/**
+		 * The right-hand side [text editor](#TextEditor) of this diff.
+		 */
+		readonly right: TextEditor;
+
+		/**
+		 * The [line changes](#LineChange) associated with this diff.
+		 */
+		readonly lineChanges: LineChange[];
 	}
 
 	/**
@@ -4145,6 +4188,11 @@ declare module 'vscode' {
 		 * An event that is emitted when a [text document](#TextDocument) is saved to disk.
 		 */
 		export const onDidSaveTextDocument: Event<TextDocument>;
+
+		/**
+		 * An event that is emitted when a [diff](#DiffInformation) is changed.
+		 */
+		export const onDidChangeDiffInformation: Event<DiffInformation>;
 
 		/**
 		 * Get a configuration object.

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -632,12 +632,12 @@ declare module 'vscode' {
 		export function registerSCMProvider(id: string, provider: SCMProvider): Disposable;
 	}
 
-	export interface LineChange {
+	export interface LineChange2 {
 		readonly originalStartLineNumber: number;
 		readonly originalEndLineNumber: number;
 		readonly modifiedStartLineNumber: number;
 		readonly modifiedEndLineNumber: number;
 	}
 
-	export function computeDiff(oneDocument: TextDocument, otherDocument: TextDocument): Thenable<LineChange[]>;
+	export function computeDiff(oneDocument: TextDocument, otherDocument: TextDocument): Thenable<LineChange2[]>;
 }

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { Emitter } from 'vs/base/common/event';
+import { Emitter, createEmptyEvent } from 'vs/base/common/event';
 import { TrieMap } from 'vs/base/common/map';
 import { score } from 'vs/editor/common/modes/languageSelector';
 import * as Platform from 'vs/base/common/platform';
@@ -408,6 +408,10 @@ export function createApiFactory(initData: IInitData, threadService: IThreadServ
 			},
 			onWillSaveTextDocument: (listener, thisArgs?, disposables?) => {
 				return extHostDocumentSaveParticipant.onWillSaveTextDocumentEvent(listener, thisArgs, disposables);
+			},
+			onDidChangeDiffInformation: (listener, thisArgs?, disposables?) => {
+				// TODO@joao
+				return createEmptyEvent()(listener, thisArgs, disposables);
 			},
 			onDidChangeConfiguration: (listener: () => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) => {
 				return extHostConfiguration.onDidChangeConfiguration(listener, thisArgs, disposables);

--- a/src/vs/workbench/api/node/extHostFunctions.ts
+++ b/src/vs/workbench/api/node/extHostFunctions.ts
@@ -17,7 +17,7 @@ function getTextDocumentLines(document: vscode.TextDocument): string[] {
 	return result;
 }
 
-export function computeDiff(oneDocument: vscode.TextDocument, otherDocument: vscode.TextDocument): Thenable<vscode.LineChange[]> {
+export function computeDiff(oneDocument: vscode.TextDocument, otherDocument: vscode.TextDocument): Thenable<vscode.LineChange2[]> {
 	const oneLines = getTextDocumentLines(oneDocument);
 	const otherLines = getTextDocumentLines(otherDocument);
 	const computer = new DiffComputer(oneLines, otherLines, {


### PR DESCRIPTION
Related to #15513 #20818

According to @jrieken:

> each editor side is represented as an editor right now

It will be very hard to introduce a new `TextDiffEditor` type now since we'd need to adopt occurrences of `TextEditor` to become `TextEditor | TextDiffEditor` everywhere.

One idea we had is to augment the `TextEditor` interface in the following way:

```ts
interface TextEditor {
  // ...
  readonly diffEditor?: DiffEditor;
}

interface DiffEditor {
  readonly left: TextEditor;
  readonly right: TextEditor;
}
```

This will enable extension authors to detect whether a `TextEditor` is contained in a `DiffEditor` and determine which side it is so.

We should augment the interface to expose the diff result as `LineChanges[]` to the extension host. One idea is to constantly synchronise this and notify the user when it has updated:

```ts
interface DiffEditor {
  // ...
  readonly onDidChange: Event<LineChanges[]>;
  readonly diff: LineChanges[];
}
```

This could be spammy and so another idea is to it request based:

```ts
interface DiffEditor {
  // ...
  readonly onDidChange: Event<Thenable<LineChanges[]>>;
  readonly getDiff(): Thenable<LineChanges[]>;
}
```

@jrieken @alexandrudima Any thoughts?