### PR TITLE
Route emmet actions to extension

### DIFF
--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -23,6 +23,7 @@ import * as pfs from 'vs/base/node/pfs';
 import Severity from 'vs/base/common/severity';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 interface IEmmetConfiguration {
 	emmet: {
@@ -235,6 +236,14 @@ export interface IEmmetActionOptions extends IActionOptions {
 
 export abstract class EmmetEditorAction extends EditorAction {
 
+	private actionMap = {
+		'editor.emmet.action.removeTag': 'emmet.removeTag',
+		'editor.emmet.action.updateTag': 'emmet.updateTag',
+		'editor.emmet.action.matchingPair': 'emmet.matchTag',
+		'editor.emmet.action.wrapWithAbbreviation': 'emmet.wrapWithAbbreviation',
+		'editor.emmet.action.expandAbbreviation': 'emmet.expandAbbreviation'
+	};
+
 	protected emmetActionName: string;
 
 	constructor(opts: IEmmetActionOptions) {
@@ -269,6 +278,12 @@ export abstract class EmmetEditorAction extends EditorAction {
 		const contextService = accessor.get(IWorkspaceContextService);
 		const workspaceRoot = contextService.getWorkspace() ? contextService.getWorkspace().resource.fsPath : '';
 		const telemetryService = accessor.get(ITelemetryService);
+		const commandService = accessor.get(ICommandService);
+
+		let overrideByExtension = configurationService.getConfiguration()['emmet']['overrideBuiltinActions'];
+		if (overrideByExtension && this.actionMap[this.id]) {
+			return commandService.executeCommand(this.actionMap[this.id]).then(() => { });
+		}
 
 		return this._withGrammarContributions(extensionService).then((grammarContributions) => {
 
@@ -296,7 +311,6 @@ export abstract class EmmetEditorAction extends EditorAction {
 					this.runEmmetAction(accessor, new EmmetActionContext(editor, _emmet, editorAccessor));
 				});
 				editorAccessor.onAfterEmmetAction();
-				telemetryService.publicLog('emmetActionCompleted', { action: this.emmetActionName });
 			});
 		});
 

--- a/src/vs/workbench/parts/emmet/node/emmetActions.ts
+++ b/src/vs/workbench/parts/emmet/node/emmetActions.ts
@@ -23,7 +23,7 @@ import * as pfs from 'vs/base/node/pfs';
 import Severity from 'vs/base/common/severity';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ICommandService, CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 interface IEmmetConfiguration {
 	emmet: {
@@ -280,9 +280,9 @@ export abstract class EmmetEditorAction extends EditorAction {
 		const telemetryService = accessor.get(ITelemetryService);
 		const commandService = accessor.get(ICommandService);
 
-		let overrideByExtension = configurationService.getConfiguration()['emmet']['overrideBuiltinActions'];
-		if (overrideByExtension && this.actionMap[this.id]) {
-			return commandService.executeCommand(this.actionMap[this.id]).then(() => { });
+		let mappedCommand = this.actionMap[this.id];
+		if (mappedCommand && CommandsRegistry.getCommand(mappedCommand)) {
+			return commandService.executeCommand<void>(mappedCommand);
 		}
 
 		return this._withGrammarContributions(extensionService).then((grammarContributions) => {


### PR DESCRIPTION
https://github.com/Microsoft/vscode-emmet is the new Emmet extension that has implemented 5 of the various emmet related builtin actions.

This PR is to route these 5 actions to the extension, if the user has the extension installed and the setting `emmet.overrideBuiltinActions` enabled (which is enabled by default once extension is installed)
