### PR TITLE
Show ahead/behind indicator while git syncing

### DIFF
--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -127,7 +127,6 @@ class SyncStatusBar {
 
 		if (this.state.isSyncRunning) {
 			icon = '$(sync~spin)';
-			text = '';
 			command = '';
 			tooltip = localize('syncing changes', "Synchronizing changes...");
 		}


### PR DESCRIPTION
This implements https://github.com/Microsoft/vscode/issues/25936

![vscode-sync-ahead-behind](https://cloud.githubusercontent.com/assets/530988/25739945/22f0b29e-317c-11e7-9b1b-91c4f796ea60.gif)
