### PR TITLE
allow hiding explorer arrows via icon theme

### DIFF
--- a/src/vs/workbench/parts/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/parts/files/browser/media/explorerviewlet.css
@@ -106,6 +106,10 @@
 	background-image: url("collapsed-hc.svg");
 }
 
+.explorer-folders-view.hide-arrows .monaco-tree-row .content::before {
+	display: none;
+}
+
 .explorer-viewlet .explorer-open-editors .monaco-tree .monaco-tree-row:hover > .content .monaco-action-bar,
 .explorer-viewlet .explorer-open-editors .monaco-tree.focused .monaco-tree-row.focused > .content .monaco-action-bar,
 .explorer-viewlet .explorer-open-editors .monaco-tree .monaco-tree-row > .content.dirty > .monaco-action-bar {

--- a/src/vs/workbench/parts/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/parts/files/browser/media/explorerviewlet.css
@@ -107,7 +107,7 @@
 }
 
 .explorer-folders-view.hide-arrows .monaco-tree-row .content::before {
-	display: none;
+	background-image: none;
 }
 
 .explorer-viewlet .explorer-open-editors .monaco-tree .monaco-tree-row:hover > .content .monaco-action-bar,

--- a/src/vs/workbench/parts/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/browser/views/explorerView.ts
@@ -161,6 +161,7 @@ export class ExplorerView extends ViewsViewletPanel {
 
 		const onFileIconThemeChange = (fileIconTheme: IFileIconTheme) => {
 			DOM.toggleClass(this.treeContainer, 'align-icons-and-twisties', fileIconTheme.hasFileIcons && !fileIconTheme.hasFolderIcons);
+			DOM.toggleClass(this.treeContainer, 'hide-arrows', fileIconTheme.hidesExplorerArrows);
 		};
 
 		this.disposables.push(this.themeService.onDidFileIconThemeChange(onFileIconThemeChange));

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -47,6 +47,7 @@ export interface IFileIconTheme {
 	readonly isLoaded: boolean;
 	readonly hasFileIcons?: boolean;
 	readonly hasFolderIcons?: boolean;
+	readonly hidesExplorerArrows?: boolean;
 }
 
 export interface IWorkbenchThemeService extends IThemeService {

--- a/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
@@ -21,6 +21,7 @@ export class FileIconThemeData implements IFileIconTheme {
 	description?: string;
 	hasFileIcons?: boolean;
 	hasFolderIcons?: boolean;
+	hidesExplorerArrows?: boolean;
 	isLoaded: boolean;
 	path?: string;
 	extensionData: ExtensionData;
@@ -38,6 +39,7 @@ export class FileIconThemeData implements IFileIconTheme {
 					this.styleSheetContent = result.content;
 					this.hasFileIcons = result.hasFileIcons;
 					this.hasFolderIcons = result.hasFolderIcons;
+					this.hidesExplorerArrows = result.hidesExplorerArrows;
 					this.isLoaded = true;
 					return this.styleSheetContent;
 				});
@@ -69,6 +71,7 @@ export class FileIconThemeData implements IFileIconTheme {
 			themeData.settingsId = null;
 			themeData.hasFileIcons = false;
 			themeData.hasFolderIcons = false;
+			themeData.hidesExplorerArrows = false;
 			themeData.isLoaded = true;
 			themeData.extensionData = null;
 		}
@@ -110,6 +113,7 @@ interface IconThemeDocument extends IconsAssociation {
 	fonts: FontDefinition[];
 	light?: IconsAssociation;
 	highContrast?: IconsAssociation;
+	hidesExplorerArrows?: boolean;
 }
 
 function _loadIconThemeDocument(fileSetPath: string): TPromise<IconThemeDocument> {
@@ -123,9 +127,9 @@ function _loadIconThemeDocument(fileSetPath: string): TPromise<IconThemeDocument
 	});
 }
 
-function _processIconThemeDocument(id: string, iconThemeDocumentPath: string, iconThemeDocument: IconThemeDocument): { content: string; hasFileIcons: boolean; hasFolderIcons: boolean; } {
+function _processIconThemeDocument(id: string, iconThemeDocumentPath: string, iconThemeDocument: IconThemeDocument): { content: string; hasFileIcons: boolean; hasFolderIcons: boolean; hidesExplorerArrows: boolean; } {
 
-	let result = { content: '', hasFileIcons: false, hasFolderIcons: false };
+	let result = { content: '', hasFileIcons: false, hasFolderIcons: false, hidesExplorerArrows: false };
 
 	if (!iconThemeDocument.iconDefinitions) {
 		return result;
@@ -245,6 +249,10 @@ function _processIconThemeDocument(id: string, iconThemeDocumentPath: string, ic
 
 	if (!result.hasFileIcons && !result.hasFolderIcons) {
 		return result;
+	}
+
+	if (iconThemeDocument.hidesExplorerArrows) {
+		result.hidesExplorerArrows = true;
 	}
 
 	let cssRules: string[] = [];

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -118,6 +118,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 			isLoaded: false,
 			hasFileIcons: false,
 			hasFolderIcons: false,
+			hidesExplorerArrows: false,
 			extensionData: null
 		};
 


### PR DESCRIPTION
Addresses #25655.

Allows file icon themes to hide the explorer arrows by setting `hidesExplorerArrows: true` in the icon theme config.