### PR TITLE
Support Sublime-Text-style selection transpose

### DIFF
--- a/src/vs/editor/common/commands/replaceCommand.ts
+++ b/src/vs/editor/common/commands/replaceCommand.ts
@@ -118,3 +118,31 @@ export class ReplaceCommandThatPreservesSelection implements editorCommon.IComma
 		return helper.getTrackedSelection(this._selectionId);
 	}
 }
+
+export class ReplaceCommandThatSelectsReplacement implements editorCommon.ICommand {
+
+	private readonly _range: Range;
+	private readonly _text: string;
+	public readonly insertsAutoWhitespace: boolean;
+
+	constructor(range: Range, text: string, insertsAutoWhitespace: boolean = false) {
+		this._range = range;
+		this._text = text;
+		this.insertsAutoWhitespace = insertsAutoWhitespace;
+	}
+
+	public getEditOperations(model: editorCommon.ITokenizedModel, builder: editorCommon.IEditOperationBuilder): void {
+		builder.addTrackedEditOperation(this._range, this._text);
+	}
+
+	public computeCursorState(model: editorCommon.ITokenizedModel, helper: editorCommon.ICursorStateComputerData): Selection {
+		let inverseEditOperations = helper.getInverseEditOperations();
+		let srcRange = inverseEditOperations[0].range;
+		return new Selection(
+			srcRange.startLineNumber,
+			srcRange.startColumn,
+			srcRange.endLineNumber,
+			srcRange.endColumn
+		);
+	}
+}

--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -684,7 +684,7 @@ export class TransposeAction extends EditorAction {
 		super({
 			id: 'editor.action.transpose',
 			label: nls.localize('editor.transpose', "Transpose characters around the cursor"),
-			alias: 'Transpose characters around the cursor',
+			alias: 'Transpose characters or selections',
 			precondition: EditorContextKeys.writable
 		});
 	}

--- a/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/common/linesOperations.test.ts
@@ -238,6 +238,10 @@ suite('Editor Contrib - Line Operations', () => {
 				transposeAction.run(null, editor);
 				assert.equal(model.getLineContent(8), 'hello world', '019');
 				assert.deepEqual(editor.getSelection().toString(), new Selection(8, 12, 8, 12).toString(), '020');
+
+				editor.setSelections([new Selection(3, 1, 3, 4), new Selection(4, 1, 4, 6)]);
+				transposeAction.run(null, editor);
+				assert.equal(model.getLineContent(3) + '\n' + model.getLineContent(4), 'oworll\nheld', '021');
 			}
 		);
 	});


### PR DESCRIPTION
([Way back in December](https://github.com/Microsoft/vscode/issues/3776#issuecomment-267736625), @rebornix said in #3776 that this was a good idea to contribute to core, but I never really got around to it until now...)

This commit adds Sublime Text 3's other transpose behavior to the `transpose` action: Transposing selections.

`transpose` will behave as before if all selections are empty. But if at least one selection is non-empty, `transpose` will instead transpose the contents of the selection, replacing the contents of selection 2 with selection 1, selection 3 with selection 2, and so on until selection 1 is replaced with the contents of the last selection.

This allows quick swaps, for instance, you can double-click on one word, Opt+double-click on another word, and press Ctrl+T to swap them.

VS Code currently has two Transpose actions:

- `editor.action.transposeLetters`
  "Transpose Letters" (bound to `^t` by default)
- `editor.action.transpose`
  "Transpose characters around the cursor" (not bound to anything by default)

These are very subtly different: `transposeLetters` does nothing at the end of a line, while `transpose` transposes the last character to the other side of the line break (in a clone of Sublime Text's behavior).

(Note that neither of these matches the emacs/macOS behavior, which is to transpose the last two characters of the line.)

This behavior has been added to `transpose` rather than `transposeLetters`, because `transpose` seems to both be a less specific name, and because it was designed for Sublime compatibility.