### PR TITLE
fix some typos

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -524,6 +524,7 @@ class CodeEditorWidgetFocusTracker extends Disposable {
 	private _domFocusTracker: dom.IFocusTracker;
 
 	private _onChange: Emitter<void> = this._register(new Emitter<void>());
+	// TODO: Fix name
 	public onChage: Event<void> = this._onChange.event;
 
 	constructor(domElement: HTMLElement) {

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -172,7 +172,7 @@ export class DebugService implements debug.IDebugService {
 		// attach: PH is ready to be attached to
 		// TODO@Isidor this is a hack to just get any 'extensionHost' session.
 		// Optimally the broadcast would contain the id of the session
-		// We are only intersted if we have an active debug session for extensionHost
+		// We are only interested if we have an active debug session for extensionHost
 		const process = this.model.getProcesses().filter(p => strings.equalsIgnoreCase(p.configuration.type, 'extensionhost')).pop();
 		const session = process ? <RawDebugSession>process.session : null;
 		if (broadcast.channel === EXTENSION_ATTACH_BROADCAST_CHANNEL) {
@@ -258,7 +258,7 @@ export class DebugService implements debug.IDebugService {
 			}
 
 			// flush simple values
-			// always append a new line for output coming from an extension such that seperate logs go to seperate lines #23695
+			// always append a new line for output coming from an extension such that separate logs go to separate lines #23695
 			if (simpleVals.length) {
 				this.model.appendToRepl(simpleVals.join(' ') + '\n', sev);
 			}

--- a/src/vs/workbench/parts/debug/electron-browser/debugViews.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugViews.ts
@@ -64,7 +64,7 @@ export class VariablesView extends CollapsibleViewletView {
 		super(actionRunner, !!settings[VariablesView.MEMENTO], nls.localize('variablesSection', "Variables Section"), messageService, keybindingService, contextMenuService);
 
 		this.variablesFocusedContext = CONTEXT_VARIABLES_FOCUSED.bindTo(contextKeyService);
-		// Use schedulre to prevent unnecessary flashing
+		// Use scheduler to prevent unnecessary flashing
 		this.onFocusStackFrameScheduler = new RunOnceScheduler(() => {
 			// Always clear tree highlight to avoid ending up in a broken state #12203
 			this.tree.clearHighlight();
@@ -116,7 +116,7 @@ export class VariablesView extends CollapsibleViewletView {
 		this.toolBar.setActions(prepareActions([collapseAction]))();
 
 		this.toDispose.push(viewModel.onDidFocusStackFrame(sf => {
-			// Refresh the tree immediatly if it is not visible.
+			// Refresh the tree immediately if it is not visible.
 			// Otherwise postpone the refresh until user stops stepping.
 			if (!this.tree.getContentHeight()) {
 				this.onFocusStackFrameScheduler.schedule(0);
@@ -281,7 +281,7 @@ export class CallStackView extends CollapsibleViewletView {
 			}
 
 			// Only show the global pause message if we do not display threads.
-			// Otherwsie there will be a pause message per thread and there is no need for a global one.
+			// Otherwise there will be a pause message per thread and there is no need for a global one.
 			if (newTreeInput instanceof Thread && newTreeInput.stoppedDetails) {
 				this.pauseMessageLabel.text(newTreeInput.stoppedDetails.description || nls.localize('debugStopped', "Paused on {0}", newTreeInput.stoppedDetails.reason));
 				if (newTreeInput.stoppedDetails.text) {
@@ -355,7 +355,7 @@ export class CallStackView extends CollapsibleViewletView {
 
 	private updateTreeSelection(): TPromise<void> {
 		if (!this.tree.getInput()) {
-			// Tree not initialitized yet
+			// Tree not initialized yet
 			return TPromise.as(null);
 		}
 


### PR DESCRIPTION
I digged into the debugging code and found some typos, I fixed them.

There is actually a misspelled property, I just added a todo note, so extensions won't break.