### PR TITLE
Let the widgetactions debug UI reflect the state of a focused thread

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -445,6 +445,10 @@ export class DebugService implements debug.IDebugService {
 	}
 
 	public get state(): debug.State {
+		const focusedThread = this.viewModel.focusedThread;
+		if (focusedThread && focusedThread.stopped) {
+			return debug.State.Stopped;
+		}
 		const focusedProcess = this.viewModel.focusedProcess;
 		if (focusedProcess) {
 			return this.sessionStates.get(focusedProcess.getId());


### PR DESCRIPTION
Currently when we have a multi-threaded debugging session open, Continuing a thread and having another stopped thread  get autofocused on the first thread's exit, or simply manually focusing a stopped thread, causes the widgetactions debugger UI to reflect the stale running state of the old thread instead of the stopped state of the newly focused thread, leaving no means to continue any of the stopped threads.  

The commit here fixes that.

The editor and the debug viewlet appear to reflect the state of the debugger correctly.

If you require I can open an issue specific to this PR and attach a gif capture of my screen to better explain myself if that's required.