### PR TITLE
Add noValuePreselect option to showInputBox

### DIFF
--- a/src/vs/platform/quickOpen/common/quickOpen.ts
+++ b/src/vs/platform/quickOpen/common/quickOpen.ts
@@ -67,6 +67,11 @@ export interface IInputOptions {
 	value?: string;
 
 	/**
+	 * whether to automatically select the first value set
+	 */
+	noValuePreselect?: boolean;
+
+	/**
 	 * the text to display underneath the input box
 	 */
 	prompt?: string;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1466,6 +1466,11 @@ declare module 'vscode' {
 		value?: string;
 
 		/**
+		 * Whether to preselect the given `value` when the box is first shown.
+		 */
+		noValuePreselect?: boolean;
+
+		/**
 		 * The text to display underneath the input box.
 		 */
 		prompt?: string;

--- a/src/vs/workbench/api/node/mainThreadQuickOpen.ts
+++ b/src/vs/workbench/api/node/mainThreadQuickOpen.ts
@@ -82,6 +82,7 @@ export class MainThreadQuickOpen extends MainThreadQuickOpenShape {
 		if (options) {
 			inputOptions.password = options.password;
 			inputOptions.placeHolder = options.placeHolder;
+			inputOptions.noValuePreselect = options.noValuePreselect;
 			inputOptions.prompt = options.prompt;
 			inputOptions.value = options.value;
 			inputOptions.ignoreFocusLost = options.ignoreFocusOut;

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -183,7 +183,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 				password: options.password,
 				placeHolder: options.placeHolder,
 				value: lastValue === void 0 ? options.value : lastValue,
-				valueSelect: lastValue === void 0,
+				valueSelect: options.noValuePreselect ? false : lastValue === void 0,
 				inputDecoration: currentDecoration,
 				onDidType: (value) => {
 					lastValue = value;


### PR DESCRIPTION
Allow extensions to decide if a value passed to vscode.window.showInputBox should start selected or not. Defaults to current behavior as to not break the experience of existing extensions.
Fixes https://github.com/Microsoft/vscode/issues/10582.