### PR TITLE
Fix uncaught exception while opening file that does not exist

### DIFF
--- a/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
+++ b/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
@@ -47,7 +47,7 @@ class ResourceModelCollection extends ReferenceCollection<TPromise<ITextEditorMo
 			} else {
 				model.dispose();
 			}
-		});
+		}, () => void 0);
 	}
 
 	public registerTextModelContentProvider(scheme: string, provider: ITextModelContentProvider): IDisposable {


### PR DESCRIPTION
**Bug**
Calling workspace.openTextDocument for a url that does not exist can trigger an uncaught exception. The root cause of this appears to be `destroyReferencedObject` calling `done` without an error handler.

**Fix**
Add a void error sink in this case

Fixes #27809