### PR TITLE
Closes #27408 - Adds ViewColumn.Active

### DIFF
--- a/extensions/vscode-api-tests/src/window.test.ts
+++ b/extensions/vscode-api-tests/src/window.test.ts
@@ -138,6 +138,26 @@ suite('window namespace tests', () => {
 		assert.equal(window.activeTextEditor!.viewColumn, ViewColumn.One);
 	});
 
+	test('issue #27408 - showTextDocument & vscode.diff always default to ViewColumn.One', async () => {
+		const [docA, docB, docC] = await Promise.all([
+			workspace.openTextDocument(await createRandomFile()),
+			workspace.openTextDocument(await createRandomFile()),
+			workspace.openTextDocument(await createRandomFile())
+		]);
+
+		await window.showTextDocument(docA, ViewColumn.One);
+		await window.showTextDocument(docB, ViewColumn.Two);
+
+		assert.ok(window.activeTextEditor);
+		assert.ok(window.activeTextEditor!.document === docB);
+		assert.equal(window.activeTextEditor!.viewColumn, ViewColumn.Two);
+
+		await window.showTextDocument(docC, ViewColumn.Active);
+
+		assert.ok(window.activeTextEditor!.document === docC);
+		assert.equal(window.activeTextEditor!.viewColumn, ViewColumn.Two);
+	});
+
 	test('issue #5362 - Incorrect TextEditor passed by onDidChangeTextEditorSelection', (done) => {
 		const file10Path = join(workspace.rootPath || '', './10linefile.ts');
 		const file30Path = join(workspace.rootPath || '', './30linefile.ts');

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3311,6 +3311,7 @@ declare module 'vscode' {
 	 * used to show editors side by side.
 	 */
 	export enum ViewColumn {
+		Active = -1,
 		One = 1,
 		Two = 2,
 		Three = 3

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -115,6 +115,8 @@ export function fromViewColumn(column?: vscode.ViewColumn): EditorPosition {
 		editorColumn = EditorPosition.TWO;
 	} else if (column === <number>types.ViewColumn.Three) {
 		editorColumn = EditorPosition.THREE;
+	} else if (column === <number>types.ViewColumn.Active) {
+		editorColumn = undefined;
 	}
 	return editorColumn;
 }

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -953,6 +953,7 @@ export class CompletionList {
 }
 
 export enum ViewColumn {
+	Active = -1,
 	One = 1,
 	Two = 2,
 	Three = 3


### PR DESCRIPTION
This should close https://github.com/Microsoft/vscode/issues/27408, since we don't want to change the default -- there is now an explicit way for an extension to target the active view column.

Once this is in, the Git extension can be updated to use this re: https://github.com/Microsoft/vscode/issues/34459

FYI, I used `-1` to help avoid any falsey issues.

/cc @jrieken @bpasero 
