### PR TITLE
Add support for localizing ts errors

### DIFF
--- a/extensions/npm-shrinkwrap.json
+++ b/extensions/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "dependencies": {
     "typescript": {
-      "version": "2.6.1-insiders.20171016",
-      "from": "typescript@2.6.1-insiders.20171016",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1-insiders.20171016.tgz"
+      "version": "2.6.1-insiders.20171019",
+      "from": "typescript@2.6.1-insiders.20171019",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1-insiders.20171019.tgz"
     }
   }
 }

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "2.6.1-insiders.20171016"
+    "typescript": "^2.6.1-insiders.20171019"
   },
   "scripts": {
     "postinstall": "node ./postinstall"

--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -399,6 +399,15 @@
           "default": true,
           "description": "%typescript.quickSuggestionsForPaths%",
           "scope": "resource"
+        },
+        "typescript.locale": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null,
+          "description": "%typescript.locale%",
+          "scope": "window"
         }
       }
     },

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -42,5 +42,6 @@
 	"typescript.tsc.autoDetect": "Controls auto detection of tsc tasks. 'off' disables this feature. 'build' only creates single run compile tasks. 'watch' only creates compile and watch tasks. 'on' creates both build and watch tasks. Default is 'on'.",
 	"typescript.problemMatchers.tsc.label": "TypeScript problems",
 	"typescript.problemMatchers.tscWatch.label": "TypeScript problems (watch mode)",
-	"typescript.quickSuggestionsForPaths": "Enable/disable quick suggestions when typing out an import path."
+	"typescript.quickSuggestionsForPaths": "Enable/disable quick suggestions when typing out an import path.",
+	"typescript.locale": "Sets the locale used to report TypeScript errors. Requires TypeScript >= 2.6.0. Default of 'null' uses VS Code's locale for TypeScript errors."
 }

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -690,7 +690,9 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 			const converted = new Diagnostic(range, text);
 			converted.severity = this.getDiagnosticSeverity(diagnostic);
 			converted.source = diagnostic.source || source;
-			converted.code = '' + diagnostic.code;
+			if (diagnostic.code) {
+				converted.code = diagnostic.code;
+			}
 			result.push(converted);
 		}
 		return result;

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -11,7 +11,7 @@ import * as os from 'os';
 import * as electron from './utils/electron';
 import { Reader } from './utils/wireProtocol';
 
-import { workspace, window, Uri, CancellationToken, Disposable, Memento, MessageItem, EventEmitter, Event, commands } from 'vscode';
+import { workspace, window, Uri, CancellationToken, Disposable, Memento, MessageItem, EventEmitter, Event, commands, env } from 'vscode';
 import * as Proto from './protocol';
 import { ITypescriptServiceClient, ITypescriptServiceClientHost } from './typescriptService';
 import { TypeScriptServerPlugin } from './utils/plugins';
@@ -378,6 +378,13 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 				if (this.apiVersion.has234Features()) {
 					if (this.configuration.npmLocation) {
 						args.push('--npmLocation', `"${this.configuration.npmLocation}"`);
+					}
+				}
+
+				if (this.apiVersion.has260Features()) {
+					const tsLocale = getTsLocale(this.configuration);
+					if (tsLocale) {
+						args.push('--locale', tsLocale);
 					}
 				}
 
@@ -862,3 +869,9 @@ export default class TypeScriptServiceClient implements ITypescriptServiceClient
 		this.logTelemetry(telemetryData.telemetryEventName, properties);
 	}
 }
+
+
+const getTsLocale = (configuration: TypeScriptServiceConfiguration): string | undefined =>
+	(configuration.locale
+		? configuration.locale
+		: env.language);

--- a/extensions/typescript/src/utils/api.ts
+++ b/extensions/typescript/src/utils/api.ts
@@ -69,4 +69,8 @@ export default class API {
 	public has250Features(): boolean {
 		return semver.gte(this.version, '2.5.0');
 	}
+
+	public has260Features(): boolean {
+		return semver.gte(this.version, '2.6.0');
+	}
 }

--- a/extensions/typescript/src/utils/configuration.ts
+++ b/extensions/typescript/src/utils/configuration.ts
@@ -42,6 +42,7 @@ export namespace TsServerLogLevel {
 }
 
 export class TypeScriptServiceConfiguration {
+	public readonly locale: string | null;
 	public readonly globalTsdk: string | null;
 	public readonly localTsdk: string | null;
 	public readonly npmLocation: string | null;
@@ -56,6 +57,7 @@ export class TypeScriptServiceConfiguration {
 	private constructor() {
 		const configuration = workspace.getConfiguration();
 
+		this.locale = TypeScriptServiceConfiguration.extractLocale(configuration);
 		this.globalTsdk = TypeScriptServiceConfiguration.extractGlobalTsdk(configuration);
 		this.localTsdk = TypeScriptServiceConfiguration.extractLocalTsdk(configuration);
 		this.npmLocation = TypeScriptServiceConfiguration.readNpmLocation(configuration);
@@ -65,7 +67,8 @@ export class TypeScriptServiceConfiguration {
 	}
 
 	public isEqualTo(other: TypeScriptServiceConfiguration): boolean {
-		return this.globalTsdk === other.globalTsdk
+		return this.locale === other.locale
+			&& this.globalTsdk === other.globalTsdk
 			&& this.localTsdk === other.localTsdk
 			&& this.npmLocation === other.npmLocation
 			&& this.tsServerLogLevel === other.tsServerLogLevel
@@ -104,5 +107,9 @@ export class TypeScriptServiceConfiguration {
 
 	private static readDisableAutomaticTypeAcquisition(configuration: WorkspaceConfiguration): boolean {
 		return configuration.get<boolean>('typescript.disableAutomaticTypeAcquisition', false);
+	}
+
+	private static extractLocale(configuration: WorkspaceConfiguration): string | null {
+		return configuration.get<string | null>('typescript.locale', null);
 	}
 }


### PR DESCRIPTION
Will wait on https://github.com/Microsoft/TypeScript/issues/19270 before merging this

Also need to check it will not break ts 2.6 builds without `--locale` support

Fixes #18634