### PR TITLE
Encoding auto guessing: Use buffer properly

### DIFF
--- a/src/vs/base/node/mime.ts
+++ b/src/vs/base/node/mime.ts
@@ -88,7 +88,7 @@ export function detectMimeAndEncodingFromBuffer({ buffer, bytesRead }: stream.Re
 		}
 	}
 	if (autoGuessEncoding && isText && !enc) {
-		enc = encoding.guessEncodingByBuffer(buffer);
+		enc = encoding.guessEncodingByBuffer(buffer.slice(0, bytesRead));
 	}
 
 	return {


### PR DESCRIPTION
Related to #21416 
Fixed to use slice of the part of bytesRead.

Before the change, even if bytesRead is smaller than 512,the buffer of 512 byte whose last some bytes are uninitialized values is passed to `encoding.guessEncodingByBuffer`.
Maybe it cause weired encoding guessing.