### PR TITLE
Make settings for each version of VS Code available for download

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -470,11 +470,11 @@ gulp.task('generate-vscode-configuration', () => {
 		}
 
 		const appPath = path.join(buildDir, 'VSCode-darwin/Visual\\ Studio\\ Code\\ -\\ Insiders.app/Contents/Resources/app/bin/code');
-		const codeProc = cp.exec(`${appPath} --dump-default-configuration='${allConfigDetailsPath}' --wait`);
+		const codeProc = cp.exec(`${appPath} --export-default-configuration='${allConfigDetailsPath}' --wait`);
 
 		const timer = setTimeout(() => {
 			codeProc.kill();
-			reject(new Error('dump-default-configuration process timed out'));
+			reject(new Error('export-default-configuration process timed out'));
 		}, 10 * 1000);
 
 		codeProc.stdout.on('data', d => console.log(d.toString()));

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -7,6 +7,8 @@
 
 const gulp = require('gulp');
 const fs = require('fs');
+const os = require('os');
+const cp = require('child_process');
 const path = require('path');
 const es = require('event-stream');
 const azure = require('gulp-azure-storage');
@@ -442,4 +444,53 @@ gulp.task('upload-vscode-sourcemaps', ['minify-vscode'], () => {
 			container: 'sourcemaps',
 			prefix: commit + '/'
 		}));
+});
+
+const allConfigDetailsPath = path.join(os.tmpdir(), 'configuration.json');
+gulp.task('upload-vscode-configuration', ['generate-vscode-configuration'], () => {
+	if (!fs.existsSync(allConfigDetailsPath)) {
+		console.error(`configuration file at ${allConfigDetailsPath} does not exist`);
+		return;
+	}
+
+	return gulp.src(allConfigDetailsPath)
+		.pipe(azure.upload({
+			account: process.env.AZURE_STORAGE_ACCOUNT,
+			key: process.env.AZURE_STORAGE_ACCESS_KEY,
+			container: 'configuration',
+			prefix: `${packageJson.version}/${commit}/`
+		}));
+});
+
+gulp.task('generate-vscode-configuration', () => {
+	return new Promise((resolve, reject) => {
+		const buildDir = process.env['AGENT_BUILDDIRECTORY'];
+		if (!buildDir) {
+			return reject(new Error('$AGENT_BUILDDIRECTORY not set'));
+		}
+
+		const appPath = path.join(buildDir, 'VSCode-darwin/Visual\\ Studio\\ Code\\ -\\ Insiders.app/Contents/Resources/app/bin/code');
+		const codeProc = cp.exec(`${appPath} --dump-default-configuration='${allConfigDetailsPath}' --wait`);
+
+		const timer = setTimeout(() => {
+			codeProc.kill();
+			reject(new Error('dump-default-configuration process timed out'));
+		}, 10 * 1000);
+
+		codeProc.stdout.on('data', d => console.log(d.toString()));
+		codeProc.stderr.on('data', d => console.log(d.toString()));
+
+		codeProc.on('exit', () => {
+			clearTimeout(timer);
+			resolve();
+		});
+
+		codeProc.on('error', err => {
+			clearTimeout(timer);
+			reject(err);
+		});
+	}).catch(e => {
+		// Don't fail the build
+		console.error(e.toString());
+	});
 });

--- a/build/tfs/darwin/build.sh
+++ b/build/tfs/darwin/build.sh
@@ -28,14 +28,20 @@ step "Install distro dependencies" \
 step "Build minified & upload source maps" \
 	npm run gulp -- vscode-darwin-min upload-vscode-sourcemaps
 
+step "Generate and upload configuration.json" \
+	npm run gulp -- upload-vscode-configuration
+
 # step "Create loader snapshot"
 #	node build/lib/snapshotLoader.js
 
-step "Run unit tests" \
-	./scripts/test.sh --build --reporter dot
+# step "Run unit tests" \
+# 	./scripts/test.sh --build --reporter dot
 
-step "Run integration tests" \
-	./scripts/test-integration.sh
+# step "Run integration tests" \
+# 	./scripts/test-integration.sh
 
 step "Publish release" \
 	./build/tfs/darwin/release.sh
+
+step "Generate and upload configuration.json" \
+	npm run gulp -- upload-vscode-configuration

--- a/build/tfs/darwin/build.sh
+++ b/build/tfs/darwin/build.sh
@@ -28,17 +28,14 @@ step "Install distro dependencies" \
 step "Build minified & upload source maps" \
 	npm run gulp -- vscode-darwin-min upload-vscode-sourcemaps
 
-step "Generate and upload configuration.json" \
-	npm run gulp -- upload-vscode-configuration
-
 # step "Create loader snapshot"
 #	node build/lib/snapshotLoader.js
 
-# step "Run unit tests" \
-# 	./scripts/test.sh --build --reporter dot
+step "Run unit tests" \
+	./scripts/test.sh --build --reporter dot
 
-# step "Run integration tests" \
-# 	./scripts/test-integration.sh
+step "Run integration tests" \
+	./scripts/test-integration.sh
 
 step "Publish release" \
 	./build/tfs/darwin/release.sh

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "gulp-buffer": "0.0.2",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.0",
+    "gulp-debug": "^3.1.0",
     "gulp-eslint": "^3.0.1",
     "gulp-filter": "^3.0.0",
     "gulp-flatmap": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "gulp-buffer": "0.0.2",
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.0",
-    "gulp-debug": "^3.1.0",
     "gulp-eslint": "^3.0.1",
     "gulp-filter": "^3.0.0",
     "gulp-flatmap": "^1.0.0",

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -41,6 +41,7 @@ export interface ParsedArgs {
 	'open-url'?: string | string[];
 	'skip-getting-started'?: boolean;
 	'sticky-quickopen'?: boolean;
+	'dump-default-configuration'?: string;
 }
 
 export const IEnvironmentService = createDecorator<IEnvironmentService>('environmentService');

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -41,7 +41,7 @@ export interface ParsedArgs {
 	'open-url'?: string | string[];
 	'skip-getting-started'?: boolean;
 	'sticky-quickopen'?: boolean;
-	'dump-default-configuration'?: string;
+	'export-default-configuration'?: string;
 }
 
 export const IEnvironmentService = createDecorator<IEnvironmentService>('environmentService');

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -26,7 +26,8 @@ const options: minimist.Opts = {
 		'debugSearch',
 		'debugBrkSearch',
 		'open-url',
-		'enable-proposed-api'
+		'enable-proposed-api',
+		'dump-default-configuration'
 	],
 	boolean: [
 		'help',

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -27,7 +27,7 @@ const options: minimist.Opts = {
 		'debugBrkSearch',
 		'open-url',
 		'enable-proposed-api',
-		'dump-default-configuration'
+		'export-default-configuration'
 	],
 	boolean: [
 		'help',

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -46,7 +46,7 @@ import { IStorageService, StorageScope } from 'vs/platform/storage/common/storag
 import { ContextMenuService } from 'vs/workbench/services/contextview/electron-browser/contextmenuService';
 import { WorkbenchKeybindingService } from 'vs/workbench/services/keybinding/electron-browser/keybindingService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { WorkspaceService, DefaultConfigurationDumpHelper } from 'vs/workbench/services/configuration/node/configuration';
+import { WorkspaceService, DefaultConfigurationExportHelper } from 'vs/workbench/services/configuration/node/configuration';
 import { IConfigurationEditingService } from 'vs/workbench/services/configuration/common/configurationEditing';
 import { ConfigurationEditingService } from 'vs/workbench/services/configuration/node/configurationEditingService';
 import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
@@ -623,7 +623,7 @@ export class Workbench implements IPartService {
 		Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).setInstantiationService(this.instantiationService);
 		Registry.as<IEditorRegistry>(EditorExtensions.Editors).setInstantiationService(this.instantiationService);
 
-		this.instantiationService.createInstance(DefaultConfigurationDumpHelper);
+		this.instantiationService.createInstance(DefaultConfigurationExportHelper);
 	}
 
 	private initSettings(): void {

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -46,7 +46,7 @@ import { IStorageService, StorageScope } from 'vs/platform/storage/common/storag
 import { ContextMenuService } from 'vs/workbench/services/contextview/electron-browser/contextmenuService';
 import { WorkbenchKeybindingService } from 'vs/workbench/services/keybinding/electron-browser/keybindingService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { WorkspaceService } from 'vs/workbench/services/configuration/node/configuration';
+import { WorkspaceService, DefaultConfigurationDumpHelper } from 'vs/workbench/services/configuration/node/configuration';
 import { IConfigurationEditingService } from 'vs/workbench/services/configuration/common/configurationEditing';
 import { ConfigurationEditingService } from 'vs/workbench/services/configuration/node/configurationEditingService';
 import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
@@ -622,6 +622,8 @@ export class Workbench implements IPartService {
 		Registry.as<IActionBarRegistry>(ActionBarExtensions.Actionbar).setInstantiationService(this.instantiationService);
 		Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).setInstantiationService(this.instantiationService);
 		Registry.as<IEditorRegistry>(EditorExtensions.Editors).setInstantiationService(this.instantiationService);
+
+		this.instantiationService.createInstance(DefaultConfigurationDumpHelper);
 	}
 
 	private initSettings(): void {


### PR DESCRIPTION
Addresses https://github.com/Microsoft/vscode-bing/issues/7 by implementing a CLI arg to make code start up, write out a list of all registered configurations, then shut down. publish.ts uses this to upload the resulting .json file alongside the built bits.

I have no idea where to start this process, so I added it to the end of `initServices` in workbench.ts. Is that appropriate, or can you suggest somewhere else?

And let me know if the approach in `publish.ts` is ok.