### PR TITLE
Expose status bar debugging and no-folder foreground colors.

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -27,7 +27,7 @@ import { getCodeEditor } from 'vs/editor/common/services/codeEditorService';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { Action } from 'vs/base/common/actions';
 import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { STATUS_BAR_BACKGROUND, STATUS_BAR_FOREGROUND, STATUS_BAR_NO_FOLDER_BACKGROUND, STATUS_BAR_ITEM_HOVER_BACKGROUND, STATUS_BAR_ITEM_ACTIVE_BACKGROUND, STATUS_BAR_PROMINENT_ITEM_BACKGROUND, STATUS_BAR_PROMINENT_ITEM_HOVER_BACKGROUND } from 'vs/workbench/common/theme';
+import { STATUS_BAR_BACKGROUND, STATUS_BAR_FOREGROUND, STATUS_BAR_NO_FOLDER_BACKGROUND, STATUS_BAR_NO_FOLDER_FOREGROUND, STATUS_BAR_ITEM_HOVER_BACKGROUND, STATUS_BAR_ITEM_ACTIVE_BACKGROUND, STATUS_BAR_PROMINENT_ITEM_BACKGROUND, STATUS_BAR_PROMINENT_ITEM_HOVER_BACKGROUND } from 'vs/workbench/common/theme';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
 
@@ -136,7 +136,7 @@ export class StatusbarPart extends Part implements IStatusbarService {
 
 		const container = this.getContainer();
 
-		container.style('color', this.getColor(STATUS_BAR_FOREGROUND));
+		container.style('color', this.getColor(this.contextService.hasWorkspace() ? STATUS_BAR_FOREGROUND : STATUS_BAR_NO_FOLDER_FOREGROUND));
 		container.style('background-color', this.getColor(this.contextService.hasWorkspace() ? STATUS_BAR_BACKGROUND : STATUS_BAR_NO_FOLDER_BACKGROUND));
 
 		const contrastBorderColor = this.getColor(contrastBorder);

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -119,9 +119,9 @@ export const STATUS_BAR_FOREGROUND = registerColor('statusBar.foreground', {
 }, nls.localize('statusBarForeground', "Status bar foreground color. The status bar is shown in the bottom of the window."));
 
 export const STATUS_BAR_NO_FOLDER_FOREGROUND = registerColor('statusBar.noFolderForeground', {
-	dark: '#FFFFFF',
-	light: '#FFFFFF',
-	hc: '#FFFFFF'
+	dark: STATUS_BAR_FOREGROUND,
+	light: STATUS_BAR_FOREGROUND,
+	hc: STATUS_BAR_FOREGROUND
 }, nls.localize('statusBarNoFolderForeground', "Status bar foreground color when no folder is opened. The status bar is shown in the bottom of the window."));
 
 export const STATUS_BAR_BACKGROUND = registerColor('statusBar.background', {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -118,6 +118,12 @@ export const STATUS_BAR_FOREGROUND = registerColor('statusBar.foreground', {
 	hc: '#FFFFFF'
 }, nls.localize('statusBarForeground', "Status bar foreground color. The status bar is shown in the bottom of the window."));
 
+export const STATUS_BAR_NO_FOLDER_FOREGROUND = registerColor('statusBar.noFolderForeground', {
+	dark: '#FFFFFF',
+	light: '#FFFFFF',
+	hc: '#FFFFFF'
+}, nls.localize('statusBarNoFolderForeground', "Status bar foreground color when no folder is opened. The status bar is shown in the bottom of the window."));
+
 export const STATUS_BAR_BACKGROUND = registerColor('statusBar.background', {
 	dark: '#007ACC',
 	light: '#007ACC',

--- a/src/vs/workbench/parts/debug/electron-browser/statusbarColorProvider.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/statusbarColorProvider.ts
@@ -21,9 +21,9 @@ export const STATUS_BAR_DEBUGGING_BACKGROUND = registerColor('statusBar.debuggin
 }, localize('statusBarDebuggingBackground', "Status bar background color when a program is being debugged. The status bar is shown in the bottom of the window"));
 
 export const STATUS_BAR_DEBUGGING_FOREGROUND = registerColor('statusBar.debuggingForeground', {
-	dark: '#FFFFFF',
-	light: '#FFFFFF',
-	hc: '#FFFFFF'
+	dark: STATUS_BAR_FOREGROUND,
+	light: STATUS_BAR_FOREGROUND,
+	hc: STATUS_BAR_FOREGROUND
 }, localize('statusBarDebuggingForeground', "Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window"));
 
 export class StatusBarColorProvider extends Themable implements IWorkbenchContribution {

--- a/src/vs/workbench/parts/debug/electron-browser/statusbarColorProvider.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/statusbarColorProvider.ts
@@ -10,7 +10,7 @@ import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { IPartService, Parts } from 'vs/workbench/services/part/common/partService';
 import { IDebugService, State } from 'vs/workbench/parts/debug/common/debug';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { STATUS_BAR_NO_FOLDER_BACKGROUND, STATUS_BAR_BACKGROUND, Themable } from 'vs/workbench/common/theme';
+import { STATUS_BAR_NO_FOLDER_BACKGROUND, STATUS_BAR_BACKGROUND, STATUS_BAR_NO_FOLDER_FOREGROUND, STATUS_BAR_FOREGROUND, Themable } from 'vs/workbench/common/theme';
 
 // colors for theming
 
@@ -19,6 +19,12 @@ export const STATUS_BAR_DEBUGGING_BACKGROUND = registerColor('statusBar.debuggin
 	light: '#CC6633',
 	hc: '#CC6633'
 }, localize('statusBarDebuggingBackground', "Status bar background color when a program is being debugged. The status bar is shown in the bottom of the window"));
+
+export const STATUS_BAR_DEBUGGING_FOREGROUND = registerColor('statusBar.debuggingForeground', {
+	dark: '#FFFFFF',
+	light: '#FFFFFF',
+	hc: '#FFFFFF'
+}, localize('statusBarDebuggingForeground', "Status bar foreground color when a program is being debugged. The status bar is shown in the bottom of the window"));
 
 export class StatusBarColorProvider extends Themable implements IWorkbenchContribution {
 	private static ID = 'debug.statusbarColorProvider';
@@ -48,12 +54,12 @@ export class StatusBarColorProvider extends Themable implements IWorkbenchContri
 		if (this.partService.isVisible(Parts.STATUSBAR_PART)) {
 			const container = this.partService.getContainer(Parts.STATUSBAR_PART);
 			container.style.backgroundColor = this.getColor(this.getBackgroundColorKey());
+			container.style.color = this.getColor(this.getForegroundColorKey());
 		}
 	}
 
 	private getBackgroundColorKey(): string {
-
-		// no debugging
+		// Not debugging
 		if (this.debugService.state === State.Inactive || this.isRunningWithoutDebug()) {
 			if (this.contextService.hasWorkspace()) {
 				return STATUS_BAR_BACKGROUND;
@@ -62,8 +68,22 @@ export class StatusBarColorProvider extends Themable implements IWorkbenchContri
 			return STATUS_BAR_NO_FOLDER_BACKGROUND;
 		}
 
-		// debugging
+		// Debugging
 		return STATUS_BAR_DEBUGGING_BACKGROUND;
+	}
+
+	private getForegroundColorKey(): string {
+		// Not debugging
+		if (this.debugService.state === State.Inactive || this.isRunningWithoutDebug()) {
+			if (this.contextService.hasWorkspace()) {
+				return STATUS_BAR_FOREGROUND;
+			}
+
+			return STATUS_BAR_NO_FOLDER_FOREGROUND;
+		}
+
+		// Debugging
+		return STATUS_BAR_DEBUGGING_FOREGROUND;
 	}
 
 	private isRunningWithoutDebug(): boolean {

--- a/src/vs/workbench/parts/debug/electron-browser/statusbarColorProvider.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/statusbarColorProvider.ts
@@ -53,37 +53,23 @@ export class StatusBarColorProvider extends Themable implements IWorkbenchContri
 
 		if (this.partService.isVisible(Parts.STATUSBAR_PART)) {
 			const container = this.partService.getContainer(Parts.STATUSBAR_PART);
-			container.style.backgroundColor = this.getColor(this.getBackgroundColorKey());
-			container.style.color = this.getColor(this.getForegroundColorKey());
+			container.style.backgroundColor = this.getColor(this.getColorKey(STATUS_BAR_NO_FOLDER_BACKGROUND, STATUS_BAR_DEBUGGING_BACKGROUND, STATUS_BAR_BACKGROUND));
+			container.style.color = this.getColor(this.getColorKey(STATUS_BAR_NO_FOLDER_FOREGROUND, STATUS_BAR_DEBUGGING_FOREGROUND, STATUS_BAR_FOREGROUND));
 		}
 	}
 
-	private getBackgroundColorKey(): string {
+	private getColorKey(noFolderColor: string, debuggingColor: string, normalColor: string): string {
 		// Not debugging
 		if (this.debugService.state === State.Inactive || this.isRunningWithoutDebug()) {
 			if (this.contextService.hasWorkspace()) {
-				return STATUS_BAR_BACKGROUND;
+				return normalColor;
 			}
 
-			return STATUS_BAR_NO_FOLDER_BACKGROUND;
+			return noFolderColor;
 		}
 
 		// Debugging
-		return STATUS_BAR_DEBUGGING_BACKGROUND;
-	}
-
-	private getForegroundColorKey(): string {
-		// Not debugging
-		if (this.debugService.state === State.Inactive || this.isRunningWithoutDebug()) {
-			if (this.contextService.hasWorkspace()) {
-				return STATUS_BAR_FOREGROUND;
-			}
-
-			return STATUS_BAR_NO_FOLDER_FOREGROUND;
-		}
-
-		// Debugging
-		return STATUS_BAR_DEBUGGING_FOREGROUND;
+		return debuggingColor;
 	}
 
 	private isRunningWithoutDebug(): boolean {


### PR DESCRIPTION
Just being able to change the foreground color may not be enough in cases where the background color is radically different.