### PR TITLE
Replace bash shebang with '#!/usr/bin/env bash" for portability

### DIFF
--- a/build/tfs/common/common.sh
+++ b/build/tfs/common/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # set agent specific npm cache

--- a/build/tfs/common/node.sh
+++ b/build/tfs/common/node.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # setup nvm

--- a/build/tfs/linux/build-ia32.sh
+++ b/build/tfs/linux/build-ia32.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ./build/tfs/linux/build.sh ia32 "$@"

--- a/build/tfs/linux/build-x64.sh
+++ b/build/tfs/linux/build-x64.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ./build/tfs/linux/build.sh x64 "$@"

--- a/build/tfs/linux/build.sh
+++ b/build/tfs/linux/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ./build/tfs/common/node.sh
 . ./scripts/env.sh

--- a/build/tfs/linux/ia32/run-agent.sh
+++ b/build/tfs/linux/ia32/run-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f pat ]; then
 	echo "Error: file pat not found"

--- a/build/tfs/linux/ia32/xvfb.init
+++ b/build/tfs/linux/ia32/xvfb.init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # /etc/rc.d/init.d/xvfbd
 #

--- a/build/tfs/linux/release.sh
+++ b/build/tfs/linux/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . ./scripts/env.sh
 . ./build/tfs/common/common.sh

--- a/build/tfs/linux/repoapi_client.sh
+++ b/build/tfs/linux/repoapi_client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # This is a VERY basic script for Create/Delete operations on repos and packages
 # 
 cmd=$1

--- a/build/tfs/linux/smoketest.sh
+++ b/build/tfs/linux/smoketest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 . ./build/tfs/common/node.sh

--- a/build/tfs/linux/x64/run-agent.sh
+++ b/build/tfs/linux/x64/run-agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f pat ]; then
 	echo "Error: file pat not found"

--- a/build/tfs/linux/x64/xvfb.init
+++ b/build/tfs/linux/x64/xvfb.init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # /etc/rc.d/init.d/xvfbd
 #

--- a/resources/linux/debian/postrm.template
+++ b/resources/linux/debian/postrm.template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export npm_config_disturl=https://atom.io/download/electron
 export npm_config_target=$(node -p "require('./package.json').electronVersion")
 export npm_config_runtime=electron

--- a/scripts/npm.sh
+++ b/scripts/npm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/test-mocha.sh
+++ b/scripts/test-mocha.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/src/vs/base/node/terminateProcess.sh
+++ b/src/vs/base/node/terminateProcess.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 terminateTree() {
     for cpid in $(/usr/bin/pgrep -P $1); do


### PR DESCRIPTION
The example system that does not put `bash` in a `/bin` directory is FreeBSD. Instead, they put it inside `/usr/local/bin`.