### PR TITLE
Support the "reason" arg for trimming trailing whitespace

### DIFF
--- a/src/vs/editor/common/commands/trimTrailingWhitespaceCommand.ts
+++ b/src/vs/editor/common/commands/trimTrailingWhitespaceCommand.ts
@@ -15,13 +15,20 @@ export class TrimTrailingWhitespaceCommand implements editorCommon.ICommand {
 
 	private selection: Selection;
 	private selectionId: string;
+	private preserveCursor: boolean;
 
-	constructor(selection: Selection) {
+	constructor(selection: Selection, preserveCursor?: boolean) {
 		this.selection = selection;
+		this.preserveCursor = preserveCursor;
 	}
 
 	public getEditOperations(model: editorCommon.ITokenizedModel, builder: editorCommon.IEditOperationBuilder): void {
-		let ops = trimTrailingWhitespace(model, []);
+		var cursors: [Position];
+		if (this.selection && this.preserveCursor) {
+			cursors = [new Position(this.selection.positionLineNumber, this.selection.positionColumn)];
+		}
+
+		let ops = trimTrailingWhitespace(model, cursors || []);
 		for (let i = 0, len = ops.length; i < len; i++) {
 			let op = ops[i];
 

--- a/src/vs/editor/common/commands/trimTrailingWhitespaceCommand.ts
+++ b/src/vs/editor/common/commands/trimTrailingWhitespaceCommand.ts
@@ -15,20 +15,15 @@ export class TrimTrailingWhitespaceCommand implements editorCommon.ICommand {
 
 	private selection: Selection;
 	private selectionId: string;
-	private preserveCursor: boolean;
+	private cursors: Position[];
 
-	constructor(selection: Selection, preserveCursor?: boolean) {
+	constructor(selection: Selection, cursors: Position[] = []) {
 		this.selection = selection;
-		this.preserveCursor = preserveCursor;
+		this.cursors = cursors;
 	}
 
 	public getEditOperations(model: editorCommon.ITokenizedModel, builder: editorCommon.IEditOperationBuilder): void {
-		var cursors: [Position];
-		if (this.selection && this.preserveCursor) {
-			cursors = [new Position(this.selection.positionLineNumber, this.selection.positionColumn)];
-		}
-
-		let ops = trimTrailingWhitespace(model, cursors || []);
+		let ops = trimTrailingWhitespace(model, this.cursors);
 		for (let i = 0, len = ops.length; i < len; i++) {
 			let op = ops[i];
 

--- a/src/vs/editor/common/commands/trimTrailingWhitespaceCommand.ts
+++ b/src/vs/editor/common/commands/trimTrailingWhitespaceCommand.ts
@@ -17,7 +17,7 @@ export class TrimTrailingWhitespaceCommand implements editorCommon.ICommand {
 	private selectionId: string;
 	private cursors: Position[];
 
-	constructor(selection: Selection, cursors: Position[] = []) {
+	constructor(selection: Selection, cursors: Position[]) {
 		this.selection = selection;
 		this.cursors = cursors;
 	}

--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -14,6 +14,7 @@ import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { ReplaceCommand, ReplaceCommandThatPreservesSelection } from 'vs/editor/common/commands/replaceCommand';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
+import { Position } from 'vs/editor/common/core/position';
 import { editorAction, ServicesAccessor, IActionOptions, EditorAction } from 'vs/editor/common/editorCommonExtensions';
 import { CopyLinesCommand } from './copyLinesCommand';
 import { DeleteLinesCommand } from './deleteLinesCommand';
@@ -208,9 +209,12 @@ export class TrimTrailingWhitespaceAction extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICommonCodeEditor, args: any): void {
 
-		let preserveCursor: boolean = (args.reason === 'auto-save');
+		var cursors: Position[];
+		if (args.reason === 'auto-save') {
+			cursors = editor.getSelections().map(s => new Position(s.positionLineNumber, s.positionColumn));
+		}
 
-		var command = new TrimTrailingWhitespaceCommand(editor.getSelection(), preserveCursor);
+		var command = new TrimTrailingWhitespaceCommand(editor.getSelection(), cursors);
 
 		editor.pushUndoStop();
 		editor.executeCommands(this.id, [command]);

--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -206,9 +206,11 @@ export class TrimTrailingWhitespaceAction extends EditorAction {
 		});
 	}
 
-	public run(accessor: ServicesAccessor, editor: ICommonCodeEditor): void {
+	public run(accessor: ServicesAccessor, editor: ICommonCodeEditor, args: any): void {
 
-		var command = new TrimTrailingWhitespaceCommand(editor.getSelection());
+		let preserveCursor: boolean = (args.reason === 'auto-save');
+
+		var command = new TrimTrailingWhitespaceCommand(editor.getSelection(), preserveCursor);
 
 		editor.pushUndoStop();
 		editor.executeCommands(this.id, [command]);

--- a/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/common/linesOperations.ts
@@ -209,8 +209,11 @@ export class TrimTrailingWhitespaceAction extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICommonCodeEditor, args: any): void {
 
-		var cursors: Position[];
+		let cursors: Position[] = [];
 		if (args.reason === 'auto-save') {
+			// See https://github.com/editorconfig/editorconfig-vscode/issues/47
+			// It is very convenient for the editor config extension to invoke this action.
+			// So, if we get a reason:'auto-save' passed in, let's preserve cursor positions.
 			cursors = editor.getSelections().map(s => new Position(s.positionLineNumber, s.positionColumn));
 		}
 

--- a/src/vs/editor/test/common/commands/trimTrailingWhitespaceCommand.test.ts
+++ b/src/vs/editor/test/common/commands/trimTrailingWhitespaceCommand.test.ts
@@ -14,7 +14,7 @@ import { withEditorModel } from 'vs/editor/test/common/editorTestUtils';
 
 function assertTrimTrailingWhitespaceCommand(text: string[], expected: IIdentifiedSingleEditOperation[]): void {
 	return withEditorModel(text, (model) => {
-		var op = new TrimTrailingWhitespaceCommand(new Selection(1, 1, 1, 1));
+		var op = new TrimTrailingWhitespaceCommand(new Selection(1, 1, 1, 1), []);
 		var actual = getEditOperation(model, op);
 		assert.deepEqual(actual, expected);
 	});


### PR DESCRIPTION
This is in support of #24400. The reason this enhancement is needed is that extensions like [editorconfig-vscode](https://github.com/editorconfig/editorconfig-vscode) call the `editor.action.trimTrailingWhitespace` command during an auto-save event, and without knowing whether the command was triggered by an auto-save event the code can't know whether to trim trailing whitespace at the cursor (causing the cursor to move) or not.

This change will allow fixing [editorconfig-vscode #47](https://github.com/editorconfig/editorconfig-vscode/issues/47).