### PR TITLE
Characters Limit for 'Report Issue' Extensions Listing

### DIFF
--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -730,6 +730,12 @@ Steps to Reproduce:
 			return `|${e.manifest.name}|${e.manifest.publisher}|${e.manifest.version}|`;
 		}).join('\n');
 
+		// 2000 chars is browsers de-facto limit for URLs, 250 chars is allowed for other string parts of the issue URL
+		// http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+		if (tableHeader.length + table.length > 1750) {
+			return 'the listing exceeds the lower minimum of browsers\' URL characters limit';
+		}
+
 		return `
 
 ${tableHeader}\n${table};


### PR DESCRIPTION
Added chars limit for extensions listing to prevent not responsive behaviour as in #21737 

URL length discussed in #11655 but never implemented, adding the limit here now.
It is difficult to come up with the exact number because different browsers and their versions impose different limitations, putting 2000 chars as described in 
http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers

Falling back to not listing any if the limit is exceeded.