### PR TITLE
Handle Alt+Click for terminal links. Fixes #30761

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
@@ -75,7 +75,6 @@ export class TerminalLinkHandler {
 
 		this._xterm.setHypertextLinkHandler(this._wrapLinkHandler(uri => {
 			this._handleHypertextLink(uri);
-			return;
 		}));
 
 		this._xterm.setHypertextValidationCallback((uri: string, element: HTMLElement, callback: (isValid: boolean) => void) => {
@@ -106,7 +105,6 @@ export class TerminalLinkHandler {
 	public registerLocalLinkHandler(): number {
 		const wrappedHandler = this._wrapLinkHandler(url => {
 			this._handleLocalLink(url);
-			return;
 		});
 
 		return this._xterm.registerLinkMatcher(this._localLinkRegex, wrappedHandler, {
@@ -170,10 +168,9 @@ export class TerminalLinkHandler {
 		callback(true);
 	}
 
-	private _handleHypertextLink(url: string) {
+	private _handleHypertextLink(url: string): void {
 		let uri = Uri.parse(url);
 		this._openerService.open(uri);
-		return;
 	}
 
 	private _isLinkActivationModifierDown(event: MouseEvent): boolean {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
@@ -72,7 +72,12 @@ export class TerminalLinkHandler {
 		const baseLocalLinkClause = _platform === platform.Platform.Windows ? winLocalLinkClause : unixLocalLinkClause;
 		// Append line and column number regex
 		this._localLinkPattern = new RegExp(`${baseLocalLinkClause}(${lineAndColumnClause})`);
-		this._xterm.setHypertextLinkHandler(this._wrapLinkHandler(() => true));
+
+		this._xterm.setHypertextLinkHandler(this._wrapLinkHandler(uri => {
+			this._handleHypertextLink(uri);
+			return;
+		}));
+
 		this._xterm.setHypertextValidationCallback((uri: string, element: HTMLElement, callback: (isValid: boolean) => void) => {
 			this._validateWebLink(uri, element, callback);
 		});
@@ -117,9 +122,10 @@ export class TerminalLinkHandler {
 
 	private _wrapLinkHandler(handler: (uri: string) => boolean | void): XtermLinkMatcherHandler {
 		return (event: MouseEvent, uri: string) => {
+			// Prevent default electron link handling so Alt+Click mode works normally
+			event.preventDefault();
 			// Require correct modifier on click
 			if (!this._isLinkActivationModifierDown(event)) {
-				event.preventDefault();
 				return false;
 			}
 			return handler(uri);
@@ -162,6 +168,12 @@ export class TerminalLinkHandler {
 	private _validateWebLink(link: string, element: HTMLElement, callback: (isValid: boolean) => void): void {
 		this._addTooltipEventListeners(element);
 		callback(true);
+	}
+
+	private _handleHypertextLink(url: string) {
+		let uri = Uri.parse(url);
+		this._openerService.open(uri);
+		return;
 	}
 
 	private _isLinkActivationModifierDown(event: MouseEvent): boolean {


### PR DESCRIPTION
@Tyriar 
- See #30761 for discussion
- Added hypertext link handling to bypass default electron link handling for Alt+Click (was opening save dialog)
- Tested on Windows and OS X
- The validate links should provide the error handling before the opener calls

Fixes #30761