### PR TITLE
Added missing commands to the Settings page

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -593,6 +593,16 @@
           "description": "%config.confirmSync%",
           "default": true
         },
+        "git.enableLongCommitWarning": {
+          "type": "boolean",
+          "description": "%config.enableLongCommitWarning%",
+          "default": true
+        },
+        "git.allowLargeRepositories": {
+          "type": "boolean",
+          "description": "%config.allowLargeRepositories%",
+          "default": false
+        },
         "git.countBadge": {
           "type": "string",
           "enum": [

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -33,6 +33,7 @@
 	"config.autorefresh": "Whether auto refreshing is enabled",
 	"config.autofetch": "Whether auto fetching is enabled",
 	"config.enableLongCommitWarning": "Whether long commit messages should be warned about",
+	"config.allowLargeRepositories": "Always allow large repositories to be managed by Code.",
 	"config.confirmSync": "Confirm before synchronizing git repositories",
 	"config.countBadge": "Controls the git badge counter",
 	"config.checkoutType": "Controls what type of branches are listed"


### PR DESCRIPTION
**Before**:
In the Settings page (`Cmd + ,` on Mac), certain git commands were missing in the search and were also marked as not recognized when using them:
![screen shot 2017-04-07 at 2 18 47 pm](https://cloud.githubusercontent.com/assets/3534924/24813753/423ef5a6-1b9d-11e7-9aa9-d56ca3eb77ac.png)
![screen shot 2017-04-07 at 2 18 23 pm](https://cloud.githubusercontent.com/assets/3534924/24813754/424597bc-1b9d-11e7-9874-ab9dd5be362f.png)

**Now**:
The Settings page correctly returns the missing git commands and they are recognized by the editor:
![screen shot 2017-04-07 at 2 19 24 pm](https://cloud.githubusercontent.com/assets/3534924/24813777/5bff9fd6-1b9d-11e7-8d47-0d76206e0f57.png)
![screen shot 2017-04-07 at 2 19 00 pm](https://cloud.githubusercontent.com/assets/3534924/24813776/5bff7dda-1b9d-11e7-97c1-7a88e012881b.png)

