### PR TITLE
Add API to open a file or diff editor on a specific selection range (fixes #30241)

### DIFF
--- a/extensions/vscode-api-tests/src/commands.test.ts
+++ b/extensions/vscode-api-tests/src/commands.test.ts
@@ -7,7 +7,7 @@
 
 import * as assert from 'assert';
 import { join } from 'path';
-import { commands, workspace, window, Uri, ViewColumn } from 'vscode';
+import { commands, workspace, window, Uri, ViewColumn, Range, Position } from 'vscode';
 
 suite('commands namespace tests', () => {
 
@@ -114,10 +114,15 @@ suite('commands namespace tests', () => {
 			registration.dispose();
 		});
 
-		let c = commands.executeCommand('vscode.diff').then(() => assert.ok(false), () => assert.ok(true));
-		let d = commands.executeCommand('vscode.diff', 1, 2, 3).then(() => assert.ok(false), () => assert.ok(true));
+		let c = commands.executeCommand('vscode.diff', Uri.parse('sc:a'), Uri.parse('sc:b'), 'Title', { selection: new Range(new Position(1, 1), new Position(1, 2)) }).then(value => {
+			assert.ok(value === void 0);
+			registration.dispose();
+		});
 
-		return Promise.all([a, b, c, d]);
+		let d = commands.executeCommand('vscode.diff').then(() => assert.ok(false), () => assert.ok(true));
+		let e = commands.executeCommand('vscode.diff', 1, 2, 3).then(() => assert.ok(false), () => assert.ok(true));
+
+		return Promise.all([a, b, c, d, e]);
 	});
 
 	test('api-command: vscode.open', function () {

--- a/extensions/vscode-api-tests/src/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/workspace.test.ts
@@ -260,6 +260,19 @@ suite('workspace-namespace', () => {
 		});
 	});
 
+	test('openTextDocument, with selection', function () {
+		return createRandomFile('foo\nbar\nbar').then(file => {
+			return vscode.workspace.openTextDocument(file).then(doc => {
+				return vscode.window.showTextDocument(doc, { selection: new vscode.Range(new vscode.Position(1, 1), new vscode.Position(1, 2)) }).then(editor => {
+					assert.equal(editor.selection.start.line, 1);
+					assert.equal(editor.selection.start.character, 1);
+					assert.equal(editor.selection.end.line, 1);
+					assert.equal(editor.selection.end.character, 2);
+				});
+			});
+		});
+	});
+
 	test('registerTextDocumentContentProvider, simple', function () {
 
 		let registration = vscode.workspace.registerTextDocumentContentProvider('foo', {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -743,6 +743,11 @@ declare module 'vscode' {
 		 * with the next editor or if it will be kept.
 		 */
 		preview?: boolean;
+
+		/**
+		 * An optional selection to apply for the document in the [editor](#TextEditor).
+		 */
+		selection?: Range;
 	}
 
 	/**

--- a/src/vs/workbench/api/electron-browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadEditors.ts
@@ -12,7 +12,7 @@ import { ISingleEditOperation, IDecorationRenderOptions, IDecorationOptions, ILi
 import { ICodeEditorService } from 'vs/editor/common/services/codeEditorService';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
-import { IEditorOptions, Position as EditorPosition } from 'vs/platform/editor/common/editor';
+import { Position as EditorPosition, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { MainThreadTextEditor } from './mainThreadEditor';
 import { ITextEditorConfigurationUpdate, TextEditorRevealType, IApplyEditsOptions, IUndoStopOptions } from 'vs/workbench/api/node/extHost.protocol';
 
@@ -107,9 +107,10 @@ export class MainThreadEditors extends MainThreadEditorsShape {
 	// --- from extension host process
 
 	$tryShowTextDocument(resource: URI, options: ITextDocumentShowOptions): TPromise<string> {
-		const editorOptions: IEditorOptions = {
+		const editorOptions: ITextEditorOptions = {
 			preserveFocus: options.preserveFocus,
-			pinned: options.pinned
+			pinned: options.pinned,
+			selection: options.selection
 		};
 
 		const input = {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -183,6 +183,7 @@ export interface ITextDocumentShowOptions {
 	position?: EditorPosition;
 	preserveFocus?: boolean;
 	pinned?: boolean;
+	selection?: IRange;
 }
 
 export abstract class MainThreadEditorsShape {

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -15,7 +15,7 @@ import * as modes from 'vs/editor/common/modes';
 import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
 import { ExtHostCommands } from 'vs/workbench/api/node/extHostCommands';
 import { IWorkspaceSymbolProvider } from 'vs/workbench/parts/search/common/search';
-import { IEditorOptions } from 'vs/platform/editor/common/editor';
+import { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 
 export class ExtHostApiCommands {
 
@@ -205,11 +205,12 @@ export class ExtHostApiCommands {
 			});
 
 		this._register('vscode.diff', (left: URI, right: URI, label: string, options?: vscode.TextDocumentShowOptions) => {
-			let editorOptions: IEditorOptions;
+			let editorOptions: ITextEditorOptions;
 			if (options) {
 				editorOptions = {
 					pinned: typeof options.preview === 'boolean' ? !options.preview : undefined,
-					preserveFocus: options.preserveFocus
+					preserveFocus: options.preserveFocus,
+					selection: typeof options.selection === 'object' ? typeConverters.fromRange(options.selection) : undefined
 				};
 			}
 

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -69,6 +69,7 @@ export class ExtHostEditors extends ExtHostEditorsShape {
 			options = {
 				position: TypeConverters.fromViewColumn(columnOrOptions.viewColumn),
 				preserveFocus: columnOrOptions.preserveFocus,
+				selection: typeof columnOrOptions.selection === 'object' ? TypeConverters.fromRange(columnOrOptions.selection) : undefined,
 				pinned: typeof columnOrOptions.preview === 'boolean' ? !columnOrOptions.preview : undefined
 			};
 		} else {


### PR DESCRIPTION
To use, e.g. for the diff editor:

```typescript
vscode.commands.executeCommand(
  'vscode.diff',
  vscode.Uri.file('/Users/bpasero/Desktop/test-ts/CHANGELOG.md'),
  vscode.Uri.file('/Users/bpasero/Desktop/test-ts/package.json'),
  'title',
  {
    selection: new vscode.Range(new vscode.Position(1, 1), new vscode.Position(1, 2))
  }
);
```

For https://github.com/Microsoft/vscode/issues/30085