### PR TITLE
Spaces in block comment. #28169

### DIFF
--- a/src/vs/editor/contrib/comment/common/blockCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/common/blockCommentCommand.ts
@@ -97,16 +97,16 @@ export class BlockCommentCommand implements editorCommon.ICommand {
 
 		if (!Range.isEmpty(r)) {
 			// Insert block comment start
-			res.push(EditOperation.insert(new Position(r.startLineNumber, r.startColumn), startToken));
+			res.push(EditOperation.insert(new Position(r.startLineNumber, r.startColumn), startToken + ' '));
 
 			// Insert block comment end
-			res.push(EditOperation.insert(new Position(r.endLineNumber, r.endColumn), endToken));
+			res.push(EditOperation.insert(new Position(r.endLineNumber, r.endColumn), ' ' + endToken));
 		} else {
 			// Insert both continuously
 			res.push(EditOperation.replace(new Range(
 				r.startLineNumber, r.startColumn,
 				r.endLineNumber, r.endColumn
-			), startToken + endToken));
+			), startToken + '  ' + endToken));
 		}
 
 		return res;

--- a/src/vs/editor/contrib/comment/common/blockCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/common/blockCommentCommand.ts
@@ -145,7 +145,7 @@ export class BlockCommentCommand implements editorCommon.ICommand {
 			);
 		} else {
 			var srcRange = inverseEditOperations[0].range;
-			var deltaColumn = this._usedEndToken ? -this._usedEndToken.length : 0;
+			var deltaColumn = this._usedEndToken ? -this._usedEndToken.length - 1 : 0; // minus 1 space before endToken
 			return new Selection(
 				srcRange.endLineNumber,
 				srcRange.endColumn + deltaColumn,

--- a/src/vs/editor/contrib/comment/test/common/blockCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/common/blockCommentCommand.test.ts
@@ -28,13 +28,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(1, 3, 1, 3),
 			[
-				'fi<00>rst',
+				'fi<0  0>rst',
 				'\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 5, 1, 5)
+			new Selection(1, 6, 1, 6)
 		);
 	});
 
@@ -49,13 +49,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 1, 1, 1),
 			[
-				'<0first',
-				'0>\tsecond line',
+				'<0 first',
+				' 0>\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 3, 2, 1)
+			new Selection(1, 4, 2, 1)
 		);
 	});
 
@@ -70,13 +70,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(1, 6, 1, 1),
 			[
-				'<0first0>',
+				'<0 first 0>',
 				'\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 3, 1, 8)
+			new Selection(1, 4, 1, 9)
 		);
 
 		testBlockCommentCommand(
@@ -110,13 +110,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(1, 6, 1, 3),
 			[
-				'fi<0rst0>',
+				'fi<0 rst 0>',
 				'\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 5, 1, 8)
+			new Selection(1, 6, 1, 9)
 		);
 	});
 
@@ -131,13 +131,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(1, 6, 1, 3),
 			[
-				'fi<0rst0>',
+				'fi<0 rst 0>',
 				'\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 5, 1, 8)
+			new Selection(1, 6, 1, 9)
 		);
 
 		testBlockCommentCommand(
@@ -171,13 +171,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 4, 1, 1),
 			[
-				'<0first',
-				'\tse0>cond line',
+				'<0 first',
+				'\tse 0>cond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 3, 2, 4)
+			new Selection(1, 4, 2, 4)
 		);
 	});
 
@@ -192,13 +192,13 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 4, 1, 1),
 			[
-				'<0first',
-				'\tse0>cond line',
+				'<0 first',
+				'\tse 0>cond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 3, 2, 4)
+			new Selection(1, 4, 2, 4)
 		);
 
 		testBlockCommentCommand(

--- a/src/vs/editor/contrib/comment/test/common/lineCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/common/lineCommentCommand.test.ts
@@ -544,13 +544,13 @@ suite('Editor Contrib - Line Comment As Block Comment', () => {
 			],
 			new Selection(1, 1, 1, 1),
 			[
-				'(first)',
+				'( first )',
 				'\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 2, 1, 2)
+			new Selection(1, 3, 1, 3)
 		);
 	});
 
@@ -586,13 +586,13 @@ suite('Editor Contrib - Line Comment As Block Comment', () => {
 			],
 			new Selection(1, 1, 1, 1),
 			[
-				'(first)',
+				'( first )',
 				'\tsecond line',
 				'third line',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 2, 1, 2)
+			new Selection(1, 3, 1, 3)
 		);
 	});
 
@@ -607,13 +607,13 @@ suite('Editor Contrib - Line Comment As Block Comment', () => {
 			],
 			new Selection(3, 2, 1, 3),
 			[
-				'(first',
+				'( first',
 				'\tsecond line',
-				'third line)',
+				'third line )',
 				'fourth line',
 				'fifth'
 			],
-			new Selection(1, 4, 3, 2)
+			new Selection(1, 5, 3, 2)
 		);
 
 		testLineCommentCommand(
@@ -655,7 +655,7 @@ suite('Editor Contrib - Line Comment As Block Comment 2', () => {
 			],
 			new Selection(1, 1, 1, 1),
 			[
-				'\t\t<!@#first\t    #@!>',
+				'\t\t<!@# first\t     #@!>',
 				'\t\tsecond line',
 				'\tthird line',
 				'fourth line',
@@ -809,8 +809,8 @@ suite('Editor Contrib - Line Comment As Block Comment 2', () => {
 			],
 			new Selection(1, 1, 3, 1),
 			[
-				'     <!@#asd qwe',
-				'     asd qwe#@!>',
+				'     <!@# asd qwe',
+				'     asd qwe #@!>',
 				''
 			],
 			new Selection(1, 1, 3, 1)
@@ -927,13 +927,13 @@ suite('Editor Contrib - Line Comment in mixed modes', () => {
 			[
 				'import React from \'react\';',
 				'const Loader = () => (',
-				'  {/*<div>*/}',
+				'  {/* <div> */}',
 				'    Loading...',
 				'  </div>',
 				');',
 				'export default Loader;'
 			],
-			new Selection(3, 7, 3, 7),
+			new Selection(3, 8, 3, 8),
 		);
 	});
 


### PR DESCRIPTION
Resolve #28169.

According to [that](https://github.com/Microsoft/vscode/blob/master/src/vs/editor/contrib/comment/common/lineCommentCommand.ts#L370) in `lineCommentCommand.ts`.