### PR TITLE
Fix VSCode/Extensions for TS 2.3.1

### DIFF
--- a/extensions/git/src/askpass.ts
+++ b/extensions/git/src/askpass.ts
@@ -20,7 +20,7 @@ export class Askpass implements Disposable {
 
 		try {
 			this.server.listen(0);
-			this.portPromise = new Promise(c => this.server.on('listening', () => c(this.server.address().port)));
+			this.portPromise = new Promise<number>(c => this.server.on('listening', () => c(this.server.address().port)));
 			this.server.on('error', err => console.error(err));
 		} catch (err) {
 			this.enabled = false;

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -523,7 +523,7 @@ export class CommandCenter {
 	}
 
 	private async smartCommit(
-		getCommitMessage: () => Promise<string>,
+		getCommitMessage: () => Promise<string | undefined>,
 		opts?: CommitOptions
 	): Promise<boolean> {
 		if (!opts) {

--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -68,7 +68,7 @@ export function once<T>(event: Event<T>): Event<T> {
 }
 
 export function eventToPromise<T>(event: Event<T>): Promise<T> {
-	return new Promise(c => once(event)(c));
+	return new Promise<T>(c => once(event)(c));
 }
 
 // TODO@Joao: replace with Object.assign
@@ -104,11 +104,11 @@ export function groupBy<T>(arr: T[], fn: (el: T) => string): { [key: string]: T[
 }
 
 export function denodeify<R>(fn: Function): (...args) => Promise<R> {
-	return (...args) => new Promise((c, e) => fn(...args, (err, r) => err ? e(err) : c(r)));
+	return (...args) => new Promise<R>((c, e) => fn(...args, (err, r) => err ? e(err) : c(r)));
 }
 
 export function nfcall<R>(fn: Function, ...args): Promise<R> {
-	return new Promise((c, e) => fn(...args, (err, r) => err ? e(err) : c(r)));
+	return new Promise<R>((c, e) => fn(...args, (err, r) => err ? e(err) : c(r)));
 }
 
 export async function mkdirp(path: string, mode?: number): Promise<boolean> {

--- a/extensions/php/src/features/utils/async.ts
+++ b/extensions/php/src/features/utils/async.ts
@@ -176,7 +176,7 @@ export class ThrottledDelayer<T> extends Delayer<Promise<T>> {
 	constructor(defaultDelay: number) {
 		super(defaultDelay);
 
-		this.throttler = new Throttler();
+		this.throttler = new Throttler<T>();
 	}
 
 	public trigger(promiseFactory: ITask<Promise<T>>, delay?: number): Promise<Promise<T>> {

--- a/extensions/typescript/src/features/formattingProvider.ts
+++ b/extensions/typescript/src/features/formattingProvider.ts
@@ -117,13 +117,15 @@ export default class TypeScriptFormattingProvider implements DocumentRangeFormat
 			if (!absPath) {
 				return Promise.resolve(Object.create(null));
 			}
+
+			const formatOptions = this.getFormatOptions(options);
 			const args: Proto.ConfigureRequestArguments = {
 				file: absPath,
-				formatOptions: this.getFormatOptions(options)
+				formatOptions: formatOptions
 			};
 			return this.client.execute('configure', args, token).then(_ => {
-				this.formatOptions[key] = args.formatOptions;
-				return args.formatOptions;
+				this.formatOptions[key] = formatOptions;
+				return formatOptions;
 			});
 		}
 	}

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -123,7 +123,7 @@ export function activate(context: ExtensionContext): void {
 	window.onDidChangeActiveTextEditor(VersionStatus.showHideStatus, null, context.subscriptions);
 	client.onReady().then(() => {
 		context.subscriptions.push(ProjectStatus.create(client,
-			path => new Promise(resolve => setTimeout(() => resolve(clientHost.handles(path)), 750)),
+			path => new Promise<boolean>(resolve => setTimeout(() => resolve(clientHost.handles(path)), 750)),
 			context.workspaceState));
 	}, () => {
 		// Nothing to do here. The client did show a message;

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -686,7 +686,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 								if (localModulePath) {
 									tryShowRestart(localModulePath);
 								}
-								return localModulePath;
+								return localModulePath || '';
 							});
 					case MessageAction.useBundled:
 						return this.workspaceState.update(TypeScriptServiceClient.useWorkspaceTsdkStorageKey, false)

--- a/extensions/typescript/src/utils/async.ts
+++ b/extensions/typescript/src/utils/async.ts
@@ -13,7 +13,7 @@ export class Delayer<T> {
 
 	public defaultDelay: number;
 	private timeout: any; // Timer
-	private completionPromise: Promise<T> | null;
+	private completionPromise: Promise<T | null> | null;
 	private onSuccess: ((value?: T | Thenable<T>) => void) | null;
 	private task: ITask<T> | null;
 
@@ -25,7 +25,7 @@ export class Delayer<T> {
 		this.task = null;
 	}
 
-	public trigger(task: ITask<T>, delay: number = this.defaultDelay): Promise<T> {
+	public trigger(task: ITask<T>, delay: number = this.defaultDelay): Promise<T | null> {
 		this.task = task;
 		if (delay >= 0) {
 			this.cancelTimeout();
@@ -55,7 +55,7 @@ export class Delayer<T> {
 		return this.completionPromise;
 	}
 
-	public forceDelivery(): Promise<T> | null {
+	public forceDelivery(): Promise<T | null> | null {
 		if (!this.completionPromise) {
 			return null;
 		}


### PR DESCRIPTION
From: https://github.com/Microsoft/TypeScript/issues/15352

TS 2.3.1 introduced a breaking change by [switching to covariant types for callbacks](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#covariance-in-callback-parameters). This change tries to fix these compiler errors in the extensions codebase