### PR TITLE
Fix unnatural machine-generated Japanese translation of "n of m" in the text-search box

### DIFF
--- a/i18n/jpn/src/vs/editor/contrib/find/browser/findWidget.i18n.json
+++ b/i18n/jpn/src/vs/editor/contrib/find/browser/findWidget.i18n.json
@@ -16,6 +16,6 @@
 	"label.replaceAllButton": "すべて置換",
 	"label.toggleReplaceButton": "置換モードの切り替え",
 	"title.matchesCountLimit": "最初の 999 の結果だけを強調表示しますが、テキスト全体を検索します。",
-	"label.matchesLocation": "{1} の {0}",
+	"label.matchesLocation": "{0}/{1} 件",
 	"label.noResults": "結果なし"
 }


### PR DESCRIPTION
Japanese don't use “の” as the context of “[number] (out) of [number]” such as the following illustrative sentences.  The “of” is translated to “中” or “のうち (の)” in many cases.
 
> It displays 150 of the 1,290 in order.
> 順に１，２９０件中１５０件を表示します
>
> http://ejje.weblio.jp/sentence/content/of+%22%E4%BB%B6%E4%B8%AD%22

> Five of the seven were found dead, and two are still missing.
> ７人中５人が遺体で見つかり，２人はいまだに行方がわからない。
>
> http://ejje.weblio.jp/sentence/content/of+%22%E4%BA%BA%E4%B8%AD%22

> Nine of the 12 had to agree for an indictment to be made.
> 起訴するには12人のうち９人が賛成しなければならなかった。
>
> and it was one of the other four who fell.
> 倒れたのは、他の４人のうちの１人だった。
>
> http://ejje.weblio.jp/sentence/content/of+%22%E4%BA%BA%E3%81%AE%E3%81%86%E3%81%A1%22

> Only 5 of the 120 cases docketed were tried.
> 訴訟事件表に記載された120件のうち5件だけが審理された
>
> http://ejje.weblio.jp/sentence/content/of+%22%E4%BB%B6%E3%81%AE%E3%81%86%E3%81%A1%22

However, regular translations (e.g. n of m → m 件中 n 件目 or m 件のうちの n 件目) seem to be too verbose to adopt for the small area of the text-search box, so I suggest an abbreviated translation “n/m 件” that is adopted in Microsoft Word instead of them and the original machine-generated and unnatural one that is said not to be changed.

P.S. I feel “最初の 999 の結果だけを強調表示しますが、テキスト全体を検索します。” strange because it lacks an numeraration “件” of 999, but this PR does not contain fix of it.