### PR TITLE
Removes the expression that returns 'red' as a color if the 'string' parameter is not set

### DIFF
--- a/src/vs/base/common/color.ts
+++ b/src/vs/base/common/color.ts
@@ -256,7 +256,7 @@ export class HSVA {
 export class Color {
 
 	static fromHex(hex: string): Color {
-		return Color.Format.CSS.parseHex(hex) || Color.red;
+		return Color.Format.CSS.parseHex(hex);
 	}
 
 	readonly rgba: RGBA;


### PR DESCRIPTION
Removes the expression that returns 'red' as a color if the 'string' parameter is not set.

I was using a theme that is compiled from a .yml file to a .json file. The issue was that if I had a variable whose value was not set in the .yml file, the generated .json file would contain a null value. Looking through the source code, I found the method `fromHex` that would return `Color.red` if if the parameter passed to it couldn't be resolved.