### PR TITLE
Disable emmet expansion on tab if autocomplete is enabled

### DIFF
--- a/src/vs/workbench/parts/emmet/node/actions/expandAbbreviation.ts
+++ b/src/vs/workbench/parts/emmet/node/actions/expandAbbreviation.ts
@@ -31,7 +31,8 @@ class ExpandAbbreviationAction extends BasicEmmetEditorAction {
 					EditorContextKeys.hasOnlyEmptySelection,
 					EditorContextKeys.hasSingleSelection,
 					EditorContextKeys.tabDoesNotMoveFocus,
-					ContextKeyExpr.has('config.emmet.triggerExpansionOnTab')
+					ContextKeyExpr.has('config.emmet.triggerExpansionOnTab'),
+					ContextKeyExpr.not('config.emmet.autocomplete')
 				)
 			}
 		);

--- a/src/vs/workbench/parts/emmet/node/editorAccessor.ts
+++ b/src/vs/workbench/parts/emmet/node/editorAccessor.ts
@@ -33,7 +33,7 @@ export class EditorAccessor implements emmet.Editor {
 	private _emmetActionName: string;
 	private _hasMadeEdits: boolean;
 
-	private emmetSupportedModes = ['html', 'css', 'xml', 'xsl', 'haml', 'jade', 'jsx', 'slim', 'scss', 'sass', 'less', 'stylus', 'styl', 'svg'];
+	private readonly emmetSupportedModes = ['html', 'css', 'xml', 'xsl', 'haml', 'jade', 'jsx', 'slim', 'scss', 'sass', 'less', 'stylus', 'styl', 'svg'];
 
 	constructor(languageIdentifierResolver: ILanguageIdentifierResolver, editor: ICommonCodeEditor, syntaxProfiles: any, excludedLanguages: String[], grammars: IGrammarContributions, emmetActionName?: string) {
 		this._languageIdentifierResolver = languageIdentifierResolver;
@@ -45,8 +45,11 @@ export class EditorAccessor implements emmet.Editor {
 		this._emmetActionName = emmetActionName;
 	}
 
-	public isEmmetEnabledMode(): boolean {
+	public getEmmetSupportedModes(): string[] {
+		return this.emmetSupportedModes;
+	}
 
+	public isEmmetEnabledMode(): boolean {
 		return this.emmetSupportedModes.indexOf(this.getSyntax()) !== -1;
 	}
 

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -72,13 +72,15 @@ class LazyEmmet {
 	private static syntaxProfilesFromFile = {};
 	private static preferencesFromFile = {};
 	private static workspaceRoot = '';
+	private emmetSupportedModes = ['html', 'css', 'xml', 'xsl', 'haml', 'jade', 'jsx', 'slim', 'scss', 'sass', 'less', 'stylus', 'styl', 'svg'];
 
 	public static withConfiguredEmmet(configurationService: IConfigurationService,
 		messageService: IMessageService,
+		telemetryService: ITelemetryService,
 		workspaceRoot: string,
 		callback: (_emmet: typeof emmet) => void): TPromise<void> {
 		LazyEmmet.workspaceRoot = workspaceRoot;
-		return LazyEmmet._INSTANCE.withEmmetPreferences(configurationService, messageService, callback);
+		return LazyEmmet._INSTANCE.withEmmetPreferences(configurationService, messageService, telemetryService, callback);
 	}
 
 	private _emmetPromise: TPromise<typeof emmet>;
@@ -90,10 +92,11 @@ class LazyEmmet {
 
 	public withEmmetPreferences(configurationService: IConfigurationService,
 		messageService: IMessageService,
+		telemetryService: ITelemetryService,
 		callback: (_emmet: typeof emmet) => void): TPromise<void> {
 		return this._loadEmmet().then((_emmet: typeof emmet) => {
 			this._messageService = messageService;
-			this._withEmmetPreferences(configurationService, _emmet, callback);
+			this._withEmmetPreferences(configurationService, telemetryService, _emmet, callback);
 		}, (e) => {
 			callback(null);
 		});
@@ -108,17 +111,34 @@ class LazyEmmet {
 		return this._emmetPromise;
 	}
 
-	private updateEmmetPreferences(configurationService: IConfigurationService, _emmet: typeof emmet): TPromise<any> {
+	private updateEmmetPreferences(configurationService: IConfigurationService,
+		telemetryService: ITelemetryService,
+		_emmet: typeof emmet): TPromise<any> {
 		let emmetPreferences = configurationService.getConfiguration<IEmmetConfiguration>().emmet;
 		let loadEmmetSettings = () => {
 			let syntaxProfiles = { ...LazyEmmet.syntaxProfilesFromFile, ...emmetPreferences.syntaxProfiles };
 			let preferences = { ...LazyEmmet.preferencesFromFile, ...emmetPreferences.preferences };
 			let snippets = LazyEmmet.snippetsFromFile;
+			let mappedModes = [];
+			for (let key in emmetPreferences.syntaxProfiles) {
+				if (this.emmetSupportedModes.indexOf(key) === -1) {
+					mappedModes.push(key);
+				}
+			}
 
 			try {
 				_emmet.loadPreferences(preferences);
 				_emmet.loadProfiles(syntaxProfiles);
 				_emmet.loadSnippets(snippets);
+
+				let emmetCustomizationTelemetry = {
+					emmetPreferencesFromFile: Object.keys(LazyEmmet.preferencesFromFile).length > 0,
+					emmetSyntaxProfilesFromFile: Object.keys(LazyEmmet.syntaxProfilesFromFile).length > 0,
+					emmetSnippetsFromFile: Object.keys(LazyEmmet.snippetsFromFile).length > 0,
+					emmetPreferencesFromSettings: Object.keys(emmetPreferences.preferences).length > 0,
+					emmetMappedModes: mappedModes
+				};
+				telemetryService.publicLog('emmetCustomizations', emmetCustomizationTelemetry);
 			} catch (err) {
 				// ignore
 			}
@@ -177,8 +197,11 @@ class LazyEmmet {
 		});
 	}
 
-	private _withEmmetPreferences(configurationService: IConfigurationService, _emmet: typeof emmet, callback: (_emmet: typeof emmet) => void): void {
-		this.updateEmmetPreferences(configurationService, _emmet).then(() => {
+	private _withEmmetPreferences(configurationService: IConfigurationService,
+		telemetryService: ITelemetryService,
+		_emmet: typeof emmet,
+		callback: (_emmet: typeof emmet) => void): void {
+		this.updateEmmetPreferences(configurationService, telemetryService, _emmet).then(() => {
 			try {
 				callback(_emmet);
 			} finally {
@@ -257,7 +280,7 @@ export abstract class EmmetEditorAction extends EditorAction {
 				return undefined;
 			}
 
-			return LazyEmmet.withConfiguredEmmet(configurationService, messageService, workspaceRoot, (_emmet) => {
+			return LazyEmmet.withConfiguredEmmet(configurationService, messageService, telemetryService, workspaceRoot, (_emmet) => {
 				if (!_emmet) {
 					this.noExpansionOccurred(editor);
 					return undefined;

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -72,14 +72,16 @@ class LazyEmmet {
 	private static syntaxProfilesFromFile = {};
 	private static preferencesFromFile = {};
 	private static workspaceRoot = '';
-	private emmetSupportedModes = ['html', 'css', 'xml', 'xsl', 'haml', 'jade', 'jsx', 'slim', 'scss', 'sass', 'less', 'stylus', 'styl', 'svg'];
+	private static emmetSupportedModes: string[];
 
 	public static withConfiguredEmmet(configurationService: IConfigurationService,
 		messageService: IMessageService,
 		telemetryService: ITelemetryService,
+		emmetSupportedModes: string[],
 		workspaceRoot: string,
 		callback: (_emmet: typeof emmet) => void): TPromise<void> {
 		LazyEmmet.workspaceRoot = workspaceRoot;
+		LazyEmmet.emmetSupportedModes = emmetSupportedModes;
 		return LazyEmmet._INSTANCE.withEmmetPreferences(configurationService, messageService, telemetryService, callback);
 	}
 
@@ -121,7 +123,7 @@ class LazyEmmet {
 			let snippets = LazyEmmet.snippetsFromFile;
 			let mappedModes = [];
 			for (let key in emmetPreferences.syntaxProfiles) {
-				if (this.emmetSupportedModes.indexOf(key) === -1) {
+				if (LazyEmmet.emmetSupportedModes.indexOf(key) === -1) {
 					mappedModes.push(key);
 				}
 			}
@@ -280,7 +282,7 @@ export abstract class EmmetEditorAction extends EditorAction {
 				return undefined;
 			}
 
-			return LazyEmmet.withConfiguredEmmet(configurationService, messageService, telemetryService, workspaceRoot, (_emmet) => {
+			return LazyEmmet.withConfiguredEmmet(configurationService, messageService, telemetryService, editorAccessor.getEmmetSupportedModes(), workspaceRoot, (_emmet) => {
 				if (!_emmet) {
 					this.noExpansionOccurred(editor);
 					return undefined;

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -122,9 +122,12 @@ class LazyEmmet {
 			let preferences = { ...LazyEmmet.preferencesFromFile, ...emmetPreferences.preferences };
 			let snippets = LazyEmmet.snippetsFromFile;
 			let mappedModes = [];
+			let outputProfileFromSettings = false;
 			for (let key in emmetPreferences.syntaxProfiles) {
 				if (LazyEmmet.emmetSupportedModes.indexOf(key) === -1) {
 					mappedModes.push(key);
+				} else {
+					outputProfileFromSettings = true;
 				}
 			}
 
@@ -138,6 +141,7 @@ class LazyEmmet {
 					emmetSyntaxProfilesFromFile: Object.keys(LazyEmmet.syntaxProfilesFromFile).length > 0,
 					emmetSnippetsFromFile: Object.keys(LazyEmmet.snippetsFromFile).length > 0,
 					emmetPreferencesFromSettings: Object.keys(emmetPreferences.preferences).length > 0,
+					emmetSyntaxProfilesFromSettings: outputProfileFromSettings,
 					emmetMappedModes: mappedModes
 				};
 				telemetryService.publicLog('emmetCustomizations', emmetCustomizationTelemetry);


### PR DESCRIPTION
When users do eventually install the emmet extension (https://github.com/Microsoft/vscode-emmet) they will get emmet expansions via the auto completions. In such case, the default emmet expansion on TAB should be disabled.

Users can opt out of the autocompletions by setting `emmet.autocomplete` to `false`

Also added telemetry for emmet customizations.
Since new Emmet 2.0 may not have some of these customizations, its important to see the usage of the same

cc @kieferrm, @alexandrudima, @jrieken , @egamma 