### PR TITLE
disable lookup for GitHub's version of Git

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -118,26 +118,11 @@ function findSystemGitWin32(base: string): Promise<IGit> {
 	return findSpecificGit(path.join(base, 'Git', 'cmd', 'git.exe'));
 }
 
-function findGitHubGitWin32(): Promise<IGit> {
-	const github = path.join(process.env['LOCALAPPDATA'], 'GitHub');
-
-	return readdir(github).then(children => {
-		const git = children.filter(child => /^PortableGit/.test(child))[0];
-
-		if (!git) {
-			return Promise.reject<IGit>('Not found');
-		}
-
-		return findSpecificGit(path.join(github, git, 'cmd', 'git.exe'));
-	});
-}
-
 function findGitWin32(): Promise<IGit> {
 	return findSystemGitWin32(process.env['ProgramW6432'])
 		.then(void 0, () => findSystemGitWin32(process.env['ProgramFiles(x86)']))
 		.then(void 0, () => findSystemGitWin32(process.env['ProgramFiles']))
-		.then(void 0, () => findSpecificGit('git'))
-		.then(void 0, () => findGitHubGitWin32());
+		.then(void 0, () => findSpecificGit('git'));
 }
 
 export function findGit(hint: string | undefined): Promise<IGit> {


### PR DESCRIPTION
:wave: GitHub Desktop team member dropping in. We had report from someone who was seeing our app launch every few minutes, trying to open a weird path: https://github.com/desktop/desktop/issues/2962

**Repro steps:**

 - on Windows
 - have classic GitHub for Windows installed
 - install new GitHub Desktop
 - open a private Git repository in Code
 - force a pull to trigger retrieving credentials

**Actual behaviour:**

GitHub Desktop is launched, trying to open a folder that doesn't look like a folder:

![](https://user-images.githubusercontent.com/634063/31217330-eca0daee-a9b6-11e7-82e1-59a54fdb4cad.png)

**Expected behaviour:**

No launching UI

**What's Happening**

The classic Git Shell had system-level config value to make itself act as a credential helper:

```
[credential]
	helper = !github --credentials
```

This was fine because we put `github.exe` first on the `PATH` when you launched Git Shell _and only then_, but we never added ourselves to the user's PATH for historical reasons (not wanting to interfere with existing Git installations mostly). Time passed, things changed, and with the new Desktop people wanted us to bring back the `github` command line for doing things like adding repositories to the app.

This time around we didn't have a Git Shell in-the-box, so we appended the location of `github.bat` to `PATH` so that it'd be available in whatever shell you like. 

Now we have different problems, because `github.bat` doesn't act as a credential helper, and the classic `github.exe` will call `github.bat` and never itself because your PATH is setup that way.

So I'd like to just :fire: this lookup code and encourage people to setup Git for Windows.