### PR TITLE
Small comment fix

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4682,7 +4682,7 @@ declare module 'vscode' {
 
 		/**
 		 * Whether the [source control resource state](#SourceControlResourceState) should
-		 * be striked-through in the UI.
+		 * be faded in the UI.
 		 */
 		readonly faded?: boolean;
 


### PR DESCRIPTION
I noticed this in another recent commit.

Should be "faded" instead of "striked-through" for this field.