### PR TITLE
Add support for Git Stash (Include Untracked)

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -257,6 +257,11 @@
         "category": "Git"
       },
       {
+        "command": "git.stashIncludeUntracked",
+        "title": "%command.stashIncludeUntracked%",
+        "category": "Git"
+      },
+      {
         "command": "git.stash",
         "title": "%command.stash%",
         "category": "Git"
@@ -542,6 +547,11 @@
         {
           "command": "git.cleanAll",
           "group": "4_stage",
+          "when": "config.git.enabled && scmProvider == git"
+        },
+        {
+          "command": "git.stashIncludeUntracked",
+          "group": "5_stash",
           "when": "config.git.enabled && scmProvider == git"
         },
         {

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -38,6 +38,7 @@
 	"command.publish": "Publish Branch",
 	"command.showOutput": "Show Git Output",
 	"command.ignore": "Add File to .gitignore",
+	"command.stashIncludeUntracked": "Stash (Include Untracked)",
 	"command.stash": "Stash",
 	"command.stashPop": "Pop Stash...",
 	"command.stashPopLatest": "Pop Latest Stash",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1236,6 +1236,21 @@ export class CommandCenter {
 		await repository.ignore(uris);
 	}
 
+	@command('git.stashIncludeUntracked', { repository: true })
+	async stashIncludeUntracked(repository: Repository): Promise<void> {
+		if (repository.workingTreeGroup.resourceStates.length === 0) {
+			window.showInformationMessage(localize('no changes stash', "There are no changes to stash."));
+			return;
+		}
+
+		const message = await this.getStashMessage();
+
+		if (typeof message === 'undefined') {
+			return;
+		}
+		await repository.createStash(message, true);
+	}
+
 	@command('git.stash', { repository: true })
 	async stash(repository: Repository): Promise<void> {
 		if (repository.workingTreeGroup.resourceStates.length === 0) {
@@ -1243,16 +1258,20 @@ export class CommandCenter {
 			return;
 		}
 
-		const message = await window.showInputBox({
-			prompt: localize('provide stash message', "Optionally provide a stash message"),
-			placeHolder: localize('stash message', "Stash message")
-		});
+		const message = await this.getStashMessage();
 
 		if (typeof message === 'undefined') {
 			return;
 		}
 
 		await repository.createStash(message);
+	}
+
+	private async getStashMessage(): Promise<string | undefined> {
+		return await window.showInputBox({
+			prompt: localize('provide stash message', "Optionally provide a stash message"),
+			placeHolder: localize('stash message', "Stash message")
+		});
 	}
 
 	@command('git.stashPop', { repository: true })

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -842,9 +842,13 @@ export class Repository {
 		}
 	}
 
-	async createStash(message?: string): Promise<void> {
+	async createStash(message?: string, includeUntracked?: boolean): Promise<void> {
 		try {
 			const args = ['stash', 'save'];
+
+			if (includeUntracked) {
+				args.push('-u');
+			}
 
 			if (message) {
 				args.push('--', message);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -593,8 +593,8 @@ export class Repository implements Disposable {
 		return await this.repository.getStashes();
 	}
 
-	async createStash(message?: string): Promise<void> {
-		return await this.run(Operation.Stash, () => this.repository.createStash(message));
+	async createStash(message?: string, includeUntracked?: boolean): Promise<void> {
+		return await this.run(Operation.Stash, () => this.repository.createStash(message, includeUntracked));
 	}
 
 	async popStash(index?: number): Promise<void> {


### PR DESCRIPTION
#34527

This PR adds support for `git stash -u`, which stashes untracked files in the repository

![image](https://user-images.githubusercontent.com/4201242/30628147-993d3f8a-9e28-11e7-96fd-284e86562c6b.png)

