### PR TITLE
Fix a potential hang when tsserver exits improperly

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -153,7 +153,6 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 	private lastError: Error | null;
 	private reader: Reader<Proto.Response>;
 	private sequenceNumber: number;
-	private exitRequested: boolean;
 	private firstStart: number;
 	private lastStart: number;
 	private numberRestarts: number;
@@ -187,7 +186,6 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		this.servicePromise = null;
 		this.lastError = null;
 		this.sequenceNumber = 0;
-		this.exitRequested = false;
 		this.firstStart = Date.now();
 		this.numberRestarts = 0;
 
@@ -522,6 +520,11 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 					this.globalState.update(doGlobalVersionCheckKey, true);
 				}
 
+				this.sequenceNumber = 0;
+				this.requestQueue = [];
+				this.pendingResponses = 0;
+				this.lastError = null;
+
 				try {
 					let options: electron.IForkOptions = {
 						execArgv: [] // [`--debug-brk=5859`]
@@ -851,7 +854,7 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 			this.callbacks[parseInt(key)].e(new Error('Service died.'));
 		});
 		this.callbacks = Object.create(null);
-		if (!this.exitRequested && restart) {
+		if (restart) {
 			let diff = Date.now() - this.lastStart;
 			this.numberRestarts++;
 			let startService = true;


### PR DESCRIPTION
**Bug**
If the TSServer restarts with ongoing requests queued, the new server instance may not properly startup. in the logs, this looks like a series of cancelled request followed by a restart message, and then more cancelled requests of the same series

**fix**
I believe the root cause of this is that the request queue is not properly flushed and the request sequence numbers are not properly reset when starting the new server instance.

Fixes #25807