### PR TITLE
Add terminal quick picker

### DIFF
--- a/src/vs/workbench/parts/terminal/browser/terminalQuickOpen.ts
+++ b/src/vs/workbench/parts/terminal/browser/terminalQuickOpen.ts
@@ -15,8 +15,6 @@ import { QuickOpenHandler } from 'vs/workbench/browser/quickopen';
 import { ITerminalService } from 'vs/workbench/parts/terminal/common/terminal';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 
-export const TERMINAL_PICKER_PREFIX = 'term ';
-
 export class TerminalEntry extends QuickOpenEntryGroup {
 
 	constructor(
@@ -95,7 +93,7 @@ export class TerminalPickerHandler extends QuickOpenHandler {
 				e.setGroupLabel(lastCategory);
 			} else {
 				e.setShowBorder(false);
-				e.setGroupLabel(void 0);
+				e.setGroupLabel(null);
 			}
 		});
 
@@ -104,29 +102,17 @@ export class TerminalPickerHandler extends QuickOpenHandler {
 
 	private getTerminals(): TerminalEntry[] {
 		const termninalEntries: TerminalEntry[] = [];
-		const taskEntries: TerminalEntry[] = [];
-		const terminals = this.terminalService.terminalInstances;
+		const terminals = this.terminalService.getInstanceLabels();
 
 		terminals.forEach((terminal, index) => {
 			const terminalsCategory = nls.localize('terminals', "Terminal");
-			const taskCategory = nls.localize('task', "Task");
-			if (terminal.title.indexOf('Task') >= 0) {
-				taskEntries.push(new TerminalEntry(nls.localize('terminalTitle', "{0}: {1}", index + 1, terminal.title), taskCategory, () => {
-					this.terminalService.showPanel(true).done(() => {
-						this.terminalService.setActiveInstance(terminal);
-					}, errors.onUnexpectedError);
-				}));
-			} else {
-				termninalEntries.push(new TerminalEntry(nls.localize('terminalTitle', "{0}: {1}", index + 1, terminal.title), terminalsCategory, () => {
-					this.terminalService.showPanel(true).done(() => {
-						this.terminalService.setActiveInstance(terminal);
-					}, errors.onUnexpectedError);
-				}));
-			}
-
-
+			termninalEntries.push(new TerminalEntry(terminal, terminalsCategory, () => {
+				this.terminalService.showPanel(true).done(() => {
+					this.terminalService.setActiveInstanceByIndex(parseInt(terminal.split(':')[0], 10) - 1);
+				}, errors.onUnexpectedError);
+			}));
 		});
-		return termninalEntries.concat(taskEntries);
+		return termninalEntries;
 	}
 
 	public getAutoFocus(searchValue: string, context: { model: IModel<QuickOpenEntry>, quickNavigateConfiguration?: IQuickNavigateConfiguration }): IAutoFocus {

--- a/src/vs/workbench/parts/terminal/browser/terminalQuickOpen.ts
+++ b/src/vs/workbench/parts/terminal/browser/terminalQuickOpen.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import nls = require('vs/nls');
+import errors = require('vs/base/common/errors');
+import strings = require('vs/base/common/strings');
+import scorer = require('vs/base/common/scorer');
+import { TPromise } from 'vs/base/common/winjs.base';
+import { Mode, IEntryRunContext, IAutoFocus, IQuickNavigateConfiguration, IModel } from 'vs/base/parts/quickopen/common/quickOpen';
+import { QuickOpenModel, QuickOpenEntryGroup, QuickOpenEntry } from 'vs/base/parts/quickopen/browser/quickOpenModel';
+import { QuickOpenHandler } from 'vs/workbench/browser/quickopen';
+import { ITerminalService } from 'vs/workbench/parts/terminal/common/terminal';
+import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
+
+export const TERMINAL_PICKER_PREFIX = 'term ';
+
+export class TerminalEntry extends QuickOpenEntryGroup {
+
+	constructor(
+		private label: string,
+		private category: string,
+		private open: () => void
+	) {
+		super();
+	}
+
+	public getLabel(): string {
+		return this.label;
+	}
+
+	public getCategory(): string {
+		return this.category;
+	}
+
+	public getAriaLabel(): string {
+		return nls.localize('entryAriaLabel', "{0}, terminal picker", this.getLabel());
+	}
+
+	public run(mode: Mode, context: IEntryRunContext): boolean {
+		if (mode === Mode.OPEN) {
+			return this.runOpen(context);
+		}
+
+		return super.run(mode, context);
+	}
+
+	private runOpen(context: IEntryRunContext): boolean {
+		setTimeout(() => {
+			this.open();
+		}, 0);
+
+		return true;
+	}
+}
+
+export class TerminalPickerHandler extends QuickOpenHandler {
+
+	constructor(
+		@ITerminalService private terminalService: ITerminalService,
+		@IPanelService private panelService: IPanelService
+	) {
+		super();
+	}
+
+	public getResults(searchValue: string): TPromise<QuickOpenModel> {
+		searchValue = searchValue.trim();
+		const normalizedSearchValueLowercase = strings.stripWildcards(searchValue).toLowerCase();
+
+		const terminalEntries = this.getTerminals();
+
+		const entries = terminalEntries.filter(e => {
+			if (!searchValue) {
+				return true;
+			}
+
+			if (!scorer.matches(e.getLabel(), normalizedSearchValueLowercase) && !scorer.matches(e.getCategory(), normalizedSearchValueLowercase)) {
+				return false;
+			}
+
+			const { labelHighlights, descriptionHighlights } = QuickOpenEntry.highlight(e, searchValue);
+			e.setHighlights(labelHighlights, descriptionHighlights);
+
+			return true;
+		});
+
+		let lastCategory: string;
+		entries.forEach((e, index) => {
+			if (lastCategory !== e.getCategory()) {
+				lastCategory = e.getCategory();
+
+				e.setShowBorder(index > 0);
+				e.setGroupLabel(lastCategory);
+			} else {
+				e.setShowBorder(false);
+				e.setGroupLabel(void 0);
+			}
+		});
+
+		return TPromise.as(new QuickOpenModel(entries));
+	}
+
+	private getTerminals(): TerminalEntry[] {
+		const termninalEntries: TerminalEntry[] = [];
+		const taskEntries: TerminalEntry[] = [];
+		const terminals = this.terminalService.terminalInstances;
+
+		terminals.forEach((terminal, index) => {
+			const terminalsCategory = nls.localize('terminals', "Terminal");
+			const taskCategory = nls.localize('task', "Task");
+			if (terminal.title.indexOf('Task') >= 0) {
+				taskEntries.push(new TerminalEntry(nls.localize('terminalTitle', "{0}: {1}", index + 1, terminal.title), taskCategory, () => {
+					this.terminalService.showPanel(true).done(() => {
+						this.terminalService.setActiveInstance(terminal);
+					}, errors.onUnexpectedError);
+				}));
+			} else {
+				termninalEntries.push(new TerminalEntry(nls.localize('terminalTitle', "{0}: {1}", index + 1, terminal.title), terminalsCategory, () => {
+					this.terminalService.showPanel(true).done(() => {
+						this.terminalService.setActiveInstance(terminal);
+					}, errors.onUnexpectedError);
+				}));
+			}
+
+
+		});
+		return termninalEntries.concat(taskEntries);
+	}
+
+	public getAutoFocus(searchValue: string, context: { model: IModel<QuickOpenEntry>, quickNavigateConfiguration?: IQuickNavigateConfiguration }): IAutoFocus {
+		return {
+			autoFocusFirstEntry: !!searchValue || !!context.quickNavigateConfiguration
+		};
+	}
+}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -7,7 +7,6 @@ import 'vs/css!./media/scrollbar';
 import 'vs/css!./media/terminal';
 import 'vs/css!./media/xterm';
 import 'vs/css!./media/widgets';
-import 'vs/workbench/parts/terminal/browser/terminalQuickOpen';
 import * as debugActions from 'vs/workbench/parts/debug/browser/debugActions';
 import * as nls from 'vs/nls';
 import * as panel from 'vs/workbench/browser/panel';
@@ -33,15 +32,17 @@ import { NavigateUpAction, NavigateDownAction, NavigateLeftAction, NavigateRight
 import { QUICKOPEN_ACTION_ID } from "vs/workbench/browser/parts/quickopen/quickopen";
 import { IQuickOpenRegistry, Extensions as QuickOpenExtensions, QuickOpenHandlerDescriptor } from 'vs/workbench/browser/quickopen';
 
+export const TERMINAL_PICKER_PREFIX = 'term ';
+const terminalPickerContextKey = 'inTerminalPicker';
 const quickOpenRegistry = (<IQuickOpenRegistry>Registry.as(QuickOpenExtensions.Quickopen));
 
 quickOpenRegistry.registerQuickOpenHandler(
 	new QuickOpenHandlerDescriptor(
 		'vs/workbench/parts/terminal/browser/terminalQuickOpen',
 		'TerminalPickerHandler',
-		'term ',
-		'inTerminalPicker',
-		nls.localize('quickOpen.terminal', "Quickpick Terminal")
+		TERMINAL_PICKER_PREFIX,
+		terminalPickerContextKey,
+		nls.localize('quickOpen.terminal', "Show All Opened Terminals")
 	)
 );
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -7,6 +7,7 @@ import 'vs/css!./media/scrollbar';
 import 'vs/css!./media/terminal';
 import 'vs/css!./media/xterm';
 import 'vs/css!./media/widgets';
+import 'vs/workbench/parts/terminal/browser/terminalQuickOpen';
 import * as debugActions from 'vs/workbench/parts/debug/browser/debugActions';
 import * as nls from 'vs/nls';
 import * as panel from 'vs/workbench/browser/panel';
@@ -30,6 +31,19 @@ import { EDITOR_FONT_DEFAULTS } from 'vs/editor/common/config/editorOptions';
 import { registerColors } from './terminalColorRegistry';
 import { NavigateUpAction, NavigateDownAction, NavigateLeftAction, NavigateRightAction } from "vs/workbench/electron-browser/actions";
 import { QUICKOPEN_ACTION_ID } from "vs/workbench/browser/parts/quickopen/quickopen";
+import { IQuickOpenRegistry, Extensions as QuickOpenExtensions, QuickOpenHandlerDescriptor } from 'vs/workbench/browser/quickopen';
+
+const quickOpenRegistry = (<IQuickOpenRegistry>Registry.as(QuickOpenExtensions.Quickopen));
+
+quickOpenRegistry.registerQuickOpenHandler(
+	new QuickOpenHandlerDescriptor(
+		'vs/workbench/parts/terminal/browser/terminalQuickOpen',
+		'TerminalPickerHandler',
+		'term ',
+		'inTerminalPicker',
+		nls.localize('quickOpen.terminal', "Quickpick Terminal")
+	)
+);
 
 let configurationRegistry = <IConfigurationRegistry>Registry.as(Extensions.Configuration);
 configurationRegistry.registerConfiguration({
@@ -317,3 +331,4 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DeleteWordRightT
 	mac: { primary: KeyMod.Alt | KeyCode.Delete }
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Delete Word After Cursor', category);
 registerColors();
+

--- a/src/vs/workbench/workbench.main.ts
+++ b/src/vs/workbench/workbench.main.ts
@@ -69,6 +69,7 @@ import 'vs/workbench/parts/output/browser/output.contribution';
 import 'vs/workbench/parts/output/browser/outputPanel'; // can be packaged separately
 
 import 'vs/workbench/parts/terminal/electron-browser/terminal.contribution';
+import 'vs/workbench/parts/terminal/browser/terminalQuickOpen';
 import 'vs/workbench/parts/terminal/electron-browser/terminalPanel'; // can be packaged separately
 
 import 'vs/workbench/electron-browser/workbench';


### PR DESCRIPTION
- If you type in `term␣` in quick picker, you get a list of active terminals 

![image](https://user-images.githubusercontent.com/13241824/28395964-13632872-6cad-11e7-86fd-b208c429345c.png)

This is like viewPickerHandler, but only for terminal.

Addresses #29879 . Doesn't have a command attached to it yet for a keybinding.