### PR TITLE
Improve search aria label generation performance

### DIFF
--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -310,12 +310,12 @@ export class SearchAccessibilityProvider implements IAccessibilityProvider {
 			const match = <Match>element;
 			const searchModel: SearchModel = (<SearchResult>tree.getInput()).searchModel;
 			const replace = searchModel.isReplaceActive() && !!searchModel.replaceString;
-			const preview = match.preview();
+			const matchString = match.getMatchString();
 			const range = match.range();
 			if (replace) {
-				return nls.localize('replacePreviewResultAria', "Replace term {0} with {1} at column position {2} in line with text {3}", preview.inside, match.replaceString, range.startColumn + 1, match.text());
+				return nls.localize('replacePreviewResultAria', "Replace term {0} with {1} at column position {2} in line with text {3}", matchString, match.replaceString, range.startColumn + 1, match.text());
 			}
-			return nls.localize('searchResultAria', "Found term {0} at column position {1} in line with text {2}", preview.inside, range.startColumn + 1, match.text());
+			return nls.localize('searchResultAria', "Found term {0} at column position {1} in line with text {2}", matchString, range.startColumn + 1, match.text());
 		}
 		return undefined;
 	}


### PR DESCRIPTION
When using search, if a matched line is really long (i.e. from a minified file), the UI freezes briefly because of a call to `strings.lcut()` which internally calls `split(/\b/)`. This change removes the call with no change to behavior.