### PR TITLE
Add configuration to always show tab descriptions. (#12965)

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -104,6 +104,11 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'description': nls.localize('showEditorTabs', "Controls if opened editors should show in tabs or not."),
 		'default': true
 	},
+	'workbench.editor.alwaysShowTabDescription': {
+		'type': 'boolean',
+		'description': nls.localize('alwaysShowTabDescription', "Controls if editor tabs always show their description or not."),
+		'default': false
+	},
 	'workbench.editor.tabCloseButton': {
 		'type': 'string',
 		'enum': ['left', 'right', 'off'],


### PR DESCRIPTION
Provides the configuration entry `workbench.editor.alwaysShowTabDescription`, which controls whether tab descriptions are always shown. (#12965)