### PR TITLE
Compare to correct Ressource-URI when fetching content

### DIFF
--- a/extensions/git/src/contentProvider.ts
+++ b/extensions/git/src/contentProvider.ts
@@ -84,7 +84,7 @@ export class GitContentProvider {
 		if (ref === '~') {
 			const fileUri = Uri.file(path);
 			const uriString = fileUri.toString();
-			const [indexStatus] = repository.indexGroup.resourceStates.filter(r => r.original.toString() === uriString);
+			const [indexStatus] = repository.indexGroup.resourceStates.filter(r => r.resourceUri.toString() === uriString);
 			ref = indexStatus ? '' : 'HEAD';
 		}
 


### PR DESCRIPTION
@joaomoreno here you go. Fixes #34629.

Thanks for the pointers! I already had a quick look yesterday and thought the fix would have to be in [getLeftResource()](https://github.com/Microsoft/vscode/blob/ccb631c756878ca7c24acf663403b003db6ed332/extensions/git/src/commands.ts#L190). I obviously can't say that I fully understand the code, so I hope this doesn't break something else....