### PR TITLE
Add selection parameter to vscode.open command

### DIFF
--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -238,7 +238,7 @@ export class ExtHostApiCommands {
 				args: [
 					{ name: 'resource', description: 'Resource to open', constraint: URI },
 					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' },
-					{ name: 'selection', description: '(optional) The range to select in the opened document', constraint: types.Range },
+					{ name: 'selection', description: '(optional) The range to select in the opened document', constraint: v => v === void 0 || types.Range.isRange(v) },
 				]
 			});
 	}

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -231,13 +231,14 @@ export class ExtHostApiCommands {
 				]
 			});
 
-		this._register('vscode.open', (resource: URI, column: vscode.ViewColumn) => {
-			return this._commands.executeCommand('_workbench.open', [resource, typeConverters.fromViewColumn(column)]);
+		this._register('vscode.open', (resource: URI, column: vscode.ViewColumn, selection: types.Range) => {
+			return this._commands.executeCommand('_workbench.open', [resource, typeConverters.fromViewColumn(column), typeConverters.fromRange(selection)]);
 		}, {
 				description: 'Opens the provided resource in the editor. Can be a text or binary file, or a http(s) url',
 				args: [
 					{ name: 'resource', description: 'Resource to open', constraint: URI },
-					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' }
+					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' },
+					{ name: 'selection', description: '(optional) The range to select in the opened document', constraint: types.Range },
 				]
 			});
 	}

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -21,6 +21,7 @@ import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import URI from 'vs/base/common/uri';
 import { IEditorOptions, Position as EditorPosition } from 'vs/platform/editor/common/editor';
+import { IRange } from 'vs/editor/common/core/range';
 
 // --- List Commands
 
@@ -414,11 +415,11 @@ export function registerCommands(): void {
 		});
 	});
 
-	CommandsRegistry.registerCommand('_workbench.open', function (accessor: ServicesAccessor, args: [URI, number]) {
+	CommandsRegistry.registerCommand('_workbench.open', function (accessor: ServicesAccessor, args: [URI, number, IRange]) {
 		const editorService = accessor.get(IWorkbenchEditorService);
-		const [resource, column] = args;
+		const [resource, column, selection] = args;
 
-		return editorService.openEditor({ resource }, column).then(() => {
+		return editorService.openEditor({ resource, options: { selection } }, column).then(() => {
 			return void 0;
 		});
 	});


### PR DESCRIPTION
Allow extensions to specify text to select when opening a document via the vscode.open command.