### PR TITLE
Consistent highlighting of puctuators in ts/js return types

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus.json
+++ b/extensions/theme-defaults/themes/dark_plus.json
@@ -48,7 +48,6 @@
 		{
 			"name": "Types declaration and references, TS grammar specific",
 			"scope": [
-				"meta.return.type",
 				"meta.type.cast.expr",
 				"meta.type.new.expr",
 				"support.constant.math",

--- a/extensions/theme-defaults/themes/light_plus.json
+++ b/extensions/theme-defaults/themes/light_plus.json
@@ -48,7 +48,6 @@
 		{
 			"name": "Types declaration and references, TS grammar specific",
 			"scope": [
-				"meta.return.type",
 				"meta.type.cast.expr",
 				"meta.type.new.expr",
 				"support.constant.math",

--- a/extensions/typescript/test/colorize-results/test-issue5566_ts.json
+++ b/extensions/typescript/test/colorize-results/test-issue5566_ts.json
@@ -190,8 +190,8 @@
 		"c": " ",
 		"t": "source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts",
 		"r": {
-			"dark_plus": "meta.return.type: #4EC9B0",
-			"light_plus": "meta.return.type: #267F99",
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
@@ -212,8 +212,8 @@
 		"c": " ",
 		"t": "source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts",
 		"r": {
-			"dark_plus": "meta.return.type: #4EC9B0",
-			"light_plus": "meta.return.type: #267F99",
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"

--- a/extensions/typescript/test/colorize-results/test_ts.json
+++ b/extensions/typescript/test/colorize-results/test_ts.json
@@ -3743,8 +3743,8 @@
 		"c": " ",
 		"t": "source.ts meta.block.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts",
 		"r": {
-			"dark_plus": "meta.return.type: #4EC9B0",
-			"light_plus": "meta.return.type: #267F99",
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
@@ -3765,8 +3765,8 @@
 		"c": " ",
 		"t": "source.ts meta.block.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts",
 		"r": {
-			"dark_plus": "meta.return.type: #4EC9B0",
-			"light_plus": "meta.return.type: #267F99",
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"
@@ -3787,8 +3787,8 @@
 		"c": " ",
 		"t": "source.ts meta.block.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts",
 		"r": {
-			"dark_plus": "meta.return.type: #4EC9B0",
-			"light_plus": "meta.return.type: #267F99",
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
 			"hc_black": "default: #FFFFFF"


### PR DESCRIPTION
Fixes #23669

Makes the highlighting of return types in JS/TS consistent with regular  type annotations for the dark+ and light+ themes

