### PR TITLE
Added darwinHelpBook and darwinHelpName to build process for MacOS

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -117,6 +117,8 @@ const config = {
 	darwinIcon: 'resources/darwin/code.icns',
 	darwinBundleIdentifier: product.darwinBundleIdentifier,
 	darwinApplicationCategoryType: 'public.app-category.developer-tools',
+	darwinHelpBookFolder: 'VS Code HelpBook',
+	darwinHelpBookName: 'VS Code HelpBook',
 	darwinBundleDocumentTypes: [{
 		name: product.nameLong + ' document',
 		role: 'Editor',


### PR DESCRIPTION
Fixes #18697 

Note: The Helpbook files need not exist to fix this bug.  Creating a thorough and useful Helpbook is a large feature in its own right. This commit simply enables that book to be made in the future.