### PR TITLE
prevent reload window closes the debuggee; fixes #23390

### DIFF
--- a/src/vs/workbench/electron-browser/extensionHost.ts
+++ b/src/vs/workbench/electron-browser/extensionHost.ts
@@ -346,7 +346,8 @@ export class ExtensionHostProcessWorker {
 
 		// If the extension development host was started without debugger attached we need
 		// to communicate this back to the main side to terminate the debug session
-		if (this.isExtensionDevelopmentHost && !this.isExtensionDevelopmentTestFromCli && !this.isExtensionDevelopmentDebugging) {
+		const debugMode = !!this.environmentService.debugExtensionHost.port; // see #23390
+		if (this.isExtensionDevelopmentHost && !this.isExtensionDevelopmentTestFromCli && !debugMode) {
 			this.windowService.broadcast({
 				channel: EXTENSION_TERMINATE_BROADCAST_CHANNEL,
 				payload: true

--- a/src/vs/workbench/electron-browser/extensionHost.ts
+++ b/src/vs/workbench/electron-browser/extensionHost.ts
@@ -76,7 +76,8 @@ export class ExtensionHostProcessWorker {
 
 	private isExtensionDevelopmentHost: boolean;
 	private isExtensionDevelopmentTestFromCli: boolean;
-	private isExtensionDevelopmentDebugging: boolean;
+	private isExtensionDevelopmentDebug: boolean;
+	private isExtensionDevelopmentDebugBrk: boolean;
 
 	public readonly messagingProtocol = new LazyMessagePassingProtol();
 
@@ -95,7 +96,8 @@ export class ExtensionHostProcessWorker {
 	) {
 		// handle extension host lifecycle a bit special when we know we are developing an extension that runs inside
 		this.isExtensionDevelopmentHost = environmentService.isExtensionDevelopment;
-		this.isExtensionDevelopmentDebugging = !!environmentService.debugExtensionHost.break;
+		this.isExtensionDevelopmentDebug = (typeof environmentService.debugExtensionHost.port === 'number');
+		this.isExtensionDevelopmentDebugBrk = !!environmentService.debugExtensionHost.break;
 		this.isExtensionDevelopmentTestFromCli = this.isExtensionDevelopmentHost && !!environmentService.extensionTestsPath && !environmentService.debugExtensionHost.break;
 
 		lifecycleService.onWillShutdown(this._onWillShutdown, this);
@@ -124,7 +126,7 @@ export class ExtensionHostProcessWorker {
 				// (i.e. extension host) is taken down in a brutal fashion by the OS
 				detached: !!isWindows,
 				execArgv: port
-					? ['--nolazy', (this.isExtensionDevelopmentDebugging ? '--debug-brk=' : '--debug=') + port]
+					? ['--nolazy', (this.isExtensionDevelopmentDebugBrk ? '--debug-brk=' : '--debug=') + port]
 					: undefined
 			};
 
@@ -156,7 +158,7 @@ export class ExtensionHostProcessWorker {
 			let startupTimeoutHandle: number;
 			if (!this.environmentService.isBuilt || this.isExtensionDevelopmentHost) {
 				startupTimeoutHandle = setTimeout(() => {
-					const msg = this.isExtensionDevelopmentDebugging
+					const msg = this.isExtensionDevelopmentDebugBrk
 						? nls.localize('extensionHostProcess.startupFailDebug', "Extension host did not start in 10 seconds, it might be stopped on the first line and needs a debugger to continue.")
 						: nls.localize('extensionHostProcess.startupFail', "Extension host did not start in 10 seconds, that might be a problem.");
 
@@ -198,7 +200,7 @@ export class ExtensionHostProcessWorker {
 				if (port !== extensionHostPort) {
 					console.warn(`%c[Extension Host] %cProvided debugging port ${extensionHostPort} is not free, using ${port} instead.`, 'color: blue', 'color: black');
 				}
-				if (this.isExtensionDevelopmentDebugging) {
+				if (this.isExtensionDevelopmentDebugBrk) {
 					console.warn(`%c[Extension Host] %cSTOPPED on first line for debugging on port ${port}`, 'color: blue', 'color: black');
 				} else {
 					console.info(`%c[Extension Host] %cdebugger listening on port ${port}`, 'color: blue', 'color: black');
@@ -346,8 +348,7 @@ export class ExtensionHostProcessWorker {
 
 		// If the extension development host was started without debugger attached we need
 		// to communicate this back to the main side to terminate the debug session
-		const debugMode = !!this.environmentService.debugExtensionHost.port; // see #23390
-		if (this.isExtensionDevelopmentHost && !this.isExtensionDevelopmentTestFromCli && !debugMode) {
+		if (this.isExtensionDevelopmentHost && !this.isExtensionDevelopmentTestFromCli && !this.isExtensionDevelopmentDebug) {
 			this.windowService.broadcast({
 				channel: EXTENSION_TERMINATE_BROADCAST_CHANNEL,
 				payload: true


### PR DESCRIPTION
I cannot reproduce the problem when running out of source, so I could not really verify that the fix works.

`environmentService.debugExtensionHost.break` is used for two things: 1) as an indication that debug mode is active and 2) it indicates that break mode is active. The first use is now broken, because debug mode can be enabled with the command line flag `--debugPluginHost` too.  This dual use forbids that we can just add a test for `--debugPluginHost` when parsing the value from the command line. For this reason I'm following @bpasero's suggestion to use the `debugExtensionHost.port` as an indication that debug mode is active.