### PR TITLE
Support terminal bg and fg color keys

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/media/xterm.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/xterm.css
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-workbench .panel.integrated-terminal .xterm {
-	background-color: transparent!important;
 	position: relative;
 	height: 100%;
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalColorRegistry.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalColorRegistry.ts
@@ -13,6 +13,9 @@ import { registerColor, ColorIdentifier } from 'vs/platform/theme/common/colorRe
  */
 export const ansiColorIdentifiers: ColorIdentifier[] = [];
 
+export const TERMINAL_BACKGROUND_COLOR = registerColor('terminal.background', null, nls.localize('terminal.background', 'The background color of the terminal, this allows coloring the terminal differently to the panel.'));
+export const TERMINAL_FOREGROUND_COLOR = registerColor('terminal.foreground', null, nls.localize('terminal.foreground', 'The foreground color of the terminal.'));
+
 const ansiColorMap = {
 	'terminal.ansiBlack': {
 		index: 0,
@@ -150,4 +153,5 @@ export function registerColors(): void {
 		let colorName = id.substring(13);
 		ansiColorIdentifiers[entry.index] = registerColor(id, entry.defaults, nls.localize('terminal.ansiColor', '\'{0}\' ansi color in the terminal.', colorName));
 	}
+
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -16,7 +16,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ITerminalService, ITerminalFont, TERMINAL_PANEL_ID } from 'vs/workbench/parts/terminal/common/terminal';
 import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
-import { ansiColorIdentifiers } from './terminalColorRegistry';
+import { ansiColorIdentifiers, TERMINAL_BACKGROUND_COLOR, TERMINAL_FOREGROUND_COLOR } from './terminalColorRegistry';
 import { ColorIdentifier } from 'vs/platform/theme/common/colorRegistry';
 import { KillTerminalAction, CreateNewTerminalAction, SwitchTerminalInstanceAction, SwitchTerminalInstanceActionItem, CopyTerminalSelectionAction, TerminalPasteAction, ClearTerminalAction } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
 import { Panel } from 'vs/workbench/browser/panel';
@@ -226,6 +226,15 @@ export class TerminalPanel extends Panel {
 					`.monaco-workbench .panel.integrated-terminal .xterm .xterm-bg-color-${index}::selection { color: ${color}; }`;
 			}
 		});
+		const bgColor = theme.getColor(TERMINAL_BACKGROUND_COLOR);
+		if (bgColor) {
+			console.log('set bgColor to: ' + bgColor);
+			css += `.monaco-workbench .panel.integrated-terminal .terminal-outer-container { background-color: ${bgColor}; }`;
+		}
+		const fgColor = theme.getColor(TERMINAL_FOREGROUND_COLOR);
+		if (bgColor) {
+			css += `.monaco-workbench .panel.integrated-terminal .xterm { color: ${fgColor}; }`;
+		}
 
 		this._themeStyleElement.innerHTML = css;
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -228,7 +228,6 @@ export class TerminalPanel extends Panel {
 		});
 		const bgColor = theme.getColor(TERMINAL_BACKGROUND_COLOR);
 		if (bgColor) {
-			console.log('set bgColor to: ' + bgColor);
 			css += `.monaco-workbench .panel.integrated-terminal .terminal-outer-container { background-color: ${bgColor}; }`;
 		}
 		const fgColor = theme.getColor(TERMINAL_FOREGROUND_COLOR);


### PR DESCRIPTION
Fixes #24735 

---

@aeschli @bpasero please review 😃 

Most terminal emulators support this, this will allow putting a very high contrast background (due to wide variety of colors like dim/bright white and black) or just styling the terminal differently to the rest of the UI. For example a powershell user might like a terminal with a blue background.

<img width="835" alt="screen shot 2017-05-05 at 8 42 47 am" src="https://cloud.githubusercontent.com/assets/2193314/25753070/14e30042-316f-11e7-88fe-3830fb1fa976.png">
