### PR TITLE
Use Tahoma font as a fallback for system-ui

### DIFF
--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -143,7 +143,7 @@
 				},
 				"markdown.preview.fontFamily": {
 					"type": "string",
-					"default": "system-ui",
+					"default": "system-ui, 'Segoe WPC', 'Segoe UI', 'HelveticaNeue-Light', 'Ubuntu', 'Droid Sans', sans-serif",
 					"description": "%markdown.preview.fontFamily.desc%"
 				},
 				"markdown.preview.fontSize": {

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -15,7 +15,7 @@
 
 /* Font Families (with CJK support) */
 
-.monaco-shell { font-family: system-ui; }
+.monaco-shell { font-family: system-ui, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif; }
 .monaco-shell:lang(zh-Hans) { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Noto Sans", "Microsoft YaHei", "PingFang SC", "Hiragino Sans GB", "Source Han Sans SC", "Source Han Sans CN", "Source Han Sans", sans-serif; }
 .monaco-shell:lang(zh-Hant) { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Noto Sans", "Microsoft Jhenghei", "PingFang TC", "Source Han Sans TC", "Source Han Sans", "Source Han Sans TW", sans-serif; }
 .monaco-shell:lang(ja) { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Noto Sans", "Meiryo", "Hiragino Kaku Gothic Pro", "Source Han Sans J", "Source Han Sans JP", "Source Han Sans", "Sazanami Gothic", "IPA Gothic", sans-serif; }

--- a/src/vs/workbench/parts/terminal/electron-browser/media/widgets.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/widgets.css
@@ -12,7 +12,7 @@
 }
 
 .monaco-workbench .terminal-message-widget {
-	font-family: system-ui;
+	font-family: system-ui, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif;
 	font-size: 14px;
 	line-height: 19px;
 	padding: 4px 5px;


### PR DESCRIPTION
Workaround for:
https://bugs.chromium.org/p/chromium/issues/detail?id=724393