### PR TITLE
[XML] Allow space after/before the equal sign in(fix #26570)

### DIFF
--- a/extensions/xml/syntaxes/xml.json
+++ b/extensions/xml/syntaxes/xml.json
@@ -4,6 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
+	"version": "https://github.com/atom/language-xml/commit/27352842917b911383122bdcf98ed0d69d55c179",
 	"scopeName": "text.xml",
 	"name": "XML",
 	"fileTypes": [
@@ -418,7 +419,7 @@
 							"name": "entity.other.attribute-name.localname.xml"
 						}
 					},
-					"match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)="
+					"match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*="
 				},
 				{
 					"include": "#doublequotedString"

--- a/extensions/xml/test/colorize-fixtures/test.xml
+++ b/extensions/xml/test/colorize-fixtures/test.xml
@@ -1,5 +1,5 @@
 <project>
-    <target name="jar">
+    <target name = "jar">
         <mkdir dir="build/jar"/>
         <jar destfile="build/jar/HelloWorld.jar" basedir="build/classes">
             <manifest>

--- a/extensions/xml/test/colorize-results/test_xml.json
+++ b/extensions/xml/test/colorize-results/test_xml.json
@@ -88,7 +88,7 @@
 		}
 	},
 	{
-		"c": "=",
+		"c": " = ",
 		"t": "text.xml meta.tag.xml",
 		"r": {
 			"dark_plus": "default: #D4D4D4",


### PR DESCRIPTION
Fix #26570

Made by command
```
$ ./build/npm/update-grammar.js atom/language-xml grammars/xml.cson ./extensions/xml/syntaxes/xml.json grammars/xsl.cson ./extensions/x
ml/syntaxes/xsl.json
```

result
<img width="604" alt="screen shot 2017-06-21 at 20 51 55" src="https://user-images.githubusercontent.com/8369346/27382977-eba232dc-56c3-11e7-9c6c-9492b5003818.png">
