### PR TITLE
Fix tabbing in quick pick

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -336,6 +336,16 @@ export class QuickOpenWidget implements IModelProvider {
 
 		this.applyStyles();
 
+		// Allows focus to switch to next/previous entry after tab into an actionbar item
+		DOM.addDisposableListener(this.treeContainer.getHTMLElement(), DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const keyboardEvent: StandardKeyboardEvent = new StandardKeyboardEvent(e);
+			if (keyboardEvent.keyCode === KeyCode.DownArrow || keyboardEvent.keyCode === KeyCode.UpArrow || keyboardEvent.keyCode === KeyCode.PageDown || keyboardEvent.keyCode === KeyCode.PageUp) {
+				DOM.EventHelper.stop(e, true);
+				this.navigateInTree(keyboardEvent.keyCode, keyboardEvent.shiftKey);
+				this.inputBox.inputElement.focus();
+			}
+		});
+
 		return this.builder.getHTMLElement();
 	}
 

--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -244,7 +244,8 @@ export class QuickOpenWidget implements IModelProvider {
 						alwaysFocused: true,
 						verticalScrollMode: ScrollbarVisibility.Visible,
 						ariaLabel: nls.localize('treeAriaLabel', "Quick Picker"),
-						keyboardSupport: this.options.keyboardSupport
+						keyboardSupport: this.options.keyboardSupport,
+						preventRootFocus: true
 					});
 
 				this.treeElement = this.tree.getHTMLElement();

--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -670,6 +670,7 @@ export interface ITreeOptions extends ITreeStyles {
 	paddingOnRow?: boolean;
 	ariaLabel?: string;
 	keyboardSupport?: boolean;
+	preventRootFocus?: boolean;
 }
 
 export interface ITreeStyles {

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -444,7 +444,7 @@ export class TreeView extends HeightMap {
 
 		this.domNode = document.createElement('div');
 		this.domNode.className = `monaco-tree no-focused-item monaco-tree-instance-${this.instance}`;
-		this.domNode.tabIndex = 0;
+		this.domNode.tabIndex = container.className === 'quick-open-tree' ? -1 : 0;
 
 		this.styleElement = DOM.createStyleSheet(this.domNode);
 

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -444,7 +444,9 @@ export class TreeView extends HeightMap {
 
 		this.domNode = document.createElement('div');
 		this.domNode.className = `monaco-tree no-focused-item monaco-tree-instance-${this.instance}`;
-		this.domNode.tabIndex = container.className === 'quick-open-tree' ? -1 : 0;
+		if (!context.options.preventRootFocus) {
+			this.domNode.tabIndex = 0;
+		}
 
 		this.styleElement = DOM.createStyleSheet(this.domNode);
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/31835 and https://github.com/Microsoft/vscode/issues/31836

- makes the tree view untabbable in order to get to the actionbar item in one tab
- adds a listener for arrow keys and page up/down to focus next/previous entries from a tabbed actionbar state