### PR TITLE
Fix for console warnings on merge #27584 and compare view #27585.

### DIFF
--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -91,7 +91,13 @@ export default class CommandHandler implements vscode.Disposable {
 		const rightUri = leftUri.with({ query: JSON.stringify(range) });
 
 		const title = localize('compareChangesTitle', '{0}: Current Changes ⟷ Incoming Changes', fileName);
-		vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title);
+
+		// Temporary fix for edits attempting to be applied to a disposed TextEditor.
+		// If the diff window opens over the top of this window, at some later point
+		// vscode core will attempt to apply edits to a non-visble, disposed editor,
+		// even though we don't actually use the edit builder.
+		// We need to return from this method, and execute the diff command lazily.
+		setTimeout(() => vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title), 200);
 	}
 
 	navigateNext(editor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args): Promise<void> {

--- a/extensions/merge-conflict/src/documentMergeConflict.ts
+++ b/extensions/merge-conflict/src/documentMergeConflict.ts
@@ -19,19 +19,17 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
 		this.splitter = descriptor.splitter;
 	}
 
-	public commitEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Thenable<boolean> {
+	public async commitEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Promise<boolean> {
 
 		if (edit) {
-
 			this.applyEdit(type, editor, edit);
-			return Promise.resolve(true);
+			return true;
 		};
 
-		return editor.edit((edit) => this.applyEdit(type, editor, edit));
+		return await editor.edit((edit) => this.applyEdit(type, editor, edit));
 	}
 
 	public applyEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit): void {
-
 		// Each conflict is a set of ranges as follows, note placements or newlines
 		// which may not in in spans
 		// [ Conflict Range             -- (Entire content below)

--- a/extensions/merge-conflict/src/documentTracker.ts
+++ b/extensions/merge-conflict/src/documentTracker.ts
@@ -38,6 +38,10 @@ class OriginDocumentMergeConflictTracker implements interfaces.IDocumentMergeCon
 		return this.parent.getConflicts(document, this.origin);
 	}
 
+	getConflictsSync(document: vscode.TextDocument): interfaces.IDocumentMergeConflict[] {
+		return this.parent.getConflictsSync(document, this.origin);
+	}
+
 	isPending(document: vscode.TextDocument): boolean {
 		return this.parent.isPending(document, this.origin);
 	}
@@ -50,6 +54,10 @@ class OriginDocumentMergeConflictTracker implements interfaces.IDocumentMergeCon
 export default class DocumentMergeConflictTracker implements vscode.Disposable, interfaces.IDocumentMergeConflictTrackerService {
 	private cache: Map<string, ScanTask> = new Map();
 	private delayExpireTime: number = 250;
+
+	getConflictsSync(document: vscode.TextDocument, origin: string): interfaces.IDocumentMergeConflict[] {
+		return this.getConflictsOrEmpty(document, [origin]);
+	}
 
 	getConflicts(document: vscode.TextDocument, origin: string): PromiseLike<interfaces.IDocumentMergeConflict[]> {
 		// Attempt from cache

--- a/extensions/merge-conflict/src/interfaces.ts
+++ b/extensions/merge-conflict/src/interfaces.ts
@@ -24,7 +24,7 @@ export interface IExtensionConfiguration {
 }
 
 export interface IDocumentMergeConflict extends IDocumentMergeConflictDescriptor {
-	commitEdit(type: CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit);
+	commitEdit(type: CommitType, editor: vscode.TextEditor, edit?: vscode.TextEditorEdit): Thenable<boolean>;
 	applyEdit(type: CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit);
 }
 
@@ -37,6 +37,7 @@ export interface IDocumentMergeConflictDescriptor {
 
 export interface IDocumentMergeConflictTracker {
 	getConflicts(document: vscode.TextDocument): PromiseLike<IDocumentMergeConflict[]>;
+	getConflictsSync(document: vscode.TextDocument): IDocumentMergeConflict[];
 	isPending(document: vscode.TextDocument): boolean;
 	forget(document: vscode.TextDocument);
 }


### PR DESCRIPTION
merge-conflict edit commands are falsely async. They generated an edit from the editor to work around the supplied TextEditorEdit being ignored if execution was not synchronous. This change creates a sync code path for getting document conflicts, the reality the await aync get document conflicts would unlikely ever be "delayed" and shared between multiple invocations on the command execution path. It'll happen "some time" after initial scanning completes.