### PR TITLE
Fix #32822. Stop propagation keydown event when keybinding.

### DIFF
--- a/src/vs/editor/browser/controller/textAreaInput.ts
+++ b/src/vs/editor/browser/controller/textAreaInput.ts
@@ -111,7 +111,7 @@ export class TextAreaInput extends Disposable {
 		this._nextCommand = ReadFromTextArea.Type;
 
 		this._register(dom.addStandardDisposableListener(textArea.domNode, 'keydown', (e: IKeyboardEvent) => {
-			if (this._isDoingComposition && e.equals(KeyCode.KEY_IN_COMPOSITION)) {
+			if (this._isDoingComposition && e.keyCode === KeyCode.KEY_IN_COMPOSITION) {
 				// Stop propagation for keyDown events if the IME is processing key input
 				e.stopPropagation();
 			}


### PR DESCRIPTION
Fix the bug in #32822 due to event propagation is not stopped when ctrl key is pressed during composition.
