### PR TITLE
Maintain focus on stopped thread when stepping a multithreaded session

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -236,7 +236,7 @@ export class DebugService implements debug.IDebugService {
 
 	private tryToAutoFocusStackFrame(thread: debug.IThread): TPromise<any> {
 		const callStack = thread.getCallStack();
-		if (!callStack.length || this.viewModel.focusedStackFrame) {
+		if (!callStack.length || (this.viewModel.focusedStackFrame && this.viewModel.focusedStackFrame.thread.threadId === thread.threadId)) {
 			return TPromise.as(null);
 		}
 
@@ -496,7 +496,7 @@ export class DebugService implements debug.IDebugService {
 		}
 		if (!stackFrame) {
 			const threads = process ? process.getAllThreads() : null;
-			const callStack = threads && threads.length ? threads[0].getCallStack() : null;
+			const callStack = threads && threads.length === 1 ? threads[0].getCallStack() : null;
 			stackFrame = callStack && callStack.length ? callStack[0] : null;
 		}
 


### PR DESCRIPTION
### What does this PR do?
There are a couple of issues with multithreaded debugging. When a second thread gets the first stopped event, the UI does not autofocus to that thread. When the user steps the second thread, the UI switches focus to the first thread.

![before](https://user-images.githubusercontent.com/7286437/30454245-84280274-9950-11e7-8cf5-26fceed487f9.gif)

The proposed fix is to allow focus if the currently focused thread is different than the one that wants to be focused on. Also, only auto-focus to the first thread if there's only one thread.

![after](https://user-images.githubusercontent.com/7286437/30454310-b2c3abc4-9950-11e7-9e77-eda6e27a6e56.gif)


#### What issues does this PR fix?
https://github.com/Microsoft/vscode/issues/34246