### PR TITLE
🐛 include setext heading levels (Markdown)

### DIFF
--- a/extensions/markdown/src/documentSymbolProvider.ts
+++ b/extensions/markdown/src/documentSymbolProvider.ts
@@ -19,7 +19,7 @@ export default class MDDocumentSymbolProvider implements vscode.DocumentSymbolPr
 	public async provideDocumentSymbols(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]> {
 		const toc = await new TableOfContentsProvider(this.engine, document).getToc();
 		return toc.map(entry => {
-			return new vscode.SymbolInformation(entry.text, vscode.SymbolKind.Namespace, '', entry.location);
+			return new vscode.SymbolInformation('#'.repeat(entry.level) + ' ' + entry.text, vscode.SymbolKind.Namespace, '', entry.location);
 		});
 	}
 }

--- a/extensions/markdown/src/tableOfContentsProvider.ts
+++ b/extensions/markdown/src/tableOfContentsProvider.ts
@@ -12,6 +12,7 @@ import { MarkdownEngine } from './markdownEngine';
 export interface TocEntry {
 	slug: string;
 	text: string;
+	level: number;
 	line: number;
 	location: vscode.Location;
 }
@@ -53,10 +54,12 @@ export class TableOfContentsProvider {
 			const lineNumber = heading.map[0];
 			const line = document.lineAt(lineNumber);
 			const href = TableOfContentsProvider.slugify(line.text);
+			const level = TableOfContentsProvider.getHeaderLevel(tokens.markup);
 			if (href) {
 				toc.push({
 					slug: href,
 					text: TableOfContentsProvider.getHeaderText(line.text),
+					level: level,
 					line: lineNumber,
 					location: new vscode.Location(document.uri, line.range)
 				});
@@ -65,14 +68,24 @@ export class TableOfContentsProvider {
 		return toc;
 	}
 
+	private static getHeaderLevel(markup: string): number {
+		if (markup == '=') {
+			return 1;
+		} else if (markup == '-') {
+			return 2;
+		} else { // '#', '##', ...
+			return markup.length;
+		}
+	}
+
 	private static getHeaderText(header: string): string {
-		return header.replace(/^\s*(#+)\s*(.*?)\s*\1*$/, (_, level, word) => `${level} ${word.trim()}`);
+		return header.replace(/^\s*#+\s*(.*?)\s*\1*$/, (_, word) => `${word.trim()}`);
 	}
 
 	public static slugify(header: string): string {
 		return encodeURI(header.trim()
 			.toLowerCase()
-			.replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~]/g, '')
+			.replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`]/g, '')
 			.replace(/\s+/g, '-')
 			.replace(/^\-+/, '')
 			.replace(/\-+$/, ''));

--- a/extensions/markdown/src/tableOfContentsProvider.ts
+++ b/extensions/markdown/src/tableOfContentsProvider.ts
@@ -54,7 +54,7 @@ export class TableOfContentsProvider {
 			const lineNumber = heading.map[0];
 			const line = document.lineAt(lineNumber);
 			const href = TableOfContentsProvider.slugify(line.text);
-			const level = TableOfContentsProvider.getHeaderLevel(tokens.markup);
+			const level = TableOfContentsProvider.getHeaderLevel(heading.markup);
 			if (href) {
 				toc.push({
 					slug: href,

--- a/extensions/markdown/src/tableOfContentsProvider.ts
+++ b/extensions/markdown/src/tableOfContentsProvider.ts
@@ -69,9 +69,9 @@ export class TableOfContentsProvider {
 	}
 
 	private static getHeaderLevel(markup: string): number {
-		if (markup == '=') {
+		if (markup === '=') {
 			return 1;
-		} else if (markup == '-') {
+		} else if (markup === '-') {
 			return 2;
 		} else { // '#', '##', ...
 			return markup.length;


### PR DESCRIPTION
Fix #32859 and at the same time #32844 (Markdown `slugify` misses backticks).