### PR TITLE
Issue with the text in Spanish when the window of Code should be reloaded

### DIFF
--- a/i18n/esn/src/vs/workbench/parts/extensions/browser/extensionsActions.i18n.json
+++ b/i18n/esn/src/vs/workbench/parts/extensions/browser/extensionsActions.i18n.json
@@ -34,7 +34,7 @@
 	"postDisableMessage": "¿Quiere recargar esta ventana para desactivar la extensión '{0}'?",
 	"postUninstallTooltip": "Recargar para desactivar",
 	"postUninstallMessage": "¿Quiere recargar esta ventana para desactivar la extensión desinstalada '{0}'?",
-	"reload": "&&Volver a cargar Window",
+	"reload": "&&Volver a cargar la ventana",
 	"toggleExtensionsViewlet": "Mostrar extensiones",
 	"installExtensions": "Instalar extensiones",
 	"showInstalledExtensions": "Mostrar extensiones instaladas",


### PR DESCRIPTION
VSCode Version: (1.14.0) [all versions]
OS Version: All


Description of the issue:
The text of the button "Volver a cargar Windows" is wrong.
The correct text of the button is: "Volver a cargar la ventana".


Steps to Reproduce:
Install the Visual Studio Code - Spanish language
Install a new extension for Visual Studio Code or uninstall an existing extension.
The windows shows the wrong message to reload the window.

![vscode_issue_spanish](https://user-images.githubusercontent.com/6237500/28084395-c6f0b4b2-6678-11e7-9ea8-140927fa7382.png)
