### PR TITLE
Added setting "git.autoRepositoryDetection"

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -769,6 +769,11 @@
           "default": null,
           "isExecutable": true
         },
+        "git.autoRepositoryDetection": {
+          "type": "boolean",
+          "description": "%config.autoRepositoryDetection%",
+          "default": true
+        },
         "git.autorefresh": {
           "type": "boolean",
           "description": "%config.autorefresh%",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -45,6 +45,7 @@
 	"command.stashPopLatest": "Pop Latest Stash",
 	"config.enabled": "Whether git is enabled",
 	"config.path": "Path to the git executable",
+	"config.autoRepositoryDetection": "Whether a repository should be automatically detected for a single file",
 	"config.autorefresh": "Whether auto refreshing is enabled",
 	"config.autofetch": "Whether auto fetching is enabled",
 	"config.enableLongCommitWarning": "Whether long commit messages should be warned about",

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -742,9 +742,18 @@ export class Repository implements Disposable {
 		const index: Resource[] = [];
 		const workingTree: Resource[] = [];
 		const merge: Resource[] = [];
+		const repoDetection = config.get<boolean>('autoRepositoryDetection') === true;
 
 		status.forEach(raw => {
-			const uri = Uri.file(path.join(this.repository.root, raw.path));
+			const fullFilePath = path.join(this.repository.root, raw.path);
+
+			if (!repoDetection && workspace.workspaceFolders === undefined) {
+				if (!this.detectActiveFile(fullFilePath)) {
+					return;
+				}
+			}
+
+			const uri = Uri.file(fullFilePath);
 			const renameUri = raw.rename ? Uri.file(path.join(this.repository.root, raw.rename)) : undefined;
 
 			switch (raw.x + raw.y) {
@@ -800,6 +809,16 @@ export class Repository implements Disposable {
 		}
 
 		this._onDidChangeStatus.fire();
+	}
+
+	private detectActiveFile(fullFilePath: string): boolean {
+		if (window.activeTextEditor !== undefined) {
+			if (window.activeTextEditor.document.fileName === fullFilePath) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private onFSChange(uri: Uri): void {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -811,14 +811,8 @@ export class Repository implements Disposable {
 		this._onDidChangeStatus.fire();
 	}
 
-	private detectActiveFile(fullFilePath: string): boolean {
-		if (window.activeTextEditor !== undefined) {
-			if (window.activeTextEditor.document.fileName === fullFilePath) {
-				return true;
-			}
-		}
-
-		return false;
+	private detectActiveFile(fullFilePath: string): boolean | undefined {
+		return window.activeTextEditor && window.activeTextEditor.document.fileName === fullFilePath;
 	}
 
 	private onFSChange(uri: Uri): void {


### PR DESCRIPTION
Issue: #35555

This pull request adds the setting "git.autoRepositoryDetection". (Thank you for the suggestion @joaomoreno)

When opening just one file, the setting "autoRepositoryDetection" allows the user to control whether the entire repository changes will be displayed or just the changes of the current file.

![example](https://user-images.githubusercontent.com/3441183/31526211-fd7d9f26-af8a-11e7-90f3-e321f5671cca.gif)

**Note:** I deleted my previous pull request and created this new one because I accidentally messed it up through re-basing it. I had trouble cleanly reverting it so making a new pull request seemed like the best solution. Really sorry if that spammed anyone or wasn't the correct way to handle it. If anyone can let me know how to handle that better next time it would be greatly appreciated!
