### PR TITLE
Use local gulp in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
   - nvm install 7.9.0
   - nvm use 7.9.0
   - npm config set python `which python`
-  - npm install -g gulp
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
@@ -41,10 +40,10 @@ install:
   - ./scripts/npm.sh install
 
 script:
-  - gulp hygiene --silent
-  - gulp electron --silent
-  - gulp compile --silent --max_old_space_size=4096
-  - gulp optimize-vscode --silent --max_old_space_size=4096
+  - node_modules/.bin/gulp hygiene --silent
+  - node_modules/.bin/gulp electron --silent
+  - node_modules/.bin/gulp compile --silent --max_old_space_size=4096
+  - node_modules/.bin/gulp optimize-vscode --silent --max_old_space_size=4096
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/test.sh --coverage --reporter dot; else ./scripts/test.sh --reporter dot; fi
   - ./scripts/test-integration.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,10 @@ environment:
 install:
   - ps: Install-Product node 7.9.0 x64
   - npm install -g npm@4 --silent
-  - npm install -g gulp mocha --silent
 
 build_script:
   - .\scripts\npm.bat install
-  - gulp electron
+  - .\node_modules\.bin\gulp electron
   - npm run compile
 
 test_script:


### PR DESCRIPTION
We already install `gulp` in `node_modules`, installing it again globally takes ~17s on every build.
It also means that we currently always use the latest version of Gulp (if Gulp 4 came out tomorrow, CI would break). This always uses the same version in package.json / npm-shrinkwrap.json. 

All the shell scripts already reference `gulp` and `mocha` from node_modules, so no changes needed there.