### PR TITLE
Can no longer open image files from the git viewlet

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -179,8 +179,7 @@ export class CommandCenter {
 		}
 
 		if (!left) {
-			const document = await workspace.openTextDocument(right);
-			await window.showTextDocument(document, opts);
+			await commands.executeCommand<void>('vscode.open', right, opts);
 			return;
 		}
 
@@ -372,8 +371,7 @@ export class CommandCenter {
 				opts.selection = activeTextEditor.selection;
 			}
 
-			const document = await workspace.openTextDocument(uri);
-			await window.showTextDocument(document, opts);
+			await commands.executeCommand<void>('vscode.open', uri, opts);
 		}
 	}
 

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -15,7 +15,7 @@ import * as modes from 'vs/editor/common/modes';
 import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
 import { ExtHostCommands } from 'vs/workbench/api/node/extHostCommands';
 import { IWorkspaceSymbolProvider } from 'vs/workbench/parts/search/common/search';
-import { ITextEditorOptions } from 'vs/platform/editor/common/editor';
+import { Position as EditorPosition, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 
 export class ExtHostApiCommands {
 
@@ -205,20 +205,11 @@ export class ExtHostApiCommands {
 			});
 
 		this._register('vscode.diff', (left: URI, right: URI, label: string, options?: vscode.TextDocumentShowOptions) => {
-			let editorOptions: ITextEditorOptions;
-			if (options) {
-				editorOptions = {
-					pinned: typeof options.preview === 'boolean' ? !options.preview : undefined,
-					preserveFocus: options.preserveFocus,
-					selection: typeof options.selection === 'object' ? typeConverters.fromRange(options.selection) : undefined
-				};
-			}
-
 			return this._commands.executeCommand('_workbench.diff', [
 				left, right,
 				label,
 				undefined,
-				editorOptions,
+				typeConverters.toTextEditorOptions(options),
 				options ? typeConverters.fromViewColumn(options.viewColumn) : undefined
 			]);
 		}, {
@@ -231,13 +222,29 @@ export class ExtHostApiCommands {
 				]
 			});
 
-		this._register('vscode.open', (resource: URI, column: vscode.ViewColumn) => {
-			return this._commands.executeCommand('_workbench.open', [resource, typeConverters.fromViewColumn(column)]);
+		this._register('vscode.open', (resource: URI, columnOrOptions?: vscode.ViewColumn | vscode.TextDocumentShowOptions) => {
+			let options: ITextEditorOptions;
+			let column: EditorPosition;
+
+			if (columnOrOptions) {
+				if (typeof columnOrOptions === 'number') {
+					column = typeConverters.fromViewColumn(columnOrOptions);
+				} else {
+					options = typeConverters.toTextEditorOptions(columnOrOptions);
+					column = typeConverters.fromViewColumn(columnOrOptions.viewColumn);
+				}
+			}
+
+			return this._commands.executeCommand('_workbench.open', [
+				resource,
+				options,
+				column
+			]);
 		}, {
 				description: 'Opens the provided resource in the editor. Can be a text or binary file, or a http(s) url. If you need more control over the options for opening a text file, use vscode.window.showTextDocument instead.',
 				args: [
 					{ name: 'resource', description: 'Resource to open', constraint: URI },
-					{ name: 'column', description: '(optional) Column in which to open', constraint: v => v === void 0 || typeof v === 'number' }
+					{ name: 'columnOrOptions', description: '(optional) Either the column in which to open or editor options, see vscode.TextDocumentShowOptions', constraint: v => v === void 0 || typeof v === 'number' || typeof v === 'object' }
 				]
 			});
 	}

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -7,7 +7,7 @@
 import Severity from 'vs/base/common/severity';
 import * as modes from 'vs/editor/common/modes';
 import * as types from './extHostTypes';
-import { Position as EditorPosition } from 'vs/platform/editor/common/editor';
+import { Position as EditorPosition, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IDecorationOptions, EndOfLineSequence } from 'vs/editor/common/editorCommon';
 import * as vscode from 'vscode';
 import URI from 'vs/base/common/uri';
@@ -451,4 +451,16 @@ export namespace ProgressLocation {
 		}
 		return undefined;
 	}
+}
+
+export function toTextEditorOptions(options?: vscode.TextDocumentShowOptions): ITextEditorOptions {
+	if (options) {
+		return {
+			pinned: typeof options.preview === 'boolean' ? !options.preview : undefined,
+			preserveFocus: options.preserveFocus,
+			selection: typeof options.selection === 'object' ? fromRange(options.selection) : undefined
+		} as ITextEditorOptions;
+	}
+
+	return undefined;
 }

--- a/src/vs/workbench/electron-browser/commands.ts
+++ b/src/vs/workbench/electron-browser/commands.ts
@@ -412,11 +412,11 @@ export function registerCommands(): void {
 		});
 	});
 
-	CommandsRegistry.registerCommand('_workbench.open', function (accessor: ServicesAccessor, args: [URI, number]) {
+	CommandsRegistry.registerCommand('_workbench.open', function (accessor: ServicesAccessor, args: [URI, IEditorOptions, EditorPosition]) {
 		const editorService = accessor.get(IWorkbenchEditorService);
-		const [resource, column] = args;
+		const [resource, options, column] = args;
 
-		return editorService.openEditor({ resource }, column).then(() => {
+		return editorService.openEditor({ resource, options }, column).then(() => {
 			return void 0;
 		});
 	});


### PR DESCRIPTION
fixes #33739 

The SCM viewlet is always using `window.showTextDocument` when clicking on a file in the list of outgoing changes, however this will fail with an error if the file is binary. Previously it was using the `vscode.open` command which handled this nicely. However, that was changed via https://github.com/Microsoft/vscode/commit/c0381f2b62b9bf1b3d81f9f88b82a9eb5bd873dc to support more options when opening actual text files.

This fix adds `TextDocumentShowOptions` to the `vscode.open` command so that binary files can also be opened. 

I realize we had this request going on already via https://github.com/Microsoft/vscode/pull/30675 but at that time I did not see the issue with binary files. 