### PR TITLE
Add showTextDocument(uri|file)

### DIFF
--- a/extensions/vscode-api-tests/src/window.test.ts
+++ b/extensions/vscode-api-tests/src/window.test.ts
@@ -24,6 +24,24 @@ suite('window namespace tests', () => {
 		});
 	});
 
+	test('editor, opened via fileName', () => {
+		const fileName = join(workspace.rootPath || '', './far.js');
+		return window.showTextDocument(fileName).then((editor) => {
+			const active = window.activeTextEditor;
+			assert.ok(active);
+			assert.ok(pathEquals(active!.document.uri.fsPath, fileName));
+		});
+	});
+
+	test('editor, opened via resource', () => {
+		const uri = Uri.file(join(workspace.rootPath || '', './far.js'));
+		return window.showTextDocument(uri).then((editor) => {
+			const active = window.activeTextEditor;
+			assert.ok(active);
+			assert.ok(pathEquals(active!.document.uri.fsPath, uri.fsPath));
+		});
+	});
+
 	// test('editor, UN-active text editor', () => {
 	// 	assert.equal(window.visibleTextEditors.length, 0);
 	// 	assert.ok(window.activeTextEditor === undefined);

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4060,14 +4060,40 @@ declare module 'vscode' {
 		export function showTextDocument(document: TextDocument, column?: ViewColumn, preserveFocus?: boolean): Thenable<TextEditor>;
 
 		/**
-		 * Show the given document in a text editor. A [column](#ViewColumn) can be provided
-		 * to control where the editor is being shown. Might change the [active editor](#window.activeTextEditor).
+		 * Show the given document in a text editor. [Options](#TextDocumentShowOptions) can be provided
+		 * to control options of the editor is being shown. Might change the [active editor](#window.activeTextEditor).
 		 *
 		 * @param document A text document to be shown.
 		 * @param options [Editor options](#ShowTextDocumentOptions) to configure the behavior of showing the [editor](#TextEditor).
 		 * @return A promise that resolves to an [editor](#TextEditor).
 		 */
 		export function showTextDocument(document: TextDocument, options?: TextDocumentShowOptions): Thenable<TextEditor>;
+
+		/**
+		 * A short-hand for `openTextDocument(fileName).then(document => showTextDocument(document))` to show the given file in a text
+		 * editor (see [openTextDocument](#openTextDocument)).
+		 *
+		 * [Options](#TextDocumentShowOptions) can be provided to control options of the editor is being shown.
+		 * Might change the [active editor](#window.activeTextEditor).
+		 *
+		 * @param uri A resource identifier.
+		 * @param options [Editor options](#ShowTextDocumentOptions) to configure the behavior of showing the [editor](#TextEditor).
+		 * @return A promise that resolves to an [editor](#TextEditor).
+		 */
+		export function showTextDocument(fileName: string, options?: TextDocumentShowOptions): Thenable<TextEditor>;
+
+		/**
+		 * A short-hand for `openTextDocument(uri).then(document => showTextDocument(document))` to show the given resource in a text
+		 * editor (see [openTextDocument](#openTextDocument)).
+		 *
+		 * [Options](#TextDocumentShowOptions) can be provided to control options of the editor is being shown.
+		 * Might change the [active editor](#window.activeTextEditor).
+		 *
+		 * @param uri A resource identifier.
+		 * @param options [Editor options](#ShowTextDocumentOptions) to configure the behavior of showing the [editor](#TextEditor).
+		 * @return A promise that resolves to an [editor](#TextEditor).
+		 */
+		export function showTextDocument(uri: Uri, options?: TextDocumentShowOptions): Thenable<TextEditor>;
 
 		/**
 		 * Create a TextEditorDecorationType that can be used to add decorations to text editors.

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -282,8 +282,20 @@ export function createApiFactory(
 			get visibleTextEditors() {
 				return extHostEditors.getVisibleTextEditors();
 			},
-			showTextDocument(document: vscode.TextDocument, columnOrOptions?: vscode.ViewColumn | vscode.TextDocumentShowOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
-				return extHostEditors.showTextDocument(document, columnOrOptions, preserveFocus);
+			showTextDocument(documentOrUriOrFilename: vscode.TextDocument | vscode.Uri | string, columnOrOptions?: vscode.ViewColumn | vscode.TextDocumentShowOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
+				let documentPromise: TPromise<vscode.TextDocument>;
+
+				if (typeof documentOrUriOrFilename === 'string') {
+					documentPromise = workspace.openTextDocument(documentOrUriOrFilename) as TPromise<vscode.TextDocument>;
+				} else if (URI.isUri(documentOrUriOrFilename)) {
+					documentPromise = workspace.openTextDocument(documentOrUriOrFilename) as TPromise<vscode.TextDocument>;
+				} else {
+					documentPromise = TPromise.as(documentOrUriOrFilename as vscode.TextDocument);
+				}
+
+				return documentPromise.then(document => {
+					return extHostEditors.showTextDocument(document, columnOrOptions, preserveFocus);
+				});
 			},
 			createTextEditorDecorationType(options: vscode.DecorationRenderOptions): vscode.TextEditorDecorationType {
 				return extHostEditors.createTextEditorDecorationType(options);

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -234,7 +234,7 @@ export class ExtHostApiCommands {
 		this._register('vscode.open', (resource: URI, column: vscode.ViewColumn) => {
 			return this._commands.executeCommand('_workbench.open', [resource, typeConverters.fromViewColumn(column)]);
 		}, {
-				description: 'Opens the provided resource in the editor. Can be a text or binary file, or a http(s) url',
+				description: 'Opens the provided resource in the editor. Can be a text or binary file, or a http(s) url. If you need more control over the options for opening a text file, use vscode.window.showTextDocument instead.',
 				args: [
 					{ name: 'resource', description: 'Resource to open', constraint: URI },
 					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' }


### PR DESCRIPTION
Adds new overloads to `showTextDocument` to pass in a URI or file path similar to the overloads in `openTextDocument`.