### PR TITLE
Improving the sample build task template

### DIFF
--- a/src/vs/workbench/parts/tasks/common/taskTemplates.ts
+++ b/src/vs/workbench/parts/tasks/common/taskTemplates.ts
@@ -88,7 +88,11 @@ const command: TaskEntry = {
 		'\t\t{',
 		'\t\t\t"taskName": "echo",',
 		'\t\t\t"type": "shell",',
-		'\t\t\t"command": "echo Hello"',
+		'\t\t\t"command": "echo Hello",',
+		'\t\t\t"group": {',
+		'\t\t\t\t"kind": "build",',
+		'\t\t\t\t"isDefault": "true"',
+		'\t\t\t}',
 		'\t\t}',
 		'\t]',
 		'}'


### PR DESCRIPTION
Fixes #35352

This PR improves the default "others" build task template to include an options group that declares the new task as the default build task. This will expose this "feature" to users, helping them correctly declare a default build task and eliminate the "No build tasks found" toast.