### PR TITLE
Only update viewlet switcher if it has already been rendered

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -293,6 +293,11 @@ export class ActivitybarPart extends Part implements IActivityBarService {
 	}
 
 	private updateViewletSwitcher() {
+		if (!this.viewletSwitcherBar) {
+			// We have not been rendered yet so there is nothing to update.
+			return;
+		}
+
 		let viewletsToShow = this.getPinnedViewlets();
 
 		// Always show the active viewlet even if it is marked to be hidden
@@ -462,9 +467,7 @@ export class ActivitybarPart extends Part implements IActivityBarService {
 			const index = this.pinnedViewlets.indexOf(viewletId);
 			this.pinnedViewlets.splice(index, 1);
 
-			if (this.viewletSwitcherBar) {
-				this.updateViewletSwitcher();
-			}
+			this.updateViewletSwitcher();
 		});
 	}
 

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -462,7 +462,9 @@ export class ActivitybarPart extends Part implements IActivityBarService {
 			const index = this.pinnedViewlets.indexOf(viewletId);
 			this.pinnedViewlets.splice(index, 1);
 
-			this.updateViewletSwitcher();
+			if (this.viewletSwitcherBar) {
+				this.updateViewletSwitcher();
+			}
 		});
 	}
 


### PR DESCRIPTION
This avoids a javascript error if unpin is called before the activity bar renders.