### PR TITLE
Add spaces and fix switch to actual MarkDown

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,8 +1,8 @@
 Do you have a question? Please ask it on [Stack Overflow with `vscode` tag](http://stackoverflow.com/questions/tagged/vscode)
 
+(Use Help > Report Issues to prefill these)
 - VSCode Version: 
 - OS Version: 
-(Use Help > Report Issues to prefill these)
 
 Steps to Reproduce:
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,9 +1,9 @@
-<!-- Do you have a question? Please ask it on http://stackoverflow.com/questions/tagged/vscode -->
+Do you have a question? Please ask it on [Stack Overflow with `vscode` tag](http://stackoverflow.com/questions/tagged/vscode)
 
-- VSCode Version:
-- OS Version:
+- VSCode Version: (Help -> About)
+- OS Version: 
 
 Steps to Reproduce:
 
-1.
-2.
+1. 
+2. 

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,7 +1,8 @@
 Do you have a question? Please ask it on [Stack Overflow with `vscode` tag](http://stackoverflow.com/questions/tagged/vscode)
 
-- VSCode Version: (Help -> About)
+- VSCode Version: 
 - OS Version: 
+(Use Help > Report Issues to prefill these)
 
 Steps to Reproduce:
 


### PR DESCRIPTION
I've added spaces after the colons and the numbered list does so the reporter doesn't have to do it themselves or worse yet doesn't default to not adding them.

I've also removed the HTML comment, because it makes no sense in a MarkDown file, especially when it defaults to edit view when creating an issue. I've converted the link to MarkDown link, too.