### PR TITLE
use previous commit msg for amend, Fixes #35182

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -856,9 +856,17 @@ export class CommandCenter {
 				return message;
 			}
 
+			const getPreviousCommitMessage = async () => {
+				//Only return the previous commit message if it's an amend commit and the repo already has a commit
+				if (opts && opts.amend && repository.HEAD && repository.HEAD.commit) {
+					return (await repository.getCommit('HEAD')).message;
+				}
+			};
+
 			return await window.showInputBox({
 				placeHolder: localize('commit message', "Commit message"),
 				prompt: localize('provide commit message', "Please provide a commit message"),
+				value: await getPreviousCommitMessage(),
 				ignoreFocusOut: true
 			});
 		};


### PR DESCRIPTION
This is my first pull request! 

Fixes #35182

When you use the amend commit feature, the commit message dialog shows the previous commit's message. If the commit isn't an amend commit or there are no previous commits to get a message from, it defaults to `undefined` (which displays a blank dialog box). 

Hopefully this fits with the coding style for this project. If there are any issues/changes that need to be made to it, let me know.