### PR TITLE
Handle failing extension installation

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -79,13 +79,20 @@ export class InstallVSIXAction extends Action {
 		if (!result) {
 			return TPromise.as(null);
 		}
-
 		return TPromise.join(result.map(vsix => this.extensionsWorkbenchService.install(vsix))).then(() => {
 			this.messageService.show(
 				severity.Info,
 				{
 					message: localize('InstallVSIXAction.success', "Successfully installed the extension. Restart to enable it."),
 					actions: [this.instantiationService.createInstance(ReloadWindowAction, ReloadWindowAction.ID, localize('InstallVSIXAction.reloadNow', "Reload Now"))]
+				}
+			);
+		}, () => {
+			this.messageService.show(
+				severity.Error,
+				{
+					message: localize('InstallVSIXAction.failed', "Installing the extension failed."),
+					actions: []
 				}
 			);
 		});


### PR DESCRIPTION
Fixes #28475.

Well, let's say. It provides generic error message when installation failed, not only when `package.json` is missing
