### PR TITLE
Fix onEnter Rules Detected Language Mode When There is a Selection

### DIFF
--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -288,8 +288,8 @@ export class LanguageConfigurationRegistryImpl {
 		if (range.isEmpty()) {
 			afterEnterText = scopedLineText.substr(range.startColumn - 1 - scopedLineTokens.firstCharOffset);
 		} else {
-			let endScopedLineTokens = this.getScopedLineTokens(model, range.endLineNumber);
-			afterEnterText = endScopedLineTokens.getLineContent().substr(range.endColumn - 1);
+			const endScopedLineTokens = this.getScopedLineTokens(model, range.endLineNumber, range.endColumn);
+			afterEnterText = endScopedLineTokens.getLineContent().substr(range.endColumn - 1 - scopedLineTokens.firstCharOffset);
 		}
 
 		let lineNumber = range.startLineNumber;


### PR DESCRIPTION
Fixes #26406

**Bug**
If there is an active selection, the on Enter rules may use the wrong language mode which results in the incorrect `afterEnterText`. See #26406 for an example of this case

**Fix**
Use language mode from the selection and  correctly compute offset when grabbing `afterEnterText`