### PR TITLE
Remove inner whitespace on Toggle Block Comment. Fixes #30656 & #30729

### DIFF
--- a/src/vs/editor/contrib/comment/common/blockCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/common/blockCommentCommand.ts
@@ -10,6 +10,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { ICommentsConfiguration, LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
+import { CharCode } from 'vs/base/common/charCode';
 
 export class BlockCommentCommand implements editorCommon.ICommand {
 
@@ -53,6 +54,16 @@ export class BlockCommentCommand implements editorCommon.ICommand {
 		var ops: editorCommon.IIdentifiedSingleEditOperation[];
 
 		if (startTokenIndex !== -1 && endTokenIndex !== -1) {
+			// We have to adjust to possible inner white space
+			// For Space after startToken, add Space to startToken - range math will work out
+			if (model.getLineContent(startLineNumber).charCodeAt(startTokenIndex + startToken.length) === CharCode.Space) {
+				startToken += ' ';
+			}
+			// For Space before endToken, add Space before endToken and shift index one left
+			if (model.getLineContent(endLineNumber).charCodeAt(endTokenIndex - 1) === CharCode.Space) {
+				endToken = ' ' + endToken;
+				endTokenIndex -= 1;
+			}
 			ops = BlockCommentCommand._createRemoveBlockCommentOperations(
 				new Range(startLineNumber, startTokenIndex + 1 + startToken.length, endLineNumber, endTokenIndex + 1), startToken, endToken
 			);

--- a/src/vs/editor/contrib/comment/common/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/common/lineCommentCommand.ts
@@ -241,6 +241,18 @@ export class LineCommentCommand implements editorCommon.ICommand {
 			}
 		}
 
+		// We have to adjust to possible inner white space.
+		// For Space after startToken, add Space to startToken - range math will work out.
+		if (startTokenIndex !== -1 && model.getLineContent(startLineNumber).charCodeAt(startTokenIndex + startToken.length) === CharCode.Space) {
+			startToken += ' ';
+		}
+
+		// For Space before endToken, add Space before endToken and shift index one left.
+		if (endTokenIndex !== -1 && model.getLineContent(endLineNumber).charCodeAt(endTokenIndex - 1) === CharCode.Space) {
+			endToken = ' ' + endToken;
+			endTokenIndex -= 1;
+		}
+
 		if (startTokenIndex !== -1 && endTokenIndex !== -1) {
 			return BlockCommentCommand._createRemoveBlockCommentOperations(
 				new Range(startLineNumber, startTokenIndex + startToken.length + 1, endLineNumber, endTokenIndex + 1), startToken, endToken

--- a/src/vs/editor/contrib/comment/test/common/blockCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/common/blockCommentCommand.test.ts
@@ -158,6 +158,101 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(1, 3, 1, 6)
 		);
+
+		testBlockCommentCommand(
+			[
+				'<0 first 0>',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 10, 1, 1),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 1, 6)
+		);
+
+		testBlockCommentCommand(
+			[
+				'<0 first 0>',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 10, 1, 1),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 1, 6)
+		);
+
+		testBlockCommentCommand(
+			[
+				'<0 first0>',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 9, 1, 1),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 1, 6)
+		);
+
+		testBlockCommentCommand(
+			[
+				'<0first 0>',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 9, 1, 1),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 1, 6)
+		);
+
+		testBlockCommentCommand(
+			[
+				'fi<0rst0>',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 8, 1, 5),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 3, 1, 6)
+		);
 	});
 
 	test('multi line selection', function () {
@@ -219,6 +314,63 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(1, 1, 2, 4)
 		);
+
+		testBlockCommentCommand(
+			[
+				'<0 first',
+				'\tse0>cond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(2, 4, 1, 3),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 2, 4)
+		);
+
+		testBlockCommentCommand(
+			[
+				'<0first',
+				'\tse 0>cond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(2, 4, 1, 3),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 2, 4)
+		);
+
+		testBlockCommentCommand(
+			[
+				'<0 first',
+				'\tse 0>cond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(2, 4, 1, 3),
+			[
+				'first',
+				'\tsecond line',
+				'third line',
+				'fourth line',
+				'fifth'
+			],
+			new Selection(1, 1, 2, 4)
+		);
 	});
 
 	test('fuzzy removes', function () {
@@ -229,10 +381,10 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 5, 1, 7),
 			[
-				'asd  qwe',
-				'asd  qwe'
+				'asd qwe',
+				'asd qwe'
 			],
-			new Selection(1, 5, 2, 5)
+			new Selection(1, 5, 2, 4)
 		);
 
 		testBlockCommentCommand(
@@ -242,10 +394,10 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 5, 1, 6),
 			[
-				'asd  qwe',
-				'asd  qwe'
+				'asd qwe',
+				'asd qwe'
 			],
-			new Selection(1, 5, 2, 5)
+			new Selection(1, 5, 2, 4)
 		);
 
 		testBlockCommentCommand(
@@ -255,10 +407,10 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 5, 1, 5),
 			[
-				'asd  qwe',
-				'asd  qwe'
+				'asd qwe',
+				'asd qwe'
 			],
-			new Selection(1, 5, 2, 5)
+			new Selection(1, 5, 2, 4)
 		);
 
 		testBlockCommentCommand(
@@ -268,10 +420,10 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 5, 1, 11),
 			[
-				'asd  qwe',
-				'asd  qwe'
+				'asd qwe',
+				'asd qwe'
 			],
-			new Selection(1, 5, 2, 5)
+			new Selection(1, 5, 2, 4)
 		);
 
 		testBlockCommentCommand(
@@ -281,10 +433,10 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 1, 1, 11),
 			[
-				'asd  qwe',
-				'asd  qwe'
+				'asd qwe',
+				'asd qwe'
 			],
-			new Selection(1, 5, 2, 5)
+			new Selection(1, 5, 2, 4)
 		);
 
 		testBlockCommentCommand(
@@ -294,11 +446,10 @@ suite('Editor Contrib - Block Comment Command', () => {
 			],
 			new Selection(2, 7, 1, 11),
 			[
-				'asd  qwe',
-				'asd  qwe'
+				'asd qwe',
+				'asd qwe'
 			],
-			new Selection(1, 5, 2, 5)
+			new Selection(1, 5, 2, 4)
 		);
 	});
 });
-

--- a/src/vs/editor/contrib/comment/test/common/lineCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/common/lineCommentCommand.test.ts
@@ -674,7 +674,7 @@ suite('Editor Contrib - Line Comment As Block Comment 2', () => {
 			],
 			new Selection(1, 1, 1, 1),
 			[
-				'\t\tfirst\t    ',
+				'\t\tfirst\t   ',
 				'\t\tsecond line',
 				'\tthird line',
 				'fourth line',


### PR DESCRIPTION
@rebornix 
- adjusted whitespace in similar fashion to single-line comment
- everything language independent