### PR TITLE
Add getLanguage Api to retrieve language based only on uri

### DIFF
--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -8,7 +8,7 @@
  * https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/TypeScript%20Indent.tmPreferences
  * ------------------------------------------------------------------------------------------ */
 
-import { env, languages, commands, workspace, window, ExtensionContext, Memento, IndentAction, Diagnostic, DiagnosticCollection, Range, Disposable, Uri, MessageItem, TextEditor, DiagnosticSeverity, TextDocument } from 'vscode';
+import { env, languages, commands, workspace, window, ExtensionContext, Memento, IndentAction, Diagnostic, DiagnosticCollection, Range, Disposable, Uri, MessageItem, TextEditor, DiagnosticSeverity } from 'vscode';
 
 // This must be the first statement otherwise modules might got loaded with
 // the wrong locale.
@@ -356,8 +356,8 @@ class LanguageProvider {
 		}
 	}
 
-	public handles(file: string, doc: TextDocument): boolean {
-		if (doc && this.description.modeIds.indexOf(doc.languageId) >= 0) {
+	public handles(file: string, languageId: string): boolean {
+		if (this.description.modeIds.indexOf(languageId) >= 0) {
 			return true;
 		}
 
@@ -606,9 +606,9 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	}
 
 	private findLanguage(file: string): Thenable<LanguageProvider | null> {
-		return workspace.openTextDocument(this.client.asUrl(file)).then((doc: TextDocument) => {
+		return languages.getLanguage(this.client.asUrl(file)).then((languageId: string) => {
 			for (const language of this.languages) {
-				if (language.handles(file, doc)) {
+				if (language.handles(file, languageId)) {
 					return language;
 				}
 			}

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -606,7 +606,7 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	}
 
 	private findLanguage(file: string): Thenable<LanguageProvider | null> {
-		return languages.getLanguage(this.client.asUrl(file)).then((languageId: string) => {
+		return languages.getLanguage(this.client.asUrl(file)).then(languageId => {
 			for (const language of this.languages) {
 				if (language.handles(file, languageId)) {
 					return language;

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -8,7 +8,7 @@
  * https://github.com/Microsoft/TypeScript-Sublime-Plugin/blob/master/TypeScript%20Indent.tmPreferences
  * ------------------------------------------------------------------------------------------ */
 
-import { env, languages, commands, workspace, window, ExtensionContext, Memento, IndentAction, Diagnostic, DiagnosticCollection, Range, Disposable, Uri, MessageItem, TextEditor, DiagnosticSeverity } from 'vscode';
+import { env, languages, commands, workspace, window, ExtensionContext, Memento, IndentAction, Diagnostic, DiagnosticCollection, Range, Disposable, Uri, MessageItem, TextEditor, DiagnosticSeverity, TextDocument } from 'vscode';
 
 // This must be the first statement otherwise modules might got loaded with
 // the wrong locale.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4500,13 +4500,12 @@ declare module 'vscode' {
 		/**
 		 * Get the default language associated with a uri.
 		 *
-		 * Only retrieves language based on the resource path.
-		 *
 		 * @param uri The uri of the resource.
-		 *
+		 * @param uri A location within the resource to check. Used for embedded languages.
+
 		 * @return Promise resolving to language identifier.
 		 */
-		export function getLanguage(uri: Uri): Thenable<string>;
+		export function getLanguage(uri: Uri, position?: Position): Thenable<string>;
 
 		/**
 		 * Compute the match between a document [selector](#DocumentSelector) and a document. Values

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4498,6 +4498,17 @@ declare module 'vscode' {
 		export function getLanguages(): Thenable<string[]>;
 
 		/**
+		 * Get the default language associated with a uri.
+		 *
+		 * Only retrieves language based on the resource path.
+		 *
+		 * @param uri The uri of the resource.
+		 *
+		 * @return Promise resolving to language identifier.
+		 */
+		export function getLanguage(uri: Uri): Thenable<string>;
+
+		/**
 		 * Compute the match between a document [selector](#DocumentSelector) and a document. Values
 		 * greater than zero mean the selector matches the document.
 		 *

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguages.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguages.ts
@@ -5,7 +5,9 @@
 'use strict';
 
 import { TPromise } from 'vs/base/common/winjs.base';
+import { IPosition } from 'vs/editor/common/core/position';
 import { IModeService } from 'vs/editor/common/services/modeService';
+import { IModelService } from 'vs/editor/common/services/modelService';
 import { MainThreadLanguagesShape } from '../node/extHost.protocol';
 import URI from 'vs/base/common/uri';
 
@@ -14,7 +16,8 @@ export class MainThreadLanguages extends MainThreadLanguagesShape {
 	private _modeService: IModeService;
 
 	constructor(
-		@IModeService modeService: IModeService
+		@IModeService modeService: IModeService,
+		@IModelService private modelService: IModelService,
 	) {
 		super();
 		this._modeService = modeService;
@@ -24,7 +27,11 @@ export class MainThreadLanguages extends MainThreadLanguagesShape {
 		return TPromise.as(this._modeService.getRegisteredModes());
 	}
 
-	$getLanguage(resource: URI): TPromise<string> {
+	$getLanguage(resource: URI, position?: IPosition): TPromise<string> {
+		const model = this.modelService.getModel(resource);
+		if (model) {
+			return TPromise.as(position ? this._modeService.getLanguageIdentifier(model.getLanguageIdAtPosition(position.lineNumber, position.column)).language : model.getLanguageIdentifier().language);
+		}
 		return TPromise.as(this._modeService.getModeIdByFilenameOrFirstLine(resource.fsPath));
 	}
 }

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguages.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguages.ts
@@ -7,6 +7,7 @@
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { MainThreadLanguagesShape } from '../node/extHost.protocol';
+import URI from 'vs/base/common/uri';
 
 export class MainThreadLanguages extends MainThreadLanguagesShape {
 
@@ -21,5 +22,9 @@ export class MainThreadLanguages extends MainThreadLanguagesShape {
 
 	$getLanguages(): TPromise<string[]> {
 		return TPromise.as(this._modeService.getRegisteredModes());
+	}
+
+	$getLanguage(resource: URI): TPromise<string> {
+		return TPromise.as(this._modeService.getModeIdByFilenameOrFirstLine(resource.fsPath));
 	}
 }

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -199,6 +199,9 @@ export function createApiFactory(
 			getLanguages(): TPromise<string[]> {
 				return extHostLanguages.getLanguages();
 			},
+			getLanguage(resource: vscode.Uri): TPromise<string> {
+				return extHostLanguages.getLanguage(<URI>resource);
+			},
 			match(selector: vscode.DocumentSelector, document: vscode.TextDocument): number {
 				return score(selector, <any>document.uri, document.languageId);
 			},

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -199,8 +199,8 @@ export function createApiFactory(
 			getLanguages(): TPromise<string[]> {
 				return extHostLanguages.getLanguages();
 			},
-			getLanguage(resource: vscode.Uri): TPromise<string> {
-				return extHostLanguages.getLanguage(<URI>resource);
+			getLanguage(resource: vscode.Uri, position?: vscode.Position): TPromise<string> {
+				return extHostLanguages.getLanguage(<URI>resource, position ? { lineNumber: position.line, column: position.character } : undefined);
 			},
 			match(selector: vscode.DocumentSelector, document: vscode.TextDocument): number {
 				return score(selector, <any>document.uri, document.languageId);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -234,6 +234,7 @@ export abstract class MainThreadLanguageFeaturesShape {
 
 export abstract class MainThreadLanguagesShape {
 	$getLanguages(): TPromise<string[]> { throw ni(); }
+	$getLanguage(resource: URI): TPromise<string> { throw ni(); }
 }
 
 export abstract class MainThreadMessageServiceShape {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -234,7 +234,7 @@ export abstract class MainThreadLanguageFeaturesShape {
 
 export abstract class MainThreadLanguagesShape {
 	$getLanguages(): TPromise<string[]> { throw ni(); }
-	$getLanguage(resource: URI): TPromise<string> { throw ni(); }
+	$getLanguage(resource: URI, position?: IPosition): TPromise<string> { throw ni(); }
 }
 
 export abstract class MainThreadMessageServiceShape {

--- a/src/vs/workbench/api/node/extHostLanguages.ts
+++ b/src/vs/workbench/api/node/extHostLanguages.ts
@@ -8,6 +8,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IThreadService } from 'vs/workbench/services/thread/common/threadService';
 import { MainContext, MainThreadLanguagesShape } from './extHost.protocol';
 import URI from 'vs/base/common/uri';
+import { IPosition } from "vs/editor/common/core/position";
 
 export class ExtHostLanguages {
 
@@ -23,8 +24,8 @@ export class ExtHostLanguages {
 		return this._proxy.$getLanguages();
 	}
 
-	getLanguage(resource: URI): TPromise<string> {
-		return this._proxy.$getLanguage(resource);
+	getLanguage(resource: URI, position?: IPosition): TPromise<string> {
+		return this._proxy.$getLanguage(resource, position);
 	}
 }
 

--- a/src/vs/workbench/api/node/extHostLanguages.ts
+++ b/src/vs/workbench/api/node/extHostLanguages.ts
@@ -7,6 +7,7 @@
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IThreadService } from 'vs/workbench/services/thread/common/threadService';
 import { MainContext, MainThreadLanguagesShape } from './extHost.protocol';
+import URI from 'vs/base/common/uri';
 
 export class ExtHostLanguages {
 
@@ -20,6 +21,10 @@ export class ExtHostLanguages {
 
 	getLanguages(): TPromise<string[]> {
 		return this._proxy.$getLanguages();
+	}
+
+	getLanguage(resource: URI): TPromise<string> {
+		return this._proxy.$getLanguage(resource);
 	}
 }
 


### PR DESCRIPTION
**Bug**
Typescript previously used file extensions to determine which files it handles or not. This was not great because it duplicates information and also fails to account for `file.associations`.

For the upcoming work on TS server plugin work, I switched to use `openTextDocument` for this check instead. However Dirk pointed out that this brings its own problems: https://github.com/Microsoft/vscode/pull/26413#issuecomment-301010494 . I don't see any ways around this using the current api, and I also don't see how we can fix the `file.associations` issue using the old file extensions based approach

**Fix**
Add a new `getLanguage` api to VSCode. This api returns the language normally associated with a resource (uri). It does not take into account any language mode that a user has explicitly changed or the first line based language detection (since the goal was to avoid opening the resource in the first place).

It's not clear to me if the current implementation based on openTextDocument will actually cause any problems. This new API may help us avoid some perf issues but also is not perfect. Let me know if you have any thoughts on a better way to achieve this