### PR TITLE
Allow for reindenting only selected text

### DIFF
--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -317,7 +317,26 @@ export class ReindentLinesAction extends EditorAction {
 		if (!model) {
 			return;
 		}
-		let edits = getReindentEditOperations(model, 1, model.getLineCount());
+
+		let edits: IIdentifiedSingleEditOperation[] = [];
+		let selections: Selection[] = [];
+
+		for (let selection of editor.getSelections()) {
+			if (selection.isEmpty()) { continue; }
+			selections.push(selection);
+		}
+
+		if (selections.length > 0) {
+			for (let selection of selections) {
+				let editOperations = getReindentEditOperations(model, selection.startLineNumber, selection.endLineNumber) || [];
+				for (let editOp of editOperations) {
+					edits.push(editOp);
+				}
+			}
+		} else {
+			edits = getReindentEditOperations(model, 1, model.getLineCount());
+		}
+
 		if (edits) {
 			editor.pushUndoStop();
 			editor.executeEdits(this.id, edits);


### PR DESCRIPTION
Based on feedback from, https://github.com/Microsoft/vscode/issues/28658. Particularly https://github.com/Microsoft/vscode/issues/28658#issuecomment-314560204

@rebornix This would be very helpful for me and it looks like selection is already supported for `getReindentEditOperations`, it just needed to be wired up.