### PR TITLE
Use Shared TypeScript to Compile VSCode Colorizer Tests

### DIFF
--- a/extensions/vscode-colorize-tests/package.json
+++ b/extensions/vscode-colorize-tests/package.json
@@ -8,14 +8,12 @@
 		"vscode": "*"
 	},
 	"scripts": {
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
 		"vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../build/gulpfile.extensions.js compile-extension:vscode-colorize-tests ./tsconfig.json",
 		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.38",
 		"@types/node": "^7.0.4",
-		"typescript": "^1.6.2",
 		"vscode": "1.0.1"
 	}
 }

--- a/extensions/vscode-colorize-tests/src/colorizer.test.ts
+++ b/extensions/vscode-colorize-tests/src/colorizer.test.ts
@@ -38,7 +38,7 @@ function assertUnchangedTokens(testFixurePath: string, done) {
 	}, done);
 }
 
-suite("colorization", () => {
+suite('colorization', () => {
 	let extensionsFolder = normalize(join(__dirname, '../../'));
 	let extensions = fs.readdirSync(extensionsFolder);
 	extensions.forEach(extension => {


### PR DESCRIPTION
**Bug**
Colorizer-tests currently installs an old version of typescript

**Fix**
Switch to using the standard typescript that all other extensions use. 