### PR TITLE
Enable Semantic Diagnostics for Inline JS

### DIFF
--- a/extensions/html/server/src/modes/javascriptMode.ts
+++ b/extensions/html/server/src/modes/javascriptMode.ts
@@ -71,8 +71,9 @@ export function getJavascriptMode(documentRegions: LanguageModelCache<HTMLDocume
 		},
 		doValidation(document: TextDocument): Diagnostic[] {
 			updateCurrentTextDocument(document);
-			const diagnostics = jsLanguageService.getSyntacticDiagnostics(FILE_NAME);
-			return diagnostics.map((diag): Diagnostic => {
+			const syntaxDiagnostics = jsLanguageService.getSyntacticDiagnostics(FILE_NAME);
+			const semanticDiagnostics = jsLanguageService.getSemanticDiagnostics(FILE_NAME);
+			return syntaxDiagnostics.concat(semanticDiagnostics).map((diag): Diagnostic => {
 				return {
 					range: convertRange(currentTextDocument, diag),
 					severity: DiagnosticSeverity.Error,


### PR DESCRIPTION
Fixes #25809

**Bug**
Inline js in html currently only reports syntax errors. This means that `// @ts-check` does not work to help catch programming errors

**Fix**
Also report semantic errors in script tags

**Risk**
This may result in many more errors being reported in script tags, possibly incorrectly. `ts-check` is not enabled by default however, you must opt the file into it