### PR TITLE
Fix comment in User Settings for the Minimap

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -262,7 +262,7 @@ const editorConfiguration: IConfigurationNode = {
 			'type': 'string',
 			'enum': ['always', 'mouseover'],
 			'default': EDITOR_DEFAULTS.viewInfo.minimap.showSlider,
-			'description': nls.localize('minimap.showSlider', "Controls whether the minimap slider is automatically hidden.")
+			'description': nls.localize('minimap.showSlider', "Controls whether the minimap slider is automatically hidden. Possible values are \'always\' and \'mouseover\'')
 		},
 		'editor.minimap.renderCharacters': {
 			'type': 'boolean',


### PR DESCRIPTION


I would like to suggest fixing the comment in User Settings to provide a list of possible values available for the Editor Minimap Showsliders option.

Currently:

	// Controls whether the minimap slider is automatically hidden.
	"editor.minimap.showSlider": "always",

With this modification:

	// Controls whether the minimap slider is automatically hidden. Possible values are 'always' and 'mouseover'
	"editor.minimap.showSlider": "always",