### PR TITLE
[WIP] Nav toolbar - impements #9418

### DIFF
--- a/src/vs/editor/browser/config/configuration.ts
+++ b/src/vs/editor/browser/config/configuration.ts
@@ -274,6 +274,15 @@ class CSSBasedConfiguration extends Disposable {
 	}
 }
 
+export interface IEdgePaddings {
+	top: number;
+	bottom: number;
+}
+
+export interface IEdgePaddingSource {
+	getEdgePadding(): IEdgePaddings;
+}
+
 export class Configuration extends CommonEditorConfiguration {
 
 	public static applyFontInfoSlow(domNode: HTMLElement, fontInfo: BareFontInfo): void {
@@ -293,11 +302,13 @@ export class Configuration extends CommonEditorConfiguration {
 	}
 
 	private readonly _elementSizeObserver: ElementSizeObserver;
+	private readonly _edgePaddingSource: IEdgePaddingSource;
 
-	constructor(options: IEditorOptions, referenceDomElement: HTMLElement = null) {
+	constructor(options: IEditorOptions, referenceDomElement: HTMLElement = null, edgePaddingSource: IEdgePaddingSource = null) {
 		super(options);
 
 		this._elementSizeObserver = this._register(new ElementSizeObserver(referenceDomElement, () => this._onReferenceDomElementSizeChanged()));
+		this._edgePaddingSource = edgePaddingSource;
 
 		this._register(CSSBasedConfiguration.INSTANCE.onDidChange(() => this._onCSSBasedConfigurationChanged()));
 
@@ -343,8 +354,12 @@ export class Configuration extends CommonEditorConfiguration {
 	}
 
 	protected _getEnvConfiguration(): IEnvConfiguration {
+		const edgePaddings = this._edgePaddingSource && this._edgePaddingSource.getEdgePadding() || null;
+
 		return {
 			extraEditorClassName: this._getExtraEditorClassName(),
+			paddingTop: edgePaddings.top,
+			paddingBottom: edgePaddings.bottom,
 			outerWidth: this._elementSizeObserver.getWidth(),
 			outerHeight: this._elementSizeObserver.getHeight(),
 			emptySelectionClipboard: browser.isWebKit,

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -57,6 +57,7 @@ export class TextAreaHandler extends ViewPart {
 	private readonly _viewHelper: ITextAreaHandlerHelper;
 	private _accessibilitySupport: platform.AccessibilitySupport;
 	private _contentLeft: number;
+	private _contentTop: number;
 	private _contentWidth: number;
 	private _contentHeight: number;
 	private _scrollLeft: number;
@@ -87,6 +88,7 @@ export class TextAreaHandler extends ViewPart {
 
 		this._accessibilitySupport = conf.accessibilitySupport;
 		this._contentLeft = conf.layoutInfo.contentLeft;
+		this._contentTop = conf.layoutInfo.contentTop;
 		this._contentWidth = conf.layoutInfo.contentWidth;
 		this._contentHeight = conf.layoutInfo.contentHeight;
 		this._scrollLeft = 0;
@@ -298,6 +300,7 @@ export class TextAreaHandler extends ViewPart {
 		}
 		if (e.layoutInfo) {
 			this._contentLeft = conf.layoutInfo.contentLeft;
+			this._contentTop = conf.layoutInfo.contentTop;
 			this._contentWidth = conf.layoutInfo.contentWidth;
 			this._contentHeight = conf.layoutInfo.contentHeight;
 		}
@@ -380,7 +383,7 @@ export class TextAreaHandler extends ViewPart {
 		if (this._visibleTextArea) {
 			// The text area is visible for composition reasons
 			this._renderInsideEditor(
-				this._visibleTextArea.top - this._scrollTop,
+				this._contentTop + this._visibleTextArea.top - this._scrollTop,
 				this._contentLeft + this._visibleTextArea.left - this._scrollLeft,
 				this._visibleTextArea.width,
 				this._lineHeight,
@@ -402,7 +405,7 @@ export class TextAreaHandler extends ViewPart {
 			return;
 		}
 
-		const top = this._context.viewLayout.getVerticalOffsetForLineNumber(this._selections[0].positionLineNumber) - this._scrollTop;
+		const top = this._contentTop + this._context.viewLayout.getVerticalOffsetForLineNumber(this._selections[0].positionLineNumber) - this._scrollTop;
 		if (top < 0 || top > this._contentHeight) {
 			// cursor is outside the viewport
 			this._renderAtTopLeft();

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -195,6 +195,45 @@ export interface IOverlayWidget {
 }
 
 /**
+ * A positioning preference for rendering content widgets.
+ */
+export enum EdgeWidgetPositionEdge {
+	/**
+	 * Place the edge widget at the top
+	 */
+	TOP,
+	/**
+	 * Place the edge widget at the bottom
+	 */
+	BOTTOM
+}
+/**
+ * A position for rendering edge widgets.
+ */
+export interface IEdgeWidgetPosition {
+	size: number;
+	edge: EdgeWidgetPositionEdge;
+}
+/**
+ * An edge widget renders at the requested edge and pushed content inside.
+ */
+export interface IEdgeWidget {
+	/**
+	 * Get a unique identifier of the edge widget.
+	 */
+	getId(): string;
+	/**
+	 * Get the dom node of the content widget.
+	 */
+	getDomNode(): HTMLElement;
+	/**
+	 * Get the placement of the content widget.
+	 * If null is returned, the content widget will be placed off screen.
+	 */
+	getPosition(): IEdgeWidgetPosition;
+}
+
+/**
  * Type of hit element with the mouse in the editor.
  */
 export enum MouseTargetType {

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -718,6 +718,20 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	removeOverlayWidget(widget: IOverlayWidget): void;
 
 	/**
+	 * Add an edge widget. Widgets must have unique ids, otherwise they will be overwritten.
+	 */
+	addEdgeWidget(widget: IEdgeWidget): void;
+	/**
+	 * Layout/Reposition an edge widget. This is a ping to the editor to call widget.getPosition()
+	 * and update appropiately.
+	 */
+	layoutEdgeWidget(widget: IEdgeWidget): void;
+	/**
+	 * Remove an edge widget.
+	 */
+	removeEdgeWidget(widget: IEdgeWidget): void;
+
+	/**
 	 * Change the view zones. View zones are lost when a new model is attached to the editor.
 	 */
 	changeViewZones(callback: (accessor: IViewZoneChangeAccessor) => void): void;

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -244,6 +244,7 @@ export class View extends ViewEventHandler {
 		this.overflowGuardContainer.appendChild(minimap.getDomNode());
 		this.domNode.appendChild(this.overflowGuardContainer);
 		this.domNode.appendChild(this.contentWidgets.overflowingContentWidgetsDomNode);
+		this.domNode.appendChild(this.edgeWidgets.getDomNode());
 	}
 
 	private _flushAccumulatedAndRenderNow(): void {

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -212,6 +212,10 @@ export class View extends ViewEventHandler {
 		this.overlayWidgets = new ViewOverlayWidgets(this._context);
 		this.viewParts.push(this.overlayWidgets);
 
+		// Edge widgets
+		this.edgeWidgets = new ViewEdgeWidgets(this._context);
+		this.viewParts.push(this.edgeWidgets);
+
 		let rulers = new Rulers(this._context);
 		this.viewParts.push(rulers);
 

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -30,6 +30,7 @@ import { Margin } from 'vs/editor/browser/viewParts/margin/margin';
 import { LinesDecorationsOverlay } from 'vs/editor/browser/viewParts/linesDecorations/linesDecorations';
 import { MarginViewLineDecorationsOverlay } from 'vs/editor/browser/viewParts/marginDecorations/marginDecorations';
 import { ViewOverlayWidgets } from 'vs/editor/browser/viewParts/overlayWidgets/overlayWidgets';
+import { ViewEdgeWidgets } from 'vs/editor/browser/viewParts/edgeWidgets/edgeWidgets';
 import { DecorationsOverviewRuler } from 'vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler';
 import { OverviewRuler } from 'vs/editor/browser/viewParts/overviewRuler/overviewRuler';
 import { Rulers } from 'vs/editor/browser/viewParts/rulers/rulers';
@@ -50,6 +51,7 @@ import * as viewEvents from 'vs/editor/common/view/viewEvents';
 import { IThemeService, getThemeTypeSelector } from 'vs/platform/theme/common/themeService';
 import { Cursor } from 'vs/editor/common/controller/cursor';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
+import { EditorSnippetVariableResolver } from 'vs/editor/contrib/snippet/snippetVariables';
 
 export interface IContentWidgetData {
 	widget: editorBrowser.IContentWidget;
@@ -59,6 +61,11 @@ export interface IContentWidgetData {
 export interface IOverlayWidgetData {
 	widget: editorBrowser.IOverlayWidget;
 	position: editorBrowser.IOverlayWidgetPosition;
+}
+
+export interface IEdgeWidgetData {
+	widget: editorBrowser.IEdgeWidget;
+	position: editorBrowser.IEdgeWidgetPosition;
 }
 
 export class View extends ViewEventHandler {
@@ -76,6 +83,7 @@ export class View extends ViewEventHandler {
 	private viewZones: ViewZones;
 	private contentWidgets: ViewContentWidgets;
 	private overlayWidgets: ViewOverlayWidgets;
+	private edgeWidgets: ViewEdgeWidgets;
 	private viewCursors: ViewCursors;
 	private viewParts: ViewPart[];
 
@@ -571,6 +579,26 @@ export class View extends ViewEventHandler {
 
 	public removeOverlayWidget(widgetData: IOverlayWidgetData): void {
 		this.overlayWidgets.removeWidget(widgetData.widget);
+		this._scheduleRender();
+	}
+
+	public addEdgeWidget(widgetData: IEdgeWidgetData): void {
+		this.edgeWidgets.addWidget(widgetData.widget);
+		this.layoutEdgeWidget(widgetData);
+		this._scheduleRender();
+	}
+
+	public layoutEdgeWidget(widgetData: IEdgeWidgetData): void {
+		let newEdge = widgetData.position ? widgetData.position.edge : null;
+		let newSize = widgetData.position ? widgetData.position.size : null;
+		let shouldRender = this.edgeWidgets.setWidgetPosition(widgetData.widget, newEdge, newSize);
+		if (shouldRender) {
+			this._scheduleRender();
+		}
+	}
+
+	public removeEdgeWidget(widgetData: IEdgeWidgetData): void {
+		this.edgeWidgets.removeWidget(widgetData.widget);
 		this._scheduleRender();
 	}
 

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -51,7 +51,6 @@ import * as viewEvents from 'vs/editor/common/view/viewEvents';
 import { IThemeService, getThemeTypeSelector } from 'vs/platform/theme/common/themeService';
 import { Cursor } from 'vs/editor/common/controller/cursor';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
-import { EditorSnippetVariableResolver } from 'vs/editor/contrib/snippet/snippetVariables';
 
 export interface IContentWidgetData {
 	widget: editorBrowser.IContentWidget;

--- a/src/vs/editor/browser/view/viewPart.ts
+++ b/src/vs/editor/browser/view/viewPart.ts
@@ -35,6 +35,7 @@ export const enum PartFingerprint {
 	OverflowingContentWidgets,
 	OverflowGuard,
 	OverlayWidgets,
+	EdgeWidgets,
 	ScrollableElement,
 	TextArea,
 	ViewLines,

--- a/src/vs/editor/browser/viewParts/edgeWidgets/edgeWidgets.css
+++ b/src/vs/editor/browser/viewParts/edgeWidgets/edgeWidgets.css
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.monaco-editor .edgeWidgets {
+}

--- a/src/vs/editor/browser/viewParts/edgeWidgets/edgeWidgets.ts
+++ b/src/vs/editor/browser/viewParts/edgeWidgets/edgeWidgets.ts
@@ -80,7 +80,7 @@ export class ViewEdgeWidgets extends ViewPart {
 
 	public setWidgetPosition(widget: IEdgeWidget, edge: EdgeWidgetPositionEdge, size: number): boolean {
 		let widgetData = this._widgets[widget.getId()];
-		if (widgetData.edge === edge) {
+		if (widgetData.edge === edge && widgetData.size === size) {
 			return false;
 		}
 

--- a/src/vs/editor/browser/viewParts/edgeWidgets/edgeWidgets.ts
+++ b/src/vs/editor/browser/viewParts/edgeWidgets/edgeWidgets.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import 'vs/css!./edgeWidgets';
+import { FastDomNode, createFastDomNode } from 'vs/base/browser/fastDomNode';
+import { IEdgeWidget, EdgeWidgetPositionEdge } from 'vs/editor/browser/editorBrowser';
+import { ViewPart, PartFingerprint, PartFingerprints } from 'vs/editor/browser/view/viewPart';
+import { ViewContext } from 'vs/editor/common/view/viewContext';
+import { RenderingContext, RestrictedRenderingContext } from 'vs/editor/common/view/renderingContext';
+import * as viewEvents from 'vs/editor/common/view/viewEvents';
+
+interface IWidgetData {
+	widget: IEdgeWidget;
+	edge: EdgeWidgetPositionEdge;
+	size: number;
+	domNode: FastDomNode<HTMLElement>;
+}
+
+interface IWidgetMap {
+	[key: string]: IWidgetData;
+}
+
+export class ViewEdgeWidgets extends ViewPart {
+
+	private _widgets: IWidgetMap;
+	private _domNode: FastDomNode<HTMLElement>;
+
+	constructor(context: ViewContext) {
+		super(context);
+
+		this._widgets = {};
+
+		this._domNode = createFastDomNode(document.createElement('div'));
+		PartFingerprints.write(this._domNode, PartFingerprint.EdgeWidgets);
+		this._domNode.setClassName('edgeWidgets');
+	}
+
+	public dispose(): void {
+		super.dispose();
+		this._widgets = null;
+	}
+
+	public getDomNode(): FastDomNode<HTMLElement> {
+		return this._domNode;
+	}
+
+	// ---- begin view event handlers
+
+	public onConfigurationChanged(e: viewEvents.ViewConfigurationChangedEvent): boolean {
+		if (e.layoutInfo) {
+			//this._editorWidth = this._context.configuration.editor.layoutInfo.width;
+			return true;
+		}
+		return false;
+	}
+
+	// ---- end view event handlers
+
+	public addWidget(widget: IEdgeWidget): void {
+		const domNode = createFastDomNode(widget.getDomNode());
+
+		this._widgets[widget.getId()] = {
+			widget: widget,
+			edge: null,
+			size: null,
+			domNode: domNode
+		};
+
+		// This is sync because a widget wants to be in the dom
+		domNode.setPosition('absolute');
+		domNode.setAttribute('widgetId', widget.getId());
+		this._domNode.appendChild(domNode);
+
+		this.setShouldRender();
+	}
+
+	public setWidgetPosition(widget: IEdgeWidget, edge: EdgeWidgetPositionEdge, size: number): boolean {
+		let widgetData = this._widgets[widget.getId()];
+		if (widgetData.edge === edge) {
+			return false;
+		}
+
+		widgetData.edge = edge;
+		widgetData.size = size;
+		this.setShouldRender();
+
+		return true;
+	}
+
+	public removeWidget(widget: IEdgeWidget): void {
+		let widgetId = widget.getId();
+		if (this._widgets.hasOwnProperty(widgetId)) {
+			const widgetData = this._widgets[widgetId];
+			const domNode = widgetData.domNode.domNode;
+			delete this._widgets[widgetId];
+
+			domNode.parentNode.removeChild(domNode);
+			this.setShouldRender();
+		}
+	}
+
+	private _renderWidget(widgetData: IWidgetData): void {
+		const domNode = widgetData.domNode;
+
+		if (widgetData.edge === null) {
+			domNode.unsetTop();
+			return;
+		}
+
+		if (widgetData.edge === EdgeWidgetPositionEdge.TOP) {
+			domNode.setTop(0);
+			domNode.setLeft(0);
+			//domNode.setWidth
+		} else if (widgetData.edge === EdgeWidgetPositionEdge.BOTTOM) {
+			domNode.setBottom(0);
+			domNode.setLeft(0);
+		}
+	}
+
+	public prepareRender(ctx: RenderingContext): void {
+		// Nothing to read
+	}
+
+	public render(ctx: RestrictedRenderingContext): void {
+		//this._domNode.setWidth(this._editorWidth);
+
+		let keys = Object.keys(this._widgets);
+		for (let i = 0, len = keys.length; i < len; i++) {
+			let widgetId = keys[i];
+			this._renderWidget(this._widgets[widgetId]);
+		}
+	}
+}

--- a/src/vs/editor/browser/viewParts/editorScrollbar/editorScrollbar.ts
+++ b/src/vs/editor/browser/viewParts/editorScrollbar/editorScrollbar.ts
@@ -99,6 +99,7 @@ export class EditorScrollbar extends ViewPart {
 		const layoutInfo = this._context.configuration.editor.layoutInfo;
 
 		this.scrollbarDomNode.setLeft(layoutInfo.contentLeft);
+		this.scrollbarDomNode.setTop(layoutInfo.contentTop);
 		this.scrollbarDomNode.setWidth(layoutInfo.contentWidth + layoutInfo.minimapWidth);
 		this.scrollbarDomNode.setHeight(layoutInfo.contentHeight);
 	}

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -314,6 +314,7 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 		}
 
 		this.edgeWidgets[widget.getId()] = widgetData;
+		this._edgePaddings = null; // invalidate edge padding
 
 		if (this.hasView) {
 			this._view.addEdgeWidget(widgetData);
@@ -335,6 +336,7 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 	public removeEdgeWidget(widget: editorBrowser.IEdgeWidget): void {
 		let widgetId = widget.getId();
 		if (this.edgeWidgets.hasOwnProperty(widgetId)) {
+			this._edgePaddings = null; // invalidate edge padding
 			let widgetData = this.edgeWidgets[widgetId];
 			delete this.edgeWidgets[widgetId];
 			if (this.hasView) {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -149,20 +149,24 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 		return new Configuration(
 			options,
 			this.domElement,
-			{ getEdgePadding: () => this._getEdgePadding()});
+			{ getEdgePadding: () => this._getEdgePadding() });
 	}
 
 	private _getEdgePadding(): IEdgePaddings {
 		// TODO: cache the edge padding metrics in view
 		let topPadding = 0;
 		let bottomPadding = 0;
-		for (let key in this.edgeWidgets) if (Object.prototype.hasOwnProperty.apply(null, [key])) {
-			const edgew = this.edgeWidgets[key];
-			const posn = edgew.position;
-			if (posn.edge === editorBrowser.EdgeWidgetPositionEdge.TOP)
-				topPadding += posn.size; // TODO: sanitize
-			else if (posn.edge === editorBrowser.EdgeWidgetPositionEdge.BOTTOM)
-				bottomPadding += posn.size; // TODO: sanitize
+		for (let key in this.edgeWidgets) {
+			if (Object.prototype.hasOwnProperty.apply(null, [key])) {
+				const edgew = this.edgeWidgets[key];
+				const posn = edgew.position;
+				if (posn.edge === editorBrowser.EdgeWidgetPositionEdge.TOP) {
+					topPadding += posn.size; // TODO: sanitize
+				}
+				else if (posn.edge === editorBrowser.EdgeWidgetPositionEdge.BOTTOM) {
+					bottomPadding += posn.size; // TODO: sanitize
+				}
+			}
 		}
 
 		return {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -19,7 +19,7 @@ import { EditorAction, EditorExtensionsRegistry, IEditorContributionCtor } from 
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { Configuration } from 'vs/editor/browser/config/configuration';
 import * as editorBrowser from 'vs/editor/browser/editorBrowser';
-import { View, IOverlayWidgetData, IContentWidgetData } from 'vs/editor/browser/view/viewImpl';
+import { View, IOverlayWidgetData, IContentWidgetData, IEdgeWidgetData } from 'vs/editor/browser/view/viewImpl';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import Event, { Emitter } from 'vs/base/common/event';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
@@ -79,6 +79,7 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 
 	private contentWidgets: { [key: string]: IContentWidgetData; };
 	private overlayWidgets: { [key: string]: IOverlayWidgetData; };
+	private edgeWidgets: { [key: string]: IEdgeWidgetData; };
 
 	_view: View;
 
@@ -269,6 +270,45 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 			delete this.overlayWidgets[widgetId];
 			if (this.hasView) {
 				this._view.removeOverlayWidget(widgetData);
+			}
+		}
+	}
+
+	public addEdgeWidget(widget: editorBrowser.IEdgeWidget): void {
+		let widgetData: IEdgeWidgetData = {
+			widget: widget,
+			position: widget.getPosition()
+		};
+
+		if (this.edgeWidgets.hasOwnProperty(widget.getId())) {
+			console.warn('Overwriting an edge widget with the same id.');
+		}
+
+		this.edgeWidgets[widget.getId()] = widgetData;
+
+		if (this.hasView) {
+			this._view.addEdgeWidget(widgetData);
+		}
+	}
+
+	public layoutEdgeWidget(widget: editorBrowser.IEdgeWidget): void {
+		let widgetId = widget.getId();
+		if (this.edgeWidgets.hasOwnProperty(widgetId)) {
+			let widgetData = this.edgeWidgets[widgetId];
+			widgetData.position = widget.getPosition();
+			if (this.hasView) {
+				this._view.layoutEdgeWidget(widgetData);
+			}
+		}
+	}
+
+	public removeEdgeWidget(widget: editorBrowser.IEdgeWidget): void {
+		let widgetId = widget.getId();
+		if (this.edgeWidgets.hasOwnProperty(widgetId)) {
+			let widgetData = this.edgeWidgets[widgetId];
+			delete this.edgeWidgets[widgetId];
+			if (this.hasView) {
+				this._view.removeEdgeWidget(widgetData);
 			}
 		}
 	}

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -77,9 +77,9 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 
 	_configuration: Configuration;
 
-	private contentWidgets: { [key: string]: IContentWidgetData; };
-	private overlayWidgets: { [key: string]: IOverlayWidgetData; };
-	private edgeWidgets: { [key: string]: IEdgeWidgetData; };
+	private contentWidgets: { [key: string]: IContentWidgetData; } = {};
+	private overlayWidgets: { [key: string]: IOverlayWidgetData; } = {};
+	private edgeWidgets: { [key: string]: IEdgeWidgetData; } = {};
 
 	private _edgePaddings: IEdgePaddings;
 
@@ -109,10 +109,6 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 				this._onDidBlurEditor.fire();
 			}
 		});
-
-		this.contentWidgets = {};
-		this.overlayWidgets = {};
-		this.edgeWidgets = {};
 
 		let contributions = this._getContributions();
 		for (let i = 0, len = contributions.length; i < len; i++) {
@@ -159,7 +155,7 @@ export abstract class CodeEditorWidget extends CommonCodeEditor implements edito
 			let topPadding = 0;
 			let bottomPadding = 0;
 
-			let keys = Object.keys(this.edgeWidgets);
+			let keys = Object.keys(this.edgeWidgets || {}); // in case it's called before the constructor!
 			for (let i = 0; i < keys.length; i++) {
 				const edgew = this.edgeWidgets[keys[i]];
 				const posn = edgew.position;

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -53,6 +53,8 @@ export const TabFocus: ITabFocus = new class implements ITabFocus {
 
 export interface IEnvConfiguration {
 	extraEditorClassName: string;
+	paddingTop: number;
+	paddingBottom: number;
 	outerWidth: number;
 	outerHeight: number;
 	emptySelectionClipboard: boolean;
@@ -118,6 +120,8 @@ export abstract class CommonEditorConfiguration extends Disposable implements ed
 		const partialEnv = this._getEnvConfiguration();
 		const bareFontInfo = BareFontInfo.createFromRawSettings(this._rawOptions, partialEnv.zoomLevel);
 		const env: editorOptions.IEnvironmentalOptions = {
+			paddingTop: partialEnv.paddingTop,
+			paddingBottom: partialEnv.paddingBottom,
 			outerWidth: partialEnv.outerWidth,
 			outerHeight: partialEnv.outerHeight,
 			fontInfo: this.readConfiguration(bareFontInfo),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -996,6 +996,7 @@ export class InternalEditorOptions {
 			&& a.glyphMarginWidth === b.glyphMarginWidth
 			&& a.glyphMarginHeight === b.glyphMarginHeight
 			&& a.lineNumbersLeft === b.lineNumbersLeft
+			&& a.lineNumbersLeft === b.lineNumbersLeft
 			&& a.lineNumbersWidth === b.lineNumbersWidth
 			&& a.lineNumbersHeight === b.lineNumbersHeight
 			&& a.decorationsLeft === b.decorationsLeft
@@ -1238,6 +1239,10 @@ export interface EditorLayoutInfo {
 	 * Left position for the line numbers.
 	 */
 	readonly lineNumbersLeft: number;
+	/**
+	 * Top position for the line numbers.
+	 */
+	readonly lineNumbersTop: number;
 	/**
 	 * The width of the line numbers.
 	 */
@@ -2019,6 +2024,7 @@ export class EditorLayoutProvider {
 
 		const glyphMarginLeft = 0;
 		const lineNumbersLeft = glyphMarginLeft + glyphMarginWidth;
+		const lineNumbersTop = _opts.paddingTop;
 		const decorationsLeft = lineNumbersLeft + lineNumbersWidth;
 		const contentLeft = decorationsLeft + lineDecorationsWidth;
 		const contentTop = _opts.paddingTop;
@@ -2077,8 +2083,9 @@ export class EditorLayoutProvider {
 			glyphMarginHeight: outerHeight,
 
 			lineNumbersLeft: lineNumbersLeft,
+			lineNumbersTop: lineNumbersTop,
 			lineNumbersWidth: lineNumbersWidth,
-			lineNumbersHeight: outerHeight,
+			lineNumbersHeight: contentHeight,
 
 			decorationsLeft: decorationsLeft,
 			decorationsWidth: lineDecorationsWidth,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1336,6 +1336,8 @@ export interface IConfigurationChangedEvent {
  * @internal
  */
 export interface IEnvironmentalOptions {
+	readonly paddingTop: number;
+	readonly paddingBottom: number;
 	readonly outerWidth: number;
 	readonly outerHeight: number;
 	readonly fontInfo: FontInfo;
@@ -1821,6 +1823,8 @@ export class InternalEditorOptionsFactory {
 		}
 
 		const layoutInfo = EditorLayoutProvider.compute({
+			paddingTop: env.paddingTop,
+			paddingBottom: env.paddingBottom,
 			outerWidth: env.outerWidth,
 			outerHeight: env.outerHeight,
 			showGlyphMargin: opts.viewInfo.glyphMargin,
@@ -1947,6 +1951,9 @@ export class InternalEditorOptionsFactory {
  * @internal
  */
 export interface IEditorLayoutProviderOpts {
+	paddingTop: number;
+	paddingBottom: number;
+
 	outerWidth: number;
 	outerHeight: number;
 
@@ -1978,6 +1985,8 @@ export interface IEditorLayoutProviderOpts {
  */
 export class EditorLayoutProvider {
 	public static compute(_opts: IEditorLayoutProviderOpts): EditorLayoutInfo {
+		const paddingTop = _opts.paddingTop | 0;
+		const paddingBottom = _opts.paddingBottom | 0;
 		const outerWidth = _opts.outerWidth | 0;
 		const outerHeight = _opts.outerHeight | 0;
 		const showGlyphMargin = _opts.showGlyphMargin;
@@ -2057,6 +2066,8 @@ export class EditorLayoutProvider {
 
 		const verticalArrowSize = (verticalScrollbarHasArrows ? scrollbarArrowSize : 0);
 
+		const contentHeight = outerHeight - paddingTop - paddingBottom;
+
 		return {
 			width: outerWidth,
 			height: outerHeight,
@@ -2076,7 +2087,7 @@ export class EditorLayoutProvider {
 			contentLeft: contentLeft,
 			contentTop: contentTop,
 			contentWidth: contentWidth,
-			contentHeight: outerHeight,
+			contentHeight: contentHeight,
 
 			renderMinimap: renderMinimap,
 			minimapWidth: minimapWidth,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2021,7 +2021,7 @@ export class EditorLayoutProvider {
 		const lineNumbersLeft = glyphMarginLeft + glyphMarginWidth;
 		const decorationsLeft = lineNumbersLeft + lineNumbersWidth;
 		const contentLeft = decorationsLeft + lineDecorationsWidth;
-		const contentTop = 0;
+		const contentTop = _opts.paddingTop;
 
 		const remainingWidth = outerWidth - glyphMarginWidth - lineNumbersWidth - lineDecorationsWidth;
 

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1002,6 +1002,7 @@ export class InternalEditorOptions {
 			&& a.decorationsWidth === b.decorationsWidth
 			&& a.decorationsHeight === b.decorationsHeight
 			&& a.contentLeft === b.contentLeft
+			&& a.contentTop === b.contentTop
 			&& a.contentWidth === b.contentWidth
 			&& a.contentHeight === b.contentHeight
 			&& a.renderMinimap === b.renderMinimap
@@ -1259,6 +1260,10 @@ export interface EditorLayoutInfo {
 	 */
 	readonly decorationsHeight: number;
 
+	/**
+	 * Top position for the content (actual text)
+	 */
+	readonly contentTop: number;
 	/**
 	 * Left position for the content (actual text)
 	 */
@@ -2007,6 +2012,7 @@ export class EditorLayoutProvider {
 		const lineNumbersLeft = glyphMarginLeft + glyphMarginWidth;
 		const decorationsLeft = lineNumbersLeft + lineNumbersWidth;
 		const contentLeft = decorationsLeft + lineDecorationsWidth;
+		const contentTop = 0;
 
 		const remainingWidth = outerWidth - glyphMarginWidth - lineNumbersWidth - lineDecorationsWidth;
 
@@ -2068,6 +2074,7 @@ export class EditorLayoutProvider {
 			decorationsHeight: outerHeight,
 
 			contentLeft: contentLeft,
+			contentTop: contentTop,
 			contentWidth: contentWidth,
 			contentHeight: outerHeight,
 

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -6,7 +6,7 @@
 
 import 'vs/css!./standalone-tokens';
 import * as editorCommon from 'vs/editor/common/editorCommon';
-import { ICodeEditor, ContentWidgetPositionPreference, OverlayWidgetPositionPreference, MouseTargetType } from 'vs/editor/browser/editorBrowser';
+import { ICodeEditor, ContentWidgetPositionPreference, OverlayWidgetPositionPreference, MouseTargetType, EdgeWidgetPositionEdge } from 'vs/editor/browser/editorBrowser';
 import { StandaloneEditor, IStandaloneCodeEditor, StandaloneDiffEditor, IStandaloneDiffEditor, IEditorConstructionOptions, IDiffEditorConstructionOptions } from 'vs/editor/standalone/browser/standaloneCodeEditor';
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { IEditorOverrideServices, DynamicStandaloneServices, StaticServices } from 'vs/editor/standalone/browser/standaloneServices';
@@ -388,6 +388,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		TextEditorCursorBlinkingStyle: editorOptions.TextEditorCursorBlinkingStyle,
 		ContentWidgetPositionPreference: ContentWidgetPositionPreference,
 		OverlayWidgetPositionPreference: OverlayWidgetPositionPreference,
+		EdgeWidgetPositionEdge: EdgeWidgetPositionEdge,
 		RenderMinimap: editorOptions.RenderMinimap,
 		ScrollType: <any>ScrollType,
 		RenderLineNumbersType: <any>RenderLineNumbersType,

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -118,6 +118,9 @@ export class TestCodeEditor extends CommonCodeEditor implements editorBrowser.IC
 	addOverlayWidget(widget: editorBrowser.IOverlayWidget): void { throw new Error('Not implemented'); }
 	layoutOverlayWidget(widget: editorBrowser.IOverlayWidget): void { throw new Error('Not implemented'); }
 	removeOverlayWidget(widget: editorBrowser.IOverlayWidget): void { throw new Error('Not implemented'); }
+	addEdgeWidget(widget: editorBrowser.IEdgeWidget): void { throw new Error('Not implemented'); }
+	layoutEdgeWidget(widget: editorBrowser.IEdgeWidget): void { throw new Error('Not implemented'); }
+	removeEdgeWidget(widget: editorBrowser.IEdgeWidget): void { throw new Error('Not implemented'); }
 	changeViewZones(callback: (accessor: editorBrowser.IViewZoneChangeAccessor) => void): void { throw new Error('Not implemented'); }
 	getOffsetForColumn(lineNumber: number, column: number): number { throw new Error('Not implemented'); }
 	render(): void { throw new Error('Not implemented'); }

--- a/src/vs/editor/test/common/mocks/testConfiguration.ts
+++ b/src/vs/editor/test/common/mocks/testConfiguration.ts
@@ -19,6 +19,8 @@ export class TestConfiguration extends CommonEditorConfiguration {
 	protected _getEnvConfiguration(): IEnvConfiguration {
 		return {
 			extraEditorClassName: '',
+			paddingTop: 0,
+			paddingBottom: 0,
 			outerWidth: 100,
 			outerHeight: 100,
 			emptySelectionClipboard: true,

--- a/src/vs/editor/test/common/viewLayout/editorLayoutProvider.test.ts
+++ b/src/vs/editor/test/common/viewLayout/editorLayoutProvider.test.ts
@@ -51,6 +51,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 800,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 990,
 				contentHeight: 800,
 
@@ -107,6 +108,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 800,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 990,
 				contentHeight: 800,
 
@@ -163,6 +165,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 800,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 890,
 				contentHeight: 800,
 
@@ -219,6 +222,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 890,
 				contentHeight: 900,
 
@@ -275,6 +279,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 890,
 				contentHeight: 900,
 
@@ -331,6 +336,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 60,
+				contentTop: 0,
 				contentWidth: 840,
 				contentHeight: 900,
 
@@ -387,6 +393,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 60,
+				contentTop: 0,
 				contentWidth: 840,
 				contentHeight: 900,
 
@@ -443,6 +450,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 70,
+				contentTop: 0,
 				contentWidth: 830,
 				contentHeight: 900,
 
@@ -499,6 +507,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 40,
+				contentTop: 0,
 				contentWidth: 860,
 				contentHeight: 900,
 
@@ -555,6 +564,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 900,
 
 				contentLeft: 40,
+				contentTop: 0,
 				contentWidth: 860,
 				contentHeight: 900,
 
@@ -611,6 +621,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 800,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 900,
 				contentHeight: 800,
 
@@ -667,6 +678,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 800,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 900,
 				contentHeight: 800,
 
@@ -723,6 +735,7 @@ suite('Editor ViewLayout - EditorLayoutProvider', () => {
 				decorationsHeight: 800,
 
 				contentLeft: 10,
+				contentTop: 0,
 				contentWidth: 943,
 				contentHeight: 800,
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3162,6 +3162,10 @@ declare module monaco.editor {
 		 */
 		readonly lineNumbersLeft: number;
 		/**
+		 * Top position for the line numbers.
+		 */
+		readonly lineNumbersTop: number;
+		/**
 		 * The width of the line numbers.
 		 */
 		readonly lineNumbersWidth: number;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3182,6 +3182,10 @@ declare module monaco.editor {
 		 */
 		readonly decorationsHeight: number;
 		/**
+		 * Top position for the content (actual text)
+		 */
+		readonly contentTop: number;
+		/**
 		 * Left position for the content (actual text)
 		 */
 		readonly contentLeft: number;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3422,6 +3422,47 @@ declare module monaco.editor {
 	}
 
 	/**
+	 * A positioning preference for rendering content widgets.
+	 */
+	export enum EdgeWidgetPositionEdge {
+		/**
+		 * Place the edge widget at the top
+		 */
+		TOP = 0,
+		/**
+		 * Place the edge widget at the bottom
+		 */
+		BOTTOM = 1,
+	}
+
+	/**
+	 * A position for rendering edge widgets.
+	 */
+	export interface IEdgeWidgetPosition {
+		size: number;
+		edge: EdgeWidgetPositionEdge;
+	}
+
+	/**
+	 * An edge widget renders at the requested edge and pushed content inside.
+	 */
+	export interface IEdgeWidget {
+		/**
+		 * Get a unique identifier of the edge widget.
+		 */
+		getId(): string;
+		/**
+		 * Get the dom node of the content widget.
+		 */
+		getDomNode(): HTMLElement;
+		/**
+		 * Get the placement of the content widget.
+		 * If null is returned, the content widget will be placed off screen.
+		 */
+		getPosition(): IEdgeWidgetPosition;
+	}
+
+	/**
 	 * Type of hit element with the mouse in the editor.
 	 */
 	export enum MouseTargetType {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3830,6 +3830,19 @@ declare module monaco.editor {
 		 */
 		removeOverlayWidget(widget: IOverlayWidget): void;
 		/**
+		 * Add an edge widget. Widgets must have unique ids, otherwise they will be overwritten.
+		 */
+		addEdgeWidget(widget: IEdgeWidget): void;
+		/**
+		 * Layout/Reposition an edge widget. This is a ping to the editor to call widget.getPosition()
+		 * and update appropiately.
+		 */
+		layoutEdgeWidget(widget: IEdgeWidget): void;
+		/**
+		 * Remove an edge widget.
+		 */
+		removeEdgeWidget(widget: IEdgeWidget): void;
+		/**
 		 * Change the view zones. View zones are lost when a new model is attached to the editor.
 		 */
 		changeViewZones(callback: (accessor: IViewZoneChangeAccessor) => void): void;


### PR DESCRIPTION
Fully functional, but not very well styled navigational toolbar, as described in <a href="https://github.com/Microsoft/vscode/issues/9418">#9418 Feature Request : Navigation Bar like Visual Studio or Eclipse</a>

<img width="866" alt="screen shot 2017-07-25 at 08 17 47" src="https://user-images.githubusercontent.com/4041967/28586910-384d545e-716d-11e7-8d5a-b0833233429b.png">

Clicking on the breadcrumb element scrolls editor and places cursor onto it. Also flashes the symbol momentarily. Neat navigation!

On startup it takes a little while to appear (language service need to initialise). Then it follows cursor movement and editing of course!

By relying on standard `DocumentSymbolProvider`, it just works with whatever lexical model current editor uses. Picks up deep parsing features in TypeScript, and uses dumber match editing JSON.

Missing pieces
--------------

**Styling** is beyond naive: just applying CSS within code. I'm keen to do it properly, but need guidance please!

**Diff mode** only populates navbar for edited panel, the original code isn't decorated with navbar. It looks silly on screen, and could be helpful to enable in Diff/original too.

**Everything is in one file** -- should I separate the logic from that `codeEditor` somewhere else? Any guidance is welcome!

**No tests** please guide me what's the best approach here: where should tests go?

More features to add
-------------------

* Hover over symbol name in navbar can highlight its location in editor
* Icons for different symbol kinds
* Use further language service features for tooltips
* Allow dropdown-like functionality for selecting and navigating to sibling symbols