### PR TITLE
vscode.TaskGroup.Test should be Test, not Clean

### DIFF
--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1042,7 +1042,7 @@ export class TaskGroup implements vscode.TaskGroup {
 
 	public static Rebuild: TaskGroup = new TaskGroup('rebuild', 'Rebuild');
 
-	public static Test: TaskGroup = new TaskGroup('clean', 'Clean');
+	public static Test: TaskGroup = new TaskGroup('test', 'Test');
 
 	constructor(id: string, label: string) {
 		if (typeof id !== 'string') {


### PR DESCRIPTION
This should help resolve a minor bug

Also, should VSCode also support a "Run" task by default? We imply a build when you perform "test" in our own command-line tools, I'm not sure if this is the intended behavior of the VSCode "Test" group, or if its meant to run only?

Thanks!