### PR TITLE
Avoid fssync calls in workbench in extensionTipsService

### DIFF
--- a/src/vs/platform/node/product.ts
+++ b/src/vs/platform/node/product.ts
@@ -26,7 +26,7 @@ export interface IProductConfiguration {
 	};
 	extensionTips: { [id: string]: string; };
 	extensionImportantTips: { [id: string]: { name: string; pattern: string; }; };
-	exeBasedExtensionTips: { [id: string]: string; };
+	exeBasedExtensionTips: { [id: string]: any; };
 	extensionKeywords: { [extension: string]: string[]; };
 	extensionAllowedBadgeProviders: string[];
 	keymapExtensionTips: string[];


### PR DESCRIPTION
Fixes #34423

In this PR `fs.existsSync` is replaced with `pfs.fileExists`
Instead of looking at all the paths in the PATH variable we look only in the default location used for installation


