### PR TITLE
Update Exec param at code.desktop

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -2,7 +2,7 @@
 Name=@@NAME_LONG@@
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=/usr/share/@@NAME@@/@@NAME@@ --unity-launch %U
+Exec=/usr/share/@@NAME@@/bin/@@NAME@@ --unity-launch %U
 Icon=@@NAME@@
 Type=Application
 StartupNotify=true
@@ -23,5 +23,5 @@ Name[ko]=새 창
 Name[ru]=Новое окно
 Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
-Exec=/usr/share/@@NAME@@/@@NAME@@ --new-window %U
+Exec=/usr/share/@@NAME@@/bin/@@NAME@@ --new-window %U
 Icon=@@NAME@@


### PR DESCRIPTION
The `/usr/share/code/code/` path opens a new window with errors.
Adding bin to the path fixes it.

Fixes #10091