### PR TITLE
Add optional CompletionContext to provideCompletionItems

### DIFF
--- a/extensions/vscode-api-tests/src/languages.test.ts
+++ b/extensions/vscode-api-tests/src/languages.test.ts
@@ -69,7 +69,7 @@ suite('languages namespace tests', () => {
 		let jsonDocumentFilter = [{ language: 'json', pattern: '**/package.json' }, { language: 'json', pattern: '**/bower.json' }, { language: 'json', pattern: '**/.bower.json' }];
 
 		let r1 = languages.registerCompletionItemProvider(jsonDocumentFilter, {
-		provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): CompletionItem[] {
+			provideCompletionItems: (document: TextDocument, position: Position, token: CancellationToken): CompletionItem[] => {
 				let proposal = new CompletionItem('foo');
 				proposal.kind = CompletionItemKind.Property;
 				ran = true;

--- a/extensions/vscode-api-tests/src/languages.test.ts
+++ b/extensions/vscode-api-tests/src/languages.test.ts
@@ -69,7 +69,7 @@ suite('languages namespace tests', () => {
 		let jsonDocumentFilter = [{ language: 'json', pattern: '**/package.json' }, { language: 'json', pattern: '**/bower.json' }, { language: 'json', pattern: '**/.bower.json' }];
 
 		let r1 = languages.registerCompletionItemProvider(jsonDocumentFilter, {
-			provideCompletionItems: (document: TextDocument, position: Position, token: CancellationToken): CompletionItem[] => {
+		provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): CompletionItem[] {
 				let proposal = new CompletionItem('foo');
 				proposal.kind = CompletionItemKind.Property;
 				ran = true;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -251,6 +251,7 @@ export interface ISuggestResult {
  * @internal
  */
 export interface SuggestContext {
+	trigger: 'auto' | 'manual';
 	triggerCharacter?: string;
 }
 

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -248,10 +248,18 @@ export interface ISuggestResult {
 }
 
 /**
+ * How a suggest provider was triggered.
+ */
+export enum SuggestTriggerKind {
+	Invoke = 0,
+	TriggerCharacter = 1
+}
+
+/**
  * @internal
  */
 export interface SuggestContext {
-	trigger: 'auto' | 'manual';
+	triggerKind: SuggestTriggerKind;
 	triggerCharacter?: string;
 }
 

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -250,11 +250,18 @@ export interface ISuggestResult {
 /**
  * @internal
  */
+export interface SuggestContext {
+	triggerCharacter?: string;
+}
+
+/**
+ * @internal
+ */
 export interface ISuggestSupport {
 
 	triggerCharacters?: string[];
 
-	provideCompletionItems(model: editorCommon.IModel, position: Position, token: CancellationToken): ISuggestResult | Thenable<ISuggestResult>;
+	provideCompletionItems(model: editorCommon.IModel, position: Position, context: SuggestContext, token: CancellationToken): ISuggestResult | Thenable<ISuggestResult>;
 
 	resolveCompletionItem?(model: editorCommon.IModel, position: Position, item: ISuggestion, token: CancellationToken): ISuggestion | Thenable<ISuggestion>;
 }

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -42,6 +42,8 @@ export function setSnippetSuggestSupport(support: ISuggestSupport): ISuggestSupp
 	return old;
 }
 
+const emptySuggestContext: SuggestContext = {};
+
 export function provideSuggestionItems(model: IModel, position: Position, snippetConfig: SnippetConfig = 'bottom', onlyFrom?: ISuggestSupport[], context?: SuggestContext): TPromise<ISuggestionItem[]> {
 
 	const allSuggestions: ISuggestionItem[] = [];
@@ -73,7 +75,7 @@ export function provideSuggestionItems(model: IModel, position: Position, snippe
 					return undefined;
 				}
 
-				return asWinJsPromise(token => support.provideCompletionItems(model, position, context || {}, token)).then(container => {
+				return asWinJsPromise(token => support.provideCompletionItems(model, position, context || emptySuggestContext, token)).then(container => {
 
 					const len = allSuggestions.length;
 

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -12,7 +12,7 @@ import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IModel, IEditorContribution, ICommonCodeEditor } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
-import { ISuggestResult, ISuggestSupport, ISuggestion, SuggestRegistry, SuggestContext } from 'vs/editor/common/modes';
+import { ISuggestResult, ISuggestSupport, ISuggestion, SuggestRegistry, SuggestContext, SuggestTriggerKind } from 'vs/editor/common/modes';
 import { Position, IPosition } from 'vs/editor/common/core/position';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
@@ -57,7 +57,7 @@ export function provideSuggestionItems(model: IModel, position: Position, snippe
 		supports.unshift([_snippetSuggestSupport]);
 	}
 
-	const suggestConext = context || { trigger: 'auto' };
+	const suggestConext = context || { triggerKind: SuggestTriggerKind.Invoke };
 
 	// add suggestions from contributed providers - providers are ordered in groups of
 	// equal score and once a group produces a result the process stops

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -42,8 +42,6 @@ export function setSnippetSuggestSupport(support: ISuggestSupport): ISuggestSupp
 	return old;
 }
 
-const emptySuggestContext: SuggestContext = {};
-
 export function provideSuggestionItems(model: IModel, position: Position, snippetConfig: SnippetConfig = 'bottom', onlyFrom?: ISuggestSupport[], context?: SuggestContext): TPromise<ISuggestionItem[]> {
 
 	const allSuggestions: ISuggestionItem[] = [];
@@ -58,6 +56,8 @@ export function provideSuggestionItems(model: IModel, position: Position, snippe
 	if (snippetConfig !== 'none' && _snippetSuggestSupport) {
 		supports.unshift([_snippetSuggestSupport]);
 	}
+
+	const suggestConext = context || { trigger: 'auto' };
 
 	// add suggestions from contributed providers - providers are ordered in groups of
 	// equal score and once a group produces a result the process stops
@@ -75,7 +75,7 @@ export function provideSuggestionItems(model: IModel, position: Position, snippe
 					return undefined;
 				}
 
-				return asWinJsPromise(token => support.provideCompletionItems(model, position, context || emptySuggestContext, token)).then(container => {
+				return asWinJsPromise(token => support.provideCompletionItems(model, position, suggestConext, token)).then(container => {
 
 					const len = allSuggestions.length;
 

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -12,7 +12,7 @@ import { onUnexpectedExternalError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IModel, IEditorContribution, ICommonCodeEditor } from 'vs/editor/common/editorCommon';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
-import { ISuggestResult, ISuggestSupport, ISuggestion, SuggestRegistry } from 'vs/editor/common/modes';
+import { ISuggestResult, ISuggestSupport, ISuggestion, SuggestRegistry, SuggestContext } from 'vs/editor/common/modes';
 import { Position, IPosition } from 'vs/editor/common/core/position';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
@@ -42,7 +42,7 @@ export function setSnippetSuggestSupport(support: ISuggestSupport): ISuggestSupp
 	return old;
 }
 
-export function provideSuggestionItems(model: IModel, position: Position, snippetConfig: SnippetConfig = 'bottom', onlyFrom?: ISuggestSupport[]): TPromise<ISuggestionItem[]> {
+export function provideSuggestionItems(model: IModel, position: Position, snippetConfig: SnippetConfig = 'bottom', onlyFrom?: ISuggestSupport[], context?: SuggestContext): TPromise<ISuggestionItem[]> {
 
 	const allSuggestions: ISuggestionItem[] = [];
 	const acceptSuggestion = createSuggesionFilter(snippetConfig);
@@ -73,7 +73,7 @@ export function provideSuggestionItems(model: IModel, position: Position, snippe
 					return undefined;
 				}
 
-				return asWinJsPromise(token => support.provideCompletionItems(model, position, token)).then(container => {
+				return asWinJsPromise(token => support.provideCompletionItems(model, position, context || {}, token)).then(container => {
 
 					const len = allSuggestions.length;
 

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -209,7 +209,7 @@ export class SuggestController implements IEditorContribution {
 	}
 
 	triggerSuggest(onlyFrom?: ISuggestSupport[]): void {
-		this._model.trigger(false, false, onlyFrom);
+		this._model.trigger({ auto: false }, false, onlyFrom);
 		this._editor.revealLine(this._editor.getPosition().lineNumber, ScrollType.Smooth);
 		this._editor.focus();
 	}

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -357,7 +357,8 @@ export class SuggestModel implements IDisposable {
 			this.editor.getConfiguration().contribInfo.snippetSuggestions,
 			onlyFrom,
 			{
-				triggerCharacter: context.triggerCharacter
+				triggerCharacter: context.triggerCharacter,
+				trigger: context.auto ? 'auto' : 'manual'
 			}
 		).then(items => {
 

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -356,7 +356,9 @@ export class SuggestModel implements IDisposable {
 		this.requestPromise = provideSuggestionItems(model, this.editor.getPosition(),
 			this.editor.getConfiguration().contribInfo.snippetSuggestions,
 			onlyFrom,
-			context
+			{
+				triggerCharacter: context.triggerCharacter
+			}
 		).then(items => {
 
 			this.requestPromise = null;

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -11,7 +11,7 @@ import Event, { Emitter } from 'vs/base/common/event';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { ICommonCodeEditor, IModel, IWordAtPosition } from 'vs/editor/common/editorCommon';
-import { ISuggestSupport, SuggestRegistry, StandardTokenType } from 'vs/editor/common/modes';
+import { ISuggestSupport, SuggestRegistry, StandardTokenType, SuggestTriggerKind } from 'vs/editor/common/modes';
 import { Position } from 'vs/editor/common/core/position';
 import { provideSuggestionItems, getSuggestionComparator, ISuggestionItem } from './suggest';
 import { CompletionModel } from './completionModel';
@@ -358,7 +358,7 @@ export class SuggestModel implements IDisposable {
 			onlyFrom,
 			{
 				triggerCharacter: context.triggerCharacter,
-				trigger: context.auto ? 'auto' : 'manual'
+				triggerKind: context.triggerCharacter ? SuggestTriggerKind.TriggerCharacter : SuggestTriggerKind.Invoke
 			}
 		).then(items => {
 

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -11,7 +11,7 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Model } from 'vs/editor/common/model/model';
 import { ICommonCodeEditor, Handler } from 'vs/editor/common/editorCommon';
-import { ISuggestSupport, ISuggestResult, SuggestRegistry } from 'vs/editor/common/modes';
+import { ISuggestSupport, ISuggestResult, SuggestRegistry, SuggestTriggerKind } from 'vs/editor/common/modes';
 import { SuggestModel, LineContext } from 'vs/editor/contrib/suggest/browser/suggestModel';
 import { MockCodeEditor, MockScopeLocation } from 'vs/editor/test/common/mocks/mockCodeEditor';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -458,12 +458,12 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 		});
 	});
 
-	test('Trigger characters is provided in suggest context', function () {
+	test('Trigger character is provided in suggest context', function () {
 		let triggerCharacter = '';
 		disposables.push(SuggestRegistry.register({ scheme: 'test' }, {
 			triggerCharacters: ['.'],
 			provideCompletionItems(doc, pos, context) {
-				assert.equal(context.trigger, 'auto');
+				assert.equal(context.triggerKind, SuggestTriggerKind.TriggerCharacter);
 				triggerCharacter = context.triggerCharacter;
 				return <ISuggestResult>{
 					currentWord: '',

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -149,25 +149,25 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 
 				// cancel on trigger
 				assertEvent(model.onDidCancel, function () {
-					model.trigger(false);
+					model.trigger({ auto: false });
 				}, function (event) {
 					assert.equal(event.retrigger, false);
 				}),
 
 				assertEvent(model.onDidCancel, function () {
-					model.trigger(false, true);
+					model.trigger({ auto: false }, true);
 				}, function (event) {
 					assert.equal(event.retrigger, true);
 				}),
 
 				assertEvent(model.onDidTrigger, function () {
-					model.trigger(true);
+					model.trigger({ auto: true });
 				}, function (event) {
 					assert.equal(event.auto, true);
 				}),
 
 				assertEvent(model.onDidTrigger, function () {
-					model.trigger(false);
+					model.trigger({ auto: false });
 				}, function (event) {
 					assert.equal(event.auto, false);
 				})
@@ -183,12 +183,12 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 		return withOracle(model => {
 			return TPromise.join([
 				assertEvent(model.onDidCancel, function () {
-					model.trigger(true);
+					model.trigger({ auto: true });
 				}, function (event) {
 					assert.equal(event.retrigger, false);
 				}),
 				assertEvent(model.onDidSuggest, function () {
-					model.trigger(false);
+					model.trigger({ auto: false });
 				}, function (event) {
 					assert.equal(event.auto, false);
 					assert.equal(event.isFrozen, false);
@@ -239,7 +239,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 
 			return assertEvent(model.onDidSuggest, () => {
 				// make sure completionModel starts here!
-				model.trigger(true);
+				model.trigger({ auto: true });
 			}, event => {
 
 				return assertEvent(model.onDidSuggest, () => {
@@ -338,7 +338,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 3 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger(false);
+				model.trigger({ auto: false });
 			}, event => {
 				assert.equal(event.auto, false);
 				assert.equal(event.isFrozen, false);
@@ -363,7 +363,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 3 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger(false);
+				model.trigger({ auto: false });
 			}, event => {
 				assert.equal(event.auto, false);
 				assert.equal(event.isFrozen, false);
@@ -400,7 +400,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 4 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger(false);
+				model.trigger({ auto: false });
 			}, event => {
 				assert.equal(event.auto, false);
 				assert.equal(event.completionModel.incomplete, true);
@@ -437,7 +437,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			editor.setPosition({ lineNumber: 1, column: 4 });
 
 			return assertEvent(model.onDidSuggest, () => {
-				model.trigger(false);
+				model.trigger({ auto: false });
 			}, event => {
 				assert.equal(event.auto, false);
 				assert.equal(event.completionModel.incomplete, true);
@@ -454,6 +454,40 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 					assert.equal(event.completionModel.items.length, 1);
 
 				});
+			});
+		});
+	});
+
+	test('Trigger characters is provided in suggest context', function () {
+		let triggerCharacter = '';
+		disposables.push(SuggestRegistry.register({ scheme: 'test' }, {
+			triggerCharacters: ['.'],
+			provideCompletionItems(doc, pos, context) {
+				triggerCharacter = context.triggerCharacter;
+				return <ISuggestResult>{
+					currentWord: '',
+					incomplete: false,
+					suggestions: [
+						{
+							label: 'foo.bar',
+							type: 'property',
+							insertText: 'foo.bar',
+							overwriteBefore: pos.column - 1
+						}
+					]
+				};
+			}
+		}));
+
+		model.setValue('');
+
+		return withOracle((model, editor) => {
+
+			return assertEvent(model.onDidSuggest, () => {
+				editor.setPosition({ lineNumber: 1, column: 1 });
+				editor.trigger('keyboard', Handler.Type, { text: 'foo.' });
+			}, event => {
+				assert.equal(triggerCharacter, '.');
 			});
 		});
 	});

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -463,6 +463,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 		disposables.push(SuggestRegistry.register({ scheme: 'test' }, {
 			triggerCharacters: ['.'],
 			provideCompletionItems(doc, pos, context) {
+				assert.equal(context.trigger, 'auto');
 				triggerCharacter = context.triggerCharacter;
 				return <ISuggestResult>{
 					currentWord: '',

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -373,8 +373,8 @@ export function registerCompletionItemProvider(languageId: string, provider: Com
 	let adapter = new SuggestAdapter(provider);
 	return modes.SuggestRegistry.register(languageId, {
 		triggerCharacters: provider.triggerCharacters,
-		provideCompletionItems: (model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Thenable<modes.ISuggestResult> => {
-			return adapter.provideCompletionItems(model, position, token);
+		provideCompletionItems: (model: editorCommon.IReadOnlyModel, position: Position, context: modes.SuggestContext, token: CancellationToken): Thenable<modes.ISuggestResult> => {
+			return adapter.provideCompletionItems(model, position, context, token);
 		},
 		resolveCompletionItem: (model: editorCommon.IReadOnlyModel, position: Position, suggestion: modes.ISuggestion, token: CancellationToken): Thenable<modes.ISuggestion> => {
 			return adapter.resolveCompletionItem(model, position, suggestion, token);
@@ -537,6 +537,23 @@ export interface CompletionList {
 	 */
 	items: CompletionItem[];
 }
+
+/**
+ * Contains additional information about the context in which
+ * [completion provider](#CompletionItemProvider.provideCompletionItems) is triggered.
+ */
+export interface CompletionContext {
+	/**
+	 * Character that triggered the completion item provider.
+	 *
+	 * Undefined if provider was not triggered by a character.
+	 */
+	triggerCharacter?: string;
+}
+
+export type ProviderCompletionItems = (document: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken) => CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+export type ProviderCompletionItemsForContext = (document: editorCommon.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken) => CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+
 /**
  * The completion item provider interface defines the contract between extensions and
  * the [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
@@ -553,7 +570,7 @@ export interface CompletionItemProvider {
 	/**
 	 * Provide completion items for the given position and document.
 	 */
-	provideCompletionItems(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+	provideCompletionItems: ProviderCompletionItems | ProviderCompletionItemsForContext;
 	/**
 	 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
 	 * or [details](#CompletionItem.detail).
@@ -639,9 +656,14 @@ class SuggestAdapter {
 		return suggestion;
 	}
 
-	provideCompletionItems(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Thenable<modes.ISuggestResult> {
-
-		return toThenable<CompletionItem[] | CompletionList>(this._provider.provideCompletionItems(model, position, token)).then(value => {
+	provideCompletionItems(model: editorCommon.IReadOnlyModel, position: Position, context: modes.SuggestContext, token: CancellationToken): Thenable<modes.ISuggestResult> {
+		let request: any;
+		if (this._provider.provideCompletionItems.length <= 3) {
+			request = (this._provider.provideCompletionItems as ProviderCompletionItems)(model, position, token);
+		} else {
+			request = (this._provider.provideCompletionItems as ProviderCompletionItemsForContext)(model, position, context, token);
+		}
+		return toThenable<CompletionItem[] | CompletionList>(request).then(value => {
 			const result: modes.ISuggestResult = {
 				suggestions: []
 			};

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -546,7 +546,7 @@ export interface CompletionContext {
 	/**
 	 * How the completion was triggered.
 	 */
-	readonly trigger: 'auto' | 'manual';
+	triggerKind: modes.SuggestTriggerKind;
 
 	/**
 	 * Character that triggered the completion item provider.
@@ -610,6 +610,7 @@ function convertKind(kind: CompletionItemKind): modes.SuggestionType {
 	}
 	return 'property';
 }
+
 class SuggestAdapter {
 
 	private _provider: CompletionItemProvider;
@@ -758,6 +759,7 @@ export function createMonacoLanguagesAPI(): typeof monaco.languages {
 		DocumentHighlightKind: modes.DocumentHighlightKind,
 		CompletionItemKind: CompletionItemKind,
 		SymbolKind: modes.SymbolKind,
-		IndentAction: IndentAction
+		IndentAction: IndentAction,
+		SuggestTriggerKind: modes.SuggestTriggerKind
 	};
 }

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -556,16 +556,6 @@ export interface CompletionContext {
 	triggerCharacter?: string;
 }
 
-export namespace CompletionItemProvider {
-	export interface ProvideCompletionItems {
-		(document: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-	}
-
-	export interface ProvideCompletionItemsForContext {
-		(document: editorCommon.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-	}
-}
-
 /**
  * The completion item provider interface defines the contract between extensions and
  * the [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
@@ -582,7 +572,7 @@ export interface CompletionItemProvider {
 	/**
 	 * Provide completion items for the given position and document.
 	 */
-	provideCompletionItems: CompletionItemProvider.ProvideCompletionItems | CompletionItemProvider.ProvideCompletionItemsForContext;
+	provideCompletionItems(document: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken, context: CompletionContext): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
 
 	/**
 	 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
@@ -670,10 +660,7 @@ class SuggestAdapter {
 	}
 
 	provideCompletionItems(model: editorCommon.IReadOnlyModel, position: Position, context: modes.SuggestContext, token: CancellationToken): Thenable<modes.ISuggestResult> {
-		const result = this._provider.provideCompletionItems.length <= 3
-			? (this._provider.provideCompletionItems as CompletionItemProvider.ProvideCompletionItems)(model, position, token)
-			: (this._provider.provideCompletionItems as CompletionItemProvider.ProvideCompletionItemsForContext)(model, position, context, token);
-
+		const result = this._provider.provideCompletionItems(model, position, token, context);
 		return toThenable<CompletionItem[] | CompletionList>(result).then(value => {
 			const result: modes.ISuggestResult = {
 				suggestions: []

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4230,6 +4230,23 @@ declare module monaco.languages {
 	}
 
 	/**
+	 * Contains additional information about the context in which
+	 * [completion provider](#CompletionItemProvider.provideCompletionItems) is triggered.
+	 */
+	export interface CompletionContext {
+		/**
+		 * Character that triggered the completion item provider.
+		 *
+		 * Undefined if provider was not triggered by a character.
+		 */
+		triggerCharacter?: string;
+	}
+
+	export type ProviderCompletionItems = (document: editor.IReadOnlyModel, position: Position, token: CancellationToken) => CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+
+	export type ProviderCompletionItemsForContext = (document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken) => CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+
+	/**
 	 * The completion item provider interface defines the contract between extensions and
 	 * the [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
 	 *
@@ -4245,7 +4262,7 @@ declare module monaco.languages {
 		/**
 		 * Provide completion items for the given position and document.
 		 */
-		provideCompletionItems(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+		provideCompletionItems: ProviderCompletionItems | ProviderCompletionItemsForContext;
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
 		 * or [details](#CompletionItem.detail).

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4237,14 +4237,10 @@ declare module monaco.languages {
 		/**
 		 * Character that triggered the completion item provider.
 		 *
-		 * Undefined if provider was not triggered by a character.
+		 * `undefined` if provider was not triggered by a character.
 		 */
 		triggerCharacter?: string;
 	}
-
-	export type ProviderCompletionItems = (document: editor.IReadOnlyModel, position: Position, token: CancellationToken) => CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-
-	export type ProviderCompletionItemsForContext = (document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken) => CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
 
 	/**
 	 * The completion item provider interface defines the contract between extensions and
@@ -4262,7 +4258,8 @@ declare module monaco.languages {
 		/**
 		 * Provide completion items for the given position and document.
 		 */
-		provideCompletionItems: ProviderCompletionItems | ProviderCompletionItemsForContext;
+		provideCompletionItems(document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+		provideCompletionItems(document: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
 		 * or [details](#CompletionItem.detail).

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4235,11 +4235,32 @@ declare module monaco.languages {
 	 */
 	export interface CompletionContext {
 		/**
+		 * How the completion was triggered.
+		 */
+		readonly trigger: 'auto' | 'manual';
+		/**
 		 * Character that triggered the completion item provider.
 		 *
 		 * `undefined` if provider was not triggered by a character.
 		 */
 		triggerCharacter?: string;
+	}
+
+	export namespace CompletionItemProvider {
+		interface ProvideCompletionItems {
+			(document: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+		}
+		interface ProvideCompletionItemsForContext {
+			(document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+		}
+	}
+
+	interface ProvideCompletionItems {
+		(document: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+	}
+
+	interface ProvideCompletionItemsForContext {
+		(document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
 	}
 
 	/**
@@ -4258,8 +4279,7 @@ declare module monaco.languages {
 		/**
 		 * Provide completion items for the given position and document.
 		 */
-		provideCompletionItems(document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-		provideCompletionItems(document: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
+		provideCompletionItems: CompletionItemProvider.ProvideCompletionItems | CompletionItemProvider.ProvideCompletionItemsForContext;
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
 		 * or [details](#CompletionItem.detail).

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4237,7 +4237,7 @@ declare module monaco.languages {
 		/**
 		 * How the completion was triggered.
 		 */
-		readonly trigger: 'auto' | 'manual';
+		triggerKind: SuggestTriggerKind;
 		/**
 		 * Character that triggered the completion item provider.
 		 *
@@ -4511,6 +4511,14 @@ declare module monaco.languages {
 		 * to the word range at the position when omitted.
 		 */
 		provideHover(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Hover | Thenable<Hover>;
+	}
+
+	/**
+	 * How a suggest provider was triggered.
+	 */
+	export enum SuggestTriggerKind {
+		Invoke = 0,
+		TriggerCharacter = 1,
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4246,23 +4246,6 @@ declare module monaco.languages {
 		triggerCharacter?: string;
 	}
 
-	export namespace CompletionItemProvider {
-		interface ProvideCompletionItems {
-			(document: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-		}
-		interface ProvideCompletionItemsForContext {
-			(document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-		}
-	}
-
-	interface ProvideCompletionItems {
-		(document: editor.IReadOnlyModel, position: Position, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-	}
-
-	interface ProvideCompletionItemsForContext {
-		(document: editor.IReadOnlyModel, position: Position, context: CompletionContext, token: CancellationToken): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
-	}
-
 	/**
 	 * The completion item provider interface defines the contract between extensions and
 	 * the [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
@@ -4279,7 +4262,7 @@ declare module monaco.languages {
 		/**
 		 * Provide completion items for the given position and document.
 		 */
-		provideCompletionItems: CompletionItemProvider.ProvideCompletionItems | CompletionItemProvider.ProvideCompletionItemsForContext;
+		provideCompletionItems(document: editor.IReadOnlyModel, position: Position, token: CancellationToken, context: CompletionContext): CompletionItem[] | Thenable<CompletionItem[]> | CompletionList | Thenable<CompletionList>;
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
 		 * or [details](#CompletionItem.detail).

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2719,6 +2719,20 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * How a [completion provider](#CompletionItemProvider) was triggered
+	 */
+	export enum CompletionTriggerKind {
+		/**
+		 * Completion was triggered normally.
+		 */
+		Invoke = 0,
+		/**
+		 * Completion was triggered by a trigger character.
+		 */
+		TriggerCharacter = 1
+	}
+
+	/**
 	 * Contains additional information about the context in which
 	 * [completion provider](#CompletionItemProvider.provideCompletionItems) is triggered.
 	 */
@@ -2726,7 +2740,7 @@ declare module 'vscode' {
 		/**
 		 * How the completion was triggered.
 		 */
-		readonly trigger: 'auto' | 'manual';
+		readonly triggerKind: CompletionTriggerKind;
 
 		/**
 		 * Character that triggered the completion item provider.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2746,6 +2746,8 @@ declare module 'vscode' {
 		 * Character that triggered the completion item provider.
 		 *
 		 * `undefined` if provider was not triggered by a character.
+		 *
+		 * The trigger character is already in the document when the completion provider is triggered.
 		 */
 		readonly triggerCharacter?: string;
 	}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2724,6 +2724,11 @@ declare module 'vscode' {
 	 */
 	export interface CompletionContext {
 		/**
+		 * How the completion was triggered.
+		 */
+		readonly trigger: 'auto' | 'manual';
+
+		/**
 		 * Character that triggered the completion item provider.
 		 *
 		 * `undefined` if provider was not triggered by a character.
@@ -2731,6 +2736,39 @@ declare module 'vscode' {
 		readonly triggerCharacter?: string;
 	}
 
+
+	namespace CompletionItemProvider {
+		export interface ProvideCompletionItems {
+			/**
+			 * Provide completion items for the given position and document.
+			 *
+			 * @deprecated Used [ProvideCompletionItemsForContext](#ProvideCompletionItemsForContext) instead
+			 *
+			 * @param document The document in which the command was invoked.
+			 * @param position The position at which the command was invoked.
+			 * @param token A cancellation token.
+			 *
+			 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
+			 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
+			 */
+			(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
+		}
+
+		export interface ProvideCompletionItemsForContext {
+			/**
+			 * Provide completion items for the given position and document.
+			 *
+			 * @param document The document in which the command was invoked.
+			 * @param position The position at which the command was invoked.
+			 * @param context How the completion was triggered.
+			 * @param token A cancellation token.
+			 *
+			 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
+			 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
+			 */
+			(document: TextDocument, position: Position, context: CompletionContext, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
+		}
+	}
 	/**
 	 * The completion item provider interface defines the contract between extensions and
 	 * [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
@@ -2749,15 +2787,8 @@ declare module 'vscode' {
 
 		/**
 		 * Provide completion items for the given position and document.
-		 *
-		 * @param document The document in which the command was invoked.
-		 * @param position The position at which the command was invoked.
-		 * @param token A cancellation token.
-		 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
-		 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
-		provideCompletionItems(document: TextDocument, position: Position, context: CompletionContext, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
+		provideCompletionItems: CompletionItemProvider.ProvideCompletionItems | CompletionItemProvider.ProvideCompletionItemsForContext;
 
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2726,13 +2726,10 @@ declare module 'vscode' {
 		/**
 		 * Character that triggered the completion item provider.
 		 *
-		 * Undefined if provider was not triggered by a character.
+		 * `undefined` if provider was not triggered by a character.
 		 */
 		readonly triggerCharacter?: string;
 	}
-
-	export type ProviderCompletionItems = (document: TextDocument, position: Position, token: CancellationToken) => ProviderResult<CompletionItem[] | CompletionList>;
-	export type ProviderCompletionItemsForContext = (document: TextDocument, position: Position, context: CompletionContext, token: CancellationToken) => ProviderResult<CompletionItem[] | CompletionList>;
 
 	/**
 	 * The completion item provider interface defines the contract between extensions and
@@ -2759,7 +2756,8 @@ declare module 'vscode' {
 		 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
 		 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideCompletionItems: ProviderCompletionItems | ProviderCompletionItemsForContext;
+		provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
+		provideCompletionItems(document: TextDocument, position: Position, context: CompletionContext, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
 
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2736,39 +2736,6 @@ declare module 'vscode' {
 		readonly triggerCharacter?: string;
 	}
 
-
-	namespace CompletionItemProvider {
-		export interface ProvideCompletionItems {
-			/**
-			 * Provide completion items for the given position and document.
-			 *
-			 * @deprecated Used [ProvideCompletionItemsForContext](#ProvideCompletionItemsForContext) instead
-			 *
-			 * @param document The document in which the command was invoked.
-			 * @param position The position at which the command was invoked.
-			 * @param token A cancellation token.
-			 *
-			 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
-			 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
-			 */
-			(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
-		}
-
-		export interface ProvideCompletionItemsForContext {
-			/**
-			 * Provide completion items for the given position and document.
-			 *
-			 * @param document The document in which the command was invoked.
-			 * @param position The position at which the command was invoked.
-			 * @param context How the completion was triggered.
-			 * @param token A cancellation token.
-			 *
-			 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
-			 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
-			 */
-			(document: TextDocument, position: Position, context: CompletionContext, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
-		}
-	}
 	/**
 	 * The completion item provider interface defines the contract between extensions and
 	 * [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
@@ -2787,8 +2754,16 @@ declare module 'vscode' {
 
 		/**
 		 * Provide completion items for the given position and document.
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param position The position at which the command was invoked.
+		 * @param token A cancellation token.
+		 * @param context How the completion was triggered.
+		 *
+		 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
+		 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideCompletionItems: CompletionItemProvider.ProvideCompletionItems | CompletionItemProvider.ProvideCompletionItemsForContext;
+		provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken, context: CompletionContext): ProviderResult<CompletionItem[] | CompletionList>;
 
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2719,6 +2719,22 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Contains additional information about the context in which
+	 * [completion provider](#CompletionItemProvider.provideCompletionItems) is triggered.
+	 */
+	export interface CompletionContext {
+		/**
+		 * Character that triggered the completion item provider.
+		 *
+		 * Undefined if provider was not triggered by a character.
+		 */
+		readonly triggerCharacter?: string;
+	}
+
+	export type ProviderCompletionItems = (document: TextDocument, position: Position, token: CancellationToken) => ProviderResult<CompletionItem[] | CompletionList>;
+	export type ProviderCompletionItemsForContext = (document: TextDocument, position: Position, context: CompletionContext, token: CancellationToken) => ProviderResult<CompletionItem[] | CompletionList>;
+
+	/**
 	 * The completion item provider interface defines the contract between extensions and
 	 * [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense).
 	 *
@@ -2743,7 +2759,7 @@ declare module 'vscode' {
 		 * @return An array of completions, a [completion list](#CompletionList), or a thenable that resolves to either.
 		 * The lack of a result can be signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<CompletionItem[] | CompletionList>;
+		provideCompletionItems: ProviderCompletionItems | ProviderCompletionItemsForContext;
 
 		/**
 		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -233,8 +233,8 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 		this._registrations[handle] = modes.SuggestRegistry.register(selector, <modes.ISuggestSupport>{
 			triggerCharacters,
-			provideCompletionItems: (model: IReadOnlyModel, position: EditorPosition, token: CancellationToken): Thenable<modes.ISuggestResult> => {
-				return wireCancellationToken(token, this._proxy.$provideCompletionItems(handle, model.uri, position)).then(result => {
+			provideCompletionItems: (model: IReadOnlyModel, position: EditorPosition, context: modes.SuggestContext, token: CancellationToken): Thenable<modes.ISuggestResult> => {
+				return wireCancellationToken(token, this._proxy.$provideCompletionItems(handle, model.uri, position, context)).then(result => {
 					if (!result) {
 						return result;
 					}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -563,6 +563,7 @@ export function createApiFactory(
 			CompletionItem: extHostTypes.CompletionItem,
 			CompletionItemKind: extHostTypes.CompletionItemKind,
 			CompletionList: extHostTypes.CompletionList,
+			CompletionTriggerKind: extHostTypes.CompletionTriggerKind,
 			Diagnostic: extHostTypes.Diagnostic,
 			DiagnosticSeverity: extHostTypes.DiagnosticSeverity,
 			Disposable: extHostTypes.Disposable,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -552,7 +552,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideWorkspaceSymbols(handle: number, search: string): TPromise<modes.SymbolInformation[]>;
 	$resolveWorkspaceSymbol(handle: number, symbol: modes.SymbolInformation): TPromise<modes.SymbolInformation>;
 	$provideRenameEdits(handle: number, resource: URI, position: IPosition, newName: string): TPromise<modes.WorkspaceEdit>;
-	$provideCompletionItems(handle: number, resource: URI, position: IPosition): TPromise<IExtHostSuggestResult>;
+	$provideCompletionItems(handle: number, resource: URI, position: IPosition, context: modes.SuggestContext): TPromise<IExtHostSuggestResult>;
 	$resolveCompletionItem(handle: number, resource: URI, position: IPosition, suggestion: modes.ISuggestion): TPromise<modes.ISuggestion>;
 	$releaseCompletionItems(handle: number, id: number): void;
 	$provideSignatureHelp(handle: number, resource: URI, position: IPosition): TPromise<modes.SignatureHelp>;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -493,9 +493,9 @@ class SuggestAdapter {
 
 		return asWinJsPromise<vscode.CompletionItem[] | vscode.CompletionList>(token => {
 			if (this._provider.provideCompletionItems.length <= 3) {
-				return (this._provider.provideCompletionItems as vscode.ProviderCompletionItems)(doc, pos, token);
+				return this._provider.provideCompletionItems(doc, pos, token);
 			}
-			return (this._provider.provideCompletionItems as vscode.ProviderCompletionItemsForContext)(doc, pos, context, token);
+			return this._provider.provideCompletionItems(doc, pos, context, token);
 		}).then(value => {
 
 			const _id = this._idPool++;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -486,12 +486,17 @@ class SuggestAdapter {
 		this._provider = provider;
 	}
 
-	provideCompletionItems(resource: URI, position: IPosition): TPromise<IExtHostSuggestResult> {
+	provideCompletionItems(resource: URI, position: IPosition, context: modes.SuggestContext): TPromise<IExtHostSuggestResult> {
 
 		const doc = this._documents.getDocumentData(resource).document;
 		const pos = TypeConverters.toPosition(position);
 
-		return asWinJsPromise<vscode.CompletionItem[] | vscode.CompletionList>(token => this._provider.provideCompletionItems(doc, pos, token)).then(value => {
+		return asWinJsPromise<vscode.CompletionItem[] | vscode.CompletionList>(token => {
+			if (this._provider.provideCompletionItems.length <= 3) {
+				return (this._provider.provideCompletionItems as vscode.ProviderCompletionItems)(doc, pos, token);
+			}
+			return (this._provider.provideCompletionItems as vscode.ProviderCompletionItemsForContext)(doc, pos, context, token);
+		}).then(value => {
 
 			const _id = this._idPool++;
 
@@ -1001,8 +1006,8 @@ export class ExtHostLanguageFeatures implements ExtHostLanguageFeaturesShape {
 		return this._createDisposable(handle);
 	}
 
-	$provideCompletionItems(handle: number, resource: URI, position: IPosition): TPromise<IExtHostSuggestResult> {
-		return this._withAdapter(handle, SuggestAdapter, adapter => adapter.provideCompletionItems(resource, position));
+	$provideCompletionItems(handle: number, resource: URI, position: IPosition, context: modes.SuggestContext): TPromise<IExtHostSuggestResult> {
+		return this._withAdapter(handle, SuggestAdapter, adapter => adapter.provideCompletionItems(resource, position, context));
 	}
 
 	$resolveCompletionItem(handle: number, resource: URI, position: IPosition, suggestion: modes.ISuggestion): TPromise<modes.ISuggestion> {

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -492,10 +492,7 @@ class SuggestAdapter {
 		const pos = TypeConverters.toPosition(position);
 
 		return asWinJsPromise<vscode.CompletionItem[] | vscode.CompletionList>(token => {
-			if (this._provider.provideCompletionItems.length <= 3) {
-				return (this._provider.provideCompletionItems as vscode.CompletionItemProvider.ProvideCompletionItems)(doc, pos, token);
-			}
-			return (this._provider.provideCompletionItems as vscode.CompletionItemProvider.ProvideCompletionItemsForContext)(doc, pos, context, token);
+			return this._provider.provideCompletionItems(doc, pos, token, context);
 		}).then(value => {
 
 			const _id = this._idPool++;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -493,9 +493,9 @@ class SuggestAdapter {
 
 		return asWinJsPromise<vscode.CompletionItem[] | vscode.CompletionList>(token => {
 			if (this._provider.provideCompletionItems.length <= 3) {
-				return this._provider.provideCompletionItems(doc, pos, token);
+				return (this._provider.provideCompletionItems as vscode.CompletionItemProvider.ProvideCompletionItems)(doc, pos, token);
 			}
-			return this._provider.provideCompletionItems(doc, pos, context, token);
+			return (this._provider.provideCompletionItems as vscode.CompletionItemProvider.ProvideCompletionItemsForContext)(doc, pos, context, token);
 		}).then(value => {
 
 			const _id = this._idPool++;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -492,7 +492,7 @@ class SuggestAdapter {
 		const pos = TypeConverters.toPosition(position);
 
 		return asWinJsPromise<vscode.CompletionItem[] | vscode.CompletionList>(token => {
-			return this._provider.provideCompletionItems(doc, pos, token, context);
+			return this._provider.provideCompletionItems(doc, pos, token, TypeConverters.CompletionContext.from(context));
 		}).then(value => {
 
 			const _id = this._idPool++;

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -307,6 +307,28 @@ export function toDocumentHighlight(occurrence: modes.DocumentHighlight): types.
 	return new types.DocumentHighlight(toRange(occurrence.range), occurrence.kind);
 }
 
+export namespace CompletionTriggerKind {
+	export function from(kind: modes.SuggestTriggerKind) {
+		switch (kind) {
+			case modes.SuggestTriggerKind.TriggerCharacter:
+				return types.CompletionTriggerKind.TriggerCharacter;
+
+			case modes.SuggestTriggerKind.Invoke:
+			default:
+				return types.CompletionTriggerKind.Invoke;
+		}
+	}
+}
+
+export namespace CompletionContext {
+	export function from(context: modes.SuggestContext): types.CompletionContext {
+		return {
+			triggerKind: CompletionTriggerKind.from(context.triggerKind),
+			triggerCharacter: context.triggerCharacter
+		};
+	}
+}
+
 export const CompletionItemKind = {
 
 	from(kind: types.CompletionItemKind): modes.SuggestionType {

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -879,6 +879,16 @@ export class SignatureHelp {
 	}
 }
 
+export enum CompletionTriggerKind {
+	Invoke = 0,
+	TriggerCharacter = 1
+}
+
+export interface CompletionContext {
+	triggerKind: CompletionTriggerKind;
+	triggerCharacter: string;
+}
+
 export enum CompletionItemKind {
 	Text = 0,
 	Method = 1,

--- a/src/vs/workbench/parts/debug/electron-browser/repl.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/repl.ts
@@ -180,7 +180,7 @@ export class Repl extends Panel implements IPrivateReplService {
 
 		modes.SuggestRegistry.register({ scheme: debug.DEBUG_SCHEME }, {
 			triggerCharacters: ['.'],
-			provideCompletionItems: (model: IReadOnlyModel, position: Position, token: CancellationToken): Thenable<modes.ISuggestResult> => {
+			provideCompletionItems: (model: IReadOnlyModel, position: Position, _context: modes.SuggestContext, token: CancellationToken): Thenable<modes.ISuggestResult> => {
 				const word = this.replInput.getModel().getWordAtPosition(position);
 				const overwriteBefore = word ? word.word.length : 0;
 				const text = this.replInput.getModel().getLineContent(position.lineNumber);


### PR DESCRIPTION
Handles the completion item provider part of #752

Adds a new overload of `provideCompletionItems` that takes a context argument. This context is currently used to provide the trigger character of the suggestion

Part of #21543