### PR TITLE
Prototype TS Compile on Save

### DIFF
--- a/extensions/typescript/src/features/taskProvider.ts
+++ b/extensions/typescript/src/features/taskProvider.ts
@@ -10,10 +10,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import * as Proto from '../protocol';
-import TypeScriptServiceClient from '../typescriptServiceClient';
+import { ITypescriptServiceClient } from '../typescriptService';
 import TsConfigProvider, { TSConfig } from '../utils/tsconfigProvider';
 import { isImplicitProjectConfigFile } from '../utils/tsconfig';
-
 
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
@@ -37,7 +36,7 @@ class TscTaskProvider implements vscode.TaskProvider {
 	private readonly tsconfigProvider: TsConfigProvider;
 
 	public constructor(
-		private readonly lazyClient: () => TypeScriptServiceClient
+		private readonly lazyClient: () => ITypescriptServiceClient
 	) {
 		this.tsconfigProvider = new TsConfigProvider();
 	}
@@ -199,7 +198,7 @@ export default class TypeScriptTaskProviderManager {
 	private readonly disposables: vscode.Disposable[] = [];
 
 	constructor(
-		private readonly lazyClient: () => TypeScriptServiceClient
+		private readonly lazyClient: () => ITypescriptServiceClient
 	) {
 		vscode.workspace.onDidChangeConfiguration(this.onConfigurationChanged, this, this.disposables);
 		this.onConfigurationChanged();

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -35,6 +35,7 @@ import SignatureHelpProvider from './features/signatureHelpProvider';
 import RenameProvider from './features/renameProvider';
 import { TypeScriptFormattingProvider, FormattingProviderManager } from './features/formattingProvider';
 import BufferSyncSupport from './features/bufferSyncSupport';
+import CompileOnSaveHelper from './utils/CompileOnSave';
 import CompletionItemProvider from './features/completionItemProvider';
 import WorkspaceSymbolProvider from './features/workspaceSymbolProvider';
 import CodeActionProvider from './features/codeActionProvider';
@@ -211,6 +212,10 @@ class LanguageProvider {
 		}, this._validate);
 		this.syntaxDiagnostics = Object.create(null);
 		this.currentDiagnostics = languages.createDiagnosticCollection(description.id);
+
+		if (!this.description.isExternal) {
+			this.disposables.push(new CompileOnSaveHelper(client, description.modeIds));
+		}
 
 		this.typingsStatus = new TypingsStatus(client);
 		new AtaProgressReporter(client);

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -63,7 +63,7 @@ export interface ITypescriptServiceClient {
 	execute(command: 'docCommentTemplate', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DocCommandTemplateResponse>;
 	execute(command: 'getApplicableRefactors', args: Proto.GetApplicableRefactorsRequestArgs, token?: CancellationToken): Promise<Proto.GetApplicableRefactorsResponse>;
 	execute(command: 'getEditsForRefactor', args: Proto.GetEditsForRefactorRequestArgs, token?: CancellationToken): Promise<Proto.GetEditsForRefactorResponse>;
-	// execute(command: 'compileOnSaveAffectedFileList', args: Proto.CompileOnSaveEmitFileRequestArgs, token?: CancellationToken): Promise<Proto.CompileOnSaveAffectedFileListResponse>;
-	// execute(command: 'compileOnSaveEmitFile', args: Proto.CompileOnSaveEmitFileRequestArgs, token?: CancellationToken): Promise<any>;
+	execute(command: 'compileOnSaveAffectedFileList', args: Proto.FileRequestArgs, token?: CancellationToken): Promise<Proto.CompileOnSaveAffectedFileListResponse>;
+	execute(command: 'compileOnSaveEmitFile', args: Proto.CompileOnSaveEmitFileRequestArgs, token?: CancellationToken): Promise<any>;
 	execute(command: string, args: any, expectedResult: boolean | CancellationToken, token?: CancellationToken): Promise<any>;
 }

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -9,8 +9,8 @@ import * as Proto from './protocol';
 import API from './utils/api';
 
 export interface ITypescriptServiceClientHost {
-	syntaxDiagnosticsReceived(event: Proto.DiagnosticEvent): void;
-	semanticDiagnosticsReceived(event: Proto.DiagnosticEvent): void;
+	syntaxDiagnosticsReceived(file: string, diagnostics: Proto.Diagnostic[]): void;
+	semanticDiagnosticsReceived(file: string, diagnostics: Proto.Diagnostic[]): void;
 	configFileDiagnosticsReceived(event: Proto.ConfigFileDiagnosticEvent): void;
 	populateService(): void;
 }
@@ -65,5 +65,8 @@ export interface ITypescriptServiceClient {
 	execute(command: 'getEditsForRefactor', args: Proto.GetEditsForRefactorRequestArgs, token?: CancellationToken): Promise<Proto.GetEditsForRefactorResponse>;
 	execute(command: 'compileOnSaveAffectedFileList', args: Proto.FileRequestArgs, token?: CancellationToken): Promise<Proto.CompileOnSaveAffectedFileListResponse>;
 	execute(command: 'compileOnSaveEmitFile', args: Proto.CompileOnSaveEmitFileRequestArgs, token?: CancellationToken): Promise<any>;
+	execute(command: 'semanticDiagnosticsSync', args: Proto.SemanticDiagnosticsSyncRequestArgs, token?: CancellationToken): Promise<Proto.SemanticDiagnosticsSyncResponse>;
+	execute(command: 'syntaxDiagnosticsSync', args: Proto.SyntacticDiagnosticsSyncRequestArgs, token?: CancellationToken): Promise<Proto.SyntacticDiagnosticsSyncResponse>;
+
 	execute(command: string, args: any, expectedResult: boolean | CancellationToken, token?: CancellationToken): Promise<any>;
 }

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -743,9 +743,15 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 
 	private dispatchEvent(event: Proto.Event) {
 		if (event.event === 'syntaxDiag') {
-			this.host.syntaxDiagnosticsReceived(event as Proto.DiagnosticEvent);
+			const diagnosticEvent = event as Proto.DiagnosticEvent;
+			if (diagnosticEvent.body) {
+				this.host.syntaxDiagnosticsReceived(diagnosticEvent.body.file, diagnosticEvent.body.diagnostics);
+			}
 		} else if (event.event === 'semanticDiag') {
-			this.host.semanticDiagnosticsReceived(event as Proto.DiagnosticEvent);
+			const diagnosticEvent = event as Proto.DiagnosticEvent;
+			if (diagnosticEvent.body) {
+				this.host.semanticDiagnosticsReceived(diagnosticEvent.body.file, diagnosticEvent.body.diagnostics);
+			}
 		} else if (event.event === 'configFileDiag') {
 			this.host.configFileDiagnosticsReceived(event as Proto.ConfigFileDiagnosticEvent);
 		} else if (event.event === 'telemetry') {
@@ -771,6 +777,8 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 			if (data) {
 				this._onTypesInstallerInitializationFailed.fire(data);
 			}
+		} else {
+			console.log(event.event);
 		}
 	}
 

--- a/extensions/typescript/src/utils/compileOnSave.ts
+++ b/extensions/typescript/src/utils/compileOnSave.ts
@@ -109,8 +109,17 @@ export default class CompileOnSaveHelper {
 	}
 
 	private emit(files: Set<string>): void {
+		if (!files.size) {
+			return;
+		}
+
 		for (const file of files) {
 			this.client.execute('compileOnSaveEmitFile', { file }, false);
 		}
+		const args: Proto.GeterrRequestArgs = {
+			delay: 0,
+			files: Array.from(files)
+		};
+		this.client.execute('geterr', args, false);
 	}
 }

--- a/extensions/typescript/src/utils/compileOnSave.ts
+++ b/extensions/typescript/src/utils/compileOnSave.ts
@@ -89,7 +89,7 @@ export default class CompileOnSaveHelper {
 		}
 
 		const affectedFileList = await this.client.execute('compileOnSaveAffectedFileList', { file });
-		if (!affectedFileList || !affectedFileList.body || !affectedFileList.body.length) {
+		if (!affectedFileList || !affectedFileList.body) {
 			return;
 		}
 

--- a/extensions/typescript/src/utils/compileOnSave.ts
+++ b/extensions/typescript/src/utils/compileOnSave.ts
@@ -107,8 +107,12 @@ export default class CompileOnSaveHelper {
 			return false;
 		}
 
-		const config = JSON.parse(fs.readFileSync(info.body.configFileName, 'utf8'));
-		return config && config.compileOnSave;
+		try {
+			const config = JSON.parse(fs.readFileSync(info.body.configFileName, 'utf8'));
+			return config && config.compileOnSave;
+		} catch (e) {
+			return false;
+		}
 	}
 
 	private emit(project: string, files: Set<string>): void {

--- a/extensions/typescript/src/utils/compileOnSave.ts
+++ b/extensions/typescript/src/utils/compileOnSave.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+import { ITypescriptServiceClient } from '../typescriptService';
+import { Delayer } from './async';
+import { isImplicitProjectConfigFile } from './tsconfig';
+
+interface PendingProjectUpdate {
+	delayer: Delayer<void>;
+	files: Set<string>;
+}
+
+class ProjectDelayer {
+	private readonly pendingProjectUpdates = new Map<string, PendingProjectUpdate>();
+
+	constructor(
+		private task: (fileNames: Set<string>) => void
+	) { }
+
+	dispose() {
+		for (const update of this.pendingProjectUpdates.values()) {
+			update.delayer.cancel();
+		}
+		this.pendingProjectUpdates.clear();
+	}
+
+	public trigger(projectFileName: string, fileNames: string[]): void {
+		if (!fileNames.length) {
+			return;
+		}
+
+		let entry: PendingProjectUpdate | undefined = this.pendingProjectUpdates.get(projectFileName);
+		if (!entry) {
+			entry = {
+				delayer: new Delayer<void>(500),
+				files: new Set()
+			};
+			this.pendingProjectUpdates.set(projectFileName, entry);
+		}
+
+		for (const file of fileNames) {
+			entry.files.add(file);
+		}
+
+		entry.delayer.trigger(() => this.onDidTrigger(projectFileName));
+	}
+
+	private onDidTrigger(projectFileName: string): void {
+		const entry = this.pendingProjectUpdates.get(projectFileName);
+		if (!entry) {
+			return;
+		}
+		this.task(entry.files);
+		this.pendingProjectUpdates.delete(projectFileName);
+	}
+}
+
+export default class CompileOnSaveHelper {
+	private saveSubscription: vscode.Disposable;
+
+	private readonly emitter: ProjectDelayer;
+
+	constructor(
+		private client: ITypescriptServiceClient,
+		private languages: string[]
+	) {
+		this.emitter = new ProjectDelayer(files => this.emit(files));
+		this.saveSubscription = vscode.workspace.onDidSaveTextDocument(this.onDidSave, this);
+	}
+
+	dispose() {
+		this.saveSubscription.dispose();
+		this.emitter.dispose();
+	}
+
+	private async onDidSave(textDocument: vscode.TextDocument) {
+		if (this.languages.indexOf(textDocument.languageId) === -1) {
+			return;
+		}
+
+		const file = this.client.normalizePath(textDocument.uri);
+		if (!file || !await this.isFileInCompileOnSaveEnabledProject(file)) {
+			return;
+		}
+
+		const affectedFileList = await this.client.execute('compileOnSaveAffectedFileList', { file });
+		if (!affectedFileList || !affectedFileList.body || !affectedFileList.body.length) {
+			return;
+		}
+
+		for (const project of affectedFileList.body) {
+			this.emitter.trigger(project.projectFileName, project.fileNames);
+		}
+	}
+
+	private async isFileInCompileOnSaveEnabledProject(file: string): Promise<boolean> {
+		const info = await this.client.execute('projectInfo', { file, needFileNameList: false });
+		if (!info || !info.body || !info.body.configFileName || isImplicitProjectConfigFile(info.body.configFileName)) {
+			return false;
+		}
+
+		const config = JSON.parse(fs.readFileSync(info.body.configFileName, 'utf8'));
+		return config && config.compileOnSave;
+	}
+
+	private emit(files: Set<string>): void {
+		for (const file of files) {
+			this.client.execute('compileOnSaveEmitFile', { file }, false);
+		}
+	}
+}


### PR DESCRIPTION
Initial prototype enabling compileOnSave for TypeScript in VSCode

TODO:

- [ ] Possibly gate using an experimental setting. We probably want to wait for TS 2.5 for this as well.
- [ ] Better handle reading `compileOnSave` from project config file. Possibly could benefit from Microsoft/TypeScript#17659
- [X] Request errors for compiled files. Would benefit from Microsoft/TypeScript#17630
- [ ] Investigate why `node_modules` files are sometimes included in `affectedFileList`
- [ ] Check perf implications on larger projects

@dbaeumer Can you please remind me what the main concerns were for enabling compileOnSave?


// cc @sheetalkamat