### PR TITLE
Adding option to report issues about extensions

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -107,6 +107,7 @@ export interface IExtensionManifest {
 	activationEvents?: string[];
 	extensionDependencies?: string[];
 	contributes?: IExtensionContributions;
+	bugs?: { url: string };
 }
 
 export interface IGalleryExtensionProperties {

--- a/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
@@ -72,3 +72,30 @@ export function getGalleryExtensionTelemetryData(extension: IGalleryExtension): 
 		dependencies: extension.properties.dependencies.length > 0
 	};
 }
+
+/**
+ * Generates the New Issue Url for extensions
+ */
+export function generateExtensionNewIssueUrl(baseUrl: string, name: string, version: string, commit: string, date: string, extensionVersion: string, osVersion: string): string {
+	if (!baseUrl.match(/^https?\:\/\/(www.)?github.com\/.*\/issues\/?$/)) {
+		return baseUrl;
+	}
+	let separator = baseUrl.charAt(baseUrl.length - 1) === '/' ? '' : '/';
+	const newUrl = `${baseUrl}${separator}new`;
+
+	// Avoid backticks, these can trigger XSS detectors. (https://github.com/Microsoft/vscode/issues/13098)
+	const queryStringPrefix = newUrl.indexOf('?') === -1 ? '?' : '&';
+	const body = encodeURIComponent(
+		`- VSCode Version: ${name} ${version} (${commit || 'Commit unknown'}, ${date || 'Date unknown'})
+- OS Version: ${osVersion}
+- Extension Version: ${extensionVersion}
+---
+
+Steps to Reproduce:
+
+1.
+2.`
+	);
+
+	return `${newUrl}${queryStringPrefix}body=${body}`;
+}

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -24,7 +24,7 @@ import { IExtensionManagementService, LocalExtensionType, ILocalExtension } from
 import { IWorkspaceConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
 import paths = require('vs/base/common/paths');
 import { isMacintosh, isLinux } from 'vs/base/common/platform';
-import { IQuickOpenService, IFilePickOpenEntry, ISeparator } from 'vs/platform/quickOpen/common/quickOpen';
+import { IQuickOpenService, IFilePickOpenEntry, ISeparator, IPickOpenEntry } from 'vs/platform/quickOpen/common/quickOpen';
 import { KeyMod } from 'vs/base/common/keyCodes';
 import * as browser from 'vs/base/browser/browser';
 import { IIntegrityService } from 'vs/platform/integrity/common/integrity';
@@ -34,6 +34,8 @@ import { IEditorGroupService } from 'vs/workbench/services/group/common/groupSer
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { IPartService, Parts, Position as SidebarPosition } from 'vs/workbench/services/part/common/partService';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
+import { generateExtensionNewIssueUrl } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
+
 
 import * as os from 'os';
 import { webFrame } from 'electron';
@@ -672,7 +674,8 @@ export class ReportIssueAction extends Action {
 		id: string,
 		label: string,
 		@IIntegrityService private integrityService: IIntegrityService,
-		@IExtensionManagementService private extensionManagementService: IExtensionManagementService
+		@IExtensionManagementService private extensionManagementService: IExtensionManagementService,
+		@IQuickOpenService private quickOpenService: IQuickOpenService
 	) {
 		super(id, label);
 	}
@@ -691,13 +694,46 @@ export class ReportIssueAction extends Action {
 	public run(): TPromise<boolean> {
 		return this._optimisticIsPure().then(isPure => {
 			return this.extensionManagementService.getInstalled(LocalExtensionType.User).then(extensions => {
-				const issueUrl = this.generateNewIssueUrl(product.reportIssueUrl, pkg.name, pkg.version, product.commit, product.date, isPure, extensions);
+				const extensionsWithBugsUrl = extensions.filter(extension => extension.manifest.bugs && extension.manifest.bugs.url);
 
-				window.open(issueUrl);
-
+				if (extensionsWithBugsUrl.length === 0) {
+					return this.generateNewIssueUrl(product.reportIssueUrl, pkg.name, pkg.version, product.commit, product.date, isPure, extensions);
+				}
+				return this.pickExtensionToReport(extensions, isPure);
+			}).then(issueUrl => {
+				if (issueUrl) {
+					window.open(issueUrl);
+				}
 				return TPromise.as(true);
 			});
 		});
+	}
+
+	private pickExtensionToReport(extensions: ILocalExtension[], isPure: boolean): TPromise<string> {
+		const picks = ReportExtensionIssueAction.getExtensionPicks(extensions);
+
+		// adds a default pick at the top, to submit issues to the VS Code project
+		picks.unshift({
+			id: 'default',
+			label: product.nameLong
+		});
+
+		return this.quickOpenService.pick(picks, { placeHolder: nls.localize('pickExtension', "Select Extension") })
+			.then(pick => {
+				if (!pick) {
+					return null;
+				}
+				if (pick.id === 'default') {
+					return this.generateNewIssueUrl(product.reportIssueUrl, pkg.name, pkg.version, product.commit, product.date, isPure, extensions);
+				}
+
+				const extension = extensions.filter(ext => ext.id === pick.id)[0];
+				const url = extension.manifest.bugs.url;
+				const extensionVersion = extension.manifest.version;
+				const osVersion = `${os.type()} ${os.arch()} ${os.release()}`;
+
+				return generateExtensionNewIssueUrl(url, pkg.name, pkg.version, product.commit, product.date, extensionVersion, osVersion);
+			});
 	}
 
 	private generateNewIssueUrl(baseUrl: string, name: string, version: string, commit: string, date: string, isPure: boolean, extensions: ILocalExtension[]): string {
@@ -744,6 +780,55 @@ ${tableHeader}\n${table};
 		return extensionTable;
 	}
 }
+
+export class ReportExtensionIssueAction extends Action {
+
+	public static ID = 'workbench.action.reportExtensionIssues';
+	public static LABEL = nls.localize('reportExtensionIssues', "Report Extension Issues");
+
+	constructor(
+		id: string,
+		label: string,
+		@IIntegrityService private integrityService: IIntegrityService,
+		@IExtensionManagementService private extensionManagementService: IExtensionManagementService,
+		@IQuickOpenService private quickOpenService: IQuickOpenService
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<boolean> {
+		return this.extensionManagementService.getInstalled(LocalExtensionType.User).then(extensions => {
+			const picks = ReportExtensionIssueAction.getExtensionPicks(extensions);
+			return this.quickOpenService.pick(picks, { placeHolder: nls.localize('pickExtension', "Select Extension") })
+				.then(pick => {
+					if (!pick) {
+						return null;
+					}
+					const extension = extensions.filter(ext => ext.id === pick.id)[0];
+					const url = extension.manifest.bugs.url;
+					const extensionVersion = extension.manifest.version;
+					const osVersion = `${os.type()} ${os.arch()} ${os.release()}`;
+					return generateExtensionNewIssueUrl(url, pkg.name, pkg.version, product.commit, product.date, extensionVersion, osVersion);
+				});
+		}).then(issueUrl => {
+			if (issueUrl) {
+				window.open(issueUrl);
+			}
+			return TPromise.as(true);
+		});
+	}
+
+	public static getExtensionPicks(extensions: ILocalExtension[]): IPickOpenEntry[] {
+		return extensions
+			.filter(extension => extension.manifest.bugs && extension.manifest.bugs.url)
+			.map(extension => ({
+				id: extension.id,
+				label: extension.manifest.name
+			}))
+			.sort((t1, t2) => t1.label.localeCompare(t2.label));
+	}
+}
+
 
 export class ReportPerformanceIssueAction extends Action {
 

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -14,7 +14,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'v
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actionRegistry';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
-import { CloseEditorAction, KeybindingsReferenceAction, OpenDocumentationUrlAction, OpenIntroductoryVideosUrlAction, ReportIssueAction, ReportPerformanceIssueAction, ZoomResetAction, ZoomOutAction, ZoomInAction, ToggleFullScreenAction, ToggleMenuBarAction, CloseFolderAction, CloseWindowAction, SwitchWindow, NewWindowAction, CloseMessagesAction, NavigateUpAction, NavigateDownAction, NavigateLeftAction, NavigateRightAction, IncreaseViewSizeAction, DecreaseViewSizeAction } from 'vs/workbench/electron-browser/actions';
+import { CloseEditorAction, KeybindingsReferenceAction, OpenDocumentationUrlAction, OpenIntroductoryVideosUrlAction, ReportIssueAction, ReportPerformanceIssueAction, ReportExtensionIssueAction, ZoomResetAction, ZoomOutAction, ZoomInAction, ToggleFullScreenAction, ToggleMenuBarAction, CloseFolderAction, CloseWindowAction, SwitchWindow, NewWindowAction, CloseMessagesAction, NavigateUpAction, NavigateDownAction, NavigateLeftAction, NavigateRightAction, IncreaseViewSizeAction, DecreaseViewSizeAction } from 'vs/workbench/electron-browser/actions';
 import { MessagesVisibleContext } from 'vs/workbench/electron-browser/workbench';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { registerCommands } from 'vs/workbench/electron-browser/commands';
@@ -35,6 +35,9 @@ if (!!product.reportIssueUrl) {
 	workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ReportIssueAction, ReportIssueAction.ID, ReportIssueAction.LABEL), 'Help: Report Issues', helpCategory);
 	workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ReportPerformanceIssueAction, ReportPerformanceIssueAction.ID, ReportPerformanceIssueAction.LABEL), 'Help: Report Performance Issues', helpCategory);
 }
+
+workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(ReportExtensionIssueAction, ReportExtensionIssueAction.ID, ReportExtensionIssueAction.LABEL, null), 'Help: Report Extension Issues', helpCategory);
+
 if (KeybindingsReferenceAction.AVAILABLE) {
 	workbenchActionsRegistry.registerWorkbenchAction(new SyncActionDescriptor(KeybindingsReferenceAction, KeybindingsReferenceAction.ID, KeybindingsReferenceAction.LABEL, { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_R) }), 'Help: Keyboard Shortcuts Reference', helpCategory);
 }

--- a/src/vs/workbench/parts/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/browser/extensionEditor.ts
@@ -35,7 +35,7 @@ import { ITemplateData } from 'vs/workbench/parts/extensions/browser/extensionsL
 import { RatingsWidget, InstallWidget } from 'vs/workbench/parts/extensions/browser/extensionsWidgets';
 import { EditorOptions } from 'vs/workbench/common/editor';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
-import { CombinedInstallAction, UpdateAction, EnableAction, DisableAction, BuiltinStatusLabelAction, ReloadAction } from 'vs/workbench/parts/extensions/browser/extensionsActions';
+import { CombinedInstallAction, UpdateAction, EnableAction, DisableAction, BuiltinStatusLabelAction, ReloadAction, ReportIssueAction } from 'vs/workbench/parts/extensions/browser/extensionsActions';
 import WebView from 'vs/workbench/parts/html/browser/webview';
 import { KeybindingIO } from 'vs/workbench/services/keybinding/common/keybindingIO';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -279,6 +279,7 @@ export class ExtensionEditor extends BaseEditor {
 		const enableAction = this.instantiationService.createInstance(EnableAction);
 		const disableAction = this.instantiationService.createInstance(DisableAction);
 		const reloadAction = this.instantiationService.createInstance(ReloadAction);
+		const reportIssueAction = this.instantiationService.createInstance(ReportIssueAction);
 
 		installAction.extension = extension;
 		builtinStatusAction.extension = extension;
@@ -286,10 +287,11 @@ export class ExtensionEditor extends BaseEditor {
 		enableAction.extension = extension;
 		disableAction.extension = extension;
 		reloadAction.extension = extension;
+		reportIssueAction.extension = extension;
 
 		this.extensionActionBar.clear();
-		this.extensionActionBar.push([reloadAction, updateAction, enableAction, disableAction, installAction, builtinStatusAction], { icon: true, label: true });
-		this.transientDisposables.push(enableAction, updateAction, reloadAction, disableAction, installAction, builtinStatusAction);
+		this.extensionActionBar.push([reloadAction, updateAction, enableAction, disableAction, installAction, builtinStatusAction, reportIssueAction], { icon: true, label: true });
+		this.transientDisposables.push(enableAction, updateAction, reloadAction, disableAction, installAction, builtinStatusAction, reportIssueAction);
 
 		this.navbar.clear();
 		this.navbar.onChange(this.onNavbarChange.bind(this, extension), this, this.transientDisposables);

--- a/src/vs/workbench/parts/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/browser/extensionsActions.ts
@@ -1303,3 +1303,48 @@ CommandsRegistry.registerCommand('workbench.extensions.action.showLanguageExtens
 			viewlet.focus();
 		});
 });
+
+export class ReportIssueAction extends Action {
+
+	static ID = 'workbench.extensions.action.reportIssue';
+	static LABEL = localize('reportIssue', "Report Issue");
+	private static EnabledClass = 'extension-action report';
+	private static DisabledClass = `${ReportIssueAction.EnabledClass} disabled`;
+
+	private _issueUrl: string;
+	private disposables: IDisposable[] = [];
+	private _extension: IExtension;
+	get extension(): IExtension { return this._extension; }
+	set extension(extension: IExtension) { this._extension = extension; this.update(); }
+
+	constructor(
+		@IExtensionsWorkbenchService private extensionsWorkbenchService: IExtensionsWorkbenchService
+	) {
+		super(ReportIssueAction.ID, ReportIssueAction.LABEL);
+		this.disposables.push(this.extensionsWorkbenchService.onChange(() => this.update()));
+		this.update();
+	}
+
+	private update(): void {
+		this.class = ReportIssueAction.DisabledClass;
+		this.enabled = false;
+		this._issueUrl = null;
+
+		if (this.extension && this.extension.issueUrl) {
+			this.enabled = true;
+			this.class = ReportIssueAction.EnabledClass;
+		}
+	}
+
+	run(): TPromise<any> {
+		if (this.extension.issueUrl) {
+			window.open(this.extension.issueUrl);
+		}
+		return TPromise.as(null);
+	}
+
+	dispose(): void {
+		super.dispose();
+		this.disposables = dispose(this.disposables);
+	}
+}

--- a/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
@@ -89,6 +89,7 @@
 .monaco-action-bar .action-item.disabled .action-label.extension-action.enable,
 .monaco-action-bar .action-item.disabled .action-label.extension-action.disable,
 .monaco-action-bar .action-item.disabled .action-label.extension-action.reload,
+.monaco-action-bar .action-item.disabled .action-label.extension-action.report,
 .monaco-action-bar .action-item.disabled .action-label.extension-action.built-in-status.user {
 	display: none;
 }

--- a/src/vs/workbench/parts/extensions/common/extensions.ts
+++ b/src/vs/workbench/parts/extensions/common/extensions.ts
@@ -46,6 +46,7 @@ export interface IExtension {
 	disabledForWorkspace: boolean;
 	dependencies: string[];
 	telemetryData: any;
+	issueUrl: string;
 	getManifest(): TPromise<IExtensionManifest>;
 	getReadme(): TPromise<string>;
 	getChangelog(): TPromise<string>;

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -23,7 +23,7 @@ import {
 	IExtensionManagementService, IExtensionGalleryService, ILocalExtension, IGalleryExtension, IQueryOptions, IExtensionManifest,
 	InstallExtensionEvent, DidInstallExtensionEvent, LocalExtensionType, DidUninstallExtensionEvent, IExtensionEnablementService, IExtensionTipsService
 } from 'vs/platform/extensionManagement/common/extensionManagement';
-import { getGalleryExtensionIdFromLocal, getGalleryExtensionTelemetryData, getLocalExtensionTelemetryData } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
+import { getGalleryExtensionIdFromLocal, getGalleryExtensionTelemetryData, getLocalExtensionTelemetryData, generateExtensionNewIssueUrl } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IChoiceService, IMessageService } from 'vs/platform/message/common/message';
@@ -35,6 +35,9 @@ import { IURLService } from 'vs/platform/url/common/url';
 import { ExtensionsInput } from 'vs/workbench/parts/extensions/common/extensionsInput';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import product from 'vs/platform/node/product';
+import pkg from 'vs/platform/node/package';
+
+import * as os from 'os';
 
 interface IExtensionStateProvider {
 	(extension: Extension): ExtensionState;
@@ -220,6 +223,17 @@ class Extension implements IExtension {
 			return gallery.properties.dependencies;
 		}
 		return [];
+	}
+
+	get issueUrl(): string {
+		const bugsUrl = this.local.manifest.bugs && this.local.manifest.bugs.url;
+		if (!bugsUrl) {
+			return null;
+		}
+
+		const osVersion = `${os.type()} ${os.arch()} ${os.release()}`;
+
+		return generateExtensionNewIssueUrl(bugsUrl, pkg.name, pkg.version, product.commit, product.date, this.version, osVersion);
 	}
 }
 


### PR DESCRIPTION
Implements the feature requested in https://github.com/Microsoft/vscode/issues/21376

I added the three requested options:

* Added a Report Issue button, next to the Uninstall button, on the Extension view
* Added a `Help: Report Extension Issue` command that displays a quick pick of all extensions with available issue URLs, letting you choose which one to report
* Added an intermediary step into the `Help: Report Issue` command, that will display the extensions along with VS Code, as an option to report an issue.

I personally feel like adding the extensions to the `Help: Report Issue` command is confusing, so I'm wondering if we should just stick with the first two options.

I struggled a bit on deciding the best place to put the common code, let me know if you have any suggestions.

I also simplified a bit the new issue "template" generated by the Report Extension Issue. I removed the extensions table and the isPure parameter. I've added the version of the selected extension in there, as that's interesting to have.