### PR TITLE
Update environmentService.ts to enable ENV defined extenstions-dir

### DIFF
--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -90,7 +90,7 @@ export class EnvironmentService implements IEnvironmentService {
 	get backupWorkspacesPath(): string { return path.join(this.backupHome, 'workspaces.json'); }
 
 	@memoize
-	get extensionsPath(): string { return parsePathArg(this._args['extensions-dir'], process) || path.join(this.userHome, product.dataFolderName, 'extensions'); }
+	get extensionsPath(): string { return parsePathArg(this._args['extensions-dir'], process) || process.env['vscode_config_ext'] || path.join(this.userHome, product.dataFolderName, 'extensions'); }
 
 	@memoize
 	get extensionDevelopmentPath(): string { return this._args.extensionDevelopmentPath ? path.normalize(this._args.extensionDevelopmentPath) : this._args.extensionDevelopmentPath; }


### PR DESCRIPTION
This update allows VS Code users to define the desired extensions directory by means of an environment variable "vscode_config_ext", instead of having to rely on the command-line arguments.  By providing a path to the extensions directory in an environment variable, VS Code is able to have a system or user defined extensions directory that does not require a wrapper script to launch code for the settings to take effect.  This solution is similar to the npm ENV variable solution "npm_config_cache".

This is 1/2 of the solution for providing a portable solution to remove VS Code from the Windows roaming profile.