### PR TITLE
Adding ractive syntax highlighting to vscode

### DIFF
--- a/extensions/html/syntaxes/html.json
+++ b/extensions/html/syntaxes/html.json
@@ -345,7 +345,7 @@
 								},
 								{
 									"begin": "\\G",
-									"end": "(?i:(?=/?>|type(?=[\\s=])(?!\\s*=\\s*('|\"|)(text/(javascript|ecmascript|babel)|application/((x-)?javascript|ecmascript|babel)|module)[\\s\"'>])))",
+									"end": "(?i:(?=/?>|type(?=[\\s=])(?!\\s*=\\s*('|\"|)(text/(javascript|ecmascript|babel|ractive)|application/((x-)?javascript|ecmascript|babel)|module)[\\s\"'>])))",
 									"name": "meta.tag.metadata.script.html",
 									"patterns": [
 										{


### PR DESCRIPTION
Adding ractive (https://ractive.js.org/) syntax highlighting to html documents