### PR TITLE
Add feature from #22769

### DIFF
--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -290,25 +290,6 @@ export function registerCommands(): void {
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
-		id: 'list.selectAll',
-		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
-		when: ListFocusContext,
-		primary: KeyMod.CtrlCmd | KeyCode.KEY_A,
-		handler: (accessor) => {
-			const listService = accessor.get(IListService);
-			const focused = listService.getFocused();
-
-			if (focused instanceof List) {
-				const list = focused;
-				if (list.length !== 0) {
-					list.setSelection(Array.apply(null, { length: list.length }).map(Function.call, Number));
-					list.focusFirst();
-				}
-			}
-		}
-	});
-
-	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: 'list.toggleExpand',
 		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
 		when: ListFocusContext,

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -290,6 +290,25 @@ export function registerCommands(): void {
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
+		id: 'list.selectAll',
+		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
+		when: ListFocusContext,
+		primary: KeyMod.CtrlCmd | KeyCode.KEY_A,
+		handler: (accessor) => {
+			const listService = accessor.get(IListService);
+			const focused = listService.getFocused();
+
+			if (focused instanceof List) {
+				const list = focused;
+				if (list.length !== 0) {
+					list.setSelection(Array.apply(null, { length: list.length }).map(Function.call, Number));
+					list.focusFirst();
+				}
+			}
+		}
+	});
+
+	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: 'list.toggleExpand',
 		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
 		when: ListFocusContext,

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -309,7 +309,8 @@ export class SCMViewlet extends Viewlet {
 
 		this.list = new List(this.listContainer, delegate, renderers, {
 			identityProvider,
-			keyboardSupport: false
+			keyboardSupport: true,
+			selectAllEnabled: true
 		});
 
 		this.disposables.push(attachListStyler(this.list, this.themeService));


### PR DESCRIPTION
- `Ctrl+A` now selects all files when focused on the scm viewlet