### PR TITLE
Isidorn/action items lifecycle fixes #23822

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -554,8 +554,7 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 	}
 
 	public clear(): void {
-		// Do not dispose action items if they were provided from outside
-		this.items = this.options.actionItemProvider ? [] : lifecycle.dispose(this.items);
+		this.items = lifecycle.dispose(this.items);
 		$(this.actionsList).empty();
 	}
 
@@ -670,7 +669,7 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 
 	public dispose(): void {
 		if (this.items !== null) {
-			lifecycle.dispose(this.items);
+			this.clear();
 		}
 		this.items = null;
 

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -669,7 +669,7 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 
 	public dispose(): void {
 		if (this.items !== null) {
-			this.clear();
+			lifecycle.dispose(this.items);
 		}
 		this.items = null;
 

--- a/src/vs/workbench/parts/debug/browser/debugActionsWidget.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActionsWidget.ts
@@ -52,7 +52,6 @@ export class DebugActionsWidget extends Themable implements IWorkbenchContributi
 
 	private isVisible: boolean;
 	private isBuilt: boolean;
-	private focusProcessActionItem: FocusProcessActionItem;
 
 	constructor(
 		@IMessageService private messageService: IMessageService,
@@ -79,12 +78,7 @@ export class DebugActionsWidget extends Themable implements IWorkbenchContributi
 			orientation: ActionsOrientation.HORIZONTAL,
 			actionItemProvider: (action: IAction) => {
 				if (action.id === FocusProcessAction.ID) {
-					if (!this.focusProcessActionItem) {
-						this.focusProcessActionItem = this.instantiationService.createInstance(FocusProcessActionItem, action);
-						this.toDispose.push(this.focusProcessActionItem);
-					}
-
-					return this.focusProcessActionItem;
+					return this.instantiationService.createInstance(FocusProcessActionItem, action);
 				}
 
 				return null;

--- a/src/vs/workbench/parts/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/parts/debug/browser/debugViewlet.ts
@@ -131,10 +131,7 @@ export class DebugViewlet extends Viewlet {
 
 	public getActionItem(action: IAction): IActionItem {
 		if (action.id === StartAction.ID && this.contextService.getWorkspace()) {
-			if (!this.startDebugActionItem) {
-				this.startDebugActionItem = this.instantiationService.createInstance(StartDebugActionItem, null, action);
-			}
-
+			this.startDebugActionItem = this.instantiationService.createInstance(StartDebugActionItem, null, action);
 			return this.startDebugActionItem;
 		}
 


### PR DESCRIPTION
1. ActionBar now always disposes the action item and is in control of its lifecycle
2. Debug no longer caches action items since the actionBar is now reponsible for the lifecycle of all action items - including those externaly contributed