### PR TITLE
[WIP] Add leading commas json formatting option

### DIFF
--- a/src/vs/base/common/jsonFormatter.ts
+++ b/src/vs/base/common/jsonFormatter.ts
@@ -79,9 +79,17 @@ export function format(documentText: string, range: { offset: number, length: nu
 
 	let scanner = Json.createScanner(value, false);
 
+	/**
+	 * Utility function to add a newline character and indent with the options
+	 * given.
+	 */
 	function newLineAndIndent(): string {
 		return eol + repeat(indentValue, initialIndentLevel + indentLevel);
 	}
+
+	/**
+	 * Get the next token from scanner
+	 */
 	function scanNext(): Json.SyntaxKind {
 		let token = scanner.scan();
 		lineBreak = false;
@@ -91,6 +99,7 @@ export function format(documentText: string, range: { offset: number, length: nu
 		}
 		return token;
 	}
+
 	let editOperations: Edit[] = [];
 	function addEdit(text: string, startOffset: number, endOffset: number) {
 		if (documentText.substring(startOffset, endOffset) !== text) {
@@ -98,6 +107,9 @@ export function format(documentText: string, range: { offset: number, length: nu
 		}
 	}
 
+	/**
+	 * Add the initial indent
+	 */
 	let firstToken = scanNext();
 	if (firstToken !== Json.SyntaxKind.EOF) {
 		let firstTokenStart = scanner.getTokenOffset() + rangeStart;
@@ -105,7 +117,15 @@ export function format(documentText: string, range: { offset: number, length: nu
 		addEdit(initialIndent, rangeStart, firstTokenStart);
 	}
 
+	/**
+	 * Loop through the tokens from scanner until we reach the end of file (EOF)
+	 * token.
+	 */
 	while (firstToken !== Json.SyntaxKind.EOF) {
+		/**
+		 * Within this loop `firstToken` is the "current" token we are looking at
+		 * and `secondToken` is the one following.
+		 */
 		let firstTokenEnd = scanner.getTokenOffset() + scanner.getTokenLength() + rangeStart;
 		let secondToken = scanNext();
 
@@ -214,6 +234,13 @@ function computeIndentLevel(content: string, offset: number, options: Formatting
 	return Math.floor(nChars / tabSize);
 }
 
+/**
+ * Get the newline character to use.
+ *
+ * Analyzes the text given for popular newline characters and uses those if
+ * found, falling back to the character given in `options.eol` and finally
+ * defaulting to the `\n` character.
+ */
 function getEOL(options: FormattingOptions, text: string): string {
 	for (let i = 0; i < text.length; i++) {
 		let ch = text.charAt(i);
@@ -229,6 +256,9 @@ function getEOL(options: FormattingOptions, text: string): string {
 	return (options && options.eol) || '\n';
 }
 
+/**
+ * Check if character at a given position is a newlint character.
+ */
 function isEOL(text: string, offset: number) {
 	return '\r\n'.indexOf(text.charAt(offset)) !== -1;
 }

--- a/src/vs/base/common/jsonFormatter.ts
+++ b/src/vs/base/common/jsonFormatter.ts
@@ -19,6 +19,10 @@ export interface FormattingOptions {
 	 * The default end of line line character
 	 */
 	eol: string;
+	/**
+	 * Format lines with leading commas?
+	 */
+	leadingCommas: boolean;
 }
 
 export interface Edit {
@@ -129,12 +133,20 @@ export function format(documentText: string, range: { offset: number, length: nu
 			switch (firstToken) {
 				case Json.SyntaxKind.OpenBracketToken:
 				case Json.SyntaxKind.OpenBraceToken:
-					indentLevel++;
-					replaceContent = newLineAndIndent();
+					if (!options.leadingCommas) {
+						indentLevel++;
+						replaceContent = newLineAndIndent();
+					} else {
+						replaceContent = ' ';
+					}
 					break;
 				case Json.SyntaxKind.CommaToken:
 				case Json.SyntaxKind.LineCommentTrivia:
-					replaceContent = newLineAndIndent();
+					if (!options.leadingCommas) {
+						replaceContent = newLineAndIndent();
+					} else {
+						replaceContent = ' ';
+					}
 					break;
 				case Json.SyntaxKind.BlockCommentTrivia:
 					if (lineBreak) {
@@ -151,8 +163,16 @@ export function format(documentText: string, range: { offset: number, length: nu
 				case Json.SyntaxKind.TrueKeyword:
 				case Json.SyntaxKind.FalseKeyword:
 				case Json.SyntaxKind.NumericLiteral:
+					if (options.leadingCommas) {
+						replaceContent = newLineAndIndent();
+					}
 					if (secondToken === Json.SyntaxKind.NullKeyword || secondToken === Json.SyntaxKind.FalseKeyword || secondToken === Json.SyntaxKind.NumericLiteral) {
 						replaceContent = ' ';
+					}
+					break;
+				case Json.SyntaxKind.StringLiteral:
+					if (options.leadingCommas) {
+						replaceContent = newLineAndIndent();
 					}
 					break;
 			}

--- a/src/vs/base/test/common/jsonEdit.test.ts
+++ b/src/vs/base/test/common/jsonEdit.test.ts
@@ -26,6 +26,7 @@ suite('JSON - edits', () => {
 
 	let formatterOptions: FormattingOptions = {
 		insertSpaces: true,
+		leadingCommas: false,
 		tabSize: 2,
 		eol: '\n'
 	};

--- a/src/vs/base/test/common/jsonFormatter.test.ts
+++ b/src/vs/base/test/common/jsonFormatter.test.ts
@@ -9,7 +9,7 @@ import assert = require('assert');
 
 suite('JSON - formatter', () => {
 
-	function format(content: string, expected: string, insertSpaces = true) {
+	function format(content: string, expected: string, insertSpaces = true, leadingCommas = false) {
 		let range = void 0;
 		var rangeStart = content.indexOf('|');
 		var rangeEnd = content.lastIndexOf('|');
@@ -18,7 +18,7 @@ suite('JSON - formatter', () => {
 			range = { offset: rangeStart, length: rangeEnd - rangeStart };
 		}
 
-		var edits = Formatter.format(content, range, { tabSize: 2, insertSpaces: insertSpaces, eol: '\n' });
+		var edits = Formatter.format(content, range, { tabSize: 2, insertSpaces: insertSpaces, eol: '\n', leadingCommas: leadingCommas });
 
 		let lastEditOffset = content.length;
 		for (let i = edits.length - 1; i >= 0; i--) {
@@ -439,5 +439,23 @@ suite('JSON - formatter', () => {
 		].join('\n');
 
 		format(content, expected);
+	});
+	test('leading comma if option is set', () => {
+		var content = [
+			'{',
+			' a: null,',
+			' b: "foo",',
+			' c: null',
+			'}'
+		].join('\n');
+
+		var expected = [
+			'{ a: null',
+			', b: "foo"',
+			', c: null',
+			'}'
+		].join('\n');
+
+		format(content, expected, true, true);
 	});
 });

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -229,6 +229,11 @@ const editorConfiguration: IConfigurationNode = {
 			'description': nls.localize('insertSpaces', "Insert spaces when pressing Tab. This setting is overriden based on the file contents when `editor.detectIndentation` is on."),
 			'errorMessage': nls.localize('insertSpaces.errorMessage', "Expected 'boolean'. Note that the value \"auto\" has been replaced by the `editor.detectIndentation` setting.")
 		},
+		'editor.leadingCommas': {
+			'type': 'boolean',
+			'default': EDITOR_MODEL_DEFAULTS.leadingCommas,
+			'description': nls.localize('leadingCommas', "Put commas before each line as opposed to after each line.")
+		},
 		'editor.detectIndentation': {
 			'type': 'boolean',
 			'default': EDITOR_MODEL_DEFAULTS.detectIndentation,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1997,7 +1997,8 @@ export const EDITOR_MODEL_DEFAULTS = {
 	tabSize: 4,
 	insertSpaces: true,
 	detectIndentation: true,
-	trimAutoWhitespace: true
+	trimAutoWhitespace: true,
+	leadingCommas: false
 };
 
 /**

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -425,6 +425,7 @@ export class TextModelResolvedOptions {
 	readonly insertSpaces: boolean;
 	readonly defaultEOL: DefaultEndOfLine;
 	readonly trimAutoWhitespace: boolean;
+	readonly leadingCommas: boolean;
 
 	/**
 	 * @internal
@@ -434,11 +435,13 @@ export class TextModelResolvedOptions {
 		insertSpaces: boolean;
 		defaultEOL: DefaultEndOfLine;
 		trimAutoWhitespace: boolean;
+		leadingCommas: boolean;
 	}) {
 		this.tabSize = src.tabSize | 0;
 		this.insertSpaces = Boolean(src.insertSpaces);
 		this.defaultEOL = src.defaultEOL | 0;
 		this.trimAutoWhitespace = Boolean(src.trimAutoWhitespace);
+		this.leadingCommas = Boolean(src.leadingCommas);
 	}
 
 	/**
@@ -450,6 +453,7 @@ export class TextModelResolvedOptions {
 			&& this.insertSpaces === other.insertSpaces
 			&& this.defaultEOL === other.defaultEOL
 			&& this.trimAutoWhitespace === other.trimAutoWhitespace
+			&& this.leadingCommas === other.leadingCommas
 		);
 	}
 
@@ -461,6 +465,7 @@ export class TextModelResolvedOptions {
 			tabSize: this.tabSize !== newOpts.tabSize,
 			insertSpaces: this.insertSpaces !== newOpts.insertSpaces,
 			trimAutoWhitespace: this.trimAutoWhitespace !== newOpts.trimAutoWhitespace,
+			leadingCommas: this.leadingCommas !== newOpts.leadingCommas
 		};
 	}
 }
@@ -474,12 +479,14 @@ export interface ITextModelCreationOptions {
 	detectIndentation: boolean;
 	trimAutoWhitespace: boolean;
 	defaultEOL: DefaultEndOfLine;
+	leadingCommas: boolean;
 }
 
 export interface ITextModelUpdateOptions {
 	tabSize?: number;
 	insertSpaces?: boolean;
 	trimAutoWhitespace?: boolean;
+	leadingCommas?: boolean;
 }
 
 /**

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -37,6 +37,7 @@ export class TextModel implements editorCommon.ITextModel {
 		detectIndentation: false,
 		defaultEOL: editorCommon.DefaultEndOfLine.LF,
 		trimAutoWhitespace: EDITOR_MODEL_DEFAULTS.trimAutoWhitespace,
+		leadingCommas: EDITOR_MODEL_DEFAULTS.leadingCommas,
 	};
 
 	public static createFromString(text: string, options: editorCommon.ITextModelCreationOptions = TextModel.DEFAULT_CREATION_OPTIONS): TextModel {
@@ -53,14 +54,16 @@ export class TextModel implements editorCommon.ITextModel {
 				tabSize: guessedIndentation.tabSize,
 				insertSpaces: guessedIndentation.insertSpaces,
 				trimAutoWhitespace: options.trimAutoWhitespace,
-				defaultEOL: options.defaultEOL
+				defaultEOL: options.defaultEOL,
+				leadingCommas: options.leadingCommas
 			});
 		} else {
 			resolvedOpts = new editorCommon.TextModelResolvedOptions({
 				tabSize: options.tabSize,
 				insertSpaces: options.insertSpaces,
 				trimAutoWhitespace: options.trimAutoWhitespace,
-				defaultEOL: options.defaultEOL
+				defaultEOL: options.defaultEOL,
+				leadingCommas: options.leadingCommas,
 			});
 		}
 
@@ -137,12 +140,14 @@ export class TextModel implements editorCommon.ITextModel {
 		let tabSize = (typeof _newOpts.tabSize !== 'undefined') ? _newOpts.tabSize : this._options.tabSize;
 		let insertSpaces = (typeof _newOpts.insertSpaces !== 'undefined') ? _newOpts.insertSpaces : this._options.insertSpaces;
 		let trimAutoWhitespace = (typeof _newOpts.trimAutoWhitespace !== 'undefined') ? _newOpts.trimAutoWhitespace : this._options.trimAutoWhitespace;
+		let leadingCommas = (typeof _newOpts.leadingCommas !== 'undefined') ? _newOpts.leadingCommas : this._options.leadingCommas;
 
 		let newOpts = new editorCommon.TextModelResolvedOptions({
 			tabSize: tabSize,
 			insertSpaces: insertSpaces,
 			defaultEOL: this._options.defaultEOL,
-			trimAutoWhitespace: trimAutoWhitespace
+			trimAutoWhitespace: trimAutoWhitespace,
+			leadingCommas: leadingCommas
 		});
 
 		if (this._options.equals(newOpts)) {

--- a/src/vs/editor/common/model/textModelEvents.ts
+++ b/src/vs/editor/common/model/textModelEvents.ts
@@ -115,6 +115,7 @@ export interface IModelOptionsChangedEvent {
 	readonly tabSize: boolean;
 	readonly insertSpaces: boolean;
 	readonly trimAutoWhitespace: boolean;
+	readonly leadingCommas: boolean;
 }
 
 /**

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -177,6 +177,7 @@ interface IRawConfig {
 		insertSpaces?: any;
 		detectIndentation?: any;
 		trimAutoWhitespace?: any;
+		leadingCommas?: any;
 	};
 }
 
@@ -255,12 +256,18 @@ export class ModelServiceImpl implements IModelService {
 			detectIndentation = (config.editor.detectIndentation === 'false' ? false : Boolean(config.editor.detectIndentation));
 		}
 
+		let leadingCommas = EDITOR_MODEL_DEFAULTS.leadingCommas;
+		if (config.editor && typeof config.editor.leadingCommas !== 'undefined') {
+			insertSpaces = (config.editor.leadingCommas === 'false' ? false : Boolean(config.editor.leadingCommas));
+		}
+
 		return {
 			tabSize: tabSize,
 			insertSpaces: insertSpaces,
 			detectIndentation: detectIndentation,
 			defaultEOL: newDefaultEOL,
-			trimAutoWhitespace: trimAutoWhitespace
+			trimAutoWhitespace: trimAutoWhitespace,
+			leadingCommas: leadingCommas
 		};
 	}
 

--- a/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
@@ -586,7 +586,8 @@ suite('Editor Contrib - Line Operations', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 

--- a/src/vs/editor/test/common/controller/cursor.test.ts
+++ b/src/vs/editor/test/common/controller/cursor.test.ts
@@ -1141,7 +1141,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: false
+				trimAutoWhitespace: false,
+				leadingCommas: false
 			},
 		);
 
@@ -1211,7 +1212,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			mode.getLanguageIdentifier()
 		);
@@ -1244,7 +1246,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			mode.getLanguageIdentifier()
 		);
@@ -1278,7 +1281,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			mode.getLanguageIdentifier()
 		);
@@ -1311,7 +1315,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			mode.getLanguageIdentifier()
 		);
@@ -1344,7 +1349,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			mode.getLanguageIdentifier()
 		);
@@ -1372,7 +1378,8 @@ suite('Editor Controller - Regression tests', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			mode.getLanguageIdentifier()
 		);
@@ -1400,7 +1407,8 @@ suite('Editor Controller - Regression tests', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -1432,7 +1440,8 @@ suite('Editor Controller - Regression tests', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 		);
 
@@ -1493,7 +1502,7 @@ suite('Editor Controller - Regression tests', () => {
 				'hello'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { tabSize: 4, insertSpaces: true, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { tabSize: 4, insertSpaces: true, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 3, false);
 			moveTo(cursor, 1, 5, true);
@@ -1521,7 +1530,8 @@ suite('Editor Controller - Regression tests', () => {
 				insertSpaces: true,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 		);
 
@@ -1570,7 +1580,8 @@ suite('Editor Controller - Regression tests', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -1617,7 +1628,7 @@ suite('Editor Controller - Regression tests', () => {
 				'just some text',
 			],
 			languageIdentifier: null,
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 3, 1, false);
 
@@ -1645,7 +1656,8 @@ suite('Editor Controller - Regression tests', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -1669,7 +1681,8 @@ suite('Editor Controller - Regression tests', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -1868,7 +1881,7 @@ suite('Editor Controller - Cursor Configuration', () => {
 				'',
 				'1'
 			],
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			CoreNavigationCommands.MoveTo.runCoreEditorCommand(cursor, { position: new Position(1, 21), source: 'keyboard' });
 			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
@@ -1891,7 +1904,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 13,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -1961,7 +1975,7 @@ suite('Editor Controller - Cursor Configuration', () => {
 				'\thello'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 7, false);
 			assertCursor(cursor, new Selection(1, 7, 1, 7));
@@ -1979,7 +1993,7 @@ suite('Editor Controller - Cursor Configuration', () => {
 				'\thello'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 7, false);
 			assertCursor(cursor, new Selection(1, 7, 1, 7));
@@ -1997,7 +2011,7 @@ suite('Editor Controller - Cursor Configuration', () => {
 				'\thell()'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 7, false);
 			assertCursor(cursor, new Selection(1, 7, 1, 7));
@@ -2018,7 +2032,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: false
+				trimAutoWhitespace: false,
+				leadingCommas: false
 			}
 		}, (model, cursor) => {
 
@@ -2046,7 +2061,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		}, (model, cursor) => {
 			moveTo(cursor, 1, model.getLineContent(1).length + 1);
@@ -2072,7 +2088,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			languageIdentifier: mode.getLanguageIdentifier(),
 		}, (model, cursor) => {
@@ -2120,7 +2137,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -2164,7 +2182,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -2230,7 +2249,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -2256,7 +2276,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				tabSize: 4,
 				detectIndentation: false,
 				defaultEOL: DefaultEndOfLine.LF,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -2327,7 +2348,8 @@ suite('Editor Controller - Cursor Configuration', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			}
 		);
 
@@ -2405,7 +2427,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\tif (true) {'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 12, false);
 			assertCursor(cursor, new Selection(1, 12, 1, 12));
@@ -2428,7 +2450,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\t}'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 2, 3, false);
 			assertCursor(cursor, new Selection(2, 3, 2, 3));
@@ -2446,7 +2468,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\t\t\treturn true'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 2, 15, false);
 			assertCursor(cursor, new Selection(2, 15, 2, 15));
@@ -2465,7 +2487,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\t\t\t\treturn true'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 2, 14, false);
 			assertCursor(cursor, new Selection(2, 14, 2, 14));
@@ -2490,7 +2512,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\t\t}}'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 4, 4, false);
 			assertCursor(cursor, new Selection(4, 4, 4, 4));
@@ -2510,7 +2532,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'}}'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 4, 2, false);
 			assertCursor(cursor, new Selection(4, 2, 4, 2));
@@ -2530,7 +2552,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\t\t}a}'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 4, 4, false);
 			moveTo(cursor, 4, 5, true);
@@ -2549,7 +2571,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\tif (true) {'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 2, 12, false);
 			moveTo(cursor, 2, 13, true);
@@ -2570,7 +2592,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\tif (true) {'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 12, false);
 			assertCursor(cursor, new Selection(1, 12, 1, 12));
@@ -2593,7 +2615,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'    if (true) {'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: true, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 12, false);
 			assertCursor(cursor, new Selection(1, 12, 1, 12));
@@ -2617,7 +2639,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'    if (true) {'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 1, 12, false);
 			assertCursor(cursor, new Selection(1, 12, 1, 12));
@@ -2645,7 +2667,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'\t}'
 			],
 			languageIdentifier: mode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 5, 4, false);
 			assertCursor(cursor, new Selection(5, 4, 5, 4));
@@ -2669,7 +2691,8 @@ suite('Editor Controller - Indentation Rules', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			languageIdentifier: mode.getLanguageIdentifier(),
 		}, (model, cursor) => {
@@ -2696,7 +2719,8 @@ suite('Editor Controller - Indentation Rules', () => {
 				detectIndentation: false,
 				insertSpaces: false,
 				tabSize: 4,
-				trimAutoWhitespace: true
+				trimAutoWhitespace: true,
+				leadingCommas: false
 			},
 			languageIdentifier: mode.getLanguageIdentifier(),
 		}, (model, cursor) => {
@@ -2721,7 +2745,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'?>'
 			],
 			languageIdentifier: emptyRulesMode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 5, 3, false);
 			assertCursor(cursor, new Selection(5, 3, 5, 3));
@@ -2741,7 +2765,7 @@ suite('Editor Controller - Indentation Rules', () => {
 				'	'
 			],
 			languageIdentifier: emptyRulesMode.getLanguageIdentifier(),
-			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true }
+			modelOpts: { insertSpaces: false, tabSize: 4, detectIndentation: false, defaultEOL: DefaultEndOfLine.LF, trimAutoWhitespace: true, leadingCommas: false }
 		}, (model, cursor) => {
 			moveTo(cursor, 3, 2, false);
 			assertCursor(cursor, new Selection(3, 2, 3, 2));

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -11,7 +11,7 @@ import { TextModel, ITextModelCreationData } from 'vs/editor/common/model/textMo
 import { DefaultEndOfLine, TextModelResolvedOptions } from 'vs/editor/common/editorCommon';
 import { RawTextSource } from 'vs/editor/common/model/textSource';
 
-function testGuessIndentation(defaultInsertSpaces: boolean, defaultTabSize: number, expectedInsertSpaces: boolean, expectedTabSize: number, text: string[], msg?: string): void {
+function testGuessIndentation(defaultInsertSpaces: boolean, defaultTabSize: number, expectedInsertSpaces: boolean, expectedTabSize: number, text: string[], msg?: string, ): void {
 	var m = TextModel.createFromString(
 		text.join('\n'),
 		{
@@ -19,7 +19,8 @@ function testGuessIndentation(defaultInsertSpaces: boolean, defaultTabSize: numb
 			insertSpaces: defaultInsertSpaces,
 			detectIndentation: true,
 			defaultEOL: DefaultEndOfLine.LF,
-			trimAutoWhitespace: true
+			trimAutoWhitespace: true,
+			leadingCommas: false
 		}
 	);
 	var r = m.getOptions();
@@ -80,6 +81,7 @@ suite('TextModelData.fromString', () => {
 				insertSpaces: true,
 				tabSize: 4,
 				trimAutoWhitespace: true,
+				leadingCommas: false
 			})
 		});
 	});
@@ -105,6 +107,7 @@ suite('TextModelData.fromString', () => {
 				insertSpaces: true,
 				tabSize: 4,
 				trimAutoWhitespace: true,
+				leadingCommas: false
 			})
 		});
 	});
@@ -127,6 +130,7 @@ suite('TextModelData.fromString', () => {
 				insertSpaces: true,
 				tabSize: 4,
 				trimAutoWhitespace: true,
+				leadingCommas: false
 			})
 		});
 	});
@@ -149,6 +153,7 @@ suite('TextModelData.fromString', () => {
 				insertSpaces: true,
 				tabSize: 4,
 				trimAutoWhitespace: true,
+				leadingCommas: false
 			})
 		});
 	});
@@ -171,6 +176,7 @@ suite('TextModelData.fromString', () => {
 				insertSpaces: true,
 				tabSize: 4,
 				trimAutoWhitespace: true,
+				leadingCommas: false,
 			})
 		});
 	});
@@ -739,7 +745,8 @@ suite('Editor Model - TextModel', () => {
 				tabSize: 4,
 				insertSpaces: false,
 				trimAutoWhitespace: true,
-				defaultEOL: DefaultEndOfLine.LF
+				defaultEOL: DefaultEndOfLine.LF,
+				leadingCommas: false
 			}
 		);
 
@@ -775,7 +782,8 @@ suite('Editor Model - TextModel', () => {
 				tabSize: 4,
 				insertSpaces: true,
 				trimAutoWhitespace: true,
-				defaultEOL: DefaultEndOfLine.LF
+				defaultEOL: DefaultEndOfLine.LF,
+				leadingCommas: false
 			}
 		);
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1390,12 +1390,14 @@ declare module monaco.editor {
 		readonly insertSpaces: boolean;
 		readonly defaultEOL: DefaultEndOfLine;
 		readonly trimAutoWhitespace: boolean;
+		readonly leadingCommas: boolean;
 	}
 
 	export interface ITextModelUpdateOptions {
 		tabSize?: number;
 		insertSpaces?: boolean;
 		trimAutoWhitespace?: boolean;
+		leadingCommas?: boolean;
 	}
 
 	/**
@@ -2484,6 +2486,7 @@ declare module monaco.editor {
 		readonly tabSize: boolean;
 		readonly insertSpaces: boolean;
 		readonly trimAutoWhitespace: boolean;
+		readonly leadingCommas: boolean;
 	}
 
 	/**

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -205,6 +205,7 @@ const configurationValueWhitelist = [
 	'editor.wordWrap',
 	'editor.wordWrapColumn',
 	'editor.insertSpaces',
+	'editor.leadingCommas',
 	'editor.renderIndentGuides',
 	'files.trimTrailingWhitespace',
 	'git.confirmSync',

--- a/src/vs/workbench/services/configuration/node/configurationEditingService.ts
+++ b/src/vs/workbench/services/configuration/node/configurationEditingService.ts
@@ -185,7 +185,7 @@ export class ConfigurationEditingService implements IConfigurationEditingService
 	}
 
 	private getEdits(model: editorCommon.IModel, edit: IConfigurationEditOperation): Edit[] {
-		const { tabSize, insertSpaces } = model.getOptions();
+		const { tabSize, insertSpaces, leadingCommas } = model.getOptions();
 		const eol = model.getEOL();
 		const { key, value, overrideIdentifier } = edit;
 
@@ -199,7 +199,7 @@ export class ConfigurationEditingService implements IConfigurationEditingService
 			}];
 		}
 
-		return setProperty(model.getValue(), overrideIdentifier ? [keyFromOverrideIdentifier(overrideIdentifier), key] : [key], value, { tabSize, insertSpaces, eol });
+		return setProperty(model.getValue(), overrideIdentifier ? [keyFromOverrideIdentifier(overrideIdentifier), key] : [key], value, { tabSize, insertSpaces, eol, leadingCommas });
 	}
 
 	private resolveModelReference(resource: URI): TPromise<IReference<ITextEditorModel>> {

--- a/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
@@ -113,56 +113,56 @@ export class KeybindingsEditingService extends Disposable implements IKeybinding
 	}
 
 	private updateUserKeybinding(newKey: string, keybindingItem: ResolvedKeybindingItem, model: editorCommon.IModel): void {
-		const { tabSize, insertSpaces } = model.getOptions();
+		const { tabSize, insertSpaces, leadingCommas } = model.getOptions();
 		const eol = model.getEOL();
 		const userKeybindingEntries = <IUserFriendlyKeybinding[]>json.parse(model.getValue());
 		const userKeybindingEntryIndex = this.findUserKeybindingEntryIndex(keybindingItem, userKeybindingEntries);
 		if (userKeybindingEntryIndex !== -1) {
-			this.applyEditsToBuffer(setProperty(model.getValue(), [userKeybindingEntryIndex, 'key'], newKey, { tabSize, insertSpaces, eol })[0], model);
+			this.applyEditsToBuffer(setProperty(model.getValue(), [userKeybindingEntryIndex, 'key'], newKey, { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 		}
 	}
 
 	private updateDefaultKeybinding(newKey: string, keybindingItem: ResolvedKeybindingItem, model: editorCommon.IModel): void {
-		const { tabSize, insertSpaces } = model.getOptions();
+		const { tabSize, insertSpaces, leadingCommas } = model.getOptions();
 		const eol = model.getEOL();
 		const userKeybindingEntries = <IUserFriendlyKeybinding[]>json.parse(model.getValue());
 		const userKeybindingEntryIndex = this.findUserKeybindingEntryIndex(keybindingItem, userKeybindingEntries);
 		if (userKeybindingEntryIndex !== -1) {
 			// Update the keybinding with new key
-			this.applyEditsToBuffer(setProperty(model.getValue(), [userKeybindingEntryIndex, 'key'], newKey, { tabSize, insertSpaces, eol })[0], model);
+			this.applyEditsToBuffer(setProperty(model.getValue(), [userKeybindingEntryIndex, 'key'], newKey, { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 		} else {
 			// Add the new keybinidng with new key
-			this.applyEditsToBuffer(setProperty(model.getValue(), [-1], this.asObject(newKey, keybindingItem.command, keybindingItem.when, false), { tabSize, insertSpaces, eol })[0], model);
+			this.applyEditsToBuffer(setProperty(model.getValue(), [-1], this.asObject(newKey, keybindingItem.command, keybindingItem.when, false), { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 		}
 		if (keybindingItem.resolvedKeybinding) {
 			// Unassign the default keybinding
-			this.applyEditsToBuffer(setProperty(model.getValue(), [-1], this.asObject(keybindingItem.resolvedKeybinding.getUserSettingsLabel(), keybindingItem.command, keybindingItem.when, true), { tabSize, insertSpaces, eol })[0], model);
+			this.applyEditsToBuffer(setProperty(model.getValue(), [-1], this.asObject(keybindingItem.resolvedKeybinding.getUserSettingsLabel(), keybindingItem.command, keybindingItem.when, true), { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 		}
 	}
 
 	private removeUserKeybinding(keybindingItem: ResolvedKeybindingItem, model: editorCommon.IModel): void {
-		const { tabSize, insertSpaces } = model.getOptions();
+		const { tabSize, insertSpaces, leadingCommas } = model.getOptions();
 		const eol = model.getEOL();
 		const userKeybindingEntries = <IUserFriendlyKeybinding[]>json.parse(model.getValue());
 		const userKeybindingEntryIndex = this.findUserKeybindingEntryIndex(keybindingItem, userKeybindingEntries);
 		if (userKeybindingEntryIndex !== -1) {
-			this.applyEditsToBuffer(setProperty(model.getValue(), [userKeybindingEntryIndex], void 0, { tabSize, insertSpaces, eol })[0], model);
+			this.applyEditsToBuffer(setProperty(model.getValue(), [userKeybindingEntryIndex], void 0, { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 		}
 	}
 
 	private removeDefaultKeybinding(keybindingItem: ResolvedKeybindingItem, model: editorCommon.IModel): void {
-		const { tabSize, insertSpaces } = model.getOptions();
+		const { tabSize, insertSpaces, leadingCommas } = model.getOptions();
 		const eol = model.getEOL();
-		this.applyEditsToBuffer(setProperty(model.getValue(), [-1], this.asObject(keybindingItem.resolvedKeybinding.getUserSettingsLabel(), keybindingItem.command, keybindingItem.when, true), { tabSize, insertSpaces, eol })[0], model);
+		this.applyEditsToBuffer(setProperty(model.getValue(), [-1], this.asObject(keybindingItem.resolvedKeybinding.getUserSettingsLabel(), keybindingItem.command, keybindingItem.when, true), { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 	}
 
 	private removeUnassignedDefaultKeybinding(keybindingItem: ResolvedKeybindingItem, model: editorCommon.IModel): void {
-		const { tabSize, insertSpaces } = model.getOptions();
+		const { tabSize, insertSpaces, leadingCommas } = model.getOptions();
 		const eol = model.getEOL();
 		const userKeybindingEntries = <IUserFriendlyKeybinding[]>json.parse(model.getValue());
 		const index = this.findUnassignedDefaultKeybindingEntryIndex(keybindingItem, userKeybindingEntries);
 		if (index !== -1) {
-			this.applyEditsToBuffer(setProperty(model.getValue(), [index], void 0, { tabSize, insertSpaces, eol })[0], model);
+			this.applyEditsToBuffer(setProperty(model.getValue(), [index], void 0, { tabSize, insertSpaces, eol, leadingCommas })[0], model);
 		}
 	}
 


### PR DESCRIPTION
👋 

I thought I'd try to see if I can add this feature. I have something that's working in the one test that I added and I got some questions so I figured I'd open up a PR early, maybe get some pointers on some stuff that I'm not sure how to add? Hope that's ok. I didn't think StackOverflow or Gitter was the best place to ask questions about the codebase.

### Feature description
By changing the key `editor.leadingCommas` to `true`, the JSON formatter will format documents with a leading comma like so:

```json
{ "a": null
, "b": null
, "c": null
,}
```

### Things I haven't figured out and am not sure where to ask 😬
- Show `editor.leadingCommas` in user/workspace settings. Not sure why this isn't showing up. I thought adding the key in [`commonEditorConfig.ts`](https://github.com/Microsoft/vscode/compare/master...koddsson:add-leading-commas-json-formatting-option?expand=1#diff-6728189afcd9d7e37ec62aa3e7e67056R232-R236) would do the trick but so far I can't see it when running `./scripts/code.sh`.
- Manually test to see this working. When running `./scripts/code.sh` I get a editor and I can see the code in the Developer Tools but I can't get my breakpoints to hit so I can debug why the formatter actually isn't working in the editor
![image](https://cloud.githubusercontent.com/assets/318208/26426777/04fd9b70-40d2-11e7-88c8-862505b3976f.png)
- Moving the settings key from `editor.leadingCommas` to something like `json.format.leadingCommas`? I figured I'd get this working first and then I can move it.
- Add more test cases. My one test case is maybe not enough to cover all the cases we wanna cover.

I hope this is cool and it's not just more noise for you maintainers 😺 