### PR TITLE
Allow escape to be used to close terminal

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -709,6 +709,13 @@ export class TerminalInstance implements ITerminalInstance {
 	}
 
 	private _attachPressAnyKeyToCloseListener() {
+		//Allow Escape to be used to close terminal #33683
+		this._processDisposables.push(dom.addDisposableListener(this._xterm.textarea, 'keydown', (event: KeyboardEvent) => {
+			if (event.keyCode === 27) {
+				this.dispose();
+				event.preventDefault();
+			}
+		}));
 		this._processDisposables.push(dom.addDisposableListener(this._xterm.textarea, 'keypress', (event: KeyboardEvent) => {
 			this.dispose();
 			event.preventDefault();


### PR DESCRIPTION
Fixes #33683

A `keydown` listener is added to detect the escape key being pressed as `keypress` will not detect the escape key.

Checks for the escape key in the listener so modifier keys will not be detected.