### PR TITLE
Fixes #36544.

### DIFF
--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -572,15 +572,16 @@ export class HistoryService extends BaseHistoryService implements IHistoryServic
 				this.stack = this.stack.slice(0, this.index + 1);
 			}
 
-			this.setIndex(this.index + 1);
-			this.stack.splice(this.index, 0, entry);
+			this.stack.splice(this.index + 1, 0, entry);
 
 			// Check for limit
 			if (this.stack.length > HistoryService.MAX_STACK_ITEMS) {
 				this.stack.shift(); // remove first and dispose
-				if (this.index > 0) {
-					this.setIndex(this.index - 1);
+				if (this.lastIndex >= 0) {
+					this.lastIndex--;
 				}
+			} else {
+				this.setIndex(this.index + 1);
 			}
 		}
 


### PR DESCRIPTION
This was definitely a bug in my "Go Last" implementation, but it was only exposed by using 499086dc20d4a7dd978f97ddbe5821da38aa0e85 (and/also 273dbee) which made more aggressive use of the `addOrReplaceInStack` method.

The problem is that when the navigation stack is full, the array is shifted over and indexes are patched up. This can result with a lastIndex that exceeds the length of the array, since `setIndex` was being called twice during the patch up with inconsistent array lengths. The fix is to only call setIndex once, after the length is corrected. This also fixes a bug in "Go Last" where the "last" position is wrong if it's not `this.stack.length - 1` after the history buffer fills up. To fix that, we slide the `lastIndex` over along with the array unshift. If the last index falls off the left side of the array, it will be -1, which is already handled by `last()` to fallback to the behavior of `back()`.