### PR TITLE
Fix #33939

### DIFF
--- a/extensions/ruby/language-configuration.json
+++ b/extensions/ruby/language-configuration.json
@@ -23,7 +23,7 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*((begin|class|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\\sdo\\b))\\b[^\\{;]*$",
-		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)"
+		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while)|(.*\\sdo\\b))\\b[^\\{;]*$",
+		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif)\\b)"
 	}
 }


### PR DESCRIPTION
- Add protected and private visibility keywords to increaseIndentPattern
- Remove `when` keyword from decreaseIndentPattern

Before:

![private](https://i.imgur.com/wY66iNe.gif)

![when](https://i.imgur.com/bVYcuZo.gif)

Using this PR:

![private-when](https://i.imgur.com/29TGgQC.gif "bug solved")

/cc @rebornix @alexandrudima