### PR TITLE
AccessibilityProvider getPosInSet and getSetSize

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenViewer.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenViewer.ts
@@ -55,6 +55,16 @@ export class AccessibilityProvider implements IAccessibilityProvider {
 
 		return model.accessibilityProvider && model.accessibilityProvider.getAriaLabel(element);
 	}
+
+	public getPosInSet(tree: ITree, element: any): string {
+		const model = this.modelProvider.getModel();
+		return String(model.entries.indexOf(element) + 1);
+	}
+
+	public getSetSize(): string {
+		const model = this.modelProvider.getModel();
+		return String(model.entries.length);
+	}
 }
 
 export class Filter implements IFilter {

--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -428,6 +428,10 @@ export interface IAccessibilityProvider {
 	 * See also: https://www.w3.org/TR/wai-aria/states_and_properties#aria-label
 	 */
 	getAriaLabel(tree: ITree, element: any): string;
+
+	getPosInSet?(tree: ITree, element: any): string;
+
+	getSetSize?(): string;
 }
 
 export /* abstract */ class ContextMenuEvent {

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -197,9 +197,14 @@ export class ViewItem implements IViewItem {
 
 		// ARIA
 		this.element.setAttribute('role', 'treeitem');
-		const ariaLabel = this.context.accessibilityProvider.getAriaLabel(this.context.tree, this.model.getElement());
+		const accessibility = this.context.accessibilityProvider;
+		const ariaLabel = accessibility.getAriaLabel(this.context.tree, this.model.getElement());
 		if (ariaLabel) {
 			this.element.setAttribute('aria-label', ariaLabel);
+		}
+		if (accessibility.getPosInSet && accessibility.getSetSize) {
+			this.element.setAttribute('aria-setsize', accessibility.getSetSize());
+			this.element.setAttribute('aria-posinset', accessibility.getPosInSet(this.context.tree, this.model.getElement()));
 		}
 		if (this.model.hasTrait('focused')) {
 			const base64Id = strings.safeBtoa(this.model.id);


### PR DESCRIPTION
An attempt to enrich the `Tree` `AccessibilityProvider` by adding optional `getPosInSet` and `getSetSize`. This fixes the https://github.com/Microsoft/monaco-editor/issues/444 and gives all trees the option to opt into this

Note that it is not possible to solve this issue only in the QuickOpen world since QuickOpen does not have access to the proper dom element which should have this area attributes.


fixes #27900
fyi @alexandrudima 