### PR TITLE
Allow Code Lenses to only Provide a Title and no Backing Command 

### DIFF
--- a/extensions/typescript/src/features/implementationsCodeLensProvider.ts
+++ b/extensions/typescript/src/features/implementationsCodeLensProvider.ts
@@ -62,7 +62,7 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 				title: locations.length === 1
 					? localize('oneImplementationLabel', '1 implementation')
 					: localize('manyImplementationLabel', '{0} implementations', locations.length),
-				command: 'editor.action.showReferences',
+				command: locations.length ? 'editor.action.showReferences' : '',
 				arguments: [codeLens.document, codeLens.range.start, locations]
 			};
 			return codeLens;

--- a/extensions/typescript/src/features/referencesCodeLensProvider.ts
+++ b/extensions/typescript/src/features/referencesCodeLensProvider.ts
@@ -56,7 +56,7 @@ export default class TypeScriptReferencesCodeLensProvider extends TypeScriptBase
 				title: locations.length === 1
 					? localize('oneReferenceLabel', '1 reference')
 					: localize('manyReferenceLabel', '{0} references', locations.length),
-				command: 'editor.action.showReferences',
+				command: locations.length ? 'editor.action.showReferences' : '',
 				arguments: [codeLens.document, codeLens.range.start, locations]
 			};
 			return codeLens;

--- a/src/vs/workbench/api/node/extHostCommands.ts
+++ b/src/vs/workbench/api/node/extHostCommands.ts
@@ -181,7 +181,7 @@ export class CommandsConverter {
 			title: command.title
 		};
 
-		if (!isFalsyOrEmpty(command.arguments)) {
+		if (command.command && !isFalsyOrEmpty(command.arguments)) {
 			// we have a contributed command with arguments. that
 			// means we don't want to send the arguments around
 


### PR DESCRIPTION
Fixes #24209

**Bug**
Currently, for the js/ts references code lens, even if there are zero references you can click on the lens. This display an empty peek view. The root cause is that we always have to provide a command for these lenses, even if no action can really be taken

**Fix**
Allow code lenses to only register a title for the lens with no actual backing command. This lets a code lens display info to the user while not potentially incorrectly suggesting that more information is available by clicking

![apr-10-2017 15-03-27](https://cloud.githubusercontent.com/assets/12821956/24884575/e2241b92-1dfe-11e7-80e4-1c6280aa8c5f.gif)
