### PR TITLE
fix 'Source Control Providers' not showing up for only one repo

### DIFF
--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -811,7 +811,7 @@ export class SCMViewlet extends PanelViewlet implements IViewModel {
 	private onDidChangeRepositories(): void {
 		toggleClass(this.el, 'empty', this.scmService.repositories.length === 0);
 
-		const shouldMainPanelBeVisible = this.scmService.repositories.length > 1;
+		const shouldMainPanelBeVisible = this.scmService.repositories.length > 0;
 
 		if (!!this.mainPanel === shouldMainPanelBeVisible) {
 			return;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/35279. If the existing behavior is intended, feel free to close this. 