### PR TITLE
Support `...` terminating Yaml FrontMatter

### DIFF
--- a/extensions/markdown/src/markdownEngine.ts
+++ b/extensions/markdown/src/markdownEngine.ts
@@ -22,7 +22,7 @@ interface MarkdownIt {
 	utils: any;
 }
 
-const FrontMatterRegex = /^---\s*[^]*?---\s*/;
+const FrontMatterRegex = /^---\s*[^]*?(-{3}|\.{3})\s*/;
 
 export class MarkdownEngine {
 	private md: MarkdownIt;

--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -3551,7 +3551,7 @@
 			<key>begin</key>
 			<string>\A-{3}\s*$</string>
 			<key>while</key>
-			<string>^(?!-{3}\s*$)</string>
+			<string>^(?!(-{3}|\.{3})\s*$)</string>
 			<key>patterns</key>
 			<array>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage.base
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage.base
@@ -1184,7 +1184,7 @@
 			<key>begin</key>
 			<string>\A-{3}\s*$</string>
 			<key>while</key>
-			<string>^(?!-{3}\s*$)</string>
+			<string>^(?!(-{3}|\.{3})\s*$)</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
This PR adds support for FrontMatter termination with ... in MarkDown for both the preview provider and the editor grammar.

Before:
<img width="376" alt="screen shot 2017-03-24 at 7 48 36 pm" src="https://cloud.githubusercontent.com/assets/9055268/24318895/084bd4ae-10cb-11e7-9661-b8c286c4b921.png">

After:
<img width="295" alt="screen shot 2017-03-24 at 7 48 07 pm" src="https://cloud.githubusercontent.com/assets/9055268/24318886/d6f464b6-10ca-11e7-843b-351d69b4d6ee.png">




Original issue: #23178 