### PR TITLE
Allow an indent increase pattern to span multiple lines

### DIFF
--- a/extensions/html/client/src/htmlMain.ts
+++ b/extensions/html/client/src/htmlMain.ts
@@ -114,7 +114,8 @@ export function activate(context: ExtensionContext) {
 	languages.setLanguageConfiguration('html', {
 		indentationRules: {
 			increaseIndentPattern: /<(?!\?|(?:area|base|br|col|frame|hr|html|img|input|link|meta|param)\b|[^>]*\/>)([-_\.A-Za-z0-9]+)(?=\s|>)\b[^>]*>(?!.*<\/\1>)|<!--(?!.*-->)|\{[^}"']*$/,
-			decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/
+			decreaseIndentPattern: /^\s*(<\/(?!html)[-_\.A-Za-z0-9]+\b[^>]*>|-->|\})/,
+			partialEndOfIncreaseIndentPattern: /.*>\s*/
 		},
 		wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\$\^\&\*\(\)\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\s]+)/g,
 		onEnterRules: [

--- a/src/vs/editor/common/modes/languageConfiguration.ts
+++ b/src/vs/editor/common/modes/languageConfiguration.ts
@@ -86,6 +86,12 @@ export interface IndentationRule {
 	 */
 	indentNextLinePattern?: RegExp;
 	/**
+	 * If this is passed, vscode will assume that the increase indent pattern
+	 * can span multiple lines. A match against this pattern will
+	 * determine whether increaseIndentPattern will be called matched against more lines or not
+	 */
+	partialEndOfIncreaseIndentPattern?: RegExp;
+	/**
 	 * If a line matches this pattern, then its indentation should not be changed and it should not be evaluated against the other rules.
 	 */
 	unIndentedLinePattern?: RegExp;

--- a/src/vs/editor/common/modes/supports/indentRules.ts
+++ b/src/vs/editor/common/modes/supports/indentRules.ts
@@ -12,6 +12,7 @@ export const enum IndentConsts {
 	DECREASE_MASK = 0b00000010,
 	INDENT_NEXTLINE_MASK = 0b00000100,
 	UNINDENT_MASK = 0b00001000,
+	MAX_LINES_LOOKBEHIND = 64
 };
 
 export class IndentRulesSupport {
@@ -56,6 +57,18 @@ export class IndentRulesSupport {
 			// }
 		}
 		return false;
+	}
+
+	public mightIncrease(text: string): boolean {
+		if (!this._indentationRules) {
+			return false;
+		}
+
+		if (!this._indentationRules.partialEndOfIncreaseIndentPattern) {
+			return false;
+		}
+
+		return this._indentationRules.partialEndOfIncreaseIndentPattern.test(text);
 	}
 
 	public shouldDecrease(text: string): boolean {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4303,6 +4303,12 @@ declare module monaco.languages {
 		 */
 		indentNextLinePattern?: RegExp;
 		/**
+		 * If this is passed, vscode will assume that the increase indent pattern
+		 * can span multiple lines. A match against this pattern will
+		 * determine whether increaseIndentPattern will be called matched against more lines or not
+		 */
+		partialEndOfIncreaseIndentPattern?: RegExp;
+		/**
 		 * If a line matches this pattern, then its indentation should not be changed and it should not be evaluated against the other rules.
 		 */
 		unIndentedLinePattern?: RegExp;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2855,6 +2855,12 @@ declare module 'vscode' {
 		/**
 		 * If a line matches this pattern, then its indentation should not be changed and it should not be evaluated against the other rules.
 		 */
+		/**
+		 * If this is passed, vscode will assume that the increase indent pattern
+		 * can span multiple lines. A match against this pattern will
+		 * determine whether increaseIndentPattern will be called matched against more lines or not
+		 */
+		partialEndOfIncreaseIndentPattern?: RegExp;
 		unIndentedLinePattern?: RegExp;
 	}
 


### PR DESCRIPTION
Refs:https://github.com/Microsoft/vscode/issues/31869 #30859 
Fixes reffed issue, automatically indents next line after an html tag is opened

The changes allow a language to supply a `partialEndOfIncreaseIndentPattern` RegExp.
When supplied, vscode will use this pattern to determine whether or not to test `increaseIndentPattern` against more lines.

For example if we have
```
<div data-foor="foo"
        data-bar="bar">
```
Hitting return when the cursor is ahead of the `>` will now correctly indent the new line (it did not previously)

As mentioned in the commit, this is also fixes the reffed issue, when now a `</div>` will be correctly indented
 
One unfortunate issue I see is that github makes my changes look much more dramatic than they actually are.
To display the changes as intended use visual studio code and you'll get a cleaner diff

One basic change I made to the function I had to add my changes to is change something like this.
```
if(condition){
      return val;
} else if (condition2){
      return val2;
} else {
      return val3
}
```

to

```
if(condition){
      return val;
} 

if (condition2){
      return val2;
} 

return val3
```


The reason I did this is because one of the conditions required a little more logic than what can be squeezed in into an expression within the parentheses of an if, and I noticed that a lot of the logic for the last else was squeezed into the function rather than being factored out in a separate method (which is what I could have also done while maintaining the previous condition structure)

Let me know if any changes are required

Cheers