### PR TITLE
Added missing . to hc-black so that it displays the correct scm actio…

### DIFF
--- a/src/vs/platform/actions/electron-browser/menusExtensionPoint.ts
+++ b/src/vs/platform/actions/electron-browser/menusExtensionPoint.ts
@@ -275,7 +275,7 @@ ExtensionsRegistry.registerExtensionPoint<schema.IUserFriendlyCommand | schema.I
 				const light = join(extension.description.extensionFolderPath, icon.light);
 				const dark = join(extension.description.extensionFolderPath, icon.dark);
 				createCSSRule(`.icon.${iconClass}`, `background-image: url("${URI.file(light).toString()}")`);
-				createCSSRule(`.vs-dark .icon.${iconClass}, hc-black .icon.${iconClass}`, `background-image: url("${URI.file(dark).toString()}")`);
+				createCSSRule(`.vs-dark .icon.${iconClass}, .hc-black .icon.${iconClass}`, `background-image: url("${URI.file(dark).toString()}")`);
 			}
 		}
 


### PR DESCRIPTION
…n icon colors.
Fixes #24221 

High contrast action icons were wrong color due to css not applying properly. Fix was to add a `.` to the inlined css string to look at `.hc-black` class.