### PR TITLE
[WIP] Inline all decorations - attempt 2

### DIFF
--- a/src/vs/editor/contrib/gotoError/browser/gotoError.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoError.ts
@@ -222,7 +222,7 @@ class MarkerWidget implements IViewZone {
 
 	private _fillDomNode(): void {
 		this.domNode = document.createElement('div');
-		dom.addClass(this.domNode, 'zone-widget')
+		dom.addClass(this.domNode, 'zone-widget');
 
 		this._container = document.createElement('div');
 		dom.addClass(this._container, 'marker-widget');


### PR DESCRIPTION
This is follow up on https://github.com/Microsoft/vscode/pull/20042.
Original issue:  https://github.com/Microsoft/vscode/issues/19749

CC:  @jrieken

This is not ready yet, but I just would love to get some input whether I'm moving in right direction. 
Right now I'm just trying to replicate current behavior [without adding possibility to display all errors] but moving implementation to `IViewZone` as described in comments in original PR.