### PR TITLE
Removed .tildify so that long path would return absolute path.

### DIFF
--- a/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
@@ -159,7 +159,7 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 				title = this.mediumTitle ? this.mediumTitle : (this.mediumTitle = labels.getPathLabel(this.resource, this.contextService));
 				break;
 			case Verbosity.LONG:
-				title = this.longTitle ? this.longTitle : (this.longTitle = labels.tildify(labels.getPathLabel(this.resource), this.environmentService.userHome));
+				title = this.longTitle ? this.longTitle : (this.longTitle = labels.getPathLabel(this.resource), this.environmentService.userHome);
 				break;
 		}
 


### PR DESCRIPTION
Fixes #24045 by changing `editorInput.getTitle(Verbosity.LONG)` to return the full path of the file as appose to the `tildify` version. When looking around the rest of the editor all tools tips consistently return the full path.