### PR TITLE
[theme] remove editorOptions.theme

### DIFF
--- a/src/vs/editor/browser/standalone/standaloneCodeEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneCodeEditor.ts
@@ -44,12 +44,26 @@ export interface IEditorConstructionOptions extends IEditorOptions {
 	 * To not create automatically a model, use `model: null`.
 	 */
 	language?: string;
+	/**
+	 * Initial theme to be used for rendering.
+	 * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
+	 * You can create custom themes via `monaco.editor.defineTheme`.
+	 * To switch a theme, use `monaco.editor.setTheme`
+	 */
+	theme?: string;
 }
 
 /**
  * The options to create a diff editor.
  */
 export interface IDiffEditorConstructionOptions extends IDiffEditorOptions {
+	/**
+	 * Initial theme to be used for rendering.
+	 * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
+	 * You can create custom themes via `monaco.editor.defineTheme`.
+	 * To switch a theme, use `monaco.editor.setTheme`
+	 */
+	theme?: string;
 }
 
 export interface IStandaloneCodeEditor extends ICodeEditor {
@@ -193,7 +207,6 @@ export class StandaloneCodeEditor extends CodeEditor implements IStandaloneCodeE
 export class StandaloneEditor extends StandaloneCodeEditor implements IStandaloneCodeEditor {
 
 	private _contextViewService: IEditorContextViewService;
-	private _standaloneThemeService: IStandaloneThemeService;
 	private _ownsModel: boolean;
 
 	constructor(
@@ -206,18 +219,17 @@ export class StandaloneEditor extends StandaloneCodeEditor implements IStandalon
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextViewService contextViewService: IContextViewService,
-		@IStandaloneThemeService standaloneThemeService: IStandaloneThemeService
+		@IStandaloneThemeService themeService: IStandaloneThemeService
 	) {
 		options = options || {};
 		if (typeof options.theme === 'string') {
-			options.theme = standaloneThemeService.setTheme(options.theme);
+			themeService.setTheme(options.theme);
 		}
 		let model: IModel = options.model;
 		delete options.model;
-		super(domElement, options, instantiationService, codeEditorService, commandService, contextKeyService, keybindingService, standaloneThemeService);
+		super(domElement, options, instantiationService, codeEditorService, commandService, contextKeyService, keybindingService, themeService);
 
 		this._contextViewService = <IEditorContextViewService>contextViewService;
-		this._standaloneThemeService = standaloneThemeService;
 		this._register(toDispose);
 
 		if (typeof model === 'undefined') {
@@ -245,13 +257,6 @@ export class StandaloneEditor extends StandaloneCodeEditor implements IStandalon
 		this.dispose();
 	}
 
-	public updateOptions(newOptions: IEditorOptions): void {
-		if (typeof newOptions.theme === 'string') {
-			newOptions.theme = this._standaloneThemeService.setTheme(newOptions.theme);
-		}
-		super.updateOptions(newOptions);
-	}
-
 	_attachModel(model: IModel): void {
 		super._attachModel(model);
 		if (this._view) {
@@ -271,7 +276,6 @@ export class StandaloneEditor extends StandaloneCodeEditor implements IStandalon
 export class StandaloneDiffEditor extends DiffEditorWidget implements IStandaloneDiffEditor {
 
 	private _contextViewService: IEditorContextViewService;
-	private _standaloneThemeService: IStandaloneThemeService;
 	private _standaloneKeybindingService: StandaloneKeybindingService;
 
 	constructor(
@@ -282,14 +286,13 @@ export class StandaloneDiffEditor extends DiffEditorWidget implements IStandalon
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextViewService contextViewService: IContextViewService,
-		@IStandaloneThemeService standaloneColorService: IStandaloneThemeService,
 		@IEditorWorkerService editorWorkerService: IEditorWorkerService,
 		@ICodeEditorService codeEditorService: ICodeEditorService,
-		@IThemeService themeService: IThemeService
+		@IStandaloneThemeService themeService: IStandaloneThemeService
 	) {
 		options = options || {};
 		if (typeof options.theme === 'string') {
-			options.theme = standaloneColorService.setTheme(options.theme);
+			options.theme = themeService.setTheme(options.theme);
 		}
 
 		super(domElement, options, editorWorkerService, contextKeyService, instantiationService, codeEditorService, themeService);
@@ -299,7 +302,6 @@ export class StandaloneDiffEditor extends DiffEditorWidget implements IStandalon
 		}
 
 		this._contextViewService = <IEditorContextViewService>contextViewService;
-		this._standaloneThemeService = standaloneColorService;
 
 		this._register(toDispose);
 
@@ -312,13 +314,6 @@ export class StandaloneDiffEditor extends DiffEditorWidget implements IStandalon
 
 	public destroy(): void {
 		this.dispose();
-	}
-
-	public updateOptions(newOptions: IEditorOptions): void {
-		if (typeof newOptions.theme === 'string') {
-			newOptions.theme = this._standaloneThemeService.setTheme(newOptions.theme);
-		}
-		super.updateOptions(newOptions);
 	}
 
 	protected _createInnerEditor(instantiationService: IInstantiationService, container: HTMLElement, options: IEditorOptions): CodeEditor {

--- a/src/vs/editor/browser/standalone/standaloneEditor.ts
+++ b/src/vs/editor/browser/standalone/standaloneEditor.ts
@@ -125,7 +125,6 @@ export function createDiffEditor(domElement: HTMLElement, options?: IDiffEditorC
 			services.get(IContextKeyService),
 			services.get(IKeybindingService),
 			services.get(IContextViewService),
-			services.get(IStandaloneThemeService),
 			services.get(IEditorWorkerService),
 			services.get(ICodeEditorService),
 			services.get(IStandaloneThemeService)
@@ -310,6 +309,13 @@ export function defineTheme(themeName: string, themeData: IStandaloneThemeData):
 }
 
 /**
+ * Switches to a theme.
+ */
+export function setTheme(themeName: string): void {
+	StaticServices.standaloneThemeService.get().setTheme(themeName);
+}
+
+/**
  * @internal
  */
 export function createMonacoEditorAPI(): typeof monaco.editor {
@@ -336,6 +342,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		colorizeModelLine: colorizeModelLine,
 		tokenize: tokenize,
 		defineTheme: defineTheme,
+		setTheme: setTheme,
 
 		// enums
 		ScrollbarVisibility: ScrollbarVisibility,

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -48,7 +48,7 @@ import { ViewportData } from 'vs/editor/common/viewLayout/viewLinesViewportData'
 import { EditorScrollbar } from 'vs/editor/browser/viewParts/editorScrollbar/editorScrollbar';
 import { Minimap } from 'vs/editor/browser/viewParts/minimap/minimap';
 import * as viewEvents from 'vs/editor/common/view/viewEvents';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IThemeService, getThemeTypeSelector } from 'vs/platform/theme/common/themeService';
 
 export interface IContentWidgetData {
 	widget: editorBrowser.IContentWidget;
@@ -118,6 +118,7 @@ export class View extends ViewEventHandler {
 		this._register(themeService.onThemeChange(theme => {
 			this._context.theme = theme;
 			this.eventDispatcher.emit(new viewEvents.ViewThemeChangedEvent());
+			this.render(true, false);
 		}));
 
 		this.viewParts = [];
@@ -144,7 +145,7 @@ export class View extends ViewEventHandler {
 		this.linesContent.setPosition('absolute');
 
 		this.domNode = createFastDomNode(document.createElement('div'));
-		this.domNode.setClassName(this._context.configuration.editor.editorClassName);
+		this.domNode.setClassName(this.getEditorClassName());
 
 		this.overflowGuardContainer = createFastDomNode(document.createElement('div'));
 		PartFingerprints.write(this.overflowGuardContainer, PartFingerprint.OverflowGuard);
@@ -305,11 +306,15 @@ export class View extends ViewEventHandler {
 
 	}
 
+	private getEditorClassName() {
+		return this._context.configuration.editor.editorClassName + ' ' + getThemeTypeSelector(this._context.theme.type);
+	}
+
 	// --- begin event handlers
 
 	public onConfigurationChanged(e: viewEvents.ViewConfigurationChangedEvent): boolean {
 		if (e.editorClassName) {
-			this.domNode.setClassName(this._context.configuration.editor.editorClassName);
+			this.domNode.setClassName(this.getEditorClassName());
 		}
 		if (e.layoutInfo) {
 			this._setLayout();
@@ -327,6 +332,10 @@ export class View extends ViewEventHandler {
 	}
 	public onScrollChanged(e: viewEvents.ViewScrollChangedEvent): boolean {
 		this.outgoingEvents.emitScrollChanged(e);
+		return false;
+	}
+	public onThemeChanged(e: viewEvents.ViewThemeChangedEvent): boolean {
+		this.domNode.setClassName(this.getEditorClassName());
 		return false;
 	}
 

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -158,16 +158,6 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 		super.dispose();
 	}
 
-	public updateOptions(newOptions: IEditorOptions): void {
-		let oldTheme = this._configuration.editor.viewInfo.theme;
-		super.updateOptions(newOptions);
-		let newTheme = this._configuration.editor.viewInfo.theme;
-
-		if (oldTheme !== newTheme) {
-			this.render();
-		}
-	}
-
 	public colorizeModelLine(lineNumber: number, model: editorCommon.IModel = this.model): string {
 		if (!model) {
 			return '';

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -111,12 +111,11 @@ export abstract class CommonEditorConfiguration extends Disposable implements ed
 		const opts = this._validatedOptions;
 		const partialEnv = this._getEnvConfiguration();
 		const bareFontInfo = BareFontInfo.createFromRawSettings(this._rawOptions, partialEnv.zoomLevel);
-		const editorClassName = this._getEditorClassName(opts.viewInfo.theme, opts.viewInfo.fontLigatures, opts.mouseStyle);
 		const env: editorOptions.IEnvironmentalOptions = {
 			outerWidth: partialEnv.outerWidth,
 			outerHeight: partialEnv.outerHeight,
 			fontInfo: this.readConfiguration(bareFontInfo),
-			editorClassName: editorClassName + ' ' + partialEnv.extraEditorClassName,
+			extraEditorClassName: partialEnv.extraEditorClassName,
 			isDominatedByLongLines: this._isDominatedByLongLines,
 			lineNumbersDigitCount: this._lineNumbersDigitCount,
 			canUseTranslate3d: partialEnv.canUseTranslate3d,
@@ -154,20 +153,6 @@ export abstract class CommonEditorConfiguration extends Disposable implements ed
 		}
 		return r ? r : 1;
 	}
-
-	private _getEditorClassName(theme: string, fontLigatures: boolean, mouseStyle: 'text' | 'default' | 'copy'): string {
-		let extra = '';
-		if (fontLigatures) {
-			extra += 'enable-ligatures ';
-		}
-		if (mouseStyle === 'default') {
-			extra += 'mouse-default ';
-		} else if (mouseStyle === 'copy') {
-			extra += 'mouse-copy ';
-		}
-		return 'monaco-editor ' + extra + theme;
-	}
-
 	protected abstract _getEnvConfiguration(): IEnvConfiguration;
 
 	protected abstract readConfiguration(styling: BareFontInfo): FontInfo;

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -170,11 +170,9 @@ export interface IEditorOptions {
 	 */
 	roundedSelection?: boolean;
 	/**
-	 * Theme to be used for rendering.
-	 * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
-	 * You can create custom themes via `monaco.editor.defineTheme`.
+	 * Class name to be added to the editor.
 	 */
-	theme?: string;
+	extraEditorClassName?: string;
 	/**
 	 * Should the editor be read only.
 	 * Defaults to false.
@@ -683,7 +681,7 @@ export interface EditorWrappingInfo {
 }
 
 export interface InternalEditorViewOptions {
-	readonly theme: string;
+	readonly extraEditorClassName: string;
 	readonly disableMonospaceOptimizations: boolean;
 	readonly experimentalScreenReader: boolean;
 	readonly rulers: number[];
@@ -893,7 +891,7 @@ export class InternalEditorOptions {
 	 */
 	private static _equalsViewOptions(a: InternalEditorViewOptions, b: InternalEditorViewOptions): boolean {
 		return (
-			a.theme === b.theme
+			a.extraEditorClassName === b.extraEditorClassName
 			&& a.disableMonospaceOptimizations === b.disableMonospaceOptimizations
 			&& a.experimentalScreenReader === b.experimentalScreenReader
 			&& this._equalsNumberArrays(a.rulers, b.rulers)
@@ -1179,7 +1177,7 @@ export interface IEnvironmentalOptions {
 	readonly outerWidth: number;
 	readonly outerHeight: number;
 	readonly fontInfo: FontInfo;
-	readonly editorClassName: string;
+	readonly extraEditorClassName: string;
 	readonly isDominatedByLongLines: boolean;
 	readonly lineNumbersDigitCount: number;
 	readonly canUseTranslate3d: boolean;
@@ -1473,7 +1471,7 @@ export class EditorOptionsValidator {
 		const minimap = this._sanitizeMinimapOpts(opts.minimap, defaults.minimap);
 
 		return {
-			theme: _string(opts.theme, defaults.theme),
+			extraEditorClassName: _string(opts.extraEditorClassName, defaults.extraEditorClassName),
 			disableMonospaceOptimizations: disableMonospaceOptimizations,
 			experimentalScreenReader: _boolean(opts.experimentalScreenReader, defaults.experimentalScreenReader),
 			rulers: rulers,
@@ -1630,10 +1628,26 @@ export class InternalEditorOptionsFactory {
 			wordWrapBreakObtrusiveCharacters: opts.wordWrapBreakObtrusiveCharacters,
 		};
 
+		let className = 'monaco-editor';
+		if (opts.viewInfo.extraEditorClassName) {
+			className += ' ' + opts.viewInfo.extraEditorClassName;
+		}
+		if (env.extraEditorClassName) {
+			className += ' ' + env.extraEditorClassName;
+		}
+		if (opts.viewInfo.fontLigatures) {
+			className += ' enable-ligatures';
+		}
+		if (opts.mouseStyle === 'default') {
+			className += ' mouse-default';
+		} else if (opts.mouseStyle === 'copy') {
+			className += ' mouse-copy';
+		}
+
 		return new InternalEditorOptions({
 			canUseTranslate3d: opts.disableTranslate3d ? false : env.canUseTranslate3d,
 			pixelRatio: env.pixelRatio,
-			editorClassName: env.editorClassName,
+			editorClassName: className,
 			lineHeight: env.fontInfo.lineHeight,
 			readOnly: opts.readOnly,
 			wordSeparators: opts.wordSeparators,
@@ -1853,7 +1867,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 	useTabStops: true,
 
 	viewInfo: {
-		theme: 'vs',
+		extraEditorClassName: '',
 		disableMonospaceOptimizations: false,
 		experimentalScreenReader: true,
 		rulers: [],

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -892,6 +892,11 @@ declare module monaco.editor {
 	 */
 	export function defineTheme(themeName: string, themeData: IStandaloneThemeData): void;
 
+	/**
+	 * Switches to a theme.
+	 */
+	export function setTheme(themeName: string): void;
+
 	export type BuiltinTheme = 'vs' | 'vs-dark' | 'hc-black';
 
 	export interface IStandaloneThemeData {
@@ -965,12 +970,26 @@ declare module monaco.editor {
 		 * To not create automatically a model, use `model: null`.
 		 */
 		language?: string;
+		/**
+		 * Initial theme to be used for rendering.
+		 * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
+		 * You can create custom themes via `monaco.editor.defineTheme`.
+		 * To switch a theme, use `monaco.editor.setTheme`
+		 */
+		theme?: string;
 	}
 
 	/**
 	 * The options to create a diff editor.
 	 */
 	export interface IDiffEditorConstructionOptions extends IDiffEditorOptions {
+		/**
+		 * Initial theme to be used for rendering.
+		 * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
+		 * You can create custom themes via `monaco.editor.defineTheme`.
+		 * To switch a theme, use `monaco.editor.setTheme`
+		 */
+		theme?: string;
 	}
 
 	export interface IStandaloneCodeEditor extends ICodeEditor {
@@ -2717,11 +2736,9 @@ declare module monaco.editor {
 		 */
 		roundedSelection?: boolean;
 		/**
-		 * Theme to be used for rendering.
-		 * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
-		 * You can create custom themes via `monaco.editor.defineTheme`.
+		 * Class name to be added to the editor.
 		 */
-		theme?: string;
+		extraEditorClassName?: string;
 		/**
 		 * Should the editor be read only.
 		 * Defaults to false.
@@ -3163,7 +3180,7 @@ declare module monaco.editor {
 	}
 
 	export interface InternalEditorViewOptions {
-		readonly theme: string;
+		readonly extraEditorClassName: string;
 		readonly disableMonospaceOptimizations: boolean;
 		readonly experimentalScreenReader: boolean;
 		readonly rulers: number[];

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -30,7 +30,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
@@ -53,7 +53,7 @@ export class TextDiffEditor extends BaseTextEditor {
 		@IStorageService storageService: IStorageService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
-		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
+		@IThemeService themeService: IThemeService,
 		@IEditorGroupService editorGroupService: IEditorGroupService,
 		@IModeService modeService: IModeService,
 		@ITextFileService textFileService: ITextFileService

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -21,7 +21,7 @@ import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { Scope } from 'vs/workbench/common/memento';
 import { getCodeEditor } from 'vs/editor/common/services/codeEditorService';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -58,7 +58,7 @@ export abstract class BaseTextEditor extends BaseEditor {
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IStorageService private storageService: IStorageService,
 		@IConfigurationService private _configurationService: IConfigurationService,
-		@IWorkbenchThemeService protected themeService: IWorkbenchThemeService,
+		@IThemeService protected themeService: IThemeService,
 		@IModeService private modeService: IModeService,
 		@ITextFileService private textFileService: ITextFileService,
 		@IEditorGroupService protected editorGroupService: IEditorGroupService
@@ -66,7 +66,6 @@ export abstract class BaseTextEditor extends BaseEditor {
 		super(id, telemetryService, themeService);
 
 		this.toUnbind.push(this.configurationService.onDidUpdateConfiguration(e => this.handleConfigurationChangeEvent(e.config)));
-		this.toUnbind.push(themeService.onDidColorThemeChange(e => this.handleConfigurationChangeEvent())); // TODO@theme this should be done from the editor itself and not from the outside
 	}
 
 	protected get instantiationService(): IInstantiationService {
@@ -125,7 +124,6 @@ export abstract class BaseTextEditor extends BaseEditor {
 		objects.assign(overrides, {
 			overviewRulerLanes: 3,
 			lineNumbersMinChars: 3,
-			theme: this.themeService.getColorTheme().id,
 			fixedOverflowWidgets: true
 		});
 

--- a/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
@@ -19,7 +19,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -38,7 +38,7 @@ export class TextResourceEditor extends BaseTextEditor {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IStorageService storageService: IStorageService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
+		@IThemeService themeService: IThemeService,
 		@IUntitledEditorService private untitledEditorService: IUntitledEditorService,
 		@IEditorGroupService editorGroupService: IEditorGroupService,
 		@IModeService modeService: IModeService,

--- a/src/vs/workbench/parts/debug/electron-browser/repl.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/repl.ts
@@ -38,11 +38,11 @@ import * as debug from 'vs/workbench/parts/debug/common/debug';
 import { ClearReplAction } from 'vs/workbench/parts/debug/browser/debugActions';
 import { ReplHistory } from 'vs/workbench/parts/debug/common/replHistory';
 import { Panel } from 'vs/workbench/browser/panel';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { IListService } from 'vs/platform/list/browser/listService';
 import { attachListStyler } from 'vs/platform/theme/common/styler';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 const $ = dom.$;
 
@@ -89,7 +89,7 @@ export class Repl extends Panel implements IPrivateReplService {
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@IStorageService private storageService: IStorageService,
 		@IPanelService private panelService: IPanelService,
-		@IWorkbenchThemeService protected themeService: IWorkbenchThemeService,
+		@IThemeService protected themeService: IThemeService,
 		@IModelService private modelService: IModelService,
 		@IContextKeyService private contextKeyService: IContextKeyService,
 		@IListService private listService: IListService
@@ -105,7 +105,6 @@ export class Repl extends Panel implements IPrivateReplService {
 		this.toDispose.push(this.debugService.getModel().onDidChangeReplElements(() => {
 			this.refreshReplElements(this.debugService.getModel().getReplElements().length === 0);
 		}));
-		this.toDispose.push(this.themeService.onDidColorThemeChange(e => this.replInput.updateOptions(this.getReplInputOptions()))); // TODO@theme this should be done from the editor itself and not from the outside
 		this.toDispose.push(this.panelService.onDidPanelOpen(panel => this.refreshReplElements(true)));
 	}
 
@@ -280,7 +279,6 @@ export class Repl extends Panel implements IPrivateReplService {
 			},
 			lineDecorationsWidth: 0,
 			scrollBeyondLastLine: false,
-			theme: this.themeService.getColorTheme().id,
 			renderLineHighlight: 'none',
 			fixedOverflowWidgets: true
 		};

--- a/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
@@ -28,7 +28,7 @@ import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { CancelAction } from 'vs/platform/message/common/message';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IModeService } from 'vs/editor/common/services/modeService';
 
@@ -49,7 +49,7 @@ export class TextFileEditor extends BaseTextEditor {
 		@IHistoryService private historyService: IHistoryService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
-		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
+		@IThemeService themeService: IThemeService,
 		@IEditorGroupService editorGroupService: IEditorGroupService,
 		@IModeService modeService: IModeService,
 		@ITextFileService textFileService: ITextFileService,

--- a/src/vs/workbench/parts/output/browser/outputPanel.ts
+++ b/src/vs/workbench/parts/output/browser/outputPanel.ts
@@ -21,7 +21,7 @@ import { EditorInput, EditorOptions } from 'vs/workbench/common/editor';
 import { TextResourceEditor } from 'vs/workbench/browser/parts/editor/textResourceEditor';
 import { OutputEditors, OUTPUT_PANEL_ID, IOutputService, CONTEXT_IN_OUTPUT } from 'vs/workbench/parts/output/common/output';
 import { SwitchOutputAction, SwitchOutputActionItem, ClearOutputAction, ToggleOutputScrollLockAction } from 'vs/workbench/parts/output/browser/outputActions';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -37,7 +37,7 @@ export class OutputPanel extends TextResourceEditor {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IStorageService storageService: IStorageService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
+		@IThemeService themeService: IThemeService,
 		@IOutputService private outputService: IOutputService,
 		@IUntitledEditorService untitledEditorService: IUntitledEditorService,
 		@IContextKeyService private contextKeyService: IContextKeyService,

--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -32,7 +32,7 @@ import { SearchWidget, SettingsTabsWidget } from 'vs/workbench/parts/preferences
 import { ContextKeyExpr, IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { Command } from 'vs/editor/common/editorCommonExtensions';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
@@ -111,7 +111,7 @@ export class PreferencesEditor extends BaseEditor {
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
 		@IContextKeyService private contextKeyService: IContextKeyService,
 		@IInstantiationService private instantiationService: IInstantiationService,
-		@IWorkbenchThemeService themeService: IWorkbenchThemeService
+		@IThemeService themeService: IThemeService
 	) {
 		super(PreferencesEditor.ID, telemetryService, themeService);
 		this.defaultSettingsEditorContextKey = CONTEXT_SETTINGS_EDITOR.bindTo(this.contextKeyService);
@@ -461,7 +461,7 @@ export class DefaultPreferencesEditor extends BaseTextEditor {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IStorageService storageService: IStorageService,
 		@IConfigurationService configurationService: IConfigurationService,
-		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
+		@IThemeService themeService: IThemeService,
 		@IPreferencesService private preferencesService: IPreferencesService,
 		@IModelService private modelService: IModelService,
 		@IModeService modeService: IModeService,


### PR DESCRIPTION
@alexandrudima As mentioned in the standup, I'd like to remove editorOptions.theme as theme configuration is now done through the themeService.

editorOption.theme got replaced by editorOption.extraEditorClassName as the diff editor uses the theme field to add an additional class name. I migrated all users of editorOption.theme to the theme service. I preserved any updating/rerender logic, even for some cases this could be reviewed.

Please have a look at the changes to the standalone editor.
I kept 'theme' on the `IEditorConstructionOptions` so to stay compatible with the old API where users can create an editor and set the theme at the same time.
However, switching a theme while the editor is open now needs to be done through a new API `monaco.editor.setTheme`.
