### PR TITLE
Added a `singleInstanceOnly` option in tasks, Fixes #32264

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3866,6 +3866,11 @@ declare module 'vscode' {
 		isBackground: boolean;
 
 		/**
+		 * Defines if the application can have only 1 active instance at a time
+		 */
+		singleInstanceOnly?: boolean;
+
+		/**
 		 * A human-readable string describing the source of this
 		 * shell task, e.g. 'gulp' or 'npm'.
 		 */

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -352,6 +352,7 @@ namespace Tasks {
 			group: task.group ? (task.group as types.TaskGroup).id : undefined,
 			command: command,
 			isBackground: !!task.isBackground,
+			singleInstanceOnly: !!task.singleInstanceOnly,
 			problemMatchers: task.problemMatchers.slice(),
 			hasDefinedMatchers: (task as types.Task).hasDefinedMatchers
 		};

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1212,6 +1212,7 @@ export class Task implements vscode.Task {
 	private _problemMatchers: string[];
 	private _hasDefinedMatchers: boolean;
 	private _isBackground: boolean;
+	private _singleInstanceOnly: boolean;
 	private _source: string;
 	private _group: TaskGroup;
 	private _presentationOptions: vscode.TaskPresentationOptions;
@@ -1232,6 +1233,7 @@ export class Task implements vscode.Task {
 			this._hasDefinedMatchers = false;
 		}
 		this._isBackground = false;
+		this._singleInstanceOnly = false;
 	}
 
 	get definition(): vscode.TaskDefinition {
@@ -1299,11 +1301,22 @@ export class Task implements vscode.Task {
 		return this._isBackground;
 	}
 
+	get singleInstanceOnly(): boolean {
+		return this._singleInstanceOnly;
+	}
+
 	set isBackground(value: boolean) {
 		if (value !== true && value !== false) {
 			value = false;
 		}
 		this._isBackground = value;
+	}
+
+	set singleInstanceOnly(value: boolean) {
+		if (value !== true && value !== false) {
+			value = false;
+		}
+		this._singleInstanceOnly = value;
 	}
 
 	get source(): string {

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -268,6 +268,11 @@ export interface ConfigurationProperties {
 	isBackground?: boolean;
 
 	/**
+	 * Defines if the application can have only 1 active instance at a time
+	 */
+	singleInstanceOnly?: boolean;
+
+	/**
 	 * Whether the task should prompt on close for confirmation if running.
 	 */
 	promptOnClose?: boolean;

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchemaCommon.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchemaCommon.ts
@@ -152,6 +152,11 @@ const schema: IJSONSchema = {
 					description: nls.localize('JsonSchema.tasks.background', 'Whether the executed task is kept alive and is running in the background.'),
 					default: true
 				},
+				singleInstanceOnly: {
+					type: 'boolean',
+					description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+					default: false
+				},
 				promptOnClose: {
 					type: 'boolean',
 					description: nls.localize('JsonSchema.tasks.promptOnClose', 'Whether the user is prompted when VS Code closes with a running task.'),
@@ -204,6 +209,11 @@ const schema: IJSONSchema = {
 					type: 'boolean',
 					description: nls.localize('JsonSchema.background', 'Whether the executed task is kept alive and is running in the background.'),
 					default: true
+				},
+				singleInstanceOnly: {
+					type: 'boolean',
+					description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+					default: false
 				},
 				promptOnClose: {
 					type: 'boolean',

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
@@ -175,6 +175,11 @@ let taskConfiguration: IJSONSchema = {
 			description: nls.localize('JsonSchema.tasks.background', 'Whether the executed task is kept alive and is running in the background.'),
 			default: true
 		},
+		singleInstanceOnly: {
+			type: 'boolean',
+			description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+			default: false
+		},
 		promptOnClose: {
 			type: 'boolean',
 			description: nls.localize('JsonSchema.tasks.promptOnClose', 'Whether the user is prompted when VS Code closes with a running task.'),

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1203,6 +1203,11 @@ class TaskService extends EventEmitter implements ITaskService {
 				if (executeResult.kind === TaskExecuteKind.Active) {
 					let active = executeResult.active;
 					if (active.same) {
+						if (task.singleInstanceOnly) {
+							this.restart(task);
+							this.messageService.show(Severity.Info, nls.localize('TaskSystem.singleInstanceOnly', 'Restarting \'{0}\'.', task._label));
+							return executeResult.promise;
+						}
 						if (active.background) {
 							this.messageService.show(Severity.Info, nls.localize('TaskSystem.activeSame.background', 'The task \'{0}\' is already active and in background mode. To terminate it use `Terminate Task...` from the Tasks menu.', task._label));
 						} else {

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -225,6 +225,11 @@ export interface ConfigurationProperties {
 	isBackground?: boolean;
 
 	/**
+	 * Defines if the application can have only 1 active instance at a time.
+	 */
+	singleInstanceOnly?: boolean;
+
+	/**
 	 * Whether the task should prompt on close for confirmation if running.
 	 */
 	promptOnClose?: boolean;
@@ -361,6 +366,11 @@ export interface BaseTaskRunnerConfiguration {
 	 * Specifies whether a global command is a background task.
 	 */
 	isBackground?: boolean;
+
+	/**
+	 * Defines if the application can have only 1 active instance at a time.
+	 */
+	singleInstanceOnly?: boolean;
 
 	/**
 	 * Whether the task should prompt on close for confirmation if running.
@@ -1049,7 +1059,7 @@ namespace ConfigurationProperties {
 	const properties: MetaData<Tasks.ConfigurationProperties, any>[] = [
 
 		{ property: 'name' }, { property: 'identifier' }, { property: 'group' }, { property: 'isBackground' },
-		{ property: 'promptOnClose' }, { property: 'dependsOn' },
+		{ property: 'promptOnClose' }, { property: 'dependsOn' }, { property: 'singleInstanceOnly' },
 		{ property: 'presentation', type: CommandConfiguration.PresentationOptions }, { property: 'problemMatchers' }
 	];
 
@@ -1069,6 +1079,9 @@ namespace ConfigurationProperties {
 		}
 		if (external.isBackground !== void 0) {
 			result.isBackground = !!external.isBackground;
+		}
+		if (external.singleInstanceOnly !== void 0) {
+			result.singleInstanceOnly = !!external.singleInstanceOnly;
 		}
 		if (external.promptOnClose !== void 0) {
 			result.promptOnClose = !!external.promptOnClose;
@@ -1265,6 +1278,9 @@ namespace CustomTask {
 		if (task.isBackground === void 0) {
 			task.isBackground = false;
 		}
+		if (task.singleInstanceOnly === void 0) {
+			task.singleInstanceOnly = false;
+		}
 		if (task.problemMatchers === void 0) {
 			task.problemMatchers = EMPTY_ARRAY;
 		}
@@ -1288,6 +1304,7 @@ namespace CustomTask {
 		assignProperty(resultConfigProps, configuredProps, 'group');
 		assignProperty(resultConfigProps, configuredProps, 'isDefaultGroupEntry');
 		assignProperty(resultConfigProps, configuredProps, 'isBackground');
+		assignProperty(resultConfigProps, configuredProps, 'singleInstanceOnly');
 		assignProperty(resultConfigProps, configuredProps, 'dependsOn');
 		assignProperty(resultConfigProps, configuredProps, 'problemMatchers');
 		assignProperty(resultConfigProps, configuredProps, 'promptOnClose');
@@ -1298,6 +1315,7 @@ namespace CustomTask {
 		fillProperty(resultConfigProps, contributedConfigProps, 'group');
 		fillProperty(resultConfigProps, contributedConfigProps, 'isDefaultGroupEntry');
 		fillProperty(resultConfigProps, contributedConfigProps, 'isBackground');
+		fillProperty(resultConfigProps, contributedConfigProps, 'singleInstanceOnly');
 		fillProperty(resultConfigProps, contributedConfigProps, 'dependsOn');
 		fillProperty(resultConfigProps, contributedConfigProps, 'problemMatchers');
 		fillProperty(resultConfigProps, contributedConfigProps, 'promptOnClose');
@@ -1739,6 +1757,7 @@ class ConfigurationParser {
 		if ((!result.custom || result.custom.length === 0) && (globals.command && globals.command.name)) {
 			let matchers: ProblemMatcher[] = ProblemMatcherConverter.from(fileConfig.problemMatcher, context);
 			let isBackground = fileConfig.isBackground ? !!fileConfig.isBackground : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
+			let singleInstanceOnly = fileConfig.singleInstanceOnly ? !!fileConfig.singleInstanceOnly : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
 			let task: Tasks.CustomTask = {
 				_id: context.uuidMap.getUUID(globals.command.name),
 				_source: Objects.assign({}, source, { config: { index: -1, element: fileConfig } }),
@@ -1754,6 +1773,7 @@ class ConfigurationParser {
 					suppressTaskName: true
 				},
 				isBackground: isBackground,
+				singleInstanceOnly: singleInstanceOnly,
 				problemMatchers: matchers
 			};
 			let value = GroupKind.from(fileConfig.group);

--- a/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts
+++ b/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts
@@ -184,6 +184,7 @@ class CustomTaskBuilder {
 			name: name,
 			command: this.commandBuilder.result,
 			isBackground: false,
+			singleInstanceOnly: false,
 			promptOnClose: true,
 			problemMatchers: []
 		};
@@ -207,6 +208,11 @@ class CustomTaskBuilder {
 
 	public isBackground(value: boolean): CustomTaskBuilder {
 		this.result.isBackground = value;
+		return this;
+	}
+
+	public singleInstanceOnly(value: boolean): CustomTaskBuilder {
+		this.result.singleInstanceOnly = value;
 		return this;
 	}
 


### PR DESCRIPTION
Added a `singleInstanceOnly` option in `tasks.json`. 
Default value is `false`.

When this option is true, Then starting a task that is already running will kill the existing task and restart it.

When this option is false, It'll show the current behaviour, i.e. Give user an error about first terminating the task before starting it again.

I've not added tests yet because I am not sure, If I should write separate tests for it, or combine it with other tests like [this](https://github.com/Microsoft/vscode/blob/c185e7d44eeacf5bf909131b0f661daaeff1ac59/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts#L628). I can write tests in any way you would prefer. 

This PR fixes #32264.

Regards
Ishan Jain

