### PR TITLE
Move line autoindent#14390

### DIFF
--- a/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
@@ -107,7 +107,10 @@ export class MoveLinesCommand implements ICommand {
 
 						const allOpenbrackets = Strings.escapeRegExpCharacters(brackets.map(x => x.open).reduce((x, y) => x + y, ''));
 
-						if (movingLineText.match(new RegExp('[^' + lineComment + '.*][' + allOpenbrackets + ']\\s*' + lineComment + '.*$'))) {
+						if (
+							movingLineText.match(new RegExp('[' + allOpenbrackets + ']\\s*(' + lineComment + '.*)?$')) &&
+							!movingLineText.match(new RegExp(lineComment + '.*[' + allOpenbrackets + ']\\s*(' + lineComment + '.*)?$'))
+						) {
 							newMovingWhitespaces += oneIndent;
 						}
 						// Replace the current line whitespaces with the moving line whitespaces

--- a/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
@@ -23,11 +23,11 @@ export class MoveLinesCommand implements ICommand {
 		this._isMovingDown = isMovingDown;
 	}
 
-	public static getBeginWhitespaces(string: string){
-		return string.match(/^\s*/)[0] || "";
+	public static getBeginWhitespaces(string: string) {
+		return string.match(/^\s*/)[0] || '';
 	}
 
-	public static replaceLine(model: ITokenizedModel, builder: IEditOperationBuilder, lineNumber: number, newText: string){
+	public static replaceLine(model: ITokenizedModel, builder: IEditOperationBuilder, lineNumber: number, newText: string) {
 		builder.addEditOperation(new Range(
 			lineNumber, 1,
 			lineNumber, model.getLineMaxColumn(lineNumber)
@@ -78,14 +78,14 @@ export class MoveLinesCommand implements ICommand {
 				movingLineText: string;
 
 			const options = model.getOptions();
-			let oneIndent = "	";
+			let oneIndent = '	';
 			if (options.insertSpaces) {
-				oneIndent = Array(options.tabSize).join(" ");
+				oneIndent = Array(options.tabSize).join(' ');
 			}
 
 			let bracketsSupport = LanguageConfigurationRegistry.getBracketsSupport(model.getLanguageIdentifier().id);
 			let brackets = [];
-			if(bracketsSupport){
+			if (bracketsSupport) {
 				brackets = bracketsSupport.brackets;
 			}
 
@@ -98,19 +98,19 @@ export class MoveLinesCommand implements ICommand {
 				const lastLineWhitespaces = MoveLinesCommand.getBeginWhitespaces(model.getLineContent(s.endLineNumber));
 
 				// If selection have the same indentation for the first and last line, apply an auto indent to the selected block
-				if(firstLineWhitespaces.length === lastLineWhitespaces.length && movingLineText.length > 0){
-					for(var lineNumber = s.startLineNumber; lineNumber <= s.endLineNumber; ++lineNumber){
+				if (firstLineWhitespaces.length === lastLineWhitespaces.length && movingLineText.length > 0) {
+					for (var lineNumber = s.startLineNumber; lineNumber <= s.endLineNumber; ++lineNumber) {
 						// If line end with language open bracket, use indentation of the next next line
 						let newMovingWhitespaces = movingLineWhitespaces;
 
-						const allOpenbrackets = Strings.escapeRegExpCharacters(brackets.map(x=>x.open).reduce((x, y)=>x + y, ""));
+						const allOpenbrackets = Strings.escapeRegExpCharacters(brackets.map(x => x.open).reduce((x, y) => x + y, ''));
 
-						if( movingLineText.match(new RegExp("[" + allOpenbrackets + "]\\s*$"))){
+						if (movingLineText.match(new RegExp('[' + allOpenbrackets + ']\\s*$'))) {
 							newMovingWhitespaces += oneIndent;
 						}
 						// Replace the current line whitespaces with the moving line whitespaces
 						const lineText = model.getLineContent(lineNumber).replace(
-							new RegExp("^" + firstLineWhitespaces), newMovingWhitespaces
+							new RegExp('^' + firstLineWhitespaces), newMovingWhitespaces
 						);
 						MoveLinesCommand.replaceLine(model, builder, lineNumber, lineText);
 					}
@@ -130,18 +130,18 @@ export class MoveLinesCommand implements ICommand {
 				const lastLineWhitespaces = MoveLinesCommand.getBeginWhitespaces(model.getLineContent(s.endLineNumber));
 
 				// If selection have the same indentation for the first and last line, apply an auto indent to the selected block
-				if(firstLineWhitespaces.length === lastLineWhitespaces.length && movingLineText.length > 0){
-					for(var lineNumber = s.startLineNumber; lineNumber <= s.endLineNumber; ++lineNumber){
+				if (firstLineWhitespaces.length === lastLineWhitespaces.length && movingLineText.length > 0) {
+					for (var lineNumber = s.startLineNumber; lineNumber <= s.endLineNumber; ++lineNumber) {
 						// If line start with language closing bracket, use indentation of the next next line
-						const allClosingbrackets = Strings.escapeRegExpCharacters(brackets.map(x=>x.close).reduce((x, y) => x + y, ""));
+						const allClosingbrackets = Strings.escapeRegExpCharacters(brackets.map(x => x.close).reduce((x, y) => x + y, ''));
 						let newMovingWhitespaces = movingLineWhitespaces;
 
-						if( movingLineText.match(new RegExp("^\\s*[" + allClosingbrackets + "]"))){
+						if (movingLineText.match(new RegExp('^\\s*[' + allClosingbrackets + ']'))) {
 							newMovingWhitespaces += oneIndent;
 						}
 						// Replace the current line whitespaces with the moving line whitespaces
 						const lineText = model.getLineContent(lineNumber).replace(
-							new RegExp("^" + firstLineWhitespaces), newMovingWhitespaces
+							new RegExp('^' + firstLineWhitespaces), newMovingWhitespaces
 						);
 						MoveLinesCommand.replaceLine(model, builder, lineNumber, lineText);
 					}

--- a/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
@@ -126,7 +126,7 @@ export class MoveLinesCommand implements ICommand {
 				const lastLineWhitespaces = MoveLinesCommand.getBeginWhitespaces(model.getLineContent(s.endLineNumber));
 
 				// If selection have the same indentation for the first and last line, apply an auto indent to the selected block
-				if(firstLineWhitespaces.length === lastLineWhitespaces.length && movingLineText.length > 1){
+				if(firstLineWhitespaces.length === lastLineWhitespaces.length && movingLineText.length > 0){
 					for(var lineNumber = s.startLineNumber; lineNumber <= s.endLineNumber; ++lineNumber){
 						// If line start with language closing bracket, use indentation of the next next line
 						const allClosingbrackets = Strings.escapeRegExpCharacters(brackets.map(x=>x.close).reduce((x, y) => x + y, ""));

--- a/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
@@ -83,7 +83,11 @@ export class MoveLinesCommand implements ICommand {
 				oneIndent = Array(options.tabSize).join(" ");
 			}
 
-			let brackets = LanguageConfigurationRegistry.getBracketsSupport(model.getLanguageIdentifier().id).brackets;
+			let bracketsSupport = LanguageConfigurationRegistry.getBracketsSupport(model.getLanguageIdentifier().id);
+			let brackets = [];
+			if(bracketsSupport){
+				brackets = bracketsSupport.brackets;
+			}
 
 			if (this._isMovingDown) {
 				movingLineNumber = s.endLineNumber + 1;

--- a/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
+++ b/src/vs/editor/contrib/linesOperations/common/moveLinesCommand.ts
@@ -84,7 +84,9 @@ export class MoveLinesCommand implements ICommand {
 			}
 
 			let bracketsSupport = LanguageConfigurationRegistry.getBracketsSupport(model.getLanguageIdentifier().id);
+			const lineComment = Strings.escapeRegExpCharacters(LanguageConfigurationRegistry.getComments(model.getLanguageIdentifier().id).lineCommentToken);
 			let brackets = [];
+			// If language have brackets, use them to detect blocks
 			if (bracketsSupport) {
 				brackets = bracketsSupport.brackets;
 			}
@@ -105,7 +107,7 @@ export class MoveLinesCommand implements ICommand {
 
 						const allOpenbrackets = Strings.escapeRegExpCharacters(brackets.map(x => x.open).reduce((x, y) => x + y, ''));
 
-						if (movingLineText.match(new RegExp('[' + allOpenbrackets + ']\\s*$'))) {
+						if (movingLineText.match(new RegExp('[^' + lineComment + '.*][' + allOpenbrackets + ']\\s*' + lineComment + '.*$'))) {
 							newMovingWhitespaces += oneIndent;
 						}
 						// Replace the current line whitespaces with the moving line whitespaces

--- a/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
@@ -10,6 +10,7 @@ import { testCommand } from 'vs/editor/test/common/commands/commandTestUtils';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { TextModel } from 'vs/editor/common/model/textModel';
 import { MockMode } from 'vs/editor/test/common/mocks/mockMode';
+import { LanguageIdentifier } from 'vs/editor/common/modes';
 import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
 
 const openBlockChars = ['{', '(', '['];

--- a/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
@@ -9,13 +9,12 @@ import { MoveLinesCommand } from 'vs/editor/contrib/linesOperations/common/moveL
 import { testCommand } from 'vs/editor/test/common/commands/commandTestUtils';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { TextModel } from 'vs/editor/common/model/textModel';
-import { LanguageIdentifier, LanguageId } from 'vs/editor/common/modes';
 import { MockMode } from 'vs/editor/test/common/mocks/mockMode';
 import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
 
-const openBlockChars = ["{", "(", "["];
-const closingBlockChars = ["}", ")", "]"];
-const indentationType = ["	", "  ", "    "];
+const openBlockChars = ['{', '(', '['];
+const closingBlockChars = ['}', ')', ']'];
+const indentationType = ['	', '  ', '    '];
 class BracketMode extends MockMode {
 	private static _id = new LanguageIdentifier('bracketMode', 3);
 
@@ -47,34 +46,34 @@ function getOptionWithIndentation(indentation: string): editorCommon.ITextModelC
 	options.tabSize = indentation.length + 1;
 	options.insertSpaces = true;
 
-	if(indentation.match(/\t/)){
+	if (indentation.match(/\t/)) {
 		options.insertSpaces = false;
 	}
 
 	return options;
 }
 
-function testMoveLinesUpCommandWithAndWithoutPreindentation(oneIndentation: string, lines: string[], selection: Selection, expectedLines: string[], expectedSelection: Selection){
+function testMoveLinesUpCommandWithAndWithoutPreindentation(oneIndentation: string, lines: string[], selection: Selection, expectedLines: string[], expectedSelection: Selection) {
 	const options = getOptionWithIndentation(oneIndentation);
 
 	testMoveLinesUpCommand(lines, selection, expectedLines, expectedSelection, options);
 	testMoveLinesUpCommand(
-		lines.map((x: string) => {return oneIndentation + oneIndentation + x;}),
+		lines.map((x: string) => { return oneIndentation + oneIndentation + x; }),
 		selection,
-		expectedLines.map((x: string) => {return oneIndentation + oneIndentation + x;}),
+		expectedLines.map((x: string) => { return oneIndentation + oneIndentation + x; }),
 		expectedSelection,
 		options
 	);
 }
 
-function testMoveLinesDownCommandWithAndWithoutPreindentation(oneIndentation: string, lines: string[], selection: Selection, expectedLines: string[], expectedSelection: Selection){
+function testMoveLinesDownCommandWithAndWithoutPreindentation(oneIndentation: string, lines: string[], selection: Selection, expectedLines: string[], expectedSelection: Selection) {
 	const options = getOptionWithIndentation(oneIndentation);
 
 	testMoveLinesDownCommand(lines, selection, expectedLines, expectedSelection, options);
 	testMoveLinesDownCommand(
-		lines.map((x: string) => {return oneIndentation + oneIndentation + x;}),
+		lines.map((x: string) => { return oneIndentation + oneIndentation + x; }),
 		selection,
-		expectedLines.map((x: string) => {return oneIndentation + oneIndentation + x;}),
+		expectedLines.map((x: string) => { return oneIndentation + oneIndentation + x; }),
 		expectedSelection,
 		options
 	);
@@ -344,13 +343,13 @@ suite('Editor Contrib - Move Lines Command', () => {
 						'open block',
 						indentation + 'let a = 10',
 						indentation + 'line to move',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 					],
 					new Selection(3, 1, 3, 1),
 					[
 						'open block',
 						indentation + 'let a = 10',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 						'line to move',
 					],
 					new Selection(4, 1, 4, 1)
@@ -389,12 +388,12 @@ suite('Editor Contrib - Move Lines Command', () => {
 					[
 						'open block',
 						indentation + 'line to move',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 					],
 					new Selection(2, 1, 2, 1),
 					[
 						'open block',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 						'line to move',
 					],
 					new Selection(3, 1, 3, 1)
@@ -411,7 +410,7 @@ suite('Editor Contrib - Move Lines Command', () => {
 					[
 						'open block',
 						indentation + 'let a = 10',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 						'line to move',
 					],
 					new Selection(4, 1, 4, 1),
@@ -419,7 +418,7 @@ suite('Editor Contrib - Move Lines Command', () => {
 						'open block',
 						indentation + 'let a = 10',
 						indentation + 'line to move',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 					],
 					new Selection(3, 1, 3, 1)
 				);
@@ -458,7 +457,7 @@ suite('Editor Contrib - Move Lines Command', () => {
 					indentation,
 					[
 						'open block',
-						closingBracket +'end block',
+						closingBracket + 'end block',
 						'line to move',
 					],
 					new Selection(3, 1, 3, 1),

--- a/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
@@ -16,6 +16,8 @@ import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageCo
 const openBlockChars = ['{', '(', '['];
 const closingBlockChars = ['}', ')', ']'];
 const indentationType = ['	', '  ', '    '];
+const lineComment = '//';
+
 class BracketMode extends MockMode {
 	private static _id = new LanguageIdentifier('bracketMode', 3);
 
@@ -26,6 +28,10 @@ class BracketMode extends MockMode {
 				[openBlockChars[0], closingBlockChars[0]],
 				[openBlockChars[1], closingBlockChars[1]],
 				[openBlockChars[2], closingBlockChars[2]],
+			],
+			comments: {
+				'lineComment': lineComment
+			}
 		}));
 	}
 }
@@ -791,6 +797,182 @@ suite('Editor Contrib - Move Lines Command', () => {
 				],
 				new Selection(3, 1, 5, 2)
 			);
+		});
+	});
+
+	test('move line up leave commented block', function () {
+		openBlockChars.forEach((openBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesUpCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						lineComment + 'open block' + openBracket,
+						'line to move',
+					],
+					new Selection(2, 1, 2, 2),
+					[
+						'line to move',
+						lineComment + 'open block' + openBracket,
+					],
+					new Selection(1, 1, 1, 2)
+				);
+			});
+		});
+	});
+
+	test('move lines up leave commented block', function () {
+		openBlockChars.forEach((openBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesUpCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						lineComment + 'open block' + openBracket,
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+					],
+					new Selection(2, 1, 4, 2),
+					[
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+						lineComment + 'open block' + openBracket,
+					],
+					new Selection(1, 1, 3, 2)
+				);
+			});
+		});
+	});
+
+	test('move line up enter commented block', function () {
+		closingBlockChars.forEach((closeBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesUpCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						lineComment + closeBracket + 'close block',
+						'line to move',
+					],
+					new Selection(2, 1, 2, 2),
+					[
+						'line to move',
+						lineComment + closeBracket + 'closeblock',
+					],
+					new Selection(1, 1, 1, 2)
+				);
+			});
+		});
+	});
+
+	test('move lines up enter commented block', function () {
+		closingBlockChars.forEach((closeBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesUpCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						lineComment + closeBracket + 'close block',
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+					],
+					new Selection(2, 1, 4, 2),
+					[
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+						lineComment + closeBracket + 'close block',
+					],
+					new Selection(1, 1, 3, 2)
+				);
+			});
+		});
+	});
+
+	test('move line down enter commented block', function () {
+		openBlockChars.forEach((openBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesDownCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						'line to move',
+						lineComment + 'open block' + openBracket,
+					],
+					new Selection(1, 1, 1, 2),
+					[
+						lineComment + 'open block' + openBracket,
+						'line to move',
+					],
+					new Selection(2, 1, 2, 2)
+				);
+			});
+		});
+	});
+
+	test('move lines down enter commented block', function () {
+		openBlockChars.forEach((openBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesDownCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+						lineComment + 'open block' + openBracket,
+					],
+					new Selection(1, 1, 3, 2),
+					[
+						lineComment + 'open block' + openBracket,
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+					],
+					new Selection(4, 1, 4, 2)
+				);
+			});
+		});
+	});
+
+	test('move line down leave commented block', function () {
+		closingBlockChars.forEach((closeBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesDownCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						'line to move',
+						lineComment + ' ' + closeBracket,
+					],
+					new Selection(1, 1, 1, 2),
+					[
+						lineComment + ' ' + closeBracket,
+						'line to move',
+					],
+					new Selection(2, 1, 2, 2)
+				);
+			});
+		});
+	});
+
+	test('move lines down leave commented block', function () {
+		closingBlockChars.forEach((closeBracket: string) => {
+			indentationType.forEach((indentation: string) => {
+				testMoveLinesDownCommandWithAndWithoutPreindentation(
+					indentation,
+					[
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+						lineComment + ' ' + closeBracket,
+					],
+					new Selection(1, 1, 3, 2),
+					[
+						lineComment + ' ' + closeBracket,
+						'blocktomove start',
+						indentation + 'blocktomove middle',
+						'blocktomove end',
+					],
+					new Selection(2, 1, 4, 2)
+				);
+			});
 		});
 	});
 

--- a/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
@@ -856,7 +856,7 @@ suite('Editor Contrib - Move Lines Command', () => {
 					new Selection(2, 1, 2, 2),
 					[
 						'line to move',
-						lineComment + closeBracket + 'closeblock',
+						lineComment + closeBracket + 'close block',
 					],
 					new Selection(1, 1, 1, 2)
 				);
@@ -926,7 +926,7 @@ suite('Editor Contrib - Move Lines Command', () => {
 						indentation + 'blocktomove middle',
 						'blocktomove end',
 					],
-					new Selection(4, 1, 4, 2)
+					new Selection(2, 1, 4, 2)
 				);
 			});
 		});

--- a/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/moveLinesCommand.test.ts
@@ -23,10 +23,9 @@ class BracketMode extends MockMode {
 		super(BracketMode._id);
 		this._register(LanguageConfigurationRegistry.register(this.getLanguageIdentifier(), {
 			brackets: [
-				['{', '}'],
-				['[', ']'],
-				['(', ')'],
-			]
+				[openBlockChars[0], closingBlockChars[0]],
+				[openBlockChars[1], closingBlockChars[1]],
+				[openBlockChars[2], closingBlockChars[2]],
 		}));
 	}
 }

--- a/src/vs/editor/test/common/commands/commandTestUtils.ts
+++ b/src/vs/editor/test/common/commands/commandTestUtils.ts
@@ -20,10 +20,11 @@ export function testCommand(
 	selection: Selection,
 	commandFactory: (selection: Selection) => editorCommon.ICommand,
 	expectedLines: string[],
-	expectedSelection: Selection
+	expectedSelection: Selection,
+	options: editorCommon.ITextModelCreationOptions = undefined
 ): void {
 
-	let model = Model.createFromString(lines.join('\n'), undefined, languageIdentifier);
+	let model = Model.createFromString(lines.join('\n'), options, languageIdentifier);
 	let config = new TestConfiguration(null);
 	let cursor = new Cursor(config, model, viewModelHelper(model), false);
 
@@ -87,3 +88,4 @@ export function createInsertDeleteSingleEditOp(text: string, positionLineNumber:
 		forceMoveMarkers: true
 	};
 }
+


### PR DESCRIPTION
Main issue #14390
Another Issue in which it could be related #22093.

Questions, is there a way to test performances ?
The algorithm work like this:

- When moving lines, it will inherit the whitespaces of the next line.
- In some cases depending on the start or end of the line, if it's one of thoses chars []{}(): it will indent correctly the line

I created some tests, but I need to have some other feedbacks:

- Does the tests cover all the cases ?
- Could be possible performence issue ?
- Anything else that could be bad ?

For the issue #22093, they are talking aboit a different approache, after moving the lines, we use an auto indent functionality. Why not I would say but it seems for now the current autoindent feature isn't working well for selected code.