### PR TITLE
Fix onDidChangeTextEditorSelection firing when the editor is resized

### DIFF
--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -389,7 +389,11 @@ export class Cursor extends viewEvents.ViewEventEmitter implements ICursors {
 		this._emit([new viewEvents.ViewCursorStateChangedEvent(viewSelections, isInEditableRange)]);
 
 		// Only after the view has been notified, let the rest of the world know...
-		this._onDidChange.fire(new CursorStateChangedEvent(selections, source || 'keyboard', reason));
+		if (oldState.cursorState.length !== newState.cursorState.length
+			|| oldState.cursorState.some((old, i) => !old.modelState.equals(newState.cursorState[i].modelState))
+		) {
+			this._onDidChange.fire(new CursorStateChangedEvent(selections, source || 'keyboard', reason));
+		}
 
 		return true;
 	}

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -389,8 +389,9 @@ export class Cursor extends viewEvents.ViewEventEmitter implements ICursors {
 		this._emit([new viewEvents.ViewCursorStateChangedEvent(viewSelections, isInEditableRange)]);
 
 		// Only after the view has been notified, let the rest of the world know...
-		if (oldState.cursorState.length !== newState.cursorState.length
-			|| oldState.cursorState.some((old, i) => !old.modelState.equals(newState.cursorState[i].modelState))
+		if (!oldState
+			|| oldState.cursorState.length !== newState.cursorState.length
+			|| newState.cursorState.some((newCursorState, i) => !newCursorState.modelState.equals(oldState.cursorState[i].modelState))
 		) {
 			this._onDidChange.fire(new CursorStateChangedEvent(selections, source || 'keyboard', reason));
 		}

--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -415,7 +415,7 @@ export class CursorState {
 	}
 
 	public equals(other: CursorState): boolean {
-		return (this.viewState.equals(other.viewState) && this.modelState.equals(other.viewState));
+		return (this.viewState.equals(other.viewState) && this.modelState.equals(other.modelState));
 	}
 }
 


### PR DESCRIPTION
**Bug**
`onDidChangeTextEditorSelection` is being fired when the editor window is resized. This does not seem correct since the selection has not actually changed

**Fix**
Make sure we do not refire this event if the selection as not changed

Fixes #32092