### PR TITLE
Added support for recursively collapsing directory using alt-click

### DIFF
--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -104,7 +104,7 @@ export interface ITree extends Events.IEventEmitter {
 	/**
 	 * Toggles an element's expansion state.
 	 */
-	toggleExpansion(element: any): WinJS.Promise;
+	toggleExpansion(element: any, recursive?: boolean): WinJS.Promise;
 
 	/**
 	 * Toggles several element's expansion state.

--- a/src/vs/base/parts/tree/browser/treeImpl.ts
+++ b/src/vs/base/parts/tree/browser/treeImpl.ts
@@ -186,8 +186,8 @@ export class Tree extends Events.EventEmitter implements _.ITree {
 		return this.model.collapseAll(elements, recursive);
 	}
 
-	public toggleExpansion(element: any): WinJS.Promise {
-		return this.model.toggleExpansion(element);
+	public toggleExpansion(element: any, recursive: boolean = false): WinJS.Promise {
+		return this.model.toggleExpansion(element, recursive);
 	}
 
 	public toggleExpansionAll(elements: any[]): WinJS.Promise {

--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -894,8 +894,8 @@ export class TreeModel extends Events.EventEmitter {
 		return WinJS.Promise.join(promises);
 	}
 
-	public toggleExpansion(element: any): WinJS.Promise {
-		return this.isExpanded(element) ? this.collapse(element) : this.expand(element);
+	public toggleExpansion(element: any, recursive: boolean = false): WinJS.Promise {
+		return this.isExpanded(element) ? this.collapse(element, recursive) : this.expand(element);
 	}
 
 	public toggleExpansionAll(elements: any[]): WinJS.Promise {

--- a/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerViewer.ts
@@ -445,7 +445,7 @@ export class FileController extends DefaultController {
 		tree.DOMFocus();
 
 		// Expand / Collapse
-		tree.toggleExpansion(stat);
+		tree.toggleExpansion(stat, event.altKey);
 
 		// Allow to unselect
 		if (event.shiftKey && !(stat instanceof NewStatPlaceholder)) {


### PR DESCRIPTION
This is partially implementing feature request #9456

You can now use `alt+click` to recursively collapse a directory.