### PR TITLE
Fixes #27408 - stops forcing column ONE as the default

### DIFF
--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -219,7 +219,7 @@ export class ExtHostApiCommands {
 				label,
 				undefined,
 				editorOptions,
-				options ? typeConverters.fromViewColumn(options.viewColumn) : undefined
+				options && options.viewColumn !== undefined ? typeConverters.fromViewColumn(options.viewColumn) : undefined
 			]);
 		}, {
 				description: 'Opens the provided resources in the diff editor to compare their contents.',

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -13,7 +13,6 @@ import { TextEditorSelectionChangeKind } from './extHostTypes';
 import * as TypeConverters from './extHostTypeConverters';
 import { TextEditorDecorationType, ExtHostTextEditor } from './extHostTextEditor';
 import { ExtHostDocumentsAndEditors } from './extHostDocumentsAndEditors';
-import { Position as EditorPosition } from 'vs/platform/editor/common/editor';
 import { MainContext, MainThreadEditorsShape, ExtHostEditorsShape, ITextDocumentShowOptions, ITextEditorPositionData, IResolvedTextEditorConfiguration, ISelectionChangeEvent } from './extHost.protocol';
 import * as vscode from 'vscode';
 
@@ -67,14 +66,14 @@ export class ExtHostEditors extends ExtHostEditorsShape {
 			};
 		} else if (typeof columnOrOptions === 'object') {
 			options = {
-				position: TypeConverters.fromViewColumn(columnOrOptions.viewColumn),
+				position: columnOrOptions.viewColumn !== undefined ? TypeConverters.fromViewColumn(columnOrOptions.viewColumn) : undefined,
 				preserveFocus: columnOrOptions.preserveFocus,
 				selection: typeof columnOrOptions.selection === 'object' ? TypeConverters.fromRange(columnOrOptions.selection) : undefined,
 				pinned: typeof columnOrOptions.preview === 'boolean' ? !columnOrOptions.preview : undefined
 			};
 		} else {
 			options = {
-				position: EditorPosition.ONE,
+				position: undefined,
 				preserveFocus: false
 			};
 		}


### PR DESCRIPTION
See https://github.com/Microsoft/vscode/issues/27408

This allows `showTextDocument` & `vscode.diff` to be defaulted to the active column.