### PR TITLE
Better reveal logic

### DIFF
--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -393,9 +393,14 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 
 		this.editor.setSelection(where);
 
-		// Reveal the line above or below the zone widget, to get the zone widget in the viewport
-		const revealLineNumber = Math.min(this.editor.getModel().getLineCount(), Math.max(1, where.endLineNumber + 1));
-		this.revealLine(revealLineNumber);
+		// There are two points of interest that we want to reveal in ascending importance:
+		// 1. The line below the zone widget (to make sure that the bottom of the widget is visible).
+		// 2. The line above the zone widget (to make sure that the top of the widget is visible).
+		// We reveal them in this order so if they both can't fit on screen at once,
+		// then the top of the widget is visible.
+		const lineBelowZone = Math.min(this.editor.getModel().getLineCount(), Math.max(1, where.endLineNumber + 1));
+		this.revealLine(lineBelowZone);
+		this.revealLine(where.endLineNumber);
 	}
 
 	protected revealLine(lineNumber: number) {


### PR DESCRIPTION
The current logic only attempts to reveal the line below the zone widget. This does not guarantee that the zone widget is entirely visible.

The logic in this pr first reveals the line above the zone widget (in the center if not already in the viewport) and then reveals the line below the zone widget.