### PR TITLE
Add "Include" to extension TSConfig Files

### DIFF
--- a/extensions/configuration-editing/tsconfig.json
+++ b/extensions/configuration-editing/tsconfig.json
@@ -8,7 +8,7 @@
 		],
 		"strictNullChecks": true
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/css/client/tsconfig.json
+++ b/extensions/css/client/tsconfig.json
@@ -7,7 +7,7 @@
 			"es5", "es2015.promise"
 		]
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/css/server/tsconfig.json
+++ b/extensions/css/server/tsconfig.json
@@ -7,7 +7,7 @@
 			"es5"
 		]
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/extension-editing/tsconfig.json
+++ b/extensions/extension-editing/tsconfig.json
@@ -7,7 +7,7 @@
 		"module": "commonjs",
 		"outDir": "./out"
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/git/tsconfig.json
+++ b/extensions/git/tsconfig.json
@@ -9,7 +9,7 @@
 		"strictNullChecks": true,
 		"experimentalDecorators": true
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/grunt/tsconfig.json
+++ b/extensions/grunt/tsconfig.json
@@ -12,8 +12,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"exclude": [
-		"node_modules",
-		"out"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/gulp/tsconfig.json
+++ b/extensions/gulp/tsconfig.json
@@ -12,8 +12,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"exclude": [
-		"node_modules",
-		"out"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/javascript/tsconfig.json
+++ b/extensions/javascript/tsconfig.json
@@ -7,7 +7,7 @@
 			"es2015"
 		]
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/json/server/tsconfig.json
+++ b/extensions/json/server/tsconfig.json
@@ -9,7 +9,7 @@
 			"es5", "es2015.promise"
 		]
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/markdown/tsconfig.json
+++ b/extensions/markdown/tsconfig.json
@@ -14,7 +14,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/php/tsconfig.json
+++ b/extensions/php/tsconfig.json
@@ -7,7 +7,7 @@
 		"module": "commonjs",
 		"outDir": "./out"
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/python/tsconfig.json
+++ b/extensions/python/tsconfig.json
@@ -7,7 +7,7 @@
 		"module": "commonjs",
 		"outDir": "./out"
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/ruby/tsconfig.json
+++ b/extensions/ruby/tsconfig.json
@@ -8,7 +8,7 @@
 		],
 		"sourceMap": true
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/typescript/tsconfig.json
+++ b/extensions/typescript/tsconfig.json
@@ -13,10 +13,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true
 	},
-	"exclude": [
-		"node_modules",
-		"server",
-		"out",
-		"test/colorize-fixtures"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/vscode-api-tests/tsconfig.json
+++ b/extensions/vscode-api-tests/tsconfig.json
@@ -9,7 +9,7 @@
 		"sourceMap": true,
 		"strictNullChecks": true
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }

--- a/extensions/vscode-colorize-tests/tsconfig.json
+++ b/extensions/vscode-colorize-tests/tsconfig.json
@@ -8,7 +8,7 @@
 		],
 		"sourceMap": true
 	},
-	"exclude": [
-		"node_modules"
+	"include": [
+		"src/**/*"
 	]
 }


### PR DESCRIPTION
**Bug**
Most VSCode extensions currently specify `"exclude"` in their `tsconfig.json` but not `"include"`. This may result in extra files being included in each project

**Fix**
Add  `"include": ["src/**/*"]` to all extension tsconfig files