### PR TITLE
Fix for #32342

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -141,7 +141,9 @@ export function expandEmmetAbbreviation(args): Thenable<boolean> {
 
 	let selectionsInReverseOrder = editor.selections.slice(0);
 	selectionsInReverseOrder.sort((a, b) => {
-		return a.anchor.compareTo(b.anchor) * -1;
+		var posA = a.isReversed ? a.anchor : a.active;
+		var posB = b.isReversed ? b.anchor : b.active;
+		return posA.compareTo(posB) * -1;
 	});
 
 	selectionsInReverseOrder.forEach(selection => {

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -139,7 +139,12 @@ export function expandEmmetAbbreviation(args): Thenable<boolean> {
 		return [new vscode.Range(abbreviationRange.start.line, abbreviationRange.start.character, abbreviationRange.end.line, abbreviationRange.end.character), abbreviation, filter];
 	};
 
-	editor.selections.forEach(selection => {
+	let selectionsInReverseOrder = editor.selections.slice(0);
+	selectionsInReverseOrder.sort((a, b) => {
+		return a.anchor.compareTo(b.anchor) * -1;
+	});
+
+	selectionsInReverseOrder.forEach(selection => {
 		let position = selection.isReversed ? selection.anchor : selection.active;
 		let [rangeToReplace, abbreviation, filter] = getAbbreviation(editor.document, selection, position, syntax);
 		if (!rangeToReplace) {


### PR DESCRIPTION
When expanding abbreviations, do so from bottom to top.  This way a change higher up will not interfere with text below.