### PR TITLE
Improve "uninstall first" messaging/grammar

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -821,7 +821,7 @@ begin
     end;
 
     if not Result then begin
-      MsgBox('Please uninstall {#NameShort} ' + AltArch + 'bits before installing this ' + ThisArch + 'bits version.', mbInformation, MB_OK);
+      MsgBox('Please uninstall the ' + AltArch + '-bit version of {#NameShort} before installing this ' + ThisArch + '-bit version.', mbInformation, MB_OK);
     end;
   end;
 end;


### PR DESCRIPTION
See #29537

Now that both 32- and 64-bit Windows builds are supported, if a user tries to install the 64-bit version over the 32-bit version (or vice versa), they receive the following message:
e.g. ```Please uninstall Code 32bits before installing this 64bits version.```

I have updated this to improve the grammar and use a more industry-standard presentation of CPU/architecture:
e.g. ```Please uninstall the 32-bit version of Code before installing this 64-bit version.```