### PR TITLE
Allow to pass in editor options to vscode.open command

### DIFF
--- a/extensions/vscode-api-tests/src/commands.test.ts
+++ b/extensions/vscode-api-tests/src/commands.test.ts
@@ -131,7 +131,8 @@ suite('commands namespace tests', () => {
 		let b = commands.executeCommand('vscode.open', uri, ViewColumn.Two).then(() => assert.ok(true), () => assert.ok(false));
 		let c = commands.executeCommand('vscode.open').then(() => assert.ok(false), () => assert.ok(true));
 		let d = commands.executeCommand('vscode.open', uri, true).then(() => assert.ok(false), () => assert.ok(true));
+		let e = commands.executeCommand('vscode.open', uri, { selection: new Range(new Position(1, 1), new Position(1, 2)) }).then(() => assert.ok(true), () => assert.ok(false));
 
-		return Promise.all([a, b, c, d]);
+		return Promise.all([a, b, c, d, e]);
 	});
 });

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -231,13 +231,32 @@ export class ExtHostApiCommands {
 				]
 			});
 
-		this._register('vscode.open', (resource: URI, column: vscode.ViewColumn) => {
-			return this._commands.executeCommand('_workbench.open', [resource, typeConverters.fromViewColumn(column)]);
+		this._register('vscode.open', (resource: URI, arg2: vscode.ViewColumn | vscode.TextDocumentShowOptions) => {
+			let editorOptions: ITextEditorOptions;
+			let column: vscode.ViewColumn;
+
+			if (arg2) {
+				if (typeof arg2 === 'number') {
+					column = arg2;
+				} else {
+					const options = arg2;
+
+					editorOptions = {
+						pinned: typeof options.preview === 'boolean' ? !options.preview : undefined,
+						preserveFocus: options.preserveFocus,
+						selection: typeof options.selection === 'object' ? typeConverters.fromRange(options.selection) : undefined
+					};
+
+					column = options.viewColumn;
+				}
+			}
+
+			return this._commands.executeCommand('_workbench.open', [resource, editorOptions, column]);
 		}, {
 				description: 'Opens the provided resource in the editor. Can be a text or binary file, or a http(s) url',
 				args: [
 					{ name: 'resource', description: 'Resource to open', constraint: URI },
-					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' }
+					{ name: 'columnOrOptions', description: '(optional) Either the column in which to open or editor options, see vscode.TextDocumentShowOptions', constraint: v => v === void 0 || typeof v === 'number' || typeof v === 'object' }
 				]
 			});
 	}

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -412,11 +412,17 @@ export function registerCommands(): void {
 		});
 	});
 
-	CommandsRegistry.registerCommand('_workbench.open', function (accessor: ServicesAccessor, args: [URI, number]) {
+	CommandsRegistry.registerCommand('_workbench.open', function (accessor: ServicesAccessor, args: [URI, IEditorOptions, EditorPosition]) {
 		const editorService = accessor.get(IWorkbenchEditorService);
-		const [resource, column] = args;
+		let [resource, options, column] = args;
 
-		return editorService.openEditor({ resource }, column).then(() => {
+		if (!options || typeof options !== 'object') {
+			options = {
+				preserveFocus: false
+			};
+		}
+
+		return editorService.openEditor({ resource, options }, column).then(() => {
 			return void 0;
 		});
 	});


### PR DESCRIPTION
Enables https://github.com/Microsoft/vscode/issues/30674