### PR TITLE
Treat emmet snippets as textmate

### DIFF
--- a/src/vs/editor/contrib/snippet/common/snippet.ts
+++ b/src/vs/editor/contrib/snippet/common/snippet.ts
@@ -8,7 +8,7 @@
 import * as strings from 'vs/base/common/strings';
 import { Range } from 'vs/editor/common/core/range';
 import * as editorCommon from 'vs/editor/common/editorCommon';
-import * as collections from 'vs/base/common/collections';
+// import * as collections from 'vs/base/common/collections';
 import { Marker, Variable, Placeholder, Text, SnippetParser } from 'vs/editor/contrib/snippet/common/snippetParser';
 
 export interface IIndentationNormalizer {
@@ -55,7 +55,39 @@ export class CodeSnippet implements ICodeSnippet {
 	}
 
 	static fromEmmet(template: string): CodeSnippet {
-		return EmmetSnippetParser.parse(template);
+		//return EmmetSnippetParser.parse(template);
+
+		let matchFinalStops = template.match(/\$\{0\}/g);
+		if (!matchFinalStops || matchFinalStops.length === 1) {
+			return CodeSnippet.fromTextmate(template);
+		}
+
+		// Emmet sometimes returns snippets with multiple ${0}
+		// In such cases, replace ${0} with incremental tab stops
+
+		let maxTabStop = -1;
+		let matches = [];
+		let regex = /\$\{(\d+)\}/g;
+		while (matches = regex.exec(template)) {
+			let tabStop = Number(matches[1]);
+			if (tabStop > maxTabStop) {
+				maxTabStop = tabStop;
+			}
+		}
+		regex = /\$\{(\d+):[^\}]+\}/g;
+		matches = [];
+		while (matches = regex.exec(template)) {
+			let tabStop = Number(matches[1]);
+			if (tabStop > maxTabStop) {
+				maxTabStop = tabStop;
+			}
+		}
+
+		template = template.replace(/\$\{0\}/g, (substring) => {
+			return `\$\{${++maxTabStop}\}`;
+		});
+
+		return CodeSnippet.fromTextmate(template);
 	}
 
 	public lines: string[] = [];
@@ -179,296 +211,296 @@ interface IParsedLine {
 	placeHolders: IParsedLinePlaceHolderInfo[];
 }
 
-const InternalFormatSnippetParser = new class implements ISnippetParser {
+// const InternalFormatSnippetParser = new class implements ISnippetParser {
 
-	private _lastGeneratedId: number;
-	private _snippet: CodeSnippet;
+// 	private _lastGeneratedId: number;
+// 	private _snippet: CodeSnippet;
 
-	parse(template: string): CodeSnippet {
-		this._lastGeneratedId = 0;
-		this._snippet = new CodeSnippet();
-		this.parseTemplate(template);
-		return this._snippet;
-	}
+// 	parse(template: string): CodeSnippet {
+// 		this._lastGeneratedId = 0;
+// 		this._snippet = new CodeSnippet();
+// 		this.parseTemplate(template);
+// 		return this._snippet;
+// 	}
 
-	private parseTemplate(template: string): void {
+// 	private parseTemplate(template: string): void {
 
-		var placeHoldersMap: collections.IStringDictionary<IPlaceHolder> = Object.create(null);
-		var i: number, len: number, j: number, lenJ: number, templateLines = template.split('\n');
+// 		var placeHoldersMap: collections.IStringDictionary<IPlaceHolder> = Object.create(null);
+// 		var i: number, len: number, j: number, lenJ: number, templateLines = template.split('\n');
 
-		for (i = 0, len = templateLines.length; i < len; i++) {
-			var parsedLine = this.parseLine(templateLines[i], (id: string) => {
-				if (placeHoldersMap[id]) {
-					return placeHoldersMap[id].value;
-				}
-				return '';
-			});
-			for (j = 0, lenJ = parsedLine.placeHolders.length; j < lenJ; j++) {
-				var linePlaceHolder = parsedLine.placeHolders[j];
-				var occurence = new Range(i + 1, linePlaceHolder.startColumn, i + 1, linePlaceHolder.endColumn);
-				var placeHolder: IPlaceHolder;
+// 		for (i = 0, len = templateLines.length; i < len; i++) {
+// 			var parsedLine = this.parseLine(templateLines[i], (id: string) => {
+// 				if (placeHoldersMap[id]) {
+// 					return placeHoldersMap[id].value;
+// 				}
+// 				return '';
+// 			});
+// 			for (j = 0, lenJ = parsedLine.placeHolders.length; j < lenJ; j++) {
+// 				var linePlaceHolder = parsedLine.placeHolders[j];
+// 				var occurence = new Range(i + 1, linePlaceHolder.startColumn, i + 1, linePlaceHolder.endColumn);
+// 				var placeHolder: IPlaceHolder;
 
-				if (placeHoldersMap[linePlaceHolder.id]) {
-					placeHolder = placeHoldersMap[linePlaceHolder.id];
-				} else {
-					placeHolder = {
-						id: linePlaceHolder.id,
-						value: linePlaceHolder.value,
-						occurences: []
-					};
-					this._snippet.placeHolders.push(placeHolder);
-					placeHoldersMap[linePlaceHolder.id] = placeHolder;
-				}
+// 				if (placeHoldersMap[linePlaceHolder.id]) {
+// 					placeHolder = placeHoldersMap[linePlaceHolder.id];
+// 				} else {
+// 					placeHolder = {
+// 						id: linePlaceHolder.id,
+// 						value: linePlaceHolder.value,
+// 						occurences: []
+// 					};
+// 					this._snippet.placeHolders.push(placeHolder);
+// 					placeHoldersMap[linePlaceHolder.id] = placeHolder;
+// 				}
 
-				placeHolder.occurences.push(occurence);
-			}
+// 				placeHolder.occurences.push(occurence);
+// 			}
 
-			this._snippet.lines.push(parsedLine.line);
-		}
+// 			this._snippet.lines.push(parsedLine.line);
+// 		}
 
-		// Named variables (e.g. {greeting} and {greeting:Hello}) are sorted first, followed by
-		// tab-stops and numeric variables (e.g. $1, $2, ${3:foo}) which are sorted in ascending order
-		this._snippet.placeHolders.sort((a, b) => {
-			let nonIntegerId = (v: IPlaceHolder) => !(/^\d+$/).test(v.id);
-			let isFinishPlaceHolder = (v: IPlaceHolder) => v.id === '' && v.value === '';
+// 		// Named variables (e.g. {greeting} and {greeting:Hello}) are sorted first, followed by
+// 		// tab-stops and numeric variables (e.g. $1, $2, ${3:foo}) which are sorted in ascending order
+// 		this._snippet.placeHolders.sort((a, b) => {
+// 			let nonIntegerId = (v: IPlaceHolder) => !(/^\d+$/).test(v.id);
+// 			let isFinishPlaceHolder = (v: IPlaceHolder) => v.id === '' && v.value === '';
 
-			// Sort finish placeholder last
-			if (isFinishPlaceHolder(a)) {
-				return 1;
-			} else if (isFinishPlaceHolder(b)) {
-				return -1;
-			}
+// 			// Sort finish placeholder last
+// 			if (isFinishPlaceHolder(a)) {
+// 				return 1;
+// 			} else if (isFinishPlaceHolder(b)) {
+// 				return -1;
+// 			}
 
-			// Sort named placeholders first
-			if (nonIntegerId(a) && nonIntegerId(b)) {
-				return 0;
-			} else if (nonIntegerId(a)) {
-				return -1;
-			} else if (nonIntegerId(b)) {
-				return 1;
-			}
+// 			// Sort named placeholders first
+// 			if (nonIntegerId(a) && nonIntegerId(b)) {
+// 				return 0;
+// 			} else if (nonIntegerId(a)) {
+// 				return -1;
+// 			} else if (nonIntegerId(b)) {
+// 				return 1;
+// 			}
 
-			if (a.id === b.id) {
-				return 0;
-			}
+// 			if (a.id === b.id) {
+// 				return 0;
+// 			}
 
-			return Number(a.id) < Number(b.id) ? -1 : 1;
-		});
+// 			return Number(a.id) < Number(b.id) ? -1 : 1;
+// 		});
 
-		if (this._snippet.placeHolders.length > 0 && this._snippet.placeHolders[this._snippet.placeHolders.length - 1].value === '') {
-			this._snippet.finishPlaceHolderIndex = this._snippet.placeHolders.length - 1;
-		}
-	}
+// 		if (this._snippet.placeHolders.length > 0 && this._snippet.placeHolders[this._snippet.placeHolders.length - 1].value === '') {
+// 			this._snippet.finishPlaceHolderIndex = this._snippet.placeHolders.length - 1;
+// 		}
+// 	}
 
-	private parseLine(line: string, findDefaultValueForIdFromPrevLines: (id: string) => string): IParsedLine {
+// 	private parseLine(line: string, findDefaultValueForIdFromPrevLines: (id: string) => string): IParsedLine {
 
-		// Placeholder 0 is the entire line
-		var placeHolderStack: { placeHolderId: string; placeHolderText: string; }[] = [{ placeHolderId: '', placeHolderText: '' }];
-		var placeHolders: IParsedLinePlaceHolderInfo[] = [];
+// 		// Placeholder 0 is the entire line
+// 		var placeHolderStack: { placeHolderId: string; placeHolderText: string; }[] = [{ placeHolderId: '', placeHolderText: '' }];
+// 		var placeHolders: IParsedLinePlaceHolderInfo[] = [];
 
-		const findDefaultValueForId = (id) => {
-			const result = findDefaultValueForIdFromPrevLines(id);
-			if (result) {
-				return result;
-			}
-			for (const placeHolder of placeHolders) {
-				if (placeHolder.id === id && placeHolder.value) {
-					return placeHolder.value;
-				}
-			}
-			return '';
-		};
+// 		const findDefaultValueForId = (id) => {
+// 			const result = findDefaultValueForIdFromPrevLines(id);
+// 			if (result) {
+// 				return result;
+// 			}
+// 			for (const placeHolder of placeHolders) {
+// 				if (placeHolder.id === id && placeHolder.value) {
+// 					return placeHolder.value;
+// 				}
+// 			}
+// 			return '';
+// 		};
 
-		var i = 0;
-		var len = line.length;
-		var resultIndex = 0;
-		while (i < len) {
+// 		var i = 0;
+// 		var len = line.length;
+// 		var resultIndex = 0;
+// 		while (i < len) {
 
-			var restOfLine = line.substr(i);
+// 			var restOfLine = line.substr(i);
 
-			// Look for the start of a placeholder {{
-			if (/^{{/.test(restOfLine)) {
-				i += 2;
-				placeHolderStack.push({ placeHolderId: '', placeHolderText: '' });
+// 			// Look for the start of a placeholder {{
+// 			if (/^{{/.test(restOfLine)) {
+// 				i += 2;
+// 				placeHolderStack.push({ placeHolderId: '', placeHolderText: '' });
 
-				// Look for id
-				var matches = restOfLine.match(/^{{(\w+):/);
-				if (Array.isArray(matches) && matches.length === 2) {
-					placeHolderStack[placeHolderStack.length - 1].placeHolderId = matches[1];
-					i += matches[1].length + 1; // +1 to account for the : at the end of the id
-				}
+// 				// Look for id
+// 				var matches = restOfLine.match(/^{{(\w+):/);
+// 				if (Array.isArray(matches) && matches.length === 2) {
+// 					placeHolderStack[placeHolderStack.length - 1].placeHolderId = matches[1];
+// 					i += matches[1].length + 1; // +1 to account for the : at the end of the id
+// 				}
 
-				continue;
-			}
+// 				continue;
+// 			}
 
-			// Look for the end of a placeholder. placeHolderStack[0] is the top-level line.
-			if (placeHolderStack.length > 1 && /^}}/.test(restOfLine)) {
-				i += 2;
+// 			// Look for the end of a placeholder. placeHolderStack[0] is the top-level line.
+// 			if (placeHolderStack.length > 1 && /^}}/.test(restOfLine)) {
+// 				i += 2;
 
-				if (placeHolderStack[placeHolderStack.length - 1].placeHolderId.length === 0) {
-					// This placeholder did not have an explicit id
-					placeHolderStack[placeHolderStack.length - 1].placeHolderId = placeHolderStack[placeHolderStack.length - 1].placeHolderText;
+// 				if (placeHolderStack[placeHolderStack.length - 1].placeHolderId.length === 0) {
+// 					// This placeholder did not have an explicit id
+// 					placeHolderStack[placeHolderStack.length - 1].placeHolderId = placeHolderStack[placeHolderStack.length - 1].placeHolderText;
 
-					if (placeHolderStack[placeHolderStack.length - 1].placeHolderId === '_') {
-						// This is just an empty tab stop
-						placeHolderStack[placeHolderStack.length - 1].placeHolderId = 'TAB_STOP_' + String(++this._lastGeneratedId);
-						placeHolderStack[placeHolderStack.length - 1].placeHolderText = '';
-						--resultIndex; // Roll back one iteration of the result index as we made the text empty
-					}
-				}
+// 					if (placeHolderStack[placeHolderStack.length - 1].placeHolderId === '_') {
+// 						// This is just an empty tab stop
+// 						placeHolderStack[placeHolderStack.length - 1].placeHolderId = 'TAB_STOP_' + String(++this._lastGeneratedId);
+// 						placeHolderStack[placeHolderStack.length - 1].placeHolderText = '';
+// 						--resultIndex; // Roll back one iteration of the result index as we made the text empty
+// 					}
+// 				}
 
-				if (placeHolderStack[placeHolderStack.length - 1].placeHolderText.length === 0) {
-					// This placeholder is empty or was a mirror
-					var defaultValue = findDefaultValueForId(placeHolderStack[placeHolderStack.length - 1].placeHolderId);
-					placeHolderStack[placeHolderStack.length - 1].placeHolderText = defaultValue;
-					resultIndex += defaultValue.length;
-				}
+// 				if (placeHolderStack[placeHolderStack.length - 1].placeHolderText.length === 0) {
+// 					// This placeholder is empty or was a mirror
+// 					var defaultValue = findDefaultValueForId(placeHolderStack[placeHolderStack.length - 1].placeHolderId);
+// 					placeHolderStack[placeHolderStack.length - 1].placeHolderText = defaultValue;
+// 					resultIndex += defaultValue.length;
+// 				}
 
-				placeHolders.push({
-					id: placeHolderStack[placeHolderStack.length - 1].placeHolderId,
-					value: placeHolderStack[placeHolderStack.length - 1].placeHolderText,
-					startColumn: resultIndex + 1 - placeHolderStack[placeHolderStack.length - 1].placeHolderText.length,
-					endColumn: resultIndex + 1
-				});
+// 				placeHolders.push({
+// 					id: placeHolderStack[placeHolderStack.length - 1].placeHolderId,
+// 					value: placeHolderStack[placeHolderStack.length - 1].placeHolderText,
+// 					startColumn: resultIndex + 1 - placeHolderStack[placeHolderStack.length - 1].placeHolderText.length,
+// 					endColumn: resultIndex + 1
+// 				});
 
-				// Insert our text into the previous placeholder
-				placeHolderStack[placeHolderStack.length - 2].placeHolderText += placeHolderStack[placeHolderStack.length - 1].placeHolderText;
-				placeHolderStack.pop();
-				continue;
-			}
+// 				// Insert our text into the previous placeholder
+// 				placeHolderStack[placeHolderStack.length - 2].placeHolderText += placeHolderStack[placeHolderStack.length - 1].placeHolderText;
+// 				placeHolderStack.pop();
+// 				continue;
+// 			}
 
-			// Look for escapes
-			if (/^\\./.test(restOfLine)) {
-				if (restOfLine.charAt(1) === '{' || restOfLine.charAt(1) === '}' || restOfLine.charAt(1) === '\\') {
-					++i; // Skip the escape slash and take the character literally
-				} else {
-					// invalid escapes
-					placeHolderStack[placeHolderStack.length - 1].placeHolderText += line.charAt(i);
-					++resultIndex;
-					++i;
-				}
-			}
+// 			// Look for escapes
+// 			if (/^\\./.test(restOfLine)) {
+// 				if (restOfLine.charAt(1) === '{' || restOfLine.charAt(1) === '}' || restOfLine.charAt(1) === '\\') {
+// 					++i; // Skip the escape slash and take the character literally
+// 				} else {
+// 					// invalid escapes
+// 					placeHolderStack[placeHolderStack.length - 1].placeHolderText += line.charAt(i);
+// 					++resultIndex;
+// 					++i;
+// 				}
+// 			}
 
-			//This is an escape sequence or not a special character, just insert it
-			placeHolderStack[placeHolderStack.length - 1].placeHolderText += line.charAt(i);
-			++resultIndex;
-			++i;
-		}
+// 			//This is an escape sequence or not a special character, just insert it
+// 			placeHolderStack[placeHolderStack.length - 1].placeHolderText += line.charAt(i);
+// 			++resultIndex;
+// 			++i;
+// 		}
 
-		// Sort the placeholder in order of apperance:
-		placeHolders.sort((a, b) => {
-			if (a.startColumn < b.startColumn) {
-				return -1;
-			}
-			if (a.startColumn > b.startColumn) {
-				return 1;
-			}
-			if (a.endColumn < b.endColumn) {
-				return -1;
-			}
-			if (a.endColumn > b.endColumn) {
-				return 1;
-			}
-			return 0;
-		});
+// 		// Sort the placeholder in order of apperance:
+// 		placeHolders.sort((a, b) => {
+// 			if (a.startColumn < b.startColumn) {
+// 				return -1;
+// 			}
+// 			if (a.startColumn > b.startColumn) {
+// 				return 1;
+// 			}
+// 			if (a.endColumn < b.endColumn) {
+// 				return -1;
+// 			}
+// 			if (a.endColumn > b.endColumn) {
+// 				return 1;
+// 			}
+// 			return 0;
+// 		});
 
-		return {
-			line: placeHolderStack[0].placeHolderText,
-			placeHolders: placeHolders
-		};
-	}
-};
+// 		return {
+// 			line: placeHolderStack[0].placeHolderText,
+// 			placeHolders: placeHolders
+// 		};
+// 	}
+// };
 
-const EmmetSnippetParser = new class implements ISnippetParser {
+// const EmmetSnippetParser = new class implements ISnippetParser {
 
-	parse(template: string): CodeSnippet {
-		template = _convertExternalSnippet(template, ExternalSnippetType.EmmetSnippet);
-		return InternalFormatSnippetParser.parse(template);
-	}
-};
+// 	parse(template: string): CodeSnippet {
+// 		template = _convertExternalSnippet(template, ExternalSnippetType.EmmetSnippet);
+// 		return InternalFormatSnippetParser.parse(template);
+// 	}
+// };
 
-export enum ExternalSnippetType {
-	TextMateSnippet,
-	EmmetSnippet
-}
+// export enum ExternalSnippetType {
+// 	TextMateSnippet,
+// 	EmmetSnippet
+// }
 
-// This is used for both TextMate and Emmet
-function _convertExternalSnippet(snippet: string, snippetType: ExternalSnippetType): string {
-	var openBraces = 0;
-	var convertedSnippet = '';
-	var i = 0;
-	var len = snippet.length;
+// // This is used for both TextMate and Emmet
+// function _convertExternalSnippet(snippet: string, snippetType: ExternalSnippetType): string {
+// 	var openBraces = 0;
+// 	var convertedSnippet = '';
+// 	var i = 0;
+// 	var len = snippet.length;
 
-	while (i < len) {
-		var restOfLine = snippet.substr(i);
+// 	while (i < len) {
+// 		var restOfLine = snippet.substr(i);
 
-		// Cursor tab stop
-		if (/^\$0/.test(restOfLine)) {
-			i += 2;
-			convertedSnippet += snippetType === ExternalSnippetType.EmmetSnippet ? '{{_}}' : '{{}}';
-			continue;
-		}
-		if (/^\$\{0\}/.test(restOfLine)) {
-			i += 4;
-			convertedSnippet += snippetType === ExternalSnippetType.EmmetSnippet ? '{{_}}' : '{{}}';
-			continue;
-		}
+// 		// Cursor tab stop
+// 		if (/^\$0/.test(restOfLine)) {
+// 			i += 2;
+// 			convertedSnippet += snippetType === ExternalSnippetType.EmmetSnippet ? '{{_}}' : '{{}}';
+// 			continue;
+// 		}
+// 		if (/^\$\{0\}/.test(restOfLine)) {
+// 			i += 4;
+// 			convertedSnippet += snippetType === ExternalSnippetType.EmmetSnippet ? '{{_}}' : '{{}}';
+// 			continue;
+// 		}
 
-		// Tab stops
-		var matches = restOfLine.match(/^\$(\d+)/);
-		if (Array.isArray(matches) && matches.length === 2) {
-			i += 1 + matches[1].length;
-			convertedSnippet += '{{' + matches[1] + ':}}';
-			continue;
-		}
-		matches = restOfLine.match(/^\$\{(\d+)\}/);
-		if (Array.isArray(matches) && matches.length === 2) {
-			i += 3 + matches[1].length;
-			convertedSnippet += '{{' + matches[1] + ':}}';
-			continue;
-		}
+// 		// Tab stops
+// 		var matches = restOfLine.match(/^\$(\d+)/);
+// 		if (Array.isArray(matches) && matches.length === 2) {
+// 			i += 1 + matches[1].length;
+// 			convertedSnippet += '{{' + matches[1] + ':}}';
+// 			continue;
+// 		}
+// 		matches = restOfLine.match(/^\$\{(\d+)\}/);
+// 		if (Array.isArray(matches) && matches.length === 2) {
+// 			i += 3 + matches[1].length;
+// 			convertedSnippet += '{{' + matches[1] + ':}}';
+// 			continue;
+// 		}
 
-		// Open brace patterns placeholder
-		if (/^\${/.test(restOfLine)) {
-			i += 2;
-			++openBraces;
-			convertedSnippet += '{{';
-			continue;
-		}
+// 		// Open brace patterns placeholder
+// 		if (/^\${/.test(restOfLine)) {
+// 			i += 2;
+// 			++openBraces;
+// 			convertedSnippet += '{{';
+// 			continue;
+// 		}
 
-		// Close brace patterns placeholder
-		if (openBraces > 0 && /^}/.test(restOfLine)) {
-			i += 1;
-			--openBraces;
-			convertedSnippet += '}}';
-			continue;
-		}
+// 		// Close brace patterns placeholder
+// 		if (openBraces > 0 && /^}/.test(restOfLine)) {
+// 			i += 1;
+// 			--openBraces;
+// 			convertedSnippet += '}}';
+// 			continue;
+// 		}
 
-		// Escapes
-		if (/^\\./.test(restOfLine)) {
-			i += 2;
-			if (/^\\\$/.test(restOfLine)) {
-				convertedSnippet += '$';
-			} else {
-				convertedSnippet += restOfLine.substr(0, 2);
-			}
-			continue;
-		}
+// 		// Escapes
+// 		if (/^\\./.test(restOfLine)) {
+// 			i += 2;
+// 			if (/^\\\$/.test(restOfLine)) {
+// 				convertedSnippet += '$';
+// 			} else {
+// 				convertedSnippet += restOfLine.substr(0, 2);
+// 			}
+// 			continue;
+// 		}
 
-		// Escape braces that don't belong to a placeholder
-		matches = restOfLine.match(/^({|})/);
-		if (Array.isArray(matches) && matches.length === 2) {
-			i += 1;
-			convertedSnippet += '\\' + matches[1];
-			continue;
-		}
+// 		// Escape braces that don't belong to a placeholder
+// 		matches = restOfLine.match(/^({|})/);
+// 		if (Array.isArray(matches) && matches.length === 2) {
+// 			i += 1;
+// 			convertedSnippet += '\\' + matches[1];
+// 			continue;
+// 		}
 
-		i += 1;
-		convertedSnippet += restOfLine.charAt(0);
-	}
+// 		i += 1;
+// 		convertedSnippet += restOfLine.charAt(0);
+// 	}
 
-	return convertedSnippet;
-};
+// 	return convertedSnippet;
+// };
 
 
 function _resolveSnippetVariables(marker: Marker[], resolver: ISnippetVariableResolver) {

--- a/src/vs/editor/contrib/snippet/common/snippet.ts
+++ b/src/vs/editor/contrib/snippet/common/snippet.ts
@@ -8,7 +8,6 @@
 import * as strings from 'vs/base/common/strings';
 import { Range } from 'vs/editor/common/core/range';
 import * as editorCommon from 'vs/editor/common/editorCommon';
-// import * as collections from 'vs/base/common/collections';
 import { Marker, Variable, Placeholder, Text, SnippetParser } from 'vs/editor/contrib/snippet/common/snippetParser';
 
 export interface IIndentationNormalizer {
@@ -55,9 +54,7 @@ export class CodeSnippet implements ICodeSnippet {
 	}
 
 	static fromEmmet(template: string): CodeSnippet {
-		//return EmmetSnippetParser.parse(template);
-
-		let matchFinalStops = template.match(/\$\{0\}/g);
+		let matchFinalStops = template.match(/\$\{0\}|\$0/g);
 		if (!matchFinalStops || matchFinalStops.length === 1) {
 			return CodeSnippet.fromTextmate(template);
 		}
@@ -65,29 +62,37 @@ export class CodeSnippet implements ICodeSnippet {
 		// Emmet sometimes returns snippets with multiple ${0}
 		// In such cases, replace ${0} with incremental tab stops
 
-		let maxTabStop = -1;
-		let matches = [];
-		let regex = /\$\{(\d+)\}/g;
-		while (matches = regex.exec(template)) {
-			let tabStop = Number(matches[1]);
-			if (tabStop > maxTabStop) {
-				maxTabStop = tabStop;
-			}
-		}
-		regex = /\$\{(\d+):[^\}]+\}/g;
-		matches = [];
-		while (matches = regex.exec(template)) {
-			let tabStop = Number(matches[1]);
-			if (tabStop > maxTabStop) {
-				maxTabStop = tabStop;
-			}
-		}
+		const snippetMarkers: Marker[] = new SnippetParser(true, false).parse(template) || [];
+		let getMaxTabStop = (markers: Marker[]): number => {
+			let currentMaxTabStop = -1;
+			markers.forEach(marker => {
+				if (marker instanceof Placeholder && /^\d+$/.test(marker['name'])) {
+					let currentTabStop = Number(marker['name']);
+					let nestedMaxTabStop = getMaxTabStop(marker['defaultValue'] || []);
+					currentMaxTabStop = Math.max(currentMaxTabStop, currentTabStop, nestedMaxTabStop);
+				}
+			});
+			return currentMaxTabStop;
+		};
 
-		template = template.replace(/\$\{0\}/g, (substring) => {
-			return `\$\{${++maxTabStop}\}`;
-		});
+		let maxTabStop = getMaxTabStop(snippetMarkers);
 
-		return CodeSnippet.fromTextmate(template);
+		let setNextTabStop = (markers: Marker[]) => {
+			markers.forEach(marker => {
+				if (marker instanceof Placeholder) {
+					if (marker['name'] === '0') {
+						marker['name'] = ++maxTabStop + '';
+					}
+					setNextTabStop(marker['defaultValue'] || []);
+				}
+			});
+		};
+
+		setNextTabStop(snippetMarkers);
+
+		const snippet = new CodeSnippet();
+		_fillCodeSnippetFromMarker(snippet, snippetMarkers);
+		return snippet;
 	}
 
 	public lines: string[] = [];
@@ -152,7 +157,7 @@ export class CodeSnippet implements ICodeSnippet {
 		for (const originalPlaceHolder of this.placeHolders) {
 			let resultOccurences = [];
 
-			for (let {startLineNumber, startColumn, endLineNumber, endColumn} of originalPlaceHolder.occurences) {
+			for (let { startLineNumber, startColumn, endLineNumber, endColumn } of originalPlaceHolder.occurences) {
 
 				if (startColumn > 1 || startLineNumber === 1) {
 					// placeholders that aren't at the beginning of new snippet lines
@@ -210,298 +215,6 @@ interface IParsedLine {
 	line: string;
 	placeHolders: IParsedLinePlaceHolderInfo[];
 }
-
-// const InternalFormatSnippetParser = new class implements ISnippetParser {
-
-// 	private _lastGeneratedId: number;
-// 	private _snippet: CodeSnippet;
-
-// 	parse(template: string): CodeSnippet {
-// 		this._lastGeneratedId = 0;
-// 		this._snippet = new CodeSnippet();
-// 		this.parseTemplate(template);
-// 		return this._snippet;
-// 	}
-
-// 	private parseTemplate(template: string): void {
-
-// 		var placeHoldersMap: collections.IStringDictionary<IPlaceHolder> = Object.create(null);
-// 		var i: number, len: number, j: number, lenJ: number, templateLines = template.split('\n');
-
-// 		for (i = 0, len = templateLines.length; i < len; i++) {
-// 			var parsedLine = this.parseLine(templateLines[i], (id: string) => {
-// 				if (placeHoldersMap[id]) {
-// 					return placeHoldersMap[id].value;
-// 				}
-// 				return '';
-// 			});
-// 			for (j = 0, lenJ = parsedLine.placeHolders.length; j < lenJ; j++) {
-// 				var linePlaceHolder = parsedLine.placeHolders[j];
-// 				var occurence = new Range(i + 1, linePlaceHolder.startColumn, i + 1, linePlaceHolder.endColumn);
-// 				var placeHolder: IPlaceHolder;
-
-// 				if (placeHoldersMap[linePlaceHolder.id]) {
-// 					placeHolder = placeHoldersMap[linePlaceHolder.id];
-// 				} else {
-// 					placeHolder = {
-// 						id: linePlaceHolder.id,
-// 						value: linePlaceHolder.value,
-// 						occurences: []
-// 					};
-// 					this._snippet.placeHolders.push(placeHolder);
-// 					placeHoldersMap[linePlaceHolder.id] = placeHolder;
-// 				}
-
-// 				placeHolder.occurences.push(occurence);
-// 			}
-
-// 			this._snippet.lines.push(parsedLine.line);
-// 		}
-
-// 		// Named variables (e.g. {greeting} and {greeting:Hello}) are sorted first, followed by
-// 		// tab-stops and numeric variables (e.g. $1, $2, ${3:foo}) which are sorted in ascending order
-// 		this._snippet.placeHolders.sort((a, b) => {
-// 			let nonIntegerId = (v: IPlaceHolder) => !(/^\d+$/).test(v.id);
-// 			let isFinishPlaceHolder = (v: IPlaceHolder) => v.id === '' && v.value === '';
-
-// 			// Sort finish placeholder last
-// 			if (isFinishPlaceHolder(a)) {
-// 				return 1;
-// 			} else if (isFinishPlaceHolder(b)) {
-// 				return -1;
-// 			}
-
-// 			// Sort named placeholders first
-// 			if (nonIntegerId(a) && nonIntegerId(b)) {
-// 				return 0;
-// 			} else if (nonIntegerId(a)) {
-// 				return -1;
-// 			} else if (nonIntegerId(b)) {
-// 				return 1;
-// 			}
-
-// 			if (a.id === b.id) {
-// 				return 0;
-// 			}
-
-// 			return Number(a.id) < Number(b.id) ? -1 : 1;
-// 		});
-
-// 		if (this._snippet.placeHolders.length > 0 && this._snippet.placeHolders[this._snippet.placeHolders.length - 1].value === '') {
-// 			this._snippet.finishPlaceHolderIndex = this._snippet.placeHolders.length - 1;
-// 		}
-// 	}
-
-// 	private parseLine(line: string, findDefaultValueForIdFromPrevLines: (id: string) => string): IParsedLine {
-
-// 		// Placeholder 0 is the entire line
-// 		var placeHolderStack: { placeHolderId: string; placeHolderText: string; }[] = [{ placeHolderId: '', placeHolderText: '' }];
-// 		var placeHolders: IParsedLinePlaceHolderInfo[] = [];
-
-// 		const findDefaultValueForId = (id) => {
-// 			const result = findDefaultValueForIdFromPrevLines(id);
-// 			if (result) {
-// 				return result;
-// 			}
-// 			for (const placeHolder of placeHolders) {
-// 				if (placeHolder.id === id && placeHolder.value) {
-// 					return placeHolder.value;
-// 				}
-// 			}
-// 			return '';
-// 		};
-
-// 		var i = 0;
-// 		var len = line.length;
-// 		var resultIndex = 0;
-// 		while (i < len) {
-
-// 			var restOfLine = line.substr(i);
-
-// 			// Look for the start of a placeholder {{
-// 			if (/^{{/.test(restOfLine)) {
-// 				i += 2;
-// 				placeHolderStack.push({ placeHolderId: '', placeHolderText: '' });
-
-// 				// Look for id
-// 				var matches = restOfLine.match(/^{{(\w+):/);
-// 				if (Array.isArray(matches) && matches.length === 2) {
-// 					placeHolderStack[placeHolderStack.length - 1].placeHolderId = matches[1];
-// 					i += matches[1].length + 1; // +1 to account for the : at the end of the id
-// 				}
-
-// 				continue;
-// 			}
-
-// 			// Look for the end of a placeholder. placeHolderStack[0] is the top-level line.
-// 			if (placeHolderStack.length > 1 && /^}}/.test(restOfLine)) {
-// 				i += 2;
-
-// 				if (placeHolderStack[placeHolderStack.length - 1].placeHolderId.length === 0) {
-// 					// This placeholder did not have an explicit id
-// 					placeHolderStack[placeHolderStack.length - 1].placeHolderId = placeHolderStack[placeHolderStack.length - 1].placeHolderText;
-
-// 					if (placeHolderStack[placeHolderStack.length - 1].placeHolderId === '_') {
-// 						// This is just an empty tab stop
-// 						placeHolderStack[placeHolderStack.length - 1].placeHolderId = 'TAB_STOP_' + String(++this._lastGeneratedId);
-// 						placeHolderStack[placeHolderStack.length - 1].placeHolderText = '';
-// 						--resultIndex; // Roll back one iteration of the result index as we made the text empty
-// 					}
-// 				}
-
-// 				if (placeHolderStack[placeHolderStack.length - 1].placeHolderText.length === 0) {
-// 					// This placeholder is empty or was a mirror
-// 					var defaultValue = findDefaultValueForId(placeHolderStack[placeHolderStack.length - 1].placeHolderId);
-// 					placeHolderStack[placeHolderStack.length - 1].placeHolderText = defaultValue;
-// 					resultIndex += defaultValue.length;
-// 				}
-
-// 				placeHolders.push({
-// 					id: placeHolderStack[placeHolderStack.length - 1].placeHolderId,
-// 					value: placeHolderStack[placeHolderStack.length - 1].placeHolderText,
-// 					startColumn: resultIndex + 1 - placeHolderStack[placeHolderStack.length - 1].placeHolderText.length,
-// 					endColumn: resultIndex + 1
-// 				});
-
-// 				// Insert our text into the previous placeholder
-// 				placeHolderStack[placeHolderStack.length - 2].placeHolderText += placeHolderStack[placeHolderStack.length - 1].placeHolderText;
-// 				placeHolderStack.pop();
-// 				continue;
-// 			}
-
-// 			// Look for escapes
-// 			if (/^\\./.test(restOfLine)) {
-// 				if (restOfLine.charAt(1) === '{' || restOfLine.charAt(1) === '}' || restOfLine.charAt(1) === '\\') {
-// 					++i; // Skip the escape slash and take the character literally
-// 				} else {
-// 					// invalid escapes
-// 					placeHolderStack[placeHolderStack.length - 1].placeHolderText += line.charAt(i);
-// 					++resultIndex;
-// 					++i;
-// 				}
-// 			}
-
-// 			//This is an escape sequence or not a special character, just insert it
-// 			placeHolderStack[placeHolderStack.length - 1].placeHolderText += line.charAt(i);
-// 			++resultIndex;
-// 			++i;
-// 		}
-
-// 		// Sort the placeholder in order of apperance:
-// 		placeHolders.sort((a, b) => {
-// 			if (a.startColumn < b.startColumn) {
-// 				return -1;
-// 			}
-// 			if (a.startColumn > b.startColumn) {
-// 				return 1;
-// 			}
-// 			if (a.endColumn < b.endColumn) {
-// 				return -1;
-// 			}
-// 			if (a.endColumn > b.endColumn) {
-// 				return 1;
-// 			}
-// 			return 0;
-// 		});
-
-// 		return {
-// 			line: placeHolderStack[0].placeHolderText,
-// 			placeHolders: placeHolders
-// 		};
-// 	}
-// };
-
-// const EmmetSnippetParser = new class implements ISnippetParser {
-
-// 	parse(template: string): CodeSnippet {
-// 		template = _convertExternalSnippet(template, ExternalSnippetType.EmmetSnippet);
-// 		return InternalFormatSnippetParser.parse(template);
-// 	}
-// };
-
-// export enum ExternalSnippetType {
-// 	TextMateSnippet,
-// 	EmmetSnippet
-// }
-
-// // This is used for both TextMate and Emmet
-// function _convertExternalSnippet(snippet: string, snippetType: ExternalSnippetType): string {
-// 	var openBraces = 0;
-// 	var convertedSnippet = '';
-// 	var i = 0;
-// 	var len = snippet.length;
-
-// 	while (i < len) {
-// 		var restOfLine = snippet.substr(i);
-
-// 		// Cursor tab stop
-// 		if (/^\$0/.test(restOfLine)) {
-// 			i += 2;
-// 			convertedSnippet += snippetType === ExternalSnippetType.EmmetSnippet ? '{{_}}' : '{{}}';
-// 			continue;
-// 		}
-// 		if (/^\$\{0\}/.test(restOfLine)) {
-// 			i += 4;
-// 			convertedSnippet += snippetType === ExternalSnippetType.EmmetSnippet ? '{{_}}' : '{{}}';
-// 			continue;
-// 		}
-
-// 		// Tab stops
-// 		var matches = restOfLine.match(/^\$(\d+)/);
-// 		if (Array.isArray(matches) && matches.length === 2) {
-// 			i += 1 + matches[1].length;
-// 			convertedSnippet += '{{' + matches[1] + ':}}';
-// 			continue;
-// 		}
-// 		matches = restOfLine.match(/^\$\{(\d+)\}/);
-// 		if (Array.isArray(matches) && matches.length === 2) {
-// 			i += 3 + matches[1].length;
-// 			convertedSnippet += '{{' + matches[1] + ':}}';
-// 			continue;
-// 		}
-
-// 		// Open brace patterns placeholder
-// 		if (/^\${/.test(restOfLine)) {
-// 			i += 2;
-// 			++openBraces;
-// 			convertedSnippet += '{{';
-// 			continue;
-// 		}
-
-// 		// Close brace patterns placeholder
-// 		if (openBraces > 0 && /^}/.test(restOfLine)) {
-// 			i += 1;
-// 			--openBraces;
-// 			convertedSnippet += '}}';
-// 			continue;
-// 		}
-
-// 		// Escapes
-// 		if (/^\\./.test(restOfLine)) {
-// 			i += 2;
-// 			if (/^\\\$/.test(restOfLine)) {
-// 				convertedSnippet += '$';
-// 			} else {
-// 				convertedSnippet += restOfLine.substr(0, 2);
-// 			}
-// 			continue;
-// 		}
-
-// 		// Escape braces that don't belong to a placeholder
-// 		matches = restOfLine.match(/^({|})/);
-// 		if (Array.isArray(matches) && matches.length === 2) {
-// 			i += 1;
-// 			convertedSnippet += '\\' + matches[1];
-// 			continue;
-// 		}
-
-// 		i += 1;
-// 		convertedSnippet += restOfLine.charAt(0);
-// 	}
-
-// 	return convertedSnippet;
-// };
-
 
 function _resolveSnippetVariables(marker: Marker[], resolver: ISnippetVariableResolver) {
 	if (resolver) {


### PR DESCRIPTION
Emmet snippets follow text mate syntax.
See https://docs.emmet.io/customization/snippets/#text-snippets
Therefore we should be able to use `CodeSnippet.fromTextmate` instead of `CodeSnippet.fromEmmet` and all the special code we have for emmet

The only catch is when in certain cases emmet returns multiple ${0}
${0} is meant to be the final cursor position and shouldn't occur more than once in a snippet.
This is clearly a bug in emmet. 

_Note_1:_ Emmet 2.0 doesn't have these issues. 

_Note_2:_ There are multiple cases where this happens. I was able to figure out root causes and fixes for a few of these cases, but decided its not worth chasing down these issues in emmet. Mainly because it is in maintenance mode and also, there might be more scenarios which we don't know. We can't fix what we don't know.

Till now, we went around this issue, by assigning [incremental values](https://github.com/Microsoft/vscode/blob/1.11.2/src/vs/editor/contrib/snippet/common/snippet.ts#L263) to such tabstops and [sorting](https://github.com/Microsoft/vscode/blob/1.11.2/src/vs/editor/contrib/snippet/common/snippet.ts#L231) them so that they appear before the numbered placeholder.

So in `<input type="${1:text}" class="${0}" id="${0}" style="${2}">`, the order of tabstops would be
- class
- id
- type
- style

which is not perfect, but this is the current behavior.

In this PR, we replace the multiple ${0} with tab stops starting from the max stop + 1

So `<input type="${1:text}" class="${0}" id="${0}" style="${2}">`
will be `<input type="${1:text}" class="${3}" id="${4}" style="${2}">`

Again, not perfect or ideal, but we don't lose any tabstops which is important.

With this, we can not only fix #19246 but also pave the way for simplifying the way we do snippets
(and remove legacy code, who doesn't like that? :) )


