### PR TITLE
Only restore expansion state when there are items.

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugViews.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugViews.ts
@@ -47,6 +47,7 @@ export class VariablesView extends ViewsViewletPanel {
 	private onFocusStackFrameScheduler: RunOnceScheduler;
 	private variablesFocusedContext: IContextKey<boolean>;
 	private settings: any;
+	private expandedElements: any[];
 
 	constructor(
 		private options: IViewletViewOptions,
@@ -63,14 +64,18 @@ export class VariablesView extends ViewsViewletPanel {
 
 		this.settings = options.viewletSettings;
 		this.variablesFocusedContext = CONTEXT_VARIABLES_FOCUSED.bindTo(contextKeyService);
+		this.expandedElements = [];
 		// Use scheduler to prevent unnecessary flashing
 		this.onFocusStackFrameScheduler = new RunOnceScheduler(() => {
+			// Remember expanded elements when there are some (otherwise don't override/erase the previous ones)
+			if (this.tree.getExpandedElements().length > 0) {
+				this.expandedElements = this.tree.getExpandedElements();
+			}
 			// Always clear tree highlight to avoid ending up in a broken state #12203
 			this.tree.clearHighlight();
-			const expanded = this.tree.getExpandedElements();
 			this.tree.refresh().then(() => {
 				const stackFrame = this.debugService.getViewModel().focusedStackFrame;
-				return sequence(expanded.map(e => () => this.tree.expand(e))).then(() => {
+				return sequence(this.expandedElements.map(e => () => this.tree.expand(e))).then(() => {
 					// If there is no preserved expansion state simply expand the first scope
 					if (stackFrame && this.tree.getExpandedElements().length === 0) {
 						return stackFrame.getScopes().then(scopes => {


### PR DESCRIPTION
This modifies the change for #16031 to prevent the tree from collapsing
in case a debugger needs more time providing content.