### PR TITLE
Don't treat regular string SignatureInformation documentation as markdown

### DIFF
--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -405,11 +405,19 @@ export namespace Suggest {
 	}
 };
 
+
+function convertSignatureDocumentation(documentation: string | types.MarkdownString): undefined | string | htmlContent.IMarkdownString {
+	if (!documentation) {
+		return undefined;
+	}
+	return typeof documentation === 'string' ? documentation : MarkdownString.from(documentation);
+}
+
 export namespace ParameterInformation {
 	export function from(info: types.ParameterInformation): modes.ParameterInformation {
 		return {
 			label: info.label,
-			documentation: info.documentation && MarkdownString.from(info.documentation)
+			documentation: convertSignatureDocumentation(info.documentation)
 		};
 	}
 	export function to(info: modes.ParameterInformation): types.ParameterInformation {
@@ -425,7 +433,7 @@ export namespace SignatureInformation {
 	export function from(info: types.SignatureInformation): modes.SignatureInformation {
 		return {
 			label: info.label,
-			documentation: info.documentation && MarkdownString.from(info.documentation),
+			documentation: convertSignatureDocumentation(info.documentation),
 			parameters: info.parameters && info.parameters.map(ParameterInformation.from)
 		};
 	}

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -180,6 +180,13 @@ export namespace MarkdownString {
 		ret.isTrusted = value.isTrusted;
 		return ret;
 	}
+
+	export function fromStrict(value: string | types.MarkdownString): undefined | string | htmlContent.IMarkdownString {
+		if (!value) {
+			return undefined;
+		}
+		return typeof value === 'string' ? value : MarkdownString.from(value);
+	}
 }
 
 export function fromRangeOrRangeWithMessage(ranges: vscode.Range[] | vscode.DecorationOptions[]): IDecorationOptions[] {
@@ -405,19 +412,11 @@ export namespace Suggest {
 	}
 };
 
-
-function convertSignatureDocumentation(documentation: string | types.MarkdownString): undefined | string | htmlContent.IMarkdownString {
-	if (!documentation) {
-		return undefined;
-	}
-	return typeof documentation === 'string' ? documentation : MarkdownString.from(documentation);
-}
-
 export namespace ParameterInformation {
 	export function from(info: types.ParameterInformation): modes.ParameterInformation {
 		return {
 			label: info.label,
-			documentation: convertSignatureDocumentation(info.documentation)
+			documentation: MarkdownString.fromStrict(info.documentation)
 		};
 	}
 	export function to(info: modes.ParameterInformation): types.ParameterInformation {
@@ -433,7 +432,7 @@ export namespace SignatureInformation {
 	export function from(info: types.SignatureInformation): modes.SignatureInformation {
 		return {
 			label: info.label,
-			documentation: convertSignatureDocumentation(info.documentation),
+			documentation: MarkdownString.fromStrict(info.documentation),
 			parameters: info.parameters && info.parameters.map(ParameterInformation.from)
 		};
 	}


### PR DESCRIPTION
Fixes #35937, documentation in signature information always being treated as markdown