### PR TITLE
Proposed Terminal API onData

### DIFF
--- a/extensions/vscode-api-tests/src/window.test.ts
+++ b/extensions/vscode-api-tests/src/window.test.ts
@@ -354,4 +354,19 @@ suite('window namespace tests', () => {
 	test('terminal, name should set terminal.name', () => {
 		assert.equal(window.createTerminal('foo').name, 'foo');
 	});
+
+	test('terminal, listening to onData should report data from the pty process', done => {
+		const terminal = window.createTerminal();
+		let fromPty = '';
+		let isFinished = false;
+		(<any>terminal).onData(data => {
+			// The text could be split over multiple callbacks
+			fromPty += data;
+			if (!isFinished && fromPty.indexOf('test') >= 0) {
+				isFinished = true;
+				done();
+			}
+		});
+		terminal.sendText('test');
+	});
 });

--- a/extensions/vscode-api-tests/src/window.test.ts
+++ b/extensions/vscode-api-tests/src/window.test.ts
@@ -367,6 +367,6 @@ suite('window namespace tests', () => {
 				done();
 			}
 		});
-		terminal.sendText('test');
+		terminal.sendText('test', false);
 	});
 });

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -809,4 +809,53 @@ declare module 'vscode' {
 		 */
 		export function registerDiffInformationCommand(command: string, callback: (diff: LineChange[], ...args: any[]) => any, thisArg?: any): Disposable;
 	}
+
+	export interface Terminal {
+
+		/**
+		 * The name of the terminal.
+		 */
+		readonly name: string;
+
+		/**
+		 * The process ID of the shell process.
+		 */
+		readonly processId: Thenable<number>;
+
+		/**
+		 * Send text to the terminal. The text is written to the stdin of the underlying pty process
+		 * (shell) of the terminal.
+		 *
+		 * @param text The text to send.
+		 * @param addNewLine Whether to add a new line to the text being sent, this is normally
+		 * required to run a command in the terminal. The character(s) added are \n or \r\n
+		 * depending on the platform. This defaults to `true`.
+		 */
+		sendText(text: string, addNewLine?: boolean): void;
+
+		/**
+		 * Show the terminal panel and reveal this terminal in the UI.
+		 *
+		 * @param preserveFocus When `true` the terminal will not take focus.
+		 */
+		show(preserveFocus?: boolean): void;
+
+		/**
+		 * Hide the terminal panel if this terminal is currently showing.
+		 */
+		hide(): void;
+
+		/**
+		 * Dispose and free associated resources.
+		 */
+		dispose(): void;
+
+		/**
+		 * Experimental API that allows listening to the raw data stream coming from the terminal's
+		 * pty process (including ANSI escape sequences).
+		 *
+		 * @param callback The callback that is triggered when data is sent to the terminal.
+		 */
+		onData(callback: (data: string) => any): void;
+	}
 }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -204,6 +204,7 @@ export abstract class MainThreadTerminalServiceShape {
 	$hide(terminalId: number): void { throw ni(); }
 	$sendText(terminalId: number, text: string, addNewLine: boolean): void { throw ni(); }
 	$show(terminalId: number, preserveFocus: boolean): void { throw ni(); }
+	$registerOnData(terminalId: number): void { throw ni(); }
 }
 
 export interface MyQuickPickItems extends IPickOpenEntry {
@@ -413,6 +414,7 @@ export abstract class ExtHostQuickOpenShape {
 export abstract class ExtHostTerminalServiceShape {
 	$acceptTerminalClosed(id: number): void { throw ni(); }
 	$acceptTerminalProcessId(id: number, processId: number): void { throw ni(); }
+	$acceptTerminalData(id: number, data: string): void { throw ni(); }
 }
 
 export abstract class ExtHostSCMShape {

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -20,6 +20,8 @@ export class ExtHostTerminal implements vscode.Terminal {
 	private _pidPromise: TPromise<number>;
 	private _pidPromiseComplete: TValueCallback<number>;
 
+	private _onDataCallback: (data: string) => any;
+
 	constructor(
 		proxy: MainThreadTerminalServiceShape,
 		name?: string,
@@ -67,6 +69,11 @@ export class ExtHostTerminal implements vscode.Terminal {
 		this._queueApiRequest(this._proxy.$hide, []);
 	}
 
+	public onData(callback: (data: string) => any): void {
+		this._onDataCallback = callback;
+		this._queueApiRequest(this._proxy.$registerOnData, []);
+	}
+
 	public dispose(): void {
 		if (!this._disposed) {
 			this._disposed = true;
@@ -77,6 +84,10 @@ export class ExtHostTerminal implements vscode.Terminal {
 	public _setProcessId(processId: number): void {
 		this._pidPromiseComplete(processId);
 		this._pidPromiseComplete = null;
+	}
+
+	public _onData(data: string): void {
+		this._onDataCallback(data);
 	}
 
 	private _queueApiRequest(callback: (...args: any[]) => void, args: any[]) {
@@ -136,6 +147,11 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 	public $acceptTerminalProcessId(id: number, processId: number): void {
 		let terminal = this._getTerminalById(id);
 		terminal._setProcessId(processId);
+	}
+
+	public $acceptTerminalData(id: number, data: string): void {
+		let terminal = this._getTerminalById(id);
+		terminal._onData(data);
 	}
 
 	private _getTerminalById(id: number): ExtHostTerminal {

--- a/src/vs/workbench/api/node/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/node/mainThreadTerminalService.ts
@@ -24,6 +24,7 @@ export class MainThreadTerminalService extends MainThreadTerminalServiceShape {
 		this._toDispose = [];
 		this._toDispose.push(terminalService.onInstanceDisposed((terminalInstance) => this._onTerminalDisposed(terminalInstance)));
 		this._toDispose.push(terminalService.onInstanceProcessIdReady((terminalInstance) => this._onTerminalProcessIdReady(terminalInstance)));
+		this._toDispose.push(terminalService.onInstanceData(event => this._onTerminalData(event.instance, event.data)));
 	}
 
 	public dispose(): void {
@@ -55,6 +56,13 @@ export class MainThreadTerminalService extends MainThreadTerminalServiceShape {
 		}
 	}
 
+	public $registerOnData(terminalId: number): void {
+		let terminalInstance = this.terminalService.getInstanceFromId(terminalId);
+		if (terminalInstance) {
+			terminalInstance.enableApiOnData();
+		}
+	}
+
 	public $dispose(terminalId: number): void {
 		let terminalInstance = this.terminalService.getInstanceFromId(terminalId);
 		if (terminalInstance) {
@@ -75,5 +83,9 @@ export class MainThreadTerminalService extends MainThreadTerminalServiceShape {
 
 	private _onTerminalProcessIdReady(terminalInstance: ITerminalInstance): void {
 		this._proxy.$acceptTerminalProcessId(terminalInstance.id, terminalInstance.processId);
+	}
+
+	private _onTerminalData(terminalInstance: ITerminalInstance, data: string): void {
+		this._proxy.$acceptTerminalData(terminalInstance.id, data);
 	}
 }

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -126,6 +126,7 @@ export interface ITerminalService {
 	onActiveInstanceChanged: Event<string>;
 	onInstanceDisposed: Event<ITerminalInstance>;
 	onInstanceProcessIdReady: Event<ITerminalInstance>;
+	onInstanceData: Event<{ instance: ITerminalInstance, data: string }>;
 	onInstancesChanged: Event<string>;
 	onInstanceTitleChanged: Event<string>;
 	terminalInstances: ITerminalInstance[];
@@ -314,4 +315,6 @@ export interface ITerminalInstance {
 	 * @param shell The new launch configuration.
 	 */
 	reuseTerminal(shell?: IShellLaunchConfig): void;
+
+	enableApiOnData(): void;
 }

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -316,5 +316,8 @@ export interface ITerminalInstance {
 	 */
 	reuseTerminal(shell?: IShellLaunchConfig): void;
 
+	/**
+	 * Experimental: Call to enable onData to be passed over IPC to the extension host.
+	 */
 	enableApiOnData(): void;
 }

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -21,6 +21,7 @@ export abstract class TerminalService implements ITerminalService {
 	protected _onInstancesChanged: Emitter<string>;
 	protected _onInstanceDisposed: Emitter<ITerminalInstance>;
 	protected _onInstanceProcessIdReady: Emitter<ITerminalInstance>;
+	protected _onInstanceData: Emitter<{ instance: ITerminalInstance, data: string }>;
 	protected _onInstanceTitleChanged: Emitter<string>;
 	protected _terminalInstances: ITerminalInstance[];
 
@@ -31,6 +32,7 @@ export abstract class TerminalService implements ITerminalService {
 	public get onActiveInstanceChanged(): Event<string> { return this._onActiveInstanceChanged.event; }
 	public get onInstanceDisposed(): Event<ITerminalInstance> { return this._onInstanceDisposed.event; }
 	public get onInstanceProcessIdReady(): Event<ITerminalInstance> { return this._onInstanceProcessIdReady.event; }
+	public get onInstanceData(): Event<{ instance: ITerminalInstance, data: string }> { return this._onInstanceData.event; }
 	public get onInstanceTitleChanged(): Event<string> { return this._onInstanceTitleChanged.event; }
 	public get onInstancesChanged(): Event<string> { return this._onInstancesChanged.event; }
 	public get terminalInstances(): ITerminalInstance[] { return this._terminalInstances; }
@@ -50,6 +52,7 @@ export abstract class TerminalService implements ITerminalService {
 		this._onActiveInstanceChanged = new Emitter<string>();
 		this._onInstanceDisposed = new Emitter<ITerminalInstance>();
 		this._onInstanceProcessIdReady = new Emitter<ITerminalInstance>();
+		this._onInstanceData = new Emitter<{ instance: ITerminalInstance, data: string }>();
 		this._onInstanceTitleChanged = new Emitter<string>();
 		this._onInstancesChanged = new Emitter<string>();
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -56,6 +56,7 @@ export class TerminalInstance implements ITerminalInstance {
 	private _isVisible: boolean;
 	private _isDisposed: boolean;
 	private _onDisposed: Emitter<ITerminalInstance>;
+	private _onDataForApi: Emitter<{ instance: ITerminalInstance, data: string }>;
 	private _onProcessIdReady: Emitter<TerminalInstance>;
 	private _onTitleChanged: Emitter<string>;
 	private _process: cp.ChildProcess;
@@ -77,6 +78,7 @@ export class TerminalInstance implements ITerminalInstance {
 	public get id(): number { return this._id; }
 	public get processId(): number { return this._processId; }
 	public get onDisposed(): Event<ITerminalInstance> { return this._onDisposed.event; }
+	public get onDataForApi(): Event<{ instance: ITerminalInstance, data: string }> { return this._onDataForApi.event; }
 	public get onProcessIdReady(): Event<TerminalInstance> { return this._onProcessIdReady.event; }
 	public get onTitleChanged(): Event<string> { return this._onTitleChanged.event; }
 	public get title(): string { return this._title; }
@@ -107,6 +109,7 @@ export class TerminalInstance implements ITerminalInstance {
 		this._terminalHasTextContextKey = KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED.bindTo(this._contextKeyService);
 
 		this._onDisposed = new Emitter<TerminalInstance>();
+		this._onDataForApi = new Emitter<{ instance: ITerminalInstance, data: string }>();
 		this._onProcessIdReady = new Emitter<TerminalInstance>();
 		this._onTitleChanged = new Emitter<string>();
 
@@ -735,6 +738,11 @@ export class TerminalInstance implements ITerminalInstance {
 				rows: this._rows
 			});
 		}
+	}
+
+	public enableApiOnData(): void {
+		// Only send data through IPC if the API explicitly requests it.
+		this.onData(data => this._onDataForApi.fire({ instance: this, data }));
 	}
 
 	public static setTerminalProcessFactory(factory: ITerminalProcessFactory): void {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -57,6 +57,7 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 			shell);
 		terminalInstance.addDisposable(terminalInstance.onTitleChanged(this._onInstanceTitleChanged.fire, this._onInstanceTitleChanged));
 		terminalInstance.addDisposable(terminalInstance.onDisposed(this._onInstanceDisposed.fire, this._onInstanceDisposed));
+		terminalInstance.addDisposable(terminalInstance.onDataForApi(this._onInstanceData.fire, this._onInstanceData));
 		terminalInstance.addDisposable(terminalInstance.onProcessIdReady(this._onInstanceProcessIdReady.fire, this._onInstanceProcessIdReady));
 		this.terminalInstances.push(terminalInstance);
 		if (this.terminalInstances.length === 1) {


### PR DESCRIPTION
Fixes #23177 

---

**API**

```ts
export interface Terminal {
	/**
	 * Experimental API that allows listening to the raw data stream coming from the terminal's
	 * pty process (including ANSI escape sequences).
	 *
	 * @param callback The callback that is triggered when data is sent to the terminal.
	 */
	onData(callback: (data: string) => any): void;
}
```

**Usage**

```ts
const terminal = vscode.window.createTerminal();
terminal.onData(data => console.log(data));
```

Results in something like this:

![image](https://cloud.githubusercontent.com/assets/2193314/24314062/f189f1ac-109c-11e7-8f90-daa191d99c57.png)

If we wanted to ship this it might make more sense to strip escape sequences before firing the `onData` callback. In the meantime use something like [`Strings.removeAnsiEscapeCodes`](https://github.com/Microsoft/vscode/blob/08b14f723067b729ab4b952c30cdc976242e2100/src/vs/base/common/strings.ts#L626) or [`TerminalDecoder`](https://github.com/Microsoft/vscode/blob/08b14f723067b729ab4b952c30cdc976242e2100/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts#L39) to strip them.

**Notes**

- Only one `onData` callback can be registered at once, called it again will override the old one.
- Only when `onData` is called will the terminal send the data stream over IPC.