### PR TITLE
For line comment, always use start line of language when falling back to block comments

### DIFF
--- a/src/vs/editor/contrib/comment/common/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/common/lineCommentCommand.ts
@@ -270,7 +270,7 @@ export class LineCommentCommand implements editorCommon.ICommand {
 	 */
 	private _executeBlockComment(model: editorCommon.ITokenizedModel, builder: editorCommon.IEditOperationBuilder, s: Selection): void {
 		model.tokenizeIfCheap(s.startLineNumber);
-		let languageId = model.getLanguageIdAtPosition(s.startLineNumber, s.startColumn);
+		let languageId = model.getLanguageIdAtPosition(s.startLineNumber, 1);
 		let config = LanguageConfigurationRegistry.getComments(languageId);
 		if (!config || !config.blockCommentStartToken || !config.blockCommentEndToken) {
 			// Mode does not support block comments

--- a/src/vs/editor/contrib/comment/test/common/lineCommentCommand.test.ts
+++ b/src/vs/editor/contrib/comment/test/common/lineCommentCommand.test.ts
@@ -1002,4 +1002,20 @@ suite('Editor Contrib - Line Comment in mixed modes', () => {
 		);
 	});
 
+	test('issue #36173: Commenting code in JSX tag body', () => {
+		testLineCommentCommand(
+			[
+				'<div>',
+				'  {123}',
+				'</div>',
+			],
+			new Selection(2, 4, 2, 4),
+			[
+				'<div>',
+				'  {/* {123} */}',
+				'</div>',
+			],
+			new Selection(2, 8, 2, 8),
+		);
+	});
 });


### PR DESCRIPTION
**Bug**
When a line comment command falls back to a block comment, we currently get the language mode from the selection location. In jsx, when you are inside of a javascript expression, this results in the wrong language mode being selected and the wrong type of comment being used

**Fix**
Make sure we always grab the language mode from the start of the line. This is consistent with what we do for regular line comments

Fixes #36173