### PR TITLE
Terminal: Add Find next/previous key bindings. Fixes: #29661

### DIFF
--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -159,6 +159,8 @@ export interface ITerminalService {
 	hidePanel(): void;
 	focusFindWidget(): TPromise<void>;
 	hideFindWidget(): void;
+	nextMatchFindWidget(): void;
+	previousMatchFindWidget(): void;
 	setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): void;
 	updateConfig(): void;
 	selectDefaultWindowsShell(): TPromise<string>;

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -204,6 +204,8 @@ export abstract class TerminalService implements ITerminalService {
 
 	public abstract focusFindWidget(): TPromise<void>;
 	public abstract hideFindWidget(): void;
+	public abstract nextMatchFindWidget(): void;
+	public abstract previousMatchFindWidget(): void;
 
 	private _getIndexFromId(terminalId: number): number {
 		let terminalIndex = -1;

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -325,12 +325,10 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(HideTerminalFind
 	secondary: [KeyCode.Shift | KeyCode.Escape]
 }, ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE)), 'Terminal: Focus Find Widget', category);
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(NextMatchTerminalFindWidgetAction, NextMatchTerminalFindWidgetAction.ID, NextMatchTerminalFindWidgetAction.LABEL, {
-	primary: KeyCode.F3,
-	mac: { primary: KeyMod.CtrlCmd | KeyCode.F3 }
+	primary: KeyCode.F3
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Find Next', category);
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(PreviousMatchTerminalFindWidgetAction, PreviousMatchTerminalFindWidgetAction.ID, PreviousMatchTerminalFindWidgetAction.LABEL, {
-	primary: KeyMod.Shift | KeyCode.F3,
-	mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F3 }
+	primary: KeyMod.Shift | KeyCode.F3
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Find Previous', category);
 
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -17,7 +17,7 @@ import { TERMINAL_DEFAULT_SHELL_LINUX, TERMINAL_DEFAULT_SHELL_OSX, TERMINAL_DEFA
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actionRegistry';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { KillTerminalAction, CopyTerminalSelectionAction, CreateNewTerminalAction, FocusActiveTerminalAction, FocusNextTerminalAction, FocusPreviousTerminalAction, FocusTerminalAtIndexAction, SelectDefaultShellWindowsTerminalAction, RunSelectedTextInTerminalAction, RunActiveFileInTerminalAction, ScrollDownTerminalAction, ScrollDownPageTerminalAction, ScrollToBottomTerminalAction, ScrollUpTerminalAction, ScrollUpPageTerminalAction, ScrollToTopTerminalAction, TerminalPasteAction, ToggleTerminalAction, ClearTerminalAction, AllowWorkspaceShellTerminalCommand, DisallowWorkspaceShellTerminalCommand, RenameTerminalAction, SelectAllTerminalAction, FocusTerminalFindWidgetAction, HideTerminalFindWidgetAction, DeleteWordLeftTerminalAction, DeleteWordRightTerminalAction } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
+import { KillTerminalAction, CopyTerminalSelectionAction, CreateNewTerminalAction, FocusActiveTerminalAction, FocusNextTerminalAction, FocusPreviousTerminalAction, FocusTerminalAtIndexAction, SelectDefaultShellWindowsTerminalAction, RunSelectedTextInTerminalAction, RunActiveFileInTerminalAction, ScrollDownTerminalAction, ScrollDownPageTerminalAction, ScrollToBottomTerminalAction, ScrollUpTerminalAction, ScrollUpPageTerminalAction, ScrollToTopTerminalAction, TerminalPasteAction, ToggleTerminalAction, ClearTerminalAction, AllowWorkspaceShellTerminalCommand, DisallowWorkspaceShellTerminalCommand, RenameTerminalAction, SelectAllTerminalAction, FocusTerminalFindWidgetAction, HideTerminalFindWidgetAction, DeleteWordLeftTerminalAction, DeleteWordRightTerminalAction, NextMatchTerminalFindWidgetAction, PreviousMatchTerminalFindWidgetAction } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ShowAllCommandsAction } from 'vs/workbench/parts/quickopen/browser/commandsHandler';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
@@ -204,6 +204,8 @@ configurationRegistry.registerConfiguration({
 				SelectAllTerminalAction.ID,
 				FocusTerminalFindWidgetAction.ID,
 				HideTerminalFindWidgetAction.ID,
+				NextMatchTerminalFindWidgetAction.ID,
+				PreviousMatchTerminalFindWidgetAction.ID,
 				NavigateUpAction.ID,
 				NavigateDownAction.ID,
 				NavigateRightAction.ID,
@@ -322,6 +324,16 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(HideTerminalFind
 	primary: KeyCode.Escape,
 	secondary: [KeyCode.Shift | KeyCode.Escape]
 }, ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE)), 'Terminal: Focus Find Widget', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(NextMatchTerminalFindWidgetAction, NextMatchTerminalFindWidgetAction.ID, NextMatchTerminalFindWidgetAction.LABEL, {
+	primary: KeyCode.F3,
+	mac: { primary: KeyMod.CtrlCmd | KeyCode.F3 }
+}, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Find Next', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(PreviousMatchTerminalFindWidgetAction, PreviousMatchTerminalFindWidgetAction.ID, PreviousMatchTerminalFindWidgetAction.LABEL, {
+	primary: KeyMod.Shift | KeyCode.F3,
+	mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F3 }
+}, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Find Previous', category);
+
+
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DeleteWordLeftTerminalAction, DeleteWordLeftTerminalAction.ID, DeleteWordLeftTerminalAction.LABEL, {
 	primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 	mac: { primary: KeyMod.Alt | KeyCode.Backspace }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -325,10 +325,12 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(HideTerminalFind
 	secondary: [KeyCode.Shift | KeyCode.Escape]
 }, ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE)), 'Terminal: Focus Find Widget', category);
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(NextMatchTerminalFindWidgetAction, NextMatchTerminalFindWidgetAction.ID, NextMatchTerminalFindWidgetAction.LABEL, {
-	primary: KeyCode.F3
+	primary: KeyCode.F3,
+	mac: { primary: KeyMod.CtrlCmd | KeyCode.KEY_G, secondary: [KeyCode.F3] }
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Find Next', category);
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(PreviousMatchTerminalFindWidgetAction, PreviousMatchTerminalFindWidgetAction.ID, PreviousMatchTerminalFindWidgetAction.LABEL, {
-	primary: KeyMod.Shift | KeyCode.F3
+	primary: KeyMod.Shift | KeyCode.F3,
+	mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_G, secondary: [KeyMod.Shift | KeyCode.F3] }
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Find Previous', category);
 
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -665,7 +665,7 @@ export class HideTerminalFindWidgetAction extends Action {
 export class NextMatchTerminalFindWidgetAction extends Action {
 
 	public static ID = 'workbench.action.terminal.nextMatchFindWidget';
-	public static LABEL = nls.localize('workbench.action.terminal.nextMatchFindWidget', "Find Widget: Next Match");
+	public static LABEL = nls.localize('workbench.action.terminal.nextMatchFindWidget', "Terminal: Find Next Match");
 
 	constructor(
 		id: string, label: string,
@@ -682,7 +682,7 @@ export class NextMatchTerminalFindWidgetAction extends Action {
 export class PreviousMatchTerminalFindWidgetAction extends Action {
 
 	public static ID = 'workbench.action.terminal.previousMatchFindWidget';
-	public static LABEL = nls.localize('workbench.action.terminal.previousMatchFindWidget', "Find Widget: previous Match");
+	public static LABEL = nls.localize('workbench.action.terminal.previousMatchFindWidget', "Terminal: Find Previous Match");
 
 	constructor(
 		id: string, label: string,

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -661,3 +661,37 @@ export class HideTerminalFindWidgetAction extends Action {
 		return TPromise.as(this.terminalService.hideFindWidget());
 	}
 }
+
+export class NextMatchTerminalFindWidgetAction extends Action {
+
+	public static ID = 'workbench.action.terminal.nextMatchFindWidget';
+	public static LABEL = nls.localize('workbench.action.terminal.nextMatchFindWidget', "Find Widget: Next Match");
+
+	constructor(
+		id: string, label: string,
+		@ITerminalService private terminalService: ITerminalService
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<any> {
+		return TPromise.as(this.terminalService.nextMatchFindWidget());
+	}
+}
+
+export class PreviousMatchTerminalFindWidgetAction extends Action {
+
+	public static ID = 'workbench.action.terminal.previousMatchFindWidget';
+	public static LABEL = nls.localize('workbench.action.terminal.previousMatchFindWidget', "Find Widget: previous Match");
+
+	constructor(
+		id: string, label: string,
+		@ITerminalService private terminalService: ITerminalService
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<any> {
+		return TPromise.as(this.terminalService.previousMatchFindWidget());
+	}
+}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -174,6 +174,14 @@ export class TerminalPanel extends Panel {
 		this._findWidget.hide();
 	}
 
+	public nextMatchFindWidget(): void {
+		this._findWidget.find(false);
+	}
+
+	public previousMatchFindWidget(): void {
+		this._findWidget.find(true);
+	}
+
 	private _attachEventListeners(): void {
 		this._register(dom.addDisposableListener(this._parentDomElement, 'mousedown', (event: MouseEvent) => {
 			if (this._terminalService.terminalInstances.length === 0) {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -86,6 +86,20 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 		}
 	}
 
+	public nextMatchFindWidget(): void {
+		const panel = this._panelService.getActivePanel() as TerminalPanel;
+		if (panel && panel.getId() === TERMINAL_PANEL_ID) {
+			panel.nextMatchFindWidget();
+		}
+	}
+
+	public previousMatchFindWidget(): void {
+		const panel = this._panelService.getActivePanel() as TerminalPanel;
+		if (panel && panel.getId() === TERMINAL_PANEL_ID) {
+			panel.previousMatchFindWidget();
+		}
+	}
+
 	private _suggestShellChange(wasNewTerminalAction?: boolean): void {
 		// Only suggest on Windows since $SHELL works great for macOS/Linux
 		if (!platform.isWindows) {


### PR DESCRIPTION
@Tyriar 
- Tried my best at naming nomenclature not perfect but matches most things
- Went through terminal services like focus and hide commands 
- Testing both Windows and OS X

Fixes: #29661 