### PR TITLE
Fix #26821 Memento

### DIFF
--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -1351,7 +1351,6 @@ export class SearchViewlet extends Viewlet {
 
 	public shutdown(): void {
 		this.viewletSettings['query.contentPattern'] = this.searchWidget.searchInput.getValue();
-		this.saveMemento();
 
 		super.shutdown();
 	}

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -905,22 +905,9 @@ export class SearchViewlet extends Viewlet {
 		const isCaseSensitive = this.searchWidget.searchInput.getCaseSensitive();
 		const contentPattern = this.searchWidget.searchInput.getValue();
 		const patternExcludes = this.inputPatternExclusions.getValue().trim();
-		const exclusionsUsePattern = this.inputPatternExclusions.isGlobPattern();
 		const patternIncludes = this.inputPatternIncludes.getValue().trim();
-		const includesUsePattern = this.inputPatternIncludes.isGlobPattern();
 		const useIgnoreFiles = this.inputPatternExclusions.useIgnoreFiles();
 		const useExcludeSettings = this.inputPatternExclusions.useExcludeSettings();
-
-		// store memento
-		this.viewletSettings['query.contentPattern'] = contentPattern;
-		this.viewletSettings['query.regex'] = isRegex;
-		this.viewletSettings['query.wholeWords'] = isWholeWords;
-		this.viewletSettings['query.caseSensitive'] = isCaseSensitive;
-		this.viewletSettings['query.folderExclusions'] = patternExcludes;
-		this.viewletSettings['query.exclusionsUsePattern'] = exclusionsUsePattern;
-		this.viewletSettings['query.folderIncludes'] = patternIncludes;
-		this.viewletSettings['query.includesUsePattern'] = includesUsePattern;
-		this.viewletSettings['query.useIgnoreFiles'] = useIgnoreFiles;
 
 		if (!rerunQuery) {
 			return;
@@ -1350,7 +1337,27 @@ export class SearchViewlet extends Viewlet {
 	}
 
 	public shutdown(): void {
-		this.viewletSettings['query.contentPattern'] = this.searchWidget.searchInput.getValue();
+		const isRegex = this.searchWidget.searchInput.getRegex();
+		const isWholeWords = this.searchWidget.searchInput.getWholeWords();
+		const isCaseSensitive = this.searchWidget.searchInput.getCaseSensitive();
+		const contentPattern = this.searchWidget.searchInput.getValue();
+		const patternExcludes = this.inputPatternExclusions.getValue().trim();
+		const exclusionsUsePattern = this.inputPatternExclusions.isGlobPattern();
+		const patternIncludes = this.inputPatternIncludes.getValue().trim();
+		const includesUsePattern = this.inputPatternIncludes.isGlobPattern();
+		const useIgnoreFiles = this.inputPatternExclusions.useIgnoreFiles();
+
+		// store memento
+		this.viewletSettings['query.contentPattern'] = contentPattern;
+		this.viewletSettings['query.regex'] = isRegex;
+		this.viewletSettings['query.wholeWords'] = isWholeWords;
+		this.viewletSettings['query.caseSensitive'] = isCaseSensitive;
+		this.viewletSettings['query.folderExclusions'] = patternExcludes;
+		this.viewletSettings['query.exclusionsUsePattern'] = exclusionsUsePattern;
+		this.viewletSettings['query.folderIncludes'] = patternIncludes;
+		this.viewletSettings['query.includesUsePattern'] = includesUsePattern;
+		this.viewletSettings['query.useIgnoreFiles'] = useIgnoreFiles;
+		this.viewletSettings['query.contentPattern'] = contentPattern;
 
 		super.shutdown();
 	}

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -1349,6 +1349,13 @@ export class SearchViewlet extends Viewlet {
 		];
 	}
 
+	public shutdown(): void {
+		this.viewletSettings['query.contentPattern'] = this.searchWidget.searchInput.getValue();
+		this.saveMemento();
+
+		super.shutdown();
+	}
+
 	public dispose(): void {
 		this.isDisposed = true;
 


### PR DESCRIPTION
- Search now remembers if you cleared your input before shutdown

Right now, mementos are changed when the query changes. This means that when someone erases the search input and immediately closes/reloads, the text is persisted anyways. One way to fix it is to change and save the memento only when the user closes/reloads vscode. However, I wasn't sure if this new behaviour is okay. What are your thoughts? If this is fine, then can we move all the memento's into `shutdown()`?

Also, it looks like the search viewlet's `dispose()` is not being called. Is this expected behaviour?