### PR TITLE
Use js/tsconfig schema for jsconfig.*.json files

### DIFF
--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -111,11 +111,19 @@
       },
       {
         "fileMatch": "jsconfig.json",
-        "url": "./schemas/jsconfig.schema.json"
+        "url": "http://json.schemastore.org/jsconfig"
       },
       {
         "fileMatch": "jsconfig.json",
+        "url": "./schemas/jsconfig.schema.json"
+      },
+      {
+        "fileMatch": "jsconfig.*.json",
         "url": "http://json.schemastore.org/jsconfig"
+      },
+      {
+        "fileMatch": "jsconfig.*.json",
+        "url": "./schemas/jsconfig.schema.json"
       }
     ]
   },

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -383,6 +383,14 @@
         "fileMatch": "tsconfig.json",
         "url": "./schemas/tsconfig.schema.json"
       },
+       {
+        "fileMatch": "tsconfig.*.json",
+        "url": "http://json.schemastore.org/tsconfig"
+      },
+      {
+        "fileMatch": "tsconfig.*.json",
+        "url": "./schemas/tsconfig.schema.json"
+      },
       {
         "fileMatch": "typings.json",
         "url": "http://json.schemastore.org/typings"


### PR DESCRIPTION
Fixes #24572

Applies the js/tsconfig schema to file names such as `jsconfig.app.json`