### PR TITLE
Added tfvars for Terraform to vs-seti-icon-theme.json

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -1048,6 +1048,7 @@
 		"styl": "_stylus",
 		"tf": "_terraform",
 		"tf.json": "_terraform",
+		"tfvars": "_terraform",
 		"tex": "_tex",
 		"sty": "_tex",
 		"dtx": "_tex",


### PR DESCRIPTION
The .tfvars extension for Terraform is a commonly used Terraform extension (https://www.terraform.io/intro/getting-started/variables.html#from-a-file).  This adds the tfvars extension to the icon theme JSON.