### PR TITLE
Using node 7.9.0 after  updated from Electron 1.6.6 to 1.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_install:
   - git submodule update --init --recursive
   - git clone --depth 1 https://github.com/creationix/nvm.git ./.nvm
   - source ./.nvm/nvm.sh
-  - nvm install 7.4.0
-  - nvm use 7.4.0
+  - nvm install 7.9.0
+  - nvm use 7.9.0
   - npm config set python `which python`
   - npm install -g gulp
   - if [ $TRAVIS_OS_NAME == "linux" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
   VSCODE_BUILD_VERBOSE: true
 
 install:
-  - ps: Install-Product node 7.4.0 x64
+  - ps: Install-Product node 7.9.0 x64
   - npm install -g npm@4 --silent
   - npm install -g gulp mocha --silent
 


### PR DESCRIPTION
I think VS Code can use node 7.9.0.