### PR TITLE
Immediately submit file search

### DIFF
--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -684,6 +684,7 @@ export class SearchViewlet extends Viewlet {
 			this.searchWidget.searchInput.setValue(selectedText);
 		}
 		this.searchWidget.focus();
+		this.searchWidget.submitSearch();
 	}
 
 	public focusNextInputBox(): void {


### PR DESCRIPTION
Currently, when highlighting text in the editor, and invoking "Find in Files" (Ctrl/Cmd-Shift-F), the side bar is changed to the Search view, and the search input box is filled in with the selected text, but the search is not actually invoked. This change submits the search immediately after the input is changed.

This could have some sort of preference choice (to auto-search or not), but I think this functionality is actually what's expected.