### PR TITLE
Resolve promise to fix webdriver types issue (Fixes broken build mentioned in #35543)

### DIFF
--- a/test/smoke/src/spectron/client.ts
+++ b/test/smoke/src/spectron/client.ts
@@ -25,7 +25,7 @@ export class SpectronClient {
 	}
 
 	public async keys(keys: string[] | string, capture: boolean = true): Promise<any> {
-		return this.spectron.client.keys(keys);
+		return Promise.resolve(this.spectron.client.keys(keys));
 	}
 
 	public async getText(selector: string, capture: boolean = true): Promise<any> {


### PR DESCRIPTION
The typing for WebdriverIO changed several times for `keys(` causing builds to fail. This resolves the broken current build that's mentioned in https://github.com/Microsoft/vscode/issues/35543.