### PR TITLE
Correct the EBNF for snippets

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippet.md
+++ b/src/vs/editor/contrib/snippet/browser/snippet.md
@@ -71,7 +71,7 @@ format      ::= '$' int | '${' int '}'
                 | '${' int ':' '/upcase' | '/downcase' | '/capitalize' '}'
                 | '${' int ':+' if '}'
                 | '${' int ':?' if ':' else '}'
-                | '${' int ':-' else '}' '${' int ':' else '}'
+                | '${' int ':-' else '}' | '${' int ':' else '}'
 regex       ::= JavaScript Regular Expression value (ctor-string)
 options     ::= JavaScript Regular Expression option (ctor-options)
 var         ::= [_a-zA-Z] [_a-zA-Z0-9]*


### PR DESCRIPTION
I reviewed the parse's code and think that `${sn:-else}` and `${sn:else}` may have the same function and should share the same status，which means that  the pattern should be something like `'${' int ':-' else '}' | '${' int ':' else '}'` or not  `'${' int ':-' else '}'  '${' int ':' else '}'`.