### PR TITLE
Fixes #4803: Adding support for swipe gestures on macOS.

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -372,6 +372,19 @@ export class VSCodeWindow {
 				this.send('vscode:runAction', 'workbench.action.navigateForward');
 			}
 		});
+		
+		// Swipe command support (macOS)
+		this._win.on('swipe', (e, cmd) => {
+			if (this.readyState !== ReadyState.READY) {
+				return; // window must be ready
+			}
+
+			if (cmd === 'left') {
+				this.send('vscode:runAction', 'workbench.action.navigateBack');
+			} else if (cmd === 'right') {
+				this.send('vscode:runAction', 'workbench.action.navigateForward');
+			}
+		});
 
 		// Handle code that wants to open links
 		this._win.webContents.on('new-window', (event: Event, url: string) => {

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -372,7 +372,7 @@ export class VSCodeWindow {
 				this.send('vscode:runAction', 'workbench.action.navigateForward');
 			}
 		});
-		
+
 		// Swipe command support (macOS)
 		this._win.on('swipe', (e, cmd) => {
 			if (this.readyState !== ReadyState.READY) {

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -345,8 +345,6 @@ export class VSCodeWindow {
 				this.send('vscode:runAction', 'workbench.action.navigateBack');
 			} else if (cmd === forward) {
 				this.send('vscode:runAction', 'workbench.action.navigateForward');
-			} else {
-				console.warn('[electron command]: did not handle: ', command);
 			}
 		});
 
@@ -439,7 +437,8 @@ export class VSCodeWindow {
 
 		// Swipe command support (macOS)
 		const workbenchConfig = this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
-		if (workbenchConfig && workbenchConfig.workbench && workbenchConfig.workbench.editor.swipeBetweenOpenFiles) {
+
+		if (workbenchConfig && workbenchConfig.workbench && workbenchConfig.workbench.editor && workbenchConfig.workbench.editor.swipeToNavigate) {
 			this.registerNavigationListenerOn('swipe', 'left', 'right');
 		} else {
 			this._win.removeAllListeners('swipe');

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -439,7 +439,7 @@ export class VSCodeWindow {
 
 		// Swipe command support (macOS)
 		const workbenchConfig = this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
-		if (workbenchConfig && workbenchConfig.workbench && workbenchConfig.workbench.editor.swipeToNavigateTabs) {
+		if (workbenchConfig && workbenchConfig.workbench && workbenchConfig.workbench.editor.swipeBetweenOpenFiles) {
 			this.registerNavigationListenerOn('swipe', 'left', 'right');
 		} else {
 			this._win.removeAllListeners('swipe');

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -379,12 +379,6 @@ export class VSCodeWindow {
 		// App commands support
 		this.registerNavigationListenerOn('app-command', 'browser-backward', 'browser-forward');
 
-		// Swipe command support (macOS)
-		const config = this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
-		if (config.workbench.editor.swipeToNavigateTabs) {
-			this.registerNavigationListenerOn('swipe', 'left', 'right');
-		}
-
 		// Handle code that wants to open links
 		this._win.webContents.on('new-window', (event: Event, url: string) => {
 			event.preventDefault();
@@ -437,11 +431,20 @@ export class VSCodeWindow {
 	}
 
 	private onConfigurationUpdated(config: IConfiguration): void {
-		const newMenuBarVisibility = this.getMenuBarVisibility(config);
+		const newMenuBarVisibility = this.getMenuBarVisibility();
 		if (newMenuBarVisibility !== this.currentMenuBarVisibility) {
 			this.currentMenuBarVisibility = newMenuBarVisibility;
 			this.setMenuBarVisibility(newMenuBarVisibility);
 		}
+
+		// Swipe command support (macOS)
+		const workbenchConfig = this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
+		if (workbenchConfig.workbench.editor.swipeToNavigateTabs) {
+			this.registerNavigationListenerOn('swipe', 'left', 'right');
+		} else {
+			this._win.removeAllListeners('swipe');
+		}
+
 	};
 
 	public load(config: IWindowConfiguration): void {
@@ -706,7 +709,7 @@ export class VSCodeWindow {
 		this.setMenuBarVisibility(this.currentMenuBarVisibility, false);
 	}
 
-	private getMenuBarVisibility(configuration: IConfiguration): MenuBarVisibility {
+	private getMenuBarVisibility(): MenuBarVisibility {
 		const windowConfig = this.configurationService.getConfiguration<IWindowSettings>('window');
 
 		if (!windowConfig || !windowConfig.menuBarVisibility) {

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -439,7 +439,7 @@ export class VSCodeWindow {
 
 		// Swipe command support (macOS)
 		const workbenchConfig = this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
-		if (workbenchConfig.workbench.editor.swipeToNavigateTabs) {
+		if (workbenchConfig && workbenchConfig.workbench && workbenchConfig.workbench.editor.swipeToNavigateTabs) {
 			this.registerNavigationListenerOn('swipe', 'left', 'right');
 		} else {
 			this._win.removeAllListeners('swipe');

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -16,6 +16,7 @@ import { TPromise, TValueCallback } from 'vs/base/common/winjs.base';
 import { IEnvironmentService, ParsedArgs } from 'vs/platform/environment/common/environment';
 import { ILogService } from 'vs/code/electron-main/log';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IWorkbenchEditorConfiguration } from 'vs/workbench/common/editor';
 import { parseArgs } from 'vs/platform/environment/node/argv';
 import product from 'vs/platform/node/product';
 import { getCommonHTTPHeaders } from 'vs/platform/environment/node/http';
@@ -379,7 +380,10 @@ export class VSCodeWindow {
 		this.registerNavigationListenerOn('app-command', 'browser-backward', 'browser-forward');
 
 		// Swipe command support (macOS)
-		this.registerNavigationListenerOn('swipe', 'left', 'right');
+		const config = this.configurationService.getConfiguration<IWorkbenchEditorConfiguration>();
+		if (config.workbench.editor.swipeToNavigateTabs) {
+			this.registerNavigationListenerOn('swipe', 'left', 'right');
+		}
 
 		// Handle code that wants to open links
 		this._win.webContents.on('new-window', (event: Event, url: string) => {

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -260,7 +260,7 @@ const configurationValueWhitelist = [
 	'editor.folding',
 	'editor.matchBrackets',
 	'workbench.editor.enablePreviewFromQuickOpen',
-	'workbench.editor.swipeBetweenOpenFiles',
+	'workbench.editor.swipeToNavigate',
 	'php.builtInCompletions.enable',
 	'php.validate.enable',
 	'php.validate.run',

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -260,7 +260,7 @@ const configurationValueWhitelist = [
 	'editor.folding',
 	'editor.matchBrackets',
 	'workbench.editor.enablePreviewFromQuickOpen',
-	'workbench.editor.swipeToNavigateTabs',
+	'workbench.editor.swipeBetweenOpenFiles',
 	'php.builtInCompletions.enable',
 	'php.validate.enable',
 	'php.validate.run',

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -260,6 +260,7 @@ const configurationValueWhitelist = [
 	'editor.folding',
 	'editor.matchBrackets',
 	'workbench.editor.enablePreviewFromQuickOpen',
+	'workbench.editor.swipeToNavigateTabs',
 	'php.builtInCompletions.enable',
 	'php.validate.enable',
 	'php.validate.run',

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -904,8 +904,8 @@ export const EditorOpenPositioning = {
 };
 
 export interface IWorkbenchEditorConfiguration {
-	workbench?: {
-		editor?: {
+	workbench: {
+		editor: {
 			showTabs: boolean;
 			tabCloseButton: 'left' | 'right' | 'off';
 			showIcons: boolean;

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -914,7 +914,7 @@ export interface IWorkbenchEditorConfiguration {
 			closeOnFileDelete: boolean;
 			openPositioning: 'left' | 'right' | 'first' | 'last';
 			revealIfOpen: boolean;
-			swipeToNavigateTabs: boolean
+			swipeBetweenOpenFiles: boolean
 		}
 	};
 }

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -914,6 +914,7 @@ export interface IWorkbenchEditorConfiguration {
 			closeOnFileDelete: boolean;
 			openPositioning: 'left' | 'right' | 'first' | 'last';
 			revealIfOpen: boolean;
+			swipeToNavigateTabs: boolean
 		}
 	};
 }

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -904,8 +904,8 @@ export const EditorOpenPositioning = {
 };
 
 export interface IWorkbenchEditorConfiguration {
-	workbench: {
-		editor: {
+	workbench?: {
+		editor?: {
 			showTabs: boolean;
 			tabCloseButton: 'left' | 'right' | 'off';
 			showIcons: boolean;
@@ -914,7 +914,7 @@ export interface IWorkbenchEditorConfiguration {
 			closeOnFileDelete: boolean;
 			openPositioning: 'left' | 'right' | 'first' | 'last';
 			revealIfOpen: boolean;
-			swipeBetweenOpenFiles: boolean
+			swipeToNavigate: boolean
 		}
 	};
 }

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -149,9 +149,9 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 };
 
 if (isMacintosh) {
-	workbenchProperties['workbench.editor.swipeBetweenOpenFiles'] = {
+	workbenchProperties['workbench.editor.swipeToNavigate'] = {
 		'type': 'boolean',
-		'description': nls.localize('swipeBetweenOpenFiles', "Navigate between open files using three-finger swipe horizontally."),
+		'description': nls.localize('swipeToNavigate', "Navigate between open files using three-finger swipe horizontally."),
 		'default': false
 	};
 }

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -76,82 +76,95 @@ workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(Decrea
 
 // Configuration: Workbench
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+
+let workbenchProperties: { [path: string]: IJSONSchema; } = {
+	'workbench.editor.showTabs': {
+		'type': 'boolean',
+		'description': nls.localize('showEditorTabs', "Controls if opened editors should show in tabs or not."),
+		'default': true
+	},
+	'workbench.editor.tabCloseButton': {
+		'type': 'string',
+		'enum': ['left', 'right', 'off'],
+		'default': 'right',
+		'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'editorTabCloseButton' }, "Controls the position of the editor's tabs close buttons or disables them when set to 'off'.")
+	},
+	'workbench.editor.showIcons': {
+		'type': 'boolean',
+		'description': nls.localize('showIcons', "Controls if opened editors should show with an icon or not. This requires an icon theme to be enabled as well."),
+		'default': true
+	},
+	'workbench.editor.enablePreview': {
+		'type': 'boolean',
+		'description': nls.localize('enablePreview', "Controls if opened editors show as preview. Preview editors are reused until they are kept (e.g. via double click or editing)."),
+		'default': true
+	},
+	'workbench.editor.enablePreviewFromQuickOpen': {
+		'type': 'boolean',
+		'description': nls.localize('enablePreviewFromQuickOpen', "Controls if opened editors from Quick Open show as preview. Preview editors are reused until they are kept (e.g. via double click or editing)."),
+		'default': true
+	},
+	'workbench.editor.openPositioning': {
+		'type': 'string',
+		'enum': ['left', 'right', 'first', 'last'],
+		'default': 'right',
+		'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'editorOpenPositioning' }, "Controls where editors open. Select 'left' or 'right' to open editors to the left or right of the current active one. Select 'first' or 'last' to open editors independently from the currently active one.")
+	},
+	'workbench.editor.revealIfOpen': {
+		'type': 'boolean',
+		'description': nls.localize('revealIfOpen', "Controls if an editor is revealed in any of the visible groups if opened. If disabled, an editor will prefer to open in the currently active editor group. If enabled, an already opened editor will be revealed instead of opened again in the currently active editor group. Note that there are some cases where this setting is ignored, e.g. when forcing an editor to open in a specific group or to the side of the currently active group."),
+		'default': false
+	},
+	'workbench.quickOpen.closeOnFocusLost': {
+		'type': 'boolean',
+		'description': nls.localize('closeOnFocusLost', "Controls if Quick Open should close automatically once it loses focus."),
+		'default': true
+	},
+	'workbench.settings.openDefaultSettings': {
+		'type': 'boolean',
+		'description': nls.localize('openDefaultSettings', "Controls if opening settings also opens an editor showing all default settings."),
+		'default': true
+	},
+	'workbench.sideBar.location': {
+		'type': 'string',
+		'enum': ['left', 'right'],
+		'default': 'left',
+		'description': nls.localize('sideBarLocation', "Controls the location of the sidebar. It can either show on the left or right of the workbench.")
+	},
+	'workbench.statusBar.visible': {
+		'type': 'boolean',
+		'default': true,
+		'description': nls.localize('statusBarVisibility', "Controls the visibility of the status bar at the bottom of the workbench.")
+	},
+	'workbench.activityBar.visible': {
+		'type': 'boolean',
+		'default': true,
+		'description': nls.localize('activityBarVisibility', "Controls the visibility of the activity bar in the workbench.")
+	},
+	'workbench.editor.closeOnFileDelete': {
+		'type': 'boolean',
+		'description': nls.localize('closeOnFileDelete', "Controls if editors showing a file should close automatically when the file is deleted or renamed by some other process. Disabling this will keep the editor open as dirty on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data."),
+		'default': true
+	}
+};
+
+if (isMacintosh) {
+	workbenchProperties['workbench.editor.swipeToNavigateTabs'] = {
+		'type': 'boolean',
+		'description': nls.localize('swipeToNavigateTabs', "Navigate tab by using three-finger swipe left or right."),
+		'default': false
+	};
+}
+
+
 configurationRegistry.registerConfiguration({
 	'id': 'workbench',
 	'order': 7,
 	'title': nls.localize('workbenchConfigurationTitle', "Workbench"),
 	'type': 'object',
-	'properties': {
-		'workbench.editor.showTabs': {
-			'type': 'boolean',
-			'description': nls.localize('showEditorTabs', "Controls if opened editors should show in tabs or not."),
-			'default': true
-		},
-		'workbench.editor.tabCloseButton': {
-			'type': 'string',
-			'enum': ['left', 'right', 'off'],
-			'default': 'right',
-			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'editorTabCloseButton' }, "Controls the position of the editor's tabs close buttons or disables them when set to 'off'.")
-		},
-		'workbench.editor.showIcons': {
-			'type': 'boolean',
-			'description': nls.localize('showIcons', "Controls if opened editors should show with an icon or not. This requires an icon theme to be enabled as well."),
-			'default': true
-		},
-		'workbench.editor.enablePreview': {
-			'type': 'boolean',
-			'description': nls.localize('enablePreview', "Controls if opened editors show as preview. Preview editors are reused until they are kept (e.g. via double click or editing)."),
-			'default': true
-		},
-		'workbench.editor.enablePreviewFromQuickOpen': {
-			'type': 'boolean',
-			'description': nls.localize('enablePreviewFromQuickOpen', "Controls if opened editors from Quick Open show as preview. Preview editors are reused until they are kept (e.g. via double click or editing)."),
-			'default': true
-		},
-		'workbench.editor.openPositioning': {
-			'type': 'string',
-			'enum': ['left', 'right', 'first', 'last'],
-			'default': 'right',
-			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'editorOpenPositioning' }, "Controls where editors open. Select 'left' or 'right' to open editors to the left or right of the current active one. Select 'first' or 'last' to open editors independently from the currently active one.")
-		},
-		'workbench.editor.revealIfOpen': {
-			'type': 'boolean',
-			'description': nls.localize('revealIfOpen', "Controls if an editor is revealed in any of the visible groups if opened. If disabled, an editor will prefer to open in the currently active editor group. If enabled, an already opened editor will be revealed instead of opened again in the currently active editor group. Note that there are some cases where this setting is ignored, e.g. when forcing an editor to open in a specific group or to the side of the currently active group."),
-			'default': false
-		},
-		'workbench.quickOpen.closeOnFocusLost': {
-			'type': 'boolean',
-			'description': nls.localize('closeOnFocusLost', "Controls if Quick Open should close automatically once it loses focus."),
-			'default': true
-		},
-		'workbench.settings.openDefaultSettings': {
-			'type': 'boolean',
-			'description': nls.localize('openDefaultSettings', "Controls if opening settings also opens an editor showing all default settings."),
-			'default': true
-		},
-		'workbench.sideBar.location': {
-			'type': 'string',
-			'enum': ['left', 'right'],
-			'default': 'left',
-			'description': nls.localize('sideBarLocation', "Controls the location of the sidebar. It can either show on the left or right of the workbench.")
-		},
-		'workbench.statusBar.visible': {
-			'type': 'boolean',
-			'default': true,
-			'description': nls.localize('statusBarVisibility', "Controls the visibility of the status bar at the bottom of the workbench.")
-		},
-		'workbench.activityBar.visible': {
-			'type': 'boolean',
-			'default': true,
-			'description': nls.localize('activityBarVisibility', "Controls the visibility of the activity bar in the workbench.")
-		},
-		'workbench.editor.closeOnFileDelete': {
-			'type': 'boolean',
-			'description': nls.localize('closeOnFileDelete', "Controls if editors showing a file should close automatically when the file is deleted or renamed by some other process. Disabling this will keep the editor open as dirty on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data."),
-			'default': true
-		}
-	}
+	'properties': workbenchProperties
 });
+
 
 // Configuration: Window
 let properties: { [path: string]: IJSONSchema; } = {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -149,9 +149,9 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 };
 
 if (isMacintosh) {
-	workbenchProperties['workbench.editor.swipeToNavigateTabs'] = {
+	workbenchProperties['workbench.editor.swipeBetweenOpenFiles'] = {
 		'type': 'boolean',
-		'description': nls.localize('swipeToNavigateTabs', "Navigate tab by using three-finger swipe left or right."),
+		'description': nls.localize('swipeBetweenOpenFiles', "Navigate between open files using three-finger swipe horizontally."),
 		'default': false
 	};
 }


### PR DESCRIPTION
For https://github.com/Microsoft/vscode/issues/4803

Disabled by default, enabled with: 
```json
"workbench.editor.swipeToNavigate": true
```

![vscode](https://cloud.githubusercontent.com/assets/55424/25072832/ed59e44a-22d8-11e7-8d70-6942f6e32af5.gif)

