### PR TITLE
Recursively refresh children on expand in Tree

### DIFF
--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -295,7 +295,7 @@ export class Item extends Events.EventEmitter {
 			this.emit('item:expanding', eventData);
 
 			if (this.needsChildrenRefresh) {
-				result = this.refreshChildren(false, true, true);
+				result = this.refreshChildren(true, true, true);
 			} else {
 				result = WinJS.TPromise.as(null);
 			}


### PR DESCRIPTION
This PR is to fix a problem I noticed when I created https://github.com/Microsoft/vscode/pull/29964 

The problem is visible in this video. Note: The same issue occurs when using code in the desktop, this recording is from when I was testing for Sourcegraph

![demo](https://cl.ly/2j2U13143F1N/Screen%20Recording%202017-06-30%20at%2005.05%20pm.gif)

Note how when I expand a folder we have children (a FileMatch) with an icon indicating they are expanded, but the children are not rendered. They get rendered if one collapses FileMatch and then expands. Note: the affected FileMatches are marked as auto expanded, which I believe is somehow related to the root cause of this bug.

The more generic explanation of the issue: If an item is auto-expanded but its parent is not, then when the parent is expanded the item's children are not refreshed. This fix we always recursively refresh. This fix seems a bit heavy handed and potentially a performance regression. So I'd like some guidance.

cc @bpasero 