### PR TITLE
extension count formatting Fixes: #29491

### DIFF
--- a/src/vs/workbench/parts/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/parts/extensions/browser/extensionsWidgets.ts
@@ -80,10 +80,13 @@ export class InstallWidget implements IDisposable {
 				installLabel = `${Math.floor(installCount / 1000)}K`;
 			}
 		}
+		else {
+			installLabel = installCount.toLocaleString('en');
+		}
 
 		append(this.container, $('span.octicon.octicon-cloud-download'));
 		const count = append(this.container, $('span.count'));
-		count.textContent = installLabel || String(installCount);
+		count.textContent = installLabel;
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/parts/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/parts/extensions/browser/extensionsWidgets.ts
@@ -80,6 +80,9 @@ export class InstallWidget implements IDisposable {
 				installLabel = `${Math.floor(installCount / 1000)}K`;
 			}
 		}
+		else {
+			installLabel = installCount.toLocaleString('en');
+		}
 
 		append(this.container, $('span.octicon.octicon-cloud-download'));
 		const count = append(this.container, $('span.count'));


### PR DESCRIPTION
@Tyriar 
@joaomoreno 
See #29491  for discussion.

Note: if we used Platform.locale we would support all locales
like periods as separators for German
let me know.