### PR TITLE
Inserting file path on the terminal, when dragging a file to it

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -210,11 +210,12 @@ export class TerminalPanel extends Panel {
 				if (!e.dataTransfer) {
 					return;
 				}
-				// check if the file was dragged from the tree explorer
+
+				// Check if the file was dragged from the tree explorer
 				const url = e.dataTransfer.getData('URL');
 				let filePath = URI.parse(url).path;
 
-				// check if the file was dragged from the filesystem
+				// Check if the file was dragged from the filesystem
 				if (!filePath && e.dataTransfer.files.length > 0) {
 					filePath = e.dataTransfer.files[0].path;
 				}


### PR DESCRIPTION
This feature was suggested in https://github.com/Microsoft/vscode/issues/11907

I've tested the following scenarios, on a MacOS device:

* Dragging a file from the OS filesystem to the terminal
* Dragging a file from the tree explorer to the terminal
* Dragging a tab from the tab panel to the terminal

Let me know if any change is needed