### PR TITLE
Add CodeAction type to allow not automatically showing the lightbulb

### DIFF
--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CodeActionProvider, TextDocument, Range, CancellationToken, CodeActionContext, Command, commands, workspace, WorkspaceEdit, window, QuickPickItem, Selection, Position } from 'vscode';
+import { CodeActionProvider, TextDocument, Range, CancellationToken, CodeActionContext, Command, commands, workspace, WorkspaceEdit, window, QuickPickItem, Selection, Position, CodeAction } from 'vscode';
 
 import * as Proto from '../protocol';
 import { ITypescriptServiceClient } from '../typescriptService';
@@ -56,20 +56,22 @@ export default class TypeScriptRefactorProvider implements CodeActionProvider {
 				return [];
 			}
 
-			const actions: Command[] = [];
+			const actions: CodeAction[] = [];
 			for (const info of response.body) {
 				if (info.inlineable === false) {
 					actions.push({
 						title: info.description,
 						command: this.selectRefactorCommandId,
-						arguments: [file, info, range]
+						arguments: [file, info, range],
+						dontTriggerLightBulb: true
 					});
 				} else {
 					for (const action of info.actions) {
 						actions.push({
 							title: action.description,
 							command: this.doRefactorCommandId,
-							arguments: [file, info.name, action.name, range]
+							arguments: [file, info.name, action.name, range],
+							dontTriggerLightBulb: true
 						});
 					}
 				}

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -267,7 +267,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): Command[] | Thenable<Command[]>;
+	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
 }
 
 /**
@@ -737,6 +737,11 @@ export interface Command {
 	tooltip?: string;
 	arguments?: any[];
 }
+
+export interface CodeAction extends Command {
+	dontTriggerLightBulb?: boolean;
+}
+
 export interface ICodeLensSymbol {
 	range: IRange;
 	id?: string;

--- a/src/vs/editor/contrib/quickFix/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/quickFix/browser/lightBulbWidget.ts
@@ -70,7 +70,7 @@ export class LightBulbWidget implements IDisposable {
 		const { token } = this._futureFixes;
 
 		e.fixes.done(fixes => {
-			if (!token.isCancellationRequested && fixes && fixes.length > 0) {
+			if (!token.isCancellationRequested && fixes && fixes.some(fix => !fix.dontTriggerLightBulb)) {
 				this.show(e);
 			} else {
 				this.hide();

--- a/src/vs/editor/contrib/quickFix/browser/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/browser/quickFix.ts
@@ -7,16 +7,16 @@
 import URI from 'vs/base/common/uri';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { Range } from 'vs/editor/common/core/range';
-import { Command, CodeActionProviderRegistry } from 'vs/editor/common/modes';
+import { CodeAction, CodeActionProviderRegistry } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { onUnexpectedExternalError, illegalArgument } from 'vs/base/common/errors';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
 
-export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<Command[]> {
+export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<CodeAction[]> {
 
-	const allResults: Command[] = [];
+	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
 		return asWinJsPromise(token => support.provideCodeActions(model, range, token)).then(result => {
 			if (Array.isArray(result)) {

--- a/src/vs/editor/contrib/quickFix/browser/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/browser/quickFixModel.ts
@@ -11,7 +11,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { Range } from 'vs/editor/common/core/range';
 import { ICommonCodeEditor } from 'vs/editor/common/editorCommon';
-import { CodeActionProviderRegistry, Command } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
 import { getCodeActions } from './quickFix';
 import { Position } from 'vs/editor/common/core/position';
 
@@ -116,7 +116,7 @@ export interface QuickFixComputeEvent {
 	type: 'auto' | 'manual';
 	range: Range;
 	position: Position;
-	fixes: TPromise<Command[]>;
+	fixes: TPromise<CodeAction[]>;
 }
 
 export class QuickFixModel {

--- a/src/vs/editor/contrib/quickFix/browser/quickFixWidget.ts
+++ b/src/vs/editor/contrib/quickFix/browser/quickFixWidget.ts
@@ -10,7 +10,7 @@ import { always } from 'vs/base/common/async';
 import { getDomNodePagePosition } from 'vs/base/browser/dom';
 import { Position } from 'vs/editor/common/core/position';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { Command } from 'vs/editor/common/modes';
+import { CodeAction } from 'vs/editor/common/modes';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { Action } from 'vs/base/common/actions';
@@ -32,7 +32,7 @@ export class QuickFixContextMenu {
 		this._commandService = commandService;
 	}
 
-	show(fixes: TPromise<Command[]>, at: { x: number; y: number } | Position) {
+	show(fixes: TPromise<CodeAction[]>, at: { x: number; y: number } | Position) {
 
 		const actions = fixes.then(value => {
 			return value.map(command => {

--- a/src/vs/editor/contrib/quickFix/test/browser/quickFixModel.test.ts
+++ b/src/vs/editor/contrib/quickFix/test/browser/quickFixModel.test.ts
@@ -12,7 +12,7 @@ import { Model } from 'vs/editor/common/model/model';
 import { mockCodeEditor } from 'vs/editor/test/common/mocks/mockCodeEditor';
 import { MarkerService } from 'vs/platform/markers/common/markerService';
 import { QuickFixOracle } from 'vs/editor/contrib/quickFix/browser/quickFixModel';
-import { CodeActionProviderRegistry, LanguageIdentifier } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, LanguageIdentifier, CodeAction } from 'vs/editor/common/modes';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import Event from 'vs/base/common/event';
 import { Range } from 'vs/editor/common/core/range';
@@ -248,5 +248,4 @@ suite('QuickFix', () => {
 
 		reg.dispose();
 	});
-
 });

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -329,7 +329,7 @@ export function registerCodeLensProvider(languageId: string, provider: modes.Cod
  */
 export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider): IDisposable {
 	return modes.CodeActionProviderRegistry.register(languageId, {
-		provideCodeActions: (model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): modes.Command[] | Thenable<modes.Command[]> => {
+		provideCodeActions: (model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): modes.CodeAction[] | Thenable<modes.CodeAction[]> => {
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
 			});
@@ -411,7 +411,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): modes.Command[] | Thenable<modes.Command[]>;
+	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): modes.CodeAction[] | Thenable<modes.CodeAction[]>;
 }
 
 /**
@@ -738,6 +738,6 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		DocumentHighlightKind: modes.DocumentHighlightKind,
 		CompletionItemKind: CompletionItemKind,
 		SymbolKind: modes.SymbolKind,
-		IndentAction: IndentAction,
+		IndentAction: IndentAction
 	};
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4065,7 +4065,7 @@ declare module monaco.languages {
 		/**
 		 * Provide commands for the given document and range.
 		 */
-		provideCodeActions(model: editor.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): Command[] | Thenable<Command[]>;
+		provideCodeActions(model: editor.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
 	}
 
 	/**
@@ -4857,6 +4857,10 @@ declare module monaco.languages {
 		title: string;
 		tooltip?: string;
 		arguments?: any[];
+	}
+
+	export interface CodeAction extends Command {
+		dontTriggerLightBulb?: boolean;
 	}
 
 	export interface ICodeLensSymbol {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1665,6 +1665,16 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * A code action for the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action) feature.
+	 */
+	export interface CodeAction extends Command {
+		/**
+		 * Should the lightbulb automatically be shown in the UI?
+		 */
+		dontTriggerLightBulb?: boolean;
+	}
+
+	/**
 	 * The code action interface defines the contract between extensions and
 	 * the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action) feature.
 	 *
@@ -1682,7 +1692,7 @@ declare module 'vscode' {
 		 * @return An array of commands or a thenable of such. The lack of a result can be
 		 * signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<Command[]>;
+		provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<CodeAction[]>;
 	}
 
 	/**

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -166,7 +166,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	$registerQuickFixSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> {
 		this._registrations[handle] = modes.CodeActionProviderRegistry.register(selector, <modes.CodeActionProvider>{
-			provideCodeActions: (model: IReadOnlyModel, range: EditorRange, token: CancellationToken): Thenable<modes.Command[]> => {
+			provideCodeActions: (model: IReadOnlyModel, range: EditorRange, token: CancellationToken): Thenable<modes.CodeAction[]> => {
 				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range)));
 			}
 		});

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -499,7 +499,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideHover(handle: number, resource: URI, position: IPosition): TPromise<modes.Hover>;
 	$provideDocumentHighlights(handle: number, resource: URI, position: IPosition): TPromise<modes.DocumentHighlight[]>;
 	$provideReferences(handle: number, resource: URI, position: IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]>;
-	$provideCodeActions(handle: number, resource: URI, range: IRange): TPromise<modes.Command[]>;
+	$provideCodeActions(handle: number, resource: URI, range: IRange): TPromise<modes.CodeAction[]>;
 	$provideDocumentFormattingEdits(handle: number, resource: URI, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]>;
 	$provideDocumentRangeFormattingEdits(handle: number, resource: URI, range: IRange, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]>;
 	$provideOnTypeFormattingEdits(handle: number, resource: URI, position: IPosition, ch: string, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]>;


### PR DESCRIPTION
**Problem**
The TS extract method code action results in the quick fix light bulb being shown on almost every expression. This can be annyoing and also reveals that TS currently shows extract method in far more places than it probably should

I believe that VS does not automatically show the lightbulb for refactorings, only for quick fixes. With the current VS Code API,  there is now way for a `CodeActionProvider` to say if the lightbulb should be shown or not

**Fix**
This change adds a new `CodeAction` type with an additional `dontTriggerLightBulb` property. When a code action sets this property, the light bulb will not be automatically shown.

**Other possible API designs**
Another possible design would be to allow different `CodeActionProvider` to be provided for 'automatic' triggering (the current behavior), vs manually triggering (when the user presses ctrl+.). Such an API has the advantage of never computing manual code actions until they are actually needed. The downside is that `CodeActionProviders` would have to be polled during a UI operation in the manual case.

Fixes #33241