### PR TITLE
Fix staging lines to not corrupt line endings when autocrlf is enabled

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -566,7 +566,7 @@ export class Repository {
 	}
 
 	async stage(path: string, data: string): Promise<void> {
-		const child = this.stream(['hash-object', '--stdin', '-w'], { stdio: [null, null, null] });
+		const child = this.stream(['hash-object', '--stdin', '-w', '--path', path], { stdio: [null, null, null] });
 		child.stdin.end(data, 'utf8');
 
 		const { exitCode, stdout } = await exec(child);


### PR DESCRIPTION
Pass the --path argument to git hash-object so that filters are correctly applied when staging lines. This prevents lines with crlf from being added to files that have autocrlf=true. Old versions of git can complain quite a bit if you get into this state.

From: https://git-scm.com/docs/git-hash-object

> 
> --path
> 
> Hash object as it were located at the given path. The location of file does not directly influence on the hash value, but path is used to determine what Git filters should be applied to the object before it can be placed to the object database, and, as result of applying filters, the actual blob put into the object database may differ from the given file. This option is mainly useful for hashing temporary files located outside of the working directory or files read from stdin.

Fixes https://github.com/Microsoft/vscode/issues/16889