### PR TITLE
Highlight ShellScript built-ins in format 'var=true' without space.

### DIFF
--- a/extensions/shellscript/syntaxes/Shell-Unix-Bash.tmLanguage.json
+++ b/extensions/shellscript/syntaxes/Shell-Unix-Bash.tmLanguage.json
@@ -1163,7 +1163,7 @@
 					"name": "support.function.builtin.shell"
 				},
 				{
-					"match": "(?<=^|;|&|\\s)(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|mapfile|popd|printf|pushd|pwd|read(array)?|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)(?=\\s|;|&|$)",
+					"match": "(?<=^|;|&|\\s|=)(?:alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|dirs|disown|echo|enable|eval|exec|exit|false|fc|fg|getopts|hash|help|history|jobs|kill|let|logout|mapfile|popd|printf|pushd|pwd|read(array)?|readonly|set|shift|shopt|source|suspend|test|times|trap|true|type|ulimit|umask|unalias|unset|wait)(?=\\s|;|&|$)",
 					"name": "support.function.builtin.shell"
 				}
 			]


### PR DESCRIPTION
Before, in expression like 'export var=true', the 'true' word is not highlighted, because space is needed after equation sign.

Other IDE highlights "var=true" correctly.