### PR TITLE
Add theme key for selection

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -134,6 +134,8 @@ export const focusBorder = registerColor('focusBorder', { dark: Color.fromHex('#
 export const contrastBorder = registerColor('contrastBorder', { light: null, dark: null, hc: '#6FC3DF' }, nls.localize('contrastBorder', "An extra border around elements to separate them from others for greater contrast."));
 export const activeContrastBorder = registerColor('contrastActiveBorder', { light: null, dark: null, hc: focusBorder }, nls.localize('activeContrastBorder', "An extra border around active elements to separate them from others for greater contrast."));
 
+export const selection = registerColor('selection', { light: null, dark: null, hc: null }, nls.localize('selection', "The color of text selection in the workbench. Note that this does not apply to selections within the editor and the terminal."));
+
 // ----- widgets
 export const widgetShadow = registerColor('widget.shadow', { dark: '#000000', light: '#A8A8A8', hc: null }, nls.localize('widgetShadow', 'Shadow color of widgets such as find/replace inside the editor.'));
 

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -134,7 +134,7 @@ export const focusBorder = registerColor('focusBorder', { dark: Color.fromHex('#
 export const contrastBorder = registerColor('contrastBorder', { light: null, dark: null, hc: '#6FC3DF' }, nls.localize('contrastBorder', "An extra border around elements to separate them from others for greater contrast."));
 export const activeContrastBorder = registerColor('contrastActiveBorder', { light: null, dark: null, hc: focusBorder }, nls.localize('activeContrastBorder', "An extra border around active elements to separate them from others for greater contrast."));
 
-export const selection = registerColor('selection', { light: null, dark: null, hc: null }, nls.localize('selection', "The color of text selection in the workbench. Note that this does not apply to selections within the editor and the terminal."));
+export const selectionBackground = registerColor('selection.background', { light: null, dark: null, hc: null }, nls.localize('selectionBackground', "The background color of text selections in the workbench (e.g. for input fields or text areas). Note that this does not apply to selections within the editor and the terminal."));
 
 // ----- widgets
 export const widgetShadow = registerColor('widget.shadow', { dark: '#000000', light: '#A8A8A8', hc: null }, nls.localize('widgetShadow', 'Shadow color of widgets such as find/replace inside the editor.'));

--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -103,7 +103,7 @@ import 'vs/platform/opener/browser/opener.contribution';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { WorkbenchThemeService } from 'vs/workbench/services/themes/electron-browser/workbenchThemeService';
 import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { foreground, selection, focusBorder, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, listHighlightForeground } from 'vs/platform/theme/common/colorRegistry';
+import { foreground, selectionBackground, focusBorder, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, listHighlightForeground } from 'vs/platform/theme/common/colorRegistry';
 
 /**
  * Services that we require for the Shell
@@ -529,9 +529,10 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		collector.addRule(`.monaco-shell { color: ${windowForeground}; }`);
 	}
 
-	const windowSelection = theme.getColor(selection);
-	if (windowSelection) {
-		collector.addRule(`.monaco-shell *::selection { background-color: ${windowSelection}; }`);
+	// Selection
+	const windowSelectionBackground = theme.getColor(selectionBackground);
+	if (windowSelectionBackground) {
+		collector.addRule(`.monaco-shell ::selection { background-color: ${windowSelectionBackground}; }`);
 	}
 
 	// List highlight

--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -103,7 +103,7 @@ import 'vs/platform/opener/browser/opener.contribution';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { WorkbenchThemeService } from 'vs/workbench/services/themes/electron-browser/workbenchThemeService';
 import { registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { foreground, focusBorder, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, listHighlightForeground } from 'vs/platform/theme/common/colorRegistry';
+import { foreground, selection, focusBorder, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, listHighlightForeground } from 'vs/platform/theme/common/colorRegistry';
 
 /**
  * Services that we require for the Shell
@@ -527,6 +527,11 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const windowForeground = theme.getColor(foreground);
 	if (windowForeground) {
 		collector.addRule(`.monaco-shell { color: ${windowForeground}; }`);
+	}
+
+	const windowSelection = theme.getColor(selection);
+	if (windowSelection) {
+		collector.addRule(`.monaco-shell *::selection { background-color: ${windowSelection}; }`);
 	}
 
 	// List highlight


### PR DESCRIPTION
Fixes #25966

---

Does not affect editor:

![image](https://cloud.githubusercontent.com/assets/2193314/25767622/043fb302-31b0-11e7-9442-a9fa69c448ec.png)

Does not affect terminal:

![image](https://cloud.githubusercontent.com/assets/2193314/25767632/1b4e4270-31b0-11e7-87b0-1e87646ad0e7.png)

Examples:

![image](https://cloud.githubusercontent.com/assets/2193314/25767629/0f2c4276-31b0-11e7-9fc4-449259908124.png)

![image](https://cloud.githubusercontent.com/assets/2193314/25767637/27198696-31b0-11e7-837d-a9e4d4b0735a.png)

![image](https://cloud.githubusercontent.com/assets/2193314/25767644/3141acd4-31b0-11e7-86a3-ee325a826ed7.png)
