### PR TITLE
Nested code lines now no longer display the hover border left.

### DIFF
--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -72,6 +72,10 @@ body.showEditorSelection li.code-line:hover:before {
 	border-left: 3px solid rgba(255, 255, 255, 0.60);
 }
 
+.vscode-dark.showEditorSelection .code-line .code-line:hover:before {
+	border-left: none;
+}
+
 .vscode-high-contrast.showEditorSelection .code-active-line:before {
 	border-left: 3px solid rgba(255, 160, 0, 0.7);
 }

--- a/extensions/markdown/media/markdown.css
+++ b/extensions/markdown/media/markdown.css
@@ -64,6 +64,10 @@ body.showEditorSelection li.code-line:hover:before {
 	border-left: 3px solid rgba(0, 0, 0, 0.40);
 }
 
+.vscode-light.showEditorSelection .code-line .code-line:hover:before {
+	border-left: none;
+}
+
 .vscode-dark.showEditorSelection .code-active-line:before {
 	border-left: 3px solid rgba(255, 255, 255, 0.4);
 }
@@ -82,6 +86,10 @@ body.showEditorSelection li.code-line:hover:before {
 
 .vscode-high-contrast.showEditorSelection .code-line:hover:before {
 	border-left: 3px solid rgba(255, 160, 0, 1);
+}
+
+.vscode-high-contrast.showEditorSelection .code-line .code-line:hover:before {
+	border-left: none;
 }
 
 img {


### PR DESCRIPTION
Fixes #24239

Added css to prevent nested markdown `.code-line` from displaying an extra left bar on hover.