### PR TITLE
Use language mode at Cursor for onEnter Rules

### DIFF
--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -270,7 +270,7 @@ export class LanguageConfigurationRegistryImpl {
 		let indentation = this.getIndentationAtPosition(model, range.startLineNumber, range.startColumn);
 		let ignoreCurrentLine = false;
 
-		let scopedLineTokens = this.getScopedLineTokens(model, range.startLineNumber);
+		let scopedLineTokens = this.getScopedLineTokens(model, range.startLineNumber, range.startColumn);
 		let onEnterSupport = this._getOnEnterSupport(scopedLineTokens.languageId);
 		if (!onEnterSupport) {
 			return {
@@ -398,11 +398,11 @@ export class LanguageConfigurationRegistryImpl {
 		return lineText;
 	}
 
-	private getScopedLineTokens(model: ITokenizedModel, lineNumber: number) {
+	private getScopedLineTokens(model: ITokenizedModel, lineNumber: number, columnNumber?: number) {
 		model.forceTokenization(lineNumber);
 		let lineTokens = model.getLineTokens(lineNumber);
-		let column = model.getLineMaxColumn(lineNumber);
-		let scopedLineTokens = createScopedLineTokens(lineTokens, column - 1);
+		let column = isNaN(columnNumber) ? model.getLineMaxColumn(lineNumber) - 1 : columnNumber;
+		let scopedLineTokens = createScopedLineTokens(lineTokens, column);
 		return scopedLineTokens;
 	}
 


### PR DESCRIPTION
Fixes #26351

**bug**

For the code

```js
const x = <b>|</b>;
```

with the cursor at the `|`, our existing TS/JS onEnter rules should change the code to:

```js
const x = <b>
    |
</b>;
```

However we currently do not handle this case correctly. The root cause is the extra semicolon at the end of the line. This causes `getEnterAction` to think that we are in a javascript context for the onenter rules instead of in a `js-tags` context

**fix**
Pass in the column of the cursor when getting the language id to use for the onEnter rules instead of using the end of the line. This ensures we are in the `jsx-tags` language in the above case