### PR TITLE
Handle user information in URI

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -301,8 +301,20 @@ export default class URI {
 			parts.push('//');
 		}
 		if (authority) {
+			let idx = authority.indexOf('@');
+			if (idx !== -1) {
+				const userinfo = authority.substr(0, idx);
+				authority = authority.substr(idx + 1);
+				idx = userinfo.indexOf(':');
+				if (idx === -1) {
+					parts.push(encoder(userinfo));
+				} else {
+					parts.push(encoder(userinfo.substr(0, idx)), ':', encoder(userinfo.substr(idx + 1)));
+				}
+				parts.push('@');
+			}
 			authority = authority.toLowerCase();
-			let idx = authority.indexOf(':');
+			idx = authority.indexOf(':');
 			if (idx === -1) {
 				parts.push(encoder(authority));
 			} else {

--- a/src/vs/base/test/common/uri.test.ts
+++ b/src/vs/base/test/common/uri.test.ts
@@ -368,6 +368,23 @@ suite('URI', () => {
 		assert.equal(value.toString(), 'http://l%C3%B6calhost:8080/far');
 	});
 
+	test('URI#toString, user information in authority', () => {
+		var value = URI.parse('http://foo:bar@localhost/far');
+		assert.equal(value.toString(), 'http://foo:bar@localhost/far');
+
+		value = URI.parse('http://foo@localhost/far');
+		assert.equal(value.toString(), 'http://foo@localhost/far');
+
+		value = URI.parse('http://foo:bAr@localhost:8080/far');
+		assert.equal(value.toString(), 'http://foo:bAr@localhost:8080/far');
+
+		value = URI.parse('http://foo@localhost:8080/far');
+		assert.equal(value.toString(), 'http://foo@localhost:8080/far');
+
+		value = URI.from({ scheme: 'http', authority: 'föö:bör@löcalhost:8080', path: '/far', query: undefined, fragment: undefined });
+		assert.equal(value.toString(), 'http://f%C3%B6%C3%B6:b%C3%B6r@l%C3%B6calhost:8080/far');
+	});
+
 	test('correctFileUriToFilePath2', () => {
 
 		var test = (input: string, expected: string) => {


### PR DESCRIPTION
Without this change encoding an URL like
`git+ssh://git@github.com/Microsoft/vscode.git` results in
`git+ssh://git%40github.com/Microsoft/vscode.git`.