### PR TITLE
add ignoreCurrentOpen user settings to address #6923

### DIFF
--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -99,6 +99,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 	private previousValue = '';
 	private visibilityChangeTimeoutHandle: number;
 	private closeOnFocusLost: boolean;
+	private ignoreCurrentOpen: boolean;
 
 	constructor(
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
@@ -144,6 +145,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 		} else {
 			this.closeOnFocusLost = settings.workbench && settings.workbench.quickOpen && settings.workbench.quickOpen.closeOnFocusLost;
 		}
+		this.ignoreCurrentOpen = settings.workbench && settings.workbench.quickOpen && settings.workbench.quickOpen.ignoreCurrentOpen;
 	}
 
 	public get onShow(): Event<void> {
@@ -605,7 +607,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 				}
 
 				let autoFocus: IAutoFocus;
-				if (!quickNavigateConfiguration) {
+				if (!quickNavigateConfiguration && !this.ignoreCurrentOpen) {
 					autoFocus = { autoFocusFirstEntry: true };
 				} else {
 					const visibleEditorCount = this.editorService.getVisibleEditors().length;

--- a/src/vs/workbench/browser/quickopen.ts
+++ b/src/vs/workbench/browser/quickopen.ts
@@ -26,6 +26,7 @@ export interface IWorkbenchQuickOpenConfiguration {
 	workbench: {
 		quickOpen: {
 			closeOnFocusLost: boolean;
+			ignoreCurrentOpen: boolean;
 		},
 		commandPalette: {
 			history: number;

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -193,6 +193,11 @@ let workbenchProperties: { [path: string]: IJSONSchema; } = {
 		'description': nls.localize('closeOnFocusLost', "Controls if Quick Open should close automatically once it loses focus."),
 		'default': true
 	},
+	'workbench.quickOpen.ignoreCurrentOpen': {
+		'type': 'boolean',
+		'description': nls.localize('ignoreCurrentOpen', "Controls if Quick Open should not focus the currently open file."),
+		'default': false
+	},
 	'workbench.settings.openDefaultSettings': {
 		'type': 'boolean',
 		'description': nls.localize('openDefaultSettings', "Controls if opening settings also opens an editor showing all default settings."),


### PR DESCRIPTION
Added the boolean "ignoreCurrentOpen" in the workbench.quickOpen user settings which controls whether the current open file should be focused under the Quick Open action.
Addresses #6923 
true does not focus the current open file.
false focuses the current open file (default and the current behaviour).