### PR TITLE
Update SCM API based on feedback

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -220,305 +220,305 @@
         },
         {
           "command": "git.init",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == norepo"
+          "when": "config.git.enabled && scmProvider == git && gitState == norepo"
         },
         {
           "command": "git.refresh",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.openChange",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.openFile",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.stageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.stageSelectedRanges",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.revertSelectedRanges",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.unstage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.unstageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.unstageSelectedRanges",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.clean",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.cleanAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitStaged",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitStagedSigned",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitAllSigned",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.undoCommit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.checkout",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.branch",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.pull",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.pullRebase",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.push",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.pushTo",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.sync",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.publish",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.showOutput",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         }
       ],
       "scm/title": [
         {
           "command": "git.init",
           "group": "navigation",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == norepo"
+          "when": "config.git.enabled && scmProvider == git && gitState == norepo"
         },
         {
           "command": "git.commit",
           "group": "navigation",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.refresh",
           "group": "navigation",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.sync",
           "group": "1_sync",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.pull",
           "group": "1_sync",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.pullRebase",
           "group": "1_sync",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.push",
           "group": "1_sync",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.pushTo",
           "group": "1_sync",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.publish",
           "group": "2_publish",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitStaged",
           "group": "3_commit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitStagedSigned",
           "group": "3_commit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitAll",
           "group": "3_commit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.commitAllSigned",
           "group": "3_commit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.undoCommit",
           "group": "3_commit",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.unstageAll",
           "group": "4_stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.cleanAll",
           "group": "4_stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         },
         {
           "command": "git.showOutput",
           "group": "5_output",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle"
+          "when": "config.git.enabled && scmProvider == git && gitState == idle"
         }
       ],
       "scm/resourceGroup/context": [
         {
           "command": "git.stageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == merge",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == merge",
           "group": "1_modification"
         },
         {
           "command": "git.stageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == merge",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == merge",
           "group": "inline"
         },
         {
           "command": "git.unstageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == index",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == index",
           "group": "1_modification"
         },
         {
           "command": "git.unstageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == index",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == index",
           "group": "inline"
         },
         {
           "command": "git.cleanAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "1_modification"
         },
         {
           "command": "git.stageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "1_modification"
         },
         {
           "command": "git.cleanAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "inline"
         },
         {
           "command": "git.stageAll",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "inline"
         }
       ],
       "scm/resource/context": [
         {
           "command": "git.stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == merge",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == merge",
           "group": "1_modification"
         },
         {
           "command": "git.stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == merge",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == merge",
           "group": "inline"
         },
         {
           "command": "git.openChange",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == index",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == index",
           "group": "navigation"
         },
         {
           "command": "git.openFile",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == index",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == index",
           "group": "navigation"
         },
         {
           "command": "git.unstage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == index",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == index",
           "group": "1_modification"
         },
         {
           "command": "git.unstage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == index",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == index",
           "group": "inline"
         },
         {
           "command": "git.openChange",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "navigation"
         },
         {
           "command": "git.openFile",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "navigation"
         },
         {
           "command": "git.stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "1_modification"
         },
         {
           "command": "git.clean",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "1_modification"
         },
         {
           "command": "git.clean",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "inline"
         },
         {
           "command": "git.stage",
-          "when": "config.git.enabled && scmProvider == git && scmProviderState == idle && scmResourceGroup == workingTree",
+          "when": "config.git.enabled && scmProvider == git && gitState == idle && scmResourceGroup == workingTree",
           "group": "inline"
         }
       ],

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -112,7 +112,12 @@ export class CommandCenter {
 		await this.model.status();
 	}
 
-	async open(resource: Resource): Promise<void> {
+	@command('git.openResource')
+	async openResource(resource: Resource): Promise<void> {
+		await this._openResource(resource);
+	}
+
+	private async _openResource(resource: Resource): Promise<void> {
 		const left = this.getLeftResource(resource);
 		const right = this.getRightResource(resource);
 		const title = this.getTitle(resource);
@@ -137,7 +142,7 @@ export class CommandCenter {
 				return resource.original.with({ scheme: 'git', query: 'HEAD' });
 
 			case Status.MODIFIED:
-				return resource.sourceUri.with({ scheme: 'git', query: '~' });
+				return resource.resourceUri.with({ scheme: 'git', query: '~' });
 		}
 	}
 
@@ -146,34 +151,34 @@ export class CommandCenter {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_ADDED:
 			case Status.INDEX_COPIED:
-				return resource.sourceUri.with({ scheme: 'git' });
+				return resource.resourceUri.with({ scheme: 'git' });
 
 			case Status.INDEX_RENAMED:
-				return resource.sourceUri.with({ scheme: 'git' });
+				return resource.resourceUri.with({ scheme: 'git' });
 
 			case Status.INDEX_DELETED:
 			case Status.DELETED:
-				return resource.sourceUri.with({ scheme: 'git', query: 'HEAD' });
+				return resource.resourceUri.with({ scheme: 'git', query: 'HEAD' });
 
 			case Status.MODIFIED:
 			case Status.UNTRACKED:
 			case Status.IGNORED:
-				const uriString = resource.sourceUri.toString();
-				const [indexStatus] = this.model.indexGroup.resources.filter(r => r.sourceUri.toString() === uriString);
+				const uriString = resource.resourceUri.toString();
+				const [indexStatus] = this.model.indexGroup.resources.filter(r => r.resourceUri.toString() === uriString);
 
-				if (indexStatus && indexStatus.rename) {
-					return indexStatus.rename;
+				if (indexStatus && indexStatus.renameResourceUri) {
+					return indexStatus.renameResourceUri;
 				}
 
-				return resource.sourceUri;
+				return resource.resourceUri;
 
 			case Status.BOTH_MODIFIED:
-				return resource.sourceUri;
+				return resource.resourceUri;
 		}
 	}
 
 	private getTitle(resource: Resource): string {
-		const basename = path.basename(resource.sourceUri.fsPath);
+		const basename = path.basename(resource.resourceUri.fsPath);
 
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
@@ -251,7 +256,7 @@ export class CommandCenter {
 			return;
 		}
 
-		return await commands.executeCommand<void>('vscode.open', resource.sourceUri);
+		return await commands.executeCommand<void>('vscode.open', resource.resourceUri);
 	}
 
 	@command('git.openChange')
@@ -262,7 +267,7 @@ export class CommandCenter {
 			return;
 		}
 
-		return await this.open(resource);
+		return await this._openResource(resource);
 	}
 
 	@command('git.stage')
@@ -426,7 +431,7 @@ export class CommandCenter {
 		}
 
 		const message = resources.length === 1
-			? localize('confirm discard', "Are you sure you want to discard changes in {0}?", path.basename(resources[0].sourceUri.fsPath))
+			? localize('confirm discard', "Are you sure you want to discard changes in {0}?", path.basename(resources[0].resourceUri.fsPath))
 			: localize('confirm discard multiple', "Are you sure you want to discard changes in {0} files?", resources.length);
 
 		const yes = localize('discard', "Discard Changes");
@@ -769,20 +774,6 @@ export class CommandCenter {
 			return undefined;
 		}
 
-		if (uri.scheme === 'git-resource') {
-			const {resourceGroupId} = JSON.parse(uri.query) as { resourceGroupId: string, sourceUri: string };
-			const [resourceGroup] = this.model.resources.filter(g => g.contextKey === resourceGroupId);
-
-			if (!resourceGroup) {
-				return;
-			}
-
-			const uriStr = uri.toString();
-			const [resource] = resourceGroup.resources.filter(r => r.uri.toString() === uriStr);
-
-			return resource;
-		}
-
 		if (uri.scheme === 'git') {
 			uri = uri.with({ scheme: 'file' });
 		}
@@ -790,8 +781,8 @@ export class CommandCenter {
 		if (uri.scheme === 'file') {
 			const uriString = uri.toString();
 
-			return this.model.workingTreeGroup.resources.filter(r => r.sourceUri.toString() === uriString)[0]
-				|| this.model.indexGroup.resources.filter(r => r.sourceUri.toString() === uriString)[0];
+			return this.model.workingTreeGroup.resources.filter(r => r.resourceUri.toString() === uriString)[0]
+				|| this.model.indexGroup.resources.filter(r => r.resourceUri.toString() === uriString)[0];
 		}
 	}
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -11,7 +11,6 @@ import { Model, Resource, Status, CommitOptions } from './model';
 import * as staging from './staging';
 import * as path from 'path';
 import * as os from 'os';
-import { uniqueFilter } from './util';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import * as nls from 'vscode-nls';
 
@@ -271,9 +270,7 @@ export class CommandCenter {
 	}
 
 	@command('git.stage')
-	async stage(...uris: Uri[]): Promise<void> {
-		const resources = this.toSCMResources(uris);
-
+	async stage(...resources: Resource[]): Promise<void> {
 		if (!resources.length) {
 			return;
 		}
@@ -366,9 +363,7 @@ export class CommandCenter {
 	}
 
 	@command('git.unstage')
-	async unstage(...uris: Uri[]): Promise<void> {
-		const resources = this.toSCMResources(uris);
-
+	async unstage(...resources: Resource[]): Promise<void> {
 		if (!resources.length) {
 			return;
 		}
@@ -423,9 +418,7 @@ export class CommandCenter {
 	}
 
 	@command('git.clean')
-	async clean(...uris: Uri[]): Promise<void> {
-		const resources = this.toSCMResources(uris);
-
+	async clean(...resources: Resource[]): Promise<void> {
 		if (!resources.length) {
 			return;
 		}
@@ -784,12 +777,6 @@ export class CommandCenter {
 			return this.model.workingTreeGroup.resources.filter(r => r.resourceUri.toString() === uriString)[0]
 				|| this.model.indexGroup.resources.filter(r => r.resourceUri.toString() === uriString)[0];
 		}
-	}
-
-	private toSCMResources(uris: Uri[]): Resource[] {
-		return uris.filter(uniqueFilter(uri => uri.toString()))
-			.map(uri => this.resolveSCMResource(uri))
-			.filter(r => !!r) as Resource[];
 	}
 
 	dispose(): void {

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -78,10 +78,10 @@ async function init(context: ExtensionContext, disposables: Disposable[]): Promi
 		}
 	}
 
-	filterEvent(scm.onDidAcceptInputValue, () => scm.activeProvider === provider)
+	filterEvent(scm.onDidAcceptInputValue, () => scm.activeSourceControl === provider.sourceControl)
 		(commandCenter.commitWithInput, commandCenter, disposables);
 
-	if (scm.activeProvider === provider) {
+	if (scm.activeSourceControl === provider.sourceControl) {
 		scm.inputBox.value = await model.getCommitTemplate();
 	}
 }

--- a/extensions/git/src/merge.ts
+++ b/extensions/git/src/merge.ts
@@ -62,7 +62,7 @@ class TextEditorMergeDecorator {
 			return;
 		}
 
-		if (this.model.mergeGroup.resources.some(r => r.type === Status.BOTH_MODIFIED && r.sourceUri.toString() === this.uri)) {
+		if (this.model.mergeGroup.resources.some(r => r.type === Status.BOTH_MODIFIED && r.resourceUri.toString() === this.uri)) {
 			decorations = decorate(this.editor.document);
 		}
 

--- a/src/vs/base/common/marshalling.ts
+++ b/src/vs/base/common/marshalling.ts
@@ -30,17 +30,25 @@ function replacer(key: string, value: any): any {
 	return value;
 }
 
+// TODO@Joao hack?
+export const ResolverRegistry: { [mid: number]: (value: any) => any; } = Object.create(null);
 
 function reviver(key: string, value: any): any {
 	let marshallingConst: number;
 	if (value !== void 0 && value !== null) {
 		marshallingConst = (<MarshalledObject>value).$mid;
 	}
-	if (marshallingConst === 1) {
-		return URI.revive(value);
-	} else if (marshallingConst === 2) {
-		return new RegExp(value.source, value.flags);
-	} else {
-		return value;
+
+	switch (marshallingConst) {
+		case 1: return URI.revive(value);
+		case 2: return new RegExp(value.source, value.flags);
+		default:
+			const resolver = ResolverRegistry[marshallingConst];
+
+			if (resolver) {
+				return resolver(value);
+			} else {
+				return value;
+			}
 	}
 }

--- a/src/vs/platform/actions/browser/menuItemActionItem.ts
+++ b/src/vs/platform/actions/browser/menuItemActionItem.ts
@@ -92,19 +92,19 @@ const _altKey = new class extends Emitter<boolean> {
 	}
 };
 
-class MenuItemActionItem extends ActionItem {
+export class MenuItemActionItem extends ActionItem {
 
 	private _wantsAltCommand: boolean = false;
 
 	constructor(
 		action: MenuItemAction,
 		@IKeybindingService private _keybindingService: IKeybindingService,
-		@IMessageService private _messageService: IMessageService
+		@IMessageService protected _messageService: IMessageService
 	) {
 		super(undefined, action, { icon: !!action.class, label: !action.class });
 	}
 
-	private get _commandAction(): IAction {
+	protected get _commandAction(): IAction {
 		return this._wantsAltCommand && (<MenuItemAction>this._action).alt || this._action;
 	}
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3857,8 +3857,8 @@ declare module 'vscode' {
 		export function setStatusBarMessage(text: string): Disposable;
 
 		/**
-		 * Show progress in the scm viewlet while running the given callback and while its returned
-		 * promise isn't resolve or rejected.
+		 * Show progress in the Source Control viewlet while running the given callback and while
+		 * its returned promise isn't resolve or rejected.
 		 *
 		 * @param task A callback returning a promise. Progress increments can be reported with
 		 * the provided [progress](#Progress)-object.
@@ -4539,147 +4539,17 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * The theme-aware decorations for a [SCM resource](#SCMResource).
+	 * Represents the input box in the Source Control viewlet.
 	 */
-	export interface SCMResourceThemableDecorations {
+	export interface SourceControlInputBox {
 
 		/**
-		 * The icon path for a specific [SCM resource](#SCMResource).
+		 * Setter and getter for the contents of the input box.
 		 */
-		readonly iconPath?: string | Uri;
+		value: string;
 	}
 
-	/**
-	 * The decorations for a [SCM resource](#SCMResource). Can be specified
-	 * for light and dark themes, independently.
-	 */
-	export interface SCMResourceDecorations extends SCMResourceThemableDecorations {
-
-		/**
-		 * Whether the [SCM resource](#SCMResource) should be striked-through
-		 * in the UI.
-		 */
-		readonly strikeThrough?: boolean;
-
-		/**
-		 * The light theme decorations.
-		 */
-		readonly light?: SCMResourceThemableDecorations;
-
-		/**
-		 * The dark theme decorations.
-		 */
-		readonly dark?: SCMResourceThemableDecorations;
-	}
-
-	/**
-	 * An SCM resource represents the state of an underlying workspace
-	 * resource within a certain SCM provider state.
-	 */
-	export interface SCMResource {
-
-		/**
-		 * The [uri](#Uri) of this SCM resource. This uri should uniquely
-		 * identify this SCM resource. Its value should be semantically
-		 * related to your [SCM provider](#SCMProvider).
-		 *
-		 * For example, consider file `/foo/bar` to be modified. An SCM
-		 * resource which would represent such state could have the
-		 * following properties:
-		 *
-		 *   - `uri = 'git:workingtree/A'`
-		 *   - `sourceUri = 'file:///foo/bar'`
-		 */
-		readonly uri: Uri;
-
-		/**
-		 * The [uri](#Uri) of the underlying resource inside the workspace.
-		 */
-		readonly sourceUri: Uri;
-
-		/**
-		 * The [decorations](#SCMResourceDecorations) for this SCM resource.
-		 */
-		readonly decorations?: SCMResourceDecorations;
-	}
-
-	/**
-	 * An SCM resource group is a collection of [SCM resources](#SCMResource).
-	 */
-	export interface SCMResourceGroup {
-
-		/**
-		 * The [uri](#Uri) of this SCM resource group. This uri should
-		 * uniquely identify this SCM resource group. Its value should be
-		 * semantically related to your [SCM provider](#SCMProvider).
-		 *
-		 * For example, consider a Working Tree resource group. An SCM
-		 * resource group which would represent such state could have the
-		 * following properties:
-		 *
-		 *   - `uri = 'git:workingtree'`
-		 *   - `label = 'Working Tree'`
-		 */
-		readonly uri: Uri;
-
-		/**
-		 * The UI label of the SCM resource group.
-		 */
-		readonly label: string;
-
-		/**
-		 * The context key of the SCM resource group, which will be used to populate
-		 * the value of the `scmResourceGroup` context key.
-		 */
-		readonly contextKey?: string;
-
-		/**
-		 * The collection of [SCM resources](#SCMResource) within the SCM resource group.
-		 */
-		readonly resources: SCMResource[];
-	}
-
-	/**
-	 * An SCM provider is able to provide [SCM resources](#SCMResource) to the editor,
-	 * notify of changes in them and interact with the editor in several SCM related ways.
-	 */
-	export interface SCMProvider {
-
-		/**
-		 * A human-readable label for the name of the SCM Provider.
-		 */
-		readonly label: string;
-
-		/**
-		 * The context key of the SCM provider, which will be used to populate
-		 * the value of the `scmProvider` context key.
-		 */
-		readonly contextKey?: string;
-
-		/**
-		 * The list of SCM resource groups.
-		 */
-		readonly resources: SCMResourceGroup[];
-
-		/**
-		 * A count of resources, used in the UI as the label for the SCM changes count.
-		 */
-		readonly count?: number;
-
-		/**
-		 * A state identifier, which will be used to populate the value of the
-		 * `scmProviderState` context key.
-		 */
-		readonly stateContextKey?: string;
-
-		/**
-		 * An [event](#Event) which should fire when any of the following attributes
-		 * have changed:
-		 *   - [resources](#SCMProvider.resources)
-		 *   - [count](#SCMProvider.count)
-		 *   - [state](#SCMProvider.state)
-		 */
-		readonly onDidChange?: Event<SCMProvider>;
+	interface QuickDiffProvider {
 
 		/**
 		 * Provide a [uri](#Uri) to the original resource of any given resource uri.
@@ -4689,58 +4559,174 @@ declare module 'vscode' {
 		 * @return A thenable that resolves to uri of the matching original resource.
 		 */
 		provideOriginalResource?(uri: Uri, token: CancellationToken): ProviderResult<Uri>;
-
-		/**
-		 * Open a specific [SCM resource](#SCMResource). Called when SCM resources
-		 * are clicked in the UI, for example.
-		 *
-		 * @param resource The [SCM resource](#SCMResource) which should be open.
-		 * @param token A cancellation token.
-		 * @return A thenable which resolves when the resource is open.
-		 */
-		open?(resource: SCMResource): void;
 	}
 
 	/**
-	 * Represents the input box in the SCM view.
+	 * The theme-aware decorations for a
+	 * [source control resource state](#SourceControlResourceState).
 	 */
-	export interface SCMInputBox {
+	export interface SourceControlResourceThemableDecorations {
 
 		/**
-		 * Setter and getter for the contents of the input box.
+		 * The icon path for a specific
+		 * [source control resource state](#SourceControlResourceState).
 		 */
-		value: string;
+		readonly iconPath?: string | Uri;
+	}
+
+	/**
+	 * The decorations for a [source control resource state](#SourceControlResourceState).
+	 * Can be independently specified for light and dark themes.
+	 */
+	export interface SourceControlResourceDecorations extends SourceControlResourceThemableDecorations {
+
+		/**
+		 * Whether the [source control resource state](#SourceControlResourceState) should
+		 * be striked-through in the UI.
+		 */
+		readonly strikeThrough?: boolean;
+
+		/**
+		 * The light theme decorations.
+		 */
+		readonly light?: SourceControlResourceThemableDecorations;
+
+		/**
+		 * The dark theme decorations.
+		 */
+		readonly dark?: SourceControlResourceThemableDecorations;
+	}
+
+	/**
+	 * An source control resource state represents the state of an underlying workspace
+	 * resource within a certain [source control group](#SourceControlResourceGroup).
+	 */
+	export interface SourceControlResourceState {
+
+		/**
+		 * The [uri](#Uri) of the underlying resource inside the workspace.
+		 */
+		readonly resourceUri: Uri;
+
+		/**
+		 * The [command](#Command) which should be run when the resource
+		 * state is open in the Source Control viewlet.
+		 */
+		readonly command: Command;
+
+		/**
+		 * The [decorations](#SourceControlResourceDecorations) for this source control
+		 * resource state.
+		 */
+		readonly decorations?: SourceControlResourceDecorations;
+	}
+
+	/**
+	 * A source control resource group is a collection of
+	 * [source control resource states](#SourceControlResourceState).
+	 */
+	export interface SourceControlResourceGroup {
+
+		/**
+		 * The id of this source control resource group.
+		 */
+		readonly id: string;
+
+		/**
+		 * The label of this source control resource group.
+		 */
+		readonly label: string;
+
+		/**
+		 * Whether this source control resource group is hidden when it contains
+		 * no [source control resource states](#SourceControlResourceState).
+		 */
+		hideWhenEmpty?: boolean;
+
+		/**
+		 * This group's collection of
+		 * [source control resource states](#SourceControlResourceState).
+		 */
+		resourceStates: SourceControlResourceState[];
+
+		/**
+		 * Dispose this source control resource group.
+		 */
+		dispose(): void;
+	}
+
+	/**
+	 * An source control is able to provide [resource states](#SourceControlResourceState)
+	 * to the editor and interact with the editor in several source control related ways.
+	 */
+	export interface SourceControl {
+
+		/**
+		 * The id of this source control.
+		 */
+		readonly id: string;
+
+		/**
+		 * The human-readable label of this source control.
+		 */
+		readonly label: string;
+
+		/**
+		 * The UI-visible count of [resource states](#SourceControlResourceState) of
+		 * this source control.
+		 *
+		 * Equals to the total number of [resource state](#SourceControlResourceState)
+		 * of this source control, if undefined.
+		 */
+		count?: number;
+
+		/**
+		 * An optional [quick diff provider](#QuickDiffProvider).
+		 */
+		quickDiffProvider?: QuickDiffProvider;
+
+		/**
+		 * Create a new [resource group](#SourceControlResourceGroup).
+		 */
+		createResourceGroup(id: string, label: string): SourceControlResourceGroup;
+
+		/**
+		 * Dispose this source control.
+		 */
+		dispose(): void;
 	}
 
 	export namespace scm {
 
 		/**
-		 * The currently active [SCM provider](#SCMProvider).
+		 * The currently active [source control](#SourceControl).
 		 */
-		export let activeProvider: SCMProvider | undefined;
+		export let activeSourceControl: SourceControl | undefined;
 
 		/**
-		 * An [event](#Event) which fires when the active [SCM provider](#SCMProvider)
+		 * An [event](#Event) which fires when the active [source control](#SourceControl)
 		 * has changed.
 		 */
-		export const onDidChangeActiveProvider: Event<SCMProvider>;
+		export const onDidChangeActiveSourceControl: Event<SourceControl>;
 
 		/**
-		 * The [input box](#SCMInputBox) in the SCM view.
+		 * The [input box](#SourceControlInputBox) in the Source Control viewlet.
 		 */
-		export const inputBox: SCMInputBox;
+		export const inputBox: SourceControlInputBox;
 
 		/**
 		 * An [event](#Event) which fires when the user has accepted the changes.
 		 */
-		export const onDidAcceptInputValue: Event<SCMInputBox>;
+		export const onDidAcceptInputValue: Event<SourceControlInputBox>;
 
 		/**
-		 * Registers an [SCM provider](#SCMProvider).
+		 * Creates a new [source control](#SourceControl) instance.
 		 *
-		 * @return A disposable which unregisters the provider.
+		 * @param id A unique `id` for the source control. Something short, eg: `git`.
+		 * @param label A human-readable string for the source control. Eg: `Git`.
+		 * @return An instance of [source control](#SourceControl).
 		 */
-		export function registerSCMProvider(provider: SCMProvider): Disposable;
+		export function createSourceControl(id: string, label: string): SourceControl;
 	}
 
 	/**

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -117,7 +117,7 @@ export function createApiFactory(
 	const extHostFileSystemEvent = col.define(ExtHostContext.ExtHostFileSystemEventService).set<ExtHostFileSystemEventService>(new ExtHostFileSystemEventService());
 	const extHostQuickOpen = col.define(ExtHostContext.ExtHostQuickOpen).set<ExtHostQuickOpen>(new ExtHostQuickOpen(threadService));
 	const extHostTerminalService = col.define(ExtHostContext.ExtHostTerminalService).set<ExtHostTerminalService>(new ExtHostTerminalService(threadService));
-	const extHostSCM = col.define(ExtHostContext.ExtHostSCM).set<ExtHostSCM>(new ExtHostSCM(threadService));
+	const extHostSCM = col.define(ExtHostContext.ExtHostSCM).set<ExtHostSCM>(new ExtHostSCM(threadService, extHostCommands));
 	const extHostTask = col.define(ExtHostContext.ExtHostTask).set<ExtHostTask>(new ExtHostTask(threadService));
 	col.define(ExtHostContext.ExtHostExtensionService).set(extensionService);
 	col.finish(false, threadService);
@@ -448,30 +448,30 @@ export function createApiFactory(
 
 		class SCM {
 
-			get activeProvider() {
+			get activeSourceControl() {
 				return extHostSCM.activeProvider;
 			}
 
-			get onDidChangeActiveProvider() {
+			get onDidChangeActiveSourceControl() {
 				return extHostSCM.onDidChangeActiveProvider;
-			}
-
-			get onDidAcceptInputValue() {
-				return mapEvent(extHostSCM.inputBox.onDidAccept, () => extHostSCM.inputBox);
 			}
 
 			get inputBox() {
 				return extHostSCM.inputBox;
 			}
 
-			registerSCMProvider(provider: vscode.SCMProvider) {
+			get onDidAcceptInputValue() {
+				return mapEvent(extHostSCM.inputBox.onDidAccept, () => extHostSCM.inputBox);
+			}
+
+			createSourceControl(id: string, label: string) {
 				telemetryService.publicLog('registerSCMProvider', {
 					extensionId: extension.id,
-					providerLabel: provider.label,
-					providerContextKey: provider.contextKey
+					providerId: id,
+					providerLabel: label
 				});
 
-				return extHostSCM.registerSCMProvider(provider);
+				return extHostSCM.createSourceControl(id, label);
 			}
 		}
 

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -260,6 +260,7 @@ export interface SCMGroupFeatures {
 }
 
 export type SCMRawResource = [
+	number /*handle*/,
 	string /*resourceUri*/,
 	modes.Command /*command*/,
 	string[] /*icons: light, dark*/,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -251,30 +251,31 @@ export abstract class MainProcessExtensionServiceShape {
 }
 
 export interface SCMProviderFeatures {
-	label: string;
-	contextKey?: string;
-	supportsOpen: boolean;
-	supportsOriginalResource: boolean;
+	hasQuickDiffProvider?: boolean;
+	count?: number;
+}
+
+export interface SCMGroupFeatures {
+	hideWhenEmpty?: boolean;
 }
 
 export type SCMRawResource = [
-	string /*uri*/,
-	string /*sourceUri*/,
+	string /*resourceUri*/,
+	modes.Command /*command*/,
 	string[] /*icons: light, dark*/,
 	boolean /*strike through*/
 ];
 
-export type SCMRawResourceGroup = [
-	string /*uri*/,
-	string | undefined /*context key*/,
-	string /*label*/,
-	SCMRawResource[]
-];
-
 export abstract class MainThreadSCMShape {
-	$register(handle: number, features: SCMProviderFeatures): void { throw ni(); }
-	$unregister(handle: number): void { throw ni(); }
-	$onChange(handle: number, resources: SCMRawResourceGroup[], count: number | undefined, stateContextKey: string | undefined): void { throw ni(); }
+	$registerSourceControl(handle: number, id: string, label: string): void { throw ni(); }
+	$updateSourceControl(handle: number, features: SCMProviderFeatures): void { throw ni(); }
+	$unregisterSourceControl(handle: number): void { throw ni(); }
+
+	$registerGroup(sourceControlHandle: number, handle: number, id: string, label: string): void { throw ni(); }
+	$updateGroup(sourceControlHandle: number, handle: number, features: SCMGroupFeatures): void { throw ni(); }
+	$updateGroupResourceStates(sourceControlHandle: number, groupHandle: number, resources: SCMRawResource[]): void { throw ni(); }
+	$unregisterGroup(sourceControlHandle: number, handle: number): void { throw ni(); }
+
 	$setInputBoxValue(value: string): void { throw ni(); }
 }
 
@@ -418,9 +419,8 @@ export abstract class ExtHostTerminalServiceShape {
 }
 
 export abstract class ExtHostSCMShape {
-	$open(handle: number, uri: string): TPromise<void> { throw ni(); }
-	$getOriginalResource(handle: number, uri: URI): TPromise<URI> { throw ni(); }
-	$onActiveProviderChange(handle: number): TPromise<void> { throw ni(); }
+	$provideOriginalResource(sourceControlHandle: number, uri: URI): TPromise<URI> { throw ni(); }
+	$onActiveSourceControlChange(sourceControlHandle: number): TPromise<void> { throw ni(); }
 	$onInputBoxValueChange(value: string): TPromise<void> { throw ni(); }
 	$onInputBoxAcceptChanges(): TPromise<void> { throw ni(); }
 }

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -6,14 +6,14 @@
 
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
-import Event, { Emitter, debounceEvent, createEmptyEvent } from 'vs/base/common/event';
+import Event, { Emitter } from 'vs/base/common/event';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { IThreadService } from 'vs/workbench/services/thread/common/threadService';
-import { Disposable } from 'vs/workbench/api/node/extHostTypes';
-import { MainContext, MainThreadSCMShape, SCMRawResource, SCMRawResourceGroup } from './extHost.protocol';
+import { ExtHostCommands, CommandsConverter } from 'vs/workbench/api/node/extHostCommands';
+import { MainContext, MainThreadSCMShape, SCMRawResource } from './extHost.protocol';
 import * as vscode from 'vscode';
 
-function getIconPath(decorations: vscode.SCMResourceThemableDecorations) {
+function getIconPath(decorations: vscode.SourceControlResourceThemableDecorations) {
 	if (!decorations) {
 		return undefined;
 	} else if (typeof decorations.iconPath === 'string') {
@@ -67,6 +67,133 @@ export class ExtHostSCMInputBox {
 	}
 }
 
+class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceGroup {
+
+	private static _handlePool: number = 0;
+
+	get id(): string {
+		return this._id;
+	}
+
+	get label(): string {
+		return this._label;
+	}
+
+	private _hideWhenEmpty: boolean | undefined = undefined;
+
+	get hideWhenEmpty(): boolean | undefined {
+		return this._hideWhenEmpty;
+	}
+
+	set hideWhenEmpty(hideWhenEmpty: boolean | undefined) {
+		this._hideWhenEmpty = hideWhenEmpty;
+		this._proxy.$updateGroup(this._sourceControlHandle, this._handle, { hideWhenEmpty });
+	}
+
+	private _resourcesStates: vscode.SourceControlResourceState[] = [];
+
+	get resourceStates(): vscode.SourceControlResourceState[] {
+		return this._resourcesStates;
+	}
+
+	set resourceStates(resources: vscode.SourceControlResourceState[]) {
+		this._resourcesStates = resources;
+
+		const rawResources = resources.map(r => {
+			const sourceUri = r.resourceUri.toString();
+			const command = this._commands.toInternal(r.command);
+			const iconPath = getIconPath(r.decorations);
+			const lightIconPath = r.decorations && getIconPath(r.decorations.light) || iconPath;
+			const darkIconPath = r.decorations && getIconPath(r.decorations.dark) || iconPath;
+			const icons: string[] = [];
+
+			if (lightIconPath || darkIconPath) {
+				icons.push(lightIconPath);
+			}
+
+			if (darkIconPath !== lightIconPath) {
+				icons.push(darkIconPath);
+			}
+
+			const strikeThrough = r.decorations && !!r.decorations.strikeThrough;
+
+			return [sourceUri, command, icons, strikeThrough] as SCMRawResource;
+		});
+
+		this._proxy.$updateGroupResourceStates(this._sourceControlHandle, this._handle, rawResources);
+	}
+
+	private _handle: number = ExtHostSourceControlResourceGroup._handlePool++;
+
+	constructor(
+		private _proxy: MainThreadSCMShape,
+		private _commands: CommandsConverter,
+		private _sourceControlHandle: number,
+		private _id: string,
+		private _label: string,
+	) {
+		this._proxy.$registerGroup(_sourceControlHandle, this._handle, _id, _label);
+	}
+
+	dispose(): void {
+		this._proxy.$unregisterGroup(this._sourceControlHandle, this._handle);
+	}
+}
+
+class ExtHostSourceControl implements vscode.SourceControl {
+
+	private static _handlePool: number = 0;
+
+	get id(): string {
+		return this._id;
+	}
+
+	get label(): string {
+		return this._label;
+	}
+
+	private _count: number | undefined = undefined;
+
+	get count(): number | undefined {
+		return this._count;
+	}
+
+	set count(count: number | undefined) {
+		this._count = count;
+		this._proxy.$updateSourceControl(this._handle, { count });
+	}
+
+	private _quickDiffProvider: vscode.QuickDiffProvider | undefined = undefined;
+
+	get quickDiffProvider(): vscode.QuickDiffProvider | undefined {
+		return this._quickDiffProvider;
+	}
+
+	set quickDiffProvider(quickDiffProvider: vscode.QuickDiffProvider | undefined) {
+		this._quickDiffProvider = quickDiffProvider;
+		this._proxy.$updateSourceControl(this._handle, { hasQuickDiffProvider: !!quickDiffProvider });
+	}
+
+	private _handle: number = ExtHostSourceControl._handlePool++;
+
+	constructor(
+		private _proxy: MainThreadSCMShape,
+		private _commands: CommandsConverter,
+		private _id: string,
+		private _label: string,
+	) {
+		this._proxy.$registerSourceControl(this._handle, _id, _label);
+	}
+
+	createResourceGroup(id: string, label: string): ExtHostSourceControlResourceGroup {
+		return new ExtHostSourceControlResourceGroup(this._proxy, this._commands, this._handle, id, label);
+	}
+
+	dispose(): void {
+		this._proxy.$unregisterSourceControl(this._handle);
+	}
+}
+
 type ProviderHandle = number;
 
 export class ExtHostSCM {
@@ -74,112 +201,45 @@ export class ExtHostSCM {
 	private static _handlePool: number = 0;
 
 	private _proxy: MainThreadSCMShape;
-	private _providers: Map<ProviderHandle, vscode.SCMProvider> = new Map<ProviderHandle, vscode.SCMProvider>();
-	private _cache: Map<ProviderHandle, Map<string, vscode.SCMResource>> = new Map<ProviderHandle, Map<string, vscode.SCMResource>>();
+	private _sourceControls: Map<ProviderHandle, vscode.SourceControl> = new Map<ProviderHandle, vscode.SourceControl>();
 
-	private _onDidChangeActiveProvider = new Emitter<vscode.SCMProvider>();
-	get onDidChangeActiveProvider(): Event<vscode.SCMProvider> { return this._onDidChangeActiveProvider.event; }
+	private _onDidChangeActiveProvider = new Emitter<vscode.SourceControl>();
+	get onDidChangeActiveProvider(): Event<vscode.SourceControl> { return this._onDidChangeActiveProvider.event; }
 
-	private _activeProvider: vscode.SCMProvider | undefined;
-	get activeProvider(): vscode.SCMProvider | undefined { return this._activeProvider; }
+	private _activeProvider: vscode.SourceControl | undefined;
+	get activeProvider(): vscode.SourceControl | undefined { return this._activeProvider; }
 
 	private _inputBox: ExtHostSCMInputBox;
 	get inputBox(): ExtHostSCMInputBox { return this._inputBox; }
 
-	constructor(threadService: IThreadService) {
+	constructor(
+		threadService: IThreadService,
+		private _commands: ExtHostCommands
+	) {
 		this._proxy = threadService.get(MainContext.MainThreadSCM);
 		this._inputBox = new ExtHostSCMInputBox(this._proxy);
 	}
 
-	registerSCMProvider(provider: vscode.SCMProvider): Disposable {
+	createSourceControl(id: string, label: string): vscode.SourceControl {
 		const handle = ExtHostSCM._handlePool++;
+		const sourceControl = new ExtHostSourceControl(this._proxy, this._commands.converter, id, label);
+		this._sourceControls.set(handle, sourceControl);
 
-		this._providers.set(handle, provider);
-
-		this._proxy.$register(handle, {
-			label: provider.label,
-			contextKey: provider.contextKey,
-			supportsOpen: !!provider.open,
-			supportsOriginalResource: !!provider.provideOriginalResource
-		});
-
-		const onDidChange = debounceEvent(provider.onDidChange || createEmptyEvent<vscode.SCMProvider>(), (l, e) => e, 100);
-		const onDidChangeListener = onDidChange(scmProvider => {
-			const cache = new Map<string, vscode.SCMResource>();
-			this._cache.set(handle, cache);
-
-			const rawResourceGroups = scmProvider.resources.map(g => {
-				const rawResources = g.resources.map(r => {
-					const uri = r.uri.toString();
-					cache.set(uri, r);
-
-					const sourceUri = r.sourceUri.toString();
-					const iconPath = getIconPath(r.decorations);
-					const lightIconPath = r.decorations && getIconPath(r.decorations.light) || iconPath;
-					const darkIconPath = r.decorations && getIconPath(r.decorations.dark) || iconPath;
-					const icons: string[] = [];
-
-					if (lightIconPath || darkIconPath) {
-						icons.push(lightIconPath);
-					}
-
-					if (darkIconPath !== lightIconPath) {
-						icons.push(darkIconPath);
-					}
-
-					const strikeThrough = r.decorations && !!r.decorations.strikeThrough;
-
-					return [uri, sourceUri, icons, strikeThrough] as SCMRawResource;
-				});
-
-				return [g.uri.toString(), g.contextKey, g.label, rawResources] as SCMRawResourceGroup;
-			});
-
-			this._proxy.$onChange(handle, rawResourceGroups, provider.count, provider.stateContextKey);
-		});
-
-		return new Disposable(() => {
-			onDidChangeListener.dispose();
-			this._providers.delete(handle);
-			this._proxy.$unregister(handle);
-		});
+		return sourceControl;
 	}
 
-	$open(handle: number, uri: string): TPromise<void> {
-		const provider = this._providers.get(handle);
+	$provideOriginalResource(sourceControlHandle: number, uri: URI): TPromise<URI> {
+		const sourceControl = this._sourceControls.get(sourceControlHandle);
 
-		if (!provider) {
+		if (!sourceControl || !sourceControl.quickDiffProvider) {
 			return TPromise.as(null);
 		}
 
-		const cache = this._cache.get(handle);
-
-		if (!cache) {
-			return TPromise.as(null);
-		}
-
-		const resource = cache.get(uri);
-
-		if (!resource) {
-			return TPromise.as(null);
-		}
-
-		provider.open(resource);
-		return TPromise.as(null);
+		return asWinJsPromise(token => sourceControl.quickDiffProvider.provideOriginalResource(uri, token));
 	}
 
-	$getOriginalResource(handle: number, uri: URI): TPromise<URI> {
-		const provider = this._providers.get(handle);
-
-		if (!provider) {
-			return TPromise.as(null);
-		}
-
-		return asWinJsPromise(token => provider.provideOriginalResource(uri, token));
-	}
-
-	$onActiveProviderChange(handle: number): TPromise<void> {
-		this._activeProvider = this._providers.get(handle);
+	$onActiveSourceControlChange(handle: number): TPromise<void> {
+		this._activeProvider = this._sourceControls.get(handle);
 		return TPromise.as(null);
 	}
 

--- a/src/vs/workbench/api/node/mainThreadSCM.ts
+++ b/src/vs/workbench/api/node/mainThreadSCM.ts
@@ -7,154 +7,223 @@
 import { TPromise } from 'vs/base/common/winjs.base';
 import URI from 'vs/base/common/uri';
 import Event, { Emitter } from 'vs/base/common/event';
-import { onUnexpectedError } from 'vs/base/common/errors';
+import { assign } from 'vs/base/common/objects';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { IThreadService } from 'vs/workbench/services/thread/common/threadService';
 import { ISCMService, ISCMProvider, ISCMResource, ISCMResourceGroup } from 'vs/workbench/services/scm/common/scm';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { ExtHostContext, MainThreadSCMShape, ExtHostSCMShape, SCMProviderFeatures, SCMRawResourceGroup } from './extHost.protocol';
+import { ExtHostContext, MainThreadSCMShape, ExtHostSCMShape, SCMProviderFeatures, SCMRawResource, SCMGroupFeatures } from './extHost.protocol';
+
+interface IMainThreadSCMResourceGroup {
+	uri: URI;
+	features: SCMGroupFeatures;
+	label: string;
+	contextKey?: string;
+	resources: ISCMResource[];
+}
 
 class MainThreadSCMProvider implements ISCMProvider {
 
-	private _resources: ISCMResourceGroup[] = [];
-	get resources(): ISCMResourceGroup[] { return this._resources; }
+	private _groups: IMainThreadSCMResourceGroup[] = [];
+	private _groupsByHandle: { [handle: number]: IMainThreadSCMResourceGroup; } = Object.create(null);
 
-	private _onDidChange = new Emitter<ISCMResourceGroup[]>();
-	get onDidChange(): Event<ISCMResourceGroup[]> { return this._onDidChange.event; }
+	get resources(): ISCMResourceGroup[] {
+		return this._groups
+			.filter(g => g.resources.length > 0 || !g.features.hideWhenEmpty);
+	}
 
-	private disposables: IDisposable[] = [];
+	private _onDidChange = new Emitter<void>();
+	get onDidChange(): Event<void> { return this._onDidChange.event; }
+
+	private features: SCMProviderFeatures = {};
 
 	get handle(): number { return this._handle; }
-	get label(): string { return this.features.label; }
-	get contextKey(): string { return this.features.contextKey; }
+	get label(): string { return this._label; }
+	get contextKey(): string { return this._id; }
 
 	private _count: number | undefined = undefined;
 	get count(): number | undefined { return this._count; }
 
-	private _stateContextKey: string | undefined = undefined;
-	get stateContextKey(): string | undefined { return this._stateContextKey; }
-
 	constructor(
-		private _handle: number,
 		private proxy: ExtHostSCMShape,
-		private features: SCMProviderFeatures,
+		private _handle: number,
+		private _id: string,
+		private _label: string,
 		@ISCMService scmService: ISCMService,
 		@ICommandService private commandService: ICommandService
-	) {
-		scmService.onDidChangeProvider(this.onDidChangeProvider, this, this.disposables);
+	) { }
+
+	$updateSourceControl(features: SCMProviderFeatures): void {
+		this.features = assign(this.features, features);
+		this._onDidChange.fire();
 	}
 
-	open(resource: ISCMResource): void {
-		if (!this.features.supportsOpen) {
+	$registerGroup(handle: number, id: string, label: string): void {
+		const group: IMainThreadSCMResourceGroup = {
+			contextKey: id,
+			label,
+			uri: null,
+			resources: [],
+			features: {}
+		};
+
+		this._groups.push(group);
+		this._groupsByHandle[handle] = group;
+	}
+
+	$updateGroup(handle: number, features: SCMGroupFeatures): void {
+		const group = this._groupsByHandle[handle];
+
+		if (!group) {
 			return;
 		}
 
-		this.proxy.$open(this.handle, resource.uri.toString())
-			.done(null, onUnexpectedError);
+		group.features = assign(group.features, features);
+		this._onDidChange.fire();
+	}
+
+	$updateGroupResourceStates(handle: number, resources: SCMRawResource[]): void {
+		const group = this._groupsByHandle[handle];
+
+		if (!group) {
+			return;
+		}
+
+		group.resources = resources.map(rawResource => {
+			const [sourceUri, command, icons, strikeThrough] = rawResource;
+			const icon = icons[0];
+			const iconDark = icons[1] || icon;
+			const decorations = {
+				icon: icon && URI.parse(icon),
+				iconDark: iconDark && URI.parse(iconDark),
+				strikeThrough
+			};
+
+			return {
+				sourceUri: URI.parse(sourceUri),
+				command,
+				resourceGroup: group,
+				decorations
+			};
+		});
+
+		this._onDidChange.fire();
+	}
+
+	$unregisterGroup(handle: number): void {
+		const group = this._groupsByHandle[handle];
+
+		if (!group) {
+			return;
+		}
+
+		delete this._groupsByHandle[handle];
+		this._groups.splice(this._groups.indexOf(group), 1);
 	}
 
 	getOriginalResource(uri: URI): TPromise<URI> {
-		if (!this.features.supportsOriginalResource) {
+		if (!this.features.hasQuickDiffProvider) {
 			return TPromise.as(null);
 		}
 
-		return this.proxy.$getOriginalResource(this.handle, uri);
-	}
-
-	private onDidChangeProvider(provider: ISCMProvider): void {
-		// if (provider === this) {
-		// 	return
-		// }
-	}
-
-	$onChange(rawResourceGroups: SCMRawResourceGroup[], count: number | undefined, stateContextKey: string | undefined): void {
-		this._resources = rawResourceGroups.map(rawGroup => {
-			const [uri, contextKey, label, rawResources] = rawGroup;
-			const resources: ISCMResource[] = [];
-			const group: ISCMResourceGroup = { uri: URI.parse(uri), contextKey, label, resources };
-
-			rawResources.forEach(rawResource => {
-				const [uri, sourceUri, icons, strikeThrough] = rawResource;
-				const icon = icons[0];
-				const iconDark = icons[1] || icon;
-				const decorations = {
-					icon: icon && URI.parse(icon),
-					iconDark: iconDark && URI.parse(iconDark),
-					strikeThrough
-				};
-
-				resources.push({
-					resourceGroup: group,
-					uri: URI.parse(uri),
-					sourceUri: URI.parse(sourceUri),
-					decorations
-				});
-			});
-
-			return group;
-		});
-
-		this._count = count;
-		this._stateContextKey = stateContextKey;
-
-		this._onDidChange.fire(this.resources);
+		return this.proxy.$provideOriginalResource(this.handle, uri);
 	}
 
 	dispose(): void {
-		this.disposables = dispose(this.disposables);
+
 	}
 }
 
 export class MainThreadSCM extends MainThreadSCMShape {
 
-	private proxy: ExtHostSCMShape;
-	private providers: { [handle: number]: MainThreadSCMProvider; } = Object.create(null);
-	private providerDisposables: { [handle: number]: IDisposable; } = Object.create(null);
-
-	private disposables: IDisposable[] = [];
+	private _proxy: ExtHostSCMShape;
+	private _sourceControls: { [handle: number]: MainThreadSCMProvider; } = Object.create(null);
+	private _sourceControlDisposables: { [handle: number]: IDisposable; } = Object.create(null);
+	private _disposables: IDisposable[] = [];
 
 	constructor(
 		@IThreadService threadService: IThreadService,
 		@IInstantiationService private instantiationService: IInstantiationService,
-		@ISCMService private scmService: ISCMService
+		@ISCMService private scmService: ISCMService,
+		@ICommandService private commandService: ICommandService
 	) {
 		super();
-		this.proxy = threadService.get(ExtHostContext.ExtHostSCM);
+		this._proxy = threadService.get(ExtHostContext.ExtHostSCM);
 
-		this.scmService.onDidChangeProvider(this.onDidChangeProvider, this, this.disposables);
-		this.scmService.input.onDidChange(this.proxy.$onInputBoxValueChange, this.proxy, this.disposables);
-		this.scmService.input.onDidAccept(this.proxy.$onInputBoxAcceptChanges, this.proxy, this.disposables);
+		this.scmService.onDidChangeProvider(this.onDidChangeProvider, this, this._disposables);
+		this.scmService.input.onDidChange(this._proxy.$onInputBoxValueChange, this._proxy, this._disposables);
+		this.scmService.input.onDidAccept(this._proxy.$onInputBoxAcceptChanges, this._proxy, this._disposables);
 	}
 
-	$register(handle: number, features: SCMProviderFeatures): void {
-		const provider = this.instantiationService.createInstance(MainThreadSCMProvider, handle, this.proxy, features);
-		this.providers[handle] = provider;
-		this.providerDisposables[handle] = this.scmService.registerSCMProvider(provider);
+	$registerSourceControl(handle: number, id: string, label: string): void {
+		const provider = new MainThreadSCMProvider(this._proxy, handle, id, label, this.scmService, this.commandService);
+		this._sourceControls[handle] = provider;
+		this._sourceControlDisposables[handle] = this.scmService.registerSCMProvider(provider);
 	}
 
-	$unregister(handle: number): void {
-		const provider = this.providers[handle];
+	$updateSourceControl(handle: number, features: SCMProviderFeatures): void {
+		const sourceControl = this._sourceControls[handle];
+
+		if (!sourceControl) {
+			return;
+		}
+
+		sourceControl.$updateSourceControl(features);
+	}
+
+	$unregisterSourceControl(handle: number): void {
+		const sourceControl = this._sourceControls[handle];
+
+		if (!sourceControl) {
+			return;
+		}
+
+		this._sourceControlDisposables[handle].dispose();
+		delete this._sourceControlDisposables[handle];
+
+		sourceControl.dispose();
+		delete this._sourceControls[handle];
+	}
+
+	$registerGroup(sourceControlHandle: number, groupHandle: number, id: string, label: string): void {
+		const provider = this._sourceControls[sourceControlHandle];
 
 		if (!provider) {
 			return;
 		}
 
-		this.providerDisposables[handle].dispose();
-		delete this.providerDisposables[handle];
-
-		provider.dispose();
-		delete this.providers[handle];
+		provider.$registerGroup(groupHandle, id, label);
 	}
 
-	$onChange(handle: number, rawResourceGroups: SCMRawResourceGroup[], count: number | undefined, state: string | undefined): void {
-		const provider = this.providers[handle];
+	$updateGroup(sourceControlHandle: number, groupHandle: number, features: SCMGroupFeatures): void {
+		const provider = this._sourceControls[sourceControlHandle];
 
 		if (!provider) {
 			return;
 		}
 
-		provider.$onChange(rawResourceGroups, count, state);
+		provider.$updateGroup(groupHandle, features);
+	}
+
+	$updateGroupResourceStates(sourceControlHandle: number, groupHandle: number, resources: SCMRawResource[]): void {
+		const provider = this._sourceControls[sourceControlHandle];
+
+		if (!provider) {
+			return;
+		}
+
+		provider.$updateGroupResourceStates(groupHandle, resources);
+	}
+
+	$unregisterGroup(sourceControlHandle: number, handle: number): void {
+		const provider = this._sourceControls[sourceControlHandle];
+
+		if (!provider) {
+			return;
+		}
+
+		provider.$unregisterGroup(handle);
 	}
 
 	$setInputBoxValue(value: string): void {
@@ -162,15 +231,15 @@ export class MainThreadSCM extends MainThreadSCMShape {
 	}
 
 	private onDidChangeProvider(provider: ISCMProvider): void {
-		const handle = Object.keys(this.providers).filter(handle => this.providers[handle] === provider)[0];
-		this.proxy.$onActiveProviderChange(handle && parseInt(handle));
+		const handle = Object.keys(this._sourceControls).filter(handle => this._sourceControls[handle] === provider)[0];
+		this._proxy.$onActiveSourceControlChange(handle && parseInt(handle));
 	}
 
 	dispose(): void {
-		Object.keys(this.providers)
-			.forEach(id => this.providers[id].dispose());
+		Object.keys(this._sourceControls)
+			.forEach(id => this._sourceControls[id].dispose());
 
-		this.providers = Object.create(null);
-		this.disposables = dispose(this.disposables);
+		this._sourceControls = Object.create(null);
+		this._disposables = dispose(this._disposables);
 	}
 }

--- a/src/vs/workbench/parts/git/browser/gitScm.ts
+++ b/src/vs/workbench/parts/git/browser/gitScm.ts
@@ -25,8 +25,8 @@ export class GitSCMProvider implements IWorkbenchContribution, ISCMProvider, ITe
 	get label() { return 'Git'; }
 	get resources() { return []; }
 
-	private _onDidChange = new Emitter<ISCMResourceGroup[]>();
-	get onDidChange(): Event<ISCMResourceGroup[]> {
+	private _onDidChange = new Emitter<void>();
+	get onDidChange(): Event<void> {
 		return this._onDidChange.event;
 	}
 

--- a/src/vs/workbench/parts/scm/electron-browser/scmMenus.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmMenus.ts
@@ -142,7 +142,7 @@ export class SCMMenus implements IDisposable {
 		const primary = [];
 		const secondary = [];
 		const result = { primary, secondary };
-		fillInActions(menu, resource.uri, result, g => g === 'inline');
+		fillInActions(menu, null, result, g => g === 'inline');
 
 		menu.dispose();
 		contextKeyService.dispose();

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -34,16 +34,44 @@ import { IMessageService } from 'vs/platform/message/common/message';
 import { IListService } from 'vs/platform/list/browser/listService';
 import { IMenuService, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IAction, IActionItem, ActionRunner } from 'vs/base/common/actions';
-import { createActionItem } from 'vs/platform/actions/browser/menuItemActionItem';
+import { MenuItemActionItem } from 'vs/platform/actions/browser/menuItemActionItem';
 import { SCMMenus } from './scmMenus';
 import { ActionBar, IActionItemProvider } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IThemeService, LIGHT } from "vs/platform/theme/common/themeService";
 import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { comparePaths } from 'vs/base/common/comparers';
-import URI from 'vs/base/common/uri';
 import { isSCMResource } from './scmUtil';
 import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
+import Severity from 'vs/base/common/severity';
+
+// TODO@Joao
+// Need to subclass MenuItemActionItem in order to respect
+// the action context coming from any action bar, without breaking
+// existing users
+class SCMMenuItemActionItem extends MenuItemActionItem {
+
+	onClick(event: MouseEvent): void {
+		event.preventDefault();
+		event.stopPropagation();
+
+		this.actionRunner.run(this._commandAction, this._context)
+			.done(undefined, err => this._messageService.show(Severity.Error, err));
+	}
+}
+
+// TODO@Joao
+// Rename contextKey to something else
+function identityProvider(r: ISCMResourceGroup | ISCMResource): string {
+	if (isSCMResource(r)) {
+		const group = r.resourceGroup;
+		const provider = group.provider;
+		return `${provider.contextKey}/${group.contextKey}/${r.sourceUri.toString()}`;
+	} else {
+		const provider = r.provider;
+		return `${provider.contextKey}/${r.contextKey}`;
+	}
+}
 
 interface SearchInputEvent extends Event {
 	target: HTMLInputElement;
@@ -98,22 +126,20 @@ interface ResourceTemplate {
 
 class MultipleSelectionActionRunner extends ActionRunner {
 
-	constructor(private getSelectedResources: () => URI[]) {
+	constructor(private getSelectedResources: () => (ISCMResource | ISCMResourceGroup)[]) {
 		super();
 	}
 
-	/**
-	 * Calls the action.run method with the current selection. Note
-	 * that these actions already have the current scm resource context
-	 * within, so we don't want to pass in the selection if there is only
-	 * one selected element. The user should be able to select a single
-	 * item and run an action on another element and only the latter should
-	 * be influenced.
-	 */
-	runAction(action: IAction, context?: any): TPromise<any> {
+	runAction(action: IAction, context: ISCMResource | ISCMResourceGroup): TPromise<any> {
 		if (action instanceof MenuItemAction) {
 			const selection = this.getSelectedResources();
-			return selection.length > 1 ? action.run(...selection) : action.run();
+			const filteredSelection = selection.filter(s => s !== context);
+
+			if (selection.length === filteredSelection.length || selection.length === 1) {
+				return action.run(context);
+			}
+
+			return action.run(context, ...filteredSelection);
 		}
 
 		return super.runAction(action, context);
@@ -128,7 +154,7 @@ class ResourceRenderer implements IRenderer<ISCMResource, ResourceTemplate> {
 	constructor(
 		private scmMenus: SCMMenus,
 		private actionItemProvider: IActionItemProvider,
-		private getSelectedResources: () => URI[],
+		private getSelectedResources: () => ISCMResource[],
 		@IThemeService private themeService: IThemeService,
 		@IInstantiationService private instantiationService: IInstantiationService
 	) { }
@@ -151,6 +177,7 @@ class ResourceRenderer implements IRenderer<ISCMResource, ResourceTemplate> {
 	renderElement(resource: ISCMResource, index: number, template: ResourceTemplate): void {
 		template.fileLabel.setFile(resource.sourceUri);
 		template.actionBar.clear();
+		template.actionBar.context = resource;
 		template.actionBar.push(this.scmMenus.getResourceActions(resource));
 		toggleClass(template.name, 'strike-through', resource.decorations.strikeThrough);
 
@@ -263,7 +290,7 @@ export class SCMViewlet extends Viewlet {
 		];
 
 		this.list = new List(this.listContainer, delegate, renderers, {
-			identityProvider: e => e.uri.toString(),
+			identityProvider,
 			keyboardSupport: false
 		});
 
@@ -337,7 +364,11 @@ export class SCMViewlet extends Viewlet {
 	}
 
 	getActionItem(action: IAction): IActionItem {
-		return createActionItem(action, this.keybindingService, this.messageService);
+		if (!(action instanceof MenuItemAction)) {
+			return undefined;
+		}
+
+		return new SCMMenuItemActionItem(action, this.keybindingService, this.messageService);
 	}
 
 	private onListContextMenu(e: IListContextMenuEvent<ISCMResourceGroup | ISCMResource>): void {
@@ -353,12 +384,14 @@ export class SCMViewlet extends Viewlet {
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => e.anchor,
 			getActions: () => TPromise.as(actions),
+			getActionsContext: () => element,
 			actionRunner: new MultipleSelectionActionRunner(() => this.getSelectedResources())
 		});
 	}
 
-	private getSelectedResources(): URI[] {
-		return this.list.getSelectedElements().map(r => r.uri);
+	private getSelectedResources(): ISCMResource[] {
+		return this.list.getSelectedElements()
+			.filter(r => isSCMResource(r)) as ISCMResource[];
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -9,6 +9,7 @@ import 'vs/css!./media/scmViewlet';
 import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { chain } from 'vs/base/common/event';
+import { onUnexpectedError } from 'vs/base/common/errors';
 import * as platform from 'vs/base/common/platform';
 import { domEvent } from 'vs/base/browser/event';
 import { IDisposable, dispose, empty as EmptyDisposable } from 'vs/base/common/lifecycle';
@@ -27,6 +28,7 @@ import { ISCMService, ISCMProvider, ISCMResourceGroup, ISCMResource } from 'vs/w
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextViewService, IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IMessageService } from 'vs/platform/message/common/message';
 import { IListService } from 'vs/platform/list/browser/listService';
@@ -203,7 +205,8 @@ export class SCMViewlet extends Viewlet {
 		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IThemeService protected themeService: IThemeService,
 		@IMenuService private menuService: IMenuService,
-		@IModelService private modelService: IModelService
+		@IModelService private modelService: IModelService,
+		@ICommandService private commandService: ICommandService
 	) {
 		super(VIEWLET_ID, telemetryService, themeService);
 
@@ -321,7 +324,8 @@ export class SCMViewlet extends Viewlet {
 	}
 
 	private open(e: ISCMResource): void {
-		this.scmService.activeProvider.open(e);
+		this.commandService.executeCommand(e.command.id, ...e.command.arguments)
+			.done(undefined, onUnexpectedError);
 	}
 
 	getActions(): IAction[] {

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -34,6 +34,7 @@ export interface ISCMResource {
 
 export interface ISCMResourceGroup {
 	// readonly uri: URI;
+	readonly provider: ISCMProvider;
 	readonly label: string;
 	readonly contextKey?: string;
 	readonly resources: ISCMResource[];

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -10,6 +10,7 @@ import URI from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import Event from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import { Command } from 'vs/editor/common/modes';
 
 export interface IBaselineResourceProvider {
 	getBaselineResource(resource: URI): TPromise<URI>;
@@ -24,14 +25,15 @@ export interface ISCMResourceDecorations {
 }
 
 export interface ISCMResource {
+	// readonly uri: URI;
 	readonly resourceGroup: ISCMResourceGroup;
-	readonly uri: URI;
 	readonly sourceUri: URI;
+	readonly command: Command;
 	readonly decorations: ISCMResourceDecorations;
 }
 
 export interface ISCMResourceGroup {
-	readonly uri: URI;
+	// readonly uri: URI;
 	readonly label: string;
 	readonly contextKey?: string;
 	readonly resources: ISCMResource[];
@@ -41,11 +43,10 @@ export interface ISCMProvider extends IDisposable {
 	readonly label: string;
 	readonly contextKey?: string;
 	readonly resources: ISCMResourceGroup[];
-	readonly onDidChange: Event<ISCMResourceGroup[]>;
+	// TODO: Event<void>
+	readonly onDidChange: Event<void>;
 	readonly count?: number;
-	readonly stateContextKey?: string;
 
-	open(uri: ISCMResource): void;
 	getOriginalResource(uri: URI): TPromise<URI>;
 }
 

--- a/src/vs/workbench/services/scm/common/scmService.ts
+++ b/src/vs/workbench/services/scm/common/scmService.ts
@@ -41,7 +41,6 @@ export class SCMService implements ISCMService {
 
 	private providerChangeDisposable: IDisposable = EmptyDisposable;
 	private activeProviderContextKey: IContextKey<string | undefined>;
-	private activeProviderStateContextKey: IContextKey<string | undefined>;
 
 	private _activeProvider: ISCMProvider | undefined;
 
@@ -62,8 +61,6 @@ export class SCMService implements ISCMService {
 		this.activeProviderContextKey.set(provider ? provider.contextKey : void 0);
 
 		this.providerChangeDisposable.dispose();
-		this.providerChangeDisposable = provider.onDidChange(this.onDidChangeProviderState, this);
-		this.onDidChangeProviderState();
 
 		this._onDidChangeProvider.fire(provider);
 	}
@@ -81,7 +78,6 @@ export class SCMService implements ISCMService {
 		@IContextKeyService contextKeyService: IContextKeyService
 	) {
 		this.activeProviderContextKey = contextKeyService.createKey<string | undefined>('scmProvider', void 0);
-		this.activeProviderStateContextKey = contextKeyService.createKey<string | undefined>('scmProviderState', void 0);
 	}
 
 	registerSCMProvider(provider: ISCMProvider): IDisposable {
@@ -104,9 +100,5 @@ export class SCMService implements ISCMService {
 				this.activeProvider = this._providers[0];
 			}
 		});
-	}
-
-	private onDidChangeProviderState(): void {
-		this.activeProviderStateContextKey.set(this.activeProvider.stateContextKey);
 	}
 }


### PR DESCRIPTION
Some feedback from testers:

- The way a provider should return resources and notify Code of changes in that collection isn't intuitive.
- `contextKey` isn't a common API concept.
- There shouldn't be any requirement to provide URI for resources and resource groups. Everything should just work. Especially commands that are contextual to resources and resource groups.

Notable changes:

- `SCMProvider` renamed to `SourceControl`
- `SCMResourceGroup` renamed to `SourceControlResourceGroup`
- `SCMResource` renamed to `SourceControlResourceState`
- `sourceUri` renamed to `resourceUri`
- Instead of `scm.registerSCMProvider`, api users should use `scm.createSourceControl`. From then on, `sourceControl.createResourceGroup`. And then `resourceGroup.resourceStates = [state1,state2,state3].
- Commands located in menus which are contextual to a resource(s) will receive that resource(s) as arguments automagically, instead of `Uri` instances.
- Where you'd have to optionally specify a `contextKey` before, you now must specify an `id`.