### PR TITLE
Remove "JOAO" from Readme title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Visual Studio Code - Open Source JOAO
+# Visual Studio Code - Open Source
 
 [![Build Status](https://travis-ci.org/Microsoft/vscode.svg?branch=master)](https://travis-ci.org/Microsoft/vscode)
 [![Build Status](https://ci.appveyor.com/api/projects/status/vuhlhg80tj3e2a0l/branch/master?svg=true)](https://ci.appveyor.com/project/VSCode/vscode)


### PR DESCRIPTION
It appears @joaomoreno 's local readme made it into the master branch. This pull request simply removes it from the readme again.