### PR TITLE
Create setting that trims newlines from the end of a file

### DIFF
--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -236,6 +236,13 @@ configurationRegistry.registerConfiguration({
 			'overridable': true,
 			'scope': ConfigurationScope.RESOURCE
 		},
+		'files.trimFinalNewlines': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('trimFinalNewlines', "When enabled, will trim all new lines after the final new line at the end of the file when saving it."),
+			'overridable': true,
+			'scope': ConfigurationScope.RESOURCE
+		},
 		'files.autoSave': {
 			'type': 'string',
 			'enum': [AutoSaveConfiguration.OFF, AutoSaveConfiguration.AFTER_DELAY, AutoSaveConfiguration.ON_FOCUS_CHANGE, , AutoSaveConfiguration.ON_WINDOW_CHANGE],

--- a/src/vs/workbench/test/electron-browser/api/mainThreadSaveParticipant.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadSaveParticipant.test.ts
@@ -7,7 +7,7 @@
 
 import * as assert from 'assert';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { FinalNewLineParticipant } from 'vs/workbench/api/electron-browser/mainThreadSaveParticipant';
+import { FinalNewLineParticipant, TrimFinalNewLinesParticipant } from 'vs/workbench/api/electron-browser/mainThreadSaveParticipant';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { workbenchInstantiationService, TestTextFileService } from 'vs/workbench/test/workbenchTestServices';
 import { toResource } from 'vs/base/test/common/utils';
@@ -68,6 +68,46 @@ suite('MainThreadSaveParticipant', function () {
 			model.textEditorModel.setValue(lineContent);
 			participant.participate(model, { reason: SaveReason.EXPLICIT });
 			assert.equal(model.getValue(), `${lineContent}${model.textEditorModel.getEOL()}`);
+
+			done();
+		});
+	});
+
+	test('trim final new lines', function (done) {
+		const model: TextFileEditorModel = instantiationService.createInstance(TextFileEditorModel, toResource.call(this, '/path/trim_final_new_line.txt'), 'utf8');
+
+		model.load().then(() => {
+			const configService = new TestConfigurationService();
+			configService.setUserConfiguration('files', { 'trimFinalNewlines': true });
+
+			const participant = new TrimFinalNewLinesParticipant(configService, undefined);
+
+			const textContent = 'Trim New Line';
+			const eol = `${model.textEditorModel.getEOL()}`;
+
+			// No new line removal if last line is not new line
+			let lineContent = `${textContent}`;
+			model.textEditorModel.setValue(lineContent);
+			participant.participate(model, { reason: SaveReason.EXPLICIT });
+			assert.equal(model.getValue(), lineContent);
+
+			// No new line removal if last line is single new line
+			lineContent = `${textContent}${eol}`;
+			model.textEditorModel.setValue(lineContent);
+			participant.participate(model, { reason: SaveReason.EXPLICIT });
+			assert.equal(model.getValue(), lineContent);
+
+			// Remove new line (single line with two new lines)
+			lineContent = `${textContent}${eol}${eol}`;
+			model.textEditorModel.setValue(lineContent);
+			participant.participate(model, { reason: SaveReason.EXPLICIT });
+			assert.equal(model.getValue(), `${textContent}${eol}`);
+
+			// Remove new lines (multiple lines with multiple new lines)
+			lineContent = `${textContent}${eol}${textContent}${eol}${eol}${eol}`;
+			model.textEditorModel.setValue(lineContent);
+			participant.participate(model, { reason: SaveReason.EXPLICIT });
+			assert.equal(model.getValue(), `${textContent}${eol}${textContent}${eol}`);
 
 			done();
 		});


### PR DESCRIPTION
This implements the feature requested in #16599
* Does not add a newline to the end of the file if one does not exist