### PR TITLE
Fix #33155: treat .pac file as javascript file

### DIFF
--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -42,7 +42,8 @@
         "extensions": [
           ".js",
           ".es6",
-          ".mjs"
+          ".mjs",
+          ".pac"
         ],
         "filenames": [
           "jakefile"


### PR DESCRIPTION
#33155: treat .pac file as javascript file
Let vscode auto detect .pac file and use javascript editor to deal with it.

proxy-auto-configuration file is a kind of javascript file which browsers could use it to decide which proxy should use for certain url or ip.
Refer to this wiki for details.
https://en.wikipedia.org/wiki/Proxy_auto-config