### PR TITLE
Correct progress type for PPromise.join

### DIFF
--- a/src/vs/base/common/winjs.base.d.ts
+++ b/src/vs/base/common/winjs.base.d.ts
@@ -115,6 +115,11 @@ export declare class TPromise<V> {
 	public static addEventListener(event: 'error', promiseErrorHandler: (e: IPromiseError) => void);
 }
 
+export interface PPromiseJoinProgress {
+	Key: string;
+	Done: true;
+}
+
 // --- Generic promise with generic progress value
 export declare class PPromise<C, P> extends TPromise<C> {
 
@@ -132,8 +137,8 @@ export declare class PPromise<C, P> extends TPromise<C> {
 
 	public static as<V>(value: V): TPromise<V>;
 	public static timeout(delay: number): PPromise<void, void>;
-	public static join<C, P>(promises: PPromise<C, P>[]): PPromise<C, P[]>;
-	public static join<C, P>(promises: { [n: string]: PPromise<C, P> }): PPromise<{ [n: string]: C }, P>;
+	public static join<C, P>(promises: PPromise<C, P>[]): PPromise<C, PPromiseJoinProgress>;
+	public static join<C, P>(promises: { [n: string]: PPromise<C, P> }): PPromise<{ [n: string]: C }, PPromiseJoinProgress>;
 	public static any<C, P>(promises: PPromise<C, P>[]): PPromise<{ key: string; value: PPromise<C, P>; }, P>;
 	public static wrapError<V>(error: Error): TPromise<V>;
 }


### PR DESCRIPTION
`PPromise.join` does not forward the progress events. However, it does send a progress object notifying when each promise is finished (excluding the final promise): https://github.com/Microsoft/vscode/blob/1.15.0/src/vs/base/common/winjs.base.raw.js#L1829

FYI if you do want to forward the progress, you need to use something like:

```ts
new PPromise((complete, error, progress) => {
  PPromise.join(promises.map(p => p.then(null, null, progress))).then(complete, error);
});
```