### PR TITLE
Task Experiment 1.1

### DIFF
--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -586,7 +586,7 @@ export class CodeMenu {
 		const output = this.createMenuItem(nls.localize({ key: 'miToggleOutput', comment: ['&& denotes a mnemonic'] }, "&&Output"), 'workbench.action.output.toggleOutput');
 		const debugConsole = this.createMenuItem(nls.localize({ key: 'miToggleDebugConsole', comment: ['&& denotes a mnemonic'] }, "De&&bug Console"), 'workbench.debug.action.toggleRepl');
 		const integratedTerminal = this.createMenuItem(nls.localize({ key: 'miToggleIntegratedTerminal', comment: ['&& denotes a mnemonic'] }, "&&Integrated Terminal"), 'workbench.action.terminal.toggleTerminal');
-		const taskMenu = this.createMenuItem(nls.localize({ key: 'miShowTask', comment: ['&& denotes a mnemonic'] }, "&&Show Tasks..."), 'workbench.action.showTasks');
+		const taskMenu = this.createMenuItem(nls.localize({ key: 'miShowTask', comment: ['&& denotes a mnemonic'] }, "Show Tas&&ks..."), 'workbench.action.showTasks');
 		const problems = this.createMenuItem(nls.localize({ key: 'miMarker', comment: ['&& denotes a mnemonic'] }, "&&Problems"), 'workbench.actions.view.problems');
 
 		let additionalViewlets: Electron.MenuItem;

--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -586,7 +586,7 @@ export class CodeMenu {
 		const output = this.createMenuItem(nls.localize({ key: 'miToggleOutput', comment: ['&& denotes a mnemonic'] }, "&&Output"), 'workbench.action.output.toggleOutput');
 		const debugConsole = this.createMenuItem(nls.localize({ key: 'miToggleDebugConsole', comment: ['&& denotes a mnemonic'] }, "De&&bug Console"), 'workbench.debug.action.toggleRepl');
 		const integratedTerminal = this.createMenuItem(nls.localize({ key: 'miToggleIntegratedTerminal', comment: ['&& denotes a mnemonic'] }, "&&Integrated Terminal"), 'workbench.action.terminal.toggleTerminal');
-		const taskMenu = this.createMenuItem(nls.localize({ key: 'miShowTask', comment: ['&& denotes a mnemonic'] }, "&&Show Tasks"), 'workbench.action.showTasks');
+		const taskMenu = this.createMenuItem(nls.localize({ key: 'miShowTask', comment: ['&& denotes a mnemonic'] }, "&&Show Tasks..."), 'workbench.action.showTasks');
 		const problems = this.createMenuItem(nls.localize({ key: 'miMarker', comment: ['&& denotes a mnemonic'] }, "&&Problems"), 'workbench.actions.view.problems');
 
 		let additionalViewlets: Electron.MenuItem;

--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -586,6 +586,7 @@ export class CodeMenu {
 		const output = this.createMenuItem(nls.localize({ key: 'miToggleOutput', comment: ['&& denotes a mnemonic'] }, "&&Output"), 'workbench.action.output.toggleOutput');
 		const debugConsole = this.createMenuItem(nls.localize({ key: 'miToggleDebugConsole', comment: ['&& denotes a mnemonic'] }, "De&&bug Console"), 'workbench.debug.action.toggleRepl');
 		const integratedTerminal = this.createMenuItem(nls.localize({ key: 'miToggleIntegratedTerminal', comment: ['&& denotes a mnemonic'] }, "&&Integrated Terminal"), 'workbench.action.terminal.toggleTerminal');
+		const taskMenu = this.createMenuItem(nls.localize({ key: 'miShowTask', comment: ['&& denotes a mnemonic'] }, "&&Show Tasks"), 'workbench.action.showTasks');
 		const problems = this.createMenuItem(nls.localize({ key: 'miMarker', comment: ['&& denotes a mnemonic'] }, "&&Problems"), 'workbench.actions.view.problems');
 
 		let additionalViewlets: Electron.MenuItem;
@@ -657,6 +658,7 @@ export class CodeMenu {
 			problems,
 			debugConsole,
 			integratedTerminal,
+			taskMenu,
 			__separator__(),
 			fullscreen,
 			toggleZenMode,

--- a/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
@@ -149,6 +149,31 @@ export class ShowAllCommandsAction extends Action {
 	}
 }
 
+export class ShowTasksAction extends Action {
+
+	public static ID = 'workbench.action.showTasks';
+	public static LABEL = nls.localize('showTasks', "Show Task Menu");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		let value = ALL_COMMANDS_PREFIX;
+		let taskStr = 'tasks';
+		value = `${value}${taskStr}`;
+
+		this.quickOpenService.show(value);
+
+		return TPromise.as(null);
+	}
+}
+
 export class ClearCommandHistoryAction extends Action {
 
 	public static ID = 'workbench.action.clearCommandHistory';

--- a/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
@@ -164,10 +164,7 @@ export class ShowTasksAction extends Action {
 	}
 
 	public run(context?: any): TPromise<any> {
-		let value = ALL_COMMANDS_PREFIX;
-		let taskStr = 'tasks';
-		value = `${value}${taskStr}`;
-
+		const value = `${ALL_COMMANDS_PREFIX}tasks`;
 		this.quickOpenService.show(value);
 
 		return TPromise.as(null);

--- a/src/vs/workbench/parts/quickopen/browser/quickopen.contribution.ts
+++ b/src/vs/workbench/parts/quickopen/browser/quickopen.contribution.ts
@@ -41,7 +41,7 @@ registry.registerWorkbenchAction(new SyncActionDescriptor(QuickOpenViewPickerAct
 }), 'Quick Open View');
 
 registry.registerWorkbenchAction(new SyncActionDescriptor(ShowTasksAction, ShowTasksAction.ID, ShowTasksAction.LABEL, {
-	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_T
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_T
 }), 'Show Task Menu');
 
 // Register Quick Open Handler

--- a/src/vs/workbench/parts/quickopen/browser/quickopen.contribution.ts
+++ b/src/vs/workbench/parts/quickopen/browser/quickopen.contribution.ts
@@ -13,7 +13,7 @@ import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actionRegistry';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { GotoSymbolAction, GOTO_SYMBOL_PREFIX, SCOPE_PREFIX } from 'vs/workbench/parts/quickopen/browser/gotoSymbolHandler';
-import { ShowAllCommandsAction, ALL_COMMANDS_PREFIX, ClearCommandHistoryAction } from 'vs/workbench/parts/quickopen/browser/commandsHandler';
+import { ShowAllCommandsAction, ALL_COMMANDS_PREFIX, ClearCommandHistoryAction, ShowTasksAction } from 'vs/workbench/parts/quickopen/browser/commandsHandler';
 import { GotoLineAction, GOTO_LINE_PREFIX } from 'vs/workbench/parts/quickopen/browser/gotoLineHandler';
 import { HELP_PREFIX } from 'vs/workbench/parts/quickopen/browser/helpHandler';
 import { VIEW_PICKER_PREFIX, OpenViewPickerAction, QuickOpenViewPickerAction } from 'vs/workbench/parts/quickopen/browser/viewPickerHandler';
@@ -39,6 +39,10 @@ registry.registerWorkbenchAction(new SyncActionDescriptor(OpenViewPickerAction, 
 registry.registerWorkbenchAction(new SyncActionDescriptor(QuickOpenViewPickerAction, QuickOpenViewPickerAction.ID, QuickOpenViewPickerAction.LABEL, {
 	primary: KeyMod.CtrlCmd | KeyCode.KEY_Q, mac: { primary: KeyMod.WinCtrl | KeyCode.KEY_Q }, linux: { primary: null }
 }), 'Quick Open View');
+
+registry.registerWorkbenchAction(new SyncActionDescriptor(ShowTasksAction, ShowTasksAction.ID, ShowTasksAction.LABEL, {
+	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_T
+}), 'Show Task Menu');
 
 // Register Quick Open Handler
 


### PR DESCRIPTION
- First experiment for tasks project
- Adds a task entry in the view section that opens command palette with `>tasks`
- Should it have a keyboard shortcut? It's currently set to `cmd+shift+t`