### PR TITLE
Continue html renderer cleanup

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -13,7 +13,7 @@ import { IHTMLContentElement, MarkedString, removeMarkdownEscapes } from 'vs/bas
 import { marked } from 'vs/base/common/marked/marked';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 
-export type RenderableContent = string | IHTMLContentElement | IHTMLContentElement[];
+export type RenderableContent = string | IHTMLContentElement;
 
 export interface RenderOptions {
 	actionCallback?: (content: string, event?: IMouseEvent) => void;
@@ -21,7 +21,7 @@ export interface RenderOptions {
 }
 
 export function renderMarkedString(markedString: MarkedString, options: RenderOptions = {}): Node {
-	const htmlContentElement = typeof markedString === 'string' ? { markdown: markedString } : { code: markedString };
+	const htmlContentElement: IHTMLContentElement = typeof markedString === 'string' ? { markdown: markedString } : { code: markedString };
 	return renderHtml(htmlContentElement, options);
 }
 
@@ -34,8 +34,6 @@ export function renderMarkedString(markedString: MarkedString, options: RenderOp
 export function renderHtml(content: RenderableContent, options: RenderOptions = {}): Node {
 	if (typeof content === 'string') {
 		return document.createTextNode(content);
-	} else if (Array.isArray(content)) {
-		return _renderHtml({ children: content }, options);
 	} else if (content) {
 		return _renderHtml(content, options);
 	}
@@ -54,11 +52,6 @@ function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}):
 	}
 	if (content.text) {
 		element.textContent = content.text;
-	}
-	if (content.children) {
-		content.children.forEach((child) => {
-			element.appendChild(renderHtml(child, options));
-		});
 	}
 	if (content.formattedText) {
 		renderFormattedText(element, parseFormattedText(content.formattedText), actionCallback);

--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -86,56 +86,6 @@ export interface IHTMLContentElement {
 	text?: string;
 	className?: string;
 	inline?: boolean;
-	children?: IHTMLContentElement[];
 	markdown?: string;
 	code?: IHTMLContentElementCode;
-}
-
-function htmlContentElementCodeEqual(a: IHTMLContentElementCode, b: IHTMLContentElementCode): boolean {
-	if (!a && !b) {
-		return true;
-	}
-	if (!a || !b) {
-		return false;
-	}
-	return (
-		a.language === b.language
-		&& a.value === b.value
-	);
-}
-
-function htmlContentElementEqual(a: IHTMLContentElement, b: IHTMLContentElement): boolean {
-	return (
-		a.formattedText === b.formattedText
-		&& a.text === b.text
-		&& a.className === b.className
-		&& a.inline === b.inline
-		&& a.markdown === b.markdown
-		&& htmlContentElementCodeEqual(a.code, b.code)
-		&& htmlContentElementArrEquals(a.children, b.children)
-	);
-}
-
-export function htmlContentElementArrEquals(a: IHTMLContentElement[], b: IHTMLContentElement[]): boolean {
-	if (!a && !b) {
-		return true;
-	}
-	if (!a || !b) {
-		return false;
-	}
-
-	let aLen = a.length,
-		bLen = b.length;
-
-	if (aLen !== bLen) {
-		return false;
-	}
-
-	for (let i = 0; i < aLen; i++) {
-		if (!htmlContentElementEqual(a[i], b[i])) {
-			return false;
-		}
-	}
-
-	return true;
 }

--- a/src/vs/base/test/browser/htmlContent.test.ts
+++ b/src/vs/base/test/browser/htmlContent.test.ts
@@ -32,18 +32,6 @@ suite('HtmlContent', () => {
 		assert.strictEqual(result.className, 'testClass');
 	});
 
-	test('render element with children', () => {
-		var result: HTMLElement = <any>renderHtml({
-			className: 'parent',
-			children: [{
-				text: 'child'
-			}]
-		});
-		assert.strictEqual(result.children.length, 1);
-		assert.strictEqual(result.className, 'parent');
-		assert.strictEqual(result.firstChild.textContent, 'child');
-	});
-
 	test('simple formatting', () => {
 		var result: HTMLElement = <any>renderHtml({
 			formattedText: '**bold**'

--- a/src/vs/workbench/services/keybinding/test/keyboardMapperTestUtils.ts
+++ b/src/vs/workbench/services/keybinding/test/keyboardMapperTestUtils.ts
@@ -6,12 +6,10 @@
 'use strict';
 
 import * as assert from 'assert';
-import { IHTMLContentElement } from 'vs/base/common/htmlContent';
 import { IKeyboardMapper } from 'vs/workbench/services/keybinding/common/keyboardMapper';
 import { Keybinding, ResolvedKeybinding, SimpleKeybinding } from 'vs/base/common/keyCodes';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { readFile, writeFile } from 'vs/base/node/pfs';
-import { OperatingSystem } from 'vs/base/common/platform';
 import { IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
 import { ScanCodeBinding } from 'vs/workbench/services/keybinding/common/scanCode';
 
@@ -50,37 +48,6 @@ export function assertResolveKeyboardEvent(mapper: IKeyboardMapper, keyboardEven
 export function assertResolveUserBinding(mapper: IKeyboardMapper, firstPart: SimpleKeybinding | ScanCodeBinding, chordPart: SimpleKeybinding | ScanCodeBinding, expected: IResolvedKeybinding[]): void {
 	let actual: IResolvedKeybinding[] = mapper.resolveUserBinding(firstPart, chordPart).map(toIResolvedKeybinding);
 	assert.deepEqual(actual, expected);
-}
-
-function _htmlPieces(pieces: string[], OS: OperatingSystem): IHTMLContentElement[] {
-	let children: IHTMLContentElement[] = [];
-	for (let i = 0, len = pieces.length; i < len; i++) {
-		if (i !== 0 && OS !== OperatingSystem.Macintosh) {
-			children.push({ inline: true, text: '+' });
-		}
-		children.push({ inline: true, className: 'monaco-kbkey', text: pieces[i] });
-	}
-	return children;
-}
-
-export function simpleHTMLLabel(pieces: string[], OS: OperatingSystem): IHTMLContentElement {
-	return {
-		inline: true,
-		className: 'monaco-kb',
-		children: _htmlPieces(pieces, OS)
-	};
-}
-
-export function chordHTMLLabel(firstPart: string[], chordPart: string[], OS: OperatingSystem): IHTMLContentElement {
-	return {
-		inline: true,
-		className: 'monaco-kb',
-		children: [].concat(
-			_htmlPieces(firstPart, OS),
-			[{ tagName: 'span', text: ' ' }],
-			_htmlPieces(chordPart, OS)
-		)
-	};
 }
 
 export function readRawMapping<T>(file: string): TPromise<T> {


### PR DESCRIPTION
* Removes the `child` option for `IHTMLContentElement`. This is only used internally as far as I can tell
* Delete some unused functions