### PR TITLE
Use end position for multi-line ranges when showing zone widget

### DIFF
--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -322,10 +322,18 @@ export abstract class ZoneWidget extends Widget implements IHorizontalSashLayout
 	}
 
 	private _showImpl(where: IRange, heightInLines: number): void {
-		const position = {
-			lineNumber: where.startLineNumber,
-			column: where.startColumn
-		};
+		let position: IPosition;
+		if (Range.spansMultipleLines(where)) {
+			position = {
+				lineNumber: where.endLineNumber,
+				column: where.endColumn,
+			};
+		} else {
+			position = {
+				lineNumber: where.startLineNumber,
+				column: where.startColumn,
+			};
+		}
 
 		const width = this._getWidth();
 		this.domNode.style.width = `${width}px`;


### PR DESCRIPTION
Right now if `_showImpl` is passed a multi-line range then the zone widget will attach to the start position, which will put the zone widget in the middle of the selection.

It is more natural for the zone widget to appear below the entire selection, so this PR sets the position to the end position for a multi-line range.