### PR TITLE
Handle diff3-style merge correctly

### DIFF
--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -111,17 +111,26 @@ export default class CommandHandler implements vscode.Disposable {
 		}
 
 		let typeToAccept: interfaces.CommitType;
+		let tokenAfterCurrentBlock: vscode.Range = conflict.splitter;
+
+		if (conflict.commonAncestors !== null) {
+			tokenAfterCurrentBlock = conflict.commonAncestors.header;
+		}
 
 		// Figure out if the cursor is in current or incoming, we do this by seeing if
-		// the active position is before or after the range of the splitter. We can
-		// use this trick as the previous check in findConflictByActiveSelection will
-		// ensure it's within the conflict range, so we don't falsely identify "current"
-		// or "incoming" if outside of a conflict range.
-		if (editor.selection.active.isBefore(conflict.splitter.start)) {
+		// the active position is before or after the range of the splitter or common
+		// ancesors marker. We can use this trick as the previous check in
+		// findConflictByActiveSelection will ensure it's within the conflict range, so
+		// we don't falsely identify "current" or "incoming" if outside of a conflict range.
+		if (editor.selection.active.isBefore(tokenAfterCurrentBlock.start)) {
 			typeToAccept = interfaces.CommitType.Current;
 		}
 		else if (editor.selection.active.isAfter(conflict.splitter.end)) {
 			typeToAccept = interfaces.CommitType.Incoming;
+		}
+		else if (editor.selection.active.isBefore(conflict.splitter.start)) {
+			vscode.window.showWarningMessage(localize('cursorOnCommonAncestorsRange', 'Editor cursor is within the common ancestors block, please move it to either the "current" or "incoming" block'));
+			return;
 		}
 		else {
 			vscode.window.showWarningMessage(localize('cursorOnSplitterRange', 'Editor cursor is within the merge conflict splitter, please move it to either the "current" or "incoming" block'));

--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -113,8 +113,8 @@ export default class CommandHandler implements vscode.Disposable {
 		let typeToAccept: interfaces.CommitType;
 		let tokenAfterCurrentBlock: vscode.Range = conflict.splitter;
 
-		if (conflict.commonAncestors !== null) {
-			tokenAfterCurrentBlock = conflict.commonAncestors.header;
+		if (conflict.commonAncestors.length > 0) {
+			tokenAfterCurrentBlock = conflict.commonAncestors[0].header;
 		}
 
 		// Figure out if the cursor is in current or incoming, we do this by seeing if

--- a/extensions/merge-conflict/src/documentMergeConflict.ts
+++ b/extensions/merge-conflict/src/documentMergeConflict.ts
@@ -10,7 +10,7 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
 	public range: vscode.Range;
 	public current: interfaces.IMergeRegion;
 	public incoming: interfaces.IMergeRegion;
-	public commonAncestors: interfaces.IMergeRegion | null;
+	public commonAncestors: interfaces.IMergeRegion[];
 	public splitter: vscode.Range;
 
 	constructor(document: vscode.TextDocument, descriptor: interfaces.IDocumentMergeConflictDescriptor) {

--- a/extensions/merge-conflict/src/documentMergeConflict.ts
+++ b/extensions/merge-conflict/src/documentMergeConflict.ts
@@ -10,12 +10,14 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
 	public range: vscode.Range;
 	public current: interfaces.IMergeRegion;
 	public incoming: interfaces.IMergeRegion;
+	public commonAncestors: interfaces.IMergeRegion | null;
 	public splitter: vscode.Range;
 
 	constructor(document: vscode.TextDocument, descriptor: interfaces.IDocumentMergeConflictDescriptor) {
 		this.range = descriptor.range;
 		this.current = descriptor.current;
 		this.incoming = descriptor.incoming;
+		this.commonAncestors = descriptor.commonAncestors;
 		this.splitter = descriptor.splitter;
 	}
 

--- a/extensions/merge-conflict/src/interfaces.ts
+++ b/extensions/merge-conflict/src/interfaces.ts
@@ -32,7 +32,7 @@ export interface IDocumentMergeConflictDescriptor {
 	range: vscode.Range;
 	current: IMergeRegion;
 	incoming: IMergeRegion;
-	commonAncestors: IMergeRegion | null;
+	commonAncestors: IMergeRegion[];
 	splitter: vscode.Range;
 }
 

--- a/extensions/merge-conflict/src/interfaces.ts
+++ b/extensions/merge-conflict/src/interfaces.ts
@@ -32,6 +32,7 @@ export interface IDocumentMergeConflictDescriptor {
 	range: vscode.Range;
 	current: IMergeRegion;
 	incoming: IMergeRegion;
+	commonAncestors: IMergeRegion | null;
 	splitter: vscode.Range;
 }
 

--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -13,7 +13,7 @@ const endFooterMarker = '>>>>>>> ';
 
 interface IScanMergedConflict {
 	startHeader: vscode.TextLine;
-	commonAncestors: vscode.TextLine | null;
+	commonAncestors?: vscode.TextLine;
 	splitter?: vscode.TextLine;
 	endFooter?: vscode.TextLine;
 }
@@ -51,7 +51,7 @@ export class MergeConflictParser {
 				}
 
 				// Create a new conflict starting at this line
-				currentConflict = { startHeader: line, commonAncestors: null };
+				currentConflict = { startHeader: line };
 			}
 			// Are we within a conflict block and is this a common ancestors marker? |||||||
 			else if (currentConflict && !currentConflict.commonAncestors && line.text.startsWith(commonAncestorsMarker)) {
@@ -109,7 +109,7 @@ export class MergeConflictParser {
 					tokenAfterCurrentBlock.range.start),
 				name: scanned.startHeader.text.substring(startHeaderMarker.length)
 			},
-			commonAncestors: scanned.commonAncestors === null ? null : {
+			commonAncestors: scanned.commonAncestors ? {
 				header: scanned.commonAncestors.range,
 				decoratorContent: new vscode.Range(
 					scanned.commonAncestors.rangeIncludingLineBreak.end,
@@ -119,7 +119,7 @@ export class MergeConflictParser {
 					scanned.commonAncestors.rangeIncludingLineBreak.end,
 					scanned.splitter.range.start),
 				name: scanned.commonAncestors.text.substring(commonAncestorsMarker.length)
-			},
+			} : null,
 			splitter: scanned.splitter.range,
 			incoming: {
 				header: scanned.endFooter.range,

--- a/extensions/merge-conflict/src/mergeConflictParser.ts
+++ b/extensions/merge-conflict/src/mergeConflictParser.ts
@@ -54,11 +54,11 @@ export class MergeConflictParser {
 				currentConflict = { startHeader: line, commonAncestors: null };
 			}
 			// Are we within a conflict block and is this a common ancestors marker? |||||||
-			else if (currentConflict && line.text.startsWith(commonAncestorsMarker)) {
+			else if (currentConflict && !currentConflict.commonAncestors && line.text.startsWith(commonAncestorsMarker)) {
 				currentConflict.commonAncestors = line;
 			}
 			// Are we within a conflict block and is this a splitter? =======
-			else if (currentConflict && line.text.startsWith(splitterMarker)) {
+			else if (currentConflict && !currentConflict.splitter && line.text.startsWith(splitterMarker)) {
 				currentConflict.splitter = line;
 			}
 			// Are we withon a conflict block and is this a footer? >>>>>>>
@@ -90,11 +90,7 @@ export class MergeConflictParser {
 			return null;
 		}
 
-		let tokenAfterCurrentBlock: vscode.TextLine = scanned.splitter;
-
-		if (scanned.commonAncestors !== null) {
-			tokenAfterCurrentBlock = scanned.commonAncestors;
-		}
+		let tokenAfterCurrentBlock: vscode.TextLine = scanned.commonAncestors || scanned.splitter;
 
 		// Assume that descriptor.current.header, descriptor.incoming.header and descriptor.spliiter
 		// have valid ranges, fill in content and total ranges from these parts.

--- a/extensions/merge-conflict/src/mergeDecorator.ts
+++ b/extensions/merge-conflict/src/mergeDecorator.ts
@@ -73,6 +73,11 @@ export default class MergeDectorator implements vscode.Disposable {
 			this.decorations['incoming.content'] = vscode.window.createTextEditorDecorationType(
 				this.generateBlockRenderOptions('merge.incomingContentBackground', 'editorOverviewRuler.incomingContentForeground', config)
 			);
+
+			this.decorations['commonAncestors.content'] = vscode.window.createTextEditorDecorationType({
+				color: new vscode.ThemeColor('editor.foreground'),
+				isWholeLine: this.decorationUsesWholeLine,
+			});
 		}
 
 		if (config.enableDecorations) {
@@ -87,6 +92,11 @@ export default class MergeDectorator implements vscode.Disposable {
 					contentText: ' ' + localize('currentChange', '(Current change)'),
 					color: new vscode.ThemeColor('descriptionForeground')
 				}
+			});
+
+			this.decorations['commonAncestors.header'] = vscode.window.createTextEditorDecorationType({
+				color: new vscode.ThemeColor('editor.foreground'),
+				isWholeLine: this.decorationUsesWholeLine,
 			});
 
 			this.decorations['splitter'] = vscode.window.createTextEditorDecorationType({
@@ -187,10 +197,18 @@ export default class MergeDectorator implements vscode.Disposable {
 				pushDecoration('current.content', { range: conflict.current.decoratorContent });
 				pushDecoration('incoming.content', { range: conflict.incoming.decoratorContent });
 
+				if (conflict.commonAncestors !== null) {
+					pushDecoration('commonAncestors.content', { range: conflict.commonAncestors.decoratorContent });
+				}
+
 				if (this.config.enableDecorations) {
 					pushDecoration('current.header', { range: conflict.current.header });
 					pushDecoration('splitter', { range: conflict.splitter });
 					pushDecoration('incoming.header', { range: conflict.incoming.header });
+
+					if (conflict.commonAncestors !== null) {
+						pushDecoration('commonAncestors.header', { range: conflict.commonAncestors.header });
+					}
 				}
 			});
 

--- a/extensions/merge-conflict/src/mergeDecorator.ts
+++ b/extensions/merge-conflict/src/mergeDecorator.ts
@@ -197,18 +197,18 @@ export default class MergeDectorator implements vscode.Disposable {
 				pushDecoration('current.content', { range: conflict.current.decoratorContent });
 				pushDecoration('incoming.content', { range: conflict.incoming.decoratorContent });
 
-				if (conflict.commonAncestors !== null) {
-					pushDecoration('commonAncestors.content', { range: conflict.commonAncestors.decoratorContent });
-				}
+				conflict.commonAncestors.forEach(commonAncestorsRegion => {
+					pushDecoration('commonAncestors.content', { range: commonAncestorsRegion.decoratorContent });
+				});
 
 				if (this.config.enableDecorations) {
 					pushDecoration('current.header', { range: conflict.current.header });
 					pushDecoration('splitter', { range: conflict.splitter });
 					pushDecoration('incoming.header', { range: conflict.incoming.header });
 
-					if (conflict.commonAncestors !== null) {
-						pushDecoration('commonAncestors.header', { range: conflict.commonAncestors.header });
-					}
+					conflict.commonAncestors.forEach(commonAncestorsRegion => {
+						pushDecoration('commonAncestors.header', { range: commonAncestorsRegion.header });
+					});
 				}
 			});
 


### PR DESCRIPTION
Fixes pprice/vscode-better-merge#23.

I'm using `merge.conflictStyle = diff3` git setting, but the style (_Current/Common ancestors/Incoming_) is not supported in VS Code. In the new merge extension (#27150), the _Common ancestors_ block is merged together with the _Current_ block. This PR adds that support. As `diff3` is a superset of the default git conflict style, I've modified the original algorithm to support both styles. The same fix was also proposed by @spiffytech in the original issue.