### PR TITLE
Move search function to use Promise interface

### DIFF
--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -118,9 +118,9 @@ export class FileWalker {
 	}
 
 	public walkP(folderQueries: IFolderSearch[], extraFiles: string[]): PPromise<boolean, IRawFileMatch> {
-		return new PPromise((onComplete, onError, onResult) => {
-			this.fileWalkStartTime = Date.now();
+		this.fileWalkStartTime = Date.now();
 
+		return new PPromise((onComplete, onError, onResult) => {
 			// Support that the file pattern is a full path to a file that exists
 			this.checkFilePatternAbsoluteMatch((exists, size) => {
 				if (this.isCanceled) {
@@ -194,7 +194,7 @@ export class FileWalker {
 					if (err) {
 						onError(err);
 					}
-					onComplete(this.isLimitHit);
+					return onComplete(this.isLimitHit);
 				});
 			});
 		});
@@ -806,7 +806,6 @@ export class Engine implements ISearchEngine<IRawFileMatch> {
 		this.walker = new FileWalker(config);
 	}
 
-	// TODO: "search" function doesn't seem to emit progress out.
 	public searchP(): PPromise<ISerializedSearchComplete, ISearchProgress<IRawFileMatch>> {
 		return new PPromise((sComplete, sError, sProgress) => {
 			return this.walker.walkP(this.folderQueries, this.extraFiles).then(
@@ -816,9 +815,7 @@ export class Engine implements ISearchEngine<IRawFileMatch> {
 						stats: this.walker.getStats()
 					});
 				},
-				walkError => {
-					sError(walkError);
-				},
+				sError,
 				walkProgress => {
 					sProgress({ results: walkProgress });
 				}

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -24,7 +24,7 @@ import { IProgress, IUncachedSearchStats } from 'vs/platform/search/common/searc
 
 import extfs = require('vs/base/node/extfs');
 import flow = require('vs/base/node/flow');
-import { IRawFileMatch, ISerializedSearchComplete, IRawSearch, ISearchEngine, IFolderSearch } from './search';
+import { IRawFileMatch, ISerializedSearchComplete, IRawSearch, ISearchEngine, IFolderSearch, ISearchProgress } from './search';
 import { spawnRipgrepCmd } from './ripgrepFileSearch';
 
 enum Traversal {
@@ -807,7 +807,7 @@ export class Engine implements ISearchEngine<IRawFileMatch> {
 	}
 
 	// TODO: "search" function doesn't seem to emit progress out.
-	public searchP(): PPromise<ISerializedSearchComplete, IRawFileMatch> {
+	public searchP(): PPromise<ISerializedSearchComplete, ISearchProgress<IRawFileMatch>> {
 		return new PPromise((sComplete, sError, sProgress) => {
 			return this.walker.walkP(this.folderQueries, this.extraFiles).then(
 				walkComplete => {
@@ -820,7 +820,7 @@ export class Engine implements ISearchEngine<IRawFileMatch> {
 					sError(walkError);
 				},
 				walkProgress => {
-					sProgress(walkProgress);
+					sProgress({ results: walkProgress });
 				}
 			);
 		});

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -12,7 +12,7 @@ import fs = require('fs');
 import path = require('path');
 import { isEqualOrParent } from 'vs/base/common/paths';
 import { Readable } from 'stream';
-import { TPromise } from 'vs/base/common/winjs.base';
+import { PPromise, TPromise } from 'vs/base/common/winjs.base';
 
 import objects = require('vs/base/common/objects');
 import arrays = require('vs/base/common/arrays');
@@ -115,6 +115,89 @@ export class FileWalker {
 
 	public cancel(): void {
 		this.isCanceled = true;
+	}
+
+	public walkP(folderQueries: IFolderSearch[],extraFiles: string[]): PPromise<boolean, IRawFileMatch> {
+		return new PPromise((onComplete, onError, onResult) => {
+			this.fileWalkStartTime = Date.now();
+
+			// Support that the file pattern is a full path to a file that exists
+			this.checkFilePatternAbsoluteMatch((exists, size) => {
+				if (this.isCanceled) {
+					return onComplete(this.isLimitHit);
+				}
+
+				// Report result from file pattern if matching
+				if (exists) {
+					this.resultCount++;
+					onResult({
+						relativePath: this.filePattern,
+						basename: path.basename(this.filePattern),
+						size
+					});
+
+					// Optimization: a match on an absolute path is a good result and we do not
+					// continue walking the entire root paths array for other matches because
+					// it is very unlikely that another file would match on the full absolute path
+					return onComplete(this.isLimitHit);
+				}
+
+				// For each extra file
+				if (extraFiles) {
+					extraFiles.forEach(extraFilePath => {
+						const basename = path.basename(extraFilePath);
+						if (this.globalExcludePattern && this.globalExcludePattern(extraFilePath, basename)) {
+							return; // excluded
+						}
+
+						// File: Check for match on file pattern and include pattern
+						this.matchFile(onResult, { relativePath: extraFilePath /* no workspace relative path */, basename });
+					});
+				}
+
+				let traverse = this.nodeJSTraversal;
+				if (!this.maxFilesize) {
+					if (this.useRipgrep) {
+						this.traversal = Traversal.Ripgrep;
+						traverse = this.cmdTraversal;
+					} else if (platform.isMacintosh) {
+						this.traversal = Traversal.MacFind;
+						traverse = this.cmdTraversal;
+						// Disable 'dir' for now (#11181, #11179, #11183, #11182).
+					} /* else if (platform.isWindows) {
+						this.traversal = Traversal.WindowsDir;
+						traverse = this.windowsDirTraversal;
+					} */ else if (platform.isLinux) {
+						this.traversal = Traversal.LinuxFind;
+						traverse = this.cmdTraversal;
+					}
+				}
+
+				const isNodeTraversal = traverse === this.nodeJSTraversal;
+				if (!isNodeTraversal) {
+					this.cmdForkStartTime = Date.now();
+				}
+
+				// For each root folder
+				flow.parallel<IFolderSearch, void>(folderQueries, (folderQuery: IFolderSearch, rootFolderDone: (err: Error, result: void) => void) => {
+					this.call(traverse, this, folderQuery, onResult, (err?: Error) => {
+						if (err) {
+							const errorMessage = toErrorMessage(err);
+							console.error(errorMessage);
+							this.errors.push(errorMessage);
+							rootFolderDone(err, undefined);
+						} else {
+							rootFolderDone(undefined, undefined);
+						}
+					});
+				}, (err, result) => {
+					if (err) {
+						onError(err);
+					}
+					onComplete(this.isLimitHit);
+				});
+			});
+		});
 	}
 
 	public walk(folderQueries: IFolderSearch[], extraFiles: string[], onResult: (result: IRawFileMatch) => void, done: (error: Error, isLimitHit: boolean) => void): void {

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -806,8 +806,8 @@ export class Engine implements ISearchEngine<IRawFileMatch> {
 		this.walker = new FileWalker(config);
 	}
 
+	// TODO: "search" function doesn't seem to emit progress out.
 	public searchP(): PPromise<ISerializedSearchComplete, IRawFileMatch> {
-		// What do the progress and complete mean after promisifications. It sees more natural to invert the result set where in the "done" is called as onComplete callback (with the search result, may be?)
 		return new PPromise((sComplete, sError, sProgress) => {
 			return this.walker.walkP(this.folderQueries, this.extraFiles).then(
 				walkComplete => {

--- a/src/vs/workbench/services/search/node/search.ts
+++ b/src/vs/workbench/services/search/node/search.ts
@@ -55,6 +55,7 @@ export interface IRawFileMatch {
 }
 
 export interface ISearchEngine<T> {
+	searchP(): PPromise<ISerializedSearchComplete, ISearchProgress<T>>;
 	search: (onResult: (matches: T) => void, onProgress: (progress: IProgress) => void, done: (error: Error, complete: ISerializedSearchComplete) => void) => void;
 	cancel: () => void;
 }
@@ -68,6 +69,11 @@ export interface ISerializedFileMatch {
 	path: string;
 	lineMatches?: ILineMatch[];
 	numMatches?: number;
+}
+
+export interface ISearchProgress<T> {
+	results?: T;
+	progress?: IProgress;
 }
 
 // Type of the possible values for progress calls from the engine

--- a/src/vs/workbench/services/search/node/textSearch.ts
+++ b/src/vs/workbench/services/search/node/textSearch.ts
@@ -11,9 +11,10 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { IProgress } from 'vs/platform/search/common/search';
 import { FileWalker } from 'vs/workbench/services/search/node/fileSearch';
 
-import { ISerializedFileMatch, ISerializedSearchComplete, IRawSearch, ISearchEngine } from './search';
+import { ISerializedFileMatch, ISerializedSearchComplete, IRawSearch, ISearchEngine, ISearchProgress } from './search';
 import { ISearchWorker } from './worker/searchWorkerIpc';
 import { ITextSearchWorkerProvider } from './textSearchWorkerProvider';
+import { PPromise } from 'vs/base/common/winjs.base';
 
 export class Engine implements ISearchEngine<ISerializedFileMatch[]> {
 
@@ -57,6 +58,138 @@ export class Engine implements ISearchEngine<ISerializedFileMatch[]> {
 		this.workers.forEach(w => {
 			w.initialize()
 				.then(null, onUnexpectedError);
+		});
+	}
+
+	searchP(): PPromise<ISerializedSearchComplete, ISearchProgress<ISerializedFileMatch[]>> {
+		return new PPromise<ISerializedSearchComplete, ISearchProgress<ISerializedFileMatch[]>>((resolve, reject, emitProgress) => {
+			this.workers = this.workerProvider.getWorkers();
+			this.initializeWorkers();
+
+			const fileEncoding = this.config.folderQueries.length === 1 ?
+				this.config.folderQueries[0].fileEncoding || 'utf8' :
+				'utf8';
+
+			const progress = () => {
+				if (++this.progressed % Engine.PROGRESS_FLUSH_CHUNK_SIZE === 0) {
+					emitProgress(
+						{
+							progress: {
+								total: this.totalBytes,
+								worked: this.processedBytes
+							}
+						}
+					); // buffer progress in chunks to reduce pressure
+				}
+			};
+
+			const unwind = (processed: number) => {
+				this.processedBytes += processed;
+
+				// Emit progress() unless we got canceled or hit the limit
+				if (processed && !this.isDone && !this.isCanceled && !this.limitReached) {
+					progress();
+				}
+
+				// Emit done()
+				if (!this.isDone && this.processedBytes === this.totalBytes && this.walkerIsDone) {
+					this.isDone = true;
+					resolve({
+						limitHit: this.limitReached,
+						stats: this.walker.getStats()
+					});
+				}
+			};
+
+			const run = (batch: string[], batchBytes: number): void => {
+				const worker = this.workers[this.nextWorker];
+				this.nextWorker = (this.nextWorker + 1) % this.workers.length;
+
+				const maxResults = this.config.maxResults && (this.config.maxResults - this.numResults);
+				const searchArgs = { absolutePaths: batch, maxResults, pattern: this.config.contentPattern, fileEncoding };
+				worker.search(searchArgs).then(result => {
+					if (!result || this.limitReached || this.isCanceled) {
+						return unwind(batchBytes);
+					}
+
+					const matches = result.matches;
+					emitProgress({ results: matches });
+					this.numResults += result.numMatches;
+
+					if (this.config.maxResults && this.numResults >= this.config.maxResults) {
+						// It's possible to go over maxResults like this, but it's much simpler than trying to extract the exact number
+						// of file matches, line matches, and matches within a line to == maxResults.
+						this.limitReached = true;
+					}
+
+					unwind(batchBytes);
+				},
+					error => {
+						// An error on the worker's end, not in reading the file, but in processing the batch. Log and continue.
+						onUnexpectedError(error);
+						unwind(batchBytes);
+					});
+			};
+
+
+			// Walk over the file system
+			let nextBatch: string[] = [];
+			let nextBatchBytes = 0;
+			const batchFlushBytes = 2 ** 20; // 1MB
+			this.walker.walkP(this.config.folderQueries, this.config.extraFiles).then(
+				complete => {
+					this.walkerIsDone = true;
+					this.walkerError = null;
+
+					// Send any remaining paths to a worker, or unwind if we're stopping
+					if (nextBatch.length) {
+						if (this.limitReached || this.isCanceled) {
+							unwind(nextBatchBytes);
+						} else {
+							run(nextBatch, nextBatchBytes);
+						}
+					} else {
+						unwind(0);
+					}
+				},
+				error => {
+					this.walkerIsDone = true;
+					this.walkerError = error;
+
+					// Send any remaining paths to a worker, or unwind if we're stopping
+					if (nextBatch.length) {
+						if (this.limitReached || this.isCanceled) {
+							unwind(nextBatchBytes);
+						} else {
+							run(nextBatch, nextBatchBytes);
+						}
+					} else {
+						unwind(0);
+					}
+				},
+				result => {
+					let bytes = result.size || 1;
+					this.totalBytes += bytes;
+
+					// If we have reached the limit or we are canceled, ignore it
+					if (this.limitReached || this.isCanceled) {
+						return unwind(bytes);
+					}
+
+					// Indicate progress to the outside
+					progress();
+
+					const absolutePath = result.base ? [result.base, result.relativePath].join(path.sep) : result.relativePath;
+					nextBatch.push(absolutePath);
+					nextBatchBytes += bytes;
+
+					if (nextBatchBytes >= batchFlushBytes) {
+						run(nextBatch, nextBatchBytes);
+						nextBatch = [];
+						nextBatchBytes = 0;
+					}
+				}
+			);
 		});
 	}
 

--- a/src/vs/workbench/services/search/test/node/search.test.ts
+++ b/src/vs/workbench/services/search/test/node/search.test.ts
@@ -49,8 +49,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -71,8 +71,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -94,8 +94,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -118,8 +118,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -142,8 +142,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -167,8 +167,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -192,8 +192,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -214,8 +214,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -236,8 +236,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -258,8 +258,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -285,8 +285,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -313,8 +313,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -335,8 +335,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -357,8 +357,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -379,8 +379,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -404,11 +404,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -428,8 +428,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -450,8 +450,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -472,8 +472,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -495,8 +495,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -518,8 +518,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -541,8 +541,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -578,8 +578,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -602,11 +602,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -625,8 +625,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -650,11 +650,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -675,11 +675,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -701,11 +701,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -731,8 +731,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				res.push(result);
+			({ results }) => {
+				res.push(results);
 			}
 		);
 	});
@@ -758,11 +758,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -789,11 +789,11 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
-				res = result;
+				res = results;
 			}
 		);
 	});
@@ -818,8 +818,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}
@@ -843,8 +843,8 @@ suite('FileSearchEngine', () => {
 				done();
 			},
 			error => { assert.ok(!error); },
-			result => {
-				if (result) {
+			({ results }) => {
+				if (results) {
 					count++;
 				}
 			}

--- a/src/vs/workbench/services/search/test/node/search.test.ts
+++ b/src/vs/workbench/services/search/test/node/search.test.ts
@@ -43,15 +43,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 4);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 4);
-			done();
-		});
+		);
 	});
 
 	test('Files: maxResults', function (done: () => void) {
@@ -62,15 +65,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: maxResults without Ripgrep', function (done: () => void) {
@@ -82,15 +88,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: exists', function (done: () => void) {
@@ -102,16 +111,19 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				assert.ok(complete.limitHit);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error, complete) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			assert.ok(complete.limitHit);
-			done();
-		});
+		);
 	});
 
 	test('Files: not exists', function (done: () => void) {
@@ -123,16 +135,19 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				assert.ok(!complete.limitHit);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error, complete) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			assert.ok(!complete.limitHit);
-			done();
-		});
+		);
 	});
 
 	test('Files: exists without Ripgrep', function (done: () => void) {
@@ -145,16 +160,19 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				assert.ok(complete.limitHit);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error, complete) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			assert.ok(complete.limitHit);
-			done();
-		});
+		);
 	});
 
 	test('Files: not exists without Ripgrep', function (done: () => void) {
@@ -167,16 +185,19 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				assert.ok(!complete.limitHit);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error, complete) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			assert.ok(!complete.limitHit);
-			done();
-		});
+		);
 	});
 
 	test('Files: examples/com*', function (done: () => void) {
@@ -187,15 +208,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: examples (fuzzy)', function (done: () => void) {
@@ -206,15 +230,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 7);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 7);
-			done();
-		});
+		);
 	});
 
 	test('Files: multiroot', function (done: () => void) {
@@ -225,15 +252,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 3);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 3);
-			done();
-		});
+		);
 	});
 
 	test('Files: multiroot with includePattern and maxResults', function (done: () => void) {
@@ -249,15 +279,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error, complete) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: multiroot with includePattern and exists', function (done: () => void) {
@@ -273,16 +306,19 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				assert.ok(complete.limitHit);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error, complete) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			assert.ok(complete.limitHit);
-			done();
-		});
+		);
 	});
 
 	test('Files: NPE (CamelCase)', function (done: () => void) {
@@ -293,15 +329,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: *.*', function (done: () => void) {
@@ -312,15 +351,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 14);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 14);
-			done();
-		});
+		);
 	});
 
 	test('Files: *.as', function (done: () => void) {
@@ -331,15 +373,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			done();
-		});
+		);
 	});
 
 	test('Files: *.* without derived', function (done: () => void) {
@@ -352,17 +397,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.strictEqual(path.basename(res.relativePath), 'site.less');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.strictEqual(path.basename(res.relativePath), 'site.less');
-			done();
-		});
+		);
 	});
 
 	test('Files: *.* exclude folder without wildcard', function (done: () => void) {
@@ -374,15 +422,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 8);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 8);
-			done();
-		});
+		);
 	});
 
 	test('Files: exclude folder without wildcard #36438', function (done: () => void) {
@@ -393,15 +444,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: include folder without wildcard #36438', function (done: () => void) {
@@ -412,15 +466,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 
 	test('Files: *.* exclude folder with leading wildcard', function (done: () => void) {
@@ -432,15 +489,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 8);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 8);
-			done();
-		});
+		);
 	});
 
 	test('Files: *.* exclude folder with trailing wildcard', function (done: () => void) {
@@ -452,15 +512,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 8);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 8);
-			done();
-		});
+		);
 	});
 
 	test('Files: *.* exclude with unicode', function (done: () => void) {
@@ -472,15 +535,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 13);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 13);
-			done();
-		});
+		);
 	});
 
 	test('Files: multiroot with exclude', function (done: () => void) {
@@ -506,15 +572,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 5);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 5);
-			done();
-		});
+		);
 	});
 
 	test('Files: Unicode and Spaces', function (done: () => void) {
@@ -526,17 +595,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.equal(path.basename(res.relativePath), '汉语.txt');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), '汉语.txt');
-			done();
-		});
+		);
 	});
 
 	test('Files: no results', function (done: () => void) {
@@ -547,15 +619,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 0);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 0);
-			done();
-		});
+		);
 	});
 
 	test('Files: absolute path to file ignores excludes', function (done: () => void) {
@@ -568,17 +643,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.equal(path.basename(res.relativePath), 'site.css');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'site.css');
-			done();
-		});
+		);
 	});
 
 	test('Files: relative path matched once', function (done: () => void) {
@@ -590,17 +668,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.equal(path.basename(res.relativePath), 'company.js');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'company.js');
-			done();
-		});
+		);
 	});
 
 	test('Files: relative path to file ignores excludes', function (done: () => void) {
@@ -613,17 +694,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.equal(path.basename(res.relativePath), 'company.js');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'company.js');
-			done();
-		});
+		);
 	});
 
 	test('Files: Include pattern, single files', function (done: () => void) {
@@ -638,16 +722,19 @@ suite('FileSearchEngine', () => {
 		});
 
 		let res: IRawFileMatch[] = [];
-		engine.search((result) => {
-			res.push(result);
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			const basenames = res.map(r => path.basename(r.relativePath));
-			assert.ok(basenames.indexOf('site.css') !== -1, `site.css missing in ${JSON.stringify(basenames)}`);
-			assert.ok(basenames.indexOf('company.js') !== -1, `company.js missing in ${JSON.stringify(basenames)}`);
-			assert.ok(basenames.indexOf('subfile.txt') !== -1, `subfile.txt missing in ${JSON.stringify(basenames)}`);
-			done();
-		});
+		engine.searchP().then(
+			complete => {
+				const basenames = res.map(r => path.basename(r.relativePath));
+				assert.ok(basenames.indexOf('site.css') !== -1, `site.css missing in ${JSON.stringify(basenames)}`);
+				assert.ok(basenames.indexOf('company.js') !== -1, `company.js missing in ${JSON.stringify(basenames)}`);
+				assert.ok(basenames.indexOf('subfile.txt') !== -1, `subfile.txt missing in ${JSON.stringify(basenames)}`);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				res.push(result);
+			}
+		);
 	});
 
 	test('Files: extraFiles only', function (done: () => void) {
@@ -664,17 +751,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.equal(path.basename(res.relativePath), 'company.js');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'company.js');
-			done();
-		});
+		);
 	});
 
 	test('Files: extraFiles only (with include)', function (done: () => void) {
@@ -692,17 +782,20 @@ suite('FileSearchEngine', () => {
 
 		let count = 0;
 		let res: IRawFileMatch;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				assert.equal(path.basename(res.relativePath), 'site.css');
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
+				res = result;
 			}
-			res = result;
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			assert.equal(path.basename(res.relativePath), 'site.css');
-			done();
-		});
+		);
 	});
 
 	test('Files: extraFiles only (with exclude)', function (done: () => void) {
@@ -719,15 +812,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 2);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 2);
-			done();
-		});
+		);
 	});
 
 	test('Files: no dupes in nested folders', function (done: () => void) {
@@ -741,15 +837,18 @@ suite('FileSearchEngine', () => {
 		});
 
 		let count = 0;
-		engine.search((result) => {
-			if (result) {
-				count++;
+		engine.searchP().then(
+			complete => {
+				assert.equal(count, 1);
+				done();
+			},
+			error => { assert.ok(!error); },
+			result => {
+				if (result) {
+					count++;
+				}
 			}
-		}, () => { }, (error) => {
-			assert.ok(!error);
-			assert.equal(count, 1);
-			done();
-		});
+		);
 	});
 });
 

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -40,24 +40,30 @@ function doLegacySearchTest(config: IRawSearch, expectedResultCount: number | Fu
 		let engine = new TextSearchEngine(config, new FileWalker({ ...config, useRipgrep: false }), textSearchWorkerProvider);
 
 		let c = 0;
-		engine.search((result) => {
-			if (result) {
-				c += countAll(result);
-			}
-		}, () => { }, (error) => {
-			try {
-				assert.ok(!error);
-				if (typeof expectedResultCount === 'function') {
-					assert(expectedResultCount(c));
-				} else {
-					assert.equal(c, expectedResultCount, 'legacy');
-				}
-			} catch (e) {
-				reject(e);
-			}
 
-			resolve(undefined);
-		});
+		return engine.searchP().then(
+			complete => {
+				try {
+					if (typeof expectedResultCount === 'function') {
+						assert(expectedResultCount(c));
+					} else {
+						assert.equal(c, expectedResultCount, 'legacy');
+					}
+				} catch (e) {
+					reject(e);
+				}
+
+				resolve(undefined);
+			},
+			error => {
+				assert.ok(!error);
+			},
+			({ results }) => {
+				if (results) {
+					c += countAll(results);
+				}
+			}
+		);
 	});
 }
 


### PR DESCRIPTION
Draft to fix #20650

Initial draft of changes for moving the `search` function inside FileSearch and
TextSearch modules to ause a promise interface instead of callbacks.

I have a couple of problems with the changes I made:

1. The `complete` action's object shape is very different from that of
   `progress`. So much so that the usage doesn't feel natural to me.

   As @roblourens pointed out, may be it's time to have different interfaces
   for text and file search.

2. This doesn't clean up code related to ripgrepsearch yet.