### PR TITLE
Update coffeescript.tmLanguage.json, fixing highlighting for embedded js

### DIFF
--- a/extensions/coffeescript/syntaxes/coffeescript.tmLanguage.json
+++ b/extensions/coffeescript/syntaxes/coffeescript.tmLanguage.json
@@ -109,7 +109,7 @@
 					"name": "punctuation.definition.string.end.coffee"
 				}
 			},
-			"name": "string.quoted.script.coffee",
+			"name": "quoted.script.coffee",
 			"patterns": [
 				{
 					"include": "source.js"

--- a/extensions/coffeescript/syntaxes/coffeescript.tmLanguage.json
+++ b/extensions/coffeescript/syntaxes/coffeescript.tmLanguage.json
@@ -112,8 +112,7 @@
 			"name": "string.quoted.script.coffee",
 			"patterns": [
 				{
-					"match": "(xh{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)",
-					"name": "constant.character.escape.coffee"
+					"include": "source.js"
 				}
 			]
 		},


### PR DESCRIPTION
In coffee-script, `` means not normal strings but embedded js, but it's not correctly highlighted in vscode, like this: 

![image](https://cloud.githubusercontent.com/assets/13058150/24889910/6d1f719c-1e9f-11e7-9a2f-d3e642de1317.png)

After this fix, it should be like this: 

![image](https://cloud.githubusercontent.com/assets/13058150/24889940/90c7f04c-1e9f-11e7-84dd-7ec903c1f91b.png)

~~Note that in embedded js the symbols like `()[]{}` is green rather than white. This is intentional in order to indicate this is embedded js, not coffee-script.~~

[EDIT] Now in embedded js the symbols like `()[]{}` is white, not green. I found in string mode some feathers like brackets pairing is not avaiable, so it's better to change to normal code mode instead of string mode. 