### PR TITLE
Always reject Promises with Error instances

### DIFF
--- a/extensions/php/build/update-grammar.js
+++ b/extensions/php/build/update-grammar.js
@@ -14,7 +14,7 @@ function adaptInjectionScope(grammar) {
 	var injections = grammar.injections;
 	var injection = injections[oldInjectionKey];
 	if (!injections) {
-		throw "Can not find PHP injection";
+		throw new Error("Can not find PHP injection");
 	}
 	delete injections[oldInjectionKey];
 	injections[newInjectionKey] = injection;

--- a/src/vs/base/common/winjs.base.d.ts
+++ b/src/vs/base/common/winjs.base.d.ts
@@ -33,7 +33,7 @@ export declare class Promise {
 	// commented out to speed up adoption of TPromise
 	// static timeout(delay:number):Promise;
 
-	static wrapError(error: any): Promise;
+	static wrapError(error: Error): Promise;
 	// static is(value: any): value is Thenable<any>;
 	// static addEventListener(type: string, fn: EventCallback): void;
 
@@ -106,7 +106,7 @@ export declare class TPromise<V> {
 	public static wrap<ValueType>(value: Thenable<ValueType>): TPromise<ValueType>;
 	public static wrap<ValueType>(value: ValueType): TPromise<ValueType>;
 
-	public static wrapError<ValueType>(error: any): TPromise<ValueType>;
+	public static wrapError<ValueType>(error: Error): TPromise<ValueType>;
 
 	/**
 	 * @internal
@@ -134,5 +134,5 @@ export declare class PPromise<C, P> extends TPromise<C> {
 	public static join<C, P>(promises: PPromise<C, P>[]): PPromise<C, P[]>;
 	public static join<C, P>(promises: { [n: string]: PPromise<C, P> }): PPromise<{ [n: string]: C }, P>;
 	public static any<C, P>(promises: PPromise<C, P>[]): PPromise<{ key: string; value: PPromise<C, P>; }, P>;
-	public static wrapError<V>(error: any): TPromise<V>;
+	public static wrapError<V>(error: Error): TPromise<V>;
 }

--- a/src/vs/base/node/processes.ts
+++ b/src/vs/base/node/processes.ts
@@ -168,7 +168,7 @@ export abstract class AbstractProcess<TProgressData> {
 
 	public start(): PPromise<SuccessData, TProgressData> {
 		if (Platform.isWindows && ((this.options && this.options.cwd && TPath.isUNC(this.options.cwd)) || !this.options && !this.options.cwd && TPath.isUNC(process.cwd()))) {
-			return Promise.wrapError(nls.localize('TaskRunner.UNC', 'Can\'t execute a shell command on an UNC drive.'));
+			return Promise.wrapError(new Error(nls.localize('TaskRunner.UNC', 'Can\'t execute a shell command on an UNC drive.')));
 		}
 		return this.useExec().then((useExec) => {
 			let cc: TValueCallback<SuccessData>;

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -384,7 +384,7 @@ export class IPCServer implements IChannelServer, IRoutingChannelClient, IDispos
 			const id = router.route(command, arg);
 
 			if (!id) {
-				return TPromise.wrapError('Client id should be provided');
+				return TPromise.wrapError(new Error('Client id should be provided'));
 			}
 
 			return this.getClient(id).then(client => client.getChannel(channelName).call(command, arg));

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -95,7 +95,7 @@ export class Client implements IChannelClient, IDisposable {
 
 	protected request(channelName: string, name: string, arg: any): Promise {
 		if (!this.disposeDelayer) {
-			return Promise.wrapError('disposed');
+			return Promise.wrapError(new Error('disposed'));
 		}
 
 		this.disposeDelayer.cancel();

--- a/src/vs/base/test/common/async.test.ts
+++ b/src/vs/base/test/common/async.test.ts
@@ -495,7 +495,7 @@ suite('Async', () => {
 
 		let f1 = () => TPromise.as(true).then(() => res.push(1));
 		let f2 = () => TPromise.timeout(10).then(() => res.push(2));
-		let f3 = () => TPromise.as(true).then(() => TPromise.wrapError('error'));
+		let f3 = () => TPromise.as(true).then(() => TPromise.wrapError(new Error('error')));
 		let f4 = () => TPromise.timeout(20).then(() => res.push(4));
 		let f5 = () => TPromise.timeout(0).then(() => res.push(5));
 

--- a/src/vs/base/test/common/cache.test.ts
+++ b/src/vs/base/test/common/cache.test.ts
@@ -23,12 +23,12 @@ suite('Cache', () => {
 
 	test('simple error', () => {
 		let counter = 0;
-		const cache = new Cache(() => TPromise.wrapError(counter++));
+		const cache = new Cache(() => TPromise.wrapError(new Error(String(counter++))));
 
 		return cache.get()
-			.then(() => assert.fail(), err => assert.equal(err, 0))
+			.then(() => assert.fail(), err => assert.equal(err.message, 0))
 			.then(() => cache.get())
-			.then(() => assert.fail(), err => assert.equal(err, 0));
+			.then(() => assert.fail(), err => assert.equal(err.message, 0));
 	});
 
 	test('should retry cancellations', () => {

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -109,7 +109,7 @@ function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 						const msg = 'Running extension tests from the command line is currently only supported if no other instance of Code is running.';
 						console.error(msg);
 						client.dispose();
-						return TPromise.wrapError<Server>(msg);
+						return TPromise.wrapError<Server>(new Error(msg));
 					}
 
 					logService.log('Sending env to running instance...');
@@ -120,7 +120,7 @@ function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 					return allowSetForegroundWindow(service)
 						.then(() => service.start(environmentService.args, process.env))
 						.then(() => client.dispose())
-						.then(() => TPromise.wrapError<Server>('Sent env to running instance. Terminating...'));
+						.then(() => TPromise.wrapError<Server>(new Error('Sent env to running instance. Terminating...')));
 				},
 				err => {
 					if (!retry || platform.isWindows || err.code !== 'ECONNREFUSED') {

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -116,7 +116,7 @@ class Main {
 							const [extension] = result.firstPage;
 
 							if (!extension) {
-								return TPromise.wrapError(`${notFound(id)}\n${useId}`);
+								return TPromise.wrapError(new Error(`${notFound(id)}\n${useId}`));
 							}
 
 							console.log(localize('foundExtension', "Found '{0}' in the marketplace.", id));
@@ -137,7 +137,7 @@ class Main {
 				const [extension] = installed.filter(e => getId(e.manifest) === id);
 
 				if (!extension) {
-					return TPromise.wrapError(`${notInstalled(id)}\n${useId}`);
+					return TPromise.wrapError(new Error(`${notInstalled(id)}\n${useId}`));
 				}
 
 				console.log(localize('uninstalling', "Uninstalling {0}...", id));

--- a/src/vs/editor/common/services/bulkEdit.ts
+++ b/src/vs/editor/common/services/bulkEdit.ts
@@ -338,7 +338,7 @@ export function createBulkEdit(textModelResolverService: ITextModelService, edit
 
 		let concurrentEdits = getConcurrentEdits();
 		if (concurrentEdits) {
-			return TPromise.wrapError<ISelection>(concurrentEdits);
+			return TPromise.wrapError<ISelection>(new Error(concurrentEdits));
 		}
 
 		let uri: URI;

--- a/src/vs/editor/contrib/links/common/links.ts
+++ b/src/vs/editor/contrib/links/common/links.ts
@@ -38,7 +38,7 @@ export class Link implements ILink {
 			try {
 				return TPromise.as(URI.parse(this._link.url));
 			} catch (e) {
-				return TPromise.wrapError<URI>('invalid');
+				return TPromise.wrapError<URI>(new Error('invalid'));
 			}
 		}
 
@@ -50,11 +50,11 @@ export class Link implements ILink {
 					return this.resolve();
 				}
 
-				return TPromise.wrapError<URI>('missing');
+				return TPromise.wrapError<URI>(new Error('missing'));
 			});
 		}
 
-		return TPromise.wrapError<URI>('missing');
+		return TPromise.wrapError<URI>(new Error('missing'));
 	}
 }
 

--- a/src/vs/editor/contrib/rename/browser/rename.ts
+++ b/src/vs/editor/contrib/rename/browser/rename.ts
@@ -54,7 +54,7 @@ export function rename(model: IReadOnlyModel, position: Position, newName: strin
 					return undefined;
 				}, err => {
 					onUnexpectedExternalError(err);
-					return TPromise.wrapError<WorkspaceEdit>('provider failed');
+					return TPromise.wrapError<WorkspaceEdit>(new Error('provider failed'));
 				});
 			}
 			return undefined;
@@ -198,7 +198,7 @@ class RenameController implements IEditorContribution {
 
 		return rename(this.editor.getModel(), this.editor.getPosition(), newName).then(result => {
 			if (result.rejectReason) {
-				return TPromise.wrapError<BulkEdit>(result.rejectReason);
+				return TPromise.wrapError<BulkEdit>(new Error(result.rejectReason));
 			}
 			edit.add(result.edits);
 			return edit;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -95,7 +95,7 @@ declare module monaco {
 		public static wrap<ValueType>(value: Thenable<ValueType>): Promise<ValueType>;
 		public static wrap<ValueType>(value: ValueType): Promise<ValueType>;
 
-		public static wrapError<ValueType>(error: any): Promise<ValueType>;
+		public static wrapError<ValueType>(error: Error): Promise<ValueType>;
 	}
 
 	export class CancellationTokenSource {

--- a/src/vs/platform/commands/test/commandService.test.ts
+++ b/src/vs/platform/commands/test/commandService.test.ts
@@ -69,12 +69,12 @@ suite('CommandService', function () {
 
 		let service = new CommandService(new InstantiationService(), new class extends SimpleExtensionService {
 			activateByEvent(activationEvent: string): TPromise<void> {
-				return TPromise.wrapError<void>('bad_activate');
+				return TPromise.wrapError<void>(new Error('bad_activate'));
 			}
 		});
 
 		return service.executeCommand('foo').then(() => assert.ok(false), err => {
-			assert.equal(err, 'bad_activate');
+			assert.equal(err.message, 'bad_activate');
 		});
 	});
 

--- a/src/vs/platform/extensionManagement/common/extensionEnablementService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionEnablementService.ts
@@ -61,7 +61,7 @@ export class ExtensionEnablementService implements IExtensionEnablementService {
 
 	public setEnablement(identifier: string, enable: boolean, workspace: boolean = false): TPromise<boolean> {
 		if (workspace && !this.hasWorkspace) {
-			return TPromise.wrapError<boolean>(localize('noWorkspace', "No workspace."));
+			return TPromise.wrapError<boolean>(new Error(localize('noWorkspace', "No workspace.")));
 		}
 
 		if (this.environmentService.disableExtensions) {

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -515,7 +515,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 			const firstOptions = assign({}, options, { url: asset.uri });
 
 			return this.requestService.request(firstOptions)
-				.then(context => context.res.statusCode === 200 ? context : TPromise.wrapError('expected 200'))
+				.then(context => context.res.statusCode === 200 ? context : TPromise.wrapError(new Error('expected 200')))
 				.then(null, err => {
 					this.telemetryService.publicLog('galleryService:requestError', { cdn: true, message: getErrorMessage(err) });
 					this.telemetryService.publicLog('galleryService:cdnFallback', { url: asset.uri });

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -368,7 +368,7 @@ export class ExtensionManagementService implements IExtensionManagementService {
 		const dependenciesToUninstall = this.filterDependents(extension, dependencies, installed);
 		let dependents = this.getDependents(extension, installed).filter(dependent => extension !== dependent && dependenciesToUninstall.indexOf(dependent) === -1);
 		if (dependents.length) {
-			return TPromise.wrapError<void>(this.getDependentsErrorMessage(extension, dependents));
+			return TPromise.wrapError<void>(new Error(this.getDependentsErrorMessage(extension, dependents)));
 		}
 		return TPromise.join([this.uninstallExtension(extension.id), ...dependenciesToUninstall.map(d => this.doUninstall(d.id))]).then(() => null);
 	}

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -496,9 +496,10 @@ export interface IImportResult {
 	isNew: boolean;
 }
 
-export interface IFileOperationResult {
-	message: string;
-	fileOperationResult: FileOperationResult;
+export class FileOperationError extends Error {
+	constructor(message: string, public fileOperationResult: FileOperationResult) {
+		super(message);
+	}
 }
 
 export enum FileOperationResult {

--- a/src/vs/platform/message/common/messageIpc.ts
+++ b/src/vs/platform/message/common/messageIpc.ts
@@ -23,7 +23,7 @@ export class ChoiceChannel implements IChoiceChannel {
 		switch (command) {
 			case 'choose': return this.choiceService.choose(args[0], args[1], args[2], args[3], args[4]);
 		}
-		return TPromise.wrapError('invalid command');
+		return TPromise.wrapError(new Error('invalid command'));
 	}
 }
 

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -243,7 +243,7 @@ suite('TelemetryService', () => {
 	// 			let testAppender = new TestTelemetryAppender();
 	// 			service.addTelemetryAppender(testAppender);
 	//
-	// 			winjs.Promise.wrapError('This should not get logged');
+	// 			winjs.Promise.wrapError(new Error('This should not get logged'));
 	// 			winjs.TPromise.as(true).then(() => {
 	// 				throw new Error('This should get logged');
 	// 			});

--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -31,13 +31,13 @@ export class MainThreadDebugService extends MainThreadDebugServiceShape {
 
 	public $createDebugSession(configuration: IConfig): TPromise<DebugSessionUUID> {
 		if (configuration.request !== 'launch' && configuration.request !== 'attach') {
-			return TPromise.wrapError(`only 'launch' or 'attach' allowed for 'request' attribute`);
+			return TPromise.wrapError(new Error(`only 'launch' or 'attach' allowed for 'request' attribute`));
 		}
 		return this.debugService.createProcess(configuration).then(process => {
 			if (process) {
 				return <DebugSessionUUID>process.getId();
 			}
-			return TPromise.wrapError('cannot create debug session');
+			return TPromise.wrapError(new Error('cannot create debug session'));
 		}, err => {
 			return TPromise.wrapError(err && err.message ? err.message : 'cannot create debug session');
 		});
@@ -50,11 +50,11 @@ export class MainThreadDebugService extends MainThreadDebugServiceShape {
 				if (response.success) {
 					return response.body;
 				} else {
-					return TPromise.wrapError(response.message);
+					return TPromise.wrapError(new Error(response.message));
 				}
 			});
 		}
-		return TPromise.wrapError('debug session not found');
+		return TPromise.wrapError(new Error('debug session not found'));
 	}
 
 	private _findProcessByUUID(processId: DebugSessionUUID): IProcess | null {

--- a/src/vs/workbench/api/electron-browser/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDocuments.ts
@@ -190,7 +190,7 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 	$tryOpenDocument(uri: URI): TPromise<any> {
 
 		if (!uri.scheme || !(uri.fsPath || uri.authority)) {
-			return TPromise.wrapError(`Invalid uri. Scheme and authority or path must be set.`);
+			return TPromise.wrapError(new Error(`Invalid uri. Scheme and authority or path must be set.`));
 		}
 
 		let promise: TPromise<boolean>;
@@ -206,11 +206,11 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 
 		return promise.then(success => {
 			if (!success) {
-				return TPromise.wrapError('cannot open ' + uri.toString());
+				return TPromise.wrapError(new Error('cannot open ' + uri.toString()));
 			}
 			return undefined;
 		}, err => {
-			return TPromise.wrapError('cannot open ' + uri.toString() + '. Detail: ' + toErrorMessage(err));
+			return TPromise.wrapError(new Error('cannot open ' + uri.toString() + '. Detail: ' + toErrorMessage(err)));
 		});
 	}
 
@@ -230,7 +230,7 @@ export class MainThreadDocuments extends MainThreadDocumentsShape {
 		let asFileUri = uri.with({ scheme: 'file' });
 		return this._fileService.resolveFile(asFileUri).then(stats => {
 			// don't create a new file ontop of an existing file
-			return TPromise.wrapError<boolean>('file already exists on disk');
+			return TPromise.wrapError<boolean>(new Error('file already exists on disk'));
 		}, err => this._doCreateUntitled(asFileUri).then(resource => !!resource));
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadEditors.ts
@@ -158,7 +158,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	$trySetSelections(id: string, selections: ISelection[]): TPromise<any> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError('TextEditor disposed');
+			return TPromise.wrapError(new Error('TextEditor disposed'));
 		}
 		this._documentsAndEditors.getEditor(id).setSelections(selections);
 		return TPromise.as(null);
@@ -166,7 +166,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	$trySetDecorations(id: string, key: string, ranges: IDecorationOptions[]): TPromise<any> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError('TextEditor disposed');
+			return TPromise.wrapError(new Error('TextEditor disposed'));
 		}
 		this._documentsAndEditors.getEditor(id).setDecorations(key, ranges);
 		return TPromise.as(null);
@@ -174,7 +174,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	$tryRevealRange(id: string, range: IRange, revealType: TextEditorRevealType): TPromise<any> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError('TextEditor disposed');
+			return TPromise.wrapError(new Error('TextEditor disposed'));
 		}
 		this._documentsAndEditors.getEditor(id).revealRange(range, revealType);
 		return undefined;
@@ -182,7 +182,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	$trySetOptions(id: string, options: ITextEditorConfigurationUpdate): TPromise<any> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError('TextEditor disposed');
+			return TPromise.wrapError(new Error('TextEditor disposed'));
 		}
 		this._documentsAndEditors.getEditor(id).setConfiguration(options);
 		return TPromise.as(null);
@@ -190,14 +190,14 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 
 	$tryApplyEdits(id: string, modelVersionId: number, edits: ISingleEditOperation[], opts: IApplyEditsOptions): TPromise<boolean> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError<boolean>('TextEditor disposed');
+			return TPromise.wrapError<boolean>(new Error('TextEditor disposed'));
 		}
 		return TPromise.as(this._documentsAndEditors.getEditor(id).applyEdits(modelVersionId, edits, opts));
 	}
 
 	$tryInsertSnippet(id: string, template: string, ranges: IRange[], opts: IUndoStopOptions): TPromise<boolean> {
 		if (!this._documentsAndEditors.getEditor(id)) {
-			return TPromise.wrapError<boolean>('TextEditor disposed');
+			return TPromise.wrapError<boolean>(new Error('TextEditor disposed'));
 		}
 		return TPromise.as(this._documentsAndEditors.getEditor(id).insertSnippet(template, ranges, opts));
 	}
@@ -214,7 +214,7 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 		const editor = this._documentsAndEditors.getEditor(id);
 
 		if (!editor) {
-			return TPromise.wrapError<ILineChange[]>('No such TextEditor');
+			return TPromise.wrapError<ILineChange[]>(new Error('No such TextEditor'));
 		}
 
 		const codeEditor = editor.getCodeEditor();

--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -210,7 +210,7 @@ class ExtHostSaveParticipant implements INamedSaveParticpant {
 			this._proxy.$participateInSave(editorModel.getResource(), env.reason).then(values => {
 				for (const success of values) {
 					if (!success) {
-						return TPromise.wrapError('listener failed');
+						return TPromise.wrapError(new Error('listener failed'));
 					}
 				}
 				return undefined;

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -343,7 +343,7 @@ export class ExtHostApiCommands {
 				return undefined;
 			}
 			if (value.rejectReason) {
-				return TPromise.wrapError<types.WorkspaceEdit>(value.rejectReason);
+				return TPromise.wrapError<types.WorkspaceEdit>(new Error(value.rejectReason));
 			}
 			let workspaceEdit = new types.WorkspaceEdit();
 			for (let edit of value.edits) {

--- a/src/vs/workbench/api/node/extHostCommands.ts
+++ b/src/vs/workbench/api/node/extHostCommands.ts
@@ -104,7 +104,7 @@ export class ExtHostCommands extends ExtHostCommandsShape {
 	$executeContributedCommand<T>(id: string, ...args: any[]): Thenable<T> {
 		let command = this._commands.get(id);
 		if (!command) {
-			return TPromise.wrapError<T>(`Contributed command '${id}' does not exist.`);
+			return TPromise.wrapError<T>(new Error(`Contributed command '${id}' does not exist.`));
 		}
 
 		let { callback, thisArg, description } = command;
@@ -114,7 +114,7 @@ export class ExtHostCommands extends ExtHostCommandsShape {
 				try {
 					validateConstraint(args[i], description.args[i].constraint);
 				} catch (err) {
-					return TPromise.wrapError<T>(`Running the contributed command:'${id}' failed. Illegal argument '${description.args[i].name}' - ${description.args[i].description}`);
+					return TPromise.wrapError<T>(new Error(`Running the contributed command:'${id}' failed. Illegal argument '${description.args[i].name}' - ${description.args[i].description}`));
 				}
 			}
 		}
@@ -131,7 +131,7 @@ export class ExtHostCommands extends ExtHostCommandsShape {
 			// } catch (err) {
 			// 	//
 			// }
-			return TPromise.wrapError<T>(`Running the contributed command:'${id}' failed.`);
+			return TPromise.wrapError<T>(new Error(`Running the contributed command:'${id}' failed.`));
 		}
 	}
 

--- a/src/vs/workbench/api/node/extHostDocumentData.ts
+++ b/src/vs/workbench/api/node/extHostDocumentData.ts
@@ -101,7 +101,7 @@ export class ExtHostDocumentData extends MirrorModel {
 
 	private _save(): TPromise<boolean> {
 		if (this._isDisposed) {
-			return TPromise.wrapError<boolean>('Document has been closed');
+			return TPromise.wrapError<boolean>(new Error('Document has been closed'));
 		}
 		return this._proxy.$trySaveDocument(this._uri);
 	}

--- a/src/vs/workbench/api/node/extHostDocuments.ts
+++ b/src/vs/workbench/api/node/extHostDocuments.ts
@@ -154,7 +154,7 @@ export class ExtHostDocuments extends ExtHostDocumentsShape {
 	public $provideTextDocumentContent(handle: number, uri: URI): TPromise<string> {
 		const provider = this._documentContentProviders.get(handle);
 		if (!provider) {
-			return TPromise.wrapError<string>(`unsupported uri-scheme: ${uri.scheme}`);
+			return TPromise.wrapError<string>(new Error(`unsupported uri-scheme: ${uri.scheme}`));
 		}
 		return asWinJsPromise(token => provider.provideTextDocumentContent(uri, token));
 	}

--- a/src/vs/workbench/api/node/extHostTreeViews.ts
+++ b/src/vs/workbench/api/node/extHostTreeViews.ts
@@ -53,7 +53,7 @@ export class ExtHostTreeViews extends ExtHostTreeViewsShape {
 	$getElements(treeViewId: string): TPromise<ITreeItem[]> {
 		const treeView = this.treeViews.get(treeViewId);
 		if (!treeView) {
-			return TPromise.wrapError<ITreeItem[]>(localize('treeView.notRegistered', 'No tree view with id \'{0}\' registered.', treeViewId));
+			return TPromise.wrapError<ITreeItem[]>(new Error(localize('treeView.notRegistered', 'No tree view with id \'{0}\' registered.', treeViewId)));
 		}
 		return treeView.getTreeItems();
 	}
@@ -61,7 +61,7 @@ export class ExtHostTreeViews extends ExtHostTreeViewsShape {
 	$getChildren(treeViewId: string, treeItemHandle?: number): TPromise<ITreeItem[]> {
 		const treeView = this.treeViews.get(treeViewId);
 		if (!treeView) {
-			return TPromise.wrapError<ITreeItem[]>(localize('treeView.notRegistered', 'No tree view with id \'{0}\' registered.', treeViewId));
+			return TPromise.wrapError<ITreeItem[]>(new Error(localize('treeView.notRegistered', 'No tree view with id \'{0}\' registered.', treeViewId)));
 		}
 		return treeView.getChildren(treeItemHandle);
 	}
@@ -102,7 +102,7 @@ class ExtHostTreeView<T> extends Disposable {
 		if (extElement) {
 			this.clearChildren(extElement);
 		} else {
-			return TPromise.wrapError<ITreeItem[]>(localize('treeItem.notFound', 'No tree item with id \'{0}\' found.', treeItemHandle));
+			return TPromise.wrapError<ITreeItem[]>(new Error(localize('treeItem.notFound', 'No tree item with id \'{0}\' found.', treeItemHandle)));
 		}
 
 		return asWinJsPromise(() => this.dataProvider.getChildren(extElement))
@@ -130,7 +130,7 @@ class ExtHostTreeView<T> extends Disposable {
 				elements.filter(element => !!element)
 					.map(element => {
 						if (this.extChildrenElementsMap.has(element)) {
-							return TPromise.wrapError<ITreeItem>(localize('treeView.duplicateElement', 'Element {0} is already registered', element));
+							return TPromise.wrapError<ITreeItem>(new Error(localize('treeView.duplicateElement', 'Element {0} is already registered', element)));
 						}
 						return this.resolveElement(element);
 					}))

--- a/src/vs/workbench/browser/parts/editor/binaryEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/binaryEditor.ts
@@ -80,7 +80,7 @@ export abstract class BaseBinaryResourceEditor extends BaseEditor {
 
 			// Assert Model instance
 			if (!(resolvedModel instanceof BinaryEditorModel)) {
-				return TPromise.wrapError<void>('Unable to open file as binary');
+				return TPromise.wrapError<void>(new Error('Unable to open file as binary'));
 			}
 
 			// Assert that the current input is still the one we expect. This prevents a race condition when loading takes long and another input was set meanwhile

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -23,7 +23,7 @@ import { DiffNavigator } from 'vs/editor/browser/widget/diffNavigator';
 import { DiffEditorWidget } from 'vs/editor/browser/widget/diffEditorWidget';
 import { TextDiffEditorModel } from 'vs/workbench/common/editor/textDiffEditorModel';
 import { DelegatingWorkbenchEditorService } from 'vs/workbench/services/editor/browser/editorService';
-import { IFileOperationResult, FileOperationResult } from 'vs/platform/files/common/files';
+import { FileOperationError, FileOperationResult } from 'vs/platform/files/common/files';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/resourceConfiguration';
@@ -257,7 +257,7 @@ export class TextDiffEditor extends BaseTextEditor {
 			return errors.some(e => this.isFileBinaryError(e));
 		}
 
-		return (<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY;
+		return (<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY;
 	}
 
 	public clearInput(): void {

--- a/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
@@ -80,7 +80,7 @@ export class TextResourceEditor extends BaseTextEditor {
 
 			// Assert Model instance
 			if (!(resolvedModel instanceof BaseTextEditorModel)) {
-				return TPromise.wrapError<void>('Unable to open file as text');
+				return TPromise.wrapError<void>(new Error('Unable to open file as text'));
 			}
 
 			// Assert that the current input is still the one we expect. This prevents a race condition when loading takes long and another input was set meanwhile

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -1002,7 +1002,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 		return result.then<QuickOpenHandler>(null, (error) => {
 			delete this.mapResolvedHandlersToPrefix[id];
 
-			return TPromise.wrapError('Unable to instantiate quick open handler ' + handler.moduleName + ' - ' + handler.ctorName + ': ' + JSON.stringify(error));
+			return TPromise.wrapError(new Error('Unable to instantiate quick open handler ' + handler.moduleName + ' - ' + handler.ctorName + ': ' + JSON.stringify(error)));
 		});
 	}
 

--- a/src/vs/workbench/common/editor/resourceEditorInput.ts
+++ b/src/vs/workbench/common/editor/resourceEditorInput.ts
@@ -86,7 +86,7 @@ export class ResourceEditorInput extends EditorInput {
 			if (!(model instanceof ResourceEditorModel)) {
 				ref.dispose();
 				this.modelReference = null;
-				return TPromise.wrapError<ITextEditorModel>(`Unexpected model for ResourceInput: ${this.resource}`); // TODO@Ben eventually also files should be supported, but we guard due to the dangerous dispose of the model in dispose()
+				return TPromise.wrapError<ITextEditorModel>(new Error(`Unexpected model for ResourceInput: ${this.resource}`)); // TODO@Ben eventually also files should be supported, but we guard due to the dangerous dispose of the model in dispose()
 			}
 
 			return model;

--- a/src/vs/workbench/node/extensionHostMain.ts
+++ b/src/vs/workbench/node/extensionHostMain.ts
@@ -200,7 +200,7 @@ export class ExtensionHostMain {
 			this.gracefulExit(1 /* ERROR */);
 		}
 
-		return TPromise.wrapError<void>(requireError ? requireError.toString() : nls.localize('extensionTestError', "Path {0} does not point to a valid extension test runner.", this._environment.extensionTestsPath));
+		return TPromise.wrapError<void>(new Error(requireError ? requireError.toString() : nls.localize('extensionTestError', "Path {0} does not point to a valid extension test runner.", this._environment.extensionTestsPath)));
 	}
 
 	private gracefulExit(code: number): void {

--- a/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
+++ b/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
@@ -33,7 +33,7 @@ export class DebugContentProvider implements IWorkbenchContribution, ITextModelC
 		const process = this.debugService.getViewModel().focusedProcess;
 
 		if (!process) {
-			return TPromise.wrapError<IModel>(localize('unable', "Unable to resolve the resource without a debug session"));
+			return TPromise.wrapError<IModel>(new Error(localize('unable', "Unable to resolve the resource without a debug session")));
 		}
 		const source = process.sources.get(resource.toString());
 		let rawSource: DebugProtocol.Source;

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -188,7 +188,7 @@ class Extension implements IExtension {
 			return readFile(uri.fsPath, 'utf8');
 		}
 
-		return TPromise.wrapError<string>('not available');
+		return TPromise.wrapError<string>(new Error('not available'));
 	}
 
 	getChangelog(): TPromise<string> {
@@ -199,7 +199,7 @@ class Extension implements IExtension {
 		const changelogUrl = this.local && this.local.changelogUrl;
 
 		if (!changelogUrl) {
-			return TPromise.wrapError<string>('not available');
+			return TPromise.wrapError<string>(new Error('not available'));
 		}
 
 		const uri = URI.parse(changelogUrl);
@@ -208,7 +208,7 @@ class Extension implements IExtension {
 			return readFile(uri.fsPath, 'utf8');
 		}
 
-		return TPromise.wrapError<string>('not available');
+		return TPromise.wrapError<string>(new Error('not available'));
 	}
 
 	get dependencies(): string[] {
@@ -590,7 +590,7 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService {
 		if (!enable) {
 			let dependents = this.getDependentsAfterDisablement(extension, dependencies, this.local, workspace);
 			if (dependents.length) {
-				return TPromise.wrapError<void>(this.getDependentsErrorMessage(extension, dependents));
+				return TPromise.wrapError<void>(new Error(this.getDependentsErrorMessage(extension, dependents)));
 			}
 		}
 		return TPromise.join([extension, ...dependencies].map(e => this.doSetEnablement(e, enable, workspace)));

--- a/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
@@ -19,7 +19,7 @@ import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel'
 import { FileEditorInput } from 'vs/workbench/parts/files/common/editors/fileEditorInput';
 import { ExplorerViewlet } from 'vs/workbench/parts/files/browser/explorerViewlet';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
-import { IFileOperationResult, FileOperationResult, FileChangesEvent, IFileService } from 'vs/platform/files/common/files';
+import { FileOperationError, FileOperationResult, FileChangesEvent, IFileService } from 'vs/platform/files/common/files';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IStorageService } from 'vs/platform/storage/common/storage';
@@ -158,17 +158,17 @@ export class TextFileEditor extends BaseTextEditor {
 			// In case we tried to open a file inside the text editor and the response
 			// indicates that this is not a text file, reopen the file through the binary
 			// editor.
-			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY) {
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY) {
 				return this.openAsBinary(input, options);
 			}
 
 			// Similar, handle case where we were asked to open a folder in the text editor.
-			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_IS_DIRECTORY && this.openAsFolder(input)) {
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_IS_DIRECTORY && this.openAsFolder(input)) {
 				return;
 			}
 
 			// Offer to create a file from the error if we have a file not found and the name is valid
-			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND && paths.isValidBasename(paths.basename(input.getResource().fsPath))) {
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND && paths.isValidBasename(paths.basename(input.getResource().fsPath))) {
 				return TPromise.wrapError<void>(errors.create(toErrorMessage(error), {
 					actions: [
 						new Action('workbench.files.action.createMissingFile', nls.localize('createFile', "Create File"), null, true, () => {

--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -25,7 +25,7 @@ import { dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { VIEWLET_ID } from 'vs/workbench/parts/files/common/files';
 import labels = require('vs/base/common/labels');
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { IFileService, IFileStat, IFileOperationResult } from 'vs/platform/files/common/files';
+import { IFileService, IFileStat } from 'vs/platform/files/common/files';
 import { toResource, IEditorIdentifier, EditorInput } from 'vs/workbench/common/editor';
 import { FileStat, Model, NewStatPlaceholder } from 'vs/workbench/parts/files/common/explorerModel';
 import { ExplorerView } from 'vs/workbench/parts/files/browser/views/explorerView';
@@ -76,9 +76,8 @@ export class BaseErrorReportingAction extends Action {
 	}
 
 	protected onError(error: any): void {
-		const fileOperation = error as IFileOperationResult;
-		if (typeof fileOperation.message === 'string') {
-			error = fileOperation.message;
+		if (error.message === 'string') {
+			error = error.message;
 		}
 
 		this._messageService.show(Severity.Error, toErrorMessage(error, false));
@@ -172,17 +171,17 @@ export class TriggerRenameFileAction extends BaseFileAction {
 
 	public run(context?: any): TPromise<any> {
 		if (!context) {
-			return TPromise.wrapError('No context provided to BaseEnableFileRenameAction.');
+			return TPromise.wrapError(new Error('No context provided to BaseEnableFileRenameAction.'));
 		}
 
 		const viewletState = <IFileViewletState>context.viewletState;
 		if (!viewletState) {
-			return TPromise.wrapError('Invalid viewlet state provided to BaseEnableFileRenameAction.');
+			return TPromise.wrapError(new Error('Invalid viewlet state provided to BaseEnableFileRenameAction.'));
 		}
 
 		const stat = <IFileStat>context.stat;
 		if (!stat) {
-			return TPromise.wrapError('Invalid stat provided to BaseEnableFileRenameAction.');
+			return TPromise.wrapError(new Error('Invalid stat provided to BaseEnableFileRenameAction.'));
 		}
 
 		viewletState.setEditable(stat, {
@@ -235,12 +234,12 @@ export abstract class BaseRenameAction extends BaseFileAction {
 
 	public run(context?: any): TPromise<any> {
 		if (!context) {
-			return TPromise.wrapError('No context provided to BaseRenameFileAction.');
+			return TPromise.wrapError(new Error('No context provided to BaseRenameFileAction.'));
 		}
 
 		let name = <string>context.value;
 		if (!name) {
-			return TPromise.wrapError('No new name provided to BaseRenameFileAction.');
+			return TPromise.wrapError(new Error('No new name provided to BaseRenameFileAction.'));
 		}
 
 		// Automatically trim whitespaces and trailing dots to produce nice file names
@@ -369,12 +368,12 @@ export class BaseNewAction extends BaseFileAction {
 
 	public run(context?: any): TPromise<any> {
 		if (!context) {
-			return TPromise.wrapError('No context provided to BaseNewAction.');
+			return TPromise.wrapError(new Error('No context provided to BaseNewAction.'));
 		}
 
 		const viewletState = <IFileViewletState>context.viewletState;
 		if (!viewletState) {
-			return TPromise.wrapError('Invalid viewlet state provided to BaseNewAction.');
+			return TPromise.wrapError(new Error('Invalid viewlet state provided to BaseNewAction.'));
 		}
 
 		let folder = this.presetFolder;
@@ -389,7 +388,7 @@ export class BaseNewAction extends BaseFileAction {
 		}
 
 		if (!folder) {
-			return TPromise.wrapError('Invalid parent folder to create.');
+			return TPromise.wrapError(new Error('Invalid parent folder to create.'));
 		}
 
 		return this.tree.reveal(folder, 0.5).then(() => {

--- a/src/vs/workbench/parts/files/browser/saveErrorHandler.ts
+++ b/src/vs/workbench/parts/files/browser/saveErrorHandler.ts
@@ -12,7 +12,7 @@ import paths = require('vs/base/common/paths');
 import { Action } from 'vs/base/common/actions';
 import URI from 'vs/base/common/uri';
 import { SaveFileAsAction, RevertFileAction, SaveFileAction } from 'vs/workbench/parts/files/browser/fileActions';
-import { IFileOperationResult, FileOperationResult } from 'vs/platform/files/common/files';
+import { FileOperationError, FileOperationResult } from 'vs/platform/files/common/files';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ITextFileService, ISaveErrorHandler, ITextFileEditorModel } from 'vs/workbench/services/textfile/common/textfiles';
@@ -116,13 +116,13 @@ export class SaveErrorHandler implements ISaveErrorHandler, IWorkbenchContributi
 		const resource = model.getResource();
 
 		// Dirty write prevention
-		if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_MODIFIED_SINCE) {
+		if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_MODIFIED_SINCE) {
 			message = this.instantiationService.createInstance(ResolveSaveConflictMessage, model, null);
 		}
 
 		// Any other save error
 		else {
-			const isReadonly = (<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_READ_ONLY;
+			const isReadonly = (<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_READ_ONLY;
 			const actions: Action[] = [];
 
 			// Save As

--- a/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
@@ -25,7 +25,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { ContributableActionProvider } from 'vs/workbench/browser/actions';
 import { IFilesConfiguration } from 'vs/workbench/parts/files/common/files';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { IFileOperationResult, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
+import { FileOperationError, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
 import { ResourceMap } from 'vs/base/common/map';
 import { DuplicateFileAction, ImportFileAction, IEditableData, IFileViewletState } from 'vs/workbench/parts/files/browser/fileActions';
 import { IDataSource, ITree, IAccessibilityProvider, IRenderer, ContextMenuEvent, ISorter, IFilter, IDragAndDrop, IDragAndDropData, IDragOverReaction, DRAG_OVER_ACCEPT_BUBBLE_DOWN, DRAG_OVER_ACCEPT_BUBBLE_DOWN_COPY, DRAG_OVER_ACCEPT_BUBBLE_UP, DRAG_OVER_ACCEPT_BUBBLE_UP_COPY, DRAG_OVER_REJECT } from 'vs/base/parts/tree/browser/tree';
@@ -823,7 +823,7 @@ export class FileDragAndDrop implements IDragAndDrop {
 						return this.fileService.moveFile(source.resource, targetResource).then(null, error => {
 
 							// Conflict
-							if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_MOVE_CONFLICT) {
+							if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_MOVE_CONFLICT) {
 								didHandleConflict = true;
 
 								const confirm: IConfirmation = {

--- a/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
@@ -12,7 +12,7 @@ import URI from 'vs/base/common/uri';
 import { EncodingMode, ConfirmResult, EditorInput, IFileEditorInput, ITextEditorModel } from 'vs/workbench/common/editor';
 import { TextFileEditorModel } from 'vs/workbench/services/textfile/common/textFileEditorModel';
 import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel';
-import { IFileOperationResult, FileOperationResult } from 'vs/platform/files/common/files';
+import { FileOperationError, FileOperationResult } from 'vs/platform/files/common/files';
 import { BINARY_FILE_EDITOR_ID, TEXT_FILE_EDITOR_ID, FILE_EDITOR_INPUT_ID } from 'vs/workbench/parts/files/common/files';
 import { ITextFileService, AutoSaveMode, ModelState, TextFileModelChangeEvent } from 'vs/workbench/services/textfile/common/textfiles';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -216,7 +216,7 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 		}, error => {
 
 			// In case of an error that indicates that the file is binary or too large, just return with the binary editor model
-			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY || (<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY || (<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
 				return this.resolveAsBinary();
 			}
 

--- a/src/vs/workbench/parts/files/test/browser/fileEditorInput.test.ts
+++ b/src/vs/workbench/parts/files/test/browser/fileEditorInput.test.ts
@@ -13,7 +13,7 @@ import { workbenchInstantiationService, TestTextFileService, TestEditorGroupServ
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { EncodingMode } from 'vs/workbench/common/editor';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { FileOperationResult, IFileOperationResult } from 'vs/platform/files/common/files';
+import { FileOperationResult, FileOperationError } from 'vs/platform/files/common/files';
 import { TextFileEditorModel } from 'vs/workbench/services/textfile/common/textFileEditorModel';
 import { Verbosity } from 'vs/platform/editor/common/editor';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
@@ -173,10 +173,7 @@ suite('Files - FileEditorInput', () => {
 	test('resolve handles binary files', function (done) {
 		const input = instantiationService.createInstance(FileEditorInput, toResource.call(this, '/foo/bar/updatefile.js'), void 0);
 
-		accessor.textFileService.setResolveTextContentErrorOnce(<IFileOperationResult>{
-			message: 'error',
-			fileOperationResult: FileOperationResult.FILE_IS_BINARY
-		});
+		accessor.textFileService.setResolveTextContentErrorOnce(new FileOperationError('error', FileOperationResult.FILE_IS_BINARY));
 
 		return input.resolve(true).then(resolved => {
 			assert.ok(resolved);

--- a/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/browser/htmlPreviewPart.ts
@@ -194,7 +194,7 @@ export class HtmlPreviewPart extends WebviewEditor {
 		this._modelChangeSubscription.dispose();
 
 		if (!(input instanceof HtmlInput)) {
-			return TPromise.wrapError<void>('Invalid input');
+			return TPromise.wrapError<void>(new Error('Invalid input'));
 		}
 
 		return super.setInput(input, options).then(() => {
@@ -207,7 +207,7 @@ export class HtmlPreviewPart extends WebviewEditor {
 				}
 
 				if (!this.model) {
-					return TPromise.wrapError<void>(localize('html.voidInput', "Invalid editor input."));
+					return TPromise.wrapError<void>(new Error(localize('html.voidInput', "Invalid editor input.")));
 				}
 
 				this._modelChangeSubscription = this.model.onDidChangeContent(() => {

--- a/src/vs/workbench/parts/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesRenderers.ts
@@ -22,7 +22,7 @@ import { IContextMenuService, ContextSubMenu } from 'vs/platform/contextview/bro
 import { SettingsGroupTitleWidget, EditPreferenceWidget, SettingsHeaderWidget } from 'vs/workbench/parts/preferences/browser/preferencesWidgets';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { RangeHighlightDecorations } from 'vs/workbench/common/editor/rangeDecorations';
-import { IConfigurationEditingService, IConfigurationEditingError, ConfigurationEditingErrorCode, ConfigurationTarget } from 'vs/workbench/services/configuration/common/configurationEditing';
+import { IConfigurationEditingService, ConfigurationEditingError, ConfigurationEditingErrorCode, ConfigurationTarget } from 'vs/workbench/services/configuration/common/configurationEditing';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { overrideIdentifierFromKey } from 'vs/platform/configuration/common/model';
 import { IMarkerService, IMarkerData } from 'vs/platform/markers/common/markers';
@@ -100,7 +100,7 @@ export class UserSettingsRenderer extends Disposable implements IPreferencesRend
 			});
 	}
 
-	private toErrorMessage(error: IConfigurationEditingError, target: ConfigurationTarget): string {
+	private toErrorMessage(error: ConfigurationEditingError, target: ConfigurationTarget): string {
 		switch (error.code) {
 			case ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION: {
 				return nls.localize('errorInvalidConfiguration', "Unable to write into settings. Correct errors/warnings in the file and try again.");

--- a/src/vs/workbench/parts/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesService.ts
@@ -20,7 +20,7 @@ import { Position as EditorPosition, IEditor } from 'vs/platform/editor/common/e
 import { ICommonCodeEditor } from 'vs/editor/common/editorCommon';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { IFileService, IFileOperationResult, FileOperationResult } from 'vs/platform/files/common/files';
+import { IFileService, FileOperationError, FileOperationResult } from 'vs/platform/files/common/files';
 import { IMessageService, Severity, IChoiceService } from 'vs/platform/message/common/message';
 import { IExtensionService } from 'vs/platform/extensions/common/extensions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -269,7 +269,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 
 	private createIfNotExists(resource: URI, contents: string): TPromise<boolean> {
 		return this.fileService.resolveContent(resource, { acceptTextOnly: true }).then(null, error => {
-			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
 				return this.fileService.updateContent(resource, contents).then(null, error => {
 					return TPromise.wrapError<boolean>(new Error(nls.localize('fail.createSettings', "Unable to create '{0}' ({1}).", labels.getPathLabel(resource, this.contextService, this.environmentService), error)));
 				});

--- a/src/vs/workbench/parts/tasks/node/processTaskSystem.ts
+++ b/src/vs/workbench/parts/tasks/node/processTaskSystem.ts
@@ -280,27 +280,32 @@ export class ProcessTaskSystem extends EventEmitter implements ITaskSystem {
 		this.activeTaskPromise = null;
 	}
 
-	private handleError(task: Task, error: ErrorData): Promise {
+	private handleError(task: Task, errorData: ErrorData): Promise {
 		let makeVisible = false;
-		if (error.error && !error.terminated) {
+		if (errorData.error && !errorData.terminated) {
 			let args: string = task.command.args ? task.command.args.join(' ') : '';
 			this.log(nls.localize('TaskRunnerSystem.childProcessError', 'Failed to launch external program {0} {1}.', task.command.name, args));
-			this.outputChannel.append(error.error.message);
+			this.outputChannel.append(errorData.error.message);
 			makeVisible = true;
 		}
 
-		if (error.stdout) {
-			this.outputChannel.append(error.stdout);
+		if (errorData.stdout) {
+			this.outputChannel.append(errorData.stdout);
 			makeVisible = true;
 		}
-		if (error.stderr) {
-			this.outputChannel.append(error.stderr);
+		if (errorData.stderr) {
+			this.outputChannel.append(errorData.stderr);
 			makeVisible = true;
 		}
-		makeVisible = this.checkTerminated(task, error) || makeVisible;
+		makeVisible = this.checkTerminated(task, errorData) || makeVisible;
 		if (makeVisible) {
 			this.showOutput();
 		}
+
+		const error: Error & ErrorData = errorData.error || new Error();
+		error.stderr = errorData.stderr;
+		error.stdout = errorData.stdout;
+		error.terminated = errorData.terminated;
 		return Promise.wrapError(error);
 	}
 

--- a/src/vs/workbench/parts/update/electron-browser/update.ts
+++ b/src/vs/workbench/parts/update/electron-browser/update.ts
@@ -57,7 +57,7 @@ export function loadReleaseNotes(accessor: ServicesAccessor, version: string): T
 	const match = /^(\d+\.\d+)\./.exec(version);
 
 	if (!match) {
-		return TPromise.wrapError<string>('not found');
+		return TPromise.wrapError<string>(new Error('not found'));
 	}
 
 	const versionLabel = match[1].replace(/\./g, '_');

--- a/src/vs/workbench/services/configuration/common/configurationEditing.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditing.ts
@@ -38,9 +38,10 @@ export enum ConfigurationEditingErrorCode {
 	ERROR_INVALID_CONFIGURATION
 }
 
-export interface IConfigurationEditingError {
-	code: ConfigurationEditingErrorCode;
-	message: string;
+export class ConfigurationEditingError extends Error {
+	constructor(message: string, public code: ConfigurationEditingErrorCode) {
+		super(message);
+	}
 }
 
 export enum ConfigurationTarget {

--- a/src/vs/workbench/services/configuration/test/node/configurationEditingService.test.ts
+++ b/src/vs/workbench/services/configuration/test/node/configurationEditingService.test.ts
@@ -25,7 +25,7 @@ import { WorkspaceConfigurationService } from 'vs/workbench/services/configurati
 import URI from 'vs/base/common/uri';
 import { FileService } from 'vs/workbench/services/files/node/fileService';
 import { ConfigurationEditingService } from 'vs/workbench/services/configuration/node/configurationEditingService';
-import { ConfigurationTarget, IConfigurationEditingError, ConfigurationEditingErrorCode } from 'vs/workbench/services/configuration/common/configurationEditing';
+import { ConfigurationTarget, ConfigurationEditingError, ConfigurationEditingErrorCode } from 'vs/workbench/services/configuration/common/configurationEditing';
 import { IFileService } from 'vs/platform/files/common/files';
 import { WORKSPACE_STANDALONE_CONFIGURATIONS } from 'vs/workbench/services/configuration/common/configuration';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -171,34 +171,34 @@ suite('ConfigurationEditingService', () => {
 	test('errors cases - invalid key', () => {
 		return testObject.writeConfiguration(ConfigurationTarget.WORKSPACE, { key: 'unknown.key', value: 'value' })
 			.then(() => assert.fail('Should fail with ERROR_UNKNOWN_KEY'),
-			(error: IConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY));
+			(error: ConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY));
 	});
 
 	test('errors cases - invalid target', () => {
 		return testObject.writeConfiguration(ConfigurationTarget.USER, { key: 'tasks.something', value: 'value' })
 			.then(() => assert.fail('Should fail with ERROR_INVALID_TARGET'),
-			(error: IConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_TARGET));
+			(error: ConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_TARGET));
 	});
 
 	test('errors cases - no workspace', () => {
 		return setUpServices(true)
 			.then(() => testObject.writeConfiguration(ConfigurationTarget.WORKSPACE, { key: 'configurationEditing.service.testSetting', value: 'value' }))
 			.then(() => assert.fail('Should fail with ERROR_NO_WORKSPACE_OPENED'),
-			(error: IConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_NO_WORKSPACE_OPENED));
+			(error: ConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_NO_WORKSPACE_OPENED));
 	});
 
 	test('errors cases - invalid configuration', () => {
 		fs.writeFileSync(globalSettingsFile, ',,,,,,,,,,,,,,');
 		return testObject.writeConfiguration(ConfigurationTarget.USER, { key: 'configurationEditing.service.testSetting', value: 'value' })
 			.then(() => assert.fail('Should fail with ERROR_INVALID_CONFIGURATION'),
-			(error: IConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION));
+			(error: ConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION));
 	});
 
 	test('errors cases - dirty', () => {
 		instantiationService.stub(ITextFileService, 'isDirty', true);
 		return testObject.writeConfiguration(ConfigurationTarget.USER, { key: 'configurationEditing.service.testSetting', value: 'value' })
 			.then(() => assert.fail('Should fail with ERROR_CONFIGURATION_FILE_DIRTY error.'),
-			(error: IConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY));
+			(error: ConfigurationEditingError) => assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY));
 	});
 
 	test('dirty error is not thrown if not asked to save', () => {
@@ -213,7 +213,7 @@ suite('ConfigurationEditingService', () => {
 		instantiationService.stubPromise(IChoiceService, 'choose', target);
 		return testObject.writeConfiguration(ConfigurationTarget.USER, { key: 'configurationEditing.service.testSetting', value: 'value' }, { donotNotifyError: true })
 			.then(() => assert.fail('Should fail with ERROR_CONFIGURATION_FILE_DIRTY error.'),
-			(error: IConfigurationEditingError) => {
+			(error: ConfigurationEditingError) => {
 				assert.equal(false, target.calledOnce);
 				assert.equal(error.code, ConfigurationEditingErrorCode.ERROR_CONFIGURATION_FILE_DIRTY);
 			});

--- a/src/vs/workbench/services/files/test/node/fileService.test.ts
+++ b/src/vs/workbench/services/files/test/node/fileService.test.ts
@@ -12,7 +12,7 @@ import assert = require('assert');
 
 import { TPromise } from 'vs/base/common/winjs.base';
 import { FileService, IEncodingOverride } from 'vs/workbench/services/files/node/fileService';
-import { FileOperation, FileOperationEvent, FileChangesEvent, FileOperationResult, IFileOperationResult } from 'vs/platform/files/common/files';
+import { FileOperation, FileOperationEvent, FileChangesEvent, FileOperationResult, FileOperationError } from 'vs/platform/files/common/files';
 import uri from 'vs/base/common/uri';
 import uuid = require('vs/base/common/uuid');
 import extfs = require('vs/base/node/extfs');
@@ -229,7 +229,7 @@ suite('FileService', () => {
 		});
 
 		service.resolveFile(uri.file(path.join(testDir, 'index.html'))).done(source => {
-			return service.moveFile(source.resource, uri.file(path.join(testDir, 'binary.txt'))).then(null, (e: IFileOperationResult) => {
+			return service.moveFile(source.resource, uri.file(path.join(testDir, 'binary.txt'))).then(null, (e: FileOperationError) => {
 				assert.equal(e.fileOperationResult, FileOperationResult.FILE_MOVE_CONFLICT);
 
 				assert.ok(!event);
@@ -603,7 +603,7 @@ suite('FileService', () => {
 	test('resolveContent - FILE_IS_BINARY', function (done: () => void) {
 		let resource = uri.file(path.join(testDir, 'binary.txt'));
 
-		service.resolveContent(resource, { acceptTextOnly: true }).done(null, (e: IFileOperationResult) => {
+		service.resolveContent(resource, { acceptTextOnly: true }).done(null, (e: FileOperationError) => {
 			assert.equal(e.fileOperationResult, FileOperationResult.FILE_IS_BINARY);
 
 			return service.resolveContent(uri.file(path.join(testDir, 'small.txt')), { acceptTextOnly: true }).then(r => {
@@ -617,7 +617,7 @@ suite('FileService', () => {
 	test('resolveContent - FILE_IS_DIRECTORY', function (done: () => void) {
 		let resource = uri.file(path.join(testDir, 'deep'));
 
-		service.resolveContent(resource).done(null, (e: IFileOperationResult) => {
+		service.resolveContent(resource).done(null, (e: FileOperationError) => {
 			assert.equal(e.fileOperationResult, FileOperationResult.FILE_IS_DIRECTORY);
 
 			done();
@@ -627,7 +627,7 @@ suite('FileService', () => {
 	test('resolveContent - FILE_NOT_FOUND', function (done: () => void) {
 		let resource = uri.file(path.join(testDir, '404.html'));
 
-		service.resolveContent(resource).done(null, (e: IFileOperationResult) => {
+		service.resolveContent(resource).done(null, (e: FileOperationError) => {
 			assert.equal(e.fileOperationResult, FileOperationResult.FILE_NOT_FOUND);
 
 			done();
@@ -638,7 +638,7 @@ suite('FileService', () => {
 		let resource = uri.file(path.join(testDir, 'index.html'));
 
 		service.resolveContent(resource).done(c => {
-			return service.resolveContent(resource, { etag: c.etag }).then(null, (e: IFileOperationResult) => {
+			return service.resolveContent(resource, { etag: c.etag }).then(null, (e: FileOperationError) => {
 				assert.equal(e.fileOperationResult, FileOperationResult.FILE_NOT_MODIFIED_SINCE);
 
 				done();
@@ -652,7 +652,7 @@ suite('FileService', () => {
 		service.resolveContent(resource).done(c => {
 			fs.writeFileSync(resource.fsPath, 'Updates Incoming!');
 
-			return service.updateContent(resource, c.value, { etag: c.etag, mtime: c.mtime - 1000 }).then(null, (e: IFileOperationResult) => {
+			return service.updateContent(resource, c.value, { etag: c.etag, mtime: c.mtime - 1000 }).then(null, (e: FileOperationError) => {
 				assert.equal(e.fileOperationResult, FileOperationResult.FILE_MODIFIED_SINCE);
 
 				done();

--- a/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
@@ -225,7 +225,7 @@ export class KeybindingsEditingService extends Disposable implements IKeybinding
 
 		// Target cannot be dirty if not writing into buffer
 		if (this.textFileService.isDirty(this.resource)) {
-			return TPromise.wrapError<IReference<ITextEditorModel>>(localize('errorKeybindingsFileDirty', "Unable to write because the file is dirty. Please save the **Keybindings** file and try again."));
+			return TPromise.wrapError<IReference<ITextEditorModel>>(new Error(localize('errorKeybindingsFileDirty', "Unable to write because the file is dirty. Please save the **Keybindings** file and try again.")));
 		}
 
 		return this.resolveModelReference()
@@ -235,11 +235,11 @@ export class KeybindingsEditingService extends Disposable implements IKeybinding
 				if (model.getValue()) {
 					const parsed = this.parse(model);
 					if (parsed.parseErrors.length) {
-						return TPromise.wrapError<IReference<ITextEditorModel>>(localize('parseErrors', "Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again."));
+						return TPromise.wrapError<IReference<ITextEditorModel>>(new Error(localize('parseErrors', "Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again.")));
 					}
 					if (parsed.result) {
 						if (!isArray(parsed.result)) {
-							return TPromise.wrapError<IReference<ITextEditorModel>>(localize('errorInvalidConfiguration', "Unable to write keybindings. **Keybindings file** has an object which is not of type Array. Please open the file to clean up and try again."));
+							return TPromise.wrapError<IReference<ITextEditorModel>>(new Error(localize('errorInvalidConfiguration', "Unable to write keybindings. **Keybindings file** has an object which is not of type Array. Please open the file to clean up and try again.")));
 						}
 					} else {
 						const content = EOL + '[]';

--- a/src/vs/workbench/services/keybinding/test/node/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/node/keybindingEditing.test.ts
@@ -111,28 +111,28 @@ suite('Keybindings Editing', () => {
 		fs.writeFileSync(keybindingsFile, ',,,,,,,,,,,,,,');
 		return testObject.editKeybinding('alt+c', aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }))
 			.then(() => assert.fail('Should fail with parse errors'),
-			error => assert.equal(error, 'Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again.'));
+			error => assert.equal(error.message, 'Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again.'));
 	});
 
 	test('errors cases - parse errors 2', () => {
 		fs.writeFileSync(keybindingsFile, '[{"key": }]');
 		return testObject.editKeybinding('alt+c', aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }))
 			.then(() => assert.fail('Should fail with parse errors'),
-			error => assert.equal(error, 'Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again.'));
+			error => assert.equal(error.message, 'Unable to write keybindings. Please open **Keybindings file** to correct errors/warnings in the file and try again.'));
 	});
 
 	test('errors cases - dirty', () => {
 		instantiationService.stub(ITextFileService, 'isDirty', true);
 		return testObject.editKeybinding('alt+c', aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }))
 			.then(() => assert.fail('Should fail with dirty error'),
-			error => assert.equal(error, 'Unable to write because the file is dirty. Please save the **Keybindings** file and try again.'));
+			error => assert.equal(error.message, 'Unable to write because the file is dirty. Please save the **Keybindings** file and try again.'));
 	});
 
 	test('errors cases - did not find an array', () => {
 		fs.writeFileSync(keybindingsFile, '{"key": "alt+c", "command": "hello"}');
 		return testObject.editKeybinding('alt+c', aResolvedKeybindingItem({ firstPart: { keyCode: KeyCode.Escape } }))
 			.then(() => assert.fail('Should fail with dirty error'),
-			error => assert.equal(error, 'Unable to write keybindings. **Keybindings file** has an object which is not of type Array. Please open the file to clean up and try again.'));
+			error => assert.equal(error.message, 'Unable to write keybindings. **Keybindings file** has an object which is not of type Array. Please open the file to clean up and try again.'));
 	});
 
 	test('edit a default keybinding to an empty file', () => {

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -25,7 +25,7 @@ import { ITextFileService, IAutoSaveConfiguration, ModelState, ITextFileEditorMo
 import { EncodingMode } from 'vs/workbench/common/editor';
 import { BaseTextEditorModel } from 'vs/workbench/common/editor/textEditorModel';
 import { IBackupFileService, BACKUP_FILE_RESOLVE_OPTIONS } from 'vs/workbench/services/backup/common/backup';
-import { IFileService, IFileStat, IFileOperationResult, FileOperationResult, IContent, CONTENT_CHANGE_EVENT_BUFFER_DELAY, FileChangesEvent, FileChangeType } from 'vs/platform/files/common/files';
+import { IFileService, IFileStat, FileOperationError, FileOperationResult, IContent, CONTENT_CHANGE_EVENT_BUFFER_DELAY, FileChangesEvent, FileChangeType } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IMessageService, Severity } from 'vs/platform/message/common/message';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -331,7 +331,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 		return this.loadWithContent(content);
 	}
 
-	private handleLoadError(error: IFileOperationResult): TPromise<TextFileEditorModel> {
+	private handleLoadError(error: FileOperationError): TPromise<TextFileEditorModel> {
 		const result = error.fileOperationResult;
 
 		// Apply orphaned state based on error code
@@ -699,7 +699,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 				this.inErrorMode = true;
 
 				// Look out for a save conflict
-				if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_MODIFIED_SINCE) {
+				if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_MODIFIED_SINCE) {
 					this.inConflictMode = true;
 				}
 

--- a/src/vs/workbench/services/textfile/common/textFileService.ts
+++ b/src/vs/workbench/services/textfile/common/textFileService.ts
@@ -18,7 +18,7 @@ import { IRevertOptions, IResult, ITextFileOperationResult, ITextFileService, IR
 import { ConfirmResult } from 'vs/workbench/common/editor';
 import { ILifecycleService, ShutdownReason } from 'vs/platform/lifecycle/common/lifecycle';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { IFileService, IResolveContentOptions, IFilesConfiguration, IFileOperationResult, FileOperationResult, AutoSaveConfiguration, HotExitConfiguration } from 'vs/platform/files/common/files';
+import { IFileService, IResolveContentOptions, IFilesConfiguration, FileOperationError, FileOperationResult, AutoSaveConfiguration, HotExitConfiguration } from 'vs/platform/files/common/files';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -602,7 +602,7 @@ export abstract class TextFileService implements ITextFileService {
 		}, error => {
 
 			// binary model: delete the file and run the operation again
-			if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY || (<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_IS_BINARY || (<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
 				return this.fileService.del(target).then(() => this.doSaveTextFileAs(sourceModel, resource, target));
 			}
 
@@ -654,7 +654,7 @@ export abstract class TextFileService implements ITextFileService {
 			}, error => {
 
 				// FileNotFound means the file got deleted meanwhile, so still record as successful revert
-				if ((<IFileOperationResult>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
+				if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
 					mapResourceToResult.get(model.getResource()).success = true;
 				}
 

--- a/src/vs/workbench/services/textfile/test/textFileEditorModel.test.ts
+++ b/src/vs/workbench/services/textfile/test/textFileEditorModel.test.ts
@@ -14,7 +14,7 @@ import { ITextFileService, ModelState, StateChange } from 'vs/workbench/services
 import { workbenchInstantiationService, TestTextFileService, createFileInput, TestFileService } from 'vs/workbench/test/workbenchTestServices';
 import { onError, toResource } from 'vs/base/test/common/utils';
 import { TextFileEditorModelManager } from 'vs/workbench/services/textfile/common/textFileEditorModelManager';
-import { FileOperationResult, IFileOperationResult, IFileService } from 'vs/platform/files/common/files';
+import { FileOperationResult, FileOperationError, IFileService } from 'vs/platform/files/common/files';
 import { IModelService } from 'vs/editor/common/services/modelService';
 
 class ServiceAccessor {
@@ -195,10 +195,7 @@ suite('Files - TextFileEditorModel', () => {
 
 		model.load().done(() => {
 			const mtime = getLastModifiedTime(model);
-			accessor.textFileService.setResolveTextContentErrorOnce(<IFileOperationResult>{
-				message: 'error',
-				fileOperationResult: FileOperationResult.FILE_NOT_MODIFIED_SINCE
-			});
+			accessor.textFileService.setResolveTextContentErrorOnce(new FileOperationError('error', FileOperationResult.FILE_NOT_MODIFIED_SINCE));
 
 			return model.load().then((model: TextFileEditorModel) => {
 				assert.ok(model);
@@ -214,10 +211,7 @@ suite('Files - TextFileEditorModel', () => {
 		const model: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/index_async.txt'), 'utf8');
 
 		model.load().done(() => {
-			accessor.textFileService.setResolveTextContentErrorOnce(<IFileOperationResult>{
-				message: 'error',
-				fileOperationResult: FileOperationResult.FILE_NOT_FOUND
-			});
+			accessor.textFileService.setResolveTextContentErrorOnce(new FileOperationError('error', FileOperationResult.FILE_NOT_FOUND));
 
 			return model.load().then((model: TextFileEditorModel) => {
 				assert.ok(model);
@@ -329,7 +323,7 @@ suite('Files - TextFileEditorModel', () => {
 
 		TextFileEditorModel.setSaveParticipant({
 			participate: (model) => {
-				return TPromise.wrapError('boom');
+				return TPromise.wrapError(new Error('boom'));
 			}
 		});
 

--- a/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
+++ b/src/vs/workbench/services/textmodelResolver/common/textModelResolverService.ts
@@ -84,7 +84,7 @@ class ResourceModelCollection extends ReferenceCollection<TPromise<ITextEditorMo
 		return first(factories).then(model => {
 			if (!model) {
 				console.error(`Unable to open '${resource}' resource is not available.`); // TODO PII
-				return TPromise.wrapError<IModel>('resource is not available');
+				return TPromise.wrapError<IModel>(new Error('resource is not available'));
 			}
 
 			return model;
@@ -125,7 +125,7 @@ export class TextModelResolverService implements ITextModelService {
 			const cachedModel = this.modelService.getModel(resource);
 
 			if (!cachedModel) {
-				return TPromise.wrapError<IReference<ITextEditorModel>>('Cant resolve inmemory resource');
+				return TPromise.wrapError<IReference<ITextEditorModel>>(new Error('Cant resolve inmemory resource'));
 			}
 
 			return TPromise.as(new ImmortalReference(this.instantiationService.createInstance(ResourceEditorModel, resource)));

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -402,7 +402,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 					this.updateDynamicCSSRules(themeData);
 					return this.applyTheme(themeData, settingsTarget);
 				}, error => {
-					return TPromise.wrapError<IColorTheme>(nls.localize('error.cannotloadtheme', "Unable to load {0}: {1}", themeData.path, error.message));
+					return TPromise.wrapError<IColorTheme>(new Error(nls.localize('error.cannotloadtheme', "Unable to load {0}: {1}", themeData.path, error.message)));
 				});
 			}
 			return null;
@@ -734,7 +734,7 @@ function _applyIconTheme(data: IInternalIconThemeData, onApply: (theme: IInterna
 		_applyRules(data.styleSheetContent, iconThemeRulesClassName);
 		return onApply(data);
 	}, error => {
-		return TPromise.wrapError<IFileIconTheme>(nls.localize('error.cannotloadicontheme', "Unable to load {0}", data.path));
+		return TPromise.wrapError<IFileIconTheme>(new Error(nls.localize('error.cannotloadicontheme', "Unable to load {0}", data.path)));
 	});
 }
 

--- a/src/vs/workbench/test/electron-browser/api/extHostApiCommands.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostApiCommands.test.ts
@@ -70,7 +70,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 			_serviceBrand: undefined,
 			executeCommand(id, args): any {
 				if (!CommandsRegistry.getCommands()[id]) {
-					return TPromise.wrapError(id + ' NOT known');
+					return TPromise.wrapError(new Error(id + ' NOT known'));
 				}
 				let { handler } = CommandsRegistry.getCommands()[id];
 				return TPromise.as(instantiationService.invokeFunction(handler, args));

--- a/src/vs/workbench/test/electron-browser/api/extHostConfiguration.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostConfiguration.test.ts
@@ -11,7 +11,7 @@ import { ExtHostWorkspace } from 'vs/workbench/api/node/extHostWorkspace';
 import { ExtHostConfiguration } from 'vs/workbench/api/node/extHostConfiguration';
 import { MainThreadConfigurationShape } from 'vs/workbench/api/node/extHost.protocol';
 import { TPromise } from 'vs/base/common/winjs.base';
-import { ConfigurationTarget, ConfigurationEditingErrorCode, IConfigurationEditingError } from 'vs/workbench/services/configuration/common/configurationEditing';
+import { ConfigurationTarget, ConfigurationEditingErrorCode, ConfigurationEditingError } from 'vs/workbench/services/configuration/common/configurationEditing';
 import { ConfigurationModel } from 'vs/platform/configuration/common/configuration';
 import { TestThreadService } from './testThreadService';
 
@@ -213,7 +213,7 @@ suite('ExtHostConfiguration', function () {
 
 		const shape = new class extends MainThreadConfigurationShape {
 			$updateConfigurationOption(target: ConfigurationTarget, key: string, value: any): TPromise<any> {
-				return TPromise.wrapError(<IConfigurationEditingError>{ code: ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY, message: 'Unknown Key' }); // something !== OK
+				return TPromise.wrapError(new ConfigurationEditingError('Unknown Key', ConfigurationEditingErrorCode.ERROR_UNKNOWN_KEY)); // something !== OK
 			}
 		};
 

--- a/src/vs/workbench/test/electron-browser/api/extHostDocumentSaveParticipant.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostDocumentSaveParticipant.test.ts
@@ -235,7 +235,7 @@ suite('ExtHostDocumentSaveParticipant', () => {
 		const participant = new ExtHostDocumentSaveParticipant(documents, workspace);
 
 		let sub1 = participant.onWillSaveTextDocumentEvent(function (e) {
-			e.waitUntil(TPromise.wrapError('dddd'));
+			e.waitUntil(TPromise.wrapError(new Error('dddd')));
 		});
 
 		let event: vscode.TextDocumentWillSaveEvent;

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -34,7 +34,7 @@ import { ServiceCollection } from 'vs/platform/instantiation/common/serviceColle
 import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
 import { IEditorGroupService, GroupArrangement, GroupOrientation, ITabOptions, IMoveOptions } from 'vs/workbench/services/group/common/groupService';
 import { TextFileService } from 'vs/workbench/services/textfile/common/textFileService';
-import { FileOperationEvent, IFileService, IResolveContentOptions, IFileOperationResult, IFileStat, IImportResult, FileChangesEvent, IResolveFileOptions, IContent, IUpdateContentOptions, IStreamContent } from 'vs/platform/files/common/files';
+import { FileOperationEvent, IFileService, IResolveContentOptions, FileOperationError, IFileStat, IImportResult, FileChangesEvent, IResolveFileOptions, IContent, IUpdateContentOptions, IStreamContent } from 'vs/platform/files/common/files';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { ModeServiceImpl } from 'vs/editor/common/services/modeServiceImpl';
 import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
@@ -143,7 +143,7 @@ export class TestTextFileService extends TextFileService {
 
 	private promptPath: string;
 	private confirmResult: ConfirmResult;
-	private resolveTextContentError: IFileOperationResult;
+	private resolveTextContentError: FileOperationError;
 
 	constructor(
 		@ILifecycleService lifecycleService: ILifecycleService,
@@ -170,7 +170,7 @@ export class TestTextFileService extends TextFileService {
 		this.confirmResult = result;
 	}
 
-	public setResolveTextContentErrorOnce(error: IFileOperationResult): void {
+	public setResolveTextContentErrorOnce(error: FileOperationError): void {
 		this.resolveTextContentError = error;
 	}
 

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
 		"build/lib/tslint"
 	],
 	"rules": {
+		"no-string-throw": true,
 		"no-unused-expression": true,
 		"no-duplicate-variable": true,
 		"no-unused-variable": true,


### PR DESCRIPTION
I noticed that in many places `Promise.wrapError` is called with a string, which means the Promise will be rejected with a string instead of an `Error` instance. One might think that `wrapError` wraps the string in an Error, but it really is just a `Promise.reject()`. Rejecting with a string is like `throw`ing a string, it means no call stack, no metadata like `severity`, `code` or `actions` and possible bugs when assuming the value is an Error when it's not (e.g. `err.message` being `undefined`).

These were all the places I found with a regexp search (doesn't catch if the string is saved in a variable). I did not find any `throw` statements with a string.