### PR TITLE
Detect more def* forms in Clojure syntax

### DIFF
--- a/extensions/clojure/syntaxes/clojure.tmLanguage.json
+++ b/extensions/clojure/syntaxes/clojure.tmLanguage.json
@@ -301,7 +301,7 @@
 			"name": "meta.expression.clojure",
 			"patterns": [
 				{
-					"begin": "(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|deftest)\\s+",
+					"begin": "(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|defonce|deftest|defmulti|defmethod|defrecord|deftype)\\s+",
 					"beginCaptures": {
 						"1": {
 							"name": "keyword.control.clojure"

--- a/extensions/clojure/syntaxes/clojure.tmLanguage.json
+++ b/extensions/clojure/syntaxes/clojure.tmLanguage.json
@@ -301,7 +301,7 @@
 			"name": "meta.expression.clojure",
 			"patterns": [
 				{
-					"begin": "(?<=\\()(ns|def|def-|defn|defn-|defvar|defvar-|defmacro|defmacro-|defonce|deftest|defmulti|defmethod|defrecord|deftype)\\s+",
+					"begin": "(?<=\\()(ns|def|def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+|[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*][\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+/def[\\w\\.\\-\\_\\:\\+\\=\\>\\<\\!\\?\\*\\d]+)\\s+",
 					"beginCaptures": {
 						"1": {
 							"name": "keyword.control.clojure"


### PR DESCRIPTION
It’s a convention in Clojure to use macros whose name starts with `def` to define something. Libraries often define their own custom macros for this:

- `defroutes` (Compojure)
- `defc` (Rum)
- etc

This is why whitelisting only def macros from clojure.core isn’t working: it will detect standard vars and functions but will fail to detect custom `def*`-like macros.

This PR adds regular expression that treats all forms whose name starts with `def` (with optional namespace) similarly.

This convention is very well established so it shouldn’t hurt anyone.