### PR TITLE
Mark Completion Items with Command as MakesTextEdit

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -130,6 +130,7 @@ export class SuggestController implements IEditorContribution {
 			let value = true;
 			if (
 				this._model.state === State.Auto
+				&& !item.suggestion.command
 				&& endColumn - startColumn === item.suggestion.insertText.length
 			) {
 				const oldText = this._editor.getModel().getValueInRange({


### PR DESCRIPTION
Fixes #25998 
Fixes #25959

**Bug**
See #25998

**Fix**
A Completion item with a command should always be treated as if it may alter the current document