### PR TITLE
List Navigation for accessibility focus/tabindex  Issue #24119 (replaces PR #24628)

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -410,6 +410,13 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 				this.focusPrevious();
 			} else if (event.equals(isVertical ? KeyCode.DownArrow : KeyCode.RightArrow)) {
 				this.focusNext();
+
+
+			} else if (event.equals(!isVertical ? KeyCode.UpArrow : KeyCode.LeftArrow)) {
+				console.log('discard: Up-Left');
+			} else if (event.equals(!isVertical ? KeyCode.DownArrow : KeyCode.RightArrow)) {
+				console.log('discard: Down-Right');
+
 			} else if (event.equals(KeyCode.Escape)) {
 				this.cancel();
 			} else if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -816,10 +816,12 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 
 		if (styles.listFocusBackground) {
 			content.push(`.monaco-list.${this.idPrefix}:focus .monaco-list-row.focused { background-color: ${styles.listFocusBackground}; }`);
+			content.push(`.monaco-list.${this.idPrefix}.focused .monaco-list-row.focused { background-color: ${styles.listFocusBackground}; }`);
 		}
 
 		if (styles.listActiveSelectionBackground) {
 			content.push(`.monaco-list.${this.idPrefix}:focus .monaco-list-row.selected { background-color: ${styles.listActiveSelectionBackground}; }`);
+			content.push(`.monaco-list.${this.idPrefix}.focused:focus .monaco-list-row.selected { background-color: ${styles.listActiveSelectionBackground}; }`);
 			content.push(`.monaco-list.${this.idPrefix}:focus .monaco-list-row.selected:hover { background-color: ${styles.listActiveSelectionBackground}; }`); // overwrite :hover style in this case!
 		}
 
@@ -836,7 +838,6 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		}
 
 		if (styles.listInactiveFocusBackground) {
-			content.push(`.monaco-list.${this.idPrefix} .monaco-list-row.focused { background-color:  ${styles.listInactiveFocusBackground}; }`);
 			content.push(`.monaco-list.${this.idPrefix} .monaco-list-row.focused:hover { background-color:  ${styles.listInactiveFocusBackground}; }`); // overwrite :hover style in this case!
 		}
 

--- a/src/vs/workbench/parts/scm/electron-browser/media/scmViewlet.css
+++ b/src/vs/workbench/parts/scm/electron-browser/media/scmViewlet.css
@@ -67,10 +67,10 @@
 	display: none;
 }
 
-.scm-viewlet .monaco-list .monaco-list-row.focused > .resource-group > .actions,
-.scm-viewlet .monaco-list .monaco-list-row.focused > .resource > .actions,
-.scm-viewlet .monaco-list .monaco-list-row.focused.selected > .resource-group > .actions,
-.scm-viewlet .monaco-list .monaco-list-row.focused.selected  > .resource > .actions,
+.scm-viewlet .monaco-list.focused .monaco-list-row.focused > .resource-group > .actions,
+.scm-viewlet .monaco-list.focused .monaco-list-row.focused > .resource > .actions,
+.scm-viewlet .monaco-list.focused .monaco-list-row.focused.selected > .resource-group > .actions,
+.scm-viewlet .monaco-list.focused .monaco-list-row.focused.selected  > .resource > .actions,
 .scm-viewlet .monaco-list:not(.selection-multiple) .monaco-list-row > .resource:hover > .actions {
 	display: block;
 }

--- a/src/vs/workbench/parts/scm/electron-browser/media/scmViewlet.css
+++ b/src/vs/workbench/parts/scm/electron-browser/media/scmViewlet.css
@@ -67,8 +67,10 @@
 	display: none;
 }
 
-.scm-viewlet .monaco-list .monaco-list-row.selected > .resource-group > .actions,
-.scm-viewlet .monaco-list .monaco-list-row.selected > .resource > .actions,
+.scm-viewlet .monaco-list .monaco-list-row.focused > .resource-group > .actions,
+.scm-viewlet .monaco-list .monaco-list-row.focused > .resource > .actions,
+.scm-viewlet .monaco-list .monaco-list-row.focused.selected > .resource-group > .actions,
+.scm-viewlet .monaco-list .monaco-list-row.focused.selected  > .resource > .actions,
 .scm-viewlet .monaco-list:not(.selection-multiple) .monaco-list-row > .resource:hover > .actions {
 	display: block;
 }

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -15,7 +15,7 @@ import { domEvent } from 'vs/base/browser/event';
 import { IDisposable, dispose, empty as EmptyDisposable, combinedDisposable } from 'vs/base/common/lifecycle';
 import { Builder, Dimension } from 'vs/base/browser/builder';
 import { Viewlet } from 'vs/workbench/browser/viewlet';
-import { append, $, toggleClass } from 'vs/base/browser/dom';
+import { append, $, toggleClass, addClass, removeClass } from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -322,6 +322,17 @@ export class SCMViewlet extends Viewlet {
 
 		this.list.onContextMenu(this.onListContextMenu, this, this.disposables);
 		this.disposables.push(this.list);
+
+		// Add a logical list focus that will be active even if an action has :focus
+		this._register(this.list.onDOMFocus(() => {
+			addClass(this.list.getHTMLElement(), 'focused');
+		}));
+
+		this._register(this.list.onDOMBlur(() => {
+			removeClass(this.list.getHTMLElement(), 'focused');
+		}));
+
+
 
 		this.setActiveProvider(this.scmService.activeProvider);
 		this.scmService.onDidChangeProvider(this.setActiveProvider, this, this.disposables);


### PR DESCRIPTION
Cleaned commits
added modifications for both extensions and SCM
See issue #24119 and replaced PR #24628  for main comments

AfterReview still need to address listing key bindings
and up\down after action Escape
Ideally bubble action keyboard events to list row container
Make key bindings list behave the same