### PR TITLE
Git Extension: Expose APIs for external extensions

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -594,6 +594,10 @@ export class CommandCenter {
 		await this.model.clean(...this.model.workingTreeGroup.resources);
 	}
 
+	public async commitStagedWithMessage(commitMessage? : string): Promise<void> {
+		await this.smartCommit(async () => commitMessage, { all: false });
+	}
+
 	private async smartCommit(
 		getCommitMessage: () => Promise<string | undefined>,
 		opts?: CommitOptions


### PR DESCRIPTION
This change allows to implement external extensions which could execute build in CI for list of modified files. It exposes following APIs:
* Get list of staged resources
* `git commit` command execution with a custom message
* `git push` command execution

More details and use case in #25838.