### PR TITLE
Filter settings from no search results link

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -164,7 +164,10 @@ export class PreferencesEditor extends BaseEditor {
 		this.searchWidget.focus();
 	}
 
-	public focusSearch(): void {
+	public focusSearch(filter?: string): void {
+		if (filter !== null) {
+			this.searchWidget.setValue(filter);
+		}
 		this.searchWidget.focus();
 	}
 

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -61,6 +61,7 @@ import { attachListStyler } from 'vs/platform/theme/common/styler';
 import { IOutputService } from 'vs/workbench/parts/output/common/output';
 import { Color } from 'vs/base/common/color';
 import { getOutOfWorkspaceEditorResources } from 'vs/workbench/parts/search/common/search';
+import { PreferencesEditor } from "vs/workbench/parts/preferences/browser/preferencesEditor";
 
 export class SearchViewlet extends Viewlet {
 
@@ -1087,11 +1088,12 @@ export class SearchViewlet extends Viewlet {
 					}).on(dom.EventType.CLICK, (e: MouseEvent) => {
 						dom.EventHelper.stop(e, false);
 
-						if (this.contextService.hasWorkspace()) {
-							this.preferencesService.openWorkspaceSettings().done(() => null, errors.onUnexpectedError);
-						} else {
-							this.preferencesService.openGlobalSettings().done(() => null, errors.onUnexpectedError);
-						}
+						let editorPromise = this.contextService.hasWorkspace() ? this.preferencesService.openWorkspaceSettings() : this.preferencesService.openGlobalSettings();
+						editorPromise.done(editor => {
+							if (editor instanceof PreferencesEditor) {
+								editor.focusSearch('.exclude');
+							}
+						}, errors.onUnexpectedError);
 					});
 				}
 


### PR DESCRIPTION
The user is encouraged to check the exclude settings when there are no search
results. Previously this would just open up the settings without any indication
which settings are relevant. This change will update the search filter to show
`files.exclude` and `search.exclude`.