### PR TITLE
Add bottom padding to integrated terminal. Fixes #30626

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/media/terminal.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/terminal.css
@@ -29,6 +29,7 @@
 	position: absolute;
 	bottom: 0;
 	top: 0;
+	padding-bottom: 2px;
 }
 
 .monaco-workbench .panel.integrated-terminal .xterm a:not(.xterm-invalid-link) {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -198,13 +198,10 @@ export class TerminalInstance implements ITerminalInstance {
 		}
 
 		const padding = parseInt(getComputedStyle(document.querySelector('.terminal-outer-container')).paddingLeft.split('px')[0], 10);
-		// Have to use padding in the terminal wrapper div as it's absolutely aligned with the bottom of the container.
-		// Cannot float up like left padding.
 		const paddingBottom = parseInt(getComputedStyle(document.querySelector('.terminal-wrapper.active')).paddingBottom.split('px')[0], 10);
 
 		// Use left padding as right padding, right padding is not defined in CSS just in case
 		// xterm.js causes an unexpected overflow.
-		// Add some bottom padding and adjust inner height accordingly.
 		const innerWidth = width - padding * 2;
 		const innerHeight = height - paddingBottom;
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -198,10 +198,17 @@ export class TerminalInstance implements ITerminalInstance {
 		}
 
 		const padding = parseInt(getComputedStyle(document.querySelector('.terminal-outer-container')).paddingLeft.split('px')[0], 10);
+		// Have to use padding in the terminal wrapper div as it's absolutely aligned with the bottom of the container.
+		// Cannot float up like left padding.
+		const paddingBottom = parseInt(getComputedStyle(document.querySelector('.terminal-wrapper.active')).paddingBottom.split('px')[0], 10);
+
 		// Use left padding as right padding, right padding is not defined in CSS just in case
 		// xterm.js causes an unexpected overflow.
+		// Add some bottom padding and adjust inner height accordingly.
 		const innerWidth = width - padding * 2;
-		TerminalInstance._lastKnownDimensions = new Dimension(innerWidth, height);
+		const innerHeight = height - paddingBottom;
+
+		TerminalInstance._lastKnownDimensions = new Dimension(innerWidth, innerHeight);
 		return TerminalInstance._lastKnownDimensions;
 	}
 


### PR DESCRIPTION
@Tyriar 
- set padding to 2px, tried 1px and it was barely discernible - will change to one if you wish
- wanted to do the logical thing and add bottom padding to terminal outer container, however
 this was not possible given that the terminal wrapper is absolutely located to the bottom
 of the terminal outer container.

Fixes #30626