### PR TITLE
Markdown preview support the UNC path files.

### DIFF
--- a/extensions/markdown/src/previewContentProvider.ts
+++ b/extensions/markdown/src/previewContentProvider.ts
@@ -39,7 +39,7 @@ export function getMarkdownUri(uri: vscode.Uri) {
 
 	return uri.with({
 		scheme: 'markdown',
-		path: uri.fsPath + '.rendered',
+		path: uri.path + '.rendered',
 		query: uri.toString()
 	});
 }


### PR DESCRIPTION
Related to #26464.

+ VSCode Version: 1.12.2
+ OS Version: Windows 8.1 Pro

The built-in markdown extensions cannot preview the network files.
In my case, the network file path is UNC path(starts with`\\`).

This tiny changes affected to be able to preview even the UNC path files.