### PR TITLE
Add more tests to PHP grammar

### DIFF
--- a/extensions/php/test/colorize-fixtures/test.php
+++ b/extensions/php/test/colorize-fixtures/test.php
@@ -40,6 +40,8 @@
 		print("Uncut Point: <strong>$deck[$index]</strong> ");
 		$starting_point++;
 	}
+
+	function foo bar(){}
 ?>
 
 </body>

--- a/extensions/php/test/colorize-results/test_php.json
+++ b/extensions/php/test/colorize-results/test_php.json
@@ -3274,7 +3274,7 @@
 			"light_plus": "entity.name.function: #795E26",
 			"dark_vs": "default: #D4D4D4",
 			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
+			"hc_black": "entity.name.function: #DCDCAA"
 		}
 	},
 	{

--- a/extensions/php/test/colorize-results/test_php.json
+++ b/extensions/php/test/colorize-results/test_php.json
@@ -3234,6 +3234,94 @@
 		}
 	},
 	{
+		"c": "\t",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "function",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php storage.type.function.php",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "foo bar",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php entity.name.function.php",
+		"r": {
+			"dark_plus": "entity.name.function: #DCDCAA",
+			"light_plus": "entity.name.function: #795E26",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "(",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php punctuation.definition.parameters.begin.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ")",
+		"t": "text.html.php meta.embedded.block.php source.php meta.function.php punctuation.definition.parameters.end.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{",
+		"t": "text.html.php meta.embedded.block.php source.php punctuation.section.scope.begin.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "text.html.php meta.embedded.block.php source.php punctuation.section.scope.end.php",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
 		"c": "?",
 		"t": "text.html.php meta.embedded.block.php punctuation.section.embedded.end.php source.php",
 		"r": {


### PR DESCRIPTION
Related to #26543 I added the tests to validate the new backported grammar from atom/language-php#196