### PR TITLE
Add FoldAt/UnfoldAt to fold and unfold commands

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -430,7 +430,7 @@ export class FoldingController implements IFoldingController {
 		}
 	}
 
-	public foldAt( line: number ) {
+	public foldAt(line: number) {
 		let hasChanges = false;
 		let toFold: CollapsibleRegion[] = getCollapsibleRegionsToFoldAtLine(this.decorations, this.editor.getModel(), line, 1, true);
 		toFold.forEach(collapsibleRegion => this.editor.changeDecorations(changeAccessor => {
@@ -662,8 +662,8 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 	invoke(foldingController: FoldingController, editor: editorCommon.ICommonCodeEditor, args: FoldingArguments): void {
 		args = args ? args : { levels: 1, direction: 'up' };
 
-		if ( args && args.line ) {
-			foldingController.foldAt( args.line );
+		if (args && args.line >= 0) {
+			foldingController.foldAt(args.line);
 		} else {
 			foldingController.fold(args.levels || 1, args.direction === 'up');
 		}

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -430,6 +430,18 @@ export class FoldingController implements IFoldingController {
 		}
 	}
 
+	public foldAt( line: number ) {
+		let hasChanges = false;
+		let toFold: CollapsibleRegion[] = getCollapsibleRegionsToFoldAtLine(this.decorations, this.editor.getModel(), line, 1, true);
+		toFold.forEach(collapsibleRegion => this.editor.changeDecorations(changeAccessor => {
+			collapsibleRegion.setCollapsed(true, changeAccessor);
+			hasChanges = true;
+		}));
+		if (hasChanges) {
+			this.updateHiddenAreas(line);
+		}
+	}
+
 	public foldUnfoldRecursively(isFold: boolean): void {
 		let hasChanges = false;
 		let model = this.editor.getModel();
@@ -539,6 +551,7 @@ abstract class FoldingAction<T> extends EditorAction {
 interface FoldingArguments {
 	levels?: number;
 	direction?: 'up' | 'down';
+	line?: number;
 }
 
 function foldingArgumentsConstraint(args: any) {
@@ -648,7 +661,12 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 
 	invoke(foldingController: FoldingController, editor: editorCommon.ICommonCodeEditor, args: FoldingArguments): void {
 		args = args ? args : { levels: 1, direction: 'up' };
-		foldingController.fold(args.levels || 1, args.direction === 'up');
+
+		if ( args && args.line ) {
+			foldingController.foldAt( args.line );
+		} else {
+			foldingController.fold(args.levels || 1, args.direction === 'up');
+		}
 	}
 }
 


### PR DESCRIPTION
In reference to #3598 - Added a new parameter to the FoldingArguments that is the line number. If this parameter is passed, then it will perform a fold/unfold at the line specified.  If the line number is not specified the command works as before. 

A sample call would look:

```javascript
vscode.commands.executeCommand("editor.fold", {line:1})
```