### PR TITLE
Make WorkbenchActionRegistry just a forwarder

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -317,10 +317,11 @@ export class StandaloneKeybindingService extends AbstractKeybindingService {
 	constructor(
 		contextKeyService: IContextKeyService,
 		commandService: ICommandService,
+		telemetryService: ITelemetryService,
 		messageService: IMessageService,
 		domNode: HTMLElement
 	) {
-		super(contextKeyService, commandService, messageService);
+		super(contextKeyService, commandService, telemetryService, messageService);
 
 		this._cachedResolver = null;
 		this._dynamicKeybindings = [];

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -176,7 +176,7 @@ export class DynamicStandaloneServices extends Disposable {
 
 		let commandService = ensure(ICommandService, () => new StandaloneCommandService(this._instantiationService));
 
-		ensure(IKeybindingService, () => this._register(new StandaloneKeybindingService(contextKeyService, commandService, messageService, domElement)));
+		ensure(IKeybindingService, () => this._register(new StandaloneKeybindingService(contextKeyService, commandService, telemetryService, messageService, domElement)));
 
 		let contextViewService = ensure(IContextViewService, () => this._register(new ContextViewService(domElement, telemetryService, messageService)));
 

--- a/src/vs/editor/standalone/test/browser/simpleServices.test.ts
+++ b/src/vs/editor/standalone/test/browser/simpleServices.test.ts
@@ -11,6 +11,7 @@ import { InstantiationService } from 'vs/platform/instantiation/common/instantia
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
+import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 
 suite('StandaloneKeybindingService', () => {
 
@@ -35,7 +36,7 @@ suite('StandaloneKeybindingService', () => {
 
 		let domElement = document.createElement('div');
 
-		let keybindingService = new TestStandaloneKeybindingService(contextKeyService, commandService, messageService, domElement);
+		let keybindingService = new TestStandaloneKeybindingService(contextKeyService, commandService, NullTelemetryService, messageService, domElement);
 
 		let commandInvoked = false;
 		keybindingService.addDynamicKeybinding('testCommand', KeyCode.F9, () => {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -87,7 +87,7 @@ export interface IMenuRegistry {
 	getMenuItems(loc: MenuId): IMenuItem[];
 }
 
-export const MenuRegistry: IMenuRegistry = new class {
+export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 
 	private _commands: { [id: string]: ICommandAction } = Object.create(null);
 

--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -47,6 +47,7 @@ export abstract class AbstractKeybindingService implements IKeybindingService {
 	) {
 		this._contextKeyService = contextKeyService;
 		this._commandService = commandService;
+		this._telemetryService = telemetryService;
 		this._statusService = statusService;
 		this._messageService = messageService;
 

--- a/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
+++ b/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
@@ -19,6 +19,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 import { OS } from 'vs/base/common/platform';
 import { IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
+import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 
 function createContext(ctx: any) {
 	return {
@@ -40,7 +41,7 @@ suite('AbstractKeybindingService', () => {
 			messageService: IMessageService,
 			statusService?: IStatusbarService
 		) {
-			super(contextKeyService, commandService, messageService, statusService);
+			super(contextKeyService, commandService, NullTelemetryService, messageService, statusService);
 			this._resolver = resolver;
 		}
 

--- a/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
@@ -13,7 +13,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { ResolvedKeybinding, ResolvedKeybindingPart } from 'vs/base/common/keyCodes';
 import { AriaLabelProvider, UserSettingsLabelProvider, UILabelProvider, ModifierLabels as ModLabels } from 'vs/base/common/keybindingLabels';
 import { CommonEditorRegistry, EditorAction } from 'vs/editor/common/editorCommonExtensions';
-import { MenuRegistry, ILocalizedString, SyncActionDescriptor, ICommandAction } from 'vs/platform/actions/common/actions';
+import { MenuRegistry, ILocalizedString, ICommandAction } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { EditorModel } from 'vs/workbench/common/editor';
 import { IExtensionService } from 'vs/platform/extensions/common/extensions';
@@ -200,26 +200,21 @@ export class KeybindingsEditorModel extends EditorModel {
 	}
 
 	private static toKeybindingEntry(command: string, keybindingItem: ResolvedKeybindingItem, workbenchActionsRegistry: IWorkbenchActionRegistry, editorActions: {}): IKeybindingItem {
-		const workbenchAction = workbenchActionsRegistry.getWorkbenchAction(command);
 		const menuCommand = MenuRegistry.getCommand(command);
 		const editorAction: EditorAction = editorActions[command];
 		return <IKeybindingItem>{
 			keybinding: keybindingItem.resolvedKeybinding,
 			keybindingItem,
 			command,
-			commandLabel: KeybindingsEditorModel.getCommandLabel(workbenchAction, menuCommand, editorAction),
-			commandDefaultLabel: KeybindingsEditorModel.getCommandDefaultLabel(workbenchAction, menuCommand, workbenchActionsRegistry),
+			commandLabel: KeybindingsEditorModel.getCommandLabel(menuCommand, editorAction),
+			commandDefaultLabel: KeybindingsEditorModel.getCommandDefaultLabel(menuCommand, workbenchActionsRegistry),
 			when: keybindingItem.when ? keybindingItem.when.serialize() : '',
 			source: keybindingItem.isDefault ? localize('default', "Default") : localize('user', "User")
 		};
 	}
 
-	private static getCommandDefaultLabel(workbenchAction: SyncActionDescriptor, menuCommand: ICommandAction, workbenchActionsRegistry: IWorkbenchActionRegistry): string {
+	private static getCommandDefaultLabel(menuCommand: ICommandAction, workbenchActionsRegistry: IWorkbenchActionRegistry): string {
 		if (language !== LANGUAGE_DEFAULT) {
-			if (workbenchAction) {
-				return workbenchActionsRegistry.getAlias(workbenchAction.id);
-			}
-
 			if (menuCommand && menuCommand.title && (<ILocalizedString>menuCommand.title).original) {
 				return (<ILocalizedString>menuCommand.title).original;
 			}
@@ -227,11 +222,7 @@ export class KeybindingsEditorModel extends EditorModel {
 		return null;
 	}
 
-	private static getCommandLabel(workbenchAction: SyncActionDescriptor, menuCommand: ICommandAction, editorAction: EditorAction): string {
-		if (workbenchAction) {
-			return workbenchAction.label;
-		}
-
+	private static getCommandLabel(menuCommand: ICommandAction, editorAction: EditorAction): string {
 		if (menuCommand) {
 			return typeof menuCommand.title === 'string' ? menuCommand.title : menuCommand.title.value;
 		}

--- a/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
+++ b/src/vs/workbench/parts/quickopen/browser/commandsHandler.ts
@@ -16,8 +16,6 @@ import { Mode, IEntryRunContext, IAutoFocus, IModel, IQuickNavigateConfiguration
 import { QuickOpenEntryGroup, IHighlight, QuickOpenModel, QuickOpenEntry } from 'vs/base/parts/quickopen/browser/quickOpenModel';
 import { SyncActionDescriptor, IMenuService, MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
-import { Registry } from 'vs/platform/registry/common/platform';
 import { QuickOpenHandler, IWorkbenchQuickOpenConfiguration } from 'vs/workbench/browser/quickopen';
 import { IEditorAction, IEditor, ICommonCodeEditor } from 'vs/editor/common/editorCommon';
 import { matchesWords, matchesPrefix, matchesContiguousSubString, or } from 'vs/base/common/filters';
@@ -418,11 +416,6 @@ export class CommandsHandler extends QuickOpenHandler {
 		searchValue = searchValue.trim();
 		this.lastSearchValue = searchValue;
 
-		// Workbench Actions
-		let workbenchEntries: CommandEntry[] = [];
-		const workbenchActions = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions).getWorkbenchActions();
-		workbenchEntries = this.actionDescriptorsToEntries(workbenchActions, searchValue);
-
 		// Editor Actions
 		const activeEditor = this.editorService.getActiveEditor();
 		const activeEditorControl = activeEditor ? activeEditor.getControl() : null;
@@ -443,7 +436,7 @@ export class CommandsHandler extends QuickOpenHandler {
 		const commandEntries = this.menuItemActionsToEntries(menuActions, searchValue);
 
 		// Concat
-		let entries = [...workbenchEntries, ...editorEntries, ...commandEntries];
+		let entries = [...editorEntries, ...commandEntries];
 
 		// Remove duplicates
 		entries = arrays.distinct(entries, entry => `${entry.getLabel()}${entry.getGroupLabel()}${entry.getCommandId()}`);
@@ -496,35 +489,6 @@ export class CommandsHandler extends QuickOpenHandler {
 		}
 
 		return TPromise.as(new QuickOpenModel(entries));
-	}
-
-	private actionDescriptorsToEntries(actionDescriptors: SyncActionDescriptor[], searchValue: string): CommandEntry[] {
-		const entries: CommandEntry[] = [];
-		const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);
-
-		for (let i = 0; i < actionDescriptors.length; i++) {
-			const actionDescriptor = actionDescriptors[i];
-			if (actionDescriptor.label) {
-
-				// Label (with optional category)
-				let label = actionDescriptor.label;
-				const category = registry.getCategory(actionDescriptor.id);
-				if (category) {
-					label = nls.localize('commandLabel', "{0}: {1}", category, label);
-				}
-
-				// Alias for non default languages
-				const alias = (language !== LANGUAGE_DEFAULT) ? registry.getAlias(actionDescriptor.id) : null;
-				const labelHighlights = wordFilter(searchValue, label);
-				const aliasHighlights = alias ? wordFilter(searchValue, alias) : null;
-
-				if (labelHighlights || aliasHighlights) {
-					entries.push(this.instantiationService.createInstance(CommandEntry, actionDescriptor.id, this.keybindingService.lookupKeybinding(actionDescriptor.id), label, alias, { label: labelHighlights, alias: aliasHighlights }, actionDescriptor, (id: string) => this.onBeforeRunCommand(id)));
-				}
-			}
-		}
-
-		return entries;
 	}
 
 	private editorActionsToEntries(actions: IEditorAction[], searchValue: string): EditorActionCommandEntry[] {

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -259,13 +259,13 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 		windowElement: Window,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ICommandService commandService: ICommandService,
-		@ITelemetryService private telemetryService: ITelemetryService,
+		@ITelemetryService telemetryService: ITelemetryService,
 		@IMessageService messageService: IMessageService,
 		@IEnvironmentService environmentService: IEnvironmentService,
 		@IStatusbarService statusBarService: IStatusbarService,
 		@IConfigurationService configurationService: IConfigurationService
 	) {
-		super(contextKeyService, commandService, messageService, statusBarService);
+		super(contextKeyService, commandService, telemetryService, messageService, statusBarService);
 
 		let dispatchConfig = getDispatchConfig(configurationService);
 		configurationService.onDidUpdateConfiguration((e) => {
@@ -415,7 +415,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 					"keyCount" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 				}
 			*/
-			this.telemetryService.publicLog('customKeybindingsChanged', {
+			this._telemetryService.publicLog('customKeybindingsChanged', {
 				keyCount: cnt
 			});
 		}

--- a/src/vs/workbench/test/browser/actionRegistry.test.ts
+++ b/src/vs/workbench/test/browser/actionRegistry.test.ts
@@ -6,10 +6,7 @@
 'use strict';
 
 import * as assert from 'assert';
-import * as Platform from 'vs/platform/registry/common/platform';
-import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { Separator } from 'vs/base/browser/ui/actionbar/actionbar';
-import { Extensions, IWorkbenchActionRegistry } from 'vs/workbench/common/actions';
 import { prepareActions } from 'vs/workbench/browser/actions';
 import { Action } from 'vs/base/common/actions';
 
@@ -21,26 +18,6 @@ class MyClass extends Action {
 }
 
 suite('Workbench Action Registry', () => {
-
-	test('Workbench Action Registration', function () {
-		let Registry = <IWorkbenchActionRegistry>Platform.Registry.as(Extensions.WorkbenchActions);
-
-		let d = new SyncActionDescriptor(MyClass, 'id', 'name');
-
-		let oldActions = Registry.getWorkbenchActions().slice(0);
-		let oldCount = Registry.getWorkbenchActions().length;
-
-		Registry.registerWorkbenchAction(d, 'My Alias', 'category');
-		Registry.registerWorkbenchAction(d, null);
-
-		assert.equal(Registry.getWorkbenchActions().length, 1 + oldCount);
-		assert.strictEqual(d, Registry.getWorkbenchAction('id'));
-
-		assert.deepEqual(Registry.getAlias(d.id), 'My Alias');
-		assert.equal(Registry.getCategory(d.id), 'category');
-
-		(<any>Registry).setWorkbenchActions(oldActions);
-	});
 
 	test('Workbench Action Bar prepareActions()', function () {
 		let a1 = new Separator();


### PR DESCRIPTION
The goal about this is to remove `IWorkbenchActionRegistry` because we have commands, keybindings, and menu registries which are more flexible. However, there is weird code in places which needs to be checked first. At the end duplications like https://github.com/Microsoft/vscode/pull/35528/files#diff-b90278b8812101a32d844114fa0dc752L501 shouldn't be in our code anymore. 