### PR TITLE
Fix lua function colorizing error

### DIFF
--- a/extensions/lua/syntaxes/lua.json
+++ b/extensions/lua/syntaxes/lua.json
@@ -28,7 +28,7 @@
 					"name": "punctuation.definition.parameters.end.lua"
 				}
 			},
-			"match": "\\b(function)(?:\\s+([a-zA-Z_.:]+[.:])?([a-zA-Z_]\\w*)\\s*)?(\\()([^)]*)(\\))",
+			"match": "\\b(function)(?:\\s+([a-zA-Z_]\\w*[.:])?([a-zA-Z_]\\w*))?\\s*(\\()([^)]*)(\\))",
 			"name": "meta.function.lua"
 		},
 		{


### PR DESCRIPTION
```lua
function mt:x(a, b) end
function mt1:x(a, b) end
function(a, b) end
function (a, b) end
```
Before
![2](https://cloud.githubusercontent.com/assets/1836844/26215793/426c9af8-3c34-11e7-9f11-04b6602b9a08.png)

After
![1](https://cloud.githubusercontent.com/assets/1836844/26215804/475b7a20-3c34-11e7-847e-57301828954e.png)
