### PR TITLE
Added API to access editor markers

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -67,7 +67,7 @@ export interface ICommandHandler {
 }
 #include(vs/platform/contextkey/common/contextkey): IContextKey
 #include(vs/editor/standalone/browser/standaloneServices): IEditorOverrideServices
-#include(vs/platform/markers/common/markers): IMarkerData
+#include(vs/platform/markers/common/markers): IMarker, IMarkerData
 #include(vs/editor/standalone/browser/colorizer): IColorizerOptions, IColorizerElementOptions
 #include(vs/base/common/scrollable): ScrollbarVisibility
 #include(vs/platform/theme/common/themeService): ThemeColor

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -195,6 +195,15 @@ export function setModelMarkers(model: editorCommon.IModel, owner: string, marke
 }
 
 /**
+ * Get markers for owner ant/or resource
+ * @returns {IMarkerData[]} list of markers
+ * @param filter
+ */
+export function getModelMarkers(filter: { owner?: string, resource?: URI, take?: number }): IMarkerData[] {
+	return StaticServices.markerService.get().read(filter);
+}
+
+/**
  * Get the model that has `uri` if it exists.
  */
 export function getModel(uri: URI): editorCommon.IModel {
@@ -331,6 +340,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		createModel: createModel,
 		setModelLanguage: setModelLanguage,
 		setModelMarkers: setModelMarkers,
+		getModelMarkers: getModelMarkers,
 		getModels: getModels,
 		getModel: getModel,
 		onDidCreateModel: onDidCreateModel,

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -19,7 +19,7 @@ import { Colorizer, IColorizerElementOptions, IColorizerOptions } from 'vs/edito
 import { SimpleEditorService, SimpleEditorModelResolverService } from 'vs/editor/standalone/browser/simpleServices';
 import * as modes from 'vs/editor/common/modes';
 import { IWebWorkerOptions, MonacoWebWorker, createWebWorker as actualCreateWebWorker } from 'vs/editor/common/services/webWorker';
-import { IMarkerData } from 'vs/platform/markers/common/markers';
+import { IMarkerData, IMarker } from 'vs/platform/markers/common/markers';
 import { DiffNavigator } from 'vs/editor/browser/widget/diffNavigator';
 import { IEditorService } from 'vs/platform/editor/common/editor';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -199,7 +199,7 @@ export function setModelMarkers(model: editorCommon.IModel, owner: string, marke
  * @returns {IMarkerData[]} list of markers
  * @param filter
  */
-export function getModelMarkers(filter: { owner?: string, resource?: URI, take?: number }): IMarkerData[] {
+export function getModelMarkers(filter: { owner?: string, resource?: URI, take?: number }): IMarker[] {
 	return StaticServices.markerService.get().read(filter);
 }
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -834,6 +834,17 @@ declare module monaco.editor {
 	export function setModelMarkers(model: IModel, owner: string, markers: IMarkerData[]): void;
 
 	/**
+	 * Get markers for owner ant/or resource
+	 * @returns {IMarkerData[]} list of markers
+	 * @param filter
+	 */
+	export function getModelMarkers(filter: {
+		owner?: string;
+		resource?: Uri;
+		take?: number;
+	}): IMarkerData[];
+
+	/**
 	 * Get the model that has `uri` if it exists.
 	 */
 	export function getModel(uri: Uri): IModel;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -842,7 +842,7 @@ declare module monaco.editor {
 		owner?: string;
 		resource?: Uri;
 		take?: number;
-	}): IMarkerData[];
+	}): IMarker[];
 
 	/**
 	 * Get the model that has `uri` if it exists.
@@ -1038,6 +1038,19 @@ declare module monaco.editor {
 
 	export interface IEditorOverrideServices {
 		[index: string]: any;
+	}
+
+	export interface IMarker {
+		owner: string;
+		resource: Uri;
+		severity: Severity;
+		code?: string;
+		message: string;
+		source?: string;
+		startLineNumber: number;
+		startColumn: number;
+		endLineNumber: number;
+		endColumn: number;
 	}
 
 	/**

--- a/src/vs/platform/markers/common/markers.ts
+++ b/src/vs/platform/markers/common/markers.ts
@@ -9,8 +9,6 @@ import Severity from 'vs/base/common/severity';
 import Event from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
-export const IMarkerService = createDecorator<IMarkerService>('markerService');
-
 export interface IMarkerService {
 	_serviceBrand: any;
 
@@ -114,3 +112,5 @@ export namespace IMarkerData {
 		return result.join('¦');
 	}
 }
+
+export const IMarkerService = createDecorator<IMarkerService>('markerService');

--- a/src/vs/workbench/parts/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesWidgets.ts
@@ -17,7 +17,7 @@ import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition, OverlayWidgetPosit
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { InputBox, IInputOptions } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IContextViewService, IContextMenuService, ContextSubMenu } from 'vs/platform/contextview/browser/contextView';
+import { IContextViewService, IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { ISettingsGroup, IPreferencesService, getSettingsTargetName } from 'vs/workbench/parts/preferences/common/preferences';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';


### PR DESCRIPTION
As of now there is no public API to access markers in monaco-editor. This PR adds method `editor.getModelMarkers`. Should resolve https://github.com/Microsoft/monaco-editor/issues/30.