### PR TITLE
Disable Autoclosing Pairs for Quotes in c++ strings and comments

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -9,11 +9,11 @@
 		["(", ")"]
 	],
 	"autoClosingPairs": [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"],
-		["\"", "\""],
-		["'", "'"]
+		{ "open": "[", "close": "]" },
+		{ "open": "{", "close": "}" },
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],


### PR DESCRIPTION
Fixes #25025