### PR TITLE
Add DejaVu and Noto as fallback Linux fonts.

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2074,7 +2074,7 @@ export class EditorLayoutProvider {
 
 const DEFAULT_WINDOWS_FONT_FAMILY = 'Consolas, \'Courier New\', monospace';
 const DEFAULT_MAC_FONT_FAMILY = 'Menlo, Monaco, \'Courier New\', monospace';
-const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', \'Courier New\', monospace, \'Droid Sans Fallback\'';
+const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', \'DejaVu Sans Mono\', \'Noto Mono\', \'Courier New\', monospace, \'Droid Sans Fallback\'';
 
 /**
  * @internal


### PR DESCRIPTION
Close #5742.

This PR enable to use of fallback fonts before font bundling (suggested in #26893) is implemented.