### PR TITLE
Add Suggestion Provider For TS Directives

### DIFF
--- a/extensions/typescript/src/features/directiveCommentCompletionProvider.ts
+++ b/extensions/typescript/src/features/directiveCommentCompletionProvider.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { Position, CompletionItemProvider, CompletionItemKind, TextDocument, CancellationToken, CompletionItem, ProviderResult, Range } from 'vscode';
+
+import { ITypescriptServiceClient } from '../typescriptService';
+
+const directives = ['@ts-check', '@ts-nocheck', '@ts-ignore'];
+
+export class DirectiveCommentCompletionProvider implements CompletionItemProvider {
+	constructor(
+		private client: ITypescriptServiceClient,
+	) { }
+
+	public provideCompletionItems(document: TextDocument, position: Position, _token: CancellationToken): ProviderResult<CompletionItem[]> {
+		const file = this.client.normalizePath(document.uri);
+		if (!file) {
+			return [];
+		}
+
+		const line = document.lineAt(position.line).text;
+		const prefix = line.slice(0, position.character);
+		const match = prefix.match(/^\s*\/\/+\s?(@[a-zA-Z\-]*)?$/);
+		if (match) {
+			return directives.map(x => {
+				const item = new CompletionItem(x, CompletionItemKind.Snippet);
+				item.range = new Range(position.line, Math.max(0, position.character - match[1].length), position.line, position.character);
+				return item;
+			});
+		}
+		return [];
+	}
+
+	public resolveCompletionItem(item: CompletionItem, _token: CancellationToken) {
+		return item;
+	}
+}

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -41,6 +41,8 @@ import WorkspaceSymbolProvider from './features/workspaceSymbolProvider';
 import CodeActionProvider from './features/codeActionProvider';
 import ReferenceCodeLensProvider from './features/referencesCodeLensProvider';
 import { JsDocCompletionProvider, TryCompleteJsDocCommand } from './features/jsDocCompletionProvider';
+import { DirectiveCommentCompletionProvider } from './features/directiveCommentCompletionProvider';
+
 import ImplementationCodeLensProvider from './features/implementationsCodeLensProvider';
 
 import * as BuildStatus from './utils/buildStatus';
@@ -214,6 +216,8 @@ class LanguageProvider {
 		this.completionItemProvider = new CompletionItemProvider(client, this.typingsStatus);
 		this.completionItemProvider.updateConfiguration();
 		this.disposables.push(languages.registerCompletionItemProvider(selector, this.completionItemProvider, '.'));
+
+		this.disposables.push(languages.registerCompletionItemProvider(selector, new DirectiveCommentCompletionProvider(client), '@'));
 
 		this.formattingProvider = new FormattingProvider(client);
 		this.formattingProvider.updateConfiguration(config);
@@ -416,7 +420,7 @@ class LanguageProvider {
 
 class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	private client: TypeScriptServiceClient;
-	private languages: LanguageProvider[];
+	private languages: LanguageProvider[] = [];
 	private languagePerId: ObjectMap<LanguageProvider>;
 	private readonly disposables: Disposable[] = [];
 
@@ -442,7 +446,6 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 		configFileWatcher.onDidChange(handleProjectChange, this, this.disposables);
 
 		this.client = new TypeScriptServiceClient(this, storagePath, globalState, workspaceState, this.disposables);
-		this.languages = [];
 		this.languagePerId = Object.create(null);
 		for (const description of descriptions) {
 			const manager = new LanguageProvider(this.client, description);


### PR DESCRIPTION
Adds a new completion provider to suggest typescript comment directives, such as `@ts-check` or `@ts-ignore`

Fixes #25413