### PR TITLE
Center align keybindings in quick open

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickopen.css
+++ b/src/vs/base/parts/quickopen/browser/quickopen.css
@@ -56,7 +56,7 @@
 
 .quick-open-widget .quick-open-tree .quick-open-entry > .row {
 	display: flex;
-	align-items: center;
+	align-items: stretch;
 }
 
 .quick-open-widget .quick-open-tree .quick-open-entry .quick-open-entry-icon {
@@ -92,7 +92,7 @@
 }
 
 .quick-open-widget .quick-open-tree .quick-open-entry-keybinding .monaco-kbkey {
-	vertical-align: text-bottom;
+	margin-top: -3px;
 }
 
 .quick-open-widget .quick-open-tree .results-group {


### PR DESCRIPTION
Part of #28602

---

So I had a look and i know what's going on and why it's difficult to center this. It's hard because the `.monaco-kbkey` style uses `line-height` to size the background of the button. A negative `margin-top` is used to work around this since the size is fixed to 22px from what I can tell.

<img width="515" alt="screen shot 2017-07-05 at 2 48 31 am" src="https://user-images.githubusercontent.com/2193314/27859225-e65f7258-612c-11e7-93f0-bc76479233fd.png">
<img width="498" alt="screen shot 2017-07-05 at 2 48 40 am" src="https://user-images.githubusercontent.com/2193314/27859235-ea5db6ee-612c-11e7-98d2-583e16719ba5.png">
<img width="498" alt="screen shot 2017-07-05 at 2 48 48 am" src="https://user-images.githubusercontent.com/2193314/27859237-ec2761e6-612c-11e7-9548-0c34bd5b9604.png">

---

There is one remaining issue however, this PR fixes the alignment of all items except for those containing a separator which is 1px off:

<img width="502" alt="screen shot 2017-07-05 at 2 52 32 am" src="https://user-images.githubusercontent.com/2193314/27859261-037ee026-612d-11e7-904b-18895d09869e.png">
<img width="521" alt="screen shot 2017-07-05 at 2 52 49 am" src="https://user-images.githubusercontent.com/2193314/27859280-1182b60c-612d-11e7-8392-7a7a30e59539.png">

The reason this is off is because the size of `.results-group-separator` is 23px but its parent `.monaco-tree-row` is set to `22px`, meaning the last pixel is being hidden via `overflow:hidden`.

<img width="514" alt="screen shot 2017-07-05 at 2 54 15 am" src="https://user-images.githubusercontent.com/2193314/27859328-41494b12-612d-11e7-93a8-a45a3234195b.png">

The right fix here is to move the `.results-group-separator` class up one level to the `.monaco-tree-row` level and adjust it's height to 23px. Setting it manually in devtools to 23px seems to work just right:

<img width="525" alt="screen shot 2017-07-05 at 2 56 22 am" src="https://user-images.githubusercontent.com/2193314/27859505-ce7c1a82-612d-11e7-8203-c7de35200b35.png">

@bpasero @joaomoreno I don't feel like I know the code well enough to make this last change, will probably take no time at all for one of you though 😄 