### PR TITLE
Add workbench.fontAliasing configuration option

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -175,6 +175,11 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'type': 'boolean',
 		'description': nls.localize('closeOnFileDelete', "Controls if editors showing a file should close automatically when the file is deleted or renamed by some other process. Disabling this will keep the editor open as dirty on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data."),
 		'default': true
+	},
+	'workbench.fontAliasing': {
+		'type': 'boolean',
+		'description': nls.localize('fontAliasing', "Controls how fonts in workbench are being rendered on macOS. Enabling this will result with crisper font rendering."),
+		'default': false
 	}
 };
 

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -175,15 +175,17 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'type': 'boolean',
 		'description': nls.localize('closeOnFileDelete', "Controls if editors showing a file should close automatically when the file is deleted or renamed by some other process. Disabling this will keep the editor open as dirty on such an event. Note that deleting from within the application will always close the editor and that dirty files will never close to preserve your data."),
 		'default': true
-	},
-	'workbench.fontAliasing': {
-		'type': 'boolean',
-		'description': nls.localize('fontAliasing', "Controls how fonts in workbench are being rendered on macOS. Enabling this will result with crisper font rendering."),
-		'default': false
 	}
 };
 
 if (isMacintosh) {
+	workbenchProperties['workbench.fontAliasing'] = {
+		'type': 'string',
+		'enum': ['default', 'antialiased', 'none'],
+		'default': 'default',
+		'description': nls.localize('fontAliasing', "Controls font aliasing method in workbench.")
+	};
+
 	workbenchProperties['workbench.editor.swipeToNavigate'] = {
 		'type': 'boolean',
 		'description': nls.localize('swipeToNavigate', "Navigate between open files using three-finger swipe horizontally."),

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -918,7 +918,7 @@ export class Workbench implements IPartService {
 
 	private setFontAliasing(aliasing: string) {
 		this.fontAliasing = aliasing;
-		this.workbench.style('-webkit-font-smoothing', (aliasing === 'default' ? '' : aliasing));
+		document.body.style['-webkit-font-smoothing'] = (aliasing === 'default' ? '' : aliasing);
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -160,6 +160,8 @@ export class Workbench implements IPartService {
 
 	private static closeWhenEmptyConfigurationKey = 'window.closeWhenEmpty';
 
+	private static fontAliasingConfigurationKey = 'workbench.fontAliasing';
+
 	private _onTitleBarVisibilityChange: Emitter<void>;
 
 	public _serviceBrand: any;
@@ -202,6 +204,7 @@ export class Workbench implements IPartService {
 	private editorsVisibleContext: IContextKey<boolean>;
 	private inZenMode: IContextKey<boolean>;
 	private hasFilesToCreateOpenOrDiff: boolean;
+	private fontAliasingEnabled: boolean;
 	private zenMode: {
 		active: boolean;
 		transitionedToFullScreen: boolean;
@@ -644,6 +647,9 @@ export class Workbench implements IPartService {
 		const activityBarVisible = this.configurationService.lookup<string>(Workbench.activityBarVisibleConfigurationKey).value;
 		this.activityBarHidden = !activityBarVisible;
 
+		// Font aliasing
+		this.fontAliasingEnabled = this.configurationService.lookup<boolean>(Workbench.fontAliasingConfigurationKey).value;
+
 		// Zen mode
 		this.zenMode = {
 			active: false,
@@ -910,6 +916,11 @@ export class Workbench implements IPartService {
 		this.workbenchLayout.layout();
 	}
 
+	private setFontAliasing(enabled: boolean) {
+		this.fontAliasingEnabled = enabled;
+		this.workbench.style('-webkit-font-smoothing', enabled ? 'antialiased' : '');
+	}
+
 	public dispose(): void {
 		if (this.isStarted()) {
 			this.shutdownComponents();
@@ -1037,6 +1048,11 @@ export class Workbench implements IPartService {
 			this.setSideBarPosition(newSidebarPosition);
 		}
 
+		const fontAliasing = this.configurationService.lookup<boolean>(Workbench.fontAliasingConfigurationKey).value;
+		if (fontAliasing !== this.fontAliasingEnabled) {
+			this.setFontAliasing(fontAliasing);
+		}
+
 		if (!this.zenMode.active) {
 			const newStatusbarHiddenValue = !this.configurationService.lookup<boolean>(Workbench.statusbarVisibleConfigurationKey).value;
 			if (newStatusbarHiddenValue !== this.statusBarHidden) {
@@ -1084,6 +1100,8 @@ export class Workbench implements IPartService {
 		if (this.panelHidden) {
 			this.workbench.addClass('nopanel');
 		}
+
+		this.setFontAliasing(this.fontAliasingEnabled);
 
 		// Apply title style if shown
 		const titleStyle = this.getCustomTitleBarStyle();

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -204,7 +204,7 @@ export class Workbench implements IPartService {
 	private editorsVisibleContext: IContextKey<boolean>;
 	private inZenMode: IContextKey<boolean>;
 	private hasFilesToCreateOpenOrDiff: boolean;
-	private fontAliasingEnabled: boolean;
+	private fontAliasing: string;
 	private zenMode: {
 		active: boolean;
 		transitionedToFullScreen: boolean;
@@ -648,7 +648,7 @@ export class Workbench implements IPartService {
 		this.activityBarHidden = !activityBarVisible;
 
 		// Font aliasing
-		this.fontAliasingEnabled = this.configurationService.lookup<boolean>(Workbench.fontAliasingConfigurationKey).value;
+		this.fontAliasing = this.configurationService.lookup<string>(Workbench.fontAliasingConfigurationKey).value;
 
 		// Zen mode
 		this.zenMode = {
@@ -916,9 +916,9 @@ export class Workbench implements IPartService {
 		this.workbenchLayout.layout();
 	}
 
-	private setFontAliasing(enabled: boolean) {
-		this.fontAliasingEnabled = enabled;
-		this.workbench.style('-webkit-font-smoothing', enabled ? 'antialiased' : '');
+	private setFontAliasing(aliasing: string) {
+		this.fontAliasing = aliasing;
+		this.workbench.style('-webkit-font-smoothing', (aliasing === 'default' ? '' : aliasing));
 	}
 
 	public dispose(): void {
@@ -1048,8 +1048,8 @@ export class Workbench implements IPartService {
 			this.setSideBarPosition(newSidebarPosition);
 		}
 
-		const fontAliasing = this.configurationService.lookup<boolean>(Workbench.fontAliasingConfigurationKey).value;
-		if (fontAliasing !== this.fontAliasingEnabled) {
+		const fontAliasing = this.configurationService.lookup<string>(Workbench.fontAliasingConfigurationKey).value;
+		if (fontAliasing !== this.fontAliasing) {
 			this.setFontAliasing(fontAliasing);
 		}
 
@@ -1101,7 +1101,7 @@ export class Workbench implements IPartService {
 			this.workbench.addClass('nopanel');
 		}
 
-		this.setFontAliasing(this.fontAliasingEnabled);
+		this.setFontAliasing(this.fontAliasing);
 
 		// Apply title style if shown
 		const titleStyle = this.getCustomTitleBarStyle();


### PR DESCRIPTION
Adds new `workbench.fontAliasing` configuration option. This sets `-webkit-font-smoothing: antialiased` on entire workbench in order to improve font rendering on retina screens. See the discussion in #2577