### PR TITLE
Add empty problem matcher to "Run Dev" task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,7 +55,8 @@
 			"command": "./scripts/code.sh",
 			"windows": {
 				"command": ".\\scripts\\code.bat"
-			}
+			},
+			"problemMatcher": []
 		},
 		{
 			"type": "gulp",


### PR DESCRIPTION
Without this, vscode always asks you what to do. When you select an option, it edits this file, so we might as well put a configuration here so it doesn't keep asking.