### PR TITLE
Add --max_old_space_size to tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,9 @@
 	"linux": {
 		"command": "./node_modules/.bin/gulp"
 	},
+	"args": [
+		"--max_old_space_size=4096"
+	],
 	"isShellCommand": true,
 	"tasks": [
 		{


### PR DESCRIPTION
This was in package.json, but not in tasks.json, causing OOM errors when running through the VS Code task runner