### PR TITLE
Adds editor options overloads to showTextDocument & vscode.diff

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -705,7 +705,7 @@ declare module 'vscode' {
 		/**
 		 * An optional view column in which the [editor](#TextEditor) should be shown. The default is the [one](#ViewColumn.One), other values are adjusted to be __Min(column, columnCount + 1)__.
 		 */
-		column ?: ViewColumn,
+		column?: ViewColumn,
 
 		/**
 		 * An optional flag that when `true` will stop the [editor](#TextEditor) from taking focus.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -699,6 +699,26 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Represents options to configure the behavior of showing a [document](#TextDocument) in an [editor](#TextEditor).
+	 */
+	export interface ShowTextDocumentOptions {
+		/**
+		 * An optional view column in which the [editor](#TextEditor) should be shown. The default is the [one](#ViewColumn.One), other values are adjusted to be __Min(column, columnCount + 1)__.
+		 */
+		column ?: ViewColumn,
+
+		/**
+		 * An optional flag that when `true` will stop the [editor](#TextEditor) from taking focus.
+		 */
+		preserveFocus?: boolean,
+
+		/**
+		 * An optional flag that when `true` will pin the [editor](#TextEditor).
+		 */
+		pinned?: boolean
+	}
+
+	/**
 	 * Represents theme specific rendering styles for a [text editor decoration](#TextEditorDecorationType).
 	 */
 	export interface ThemableDecorationRenderOptions {
@@ -3664,12 +3684,10 @@ declare module 'vscode' {
 		 * to control where the editor is being shown. Might change the [active editor](#window.activeTextEditor).
 		 *
 		 * @param document A text document to be shown.
-		 * @param column A view column in which the editor should be shown. The default is the [one](#ViewColumn.One), other values
-		 * are adjusted to be __Min(column, columnCount + 1)__.
-		 * @param options Editor options for showing the text editor.
+		 * @param options [Editor options](#ShowTextDocumentOptions) to configure the behavior of showing the [editor](#TextEditor).
 		 * @return A promise that resolves to an [editor](#TextEditor).
 		 */
-		export function showTextDocument(document: TextDocument, column?: ViewColumn, options?: { preserveFocus?: boolean, pinned?: boolean }): Thenable<TextEditor>;
+		export function showTextDocument(document: TextDocument, options?: ShowTextDocumentOptions): Thenable<TextEditor>;
 
 		/**
 		 * Create a TextEditorDecorationType that can be used to add decorations to text editors.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3660,6 +3660,18 @@ declare module 'vscode' {
 		export function showTextDocument(document: TextDocument, column?: ViewColumn, preserveFocus?: boolean): Thenable<TextEditor>;
 
 		/**
+		 * Show the given document in a text editor. A [column](#ViewColumn) can be provided
+		 * to control where the editor is being shown. Might change the [active editor](#window.activeTextEditor).
+		 *
+		 * @param document A text document to be shown.
+		 * @param column A view column in which the editor should be shown. The default is the [one](#ViewColumn.One), other values
+		 * are adjusted to be __Min(column, columnCount + 1)__.
+		 * @param options Editor options for showing the text editor.
+		 * @return A promise that resolves to an [editor](#TextEditor).
+		 */
+		export function showTextDocument(document: TextDocument, column?: ViewColumn, options?: { preserveFocus?: boolean, pinned?: boolean }): Thenable<TextEditor>;
+
+		/**
 		 * Create a TextEditorDecorationType that can be used to add decorations to text editors.
 		 *
 		 * @param options Rendering options for the decoration type.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -701,7 +701,7 @@ declare module 'vscode' {
 	/**
 	 * Represents options to configure the behavior of showing a [document](#TextDocument) in an [editor](#TextEditor).
 	 */
-	export interface ShowTextDocumentOptions {
+	export interface TextDocumentShowOptions {
 		/**
 		 * An optional view column in which the [editor](#TextEditor) should be shown. The default is the [one](#ViewColumn.One), other values are adjusted to be __Min(column, columnCount + 1)__.
 		 */
@@ -715,7 +715,7 @@ declare module 'vscode' {
 		/**
 		 * An optional flag that when `true` will pin the [editor](#TextEditor).
 		 */
-		pinned?: boolean
+		preview?: boolean
 	}
 
 	/**
@@ -3687,7 +3687,7 @@ declare module 'vscode' {
 		 * @param options [Editor options](#ShowTextDocumentOptions) to configure the behavior of showing the [editor](#TextEditor).
 		 * @return A promise that resolves to an [editor](#TextEditor).
 		 */
-		export function showTextDocument(document: TextDocument, options?: ShowTextDocumentOptions): Thenable<TextEditor>;
+		export function showTextDocument(document: TextDocument, options?: TextDocumentShowOptions): Thenable<TextEditor>;
 
 		/**
 		 * Create a TextEditorDecorationType that can be used to add decorations to text editors.

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -299,8 +299,8 @@ export function createApiFactory(
 			get visibleTextEditors() {
 				return extHostEditors.getVisibleTextEditors();
 			},
-			showTextDocument(document: vscode.TextDocument, column?: vscode.ViewColumn, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
-				return extHostEditors.showTextDocument(document, column, preserveFocus);
+			showTextDocument(document: vscode.TextDocument, columnOrOptions?: vscode.ViewColumn | vscode.ShowTextDocumentOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
+				return extHostEditors.showTextDocument(document, columnOrOptions, preserveFocus);
 			},
 			createTextEditorDecorationType(options: vscode.DecorationRenderOptions): vscode.TextEditorDecorationType {
 				return extHostEditors.createTextEditorDecorationType(options);

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -299,7 +299,7 @@ export function createApiFactory(
 			get visibleTextEditors() {
 				return extHostEditors.getVisibleTextEditors();
 			},
-			showTextDocument(document: vscode.TextDocument, columnOrOptions?: vscode.ViewColumn | vscode.ShowTextDocumentOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
+			showTextDocument(document: vscode.TextDocument, columnOrOptions?: vscode.ViewColumn | vscode.TextDocumentShowOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
 				return extHostEditors.showTextDocument(document, columnOrOptions, preserveFocus);
 			},
 			createTextEditorDecorationType(options: vscode.DecorationRenderOptions): vscode.TextEditorDecorationType {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -133,8 +133,14 @@ export abstract class MainThreadDocumentsShape {
 	$trySaveDocument(uri: URI): TPromise<boolean> { throw ni(); }
 }
 
+export interface ITextDocumentShowOptions {
+	position?: EditorPosition;
+	preserveFocus?: boolean;
+	pinned?: boolean;
+}
+
 export abstract class MainThreadEditorsShape {
-	$tryShowTextDocument(resource: URI, options: vscode.ShowTextDocumentOptions): TPromise<string> { throw ni(); }
+	$tryShowTextDocument(resource: URI, options: ITextDocumentShowOptions): TPromise<string> { throw ni(); }
 	$registerTextEditorDecorationType(key: string, options: editorCommon.IDecorationRenderOptions): void { throw ni(); }
 	$removeTextEditorDecorationType(key: string): void { throw ni(); }
 	$tryShowEditor(id: string, position: EditorPosition): TPromise<void> { throw ni(); }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -134,10 +134,7 @@ export abstract class MainThreadDocumentsShape {
 }
 
 export abstract class MainThreadEditorsShape {
-	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocus: boolean): TPromise<string>;
-	$tryShowTextDocument(resource: URI, position: EditorPosition, options: { preserveFocus: boolean, pinned: boolean }): TPromise<string>;
-	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<string>;
-	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<string> { throw ni(); }
+	$tryShowTextDocument(resource: URI, options: vscode.ShowTextDocumentOptions): TPromise<string> { throw ni(); }
 	$registerTextEditorDecorationType(key: string, options: editorCommon.IDecorationRenderOptions): void { throw ni(); }
 	$removeTextEditorDecorationType(key: string): void { throw ni(); }
 	$tryShowEditor(id: string, position: EditorPosition): TPromise<void> { throw ni(); }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -134,7 +134,10 @@ export abstract class MainThreadDocumentsShape {
 }
 
 export abstract class MainThreadEditorsShape {
-	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocus: boolean): TPromise<string> { throw ni(); }
+	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocus: boolean): TPromise<string>;
+	$tryShowTextDocument(resource: URI, position: EditorPosition, options: { preserveFocus: boolean, pinned: boolean }): TPromise<string>;
+	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<string>;
+	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<string> { throw ni(); }
 	$registerTextEditorDecorationType(key: string, options: editorCommon.IDecorationRenderOptions): void { throw ni(); }
 	$removeTextEditorDecorationType(key: string): void { throw ni(); }
 	$tryShowEditor(id: string, position: EditorPosition): TPromise<void> { throw ni(); }

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -203,14 +203,15 @@ export class ExtHostApiCommands {
 				]
 			});
 
-		this._register('vscode.diff', (left: URI, right: URI, label: string) => {
-			return this._commands.executeCommand('_workbench.diff', [left, right, label]);
+		this._register('vscode.diff', (left: URI, right: URI, label: string, options?: { preserveFocus?: boolean, pinned?: boolean }) => {
+			return this._commands.executeCommand('_workbench.diff', [left, right, label, undefined, options]);
 		}, {
 				description: 'Opens the provided resources in the diff editor to compare their contents.',
 				args: [
 					{ name: 'left', description: 'Left-hand side resource of the diff editor', constraint: URI },
 					{ name: 'right', description: 'Right-hand side resource of the diff editor', constraint: URI },
-					{ name: 'title', description: '(optional) Human readable title for the diff editor', constraint: v => v === void 0 || typeof v === 'string' }
+					{ name: 'title', description: '(optional) Human readable title for the diff editor', constraint: v => v === void 0 || typeof v === 'string' },
+					{ name: 'options', description: '(optional) Editor options' }
 				]
 			});
 

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -55,8 +55,10 @@ export class ExtHostEditors extends ExtHostEditorsShape {
 		return this._extHostDocumentsAndEditors.allEditors();
 	}
 
-	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocus: boolean): TPromise<vscode.TextEditor> {
-		return this._proxy.$tryShowTextDocument(<URI>document.uri, TypeConverters.fromViewColumn(column), preserveFocus).then(id => {
+	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocus: boolean): TPromise<vscode.TextEditor>;
+	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, options: { preserveFocus: boolean, pinned: boolean }): TPromise<vscode.TextEditor>;
+	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<vscode.TextEditor> {
+		return this._proxy.$tryShowTextDocument(<URI>document.uri, TypeConverters.fromViewColumn(column), preserveFocusOrOptions).then(id => {
 			let editor = this._extHostDocumentsAndEditors.getEditor(id);
 			if (editor) {
 				return editor;

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -56,9 +56,25 @@ export class ExtHostEditors extends ExtHostEditorsShape {
 	}
 
 	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocus: boolean): TPromise<vscode.TextEditor>;
-	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, options: { preserveFocus: boolean, pinned: boolean }): TPromise<vscode.TextEditor>;
-	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<vscode.TextEditor> {
-		return this._proxy.$tryShowTextDocument(<URI>document.uri, TypeConverters.fromViewColumn(column), preserveFocusOrOptions).then(id => {
+	showTextDocument(document: vscode.TextDocument, options: { column: vscode.ViewColumn, preserveFocus: boolean, pinned: boolean }): TPromise<vscode.TextEditor>;
+	showTextDocument(document: vscode.TextDocument, columnOrOptions: vscode.ViewColumn | vscode.ShowTextDocumentOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor>;
+	showTextDocument(document: vscode.TextDocument, columnOrOptions: vscode.ViewColumn | vscode.ShowTextDocumentOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
+		let options: vscode.ShowTextDocumentOptions;
+		if (typeof columnOrOptions === 'number') {
+			options = {
+				column: columnOrOptions,
+				preserveFocus: preserveFocus,
+				pinned: true
+			};
+		} else {
+			options = {
+				column: columnOrOptions.column,
+				preserveFocus: columnOrOptions.preserveFocus,
+				pinned: columnOrOptions.pinned === undefined ? true : columnOrOptions.pinned
+			};
+		}
+
+		return this._proxy.$tryShowTextDocument(<URI>document.uri, options).then(id => {
 			let editor = this._extHostDocumentsAndEditors.getEditor(id);
 			if (editor) {
 				return editor;

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -14,7 +14,7 @@ import { IResolvedTextEditorConfiguration, ISelectionChangeEvent } from 'vs/work
 import * as TypeConverters from './extHostTypeConverters';
 import { TextEditorDecorationType, ExtHostTextEditor } from './extHostTextEditor';
 import { ExtHostDocumentsAndEditors } from './extHostDocumentsAndEditors';
-import { MainContext, MainThreadEditorsShape, ExtHostEditorsShape, ITextEditorPositionData } from './extHost.protocol';
+import { MainContext, MainThreadEditorsShape, ExtHostEditorsShape, ITextDocumentShowOptions, ITextEditorPositionData } from './extHost.protocol';
 import * as vscode from 'vscode';
 
 export class ExtHostEditors extends ExtHostEditorsShape {
@@ -57,20 +57,20 @@ export class ExtHostEditors extends ExtHostEditorsShape {
 
 	showTextDocument(document: vscode.TextDocument, column: vscode.ViewColumn, preserveFocus: boolean): TPromise<vscode.TextEditor>;
 	showTextDocument(document: vscode.TextDocument, options: { column: vscode.ViewColumn, preserveFocus: boolean, pinned: boolean }): TPromise<vscode.TextEditor>;
-	showTextDocument(document: vscode.TextDocument, columnOrOptions: vscode.ViewColumn | vscode.ShowTextDocumentOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor>;
-	showTextDocument(document: vscode.TextDocument, columnOrOptions: vscode.ViewColumn | vscode.ShowTextDocumentOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
-		let options: vscode.ShowTextDocumentOptions;
+	showTextDocument(document: vscode.TextDocument, columnOrOptions: vscode.ViewColumn | vscode.TextDocumentShowOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor>;
+	showTextDocument(document: vscode.TextDocument, columnOrOptions: vscode.ViewColumn | vscode.TextDocumentShowOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
+		let options: ITextDocumentShowOptions;
 		if (typeof columnOrOptions === 'number') {
 			options = {
-				column: columnOrOptions,
+				position: TypeConverters.fromViewColumn(columnOrOptions),
 				preserveFocus: preserveFocus,
 				pinned: true
 			};
 		} else {
 			options = {
-				column: columnOrOptions.column,
+				position: TypeConverters.fromViewColumn(columnOrOptions.column),
 				preserveFocus: columnOrOptions.preserveFocus,
-				pinned: columnOrOptions.pinned === undefined ? true : columnOrOptions.pinned
+				pinned: columnOrOptions.preview === undefined ? true : !columnOrOptions.preview
 			};
 		}
 

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -66,11 +66,16 @@ export class ExtHostEditors extends ExtHostEditorsShape {
 				preserveFocus: preserveFocus,
 				pinned: true
 			};
-		} else {
+		} else if (typeof columnOrOptions === 'object') {
 			options = {
 				position: TypeConverters.fromViewColumn(columnOrOptions.column),
 				preserveFocus: columnOrOptions.preserveFocus,
 				pinned: columnOrOptions.preview === undefined ? true : !columnOrOptions.preview
+			};
+		} else {
+			options = {
+				preserveFocus: false,
+				pinned: true
 			};
 		}
 

--- a/src/vs/workbench/api/node/mainThreadEditors.ts
+++ b/src/vs/workbench/api/node/mainThreadEditors.ts
@@ -13,15 +13,13 @@ import { ICodeEditorService } from 'vs/editor/common/services/codeEditorService'
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IEditorOptions, Position as EditorPosition } from 'vs/platform/editor/common/editor';
-import * as TypeConverters from './extHostTypeConverters';
 import { TextEditorRevealType, MainThreadTextEditor, IApplyEditsOptions, IUndoStopOptions, ITextEditorConfigurationUpdate } from 'vs/workbench/api/node/mainThreadEditor';
 import { MainThreadDocumentsAndEditors } from './mainThreadDocumentsAndEditors';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { equals as objectEquals } from 'vs/base/common/objects';
-import { ExtHostContext, MainThreadEditorsShape, ExtHostEditorsShape, ITextEditorPositionData } from './extHost.protocol';
+import { ExtHostContext, MainThreadEditorsShape, ExtHostEditorsShape, ITextDocumentShowOptions, ITextEditorPositionData } from './extHost.protocol';
 import { IRange } from "vs/editor/common/core/range";
 import { ISelection } from "vs/editor/common/core/selection";
-import * as vscode from 'vscode';
 
 export class MainThreadEditors extends MainThreadEditorsShape {
 
@@ -106,8 +104,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	// --- from extension host process
 
-	$tryShowTextDocument(resource: URI, options: vscode.ShowTextDocumentOptions): TPromise<string> {
-		const position: EditorPosition = TypeConverters.fromViewColumn(options.column);
+	$tryShowTextDocument(resource: URI, options: ITextDocumentShowOptions): TPromise<string> {
 		const editorOptions: IEditorOptions = {
 			preserveFocus: options.preserveFocus,
 			pinned: options.pinned
@@ -118,7 +115,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 			options: editorOptions
 		};
 
-		return this._workbenchEditorService.openEditor(input, position).then(editor => {
+		return this._workbenchEditorService.openEditor(input, options.position).then(editor => {
 			if (!editor) {
 				return undefined;
 			}

--- a/src/vs/workbench/api/node/mainThreadEditors.ts
+++ b/src/vs/workbench/api/node/mainThreadEditors.ts
@@ -104,11 +104,27 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	// --- from extension host process
 
-	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocus: boolean): TPromise<string> {
+	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocus: boolean): TPromise<string>;
+	$tryShowTextDocument(resource: URI, position: EditorPosition, options: { preserveFocus: boolean, pinned: boolean }): TPromise<string>;
+	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<string>;
+	$tryShowTextDocument(resource: URI, position: EditorPosition, preserveFocusOrOptions: boolean | { preserveFocus: boolean, pinned: boolean }): TPromise<string> {
+
+		let options: { preserveFocus: boolean, pinned: boolean };
+		if (typeof preserveFocusOrOptions === 'object') {
+			options = {
+				preserveFocus: preserveFocusOrOptions.preserveFocus,
+				pinned: preserveFocusOrOptions.pinned === undefined ? true : preserveFocusOrOptions.pinned
+			};
+		} else {
+			options = {
+				preserveFocus: preserveFocusOrOptions,
+				pinned: true
+			};
+		}
 
 		const input = {
 			resource,
-			options: { preserveFocus, pinned: true }
+			options
 		};
 
 		return this._workbenchEditorService.openEditor(input, position).then(editor => {

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -376,7 +376,7 @@ export function registerCommands(): void {
 		win: { primary: void 0 }
 	});
 
-	CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string, vscode.ShowTextDocumentOptions]) {
+	CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string, vscode.TextDocumentShowOptions]) {
 		const editorService = accessor.get(IWorkbenchEditorService);
 		let [leftResource, rightResource, label, description, options] = args;
 
@@ -386,7 +386,7 @@ export function registerCommands(): void {
 			position = TypeConverters.fromViewColumn(options.column);
 			editorOptions = {
 				preserveFocus: options.preserveFocus,
-				pinned: options.pinned
+				pinned: !options.preview
 			};
 		}
 		else {

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -373,15 +373,27 @@ export function registerCommands(): void {
 		win: { primary: void 0 }
 	});
 
-	CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string]) {
+	CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string, { preserveFocus?: boolean, pinned?: boolean }]) {
 		const editorService = accessor.get(IWorkbenchEditorService);
-		let [leftResource, rightResource, label, description] = args;
+		let [leftResource, rightResource, label, description, options] = args;
+
+		if (typeof options === 'object') {
+			if (options !== undefined) {
+				options = {
+					preserveFocus: options.preserveFocus,
+					pinned: options.pinned
+				};
+			}
+		}
+		else {
+			options = undefined;
+		}
 
 		if (!label) {
 			label = nls.localize('diffLeftRightLabel', "{0} ⟷ {1}", leftResource.toString(true), rightResource.toString(true));
 		}
 
-		return editorService.openEditor({ leftResource, rightResource, label, description }).then(() => {
+		return editorService.openEditor({ leftResource, rightResource, label, description, options }).then(() => {
 			return void 0;
 		});
 	});

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -20,6 +20,9 @@ import errors = require('vs/base/common/errors');
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import URI from 'vs/base/common/uri';
+import { IEditorOptions, Position as EditorPosition } from 'vs/platform/editor/common/editor';
+import * as TypeConverters from 'vs/workbench/api/node/extHostTypeConverters';
+import * as vscode from 'vscode';
 
 // --- List Commands
 
@@ -373,27 +376,31 @@ export function registerCommands(): void {
 		win: { primary: void 0 }
 	});
 
-	CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string, { preserveFocus?: boolean, pinned?: boolean }]) {
+	CommandsRegistry.registerCommand('_workbench.diff', function (accessor: ServicesAccessor, args: [URI, URI, string, string, vscode.ShowTextDocumentOptions]) {
 		const editorService = accessor.get(IWorkbenchEditorService);
 		let [leftResource, rightResource, label, description, options] = args;
 
-		if (typeof options === 'object') {
-			if (options !== undefined) {
-				options = {
-					preserveFocus: options.preserveFocus,
-					pinned: options.pinned
-				};
-			}
+		let position: EditorPosition;
+		let editorOptions: IEditorOptions;
+		if (typeof options === 'object' && options !== undefined && options !== null) {
+			position = TypeConverters.fromViewColumn(options.column);
+			editorOptions = {
+				preserveFocus: options.preserveFocus,
+				pinned: options.pinned
+			};
 		}
 		else {
-			options = undefined;
+			editorOptions = {
+				preserveFocus: false,
+				pinned: false
+			};
 		}
 
 		if (!label) {
 			label = nls.localize('diffLeftRightLabel', "{0} ⟷ {1}", leftResource.toString(true), rightResource.toString(true));
 		}
 
-		return editorService.openEditor({ leftResource, rightResource, label, description, options }).then(() => {
+		return editorService.openEditor({ leftResource, rightResource, label, description, options: editorOptions }, position).then(() => {
 			return void 0;
 		});
 	});


### PR DESCRIPTION
This PR hopefully addresses https://github.com/Microsoft/vscode/issues/10568
Also addresses a need I have with `vscode.diff` to have the same control (for GitLens)

@jrieken This is a first shot at this -- please let me know what you think. I added it as options so that it could be expanded later to allow for other editor options (but didn't want to go there at this stage). 