### PR TITLE
Fix multi-workspace support detection

### DIFF
--- a/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
@@ -29,7 +29,7 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 	}
 
 	public addRoots(rootsToAdd: URI[]): TPromise<void> {
-		if (!this.supported) {
+		if (!this.isSupported()) {
 			return TPromise.as(void 0); // we need a workspace to begin with
 		}
 
@@ -39,7 +39,7 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 	}
 
 	public removeRoots(rootsToRemove: URI[]): TPromise<void> {
-		if (!this.supported) {
+		if (!this.isSupported()) {
 			return TPromise.as(void 0); // we need a workspace to begin with
 		}
 
@@ -49,7 +49,7 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		return this.doSetRoots(roots.filter(root => rootsToRemoveRaw.indexOf(root.toString()) === -1));
 	}
 
-	private supported(): boolean {
+	private isSupported(): boolean {
 		if (this.contextService.hasMultiFolderWorkspace()) {
 			return false; // we need a multi folder workspace to begin with
 		}

--- a/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
@@ -50,12 +50,11 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 	}
 
 	private isSupported(): boolean {
-		if (!this.contextService.hasMultiFolderWorkspace()) {
-			return false; // we need a multi folder workspace to begin with
-		}
-
 		// TODO@Ben multi root
-		return this.environmentService.appQuality !== 'stable'; // not yet enabled in stable
+		return (
+			this.environmentService.appQuality !== 'stable'  // not yet enabled in stable
+			&& this.contextService.hasMultiFolderWorkspace() // we need a multi folder workspace to begin with
+		);
 	}
 
 	private doSetRoots(newRoots: URI[]): TPromise<void> {

--- a/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
@@ -50,7 +50,7 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 	}
 
 	private isSupported(): boolean {
-		if (this.contextService.hasMultiFolderWorkspace()) {
+		if (!this.contextService.hasMultiFolderWorkspace()) {
 			return false; // we need a multi folder workspace to begin with
 		}
 


### PR DESCRIPTION
Noticed this always evaluated to `true` because it didn't call the method, only checked for its presence. Also renamed it to a verb so it's more obvious this is a method.
The condition inside `isSupported()` was also inversed