### PR TITLE
Make extension list in generated issue shorter

### DIFF
--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -6,6 +6,7 @@
 'use strict';
 
 import URI from 'vs/base/common/uri';
+import * as collections from 'vs/base/common/collections';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Action } from 'vs/base/common/actions';
 import { IWindowIPCService } from 'vs/workbench/services/window/electron-browser/windowService';
@@ -721,8 +722,17 @@ Steps to Reproduce:
 	}
 
 	private generateExtensionTable(extensions: ILocalExtension[]): string {
+		const { nonThemes, themes } = collections.groupBy(extensions, ext => {
+			const manifestKeys = ext.manifest.contributes ? Object.keys(ext.manifest.contributes) : [];
+			const onlyTheme = !ext.manifest.activationEvents && manifestKeys.length === 1 && manifestKeys[0] === 'themes';
+			return onlyTheme ? 'themes' : 'nonThemes';
+		});
+
+		const themeExclusionStr = themes.length ? `\n(${themes.length} theme extensions excluded)` : '';
+		extensions = nonThemes;
+
 		if (!extensions.length) {
-			return 'none';
+			return 'none' + themeExclusionStr;
 		}
 
 		let tableHeader = `Extension|Author|Version
@@ -735,8 +745,10 @@ Steps to Reproduce:
 
 ${tableHeader}
 ${table}
+${themeExclusionStr}
 
 `;
+
 		// 2000 chars is browsers de-facto limit for URLs, 400 chars are allowed for other string parts of the issue URL
 		// http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
 		if (encodeURIComponent(extensionTable).length > 1600) {

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -735,10 +735,10 @@ Steps to Reproduce:
 			return 'none' + themeExclusionStr;
 		}
 
-		let tableHeader = `Extension|Author|Version
+		let tableHeader = `Extension|Author (truncated)|Version
 ---|---|---`;
 		const table = extensions.map(e => {
-			return `${e.manifest.name}|${e.manifest.publisher}|${e.manifest.version}`;
+			return `${e.manifest.name}|${e.manifest.publisher.substr(0, 3)}|${e.manifest.version}`;
 		}).join('\n');
 
 		const extensionTable = `

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -725,15 +725,16 @@ Steps to Reproduce:
 			return 'none';
 		}
 
-		let tableHeader = `|Extension|Author|Version|
-|---|---|---|`;
+		let tableHeader = `Extension|Author|Version
+---|---|---`;
 		const table = extensions.map(e => {
-			return `|${e.manifest.name}|${e.manifest.publisher}|${e.manifest.version}|`;
+			return `${e.manifest.name}|${e.manifest.publisher}|${e.manifest.version}`;
 		}).join('\n');
 
 		const extensionTable = `
 
-${tableHeader}\n${table};
+${tableHeader}
+${table}
 
 `;
 		// 2000 chars is browsers de-facto limit for URLs, 400 chars are allowed for other string parts of the issue URL


### PR DESCRIPTION
Fixes #27987.

Implements the following suggestions from the issue:
- Remove some unnecessary `|`s
- Exclude extensions that only contribute themes
- Truncate publisher name

With my config, the length of the generated extension table goes from 2465 characters to 1576 characters. Which is barely under the limit, but a huge improvement.