### PR TITLE
Shrink terminal find widget to max terminal width

### DIFF
--- a/src/vs/editor/contrib/find/browser/simpleFindWidget.css
+++ b/src/vs/editor/contrib/find/browser/simpleFindWidget.css
@@ -12,7 +12,7 @@
 	padding: 4px;
 	align-items: center;
 	width: 255px;
-	max-width: calc(100% - 28px - 8px);
+	max-width: calc(100% - 28px - 28px - 8px);
 
 	-webkit-transition: top 200ms linear;
 	-o-transition: top 200ms linear;

--- a/src/vs/editor/contrib/find/browser/simpleFindWidget.css
+++ b/src/vs/editor/contrib/find/browser/simpleFindWidget.css
@@ -11,7 +11,7 @@
 	display: flex;
 	padding: 4px;
 	align-items: center;
-	width: 255px;
+	width: 220px;
 	max-width: calc(100% - 28px - 28px - 8px);
 
 	-webkit-transition: top 200ms linear;

--- a/src/vs/editor/contrib/find/browser/simpleFindWidget.css
+++ b/src/vs/editor/contrib/find/browser/simpleFindWidget.css
@@ -11,6 +11,8 @@
 	display: flex;
 	padding: 4px;
 	align-items: center;
+	width: 255px;
+	max-width: calc(100% - 28px - 8px);
 
 	-webkit-transition: top 200ms linear;
 	-o-transition: top 200ms linear;
@@ -21,6 +23,10 @@
 
 .monaco-workbench .simple-find-part.visible {
 	top: 0;
+}
+
+.monaco-workbench .simple-find-part .monaco-findInput {
+	flex: 1;
 }
 
 /* Temporarily we don't show match numbers */

--- a/src/vs/editor/contrib/find/browser/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/browser/simpleFindWidget.ts
@@ -92,7 +92,6 @@ export abstract class SimpleFindWidget extends Widget {
 	) {
 		super();
 		this._findInput = this._register(new FindInput(null, this._contextViewService, {
-			width: 155,
 			label: NLS_FIND_INPUT_LABEL,
 			placeholder: NLS_FIND_INPUT_PLACEHOLDER,
 		}));


### PR DESCRIPTION
Fixes #29795

Shrink the terminal find widget to fit within the max terminal size

![jul-10-2017 11-46-57](https://user-images.githubusercontent.com/12821956/28034254-7fc20c62-6565-11e7-8787-a389f095079d.gif)
