### PR TITLE
Add "Duplicate" option to Explorer context menu

### DIFF
--- a/src/vs/workbench/parts/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/fileActions.contribution.ts
@@ -10,7 +10,7 @@ import { Action, IAction } from 'vs/base/common/actions';
 import { isMacintosh } from 'vs/base/common/platform';
 import { ActionItem, BaseActionItem, Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Scope, IActionBarRegistry, Extensions as ActionBarExtensions, ActionBarContributor } from 'vs/workbench/browser/actions';
-import { GlobalNewUntitledFileAction, SaveFileAsAction, OpenFileAction, ShowOpenedFileInNewWindow, CopyPathAction, GlobalCopyPathAction, RevealInOSAction, GlobalRevealInOSAction, pasteIntoFocusedFilesExplorerViewItem, FocusOpenEditorsView, FocusFilesExplorer, GlobalCompareResourcesAction, GlobalNewFileAction, GlobalNewFolderAction, RevertFileAction, SaveFilesAction, SaveAllAction, SaveFileAction, MoveFileToTrashAction, TriggerRenameFileAction, PasteFileAction, CopyFileAction, SelectResourceForCompareAction, CompareResourcesAction, NewFolderAction, NewFileAction, OpenToSideAction, ShowActiveFileInExplorer, CollapseExplorerView, RefreshExplorerView, CompareWithSavedAction } from 'vs/workbench/parts/files/browser/fileActions';
+import { GlobalNewUntitledFileAction, SaveFileAsAction, OpenFileAction, ShowOpenedFileInNewWindow, CopyPathAction, GlobalCopyPathAction, RevealInOSAction, GlobalRevealInOSAction, pasteIntoFocusedFilesExplorerViewItem, FocusOpenEditorsView, FocusFilesExplorer, GlobalCompareResourcesAction, GlobalNewFileAction, GlobalNewFolderAction, RevertFileAction, SaveFilesAction, SaveAllAction, SaveFileAction, MoveFileToTrashAction, TriggerRenameFileAction, PasteFileAction, CopyFileAction, DuplicateFileAction, SelectResourceForCompareAction, CompareResourcesAction, NewFolderAction, NewFileAction, OpenToSideAction, ShowActiveFileInExplorer, CollapseExplorerView, RefreshExplorerView, CompareWithSavedAction } from 'vs/workbench/parts/files/browser/fileActions';
 import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTION_CONTEXT } from 'vs/workbench/parts/files/browser/saveErrorHandler';
 import { SyncActionDescriptor, MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
@@ -110,6 +110,7 @@ class FilesViewerActionContributor extends ActionBarContributor {
 		// Copy File/Folder
 		if (!stat.isRoot) {
 			actions.push(this.instantiationService.createInstance(CopyFileAction, tree, <FileStat>stat));
+			actions.push(this.instantiationService.createInstance(DuplicateFileAction, tree, <FileStat>stat, <FileStat>stat.parent));
 		}
 
 		// Paste File/Folder


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/920019/31480109-10805e18-aed9-11e7-8017-6dd6b8778334.png)

This pull request adds a 'Duplicate' option to the Explorer context menu (see screenshot). Because the context menu's copy/paste functionality already uses a pre-existing `DuplicateFileAction` class, a simple shortcut to that action is all that is required to achieve file/folder duplication. This keeps the naming conventions for duplicate filenames consistent (`file.ext`, `file.1.ext`, etc).

## Relevant Issues
- `Option to duplicate file/folder in "explore" sidebar and then rename` - #14449
- `Add Duplicate option to tree view context menu` - #17658