### PR TITLE
Seed terminal find widget with current selection

### DIFF
--- a/src/vs/editor/contrib/find/browser/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/browser/simpleFindWidget.ts
@@ -194,7 +194,11 @@ export abstract class SimpleFindWidget extends Widget {
 		return this._domNode;
 	}
 
-	public reveal(): void {
+	public reveal(initialInput?: string): void {
+		if (typeof initialInput !== 'undefined') {
+			this._findInput.setValue(initialInput);
+		}
+
 		if (this._isVisible) {
 			this._findInput.select();
 			return;

--- a/src/vs/editor/contrib/find/browser/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/browser/simpleFindWidget.ts
@@ -195,7 +195,7 @@ export abstract class SimpleFindWidget extends Widget {
 	}
 
 	public reveal(initialInput?: string): void {
-		if (typeof initialInput !== 'undefined') {
+		if (initialInput) {
 			this._findInput.setValue(initialInput);
 		}
 

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -233,6 +233,11 @@ export interface ITerminalInstance {
 	copySelection(): void;
 
 	/**
+	 * Current selection in the terminal.
+	 */
+	readonly selection: string | undefined;
+
+	/**
 	 * Clear current selection.
 	 */
 	clearSelection(): void;

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -344,6 +344,14 @@ export class TerminalInstance implements ITerminalInstance {
 		}
 	}
 
+	get selection(): string | undefined {
+		if (this.hasSelection()) {
+			return this._xterm.getSelection();
+		} else {
+			return undefined;
+		}
+	}
+
 	public clearSelection(): void {
 		this._xterm.clearSelection();
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -345,11 +345,7 @@ export class TerminalInstance implements ITerminalInstance {
 	}
 
 	get selection(): string | undefined {
-		if (this.hasSelection()) {
-			return this._xterm.getSelection();
-		} else {
-			return undefined;
-		}
+		return this.hasSelection() ? this._xterm.getSelection() : undefined;
 	}
 
 	public clearSelection(): void {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -159,7 +159,12 @@ export class TerminalPanel extends Panel {
 	}
 
 	public focusFindWidget() {
-		this._findWidget.reveal();
+		const activeInstance = this._terminalService.getActiveInstance();
+		if (activeInstance && activeInstance.hasSelection()) {
+			this._findWidget.reveal(activeInstance.selection);
+		} else {
+			this._findWidget.reveal();
+		}
 	}
 
 	public hideFindWidget() {


### PR DESCRIPTION
Fixes #29712

Use the current selection as the search when we first show the find widget for the terminal