### PR TITLE
Reset JavaScript expression coloring in template expressions

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -254,6 +254,16 @@
 			}
 		},
 		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression.js",
+				"meta.template.expression.ts"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
 			"scope": [
 				"support.type.vendored.property-name",
 				"support.type.property-name",

--- a/extensions/theme-defaults/themes/hc_black_defaults.json
+++ b/extensions/theme-defaults/themes/hc_black_defaults.json
@@ -241,6 +241,16 @@
 			}
 		},
 		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression.js",
+				"meta.template.expression.ts"
+			],
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
 			"scope": [
 				"support.type.vendored.property-name",
 				"support.type.property-name",

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -250,6 +250,16 @@
 			}
 		},
 		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression.js",
+				"meta.template.expression.ts"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
 			"scope": [
 				"support.constant.property-value",
 				"support.constant.font-name",

--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -364,6 +364,25 @@
 			}
 		},
 		{
+			"name": "Template Definition",
+			"scope": [
+				"punctuation.definition.template-expression",
+				"punctuation.section.embedded.coffee"
+			],
+			"settings": {
+				"foreground": "#D08442"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#C5C8C6"
+			}
+		},
+		{
 			"name": "PHP Function Call",
 			"scope": "meta.function-call.object.php",
 			"settings": {
@@ -533,13 +552,6 @@
 			"scope": "token.debug-token",
 			"settings": {
 				"foreground": "#b267e6"
-			}
-		},
-		{
-			"name": "this.self",
-			"scope": "variable.language",
-			"settings": {
-				"foreground": "#c7444a"
 			}
 		},
 		{

--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -121,6 +121,15 @@
 			}
 		},
 		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#F8F8F2"
+			}
+		},
+		{
 			"name": "Number",
 			"scope": "constant.numeric",
 			"settings": {

--- a/extensions/typescript/test/colorize-results/test-issue5431_ts.json
+++ b/extensions/typescript/test/colorize-results/test-issue5431_ts.json
@@ -368,8 +368,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -412,8 +412,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},

--- a/extensions/typescript/test/colorize-results/test-strings_ts.json
+++ b/extensions/typescript/test/colorize-results/test-strings_ts.json
@@ -104,8 +104,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -355,11 +355,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -368,8 +368,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -377,11 +377,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -399,11 +399,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -412,8 +412,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -421,11 +421,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -465,11 +465,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -478,8 +478,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -487,11 +487,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -509,11 +509,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{
@@ -522,8 +522,8 @@
 		"r": {
 			"dark_plus": "variable: #9CDCFE",
 			"light_plus": "variable: #001080",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
 			"hc_black": "variable: #9CDCFE"
 		}
 	},
@@ -531,11 +531,11 @@
 		"c": " ",
 		"t": "source.ts string.template.ts meta.template.expression.ts",
 		"r": {
-			"dark_plus": "string: #CE9178",
-			"light_plus": "string: #A31515",
-			"dark_vs": "string: #CE9178",
-			"light_vs": "string: #A31515",
-			"hc_black": "string: #CE9178"
+			"dark_plus": "meta.template.expression.ts: #D4D4D4",
+			"light_plus": "meta.template.expression.ts: #000000",
+			"dark_vs": "meta.template.expression.ts: #D4D4D4",
+			"light_vs": "meta.template.expression.ts: #000000",
+			"hc_black": "meta.template.expression.ts: #FFFFFF"
 		}
 	},
 	{


### PR DESCRIPTION
Fixes #29866

Adds new rules to standard theme to reset the coloring of expression inside of js/ts template expressions