### PR TITLE
Add .git/subtree-cache/ to files.watcherExclude

### DIFF
--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -261,7 +261,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'files.watcherExclude': {
 			'type': 'object',
-			'default': platform.isWindows /* https://github.com/Microsoft/vscode/issues/23954 */ ? { '**/.git/objects/**': true, '**/node_modules/*/**': true } : { '**/.git/objects/**': true, '**/node_modules/**': true },
+			'default': platform.isWindows /* https://github.com/Microsoft/vscode/issues/23954 */ ? { '**/.git/objects/**': true, '**/.git/subtree-cache/**': true, '**/node_modules/*/**': true } : { '**/.git/objects/**': true, '**/.git/subtree-cache/**': true, '**/node_modules/**': true },
 			'description': nls.localize('watcherExclude', "Configure glob patterns of file paths to exclude from file watching. Changing this setting requires a restart. When you experience Code consuming lots of cpu time on startup, you can exclude large folders to reduce the initial load.")
 		},
 		'files.hotExit': {


### PR DESCRIPTION
In my local Linux kernel repo, this folder has a bunch of 1.9GB subfolders, which really chews up CPU.

Since this is a cache, there should not be any harm in ignoring it by default. And that way in rare cases like mine, this will make vscode will "just work" by not using a bunch of CPU and RAM for no good reason.