### PR TITLE
Created ability to toggle clickable URLs

### DIFF
--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -605,6 +605,7 @@ export class CodeMenu {
 		const splitEditor = this.createMenuItem(nls.localize({ key: 'miSplitEditor', comment: ['&& denotes a mnemonic'] }, "Split &&Editor"), 'workbench.action.splitEditor');
 		const toggleEditorLayout = this.createMenuItem(nls.localize({ key: 'miToggleEditorLayout', comment: ['&& denotes a mnemonic'] }, "Toggle Editor Group &&Layout"), 'workbench.action.toggleEditorGroupLayout');
 		const toggleSidebar = this.createMenuItem(nls.localize({ key: 'miToggleSidebar', comment: ['&& denotes a mnemonic'] }, "&&Toggle Side Bar"), 'workbench.action.toggleSidebarVisibility');
+		const toggleURLClickable = this.createMenuItem(nls.localize({ key: 'miToggleURLClickable', comment: ['&& denotes a mnemonic'] }, "&&Toggle Clickable URLs"), 'editor.action.urlClickable');
 
 		let moveSideBarLabel: string;
 		if (this.currentSidebarLocation !== 'right') {
@@ -659,6 +660,7 @@ export class CodeMenu {
 			fullscreen,
 			toggleZenMode,
 			isWindows || isLinux ? toggleMenuBar : void 0,
+			toggleURLClickable,
 			__separator__(),
 			splitEditor,
 			toggleEditorLayout,

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -573,6 +573,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.accessibilitySupport,
 			'description': nls.localize('accessibilitySupport', "Controls whether the editor should run in a mode where it is optimized for screen readers.")
 		},
+		'editor.urlClickable': {
+			'type': 'boolean',
+			'default': EDITOR_DEFAULTS.urlClickable,
+			'description': nls.localize('urlClickable', "Controls whether the editor should underline any URL and make them clickable through CTRL-Left Click")
+		},
 		'diffEditor.renderSideBySide': {
 			'type': 'boolean',
 			'default': true,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -887,7 +887,7 @@ export class InternalEditorOptions {
 		this.viewInfo = source.viewInfo;
 		this.wrappingInfo = source.wrappingInfo;
 		this.contribInfo = source.contribInfo;
-		this.urlClickable = source.urlClickable
+		this.urlClickable = source.urlClickable;
 	}
 
 	/**

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -350,6 +350,11 @@ export interface IEditorOptions {
 	 * Enable quick suggestions (shadow suggestions)
 	 * Defaults to true.
 	 */
+	urlClickable?: boolean;
+	/**
+	 * Enable quick suggestions (shadow suggestions)
+	 * Defaults to true.
+	 */
 	quickSuggestions?: boolean | { other: boolean, comments: boolean, strings: boolean };
 	/**
 	 * Quick suggestions show delay (in ms)
@@ -801,6 +806,7 @@ export interface IValidatedEditorOptions {
 	readonly useTabStops: boolean;
 	readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
 	readonly accessibilitySupport: 'auto' | 'off' | 'on';
+	readonly urlClickable: boolean;
 
 	readonly viewInfo: InternalEditorViewOptions;
 	readonly contribInfo: EditorContribOptions;
@@ -822,6 +828,7 @@ export class InternalEditorOptions {
 	 */
 	readonly accessibilitySupport: platform.AccessibilitySupport;
 	readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+	readonly urlClickable: boolean;
 
 	// ---- cursor options
 	readonly wordSeparators: string;
@@ -860,6 +867,7 @@ export class InternalEditorOptions {
 		viewInfo: InternalEditorViewOptions;
 		wrappingInfo: EditorWrappingInfo;
 		contribInfo: EditorContribOptions;
+		urlClickable: boolean;
 	}) {
 		this.canUseTranslate3d = source.canUseTranslate3d;
 		this.pixelRatio = source.pixelRatio;
@@ -879,6 +887,7 @@ export class InternalEditorOptions {
 		this.viewInfo = source.viewInfo;
 		this.wrappingInfo = source.wrappingInfo;
 		this.contribInfo = source.contribInfo;
+		this.urlClickable = source.urlClickable
 	}
 
 	/**
@@ -899,6 +908,7 @@ export class InternalEditorOptions {
 			&& this.tabFocusMode === other.tabFocusMode
 			&& this.dragAndDrop === other.dragAndDrop
 			&& this.emptySelectionClipboard === other.emptySelectionClipboard
+			&& this.urlClickable === other.urlClickable
 			&& InternalEditorOptions._equalsLayoutInfo(this.layoutInfo, other.layoutInfo)
 			&& this.fontInfo.equals(other.fontInfo)
 			&& InternalEditorOptions._equalsViewOptions(this.viewInfo, other.viewInfo)
@@ -930,6 +940,7 @@ export class InternalEditorOptions {
 			viewInfo: (!InternalEditorOptions._equalsViewOptions(this.viewInfo, newOpts.viewInfo)),
 			wrappingInfo: (!InternalEditorOptions._equalsWrappingInfo(this.wrappingInfo, newOpts.wrappingInfo)),
 			contribInfo: (!InternalEditorOptions._equalsContribOptions(this.contribInfo, newOpts.contribInfo)),
+			urlClickable: (this.urlClickable !== newOpts.urlClickable),
 		};
 	}
 
@@ -1269,6 +1280,7 @@ export interface IConfigurationChangedEvent {
 	readonly viewInfo: boolean;
 	readonly wrappingInfo: boolean;
 	readonly contribInfo: boolean;
+	readonly urlClickable: boolean;
 }
 
 /**
@@ -1443,6 +1455,7 @@ export class EditorOptionsValidator {
 			useTabStops: _boolean(opts.useTabStops, defaults.useTabStops),
 			multiCursorModifier: multiCursorModifier,
 			accessibilitySupport: _stringSet<'auto' | 'on' | 'off'>(opts.accessibilitySupport, defaults.accessibilitySupport, ['auto', 'on', 'off']),
+			urlClickable: _boolean(opts.urlClickable, defaults.urlClickable),
 			viewInfo: viewInfo,
 			contribInfo: contribInfo,
 		};
@@ -1667,6 +1680,7 @@ export class InternalEditorOptionsFactory {
 			useTabStops: opts.useTabStops,
 			multiCursorModifier: opts.multiCursorModifier,
 			accessibilitySupport: opts.accessibilitySupport,
+			urlClickable: opts.urlClickable,
 
 			viewInfo: {
 				extraEditorClassName: opts.viewInfo.extraEditorClassName,
@@ -1875,7 +1889,8 @@ export class InternalEditorOptionsFactory {
 			fontInfo: env.fontInfo,
 			viewInfo: opts.viewInfo,
 			wrappingInfo: wrappingInfo,
-			contribInfo: opts.contribInfo
+			contribInfo: opts.contribInfo,
+			urlClickable: opts.urlClickable
 		});
 	}
 }
@@ -2085,6 +2100,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 	useTabStops: true,
 	multiCursorModifier: 'altKey',
 	accessibilitySupport: 'auto',
+	urlClickable: true,
 
 	viewInfo: {
 		extraEditorClassName: '',

--- a/src/vs/editor/contrib/links/browser/links.css
+++ b/src/vs/editor/contrib/links/browser/links.css
@@ -10,7 +10,3 @@
 .monaco-editor .detected-link-active {
 	cursor: pointer;
 }
-
-.monaco-editor .detected-link-inactive {
-	text-decoration: none;
-}

--- a/src/vs/editor/contrib/links/browser/links.css
+++ b/src/vs/editor/contrib/links/browser/links.css
@@ -10,3 +10,7 @@
 .monaco-editor .detected-link-active {
 	cursor: pointer;
 }
+
+.monaco-editor .detected-link-inactive {
+	text-decoration: none;
+}

--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -261,7 +261,7 @@ class LinkDetector implements editorCommon.IEditorContribution {
 	}
 
 	private recompute(): void {
-		if(!this.editor.getConfiguration().urlClickable) {
+		if (!this.editor.getConfiguration().urlClickable) {
 			this.computePromise = getLinks(this.editor.getModel()).then(links => {
 				this.updateDecorations(links);
 				this.computePromise = null;

--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -56,11 +56,6 @@ const decoration = {
 		inlineClassName: 'detected-link-active',
 		hoverMessage: HOVER_MESSAGE_GENERAL_ALT
 	}),
-	inactive: ModelDecorationOptions.register({
-		stickiness: editorCommon.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-		inlineClassName: 'detected-link-inactive',
-		hoverMessage: null
-	})
 };
 
 class LinkOccurence {
@@ -216,23 +211,10 @@ class LinkDetector implements editorCommon.IEditorContribution {
 			}
 
 			var newDecorations: editorCommon.IModelDeltaDecoration[] = [];
-			if (links) {
+			if (links && this.editor.getConfiguration().urlClickable) {
 				// Not sure why this is sometimes null
 				for (var i = 0; i < links.length; i++) {
-					if (!this.editor.getConfiguration().urlClickable)
-					{
-						var inactiveDecoration: editorCommon.IModelDeltaDecoration = {
-							range: {
-								startLineNumber: links[i].range.startLineNumber,
-								startColumn: links[i].range.startColumn,
-								endLineNumber: links[i].range.endLineNumber,
-								endColumn: links[i].range.endColumn
-							},
-								options: (false ? decoration.inactive : decoration.inactive)
-							};
-					} else {
-						newDecorations.push(LinkOccurence.decoration(links[i], useMetaKey));
-					}
+					newDecorations.push(LinkOccurence.decoration(links[i], useMetaKey));
 				}
 			}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2896,6 +2896,11 @@ declare module monaco.editor {
 		 * Enable quick suggestions (shadow suggestions)
 		 * Defaults to true.
 		 */
+		urlClickable?: boolean;
+		/**
+		 * Enable quick suggestions (shadow suggestions)
+		 * Defaults to true.
+		 */
 		quickSuggestions?: boolean | {
 			other: boolean;
 			comments: boolean;
@@ -3275,6 +3280,7 @@ declare module monaco.editor {
 		readonly lineHeight: number;
 		readonly readOnly: boolean;
 		readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+		readonly urlClickable: boolean;
 		readonly wordSeparators: string;
 		readonly autoClosingBrackets: boolean;
 		readonly useTabStops: boolean;
@@ -3418,6 +3424,7 @@ declare module monaco.editor {
 		readonly viewInfo: boolean;
 		readonly wrappingInfo: boolean;
 		readonly contribInfo: boolean;
+		readonly urlClickable: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/parts/codeEditor/codeEditor.contribution.ts
+++ b/src/vs/workbench/parts/codeEditor/codeEditor.contribution.ts
@@ -10,3 +10,4 @@ import './electron-browser/toggleRenderWhitespace';
 import './electron-browser/toggleWordWrap';
 import './electron-browser/wordWrapMigration';
 import './electron-browser/inspectKeybindings';
+import './electron-browser/toggleURLClickable';

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleURLClickable.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleURLClickable.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as nls from 'vs/nls';
+import { ICommonCodeEditor, IEditorContribution, IModel } from 'vs/editor/common/editorCommon';
+import { editorAction, ServicesAccessor, EditorAction } from 'vs/editor/common/editorCommonExtensions';
+import { IConfigurationEditingService, ConfigurationTarget } from 'vs/workbench/services/configuration/common/configurationEditing';
+
+
+@editorAction
+export class ToggleURLClickableAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.urlClickable',
+			label: nls.localize('toggleURLClickable', "Controls whether the editor should underline any URL and make them clickable through CTRL-Left Click"),
+			alias: 'Toggle clickable URLs',
+			precondition: null
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICommonCodeEditor): void {
+		const configurationEditingService = accessor.get(IConfigurationEditingService);
+
+		let urlClickable = editor.getConfiguration().urlClickable;
+		let newURLClickable: boolean;
+		if (urlClickable === true) {
+			newURLClickable = false;
+		} else {
+			newURLClickable = true;
+		}
+
+		configurationEditingService.writeConfiguration(ConfigurationTarget.USER, { key: 'editor.urlClickable', value: newURLClickable });
+	}
+}

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleURLClickable.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleURLClickable.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as nls from 'vs/nls';
-import { ICommonCodeEditor, IEditorContribution, IModel } from 'vs/editor/common/editorCommon';
+import { ICommonCodeEditor } from 'vs/editor/common/editorCommon';
 import { editorAction, ServicesAccessor, EditorAction } from 'vs/editor/common/editorCommonExtensions';
 import { IConfigurationEditingService, ConfigurationTarget } from 'vs/workbench/services/configuration/common/configurationEditing';
 


### PR DESCRIPTION
[ISSUE 27362](https://github.com/Microsoft/vscode/issues/27632):

Unmerged code by chewong (https://github.com/chewong) was used
(https://github.com/Microsoft/vscode/pull/28160/commits/f05594583bd8aca277d2f9b50658edf1314916d3).

This update creates a menu item under "view" called "Toggle Clickable URLs". Using this item will enable or disable URL text formatting.