### PR TITLE
fixed the terminal and find widget key presses

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -407,10 +407,8 @@ export class TerminalInstance implements ITerminalInstance {
 	}
 
 	public notifyFindWidgetFocusChanged(isFocused: boolean): void {
-		// In order to support escape to close the find widget when the terminal
-		// is focused terminalFocus needs to be true when either the terminal or
-		// the find widget are focused.
-		this._terminalFocusContextKey.set(isFocused || document.activeElement === this._xterm.textarea);
+		const terminalFocused = !isFocused && (document.activeElement === this._xterm.textarea || document.activeElement === this._xterm.element);
+		this._terminalFocusContextKey.set(terminalFocused);
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
This should fix #30994 and #33833.

This function was added in [this commit](https://github.com/Microsoft/vscode/commit/8ffd4d78fc8a741fad7d3d0e4e8b76824fe6ffed), which fixed an interaction with the Esc key when the terminal find widget was visible.

I tried multiple scenarios with the Ctrl+A, Ctrl+V, Esc keys (both in the terminal and editor, with the find widget opened or closed) and I don't think there are any regressions.

CC @Tyriar 