### PR TITLE
Prototype Extension Contributed TS Plugins

### DIFF
--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -61,6 +61,10 @@ export class API {
 	public has222Features(): boolean {
 		return semver.gte(this._version, '2.2.2');
 	}
+
+	public has230Features(): boolean {
+		return semver.gte(this._version, '2.3.0');
+	}
 }
 
 export interface ITypescriptServiceClient {

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -571,7 +571,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 					}
 
 					if (this.apiVersion.has230Features()) {
-						const plugins = this.getTypeScriptServerPlugsins();
+						const plugins = this.getContributedTypeScriptServerPlugins();
 						if (plugins.length) {
 							args.push('--globalPlugins', plugins.map(x => x.name).join(','));
 							args.push('--pluginProbeLocations', plugins.map(x => x.path).join(','));
@@ -806,16 +806,15 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		return desc.version;
 	}
 
-	private getTypeScriptServerPlugsins(): TypeScriptServerPlugin[] {
+	private getContributedTypeScriptServerPlugins(): TypeScriptServerPlugin[] {
 		const plugins: TypeScriptServerPlugin[] = [];
 		for (const extension of extensions.all) {
 			const pack = extension.packageJSON;
 			if (pack.contributes && pack.contributes.typescriptServerPlugins && Array.isArray(pack.contributes.typescriptServerPlugins)) {
 				for (const plugin of pack.contributes.typescriptServerPlugins) {
-					const fullPath = path.resolve(extension.extensionPath, plugin);
 					plugins.push({
-						name: path.basename(fullPath),
-						path: path.dirname(fullPath)
+						name: plugin.name,
+						path: path.join(extension.extensionPath, 'node_modules', plugin.name)
 					});
 				}
 			}

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -13,7 +13,7 @@ import * as os from 'os';
 import * as electron from './utils/electron';
 import { Reader } from './utils/wireProtocol';
 
-import { workspace, window, Uri, CancellationToken, Disposable, OutputChannel, Memento, MessageItem, QuickPickItem, EventEmitter, Event, commands, WorkspaceConfiguration } from 'vscode';
+import { workspace, window, extensions, Uri, CancellationToken, Disposable, OutputChannel, Memento, MessageItem, QuickPickItem, EventEmitter, Event, commands, WorkspaceConfiguration } from 'vscode';
 import * as Proto from './protocol';
 import { ITypescriptServiceClient, ITypescriptServiceClientHost, API } from './typescriptService';
 
@@ -119,6 +119,11 @@ interface MyQuickPickItem extends QuickPickItem {
 
 interface MyMessageItem extends MessageItem {
 	id: MessageAction;
+}
+
+interface TypeScriptServerPlugin {
+	path: string;
+	name: string;
 }
 
 
@@ -565,6 +570,14 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 						}
 					}
 
+					if (this.apiVersion.has230Features()) {
+						const plugins = this.getTypeScriptServerPlugsins();
+						if (plugins.length) {
+							args.push('--globalPlugins', plugins.map(x => x.name).join(','));
+							args.push('--pluginProbeLocations', plugins.map(x => x.path).join(','));
+						}
+					}
+
 					electron.fork(modulePath, args, options, (err: any, childProcess: cp.ChildProcess) => {
 						if (err) {
 							this.lastError = err;
@@ -791,6 +804,23 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 			return undefined;
 		}
 		return desc.version;
+	}
+
+	private getTypeScriptServerPlugsins(): TypeScriptServerPlugin[] {
+		const plugins: TypeScriptServerPlugin[] = [];
+		for (const extension of extensions.all) {
+			const pack = extension.packageJSON;
+			if (pack.contributes && pack.contributes.typescriptServerPlugins && Array.isArray(pack.contributes.typescriptServerPlugins)) {
+				for (const plugin of pack.contributes.typescriptServerPlugins) {
+					const fullPath = path.resolve(extension.extensionPath, plugin);
+					plugins.push({
+						name: path.basename(fullPath),
+						path: path.dirname(fullPath)
+					});
+				}
+			}
+		}
+		return plugins;
 	}
 
 	private serviceExited(restart: boolean): void {

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -814,7 +814,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 				for (const plugin of pack.contributes.typescriptServerPlugins) {
 					plugins.push({
 						name: plugin.name,
-						path: path.join(extension.extensionPath, 'node_modules', plugin.name)
+						path: extension.extensionPath
 					});
 				}
 			}


### PR DESCRIPTION
Prototype of allowing extensions to contribute TSServer extensions.

Currently blocked until we pick up build with: https://github.com/Microsoft/TypeScript/issues/15233

Example extension (requires manually installing tslint-server from github): https://github.com/mjbvz/test-vscode-tsserver-plugin

