### PR TITLE
Allow CTRL+ENTER shortcut from Find input in findWidget

### DIFF
--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -568,6 +568,14 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 			return;
 		}
 
+		if (e.equals(KeyMod.CtrlCmd | KeyCode.Enter)) {
+			if (this._isReplaceVisible) {
+				this._controller.replaceAll();
+				e.preventDefault();
+				return;
+			}
+		}
+
 		if (e.equals(KeyMod.Shift | KeyCode.Enter)) {
 			this._codeEditor.getAction(FIND_IDS.PreviousMatchFindAction).run().done(null, onUnexpectedError);
 			e.preventDefault();


### PR DESCRIPTION
Fix for a usability issue.

#27945