### PR TITLE
Preserve Newlines in Signature Help Documentation

### DIFF
--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.css
@@ -55,6 +55,7 @@
 
 .monaco-editor .parameter-hints-widget .docs {
 	padding: 0 10px 0 5px;
+	white-space: pre-wrap;
 }
 
 .monaco-editor .parameter-hints-widget .buttons {


### PR DESCRIPTION
Fixes #26346

**Bug**
Signature help currently displays newlines in documentation differently than the suggest widget does. This results in inconsistent looking documentation

**fix**
Use `pre-wrap` for the signature help documentation the same way we do for documentation in the suggest widget