### PR TITLE
Add "Open to the Side" action to editor tab context menu.

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -9,7 +9,7 @@ import nls = require('vs/nls');
 import { Action } from 'vs/base/common/actions';
 import { mixin } from 'vs/base/common/objects';
 import { getCodeEditor } from 'vs/editor/common/services/codeEditorService';
-import { EditorInput, hasResource, TextEditorOptions, EditorOptions, IEditorIdentifier, IEditorContext, ActiveEditorMoveArguments, ActiveEditorMovePositioning, EditorCommands, ConfirmResult } from 'vs/workbench/common/editor';
+import { EditorInput, hasResource, TextEditorOptions, EditorOptions, IEditorIdentifier, IEditorContext, ActiveEditorMoveArguments, ActiveEditorMovePositioning, EditorCommands, ConfirmResult, toResource } from 'vs/workbench/common/editor';
 import { QuickOpenEntryGroup } from 'vs/base/parts/quickopen/browser/quickOpenModel';
 import { EditorQuickOpenEntry, EditorQuickOpenEntryGroup, IEditorQuickOpenEntry, QuickOpenAction } from 'vs/workbench/browser/quickopen';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -474,6 +474,35 @@ export class FocusNextGroup extends Action {
 		}
 
 		return TPromise.as(true);
+	}
+}
+
+// Open to the side
+export class OpenToSideContextAction extends Action {
+
+	public static ID = 'explorer.openToSide';
+	public static LABEL = nls.localize('openToSide', "Open to the Side");
+
+	constructor(
+		id: string,
+		label: string,
+		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
+		@IEditorGroupService private editorGroupService: IEditorGroupService
+	) {
+		super(id, label, 'split-editor-action');
+
+	}
+
+	public run(context: any): TPromise<any> {
+		const sideBySide = true;
+		const editor = getTarget(this.editorService, this.editorGroupService, context);
+
+		if (editor) {
+			const fileResource = toResource(editor.input, { filter: 'file' });
+			return this.editorService.openEditor({ resource: fileResource }, sideBySide);
+		}
+
+		return TPromise.as(false);
 	}
 }
 

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -480,7 +480,7 @@ export class FocusNextGroup extends Action {
 // Open to the side
 export class OpenToSideContextAction extends Action {
 
-	public static ID = 'explorer.openToSide';
+	public static ID = 'workbench.action.openToSideContext';
 	public static LABEL = nls.localize('openToSide', "Open to the Side");
 
 	constructor(

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -32,7 +32,7 @@ import { IQuickOpenService } from 'vs/platform/quickOpen/common/quickOpen';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResolvedKeybinding } from 'vs/base/common/keyCodes';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { CloseEditorsInGroupAction, SplitEditorAction, CloseEditorAction, KeepEditorAction, CloseOtherEditorsInGroupAction, CloseRightEditorsInGroupAction, ShowEditorsInGroupAction } from 'vs/workbench/browser/parts/editor/editorActions';
+import { CloseEditorsInGroupAction, SplitEditorAction, CloseEditorAction, KeepEditorAction, CloseOtherEditorsInGroupAction, CloseRightEditorsInGroupAction, ShowEditorsInGroupAction, OpenToSideContextAction } from 'vs/workbench/browser/parts/editor/editorActions';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { createActionItem, fillInActions } from 'vs/platform/actions/browser/menuItemActionItem';
 import { IMenuService, MenuId, IMenu, ExecuteCommandAction } from 'vs/platform/actions/common/actions';
@@ -68,6 +68,7 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 	protected dragged: boolean;
 
 	protected closeEditorAction: CloseEditorAction;
+	protected openToSideContextAction: OpenToSideContextAction;
 	protected pinEditorAction: KeepEditorAction;
 	protected closeOtherEditorsAction: CloseOtherEditorsInGroupAction;
 	protected closeRightEditorsAction: CloseRightEditorsInGroupAction;
@@ -227,6 +228,7 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 		this.closeEditorAction = services.createInstance(CloseEditorAction, CloseEditorAction.ID, nls.localize('close', "Close"));
 		this.closeOtherEditorsAction = services.createInstance(CloseOtherEditorsInGroupAction, CloseOtherEditorsInGroupAction.ID, nls.localize('closeOthers', "Close Others"));
 		this.closeRightEditorsAction = services.createInstance(CloseRightEditorsInGroupAction, CloseRightEditorsInGroupAction.ID, nls.localize('closeRight', "Close to the Right"));
+		this.openToSideContextAction = services.createInstance(OpenToSideContextAction, OpenToSideContextAction.ID, OpenToSideContextAction.LABEL);
 		this.closeEditorsInGroupAction = services.createInstance(CloseEditorsInGroupAction, CloseEditorsInGroupAction.ID, nls.localize('closeAll', "Close All"));
 		this.pinEditorAction = services.createInstance(KeepEditorAction, KeepEditorAction.ID, nls.localize('keepOpen', "Keep Open"));
 		this.showEditorsInGroupAction = services.createInstance(ShowEditorsInGroupAction, ShowEditorsInGroupAction.ID, nls.localize('showOpenedEditors', "Show Opened Editors"));
@@ -423,16 +425,18 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 
 	protected getContextMenuActions(identifier: IEditorIdentifier): IAction[] {
 		const { editor, group } = identifier;
+		const splitGroups = this.editorGroupService['stacks'].groups;
 
 		// Enablement
 		this.closeOtherEditorsAction.enabled = group.count > 1;
 		this.pinEditorAction.enabled = !group.isPinned(editor);
 		this.closeRightEditorsAction.enabled = group.indexOf(editor) !== group.count - 1;
+		this.openToSideContextAction.enabled = (splitGroups.length < 3);
 
 		// Actions: For all editors
 		const actions: IAction[] = [
 			this.closeEditorAction,
-			this.closeOtherEditorsAction
+			this.closeOtherEditorsAction,
 		];
 		const tabOptions = this.editorGroupService.getTabOptions();
 
@@ -448,6 +452,7 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 
 		// Fill in contributed actions
 		fillInActions(this.contextMenu, { arg: this.resourceContext.get() }, actions);
+		actions.push(this.openToSideContextAction);
 
 		return actions;
 	}
@@ -457,6 +462,7 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 
 		// Actions
 		[
+			this.openToSideContextAction,
 			this.splitEditorAction,
 			this.showEditorsInGroupAction,
 			this.closeEditorAction,

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -39,6 +39,8 @@ import { IMenuService, MenuId, IMenu, ExecuteCommandAction } from 'vs/platform/a
 import { ResourceContextKey } from 'vs/workbench/common/resourceContextKey';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { Themable } from 'vs/workbench/common/theme';
+import { Position } from 'vs/platform/editor/common/editor';
+
 
 export interface IToolbarActions {
 	primary: IAction[];
@@ -425,13 +427,13 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 
 	protected getContextMenuActions(identifier: IEditorIdentifier): IAction[] {
 		const { editor, group } = identifier;
-		const splitGroups = this.editorGroupService['stacks'].groups;
+		const activeEditor = this.editorService.getActiveEditor();
 
 		// Enablement
 		this.closeOtherEditorsAction.enabled = group.count > 1;
 		this.pinEditorAction.enabled = !group.isPinned(editor);
 		this.closeRightEditorsAction.enabled = group.indexOf(editor) !== group.count - 1;
-		this.openToSideContextAction.enabled = (splitGroups.length < 3);
+		this.openToSideContextAction.enabled = (!activeEditor || activeEditor.position !== Position.THREE);
 
 		// Actions: For all editors
 		const actions: IAction[] = [

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -438,7 +438,7 @@ export abstract class TitleControl extends Themable implements ITitleAreaControl
 		// Actions: For all editors
 		const actions: IAction[] = [
 			this.closeEditorAction,
-			this.closeOtherEditorsAction,
+			this.closeOtherEditorsAction
 		];
 		const tabOptions = this.editorGroupService.getTabOptions();
 


### PR DESCRIPTION
This implements feature-request #26966

This adds the missing "Open to the Side" option to the right click context menu on editor tabs. It is offered as the last choice in the menu which makes it easy to see, and also makes sense IMO considering it's the first choice in the folder browser right click context menu.

![vscode_opentoside](https://cloud.githubusercontent.com/assets/19689932/26223684/8b9fc8d8-3bf5-11e7-9c6f-38a9c34f40c8.gif)

Hope it can be useful.

Cheers.

edit: feature-request link