### PR TITLE
Slightly increase MAX_IMAGE_SIZE

### DIFF
--- a/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
+++ b/src/vs/base/browser/ui/resourceviewer/resourceViewer.ts
@@ -109,7 +109,7 @@ export class ResourceViewer {
 	private static GB = ResourceViewer.MB * ResourceViewer.KB;
 	private static TB = ResourceViewer.GB * ResourceViewer.KB;
 
-	private static MAX_IMAGE_SIZE = ResourceViewer.MB; // showing images inline is memory intense, so we have a limit
+	private static MAX_IMAGE_SIZE = 8 * ResourceViewer.MB; // showing images inline is memory intense, so we have a limit
 
 	public static show(
 		descriptor: IResourceDescriptor,


### PR DESCRIPTION
A workaround before https://github.com/Microsoft/vscode/issues/25122 is resolved. Lots of images have the size more than 1MB. For example, look at the sizes listed [here](https://apod.nasa.gov/apod/fap/image/1604/). A slightly larger value would solve the problem for most times.