### PR TITLE
Fix TS 2.3.1 Compiler Errors in VSCode src/workbench 

### DIFF
--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -327,7 +327,7 @@ export class ExtHostApiCommands {
 				return undefined;
 			}
 			if (value.rejectReason) {
-				return TPromise.wrapError(value.rejectReason);
+				return TPromise.wrapError<types.WorkspaceEdit>(value.rejectReason);
 			}
 			let workspaceEdit = new types.WorkspaceEdit();
 			for (let edit of value.edits) {

--- a/src/vs/workbench/api/node/extHostCommands.ts
+++ b/src/vs/workbench/api/node/extHostCommands.ts
@@ -76,7 +76,7 @@ export class ExtHostCommands extends ExtHostCommandsShape {
 		if (this._commands.has(id)) {
 			// we stay inside the extension host and support
 			// to pass any kind of parameters around
-			return this.$executeContributedCommand(id, ...args);
+			return this.$executeContributedCommand<T>(id, ...args);
 
 		} else {
 			// automagically convert some argument types
@@ -96,7 +96,7 @@ export class ExtHostCommands extends ExtHostCommandsShape {
 				}
 			});
 
-			return this._proxy.$executeCommand(id, args);
+			return this._proxy.$executeCommand<T>(id, args);
 		}
 
 	}

--- a/src/vs/workbench/api/node/extHostDocuments.ts
+++ b/src/vs/workbench/api/node/extHostDocuments.ts
@@ -94,7 +94,7 @@ export class ExtHostDocuments extends ExtHostDocumentsShape {
 				return this._documentsAndEditors.getDocument(uri.toString());
 			}, err => {
 				this._documentLoader.delete(uri.toString());
-				return TPromise.wrapError(err);
+				return TPromise.wrapError<ExtHostDocumentData>(err);
 			});
 			this._documentLoader.set(uri.toString(), promise);
 		}

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -281,7 +281,7 @@ export class ExtHostExtensionService extends AbstractExtensionService<ExtHostExt
 		});
 	}
 
-	protected _actualActivateExtension(extensionDescription: IExtensionDescription): TPromise<ActivatedExtension> {
+	protected _actualActivateExtension(extensionDescription: IExtensionDescription): TPromise<ExtHostExtension> {
 		return this._doActualActivateExtension(extensionDescription).then((activatedExtension) => {
 			this._proxy.$onExtensionActivated(extensionDescription.id);
 			return activatedExtension;
@@ -307,10 +307,10 @@ export class ExtHostExtensionService extends AbstractExtensionService<ExtHostExt
 			}, (errors: any[]) => {
 				// Avoid failing with an array of errors, fail with a single error
 				if (errors[0]) {
-					return TPromise.wrapError(errors[0]);
+					return TPromise.wrapError<ExtHostExtension>(errors[0]);
 				}
 				if (errors[1]) {
-					return TPromise.wrapError(errors[1]);
+					return TPromise.wrapError<ExtHostExtension>(errors[1]);
 				}
 				return undefined;
 			});
@@ -355,7 +355,7 @@ function loadCommonJSModule<T>(modulePath: string): TPromise<T> {
 	try {
 		r = require.__$__nodeRequire<T>(modulePath);
 	} catch (e) {
-		return TPromise.wrapError(e);
+		return TPromise.wrapError<T>(e);
 	}
 	return TPromise.as(r);
 }

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -457,7 +457,7 @@ class RenameAdapter {
 					rejectReason: err
 				};
 			}
-			return TPromise.wrapError(err);
+			return TPromise.wrapError<modes.WorkspaceEdit>(err);
 		});
 	}
 }
@@ -716,7 +716,7 @@ export class ExtHostLanguageFeatures extends ExtHostLanguageFeaturesShape {
 	private _withAdapter<A, R>(handle: number, ctor: { new (...args: any[]): A }, callback: (adapter: A) => TPromise<R>): TPromise<R> {
 		let adapter = this._adapter.get(handle);
 		if (!(adapter instanceof ctor)) {
-			return TPromise.wrapError(new Error('no adapter found'));
+			return TPromise.wrapError<R>(new Error('no adapter found'));
 		}
 		return callback(<any>adapter);
 	}

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -310,7 +310,7 @@ export class ExtHostSCM {
 		return sourceControl;
 	}
 
-	$provideOriginalResource(sourceControlHandle: number, uri: URI): TPromise<URI> {
+	$provideOriginalResource(sourceControlHandle: number, uri: URI): TPromise<vscode.Uri> {
 		const sourceControl = this._sourceControls.get(sourceControlHandle);
 
 		if (!sourceControl || !sourceControl.quickDiffProvider) {

--- a/src/vs/workbench/api/node/extHostStorage.ts
+++ b/src/vs/workbench/api/node/extHostStorage.ts
@@ -17,7 +17,7 @@ export class ExtHostStorage {
 	}
 
 	getValue<T>(shared: boolean, key: string, defaultValue?: T): TPromise<T> {
-		return this._proxy.$getValue(shared, key).then(value => value || defaultValue);
+		return this._proxy.$getValue<T>(shared, key).then(value => value || defaultValue);
 	}
 
 	setValue(shared: boolean, key: string, value: any): TPromise<void> {

--- a/src/vs/workbench/api/node/extHostTextEditor.ts
+++ b/src/vs/workbench/api/node/extHostTextEditor.ts
@@ -513,7 +513,7 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 	private _runOnProxy(callback: () => TPromise<any>, silent: boolean): TPromise<ExtHostTextEditor> {
 		if (this._disposed) {
 			if (!silent) {
-				return TPromise.wrapError(silent);
+				return TPromise.wrapError<ExtHostTextEditor>(silent);
 			} else {
 				console.warn('TextEditor is closed/disposed');
 				return TPromise.as(undefined);
@@ -521,7 +521,7 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 		}
 		return callback().then(() => this, err => {
 			if (!silent) {
-				return TPromise.wrapError(silent);
+				return TPromise.wrapError<ExtHostTextEditor>(silent);
 			}
 			console.warn(err);
 			return undefined;

--- a/src/vs/workbench/api/node/extHostTreeView.ts
+++ b/src/vs/workbench/api/node/extHostTreeView.ts
@@ -85,7 +85,7 @@ export class ExtHostTreeView extends ExtHostTreeViewShape {
 		const provider = this._extNodeProviders[providerId];
 		if (!provider) {
 			const errMessage = localize('treeExplorer.notRegistered', 'No TreeExplorerNodeProvider with id \'{0}\' registered.', providerId);
-			return TPromise.wrapError(errMessage);
+			return TPromise.wrapError<InternalTreeExplorerNode>(errMessage);
 		}
 
 		return asWinJsPromise(() => provider.provideRootNode()).then(extRootNode => {
@@ -100,7 +100,7 @@ export class ExtHostTreeView extends ExtHostTreeViewShape {
 			return internalRootNode;
 		}, err => {
 			const errMessage = localize('treeExplorer.failedToProvideRootNode', 'TreeExplorerNodeProvider \'{0}\' failed to provide root node.', providerId);
-			return TPromise.wrapError(errMessage);
+			return TPromise.wrapError<InternalTreeExplorerNode>(errMessage);
 		});
 	}
 
@@ -108,7 +108,7 @@ export class ExtHostTreeView extends ExtHostTreeViewShape {
 		const provider = this._extNodeProviders[providerId];
 		if (!provider) {
 			const errMessage = localize('treeExplorer.notRegistered', 'No TreeExplorerNodeProvider with id \'{0}\' registered.', providerId);
-			return TPromise.wrapError(errMessage);
+			return TPromise.wrapError<InternalTreeExplorerNode[]>(errMessage);
 		}
 
 		const extNodeMap = this._extNodeMaps[providerId];

--- a/src/vs/workbench/api/node/mainThreadEditors.ts
+++ b/src/vs/workbench/api/node/mainThreadEditors.ts
@@ -188,14 +188,14 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	$tryApplyEdits(id: string, modelVersionId: number, edits: ISingleEditOperation[], opts: IApplyEditsOptions): TPromise<boolean> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError('TextEditor disposed');
+			return TPromise.wrapError<boolean>('TextEditor disposed');
 		}
 		return TPromise.as(this._documentsAndEditors.getEditor(id).applyEdits(modelVersionId, edits, opts));
 	}
 
 	$tryInsertSnippet(id: string, template: string, ranges: IRange[], opts: IUndoStopOptions): TPromise<boolean> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError('TextEditor disposed');
+			return TPromise.wrapError<boolean>('TextEditor disposed');
 		}
 		return TPromise.as(this._documentsAndEditors.getEditor(id).insertSnippet(template, ranges, opts));
 	}
@@ -212,7 +212,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 		const editor = this._documentsAndEditors.getEditor(id);
 
 		if (!editor) {
-			return TPromise.wrapError('No such TextEditor');
+			return TPromise.wrapError<ILineChange[]>('No such TextEditor');
 		}
 
 		const codeEditor = editor.getCodeEditor();

--- a/src/vs/workbench/api/node/mainThreadQuickOpen.ts
+++ b/src/vs/workbench/api/node/mainThreadQuickOpen.ts
@@ -33,7 +33,7 @@ export class MainThreadQuickOpen extends MainThreadQuickOpenShape {
 
 		const myToken = ++this._token;
 
-		this._contents = new TPromise((c, e) => {
+		this._contents = new TPromise<MyQuickPickItems[]>((c, e) => {
 			this._doSetItems = (items) => {
 				if (myToken === this._token) {
 					c(items);

--- a/src/vs/workbench/api/node/mainThreadStorage.ts
+++ b/src/vs/workbench/api/node/mainThreadStorage.ts
@@ -27,7 +27,7 @@ export class MainThreadStorage extends MainThreadStorageShape {
 			value = JSON.parse(jsonValue);
 			return TPromise.as(value);
 		} catch (err) {
-			return TPromise.wrapError(err);
+			return TPromise.wrapError<T>(err);
 		}
 	}
 

--- a/src/vs/workbench/api/node/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/node/mainThreadWorkspace.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import { isPromiseCanceledError } from 'vs/base/common/errors';
+import URI from 'vs/base/common/uri';
 import { ISearchService, QueryType } from 'vs/platform/search/common/search';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -45,7 +46,7 @@ export class MainThreadWorkspace extends MainThreadWorkspaceShape {
 		this._textModelResolverService = textModelResolverService;
 	}
 
-	$startSearch(include: string, exclude: string, maxResults: number, requestId: number): Thenable<Uri[]> {
+	$startSearch(include: string, exclude: string, maxResults: number, requestId: number): Thenable<URI[]> {
 		const workspace = this._contextService.getWorkspace();
 		if (!workspace) {
 			return undefined;

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -174,7 +174,7 @@ export class WorkbenchLayout implements IVerticalSashLayoutProvider, IHorizontal
 			let sidebarPosition = this.partService.getSideBarPosition();
 			let isSidebarVisible = this.partService.isVisible(Parts.SIDEBAR_PART);
 			let newSashWidth = (sidebarPosition === Position.LEFT) ? this.startSidebarWidth + e.currentX - startX : this.startSidebarWidth - e.currentX + startX;
-			let promise = TPromise.as(null);
+			let promise = TPromise.as<void>(null);
 
 			// Sidebar visible
 			if (isSidebarVisible) {
@@ -213,7 +213,7 @@ export class WorkbenchLayout implements IVerticalSashLayoutProvider, IHorizontal
 			let doLayout = false;
 			let isPanelVisible = this.partService.isVisible(Parts.PANEL_PART);
 			let newSashHeight = this.startPanelHeight - (e.currentY - startY);
-			let promise = TPromise.as(null);
+			let promise = TPromise.as<void>(null);
 
 			// Panel visible
 			if (isPanelVisible) {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -297,7 +297,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		// We need an editor descriptor for the input
 		const descriptor = Registry.as<IEditorRegistry>(EditorExtensions.Editors).getEditor(input);
 		if (!descriptor) {
-			return TPromise.wrapError(new Error(strings.format('Can not find a registered editor for the input {0}', input)));
+			return TPromise.wrapError<BaseEditor>(new Error(strings.format('Can not find a registered editor for the input {0}', input)));
 		}
 
 		// Opened to the side
@@ -453,7 +453,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				return TPromise.as(arg);
 			}
 
-			return TPromise.wrapError(arg);
+			return TPromise.wrapError<BaseEditor | Error>(arg);
 		};
 
 		const instantiateEditorPromise = editorInstantiationService.createInstance(<EditorDescriptor>descriptor).then(onInstantiate, onInstantiate);

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -134,7 +134,7 @@ export class SideBySideEditor extends BaseEditor {
 	private _createEditor(editorInput: EditorInput, container: HTMLElement): TPromise<BaseEditor> {
 		const descriptor = Registry.as<IEditorRegistry>(EditorExtensions.Editors).getEditor(editorInput);
 		if (!descriptor) {
-			return TPromise.wrapError(new Error(strings.format('Can not find a registered editor for the input {0}', editorInput)));
+			return TPromise.wrapError<BaseEditor>(new Error(strings.format('Can not find a registered editor for the input {0}', editorInput)));
 		}
 		return this.instantiationService.createInstance(<EditorDescriptor>descriptor)
 			.then((editor: BaseEditor) => {

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -200,7 +200,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 								const newPick = message || defaultMessage;
 								if (newPick !== currentPick) {
 									currentPick = newPick;
-									resolve(new TPromise(init));
+									resolve(new TPromise<any>(init));
 								}
 
 								return !message;
@@ -324,7 +324,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 			this.pickOpenWidget.layout(this.layoutDimensions);
 		}
 
-		return new TPromise<IPickOpenEntry | string>((complete, error, progress) => {
+		return new TPromise<IPickOpenEntry>((complete, error, progress) => {
 
 			// Detect cancellation while pick promise is loading
 			this.pickOpenWidget.setCallbacks({
@@ -959,7 +959,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 			});
 		}
 
-		return result.then(null, (error) => {
+		return result.then<QuickOpenHandler>(null, (error) => {
 			delete this.mapResolvedHandlersToPrefix[id];
 
 			return TPromise.wrapError('Unable to instantiate quick open handler ' + handler.moduleName + ' - ' + handler.ctorName + ': ' + JSON.stringify(error));
@@ -975,7 +975,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 		}
 
 		// Otherwise load and create
-		return this.mapResolvedHandlersToPrefix[id] = this.instantiationService.createInstance(handler);
+		return this.mapResolvedHandlersToPrefix[id] = this.instantiationService.createInstance<QuickOpenHandler>(handler);
 	}
 
 	public layout(dimension: Dimension): void {

--- a/src/vs/workbench/common/editor/resourceEditorInput.ts
+++ b/src/vs/workbench/common/editor/resourceEditorInput.ts
@@ -20,7 +20,7 @@ export class ResourceEditorInput extends EditorInput {
 
 	static ID: string = 'workbench.editors.resourceEditorInput';
 
-	private modelReference: TPromise<IReference<ResourceEditorModel>>;
+	private modelReference: TPromise<IReference<ITextEditorModel>>;
 	private resource: URI;
 	private name: string;
 	private description: string;
@@ -86,7 +86,7 @@ export class ResourceEditorInput extends EditorInput {
 			if (!(model instanceof ResourceEditorModel)) {
 				ref.dispose();
 				this.modelReference = null;
-				return TPromise.wrapError(`Unexpected model for ResourceInput: ${this.resource}`); // TODO@Ben eventually also files should be supported, but we guard due to the dangerous dispose of the model in dispose()
+				return TPromise.wrapError<ITextEditorModel>(`Unexpected model for ResourceInput: ${this.resource}`); // TODO@Ben eventually also files should be supported, but we guard due to the dangerous dispose of the model in dispose()
 			}
 
 			return model;

--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -260,7 +260,7 @@ export class WorkbenchShell {
 						secondaryButton: nls.localize('prof.restart', "Restart")
 					});
 
-					let createIssue = TPromise.as(undefined);
+					let createIssue = TPromise.as<void>(void 0);
 					if (primaryButton) {
 						const action = this.workbench.getInstantiationService().createInstance(ReportPerformanceIssueAction, ReportPerformanceIssueAction.ID, ReportPerformanceIssueAction.LABEL);
 

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -23,9 +23,8 @@ import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { Registry } from 'vs/platform/platform';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
 import { IOptions } from 'vs/workbench/common/options';
-import { Position as EditorPosition, IResourceDiffInput, IUntitledResourceInput } from 'vs/platform/editor/common/editor';
+import { Position as EditorPosition, IResourceDiffInput, IUntitledResourceInput, IEditor } from 'vs/platform/editor/common/editor';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
-import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { IEditorRegistry, Extensions as EditorExtensions } from 'vs/workbench/common/editor';
 import { HistoryService } from 'vs/workbench/services/history/browser/history';
 import { ActivitybarPart } from 'vs/workbench/browser/parts/activitybar/activitybarPart';
@@ -313,7 +312,7 @@ export class Workbench implements IPartService {
 			// Load Editors
 			const editorRestoreStopWatch = StopWatch.create();
 			compositeAndEditorPromises.push(this.resolveEditorsToOpen().then(inputs => {
-				let editorOpenPromise: TPromise<BaseEditor[]>;
+				let editorOpenPromise: TPromise<IEditor[]>;
 				if (inputs.length) {
 					editorOpenPromise = this.editorService.openEditors(inputs.map(input => { return { input, position: EditorPosition.ONE }; }));
 				} else {
@@ -698,7 +697,7 @@ export class Workbench implements IPartService {
 			this.workbench.removeClass('nosidebar');
 		}
 
-		let promise = TPromise.as(null);
+		let promise = TPromise.as<any>(null);
 		// If sidebar becomes hidden, also hide the current active Viewlet if any
 		if (hidden && this.sidebarPart.getActiveViewlet()) {
 			promise = this.sidebarPart.hideActiveViewlet().then(() => {
@@ -743,7 +742,7 @@ export class Workbench implements IPartService {
 			this.workbench.removeClass('nopanel');
 		}
 
-		let promise = TPromise.as(null);
+		let promise = TPromise.as<any>(null);
 		// If panel part becomes hidden, also hide the current active panel if any
 		if (hidden && this.panelPart.getActivePanel()) {
 			promise = this.panelPart.hideActivePanel().then(() => {

--- a/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
+++ b/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
@@ -33,7 +33,7 @@ export class DebugContentProvider implements IWorkbenchContribution, ITextModelC
 		const process = this.debugService.getViewModel().focusedProcess;
 
 		if (!process) {
-			return TPromise.wrapError(localize('unable', "Unable to resolve the resource without a debug session"));
+			return TPromise.wrapError<IModel>(localize('unable', "Unable to resolve the resource without a debug session"));
 		}
 		const source = process.sources.get(resource.toString());
 		let rawSource: DebugProtocol.Source;

--- a/src/vs/workbench/parts/debug/electron-browser/rawDebugSession.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/rawDebugSession.ts
@@ -149,9 +149,9 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 		return this.send(request, args);
 	}
 
-	protected send(command: string, args: any, cancelOnDisconnect = true): TPromise<DebugProtocol.Response> {
+	protected send<R extends DebugProtocol.Response>(command: string, args: any, cancelOnDisconnect = true): TPromise<R> {
 		return this.initServer().then(() => {
-			const promise = super.send(command, args).then(response => response, (errorResponse: DebugProtocol.ErrorResponse) => {
+			const promise = super.send<R>(command, args).then(response => response, (errorResponse: DebugProtocol.ErrorResponse) => {
 				const error = errorResponse && errorResponse.body ? errorResponse.body.error : null;
 				const errorMessage = errorResponse ? errorResponse.message : '';
 				const telemetryMessage = error ? debug.formatPII(error.format, true, error.variables) : errorMessage;
@@ -165,7 +165,7 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 				const userMessage = error ? debug.formatPII(error.format, false, error.variables) : errorMessage;
 				if (error && error.url) {
 					const label = error.urlLabel ? error.urlLabel : nls.localize('moreInfo', "More Info");
-					return TPromise.wrapError(errors.create(userMessage, {
+					return TPromise.wrapError<R>(errors.create(userMessage, {
 						actions: [CloseAction, new Action('debug.moreInfo', label, null, true, () => {
 							window.open(error.url);
 							return TPromise.as(null);
@@ -173,7 +173,7 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 					}));
 				}
 
-				return errors.isPromiseCanceledError(errorResponse) ? undefined : TPromise.wrapError(new Error(userMessage));
+				return errors.isPromiseCanceledError(errorResponse) ? undefined : TPromise.wrapError<R>(new Error(userMessage));
 			});
 
 			if (cancelOnDisconnect) {
@@ -260,7 +260,7 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 	}
 
 	public continue(args: DebugProtocol.ContinueArguments): TPromise<DebugProtocol.ContinueResponse> {
-		return this.send('continue', args).then(response => {
+		return this.send<DebugProtocol.ContinueResponse>('continue', args).then(response => {
 			this.fireFakeContinued(args.threadId, this.allThreadsContinued);
 			return response;
 		});
@@ -271,7 +271,7 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 	}
 
 	public setVariable(args: DebugProtocol.SetVariableArguments): TPromise<DebugProtocol.SetVariableResponse> {
-		return this.send('setVariable', args);
+		return this.send<DebugProtocol.SetVariableResponse>('setVariable', args);
 	}
 
 	public restartFrame(args: DebugProtocol.RestartFrameArguments, threadId: number): TPromise<DebugProtocol.RestartFrameResponse> {
@@ -282,7 +282,7 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 	}
 
 	public completions(args: DebugProtocol.CompletionsArguments): TPromise<DebugProtocol.CompletionsResponse> {
-		return this.send('completions', args);
+		return this.send<DebugProtocol.CompletionsResponse>('completions', args);
 	}
 
 	public disconnect(restart = false, force = false): TPromise<DebugProtocol.DisconnectResponse> {
@@ -307,15 +307,15 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 	}
 
 	public setBreakpoints(args: DebugProtocol.SetBreakpointsArguments): TPromise<DebugProtocol.SetBreakpointsResponse> {
-		return this.send('setBreakpoints', args);
+		return this.send<DebugProtocol.SetBreakpointsResponse>('setBreakpoints', args);
 	}
 
 	public setFunctionBreakpoints(args: DebugProtocol.SetFunctionBreakpointsArguments): TPromise<DebugProtocol.SetFunctionBreakpointsResponse> {
-		return this.send('setFunctionBreakpoints', args);
+		return this.send<DebugProtocol.SetFunctionBreakpointsResponse>('setFunctionBreakpoints', args);
 	}
 
 	public setExceptionBreakpoints(args: DebugProtocol.SetExceptionBreakpointsArguments): TPromise<DebugProtocol.SetExceptionBreakpointsResponse> {
-		return this.send('setExceptionBreakpoints', args);
+		return this.send<DebugProtocol.SetExceptionBreakpointsResponse>('setExceptionBreakpoints', args);
 	}
 
 	public configurationDone(): TPromise<DebugProtocol.ConfigurationDoneResponse> {
@@ -323,31 +323,31 @@ export class RawDebugSession extends v8.V8Protocol implements debug.ISession {
 	}
 
 	public stackTrace(args: DebugProtocol.StackTraceArguments): TPromise<DebugProtocol.StackTraceResponse> {
-		return this.send('stackTrace', args);
+		return this.send<DebugProtocol.StackTraceResponse>('stackTrace', args);
 	}
 
 	public exceptionInfo(args: DebugProtocol.ExceptionInfoArguments): TPromise<DebugProtocol.ExceptionInfoResponse> {
-		return this.send('exceptionInfo', args);
+		return this.send<DebugProtocol.ExceptionInfoResponse>('exceptionInfo', args);
 	}
 
 	public scopes(args: DebugProtocol.ScopesArguments): TPromise<DebugProtocol.ScopesResponse> {
-		return this.send('scopes', args);
+		return this.send<DebugProtocol.ScopesResponse>('scopes', args);
 	}
 
 	public variables(args: DebugProtocol.VariablesArguments): TPromise<DebugProtocol.VariablesResponse> {
-		return this.send('variables', args);
+		return this.send<DebugProtocol.VariablesResponse>('variables', args);
 	}
 
 	public source(args: DebugProtocol.SourceArguments): TPromise<DebugProtocol.SourceResponse> {
-		return this.send('source', args);
+		return this.send<DebugProtocol.SourceResponse>('source', args);
 	}
 
 	public threads(): TPromise<DebugProtocol.ThreadsResponse> {
-		return this.send('threads', null);
+		return this.send<DebugProtocol.ThreadsResponse>('threads', null);
 	}
 
 	public evaluate(args: DebugProtocol.EvaluateArguments): TPromise<DebugProtocol.EvaluateResponse> {
-		return this.send('evaluate', args);
+		return this.send<DebugProtocol.EvaluateResponse>('evaluate', args);
 	}
 
 	public stepBack(args: DebugProtocol.StepBackArguments): TPromise<DebugProtocol.StepBackResponse> {

--- a/src/vs/workbench/parts/debug/node/v8Protocol.ts
+++ b/src/vs/workbench/parts/debug/node/v8Protocol.ts
@@ -42,11 +42,11 @@ export abstract class V8Protocol {
 		});
 	}
 
-	protected send(command: string, args: any): TPromise<DebugProtocol.Response> {
+	protected send<R extends DebugProtocol.Response>(command: string, args: any): TPromise<R> {
 		let errorCallback;
-		return new TPromise((completeDispatch, errorDispatch) => {
+		return new TPromise<R>((completeDispatch, errorDispatch) => {
 			errorCallback = errorDispatch;
-			this.doSend(command, args, (result: DebugProtocol.Response) => {
+			this.doSend(command, args, (result: R) => {
 				if (result.success) {
 					completeDispatch(result);
 				} else {

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -188,7 +188,7 @@ class Extension implements IExtension {
 			return readFile(uri.fsPath, 'utf8');
 		}
 
-		return TPromise.wrapError('not available');
+		return TPromise.wrapError<string>('not available');
 	}
 
 	getChangelog(): TPromise<string> {
@@ -199,7 +199,7 @@ class Extension implements IExtension {
 		const changelogUrl = this.local && this.local.changelogUrl;
 
 		if (!changelogUrl) {
-			return TPromise.wrapError('not available');
+			return TPromise.wrapError<string>('not available');
 		}
 
 		const uri = URI.parse(changelogUrl);
@@ -208,7 +208,7 @@ class Extension implements IExtension {
 			return readFile(uri.fsPath, 'utf8');
 		}
 
-		return TPromise.wrapError('not available');
+		return TPromise.wrapError<string>('not available');
 	}
 
 	get dependencies(): string[] {
@@ -374,13 +374,13 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService {
 					return TPromise.as(singlePagePager([]));
 				}
 
-				return TPromise.wrapError(err);
+				return TPromise.wrapError<IPager<IExtension>>(err);
 			});
 	}
 
 	loadDependencies(extension: IExtension): TPromise<IExtensionDependencies> {
 		if (!extension.dependencies.length) {
-			return TPromise.wrap(null);
+			return TPromise.wrap<IExtensionDependencies>(null);
 		}
 
 		return this.galleryService.getAllDependencies((<Extension>extension).gallery)

--- a/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
@@ -162,7 +162,7 @@ export class TextFileEditor extends BaseTextEditor {
 
 			// Offer to create a file from the error if we have a file not found and the name is valid
 			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND && paths.isValidBasename(paths.basename(input.getResource().fsPath))) {
-				return TPromise.wrapError(errors.create(toErrorMessage(error), {
+				return TPromise.wrapError<void>(errors.create(toErrorMessage(error), {
 					actions: [
 						new Action('workbench.files.action.createMissingFile', nls.localize('createFile', "Create File"), null, true, () => {
 							return this.fileService.updateContent(input.getResource(), '').then(() => {
@@ -182,7 +182,7 @@ export class TextFileEditor extends BaseTextEditor {
 			}
 
 			// Otherwise make sure the error bubbles up
-			return TPromise.wrapError(error);
+			return TPromise.wrapError<void>(error);
 		});
 	}
 

--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -843,7 +843,7 @@ export class ImportFileAction extends BaseFileAction {
 							// if the target exists and is dirty, make sure to revert it. otherwise the dirty contents
 							// of the target file would replace the contents of the imported file. since we already
 							// confirmed the overwrite before, this is OK.
-							let revertPromise = TPromise.as(null);
+							let revertPromise = TPromise.as<any>(null);
 							if (this.textFileService.isDirty(targetFile)) {
 								revertPromise = this.textFileService.revertAll([targetFile], { soft: true });
 							}

--- a/src/vs/workbench/parts/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerView.ts
@@ -265,7 +265,7 @@ export class ExplorerView extends CollapsibleViewletView {
 			if (visible) {
 
 				// If a refresh was requested and we are now visible, run it
-				let refreshPromise = TPromise.as(null);
+				let refreshPromise = TPromise.as<void>(null);
 				if (this.shouldRefresh) {
 					refreshPromise = this.doRefresh();
 					this.shouldRefresh = false; // Reset flag

--- a/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
@@ -231,7 +231,9 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 	}
 
 	private resolveAsBinary(): TPromise<BinaryEditorModel> {
-		return this.instantiationService.createInstance(BinaryEditorModel, this.resource, this.getName()).load();
+		return this.instantiationService.createInstance(BinaryEditorModel, this.resource, this.getName())
+			.load()
+			.then(x => x as BinaryEditorModel);
 	}
 
 	public isResolved(): boolean {

--- a/src/vs/workbench/parts/git/node/git.lib.ts
+++ b/src/vs/workbench/parts/git/node/git.lib.ts
@@ -324,7 +324,7 @@ export class Repository {
 		const child = this.show(object);
 
 		if (!child.stdout) {
-			return TPromise.wrapError(localize('errorBuffer', "Can't open file from git"));
+			return TPromise.wrapError<string>(localize('errorBuffer', "Can't open file from git"));
 		}
 
 		return detectMimesFromStream(child.stdout, null).then(result => {

--- a/src/vs/workbench/parts/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesService.ts
@@ -271,11 +271,11 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.fileService.resolveContent(resource, { acceptTextOnly: true }).then(null, error => {
 			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
 				return this.fileService.updateContent(resource, contents).then(null, error => {
-					return TPromise.wrapError(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", labels.getPathLabel(resource, this.contextService), error)));
+					return TPromise.wrapError<boolean>(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", labels.getPathLabel(resource, this.contextService), error)));
 				});
 			}
 
-			return TPromise.wrapError(error);
+			return TPromise.wrapError<boolean>(error);
 		});
 	}
 

--- a/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
@@ -225,7 +225,7 @@ export class KeybindingsEditingService extends Disposable implements IKeybinding
 
 		// Target cannot be dirty if not writing into buffer
 		if (this.textFileService.isDirty(this.resource)) {
-			return TPromise.wrapError(localize('errorKeybindingsFileDirty', "Unable to write because the file is dirty. Please save the **Keybindings** file and try again."));
+			return TPromise.wrapError<IReference<ITextEditorModel>>(localize('errorKeybindingsFileDirty', "Unable to write because the file is dirty. Please save the **Keybindings** file and try again."));
 		}
 
 		return this.resolveModelReference()
@@ -235,11 +235,11 @@ export class KeybindingsEditingService extends Disposable implements IKeybinding
 				if (model.getValue()) {
 					const parsed = this.parse(model);
 					if (parsed.parseErrors.length) {
-						return TPromise.wrapError(localize('parseErrors', "Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again."));
+						return TPromise.wrapError<IReference<ITextEditorModel>>(localize('parseErrors', "Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again."));
 					}
 					if (parsed.result) {
 						if (!isArray(parsed.result)) {
-							return TPromise.wrapError(localize('errorInvalidConfiguration', "Unable to write keybindings. **Keybindings file** has an object which is not of type Array. Please open the file to clean up and try again."));
+							return TPromise.wrapError<IReference<ITextEditorModel>>(localize('errorInvalidConfiguration', "Unable to write keybindings. **Keybindings file** has an object which is not of type Array. Please open the file to clean up and try again."));
 						}
 					} else {
 						const content = EOL + '[]';

--- a/src/vs/workbench/services/search/node/worker/searchWorker.ts
+++ b/src/vs/workbench/services/search/node/worker/searchWorker.ts
@@ -86,10 +86,10 @@ export class SearchWorkerEngine {
 
 	private _searchBatch(args: ISearchWorkerSearchArgs, contentPattern: RegExp, fileEncoding: string): TPromise<ISearchWorkerSearchResult> {
 		if (this.isCanceled) {
-			return TPromise.wrap(null);
+			return TPromise.wrap<ISearchWorkerSearchResult>(null);
 		}
 
-		return new TPromise(batchDone => {
+		return new TPromise<ISearchWorkerSearchResult>(batchDone => {
 			const result: ISearchWorkerSearchResult = {
 				matches: [],
 				numMatches: 0,

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -347,7 +347,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		}
 
 		// Otherwise bubble up the error
-		return TPromise.wrapError(error);
+		return TPromise.wrapError<EditorModel>(error);
 	}
 
 	private loadWithContent(content: IRawTextContent | IContent, backup?: URI): TPromise<EditorModel> {
@@ -442,7 +442,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 			}, error => {
 				this.createTextEditorModelPromise = null;
 
-				return TPromise.wrapError(error);
+				return TPromise.wrapError<TextFileEditorModel>(error);
 			});
 		});
 

--- a/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModelManager.ts
@@ -240,7 +240,7 @@ export class TextFileEditorModelManager implements ITextFileEditorModelManager {
 			// Remove from pending loads
 			this.mapResourceToPendingModelLoaders.delete(resource);
 
-			return TPromise.wrapError(error);
+			return TPromise.wrapError<ITextFileEditorModel>(error);
 		});
 	}
 

--- a/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
+++ b/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
@@ -85,7 +85,7 @@ class ResourceModelCollection extends ReferenceCollection<TPromise<ITextEditorMo
 		return first(factories).then(model => {
 			if (!model) {
 				console.error(`Unable to open '${resource}' resource is not available.`); // TODO PII
-				return TPromise.wrapError('resource is not available');
+				return TPromise.wrapError<IModel>('resource is not available');
 			}
 
 			return model;
@@ -137,7 +137,7 @@ export class TextModelResolverService implements ITextModelResolverService {
 			const cachedModel = this.modelService.getModel(resource);
 
 			if (!cachedModel) {
-				return TPromise.wrapError('Cant resolve inmemory resource');
+				return TPromise.wrapError<IReference<ITextEditorModel>>('Cant resolve inmemory resource');
 			}
 
 			return TPromise.as(new ImmortalReference(this.instantiationService.createInstance(ResourceEditorModel, resource)));
@@ -150,7 +150,7 @@ export class TextModelResolverService implements ITextModelResolverService {
 			err => {
 				ref.dispose();
 
-				return TPromise.wrapError(err);
+				return TPromise.wrapError<IReference<ITextEditorModel>>(err);
 			}
 		);
 	}

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -158,7 +158,7 @@ export class TestTextFileService extends TextFileService {
 			const error = this.resolveTextContentError;
 			this.resolveTextContentError = null;
 
-			return TPromise.wrapError(error);
+			return TPromise.wrapError<IRawTextContent>(error);
 		}
 
 		return this.fileService.resolveContent(resource, options).then((content) => {


### PR DESCRIPTION
From: https://github.com/Microsoft/TypeScript/issues/15352

TS 2.3.1 introduced a breaking change by [switching to covariant types for callbacks](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#covariance-in-callback-parameters). This change tries to fix these compiler errors in the workbench codebase