### PR TITLE
Update to latest C# TextMate grammar

### DIFF
--- a/extensions/csharp/syntaxes/csharp.tmLanguage.json
+++ b/extensions/csharp/syntaxes/csharp.tmLanguage.json
@@ -1153,7 +1153,13 @@
 					"match": "\\b(set)\\b"
 				},
 				{
+					"include": "#comment"
+				},
+				{
 					"include": "#attribute-section"
+				},
+				{
+					"include": "#expression-body"
 				},
 				{
 					"include": "#block"
@@ -1186,7 +1192,13 @@
 					"match": "\\b(remove)\\b"
 				},
 				{
+					"include": "#comment"
+				},
+				{
 					"include": "#attribute-section"
+				},
+				{
+					"include": "#expression-body"
 				},
 				{
 					"include": "#block"
@@ -3404,7 +3416,7 @@
 							"name": "keyword.operator.arrow.cs"
 						}
 					},
-					"end": "(?=\\)|;|})",
+					"end": "(?=\\)|;|}|,)",
 					"patterns": [
 						{
 							"include": "#block"
@@ -3415,7 +3427,7 @@
 					]
 				},
 				{
-					"begin": "(?x)\n(?:\\b(async)\\b\\s*)?\n(\\(.*\\))\\s*\n(=>)",
+					"begin": "(?x)\n(?:\\b(async)\\b\\s*)?\n(\\(.*?\\))\\s*\n(=>)",
 					"beginCaptures": {
 						"1": {
 							"name": "storage.modifier.cs"
@@ -3431,7 +3443,7 @@
 							"name": "keyword.operator.arrow.cs"
 						}
 					},
-					"end": "(?=\\)|;|})",
+					"end": "(?=\\)|;|}|,)",
 					"patterns": [
 						{
 							"include": "#block"
@@ -3451,7 +3463,7 @@
 							"name": "keyword.other.delegate.cs"
 						}
 					},
-					"end": "(?=\\)|;|})",
+					"end": "(?=\\)|;|}|,)",
 					"patterns": [
 						{
 							"include": "#parenthesized-parameter-list"
@@ -3467,13 +3479,13 @@
 			]
 		},
 		"lambda-parameter-list": {
-			"begin": "(\\()",
+			"begin": "\\(",
 			"beginCaptures": {
 				"0": {
 					"name": "punctuation.parenthesis.open.cs"
 				}
 			},
-			"end": "(\\))",
+			"end": "\\)",
 			"endCaptures": {
 				"0": {
 					"name": "punctuation.parenthesis.close.cs"
@@ -4175,5 +4187,5 @@
 			}
 		}
 	},
-	"version": "https://github.com/dotnet/csharp-tmLanguage/commit/c6def572109a0c7323ea1d1ca66e5af020ab070e"
+	"version": "https://github.com/dotnet/csharp-tmLanguage/commit/75fa93e836ea0571335aec5d3fcae5289e9cb138"
 }

--- a/extensions/csharp/syntaxes/csharp.tmLanguage.json
+++ b/extensions/csharp/syntaxes/csharp.tmLanguage.json
@@ -3135,7 +3135,7 @@
 			"end": "(?=(,|\\)|\\]))",
 			"patterns": [
 				{
-					"include": "#expression"
+					"include": "#argument"
 				}
 			]
 		},
@@ -4187,5 +4187,5 @@
 			}
 		}
 	},
-	"version": "https://github.com/dotnet/csharp-tmLanguage/commit/75fa93e836ea0571335aec5d3fcae5289e9cb138"
+	"version": "https://github.com/dotnet/csharp-tmLanguage/commit/4d0e50c51f336645c98689737db1be321d212d3d"
 }


### PR DESCRIPTION
Provides fixes for https://github.com/dotnet/csharp-tmLanguage/issues/44, https://github.com/dotnet/csharp-tmLanguage/issues/45, https://github.com/dotnet/csharp-tmLanguage/pull/49 and https://github.com/dotnet/csharp-tmLanguage/issues/50.