### PR TITLE
QuickPickOptions unusable typings small fix

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1495,7 +1495,7 @@ declare module 'vscode' {
 		/**
 		 * An optional function that is invoked whenever an item is selected.
 		 */
-		onDidSelectItem?<T extends QuickPickItem>(item: T | string): any;
+		onDidSelectItem?(item: QuickPickItem | string): any;
 	}
 
 	/**


### PR DESCRIPTION
When calling `vscode.window.showQuickPick` with custom type items, `onDidSelectItem` callback cannot be correctly typed:
```typescript
interface MyPickItem extends vscode.QuickPickItem { }
var items:MyPickItem[];
vscode.window.showQuickPick(items, { 
    placeHolder: "(placeholder)", 
    onDidSelectItem: (item:MyPickItem) => {
        /* Wont copile, error:
            Argument of type '{ placeHolder: string; onDidSelectItem: (item: MyPickItem) => void; }' is not assignable to parameter of type 'QuickPickOptions'.
            Types of property 'onDidSelectItem' are incompatible.
                Type '(item: MyPickItem) => void' is not assignable to type '<T extends QuickPickItem>(item: string | T) => any'.
                Types of parameters 'item' and 'item' are incompatible.
                    Type 'string | T' is not assignable to type 'MyPickItem'.
                    Type 'string' is not assignable to type 'MyPickItem'.
        */
    }
});
```
That because of way which typescript handles generic constraints ( https://github.com/Microsoft/TypeScript/issues/3410#issuecomment-111646030 ). So easy fix to make it usable is to just change constraint to base QuickPickItem interface.