### PR TITLE
Fix php function highlight

### DIFF
--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -1304,7 +1304,7 @@
 					]
 				},
 				{
-					"begin": "(?x)\\s*\n\t\t\t\t\t    ((?:(?:final|abstract|public|private|protected|static)\\s+)*)\n\t\t\t\t        (function)\n\t\t\t\t        (?:\\s+|(\\s*&\\s*))\n\t\t\t\t        (?:\n\t\t\t\t            (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic))\n\t\t\t\t            |([a-zA-Z0-9_]+)\n\t\t\t\t        )\n\t\t\t\t        \\s*\n\t\t\t\t        (\\()",
+					"begin": "(?x)\\s*\n\t\t\t\t\t    ((?:(?:final|abstract|public|private|protected|static)\\s+)*)\n\t\t\t\t        (function)\n\t\t\t\t        (?:\\s+|(\\s*&\\s*))\n\t\t\t\t        (?:\n\t\t\t\t            (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic))\n\t\t\t\t            |([a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*)\n\t\t\t\t        )\n\t\t\t\t        \\s*\n\t\t\t\t        (\\()",
 					"beginCaptures": {
 						"1": {
 							"patterns": [

--- a/extensions/php/test/colorize-fixtures/test.php
+++ b/extensions/php/test/colorize-fixtures/test.php
@@ -40,6 +40,8 @@
 		print("Uncut Point: <strong>$deck[$index]</strong> ");
 		$starting_point++;
 	}
+
+	function foo bar(){}
 ?>
 
 </body>

--- a/extensions/php/test/colorize-results/test_php.json
+++ b/extensions/php/test/colorize-results/test_php.json
@@ -3234,6 +3234,94 @@
 		}
 	},
 	{
+		"c": "\t",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "function",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php storage.type.function.php",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "foo bar",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php entity.name.function.php",
+		"r": {
+			"dark_plus": "entity.name.function: #DCDCAA",
+			"light_plus": "entity.name.function: #795E26",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php punctuation.definition.parameters.begin.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ")",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php punctuation.definition.parameters.end.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{",
+		"t": "text.html.php meta.embedded.block.php source.php punctuation.section.scope.begin.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "text.html.php meta.embedded.block.php source.php punctuation.section.scope.end.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
 		"c": "?",
 		"t": "text.html.php meta.embedded.block.php punctuation.section.embedded.end.metatag.php source.php",
 		"r": {


### PR DESCRIPTION
According to http://php.net/manual/en/functions.user-defined.php extended ascii is allowed in function name such as non breaking space ` ` (\xa0).