### PR TITLE
Fix #24971. PowerShell Extension .bat & .exe Syntax Highlighting Error

### DIFF
--- a/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
+++ b/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
@@ -240,7 +240,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(\b(([A-Za-z0-9\-_\.]+).(?i:exe|com|cmd|bat))\b)</string>
+			<string>(\b(([A-Za-z0-9\-_\.]+)\.(?i:exe|com|cmd|bat))\b)</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>

--- a/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
+++ b/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
@@ -240,7 +240,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:[a-z][a-z0-9]+-?[a-z][a-z0-9]+)(?i:\.(?i:exe|cmd|bat|ps1))</string>
+			<string>(\b(([A-Za-z0-9\-_\.]+).(?i:exe|com|cmd|bat))\b)</string>
 			<key>name</key>
 			<string>support.function.powershell</string>
 		</dict>


### PR DESCRIPTION
By changing the regular expression as per this PR, .bat and .exe files will be properly highlighted.

### Code to reproduce
```
something.bat 
ipconfig.exe
Import-Module AzureRM.Backup
Import-Module AzureRm.Batch 
Import-Module AzureRm.Exefake
Import-Module AzureRM.Cdn
21jumpstreet.bat 
```

### Results before applying this change
![image](https://cloud.githubusercontent.com/assets/13203965/25149995/b2fa1cf0-243d-11e7-87d7-123f33ad94f9.png)

### Results after applying this change
![image](https://cloud.githubusercontent.com/assets/13203965/25150211/6524e446-243e-11e7-980a-2b9eb294c9cd.png)