### PR TITLE
Capitalize cmd name

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -694,7 +694,7 @@ export class QuickOpenActionTermContributor extends ActionBarContributor {
 export class QuickOpenTermAction extends Action {
 
 	public static ID = 'workbench.action.quickOpenTerm';
-	public static LABEL = nls.localize('quickOpenTerm', "Switch active terminal");
+	public static LABEL = nls.localize('quickOpenTerm', "Terminal: Switch Active Terminal");
 
 	constructor(
 		id: string,


### PR DESCRIPTION
To align with other command palette names.