### PR TITLE
Use EditorGroupinfo to decide if to swap/reposition suggest widget

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -23,7 +23,6 @@
 
 .monaco-editor .suggest-widget > .tree {
 	height: 100%;
-	width: 220px;
 	float: left;
 	box-sizing: border-box;
 }
@@ -114,7 +113,6 @@
 	flex-direction: column;
 	cursor: default;
 	box-sizing: border-box;
-	width: 440px;
 }
 
 .monaco-editor .suggest-widget .details.no-docs {


### PR DESCRIPTION
- Increased size of list, now both list and docs have same width. As mentioned in #26217 current list width is too small for many of the existing scenarios.
- Docs will not be resized. When the size is reduced too much, the type info wraps which doesnt make for a good reading.  
- Previous logic to decide about swapping/re-positioning etc restricted the suggest widget to stay inside the editor and not flow across editors. Current logic is simpler and lets the flowing of the suggest widget across editor groups.
