### PR TITLE
Add CSP To Root Document

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -212,7 +212,8 @@ function packageTask(platform, arch, opts) {
 			'vs/workbench/electron-browser/workbench.main.js',
 			'vs/workbench/electron-browser/workbench.main.css',
 			'vs/workbench/electron-browser/bootstrap/index.html',
-			'vs/workbench/electron-browser/bootstrap/index.js'
+			'vs/workbench/electron-browser/bootstrap/index.js',
+			'vs/workbench/electron-browser/bootstrap/preload.js'
 		]);
 
 		const src = gulp.src(out + '/**', { base: '.' })

--- a/src/vs/workbench/electron-browser/bootstrap/index.html
+++ b/src/vs/workbench/electron-browser/bootstrap/index.html
@@ -3,7 +3,7 @@
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' http: https: data:; media-src 'self' http: https: data:; child-src 'self'; object-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' https:;">
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' http: https: data:; media-src 'self' http: https: data:; child-src 'self'; object-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' https:;">
 	</head>
 	<body class="monaco-shell vs-dark" aria-label="">
 		<script src="preload.js"></script>

--- a/src/vs/workbench/electron-browser/bootstrap/index.html
+++ b/src/vs/workbench/electron-browser/bootstrap/index.html
@@ -3,43 +3,10 @@
 <html>
 	<head>
 		<meta charset="utf-8" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' http: https: data:; media-src 'self' http: https: data:; child-src 'self'; object-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https:; font-src 'self' https:;">
 	</head>
 	<body class="monaco-shell vs-dark" aria-label="">
-		<script>
-			(function() {
-				function getConfig() {
-					let queryParams = window.location.search.substring(1).split('&');
-					for (let i = 0; i < queryParams.length; i++) {
-						var kv = queryParams[i].split('=');
-						if (kv[0] === 'config' && kv[1]) {
-							return JSON.parse(decodeURIComponent(kv[1]));
-						}
-					}
-					return {};
-				}
-				try {
-					let config = getConfig();
-					let document = window.document;
-
-					// sets the base theme class ('vs', 'vs-dark', 'hc-black')
-					let baseTheme = config.baseTheme || 'vs';
-					document.body.className = 'monaco-shell ' + baseTheme;
-
-					// adds a stylesheet with the backgrdound color
-					let backgroundColor = config.backgroundColor;
-					if (!backgroundColor) {
-						backgroundColor = baseTheme === 'hc-black' ? '#000000' : (baseTheme === 'vs' ? '#FFFFFF' : '#1E1E1E');
-					}
-					let foregroundColor = baseTheme === 'hc-black' ? '#FFFFFF' : (baseTheme === 'vs' ? '#6C6C6C' : '#CCCCCC');
-					let style = document.createElement('style');
-					style.innerHTML = '.monaco-shell { background-color:' + backgroundColor + '; color:' + foregroundColor + '; }';
-					document.head.appendChild(style);
-
-				} catch (error) {
-					console.error(error);
-				}
-			})();
-		</script>
+		<script src="preload.js"></script>
 	</body>
 
 	<!-- Startup via index.js -->

--- a/src/vs/workbench/electron-browser/bootstrap/preload.js
+++ b/src/vs/workbench/electron-browser/bootstrap/preload.js
@@ -6,8 +6,8 @@
 
 (function() {
 	function getConfig() {
-		let queryParams = window.location.search.substring(1).split('&');
-		for (let i = 0; i < queryParams.length; i++) {
+		const queryParams = window.location.search.substring(1).split('&');
+		for (var i = 0; i < queryParams.length; i++) {
 			var kv = queryParams[i].split('=');
 			if (kv[0] === 'config' && kv[1]) {
 				return JSON.parse(decodeURIComponent(kv[1]));
@@ -16,20 +16,20 @@
 		return {};
 	}
 	try {
-		let config = getConfig();
-		let document = window.document;
+		const config = getConfig();
+		const document = window.document;
 
 		// sets the base theme class ('vs', 'vs-dark', 'hc-black')
-		let baseTheme = config.baseTheme || 'vs';
+		const baseTheme = config.baseTheme || 'vs';
 		document.body.className = 'monaco-shell ' + baseTheme;
 
 		// adds a stylesheet with the backgrdound color
-		let backgroundColor = config.backgroundColor;
+		var backgroundColor = config.backgroundColor;
 		if (!backgroundColor) {
 			backgroundColor = baseTheme === 'hc-black' ? '#000000' : (baseTheme === 'vs' ? '#FFFFFF' : '#1E1E1E');
 		}
-		let foregroundColor = baseTheme === 'hc-black' ? '#FFFFFF' : (baseTheme === 'vs' ? '#6C6C6C' : '#CCCCCC');
-		let style = document.createElement('style');
+		const foregroundColor = baseTheme === 'hc-black' ? '#FFFFFF' : (baseTheme === 'vs' ? '#6C6C6C' : '#CCCCCC');
+		const style = document.createElement('style');
 		style.innerHTML = '.monaco-shell { background-color:' + backgroundColor + '; color:' + foregroundColor + '; }';
 		document.head.appendChild(style);
 

--- a/src/vs/workbench/electron-browser/bootstrap/preload.js
+++ b/src/vs/workbench/electron-browser/bootstrap/preload.js
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+(function() {
+	function getConfig() {
+		let queryParams = window.location.search.substring(1).split('&');
+		for (let i = 0; i < queryParams.length; i++) {
+			var kv = queryParams[i].split('=');
+			if (kv[0] === 'config' && kv[1]) {
+				return JSON.parse(decodeURIComponent(kv[1]));
+			}
+		}
+		return {};
+	}
+	try {
+		let config = getConfig();
+		let document = window.document;
+
+		// sets the base theme class ('vs', 'vs-dark', 'hc-black')
+		let baseTheme = config.baseTheme || 'vs';
+		document.body.className = 'monaco-shell ' + baseTheme;
+
+		// adds a stylesheet with the backgrdound color
+		let backgroundColor = config.backgroundColor;
+		if (!backgroundColor) {
+			backgroundColor = baseTheme === 'hc-black' ? '#000000' : (baseTheme === 'vs' ? '#FFFFFF' : '#1E1E1E');
+		}
+		let foregroundColor = baseTheme === 'hc-black' ? '#FFFFFF' : (baseTheme === 'vs' ? '#6C6C6C' : '#CCCCCC');
+		let style = document.createElement('style');
+		style.innerHTML = '.monaco-shell { background-color:' + backgroundColor + '; color:' + foregroundColor + '; }';
+		document.head.appendChild(style);
+
+	} catch (error) {
+		console.error(error);
+	}
+})();


### PR DESCRIPTION
Adds a content security policy to the root document. This limits what can be loaded. Important changes:

* Connect-src is limited to `self` or `https:`
* script-src is limited to `self`
* object and child-src are limited to `self`
* Media allows `self` `http` `https` and `data`

This CSP effects all of VSCode. I've done sanity checks to make sure basics scenarios do not produce any warnings but the CSP may still need adjustment