### PR TITLE
Use getDomNodePagePosition to position suggest docs

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -9,6 +9,17 @@
 	width: 660px;
 }
 
+.monaco-editor .suggest-widget > .tree,
+.monaco-editor .suggest-widget > .details {
+	width: 330px;
+}
+
+.monaco-editor .suggest-widget.small,
+.monaco-editor .suggest-widget.small > .tree,
+.monaco-editor .suggest-widget.small > .details {
+	width: 400px;
+}
+
 .monaco-editor .suggest-widget.visible {
 	-webkit-transition: left .05s ease-in-out;
 	-moz-transition: left .05s ease-in-out;

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -18,7 +18,6 @@
 
 .monaco-editor .suggest-widget > .message {
 	padding-left: 22px;
-	opacity: 0.7;
 }
 
 .monaco-editor .suggest-widget > .tree {

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -309,7 +309,6 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 
 	private readonly maxWidgetWidth = 660;
 	private readonly listWidth = 330;
-	private readonly docsWidth = 330;
 	private readonly minWidgetWidth = 400;
 
 	constructor(
@@ -827,16 +826,14 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		if (this.messageElement.style.display !== 'none'
 			&& this.details.element.style.display === 'none'
 			&& this.listElement.style.display === 'none') {
-			this.element.style.width = `${this.minWidgetWidth}px`;
+			addClass(this.element, 'small');
 			return;
 		}
 
 		let matches = this.element.style.maxWidth.match(/(\d+)px/);
 		if (!matches || Number(matches[1]) >= this.maxWidgetWidth) {
 			// Reset width
-			this.details.element.style.width = `${this.docsWidth}px`;
-			this.element.style.width = `${this.maxWidgetWidth}px`;
-			this.listElement.style.width = `${this.listWidth}px`;
+			removeClass(this.element, 'small');
 		}
 
 		// Reset list margin
@@ -848,28 +845,26 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		const editorCoords = getDomNodePagePosition(this.editor.getDomNode());
 		const cursorX = editorCoords.left + cursorCoords.left;
 		const cursorY = editorCoords.top + cursorCoords.top + cursorCoords.height;
-
 		const widgetX = this.element.offsetLeft;
 		const widgetY = this.element.offsetTop;
 
 		removeClass(this.element, 'list-right');
 
 		if (this.element.clientWidth < this.maxWidgetWidth && this.listElement.clientWidth !== this.minWidgetWidth) {
-			// Not enough space to show side by side
-			// So show docs below the list
-			this.listElement.style.width = `${this.minWidgetWidth}px`;
-			this.element.style.width = `${this.minWidgetWidth}px`;
-			this.details.element.style.width = `${this.minWidgetWidth}px`;
-		} else if (widgetX < cursorX - this.listWidth) {
+			// Not enough space to show side by side, so show docs below the list
+			addClass(this.element, 'small');
+			return;
+		}
+
+		if (widgetX < cursorX - this.listWidth) {
 			// Widget is too far to the left of cursor, swap list and docs
 			addClass(this.element, 'list-right');
 		}
 
-		// If docs is bigger than list and widget is above cursor, apply margin-top so that list appears right above cursor
 		if (cursorY > widgetY && this.details.element.clientHeight > this.listElement.clientHeight) {
+			// Docs is bigger than list and widget is above cursor, apply margin-top so that list appears right above cursor
 			this.listElement.style.marginTop = `${this.details.element.clientHeight - this.listElement.clientHeight}px`;
 		}
-
 	}
 
 	private renderDetails(): void {

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -30,7 +30,6 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { attachListStyler } from 'vs/platform/theme/common/styler';
 import { IThemeService, ITheme, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { registerColor, editorWidgetBackground, listFocusBackground, activeContrastBorder, listHighlightForeground, editorForeground, editorWidgetBorder } from 'vs/platform/theme/common/colorRegistry';
-import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 
 const sticky = false; // for development purposes
 
@@ -316,8 +315,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		@ITelemetryService private telemetryService: ITelemetryService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IThemeService themeService: IThemeService,
-		@IEditorGroupService private editorGroupService: IEditorGroupService
+		@IThemeService themeService: IThemeService
 	) {
 		this.isAuto = false;
 		this.focusedItem = null;
@@ -507,7 +505,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 				this.list.setFocus([index]);
 				this.list.reveal(index);
 				this.showDetails();
-				this.updateWidgetHeight(true);
+				this.adjustDocsPosition();
 				this._ariaAlert(this._getSuggestionAriaAlertLabel(item));
 			})
 			.then(null, err => !isPromiseCanceledError(err) && onUnexpectedError(err))
@@ -792,7 +790,7 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		return SuggestWidget.ID;
 	}
 
-	private updateWidgetHeight(adjustDocs?: boolean): number {
+	private updateWidgetHeight(): number {
 		let height = 0;
 		let maxSuggestionsToShow = this.editor.getLayoutInfo().contentWidth > this.minWidgetWidth ? 11 : 5;
 
@@ -813,9 +811,6 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 
 		this.adjustWidgetWidth();
 		this.editor.layoutContentWidget(this);
-		if (adjustDocs) {
-			this.adjustDocsPosition();
-		}
 
 		return height;
 	}


### PR DESCRIPTION
Fixes #26324
Fixes #26416
Fixes #26224

In this PR, `getDomNodePagePosition` is used to get the top and left offset of the cursor relative to VS Code window. These values are then compared to suggest widget's top and left offsets. Based on this comparison, we take the call whether we should show docs to the right/left of the list or show them one below the other