### PR TITLE
Add settings to control the tab subtitle style (#12965)

### DIFF
--- a/src/vs/platform/editor/common/editor.ts
+++ b/src/vs/platform/editor/common/editor.ts
@@ -204,7 +204,7 @@ export interface IEditorInput extends IDisposable {
 	/**
 	 * Returns the display description of this input.
 	 */
-	getDescription(verbose?: boolean): string;
+	getDescription(verbosity?: Verbosity): string;
 
 	/**
 	 * Returns the display title of this input.

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -159,7 +159,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				previewEditors: editorConfig.enablePreview,
 				showIcons: editorConfig.showIcons,
 				showTabs: editorConfig.showTabs,
-				tabCloseButton: editorConfig.tabCloseButton
+				tabCloseButton: editorConfig.tabCloseButton,
+				tabSubtitleStyle: editorConfig.tabSubtitle,
 			};
 
 			this.revealIfOpen = editorConfig.revealIfOpen;
@@ -170,7 +171,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				previewEditors: true,
 				showIcons: false,
 				showTabs: true,
-				tabCloseButton: 'right'
+				tabCloseButton: 'right',
+				tabSubtitleStyle: 'default',
 			};
 
 			this.revealIfOpen = false;
@@ -221,7 +223,8 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 				previewEditors: newPreviewEditors,
 				showIcons: editorConfig.showIcons,
 				tabCloseButton: editorConfig.tabCloseButton,
-				showTabs: this.forceHideTabs ? false : editorConfig.showTabs
+				showTabs: this.forceHideTabs ? false : editorConfig.showTabs,
+				tabSubtitleStyle: editorConfig.tabSubtitle,
 			};
 
 			if (!this.doNotFireTabOptionsChanged && !objects.equals(oldTabOptions, this.tabOptions)) {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -216,7 +216,7 @@ export class TabsTitleControl extends TitleControl {
 
 		// Configuration updates
 		this.toUnbind.push(this.configurationService.onDidUpdateConfiguration(() => this.onConfigurationChanged()));
-		this.onConfigurationChanged();
+		this.onConfigurationChanged(false);
 
 		// Editor Actions Container
 		const editorActionsContainer = document.createElement('div');
@@ -254,11 +254,11 @@ export class TabsTitleControl extends TitleControl {
 		return (element.className === 'tabs-container');
 	}
 
-	private onConfigurationChanged(): void {
-		const tabDescriptionTemplate = this.configurationService.lookup<string>('workbench.editor.tabDescription').value;
+	private onConfigurationChanged(doUpdate = true): void {
+		const currentTabDescriptionTemplate = this.tabDescriptionTemplate;
+		this.tabDescriptionTemplate = this.configurationService.lookup<string>('workbench.editor.tabDescription').value;
 
-		if (tabDescriptionTemplate !== this.tabDescriptionTemplate) {
-			this.tabDescriptionTemplate = tabDescriptionTemplate;
+		if (doUpdate && currentTabDescriptionTemplate !== this.tabDescriptionTemplate) {
 			this.doUpdate();
 		}
 	}

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -368,7 +368,7 @@ export class TabsTitleControl extends TitleControl {
 				const mapDescriptionToDuplicates = new Map<string, AugmentedLabel[]>();
 				// identify duplicate descriptions, while filtering out invalid descriptions
 				for (const label of duplicateTitles) {
-					if (typeof label.description !== 'string') {
+					if (typeof label.description !== 'string' || !label.description) {
 						label.description = '';
 					} else {
 						getOrSet(mapDescriptionToDuplicates, label.description, []).push(label);
@@ -394,9 +394,19 @@ export class TabsTitleControl extends TitleControl {
 					});
 				}
 
-				// shorten descriptions
+				// obtain final set of descriptions
 				const descriptions: string[] = [];
 				mapDescriptionToDuplicates.forEach((_, description) => descriptions.push(description));
+
+				// remove descriptions if all descriptions are the same
+				if (descriptions.length === 1) {
+					for (const label of mapDescriptionToDuplicates.get(descriptions[0])) {
+						label.description = '';
+					}
+					return;
+				}
+
+				// shorten descriptions
 				const shortenedDescriptions = shorten(descriptions);
 				descriptions.forEach((description, i) => {
 					const duplicateDescriptions = mapDescriptionToDuplicates.get(description);

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -176,7 +176,7 @@ export abstract class EditorInput implements IEditorInput {
 	 * Returns the description of this input that can be shown to the user. Examples include showing the description of
 	 * the input above the editor area to the side of the name of the input.
 	 */
-	public getDescription(): string {
+	public getDescription(verbosity?: Verbosity): string {
 		return null;
 	}
 
@@ -806,7 +806,8 @@ export interface IWorkbenchEditorConfiguration {
 			closeOnFileDelete: boolean;
 			openPositioning: 'left' | 'right' | 'first' | 'last';
 			revealIfOpen: boolean;
-			swipeToNavigate: boolean
+			swipeToNavigate: boolean,
+			tabSubtitle: 'default' | 'short' | 'medium' | 'long';
 		}
 	};
 }

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -104,15 +104,16 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'description': nls.localize('showEditorTabs', "Controls if opened editors should show in tabs or not."),
 		'default': true
 	},
-	'workbench.editor.tabDescription': {
+	'workbench.editor.tabSubtitle': {
 		'type': 'string',
-		'default': '${pathDifferential}',
+		'enum': ['default', 'short', 'medium', 'long'],
+		'default': 'default',
 		'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by parenthesis are not to be translated.'], key: 'tabDescription' },
-			`Controls tab descriptions. Variables are substituted based on the context:
-\${pathShort}: e.g. parent
-\${pathMedium}: e.g. more/parent
-\${pathLong}: e.g. workspace/more/parent
-\${pathDifferential}: e.g. .../parent, when another tab shares the same title`),
+			`Controls tab subtitle format:
+short:   'parent'
+medium:  'workspace/src/parent'
+long:    '/home/user/workspace/src/parent'
+default: '.../parent', when another tab shares the same title`),
 	},
 	'workbench.editor.tabCloseButton': {
 		'type': 'string',

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -107,13 +107,19 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 	'workbench.editor.tabSubtitle': {
 		'type': 'string',
 		'enum': ['default', 'short', 'medium', 'long'],
+		'enumDescriptions': [
+			nls.localize('workbench.editor.tabSubtitle.default', "When two files have the same name, shows the distinguinshing sections of each file's path."),
+			nls.localize('workbench.editor.tabSubtitle.short', "Always shows the directory which contains the file."),
+			nls.localize('workbench.editor.tabSubtitle.medium', "Always shows the file's path relative to the workspace root."),
+			nls.localize('workbench.editor.tabSubtitle.long', "Always shows the file's absolute path.")
+		],
 		'default': 'default',
 		'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by parenthesis are not to be translated.'], key: 'tabDescription' },
-			`Controls tab subtitle format:
-short:   'parent'
-medium:  'workspace/src/parent'
-long:    '/home/user/workspace/src/parent'
-default: '.../parent', when another tab shares the same title`),
+			`Controls the format of the subtitle for an editor tab. Subtitles show up next to the file name depending on this setting and make it easier to understand the location of a file:
+- short:   'parent'
+- medium:  'workspace/src/parent'
+- long:    '/home/user/workspace/src/parent'
+- default: '.../parent', when another tab shares the same title`),
 	},
 	'workbench.editor.tabCloseButton': {
 		'type': 'string',

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -104,6 +104,16 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'description': nls.localize('showEditorTabs', "Controls if opened editors should show in tabs or not."),
 		'default': true
 	},
+	'workbench.editor.tabDescription': {
+		'type': 'string',
+		'default': '${pathDifferential}',
+		'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by parenthesis are not to be translated.'], key: 'tabDescription' },
+			`Controls tab descriptions. Variables are substituted based on the context:
+\${pathShort}: e.g. parent
+\${pathMedium}: e.g. more/parent
+\${pathLong}: e.g. workspace/more/parent
+\${pathDifferential}: e.g. .../parent, when another tab shares the same title`),
+	},
 	'workbench.editor.tabCloseButton': {
 		'type': 'string',
 		'enum': ['left', 'right', 'off'],

--- a/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/parts/files/common/editors/fileEditorInput.ts
@@ -32,8 +32,10 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 	private textModelReference: TPromise<IReference<ITextEditorModel>>;
 
 	private name: string;
-	private description: string;
-	private verboseDescription: string;
+
+	private shortDescription: string;
+	private mediumDescription: string;
+	private longDescription: string;
 
 	private shortTitle: string;
 	private mediumTitle: string;
@@ -128,18 +130,25 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 		return this.decorateOrphanedFiles(this.name);
 	}
 
-	public getDescription(verbose?: boolean): string {
-		if (verbose) {
-			if (!this.verboseDescription) {
-				this.verboseDescription = labels.getPathLabel(paths.dirname(this.resource.fsPath), void 0, this.environmentService);
-			}
-		} else {
-			if (!this.description) {
-				this.description = labels.getPathLabel(paths.dirname(this.resource.fsPath), this.contextService, this.environmentService);
-			}
+	public getDescription(verbosity: Verbosity = Verbosity.MEDIUM): string {
+		switch (verbosity) {
+			case Verbosity.SHORT:
+				if (!this.shortDescription) {
+					this.shortDescription = paths.basename(labels.getPathLabel(paths.dirname(this.resource.fsPath), void 0, this.environmentService));
+				}
+				return this.shortDescription;
+			case Verbosity.LONG:
+				if (!this.longDescription) {
+					this.longDescription = labels.getPathLabel(paths.dirname(this.resource.fsPath), void 0, this.environmentService);
+				}
+				return this.longDescription;
+			case Verbosity.MEDIUM:
+			default:
+				if (!this.mediumDescription) {
+					this.mediumDescription = labels.getPathLabel(paths.dirname(this.resource.fsPath), this.contextService, this.environmentService);
+				}
+				return this.mediumDescription;
 		}
-
-		return verbose ? this.verboseDescription : this.description;
 	}
 
 	public getTitle(verbosity: Verbosity): string {

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -24,6 +24,7 @@ export interface ITabOptions {
 	tabCloseButton?: 'left' | 'right' | 'off';
 	showIcons?: boolean;
 	previewEditors?: boolean;
+	tabSubtitleStyle?: 'default' | 'short' | 'medium' | 'long';
 }
 
 export interface IMoveOptions {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/1469

Adds a template system for tab descriptions:
- `${pathShort}`: e.g. `parent`
- `${pathMedium}`: e.g. `more/parent`
- `${pathLong}`: e.g. `workspace/even/more/parent`
- `${pathDifferential}`: e.g. `.../parent`, when another tab shares the same title (current behavior)
