### PR TITLE
Group search results by root folders

### DIFF
--- a/src/vs/workbench/parts/search/browser/media/searchviewlet.css
+++ b/src/vs/workbench/parts/search/browser/media/searchviewlet.css
@@ -170,6 +170,7 @@
 	overflow: hidden;
 }
 
+.search-viewlet .foldermatch,
 .search-viewlet .filematch {
 	display: flex;
 	position: relative;
@@ -177,10 +178,12 @@
 	padding: 0;
 }
 
+.search-viewlet .foldermatch .monaco-icon-label,
 .search-viewlet .filematch .monaco-icon-label {
 	flex: 1;
 }
 
+.search-viewlet .foldermatch .directory,
 .search-viewlet .filematch .directory {
 	opacity: 0.7;
 	font-size: 0.9em;
@@ -266,9 +269,11 @@
 	margin-right: 12px;
 }
 
-.search-viewlet > .results > .monaco-tree .monaco-tree-row:hover .content .monaco-count-badge,
-.search-viewlet > .results > .monaco-tree.focused .monaco-tree-row.focused .content .monaco-count-badge {
-	display: none;
+.search-viewlet > .results > .monaco-tree .monaco-tree-row:hover .content .filematch .monaco-count-badge,
+.search-viewlet > .results > .monaco-tree .monaco-tree-row:hover .content .linematch .monaco-count-badge,
+.search-viewlet > .results > .monaco-tree.focused .monaco-tree-row.focused .content .filematch .monaco-count-badge,
+.search-viewlet > .results > .monaco-tree.focused .monaco-tree-row.focused .content .linematch .monaco-count-badge {
+		display: none;
 }
 
 .search-viewlet .focused .monaco-tree-row.selected:not(.highlighted) > .content.actions .action-remove,
@@ -382,6 +387,7 @@
 	opacity: .5;
 }
 
+.vs-dark .search-viewlet .foldermatch,
 .vs-dark .search-viewlet .filematch {
 	padding: 0;
 }
@@ -398,6 +404,7 @@
 
 /* High Contrast Theming */
 
+.hc-black .monaco-workbench .search-viewlet .foldermatch,
 .hc-black .monaco-workbench .search-viewlet .filematch,
 .hc-black .monaco-workbench .search-viewlet .linematch {
 	line-height: 20px;

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -15,7 +15,7 @@ import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { INavigator } from 'vs/base/common/iterator';
 import { SearchViewlet } from 'vs/workbench/parts/search/browser/searchViewlet';
-import { SearchResult, Match, FileMatch, FileMatchOrMatch } from 'vs/workbench/parts/search/common/searchModel';
+import { Match, FileMatch, FileMatchOrMatch } from 'vs/workbench/parts/search/common/searchModel';
 import { IReplaceService } from 'vs/workbench/parts/search/common/replace';
 import * as Constants from 'vs/workbench/parts/search/common/constants';
 import { CollapseAllAction as TreeCollapseAction } from 'vs/base/parts/tree/browser/treeDefaults';
@@ -405,13 +405,13 @@ export class RemoveAction extends AbstractSearchAndReplaceAction {
 		}
 
 		let elementToRefresh: any;
-		if (this.element instanceof FileMatch) {
-			let parent: SearchResult = <SearchResult>this.element.parent();
-			parent.remove(<FileMatch>this.element);
-			elementToRefresh = parent;
-		} else {
-			let parent: FileMatch = <FileMatch>this.element.parent();
-			parent.remove(<Match>this.element);
+		let element = this.element;
+		if (element instanceof FileMatch) {
+			elementToRefresh = element.parent();
+			element.parent().remove(element);
+		} else if (element instanceof Match) {
+			let parent = element.parent();
+			parent.remove(element);
 			elementToRefresh = parent.count() === 0 ? parent.parent() : parent;
 		}
 

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -15,7 +15,7 @@ import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { INavigator } from 'vs/base/common/iterator';
 import { SearchViewlet } from 'vs/workbench/parts/search/browser/searchViewlet';
-import { Match, FileMatch, FileMatchOrMatch } from 'vs/workbench/parts/search/common/searchModel';
+import { SearchResult, Match, FileMatch, FileMatchOrMatch } from 'vs/workbench/parts/search/common/searchModel';
 import { IReplaceService } from 'vs/workbench/parts/search/common/replace';
 import * as Constants from 'vs/workbench/parts/search/common/constants';
 import { CollapseAllAction as TreeCollapseAction } from 'vs/base/parts/tree/browser/treeDefaults';
@@ -405,13 +405,13 @@ export class RemoveAction extends AbstractSearchAndReplaceAction {
 		}
 
 		let elementToRefresh: any;
-		let element = this.element;
-		if (element instanceof FileMatch) {
-			elementToRefresh = element.parent();
-			element.parent().remove(element);
-		} else if (element instanceof Match) {
-			let parent = element.parent();
-			parent.remove(element);
+		if (this.element instanceof FileMatch) {
+			let parent: SearchResult = <SearchResult>this.element.parent();
+			parent.remove(<FileMatch>this.element);
+			elementToRefresh = parent;
+		} else {
+			let parent: FileMatch = <FileMatch>this.element.parent();
+			parent.remove(<Match>this.element);
 			elementToRefresh = parent.count() === 0 ? parent.parent() : parent;
 		}
 

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -15,7 +15,7 @@ import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { INavigator } from 'vs/base/common/iterator';
 import { SearchViewlet } from 'vs/workbench/parts/search/browser/searchViewlet';
-import { SearchResult, Match, FileMatch, FileMatchOrMatch } from 'vs/workbench/parts/search/common/searchModel';
+import { Match, FileMatch, FileMatchOrMatch, FolderMatch } from 'vs/workbench/parts/search/common/searchModel';
 import { IReplaceService } from 'vs/workbench/parts/search/common/replace';
 import * as Constants from 'vs/workbench/parts/search/common/constants';
 import { CollapseAllAction as TreeCollapseAction } from 'vs/base/parts/tree/browser/treeDefaults';
@@ -406,7 +406,7 @@ export class RemoveAction extends AbstractSearchAndReplaceAction {
 
 		let elementToRefresh: any;
 		if (this.element instanceof FileMatch) {
-			let parent: SearchResult = <SearchResult>this.element.parent();
+			let parent: FolderMatch = <FolderMatch>this.element.parent();
 			parent.remove(<FileMatch>this.element);
 			elementToRefresh = parent;
 		} else {

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -90,7 +90,7 @@ export class SearchSorter implements ISorter {
 
 	public compare(tree: ITree, elementA: FileMatchOrMatch, elementB: FileMatchOrMatch): number {
 		if (elementA instanceof FolderMatch && elementB instanceof FolderMatch) {
-			return elementA.resource().fsPath.localeCompare(elementB.resource().fsPath);
+			return elementA.index() - elementB.index();
 		}
 
 		if (elementA instanceof FileMatch && elementB instanceof FileMatch) {

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -49,7 +49,7 @@ export class SearchDataSource implements IDataSource {
 		} else if (element instanceof FolderMatch) {
 			return element.matches();
 		} else if (element instanceof SearchResult) {
-			return element.folderMatches();
+			return element.folderMatches().filter(fm => !fm.isEmpty());
 		}
 
 		return [];

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -22,6 +22,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { attachBadgeStyler } from 'vs/platform/theme/common/styler';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { getPathLabel } from 'vs/base/common/labels';
+import { FileKind } from "vs/platform/files/common/files";
 
 export class SearchDataSource implements IDataSource {
 
@@ -227,7 +228,7 @@ export class SearchRenderer extends Disposable implements IRenderer {
 
 	private renderFolderMatch(tree: ITree, folderMatch: FolderMatch, templateData: IFolderMatchTemplate): void {
 		if (folderMatch.hasRoot()) {
-			templateData.label.setFile(folderMatch.resource(), { isFolder: true });
+			templateData.label.setFile(folderMatch.resource(), { fileKind: FileKind.ROOT_FOLDER });
 		} else {
 			templateData.label.setValue(nls.localize('searchFolderMatch.other.label', "Other files"));
 		}

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -221,9 +221,9 @@ export class SearchRenderer extends Disposable implements IRenderer {
 
 	private renderFolderMatch(tree: ITree, folderMatch: FolderMatch, templateData: IFolderMatchTemplate): void {
 		templateData.label.setFile(folderMatch.resource(), { isFolder: true });
-		let count = folderMatch.count();
+		let count = folderMatch.fileCount();
 		templateData.badge.setCount(count);
-		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchMatches', "{0} matches found", count) : nls.localize('searchMatch', "{0} match found", count));
+		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchFileMatches', "{0} files found", count) : nls.localize('searchFileMatch', "{0} file found", count));
 	}
 
 	private renderFileMatch(tree: ITree, fileMatch: FileMatch, templateData: IFileMatchTemplate): void {

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -220,14 +220,20 @@ export class SearchRenderer extends Disposable implements IRenderer {
 	}
 
 	private renderFolderMatch(tree: ITree, folderMatch: FolderMatch, templateData: IFolderMatchTemplate): void {
-		templateData.label.setFile(folderMatch.resource(), { isFolder: true });
+		if (folderMatch.hasRoot()) {
+			templateData.label.setFile(folderMatch.resource(), { isFolder: true });
+		} else {
+			templateData.label.setValue(nls.localize('searchFolderMatch.other.label', "Other files"));
+		}
 		let count = folderMatch.fileCount();
 		templateData.badge.setCount(count);
 		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchFileMatches', "{0} files found", count) : nls.localize('searchFileMatch', "{0} file found", count));
 	}
 
 	private renderFileMatch(tree: ITree, fileMatch: FileMatch, templateData: IFileMatchTemplate): void {
-		templateData.label.setFile(fileMatch.resource(), { root: fileMatch.parent().resource() });
+		const folderMatch = fileMatch.parent();
+		const root = folderMatch.hasRoot() ? folderMatch.resource() : undefined;
+		templateData.label.setFile(fileMatch.resource(), { root });
 		let count = fileMatch.count();
 		templateData.badge.setCount(count);
 		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchMatches', "{0} matches found", count) : nls.localize('searchMatch', "{0} match found", count));

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -183,7 +183,7 @@ export class SearchRenderer extends Disposable implements IRenderer {
 	}
 
 	private renderFolderMatchTemplate(tree: ITree, templateId: string, container: HTMLElement): IFolderMatchTemplate {
-		let folderMatchElement = DOM.append(container, DOM.$('.filematch'));
+		let folderMatchElement = DOM.append(container, DOM.$('.foldermatch'));
 		const label = this.instantiationService.createInstance(FileLabel, folderMatchElement, void 0);
 		const badge = new CountBadge(DOM.append(folderMatchElement, DOM.$('.badge')));
 		this._register(attachBadgeStyler(badge, this.themeService));

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -220,7 +220,7 @@ export class SearchRenderer extends Disposable implements IRenderer {
 	}
 
 	private renderFolderMatch(tree: ITree, folderMatch: FolderMatch, templateData: IFolderMatchTemplate): void {
-		templateData.label.setFile(folderMatch.resource());
+		templateData.label.setFile(folderMatch.resource(), { isFolder: true });
 		let count = folderMatch.count();
 		templateData.badge.setCount(count);
 		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchMatches', "{0} matches found", count) : nls.localize('searchMatch', "{0} match found", count));

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -227,7 +227,7 @@ export class SearchRenderer extends Disposable implements IRenderer {
 	}
 
 	private renderFileMatch(tree: ITree, fileMatch: FileMatch, templateData: IFileMatchTemplate): void {
-		templateData.label.setFile(fileMatch.resource());
+		templateData.label.setFile(fileMatch.resource(), { root: fileMatch.parent().resource() });
 		let count = fileMatch.count();
 		templateData.badge.setCount(count);
 		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchMatches', "{0} matches found", count) : nls.localize('searchMatch', "{0} match found", count));

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -79,7 +79,10 @@ export class SearchDataSource implements IDataSource {
 
 	public shouldAutoexpand(tree: ITree, element: any): boolean {
 		const numChildren = this._getChildren(element).length;
-		return numChildren > 0 && numChildren < SearchDataSource.AUTOEXPAND_CHILD_LIMIT;
+		if (numChildren <= 0) {
+			return false;
+		}
+		return numChildren < SearchDataSource.AUTOEXPAND_CHILD_LIMIT || element instanceof FolderMatch;
 	}
 }
 

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -27,6 +27,8 @@ export class SearchDataSource implements IDataSource {
 
 	private static AUTOEXPAND_CHILD_LIMIT = 10;
 
+	constructor(private includeFolderMatch: boolean = true) { }
+
 	public getId(tree: ITree, element: any): string {
 		if (element instanceof FolderMatch) {
 			return element.id();
@@ -49,7 +51,11 @@ export class SearchDataSource implements IDataSource {
 		} else if (element instanceof FolderMatch) {
 			return element.matches();
 		} else if (element instanceof SearchResult) {
-			return element.folderMatches().filter(fm => !fm.isEmpty());
+			if (this.includeFolderMatch) {
+				return element.folderMatches().filter(fm => !fm.isEmpty());
+			} else {
+				return element.matches();
+			}
 		}
 
 		return [];
@@ -69,7 +75,7 @@ export class SearchDataSource implements IDataSource {
 		if (element instanceof Match) {
 			value = element.parent();
 		} else if (element instanceof FileMatch) {
-			value = element.parent();
+			value = this.includeFolderMatch ? element.parent() : element.parent().parent();
 		} else if (element instanceof FolderMatch) {
 			value = element.parent();
 		}

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -442,7 +442,7 @@ export class SearchViewlet extends Viewlet {
 			this.results = div;
 			this.results.addClass('show-file-icons');
 
-			let dataSource = new SearchDataSource();
+			let dataSource = new SearchDataSource(this.contextService.hasMultiFolderWorkspace());
 			let renderer = this.instantiationService.createInstance(SearchRenderer, this.getActionRunner(), this);
 
 			this.tree = new Tree(div.getHTMLElement(), {

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -1168,7 +1168,7 @@ export class SearchViewlet extends Viewlet {
 		const msgWasHidden = this.messages.isHidden();
 		if (fileCount > 0) {
 			const div = this.clearMessage();
-			$(div).p({ text: this.buildResultCountMessage(this.viewModel.searchResult.count(), fileCount) });
+			$(div).p({ text: this.buildResultCountMessage(fileCount, this.viewModel.searchResult.folderCount()) });
 			if (msgWasHidden) {
 				this.reLayout();
 			}
@@ -1177,15 +1177,15 @@ export class SearchViewlet extends Viewlet {
 		}
 	}
 
-	private buildResultCountMessage(resultCount: number, fileCount: number): string {
-		if (resultCount === 1 && fileCount === 1) {
-			return nls.localize('search.file.result', "{0} result in {1} file", resultCount, fileCount);
-		} else if (resultCount === 1) {
-			return nls.localize('search.files.result', "{0} result in {1} files", resultCount, fileCount);
+	private buildResultCountMessage(fileCount: number, folderCount: number): string {
+		if (folderCount === 1 && fileCount === 1) {
+			return nls.localize('search.folder.file', "{0} file in {1} folder", fileCount, folderCount);
+		} else if (folderCount === 1) {
+			return nls.localize('search.folder.files', "{0} files in {1} folder", fileCount, folderCount);
 		} else if (fileCount === 1) {
-			return nls.localize('search.file.results', "{0} results in {1} file", resultCount, fileCount);
+			return nls.localize('search.folders.file', "{0} file in {1} folders", fileCount, folderCount);
 		} else {
-			return nls.localize('search.files.results', "{0} results in {1} files", resultCount, fileCount);
+			return nls.localize('search.folders.files', "{0} files in {1} folders", fileCount, folderCount);
 		}
 	}
 

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -1168,7 +1168,7 @@ export class SearchViewlet extends Viewlet {
 		const msgWasHidden = this.messages.isHidden();
 		if (fileCount > 0) {
 			const div = this.clearMessage();
-			$(div).p({ text: this.buildResultCountMessage(fileCount, this.viewModel.searchResult.folderCount()) });
+			$(div).p({ text: this.buildResultCountMessage(this.viewModel.searchResult.count(), fileCount, this.viewModel.searchResult.folderCount()) });
 			if (msgWasHidden) {
 				this.reLayout();
 			}
@@ -1177,15 +1177,27 @@ export class SearchViewlet extends Viewlet {
 		}
 	}
 
-	private buildResultCountMessage(fileCount: number, folderCount: number): string {
-		if (folderCount === 1 && fileCount === 1) {
-			return nls.localize('search.folder.file', "{0} file in {1} folder", fileCount, folderCount);
-		} else if (folderCount === 1) {
-			return nls.localize('search.folder.files', "{0} files in {1} folder", fileCount, folderCount);
-		} else if (fileCount === 1) {
-			return nls.localize('search.folders.file', "{0} file in {1} folders", fileCount, folderCount);
+	private buildResultCountMessage(resultCount: number, fileCount: number, folderCount: number): string {
+		if (folderCount === 1) {
+			if (resultCount === 1 && fileCount === 1) {
+				return nls.localize('search.folder.file.result', "{0} result in {1} file in {2} folder", resultCount, fileCount, folderCount);
+			} else if (resultCount === 1) {
+				return nls.localize('search.folder.files.result', "{0} result in {1} files in {2} folder", resultCount, fileCount, folderCount);
+			} else if (fileCount === 1) {
+				return nls.localize('search.folder.file.results', "{0} results in {1} file in {2} folder", resultCount, fileCount, folderCount);
+			} else {
+				return nls.localize('search.folder.files.results', "{0} results in {1} files in {2} folder", resultCount, fileCount, folderCount);
+			}
 		} else {
-			return nls.localize('search.folders.files', "{0} files in {1} folders", fileCount, folderCount);
+			if (resultCount === 1 && fileCount === 1) {
+				return nls.localize('search.folders.file.result', "{0} result in {1} file in {2} folders", resultCount, fileCount, folderCount);
+			} else if (resultCount === 1) {
+				return nls.localize('search.folders.files.result', "{0} result in {1} files in {2} folders", resultCount, fileCount, folderCount);
+			} else if (fileCount === 1) {
+				return nls.localize('search.folders.file.results', "{0} results in {1} file in {2} folders", resultCount, fileCount, folderCount);
+			} else {
+				return nls.localize('search.folders.files.results', "{0} results in {1} files in {2} folders", resultCount, fileCount, folderCount);
+			}
 		}
 	}
 

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -345,19 +345,14 @@ export class FolderMatch extends Disposable {
 
 	private _fileMatches: ResourceMap<FileMatch>;
 	private _unDisposedFileMatches: ResourceMap<FileMatch>;
-	private _query: ISearchQuery = null;
 
 	public replacingAll: boolean = false;
 
-	constructor(private _resource: URI, private _parent: SearchResult, private _searchModel: SearchModel, @IReplaceService private replaceService: IReplaceService, @ITelemetryService private telemetryService: ITelemetryService,
+	constructor(private _resource: URI, private _query: ISearchQuery, private _parent: SearchResult, private _searchModel: SearchModel, @IReplaceService private replaceService: IReplaceService, @ITelemetryService private telemetryService: ITelemetryService,
 		@IInstantiationService private instantiationService: IInstantiationService) {
 		super();
 		this._fileMatches = new ResourceMap<FileMatch>();
 		this._unDisposedFileMatches = new ResourceMap<FileMatch>();
-	}
-
-	public set query(query: ISearchQuery) {
-		this._query = query;
 	}
 
 	public get searchModel(): SearchModel {
@@ -509,8 +504,7 @@ export class SearchResult extends Disposable {
 		this._query = query;
 		this._queryWorkspace.roots = (query.folderQueries || []).map((fq) => fq.folder);
 		this._queryWorkspace.roots.forEach((resource) => {
-			let folderMatch = this.instantiationService.createInstance(FolderMatch, resource, this, this._searchModel);
-			folderMatch.query = query;
+			let folderMatch = this.instantiationService.createInstance(FolderMatch, resource, query, this, this._searchModel);
 			this._folderMatches.set(resource, folderMatch);
 			let disposable = folderMatch.onChange((event) => this._onChange.fire(event));
 			folderMatch.onDispose(() => disposable.dispose());

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -587,6 +587,10 @@ export class SearchResult extends Disposable {
 		return this.folderMatches().reduce<number>((prev, match) => prev + match.fileCount(), 0);
 	}
 
+	public folderCount(): number {
+		return this.folderMatches().reduce<number>((prev, match) => prev + (match.fileCount() > 0 ? 1 : 0), 0);
+	}
+
 	public count(): number {
 		return this.matches().reduce<number>((prev, match) => prev + match.count(), 0);
 	}

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -348,7 +348,7 @@ export class FolderMatch extends Disposable {
 
 	public replacingAll: boolean = false;
 
-	constructor(private _resource: URI, private _query: ISearchQuery, private _parent: SearchResult, private _searchModel: SearchModel, @IReplaceService private replaceService: IReplaceService, @ITelemetryService private telemetryService: ITelemetryService,
+	constructor(private _resource: URI, private _index: number, private _query: ISearchQuery, private _parent: SearchResult, private _searchModel: SearchModel, @IReplaceService private replaceService: IReplaceService, @ITelemetryService private telemetryService: ITelemetryService,
 		@IInstantiationService private instantiationService: IInstantiationService) {
 		super();
 		this._fileMatches = new ResourceMap<FileMatch>();
@@ -369,6 +369,10 @@ export class FolderMatch extends Disposable {
 
 	public resource(): URI {
 		return this._resource;
+	}
+
+	public index(): number {
+		return this._index;
 	}
 
 	public name(): string {
@@ -503,8 +507,8 @@ export class SearchResult extends Disposable {
 		this.clear();
 		this._query = query;
 		this._queryWorkspace.roots = (query.folderQueries || []).map((fq) => fq.folder);
-		this._queryWorkspace.roots.forEach((resource) => {
-			let folderMatch = this.instantiationService.createInstance(FolderMatch, resource, query, this, this._searchModel);
+		this._queryWorkspace.roots.forEach((resource, index) => {
+			let folderMatch = this.instantiationService.createInstance(FolderMatch, resource, index, query, this, this._searchModel);
 			this._folderMatches.set(resource, folderMatch);
 			let disposable = folderMatch.onChange((event) => this._onChange.fire(event));
 			folderMatch.onDispose(() => disposable.dispose());

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -345,8 +345,7 @@ export class FolderMatch extends Disposable {
 
 	private _fileMatches: ResourceMap<FileMatch>;
 	private _unDisposedFileMatches: ResourceMap<FileMatch>;
-
-	public replacingAll: boolean = false;
+	private _replacingAll: boolean = false;
 
 	constructor(private _resource: URI, private _index: number, private _query: ISearchQuery, private _parent: SearchResult, private _searchModel: SearchModel, @IReplaceService private replaceService: IReplaceService, @ITelemetryService private telemetryService: ITelemetryService,
 		@IInstantiationService private instantiationService: IInstantiationService) {
@@ -361,6 +360,10 @@ export class FolderMatch extends Disposable {
 
 	public get showHighlights(): boolean {
 		return this._parent.showHighlights;
+	}
+
+	public set replacingAll(b: boolean) {
+		this._replacingAll = b;
 	}
 
 	public id(): string {
@@ -443,7 +446,7 @@ export class FolderMatch extends Disposable {
 			added = false;
 			removed = true;
 		}
-		if (!this.replacingAll) {
+		if (!this._replacingAll) {
 			this._onChange.fire({ elements: [fileMatch], added: added, removed: removed });
 		}
 	}

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -341,7 +341,7 @@ export class SearchResult extends Disposable {
 
 	private _fileMatches: ResourceMap<FileMatch>;
 	private _unDisposedFileMatches: ResourceMap<FileMatch>;
-	private _query: IPatternInfo = null;
+	private _query: ISearchQuery = null;
 	private _maxResults: number;
 	private _showHighlights: boolean;
 	private _replacingAll: boolean = false;
@@ -356,7 +356,7 @@ export class SearchResult extends Disposable {
 		this._rangeHighlightDecorations = this.instantiationService.createInstance(RangeHighlightDecorations);
 	}
 
-	public set query(query: IPatternInfo) {
+	public set query(query: ISearchQuery) {
 		this._query = query;
 	}
 
@@ -372,7 +372,7 @@ export class SearchResult extends Disposable {
 		let changed: FileMatch[] = [];
 		raw.forEach((rawFileMatch) => {
 			if (!this._fileMatches.has(rawFileMatch.resource)) {
-				let fileMatch = this.instantiationService.createInstance(FileMatch, this._query, this._maxResults, this, rawFileMatch);
+				let fileMatch = this.instantiationService.createInstance(FileMatch, this._query.contentPattern, this._maxResults, this, rawFileMatch);
 				this.doAdd(fileMatch);
 				changed.push(fileMatch);
 				let disposable = fileMatch.onChange(() => this.onFileChange(fileMatch));
@@ -566,7 +566,7 @@ export class SearchModel extends Disposable {
 
 		this.searchResult.clear();
 
-		this._searchResult.query = this._searchQuery.contentPattern;
+		this._searchResult.query = this._searchQuery;
 		this._searchResult.maxResults = this._searchQuery.maxResults;
 		this._replacePattern = new ReplacePattern(this._replaceString, this._searchQuery.contentPattern);
 

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -526,7 +526,7 @@ export class SearchResult extends Disposable {
 		// Split up raw into a list per folder so we can do a batch add per folder.
 		let rawPerFolder = new ResourceMap<IFileMatch[]>();
 		this._folderMatches.forEach((folderMatch) => rawPerFolder.set(folderMatch.resource(), []));
-		allRaw.forEach((rawFileMatch) => {
+		allRaw.forEach(rawFileMatch => {
 			let folderMatch = this.getFolderMatch(rawFileMatch.resource);
 			rawPerFolder.get(folderMatch.resource()).push(rawFileMatch);
 		});

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -342,7 +342,6 @@ export class SearchResult extends Disposable {
 	private _fileMatches: ResourceMap<FileMatch>;
 	private _unDisposedFileMatches: ResourceMap<FileMatch>;
 	private _query: ISearchQuery = null;
-	private _maxResults: number;
 	private _showHighlights: boolean;
 	private _replacingAll: boolean = false;
 
@@ -360,10 +359,6 @@ export class SearchResult extends Disposable {
 		this._query = query;
 	}
 
-	public set maxResults(maxResults: number) {
-		this._maxResults = maxResults;
-	}
-
 	public get searchModel(): SearchModel {
 		return this._searchModel;
 	}
@@ -372,7 +367,7 @@ export class SearchResult extends Disposable {
 		let changed: FileMatch[] = [];
 		raw.forEach((rawFileMatch) => {
 			if (!this._fileMatches.has(rawFileMatch.resource)) {
-				let fileMatch = this.instantiationService.createInstance(FileMatch, this._query.contentPattern, this._maxResults, this, rawFileMatch);
+				let fileMatch = this.instantiationService.createInstance(FileMatch, this._query.contentPattern, this._query.maxResults, this, rawFileMatch);
 				this.doAdd(fileMatch);
 				changed.push(fileMatch);
 				let disposable = fileMatch.onChange(() => this.onFileChange(fileMatch));
@@ -567,7 +562,6 @@ export class SearchModel extends Disposable {
 		this.searchResult.clear();
 
 		this._searchResult.query = this._searchQuery;
-		this._searchResult.maxResults = this._searchQuery.maxResults;
 		this._replacePattern = new ReplacePattern(this._replaceString, this._searchQuery.contentPattern);
 
 		const onDone = fromPromise(this.currentRequest);

--- a/src/vs/workbench/parts/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/parts/search/test/browser/searchViewlet.test.ts
@@ -25,7 +25,8 @@ suite('Search - Viewlet', () => {
 
 	test('Data Source', function () {
 		let ds = new SearchDataSource();
-		let result = instantiation.createInstance(SearchResult, null);
+		let result: SearchResult = instantiation.createInstance(SearchResult, null);
+		result.query = { type: 1, folderQueries: [{ folder: uri.parse('file://c:/') }] };
 		result.add([{
 			resource: uri.parse('file:///c:/foo'),
 			lineMatches: [{ lineNumber: 1, preview: 'bar', offsetAndLengths: [[0, 1]] }]

--- a/src/vs/workbench/parts/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/parts/search/test/common/searchModel.test.ts
@@ -11,7 +11,7 @@ import { DeferredPPromise } from 'vs/base/test/common/utils';
 import { PPromise } from 'vs/base/common/winjs.base';
 import { SearchModel } from 'vs/workbench/parts/search/common/searchModel';
 import URI from 'vs/base/common/uri';
-import { IFileMatch, ILineMatch, ISearchService, ISearchComplete, ISearchProgressItem, IUncachedSearchStats } from 'vs/platform/search/common/search';
+import { IFileMatch, IFolderQuery, ILineMatch, ISearchService, ISearchComplete, ISearchProgressItem, IUncachedSearchStats } from 'vs/platform/search/common/search';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 import { Range } from 'vs/editor/common/core/range';
@@ -57,6 +57,10 @@ suite('SearchModel', () => {
 		filesWalked: 3
 	};
 
+	const folderQueries: IFolderQuery[] = [
+		{ folder: URI.parse('file://c:/') }
+	];
+
 	setup(() => {
 		restoreStubs = [];
 		instantiationService = new TestInstantiationService();
@@ -76,8 +80,8 @@ suite('SearchModel', () => {
 		let results = [aRawMatch('file://c:/1', aLineMatch('preview 1', 1, [[1, 3], [4, 7]])), aRawMatch('file://c:/2', aLineMatch('preview 2'))];
 		instantiationService.stub(ISearchService, 'search', PPromise.as({ results: results }));
 
-		let testObject = instantiationService.createInstance(SearchModel);
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		let testObject: SearchModel = instantiationService.createInstance(SearchModel);
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		let actual = testObject.searchResult.matches();
 
@@ -103,7 +107,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', promise);
 
 		let testObject = instantiationService.createInstance(SearchModel);
-		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		promise.progress(results[0]);
 		promise.progress(results[1]);
@@ -137,7 +141,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', PPromise.as({ results: results }));
 
 		let testObject = instantiationService.createInstance(SearchModel);
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		assert.ok(target.calledOnce);
 		const data = target.args[0];
@@ -154,7 +158,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', PPromise.as({ results: [] }));
 
 		let testObject = instantiationService.createInstance(SearchModel);
-		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		const result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		setTimeout(() => {
 			result.done(() => {
@@ -176,7 +180,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', promise);
 
 		let testObject = instantiationService.createInstance(SearchModel);
-		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		promise.progress(aRawMatch('file://c:/1', aLineMatch('some preview')));
 		promise.complete({ results: [], stats: testSearchStats });
@@ -202,7 +206,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', promise);
 
 		let testObject = instantiationService.createInstance(SearchModel);
-		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		promise.error('error');
 
@@ -227,7 +231,7 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', promise);
 
 		let testObject = instantiationService.createInstance(SearchModel);
-		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		let result = testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		promise.cancel();
 
@@ -245,12 +249,12 @@ suite('SearchModel', () => {
 		let results = [aRawMatch('file://c:/1', aLineMatch('preview 1', 1, [[1, 3], [4, 7]])), aRawMatch('file://c:/2', aLineMatch('preview 2'))];
 		instantiationService.stub(ISearchService, 'search', PPromise.as({ results: results }));
 		let testObject: SearchModel = instantiationService.createInstance(SearchModel);
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 		assert.ok(!testObject.searchResult.isEmpty());
 
 		instantiationService.stub(ISearchService, 'search', new DeferredPPromise<ISearchComplete, ISearchProgressItem>());
 
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 		assert.ok(testObject.searchResult.isEmpty());
 	});
 
@@ -259,9 +263,9 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', new DeferredPPromise((c, e, p) => { }, target));
 		let testObject: SearchModel = instantiationService.createInstance(SearchModel);
 
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 		instantiationService.stub(ISearchService, 'search', new DeferredPPromise<ISearchComplete, ISearchProgressItem>());
-		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'somestring' }, type: 1, folderQueries });
 
 		assert.ok(target.calledOnce);
 	});
@@ -271,24 +275,24 @@ suite('SearchModel', () => {
 		instantiationService.stub(ISearchService, 'search', PPromise.as({ results: results }));
 
 		let testObject: SearchModel = instantiationService.createInstance(SearchModel);
-		testObject.search({ contentPattern: { pattern: 're' }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 're' }, type: 1, folderQueries });
 		testObject.replaceString = 'hello';
 		let match = testObject.searchResult.matches()[0].matches()[0];
 		assert.equal('hello', match.replaceString);
 
-		testObject.search({ contentPattern: { pattern: 're', isRegExp: true }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 're', isRegExp: true }, type: 1, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.equal('hello', match.replaceString);
 
-		testObject.search({ contentPattern: { pattern: 're(?:vi)', isRegExp: true }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 're(?:vi)', isRegExp: true }, type: 1, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.equal('hello', match.replaceString);
 
-		testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1, folderQueries });
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.equal('hello', match.replaceString);
 
-		testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1 });
+		testObject.search({ contentPattern: { pattern: 'r(e)(?:vi)', isRegExp: true }, type: 1, folderQueries });
 		testObject.replaceString = 'hello$1';
 		match = testObject.searchResult.matches()[0].matches()[0];
 		assert.equal('helloe', match.replaceString);

--- a/src/vs/workbench/parts/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/parts/search/test/common/searchResult.test.ts
@@ -368,6 +368,7 @@ suite('SearchResult', () => {
 
 	function aSearchResult(): SearchResult {
 		let searchModel = instantiationService.createInstance(SearchModel);
+		searchModel.searchResult.query = { type: 1, folderQueries: [{ folder: URI.parse('file://c:/') }] };
 		return searchModel.searchResult;
 	}
 


### PR DESCRIPTION
This is a work in progress PR to add support for grouping of search results. I am submitting it now since I believe the rest of the work is mostly minor and I'll only getting back to this PR on Monday. So hopefully will get some early feedback.

![image](https://user-images.githubusercontent.com/187831/27746459-977b6844-5dc7-11e7-816c-fef7166acb2c.png)

![image](https://user-images.githubusercontent.com/187831/27746480-a7bdfb0e-5dc7-11e7-9616-15459be2ff38.png)

TODOs:

* [x] Add replace actions. (For follow-up PR)
* [x] Make it works with extraFileResources
* [x] Always display some FileMatches. Currently will not auto-expand repos if many results
* [x] Render FileMatch names for relative to folder.
* [x] Render single folder searches without extra level.
* [x] Create CSS rule `.foldermatch`, rather than reusing `.filematch`.
* [x] Update textual descriptions of results to take into account folders.
* ~~Bug in Tree renderer for auto-expanded children~~

cc @roblourens 