### PR TITLE
Switch vscode-api-tests to uses standard TypeScript Version for Building

### DIFF
--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -41,13 +41,12 @@
 		}
 	},
 	"scripts": {
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-		"vscode:prepublish": "node ../../node_modules/gulp/bin/gulp.js --gulpfile ../../build/gulpfile.extensions.js compile-extension:vscode-api-tests ./tsconfig.json"
+		"compile": "gulp compile-extension:vscode-api-tests",
+		"watch": "gulp watch-extension:vscode-api-tests"
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.38",
 		"@types/node": "^7.0.4",
-		"typescript": "^1.6.2",
 		"vscode": "1.0.1"
 	}
 }


### PR DESCRIPTION
Change vscode-api-tests to use the global vscode typescript version for building instead of installing its own copy