### PR TITLE
List: set aria-setsize and aria-posinset

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -651,15 +651,13 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		if (options.ariaLabel) {
 			this.view.domNode.setAttribute('aria-label', options.ariaLabel);
 		}
-		this.view.domNode.setAttribute('aria-setsize', this.length.toString());
+		this.view.domNode.setAttribute('aria-setsize', '0');
 
 		this.style(options);
 	}
 
 	splice(start: number, deleteCount: number, elements: T[] = []): void {
-		this.eventBufferer.bufferEvents(() => {
-			this.spliceable.splice(start, deleteCount, elements);
-		});
+		this.eventBufferer.bufferEvents(() => this.spliceable.splice(start, deleteCount, elements));
 		this.view.domNode.setAttribute('aria-setsize', this.length.toString());
 	}
 

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -656,7 +656,10 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	}
 
 	splice(start: number, deleteCount: number, elements: T[] = []): void {
-		this.eventBufferer.bufferEvents(() => this.spliceable.splice(start, deleteCount, elements));
+		this.eventBufferer.bufferEvents(() => {
+			this.spliceable.splice(start, deleteCount, elements);
+			this.view.domNode.setAttribute('aria-setsize', this.length.toString());
+		});
 	}
 
 	get length(): number {
@@ -712,6 +715,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	setFocus(indexes: number[]): void {
 		indexes = indexes.sort(numericSort);
 		this.focus.set(indexes);
+		this.view.domNode.setAttribute('aria-posinset', indexes.length ? (indexes[0] + 1).toString() : undefined);
 	}
 
 	focusNext(n = 1, loop = false): void {

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -651,6 +651,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		if (options.ariaLabel) {
 			this.view.domNode.setAttribute('aria-label', options.ariaLabel);
 		}
+		this.view.domNode.setAttribute('aria-setsize', this.length.toString());
 
 		this.style(options);
 	}
@@ -658,8 +659,8 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	splice(start: number, deleteCount: number, elements: T[] = []): void {
 		this.eventBufferer.bufferEvents(() => {
 			this.spliceable.splice(start, deleteCount, elements);
-			this.view.domNode.setAttribute('aria-setsize', this.length.toString());
 		});
+		this.view.domNode.setAttribute('aria-setsize', this.length.toString());
 	}
 
 	get length(): number {
@@ -715,7 +716,11 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	setFocus(indexes: number[]): void {
 		indexes = indexes.sort(numericSort);
 		this.focus.set(indexes);
-		this.view.domNode.setAttribute('aria-posinset', indexes.length ? (indexes[0] + 1).toString() : undefined);
+		if (indexes.length) {
+			this.view.domNode.setAttribute('aria-posinset', (indexes[0] + 1).toString());
+		} else {
+			this.view.domNode.removeAttribute('aria-posinset');
+		}
 	}
 
 	focusNext(n = 1, loop = false): void {


### PR DESCRIPTION
Fixes #27900 for the list widget

Please note: that the `splice` seems to be called even when the focus changes in the list so I might be calling set `aria-setsize` a bit too often.

Also note that `aria-posinset` should start with 1, not 0 thus I am doing +1. More details: https://www.w3.org/TR/wai-aria/states_and_properties#aria-posinset

@joaomoreno once you approve on this I can do a similar thing for the tree
@alexandrudima fyi