### PR TITLE
Don't Use Async with TPromise in VSCode Codebase

### DIFF
--- a/src/vs/workbench/electron-browser/extensionHost.ts
+++ b/src/vs/workbench/electron-browser/extensionHost.ts
@@ -352,9 +352,8 @@ export class ExtensionHostProcessWorker {
 
 			// Unexpected termination
 			if (!this.isExtensionDevelopmentHost) {
-				const openDevTools = new Action('openDevTools', nls.localize('devTools', "Developer Tools"), '', true, async (): TPromise<boolean> => {
-					await this.windowService.openDevTools();
-					return false;
+				const openDevTools = new Action('openDevTools', nls.localize('devTools', "Developer Tools"), '', true, (): TPromise<boolean> => {
+					return this.windowService.openDevTools().then(() => false);
 				});
 
 				this.messageService.show(Severity.Error, {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -301,22 +301,23 @@ export class ExtensionsViewlet extends ComposedViewsViewlet implements IExtensio
 			.done(null, err => this.onError(err));
 	}
 
-	private async doSearch(): TPromise<any> {
+	private doSearch(): TPromise<any> {
 		const value = this.searchBox.value || '';
 		this.searchExtensionsContextKey.set(!!value);
 		this.searchInstalledExtensionsContextKey.set(InstalledExtensionsView.isInsalledExtensionsQuery(value));
 		this.searchRecommendedExtensionsContextKey.set(RecommendedExtensionsView.isRecommendedExtensionsQuery(value));
 
-		await this.updateViews(!!value);
+		return this.updateViews(!!value);
 	}
 
-	protected async updateViews(showAll?: boolean): TPromise<IView[]> {
-		const created = await super.updateViews();
-		const toShow = showAll ? this.views : created;
-		if (toShow.length) {
-			await this.progress(TPromise.join(toShow.map(view => (<ExtensionsListView>view).show(this.searchBox.value))));
-		}
-		return created;
+	protected updateViews(showAll?: boolean): TPromise<IView[]> {
+		return super.updateViews().then(created => {
+			const toShow = showAll ? this.views : created;
+			if (toShow.length) {
+				return this.progress(TPromise.join(toShow.map(view => (<ExtensionsListView>view).show(this.searchBox.value)))).then(() => created);
+			}
+			return created;
+		});
 	}
 
 	private count(): number {

--- a/src/vs/workbench/services/textmodelResolver/test/textModelResolverService.test.ts
+++ b/src/vs/workbench/services/textmodelResolver/test/textModelResolverService.test.ts
@@ -133,12 +133,12 @@ suite('Workbench - TextModelResolverService', () => {
 		let waitForIt = new TPromise(c => resolveModel = c);
 
 		const disposable = accessor.textModelResolverService.registerTextModelContentProvider('test', {
-			provideTextContent: async (resource: URI): TPromise<IModel> => {
-				await waitForIt;
-
-				let modelContent = 'Hello Test';
-				let mode = accessor.modeService.getOrCreateMode('json');
-				return accessor.modelService.createModel(modelContent, mode, resource);
+			provideTextContent: (resource: URI): TPromise<IModel> => {
+				return waitForIt.then(() => {
+					let modelContent = 'Hello Test';
+					let mode = accessor.modeService.getOrCreateMode('json');
+					return accessor.modelService.createModel(modelContent, mode, resource);
+				});
 			}
 		});
 


### PR DESCRIPTION
Fixes #30216

**Bug**
While compiling vscode with TS 2.4, there were around 10 errors reported about async functions that return a `TPromise`.

**Fix**
I'm checking with the TS team to see if these errors are expected or not. As a workaround, I believe we need to stop using `TPromise` with async functions, at least for now.

This change changes all instances that use `async` to instead use `then`.