### PR TITLE
Added support for encodings for Git.

### DIFF
--- a/extensions/git/npm-shrinkwrap.json
+++ b/extensions/git/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "applicationinsights@0.18.0",
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz"
     },
+    "iconv-lite": {
+      "version": "0.4.15",
+      "from": "iconv-lite@0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+    },
     "vscode-extension-telemetry": {
       "version": "0.0.6",
       "from": "vscode-extension-telemetry@>=0.0.6 <0.0.7",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -623,6 +623,7 @@
     }
   },
   "dependencies": {
+    "iconv-lite": "0.4.15",
     "vscode-extension-telemetry": "^0.0.6",
     "vscode-nls": "^2.0.1"
   },

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -28,6 +28,7 @@ async function init(context: ExtensionContext, disposables: Disposable[]): Promi
 	const outputChannel = window.createOutputChannel('Git');
 	disposables.push(outputChannel);
 
+	const configFiles = workspace.getConfiguration('files');
 	const config = workspace.getConfiguration('git');
 	const enabled = config.get<boolean>('enabled') === true;
 	const workspaceRootPath = workspace.rootPath;
@@ -44,7 +45,7 @@ async function init(context: ExtensionContext, disposables: Disposable[]): Promi
 		return;
 	}
 
-	const model = new Model(git, workspaceRootPath);
+	const model = new Model(git, workspaceRootPath, configFiles.get<string>('encoding'));
 
 	outputChannel.appendLine(localize('using git', "Using git {0} from {1}", info.version, info.path));
 	git.onOutput(str => outputChannel.append(str), null, disposables);

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -356,7 +356,8 @@ export class Model implements Disposable {
 
 	constructor(
 		private _git: Git,
-		private workspaceRootPath: string
+		private workspaceRootPath: string,
+		private encoding?: string
 	) {
 		const fsWatcher = workspace.createFileSystemWatcher('**');
 		this.onWorkspaceChange = anyEvent(fsWatcher.onDidChange, fsWatcher.onDidCreate, fsWatcher.onDidDelete);
@@ -480,7 +481,9 @@ export class Model implements Disposable {
 	async show(ref: string, filePath: string): Promise<string> {
 		return await this.run(Operation.Show, async () => {
 			const relativePath = path.relative(this.repository.root, filePath).replace(/\\/g, '/');
-			const result = await this.repository.git.exec(this.repository.root, ['show', `${ref}:${relativePath}`]);
+			const result = await this.repository.git.exec(this.repository.root, ['show', `${ref}:${relativePath}`], {
+				encoding: this.encoding
+			});
 
 			if (result.exitCode !== 0) {
 				throw new GitError({


### PR DESCRIPTION
Fixes #21146

**Bug**
Git always uses utf8 encoding for retrieving file contents.

**Fix**
Pass the 'files.encoding' configuration property to the git-extension and use this encoding to decode git output.