### PR TITLE
Fix #23194

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
+++ b/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import uri from 'vs/base/common/uri';
-import * as paths from 'vs/base/common/paths';
 import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { guessMimeTypes, MIME_TEXT } from 'vs/base/common/mime';
@@ -40,11 +39,9 @@ export class DebugContentProvider implements IWorkbenchContribution, ITextModelC
 		let rawSource: DebugProtocol.Source;
 		if (source) {
 			rawSource = source.raw;
-		} else if (resource.scheme === 'debug') {
+		} else {
 			// Remove debug: scheme
 			rawSource = { path: resource.with({ scheme: '' }).toString(true) };
-		} else {
-			rawSource = { path: paths.normalize(resource.fsPath, true) };
 		}
 
 		return process.session.source({ sourceReference: source ? source.reference : undefined, source: rawSource }).then(response => {

--- a/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
+++ b/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
@@ -37,7 +37,15 @@ export class DebugContentProvider implements IWorkbenchContribution, ITextModelC
 			return TPromise.wrapError(localize('unable', "Unable to resolve the resource without a debug session"));
 		}
 		const source = process.sources.get(resource.toString());
-		const rawSource = source ? source.raw : { path: paths.normalize(resource.fsPath, true) };
+		let rawSource: DebugProtocol.Source;
+		if (source) {
+			rawSource = source.raw;
+		} else if (resource.scheme === 'debug') {
+			// Remove debug: scheme
+			rawSource = { path: resource.with({ scheme: '' }).toString(true) };
+		} else {
+			rawSource = { path: paths.normalize(resource.fsPath, true) };
+		}
 
 		return process.session.source({ sourceReference: source ? source.reference : undefined, source: rawSource }).then(response => {
 			const mime = response.body.mimeType || guessMimeTypes(resource.toString())[0];


### PR DESCRIPTION
This change uses `uri.with` to get a new version which has the same fields except no scheme. It also removes `paths.normalize` because the uri may be a URL, not a path, and that causes it to have \ on windows. I don't know if that's safe or if `paths.normalize` is needed in some case. I also don't know whether the `if (resource.scheme === 'debug')` check is necessary.

I think that embedding a URL or path or made up path like `<node_internals>/...` into a URI might be unsafe in other cases too, but I don't really know. Another approach would be to just `encodeURIComponent` the entire thing from the debugger, instead of trying to interpret it in vscode, and only decode it for display. I don't know whether there's anywhere that we need it to work like an actual URI?