### PR TITLE
show lightbulb inline

### DIFF
--- a/src/vs/editor/contrib/quickFix/browser/lightBulbWidget.css
+++ b/src/vs/editor/contrib/quickFix/browser/lightBulbWidget.css
@@ -8,7 +8,8 @@
 	align-items: center;
 	justify-content: center;
 	height: 16px;
-	width: 16px;
+	width: 20px;
+	padding-left: 2px;
 }
 
 .monaco-editor .lightbulb-glyph.hidden {
@@ -18,6 +19,7 @@
 
 .monaco-editor .lightbulb-glyph:hover {
 	cursor: pointer;
+	transform: scale(1.3, 1.3);
 }
 
 .monaco-editor.vs .lightbulb-glyph {

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -283,13 +283,13 @@ class QuickFixAdapter {
 	provideCodeActions(resource: URI, range: IRange): TPromise<modes.Command[]> {
 
 		const doc = this._documents.getDocumentData(resource).document;
-		const ran = TypeConverters.toRange(range);
+		const ran = <vscode.Range>TypeConverters.toRange(range);
 		const allDiagnostics: vscode.Diagnostic[] = [];
 
 		this._diagnostics.forEach(collection => {
 			if (collection.has(resource)) {
 				for (let diagnostic of collection.get(resource)) {
-					if (diagnostic.range.intersection(ran)) {
+					if (ran.contains(diagnostic.range)) {
 						allDiagnostics.push(diagnostic);
 					}
 				}

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -273,7 +273,7 @@ class QuickFixAdapter {
 	private _diagnostics: ExtHostDiagnostics;
 	private _provider: vscode.CodeActionProvider;
 
-	constructor(documents: ExtHostDocuments, commands: CommandsConverter, diagnostics: ExtHostDiagnostics, heapService: ExtHostHeapService, provider: vscode.CodeActionProvider) {
+	constructor(documents: ExtHostDocuments, commands: CommandsConverter, diagnostics: ExtHostDiagnostics, provider: vscode.CodeActionProvider) {
 		this._documents = documents;
 		this._commands = commands;
 		this._diagnostics = diagnostics;
@@ -916,7 +916,7 @@ export class ExtHostLanguageFeatures implements ExtHostLanguageFeaturesShape {
 
 	registerCodeActionProvider(selector: vscode.DocumentSelector, provider: vscode.CodeActionProvider): vscode.Disposable {
 		const handle = this._nextHandle();
-		this._adapter.set(handle, new QuickFixAdapter(this._documents, this._commands.converter, this._diagnostics, this._heapService, provider));
+		this._adapter.set(handle, new QuickFixAdapter(this._documents, this._commands.converter, this._diagnostics, provider));
 		this._proxy.$registerQuickFixSupport(handle, selector);
 		return this._createDisposable(handle);
 	}


### PR DESCRIPTION
- [x] place lightbulb into the (usually) free space right of the line numbers, overflow top/bottom if the current line starts at a low offset
- [x] change the trigger logic to be just the selection, unless it is in whitespace only
- [x] change marker selection from range on exthost-side
- [x] keep the trigger logic to for markers if enclosed