### PR TITLE
Make npm install work again with NPM 5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -445,9 +445,9 @@
       "resolved": "git+https://github.com/Tyriar/xterm.js.git#90df2bcb7caa712e0a12591798c3e535a9d607cd"
     },
     "yauzl": {
-      "version": "2.3.1",
-      "from": "yauzl@2.3.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz"
+      "version": "2.8.0",
+      "from": "yauzl@2.8.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz"
     },
     "nsfw": {
       "version": "1.0.16",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -406,7 +406,7 @@
     },
     "v8-profiler": {
       "version": "5.6.5",
-      "from": "v8-profiler@5.6.5",
+      "from": "jrieken/v8-profiler#vscode",
       "resolved": "git://github.com/jrieken/v8-profiler.git#bc0803a4d4b2150b8a1bbffa80270769007036c2"
     },
     "vscode-debugprotocol": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vscode-textmate": "^3.1.5",
     "winreg": "1.2.0",
     "xterm": "Tyriar/xterm.js#vscode-release/1.15",
-    "yauzl": "2.3.1"
+    "yauzl": "2.8.0"
   },
   "devDependencies": {
     "7zip": "0.0.6",


### PR DESCRIPTION
Two issues fixed:

1. I think there was a version string mismatch which was causing the mainstream `v8-profiler` to be installed instead of the vscode electron-compatible fork in the shrinkwrap. This was causing the node-gyp step for v8-profiler package to fail with a build error

2. Once the above was fixed then the extract of some electron bits started failing. Updating the `yauzl` package used for unzipping stuff fixed that. I suspect something was happening under the hood that resulted in a version mismatch between `extract-zip` and `yauzl`. The future proof fix here will be to update to NPM5 package lock files I guess.
 
Relates to #30134