### PR TITLE
Fix child_process event name typo in nodejs typings

### DIFF
--- a/src/typings/node.d.ts
+++ b/src/typings/node.d.ts
@@ -1569,7 +1569,7 @@ declare module "child_process" {
         /**
          * events.EventEmitter
          * 1. close
-         * 2. disconnet
+         * 2. disconnect
          * 3. error
          * 4. exit
          * 5. message
@@ -1577,42 +1577,42 @@ declare module "child_process" {
 
         addListener(event: string, listener: Function): this;
         addListener(event: "close", listener: (code: number, signal: string) => void): this;
-        addListener(event: "disconnet", listener: () => void): this;
+        addListener(event: "disconnect", listener: () => void): this;
         addListener(event: "error", listener: (err: Error) => void): this;
         addListener(event: "exit", listener: (code: number, signal: string) => void): this;
         addListener(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;
 
         emit(event: string, ...args: any[]): boolean;
         emit(event: "close", code: number, signal: string): boolean;
-        emit(event: "disconnet"): boolean;
+        emit(event: "disconnect"): boolean;
         emit(event: "error", err: Error): boolean;
         emit(event: "exit", code: number, signal: string): boolean;
         emit(event: "message", message: any, sendHandle: net.Socket | net.Server): boolean;
 
         on(event: string, listener: Function): this;
         on(event: "close", listener: (code: number, signal: string) => void): this;
-        on(event: "disconnet", listener: () => void): this;
+        on(event: "disconnect", listener: () => void): this;
         on(event: "error", listener: (err: Error) => void): this;
         on(event: "exit", listener: (code: number, signal: string) => void): this;
         on(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;
 
         once(event: string, listener: Function): this;
         once(event: "close", listener: (code: number, signal: string) => void): this;
-        once(event: "disconnet", listener: () => void): this;
+        once(event: "disconnect", listener: () => void): this;
         once(event: "error", listener: (err: Error) => void): this;
         once(event: "exit", listener: (code: number, signal: string) => void): this;
         once(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;
 
         prependListener(event: string, listener: Function): this;
         prependListener(event: "close", listener: (code: number, signal: string) => void): this;
-        prependListener(event: "disconnet", listener: () => void): this;
+        prependListener(event: "disconnect", listener: () => void): this;
         prependListener(event: "error", listener: (err: Error) => void): this;
         prependListener(event: "exit", listener: (code: number, signal: string) => void): this;
         prependListener(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;
 
         prependOnceListener(event: string, listener: Function): this;
         prependOnceListener(event: "close", listener: (code: number, signal: string) => void): this;
-        prependOnceListener(event: "disconnet", listener: () => void): this;
+        prependOnceListener(event: "disconnect", listener: () => void): this;
         prependOnceListener(event: "error", listener: (err: Error) => void): this;
         prependOnceListener(event: "exit", listener: (code: number, signal: string) => void): this;
         prependOnceListener(event: "message", listener: (message: any, sendHandle: net.Socket | net.Server) => void): this;


### PR DESCRIPTION
disconnet -> disconnect

---

I did a simple find + replace within the Github interface. Hope that's all that's necessary / that's okay.

There was no corresponding issue for this PR.