### PR TITLE
Sort by `type` doesn't affect folders

### DIFF
--- a/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
@@ -560,7 +560,6 @@ export class FileSorter implements ISorter {
 		// Sort Directories
 		switch (this.sortOrder) {
 			case 'default':
-			case 'type':
 			case 'modified':
 				if (statA.isDirectory && !statB.isDirectory) {
 					return -1;
@@ -568,6 +567,21 @@ export class FileSorter implements ISorter {
 
 				if (statB.isDirectory && !statA.isDirectory) {
 					return 1;
+				}
+
+				break;
+
+			case 'type':
+				if (statA.isDirectory && !statB.isDirectory) {
+					return -1;
+				}
+
+				if (statB.isDirectory && !statA.isDirectory) {
+					return 1;
+				}
+
+				if (statA.isDirectory && statB.isDirectory) {
+					return comparers.compareFileNames(statA.name, statB.name);
 				}
 
 				break;


### PR DESCRIPTION
This PR addresses the discussion (here #29509) around sorting by `type` and weather it should or should not affect folders