### PR TITLE
expand editor code region styles - fsharp

### DIFF
--- a/extensions/fsharp/language-configuration.json
+++ b/extensions/fsharp/language-configuration.json
@@ -24,8 +24,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*//#region",
-			"end": "^\\s*//#endregion"
+			"start": "^\\s*//\\s*#region|^\\s*\\(\\*\\s*#region(.*)\\*\\)",
+			"end": "^\\s*//\\s*#endregion|^\\s*\\(\\*\\s*#endregion\\s*\\*\\)"
 		}
 	}
 }


### PR DESCRIPTION
Expand editor code region styles. Allow a space after the leading comment indicator. Allow both single line and block comments.
Examples:
 // #region name
(* #region name *)