### PR TITLE
Cache npm cache in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ os:
   - linux
   - osx
 
+cache:
+  directories:
+    - $HOME/.npm
+
 notifications:
   email: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ environment:
   ELECTRON_RUN_AS_NODE: 1
   VSCODE_BUILD_VERBOSE: true
 
+cache:
+  - '%APPDATA%\npm-cache'
+
 install:
   - ps: Install-Product node 7.9.0 x64
   - npm install -g npm@4 --silent


### PR DESCRIPTION
This should improve CI build time as a big time is spent on installing dependencies :)

Note that this caches the npm cache folder, which is safe as opposed to caching node_modules directly.