### PR TITLE
Improve grammar of config setting description

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -40,5 +40,5 @@
 	"config.ignoreLegacyWarning": "Ignores the legacy Git warning",
 	"config.ignoreLimitWarning": "Ignores the warning when there are too many changes in a repository",
 	"config.defaultCloneDirectory": "The default location where to clone a git repository",
-	"config.enableSmartCommit": "Commit all changes when there are not staged changes."
+	"config.enableSmartCommit": "Commit all changes when there are no staged changes."
 }


### PR DESCRIPTION
This PR changes the `config.enableSmartCommit` setting description from

```
Commit all changes when there are not staged changes.
```

to

```
Commit all changes when there are no staged changes.
```

While the former version is technically correct, I consider the proposed version easier to read.