### PR TITLE
Fix raw update-available event emitting on Windows

### DIFF
--- a/src/vs/platform/update/electron-main/auto-updater.win32.ts
+++ b/src/vs/platform/update/electron-main/auto-updater.win32.ts
@@ -68,7 +68,7 @@ export class Win32AutoUpdaterImpl extends EventEmitter implements IAutoUpdater {
 					return this.cleanup();
 				}
 
-				this.emit('update-available');
+				this.emit('update-available', null, update.url, update.version);
 
 				return this.cleanup(update.version).then(() => {
 					return this.getUpdatePackagePath(update.version).then(updatePackagePath => {


### PR DESCRIPTION
Raw updater on Windows emit  `update-available` event without payload,  and the event will be ignored by [updateService](https://github.com/Microsoft/vscode/blob/master/src/vs/platform/update/electron-main/updateService.ts#L65), thus the checkForUpdate promise will be blocked until the installer file downloaded. This behavior is not consist with the Linux one.