### PR TITLE
Fix some possible TSServer spawn issues

### DIFF
--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -599,10 +599,6 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 	}
 
 	private get mainWorkspaceRootPath(): string | undefined {
-		if (workspace.rootPath) {
-			return workspace.rootPath;
-		}
-
 		if (workspace.workspaceFolders && workspace.workspaceFolders.length) {
 			return workspace.workspaceFolders[0].uri.fsPath;
 		}


### PR DESCRIPTION
**Bug**
A few users are seeing issues spaning the tsserver. The most common error seems to be ERRNO when spawning it

**Fix**
- Ensure we always try to set `env.PATH`
- Use `require.resolve` to check the existance of the `electronForkStart` helper before calling spawn