### PR TITLE
Properly format file path on when dragging and dropping a tab into the integrated terminal in Windows

### DIFF
--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -357,4 +357,9 @@ export interface ITerminalInstance {
 	 * Sets the title of the terminal instance.
 	 */
 	setTitle(title: string): void;
+
+	/**
+	 * Returns the list of nested shells running in the terminal. This is only implemented for Windows.
+	 */
+	getShellList(): Promise<string[]>;
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -825,6 +825,47 @@ export class TerminalInstance implements ITerminalInstance {
 			this._messageTitleListener = null;
 		}
 	}
+
+	private static getChildProcesses(pid: number): Promise<{executable: string, pid: number}[]> {
+		return new Promise((resolve, reject) => {
+			cp.execFile('wmic.exe', ['process', 'where', `parentProcessId=${pid}`, 'get', 'ExecutablePath,ProcessId'], (err, stdout, stderr) => {
+				if (err) {
+					reject(err);
+				} else if (stderr.length > 0) {
+					resolve([]); // No processes found
+				} else {
+					resolve(stdout.split('\n').slice(1).filter(str => str.length > 0).map(str => {
+						const s = str.split('  ');
+						return {executable: s[0], pid: Number(s[1])};
+					}));
+				}
+			});
+		});
+	}
+
+	public async getShellList(): Promise<string[]> {
+		if (platform.platform !== platform.Platform.Windows) {
+			return [];
+		}
+
+		const shells = ['bash.exe', 'cmd.exe', 'powershell.exe'];
+		const pList = [this._shellLaunchConfig.executable];
+
+		let pid = this._processId;
+		while (pid !== null) {
+			const oldPid = pid;
+			pid = null;
+			for (const childproc of await TerminalInstance.getChildProcesses(oldPid)) {
+				if (shells.indexOf(path.basename(childproc.executable)) !== -1) {
+					pList.push(childproc.executable);
+					pid = childproc.pid;
+					break;
+				}
+			}
+		}
+
+		return pList;
+	}
 }
 
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -232,21 +232,47 @@ export class TerminalPanel extends Panel {
 					return;
 				}
 
-				// Check if the file was dragged from the tree explorer
-				let uri = e.dataTransfer.getData('URL');
-				if (uri) {
-					uri = URI.parse(uri).path;
-				} else if (e.dataTransfer.files.length > 0) {
-					// Check if the file was dragged from the filesystem
-					uri = URI.file(e.dataTransfer.files[0].path).path;
-				}
+				const winFormatters: [RegExp, (uri: URI) => string][] = [
+					// WSL bash
+					[/^C:\\Windows\\(System32|sysnative)\\bash.exe$/i, uri => '/mnt/' + uri.path[1] + uri.path.substring(3)],
+					// Git bash
+					[/bash.exe$/i, uri => uri.path.substring(0, 2) + uri.path.substring(3)],
 
-				if (!uri) {
-					return;
-				}
+					[/cmd.exe$/i, uri => uri.path[1].toUpperCase() + uri.path.substring(2).replace(/\//g, '\\')],
+					[/powershell.exe$/i, uri => uri.path[1].toUpperCase() + uri.path.substring(2).replace(/\//g, '\\')],
+				];
 
 				const terminal = this._terminalService.getActiveInstance();
-				terminal.sendText(this._preparePathForTerminal(uri), false);
+
+				const uriForm = async (uri: URI) => {
+					if (platform.isWindows) {
+						const shells = await terminal.getShellList();
+						const shell = shells[shells.length - 1];
+
+						for (const formatter of winFormatters) {
+							if (formatter[0].test(shell)) {
+								return formatter[1](uri);
+							}
+						}
+					}
+					return uri.path;
+				};
+
+				const uri = e.dataTransfer.getData('URL');
+				let urip = Promise.resolve(uri);
+				if (uri) {
+					urip = uriForm(URI.parse(uri));
+				} else if (e.dataTransfer.files.length > 0) {
+					// Check if the file was dragged from the filesystem
+					urip = uriForm(URI.file(e.dataTransfer.files[0].path));
+				}
+
+				urip.then(uri => {
+					if (!uri) {
+						return;
+					}
+					terminal.sendText(this._preparePathForTerminal(uri), false);
+				});
 			}
 		}));
 	}


### PR DESCRIPTION
This is a proof-of-concept illustrating a possible fix for #29926.

It uses the `wmic process where parentProcessId=... get ...` command to query processes spawned by the shell and matches the process executables with a set of known shells (`bash.exe`, `cmd.exe`, and `powershell.exe`). In the case that one of these spawned processes is a shell, its child processes are recursively examined until either there are no more child processes (nothing's running in the shell) or there are only non-shell child processes (a command is running).

After traversing these nested shells, the path of the last reached shell is used to pick a formatter for the path (either putting it in `C:\...`, `/mnt/c/` or `/c/` format).

A gif of using different shells is below.

![2017-07-03_12-34-30](https://user-images.githubusercontent.com/18223213/27806731-14122656-5ff1-11e7-87a5-6e3b2909cce7.gif)

The way this is implemented currently has a few disadvantages though:

1. For every nested shell that is traversed a new `wmic` command must be spawned. When the number of nested shells increases, it can take some time before the path is pasted. This could be solved by caching the current shell, but I wasn't sure how to go about this.

2. This fails to work correctly in cases that a shell is spawned in the background (i.e. `start cmd.exe`) as there are no checks to whether the shell being traversed is in the background or foreground.

I'm not going to be able to get back to this for a while soon, so feel free to play around with / heavily edit this.