### PR TITLE
Toggle expanded docs, add stickyness to expansion

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -72,6 +72,57 @@
 	font-weight: bold;
 }
 
+.monaco-editor .suggest-widget .details > .header > .go-back,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details {
+	opacity: 0.6;
+	background-position: center center;
+	background-repeat: no-repeat;
+	background-size: 70%;
+}
+
+.monaco-editor .suggest-widget .details > .header > .go-back {
+	background-image: url('./back.svg');
+}
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details {
+	background-image: url('./info.svg');
+}
+
+.monaco-editor .suggest-widget .details > .header > .go-back,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details  {
+	color: #0035DD;
+}
+
+.monaco-editor .suggest-widget .details > .header > .go-back:hover,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details:hover {
+	opacity: 1;
+}
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .type-label {
+	margin-left: 0.8em;
+	flex: 1;
+	text-align: right;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	opacity: 0.7;
+}
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .type-label > .monaco-tokenized-source {
+	display: inline;
+}
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .type-label,
+.monaco-editor .suggest-widget.docs-expanded .monaco-list .monaco-list-row.focused > .contents > .main > .docs-details,
+.monaco-editor .suggest-widget.docs-expanded .monaco-list .monaco-list-row.focused > .contents > .main > .type-label {
+	display: none;
+}
+
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .docs-details,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .type-label {
+	display: inline;
+}
+
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row .icon {
 	display: block;
 	height: 16px;
@@ -141,9 +192,20 @@
 	white-space: pre-wrap;
 }
 
-.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .type {
+.monaco-editor .suggest-widget .details > .header {
+	padding: 4px 5px;
+	display: flex;
+	box-sizing: border-box;		  	box-sizing: border-box;
+	border-bottom: 1px solid rgba(204, 204, 204, 0.5);
+}
+
+.monaco-editor .suggest-widget .details > .header > .type {
+	flex: 2;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	opacity: 0.7;
 	word-break: break-all;
+	margin: 0;
 }
 
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > p {
@@ -155,11 +217,18 @@
 	display: none;
 }
 
-/* High Contrast Theming */
+/* Dark theme */
 
-.monaco-editor.hc-black .suggest-widget .details > .monaco-scrollable-element > .body > .docs {
-	color: #C07A7A;
+.monaco-editor.vs-dark .suggest-widget .details > .header {
+	border-color: rgba(85,85,85,0.5);
 }
+
+.monaco-editor.vs-dark .suggest-widget .details > .header > .go-back,
+.monaco-editor.vs-dark .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details {
+	color: #4E94CE;
+}
+
+/* High Contrast Theming */
 
 .monaco-editor.vs-dark .suggest-widget .monaco-list .monaco-list-row .icon,
 .monaco-editor.hc-black .suggest-widget .monaco-list .monaco-list-row .icon { background-image: url('Misc_inverse_16x.svg'); }

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -72,7 +72,7 @@
 	font-weight: bold;
 }
 
-.monaco-editor .suggest-widget .details > .header > .go-back,
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back,
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details {
 	opacity: 0.6;
 	background-position: center center;
@@ -80,7 +80,7 @@
 	background-size: 70%;
 }
 
-.monaco-editor .suggest-widget .details > .header > .go-back {
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back {
 	background-image: url('./back.svg');
 }
 
@@ -88,12 +88,12 @@
 	background-image: url('./info.svg');
 }
 
-.monaco-editor .suggest-widget .details > .header > .go-back,
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back,
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details  {
 	color: #0035DD;
 }
 
-.monaco-editor .suggest-widget .details > .header > .go-back:hover,
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back:hover,
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details:hover {
 	opacity: 1;
 }
@@ -192,14 +192,14 @@
 	white-space: pre-wrap;
 }
 
-.monaco-editor .suggest-widget .details > .header {
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header {
 	padding: 4px 5px;
 	display: flex;
 	box-sizing: border-box;		  	box-sizing: border-box;
 	border-bottom: 1px solid rgba(204, 204, 204, 0.5);
 }
 
-.monaco-editor .suggest-widget .details > .header > .type {
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .type {
 	flex: 2;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -219,11 +219,11 @@
 
 /* Dark theme */
 
-.monaco-editor.vs-dark .suggest-widget .details > .header {
+.monaco-editor.vs-dark .suggest-widget .details > .monaco-scrollable-element > .body > .header {
 	border-color: rgba(85,85,85,0.5);
 }
 
-.monaco-editor.vs-dark .suggest-widget .details > .header > .go-back,
+.monaco-editor.vs-dark .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back,
 .monaco-editor.vs-dark .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details {
 	color: #4E94CE;
 }

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -79,6 +79,8 @@
 	background-position: center center;
 	background-repeat: no-repeat;
 	background-size: 70%;
+	color: #0035DD;
+	cursor: pointer;
 }
 
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back {
@@ -87,11 +89,6 @@
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details {
 	background-image: url('./info.svg');
-}
-
-.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back,
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .docs-details  {
-	color: #0035DD;
 }
 
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .go-back:hover,
@@ -197,7 +194,7 @@
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header {
 	padding: 4px 5px;
 	display: flex;
-	box-sizing: border-box;		  	box-sizing: border-box;
+	box-sizing: border-box;
 	border-bottom: 1px solid rgba(204, 204, 204, 0.5);
 }
 

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -9,15 +9,16 @@
 	width: 660px;
 }
 
-.monaco-editor .suggest-widget > .tree,
+.monaco-editor .suggest-widget.docs-expanded > .tree,
 .monaco-editor .suggest-widget > .details {
 	width: 330px;
 }
 
 .monaco-editor .suggest-widget.small,
-.monaco-editor .suggest-widget.small > .tree,
+.monaco-editor .suggest-widget > .tree,
+.monaco-editor .suggest-widget.small.docs-expanded > .tree,
 .monaco-editor .suggest-widget.small > .details {
-	width: 400px;
+	width: 430px;
 }
 
 .monaco-editor .suggest-widget.visible {
@@ -119,7 +120,8 @@
 }
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .docs-details,
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .type-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .type-label,
+.monaco-editor .suggest-widget.docs-expanded.small .monaco-list .monaco-list-row.focused > .contents > .main > .type-label {
 	display: inline;
 }
 

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -263,7 +263,7 @@ export class SuggestController implements IEditorContribution {
 
 	toggleSuggestionDetails(): void {
 		if (this._widget) {
-			this._widget.toggleDetailsFocus();
+			this._widget.toggleDetails();
 		}
 	}
 }

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -266,6 +266,12 @@ export class SuggestController implements IEditorContribution {
 			this._widget.toggleDetails();
 		}
 	}
+
+	toggleSuggestionFocus(): void {
+		if (this._widget) {
+			this._widget.toggleDetailsFocus();
+		}
+	}
 }
 
 @editorAction
@@ -406,5 +412,17 @@ CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
 		kbExpr: EditorContextKeys.textFocus,
 		primary: KeyMod.CtrlCmd | KeyCode.Space,
 		mac: { primary: KeyMod.WinCtrl | KeyCode.Space }
+	}
+}));
+
+CommonEditorRegistry.registerEditorCommand(new SuggestCommand({
+	id: 'toggleSuggestionFocus',
+	precondition: SuggestContext.Visible,
+	handler: x => x.toggleSuggestionFocus(),
+	kbOpts: {
+		weight: weight,
+		kbExpr: EditorContextKeys.textFocus,
+		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Space,
+		mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.Space }
 	}
 }));

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -207,18 +207,17 @@ class SuggestionDetails {
 		this.el = append(container, $('.details'));
 		this.disposables.push(toDisposable(() => container.removeChild(this.el)));
 
-		this.header = append(this.el, $('.header'));
-		this.type = append(this.header, $('p.type'));
-
-		this.back = append(this.header, $('span.go-back'));
-		this.back.title = nls.localize('goback', "Go back");
-
 		this.body = $('.body');
 
 		this.scrollbar = new DomScrollableElement(this.body, { canUseTranslate3d: false });
 		append(this.el, this.scrollbar.getDomNode());
 		this.disposables.push(this.scrollbar);
 
+		this.header = append(this.body, $('.header'));
+		this.type = append(this.header, $('p.type'));
+
+		this.back = append(this.header, $('span.go-back'));
+		this.back.title = nls.localize('goback', "Go back");
 
 		this.docs = append(this.body, $('p.docs'));
 		this.ariaLabel = null;
@@ -246,7 +245,7 @@ class SuggestionDetails {
 		this.type.innerText = item.suggestion.detail || '';
 		this.docs.textContent = item.suggestion.documentation;
 
-		this.el.style.height = this.header.clientHeight + this.docs.clientHeight + 'px';
+		this.el.style.height = this.type.clientHeight + this.docs.clientHeight + 8 + 'px';
 
 		this.back.onmousedown = e => {
 			e.preventDefault();

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -69,15 +69,12 @@ function canExpandCompletionItem(item: ICompletionItem) {
 
 class Renderer implements IRenderer<ICompletionItem, ISuggestionTemplateData> {
 
-	private triggerKeybindingLabel: string;
-
 	constructor(
 		private widget: SuggestWidget,
 		private editor: ICodeEditor,
-		@IKeybindingService keybindingService: IKeybindingService
+		private triggerKeybindingLabel: string
 	) {
-		const kb = keybindingService.lookupKeybinding('editor.action.triggerSuggest');
-		this.triggerKeybindingLabel = !kb ? '' : ` (${kb.getLabel()})`;
+
 	}
 
 	get templateId(): string {
@@ -200,7 +197,8 @@ class SuggestionDetails {
 	constructor(
 		container: HTMLElement,
 		private widget: SuggestWidget,
-		private editor: ICodeEditor
+		private editor: ICodeEditor,
+		private triggerKeybindingLabel: string
 	) {
 		this.disposables = [];
 
@@ -217,7 +215,7 @@ class SuggestionDetails {
 		this.type = append(this.header, $('p.type'));
 
 		this.back = append(this.header, $('span.go-back'));
-		this.back.title = nls.localize('goback', "Go back");
+		this.back.title = nls.localize('goback', "Read less...{0}", triggerKeybindingLabel);
 
 		this.docs = append(this.body, $('p.docs'));
 		this.ariaLabel = null;
@@ -365,8 +363,12 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IThemeService themeService: IThemeService,
-		@IStorageService storageService: IStorageService
+		@IStorageService storageService: IStorageService,
+		@IKeybindingService keybindingService: IKeybindingService
 	) {
+		const kb = keybindingService.lookupKeybinding('editor.action.triggerSuggest');
+		const triggerKeybindingLabel = !kb ? '' : ` (${kb.getLabel()})`;
+
 		this.isAuto = false;
 		this.focusedItem = null;
 		this.storageService = storageService;
@@ -378,9 +380,9 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 
 		this.messageElement = append(this.element, $('.message'));
 		this.listElement = append(this.element, $('.tree'));
-		this.details = new SuggestionDetails(this.element, this, this.editor);
+		this.details = new SuggestionDetails(this.element, this, this.editor, triggerKeybindingLabel);
 
-		let renderer: IRenderer<ICompletionItem, any> = instantiationService.createInstance(Renderer, this, this.editor);
+		let renderer: IRenderer<ICompletionItem, any> = instantiationService.createInstance(Renderer, this, this.editor, triggerKeybindingLabel);
 
 		this.list = new List(this.listElement, this, [renderer], {
 			useShadows: false,

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -13,7 +13,7 @@ import Event, { Emitter, chain } from 'vs/base/common/event';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { isPromiseCanceledError, onUnexpectedError } from 'vs/base/common/errors';
 import { IDisposable, dispose, toDisposable } from 'vs/base/common/lifecycle';
-import { addClass, append, $, hide, removeClass, show, toggleClass, getDomNodePagePosition } from 'vs/base/browser/dom';
+import { addClass, append, $, hide, removeClass, show, toggleClass, getDomNodePagePosition, hasClass } from 'vs/base/browser/dom';
 import { HighlightedLabel } from 'vs/base/browser/ui/highlightedlabel/highlightedLabel';
 import { IDelegate, IListEvent, IRenderer } from 'vs/base/browser/ui/list/list';
 import { List } from 'vs/base/browser/ui/list/listWidget';
@@ -810,6 +810,9 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		if (this.state !== State.Open && this.state !== State.Details) {
 			return;
 		}
+		if (this.storageService.getBoolean('expandSuggestionDocs', StorageScope.GLOBAL, false)) {
+			addClass(this.element, 'docs-expanded');
+		}
 
 		this.show();
 		this.editor.focus();
@@ -858,7 +861,10 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 
 	private updateWidgetHeight(): number {
 		let height = 0;
-		let maxSuggestionsToShow = this.editor.getLayoutInfo().contentWidth > this.minWidgetWidth ? 11 : 5;
+		let maxSuggestionsToShow = 11;
+		if (hasClass(this.element, 'small')) {
+			maxSuggestionsToShow = 5;
+		}
 
 		if (this.state === State.Empty || this.state === State.Loading) {
 			height = this.unfocusedHeight;


### PR DESCRIPTION
Fixes #26282

- Docs expand only after user chooses to do so either by `Ctrl+Space` or by clicking on the "Read More" icon
- Once docs expand, they remain expanded until user chooses to close it either by `Ctrl+Space` or by clicking on the "Read less" icon
- To move focus between the list and the docs, a new Key binding `Ctrl+Alt+Space` is introduced. 

The user choice is stored in local storage to make the experience sticky.


