### PR TITLE
Feature/file nesting

### DIFF
--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -227,7 +227,9 @@ export class Item extends Events.EventEmitter {
 		this.element = element;
 
 		this.id = id;
-		this.registry.register(this);
+		if (!this.registry.isRegistered(this.id)) {
+			this.registry.register(this);
+		}
 
 		this.doesHaveChildren = this.context.dataSource.hasChildren(this.context.tree, this.element);
 		this.needsChildrenRefresh = true;
@@ -411,6 +413,9 @@ export class Item extends Events.EventEmitter {
 				var staleItems: IItemMap = {};
 				while (this.firstChild !== null) {
 					staleItems[this.firstChild.id] = this.firstChild;
+					// if (this.registry.isRegistered(this.firstChild.id)) {
+					// 	this.registry.deregister(this.firstChild);
+					// }
 					this.removeChild(this.firstChild);
 				}
 
@@ -597,7 +602,9 @@ export class Item extends Events.EventEmitter {
 		var eventData: IItemDisposeEvent = { item: this };
 		this.emit('item:dispose', eventData);
 
-		this.registry.deregister(this);
+		if (this.registry.isRegistered(this.id)) {
+			this.registry.deregister(this);
+		}
 		super.dispose();
 
 		this._isDisposed = true;

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -555,6 +555,14 @@ export interface IFilesConfiguration {
 		eol: string;
 		hotExit: string;
 		useExperimentalFileWatcher: boolean;
+		nesting: {
+			enable: boolean;
+			rules: {
+				[glob: string]: boolean | {
+					when: string | string[];
+				};
+			};
+		};
 	};
 }
 

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -296,6 +296,35 @@ configurationRegistry.registerConfiguration({
 	}
 });
 
+let nestingPattern = {
+	'type': 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
+	// 'pattern': '\\w*\\$\\(basename\\)\\w*',
+	'default': '$(basename).ext',
+	'description': nls.localize('explorer.fileNesting.default.when', "File nesting rule. Use $(basename) as variable for the matching file name.")
+};
+
+let nestingRules = {
+	'anyOf': [
+		{
+			'type': 'boolean'
+		},
+		{
+			'type': 'object',
+			'properties': {
+				'when': {
+					'anyOf': [
+						nestingPattern,
+						{
+							'type': 'array',
+							'items': nestingPattern
+						}
+					]
+				}
+			}
+		}
+	]
+};
+
 configurationRegistry.registerConfiguration({
 	'id': 'explorer',
 	'order': 10,
@@ -334,6 +363,41 @@ configurationRegistry.registerConfiguration({
 				nls.localize('sortOrder.modified', 'Files and directories are sorted by last modified date, in descending order. Directories are displayed before files.')
 			],
 			'description': nls.localize('sortOrder', "Controls the way of sorting files and directories in the explorer.")
+		},
+		'explorer.fileNesting.enable': {
+			'type': 'boolean',
+			'description': nls.localize('fileNesting', "Enables file nesting based on naming"),
+			'default': false
+		},
+		'explorer.fileNesting.commonRules': {
+			'description': nls.localize('fileNestingCommonRules', "Common file nesting rules"),
+			'default': {
+				'*': { 'when': ['$(basename).*.$(ext)', '$(basename).$(ext).*'] },
+				'firebase.json': { 'when': '.firebaserc' },
+				'package.json': { 'when': 'package-lock.json' },
+				'Dockerfile': { 'when': '.dockerignore' }
+			},
+			'anyOf': [
+				{
+					'type': 'boolean'
+				},
+				{
+					'type': 'object',
+					'additionalProperties': nestingRules,
+				}
+			]
+		},
+		'explorer.fileNesting.rules': {
+			'description': nls.localize('fileNestingCustomRules', "Custom file nesting rules"),
+			'anyOf': [
+				{
+					'type': 'boolean'
+				},
+				{
+					'type': 'object',
+					'additionalProperties': nestingRules,
+				}
+			]
 		}
 	}
 });

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -303,28 +303,6 @@ let nestingPattern = {
 	'description': nls.localize('explorer.fileNesting.default.when', "File nesting rule. Use $(basename) as variable for the matching file name.")
 };
 
-let nestingRules = {
-	'anyOf': [
-		{
-			'type': 'boolean'
-		},
-		{
-			'type': 'object',
-			'properties': {
-				'when': {
-					'anyOf': [
-						nestingPattern,
-						{
-							'type': 'array',
-							'items': nestingPattern
-						}
-					]
-				}
-			}
-		}
-	]
-};
-
 configurationRegistry.registerConfiguration({
 	'id': 'explorer',
 	'order': 10,
@@ -369,35 +347,36 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('fileNesting', "Enables file nesting based on naming"),
 			'default': false
 		},
-		'explorer.fileNesting.commonRules': {
-			'description': nls.localize('fileNestingCommonRules', "Common file nesting rules"),
+		'explorer.fileNesting.rules': {
+			'description': nls.localize('fileNestingRules', "File nesting rules"),
 			'default': {
 				'*': { 'when': ['$(basename).*.$(ext)', '$(basename).$(ext).*'] },
 				'firebase.json': { 'when': '.firebaserc' },
 				'package.json': { 'when': 'package-lock.json' },
 				'Dockerfile': { 'when': '.dockerignore' }
 			},
-			'anyOf': [
-				{
-					'type': 'boolean'
-				},
-				{
-					'type': 'object',
-					'additionalProperties': nestingRules,
-				}
-			]
-		},
-		'explorer.fileNesting.rules': {
-			'description': nls.localize('fileNestingCustomRules', "Custom file nesting rules"),
-			'anyOf': [
-				{
-					'type': 'boolean'
-				},
-				{
-					'type': 'object',
-					'additionalProperties': nestingRules,
-				}
-			]
+			'type': 'object',
+			'additionalProperties': {
+				'anyOf': [
+					{
+						'type': 'boolean'
+					},
+					{
+						'type': 'object',
+						'properties': {
+							'when': {
+								'anyOf': [
+									nestingPattern,
+									{
+										'type': 'array',
+										'items': nestingPattern
+									}
+								]
+							}
+						}
+					}
+				]
+			},
 		}
 	}
 });

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -291,7 +291,7 @@ configurationRegistry.registerConfiguration({
 			'default': false
 		},
 		'files.nesting.rules': {
-			'description': nls.localize('fileNestingRules', "File nesting rules"),
+			'description': nls.localize('fileNestingRules', "File nesting rules. Property names are treated as globs. If a file matches a glob, the value of `when` is used to find files that should be nested under it."),
 			'default': {
 				'*': { 'when': ['$(basename).*.$(ext)', '$(basename).$(ext).*'] },
 				'firebase.json': { 'when': '.firebaserc' },

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -164,6 +164,13 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).regi
 // Configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
+let nestingPattern = {
+	'type': 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
+	// 'pattern': '\\w*\\$\\(basename\\)\\w*',
+	'default': '$(basename).ext',
+	'description': nls.localize('explorer.fileNesting.default.when', "File nesting rule. Use $(basename) as variable for the matching file name.")
+};
+
 configurationRegistry.registerConfiguration({
 	'id': 'files',
 	'order': 9,
@@ -277,6 +284,42 @@ configurationRegistry.registerConfiguration({
 		'files.defaultLanguage': {
 			'type': 'string',
 			'description': nls.localize('defaultLanguage', "The default language mode that is assigned to new files.")
+		},
+		'files.nesting.enable': {
+			'type': 'boolean',
+			'description': nls.localize('fileNesting', "Enables file nesting based on naming"),
+			'default': false
+		},
+		'files.nesting.rules': {
+			'description': nls.localize('fileNestingRules', "File nesting rules"),
+			'default': {
+				'*': { 'when': ['$(basename).*.$(ext)', '$(basename).$(ext).*'] },
+				'firebase.json': { 'when': '.firebaserc' },
+				'package.json': { 'when': 'package-lock.json' },
+				'Dockerfile': { 'when': '.dockerignore' }
+			},
+			'type': 'object',
+			'additionalProperties': {
+				'anyOf': [
+					{
+						'type': 'boolean'
+					},
+					{
+						'type': 'object',
+						'properties': {
+							'when': {
+								'anyOf': [
+									nestingPattern,
+									{
+										'type': 'array',
+										'items': nestingPattern
+									}
+								]
+							}
+						}
+					}
+				]
+			},
 		}
 	}
 });
@@ -295,13 +338,6 @@ configurationRegistry.registerConfiguration({
 		}
 	}
 });
-
-let nestingPattern = {
-	'type': 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
-	// 'pattern': '\\w*\\$\\(basename\\)\\w*',
-	'default': '$(basename).ext',
-	'description': nls.localize('explorer.fileNesting.default.when', "File nesting rule. Use $(basename) as variable for the matching file name.")
-};
 
 configurationRegistry.registerConfiguration({
 	'id': 'explorer',
@@ -341,42 +377,6 @@ configurationRegistry.registerConfiguration({
 				nls.localize('sortOrder.modified', 'Files and directories are sorted by last modified date, in descending order. Directories are displayed before files.')
 			],
 			'description': nls.localize('sortOrder', "Controls the way of sorting files and directories in the explorer.")
-		},
-		'explorer.fileNesting.enable': {
-			'type': 'boolean',
-			'description': nls.localize('fileNesting', "Enables file nesting based on naming"),
-			'default': false
-		},
-		'explorer.fileNesting.rules': {
-			'description': nls.localize('fileNestingRules', "File nesting rules"),
-			'default': {
-				'*': { 'when': ['$(basename).*.$(ext)', '$(basename).$(ext).*'] },
-				'firebase.json': { 'when': '.firebaserc' },
-				'package.json': { 'when': 'package-lock.json' },
-				'Dockerfile': { 'when': '.dockerignore' }
-			},
-			'type': 'object',
-			'additionalProperties': {
-				'anyOf': [
-					{
-						'type': 'boolean'
-					},
-					{
-						'type': 'object',
-						'properties': {
-							'when': {
-								'anyOf': [
-									nestingPattern,
-									{
-										'type': 'array',
-										'items': nestingPattern
-									}
-								]
-							}
-						}
-					}
-				]
-			},
 		}
 	}
 });

--- a/src/vs/workbench/parts/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerView.ts
@@ -13,6 +13,7 @@ import errors = require('vs/base/common/errors');
 import labels = require('vs/base/common/labels');
 import paths = require('vs/base/common/paths');
 import glob = require('vs/base/common/glob');
+import { equals } from 'vs/base/common/objects';
 import { Action, IAction } from 'vs/base/common/actions';
 import { prepareActions } from 'vs/workbench/browser/actions';
 import { memoize } from 'vs/base/common/decorators';
@@ -82,6 +83,9 @@ export class ExplorerView extends CollapsibleView {
 	private autoReveal: boolean;
 	private sortOrder: SortOrder;
 	private settings: object;
+
+	private fileNestingEnable: boolean;
+	private fileNestingRules: boolean | object;
 
 	constructor(
 		options: IExplorerViewOptions,
@@ -252,11 +256,23 @@ export class ExplorerView extends CollapsibleView {
 		}
 
 		this.autoReveal = configuration && configuration.explorer && configuration.explorer.autoReveal;
+		let fileNestingEnable = configuration && configuration.explorer && configuration.explorer.fileNesting && configuration.explorer.fileNesting.enable;
+		let fileNestingRules = configuration && configuration.explorer && configuration.explorer.fileNesting && configuration.explorer.fileNesting.rules || {};
 
 		// Push down config updates to components of viewer
 		let needsRefresh = false;
 		if (this.filter) {
 			needsRefresh = this.filter.updateConfiguration();
+		}
+
+		if (this.fileNestingEnable !== fileNestingEnable) {
+			this.fileNestingEnable = fileNestingEnable;
+			needsRefresh = true;
+		}
+
+		if (!equals(this.fileNestingRules, fileNestingRules)) {
+			this.fileNestingRules = fileNestingRules;
+			needsRefresh = true;
 		}
 
 		const configSortOrder = configuration && configuration.explorer && configuration.explorer.sortOrder || 'default';

--- a/src/vs/workbench/parts/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerView.ts
@@ -256,8 +256,8 @@ export class ExplorerView extends CollapsibleView {
 		}
 
 		this.autoReveal = configuration && configuration.explorer && configuration.explorer.autoReveal;
-		let fileNestingEnable = configuration && configuration.explorer && configuration.explorer.fileNesting && configuration.explorer.fileNesting.enable;
-		let fileNestingRules = configuration && configuration.explorer && configuration.explorer.fileNesting && configuration.explorer.fileNesting.rules || {};
+		let fileNestingEnable = configuration && configuration.files && configuration.files.nesting && configuration.files.nesting.enable;
+		let fileNestingRules = configuration && configuration.files && configuration.files.nesting && configuration.files.nesting.rules || {};
 
 		// Push down config updates to components of viewer
 		let needsRefresh = false;

--- a/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
@@ -70,7 +70,7 @@ export class FileDataSource implements IDataSource {
 
 	private updateNesting(): void {
 		let patterns = this.virtualDirectoryPatterns = {};
-		let config = this.configurationService.getConfiguration<IFilesConfiguration>().explorer.fileNesting;
+		let config = this.configurationService.getConfiguration<IFilesConfiguration>().files.nesting;
 		this.enableVirtualDirectories = config.enable && !!config.rules && Object.keys(config.rules).length > 0;
 
 		Object.keys(config.rules)
@@ -202,7 +202,7 @@ export class FileDataSource implements IDataSource {
 				return false;
 			}
 
-			let patterns = this.virtualDirectoryPatterns[g]
+			let patterns = this.virtualDirectoryPatterns[g];
 			return patterns.some(p => {
 				let _p = p.replace('$(basename)', basename).replace('$(ext)', ext);
 				return glob.match(_p, file);

--- a/src/vs/workbench/parts/files/common/explorerModel.ts
+++ b/src/vs/workbench/parts/files/common/explorerModel.ts
@@ -70,6 +70,9 @@ export class FileStat implements IFileStat {
 	public hasChildren: boolean;
 	public children: FileStat[];
 	public parent: FileStat;
+	public isVirtualDirectory: boolean;
+	public isVirtualDirectoryMember: boolean;
+	public virtualDirectoryName: string;
 
 	public isDirectoryResolved: boolean;
 

--- a/src/vs/workbench/parts/files/common/files.ts
+++ b/src/vs/workbench/parts/files/common/files.ts
@@ -52,6 +52,20 @@ export const TEXT_FILE_EDITOR_ID = 'workbench.editors.files.textFileEditor';
  */
 export const BINARY_FILE_EDITOR_ID = 'workbench.editors.files.binaryFileEditor';
 
+export interface IFileNestingRule {
+	when: string | string[];
+}
+
+export interface IFileNestingRuleMap {
+	[glob: string]: boolean | IFileNestingRule;
+}
+
+export interface IFileNestingConfiguration {
+	enable: boolean;
+	commonRules: boolean | IFileNestingRuleMap;
+	rules: boolean | IFileNestingRuleMap;
+}
+
 export interface IFilesConfiguration extends IFilesConfiguration, IWorkbenchEditorConfiguration {
 	explorer: {
 		openEditors: {
@@ -61,6 +75,7 @@ export interface IFilesConfiguration extends IFilesConfiguration, IWorkbenchEdit
 		autoReveal: boolean;
 		enableDragAndDrop: boolean;
 		sortOrder: SortOrder;
+		fileNesting: IFileNestingConfiguration;
 	};
 	editor: IEditorOptions;
 }

--- a/src/vs/workbench/parts/files/common/files.ts
+++ b/src/vs/workbench/parts/files/common/files.ts
@@ -52,20 +52,6 @@ export const TEXT_FILE_EDITOR_ID = 'workbench.editors.files.textFileEditor';
  */
 export const BINARY_FILE_EDITOR_ID = 'workbench.editors.files.binaryFileEditor';
 
-export interface IFileNestingRule {
-	when: string | string[];
-}
-
-export interface IFileNestingRuleMap {
-	[glob: string]: boolean | IFileNestingRule;
-}
-
-export interface IFileNestingConfiguration {
-	enable: boolean;
-	commonRules: boolean | IFileNestingRuleMap;
-	rules: boolean | IFileNestingRuleMap;
-}
-
 export interface IFilesConfiguration extends IFilesConfiguration, IWorkbenchEditorConfiguration {
 	explorer: {
 		openEditors: {
@@ -75,7 +61,14 @@ export interface IFilesConfiguration extends IFilesConfiguration, IWorkbenchEdit
 		autoReveal: boolean;
 		enableDragAndDrop: boolean;
 		sortOrder: SortOrder;
-		fileNesting: IFileNestingConfiguration;
+		fileNesting: {
+			enable: boolean;
+			rules: {
+				[glob: string]: boolean | {
+					when: string | string[];
+				};
+			};
+		};
 	};
 	editor: IEditorOptions;
 }

--- a/src/vs/workbench/parts/files/common/files.ts
+++ b/src/vs/workbench/parts/files/common/files.ts
@@ -61,14 +61,6 @@ export interface IFilesConfiguration extends IFilesConfiguration, IWorkbenchEdit
 		autoReveal: boolean;
 		enableDragAndDrop: boolean;
 		sortOrder: SortOrder;
-		fileNesting: {
-			enable: boolean;
-			rules: {
-				[glob: string]: boolean | {
-					when: string | string[];
-				};
-			};
-		};
 	};
 	editor: IEditorOptions;
 }


### PR DESCRIPTION
Based on #13754.

File nesting operates based on the rules defined in `files.nesting.rules`, similar to `files.exclude`. The rule names are globs. If a file matches a glob, `$(basename)` and `$(ext)` in the `when` value or values. Any files that match the resulting glob are nested under the original file.

**I am looking for advice** on how to properly handle the tree model. Without modifications to `src/vs/base/parts/tree/browser/treeModel.ts`, file nesting breaks VSCode with errors about items already having been registered. With modifications, it mostly works but has some buggy behavior.

### Nesting `.dockerignore` under `Dockerfile`

```json
{
    "Dockerfile": { "when": ".dockerignore" }
}
```

### Nesting `module.js`, `module.ts, `module.css`, etc under `module.html`

```json
{
    "*.html": { "when": [
        "$(basename).js",
        "$(basename).ts",
        "$(basename).css"
    ] }
}
```

### Nesting `module.sub.ext` under `module.ext`

```json
{
    "*": { "when": "$(basename).*.$(ext)" }
}
```

### Nesting `module.ext.sub` under `module.ext`

```json
{
    "*": { "when": "$(basename).$(ext).*" }
}
```

### Disabling a rule

```json
{
    "*.html": false
}
```
