### PR TITLE
guard against empty tooltip

### DIFF
--- a/src/vs/workbench/parts/scm/electron-browser/scmFileDecorations.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmFileDecorations.ts
@@ -62,7 +62,7 @@ class SCMDecorationsProvider implements IDecorationsProvider {
 
 	provideDecorations(uri: URI): IResourceDecorationData {
 		const resource = this._data.get(uri.toString());
-		if (!resource || !resource.decorations.color) {
+		if (!resource || !resource.decorations.color || !resource.decorations.tooltip) {
 			return undefined;
 		}
 		return {


### PR DESCRIPTION
fixes JS error "Cannot read property 'charAt' of undefined"