### PR TITLE
Telemetry for installing recommended extensions

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -194,6 +194,7 @@ export interface IQueryOptions {
 	pageSize?: number;
 	sortBy?: SortBy;
 	sortOrder?: SortOrder;
+	source?: string;
 }
 
 export enum StatisticType {

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -233,7 +233,7 @@ function getEngine(version: IRawGalleryExtensionVersion): string {
 	return (values.length > 0 && values[0].value) || '';
 }
 
-function toExtension(galleryExtension: IRawGalleryExtension, extensionsGalleryUrl: string, index: number, query: Query): IGalleryExtension {
+function toExtension(galleryExtension: IRawGalleryExtension, extensionsGalleryUrl: string, index: number, query: Query, querySource?: string): IGalleryExtension {
 	const [version] = galleryExtension.versions;
 	const assets = {
 		manifest: getVersionAsset(version, AssetType.Manifest),
@@ -265,7 +265,8 @@ function toExtension(galleryExtension: IRawGalleryExtension, extensionsGalleryUr
 		},
 		telemetryData: {
 			index: ((query.pageNumber - 1) * query.pageSize) + index,
-			searchText: query.searchText
+			searchText: query.searchText,
+			querySource
 		}
 	};
 }
@@ -355,12 +356,12 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		}
 
 		return this.queryGallery(query).then(({ galleryExtensions, total }) => {
-			const extensions = galleryExtensions.map((e, index) => toExtension(e, this.extensionsGalleryUrl, index, query));
+			const extensions = galleryExtensions.map((e, index) => toExtension(e, this.extensionsGalleryUrl, index, query, options.source));
 			const pageSize = query.pageSize;
 			const getPage = pageIndex => {
 				const nextPageQuery = query.withPage(pageIndex + 1);
 				return this.queryGallery(nextPageQuery)
-					.then(({ galleryExtensions }) => galleryExtensions.map((e, index) => toExtension(e, this.extensionsGalleryUrl, index, nextPageQuery)));
+					.then(({ galleryExtensions }) => galleryExtensions.map((e, index) => toExtension(e, this.extensionsGalleryUrl, index, nextPageQuery, options.source)));
 			};
 
 			return { firstPage: extensions, total, pageSize, getPage };

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -296,7 +296,7 @@ export class ExtensionsListView extends CollapsibleView {
 						if (!names.length) {
 							return TPromise.as(new PagedModel([]));
 						}
-
+						options.source = 'recommendations-all';
 						return this.extensionsWorkbenchService.queryGallery(assign(options, { names, pageSize: names.length }))
 							.then(pager => new PagedModel(pager || []));
 					});
@@ -318,9 +318,9 @@ export class ExtensionsListView extends CollapsibleView {
 				if (!names.length) {
 					return TPromise.as(new PagedModel([]));
 				}
-
+				options.source = 'recommendations';
 				return this.extensionsWorkbenchService.queryGallery(assign(options, { names, pageSize: names.length }))
-					.then(pager => new PagedModel(pager));
+					.then(pager => new PagedModel(pager || []));
 			});
 	}
 
@@ -334,9 +334,9 @@ export class ExtensionsListView extends CollapsibleView {
 				if (!names.length) {
 					return TPromise.as(new PagedModel([]));
 				}
-
+				options.source = 'recommendations-workspace';
 				return this.extensionsWorkbenchService.queryGallery(assign(options, { names, pageSize: names.length }))
-					.then(pager => new PagedModel(pager));
+					.then(pager => new PagedModel(pager || []));
 			});
 	}
 
@@ -349,7 +349,7 @@ export class ExtensionsListView extends CollapsibleView {
 		if (!names.length) {
 			return TPromise.as(new PagedModel([]));
 		}
-
+		options.source = 'recommendations-keymaps';
 		return this.extensionsWorkbenchService.queryGallery(assign(options, { names, pageSize: names.length }))
 			.then(result => new PagedModel(result));
 	}


### PR DESCRIPTION
This PR adds an event to track if the "Install" button on a recommended extension is clicked by the user.

I am piggy backing on the `Extension`s payload. Couldn't find any other way to pass the information that the extension is recommended all the way to `ExtensionAction.ts`. Any suggestions?