### PR TITLE
Remove kludge that adds history item when new input is set on an editor

### DIFF
--- a/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
@@ -24,7 +24,6 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/resourceConfiguration';
-import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { CancelAction } from 'vs/platform/message/common/message';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -47,7 +46,6 @@ export class TextFileEditor extends BaseTextEditor {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IWorkspaceContextService private contextService: IWorkspaceContextService,
 		@IStorageService storageService: IStorageService,
-		@IHistoryService private historyService: IHistoryService,
 		@ITextResourceConfigurationService configurationService: ITextResourceConfigurationService,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
 		@IThemeService themeService: IThemeService,
@@ -86,16 +84,6 @@ export class TextFileEditor extends BaseTextEditor {
 	}
 
 	public setInput(input: FileEditorInput, options?: EditorOptions): TPromise<void> {
-
-		// We have a current input in this editor and are about to either open a new editor or jump to a different
-		// selection inside the editor. Thus we store the current selection into the navigation history so that
-		// a user can navigate back to the exact position he left off.
-		if (this.input) {
-			const selection = this.getControl().getSelection();
-			if (selection) {
-				this.historyService.add(this.input, { startLineNumber: selection.startLineNumber, startColumn: selection.startColumn });
-			}
-		}
 
 		// Return early for same input unless we force to open
 		const forceOpen = options && options.forceOpen;


### PR DESCRIPTION
This is not related to any issue, but I noticed this code that seemed kludge-y and perhaps no longer necessary. The code was originally added to fix https://github.com/Microsoft/vscode/issues/11727, but when I remove it, the behavior remains correct. The history item this adds appears now to be redundant, and could cause issues down the line, even though it doesn't appear to cause any user-visible issues now. This is also the only place that `HistoryService.add` is invoked outside of `HistoryService` itself.