### PR TITLE
Markdown: Capture right parenthesis as part of url

### DIFF
--- a/extensions/markdown/src/documentLinkProvider.ts
+++ b/extensions/markdown/src/documentLinkProvider.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 export default class MarkdownDocumentLinkProvider implements vscode.DocumentLinkProvider {
 
-	private _linkPattern = /(\[[^\]]*\]\(\s*?)([^\s\)]+?)(\s+[^\)]+)?\)/g;
+	private _linkPattern = /(\[[^\]]*\]\(\s*?)([^\s]*)(\s+[^\)]+)?\)/g;
 
 	constructor() { }
 

--- a/extensions/markdown/src/documentLinkProvider.ts
+++ b/extensions/markdown/src/documentLinkProvider.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 export default class MarkdownDocumentLinkProvider implements vscode.DocumentLinkProvider {
 
-	private _linkPattern = /(\[[^\]]*\]\(\s*?)([^\s]*)(\s+[^\)]+)?\)/g;
+	private _linkPattern = /(\[[^\]]*\]\(\s*?)((((?=.*\)\)+)[^\s\)]+?)|[^\s]+))\)/g;
 
 	constructor() { }
 

--- a/extensions/markdown/src/documentLinkProvider.ts
+++ b/extensions/markdown/src/documentLinkProvider.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 
 export default class MarkdownDocumentLinkProvider implements vscode.DocumentLinkProvider {
 
-	private _linkPattern = /(\[[^\]]*\]\(\s*?)((((?=.*\)\)+)[^\s\)]+?)|[^\s]+))\)/g;
+	private _linkPattern = /(\[[^\]]*\]\(\s*?)(((((?=.*\)\)+)|(?=.*\)\]+))[^\s\)]+?)|([^\s]+)))\)/g;
 
 	constructor() { }
 


### PR DESCRIPTION
Fixes #25870
![screen shot 2017-05-11 at 12 16 41 pm](https://cloud.githubusercontent.com/assets/9607963/25945006/a6b5bebc-3645-11e7-8f4b-939984395333.png)
