### PR TITLE
Fix dangling active terminal on delete

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -95,7 +95,7 @@ export class QuickKillTerminalAction extends Action {
 		if (terminal) {
 			terminal.dispose();
 		}
-		if (this.terminalService.activeTerminalInstanceIndex !== terminalIndex) {
+		if (this.terminalService.terminalInstances.length > 0 && this.terminalService.activeTerminalInstanceIndex !== terminalIndex) {
 			this.terminalService.setActiveInstanceByIndex(Math.min(terminalIndex, this.terminalService.terminalInstances.length - 1));
 		}
 		return TPromise.timeout(50).then(result => this.quickOpenService.show(TERMINAL_PICKER_PREFIX, null));

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -95,6 +95,9 @@ export class QuickKillTerminalAction extends Action {
 		if (terminal) {
 			terminal.dispose();
 		}
+		if (this.terminalService.activeTerminalInstanceIndex !== terminalIndex) {
+			this.terminalService.setActiveInstanceByIndex(Math.min(terminalIndex, this.terminalService.terminalInstances.length - 1));
+		}
 		return TPromise.timeout(50).then(result => this.quickOpenService.show(TERMINAL_PICKER_PREFIX, null));
 	}
 }


### PR DESCRIPTION
Fixes an issue where if you delete a terminal that is not the last one and you also have the active terminal as the last one, the index doesn't get updated and the terminal panel title is blank.

Steps to reproduce:
1. Create three terminals and focus the last one
2. Delete the second one through the quick picker
3. Observe that the panel title is blank