### PR TITLE
Check type of token that triggered the quick suggestions

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -301,11 +301,11 @@ export class SuggestModel implements IDisposable {
 						} else if (quickSuggestions === true) {
 							// all good
 						} else {
+							// Check the type of the token that triggered this
 							model.tokenizeIfCheap(pos.lineNumber);
 							const { tokenType } = model
 								.getLineTokens(pos.lineNumber)
-								.findTokenAtOffset(pos.column - 1);
-
+								.findTokenAtOffset(Math.max(pos.column - 1 - 1, 0));
 							const inValidScope = quickSuggestions.other && tokenType === StandardTokenType.Other
 								|| quickSuggestions.comments && tokenType === StandardTokenType.Comment
 								|| quickSuggestions.strings && tokenType === StandardTokenType.String;


### PR DESCRIPTION
Fixes #34863

**Bug**
Quick suggestions currently check the token at the cursor location to determine if we are in a string or comment. Because token spans are setup like: `[start, end)`, this results in us checking the token after the current one. For example, in code like

```
a'string'
```

where `a` was just typed and triggered suggestions, we actually end up grabbing the `'string'` token instead of the `a` token


**Fix**
Check the token one index back from the cursor