### PR TITLE
Add "indentationRules" for Lua

### DIFF
--- a/extensions/lua/language-configuration.json
+++ b/extensions/lua/language-configuration.json
@@ -23,7 +23,7 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*((function|else|elseif|for|if|until|while)|(.*\\sdo\\b))\\b[^\\{;]*$",
+		"increaseIndentPattern": "^\\s*(((?:local\\s+)?function|else|elseif|for|if|until|while)|(.*\\sdo\\b))\\b[^\\{;]*$",
 		"decreaseIndentPattern": "^\\s*((end|else|elseif)|[}\\]]\b)"
 	}
 }

--- a/extensions/lua/language-configuration.json
+++ b/extensions/lua/language-configuration.json
@@ -21,5 +21,9 @@
 		["(", ")"],
 		["\"", "\""],
 		["'", "'"]
-	]
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "^\\s*((function|else|elseif|for|if|until|while)|(.*\\sdo\\b))\\b[^\\{;]*$",
+		"decreaseIndentPattern": "^\\s*((end|else|elseif)|[}\\]]\b)"
+	}
 }


### PR DESCRIPTION
This adds indentation rules for Lua, like what Ruby needed in #2272.