### PR TITLE
Handle typesInstallerInitializationFailed events

### DIFF
--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -74,6 +74,7 @@ export interface ITypescriptServiceClient {
 	onProjectLanguageServiceStateChanged: Event<Proto.ProjectLanguageServiceStateEventBody>;
 	onDidBeginInstallTypings: Event<Proto.BeginInstallTypesEventBody>;
 	onDidEndInstallTypings: Event<Proto.EndInstallTypesEventBody>;
+	onTypesInstallerInitializationFailed: Event<Proto.TypesInstallerInitializationFailedEventBody>;
 
 	logTelemetry(eventName: string, properties?: { [prop: string]: string }): void;
 

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -160,6 +160,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 	private _onProjectLanguageServiceStateChanged = new EventEmitter<Proto.ProjectLanguageServiceStateEventBody>();
 	private _onDidBeginInstallTypings = new EventEmitter<Proto.BeginInstallTypesEventBody>();
 	private _onDidEndInstallTypings = new EventEmitter<Proto.EndInstallTypesEventBody>();
+	private _onTypesInstallerInitializationFailed = new EventEmitter<Proto.TypesInstallerInitializationFailedEventBody>();
 
 	private _packageInfo: IPackageInfo | null;
 	private _apiVersion: API;
@@ -263,6 +264,10 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 
 	get onDidEndInstallTypings(): Event<Proto.EndInstallTypesEventBody> {
 		return this._onDidEndInstallTypings.event;
+	}
+
+	get onTypesInstallerInitializationFailed(): Event<Proto.TypesInstallerInitializationFailedEventBody> {
+		return this._onTypesInstallerInitializationFailed.event;
 	}
 
 	private get output(): OutputChannel {
@@ -1016,6 +1021,11 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 					const data = (event as Proto.EndInstallTypesEvent).body;
 					if (data) {
 						this._onDidEndInstallTypings.fire(data);
+					}
+				} else if (event.event === 'typesInstallerInitializationFailed') {
+					const data = (event as Proto.TypesInstallerInitializationFailedEvent).body;
+					if (data) {
+						this._onTypesInstallerInitializationFailed.fire(data);
 					}
 				}
 			} else {

--- a/extensions/typescript/src/utils/typingsStatus.ts
+++ b/extensions/typescript/src/utils/typingsStatus.ts
@@ -68,8 +68,8 @@ export class AtaProgressReporter {
 	constructor(client: ITypescriptServiceClient) {
 		this._disposable = vscode.Disposable.from(
 			client.onDidBeginInstallTypings(e => this._onBegin(e.eventId)),
-			client.onDidEndInstallTypings(e => this._onEndOrTimeout(e.eventId))
-		);
+			client.onDidEndInstallTypings(e => this._onEndOrTimeout(e.eventId)),
+			client.onTypesInstallerInitializationFailed(_ => this.onTypesInstallerInitializationFailed()));
 	}
 
 	dispose(): void {
@@ -95,5 +95,9 @@ export class AtaProgressReporter {
 			this._promises.delete(eventId);
 			resolve();
 		}
+	}
+
+	private onTypesInstallerInitializationFailed() {
+		vscode.window.showWarningMessage(localize('typesInstallerInitializationFailed', "Could not installed typings files for JS/TS language features. Please ensure that NPM is installed"));
 	}
 }

--- a/extensions/typescript/src/utils/typingsStatus.ts
+++ b/extensions/typescript/src/utils/typingsStatus.ts
@@ -98,6 +98,6 @@ export class AtaProgressReporter {
 	}
 
 	private onTypesInstallerInitializationFailed() {
-		vscode.window.showWarningMessage(localize('typesInstallerInitializationFailed', "Could not installed typings files for JS/TS language features. Please ensure that NPM is installed"));
+		vscode.window.showWarningMessage(localize('typesInstallerInitializationFailed', "Could not install typings files for JS/TS language features. Please ensure that NPM is installed"));
 	}
 }


### PR DESCRIPTION
Display a warning message when the TS typings installer fails to initilize. The major cause of this is that npm is not installed

Fixes #21646