### PR TITLE
Use Chromium's new system-ui font alias

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -143,7 +143,7 @@
 				},
 				"markdown.preview.fontFamily": {
 					"type": "string",
-					"default": "-apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', 'HelveticaNeue-Light', 'Ubuntu', 'Droid Sans', sans-serif",
+					"default": "system-ui",
 					"description": "%markdown.preview.fontFamily.desc%"
 				},
 				"markdown.preview.fontSize": {

--- a/src/vs/editor/browser/standalone/media/standalone-tokens.css
+++ b/src/vs/editor/browser/standalone/media/standalone-tokens.css
@@ -6,7 +6,7 @@
 
 /* Default standalone editor font */
 .monaco-editor {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif;
+	font-family: system-ui, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif;
 }
 
 .monaco-menu .monaco-action-bar.vertical .action-item [tabindex="0"]:focus {

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -15,7 +15,7 @@
 
 /* Font Families (with CJK support) */
 
-.monaco-shell { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif; }
+.monaco-shell { font-family: system-ui; }
 .monaco-shell:lang(zh-Hans) { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Noto Sans", "Microsoft YaHei", "PingFang SC", "Hiragino Sans GB", "Source Han Sans SC", "Source Han Sans CN", "Source Han Sans", sans-serif; }
 .monaco-shell:lang(zh-Hant) { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Noto Sans", "Microsoft Jhenghei", "PingFang TC", "Source Han Sans TC", "Source Han Sans", "Source Han Sans TW", sans-serif; }
 .monaco-shell:lang(ja) { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Noto Sans", "Meiryo", "Hiragino Kaku Gothic Pro", "Source Han Sans J", "Source Han Sans JP", "Source Han Sans", "Sazanami Gothic", "IPA Gothic", sans-serif; }

--- a/src/vs/workbench/parts/terminal/electron-browser/media/widgets.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/widgets.css
@@ -12,8 +12,7 @@
 }
 
 .monaco-workbench .terminal-message-widget {
-	/* This font list is sourced from a .monaco-shell style */
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif;
+	font-family: system-ui;
 	font-size: 14px;
 	line-height: 19px;
 	padding: 4px 5px;

--- a/src/vs/workbench/parts/welcome/page/electron-browser/welcomePage.css
+++ b/src/vs/workbench/parts/welcome/page/electron-browser/welcomePage.css
@@ -70,7 +70,6 @@
 	padding: 0;
 	margin: 0;
 	border: none;
-	/*font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI Light", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif;*/
 	font-weight: normal;
 	color: rgba(0,0,0,.8);
 	font-size: 3.6em;


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=654679

Fixes #10144.

As @Tyriar [pointed out](https://github.com/Microsoft/vscode/issues/10144#issuecomment-242803110), `sans-serif` didn't work. But Chromium 56 added `system-ui` (similar to `-apple-system` but for all operation systems) in Electron :)