### PR TITLE
Use r+ with truncation when saving existing files

### DIFF
--- a/src/vs/base/node/extfs.ts
+++ b/src/vs/base/node/extfs.ts
@@ -339,8 +339,6 @@ export function writeFileAndFlush(path: string, data: string | NodeBuffer, optio
 
 	if (!options) {
 		options = { encoding: 'utf8', mode: 0o666, flag: 'w' };
-	} else if (typeof options === 'string') {
-		options = { encoding: <string>options, mode: 0o666, flag: 'w' };
 	}
 
 	// Open the file with same flags and mode as fs.writeFile()

--- a/src/vs/base/node/extfs.ts
+++ b/src/vs/base/node/extfs.ts
@@ -332,13 +332,13 @@ export function mv(source: string, target: string, callback: (error: Error) => v
 //
 // See https://github.com/nodejs/node/blob/v5.10.0/lib/fs.js#L1194
 let canFlush = true;
-export function writeFileAndFlush(path: string, data: string | NodeBuffer, options: { encoding?: string; mode?: number; flag?: string; }, callback: (error: Error) => void): void {
+export function writeFileAndFlush(path: string, data: string | NodeBuffer, options: { mode?: number; flag?: string; }, callback: (error: Error) => void): void {
 	if (!canFlush) {
 		return fs.writeFile(path, data, options, callback);
 	}
 
 	if (!options) {
-		options = { encoding: 'utf8', mode: 0o666, flag: 'w' };
+		options = { mode: 0o666, flag: 'w' };
 	}
 
 	// Open the file with same flags and mode as fs.writeFile()
@@ -348,7 +348,7 @@ export function writeFileAndFlush(path: string, data: string | NodeBuffer, optio
 		}
 
 		// It is valid to pass a fd handle to fs.writeFile() and this will keep the handle open!
-		fs.writeFile(fd, data, options.encoding, (writeError) => {
+		fs.writeFile(fd, data, (writeError) => {
 			if (writeError) {
 				return fs.close(fd, () => callback(writeError)); // still need to close the handle on error!
 			}

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -124,9 +124,9 @@ export function readFile(path: string, encoding?: string): TPromise<Buffer | str
 // Therefor we use a Queue on the path that is given to us to sequentialize calls to the same path properly.
 const writeFilePathQueue: { [path: string]: Queue<void> } = Object.create(null);
 
-export function writeFile(path: string, data: string, options?: string | { mode?: number; flag?: string; }): TPromise<void>;
-export function writeFile(path: string, data: NodeBuffer, options?: string | { mode?: number; flag?: string; }): TPromise<void>;
-export function writeFile(path: string, data: any, options?: string | { mode?: number; flag?: string; }): TPromise<void> {
+export function writeFile(path: string, data: string, options?: { mode?: number; flag?: string; }): TPromise<void>;
+export function writeFile(path: string, data: NodeBuffer, options?: { mode?: number; flag?: string; }): TPromise<void>;
+export function writeFile(path: string, data: any, options?: { mode?: number; flag?: string; }): TPromise<void> {
 	let queueKey = toQueueKey(path);
 
 	return ensureWriteFileQueue(queueKey).queue(() => nfcall(extfs.writeFileAndFlush, path, data, options));

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -109,6 +109,10 @@ export function touch(path: string): TPromise<void> {
 	return nfcall(fs.utimes, path, now, now);
 }
 
+export function truncate(path: string, len: number): TPromise<void> {
+	return nfcall(fs.truncate, path, len);
+}
+
 export function readFile(path: string): TPromise<Buffer>;
 export function readFile(path: string, encoding: string): TPromise<string>;
 export function readFile(path: string, encoding?: string): TPromise<Buffer | string> {
@@ -120,12 +124,12 @@ export function readFile(path: string, encoding?: string): TPromise<Buffer | str
 // Therefor we use a Queue on the path that is given to us to sequentialize calls to the same path properly.
 const writeFilePathQueue: { [path: string]: Queue<void> } = Object.create(null);
 
-export function writeFile(path: string, data: string, encoding?: string): TPromise<void>;
-export function writeFile(path: string, data: NodeBuffer, encoding?: string): TPromise<void>;
-export function writeFile(path: string, data: any, encoding: string = 'utf8'): TPromise<void> {
+export function writeFile(path: string, data: string, options?: string | { encoding?: string; mode?: number; flag?: string; }): TPromise<void>;
+export function writeFile(path: string, data: NodeBuffer, options?: string | { encoding?: string; mode?: number; flag?: string; }): TPromise<void>;
+export function writeFile(path: string, data: any, options?: string | { encoding?: string; mode?: number; flag?: string; }): TPromise<void> {
 	let queueKey = toQueueKey(path);
 
-	return ensureWriteFileQueue(queueKey).queue(() => nfcall(extfs.writeFileAndFlush, path, data, encoding));
+	return ensureWriteFileQueue(queueKey).queue(() => nfcall(extfs.writeFileAndFlush, path, data, options));
 }
 
 function toQueueKey(path: string): string {

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -124,9 +124,9 @@ export function readFile(path: string, encoding?: string): TPromise<Buffer | str
 // Therefor we use a Queue on the path that is given to us to sequentialize calls to the same path properly.
 const writeFilePathQueue: { [path: string]: Queue<void> } = Object.create(null);
 
-export function writeFile(path: string, data: string, options?: string | { encoding?: string; mode?: number; flag?: string; }): TPromise<void>;
-export function writeFile(path: string, data: NodeBuffer, options?: string | { encoding?: string; mode?: number; flag?: string; }): TPromise<void>;
-export function writeFile(path: string, data: any, options?: string | { encoding?: string; mode?: number; flag?: string; }): TPromise<void> {
+export function writeFile(path: string, data: string, options?: string | { mode?: number; flag?: string; }): TPromise<void>;
+export function writeFile(path: string, data: NodeBuffer, options?: string | { mode?: number; flag?: string; }): TPromise<void>;
+export function writeFile(path: string, data: any, options?: string | { mode?: number; flag?: string; }): TPromise<void> {
 	let queueKey = toQueueKey(path);
 
 	return ensureWriteFileQueue(queueKey).queue(() => nfcall(extfs.writeFileAndFlush, path, data, options));

--- a/src/vs/workbench/services/files/node/fileService.ts
+++ b/src/vs/workbench/services/files/node/fileService.ts
@@ -368,7 +368,7 @@ export class FileService implements IFileService {
 						return this.resolve(resource);
 					}, error => {
 						// Can't use 'w' for hidden files, so truncate and use 'r+' if the file exists
-						if (!exists || error.code !== 'EPERM') {
+						if (!exists || error.code !== 'EPERM' || !isWindows) {
 							throw error;
 						}
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/931

Here's how things got this way:

1. Windows API requires the `FILE_ATTRIBUTE_HIDDEN` flag when calling [`CreateFile`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx) on a hidden file if `CREATE_ALWAYS` is specified.
2. Microsoft C run-time library never uses this flag, consequently `fopen` in `w` mode fails on hidden files.
3. libuv follows MS CRT's behavior on Windows and fails with `UV_EPERM` when `uv_fs_open` is called with `O_WRONLY|O_CREAT|O_TRUNC` (aka "w") on a hidden file.
4. Node.js uses `uv_fs_open` to implement `fs.open` and thus fails with `EPERM` when trying to open a hidden file with `flags='w'`.
5. Visual Studio Code opens the file with `flags='w'` when saving a file, which [fails on hidden files](https://github.com/Microsoft/vscode/issues/931). We've gone full circle.

This PR uses `r+` when opening existing files and truncates them. We can't do it just for hidden files since Node.js doesn't provide an API to query the hiddenness of a file. We also can't do it for all files since `r+` fails if the file doesn't exist.