### PR TITLE
Adding link detector regex to support c# extension

### DIFF
--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -32,7 +32,7 @@ export class LinkDetector {
 			')' +
 			':line\ ' +	// ends with :line literal
 			'(\d+)$', // Line number
-			'g')
+			'mg')
 	];
 
 	constructor(

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -19,18 +19,9 @@ export class LinkDetector {
 		// group 2: drive letter on windows with trailing backslash or leading slash on mac/linux
 		// group 3: line number, matched by (:(\d+))
 		// group 4: column number, matched by ((?::(\d+))?)
-
-		// Regular Expression for filepaths from node.
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		// eg: at Context.<anonymous> (c:\Users\some one\Desktop\mocha-runner\test\test.js:26:11)
-		new RegExp('(?!\()' +
-			'(?:file:\/\/)?' + // Handles file://
-			'((?:([a-zA-Z]:)|[/\\]+)(?:[\\/][^<>\\/\'\"\[\]:]*)*\.[a-zA-Z]+[0-9]*)' + // Rooted path
-			':' +
-			'(\d+)' + // Line number
-			'(?::(\d+))?' + // Column number
-			'(?=\))',	// Ends with a paranthesis
-			'g'),
+		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g,
+
 		// Regular Expression for filepaths from C# extension
 		// eg: at app1.Program.Foo() in c:\temp\dotnet\app1\Program.foo.cs:line 9
 		// eg: at app1.Program.Foo() in c:\temp folder\dotnet\app1\Program.cs:line 9

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -20,7 +20,8 @@ export class LinkDetector {
 		// group 3: line number, matched by (:(\d+))
 		// group 4: column number, matched by ((?::(\d+))?)
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g
+		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g,
+		/(?![\s])((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(?:\w+)\s(\d+)?/g
 	];
 
 	constructor(

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -19,9 +19,30 @@ export class LinkDetector {
 		// group 2: drive letter on windows with trailing backslash or leading slash on mac/linux
 		// group 3: line number, matched by (:(\d+))
 		// group 4: column number, matched by ((?::(\d+))?)
+
+		// Regular Expression for filepaths from node.
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g,
-		/(?![\s])((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(?:\w+)\s(\d+)?/g
+		// eg: at Context.<anonymous> (c:\Users\some one\Desktop\mocha-runner\test\test.js:26:11)
+		new RegExp("(?!\()" +
+						"(?:file:\/\/)?" + // Handles file://
+						"((?:([a-zA-Z]:)|[/\\]+)(?:[\\/][^<>\\/\'\"\[\]:]*)*\.[a-zA-Z]+[0-9]*)" + // Rooted path
+						":" +
+						"(\d+)" + // Line number
+						"(?::(\d+))?" + // Column number
+						"(?=\))",	// Ends with a paranthesis
+					"g"),
+
+        // Regular Expression for filepaths from C# extension
+		// at app1.Program.Foo() in c:\temp\dotnet\app1\Program.foo.cs:line 9
+        // at app1.Program.Foo() in c:\temp folder\dotnet\app1\Program.cs:line 9
+        // at app3.Program.Main(String[] args) in /Users/janraj/temp/app3/Program.cs:line 9
+		new RegExp("(" +
+						"(?:([a-zA-Z]:)|[\\]*|[\/]+)" + // Rooted file starting with c: or \\ or /
+						"(?:[\\/][^<>\\/\'\"\[\]:]*)+"+ // File path
+					")" +
+					":line\ " +	// ends with :line literal
+					"(\d+)", // Line number
+				"g")
 	];
 
 	constructor(

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -23,26 +23,25 @@ export class LinkDetector {
 		// Regular Expression for filepaths from node.
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
 		// eg: at Context.<anonymous> (c:\Users\some one\Desktop\mocha-runner\test\test.js:26:11)
-		new RegExp("(?!\()" +
-						"(?:file:\/\/)?" + // Handles file://
-						"((?:([a-zA-Z]:)|[/\\]+)(?:[\\/][^<>\\/\'\"\[\]:]*)*\.[a-zA-Z]+[0-9]*)" + // Rooted path
-						":" +
-						"(\d+)" + // Line number
-						"(?::(\d+))?" + // Column number
-						"(?=\))",	// Ends with a paranthesis
-					"g"),
-
-        // Regular Expression for filepaths from C# extension
-		// at app1.Program.Foo() in c:\temp\dotnet\app1\Program.foo.cs:line 9
-        // at app1.Program.Foo() in c:\temp folder\dotnet\app1\Program.cs:line 9
-        // at app3.Program.Main(String[] args) in /Users/janraj/temp/app3/Program.cs:line 9
-		new RegExp("(" +
-						"(?:([a-zA-Z]:)|[\\]*|[\/]+)" + // Rooted file starting with c: or \\ or /
-						"(?:[\\/][^<>\\/\'\"\[\]:]*)+"+ // File path
-					")" +
-					":line\ " +	// ends with :line literal
-					"(\d+)", // Line number
-				"g")
+		new RegExp('(?!\()' +
+			'(?:file:\/\/)?' + // Handles file://
+			'((?:([a-zA-Z]:)|[/\\]+)(?:[\\/][^<>\\/\'\"\[\]:]*)*\.[a-zA-Z]+[0-9]*)' + // Rooted path
+			':' +
+			'(\d+)' + // Line number
+			'(?::(\d+))?' + // Column number
+			'(?=\))',	// Ends with a paranthesis
+			'g'),
+		// Regular Expression for filepaths from C# extension
+		// eg: at app1.Program.Foo() in c:\temp\dotnet\app1\Program.foo.cs:line 9
+		// eg: at app1.Program.Foo() in c:\temp folder\dotnet\app1\Program.cs:line 9
+		// eg: at app3.Program.Main(String[] args) in /Users/janraj/temp/app3/Program.cs:line 9
+		new RegExp('(' +
+			'(?:([a-zA-Z]:)|[\\]*|[\/]+)' + // Rooted file starting with c: or \\ or /
+			'(?:[\\/][^<>\\/\'\"\[\]:]*)+' + // File path
+			')' +
+			':line\ ' +	// ends with :line literal
+			'(\d+)$', // Line number
+			'g')
 	];
 
 	constructor(


### PR DESCRIPTION
Adding link detector regex for file links of the following format

at app1.Program.Foo() in c:\temp\dotnet\app1\Program.cs:line 9