### PR TITLE
Treat Script Tag Contents in HTML as JS

### DIFF
--- a/extensions/html/server/src/modes/javascriptMode.ts
+++ b/extensions/html/server/src/modes/javascriptMode.ts
@@ -30,9 +30,10 @@ export function getJavascriptMode(documentRegions: LanguageModelCache<HTMLDocume
 			scriptFileVersion++;
 		}
 	}
-	let host = {
+	const host: ts.LanguageServiceHost = {
 		getCompilationSettings: () => compilerOptions,
 		getScriptFileNames: () => [FILE_NAME, JQUERY_D_TS],
+		getScriptKind: () => ts.ScriptKind.JS,
 		getScriptVersion: (fileName: string) => {
 			if (fileName === FILE_NAME) {
 				return String(scriptFileVersion);


### PR DESCRIPTION
**Bug**
Script contents in html are treated as typescript instead of javascript

**Fix**
Explicitly set the script kind to js

Fixes #25846