### PR TITLE
Remove duplicate event firing of onDidClose

### DIFF
--- a/src/vs/editor/contrib/referenceSearch/browser/peekViewWidget.ts
+++ b/src/vs/editor/contrib/referenceSearch/browser/peekViewWidget.ts
@@ -174,7 +174,6 @@ export abstract class PeekViewWidget extends ZoneWidget {
 		if (!this._isShowing && heightInPixel < 0) {
 			// Looks like the view zone got folded away!
 			this.dispose();
-			this._onDidClose.fire(this);
 			return;
 		}
 


### PR DESCRIPTION
The dispose method already calls `this._onDidClose.fire(this);` as its last statement.