### PR TITLE
Use 'modifiedStop' instead of 'modifiedStart' in line 863 of diff.ts

### DIFF
--- a/src/vs/base/common/diff/diff.ts
+++ b/src/vs/base/common/diff/diff.ts
@@ -860,7 +860,7 @@ export class LcsDiff {
 				let originalStart = change.originalStart - delta;
 				let modifiedStart = change.modifiedStart - delta;
 
-				if (originalStart < originalStop || modifiedStart < modifiedStart) {
+				if (originalStart < originalStop || modifiedStart < modifiedStop) {
 					break;
 				}
 


### PR DESCRIPTION
This is a fix to what looks like a copy-paste mistake in diff.ts.

I was testing a new linting rule ([no-dead-store](https://github.com/SonarSource/SonarTS/blob/master/docs/rules/no-dead-store.md)) on vscode and I got pointed to an [unused assignment](https://github.com/Microsoft/vscode/blob/de13fec877f790b41ff6be56fda8f47d524e925f/src/vs/base/common/diff/diff.ts#L849) of `modifiedStop` in diff.ts. Another rule ([no-identical-expressions](https://github.com/SonarSource/SonarTS/blob/master/docs/rules/no-identical-expressions.md)) points to a binary expression with [two identical operands](https://github.com/Microsoft/vscode/blob/de13fec877f790b41ff6be56fda8f47d524e925f/src/vs/base/common/diff/diff.ts#L863) on both sides: `modifiedStart`. This makes me think that what was meant was `modifiedStart < modifiedStop`.
