### PR TITLE
Calculate extensions table limit with respect to URI length

### DIFF
--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -730,17 +730,18 @@ Steps to Reproduce:
 			return `|${e.manifest.name}|${e.manifest.publisher}|${e.manifest.version}|`;
 		}).join('\n');
 
-		// 2000 chars is browsers de-facto limit for URLs, 250 chars is allowed for other string parts of the issue URL
-		// http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
-		if (tableHeader.length + table.length > 1750) {
-			return 'the listing exceeds the lower minimum of browsers\' URL characters limit';
-		}
-
-		return `
+		const extensionTable = `
 
 ${tableHeader}\n${table};
 
 `;
+		// 2000 chars is browsers de-facto limit for URLs, 400 chars are allowed for other string parts of the issue URL
+		// http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+		if (encodeURIComponent(extensionTable).length > 1600) {
+			return 'the listing exceeds the lower minimum of browsers\' URL characters limit';
+		}
+
+		return extensionTable;
 	}
 }
 


### PR DESCRIPTION
Added missing URI encoding before length check. Fixes https://github.com/Microsoft/vscode/issues/21737#issuecomment-290793621