### PR TITLE
Expand docs on the side in the suggest widget

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -28,6 +28,10 @@
 	box-sizing: border-box;
 }
 
+.monaco-editor .suggest-widget.list-right > .tree {
+	float: right
+}
+
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row {
 	display: flex;
 	-mox-box-sizing: border-box;

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -6,7 +6,7 @@
 /* Suggest */
 .monaco-editor .suggest-widget {
 	z-index: 40;
-	width: 438px;
+	width: 660px;
 }
 
 .monaco-editor .suggest-widget.visible {
@@ -23,7 +23,9 @@
 
 .monaco-editor .suggest-widget > .tree {
 	height: 100%;
-	width: 100%;
+	width: 40%;
+	float: left;
+	box-sizing: border-box;
 }
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row {
@@ -49,69 +51,8 @@
 	text-overflow: ellipsis;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .docs {
-	display: none;
-	overflow: hidden;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .docs > .docs-text {
-	flex: 2;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	opacity: 0.85;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .docs > .docs-text.no-docs {
-	opacity: 0.5;
-	font-style: italic;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .docs > .docs-details {
-	opacity: 0.6;
-	background-image: url('./info.svg');
-	background-position: center center;
-	background-repeat: no-repeat;
-	background-size: 70%;
-}
-
-.monaco-editor .suggest-widget .details > .header > .go-back,
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .docs > .docs-details {
-	color: #0035DD;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .docs > .docs-details:hover {
-	opacity: 1;
-}
-
 .monaco-editor .suggest-widget:not(.frozen) .monaco-highlighted-label .highlight {
 	font-weight: bold;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .type-label {
-	display: none;
-	margin-left: 0.8em;
-	flex: 1;
-	text-align: right;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	opacity: 0.7;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .type-label > .monaco-tokenized-source {
-	display: inline;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .type-label {
-	display: inline;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused .type-label {
-	display: inline;
-}
-
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused .docs {
-	display: flex;
 }
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row .icon {
@@ -160,37 +101,14 @@
 }
 
 .monaco-editor .suggest-widget .details {
-	height: 100%;
-	box-sizing: border-box;
+	max-height: 216px;
 	display: flex;
 	flex-direction: column;
 	cursor: default;
 }
 
-.monaco-editor .suggest-widget .details > .header {
-	padding: 4px 5px;
-	display: flex;
-	box-sizing: border-box;
-	border-bottom: 1px solid rgba(204, 204, 204, 0.5);
-}
-
-.monaco-editor .suggest-widget .details > .header > .title {
-	flex: 2;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-.monaco-editor .suggest-widget .details > .header > .go-back {
-	cursor: pointer;
-	opacity: 0.6;
-	background-image: url('./back.svg');
-	background-size: 70%;
-	background-position: center center;
-	background-repeat: no-repeat;
-}
-
-.monaco-editor .suggest-widget .details > .header > .go-back:hover {
-	opacity: 1;
+.monaco-editor .suggest-widget .details.no-docs {
+	display: none;
 }
 
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element {
@@ -218,28 +136,10 @@
 	display: none;
 }
 
-/* Dark theme */
-
-.monaco-editor.vs-dark .suggest-widget .details > .header {
-	border-color: rgba(85,85,85,0.5);
-}
-
-.monaco-editor.vs-dark .suggest-widget .monaco-list .monaco-list-row .docs > .docs-details,
-.monaco-editor.vs-dark .suggest-widget .details > .header > .go-back {
-	color: #4E94CE;
-}
-
-
 /* High Contrast Theming */
 
-.monaco-editor.hc-black .suggest-widget .details > .monaco-scrollable-element > .body > .docs,
-.monaco-editor.hc-black .suggest-widget .monaco-list .monaco-list-row .docs {
+.monaco-editor.hc-black .suggest-widget .details > .monaco-scrollable-element > .body > .docs {
 	color: #C07A7A;
-}
-
-.monaco-editor.hc-black .suggest-widget .monaco-list .monaco-list-row .docs > .docs-details,
-.monaco-editor.hc-black .suggest-widget .details > .header > .go-back {
-	color: #4E94CE;
 }
 
 .monaco-editor.vs-dark .suggest-widget .monaco-list .monaco-list-row .icon,

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -32,6 +32,10 @@
 	float: right
 }
 
+.monaco-editor .suggest-widget.docs-below > .tree {
+	float: none;
+}
+
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row {
 	display: flex;
 	-mox-box-sizing: border-box;

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -23,7 +23,7 @@
 
 .monaco-editor .suggest-widget > .tree {
 	height: 100%;
-	width: 40%;
+	width: 220px;
 	float: left;
 	box-sizing: border-box;
 }
@@ -109,6 +109,8 @@
 	display: flex;
 	flex-direction: column;
 	cursor: default;
+	box-sizing: border-box;
+	width: 440px;
 }
 
 .monaco-editor .suggest-widget .details.no-docs {

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -219,7 +219,7 @@ export class SuggestController implements IEditorContribution {
 	cancelSuggestWidget(): void {
 		if (this._widget) {
 			this._model.cancel();
-			this._widget.hideDetailsOrHideWidget();
+			this._widget.hideWidget();
 		}
 	}
 
@@ -261,7 +261,7 @@ export class SuggestController implements IEditorContribution {
 
 	toggleSuggestionDetails(): void {
 		if (this._widget) {
-			this._widget.toggleDetails();
+			this._widget.toggleDetailsFocus();
 		}
 	}
 }

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -61,7 +61,7 @@ function canExpandCompletionItem(item: ICompletionItem) {
 	if (suggestion.documentation) {
 		return true;
 	}
-	return (suggestion.detail !== suggestion.label);
+	return (suggestion.detail && suggestion.detail !== suggestion.label);
 }
 
 class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -38,9 +38,6 @@ interface ISuggestionTemplateData {
 	icon: HTMLElement;
 	colorspan: HTMLElement;
 	highlightedLabel: HighlightedLabel;
-	typeLabel: HTMLElement;
-	documentationDetails: HTMLElement;
-	documentation: HTMLElement;
 	disposables: IDisposable[];
 }
 
@@ -64,7 +61,7 @@ function canExpandCompletionItem(item: ICompletionItem) {
 	if (suggestion.documentation) {
 		return true;
 	}
-	return (suggestion.detail || '').indexOf('\n') >= 0;
+	return (suggestion.detail !== suggestion.label);
 }
 
 class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
@@ -96,13 +93,6 @@ class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 		const main = append(text, $('.main'));
 		data.highlightedLabel = new HighlightedLabel(main);
 		data.disposables.push(data.highlightedLabel);
-		data.typeLabel = append(main, $('span.type-label'));
-
-		const docs = append(text, $('.docs'));
-		data.documentation = append(docs, $('span.docs-text'));
-		data.documentationDetails = append(docs, $('span.docs-details'));
-		data.documentationDetails.title = nls.localize('readMore', "Read More...{0}", this.triggerKeybindingLabel);
-
 		const configureFont = () => {
 			const configuration = this.editor.getConfiguration();
 			const fontFamily = configuration.fontInfo.fontFamily;
@@ -116,8 +106,6 @@ class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 			main.style.lineHeight = lineHeightPx;
 			data.icon.style.height = lineHeightPx;
 			data.icon.style.width = lineHeightPx;
-			data.documentationDetails.style.height = lineHeightPx;
-			data.documentationDetails.style.width = lineHeightPx;
 		};
 
 		configureFont();
@@ -151,26 +139,8 @@ class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 		}
 
 		data.highlightedLabel.set(suggestion.label, createMatches(element.matches));
-		data.typeLabel.textContent = (suggestion.detail || '').replace(/\n.*$/m, '');
 
-		data.documentation.textContent = suggestion.documentation || '';
 
-		if (canExpandCompletionItem(element)) {
-			show(data.documentationDetails);
-			data.documentationDetails.onmousedown = e => {
-				e.stopPropagation();
-				e.preventDefault();
-			};
-			data.documentationDetails.onclick = e => {
-				e.stopPropagation();
-				e.preventDefault();
-				this.widget.toggleDetails();
-			};
-		} else {
-			hide(data.documentationDetails);
-			data.documentationDetails.onmousedown = null;
-			data.documentationDetails.onclick = null;
-		}
 	}
 
 	disposeTemplate(templateData: ISuggestionTemplateData): void {
@@ -191,9 +161,6 @@ const enum State {
 class SuggestionDetails {
 
 	private el: HTMLElement;
-	private title: HTMLElement;
-	private titleLabel: HighlightedLabel;
-	private back: HTMLElement;
 	private scrollbar: DomScrollableElement;
 	private body: HTMLElement;
 	private type: HTMLElement;
@@ -211,13 +178,6 @@ class SuggestionDetails {
 		this.el = append(container, $('.details'));
 		this.disposables.push(toDisposable(() => container.removeChild(this.el)));
 
-		const header = append(this.el, $('.header'));
-		this.title = append(header, $('span.title'));
-		this.titleLabel = new HighlightedLabel(this.title);
-		this.disposables.push(this.titleLabel);
-
-		this.back = append(header, $('span.go-back'));
-		this.back.title = nls.localize('goback', "Go back");
 		this.body = $('.body');
 
 		this.scrollbar = new DomScrollableElement(this.body, { canUseTranslate3d: false });
@@ -240,26 +200,18 @@ class SuggestionDetails {
 	}
 
 	render(item: ICompletionItem): void {
-		if (!item) {
-			this.titleLabel.set('');
+		if (!item || !canExpandCompletionItem(item)) {
 			this.type.textContent = '';
 			this.docs.textContent = '';
+			addClass(this.el, 'no-docs');
 			this.ariaLabel = null;
 			return;
 		}
-
-		this.titleLabel.set(item.suggestion.label, createMatches(item.matches));
+		removeClass(this.el, 'no-docs');
 		this.type.innerText = item.suggestion.detail || '';
 		this.docs.textContent = item.suggestion.documentation;
-		this.back.onmousedown = e => {
-			e.preventDefault();
-			e.stopPropagation();
-		};
-		this.back.onclick = e => {
-			e.preventDefault();
-			e.stopPropagation();
-			this.widget.toggleDetails();
-		};
+
+		this.el.style.height = this.type.clientHeight + this.docs.clientHeight + 'px';
 
 		this.body.scrollTop = 0;
 		this.scrollbar.scanDomNode();
@@ -295,19 +247,22 @@ class SuggestionDetails {
 		this.scrollUp(80);
 	}
 
+	setBackgroundColor(bgColor: string): void {
+		this.el.style.backgroundColor = bgColor;
+	}
+
+	setBorder(borderStyle: string): void {
+		this.el.style.border = borderStyle;
+	}
+
 	private configureFont() {
 		const configuration = this.editor.getConfiguration();
 		const fontFamily = configuration.fontInfo.fontFamily;
 		const fontSize = configuration.contribInfo.suggestFontSize || configuration.fontInfo.fontSize;
-		const lineHeight = configuration.contribInfo.suggestLineHeight || configuration.fontInfo.lineHeight;
 		const fontSizePx = `${fontSize}px`;
-		const lineHeightPx = `${lineHeight}px`;
 
 		this.el.style.fontSize = fontSizePx;
-		this.title.style.fontFamily = fontFamily;
 		this.type.style.fontFamily = fontFamily;
-		this.back.style.height = lineHeightPx;
-		this.back.style.width = lineHeightPx;
 	}
 
 	dispose(): void {
@@ -477,12 +432,15 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 	private onThemeChange(theme: ITheme) {
 		let backgroundColor = theme.getColor(editorSuggestWidgetBackground);
 		if (backgroundColor) {
-			this.element.style.backgroundColor = backgroundColor.toString();
+			this.listElement.style.backgroundColor = backgroundColor.toString();
+			this.details.setBackgroundColor(backgroundColor.toString());
 		}
 		let borderColor = theme.getColor(editorSuggestWidgetBorder);
 		if (borderColor) {
 			let borderWidth = theme.type === 'hc' ? 2 : 1;
-			this.element.style.border = `${borderWidth}px solid ${borderColor}`;
+			let borderStyle = `${borderWidth}px solid ${borderColor}`;
+			this.listElement.style.border = borderStyle;
+			this.details.setBorder(borderStyle);
 		}
 	}
 
@@ -550,7 +508,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 				this.list.setFocus([index]);
 				this.updateWidgetHeight();
 				this.list.reveal(index);
-
+				this.showDetails();
 				this._ariaAlert(this._getSuggestionAriaAlertLabel(item));
 			})
 			.then(null, err => !isPromiseCanceledError(err) && onUnexpectedError(err))
@@ -592,8 +550,8 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 				this.show();
 				break;
 			case State.Open:
-				hide(this.messageElement, this.details.element);
-				show(this.listElement);
+				hide(this.messageElement);
+				show(this.listElement, this.details.element);
 				this.show();
 				break;
 			case State.Frozen:
@@ -602,8 +560,8 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 				this.show();
 				break;
 			case State.Details:
-				hide(this.messageElement, this.listElement);
-				show(this.details.element);
+				hide(this.messageElement);
+				show(this.details.element, this.listElement);
 				this.show();
 				this._ariaAlert(this.details.getAriaLabel());
 				break;
@@ -773,26 +731,21 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		return undefined;
 	}
 
-	toggleDetails(): void {
+	toggleDetailsFocus(): void {
 		if (this.state === State.Details) {
 			this.setState(State.Open);
-			this.editor.focus();
+		} else if (this.state === State.Open) {
+			this.setState(State.Details);
+		}
+	}
+
+	showDetails(): void {
+		if (this.state !== State.Open && this.state !== State.Details) {
 			return;
 		}
 
-		if (this.state !== State.Open) {
-			return;
-		}
-
-		const item = this.list.getFocusedElements()[0];
-
-		if (!item || !canExpandCompletionItem(item)) {
-			return;
-		}
-
-		this.setState(State.Details);
+		this.show();
 		this.editor.focus();
-		this.telemetryService.publicLog('suggestWidget:toggleDetails', this.editor.getTelemetryData());
 	}
 
 	private show(): void {
@@ -815,14 +768,6 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		clearTimeout(this.loadingTimeout);
 		this.setState(State.Hidden);
 		this.onDidHideEmitter.fire(this);
-	}
-
-	hideDetailsOrHideWidget(): void {
-		if (this.state === State.Details) {
-			this.toggleDetails();
-		} else {
-			this.hideWidget();
-		}
 	}
 
 	getPosition(): IContentWidgetPosition {
@@ -849,8 +794,6 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 
 		if (this.state === State.Empty || this.state === State.Loading) {
 			height = this.unfocusedHeight;
-		} else if (this.state === State.Details) {
-			height = 12 * this.unfocusedHeight;
 		} else {
 			const focus = this.list.getFocusedElements()[0];
 			const focusHeight = focus ? this.getHeight(focus) : this.unfocusedHeight;
@@ -861,7 +804,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		}
 
 		this.element.style.lineHeight = `${this.unfocusedHeight}px`;
-		this.element.style.height = `${height}px`;
+		this.listElement.style.height = `${height}px`;
 		this.list.layout(height);
 		this.editor.layoutContentWidget(this);
 
@@ -869,10 +812,10 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 	}
 
 	private renderDetails(): void {
-		if (this.state !== State.Details) {
-			this.details.render(null);
-		} else {
+		if (this.state === State.Details || this.state === State.Open) {
 			this.details.render(this.list.getFocusedElements()[0]);
+		} else {
+			this.details.render(null);
 		}
 	}
 
@@ -890,10 +833,6 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 	// IDelegate
 
 	getHeight(element: ICompletionItem): number {
-		if (canExpandCompletionItem(element) && element === this.focusedItem) {
-			return this.focusHeight;
-		}
-
 		return this.unfocusedHeight;
 	}
 

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -248,14 +248,6 @@ class SuggestionDetails {
 		this.scrollUp(80);
 	}
 
-	setBackgroundColor(bgColor: string): void {
-		this.el.style.backgroundColor = bgColor;
-	}
-
-	setBorder(borderStyle: string): void {
-		this.el.style.border = borderStyle;
-	}
-
 	private configureFont() {
 		const configuration = this.editor.getConfiguration();
 		const fontFamily = configuration.fontInfo.fontFamily;
@@ -436,14 +428,13 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		let backgroundColor = theme.getColor(editorSuggestWidgetBackground);
 		if (backgroundColor) {
 			this.listElement.style.backgroundColor = backgroundColor.toString();
-			this.details.setBackgroundColor(backgroundColor.toString());
+			this.details.element.style.backgroundColor = backgroundColor.toString();
 		}
 		let borderColor = theme.getColor(editorSuggestWidgetBorder);
 		if (borderColor) {
 			let borderWidth = theme.type === 'hc' ? 2 : 1;
-			let borderStyle = `${borderWidth}px solid ${borderColor}`;
-			this.listElement.style.border = borderStyle;
-			this.details.setBorder(borderStyle);
+			this.listElement.style.border = `${borderWidth}px solid ${borderColor}`;
+			this.details.element.style.border = `${borderWidth}px solid ${borderColor}`;
 		}
 	}
 

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -806,6 +806,15 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		this.element.style.lineHeight = `${this.unfocusedHeight}px`;
 		this.listElement.style.height = `${height}px`;
 		this.list.layout(height);
+
+		// Experimenting with columns left to the right of cursor to decide if the list & details must be swapped
+		let columnsLeft = this.editor.getLayoutInfo().viewportColumn - this.editor.getPosition().column;
+		if (columnsLeft < 50) {
+			addClass(this.element, 'list-right');
+		} else {
+			removeClass(this.element, 'list-right');
+		}
+
 		this.editor.layoutContentWidget(this);
 
 		return height;


### PR DESCRIPTION
First draft for #18582

Features in the PR:
- If either `suggestion.details` or `suggestion.documentation` exist, they will appear on the side of the suggest list. If no docs but details match then label, then the docs section is not shown
- To use page up and down in the docs, press `ctrl+space` and then page up and down as usual
-  A logic based on cursor position and viewport length is in place to decide when to swap the list and the docs. Not fool proof yet. Just a starting point

Pending:
- [x] More testing on corner scenarios where the list and docs need to be swapped
- [x] Show docs below when editor window is too small
- [ ] A visual cue for when focus is on the docs section vs the list
- [ ] Test accessibility and screen reader

Update as of 5/7: Logic to decide when to swap list and docs, where to position the suggest widget and when to re-size the docs is finalized here: https://github.com/Microsoft/vscode/blob/ramyar/docs-on-the-side/src/vs/editor/contrib/suggest/browser/suggestWidget.ts#L817 