### PR TITLE
Implement context menu actions in CompositePart

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -435,12 +435,6 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 			}
 		});
 
-		// Prevent native context menu on actions
-		$(this.domNode).on(DOM.EventType.CONTEXT_MENU, (e: Event) => {
-			e.preventDefault();
-			e.stopPropagation();
-		});
-
 		$(this.domNode).on(DOM.EventType.KEY_UP, (e: KeyboardEvent) => {
 			let event = new StandardKeyboardEvent(e);
 
@@ -535,6 +529,12 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 			const actionItemElement = document.createElement('li');
 			actionItemElement.className = 'action-item';
 			actionItemElement.setAttribute('role', 'presentation');
+
+			// Prevent native context menu on actions
+			$(actionItemElement).on(DOM.EventType.CONTEXT_MENU, (e: Event) => {
+				e.preventDefault();
+				e.stopPropagation();
+			});
 
 			let item: IActionItem = null;
 

--- a/src/vs/workbench/browser/composite.ts
+++ b/src/vs/workbench/browser/composite.ts
@@ -156,6 +156,13 @@ export abstract class Composite extends Component implements IComposite {
 	}
 
 	/**
+	 * Returns an array of actions to show in the context menu of the composite
+	 */
+	public getContextMenuActions(): IAction[] {
+		return [];
+	}
+
+	/**
 	 * For any of the actions returned by this composite, provide an IActionItem in
 	 * cases where the implementor of the composite wants to override the presentation
 	 * of an action. Returns null to indicate that the action is not rendered through


### PR DESCRIPTION
This will enable context menu actions in `CompositePart`. This is needed to manage visibility of views in side bars similar to that in activity bar.

![image](https://user-images.githubusercontent.com/10746682/27836804-52292796-60e1-11e7-959b-b15d0f382c9d.png)


![image](https://user-images.githubusercontent.com/10746682/27836814-5945145e-60e1-11e7-9f10-6507f754f9b4.png)
