### PR TITLE
Add *.props as a recognized file extension for XML

### DIFF
--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -34,6 +34,7 @@
 				".opml",
 				".owl",
 				".proj",
+        ".props",
 				".pt",
 				".pubxml",
 				".pubxml.user",


### PR DESCRIPTION
Several MSBuild file extensions where already there including `*.targets`.

`*.props` is becoming increasingly important especially with .NET SDK projects using `Directory.Build.props` so frequently.