### PR TITLE
Fix Markdown Preview Updating on Zoom / Unrelated Config Changes

### DIFF
--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -176,12 +176,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}));
 
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
-		vscode.workspace.textDocuments.forEach(document => {
-			if (document.uri.scheme === 'markdown') {
-				// update all generated md documents
-				contentProvider.update(document.uri);
-			}
-		});
+		contentProvider.updateConfiguration();
 	}));
 
 	context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(event => {


### PR DESCRIPTION
Fixes #24808

**bug**
Markdown preview updates when you zoom. The root cause is that previews are updated whenever the config is changed.

**Fix**
Extract preview config to its own well defined object. Only update the preview when the keys we care about in the config change