### PR TITLE
Tweak HTML Preview Styling 

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -6,7 +6,7 @@
 body {
 	font-family: "Segoe WPC", "Segoe UI", "SFUIText-Light", "HelveticaNeue-Light", sans-serif, "Droid Sans Fallback";
 	font-size: 14px;
-	padding: 0 12px;
+	padding: 0 26px;
 	line-height: 22px;
 	word-wrap: break-word;
 }

--- a/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
@@ -76,7 +76,6 @@ export class HtmlPreviewPart extends BaseEditor {
 
 	protected createEditor(parent: Builder): void {
 		this._container = document.createElement('div');
-		this._container.style.paddingLeft = '20px';
 		this._container.style.position = 'absolute';
 		this._container.style.zIndex = '300';
 		parent.getHTMLElement().appendChild(this._container);
@@ -134,7 +133,7 @@ export class HtmlPreviewPart extends BaseEditor {
 	public layout(dimension: Dimension): void {
 		const {width, height} = dimension;
 		// we take the padding we set on create into account
-		this._container.style.width = `${Math.max(width - 20, 0)}px`;
+		this._container.style.width = `${width}px`;
 		this._container.style.height = `${height}px`;
 	}
 

--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -57,9 +57,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
 		initData.activeTheme = activeTheme;
 
 		// webview
-		var defaultStyles = document.getElementById('_defaultStyles');
-		defaultStyles.innerHTML = initData.styles;
-
 		var target = getTarget()
 		if (!target) {
 			return;
@@ -68,7 +65,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 		styleBody(body[0]);
 
 		// iframe
-		defaultStyles = getTarget().contentDocument.getElementById('_defaultStyles');
+		defaultStyles = target.contentDocument.getElementById('_defaultStyles');
 		if (defaultStyles) {
 			defaultStyles.innerHTML = initData.styles;
 		}

--- a/src/vs/workbench/parts/html/browser/webview.html
+++ b/src/vs/workbench/parts/html/browser/webview.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
 	<title>Virtual Document</title>
-	<style id="_defaultStyles"></style>
 </head>
 <body style="margin: 0; overflow: hidden; width: 100%; height: 100%">
 </body>

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -163,6 +163,7 @@ export default class Webview {
 			font-weight: var(--font-weight);
 			font-size: var(--font-size);
 			margin: 0;
+			padding: 0 20px;
 		}
 
 		img {


### PR DESCRIPTION
Two changes:

* Changes the logic from 41467b74b7e486f3a5857d3cc0ab15d85a2b7a84 to make the padding customizable. The default 20px padding is preserved, but extensions that use the preview should now customize this. This allows html preview page background colors to correctly fill the entire frame and for the content to be properly centered. I tested that #5883 is still fixed after this change

* Remove writing the `_defaultStyles` to the root of the webview page. These are only needed inside of the iFrame itself