### PR TITLE
Changed git renamed icon to orange color

### DIFF
--- a/extensions/git/resources/icons/dark/status-renamed.svg
+++ b/extensions/git/resources/icons/dark/status-renamed.svg
@@ -1,5 +1,5 @@
 <svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <rect fill="#4668C5" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <rect fill="#CC6633" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
   <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
     R
   </text>

--- a/extensions/git/resources/icons/light/status-renamed.svg
+++ b/extensions/git/resources/icons/light/status-renamed.svg
@@ -1,5 +1,5 @@
 <svg width="14px" height="14px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <rect fill="#4668C5" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
+  <rect fill="#CC6633" x="0" y="0" width="100" height="100" rx="35" ry="35"/>
   <text x="50" y="75" font-size="75" text-anchor="middle" style="font-family: Menlo, Monaco, Consolas, &quot;Droid Sans Mono&quot;, &quot;Inconsolata&quot;, &quot;Courier New&quot;, monospace, &quot;Droid Sans Fallback&quot;;" fill="white">
     R
   </text>


### PR DESCRIPTION
Fixes #23939

Changed both dark and light `status-renamed.svg` to have `#CC6633` background color to allow for better distinction as mentioned by issue referenced.  