### PR TITLE
expand variables sections

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugViews.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugViews.ts
@@ -72,8 +72,11 @@ export class VariablesView extends CollapsibleView {
 				const stackFrame = this.debugService.getViewModel().focusedStackFrame;
 				if (stackFrame) {
 					return stackFrame.getScopes().then(scopes => {
-						if (scopes.length > 0 && !scopes[0].expensive) {
-							return this.tree.expand(scopes[0]);
+						var expandIfNotExpensive = (scope) => {
+							return !scope.expensive && this.tree.expand(scope);
+						};
+						if (scopes.length > 0) {
+							scopes.forEach(expandIfNotExpensive);
 						}
 						return undefined;
 					});


### PR DESCRIPTION
When debugging, argument variables are just as important as local variables. Both sections should be viewable while debugging. Instead, the current version of the code only expands the first dropdown and requires the user to manually expand the argument variables section. This is a tedious requirement and a poor user experience. Instead, the default should be to expand both the local variables and argument variables sections. I have already experienced a scenario where a name conflict between argument and local variables resulted in a bug in my code. Not seeing the argument variables automatically made it a bit harder to debug. Furthermore, when debugging the code I keep having to expand the argument variables section to see what the value of the variables are.

Please note that this is my first time writing any JavaScript or TypeScript code. Of course, I did my best to write clean code, and I both ran the unit tests and tested the functionality in a fresh build of VS Code. However, I would appreciate a code review and am happy to make any modifications necessary.

Best,
Matt