### PR TITLE
add missing awaits

### DIFF
--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -204,7 +204,7 @@ class ExtHostSourceControlResourceGroup implements vscode.SourceControlResourceG
 			return;
 		}
 
-		this._commands.executeCommand(command.command, ...command.arguments);
+		await this._commands.executeCommand(command.command, ...command.arguments);
 	}
 
 	_takeResourceStateSnapshot(): SCMRawResourceSplice[] {
@@ -532,6 +532,6 @@ export class ExtHostSCM {
 			return;
 		}
 
-		group.$executeResourceCommand(handle);
+		await group.$executeResourceCommand(handle);
 	}
 }


### PR DESCRIPTION
This prevents the returned promises from prematurely resolving before the command finishes.