### PR TITLE
Fix 27195 - Json colorization of /**/

### DIFF
--- a/extensions/json/syntaxes/JSON.tmLanguage
+++ b/extensions/json/syntaxes/JSON.tmLanguage
@@ -98,7 +98,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>/\*\*</string>
+					<string>/\*\*(?!/)</string>
 					<key>captures</key>
 					<dict>
 						<key>0</key>


### PR DESCRIPTION
Make sure we handle the case of `/**/` properly in json files. Fix is to make sure we don't match `/**` the start of documentation if followed by a `/`

Fixes #27195