### PR TITLE
Bug: Exclude active file from compare list (Cannot compare with self) Fixes: #31853

### DIFF
--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -1210,6 +1210,11 @@ export class GlobalCompareResourcesAction extends Action {
 					resource = (input as IResourceInput).resource;
 				}
 
+				// Cannot compare file with self - exclude active file
+				if (!!resource && resource === globalResourceToCompare) {
+					return void 0;
+				}
+
 				if (!resource) {
 					return void 0; // only support to compare with files and untitled
 				}

--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -1211,7 +1211,7 @@ export class GlobalCompareResourcesAction extends Action {
 				}
 
 				// Cannot compare file with self - exclude active file
-				if (!!resource && resource === globalResourceToCompare) {
+				if (!!resource && resource.toString() === globalResourceToCompare.toString()) {
 					return void 0;
 				}
 


### PR DESCRIPTION
The "Compare Active File With..." does not allow to compare the active file to self
yet the active file is included in the quick picklist.

PR excludes globalResourceToCompare from compare picklist.

Fixes: #31853
