### PR TITLE
Add relativeFileNoExtension

### DIFF
--- a/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
@@ -61,6 +61,11 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 		return (this.workspaceRoot) ? paths.relative(this.workspaceRoot, this.file) : this.file;
 	}
 
+	private get relativeFileNoExtension(): string {
+		const relativeFile = this.relativeFile;
+		return relativeFile.slice(0, -paths.extname(relativeFile).length);
+	}
+
 	private get fileBasename(): string {
 		return paths.basename(this.getFilePath());
 	}

--- a/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/node/configurationResolverService.ts
@@ -63,7 +63,7 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 
 	private get relativeFileNoExtension(): string {
 		const relativeFile = this.relativeFile;
-		return relativeFile.slice(0, -paths.extname(relativeFile).length);
+		return relativeFile.slice(0, relativeFile.length - paths.extname(relativeFile).length);
 	}
 
 	private get fileBasename(): string {


### PR DESCRIPTION
Fix #25786 

I didn't see tests that are `${file} related inside `configurationResolverservice.test.ts`.

Don't know if there is a good way to put them in.