### PR TITLE
Fix - #24242

### DIFF
--- a/src/vs/workbench/parts/extensions/browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/browser/extensionsList.ts
@@ -64,8 +64,9 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const header = append(headerContainer, $('.header'));
 		const name = append(header, $('span.name'));
 		const version = append(header, $('span.version'));
-		const installCount = append(header, $('span.install-count'));
-		const ratings = append(header, $('span.ratings'));
+		const extensionstats = append(headerContainer, $('.extension-stats'));
+		const installCount = append(extensionstats, $('span.install-count'));
+		const ratings = append(extensionstats, $('span.ratings'));
 		const description = append(details, $('.description.ellipsis'));
 		const footer = append(details, $('.footer'));
 		const author = append(footer, $('.author.ellipsis'));

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -82,9 +82,8 @@
 .extensions-viewlet > .extensions .extension > .details > .header-container > .header {
 	display: flex;
 	align-items: baseline;
-	flex-wrap: wrap;
 	overflow: hidden;
-	flex: 1;
+	flex: 80%;
 	min-width: 0;
 }
 
@@ -100,20 +99,26 @@
 	font-size: 80%;
 	padding-left: 6px;
 	flex: 1;
-	min-width: fit-content;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
-.extensions-viewlet > .extensions .extension > .details > .header-container > .header > .install-count:not(:empty) {
+.extensions-viewlet	> .extensions .extension > .details > .header-container > .extension-stats {
+	justify-content: flex-end;
+}
+
+.extensions-viewlet > .extensions .extension > .details > .header-container > .extension-stats > .install-count:not(:empty) {
 	font-size: 80%;
 	margin: 0 6px;
 }
 
-.extensions-viewlet > .extensions .extension > .details > .header-container > .header > .install-count > .octicon {
+.extensions-viewlet > .extensions .extension > .details > .header-container > .extension-stats > .install-count > .octicon {
 	font-size: 100%;
 	margin-right: 2px;
 }
 
-.extensions-viewlet > .extensions .extension > .details > .header-container > .header > .ratings {
+.extensions-viewlet > .extensions .extension > .details > .header-container > .extension-stats > .ratings {
 	text-align: right;
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -122,11 +122,6 @@
 	text-align: right;
 }
 
-.extensions-viewlet.narrow > .extensions .extension > .details > .header-container > .header > .ratings,
-.extensions-viewlet.narrow > .extensions .extension > .details > .header-container > .header > .install-count {
-	display: none;
-}
-
 .extensions-viewlet > .extensions .extension > .details > .header-container .extension-status {
 	width: 8px;
 	height: 8px;


### PR DESCRIPTION
Extension count and ratings should be displayed irrespective of shrinking or expansion of extension explorer.Considering this fixed the `width` of `header` to `80%`