### PR TITLE
Preserve Webview Scroll Position

### DIFF
--- a/src/vs/workbench/browser/parts/editor/webviewEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/webviewEditor.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { BaseEditor } from "vs/workbench/browser/parts/editor/baseEditor";
+import URI from "vs/base/common/uri";
+import { IStorageService } from "vs/platform/storage/common/storage";
+import { Scope } from "vs/workbench/common/memento";
+
+export interface HtmlPreviewEditorViewState {
+	scrollYPercentage: number;
+}
+
+interface HtmlPreviewEditorViewStates {
+	0?: HtmlPreviewEditorViewState;
+	1?: HtmlPreviewEditorViewState;
+	2?: HtmlPreviewEditorViewState;
+}
+
+/**
+ * This class is only intended to be subclassed and not instantiated.
+ */
+export abstract class WebviewEditor extends BaseEditor {
+	constructor(
+		id: string,
+		telemetryService: ITelemetryService,
+		themeService: IThemeService,
+		private storageService: IStorageService
+	) {
+		super(id, telemetryService, themeService);
+	}
+
+	private get viewStateStorageKey(): string {
+		return this.getId() + '.editorViewState';
+	}
+
+	protected saveViewState(resource: URI | string, editorViewState: HtmlPreviewEditorViewState): void {
+		const memento = this.getMemento(this.storageService, Scope.WORKSPACE);
+		let editorViewStateMemento = memento[this.viewStateStorageKey];
+		if (!editorViewStateMemento) {
+			editorViewStateMemento = Object.create(null);
+			memento[this.viewStateStorageKey] = editorViewStateMemento;
+		}
+
+		let fileViewState: HtmlPreviewEditorViewStates = editorViewStateMemento[resource.toString()];
+		if (!fileViewState) {
+			fileViewState = Object.create(null);
+			editorViewStateMemento[resource.toString()] = fileViewState;
+		}
+
+		if (typeof this.position === 'number') {
+			fileViewState[this.position] = editorViewState;
+		}
+	}
+
+	protected loadViewState(resource: URI | string): HtmlPreviewEditorViewState | null {
+		const memento = this.getMemento(this.storageService, Scope.WORKSPACE);
+		const editorViewStateMemento = memento[this.viewStateStorageKey];
+		if (editorViewStateMemento) {
+			const fileViewState: HtmlPreviewEditorViewStates = editorViewStateMemento[resource.toString()];
+			if (fileViewState) {
+				return fileViewState[this.position];
+			}
+		}
+		return null;
+	}
+}

--- a/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
@@ -84,11 +84,19 @@ export class HtmlPreviewPart extends BaseEditor {
 		if (!this._webview) {
 			this._webview = new Webview(this._container, this.partService.getContainer(Parts.EDITOR_PART));
 			this._webview.baseUrl = this._baseUrl && this._baseUrl.toString(true);
+			if (this.input && this.input instanceof HtmlInput) {
+				this.webview.initialScrollProgress = this.input.scrollYPercentage;
+			}
 
 			this._webviewDisposables = [
 				this._webview,
 				this._webview.onDidClickLink(uri => this._openerService.open(uri)),
-				this._webview.onDidLoadContent(data => this.telemetryService.publicLog('previewHtml', data.stats))
+				this._webview.onDidLoadContent(data => this.telemetryService.publicLog('previewHtml', data.stats)),
+				this._webview.onDidScroll(data => {
+					if (this.input && this.input instanceof HtmlInput) {
+						this.input.updateScroll(data.scrollYPercentage);
+					}
+				})
 			];
 		}
 		return this._webview;
@@ -187,7 +195,7 @@ export class HtmlPreviewPart extends BaseEditor {
 				});
 				this.webview.baseUrl = resourceUri.toString(true);
 				this.webview.contents = this.model.getLinesContent();
-
+				this.webview.initialScrollProgress = input.scrollYPercentage;
 				return undefined;
 			});
 		});

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -112,7 +112,9 @@ export default class Webview {
 				}
 
 				if (event.channel === 'did-scroll') {
-					this._onDidScroll.fire({ scrollYPercentage: event.args[0] });
+					if (event.args && typeof event.args[0] === 'number') {
+						this._onDidScroll.fire({ scrollYPercentage: event.args[0] });
+					}
 					return;
 				}
 			})

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -52,6 +52,8 @@ export default class Webview {
 	private _onDidClickLink = new Emitter<URI>();
 	private _onDidLoadContent = new Emitter<{ stats: any }>();
 
+	private _onDidScroll = new Emitter<{ scrollYPercentage: number }>();
+
 	constructor(
 		private parent: HTMLElement,
 		private _styleElement: Element
@@ -108,6 +110,11 @@ export default class Webview {
 					this.layout();
 					return;
 				}
+
+				if (event.channel === 'did-scroll') {
+					this._onDidScroll.fire({ scrollYPercentage: event.args[0] });
+					return;
+				}
 			})
 		];
 
@@ -134,10 +141,18 @@ export default class Webview {
 		return this._onDidLoadContent.event;
 	}
 
+	get onDidScroll(): Event<{ scrollYPercentage: number }> {
+		return this._onDidScroll.event;
+	}
+
 	private _send(channel: string, ...args: any[]): void {
 		this._ready
 			.then(() => this._webview.send(channel, ...args))
 			.done(void 0, console.error);
+	}
+
+	set initialScrollProgress(value: number) {
+		this._send('initial-scroll-position', value);
 	}
 
 	set contents(value: string[]) {

--- a/src/vs/workbench/parts/html/common/htmlInput.ts
+++ b/src/vs/workbench/parts/html/common/htmlInput.ts
@@ -7,11 +7,5 @@
 import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 
 export class HtmlInput extends ResourceEditorInput {
-	private _scrollYPercentage: number = 0;
-
-	get scrollYPercentage(): number { return this._scrollYPercentage; }
-
-	updateScroll(scrollYPercentage: number) {
-		this._scrollYPercentage = scrollYPercentage;
-	}
+	// marker class
 }

--- a/src/vs/workbench/parts/html/common/htmlInput.ts
+++ b/src/vs/workbench/parts/html/common/htmlInput.ts
@@ -7,5 +7,11 @@
 import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 
 export class HtmlInput extends ResourceEditorInput {
-	// just a marker class
+	private _scrollYPercentage: number = 0;
+
+	get scrollYPercentage(): number { return this._scrollYPercentage; }
+
+	updateScroll(scrollYPercentage: number) {
+		this._scrollYPercentage = scrollYPercentage;
+	}
 }

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
@@ -10,7 +10,6 @@ import { marked } from 'vs/base/common/marked/marked';
 import { IDisposable, dispose, toDisposable } from 'vs/base/common/lifecycle';
 import { Builder } from 'vs/base/browser/builder';
 import { append, $ } from 'vs/base/browser/dom';
-import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ReleaseNotesInput } from './releaseNotesInput';
@@ -20,6 +19,8 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { tokenizeToString } from 'vs/editor/common/modes/textToHtmlTokenizer';
 import { IPartService, Parts } from 'vs/workbench/services/part/common/partService';
+import { WebviewEditor } from 'vs/workbench/browser/parts/editor/webviewEditor';
+import { IStorageService } from "vs/platform/storage/common/storage";
 
 function renderBody(body: string): string {
 	return `<!DOCTYPE html>
@@ -33,7 +34,7 @@ function renderBody(body: string): string {
 		</html>`;
 }
 
-export class ReleaseNotesEditor extends BaseEditor {
+export class ReleaseNotesEditor extends WebviewEditor {
 
 	static ID: string = 'workbench.editor.releaseNotes';
 
@@ -41,15 +42,17 @@ export class ReleaseNotesEditor extends BaseEditor {
 	private webview: WebView;
 
 	private contentDisposables: IDisposable[] = [];
+	private scrollYPercentage: number = 0;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IThemeService protected themeService: IThemeService,
 		@IOpenerService private openerService: IOpenerService,
 		@IModeService private modeService: IModeService,
-		@IPartService private partService: IPartService
+		@IPartService private partService: IPartService,
+		@IStorageService storageService: IStorageService
 	) {
-		super(ReleaseNotesEditor.ID, telemetryService, themeService);
+		super(ReleaseNotesEditor.ID, telemetryService, themeService, storageService);
 	}
 
 	createEditor(parent: Builder): void {
@@ -92,17 +95,19 @@ export class ReleaseNotesEditor extends BaseEditor {
 			.then<void>(body => {
 				this.webview = new WebView(this.content, this.partService.getContainer(Parts.EDITOR_PART));
 				this.webview.baseUrl = `https://code.visualstudio.com/raw/`;
+
 				if (this.input && this.input instanceof ReleaseNotesInput) {
-					this.webview.initialScrollProgress = this.input.scrollYPercentage;
+					const state = this.loadViewState(this.input.version);
+					if (state) {
+						this.webview.initialScrollProgress = state.scrollYPercentage;
+					}
 				}
 				this.webview.style(this.themeService.getTheme());
 				this.webview.contents = [body];
 
 				this.webview.onDidClickLink(link => this.openerService.open(link), null, this.contentDisposables);
 				this.webview.onDidScroll(event => {
-					if (this.input && this.input instanceof ReleaseNotesInput) {
-						this.input.updateScroll(event.scrollYPercentage);
-					}
+					this.scrollYPercentage = event.scrollYPercentage;
 				}, null, this.contentDisposables);
 				this.themeService.onThemeChange(themeId => this.webview.style(themeId), null, this.contentDisposables);
 				this.contentDisposables.push(this.webview);
@@ -127,5 +132,30 @@ export class ReleaseNotesEditor extends BaseEditor {
 	dispose(): void {
 		this.contentDisposables = dispose(this.contentDisposables);
 		super.dispose();
+	}
+
+	protected getViewState() {
+		return {
+			scrollYPercentage: this.scrollYPercentage
+		};
+	}
+
+	public clearInput(): void {
+		if (this.input instanceof ReleaseNotesInput) {
+			this.saveViewState(this.input.version, {
+				scrollYPercentage: this.scrollYPercentage
+			});
+		}
+		super.clearInput();
+	}
+
+
+	public shutdown(): void {
+		if (this.input instanceof ReleaseNotesInput) {
+			this.saveViewState(this.input.version, {
+				scrollYPercentage: this.scrollYPercentage
+			});
+		}
+		super.shutdown();
 	}
 }

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
@@ -92,10 +92,18 @@ export class ReleaseNotesEditor extends BaseEditor {
 			.then<void>(body => {
 				this.webview = new WebView(this.content, this.partService.getContainer(Parts.EDITOR_PART));
 				this.webview.baseUrl = `https://code.visualstudio.com/raw/`;
+				if (this.input && this.input instanceof ReleaseNotesInput) {
+					this.webview.initialScrollProgress = this.input.scrollYPercentage;
+				}
 				this.webview.style(this.themeService.getTheme());
 				this.webview.contents = [body];
 
 				this.webview.onDidClickLink(link => this.openerService.open(link), null, this.contentDisposables);
+				this.webview.onDidScroll(event => {
+					if (this.input && this.input instanceof ReleaseNotesInput) {
+						this.input.updateScroll(event.scrollYPercentage);
+					}
+				}, null, this.contentDisposables);
 				this.themeService.onThemeChange(themeId => this.webview.style(themeId), null, this.contentDisposables);
 				this.contentDisposables.push(this.webview);
 				this.contentDisposables.push(toDisposable(() => this.webview = null));

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
@@ -149,7 +149,6 @@ export class ReleaseNotesEditor extends WebviewEditor {
 		super.clearInput();
 	}
 
-
 	public shutdown(): void {
 		if (this.input instanceof ReleaseNotesInput) {
 			this.saveViewState(this.input.version, {

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesInput.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesInput.ts
@@ -13,8 +13,11 @@ export class ReleaseNotesInput extends EditorInput {
 
 	static get ID() { return 'workbench.releaseNotes.input'; }
 
+	private _scrollYPercentage: number = 0;
+
 	get version(): string { return this._version; }
 	get text(): string { return this._text; }
+	get scrollYPercentage(): number { return this._scrollYPercentage; }
 
 	constructor(private _version: string, private _text: string) {
 		super();
@@ -43,5 +46,9 @@ export class ReleaseNotesInput extends EditorInput {
 
 	supportsSplitEditor(): boolean {
 		return false;
+	}
+
+	updateScroll(scrollYPercentage: number) {
+		this._scrollYPercentage = scrollYPercentage;
 	}
 }

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesInput.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesInput.ts
@@ -13,11 +13,8 @@ export class ReleaseNotesInput extends EditorInput {
 
 	static get ID() { return 'workbench.releaseNotes.input'; }
 
-	private _scrollYPercentage: number = 0;
-
 	get version(): string { return this._version; }
 	get text(): string { return this._text; }
-	get scrollYPercentage(): number { return this._scrollYPercentage; }
 
 	constructor(private _version: string, private _text: string) {
 		super();
@@ -46,9 +43,5 @@ export class ReleaseNotesInput extends EditorInput {
 
 	supportsSplitEditor(): boolean {
 		return false;
-	}
-
-	updateScroll(scrollYPercentage: number) {
-		this._scrollYPercentage = scrollYPercentage;
 	}
 }

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesInput.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesInput.ts
@@ -13,11 +13,9 @@ export class ReleaseNotesInput extends EditorInput {
 
 	static get ID() { return 'workbench.releaseNotes.input'; }
 
-	private _scrollYPercentage: number = 0;
 
 	get version(): string { return this._version; }
 	get text(): string { return this._text; }
-	get scrollYPercentage(): number { return this._scrollYPercentage; }
 
 	constructor(private _version: string, private _text: string) {
 		super();
@@ -46,9 +44,5 @@ export class ReleaseNotesInput extends EditorInput {
 
 	supportsSplitEditor(): boolean {
 		return false;
-	}
-
-	updateScroll(scrollYPercentage: number) {
-		this._scrollYPercentage = scrollYPercentage;
 	}
 }


### PR DESCRIPTION
Fixes #22995

**Bug**
If you switch away from an editor that users a webview, the scroll position is currently not preserved. This effects our release notes and the markdown preview. The root cause is that the webview is disposed of when the view is hidden.

**Fix**
Add some presisted state to track scrollProgress through the webview. Use this state in the standard html editor and in the release notes.


**TODO**
- [ ] Make sure html preview handles case where content changes. I believe this should reset the scroll position
- [X] Handle dragging editor tab to create duplicate view. This should also copy over the scroll position