### PR TITLE
Add setting to disable NPM Not installed Warning Message

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -105,6 +105,11 @@
           "default": true,
           "description": "%typescript.check.tscVersion%"
         },
+        "typescript.check.npmIsInstalled": {
+            "type": "boolean",
+            "default": true,
+            "description": "%typescript.check.npmIsInstalled%"
+          },
         "typescript.referencesCodeLens.enabled": {
           "type": "boolean",
           "default": false,

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -33,5 +33,6 @@
 	"typescript.openTsServerLog.title": "Open TS Server log file",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version",
 	"jsDocCompletion.enabled": "Enable/disable auto JSDoc comments",
-	"javascript.implicitProjectConfig.checkJs": "Enable/disable semantic checking of JavaScript files. Existing jsconfig.json or tsconfig.json files override this setting. Requires TypeScript >=2.3.1."
+	"javascript.implicitProjectConfig.checkJs": "Enable/disable semantic checking of JavaScript files. Existing jsconfig.json or tsconfig.json files override this setting. Requires TypeScript >=2.3.1.",
+	"typescript.check.npmIsInstalled": "Check if NPM is installed for automatic typings acquisition"
 }

--- a/extensions/typescript/src/utils/typingsStatus.ts
+++ b/extensions/typescript/src/utils/typingsStatus.ts
@@ -7,17 +7,18 @@
 
 'use strict';
 
-import * as vscode from 'vscode';
+import { MessageItem, workspace, Disposable, window, commands } from 'vscode';
 import { ITypescriptServiceClient } from '../typescriptService';
 import { loadMessageBundle } from 'vscode-nls';
+
 const localize = loadMessageBundle();
 
 const typingsInstallTimeout = 30 * 1000;
 
-export default class TypingsStatus extends vscode.Disposable {
+export default class TypingsStatus extends Disposable {
 	private _acquiringTypings: { [eventId: string]: NodeJS.Timer } = Object.create({});
 	private _client: ITypescriptServiceClient;
-	private _subscriptions: vscode.Disposable[] = [];
+	private _subscriptions: Disposable[] = [];
 
 	constructor(client: ITypescriptServiceClient) {
 		super(() => this.dispose());
@@ -63,10 +64,10 @@ export default class TypingsStatus extends vscode.Disposable {
 export class AtaProgressReporter {
 
 	private _promises = new Map<number, Function>();
-	private _disposable: vscode.Disposable;
+	private _disposable: Disposable;
 
 	constructor(client: ITypescriptServiceClient) {
-		this._disposable = vscode.Disposable.from(
+		this._disposable = Disposable.from(
 			client.onDidBeginInstallTypings(e => this._onBegin(e.eventId)),
 			client.onDidEndInstallTypings(e => this._onEndOrTimeout(e.eventId)),
 			client.onTypesInstallerInitializationFailed(_ => this.onTypesInstallerInitializationFailed()));
@@ -86,7 +87,7 @@ export class AtaProgressReporter {
 			});
 		});
 
-		vscode.window.withWindowProgress(localize('installingPackages', "Fetching data for better TypeScript IntelliSense"), () => promise);
+		window.withWindowProgress(localize('installingPackages', "Fetching data for better TypeScript IntelliSense"), () => promise);
 	}
 
 	private _onEndOrTimeout(eventId: number): void {
@@ -98,6 +99,42 @@ export class AtaProgressReporter {
 	}
 
 	private onTypesInstallerInitializationFailed() {
-		vscode.window.showWarningMessage(localize('typesInstallerInitializationFailed', "Could not install typings files for JS/TS language features. Please ensure that NPM is installed"));
+		interface MyMessageItem extends MessageItem {
+			id: number;
+		}
+
+		if (workspace.getConfiguration('typescript').get<boolean>('check.npmIsInstalled', true)) {
+			window.showWarningMessage<MyMessageItem>(
+				localize(
+					'typesInstallerInitializationFailed.title',
+					"Could not install typings files for JavaScript language features. Please ensure that NPM is installed"
+				), {
+					title: localize('typesInstallerInitializationFailed.moreInformation', "More Information"),
+					id: 1
+				},
+				{
+					title: localize('typesInstallerInitializationFailed.doNotCheckAgain', "Don't Check Again"),
+					id: 2
+				},
+				{
+					title: localize('typesInstallerInitializationFailed.close', 'Close'),
+					id: 3,
+					isCloseAffordance: true
+				}
+			).then(selected => {
+				if (!selected || selected.id === 3) {
+					return;
+				}
+				switch (selected.id) {
+					case 1:
+						commands.executeCommand('open', 'https://go.microsoft.com/fwlink/?linkid=847635');
+						break;
+					case 2:
+						const tsConfig = workspace.getConfiguration('typescript');
+						tsConfig.update('check.npmIsInstalled', false, true);
+						break;
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
Fixes #25063 

**Bug**
When a user does not have npm installed, in ts 2.3.1, we show a warning message. This may annoy users in cases where we just cannot find npm but it is installed using nvm or n.

I've also opened https://github.com/Microsoft/TypeScript/issues/15287 on TypeScript to discuss how we can handle these cases better

**Fix**
To avoid too much annoyance, add a setting to suppress this warning




