### PR TITLE
Fix #24817 - Prevent overflow of the message in define keybinding widget.

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/media/keybindings.css
+++ b/src/vs/workbench/parts/preferences/browser/media/keybindings.css
@@ -11,7 +11,6 @@
 .defineKeybindingWidget .message {
 	width: 400px;
 	text-align: center;
-	white-space: nowrap;
 }
 
 .defineKeybindingWidget .monaco-inputbox,


### PR DESCRIPTION
Prevent overflow of the message in define keybinding widget.