### PR TITLE
Fix for #29608 'QuickOpen looks misaligned in monokai theme'.

### DIFF
--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -28,7 +28,7 @@
 		"tab.inactiveBackground": "#414339",
 		"tab.border": "#1e1f1c",
 		"tab.inactiveForeground": "#ccccc7", // needs to be bright so it's readable when another editor group is focused
-		"widget.shadow": "#1e1f1c",
+		"widget.shadow": "#000000",
 		"progressBar.background": "#75715E",
 		"badge.background": "#75715E",
 		"badge.foreground": "#f8f8f2",


### PR DESCRIPTION
Changed the 'widget.shadow' property of the monokai theme to #00000 so that it does not blend in with any of the backgrounds.