### PR TITLE
Replace all instances off "Focussed" with "Focused" except ContextKey

### DIFF
--- a/src/typings/electron.d.ts
+++ b/src/typings/electron.d.ts
@@ -4580,7 +4580,7 @@ declare namespace Electron {
 		 */
 		isDevToolsOpened(): boolean;
 		/**
-		 * Returns whether the developer tools are focussed.
+		 * Returns whether the developer tools are focused.
 		 */
 		isDevToolsFocused(): boolean;
 		/**

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -684,7 +684,7 @@ export class ActionBar extends EventEmitter implements IActionRunner {
 
 	private cancel(): void {
 		if (document.activeElement instanceof HTMLElement) {
-			(<HTMLElement>document.activeElement).blur(); // remove focus from focussed action
+			(<HTMLElement>document.activeElement).blur(); // remove focus from focused action
 		}
 
 		this.emit(CommonEventType.CANCEL);

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -1616,8 +1616,8 @@ class FileDialog {
 		}
 
 		// Show Dialog
-		const focussedWindow = this.windowsMainService.getWindowById(options.windowId) || this.windowsMainService.getFocusedWindow();
-		dialog.showOpenDialog(focussedWindow && focussedWindow.win, options.dialogOptions, paths => {
+		const focusedWindow = this.windowsMainService.getWindowById(options.windowId) || this.windowsMainService.getFocusedWindow();
+		dialog.showOpenDialog(focusedWindow && focusedWindow.win, options.dialogOptions, paths => {
 			if (paths && paths.length > 0) {
 
 				// Remember path in storage for next time

--- a/src/vs/code/node/windowsFinder.ts
+++ b/src/vs/code/node/windowsFinder.ts
@@ -112,9 +112,9 @@ function hasCodeSettings(folder: string, normalizedUserHome?: string, codeSettin
 }
 
 export function getLastActiveWindow<W extends ISimpleWindow>(windows: W[]): W {
-	const lastFocussedDate = Math.max.apply(Math, windows.map(window => window.lastFocusTime));
+	const lastFocusedDate = Math.max.apply(Math, windows.map(window => window.lastFocusTime));
 
-	return windows.filter(window => window.lastFocusTime === lastFocussedDate)[0];
+	return windows.filter(window => window.lastFocusTime === lastFocusedDate)[0];
 }
 
 export function findWindowOnWorkspace<W extends ISimpleWindow>(windows: W[], workspace: (IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier)): W {

--- a/src/vs/editor/contrib/find/common/findController.ts
+++ b/src/vs/editor/contrib/find/common/findController.ts
@@ -39,6 +39,7 @@ export interface IFindStartOptions {
 
 export const CONTEXT_FIND_WIDGET_VISIBLE = new RawContextKey<boolean>('findWidgetVisible', false);
 export const CONTEXT_FIND_WIDGET_NOT_VISIBLE: ContextKeyExpr = CONTEXT_FIND_WIDGET_VISIBLE.toNegated();
+// Keep ContextKey use of 'Focussed' to not break when clauses
 export const CONTEXT_FIND_INPUT_FOCUSED = new RawContextKey<boolean>('findInputFocussed', false);
 
 export class CommonFindController extends Disposable implements editorCommon.IEditorContribution {

--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -76,7 +76,7 @@ function findEditor(model: IModel, codeEditorService: ICodeEditorService): IComm
 		for (const editor of codeEditorService.listCodeEditors()) {
 			if (editor.getModel() === model) {
 				if (editor.isFocused()) {
-					return editor; // favour focussed editor if there are multiple
+					return editor; // favour focused editor if there are multiple
 				}
 
 				candidate = editor;

--- a/src/vs/workbench/browser/panel.ts
+++ b/src/vs/workbench/browser/panel.ts
@@ -101,7 +101,7 @@ export abstract class TogglePanelAction extends Action {
 		return panel && panel.getId() === this.panelId;
 	}
 
-	protected isPanelFocussed(): boolean {
+	protected isPanelFocused(): boolean {
 		const activePanel = this.panelService.getActivePanel();
 		const activeElement = document.activeElement;
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -451,7 +451,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 					}
 				});
 
-				// Grow focussed position if there is more size to spend
+				// Grow focused position if there is more size to spend
 				if (remainingSize > this.minSize) {
 					this.silosSize[this.lastActivePosition] = remainingSize;
 
@@ -482,7 +482,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 
 	private focusNextNonMinimized(): void {
 
-		// If the current focussed editor is minimized, try to focus the next largest editor
+		// If the current focused editor is minimized, try to focus the next largest editor
 		if (!types.isUndefinedOrNull(this.lastActivePosition) && this.silosMinimized[this.lastActivePosition]) {
 			let candidate: Position = null;
 			let currentSize = this.minSize;

--- a/src/vs/workbench/browser/viewlet.ts
+++ b/src/vs/workbench/browser/viewlet.ts
@@ -231,7 +231,7 @@ export class ToggleViewletAction extends Action {
 
 	public run(): TPromise<any> {
 
-		// Pass focus to viewlet if not open or focussed
+		// Pass focus to viewlet if not open or focused
 		if (this.otherViewletShowing() || !this.sidebarHasFocus()) {
 			return this.viewletService.openViewlet(this.viewletId, true);
 		}

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -99,7 +99,7 @@
 }
 
 .monaco-shell .mac select:focus {
-	border: none; /* outline is a square, but border has a radius, so we avoid this glitch when focussed (https://github.com/Microsoft/vscode/issues/26045) */
+	border: none; /* outline is a square, but border has a radius, so we avoid this glitch when focused (https://github.com/Microsoft/vscode/issues/26045) */
 }
 
 .monaco-shell.hc-black [tabindex="0"]:focus,
@@ -158,7 +158,7 @@
 }
 
 .monaco-shell .monaco-tree.focused:focus {
-	outline: 0 !important; /* tree indicates focus not via outline but through the focussed item */
+	outline: 0 !important; /* tree indicates focus not via outline but through the focused item */
 }
 
 .monaco-shell [tabindex="0"]:active,

--- a/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
+++ b/src/vs/workbench/parts/debug/browser/debugContentProvider.ts
@@ -44,7 +44,7 @@ export class DebugContentProvider implements IWorkbenchContribution, ITextModelC
 		}
 
 		if (!process) {
-			// fallback: use focussed process
+			// fallback: use focused process
 			process = this.debugService.getViewModel().focusedProcess;
 		}
 

--- a/src/vs/workbench/parts/debug/browser/debugEditorModelManager.ts
+++ b/src/vs/workbench/parts/debug/browser/debugEditorModelManager.ts
@@ -121,11 +121,11 @@ export class DebugEditorModelManager implements IWorkbenchContribution {
 			return result;
 		}
 
-		// only show decorations for the currently focussed thread.
+		// only show decorations for the currently focused thread.
 		const columnUntilEOLRange = new Range(stackFrame.range.startLineNumber, stackFrame.range.startColumn, stackFrame.range.startLineNumber, Constants.MAX_SAFE_SMALL_INTEGER);
 		const range = new Range(stackFrame.range.startLineNumber, stackFrame.range.startColumn, stackFrame.range.startLineNumber, stackFrame.range.startColumn + 1);
 
-		// compute how to decorate the editor. Different decorations are used if this is a top stack frame, focussed stack frame,
+		// compute how to decorate the editor. Different decorations are used if this is a top stack frame, focused stack frame,
 		// an exception or a stack frame that did not change the line number (we only decorate the columns, not the whole line).
 		const callStack = stackFrame.thread.getCallStack();
 		if (callStack && callStack.length && stackFrame === callStack[0]) {

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -251,7 +251,7 @@ export class DebugService implements debug.IDebugService {
 			return TPromise.as(null);
 		}
 
-		// focus first stack frame from top that has source location if no other stack frame is focussed
+		// focus first stack frame from top that has source location if no other stack frame is focused
 		const stackFrameToFocus = first(callStack, sf => sf.source && sf.source.available, undefined);
 		if (!stackFrameToFocus) {
 			return TPromise.as(null);

--- a/src/vs/workbench/parts/files/browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.ts
@@ -45,7 +45,7 @@ import { getCodeEditor } from 'vs/editor/common/services/codeEditorService';
 import { IEditorViewState, IModel } from 'vs/editor/common/editorCommon';
 import { IBackupFileService } from 'vs/workbench/services/backup/common/backup';
 import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
-import { withFocussedFilesExplorer, revealInOSCommand, revealInExplorerCommand, copyPathCommand } from 'vs/workbench/parts/files/browser/fileCommands';
+import { withFocusedFilesExplorer, revealInOSCommand, revealInExplorerCommand, copyPathCommand } from 'vs/workbench/parts/files/browser/fileCommands';
 import { ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { ITextModelService, ITextModelContentProvider } from 'vs/editor/common/services/resolverService';
@@ -1003,7 +1003,7 @@ export class PasteFileAction extends BaseFileAction {
 export const pasteIntoFocusedFilesExplorerViewItem = (accessor: ServicesAccessor) => {
 	const instantiationService = accessor.get(IInstantiationService);
 
-	withFocussedFilesExplorer(accessor).then(res => {
+	withFocusedFilesExplorer(accessor).then(res => {
 		if (res) {
 			const pasteAction = instantiationService.createInstance(PasteFileAction, res.tree, res.tree.getFocus());
 			if (pasteAction._isEnabled()) {

--- a/src/vs/workbench/parts/files/browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/browser/fileCommands.ts
@@ -180,7 +180,7 @@ export function withFocussedFilesExplorer(accessor: ServicesAccessor): TPromise<
 
 		const tree = explorer.getExplorerView().getViewer();
 
-		// Ignore if in highlight mode or not focussed
+		// Ignore if in highlight mode or not focused
 		if (tree.getHighlight() || !tree.isDOMFocused()) {
 			return void 0;
 		}
@@ -197,7 +197,7 @@ function withFocussedOpenEditorsViewItem(accessor: ServicesAccessor): TPromise<{
 
 		const tree = explorer.getOpenEditorsView().getViewer();
 
-		// Ignore if in highlight mode or not focussed
+		// Ignore if in highlight mode or not focused
 		const focus = tree.getFocus();
 		if (tree.getHighlight() || !tree.isDOMFocused() || !(focus instanceof OpenEditor)) {
 			return void 0;

--- a/src/vs/workbench/parts/files/browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/browser/fileCommands.ts
@@ -111,7 +111,7 @@ export const revealInExplorerCommand = (accessor: ServicesAccessor, resource: UR
 };
 
 function openFocusedFilesExplorerViewItem(accessor: ServicesAccessor, sideBySide: boolean): void {
-	withFocussedFilesExplorerViewItem(accessor).then(res => {
+	withFocusedFilesExplorerViewItem(accessor).then(res => {
 		if (res) {
 
 			// Directory: Toggle expansion
@@ -128,8 +128,8 @@ function openFocusedFilesExplorerViewItem(accessor: ServicesAccessor, sideBySide
 	});
 }
 
-function openFocussedOpenedEditorsViewItem(accessor: ServicesAccessor, sideBySide: boolean): void {
-	withFocussedOpenEditorsViewItem(accessor).then(res => {
+function openFocusedOpenedEditorsViewItem(accessor: ServicesAccessor, sideBySide: boolean): void {
+	withFocusedOpenEditorsViewItem(accessor).then(res => {
 		if (res) {
 			const editorService = accessor.get(IWorkbenchEditorService);
 
@@ -139,7 +139,7 @@ function openFocussedOpenedEditorsViewItem(accessor: ServicesAccessor, sideBySid
 }
 
 function runActionOnFocusedFilesExplorerViewItem(accessor: ServicesAccessor, id: string, context?: any): void {
-	withFocussedFilesExplorerViewItem(accessor).then(res => {
+	withFocusedFilesExplorerViewItem(accessor).then(res => {
 		if (res) {
 			res.explorer.getViewletState().actionProvider.runAction(res.tree, res.item, id, context).done(null, errors.onUnexpectedError);
 		}
@@ -157,8 +157,8 @@ function withVisibleExplorer(accessor: ServicesAccessor): TPromise<ExplorerViewl
 	return viewletService.openViewlet(VIEWLET_ID, false) as TPromise<ExplorerViewlet>;
 };
 
-export function withFocussedFilesExplorerViewItem(accessor: ServicesAccessor): TPromise<{ explorer: ExplorerViewlet, tree: ITree, item: FileStat }> {
-	return withFocussedFilesExplorer(accessor).then(res => {
+export function withFocusedFilesExplorerViewItem(accessor: ServicesAccessor): TPromise<{ explorer: ExplorerViewlet, tree: ITree, item: FileStat }> {
+	return withFocusedFilesExplorer(accessor).then(res => {
 		if (!res) {
 			return void 0;
 		}
@@ -172,7 +172,7 @@ export function withFocussedFilesExplorerViewItem(accessor: ServicesAccessor): T
 	});
 };
 
-export function withFocussedFilesExplorer(accessor: ServicesAccessor): TPromise<{ explorer: ExplorerViewlet, tree: ITree }> {
+export function withFocusedFilesExplorer(accessor: ServicesAccessor): TPromise<{ explorer: ExplorerViewlet, tree: ITree }> {
 	return withVisibleExplorer(accessor).then(explorer => {
 		if (!explorer || !explorer.getExplorerView()) {
 			return void 0; // empty folder or hidden explorer
@@ -189,7 +189,7 @@ export function withFocussedFilesExplorer(accessor: ServicesAccessor): TPromise<
 	});
 };
 
-function withFocussedOpenEditorsViewItem(accessor: ServicesAccessor): TPromise<{ explorer: ExplorerViewlet, tree: ITree, item: OpenEditor }> {
+function withFocusedOpenEditorsViewItem(accessor: ServicesAccessor): TPromise<{ explorer: ExplorerViewlet, tree: ITree, item: OpenEditor }> {
 	return withVisibleExplorer(accessor).then(explorer => {
 		if (!explorer || !explorer.getOpenEditorsView()) {
 			return void 0; // empty folder or hidden explorer
@@ -208,12 +208,12 @@ function withFocussedOpenEditorsViewItem(accessor: ServicesAccessor): TPromise<{
 };
 
 function withFocusedExplorerItem(accessor: ServicesAccessor): TPromise<FileStat | OpenEditor> {
-	return withFocussedFilesExplorerViewItem(accessor).then(res => {
+	return withFocusedFilesExplorerViewItem(accessor).then(res => {
 		if (res) {
 			return res.item;
 		}
 
-		return withFocussedOpenEditorsViewItem(accessor).then(res => {
+		return withFocusedOpenEditorsViewItem(accessor).then(res => {
 			if (res) {
 				return res.item as FileStat | OpenEditor;
 			}
@@ -253,7 +253,7 @@ export const openFocusedExplorerItemSideBySideCommand = (accessor: ServicesAcces
 		if (item instanceof FileStat) {
 			openFocusedFilesExplorerViewItem(accessor, true);
 		} else {
-			openFocussedOpenedEditorsViewItem(accessor, true);
+			openFocusedOpenedEditorsViewItem(accessor, true);
 		}
 	});
 };

--- a/src/vs/workbench/parts/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerView.ts
@@ -18,7 +18,7 @@ import { prepareActions } from 'vs/workbench/browser/actions';
 import { memoize } from 'vs/base/common/decorators';
 import { ITree } from 'vs/base/parts/tree/browser/tree';
 import { Tree } from 'vs/base/parts/tree/browser/treeImpl';
-import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocussedContext, ExplorerFocussedContext, SortOrderConfiguration, SortOrder } from 'vs/workbench/parts/files/common/files';
+import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocusedContext, ExplorerFocusedContext, SortOrderConfiguration, SortOrder } from 'vs/workbench/parts/files/common/files';
 import { FileOperation, FileOperationEvent, IResolveFileOptions, FileChangeType, FileChangesEvent, IFileService } from 'vs/platform/files/common/files';
 import { RefreshViewExplorerAction, NewFolderAction, NewFileAction } from 'vs/workbench/parts/files/browser/fileActions';
 import { FileDragAndDrop, FileFilter, FileSorter, FileController, FileRenderer, FileDataSource, FileViewletState, FileAccessibilityProvider } from 'vs/workbench/parts/files/browser/views/explorerViewer';
@@ -73,8 +73,8 @@ export class ExplorerView extends CollapsibleView {
 	private resourceContext: ResourceContextKey;
 	private folderContext: IContextKey<boolean>;
 
-	private filesExplorerFocussedContext: IContextKey<boolean>;
-	private explorerFocussedContext: IContextKey<boolean>;
+	private filesExplorerFocusedContext: IContextKey<boolean>;
+	private explorerFocusedContext: IContextKey<boolean>;
 
 	private fileEventsFilter: ResourceGlobMatcher;
 
@@ -114,8 +114,8 @@ export class ExplorerView extends CollapsibleView {
 		this.resourceContext = instantiationService.createInstance(ResourceContextKey);
 		this.folderContext = ExplorerFolderContext.bindTo(contextKeyService);
 
-		this.filesExplorerFocussedContext = FilesExplorerFocussedContext.bindTo(contextKeyService);
-		this.explorerFocussedContext = ExplorerFocussedContext.bindTo(contextKeyService);
+		this.filesExplorerFocusedContext = FilesExplorerFocusedContext.bindTo(contextKeyService);
+		this.explorerFocusedContext = ExplorerFocusedContext.bindTo(contextKeyService);
 
 		this.fileEventsFilter = instantiationService.createInstance(ResourceGlobMatcher, root => this.getFileEventsExcludes(root), (expression: glob.IExpression) => glob.parse(expression));
 	}
@@ -405,7 +405,7 @@ export class ExplorerView extends CollapsibleView {
 		this.toDispose.push(attachListStyler(this.explorerViewer, this.themeService));
 
 		// Register to list service
-		this.toDispose.push(this.listService.register(this.explorerViewer, [this.explorerFocussedContext, this.filesExplorerFocussedContext]));
+		this.toDispose.push(this.listService.register(this.explorerViewer, [this.explorerFocusedContext, this.filesExplorerFocusedContext]));
 
 		// Update Viewer based on File Change Events
 		this.toDispose.push(this.fileService.onAfterOperation(e => this.onFileOperation(e)));

--- a/src/vs/workbench/parts/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerView.ts
@@ -927,7 +927,7 @@ export class ExplorerView extends CollapsibleView {
 			}
 		}
 
-		// Clean up last focussed if not set
+		// Clean up last focused if not set
 		if (!this.settings[ExplorerView.MEMENTO_LAST_ACTIVE_FILE_RESOURCE]) {
 			delete this.settings[ExplorerView.MEMENTO_LAST_ACTIVE_FILE_RESOURCE];
 		}

--- a/src/vs/workbench/parts/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/browser/views/openEditorsView.ts
@@ -19,7 +19,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IEditorStacksModel, IStacksModelChangeEvent, IEditorGroup } from 'vs/workbench/common/editor';
 import { SaveAllAction } from 'vs/workbench/parts/files/browser/fileActions';
 import { CollapsibleView, IViewletViewOptions, IViewOptions } from 'vs/workbench/parts/views/browser/views';
-import { IFilesConfiguration, VIEWLET_ID, OpenEditorsFocussedContext, ExplorerFocussedContext } from 'vs/workbench/parts/files/common/files';
+import { IFilesConfiguration, VIEWLET_ID, OpenEditorsFocusedContext, ExplorerFocusedContext } from 'vs/workbench/parts/files/common/files';
 import { ITextFileService, AutoSaveMode } from 'vs/workbench/services/textfile/common/textfiles';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { OpenEditor } from 'vs/workbench/parts/files/common/explorerModel';
@@ -54,8 +54,8 @@ export class OpenEditorsView extends CollapsibleView {
 	private groupToRefresh: IEditorGroup;
 	private fullRefreshNeeded: boolean;
 
-	private openEditorsFocussedContext: IContextKey<boolean>;
-	private explorerFocussedContext: IContextKey<boolean>;
+	private openEditorsFocusedContext: IContextKey<boolean>;
+	private explorerFocusedContext: IContextKey<boolean>;
 
 	constructor(options: IViewletViewOptions,
 		@IInstantiationService private instantiationService: IInstantiationService,
@@ -79,8 +79,8 @@ export class OpenEditorsView extends CollapsibleView {
 
 		this.model = editorGroupService.getStacksModel();
 
-		this.openEditorsFocussedContext = OpenEditorsFocussedContext.bindTo(contextKeyService);
-		this.explorerFocussedContext = ExplorerFocussedContext.bindTo(contextKeyService);
+		this.openEditorsFocusedContext = OpenEditorsFocusedContext.bindTo(contextKeyService);
+		this.explorerFocusedContext = ExplorerFocusedContext.bindTo(contextKeyService);
 
 		this.structuralRefreshDelay = 0;
 		this.structuralTreeRefreshScheduler = new RunOnceScheduler(() => this.structuralTreeUpdate(), this.structuralRefreshDelay);
@@ -149,7 +149,7 @@ export class OpenEditorsView extends CollapsibleView {
 		this.toDispose.push(attachListStyler(this.tree, this.themeService));
 
 		// Register to list service
-		this.toDispose.push(this.listService.register(this.tree, [this.explorerFocussedContext, this.openEditorsFocussedContext]));
+		this.toDispose.push(this.listService.register(this.tree, [this.explorerFocusedContext, this.openEditorsFocusedContext]));
 
 		// Open when selecting via keyboard
 		this.toDispose.push(this.tree.addListener('selection', event => {

--- a/src/vs/workbench/parts/files/common/files.ts
+++ b/src/vs/workbench/parts/files/common/files.ts
@@ -28,10 +28,10 @@ const explorerResourceIsFolderId = 'explorerResourceIsFolder';
 
 export const ExplorerViewletVisibleContext = new RawContextKey<boolean>(explorerViewletVisibleId, true);
 export const ExplorerFolderContext = new RawContextKey<boolean>(explorerResourceIsFolderId, false);
-export const FilesExplorerFocussedContext = new RawContextKey<boolean>(filesExplorerFocusId, false);
+export const FilesExplorerFocusedContext = new RawContextKey<boolean>(filesExplorerFocusId, false);
 export const OpenEditorsVisibleContext = new RawContextKey<boolean>(openEditorsVisibleId, false);
-export const OpenEditorsFocussedContext = new RawContextKey<boolean>(openEditorsFocusId, false);
-export const ExplorerFocussedContext = new RawContextKey<boolean>(explorerViewletFocusId, false);
+export const OpenEditorsFocusedContext = new RawContextKey<boolean>(openEditorsFocusId, false);
+export const ExplorerFocusedContext = new RawContextKey<boolean>(explorerViewletFocusId, false);
 
 export const OpenEditorsVisibleCondition = ContextKeyExpr.has(openEditorsVisibleId);
 export const FilesExplorerFocusCondition = ContextKeyExpr.and(ContextKeyExpr.has(explorerViewletVisibleId), ContextKeyExpr.has(filesExplorerFocusId));

--- a/src/vs/workbench/parts/markers/browser/markersPanelActions.ts
+++ b/src/vs/workbench/parts/markers/browser/markersPanelActions.ts
@@ -40,7 +40,7 @@ export class ToggleMarkersPanelAction extends TogglePanelAction {
 
 	public run(): TPromise<any> {
 		let promise = super.run();
-		if (this.isPanelFocussed()) {
+		if (this.isPanelFocused()) {
 			this.telemetryService.publicLog('problems.used');
 		}
 		return promise;
@@ -62,7 +62,7 @@ export class ToggleErrorsAndWarningsAction extends TogglePanelAction {
 
 	public run(): TPromise<any> {
 		let promise = super.run();
-		if (this.isPanelFocussed()) {
+		if (this.isPanelFocused()) {
 			this.telemetryService.publicLog('problems.used');
 		}
 		return promise;

--- a/src/vs/workbench/parts/search/browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/browser/search.contribution.ts
@@ -137,7 +137,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: Constants.CloseReplaceWidgetActionId,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
-	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.ReplaceInputBoxFocussedKey),
+	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.ReplaceInputBoxFocusedKey),
 	primary: KeyCode.Escape,
 	handler: (accessor, args: any) => {
 		accessor.get(IInstantiationService).createInstance(searchActions.CloseReplaceAction, Constants.CloseReplaceWidgetActionId, '').run();
@@ -147,7 +147,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: searchActions.FocusNextInputAction.ID,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
-	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.InputBoxFocussedKey),
+	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.InputBoxFocusedKey),
 	primary: KeyCode.DownArrow,
 	handler: (accessor, args: any) => {
 		accessor.get(IInstantiationService).createInstance(searchActions.FocusNextInputAction, searchActions.FocusNextInputAction.ID, '').run();
@@ -157,7 +157,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: searchActions.FocusPreviousInputAction.ID,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
-	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.InputBoxFocussedKey, Constants.SearchInputBoxFocussedKey.toNegated()),
+	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.InputBoxFocusedKey, Constants.SearchInputBoxFocusedKey.toNegated()),
 	primary: KeyCode.UpArrow,
 	handler: (accessor, args: any) => {
 		accessor.get(IInstantiationService).createInstance(searchActions.FocusPreviousInputAction, searchActions.FocusPreviousInputAction.ID, '').run();
@@ -262,18 +262,18 @@ const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.Workbenc
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.OpenSearchViewletAction, Constants.VIEWLET_ID, nls.localize('showSearchViewlet', "Show Search"), { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F },
 	Constants.SearchViewletVisibleKey.toNegated()), 'View: Show Search', nls.localize('view', "View"));
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.FocusActiveEditorAction, Constants.FocusActiveEditorActionId, '', { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F },
-	ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocussedKey)), '');
+	ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocusedKey)), '');
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.FindInFilesAction, Constants.FindInFilesActionId, nls.localize('findInFiles', "Find in Files"), { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F },
-	Constants.SearchInputBoxFocussedKey.toNegated()), 'Find in Files');
+	Constants.SearchInputBoxFocusedKey.toNegated()), 'Find in Files');
 
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.FocusNextSearchResultAction, searchActions.FocusNextSearchResultAction.ID, searchActions.FocusNextSearchResultAction.LABEL, { primary: KeyCode.F4 }), '');
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.FocusPreviousSearchResultAction, searchActions.FocusPreviousSearchResultAction.ID, searchActions.FocusPreviousSearchResultAction.LABEL, { primary: KeyMod.Shift | KeyCode.F4 }), '');
 
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ReplaceInFilesAction, searchActions.ReplaceInFilesAction.ID, searchActions.ReplaceInFilesAction.LABEL, { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_H }), 'Replace in Files');
 
-registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ToggleCaseSensitiveAction, Constants.ToggleCaseSensitiveActionId, '', ToggleCaseSensitiveKeybinding, ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocussedKey)), '');
-registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ToggleWholeWordAction, Constants.ToggleWholeWordActionId, '', ToggleWholeWordKeybinding, ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocussedKey)), '');
-registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ToggleRegexAction, Constants.ToggleRegexActionId, '', ToggleRegexKeybinding, ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocussedKey)), '');
+registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ToggleCaseSensitiveAction, Constants.ToggleCaseSensitiveActionId, '', ToggleCaseSensitiveKeybinding, ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocusedKey)), '');
+registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ToggleWholeWordAction, Constants.ToggleWholeWordActionId, '', ToggleWholeWordKeybinding, ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocusedKey)), '');
+registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ToggleRegexAction, Constants.ToggleRegexActionId, '', ToggleRegexKeybinding, ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocusedKey)), '');
 
 // Terms navigation actions
 registry.registerWorkbenchAction(new SyncActionDescriptor(searchActions.ShowNextSearchTermAction, searchActions.ShowNextSearchTermAction.ID, searchActions.ShowNextSearchTermAction.LABEL, ShowNextFindTermKeybinding, searchActions.ShowNextSearchTermAction.CONTEXT_KEY_EXPRESSION), 'Show Next Search Term', 'Search');

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -30,7 +30,7 @@ import { explorerItemToFileResource } from 'vs/workbench/parts/files/common/file
 import { OS } from 'vs/base/common/platform';
 import { IContextKeyService, ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
-export function isSearchViewletFocussed(viewletService: IViewletService): boolean {
+export function isSearchViewletFocused(viewletService: IViewletService): boolean {
 	let activeViewlet = viewletService.getActiveViewlet();
 	let activeElement = document.activeElement;
 	return activeViewlet && activeViewlet.getId() === Constants.VIEWLET_ID && activeElement && DOM.isAncestor(activeElement, (<SearchViewlet>activeViewlet).getContainer().getHTMLElement());
@@ -92,7 +92,7 @@ export class ShowNextSearchIncludeAction extends Action {
 
 	public static ID = 'search.history.showNextIncludePattern';
 	public static LABEL = nls.localize('nextSearchIncludePattern', "Show Next Search Include Pattern");
-	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternIncludesFocussedKey);
+	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternIncludesFocusedKey);
 
 	constructor(id: string, label: string,
 		@IViewletService private viewletService: IViewletService,
@@ -113,7 +113,7 @@ export class ShowPreviousSearchIncludeAction extends Action {
 
 	public static ID = 'search.history.showPreviousIncludePattern';
 	public static LABEL = nls.localize('previousSearchIncludePattern', "Show Previous Search Include Pattern");
-	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternIncludesFocussedKey);
+	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternIncludesFocusedKey);
 
 	constructor(id: string, label: string,
 		@IViewletService private viewletService: IViewletService,
@@ -134,7 +134,7 @@ export class ShowNextSearchExcludeAction extends Action {
 
 	public static ID = 'search.history.showNextExcludePattern';
 	public static LABEL = nls.localize('nextSearchExcludePattern', "Show Next Search Exclude Pattern");
-	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternExcludesFocussedKey);
+	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternExcludesFocusedKey);
 
 	constructor(id: string, label: string,
 		@IViewletService private viewletService: IViewletService,
@@ -154,7 +154,7 @@ export class ShowPreviousSearchExcludeAction extends Action {
 
 	public static ID = 'search.history.showPreviousExcludePattern';
 	public static LABEL = nls.localize('previousSearchExcludePattern', "Show Previous Search Exclude Pattern");
-	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternExcludesFocussedKey);
+	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.PatternExcludesFocusedKey);
 
 	constructor(id: string, label: string,
 		@IViewletService private viewletService: IViewletService,
@@ -175,7 +175,7 @@ export class ShowNextSearchTermAction extends Action {
 
 	public static ID = 'search.history.showNext';
 	public static LABEL = nls.localize('nextSearchTerm', "Show Next Search Term");
-	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocussedKey);
+	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocusedKey);
 
 	constructor(id: string, label: string,
 		@IViewletService private viewletService: IViewletService,
@@ -197,7 +197,7 @@ export class ShowPreviousSearchTermAction extends Action {
 
 	public static ID = 'search.history.showPrevious';
 	public static LABEL = nls.localize('previousSearchTerm', "Show Previous Search Term");
-	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocussedKey);
+	public static CONTEXT_KEY_EXPRESSION: ContextKeyExpr = ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.SearchInputBoxFocusedKey);
 
 	constructor(id: string, label: string,
 		@IViewletService private viewletService: IViewletService,

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -77,13 +77,13 @@ export class SearchViewlet extends Viewlet {
 	private callOnModelChange: lifecycle.IDisposable[];
 
 	private viewletVisible: IContextKey<boolean>;
-	private inputBoxFocussed: IContextKey<boolean>;
-	private inputPatternIncludesFocussed: IContextKey<boolean>;
-	private inputPatternExclusionsFocussed: IContextKey<boolean>;
-	private firstMatchFocussed: IContextKey<boolean>;
-	private fileMatchOrMatchFocussed: IContextKey<boolean>;
-	private fileMatchFocussed: IContextKey<boolean>;
-	private matchFocussed: IContextKey<boolean>;
+	private inputBoxFocused: IContextKey<boolean>;
+	private inputPatternIncludesFocused: IContextKey<boolean>;
+	private inputPatternExclusionsFocused: IContextKey<boolean>;
+	private firstMatchFocused: IContextKey<boolean>;
+	private fileMatchOrMatchFocused: IContextKey<boolean>;
+	private fileMatchFocused: IContextKey<boolean>;
+	private matchFocused: IContextKey<boolean>;
 
 	private actionRegistry: { [key: string]: Action; };
 	private tree: ITree;
@@ -128,13 +128,13 @@ export class SearchViewlet extends Viewlet {
 
 		this.toDispose = [];
 		this.viewletVisible = Constants.SearchViewletVisibleKey.bindTo(contextKeyService);
-		this.inputBoxFocussed = Constants.InputBoxFocussedKey.bindTo(this.contextKeyService);
-		this.inputPatternIncludesFocussed = Constants.PatternIncludesFocussedKey.bindTo(this.contextKeyService);
-		this.inputPatternExclusionsFocussed = Constants.PatternExcludesFocussedKey.bindTo(this.contextKeyService);
-		this.firstMatchFocussed = Constants.FirstMatchFocusKey.bindTo(contextKeyService);
-		this.fileMatchOrMatchFocussed = Constants.FileMatchOrMatchFocusKey.bindTo(contextKeyService);
-		this.fileMatchFocussed = Constants.FileFocusKey.bindTo(contextKeyService);
-		this.matchFocussed = Constants.MatchFocusKey.bindTo(this.contextKeyService);
+		this.inputBoxFocused = Constants.InputBoxFocusedKey.bindTo(this.contextKeyService);
+		this.inputPatternIncludesFocused = Constants.PatternIncludesFocusedKey.bindTo(this.contextKeyService);
+		this.inputPatternExclusionsFocused = Constants.PatternExcludesFocusedKey.bindTo(this.contextKeyService);
+		this.firstMatchFocused = Constants.FirstMatchFocusKey.bindTo(contextKeyService);
+		this.fileMatchOrMatchFocused = Constants.FileMatchOrMatchFocusKey.bindTo(contextKeyService);
+		this.fileMatchFocused = Constants.FileFocusKey.bindTo(contextKeyService);
+		this.matchFocused = Constants.MatchFocusKey.bindTo(this.contextKeyService);
 		this.callOnModelChange = [];
 
 		this.queryBuilder = this.instantiationService.createInstance(QueryBuilder);
@@ -210,7 +210,7 @@ export class SearchViewlet extends Viewlet {
 
 				this.inputPatternIncludes.onSubmit(() => this.onQueryChanged(true, true));
 				this.inputPatternIncludes.onCancel(() => this.viewModel.cancelSearch()); // Cancel search without focusing the search widget
-				this.trackInputBox(this.inputPatternIncludes.inputFocusTracker, this.inputPatternIncludesFocussed);
+				this.trackInputBox(this.inputPatternIncludes.inputFocusTracker, this.inputPatternIncludesFocused);
 			});
 
 			//pattern exclusion list
@@ -235,7 +235,7 @@ export class SearchViewlet extends Viewlet {
 				this.inputPatternExcludes.onSubmit(() => this.onQueryChanged(true, true));
 				this.inputPatternExcludes.onSubmit(() => this.onQueryChanged(true, true));
 				this.inputPatternExcludes.onCancel(() => this.viewModel.cancelSearch()); // Cancel search without focusing the search widget
-				this.trackInputBox(this.inputPatternExcludes.inputFocusTracker, this.inputPatternExclusionsFocussed);
+				this.trackInputBox(this.inputPatternExcludes.inputFocusTracker, this.inputPatternExclusionsFocused);
 			});
 		}).getHTMLElement();
 
@@ -315,13 +315,13 @@ export class SearchViewlet extends Viewlet {
 
 	private trackInputBox(inputFocusTracker: dom.IFocusTracker, contextKey?: IContextKey<boolean>): void {
 		this.toUnbind.push(inputFocusTracker.addFocusListener(() => {
-			this.inputBoxFocussed.set(true);
+			this.inputBoxFocused.set(true);
 			if (contextKey) {
 				contextKey.set(true);
 			}
 		}));
 		this.toUnbind.push(inputFocusTracker.addBlurListener(() => {
-			this.inputBoxFocussed.set(this.searchWidget.searchInputHasFocus()
+			this.inputBoxFocused.set(this.searchWidget.searchInputHasFocus()
 				|| this.searchWidget.replaceInputHasFocus()
 				|| this.inputPatternIncludes.inputHasFocus()
 				|| this.inputPatternExcludes.inputHasFocus());
@@ -506,17 +506,17 @@ export class SearchViewlet extends Viewlet {
 
 			this.toUnbind.push(this.tree.onDOMFocus(e => {
 				const focus = this.tree.getFocus();
-				this.firstMatchFocussed.set(this.tree.getNavigator().first() === this.tree.getFocus());
-				this.fileMatchOrMatchFocussed.set(true);
-				this.fileMatchFocussed.set(focus instanceof FileMatch);
-				this.matchFocussed.set(focus instanceof Match);
+				this.firstMatchFocused.set(this.tree.getNavigator().first() === this.tree.getFocus());
+				this.fileMatchOrMatchFocused.set(true);
+				this.fileMatchFocused.set(focus instanceof FileMatch);
+				this.matchFocused.set(focus instanceof Match);
 			}));
 
 			this.toUnbind.push(this.tree.onDOMBlur(e => {
-				this.firstMatchFocussed.reset();
-				this.fileMatchOrMatchFocussed.reset();
-				this.fileMatchFocussed.reset();
-				this.matchFocussed.reset();
+				this.firstMatchFocused.reset();
+				this.fileMatchOrMatchFocused.reset();
+				this.fileMatchFocused.reset();
+				this.matchFocused.reset();
 			}));
 
 

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -22,7 +22,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import Event, { Emitter } from 'vs/base/common/event';
 import { Builder } from 'vs/base/browser/builder';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
-import { isSearchViewletFocussed, appendKeyBindingLabel } from 'vs/workbench/parts/search/browser/searchActions';
+import { isSearchViewletFocused, appendKeyBindingLabel } from 'vs/workbench/parts/search/browser/searchActions';
 import { CONTEXT_FIND_WIDGET_NOT_VISIBLE } from 'vs/editor/contrib/find/common/findController';
 import { HistoryNavigator } from 'vs/base/common/history';
 import * as Constants from 'vs/workbench/parts/search/common/constants';
@@ -78,8 +78,8 @@ export class SearchWidget extends Widget {
 
 	public domNode: HTMLElement;
 	public searchInput: FindInput;
-	private searchInputBoxFocussed: IContextKey<boolean>;
-	private replaceInputBoxFocussed: IContextKey<boolean>;
+	private searchInputBoxFocused: IContextKey<boolean>;
+	private replaceInputBoxFocused: IContextKey<boolean>;
 	private replaceInput: InputBox;
 
 	public searchInputFocusTracker: dom.IFocusTracker;
@@ -122,8 +122,8 @@ export class SearchWidget extends Widget {
 		super();
 		this.searchHistory = new HistoryNavigator<string>(options.history);
 		this.replaceActive = Constants.ReplaceActiveKey.bindTo(this.keyBindingService);
-		this.searchInputBoxFocussed = Constants.SearchInputBoxFocussedKey.bindTo(this.keyBindingService);
-		this.replaceInputBoxFocussed = Constants.ReplaceInputBoxFocussedKey.bindTo(this.keyBindingService);
+		this.searchInputBoxFocused = Constants.SearchInputBoxFocusedKey.bindTo(this.keyBindingService);
+		this.replaceInputBoxFocused = Constants.ReplaceInputBoxFocusedKey.bindTo(this.keyBindingService);
 		this.render(container, options);
 	}
 
@@ -196,7 +196,7 @@ export class SearchWidget extends Widget {
 	}
 
 	public searchInputHasFocus(): boolean {
-		return this.searchInputBoxFocussed.get();
+		return this.searchInputBoxFocused.get();
 	}
 
 	public replaceInputHasFocus(): boolean {
@@ -246,10 +246,10 @@ export class SearchWidget extends Widget {
 
 		this.searchInputFocusTracker = this._register(dom.trackFocus(this.searchInput.inputBox.inputElement));
 		this._register(this.searchInputFocusTracker.addFocusListener(() => {
-			this.searchInputBoxFocussed.set(true);
+			this.searchInputBoxFocused.set(true);
 		}));
 		this._register(this.searchInputFocusTracker.addBlurListener(() => {
-			this.searchInputBoxFocussed.set(false);
+			this.searchInputBoxFocused.set(false);
 		}));
 	}
 
@@ -273,10 +273,10 @@ export class SearchWidget extends Widget {
 
 		this.replaceInputFocusTracker = this._register(dom.trackFocus(this.replaceInput.inputElement));
 		this._register(this.replaceInputFocusTracker.addFocusListener(() => {
-			this.replaceInputBoxFocussed.set(true);
+			this.replaceInputBoxFocused.set(true);
 		}));
 		this._register(this.replaceInputFocusTracker.addBlurListener(() => {
-			this.replaceInputBoxFocussed.set(false);
+			this.replaceInputBoxFocused.set(false);
 		}));
 	}
 
@@ -380,7 +380,7 @@ export function registerContributions() {
 		when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.ReplaceActiveKey, CONTEXT_FIND_WIDGET_NOT_VISIBLE),
 		primary: KeyMod.Alt | KeyMod.CtrlCmd | KeyCode.Enter,
 		handler: accessor => {
-			if (isSearchViewletFocussed(accessor.get(IViewletService))) {
+			if (isSearchViewletFocused(accessor.get(IViewletService))) {
 				ReplaceAllAction.INSTANCE.run();
 			}
 		}

--- a/src/vs/workbench/parts/search/common/constants.ts
+++ b/src/vs/workbench/parts/search/common/constants.ts
@@ -22,11 +22,11 @@ export const ToggleRegexActionId = 'toggleSearchRegex';
 export const CloseReplaceWidgetActionId = 'closeReplaceInFilesWidget';
 
 export const SearchViewletVisibleKey = new RawContextKey<boolean>('searchViewletVisible', true);
-export const InputBoxFocussedKey = new RawContextKey<boolean>('inputBoxFocus', false);
-export const SearchInputBoxFocussedKey = new RawContextKey<boolean>('searchInputBoxFocus', false);
-export const ReplaceInputBoxFocussedKey = new RawContextKey<boolean>('replaceInputBoxFocus', false);
-export const PatternIncludesFocussedKey = new RawContextKey<boolean>('patternIncludesInputBoxFocus', false);
-export const PatternExcludesFocussedKey = new RawContextKey<boolean>('patternExcludesInputBoxFocus', false);
+export const InputBoxFocusedKey = new RawContextKey<boolean>('inputBoxFocus', false);
+export const SearchInputBoxFocusedKey = new RawContextKey<boolean>('searchInputBoxFocus', false);
+export const ReplaceInputBoxFocusedKey = new RawContextKey<boolean>('replaceInputBoxFocus', false);
+export const PatternIncludesFocusedKey = new RawContextKey<boolean>('patternIncludesInputBoxFocus', false);
+export const PatternExcludesFocusedKey = new RawContextKey<boolean>('patternExcludesInputBoxFocus', false);
 export const ReplaceActiveKey = new RawContextKey<boolean>('replaceActive', false);
 
 export const FirstMatchFocusKey = new RawContextKey<boolean>('firstMatchFocus', false);


### PR DESCRIPTION
- Use Focused/focused consistently instead of Focussed (English version)
- Comments
- Constants, properties, variables
- Functions/methods

- Keep "findInputFocussed" ContextKey to not break existing when clauses.

export const CONTEXT_FIND_INPUT_FOCUSED = new RawContextKey<boolean>('findInputFocussed', false);

Addresses: #32521 