### PR TITLE
Git submodules support.

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -13,6 +13,7 @@ import { toGitUri, fromGitUri } from './uri';
 import { grep } from './util';
 import { applyLineChanges, intersectDiffWithRange, toLineRanges, invertLineChange } from './staging';
 import * as path from 'path';
+import { lstatSync } from 'fs';
 import * as os from 'os';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import * as nls from 'vscode-nls';
@@ -159,6 +160,9 @@ export class CommandCenter {
 	}
 
 	private async _openResource(resource: Resource, preview?: boolean, preserveFocus?: boolean, preserveSelection?: boolean): Promise<void> {
+		if (lstatSync(resource.resourceUri.fsPath).isDirectory()) {
+			return; // it's a submodule.
+		}
 		const left = this.getLeftResource(resource);
 		const right = this.getRightResource(resource);
 		const title = this.getTitle(resource);

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -32,6 +32,11 @@ export interface Remote {
 	url: string;
 }
 
+export interface ISubmodule {
+	Root: string;
+	Status: string;
+}
+
 export interface Stash {
 	index: number;
 	description: string;
@@ -997,14 +1002,14 @@ export class Repository {
 		return uniqBy(rawRemotes, remote => remote.name);
 	}
 
-	async getSubmodules(): Promise<string[]> {
+	async getSubmodules(): Promise<ISubmodule[]> {
 		const result = await this.run(['submodule', 'status']);
 		const regex = /^([ \+\-U])\w* (\w*)( \(.*\))?/;
 		const submodules = result.stdout.split('\n')
 			.filter(b => !!b)
 			.map(line => regex.exec(line))
 			.filter(g => !!g)
-			.map((groups: RegExpExecArray) => path.join(this.repositoryRoot, groups[2]));
+			.map((groups: RegExpExecArray) => ({ Root: path.join(this.repositoryRoot, groups[2]), Status: groups[1] }));
 		//this._git.onOutput.emit('log', submodules);
 		return submodules;
 	}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -997,6 +997,18 @@ export class Repository {
 		return uniqBy(rawRemotes, remote => remote.name);
 	}
 
+	async getSubmodules(): Promise<string[]> {
+		const result = await this.run(['submodule', 'status']);
+		const regex = /^([ \+\-U])\w* (\w*)( \(.*\))?/;
+		const submodules = result.stdout.split('\n')
+			.filter(b => !!b)
+			.map(line => regex.exec(line))
+			.filter(g => !!g)
+			.map((groups: RegExpExecArray) => path.join(this.repositoryRoot, groups[2]));
+		//this._git.onOutput.emit('log', submodules);
+		return submodules;
+	}
+
 	async getBranch(name: string): Promise<Branch> {
 		if (name === 'HEAD') {
 			return this.getHEAD();

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -299,7 +299,7 @@ export class Model {
 		if (hint instanceof Uri) {
 			const resourcePath = hint.fsPath;
 
-			for (const liveRepository of this.openRepositories) {
+			for (const liveRepository of this.openRepositories.sort((a, b) => b.repository.root.length - a.repository.root.length)) {
 				const relativePath = path.relative(liveRepository.repository.root, resourcePath);
 
 				if (!/^\.\./.test(relativePath)) {

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -187,11 +187,11 @@ export class Model {
 
 	private scanForSubmodules(repository: Repository) {
 		const submodules = repository.getSubmodules();
-		submodules.then((elements) => elements.forEach(submoduleRoot => {
+		submodules.then((elements) => elements.forEach(submodule => {
 			//console.log(`Opening ${submoduleRoot} as git repository`);
 			try {
 				// We can't call tryOpenRepository, because a submodule is going to be under an open repository, so will fail.
-				const subRepository = new Repository(this.git.open((submoduleRoot)));
+				const subRepository = new Repository(this.git.open((submodule.Root)));
 				this.open(subRepository);
 			} catch (err) {
 				if (err.gitErrorCode === GitErrorCodes.NotAGitRepository) {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -602,6 +602,10 @@ export class Repository implements Disposable {
 		});
 	}
 
+	async getSubmodules(): Promise<string[]> {
+		return await this.repository.getSubmodules();
+	}
+
 	async getStashes(): Promise<Stash[]> {
 		return await this.repository.getStashes();
 	}


### PR DESCRIPTION
Basic support for #7829.

Automatically add submodules of added git repository when adding the repository.

When a repository is shown in the Index or Working tree resource groups, clicking on them does nothing. It would be better if either an informational message was shown, or the focus was shifted to that submodule in the Git view, but I'm not completely sure how to do the first, and the second doesn't seem possible at the moment.