### PR TITLE
Enable Theme Specific CSS in Webviews

### DIFF
--- a/src/vs/editor/browser/services/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/browser/services/standaloneThemeServiceImpl.ts
@@ -23,8 +23,9 @@ const colorRegistry = <IColorRegistry>Registry.as(Extensions.ColorContribution);
 const themingRegistry = Registry.as<IThemingRegistry>(ThemingExtensions.ThemingContribution);
 
 class StandaloneTheme implements IStandaloneTheme {
-	id: string;
-	selector: string;
+	readonly name: string;
+	readonly id: string;
+	readonly selector: string;
 	private rules: ITokenThemeRule[];
 	base: string;
 	private colors: { [colorId: string]: Color };
@@ -35,9 +36,11 @@ class StandaloneTheme implements IStandaloneTheme {
 		if (name.length > 0) {
 			this.id = base + ' ' + name;
 			this.selector = base + '.' + name;
+			this.name = name;
 		} else {
 			this.id = base;
 			this.selector = base;
+			this.name = base;
 		}
 		this.base = base;
 		this.rules = rules;

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -20,6 +20,7 @@ export const HIGH_CONTRAST = 'hc';
 export type ThemeType = 'light' | 'dark' | 'hc';
 
 export interface ITheme {
+	readonly name: string;
 	readonly selector: string;
 	readonly type: ThemeType;
 

--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -9,14 +9,23 @@
 	const ipcRenderer = require('electron').ipcRenderer;
 
 
-	const initData = {};
+	const initData = {
+		baseTheme: '',
+		theme: ''
+	};
 
+	/**
+	 * @param {HTMLBodyElement} body
+	 */
 	function styleBody(body) {
 		if (!body) {
 			return
 		}
 		body.classList.remove('vscode-light', 'vscode-dark', 'vscode-high-contrast');
-		body.classList.add(initData.activeTheme);
+		body.classList.add(initData.baseTheme);
+
+		body.dataset.vscodeBaseTheme = initData.baseTheme;
+		body.dataset.vscodeTheme = initData.theme;
 	}
 
 	/**
@@ -57,9 +66,10 @@
 			initData.baseUrl = value;
 		});
 
-		ipcRenderer.on('styles', function (event, value, activeTheme) {
+		ipcRenderer.on('styles', function (event, value, baseTheme, theme) {
 			initData.styles = value;
-			initData.activeTheme = activeTheme;
+			initData.baseTheme = baseTheme;
+			initData.theme = theme;
 
 			// webview
 			var target = getTarget()

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -240,7 +240,7 @@ export default class Webview {
 			activeTheme = 'vscode-high-contrast';
 		}
 
-		this._send('styles', value, activeTheme);
+		this._send('styles', value, activeTheme, theme.name);
 	}
 
 	public layout(): void {

--- a/src/vs/workbench/parts/terminal/test/electron-browser/terminalColorRegistry.test.ts
+++ b/src/vs/workbench/parts/terminal/test/electron-browser/terminalColorRegistry.test.ts
@@ -15,9 +15,9 @@ registerColors();
 
 let themingRegistry = <IColorRegistry>Registry.as(ThemeingExtensions.ColorContribution);
 function getMockTheme(type: ThemeType): ITheme {
-	let theme = {
+	let theme: ITheme = {
+		name: '',
 		selector: '',
-		label: '',
 		type: type,
 		getColor: (colorId) => themingRegistry.resolveDefaultColor(colorId, theme),
 		defines: () => true

--- a/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
@@ -28,6 +28,7 @@ export class ColorThemeData implements IColorTheme {
 	constructor() {
 	}
 
+	name: string;
 	id: string;
 	label: string;
 	settingsId: string;
@@ -153,9 +154,9 @@ export function fromStorageData(input: string): ColorThemeData {
 
 export function fromExtensionTheme(theme: IThemeExtensionPoint, normalizedAbsolutePath: string, extensionData: ExtensionData): ColorThemeData {
 	let baseTheme = theme['uiTheme'] || 'vs-dark';
-
 	let themeSelector = toCSSSelector(extensionData.extensionId + '-' + Paths.normalize(theme.path));
 	let themeData = new ColorThemeData();
+	themeData.name = theme.label;
 	themeData.id = `${baseTheme} ${themeSelector}`;
 	themeData.label = theme.label || Paths.basename(theme.path);
 	themeData.settingsId = theme.id || themeData.label;

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -999,6 +999,7 @@ export class TestWindowsService implements IWindowsService {
 }
 
 export class TestTheme implements ITheme {
+	name: string;
 	selector: string;
 	type: 'light' | 'dark' | 'hc';
 


### PR DESCRIPTION
Fixes #26078

Adds new `vscode-theme` and `vscode-base-theme` data attributes to the webview body. This allows webviews to use theme specific css selectors.

Here's an example of using this in the markdown preview with the css:

```css
[data-vscode-theme="Monokai"] {
    font-family: "Comic Sans MS";
    color: hotpink;
}

[data-vscode-base-theme="vscode-light"] a {
    color: red; 
}
```

![theme specific css](https://cloud.githubusercontent.com/assets/12821956/25766124/6dfbe564-31a5-11e7-98cf-c95caa650efc.gif)