### PR TITLE
Add new "files.defaultLanguage" configuration setting

### DIFF
--- a/extensions/configuration-editing/src/settingsDocumentHelper.ts
+++ b/extensions/configuration-editing/src/settingsDocumentHelper.ts
@@ -32,6 +32,11 @@ export class SettingsDocument {
 			return this.provideExcludeCompletionItems(location, range);
 		}
 
+		// files.defaultLanguage
+		if (location.path[0] === 'files.defaultLanguage') {
+			return this.provideDefaultLanguageCompletionItems(location, range);
+		}
+
 		return this.provideLanguageOverridesCompletionItems(location, position);
 	}
 
@@ -190,6 +195,18 @@ export class SettingsDocument {
 			});
 		}
 		return Promise.resolve([]);
+	}
+
+	private provideDefaultLanguageCompletionItems(location: Location, range: vscode.Range): vscode.ProviderResult<vscode.CompletionItem[]> {
+		// Suggestion model word matching includes a starting quote
+		// Hence exclude it from the proposal range
+		range = new vscode.Range(new vscode.Position(range.start.line, range.start.character + 1), range.end);
+
+		return vscode.languages.getLanguages().then(languages => {
+				return languages.map(l => {
+					return this.newSimpleCompletionItem(l, range, '', l + '"');
+				});
+			});
 	}
 
 	private newSimpleCompletionItem(text: string, range: vscode.Range, description?: string, insertText?: string): vscode.CompletionItem {

--- a/extensions/configuration-editing/src/settingsDocumentHelper.ts
+++ b/extensions/configuration-editing/src/settingsDocumentHelper.ts
@@ -34,7 +34,7 @@ export class SettingsDocument {
 
 		// files.defaultLanguage
 		if (location.path[0] === 'files.defaultLanguage') {
-			return this.provideDefaultLanguageCompletionItems(location, range);
+			return this.provideLanguageCompletionItems(location, range);
 		}
 
 		return this.provideLanguageOverridesCompletionItems(location, position);
@@ -147,10 +147,10 @@ export class SettingsDocument {
 		return Promise.resolve(completions);
 	}
 
-	private provideLanguageCompletionItems(location: Location, range: vscode.Range, stringify: boolean = true): vscode.ProviderResult<vscode.CompletionItem[]> {
+	private provideLanguageCompletionItems(location: Location, range: vscode.Range, formatFunc: (string) => string = (l) => JSON.stringify(l)): vscode.ProviderResult<vscode.CompletionItem[]> {
 		return vscode.languages.getLanguages().then(languages => {
 			return languages.map(l => {
-				return this.newSimpleCompletionItem(stringify ? JSON.stringify(l) : l, range);
+				return this.newSimpleCompletionItem(formatFunc(l), range);
 			});
 		});
 	}
@@ -180,33 +180,11 @@ export class SettingsDocument {
 		}
 
 		if (location.path.length === 1 && location.previousNode && typeof location.previousNode.value === 'string' && location.previousNode.value.startsWith('[')) {
-
-			// Suggestion model word matching includes starting quote and open sqaure bracket
-			// Hence exclude them from the proposal range
-			range = new vscode.Range(new vscode.Position(range.start.line, range.start.character + 2), range.end);
-
-			return vscode.languages.getLanguages().then(languages => {
-				return languages.map(l => {
-
-					// Suggestion model word matching includes closed sqaure bracket and ending quote
-					// Hence include them in the proposal to replace
-					return this.newSimpleCompletionItem(l, range, '', l + ']"');
-				});
-			});
+			// Suggestion model word matching includes closed sqaure bracket and ending quote
+			// Hence include them in the proposal to replace
+			return this.provideLanguageCompletionItems(location, range, language => `"[${language}]"`);
 		}
 		return Promise.resolve([]);
-	}
-
-	private provideDefaultLanguageCompletionItems(location: Location, range: vscode.Range): vscode.ProviderResult<vscode.CompletionItem[]> {
-		// Suggestion model word matching includes a starting quote
-		// Hence exclude it from the proposal range
-		range = new vscode.Range(new vscode.Position(range.start.line, range.start.character + 1), range.end);
-
-		return vscode.languages.getLanguages().then(languages => {
-				return languages.map(l => {
-					return this.newSimpleCompletionItem(l, range, '', l + '"');
-				});
-			});
 	}
 
 	private newSimpleCompletionItem(text: string, range: vscode.Range, description?: string, insertText?: string): vscode.CompletionItem {

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -575,6 +575,7 @@ export interface IFilesConfiguration {
 		exclude: glob.IExpression;
 		watcherExclude: { [filepattern: string]: boolean };
 		encoding: string;
+		defaultLanguage: string;
 		trimTrailingWhitespace: boolean;
 		autoSave: string;
 		autoSaveDelay: number;

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -265,6 +265,10 @@ configurationRegistry.registerConfiguration({
 				nls.localize('hotExit.onExitAndWindowClose', 'Hot exit will be triggered when the application is closed, that is when the last window is closed on Windows/Linux or when the workbench.action.quit command is triggered (command pallete, keybinding, menu), and also for any window with a folder opened regardless of whether it\'s the last window. All windows without folders opened will be restored upon next launch. To restore folder windows as they were before shutdown set "window.reopenFolders" to "all".')
 			],
 			'description': nls.localize('hotExit', "Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.", HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE)
+		},
+		'files.defaultLanguage': {
+			'type': 'string',
+			'description': nls.localize('defaultLanguage', "The default language mode that is assigned to new files.")
 		}
 	}
 });

--- a/src/vs/workbench/services/untitled/common/untitledEditorService.ts
+++ b/src/vs/workbench/services/untitled/common/untitledEditorService.ts
@@ -8,6 +8,8 @@ import URI from 'vs/base/common/uri';
 import { createDecorator, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import arrays = require('vs/base/common/arrays');
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
+import { IFilesConfiguration } from 'vs/platform/files/common/files';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import Event, { Emitter, once } from 'vs/base/common/event';
 
 export const IUntitledEditorService = createDecorator<IUntitledEditorService>('untitledEditorService');
@@ -89,7 +91,8 @@ export class UntitledEditorService implements IUntitledEditorService {
 	private _onDidDisposeModel: Emitter<URI>;
 
 	constructor(
-		@IInstantiationService private instantiationService: IInstantiationService
+		@IInstantiationService private instantiationService: IInstantiationService,
+		@IConfigurationService private configurationService: IConfigurationService
 	) {
 		this._onDidChangeContent = new Emitter<URI>();
 		this._onDidChangeDirty = new Emitter<URI>();
@@ -183,6 +186,11 @@ export class UntitledEditorService implements IUntitledEditorService {
 				resource = URI.from({ scheme: UntitledEditorInput.SCHEMA, path: `Untitled-${counter}` });
 				counter++;
 			} while (Object.keys(UntitledEditorService.CACHE).indexOf(resource.toString()) >= 0);
+		}
+
+		const configuration = this.configurationService.getConfiguration<IFilesConfiguration>();
+		if (!modeId && configuration.files && configuration.files.defaultLanguage) {
+			modeId = configuration.files.defaultLanguage;
 		}
 
 		const input = this.instantiationService.createInstance(UntitledEditorInput, resource, hasAssociatedFilePath, modeId, initialValue);


### PR DESCRIPTION
This change adds a new configuration setting that sets the default
language mode of new untitled files created with Ctrl+N
(workbench.action.files.newUntitledFile).  This activates the user's
desired language mode when a new untitled file is created.

Fixes #8729.