### PR TITLE
keytar Linux 32bit

### DIFF
--- a/build/tfs/linux/Dockerfile
+++ b/build/tfs/linux/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get install -y libgl1-mesa-glx:i386 libgl1-mesa-dri:i386
 RUN apt-get install -y libxkbfile-dev
 RUN apt-get install -y bc bsdmainutils
 RUN apt-get install -y libsecret-1-dev
+RUN apt-get install -y docker.io
 
 # Xvfb
 # Thanks https://medium.com/@griggheo/running-headless-selenium-webdriver-tests-in-docker-containers-342fdbabf756

--- a/build/tfs/linux/build-ia32.sh
+++ b/build/tfs/linux/build-ia32.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 set -e
+
+docker build -t build-ia32 ./build/tfs/linux/image-ia32
+docker run --rm -v "${WORK_MNT}:${VSTS_WORK}" -w="`pwd`" build-ia32 npm install --unsafe-perms --runtime=electron --target=1.6.6 --disturl=https://atom.io/download/atom-shell keytar
+
 ./build/tfs/linux/build.sh ia32 "$@"

--- a/build/tfs/linux/image-ia32/Dockerfile
+++ b/build/tfs/linux/image-ia32/Dockerfile
@@ -1,0 +1,17 @@
+FROM i386/ubuntu:17.04
+
+RUN apt-get update
+RUN apt-get install -y build-essential python wget
+RUN apt-get install -y libsecret-1-dev
+
+WORKDIR /build
+
+RUN wget https://nodejs.org/dist/v7.10.0/node-v7.10.0-linux-x86.tar.gz
+
+RUN tar xfz node-v7.10.0-linux-x86.tar.gz
+
+RUN chown -R root:root node-v7.10.0-linux-x86
+
+ENV PATH="/build/node-v7.10.0-linux-x86/bin:${PATH}"
+
+RUN npm install -g node-gyp

--- a/build/tfs/linux/run-agent.sh
+++ b/build/tfs/linux/run-agent.sh
@@ -11,5 +11,6 @@ docker run \
   -e VSTS_AGENT="tb-lnx-local" \
   -e VSTS_POOL=linux \
   -e VSTS_WORK="/var/vsts/work" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   --name "tb-lnx-local" \
   -it joaomoreno/vscode-vso-agent


### PR DESCRIPTION
Building keytar for Linux 32bit using a separate Docker container run inside the build agent.

I have added the following to `docker run` in `vso-start-agent`: `-e WORK_MNT="/mnt/work/tb-lnx-$i" -v /var/run/docker.sock:/var/run/docker.sock`. Not sure where that file's source is held.

This is a 'one off' solution for keytar, but could certainly expanded to include more. Having a Dockerfile that is built each time (and usually cached) makes it easy to update.