### PR TITLE
Include command id in error message

### DIFF
--- a/src/vs/workbench/api/node/extHostCommands.ts
+++ b/src/vs/workbench/api/node/extHostCommands.ts
@@ -56,7 +56,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		}
 
 		if (this._commands.has(id)) {
-			throw new Error('command with id already exists');
+			throw new Error(`command '${id}' already exists`);
 		}
 
 		this._commands.set(id, { callback, thisArg, description });


### PR DESCRIPTION
An error is thrown if an extension attempts to register a command with an id that already exists. This very small PR makes the error more helpful by including the id of the already existing command.