### PR TITLE
Empty arguments in launch commands are now properly escaped

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/terminalSupport.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/terminalSupport.ts
@@ -73,7 +73,7 @@ export class TerminalSupport {
 
 			const quote = (s: string) => {
 				s = s.replace(/\'/g, '\'\'');
-				return s.indexOf(' ') >= 0 || s.indexOf('\'') >= 0 || s.indexOf('"') >= 0 ? `'${s}'` : s;
+				return (s.indexOf(' ') >= 0 || s.indexOf('\'') >= 0 || s.indexOf('"') >= 0 || s.length === 0) ? `'${s}'` : s;
 			};
 
 			if (args.cwd) {
@@ -92,7 +92,7 @@ export class TerminalSupport {
 
 			const quote = (s: string) => {
 				s = s.replace(/\"/g, '""');
-				return (s.indexOf(' ') >= 0 || s.indexOf('"') >= 0) ? `"${s}"` : s;
+				return (s.indexOf(' ') >= 0 || s.indexOf('"') >= 0 || s.length === 0) ? `"${s}"` : s;
 			};
 
 			if (args.cwd) {
@@ -116,7 +116,7 @@ export class TerminalSupport {
 
 			const quote = (s: string) => {
 				s = s.replace(/\"/g, '\\"');
-				return s.indexOf(' ') >= 0 ? `"${s}"` : s;
+				return (s.indexOf(' ') >= 0 || s.length === 0) ? `"${s}"` : s;
 			};
 
 			if (args.cwd) {


### PR DESCRIPTION
Bug discovered with [Python debugger extension](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python). Usually, it passes `debugOptions` array to its python counterpart `visualstudio_py_launcher.py` from `launch.json`, joined with comma, like so:

**launch.json**:
`"debugOptions": ["WaitOnAbnormalExit","WaitOnNormalExit"]`

**launch command**:

> python C:\Users\...\.vscode\extensions\donjayamanne.python-0.6.3\pythonFiles\PythonTools\visualstudio_py_launcher.py working_dir 51686 34806ad9-833a-45248cd6-18ca4aa74f14 **WaitOnAbnormalExit,WaitOnNormalExit** file.py

 However, when `debugOptions` is empty, no argument is passed. As `visualstudio_py_launcher.py` relies on position of its arguments, it breaks, as `file.py` is now taking place of `debugOptions`.

I tracked this issue to `TerminalSupport.prepareCommand` not properly escaping empty argument: it should pass `""` instead of empty string for it.

With this fix, launch command for empty `debugOptions` looks like:

> python C:\Users\...\.vscode\extensions\donjayamanne.python-0.6.3\pythonFiles\PythonTools\visualstudio_py_launcher.py working_dir 51686 34806ad9-833a-45248cd6-18ca4aa74f14 **""** file.py

and successfully works.

Tested only with `cmd.exe`, but in my understanding should be the same for other shells, so I changed that too.