### PR TITLE
Change to bin/code script not using realpath.

### DIFF
--- a/resources/win32/bin/code.sh
+++ b/resources/win32/bin/code.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 NAME="@@NAME@@"
-VSCODE_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
+VSCODE_PATH="$(dirname "$(cd "$(dirname "$0")"; pwd -P)")"
 ELECTRON="$VSCODE_PATH/$NAME.exe"
 if grep -q Microsoft /proc/version; then
 	# If running under WSL don't pass cli.js to Electron as environment vars


### PR DESCRIPTION
- some environments realpath cannot be used (by default wsl does not include it)
- Issue #13138 https://github.com/Microsoft/vscode/issues/13138#issuecomment-297328734

---

Environment in error occurred

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"

$ uname -a
Linux DESKTOP-CA3OJF3 4.4.0-43-Microsoft #1-Microsoft Wed Dec 31 14:42:53 PST 2014 x86_64 x86_64 x86_64 GNU/Linux

$ code
/mnt/c/Program Files (x86)/Microsoft VS Code/bin/code: 行 7: realpath: コマンドが見つかりません
/mnt/c/Program Files (x86)/Microsoft VS Code/bin/code: 行 14: ./Code.exe: そのようなファイルやディレクトリはありません
```