### PR TITLE
Code Folding won't be remembered after latest update. (fixes #26157)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -61,7 +61,7 @@ export abstract class BaseTextEditor extends BaseEditor {
 		@IWorkbenchThemeService protected themeService: IWorkbenchThemeService,
 		@IModeService private modeService: IModeService,
 		@ITextFileService private textFileService: ITextFileService,
-		@IEditorGroupService private editorGroupService: IEditorGroupService
+		@IEditorGroupService protected editorGroupService: IEditorGroupService
 	) {
 		super(id, telemetryService, themeService);
 

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -844,6 +844,8 @@ export interface IStacksModelChangeEvent {
 export interface IEditorStacksModel {
 
 	onModelChanged: Event<IStacksModelChangeEvent>;
+
+	onWillCloseEditor: Event<IEditorIdentifier>;
 	onEditorClosed: Event<IGroupEvent>;
 
 	groups: IEditorGroup[];

--- a/src/vs/workbench/common/editor/editorStacksModel.ts
+++ b/src/vs/workbench/common/editor/editorStacksModel.ts
@@ -703,6 +703,7 @@ export class EditorStacksModel implements IEditorStacksModel {
 	private _onEditorDirty: Emitter<EditorIdentifier>;
 	private _onEditorLabelChange: Emitter<EditorIdentifier>;
 	private _onEditorOpened: Emitter<EditorIdentifier>;
+	private _onWillCloseEditor: Emitter<EditorIdentifier>;
 	private _onEditorClosed: Emitter<GroupEvent>;
 	private _onModelChanged: Emitter<IStacksModelChangeEvent>;
 
@@ -728,9 +729,10 @@ export class EditorStacksModel implements IEditorStacksModel {
 		this._onEditorDirty = new Emitter<EditorIdentifier>();
 		this._onEditorLabelChange = new Emitter<EditorIdentifier>();
 		this._onEditorOpened = new Emitter<EditorIdentifier>();
+		this._onWillCloseEditor = new Emitter<EditorIdentifier>();
 		this._onEditorClosed = new Emitter<GroupEvent>();
 
-		this.toDispose.push(this._onGroupOpened, this._onGroupClosed, this._onGroupActivated, this._onGroupDeactivated, this._onGroupMoved, this._onGroupRenamed, this._onModelChanged, this._onEditorDisposed, this._onEditorDirty, this._onEditorLabelChange, this._onEditorClosed);
+		this.toDispose.push(this._onGroupOpened, this._onGroupClosed, this._onGroupActivated, this._onGroupDeactivated, this._onGroupMoved, this._onGroupRenamed, this._onModelChanged, this._onEditorDisposed, this._onEditorDirty, this._onEditorLabelChange, this._onEditorClosed, this._onWillCloseEditor);
 
 		this.registerListeners();
 	}
@@ -781,6 +783,10 @@ export class EditorStacksModel implements IEditorStacksModel {
 
 	public get onEditorOpened(): Event<EditorIdentifier> {
 		return this._onEditorOpened.event;
+	}
+
+	public get onWillCloseEditor(): Event<EditorIdentifier> {
+		return this._onWillCloseEditor.event;
 	}
 
 	public get onEditorClosed(): Event<GroupEvent> {
@@ -1155,6 +1161,7 @@ export class EditorStacksModel implements IEditorStacksModel {
 		unbind.push(group.onEditorStateChanged(editor => this._onModelChanged.fire({ group, editor })));
 		unbind.push(group.onEditorOpened(editor => this._onEditorOpened.fire({ editor, group })));
 		unbind.push(group.onEditorClosed(event => {
+			this._onWillCloseEditor.fire({ editor: event.editor, group });
 			this.handleOnEditorClosed(event);
 			this._onEditorClosed.fire(event);
 		}));


### PR DESCRIPTION
This is a fix for #26157 intended to be pushed to the recovery release. 

Issue (original):
* open an editor
* keep some view state (folding, cursors, scroll position)
* close the editor
* reopen the editor
=> view state is lost

Issue (variant):
* make sure tab preview is enabled (it is by default)
* open an editor
* keep some view state (folding, cursors, scroll position)
* open another editor
* go back to the previous editor
=> view state is lost

We always store the view state of files when you switch between editors or when you close and come back to editors (persisted in local storage). The bug happened during last milestone because the way we dispose resources changed.

Previously:
* close an editor
* persist view state from the editor model
* dispose editor model

Now:
* close an editor
* dispose editor model
* persist view state from editor model
=> since the model is disposed, the view state is undefined

My fix introduces a new event `onWillCloseEditor` directly on the stacks model which the text file editor can use to persist the view state right before the model goes away. On top of that we also only persist the view state when the input is not disposed, because otherwise we still hit the current issue that we try to persist the view state of a disposed model.

@Tyriar can you check the code and let me know what you think? If you guys want to move ahead and release recovery today, feel free to merge. Otherwise I can do it tomorrow.