### PR TITLE
Git - fix  `there are no changes to stash` message issue 

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1283,7 +1283,9 @@ export class CommandCenter {
 
 	@command('git.stash', { repository: true })
 	async stash(repository: Repository): Promise<void> {
-		if (repository.workingTreeGroup.resourceStates.length === 0) {
+		const noUnstagedChanges = repository.workingTreeGroup.resourceStates.length === 0;
+		const noStagedChanges = repository.indexGroup.resourceStates.length === 0;
+		if (noUnstagedChanges && noStagedChanges) {
 			window.showInformationMessage(localize('no changes stash', "There are no changes to stash."));
 			return;
 		}


### PR DESCRIPTION
Show `there are no changes to stash` message only if neither staged nor unstaged files are present (#35645)