### PR TITLE
cleanup duplicate semicolons in minimapCharRenderer

### DIFF
--- a/src/vs/editor/common/view/minimapCharRenderer.ts
+++ b/src/vs/editor/common/view/minimapCharRenderer.ts
@@ -253,7 +253,7 @@ export class MinimapCharRenderer {
 		const deltaG = color.g - backgroundG;
 		const deltaB = color.b - backgroundB;
 
-		const colorR = backgroundR + deltaR * c;;
+		const colorR = backgroundR + deltaR * c;
 		const colorG = backgroundG + deltaG * c;
 		const colorB = backgroundB + deltaB * c;
 
@@ -325,7 +325,7 @@ export class MinimapCharRenderer {
 		const deltaG = color.g - backgroundG;
 		const deltaB = color.b - backgroundB;
 
-		const colorR = backgroundR + deltaR * c;;
+		const colorR = backgroundR + deltaR * c;
 		const colorG = backgroundG + deltaG * c;
 		const colorB = backgroundB + deltaB * c;
 


### PR DESCRIPTION
itroduced in https://github.com/Microsoft/vscode/commit/8f9dc8e220aef53c19ef9dfa7284689e04080a0d#diff-0e25f213bdb14a7f0c59d148e40f02f5R256 and https://github.com/Microsoft/vscode/commit/8faa03f88573dbf4b0f5a5a6b583436319d836a8#diff-0e25f213bdb14a7f0c59d148e40f02f5R256

Just saw this and fixed it with GitHub edit. Maybe it would be better to do a global search for these.