### PR TITLE
Support syntax highlighting of detail section in CompletionItems

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -282,7 +282,10 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
 				return item;
 			}
 			const detail = details[0];
-			item.detail = Previewer.plain(detail.displayParts);
+			item.detail = {
+				value: Previewer.plain(detail.displayParts),
+				language: 'typescript'
+			};
 			item.documentation = Previewer.markdownDocumentation(detail.documentation, detail.tags);
 
 			if (detail.codeActions && detail.codeActions.length) {

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -225,7 +225,7 @@ export interface ISuggestion {
 	label: string;
 	insertText: string;
 	type: SuggestionType;
-	detail?: string;
+	detail?: string | { language: string, value: string };
 	documentation?: string | IMarkdownString;
 	filterText?: string;
 	sortText?: string;

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -225,6 +225,11 @@
 	padding: 4px 0 4px 5px;
 }
 
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .type.highlighted {
+	opacity: 1;
+	white-space: pre-wrap;
+}
+
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .docs {
 	margin: 0;
 	padding: 4px 5px;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1996,13 +1996,18 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Code-block that provides a language and a code snippet.
+	 */
+	type CodeblockString = { language: string; value: string };
+
+	/**
 	 * ~~MarkedString can be used to render human readable text. It is either a markdown string
 	 * or a code-block that provides a language and a code snippet. Note that
 	 * markdown strings will be sanitized - that means html will be escaped.~~
 	 *
 	 * @deprecated This type is deprecated, please use [`MarkdownString`](#MarkdownString) instead.
 	 */
-	export type MarkedString = MarkdownString | string | { language: string; value: string };
+	export type MarkedString = MarkdownString | string | CodeblockString;
 
 	/**
 	 * A hover represents additional information for a symbol or word. Hovers are
@@ -2754,7 +2759,7 @@ declare module 'vscode' {
 		 * A human-readable string with additional information
 		 * about this item, like type or symbol information.
 		 */
-		detail?: string;
+		detail?: string | CodeblockString;
 
 		/**
 		 * A human-readable string that represents a doc-comment.

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -931,7 +931,7 @@ export class CompletionItem {
 
 	label: string;
 	kind: CompletionItemKind;
-	detail: string;
+	detail: string | { language: string, value: string };
 	documentation: string | MarkdownString;
 	sortText: string;
 	filterText: string;


### PR DESCRIPTION
Fixes #34188

Allows Completion items to mark a language for syntax highlighting on the `.detail` field