### PR TITLE
Continue refactoring html content renderer

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -9,20 +9,50 @@ import DOM = require('vs/base/browser/dom');
 import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { escape } from 'vs/base/common/strings';
 import { TPromise } from 'vs/base/common/winjs.base';
-import { IHTMLContentElement, MarkedString, removeMarkdownEscapes } from 'vs/base/common/htmlContent';
+import { MarkedString, removeMarkdownEscapes } from 'vs/base/common/htmlContent';
 import { marked } from 'vs/base/common/marked/marked';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 
-export type RenderableContent = string | IHTMLContentElement;
-
 export interface RenderOptions {
+	className?: string;
+	inline?: boolean;
 	actionCallback?: (content: string, event?: IMouseEvent) => void;
 	codeBlockRenderer?: (modeId: string, value: string) => string | TPromise<string>;
 }
 
+function createElement(options: RenderOptions): HTMLElement {
+	const tagName = options.inline ? 'span' : 'div';
+	const element = document.createElement(tagName);
+	if (options.className) {
+		element.className = options.className;
+	}
+	return element;
+}
+
+
 export function renderMarkedString(markedString: MarkedString, options: RenderOptions = {}): Node {
-	const htmlContentElement: IHTMLContentElement = typeof markedString === 'string' ? { markdown: markedString } : { code: markedString };
-	return renderHtml(htmlContentElement, options);
+	// this is sort of legacy given that we have full
+	// support for markdown. Turn this into markdown
+	// and continue
+	let markdown: string;
+	if (typeof markedString === 'string') {
+		markdown = markedString;
+	} else {
+		markdown = '```' + markedString.language + '\n' + markedString.value + '\n```';
+	}
+	return renderMarkdown(markdown, options);
+}
+
+export function renderText(text: string, options: RenderOptions = {}): Node {
+	const element = createElement(options);
+	element.textContent = text;
+	return element;
+}
+
+export function renderFormattedText(formattedText: string, options: RenderOptions = {}): Node {
+	const element = createElement(options);
+	_renderFormattedText(element, parseFormattedText(formattedText), options.actionCallback);
+	return element;
 }
 
 /**
@@ -31,143 +61,112 @@ export function renderMarkedString(markedString: MarkedString, options: RenderOp
  * @param content a html element description
  * @param actionCallback a callback function for any action links in the string. Argument is the zero-based index of the clicked action.
  */
-export function renderHtml(content: RenderableContent, options: RenderOptions = {}): Node {
-	if (typeof content === 'string') {
-		return document.createTextNode(content);
-	} else if (content) {
-		return _renderHtml(content, options);
-	}
-	return undefined;
-}
+export function renderMarkdown(markdown: string, options: RenderOptions = {}): Node {
+	const element = createElement(options);
 
-function _renderHtml(content: IHTMLContentElement, options: RenderOptions = {}): Node {
+	const { codeBlockRenderer, actionCallback } = options;
 
-	let { codeBlockRenderer, actionCallback } = options;
+	// signal to code-block render that the
+	// element has been created
+	let signalInnerHTML: Function;
+	const withInnerHTML = new TPromise(c => signalInnerHTML = c);
 
-	var tagName = content.inline ? 'span' : 'div';
-	var element = document.createElement(tagName);
-
-	if (content.className) {
-		element.className = content.className;
-	}
-	if (content.text) {
-		element.textContent = content.text;
-	}
-	if (content.formattedText) {
-		renderFormattedText(element, parseFormattedText(content.formattedText), actionCallback);
-	}
-
-	if (content.code && codeBlockRenderer) {
-		// this is sort of legacy given that we have full
-		// support for markdown. Turn this into markdown
-		// and continue
-		let { language, value } = content.code;
-		content.markdown = '```' + language + '\n' + value + '\n```';
-	}
-	if (content.markdown) {
-
-		// signal to code-block render that the
-		// element has been created
-		let signalInnerHTML: Function;
-		const withInnerHTML = new TPromise(c => signalInnerHTML = c);
-
-		const renderer = new marked.Renderer();
-		renderer.image = (href: string, title: string, text: string) => {
-			let dimensions: string[] = [];
-			if (href) {
-				const splitted = href.split('|').map(s => s.trim());
-				href = splitted[0];
-				const parameters = splitted[1];
-				if (parameters) {
-					const heightFromParams = /height=(\d+)/.exec(parameters);
-					const widthFromParams = /width=(\d+)/.exec(parameters);
-					const height = (heightFromParams && heightFromParams[1]);
-					const width = (widthFromParams && widthFromParams[1]);
-					const widthIsFinite = isFinite(parseInt(width));
-					const heightIsFinite = isFinite(parseInt(height));
-					if (widthIsFinite) {
-						dimensions.push(`width="${width}"`);
-					}
-					if (heightIsFinite) {
-						dimensions.push(`height="${height}"`);
-					}
+	const renderer = new marked.Renderer();
+	renderer.image = (href: string, title: string, text: string) => {
+		let dimensions: string[] = [];
+		if (href) {
+			const splitted = href.split('|').map(s => s.trim());
+			href = splitted[0];
+			const parameters = splitted[1];
+			if (parameters) {
+				const heightFromParams = /height=(\d+)/.exec(parameters);
+				const widthFromParams = /width=(\d+)/.exec(parameters);
+				const height = (heightFromParams && heightFromParams[1]);
+				const width = (widthFromParams && widthFromParams[1]);
+				const widthIsFinite = isFinite(parseInt(width));
+				const heightIsFinite = isFinite(parseInt(height));
+				if (widthIsFinite) {
+					dimensions.push(`width="${width}"`);
+				}
+				if (heightIsFinite) {
+					dimensions.push(`height="${height}"`);
 				}
 			}
-			let attributes: string[] = [];
-			if (href) {
-				attributes.push(`src="${href}"`);
-			}
-			if (text) {
-				attributes.push(`alt="${text}"`);
-			}
-			if (title) {
-				attributes.push(`title="${title}"`);
-			}
-			if (dimensions.length) {
-				attributes = attributes.concat(dimensions);
-			}
-			return '<img ' + attributes.join(' ') + '>';
-		};
-		renderer.link = (href, title, text): string => {
-			// Remove markdown escapes. Workaround for https://github.com/chjj/marked/issues/829
-			if (href === text) { // raw link case
-				text = removeMarkdownEscapes(text);
-			}
-			title = removeMarkdownEscapes(title);
-			href = removeMarkdownEscapes(href);
-			if (href && !href.match(/^http:|https:|file:|mailto:/i)) {
-				return text;
-			}
-			return `<a href="#" data-href="${href}" title="${title || text}">${text}</a>`;
-		};
-		renderer.paragraph = (text): string => {
-			return `<p>${text}</p>`;
-		};
-
-		if (options.codeBlockRenderer) {
-			renderer.code = (code, lang) => {
-				let value = options.codeBlockRenderer(lang, code);
-				if (typeof value === 'string') {
-					return value;
-				}
-
-				if (TPromise.is(value)) {
-					// when code-block rendering is async we return sync
-					// but update the node with the real result later.
-					const id = defaultGenerator.nextId();
-					TPromise.join([value, withInnerHTML]).done(values => {
-						let strValue = values[0] as string;
-						let span = element.querySelector(`span[data-code="${id}"]`);
-						if (span) {
-							span.innerHTML = strValue;
-						}
-					}, err => {
-						// ignore
-					});
-					return `<span data-code="${id}">${escape(code)}</span>`;
-				}
-
-				return code;
-			};
 		}
-
-		if (options.actionCallback) {
-			DOM.addStandardDisposableListener(element, 'click', event => {
-				if (event.target.tagName === 'A') {
-					const href = event.target.dataset['href'];
-					if (href) {
-						options.actionCallback(href, event);
-					}
-				}
-			});
+		let attributes: string[] = [];
+		if (href) {
+			attributes.push(`src="${href}"`);
 		}
+		if (text) {
+			attributes.push(`alt="${text}"`);
+		}
+		if (title) {
+			attributes.push(`title="${title}"`);
+		}
+		if (dimensions.length) {
+			attributes = attributes.concat(dimensions);
+		}
+		return '<img ' + attributes.join(' ') + '>';
+	};
+	renderer.link = (href, title, text): string => {
+		// Remove markdown escapes. Workaround for https://github.com/chjj/marked/issues/829
+		if (href === text) { // raw link case
+			text = removeMarkdownEscapes(text);
+		}
+		title = removeMarkdownEscapes(title);
+		href = removeMarkdownEscapes(href);
+		if (href && !href.match(/^http:|https:|file:|mailto:/i)) {
+			return text;
+		}
+		return `<a href="#" data-href="${href}" title="${title || text}">${text}</a>`;
+	};
+	renderer.paragraph = (text): string => {
+		return `<p>${text}</p>`;
+	};
 
-		element.innerHTML = marked(content.markdown, {
-			sanitize: true,
-			renderer
+	if (options.codeBlockRenderer) {
+		renderer.code = (code, lang) => {
+			let value = options.codeBlockRenderer(lang, code);
+			if (typeof value === 'string') {
+				return value;
+			}
+
+			if (TPromise.is(value)) {
+				// when code-block rendering is async we return sync
+				// but update the node with the real result later.
+				const id = defaultGenerator.nextId();
+				TPromise.join([value, withInnerHTML]).done(values => {
+					let strValue = values[0] as string;
+					let span = element.querySelector(`span[data-code="${id}"]`);
+					if (span) {
+						span.innerHTML = strValue;
+					}
+				}, err => {
+					// ignore
+				});
+				return `<span data-code="${id}">${escape(code)}</span>`;
+			}
+
+			return code;
+		};
+	}
+
+	if (options.actionCallback) {
+		DOM.addStandardDisposableListener(element, 'click', event => {
+			if (event.target.tagName === 'A') {
+				const href = event.target.dataset['href'];
+				if (href) {
+					options.actionCallback(href, event);
+				}
+			}
 		});
-		signalInnerHTML();
 	}
+
+	element.innerHTML = marked(markdown, {
+		sanitize: true,
+		renderer
+	});
+	signalInnerHTML();
 
 	return element;
 }
@@ -220,7 +219,7 @@ interface IFormatParseTree {
 	children?: IFormatParseTree[];
 }
 
-function renderFormattedText(element: Node, treeNode: IFormatParseTree, actionCallback?: (content: string, event?: IMouseEvent) => void) {
+function _renderFormattedText(element: Node, treeNode: IFormatParseTree, actionCallback?: (content: string, event?: IMouseEvent) => void) {
 	var child: Node;
 
 	if (treeNode.type === FormatType.Text) {
@@ -254,7 +253,7 @@ function renderFormattedText(element: Node, treeNode: IFormatParseTree, actionCa
 
 	if (Array.isArray(treeNode.children)) {
 		treeNode.children.forEach((nodeChild) => {
-			renderFormattedText(child, nodeChild, actionCallback);
+			_renderFormattedText(child, nodeChild, actionCallback);
 		});
 	}
 }

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -9,8 +9,7 @@ import 'vs/css!./inputBox';
 import nls = require('vs/nls');
 import * as Bal from 'vs/base/browser/browser';
 import * as dom from 'vs/base/browser/dom';
-import { IHTMLContentElement } from 'vs/base/common/htmlContent';
-import { renderHtml } from 'vs/base/browser/htmlContentRenderer';
+import { RenderOptions, renderFormattedText, renderText } from 'vs/base/browser/htmlContentRenderer';
 import aria = require('vs/base/browser/ui/aria/aria');
 import { IAction } from 'vs/base/common/actions';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
@@ -381,18 +380,14 @@ export class InputBox extends Widget {
 				div = dom.append(container, $('.monaco-inputbox-container'));
 				layout();
 
-				let renderOptions: IHTMLContentElement = {
+				const renderOptions: RenderOptions = {
 					inline: true,
-					className: 'monaco-inputbox-message',
+					className: 'monaco-inputbox-message'
 				};
 
-				if (this.message.formatContent) {
-					renderOptions.formattedText = this.message.content;
-				} else {
-					renderOptions.text = this.message.content;
-				}
-
-				let spanElement: HTMLElement = <any>renderHtml(renderOptions);
+				let spanElement: HTMLElement = (this.message.formatContent
+					? renderFormattedText(this.message.content, renderOptions)
+					: renderText(this.message.content, renderOptions)) as any;
 				dom.addClass(spanElement, this.classForType(this.message.type));
 
 				const styles = this.stylesForType(this.message.type);

--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -12,11 +12,6 @@
  */
 export type MarkedString = string | { readonly language: string; readonly value: string };
 
-export interface IHTMLContentElementCode {
-	language: string;
-	value: string;
-}
-
 export function markedStringsEquals(a: MarkedString | MarkedString[], b: MarkedString | MarkedString[]): boolean {
 	if (!a && !b) {
 		return true;
@@ -29,9 +24,9 @@ export function markedStringsEquals(a: MarkedString | MarkedString[], b: MarkedS
 		if (!Array.isArray(b)) {
 			return false;
 		}
-		return markedStringArrEquals(<MarkedString[]>a, <MarkedString[]>b);
+		return markedStringArrEquals(a, b);
 	}
-	return markedStringEqual(<MarkedString>a, <MarkedString>b);
+	return markedStringEqual(a, b as MarkedString);
 }
 
 
@@ -76,16 +71,4 @@ export function removeMarkdownEscapes(text: string): string {
 		return text;
 	}
 	return text.replace(/\\([\\`*_{}[\]()#+\-.!])/g, '$1');
-}
-
-export interface IHTMLContentElement {
-	/**
-	 * supports **bold**, __italics__, and [[actions]]
-	 */
-	formattedText?: string;
-	text?: string;
-	className?: string;
-	inline?: boolean;
-	markdown?: string;
-	code?: IHTMLContentElementCode;
 }

--- a/src/vs/base/test/browser/htmlContent.test.ts
+++ b/src/vs/base/test/browser/htmlContent.test.ts
@@ -6,26 +6,19 @@
 
 import * as assert from 'assert';
 import { marked } from 'vs/base/common/marked/marked';
-import { renderHtml } from 'vs/base/browser/htmlContentRenderer';
+import { renderMarkdown, renderText, renderFormattedText } from 'vs/base/browser/htmlContentRenderer';
 
 suite('HtmlContent', () => {
-	test('render text', () => {
-		var result = renderHtml('testing');
-		assert.strictEqual(result.nodeType, document.TEXT_NODE);
-	});
-
 	test('render simple element', () => {
-		var result: HTMLElement = <any>renderHtml({
-			text: 'testing'
-		});
+		var result: HTMLElement = <any>renderText('testing');
+
 		assert.strictEqual(result.nodeType, document.ELEMENT_NODE);
 		assert.strictEqual(result.textContent, 'testing');
 		assert.strictEqual(result.tagName, 'DIV');
 	});
 
 	test('render element with class', () => {
-		var result: HTMLElement = <any>renderHtml({
-			text: 'testing',
+		var result: HTMLElement = <any>renderText('testing', {
 			className: 'testClass'
 		});
 		assert.strictEqual(result.nodeType, document.ELEMENT_NODE);
@@ -33,51 +26,37 @@ suite('HtmlContent', () => {
 	});
 
 	test('simple formatting', () => {
-		var result: HTMLElement = <any>renderHtml({
-			formattedText: '**bold**'
-		});
+		var result: HTMLElement = <any>renderFormattedText('**bold**');
 		assert.strictEqual(result.children.length, 1);
 		assert.strictEqual(result.firstChild.textContent, 'bold');
 		assert.strictEqual((<HTMLElement>result.firstChild).tagName, 'B');
 		assert.strictEqual(result.innerHTML, '<b>bold</b>');
 
-		result = <any>renderHtml({
-			formattedText: '__italics__'
-		});
-
+		result = <any>renderFormattedText('__italics__');
 		assert.strictEqual(result.innerHTML, '<i>italics</i>');
 
-		result = <any>renderHtml({
-			formattedText: 'this string has **bold** and __italics__'
-		});
-
+		result = <any>renderFormattedText('this string has **bold** and __italics__');
 		assert.strictEqual(result.innerHTML, 'this string has <b>bold</b> and <i>italics</i>');
 	});
 
 	test('no formatting', () => {
-		var result: HTMLElement = <any>renderHtml({
-			formattedText: 'this is just a string'
-		});
+		var result: HTMLElement = <any>renderFormattedText('this is just a string');
 		assert.strictEqual(result.innerHTML, 'this is just a string');
 	});
 
 	test('preserve newlines', () => {
-		var result: HTMLElement = <any>renderHtml({
-			formattedText: 'line one\nline two'
-		});
+		var result: HTMLElement = <any>renderFormattedText('line one\nline two');
 		assert.strictEqual(result.innerHTML, 'line one<br>line two');
 	});
 
 	test('action', () => {
 		var callbackCalled = false;
-		var result: HTMLElement = <any>renderHtml({
-			formattedText: '[[action]]'
-		}, {
-				actionCallback(content) {
-					assert.strictEqual(content, '0');
-					callbackCalled = true;
-				}
-			});
+		var result: HTMLElement = <any>renderFormattedText('[[action]]', {
+			actionCallback(content) {
+				assert.strictEqual(content, '0');
+				callbackCalled = true;
+			}
+		});
 		assert.strictEqual(result.innerHTML, '<a href="#">action</a>');
 
 		var event: MouseEvent = <any>document.createEvent('MouseEvent');
@@ -88,14 +67,12 @@ suite('HtmlContent', () => {
 
 	test('fancy action', () => {
 		var callbackCalled = false;
-		var result: HTMLElement = <any>renderHtml({
-			formattedText: '__**[[action]]**__'
-		}, {
-				actionCallback(content) {
-					assert.strictEqual(content, '0');
-					callbackCalled = true;
-				}
-			});
+		var result: HTMLElement = <any>renderFormattedText('__**[[action]]**__', {
+			actionCallback(content) {
+				assert.strictEqual(content, '0');
+				callbackCalled = true;
+			}
+		});
 		assert.strictEqual(result.innerHTML, '<i><b><a href="#">action</a></b></i>');
 
 		var event: MouseEvent = <any>document.createEvent('MouseEvent');
@@ -105,52 +82,40 @@ suite('HtmlContent', () => {
 	});
 
 	test('escaped formatting', () => {
-		var result: HTMLElement = <any>renderHtml({
-			formattedText: '\\*\\*bold\\*\\*'
-		});
+		var result: HTMLElement = <any>renderFormattedText('\\*\\*bold\\*\\*');
 		assert.strictEqual(result.children.length, 0);
 		assert.strictEqual(result.innerHTML, '**bold**');
 	});
 	test('image rendering conforms to default', () => {
-		const renderableContent = {
-			markdown: `![image](someimageurl 'caption')`
-		};
-		const result: HTMLElement = <any>renderHtml(renderableContent);
+		const markdown = `![image](someimageurl 'caption')`;
+		const result: HTMLElement = <any>renderMarkdown(markdown);
 		const renderer = new marked.Renderer();
-		const imageFromMarked = marked(renderableContent.markdown, {
+		const imageFromMarked = marked(markdown, {
 			sanitize: true,
 			renderer
 		}).trim();
 		assert.strictEqual(result.innerHTML, imageFromMarked);
 	});
 	test('image rendering conforms to default without title', () => {
-		const renderableContent = {
-			markdown: `![image](someimageurl)`
-		};
-		const result: HTMLElement = <any>renderHtml(renderableContent);
+		const markdown = `![image](someimageurl)`;
+		const result: HTMLElement = <any>renderMarkdown(markdown);
 		const renderer = new marked.Renderer();
-		const imageFromMarked = marked(renderableContent.markdown, {
+		const imageFromMarked = marked(markdown, {
 			sanitize: true,
 			renderer
 		}).trim();
 		assert.strictEqual(result.innerHTML, imageFromMarked);
 	});
 	test('image width from title params', () => {
-		var result: HTMLElement = <any>renderHtml({
-			markdown: `![image](someimageurl|width=100 'caption')`
-		});
+		var result: HTMLElement = <any>renderMarkdown(`![image](someimageurl|width=100 'caption')`);
 		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100"></p>`);
 	});
 	test('image height from title params', () => {
-		var result: HTMLElement = <any>renderHtml({
-			markdown: `![image](someimageurl|height=100 'caption')`
-		});
+		var result: HTMLElement = <any>renderMarkdown(`![image](someimageurl|height=100 'caption')`);
 		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" height="100"></p>`);
 	});
 	test('image width and height from title params', () => {
-		var result: HTMLElement = <any>renderHtml({
-			markdown: `![image](someimageurl|height=200,width=100 'caption')`
-		});
+		var result: HTMLElement = <any>renderMarkdown(`![image](someimageurl|height=200,width=100 'caption')`);
 		assert.strictEqual(result.innerHTML, `<p><img src="someimageurl" alt="image" title="caption" width="100" height="200"></p>`);
 	});
 });

--- a/src/vs/workbench/parts/codeEditor/electron-browser/accessibility.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/accessibility.ts
@@ -11,7 +11,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Disposable } from 'vs/base/common/lifecycle';
 import * as strings from 'vs/base/common/strings';
 import * as dom from 'vs/base/browser/dom';
-import { renderHtml } from 'vs/base/browser/htmlContentRenderer';
+import { renderFormattedText } from 'vs/base/browser/htmlContentRenderer';
 import { FastDomNode, createFastDomNode } from 'vs/base/browser/fastDomNode';
 import { Widget } from 'vs/base/browser/ui/widget';
 import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -252,9 +252,7 @@ class AccessibilityHelpWidget extends Widget implements IOverlayWidget {
 
 		text += '\n\n' + nls.localize('outroMsg', "You can dismiss this tooltip and return to the editor by pressing Escape or Shift+Escape.");
 
-		this._contentDomNode.domNode.appendChild(renderHtml({
-			formattedText: text
-		}));
+		this._contentDomNode.domNode.appendChild(renderFormattedText(text));
 	}
 
 	public hide(): void {

--- a/src/vs/workbench/services/message/browser/messageList.ts
+++ b/src/vs/workbench/services/message/browser/messageList.ts
@@ -334,10 +334,9 @@ export class MessageList {
 				sevLabel.appendTo(div);
 
 				// Error message
-				const messageContentElement = htmlRenderer.renderHtml({
+				const messageContentElement = htmlRenderer.renderFormattedText(text, {
 					inline: true,
 					className: 'message-left-side',
-					formattedText: text
 				});
 
 				$(messageContentElement as HTMLElement).title(messageContentElement.textContent).appendTo(div);


### PR DESCRIPTION
* Splits `renderHtml` into three distict functions to prevent passing in mixed content types
* Moves the `inline` and `className` properties onto the `RenderOptions` structure