### PR TITLE
Remove Need for File Extensions in TypeScript Language Definitions

### DIFF
--- a/extensions/typescript/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript/src/features/bufferSyncSupport.ts
@@ -107,7 +107,6 @@ export default class BufferSyncSupport {
 
 	private _validate: boolean;
 	private modeIds: ObjectMap<boolean>;
-	private extensions: ObjectMap<boolean>;
 	private diagnostics: Diagnostics;
 	private disposables: Disposable[] = [];
 	private syncedBuffers: ObjectMap<SyncedBuffer>;
@@ -119,12 +118,11 @@ export default class BufferSyncSupport {
 	private emitQueue: LinkedMap<string>;
 	private checkGlobalTSCVersion: boolean;
 
-	constructor(client: ITypescriptServiceClient, modeIds: string[], diagnostics: Diagnostics, extensions: ObjectMap<boolean>, validate: boolean = true) {
+	constructor(client: ITypescriptServiceClient, modeIds: string[], diagnostics: Diagnostics, validate: boolean = true) {
 		this.client = client;
 		this.modeIds = Object.create(null);
 		modeIds.forEach(modeId => this.modeIds[modeId] = true);
 		this.diagnostics = diagnostics;
-		this.extensions = extensions;
 		this._validate = validate;
 
 		this.projectValidationRequested = false;


### PR DESCRIPTION
Part of #25740

To support TS Server plugins for languages like angular, we will allow extensions to register new langauges for TypeScript to watch. The angular language for example would want ng-html files to also be uploaded to TypeScript for checking

The current language definitions all define both a set of language modes they support and a set of file extensions. The file extension part is unnessiary and may be incorrect depending on how a user sets up their `file.associations` in the workspace.

This change removes the extensions part so that we always make use of the language mode