### PR TITLE
Allow links in hover decorations to be inside a <code> tag

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -153,11 +153,17 @@ export function renderMarkdown(markdown: string, options: RenderOptions = {}): N
 
 	if (options.actionCallback) {
 		DOM.addStandardDisposableListener(element, 'click', event => {
-			if (event.target.tagName === 'A') {
-				const href = event.target.dataset['href'];
-				if (href) {
-					options.actionCallback(href, event);
+			let target = event.target;
+			if (target.tagName !== 'A') {
+				target = target.parentElement;
+				if (!target || target.tagName !== 'A') {
+					return;
 				}
+			}
+
+			const href = target.dataset['href'];
+			if (href) {
+				options.actionCallback(href, event);
 			}
 		});
 	}


### PR DESCRIPTION
Related to #29076 

Allows link actions when links are embedded inside another tag -- e.g. `<code>` tags

For example in GitLens I want to add the following command links:
![image](https://user-images.githubusercontent.com/641685/27618753-1e0076d6-5b8c-11e7-9124-d0d379314a41.png)

And I'd like to keep the `<code>` tag styling on them.

@mjbvz @jrieken I've repurposed this PR to just allow the above.