### PR TITLE
Update paths.js to allow use of ENV variable as alternative to cmd args

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -8,10 +8,11 @@ var os = require('os');
 var pkg = require('../package.json');
 
 function getAppDataPath(platform) {
+	const userPath = process.env['vscode_config_prefix'];
 	switch (platform) {
-		case 'win32': return process.env['APPDATA'] || path.join(process.env['USERPROFILE'], 'AppData', 'Roaming');
-		case 'darwin': return path.join(os.homedir(), 'Library', 'Application Support');
-		case 'linux': return process.env['XDG_CONFIG_HOME'] || path.join(os.homedir(), '.config');
+		case 'win32': return userPath || process.env['APPDATA'] || path.join(process.env['USERPROFILE'], 'AppData', 'Roaming');
+		case 'darwin': return userPath || path.join(os.homedir(), 'Library', 'Application Support');
+		case 'linux': return userPath || process.env['XDG_CONFIG_HOME'] || path.join(os.homedir(), '.config');
 		default: throw new Error('Platform not supported');
 	}
 }


### PR DESCRIPTION
…override for userDataPath

This patch allows defining the environment variable "vscode_config_prefix" as a global default, instead of relying on command line arguments.  The solution is similar to NPM's npm_config_prefix environment variable.  if defined, APPDATA, XDG_CONFIG_HOME, and other solutions are ignored for determining the path value.  This is 1/2 the solution to removing the user data from the Windows roaming profile.