### PR TITLE
Fix #24861. Stop propagation for keyDown events if the IME is processing key input

### DIFF
--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -128,6 +128,10 @@ let KEY_CODE_MAP: { [keyCode: number]: KeyCode } = {};
 
 	KEY_CODE_MAP[226] = KeyCode.OEM_102;
 
+	/**
+	 * https://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html
+	 * If an Input Method Editor is processing key input and the event is keydown, return 229.
+	 */
 	KEY_CODE_MAP[229] = KeyCode.KEY_IN_COMPOSITION;
 
 	if (browser.isIE) {

--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -128,6 +128,8 @@ let KEY_CODE_MAP: { [keyCode: number]: KeyCode } = {};
 
 	KEY_CODE_MAP[226] = KeyCode.OEM_102;
 
+	KEY_CODE_MAP[229] = KeyCode.KEY_IN_COMPOSITION;
+
 	if (browser.isIE) {
 		KEY_CODE_MAP[91] = KeyCode.Meta;
 	} else if (browser.isFirefox) {

--- a/src/vs/base/common/keyCodes.ts
+++ b/src/vs/base/common/keyCodes.ts
@@ -186,6 +186,12 @@ export const enum KeyCode {
 	NUMPAD_DIVIDE = 108,	// VK_DIVIDE, 0x6F,
 
 	/**
+	 * https://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html
+	 * If an Input Method Editor is processing key input and the event is keydown, return 229.
+	 */
+	KEY_IN_COMPOSITION = 229,
+
+	/**
 	 * Placed last to cover the length of the enum.
 	 * Please do not depend on this value!
 	 */

--- a/src/vs/base/common/keyCodes.ts
+++ b/src/vs/base/common/keyCodes.ts
@@ -186,10 +186,9 @@ export const enum KeyCode {
 	NUMPAD_DIVIDE = 108,	// VK_DIVIDE, 0x6F,
 
 	/**
-	 * https://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html
-	 * If an Input Method Editor is processing key input and the event is keydown, return 229.
+	 * Cover all key codes when IME is processing input.
 	 */
-	KEY_IN_COMPOSITION = 229,
+	KEY_IN_COMPOSITION = 109,
 
 	/**
 	 * Placed last to cover the length of the enum.

--- a/src/vs/editor/browser/controller/input/textAreaWrapper.ts
+++ b/src/vs/editor/browser/controller/input/textAreaWrapper.ts
@@ -80,6 +80,10 @@ class KeyboardEventWrapper implements IKeyboardEventWrapper {
 		this._actual.preventDefault();
 	}
 
+	public stopPropagation(): void {
+		this._actual.stopPropagation();
+	}
+
 	public isDefaultPrevented(): boolean {
 		if (this._actual.browserEvent) {
 			return this._actual.browserEvent.defaultPrevented;

--- a/src/vs/editor/common/controller/textAreaHandler.ts
+++ b/src/vs/editor/common/controller/textAreaHandler.ts
@@ -309,6 +309,11 @@ export class TextAreaHandler extends Disposable {
 	}
 
 	private _onKeyDownHandler(e: IKeyboardEventWrapper): void {
+		if (this.textareaIsShownAtCursor && e.equals(KeyCode.KEY_IN_COMPOSITION)) {
+			// Stop propagation for keyDown events if the IME is processing key input
+			e.stopPropagation();
+		}
+
 		if (e.equals(KeyCode.Escape)) {
 			// Prevent default always for `Esc`, otherwise it will generate a keypress
 			// See https://msdn.microsoft.com/en-us/library/ie/ms536939(v=vs.85).aspx

--- a/src/vs/editor/common/controller/textAreaState.ts
+++ b/src/vs/editor/common/controller/textAreaState.ts
@@ -26,6 +26,7 @@ export interface IKeyboardEventWrapper {
 	_actual: any;
 	equals(keybinding: number): boolean;
 	preventDefault(): void;
+	stopPropagation(): void;
 	isDefaultPrevented(): boolean;
 }
 

--- a/src/vs/editor/common/standalone/standaloneBase.ts
+++ b/src/vs/editor/common/standalone/standaloneBase.ts
@@ -210,6 +210,10 @@ export enum KeyCode {
 	NUMPAD_DECIMAL = 107,
 	NUMPAD_DIVIDE = 108,
 	/**
+	 * Cover all key codes when IME is processing input.
+	 */
+	KEY_IN_COMPOSITION = 109,
+	/**
 	 * Placed last to cover the length of the enum.
 	 * Please do not depend on this value!
 	 */

--- a/src/vs/editor/test/common/standalone/standaloneBase.test.ts
+++ b/src/vs/editor/test/common/standalone/standaloneBase.test.ts
@@ -134,6 +134,7 @@ suite('KeyCode', () => {
 		assertKeyCode(StandaloneKeyCode.NUMPAD_SUBTRACT, RuntimeKeyCode.NUMPAD_SUBTRACT);
 		assertKeyCode(StandaloneKeyCode.NUMPAD_DECIMAL, RuntimeKeyCode.NUMPAD_DECIMAL);
 		assertKeyCode(StandaloneKeyCode.NUMPAD_DIVIDE, RuntimeKeyCode.NUMPAD_DIVIDE);
+		assertKeyCode(StandaloneKeyCode.KEY_IN_COMPOSITION, RuntimeKeyCode.KEY_IN_COMPOSITION);
 		assertKeyCode(StandaloneKeyCode.MAX_VALUE, RuntimeKeyCode.MAX_VALUE);
 	});
 });

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -349,10 +349,14 @@ declare module monaco {
         NUMPAD_DECIMAL = 107,
         NUMPAD_DIVIDE = 108,
         /**
+         * Cover all key codes when IME is processing input.
+         */
+        KEY_IN_COMPOSITION = 109,
+        /**
          * Placed last to cover the length of the enum.
          * Please do not depend on this value!
          */
-        MAX_VALUE = 109,
+        MAX_VALUE = 110,
     }
 
     export class KeyMod {


### PR DESCRIPTION
Make sure our keybinding service doesn't handle keyDown events if they are used for composition.

cc @alexandrudima @Tyriar 