### PR TITLE
Lua syntax extension is missing 'goto' keyword

### DIFF
--- a/extensions/lua/syntaxes/lua.json
+++ b/extensions/lua/syntaxes/lua.json
@@ -150,7 +150,7 @@
 			]
 		},
 		{
-			"match": "\\b(break|do|else|for|if|elseif|return|then|repeat|while|until|end|function|local|in)\\b",
+			"match": "\\b(break|do|else|for|if|elseif|goto|return|then|repeat|while|until|end|function|local|in)\\b",
 			"name": "keyword.control.lua"
 		},
 		{


### PR DESCRIPTION
that was reported (#942) and fixed in past in 08076f3faa66db8f2272fac2774462f02375b628, reintroduced 20b497e68c0a43f0e294a9d1ee82bb5b78f8fadb.
Lua manual ref. for keywords [here](https://www.lua.org/manual/5.3/manual.html#3.1)