### PR TITLE
Prototyping new CodeAction API

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -74,7 +74,7 @@ declare module monaco.languages {
 
 #includeAll(vs/editor/standalone/browser/standaloneLanguages;modes.=>;editorCommon.=>editor.;IMarkerData=>editor.IMarkerData):
 #includeAll(vs/editor/common/modes/languageConfiguration):
-#includeAll(vs/editor/common/modes;editorCommon.IRange=>IRange;editorCommon.IPosition=>IPosition;editorCommon.=>editor.):
+#includeAll(vs/editor/common/modes;editorCommon.IRange=>IRange;editorCommon.IPosition=>IPosition;editorCommon.=>editor.;IMarkerData=>editor.IMarkerData):
 #include(vs/editor/common/services/modeService): ILanguageExtensionPoint
 #includeAll(vs/editor/standalone/common/monarch/monarchTypes):
 

--- a/extensions/typescript/src/features/codeActionProvider.ts
+++ b/extensions/typescript/src/features/codeActionProvider.ts
@@ -41,12 +41,22 @@ export default class TypeScriptCodeActionProvider implements vscode.CodeActionPr
 		commandManager.register(new ApplyCodeActionCommand(this.client));
 	}
 
-	public async provideCodeActions(
+	public provideCodeActions(
+		_document: vscode.TextDocument,
+		_range: vscode.Range,
+		_context: vscode.CodeActionContext,
+		_token: vscode.CancellationToken
+	) {
+		// Uses provideCodeActions2 instead
+		return [];
+	}
+
+	public async provideCodeActions2(
 		document: vscode.TextDocument,
 		range: vscode.Range,
 		context: vscode.CodeActionContext,
 		token: vscode.CancellationToken
-	): Promise<vscode.Command[]> {
+	): Promise<vscode.CodeAction[]> {
 		if (!this.client.apiVersion.has213Features()) {
 			return [];
 		}
@@ -92,11 +102,14 @@ export default class TypeScriptCodeActionProvider implements vscode.CodeActionPr
 			.filter(code => supportedActions[code]));
 	}
 
-	private getCommandForAction(action: Proto.CodeAction, file: string): vscode.Command {
+	private getCommandForAction(action: Proto.CodeAction, file: string): vscode.CodeAction {
 		return {
 			title: action.description,
-			command: ApplyCodeActionCommand.ID,
-			arguments: [action, file]
+			command: {
+				title: action.description,
+				command: this.commandId,
+				arguments: [action, file]
+			}
 		};
 	}
 }

--- a/extensions/typescript/src/features/codeActionProvider.ts
+++ b/extensions/typescript/src/features/codeActionProvider.ts
@@ -9,7 +9,7 @@ import * as Proto from '../protocol';
 import { ITypeScriptServiceClient } from '../typescriptService';
 import { vsRangeToTsFileRange } from '../utils/convert';
 import FormattingConfigurationManager from './formattingConfigurationManager';
-import { applyCodeAction } from '../utils/codeAction';
+import { applyCodeAction, getEditForCodeAction } from '../utils/codeAction';
 import { CommandManager, Command } from '../utils/commandManager';
 
 interface NumberSet {
@@ -107,9 +107,11 @@ export default class TypeScriptCodeActionProvider implements vscode.CodeActionPr
 			title: action.description,
 			command: {
 				title: action.description,
-				command: this.commandId,
+				command: ApplyCodeActionCommand.ID,
 				arguments: [action, file]
-			}
+			},
+			edits: getEditForCodeAction(this.client, action),
+			diagnostics: []
 		};
 	}
 }

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -112,11 +112,11 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 	}
 
 	public async provideCodeActions2(
-		document: TextDocument,
-		range: Range,
-		_context: CodeActionContext,
-		token: CancellationToken
-	): Promise<CodeAction[]> {
+		document: vscode.TextDocument,
+		range: vscode.Range,
+		_context: vscode.CodeActionContext,
+		token: vscode.CancellationToken
+	): Promise<vscode.CodeAction[]> {
 		if (!this.client.apiVersion.has240Features()) {
 			return [];
 		}
@@ -140,7 +140,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 						title: info.description,
 						command: {
 							title: info.description,
-							command: this.selectRefactorCommandId,
+							command: SelectRefactorCommand.ID,
 							arguments: [document, file, info, range]
 						}
 					});
@@ -150,7 +150,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 							title: info.description,
 							command: {
 								title: info.description,
-								command: this.doRefactorCommandId,
+								command: ApplyRefactoringCommand.ID,
 								arguments: [document, file, info.name, action.name, range]
 							}
 						});

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -106,12 +106,17 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 		commandManager.register(new SelectRefactorCommand(doRefactoringCommand));
 	}
 
-	public async provideCodeActions(
-		document: vscode.TextDocument,
-		range: vscode.Range,
-		_context: vscode.CodeActionContext,
-		token: vscode.CancellationToken
-	): Promise<vscode.Command[]> {
+	public async provideCodeActions() {
+		// Uses provideCodeActions2 instead
+		return [];
+	}
+
+	public async provideCodeActions2(
+		document: TextDocument,
+		range: Range,
+		_context: CodeActionContext,
+		token: CancellationToken
+	): Promise<CodeAction[]> {
 		if (!this.client.apiVersion.has240Features()) {
 			return [];
 		}
@@ -128,20 +133,26 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 				return [];
 			}
 
-			const actions: vscode.Command[] = [];
+			const actions: vscode.CodeAction[] = [];
 			for (const info of response.body) {
 				if (info.inlineable === false) {
 					actions.push({
 						title: info.description,
-						command: SelectRefactorCommand.ID,
-						arguments: [document, file, info, range]
+						command: {
+							title: info.description,
+							command: this.selectRefactorCommandId,
+							arguments: [document, file, info, range]
+						}
 					});
 				} else {
 					for (const action of info.actions) {
 						actions.push({
-							title: action.description,
-							command: ApplyRefactoringCommand.ID,
-							arguments: [document, file, info.name, action.name, range]
+							title: info.description,
+							command: {
+								title: info.description,
+								command: this.doRefactorCommandId,
+								arguments: [document, file, info.name, action.name, range]
+							}
 						});
 					}
 				}

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -317,7 +317,7 @@ class LanguageProvider {
 		this.disposables.push(languages.registerDocumentSymbolProvider(selector, new (await import('./features/documentSymbolProvider')).default(client)));
 		this.disposables.push(languages.registerSignatureHelpProvider(selector, new (await import('./features/signatureHelpProvider')).default(client), '(', ','));
 		this.disposables.push(languages.registerRenameProvider(selector, new (await import('./features/renameProvider')).default(client)));
-		this.disposables.push(languages.registerCodeActionsProvider(selector, new (await import('./features/codeActionProvider')).default(client, this.formattingOptionsManager, this.commandManager)));
+		this.disposables.push(languages.registerCodeActionsProvider(selector, new (await import('./features/codeActionProvider')).default(client, this.formattingOptionsManager)));
 		this.disposables.push(languages.registerCodeActionsProvider(selector, new (await import('./features/refactorProvider')).default(client, this.formattingOptionsManager, this.commandManager)));
 		this.registerVersionDependentProviders();
 

--- a/extensions/typescript/src/utils/codeAction.ts
+++ b/extensions/typescript/src/utils/codeAction.ts
@@ -8,12 +8,10 @@ import * as Proto from '../protocol';
 import { tsTextSpanToVsRange } from './convert';
 import { ITypeScriptServiceClient } from '../typescriptService';
 
-
-export async function applyCodeAction(
+export function getEditForCodeAction(
 	client: ITypeScriptServiceClient,
-	action: Proto.CodeAction,
-	file: string
-): Promise<boolean> {
+	action: Proto.CodeAction
+): WorkspaceEdit | undefined {
 	if (action.changes && action.changes.length) {
 		const workspaceEdit = new WorkspaceEdit();
 		for (const change of action.changes) {
@@ -24,11 +22,30 @@ export async function applyCodeAction(
 			}
 		}
 
+		return workspaceEdit;
+	}
+	return undefined;
+}
+
+export async function applyCodeAction(
+	client: ITypeScriptServiceClient,
+	action: Proto.CodeAction,
+	file: string
+): Promise<boolean> {
+	const workspaceEdit = getEditForCodeAction(client, action);
+	if (workspaceEdit) {
 		if (!(await workspace.applyEdit(workspaceEdit))) {
 			return false;
 		}
 	}
+	return applyCodeActionCommands(client, action, file);
+}
 
+export async function applyCodeActionCommands(
+	client: ITypeScriptServiceClient,
+	action: Proto.CodeAction,
+	file: string
+): Promise<boolean> {
 	if (action.commands && action.commands.length) {
 		for (const command of action.commands) {
 			const response = await client.execute('applyCodeActionCommand', { file, command });

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -275,6 +275,13 @@ export interface ISuggestSupport {
 	resolveCompletionItem?(model: editorCommon.IModel, position: Position, item: ISuggestion, token: CancellationToken): ISuggestion | Thenable<ISuggestion>;
 }
 
+export interface CodeAction {
+	title: string;
+	command?: Command;
+	edits?: TextEdit[] | WorkspaceEdit;
+	diagnostics?: editorCommon.IModelDecoration[];
+}
+
 /**
  * The code action interface defines the contract between extensions and
  * the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action) feature.
@@ -284,7 +291,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): Command[] | Thenable<Command[]>;
+	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): (Command | CodeAction)[] | Thenable<(Command | CodeAction)[]>;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -16,6 +16,7 @@ import { Range, IRange } from 'vs/editor/common/core/range';
 import Event from 'vs/base/common/event';
 import { TokenizationRegistryImpl } from 'vs/editor/common/modes/tokenizationRegistry';
 import { Color } from 'vs/base/common/color';
+import { IMarkerData } from 'vs/platform/markers/common/markers';
 
 /**
  * Open ended enum at runtime
@@ -279,7 +280,7 @@ export interface CodeAction {
 	title: string;
 	command?: Command;
 	edits?: TextEdit[] | WorkspaceEdit;
-	diagnostics?: editorCommon.IModelDecoration[];
+	diagnostics?: IMarkerData[];
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -292,7 +292,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
+	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): (CodeAction | Command)[] | Thenable<(Command | CodeAction)[]>;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -279,7 +279,7 @@ export interface ISuggestSupport {
 export interface CodeAction {
 	title: string;
 	command?: Command;
-	edits?: TextEdit[] | WorkspaceEdit;
+	edits?: WorkspaceEdit;
 	diagnostics?: IMarkerData[];
 }
 
@@ -292,7 +292,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): (Command | CodeAction)[] | Thenable<(Command | CodeAction)[]>;
+	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
 }
 
 /**

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -7,16 +7,16 @@
 import URI from 'vs/base/common/uri';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { Range } from 'vs/editor/common/core/range';
-import { Command, CodeActionProviderRegistry } from 'vs/editor/common/modes';
+import { Command, CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { onUnexpectedExternalError, illegalArgument } from 'vs/base/common/errors';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
 
-export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<Command[]> {
+export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<(Command | CodeAction)[]> {
 
-	const allResults: Command[] = [];
+	const allResults: (Command | CodeAction)[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
 		return asWinJsPromise(token => support.provideCodeActions(model, range, token)).then(result => {
 			if (Array.isArray(result)) {

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -7,16 +7,16 @@
 import URI from 'vs/base/common/uri';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { Range } from 'vs/editor/common/core/range';
-import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, CodeAction, Command } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { onUnexpectedExternalError, illegalArgument } from 'vs/base/common/errors';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
 
-export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<CodeAction[]> {
+export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<(CodeAction | Command)[]> {
 
-	const allResults: CodeAction[] = [];
+	const allResults: (CodeAction | Command)[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
 		return asWinJsPromise(token => support.provideCodeActions(model, range, token)).then(result => {
 			if (Array.isArray(result)) {

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -7,16 +7,16 @@
 import URI from 'vs/base/common/uri';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { Range } from 'vs/editor/common/core/range';
-import { Command, CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { onUnexpectedExternalError, illegalArgument } from 'vs/base/common/errors';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { CommonEditorRegistry } from 'vs/editor/common/editorCommonExtensions';
 
-export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<(Command | CodeAction)[]> {
+export function getCodeActions(model: IReadOnlyModel, range: Range): TPromise<CodeAction[]> {
 
-	const allResults: (Command | CodeAction)[] = [];
+	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
 		return asWinJsPromise(token => support.provideCodeActions(model, range, token)).then(result => {
 			if (Array.isArray(result)) {

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -12,7 +12,7 @@ import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { ICommonCodeEditor } from 'vs/editor/common/editorCommon';
-import { CodeActionProviderRegistry, Command } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, CodeAction, Command } from 'vs/editor/common/modes';
 import { getCodeActions } from './quickFix';
 import { Position } from 'vs/editor/common/core/position';
 
@@ -112,11 +112,22 @@ export class QuickFixOracle {
 			const model = this._editor.getModel();
 			const range = model.validateRange(rangeOrSelection);
 			const position = rangeOrSelection instanceof Selection ? rangeOrSelection.getPosition() : rangeOrSelection.getStartPosition();
+
+			const fixes = getCodeActions(model, range).then(actions =>
+				actions.map(action => {
+					if ('id' in action) {
+						// must be a command
+						const command = action as Command;
+						return { title: command.title, command: command } as CodeAction;
+					}
+					return action;
+				}));
+
 			this._signalChange({
 				type,
 				range,
 				position,
-				fixes: getCodeActions(model, range)
+				fixes
 			});
 		}
 	}
@@ -126,7 +137,7 @@ export interface QuickFixComputeEvent {
 	type: 'auto' | 'manual';
 	range: Range;
 	position: Position;
-	fixes: TPromise<Command[]>;
+	fixes: TPromise<CodeAction[]>;
 }
 
 export class QuickFixModel {

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -12,7 +12,7 @@ import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { ICommonCodeEditor } from 'vs/editor/common/editorCommon';
-import { CodeActionProviderRegistry, CodeAction, Command } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
 import { getCodeActions } from './quickFix';
 import { Position } from 'vs/editor/common/core/position';
 
@@ -113,15 +113,7 @@ export class QuickFixOracle {
 			const range = model.validateRange(rangeOrSelection);
 			const position = rangeOrSelection instanceof Selection ? rangeOrSelection.getPosition() : rangeOrSelection.getStartPosition();
 
-			const fixes = getCodeActions(model, range).then(actions =>
-				actions.map(action => {
-					if ('id' in action) {
-						// must be a command
-						const command = action as Command;
-						return { title: command.title, command: command } as CodeAction;
-					}
-					return action;
-				}));
+			const fixes = getCodeActions(model, range);
 
 			this._signalChange({
 				type,

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -12,7 +12,7 @@ import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { ICommonCodeEditor } from 'vs/editor/common/editorCommon';
-import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
+import { CodeActionProviderRegistry, CodeAction, Command } from 'vs/editor/common/modes';
 import { getCodeActions } from './quickFix';
 import { Position } from 'vs/editor/common/core/position';
 
@@ -113,7 +113,15 @@ export class QuickFixOracle {
 			const range = model.validateRange(rangeOrSelection);
 			const position = rangeOrSelection instanceof Selection ? rangeOrSelection.getPosition() : rangeOrSelection.getStartPosition();
 
-			const fixes = getCodeActions(model, range);
+			const fixes = getCodeActions(model, range).then(actions =>
+				actions.map(action => {
+					if ('id' in action) {
+						// must be a command
+						const command = action as Command;
+						return { title: command.title, command: command } as CodeAction;
+					}
+					return action;
+				}));
 
 			this._signalChange({
 				type,

--- a/src/vs/editor/contrib/quickFix/quickFixWidget.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixWidget.ts
@@ -10,7 +10,7 @@ import { always } from 'vs/base/common/async';
 import { getDomNodePagePosition } from 'vs/base/browser/dom';
 import { Position } from 'vs/editor/common/core/position';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { Command } from 'vs/editor/common/modes';
+import { CodeAction } from 'vs/editor/common/modes';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { Action } from 'vs/base/common/actions';
@@ -33,13 +33,17 @@ export class QuickFixContextMenu {
 		this._commandService = commandService;
 	}
 
-	show(fixes: TPromise<Command[]>, at: { x: number; y: number } | Position) {
+	show(fixes: TPromise<CodeAction[]>, at: { x: number; y: number } | Position) {
 
 		const actions = fixes.then(value => {
-			return value.map(command => {
-				return new Action(command.id, command.title, undefined, true, () => {
+			return value.map(action => {
+				// TODO: just placeholders for testing
+				return new Action(action.command.id, (action.diagnostics ? '💡 ' : '✂️ ') + action.title, undefined, true, () => {
+					if (!action.command) {
+						return TPromise.as(undefined);
+					}
 					return always(
-						this._commandService.executeCommand(command.id, ...command.arguments),
+						this._commandService.executeCommand(action.command.id, ...action.command.arguments),
 						() => this._onDidExecuteCodeAction.fire(undefined)
 					);
 				});

--- a/src/vs/editor/contrib/quickFix/quickFixWidget.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixWidget.ts
@@ -33,8 +33,7 @@ export class QuickFixContextMenu {
 
 		const actions = fixes.then(value => {
 			return value.map(action => {
-				// TODO: just placeholders for testing
-				return new Action(action.command.id, (action.diagnostics ? '💡 ' : '✂️ ') + action.title, undefined, true, () => {
+				return new Action(action.command.id, action.title, undefined, true, () => {
 					return always(
 						this.onApplyCodeAction(action),
 						() => this._onDidExecuteCodeAction.fire(undefined));

--- a/src/vs/editor/contrib/quickFix/quickFixWidget.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixWidget.ts
@@ -24,24 +24,24 @@ export class QuickFixContextMenu {
 	readonly onDidExecuteCodeAction: Event<void> = this._onDidExecuteCodeAction.event;
 
 	constructor(
-		private readonly editor: ICodeEditor,
-		private readonly contextMenuService: IContextMenuService,
-		private readonly onApplyCodeAction: (action: CodeAction) => TPromise<any>
+		private readonly _editor: ICodeEditor,
+		private readonly _contextMenuService: IContextMenuService,
+		private readonly _onApplyCodeAction: (action: CodeAction) => TPromise<any>
 	) { }
 
 	show(fixes: TPromise<CodeAction[]>, at: { x: number; y: number } | Position) {
 
 		const actions = fixes.then(value => {
 			return value.map(action => {
-				return new Action(action.command.id, action.title, undefined, true, () => {
+				return new Action(action.command ? action.command.id : action.title, action.title, undefined, true, () => {
 					return always(
-						this.onApplyCodeAction(action),
+						this._onApplyCodeAction(action),
 						() => this._onDidExecuteCodeAction.fire(undefined));
 				});
 			});
 		});
 
-		this.contextMenuService.showContextMenu({
+		this._contextMenuService.showContextMenu({
 			getAnchor: () => {
 				if (Position.isIPosition(at)) {
 					at = this._toCoords(at);
@@ -60,12 +60,12 @@ export class QuickFixContextMenu {
 
 	private _toCoords(position: Position): { x: number, y: number } {
 
-		this.editor.revealPosition(position, ScrollType.Immediate);
-		this.editor.render();
+		this._editor.revealPosition(position, ScrollType.Immediate);
+		this._editor.render();
 
 		// Translate to absolute editor position
-		const cursorCoords = this.editor.getScrolledVisiblePosition(this.editor.getPosition());
-		const editorCoords = getDomNodePagePosition(this.editor.getDomNode());
+		const cursorCoords = this._editor.getScrolledVisiblePosition(this._editor.getPosition());
+		const editorCoords = getDomNodePagePosition(this._editor.getDomNode());
 		const x = editorCoords.left + cursorCoords.left;
 		const y = editorCoords.top + cursorCoords.top + cursorCoords.height;
 

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -329,7 +329,7 @@ export function registerCodeLensProvider(languageId: string, provider: modes.Cod
  */
 export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider): IDisposable {
 	return modes.CodeActionProviderRegistry.register(languageId, {
-		provideCodeActions: (model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): modes.Command[] | Thenable<modes.Command[]> => {
+		provideCodeActions: (model: editorCommon.IReadOnlyModel, range: Range, token: CancellationToken): (modes.Command | modes.CodeAction)[] | Thenable<(modes.Command | modes.CodeAction)[]> => {
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
 			});
@@ -411,7 +411,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): modes.Command[] | Thenable<modes.Command[]>;
+	provideCodeActions(model: editorCommon.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): (modes.Command | modes.CodeAction)[] | Thenable<(modes.Command | modes.CodeAction)[]>;
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4534,7 +4534,7 @@ declare module monaco.languages {
 	export interface CodeAction {
 		title: string;
 		command?: Command;
-		edits?: TextEdit[] | WorkspaceEdit;
+		edits?: WorkspaceEdit;
 		diagnostics?: editor.IMarkerData[];
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4095,7 +4095,7 @@ declare module monaco.languages {
 		/**
 		 * Provide commands for the given document and range.
 		 */
-		provideCodeActions(model: editor.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): Command[] | Thenable<Command[]>;
+		provideCodeActions(model: editor.IReadOnlyModel, range: Range, context: CodeActionContext, token: CancellationToken): (Command | CodeAction)[] | Thenable<(Command | CodeAction)[]>;
 	}
 
 	/**
@@ -4529,6 +4529,13 @@ declare module monaco.languages {
 	export enum SuggestTriggerKind {
 		Invoke = 0,
 		TriggerCharacter = 1,
+	}
+
+	export interface CodeAction {
+		title: string;
+		command?: Command;
+		edits?: TextEdit[] | WorkspaceEdit;
+		diagnostics?: editor.IModelDecoration[];
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4535,7 +4535,7 @@ declare module monaco.languages {
 		title: string;
 		command?: Command;
 		edits?: TextEdit[] | WorkspaceEdit;
-		diagnostics?: editor.IModelDecoration[];
+		diagnostics?: editor.IMarkerData[];
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1799,7 +1799,6 @@ declare module 'vscode' {
 	 * a [code action](#CodeActionProvider.provideCodeActions) is run.
 	 */
 	export interface CodeActionContext {
-
 		/**
 		 * An array of diagnostics.
 		 */

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -230,7 +230,7 @@ declare module 'vscode' {
 	 *
 	 * Shown using the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
 	 */
-	export interface CodeAction {
+	export class CodeAction {
 		/**
 		 * Label used to identify the code action in UI.
 		 */

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -224,4 +224,54 @@ declare module 'vscode' {
 		 */
 		export let console: DebugConsole;
 	}
+
+	/**
+	 * Represents an action that can be performed in code.
+	 *
+	 * Shown using the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+	 */
+	export interface CodeAction {
+		/**
+		 * Label used to identify the code action in UI.
+		 */
+		title: string;
+
+		/**
+		 * Optional command that performs the code action.
+		 *
+		 * Executed after `edits` if any edits are provided. Either `command` or `edits` must be provided for a `CodeAction`.
+		 */
+		command?: Command;
+
+		/**
+		 * Optional edit that performs the code action.
+		 *
+		 * Either `command` or `edits` must be provided for a `CodeAction`.
+		 */
+		edits?: TextEdit[] | WorkspaceEdit;
+
+		/**
+		 * Diagnostics that this code action resolves.
+		 */
+		diagnostics?: Diagnostic[];
+
+		constructor(title: string, edits?: TextEdit[] | WorkspaceEdit);
+	}
+
+	export interface CodeActionProvider {
+
+		/**
+		 * Provide commands for the given document and range.
+		 *
+		 * If implemented, overrides `provideCodeActions`
+		 *
+		 * @param document The document in which the command was invoked.
+		 * @param range The range for which the command was invoked.
+		 * @param context Context carrying additional information.
+		 * @param token A cancellation token.
+		 * @return An array of commands, quick fixes, or refactorings or a thenable of such. The lack of a result can be
+		 * signaled by returning `undefined`, `null`, or an empty array.
+		 */
+		provideCodeActions2?(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | CodeAction)[]>;
+	}
 }

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -163,7 +163,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	$registerQuickFixSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> {
 		this._registrations[handle] = modes.CodeActionProviderRegistry.register(selector, <modes.CodeActionProvider>{
-			provideCodeActions: (model: IReadOnlyModel, range: EditorRange, token: CancellationToken): Thenable<modes.Command[]> => {
+			provideCodeActions: (model: IReadOnlyModel, range: EditorRange, token: CancellationToken): Thenable<(modes.Command | modes.CodeAction)[]> => {
 				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range)));
 			}
 		});

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -531,6 +531,7 @@ export function createApiFactory(
 			debug,
 			// types
 			CancellationTokenSource: CancellationTokenSource,
+			CodeAction: extHostTypes.CodeAction,
 			CodeLens: extHostTypes.CodeLens,
 			Color: extHostTypes.Color,
 			ColorPresentation: extHostTypes.ColorPresentation,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -581,7 +581,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideHover(handle: number, resource: URI, position: IPosition): TPromise<modes.Hover>;
 	$provideDocumentHighlights(handle: number, resource: URI, position: IPosition): TPromise<modes.DocumentHighlight[]>;
 	$provideReferences(handle: number, resource: URI, position: IPosition, context: modes.ReferenceContext): TPromise<modes.Location[]>;
-	$provideCodeActions(handle: number, resource: URI, range: IRange): TPromise<modes.Command[]>;
+	$provideCodeActions(handle: number, resource: URI, range: IRange): TPromise<(modes.Command | modes.CodeAction)[]>;
 	$provideDocumentFormattingEdits(handle: number, resource: URI, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]>;
 	$provideDocumentRangeFormattingEdits(handle: number, resource: URI, range: IRange, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]>;
 	$provideOnTypeFormattingEdits(handle: number, resource: URI, position: IPosition, ch: string, options: modes.FormattingOptions): TPromise<editorCommon.ISingleEditOperation[]>;

--- a/src/vs/workbench/api/node/extHostDiagnostics.ts
+++ b/src/vs/workbench/api/node/extHostDiagnostics.ts
@@ -111,7 +111,7 @@ export class DiagnosticCollection implements vscode.DiagnosticCollection {
 					orderLoop: for (let i = 0; i < 4; i++) {
 						for (let diagnostic of diagnostics) {
 							if (diagnostic.severity === order[i]) {
-								const len = marker.push(DiagnosticCollection._toMarkerData(diagnostic));
+								const len = marker.push(DiagnosticCollection.toMarkerData(diagnostic));
 								if (len === DiagnosticCollection._maxDiagnosticsPerFile) {
 									break orderLoop;
 								}
@@ -129,7 +129,7 @@ export class DiagnosticCollection implements vscode.DiagnosticCollection {
 						endColumn: marker[marker.length - 1].endColumn
 					});
 				} else {
-					marker = diagnostics.map(DiagnosticCollection._toMarkerData);
+					marker = diagnostics.map(DiagnosticCollection.toMarkerData);
 				}
 			}
 
@@ -179,7 +179,7 @@ export class DiagnosticCollection implements vscode.DiagnosticCollection {
 		}
 	}
 
-	private static _toMarkerData(diagnostic: vscode.Diagnostic): IMarkerData {
+	public static toMarkerData(diagnostic: vscode.Diagnostic): IMarkerData {
 
 		let range = diagnostic.range;
 

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -15,7 +15,7 @@ import * as modes from 'vs/editor/common/modes';
 import { ExtHostHeapService } from 'vs/workbench/api/node/extHostHeapService';
 import { ExtHostDocuments } from 'vs/workbench/api/node/extHostDocuments';
 import { ExtHostCommands, CommandsConverter } from 'vs/workbench/api/node/extHostCommands';
-import { ExtHostDiagnostics } from 'vs/workbench/api/node/extHostDiagnostics';
+import { ExtHostDiagnostics, DiagnosticCollection } from 'vs/workbench/api/node/extHostDiagnostics';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { MainContext, MainThreadLanguageFeaturesShape, ExtHostLanguageFeaturesShape, ObjectIdentifier, IRawColorInfo, IMainContext, IExtHostSuggestResult, IExtHostSuggestion, IWorkspaceSymbols, IWorkspaceSymbol, IdObject } from './extHost.protocol';
 import { regExpLeadsToEndlessLoop } from 'vs/base/common/strings';
@@ -310,6 +310,9 @@ class QuickFixAdapter {
 						? Array.isArray(codeAction.edits)
 							? codeAction.edits.map(TypeConverters.TextEdit.from)
 							: TypeConverters.WorkspaceEdit.from(codeAction.edits)
+						: undefined,
+					diagnostics: codeAction.diagnostics
+						? codeAction.diagnostics.map(DiagnosticCollection.toMarkerData)
 						: undefined
 				} as modes.CodeAction;
 			});

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -269,7 +269,7 @@ class QuickFixAdapter {
 		this._provider = provider;
 	}
 
-	provideCodeActions(resource: URI, range: IRange): TPromise<modes.CodeAction[]> {
+	provideCodeActions(resource: URI, range: IRange): TPromise<(modes.CodeAction | modes.Command)[]> {
 
 		const doc = this._documents.getDocumentData(resource).document;
 		const ran = <vscode.Range>TypeConverters.toRange(range);
@@ -293,7 +293,7 @@ class QuickFixAdapter {
 			if (!Array.isArray(commands)) {
 				return undefined;
 			}
-			return commands.map(action => {
+			return commands.map((action): modes.CodeAction => {
 				if (!action) {
 					return undefined;
 				}

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -269,7 +269,7 @@ class QuickFixAdapter {
 		this._provider = provider;
 	}
 
-	provideCodeActions(resource: URI, range: IRange): TPromise<(modes.Command | modes.CodeAction)[]> {
+	provideCodeActions(resource: URI, range: IRange): TPromise<modes.CodeAction[]> {
 
 		const doc = this._documents.getDocumentData(resource).document;
 		const ran = <vscode.Range>TypeConverters.toRange(range);
@@ -308,7 +308,7 @@ class QuickFixAdapter {
 					command: codeAction.command ? this._commands.toInternal(codeAction.command) : undefined,
 					edits: codeAction.edits
 						? Array.isArray(codeAction.edits)
-							? codeAction.edits.map(TypeConverters.TextEdit.from)
+							? TypeConverters.WorkspaceEdit.fromTextEdits(resource, codeAction.edits)
 							: TypeConverters.WorkspaceEdit.from(codeAction.edits)
 						: undefined,
 					diagnostics: codeAction.diagnostics

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -223,6 +223,23 @@ export const TextEdit = {
 	}
 };
 
+export namespace WorkspaceEdit {
+	export function from(value: vscode.WorkspaceEdit): modes.WorkspaceEdit {
+		const result: modes.WorkspaceEdit = { edits: [] };
+		for (let entry of value.entries()) {
+			let [uri, textEdits] = entry;
+			for (let textEdit of textEdits) {
+				result.edits.push({
+					resource: uri,
+					newText: textEdit.newText,
+					range: fromRange(textEdit.range)
+				});
+			}
+		}
+		return result;
+	}
+}
+
 
 export namespace SymbolKind {
 

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -238,6 +238,18 @@ export namespace WorkspaceEdit {
 		}
 		return result;
 	}
+
+	export function fromTextEdits(uri: vscode.Uri, textEdits: vscode.TextEdit[]): modes.WorkspaceEdit {
+		const result: modes.WorkspaceEdit = { edits: [] };
+		for (let textEdit of textEdits) {
+			result.edits.push({
+				resource: uri,
+				newText: textEdit.newText,
+				range: fromRange(textEdit.range)
+			});
+		}
+		return result;
+	}
 }
 
 

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -808,6 +808,21 @@ export class SymbolInformation {
 	}
 }
 
+export class CodeAction {
+	title: string;
+
+	command?: vscode.Command;
+
+	edits?: TextEdit[] | WorkspaceEdit;
+
+	dianostics?: Diagnostic[];
+
+	constructor(title: string, edits?: TextEdit[] | WorkspaceEdit) {
+		this.title = title;
+		this.edits = edits;
+	}
+}
+
 export class CodeLens {
 
 	range: Range;
@@ -887,6 +902,11 @@ export class SignatureHelp {
 	constructor() {
 		this.signatures = [];
 	}
+}
+
+export enum CodeActionType {
+	QuickFix = 1,
+	Refactoring = 2
 }
 
 export enum CompletionTriggerKind {

--- a/src/vs/workbench/test/electron-browser/api/extHostApiCommands.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostApiCommands.test.ts
@@ -369,8 +369,8 @@ suite('ExtHostLanguageFeatureCommands', function () {
 	// --- quickfix
 
 	test('QuickFix, back and forth', function () {
-		disposables.push(extHost.registerCodeActionProvider(defaultSelector, <vscode.CodeActionProvider>{
-			provideCodeActions(): any {
+		disposables.push(extHost.registerCodeActionProvider(defaultSelector, {
+			provideCodeActions(): vscode.Command[] {
 				return [{ command: 'testing', title: 'Title', arguments: [1, 2, true] }];
 			}
 		}));

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -655,7 +655,7 @@ suite('ExtHostLanguageFeatures', function () {
 			return getCodeActions(model, model.getFullModelRange()).then(value => {
 				assert.equal(value.length, 2);
 
-				let [first, second] = value;
+				let [first, second] = <Command[]>value;
 				assert.equal(first.title, 'Testing1');
 				assert.equal(first.id, 'test1');
 				assert.equal(second.title, 'Testing2');

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -25,7 +25,7 @@ import { IHeapService } from 'vs/workbench/api/electron-browser/mainThreadHeapSe
 import { ExtHostDocuments } from 'vs/workbench/api/node/extHostDocuments';
 import { ExtHostDocumentsAndEditors } from 'vs/workbench/api/node/extHostDocumentsAndEditors';
 import { getDocumentSymbols } from 'vs/editor/contrib/quickOpen/quickOpen';
-import { DocumentSymbolProviderRegistry, DocumentHighlightKind, Hover } from 'vs/editor/common/modes';
+import { DocumentSymbolProviderRegistry, DocumentHighlightKind, Hover, Command } from 'vs/editor/common/modes';
 import { getCodeLensData } from 'vs/editor/contrib/codelens/codelens';
 import { getDefinitionsAtPosition, getImplementationsAtPosition, getTypeDefinitionsAtPosition } from 'vs/editor/contrib/goToDeclaration/goToDeclaration';
 import { getHover } from 'vs/editor/contrib/hover/getHover';
@@ -642,11 +642,11 @@ suite('ExtHostLanguageFeatures', function () {
 
 	test('Quick Fix, data conversion', function () {
 
-		disposables.push(extHost.registerCodeActionProvider(defaultSelector, <vscode.CodeActionProvider>{
-			provideCodeActions(): any {
+		disposables.push(extHost.registerCodeActionProvider(defaultSelector, {
+			provideCodeActions(): vscode.Command[] {
 				return [
-					<vscode.Command>{ command: 'test1', title: 'Testing1' },
-					<vscode.Command>{ command: 'test2', title: 'Testing2' }
+					{ command: 'test1', title: 'Testing1' },
+					{ command: 'test2', title: 'Testing2' }
 				];
 			}
 		}));
@@ -655,11 +655,11 @@ suite('ExtHostLanguageFeatures', function () {
 			return getCodeActions(model, model.getFullModelRange()).then(value => {
 				assert.equal(value.length, 2);
 
-				let [first, second] = value;
+				const [first, second]: Command[] = value as any;
 				assert.equal(first.title, 'Testing1');
-				assert.equal(first.command.id, 'test1');
+				assert.equal(first.id, 'test1');
 				assert.equal(second.title, 'Testing2');
-				assert.equal(second.command.id, 'test2');
+				assert.equal(second.id, 'test2');
 			});
 		});
 	});

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -655,11 +655,11 @@ suite('ExtHostLanguageFeatures', function () {
 			return getCodeActions(model, model.getFullModelRange()).then(value => {
 				assert.equal(value.length, 2);
 
-				let [first, second] = <Command[]>value;
+				let [first, second] = value;
 				assert.equal(first.title, 'Testing1');
-				assert.equal(first.id, 'test1');
+				assert.equal(first.command.id, 'test1');
 				assert.equal(second.title, 'Testing2');
-				assert.equal(second.id, 'test2');
+				assert.equal(second.command.id, 'test2');
 			});
 		});
 	});


### PR DESCRIPTION
Adds skeleton of a new `CodeAction` type and allows codeActionProviders to return either `Command`s or `CodeAction`s