### PR TITLE
Tab title uses parent for specified file names

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -155,7 +155,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				previewEditors: editorConfig.enablePreview,
 				showIcons: editorConfig.showIcons,
 				showTabs: editorConfig.showTabs,
-				tabCloseButton: editorConfig.tabCloseButton
+				tabCloseButton: editorConfig.tabCloseButton,
+				emphasizeParentDirectoryInTab: editorConfig.emphasizeParentDirectoryInTab
 			};
 
 			this.revealIfOpen = editorConfig.revealIfOpen;
@@ -166,7 +167,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				previewEditors: true,
 				showIcons: false,
 				showTabs: true,
-				tabCloseButton: 'right'
+				tabCloseButton: 'right',
+				emphasizeParentDirectoryInTab: []
 			};
 
 			this.revealIfOpen = false;
@@ -208,7 +210,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				previewEditors: newPreviewEditors,
 				showIcons: editorConfig.showIcons,
 				tabCloseButton: editorConfig.tabCloseButton,
-				showTabs: this.forceHideTabs ? false : editorConfig.showTabs
+				showTabs: this.forceHideTabs ? false : editorConfig.showTabs,
+				emphasizeParentDirectoryInTab: editorConfig.emphasizeParentDirectoryInTab
 			};
 
 			if (!this.doNotFireTabOptionsChanged && !objects.equals(oldTabOptions, this.tabOptions)) {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -156,7 +156,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				showIcons: editorConfig.showIcons,
 				showTabs: editorConfig.showTabs,
 				tabCloseButton: editorConfig.tabCloseButton,
-				emphasizeParentDirectoryInTab: editorConfig.emphasizeParentDirectoryInTab
+				tabTitleUsesParentFor: editorConfig.tabTitleUsesParentFor
 			};
 
 			this.revealIfOpen = editorConfig.revealIfOpen;
@@ -168,7 +168,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				showIcons: false,
 				showTabs: true,
 				tabCloseButton: 'right',
-				emphasizeParentDirectoryInTab: []
+				tabTitleUsesParentFor: []
 			};
 
 			this.revealIfOpen = false;
@@ -211,7 +211,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				showIcons: editorConfig.showIcons,
 				tabCloseButton: editorConfig.tabCloseButton,
 				showTabs: this.forceHideTabs ? false : editorConfig.showTabs,
-				emphasizeParentDirectoryInTab: editorConfig.emphasizeParentDirectoryInTab
+				tabTitleUsesParentFor: editorConfig.tabTitleUsesParentFor
 			};
 
 			if (!this.doNotFireTabOptionsChanged && !objects.equals(oldTabOptions, this.tabOptions)) {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -265,12 +265,12 @@ export class TabsTitleControl extends TitleControl {
 				const isDirty = editor.isDirty();
 
 				const tabOptions = this.editorGroupService.getTabOptions();
-				const filesToBeEmphasized = tabOptions.emphasizeParentDirectoryInTab;
+				const fileDirectoriesToBeEmphasized = tabOptions.emphasizeParentDirectoryInTab;
 
 				const label = labels[index];
 				const name = label.name;
-				const fileNameShouldBeEmphasized = Array.isArray(filesToBeEmphasized) && filesToBeEmphasized.indexOf(name) !== -1;
-				const description = label.description && (label.hasAmbiguousName || fileNameShouldBeEmphasized) ? label.description : '';
+				const fileDirectoryShouldBeEmphasized = Array.isArray(fileDirectoriesToBeEmphasized) && fileDirectoriesToBeEmphasized.indexOf(name) !== -1;
+				const description = label.description && (label.hasAmbiguousName || fileDirectoryShouldBeEmphasized) ? label.description : '';
 				const title = label.title || '';
 
 				// Container
@@ -293,7 +293,7 @@ export class TabsTitleControl extends TitleControl {
 					resource: toResource(editor, { supportSideBySide: true })
 				};
 
-				if (fileNameShouldBeEmphasized && editorLabel.description) { // emphasize name
+				if (fileDirectoryShouldBeEmphasized && editorLabel.description) { // emphasize name
 					const descriptionSubstrings = editorLabel.description.split('/');
 					const emphasizedDescription = descriptionSubstrings[descriptionSubstrings.length - 1];
 					const previousName = editorLabel.name;

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -18,7 +18,7 @@ import { Position, IEditorInput, Verbosity, IUntitledResourceInput } from 'vs/pl
 import { IEditorGroup, toResource } from 'vs/workbench/common/editor';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { EditorLabel } from 'vs/workbench/browser/labels';
+import { EditorLabel, IEditorLabel } from 'vs/workbench/browser/labels';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -264,9 +264,13 @@ export class TabsTitleControl extends TitleControl {
 				const isTabActive = group.isActive(editor);
 				const isDirty = editor.isDirty();
 
+				const tabOptions = this.editorGroupService.getTabOptions();
+				const filesToBeEmphasized = tabOptions.emphasizeParentDirectoryInTab;
+
 				const label = labels[index];
 				const name = label.name;
-				const description = label.hasAmbiguousName && label.description ? label.description : '';
+				const fileNameShouldBeEmphasized = Array.isArray(filesToBeEmphasized) && filesToBeEmphasized.indexOf(name) !== -1;
+				const description = label.description && (label.hasAmbiguousName || fileNameShouldBeEmphasized) ? label.description : '';
 				const title = label.title || '';
 
 				// Container
@@ -276,7 +280,6 @@ export class TabsTitleControl extends TitleControl {
 				tabContainer.style.borderRightColor = (index === editorsOfGroup.length - 1) ? (this.getColor(TAB_BORDER) || this.getColor(contrastBorder)) : null;
 				tabContainer.style.outlineColor = this.getColor(activeContrastBorder);
 
-				const tabOptions = this.editorGroupService.getTabOptions();
 				['off', 'left'].forEach(option => {
 					const domAction = tabOptions.tabCloseButton === option ? DOM.addClass : DOM.removeClass;
 					domAction(tabContainer, `close-button-${option}`);
@@ -284,7 +287,21 @@ export class TabsTitleControl extends TitleControl {
 
 				// Label
 				const tabLabel = this.editorLabels[index];
-				tabLabel.setLabel({ name, description, resource: toResource(editor, { supportSideBySide: true }) }, { extraClasses: ['tab-label'], italic: !isPinned });
+				const editorLabel: IEditorLabel = {
+					name,
+					description,
+					resource: toResource(editor, { supportSideBySide: true })
+				};
+
+				if (fileNameShouldBeEmphasized && editorLabel.description) { // emphasize name
+					const descriptionSubstrings = editorLabel.description.split('/');
+					const emphasizedDescription = descriptionSubstrings[descriptionSubstrings.length - 1];
+					const previousName = editorLabel.name;
+					editorLabel.name = emphasizedDescription || './';
+					editorLabel.description = previousName;
+				}
+
+				tabLabel.setLabel(editorLabel, { extraClasses: ['tab-label'], italic: !isPinned });
 
 				// Active state
 				if (isTabActive) {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -265,12 +265,12 @@ export class TabsTitleControl extends TitleControl {
 				const isDirty = editor.isDirty();
 
 				const tabOptions = this.editorGroupService.getTabOptions();
-				const fileDirectoriesToBeEmphasized = tabOptions.emphasizeParentDirectoryInTab;
+				const filesUsingParentAsTitle = tabOptions.tabTitleUsesParentFor;
 
 				const label = labels[index];
 				const name = label.name;
-				const fileDirectoryShouldBeEmphasized = Array.isArray(fileDirectoriesToBeEmphasized) && fileDirectoriesToBeEmphasized.indexOf(name) !== -1;
-				const description = label.description && (label.hasAmbiguousName || fileDirectoryShouldBeEmphasized) ? label.description : '';
+				const parentShouldBeTitle = Array.isArray(filesUsingParentAsTitle) && filesUsingParentAsTitle.indexOf(name) !== -1;
+				const description = label.description && (label.hasAmbiguousName || parentShouldBeTitle) ? label.description : '';
 				const title = label.title || '';
 
 				// Container
@@ -293,11 +293,11 @@ export class TabsTitleControl extends TitleControl {
 					resource: toResource(editor, { supportSideBySide: true })
 				};
 
-				if (fileDirectoryShouldBeEmphasized && editorLabel.description) { // emphasize name
+				if (parentShouldBeTitle && editorLabel.description) {
 					const descriptionSubstrings = editorLabel.description.split('/');
-					const emphasizedDescription = descriptionSubstrings[descriptionSubstrings.length - 1];
+					const parentAsTitle = descriptionSubstrings[descriptionSubstrings.length - 1];
 					const previousName = editorLabel.name;
-					editorLabel.name = emphasizedDescription || './';
+					editorLabel.name = parentAsTitle || './';
 					editorLabel.description = previousName;
 				}
 

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -806,7 +806,8 @@ export interface IWorkbenchEditorConfiguration {
 			closeOnFileDelete: boolean;
 			openPositioning: 'left' | 'right' | 'first' | 'last';
 			revealIfOpen: boolean;
-			swipeToNavigate: boolean
+			swipeToNavigate: boolean;
+			emphasizeParentDirectoryInTab: string[];
 		}
 	};
 }

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -807,7 +807,7 @@ export interface IWorkbenchEditorConfiguration {
 			openPositioning: 'left' | 'right' | 'first' | 'last';
 			revealIfOpen: boolean;
 			swipeToNavigate: boolean;
-			emphasizeParentDirectoryInTab: string[];
+			tabTitleUsesParentFor: string[];
 		}
 	};
 }

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -111,12 +111,12 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'description': nls.localize('showIcons', "Controls if opened editors should show with an icon or not. This requires an icon theme to be enabled as well."),
 		'default': true
 	},
-	'workbench.editor.emphasizeParentDirectoryInTab': {
+	'workbench.editor.tabTitleUsesParentFor': {
 		'type': 'array',
 		'items': {
 			'type': 'string'
 		},
-		'description': nls.localize('emphasizeParentDirectoryInTab', "Controls if should emphasize parent directory name when there are opened editors with the specified file name."),
+		'description': nls.localize('tabTitleUsesParentFor', "Controls if should emphasize parent directory name when there are opened editors with the specified file name."),
 		'default': []
 	},
 	'workbench.editor.enablePreview': {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -116,7 +116,7 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'items': {
 			'type': 'string'
 		},
-		'description': nls.localize('emphasizeParentDirectoryInTab', "Controls if should emphasize parent directory name when there are multiple opened editors with the same file name specified."),
+		'description': nls.localize('emphasizeParentDirectoryInTab', "Controls if should emphasize parent directory name when there are opened editors with the specified file name."),
 		'default': []
 	},
 	'workbench.editor.enablePreview': {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -111,6 +111,14 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'description': nls.localize('showIcons', "Controls if opened editors should show with an icon or not. This requires an icon theme to be enabled as well."),
 		'default': true
 	},
+	'workbench.editor.emphasizeParentDirectoryInTab': {
+		'type': 'array',
+		'items': {
+			'type': 'string'
+		},
+		'description': nls.localize('emphasizeParentDirectoryInTab', "Controls if should emphasize parent directory name when there are multiple opened editors with the same file name specified."),
+		'default': []
+	},
 	'workbench.editor.enablePreview': {
 		'type': 'boolean',
 		'description': nls.localize('enablePreview', "Controls if opened editors show as preview. Preview editors are reused until they are kept (e.g. via double click or editing)."),

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -24,7 +24,7 @@ export interface ITabOptions {
 	tabCloseButton?: 'left' | 'right' | 'off';
 	showIcons?: boolean;
 	previewEditors?: boolean;
-	emphasizeParentDirectoryInTab?: string[];
+	tabTitleUsesParentFor?: string[];
 }
 
 export interface IMoveOptions {

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -24,6 +24,7 @@ export interface ITabOptions {
 	tabCloseButton?: 'left' | 'right' | 'off';
 	showIcons?: boolean;
 	previewEditors?: boolean;
+	emphasizeParentDirectoryInTab?: string[];
 }
 
 export interface IMoveOptions {


### PR DESCRIPTION
This is my take for issues #27328 and #12965.
In the settings is now possible to specify an array of file names, i.e. `"workbench.editor.tabTitleUsesParentFor": ["index.js", "template.hbs"]`.
This controls if we should emphasise parent directory name when there are opened editors with the specified file name.

In the screenshot there's the outcome of this PR: for the files specified, the parent directory is highlighted, for the others nothing changes (so if there's no ambiguity the file name is shown, otherwise the file name + path).

<img width="1280" alt="screen shot 2017-07-10 at 00 33 18" src="https://user-images.githubusercontent.com/1951918/27998184-41229730-6509-11e7-8304-74acd79a33fd.png">

If this approach is considered valid, I'm open to suggestions on how to improve the code. Probably move all the logic inside the already existing method getUniqueTabLabels?