### PR TITLE
SCM: Allow inline commands in the API

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -273,4 +273,58 @@ declare module 'vscode' {
 		 */
 		resolveDebugConfiguration?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration>;
 	}
+
+	// SCM
+
+	export interface Command {
+
+		/**
+		 * An icon for the command, when represented in the UI.
+		 */
+		iconPath?: string | Uri;
+	}
+
+	export interface SourceControlResourceState {
+
+		/**
+		 * Optional inline commands.
+		 */
+		inlineCommands?: Command[];
+
+		/**
+		 * Optional context commands.
+		 */
+		contextCommands?: Command[];
+	}
+
+	export interface SourceControlResourceGroup {
+
+		/**
+		 * Optional inline commands.
+		 */
+		inlineCommands?: Command[];
+
+		/**
+		 * Optional context commands.
+		 */
+		contextCommands?: Command[];
+	}
+
+	export interface SourceControl {
+
+		/**
+		 * Optional inline commands.
+		 */
+		inlineCommands?: Command[];
+
+		/**
+		 * Optional overflow commands.
+		 */
+		overflowCommands?: Command[];
+
+		/**
+		 * Optional context commands.
+		 */
+		contextCommands?: Command[];
+	}
 }

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -288,11 +288,17 @@ declare module 'vscode' {
 
 		/**
 		 * Optional inline commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControlResourceState
+		 * instance as the first argument.
 		 */
 		inlineCommands?: Command[];
 
 		/**
 		 * Optional context commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControlResourceState
+		 * instance as the first argument.
 		 */
 		contextCommands?: Command[];
 	}
@@ -301,11 +307,17 @@ declare module 'vscode' {
 
 		/**
 		 * Optional inline commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControlResourceGroup
+		 * instance as the first argument.
 		 */
 		inlineCommands?: Command[];
 
 		/**
 		 * Optional context commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControlResourceGroup
+		 * instance as the first argument.
 		 */
 		contextCommands?: Command[];
 	}
@@ -314,16 +326,25 @@ declare module 'vscode' {
 
 		/**
 		 * Optional inline commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControl
+		 * instance as the first argument.
 		 */
 		inlineCommands?: Command[];
 
 		/**
 		 * Optional overflow commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControl
+		 * instance as the first argument.
 		 */
 		overflowCommands?: Command[];
 
 		/**
 		 * Optional context commands.
+		 *
+		 * By default, the commands will be invoked with this SourceControl
+		 * instance as the first argument.
 		 */
 		contextCommands?: Command[];
 	}

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -276,14 +276,6 @@ declare module 'vscode' {
 
 	// SCM
 
-	export interface Command {
-
-		/**
-		 * An icon for the command, when represented in the UI.
-		 */
-		iconPath?: string | Uri;
-	}
-
 	export interface SourceControlResourceState {
 
 		/**
@@ -339,13 +331,5 @@ declare module 'vscode' {
 		 * instance as the first argument.
 		 */
 		overflowCommands?: Command[];
-
-		/**
-		 * Optional context commands.
-		 *
-		 * By default, the commands will be invoked with this SourceControl
-		 * instance as the first argument.
-		 */
-		contextCommands?: Command[];
 	}
 }

--- a/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
@@ -84,7 +84,6 @@ class MainThreadSCMProvider implements ISCMProvider {
 	get statusBarCommands(): Command[] | undefined { return this.features.statusBarCommands; }
 	get inlineCommands(): Command[] | undefined { return this.features.inlineCommands; }
 	get overflowCommands(): Command[] | undefined { return this.features.overflowCommands; }
-	get contextCommands(): Command[] | undefined { return this.features.contextCommands; }
 
 	private _onDidChangeCommitTemplate = new Emitter<string>();
 	get onDidChangeCommitTemplate(): Event<string> { return this._onDidChangeCommitTemplate.event; }

--- a/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
@@ -19,6 +19,9 @@ import { extHostNamedCustomer } from "vs/workbench/api/electron-browser/extHostC
 
 class MainThreadSCMResourceGroup implements ISCMResourceGroup {
 
+	get inlineCommands(): Command[] | undefined { return this.features.inlineCommands; }
+	get contextCommands(): Command[] | undefined { return this.features.contextCommands; }
+
 	constructor(
 		private sourceControlHandle: number,
 		private handle: number,

--- a/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
@@ -82,6 +82,9 @@ class MainThreadSCMProvider implements ISCMProvider {
 	get commitTemplate(): string | undefined { return this.features.commitTemplate; }
 	get acceptInputCommand(): Command | undefined { return this.features.acceptInputCommand; }
 	get statusBarCommands(): Command[] | undefined { return this.features.statusBarCommands; }
+	get inlineCommands(): Command[] | undefined { return this.features.inlineCommands; }
+	get overflowCommands(): Command[] | undefined { return this.features.overflowCommands; }
+	get contextCommands(): Command[] | undefined { return this.features.contextCommands; }
 
 	private _onDidChangeCommitTemplate = new Emitter<string>();
 	get onDidChangeCommitTemplate(): Event<string> { return this._onDidChangeCommitTemplate.event; }

--- a/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
@@ -47,10 +47,12 @@ class MainThreadSCMResource implements ISCMResource {
 		private sourceControlHandle: number,
 		private groupHandle: number,
 		private handle: number,
-		public sourceUri: URI,
-		public command: Command | undefined,
-		public resourceGroup: ISCMResourceGroup,
-		public decorations: ISCMResourceDecorations
+		readonly sourceUri: URI,
+		readonly command: Command | undefined,
+		readonly resourceGroup: ISCMResourceGroup,
+		readonly decorations: ISCMResourceDecorations,
+		readonly inlineCommands: Command[],
+		readonly contextCommands: Command[]
 	) { }
 
 	toJSON(): any {
@@ -161,7 +163,7 @@ class MainThreadSCMProvider implements ISCMProvider {
 		}
 
 		group.resources = resources.map(rawResource => {
-			const [handle, sourceUri, command, icons, tooltip, strikeThrough, faded] = rawResource;
+			const [handle, sourceUri, command, icons, tooltip, strikeThrough, faded, inlineCommands, contextCommands] = rawResource;
 			const icon = icons[0];
 			const iconDark = icons[1] || icon;
 			const decorations = {
@@ -179,7 +181,9 @@ class MainThreadSCMProvider implements ISCMProvider {
 				URI.parse(sourceUri),
 				command,
 				group,
-				decorations
+				decorations,
+				inlineCommands,
+				contextCommands
 			);
 		});
 

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -316,7 +316,9 @@ export type SCMRawResource = [
 	string[] /*icons: light, dark*/,
 	string /*tooltip*/,
 	boolean /*strike through*/,
-	boolean /*faded*/
+	boolean /*faded*/,
+	modes.Command[] /*inline commands*/,
+	modes.Command[] /*context commands*/
 ];
 
 export interface MainThreadSCMShape extends IDisposable {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -299,6 +299,9 @@ export interface SCMProviderFeatures {
 	commitTemplate?: string;
 	acceptInputCommand?: modes.Command;
 	statusBarCommands?: modes.Command[];
+	inlineCommands?: modes.Command[];
+	overflowCommands?: modes.Command[];
+	contextCommands?: modes.Command[];
 }
 
 export interface SCMGroupFeatures {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -305,6 +305,8 @@ export interface SCMProviderFeatures {
 
 export interface SCMGroupFeatures {
 	hideWhenEmpty?: boolean;
+	inlineCommands?: modes.Command[];
+	contextCommands?: modes.Command[];
 }
 
 export type SCMRawResource = [

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -301,7 +301,6 @@ export interface SCMProviderFeatures {
 	statusBarCommands?: modes.Command[];
 	inlineCommands?: modes.Command[];
 	overflowCommands?: modes.Command[];
-	contextCommands?: modes.Command[];
 }
 
 export interface SCMGroupFeatures {

--- a/src/vs/workbench/api/node/extHostCommands.ts
+++ b/src/vs/workbench/api/node/extHostCommands.ts
@@ -187,7 +187,7 @@ export class CommandsConverter {
 			ObjectIdentifier.mixin(result, id);
 
 			result.id = '_internal_command_delegation';
-			result.arguments = [id];
+			result.arguments = [id, command.command];
 		}
 
 		if (command.tooltip) {

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -262,22 +262,6 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		this._proxy.$updateSourceControl(this._handle, { overflowCommands: internal });
 	}
 
-	private _contextCommands: vscode.Command[] | undefined = undefined;
-
-	get contextCommands(): vscode.Command[] | undefined {
-		return this._contextCommands;
-	}
-
-	set contextCommands(contextCommands: vscode.Command[] | undefined) {
-		this._contextCommands = contextCommands;
-
-		const internal = (contextCommands || [])
-			.map(c => ({ ...c, arguments: [this, ...(c.arguments || [])] }))
-			.map(c => this._commands.toInternal(c));
-
-		this._proxy.$updateSourceControl(this._handle, { contextCommands: internal });
-	}
-
 	private _handle: number = ExtHostSourceControl._handlePool++;
 
 	constructor(

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -134,6 +134,38 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
 		this._proxy.$updateGroupResourceStates(this._sourceControlHandle, this._handle, rawResources);
 	}
 
+	private _inlineCommands: vscode.Command[] | undefined = undefined;
+
+	get inlineCommands(): vscode.Command[] | undefined {
+		return this._inlineCommands;
+	}
+
+	set inlineCommands(inlineCommands: vscode.Command[] | undefined) {
+		this._inlineCommands = inlineCommands;
+
+		const internal = (inlineCommands || [])
+			.map(c => ({ ...c, arguments: [this, ...(c.arguments || [])] }))
+			.map(c => this._commands.toInternal(c));
+
+		this._proxy.$updateGroup(this._sourceControlHandle, this._handle, { inlineCommands: internal });
+	}
+
+	private _contextCommands: vscode.Command[] | undefined = undefined;
+
+	get contextCommands(): vscode.Command[] | undefined {
+		return this._contextCommands;
+	}
+
+	set contextCommands(contextCommands: vscode.Command[] | undefined) {
+		this._contextCommands = contextCommands;
+
+		const internal = (contextCommands || [])
+			.map(c => ({ ...c, arguments: [this, ...(c.arguments || [])] }))
+			.map(c => this._commands.toInternal(c));
+
+		this._proxy.$updateGroup(this._sourceControlHandle, this._handle, { contextCommands: internal });
+	}
+
 	private _handle: GroupHandle = ExtHostSourceControlResourceGroup._handlePool++;
 	get handle(): GroupHandle {
 		return this._handle;

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -230,6 +230,54 @@ class ExtHostSourceControl implements vscode.SourceControl {
 		this._proxy.$updateSourceControl(this._handle, { statusBarCommands: internal });
 	}
 
+	private _inlineCommands: vscode.Command[] | undefined = undefined;
+
+	get inlineCommands(): vscode.Command[] | undefined {
+		return this._inlineCommands;
+	}
+
+	set inlineCommands(inlineCommands: vscode.Command[] | undefined) {
+		this._inlineCommands = inlineCommands;
+
+		const internal = (inlineCommands || [])
+			.map(c => ({ ...c, arguments: [this, ...(c.arguments || [])] }))
+			.map(c => this._commands.toInternal(c));
+
+		this._proxy.$updateSourceControl(this._handle, { inlineCommands: internal });
+	}
+
+	private _overflowCommands: vscode.Command[] | undefined = undefined;
+
+	get overflowCommands(): vscode.Command[] | undefined {
+		return this._overflowCommands;
+	}
+
+	set overflowCommands(overflowCommands: vscode.Command[] | undefined) {
+		this._overflowCommands = overflowCommands;
+
+		const internal = (overflowCommands || [])
+			.map(c => ({ ...c, arguments: [this, ...(c.arguments || [])] }))
+			.map(c => this._commands.toInternal(c));
+
+		this._proxy.$updateSourceControl(this._handle, { overflowCommands: internal });
+	}
+
+	private _contextCommands: vscode.Command[] | undefined = undefined;
+
+	get contextCommands(): vscode.Command[] | undefined {
+		return this._contextCommands;
+	}
+
+	set contextCommands(contextCommands: vscode.Command[] | undefined) {
+		this._contextCommands = contextCommands;
+
+		const internal = (contextCommands || [])
+			.map(c => ({ ...c, arguments: [this, ...(c.arguments || [])] }))
+			.map(c => this._commands.toInternal(c));
+
+		this._proxy.$updateSourceControl(this._handle, { contextCommands: internal });
+	}
+
 	private _handle: number = ExtHostSourceControl._handlePool++;
 
 	constructor(

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -128,7 +128,13 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
 			const strikeThrough = r.decorations && !!r.decorations.strikeThrough;
 			const faded = r.decorations && !!r.decorations.faded;
 
-			return [handle, sourceUri, command, icons, tooltip, strikeThrough, faded] as SCMRawResource;
+			const inlineCommands = (r.inlineCommands || [])
+				.map(c => this._commands.toInternal({ ...c, arguments: [r, ...(c.arguments || [])] }));
+
+			const contextCommands = (r.inlineCommands || [])
+				.map(c => this._commands.toInternal({ ...c, arguments: [r, ...(c.arguments || [])] }));
+
+			return [handle, sourceUri, command, icons, tooltip, strikeThrough, faded, inlineCommands, contextCommands] as SCMRawResource;
 		});
 
 		this._proxy.$updateGroupResourceStates(this._sourceControlHandle, this._handle, rawResources);

--- a/src/vs/workbench/parts/scm/electron-browser/scmMenus.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmMenus.ts
@@ -169,11 +169,17 @@ export class SCMMenus implements IDisposable {
 	}
 
 	getResourceGroupActions(group: ISCMResourceGroup): IAction[] {
-		return this.getActions(MenuId.SCMResourceGroupContext, group).primary;
+		const commands = group.inlineCommands || [];
+		const inlineActions = commands.map(command => new CommandAction(command, this.commandService));
+
+		return [...inlineActions, ...this.getActions(MenuId.SCMResourceGroupContext, group).primary];
 	}
 
 	getResourceGroupContextActions(group: ISCMResourceGroup): IAction[] {
-		return this.getActions(MenuId.SCMResourceGroupContext, group).secondary;
+		const commands = group.contextCommands || [];
+		const contextActions = commands.map(command => new CommandAction(command, this.commandService));
+
+		return [...contextActions, ...this.getActions(MenuId.SCMResourceGroupContext, group).secondary];
 	}
 
 	getResourceActions(resource: ISCMResource): IAction[] {

--- a/src/vs/workbench/parts/scm/electron-browser/scmMenus.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmMenus.ts
@@ -183,11 +183,17 @@ export class SCMMenus implements IDisposable {
 	}
 
 	getResourceActions(resource: ISCMResource): IAction[] {
-		return this.getActions(MenuId.SCMResourceContext, resource).primary;
+		const commands = resource.inlineCommands || [];
+		const inlineActions = commands.map(command => new CommandAction(command, this.commandService));
+
+		return [...inlineActions, ...this.getActions(MenuId.SCMResourceContext, resource).primary];
 	}
 
 	getResourceContextActions(resource: ISCMResource): IAction[] {
-		return this.getActions(MenuId.SCMResourceContext, resource).secondary;
+		const commands = resource.contextCommands || [];
+		const contextActions = commands.map(command => new CommandAction(command, this.commandService));
+
+		return [...contextActions, ...this.getActions(MenuId.SCMResourceContext, resource).secondary];
 	}
 
 	private static readonly NoActions = { primary: [], secondary: [] };

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -188,7 +188,7 @@ class ResourceRenderer implements IRenderer<ISCMResource, ResourceTemplate> {
 		template.fileLabel.setFile(resource.sourceUri);
 		template.actionBar.clear();
 		template.actionBar.context = resource;
-		template.actionBar.push(this.scmMenus.getResourceActions(resource));
+		template.actionBar.push(this.scmMenus.getResourceActions(resource), { icon: true, label: false });
 		toggleClass(template.name, 'strike-through', resource.decorations.strikeThrough);
 		toggleClass(template.element, 'faded', resource.decorations.faded);
 

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -118,7 +118,7 @@ class ResourceGroupRenderer implements IRenderer<ISCMResourceGroup, ResourceGrou
 		template.count.setCount(group.resources.length);
 		template.actionBar.clear();
 		template.actionBar.context = group;
-		template.actionBar.push(this.scmMenus.getResourceGroupActions(group));
+		template.actionBar.push(this.scmMenus.getResourceGroupActions(group), { icon: true, label: false });
 	}
 
 	disposeTemplate(template: ResourceGroupTemplate): void {

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -51,6 +51,9 @@ export interface ISCMProvider extends IDisposable {
 	readonly onDidChangeCommitTemplate?: Event<string>;
 	readonly acceptInputCommand?: Command;
 	readonly statusBarCommands?: Command[];
+	readonly inlineCommands?: Command[];
+	readonly overflowCommands?: Command[];
+	readonly contextCommands?: Command[];
 
 	getOriginalResource(uri: URI): TPromise<URI>;
 }

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -39,6 +39,8 @@ export interface ISCMResourceGroup {
 	readonly label: string;
 	readonly id: string;
 	readonly resources: ISCMResource[];
+	readonly inlineCommands?: Command[];
+	readonly contextCommands?: Command[];
 }
 
 export interface ISCMProvider extends IDisposable {

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -32,6 +32,8 @@ export interface ISCMResource {
 	readonly sourceUri: URI;
 	readonly command?: Command;
 	readonly decorations: ISCMResourceDecorations;
+	readonly inlineCommands?: Command[];
+	readonly contextCommands?: Command[];
 }
 
 export interface ISCMResourceGroup {

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -53,7 +53,6 @@ export interface ISCMProvider extends IDisposable {
 	readonly statusBarCommands?: Command[];
 	readonly inlineCommands?: Command[];
 	readonly overflowCommands?: Command[];
-	readonly contextCommands?: Command[];
 
 	getOriginalResource(uri: URI): TPromise<URI>;
 }


### PR DESCRIPTION
Currently, SCM menus get populated using the generic menu declarative API, which has the following problems:

- The SCM menu contexts are specific to the SCM provider id. Thus, with the current `when` clause syntax, it's impossible to have commands appear on all `git` SCM providers, in a multi-provider story.
- Hard to understand what the arguments of those commands will actually be.
- Hard to use, cumbersome to get going.

This extends the API to support providing inline commands with the several SCM resources.

The idea is to also deprecate the `scm/*` menus, yet merge them with the inline commands for a few more releases.

- [x] Sketch up API changes
- [x] Implement the API changes
- [ ] Figure out how to have separators
- [ ] `console.warn` about the `scm/*` menu deprecation