### PR TITLE
Always Show File Names in Symbol Search Results

### DIFF
--- a/extensions/typescript/src/features/workspaceSymbolProvider.ts
+++ b/extensions/typescript/src/features/workspaceSymbolProvider.ts
@@ -7,8 +7,6 @@
 
 import { workspace, window, Uri, WorkspaceSymbolProvider, SymbolInformation, SymbolKind, Range, Location, CancellationToken } from 'vscode';
 
-import * as path from 'path';
-
 import * as Proto from '../protocol';
 import { ITypescriptServiceClient } from '../typescriptService';
 
@@ -76,17 +74,8 @@ export default class TypeScriptWorkspaceSymbolProvider implements WorkspaceSymbo
 					if (item.kind === 'method' || item.kind === 'function') {
 						label += '()';
 					}
-					const containerNameParts: string[] = [];
-					if (item.containerName) {
-						containerNameParts.push(item.containerName);
-					}
-					const fileUri = this.client.asUrl(item.file);
-					const fileName = path.basename(fileUri.fsPath);
-					if (fileName) {
-						containerNameParts.push(fileName);
-					}
-					result.push(new SymbolInformation(label, getSymbolKind(item), containerNameParts.join(' — '),
-						new Location(fileUri, range)));
+					result.push(new SymbolInformation(label, getSymbolKind(item), item.containerName || '',
+						new Location(this.client.asUrl(item.file), range)));
 				}
 			}
 			return result;

--- a/src/vs/workbench/browser/quickopen.ts
+++ b/src/vs/workbench/browser/quickopen.ts
@@ -288,7 +288,7 @@ export class EditorQuickOpenEntry extends QuickOpenEntry implements IEditorQuick
  */
 export class EditorQuickOpenEntryGroup extends QuickOpenEntryGroup implements IEditorQuickOpenEntry {
 
-	public getInput(): IEditorInput {
+	public getInput(): IEditorInput | IResourceInput {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes #26370

Updates the symbol search results to always display the filename. This feature was previously added to the TS extension specifically, so this change removes that work in favor of a change to the core symbol search experience

Here's what the new results look like:

<img width="629" alt="screen shot 2017-05-11 at 11 01 28 pm" src="https://cloud.githubusercontent.com/assets/12821956/25984172/ef31e5e6-369d-11e7-8cda-b14de22d13f3.png">

Compared to the current results:
 
<img width="619" alt="screen shot 2017-05-11 at 11 07 30 pm" src="https://cloud.githubusercontent.com/assets/12821956/25984284/a1447bfe-369e-11e7-85b0-6218d2d1acbe.png">

Please let me know if you have any UX suggestions on where to display everything here.


