### PR TITLE
Add publishsettings to list of xml file types

### DIFF
--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -36,6 +36,7 @@
 				".proj",
         ".props",
 				".pt",
+				".publishsettings",
 				".pubxml",
 				".pubxml.user",
 				".rdf",


### PR DESCRIPTION
I often grab a publish settings file from Azure 'Get publish profile' button, I assume I am not alone in this being helpful

Based the change on #30052
