### PR TITLE
Wrap tasks cmds as Actions for telemetry

### DIFF
--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -911,14 +911,16 @@ export class CodeMenu {
 	}
 
 	private setTaskMenu(taskMenu: Electron.Menu): void {
-		const runTask = this.createMenuItem(nls.localize({ key: 'miRunTask', comment: ['&& denotes a mnemonic'] }, "&&Run Task..."), 'workbench.action.tasks.runTask');
-		const restartTask = this.createMenuItem(nls.localize({ key: 'miRestartTask', comment: ['&& denotes a mnemonic'] }, "R&&estart Task"), 'workbench.action.tasks.restartTask');
-		const terminateTask = this.createMenuItem(nls.localize({ key: 'miTerminateTask', comment: ['&& denotes a mnemonic'] }, "&&Terminate Task"), 'workbench.action.tasks.terminate');
-		const buildTask = this.createMenuItem(nls.localize({ key: 'miBuildTask', comment: ['&& denotes a mnemonic'] }, "&&Build Task"), 'workbench.action.tasks.build');
-		const testTask = this.createMenuItem(nls.localize({ key: 'miTestTask', comment: ['&& denotes a mnemonic'] }, "Test T&&ask"), 'workbench.action.tasks.test');
-		const showTaskLog = this.createMenuItem(nls.localize({ key: 'miShowTaskLog', comment: ['&& denotes a mnemonic'] }, "&&Show Task Log"), 'workbench.action.tasks.showLog');
+		const runTask = this.createMenuItem(nls.localize({ key: 'miRunTask', comment: ['&& denotes a mnemonic'] }, "&&Run Task..."), 'workbench.action.taskAction.runTask');
+		const restartTask = this.createMenuItem(nls.localize({ key: 'miRestartTask', comment: ['&& denotes a mnemonic'] }, "R&&estart Task"), 'workbench.action.taskAction.restartTask');
+		const terminateTask = this.createMenuItem(nls.localize({ key: 'miTerminateTask', comment: ['&& denotes a mnemonic'] }, "&&Terminate Task"), 'workbench.action.taskAction.terminateTask');
+		const buildTask = this.createMenuItem(nls.localize({ key: 'miBuildTask', comment: ['&& denotes a mnemonic'] }, "&&Build Task"), 'workbench.action.taskAction.build');
+		const testTask = this.createMenuItem(nls.localize({ key: 'miTestTask', comment: ['&& denotes a mnemonic'] }, "Test T&&ask"), 'workbench.action.taskAction.test');
+		const showTaskLog = this.createMenuItem(nls.localize({ key: 'miShowTaskLog', comment: ['&& denotes a mnemonic'] }, "&&Show Task Log"), 'workbench.action.taskAction.showLog');
+		const configureTask = this.createMenuItem(nls.localize({ key: 'miConfigureTask', comment: ['&& denotes a mnemonic'] }, "&&Configure Task Runner"), 'workbench.action.tasks.configureTaskRunner');
 
 		[
+			configureTask,
 			showTaskLog,
 			runTask,
 			restartTask,

--- a/src/vs/workbench/electron-browser/workbench.main.ts
+++ b/src/vs/workbench/electron-browser/workbench.main.ts
@@ -78,7 +78,6 @@ import 'vs/workbench/parts/trust/electron-browser/unsupportedWorkspaceSettings.c
 import 'vs/workbench/parts/relauncher/electron-browser/relauncher.contribution';
 
 import 'vs/workbench/parts/tasks/electron-browser/task.contribution';
-import 'vs/workbench/parts/tasks/common/taskActions';
 
 import 'vs/workbench/parts/emmet/browser/emmet.browser.contribution';
 import 'vs/workbench/parts/emmet/electron-browser/emmet.contribution';

--- a/src/vs/workbench/electron-browser/workbench.main.ts
+++ b/src/vs/workbench/electron-browser/workbench.main.ts
@@ -78,6 +78,7 @@ import 'vs/workbench/parts/trust/electron-browser/unsupportedWorkspaceSettings.c
 import 'vs/workbench/parts/relauncher/electron-browser/relauncher.contribution';
 
 import 'vs/workbench/parts/tasks/electron-browser/task.contribution';
+import 'vs/workbench/parts/tasks/common/taskActions';
 
 import 'vs/workbench/parts/emmet/browser/emmet.browser.contribution';
 import 'vs/workbench/parts/emmet/electron-browser/emmet.contribution';

--- a/src/vs/workbench/parts/tasks/common/taskActions.ts
+++ b/src/vs/workbench/parts/tasks/common/taskActions.ts
@@ -10,8 +10,6 @@ import nls = require('vs/nls');
 import { Action } from 'vs/base/common/actions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { IQuickOpenService } from 'vs/platform/quickOpen/common/quickOpen';
-import { IConfigurationService } from "vs/platform/configuration/common/configuration";
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actionRegistry';
 
@@ -23,8 +21,6 @@ export class RunTaskAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IQuickOpenService private quickOpenService: IQuickOpenService,
-		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService
 	) {
 		super(id, label);
@@ -44,8 +40,6 @@ export class RestartTaskAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IQuickOpenService private quickOpenService: IQuickOpenService,
-		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService
 	) {
 		super(id, label);
@@ -65,8 +59,6 @@ export class TerminateTaskAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IQuickOpenService private quickOpenService: IQuickOpenService,
-		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService
 	) {
 		super(id, label);
@@ -86,8 +78,6 @@ export class BuildTaskAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IQuickOpenService private quickOpenService: IQuickOpenService,
-		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService
 	) {
 		super(id, label);
@@ -107,8 +97,6 @@ export class TestTaskAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IQuickOpenService private quickOpenService: IQuickOpenService,
-		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService
 	) {
 		super(id, label);
@@ -128,8 +116,6 @@ export class ShowTaskLogAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IQuickOpenService private quickOpenService: IQuickOpenService,
-		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService
 	) {
 		super(id, label);

--- a/src/vs/workbench/parts/tasks/common/taskActions.ts
+++ b/src/vs/workbench/parts/tasks/common/taskActions.ts
@@ -1,0 +1,155 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { TPromise } from 'vs/base/common/winjs.base';
+import nls = require('vs/nls');
+import { Action } from 'vs/base/common/actions';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
+import { IQuickOpenService } from 'vs/platform/quickOpen/common/quickOpen';
+import { IConfigurationService } from "vs/platform/configuration/common/configuration";
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actionRegistry';
+
+export class RunTaskAction extends Action {
+
+	public static ID = 'workbench.action.taskAction.runTask';
+	public static LABEL = nls.localize('runTaskAction', "Run task");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ICommandService private commandService: ICommandService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		this.commandService.executeCommand('workbench.action.tasks.runTask');
+		return TPromise.as(null);
+	}
+}
+
+export class RestartTaskAction extends Action {
+
+	public static ID = 'workbench.action.taskAction.restartTask';
+	public static LABEL = nls.localize('restartTaskAction', "Restart task");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ICommandService private commandService: ICommandService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		this.commandService.executeCommand('workbench.action.tasks.restartTask');
+		return TPromise.as(null);
+	}
+}
+
+export class TerminateTaskAction extends Action {
+
+	public static ID = 'workbench.action.taskAction.terminateTask';
+	public static LABEL = nls.localize('terminateTaskAction', "Terminate task");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ICommandService private commandService: ICommandService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		this.commandService.executeCommand('workbench.action.tasks.terminate');
+		return TPromise.as(null);
+	}
+}
+
+export class BuildTaskAction extends Action {
+
+	public static ID = 'workbench.action.taskAction.build';
+	public static LABEL = nls.localize('buildTaskAction', "Build task");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ICommandService private commandService: ICommandService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		this.commandService.executeCommand('workbench.action.tasks.build');
+		return TPromise.as(null);
+	}
+}
+
+export class TestTaskAction extends Action {
+
+	public static ID = 'workbench.action.taskAction.test';
+	public static LABEL = nls.localize('testTaskAction', "Test task");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ICommandService private commandService: ICommandService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		this.commandService.executeCommand('workbench.action.tasks.test');
+		return TPromise.as(null);
+	}
+}
+
+export class ShowTaskLogAction extends Action {
+
+	public static ID = 'workbench.action.taskAction.showLog';
+	public static LABEL = nls.localize('showTaskLogAction', "Show task log");
+
+	constructor(
+		id: string,
+		label: string,
+		@IQuickOpenService private quickOpenService: IQuickOpenService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@ICommandService private commandService: ICommandService
+	) {
+		super(id, label);
+	}
+
+	public run(context?: any): TPromise<any> {
+		this.commandService.executeCommand('workbench.action.tasks.showLog');
+		return TPromise.as(null);
+	}
+}
+
+Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
+	.registerWorkbenchAction(new SyncActionDescriptor(RunTaskAction, RunTaskAction.ID, RunTaskAction.LABEL), 'Run Task');
+Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
+	.registerWorkbenchAction(new SyncActionDescriptor(RestartTaskAction, RestartTaskAction.ID, RestartTaskAction.LABEL), 'Restart Task');
+Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
+	.registerWorkbenchAction(new SyncActionDescriptor(TerminateTaskAction, TerminateTaskAction.ID, TerminateTaskAction.LABEL), 'Terminate Task');
+Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
+	.registerWorkbenchAction(new SyncActionDescriptor(BuildTaskAction, BuildTaskAction.ID, BuildTaskAction.LABEL), 'Build Task');
+Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
+	.registerWorkbenchAction(new SyncActionDescriptor(TestTaskAction, TestTaskAction.ID, TestTaskAction.LABEL), 'Test Task');
+Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions)
+	.registerWorkbenchAction(new SyncActionDescriptor(ShowTaskLogAction, ShowTaskLogAction.ID, ShowTaskLogAction.LABEL), 'Show Task Log');

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -11,6 +11,7 @@ import 'vs/workbench/parts/tasks/browser/terminateQuickOpen';
 import 'vs/workbench/parts/tasks/browser/restartQuickOpen';
 import 'vs/workbench/parts/tasks/browser/buildQuickOpen';
 import 'vs/workbench/parts/tasks/browser/testQuickOpen';
+import 'vs/workbench/parts/tasks/common/taskActions';
 
 import * as nls from 'vs/nls';
 


### PR DESCRIPTION
- previously, we were unable to tell if cmds like `workbench.action.tasks.runTask` were accessed from the menu
- `Action` has automatic telemetry that adds a 'from' dimension that tells us where it was run
- thus, I wrapped the task commands as `Action` and called those at the task top-level menu

/cc @dbaeumer