### PR TITLE
Block Comment - Leave cursor after token and Space Fixes #30554 Bug 1

### DIFF
--- a/src/vs/editor/contrib/comment/common/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/common/lineCommentCommand.ts
@@ -296,7 +296,8 @@ export class LineCommentCommand implements editorCommon.ICommand {
 			}
 
 			if (ops.length === 1) {
-				this._deltaColumn = startToken.length;
+				// Leave cursor after token and Space
+				this._deltaColumn = startToken.length + 1;
 			}
 		}
 		this._selectionId = builder.trackSelection(s);


### PR DESCRIPTION
@rebornix 
Addresses bug 1, issue #30554 
Really big one-liner.
I didn't think this needed any extra test case.

BTW - Saw you had to cut a duplicate test case for the block comments. Sorry I missed that
will try to catch those things in the future !