### PR TITLE
Default Markdown language configuration

### DIFF
--- a/extensions/markdown/language-configuration.json
+++ b/extensions/markdown/language-configuration.json
@@ -12,7 +12,8 @@
 		["[", "]"],
 		["(", ")"]
 	],
-	"autoClosingPairs": [{
+	"autoClosingPairs": [
+		{
 			"open": "{",
 			"close": "}"
 		},

--- a/extensions/markdown/language-configuration.json
+++ b/extensions/markdown/language-configuration.json
@@ -8,31 +8,40 @@
 	},
 	// symbols used as brackets
 	"brackets": [
-		[
-			"{",
-			"}"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"(",
-			")"
-		]
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
 	],
-	"autoClosingPairs": [
-		[
-			"{",
-			"}"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"(",
-			")"
-		]
+	"autoClosingPairs": [{
+			"open": "{",
+			"close": "}"
+		},
+		{
+			"open": "[",
+			"close": "]"
+		},
+		{
+			"open": "(",
+			"close": ")"
+		},
+		{
+			"open": "<",
+			"close": ">",
+			"notIn": [
+				"string"
+			]
+		},
+		{
+			"open": "`",
+			"close": "`",
+			"notIn": [
+				"string"
+			]
+		}
+	],
+	"surroundingPairs": [
+		["(", ")"],
+		["[", "]"],
+		["`", "`"]
 	]
 }


### PR DESCRIPTION
### Changes

- use new autoClosingPairs grammar
- add `, <> to autoClosingPairs
- add surroundingPairs