### PR TITLE
GPG support 

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -678,6 +678,11 @@
           "type": "boolean",
           "description": "%config.enableSmartCommit%",
           "default": false
+        },
+        "git.enableCommitSigning": {
+          "type": "boolean",
+          "description": "%config.enableCommitSigning%",
+          "default": false
         }
       }
     }

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -44,5 +44,6 @@
 	"config.ignoreLegacyWarning": "Ignores the legacy Git warning",
 	"config.ignoreLimitWarning": "Ignores the warning when there are too many changes in a repository",
 	"config.defaultCloneDirectory": "The default location where to clone a git repository",
-	"config.enableSmartCommit": "Commit all changes when there are no staged changes."
+	"config.enableSmartCommit": "Commit all changes when there are no staged changes.",
+	"config.enableCommitSigning": "Enables commit signing with GPG."
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -600,6 +600,7 @@ export class CommandCenter {
 	): Promise<boolean> {
 		const config = workspace.getConfiguration('git');
 		const enableSmartCommit = config.get<boolean>('enableSmartCommit') === true;
+		const enableCommitSigning = config.get<boolean>('enableCommitSigning') === true;
 		const noStagedChanges = this.model.indexGroup.resources.length === 0;
 		const noUnstagedChanges = this.model.workingTreeGroup.resources.length === 0;
 
@@ -622,6 +623,9 @@ export class CommandCenter {
 		if (!opts) {
 			opts = { all: noStagedChanges };
 		}
+
+		// enable signing of commits if configurated
+		opts.signCommit = enableCommitSigning;
 
 		if (
 			// no changes

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -612,7 +612,7 @@ export class Repository {
 		}
 	}
 
-	async commit(message: string, opts: { all?: boolean, amend?: boolean, signoff?: boolean, signCommit?: boolean} = Object.create(null)): Promise<void> {
+	async commit(message: string, opts: { all?: boolean, amend?: boolean, signoff?: boolean, signCommit?: boolean } = Object.create(null)): Promise<void> {
 		const args = ['commit', '--quiet', '--allow-empty-message', '--file', '-'];
 
 		if (opts.all) {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -612,7 +612,7 @@ export class Repository {
 		}
 	}
 
-	async commit(message: string, opts: { all?: boolean, amend?: boolean, signoff?: boolean } = Object.create(null)): Promise<void> {
+	async commit(message: string, opts: { all?: boolean, amend?: boolean, signoff?: boolean, signCommit?: boolean} = Object.create(null)): Promise<void> {
 		const args = ['commit', '--quiet', '--allow-empty-message', '--file', '-'];
 
 		if (opts.all) {
@@ -625,6 +625,10 @@ export class Repository {
 
 		if (opts.signoff) {
 			args.push('--signoff');
+		}
+
+		if (opts.signCommit) {
+			args.push('-S');
 		}
 
 		try {

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -290,6 +290,7 @@ export interface CommitOptions {
 	all?: boolean;
 	amend?: boolean;
 	signoff?: boolean;
+	signCommit?: boolean;
 }
 
 export class Model implements Disposable {


### PR DESCRIPTION
Hello Added GPG support

Closes #5065 

I have added a new Git Config `git.enableCommitSigning` that will tell vscode `smartCommit` to pass the `-S` flag to git. This way all commits menu items, UI commit features will take advantage of this.

You still need to set the git up to signing which can be found here: https://help.github.com/articles/signing-commits-using-gpg/

What will *not* take advantage is if someone uses the terminal to commit (that they will need pass the `-S` themselves)

I have made all changes that I can tell are needed.

If there is anything missing please let me know and I will make changes.

Please note that I didn't find any git tests in the extension.