### PR TITLE
Set TERM_PROGRAM in terminal

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -34,6 +34,8 @@ import { scrollbarSliderBackground, scrollbarSliderHoverBackground, scrollbarSli
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
+import pkg from 'vs/platform/node/package';
+import product from 'vs/platform/node/product';
 
 /** The amount of time to consider terminal errors to be related to the launch */
 const LAUNCHING_DURATION = 500;
@@ -665,6 +667,8 @@ export class TerminalInstance implements ITerminalInstance {
 		const env = shell.env ? shell.env : TerminalInstance._cloneEnv(parentEnv);
 		env['PTYPID'] = process.pid.toString();
 		env['PTYSHELL'] = shell.executable;
+		env['TERM_PROGRAM'] = product.nameShort;
+		env['TERM_PROGRAM_VERSION'] = pkg.version;
 		if (shell.args) {
 			if (typeof shell.args === 'string') {
 				env[`PTYSHELLCMDLINE`] = shell.args;

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -35,7 +35,6 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import pkg from 'vs/platform/node/package';
-import product from 'vs/platform/node/product';
 
 /** The amount of time to consider terminal errors to be related to the launch */
 const LAUNCHING_DURATION = 500;
@@ -667,7 +666,7 @@ export class TerminalInstance implements ITerminalInstance {
 		const env = shell.env ? shell.env : TerminalInstance._cloneEnv(parentEnv);
 		env['PTYPID'] = process.pid.toString();
 		env['PTYSHELL'] = shell.executable;
-		env['TERM_PROGRAM'] = product.nameShort;
+		env['TERM_PROGRAM'] = 'vscode';
 		env['TERM_PROGRAM_VERSION'] = pkg.version;
 		if (shell.args) {
 			if (typeof shell.args === 'string') {


### PR DESCRIPTION
Fixes #29426

Sets the TERM_PROGRAM and TERM_PROGRAM_VERSION environment variables for the integrated terminal