### PR TITLE
fix: "No Results" error message color in find widget

### DIFF
--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -497,7 +497,7 @@
 		"inputValidation.warningBorder": "#ffe055",
 		"inputValidation.errorBackground": "#ffeaea",
 		"inputValidation.errorBorder": "#f1897f",
-		"errorForeground": "#ffeaea",
+		"errorForeground": "#f1897f",
 		"badge.background": "#705697AA",
 		"progressBar.background": "#705697"
 	}


### PR DESCRIPTION
Fix #28930 
Changed color to match the border with input validation border color so it looks part of the theme.