### PR TITLE
Update ts/js grammars in order to support colorizing JSX components differently from standard HTML tags

### DIFF
--- a/extensions/javascript/syntaxes/JavaScript.tmLanguage.json
+++ b/extensions/javascript/syntaxes/JavaScript.tmLanguage.json
@@ -4008,8 +4008,8 @@
 		},
 		"jsx-tag-without-attributes": {
 			"name": "meta.tag.without-attributes.js",
-			"begin": "(<)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)",
-			"end": "(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)",
+			"begin": "(<)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>)",
+			"end": "(</)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.tag.begin.js"
@@ -4018,6 +4018,9 @@
 					"name": "entity.name.tag.js"
 				},
 				"3": {
+					"name": "support.class.component.js"
+				},
+				"4": {
 					"name": "punctuation.definition.tag.end.js"
 				}
 			},
@@ -4029,6 +4032,9 @@
 					"name": "entity.name.tag.js"
 				},
 				"3": {
+					"name": "support.class.component.js"
+				},
+				"4": {
 					"name": "punctuation.definition.tag.end.js"
 				}
 			},
@@ -4041,7 +4047,7 @@
 		},
 		"jsx-tag-in-expression": {
 			"begin": "(?x)\n  (?<=[({\\[,?=>:*]|&&|\\|\\||\\?|\\Wreturn|^return|\\Wdefault|^)\\s*\n  (?!(<)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)) #look ahead is not start of tag without attributes\n  (?!<\\s*[_$[:alpha:]][_$[:alnum:]]*((\\s+extends\\s+[^=>])|,)) # look ahead is not type parameter of arrow\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
-			"end": "(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>))",
+			"end": "(/>)|(?:(</)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>))",
 			"endCaptures": {
 				"0": {
 					"name": "meta.tag.js"
@@ -4056,6 +4062,9 @@
 					"name": "entity.name.tag.js"
 				},
 				"4": {
+					"name": "support.class.component.js"
+				},
+				"5": {
 					"name": "punctuation.definition.tag.end.js"
 				}
 			},
@@ -4067,7 +4076,7 @@
 		},
 		"jsx-child-tag": {
 			"begin": "(?x)\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
-			"end": "(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>))",
+			"end": "(/>)|(?:(</)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>))",
 			"endCaptures": {
 				"0": {
 					"name": "meta.tag.js"
@@ -4082,6 +4091,9 @@
 					"name": "entity.name.tag.js"
 				},
 				"4": {
+					"name": "support.class.component.js"
+				},
+				"5": {
 					"name": "punctuation.definition.tag.end.js"
 				}
 			},
@@ -4097,13 +4109,16 @@
 			"end": "(?=(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)))",
 			"patterns": [
 				{
-					"begin": "(?x)\n  (<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>)",
+					"begin": "(?x)\n  (<)\\s*\n  ((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>)",
 					"beginCaptures": {
 						"1": {
 							"name": "punctuation.definition.tag.begin.js"
 						},
 						"2": {
 							"name": "entity.name.tag.js"
+						},
+						"3": {
+							"name": "support.class.component.js"
 						}
 					},
 					"end": "(?=[/]?>)",
@@ -4173,5 +4188,5 @@
 			]
 		}
 	},
-	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/9f6676aa2ddb75cb5a9dbe1f59024069e839d986"
+	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/cb1af7953db224204607cbe22d3a45aa0f77a4c1"
 }

--- a/extensions/javascript/test/colorize-results/test_jsx.json
+++ b/extensions/javascript/test/colorize-results/test_jsx.json
@@ -2157,10 +2157,10 @@
 	},
 	{
 		"c": "ToggleText",
-		"t": "source.js meta.tag.js entity.name.tag.js",
+		"t": "source.js meta.tag.js entity.name.tag.js support.class.component.js",
 		"r": {
-			"dark_plus": "entity.name.tag: #569CD6",
-			"light_plus": "entity.name.tag: #800000",
+			"dark_plus": "support.class: #4EC9B0",
+			"light_plus": "support.class: #267F99",
 			"dark_vs": "entity.name.tag: #569CD6",
 			"light_vs": "entity.name.tag: #800000",
 			"hc_black": "entity.name.tag: #569CD6"

--- a/extensions/typescript/syntaxes/TypeScriptReact.tmLanguage.json
+++ b/extensions/typescript/syntaxes/TypeScriptReact.tmLanguage.json
@@ -4005,8 +4005,8 @@
 		},
 		"jsx-tag-without-attributes": {
 			"name": "meta.tag.without-attributes.tsx",
-			"begin": "(<)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)",
-			"end": "(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)",
+			"begin": "(<)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>)",
+			"end": "(</)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.tag.begin.tsx"
@@ -4015,6 +4015,9 @@
 					"name": "entity.name.tag.tsx"
 				},
 				"3": {
+					"name": "support.class.component.tsx"
+				},
+				"4": {
 					"name": "punctuation.definition.tag.end.tsx"
 				}
 			},
@@ -4026,6 +4029,9 @@
 					"name": "entity.name.tag.tsx"
 				},
 				"3": {
+					"name": "support.class.component.tsx"
+				},
+				"4": {
 					"name": "punctuation.definition.tag.end.tsx"
 				}
 			},
@@ -4038,7 +4044,7 @@
 		},
 		"jsx-tag-in-expression": {
 			"begin": "(?x)\n  (?<=[({\\[,?=>:*]|&&|\\|\\||\\?|\\Wreturn|^return|\\Wdefault|^)\\s*\n  (?!(<)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)) #look ahead is not start of tag without attributes\n  (?!<\\s*[_$[:alpha:]][_$[:alnum:]]*((\\s+extends\\s+[^=>])|,)) # look ahead is not type parameter of arrow\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
-			"end": "(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>))",
+			"end": "(/>)|(?:(</)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>))",
 			"endCaptures": {
 				"0": {
 					"name": "meta.tag.tsx"
@@ -4053,6 +4059,9 @@
 					"name": "entity.name.tag.tsx"
 				},
 				"4": {
+					"name": "support.class.component.tsx"
+				},
+				"5": {
 					"name": "punctuation.definition.tag.end.tsx"
 				}
 			},
@@ -4064,7 +4073,7 @@
 		},
 		"jsx-child-tag": {
 			"begin": "(?x)\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
-			"end": "(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>))",
+			"end": "(/>)|(?:(</)\\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\\s*(>))",
 			"endCaptures": {
 				"0": {
 					"name": "meta.tag.tsx"
@@ -4079,6 +4088,9 @@
 					"name": "entity.name.tag.tsx"
 				},
 				"4": {
+					"name": "support.class.component.tsx"
+				},
+				"5": {
 					"name": "punctuation.definition.tag.end.tsx"
 				}
 			},
@@ -4094,13 +4106,16 @@
 			"end": "(?=(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)))",
 			"patterns": [
 				{
-					"begin": "(?x)\n  (<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>)",
+					"begin": "(?x)\n  (<)\\s*\n  ((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\\w.]*))(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>)",
 					"beginCaptures": {
 						"1": {
 							"name": "punctuation.definition.tag.begin.tsx"
 						},
 						"2": {
 							"name": "entity.name.tag.tsx"
+						},
+						"3": {
+							"name": "support.class.component.tsx"
 						}
 					},
 					"end": "(?=[/]?>)",
@@ -4170,5 +4185,5 @@
 			]
 		}
 	},
-	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/9f6676aa2ddb75cb5a9dbe1f59024069e839d986"
+	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/cb1af7953db224204607cbe22d3a45aa0f77a4c1"
 }


### PR DESCRIPTION
Picks up the latest js/ts grammar to fix #18752