### PR TITLE
Update dotnet build task

### DIFF
--- a/src/vs/workbench/parts/tasks/common/taskTemplates.ts
+++ b/src/vs/workbench/parts/tasks/common/taskTemplates.ts
@@ -28,7 +28,7 @@ const dotnetBuild: TaskEntry = {
 		'\t"tasks": [',
 		'\t\t{',
 		'\t\t\t"taskName": "build",',
-		'\t\t\t"command": "dotnet",',
+		'\t\t\t"command": "dotnet build",',
 		'\t\t\t"type": "shell",',
 		'\t\t\t"group": "build",',
 		'\t\t\t"presentation": {',


### PR DESCRIPTION
By updating the task configuration to 2.0.0 the task name doesn't get automatically appended to the command. The correct build command for dotnet should therefore be 'dotnet build'.