### PR TITLE
deco: Fix link tooltip hover message #36683

### DIFF
--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -40,8 +40,18 @@ const HOVER_MESSAGE_COMMAND_META = new MarkdownString().appendText(
 		: nls.localize('links.command', "Ctrl + click to execute command")
 );
 
-const HOVER_MESSAGE_GENERAL_ALT = new MarkdownString().appendText(nls.localize('links.navigate.al', "Alt + click to follow link"));
-const HOVER_MESSAGE_COMMAND_ALT = new MarkdownString().appendText(nls.localize('links.command.al', "Alt + click to execute command"));
+const HOVER_MESSAGE_GENERAL_ALT = new MarkdownString().appendText(
+	platform.isMacintosh
+		? nls.localize('links.navigate.al.mac', "Cmd + Alt + click to follow link")
+		: nls.localize('links.navigate.al', "Ctrl + Alt + click to follow link")
+);
+
+const HOVER_MESSAGE_COMMAND_ALT = new MarkdownString().appendText(
+	platform.isMacintosh
+		? nls.localize('links.command.al.mac', "Cmd + Alt + click to execute command")
+		: nls.localize('links.command.al', "Ctrl + Alt + click to execute command")
+);
+
 
 const decoration = {
 	meta: ModelDecorationOptions.register({

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
@@ -178,11 +178,14 @@ export class TerminalLinkHandler {
 
 	private _getLinkHoverString(): string {
 		const editorConf = this._configurationService.getConfiguration<{ multiCursorModifier: 'ctrlCmd' | 'alt' }>('editor');
+		if (platform.isMacintosh) {
+			if (editorConf.multiCursorModifier === 'ctrlCmd') {
+				return nls.localize('terminalLinkHandler.followLinkAltMac', 'Cmd + Alt + click to follow link');
+			}
+			return nls.localize('terminalLinkHandler.followLinkCmd', 'Cmd + click to follow link');
+		}
 		if (editorConf.multiCursorModifier === 'ctrlCmd') {
 			return nls.localize('terminalLinkHandler.followLinkAlt', 'Alt + click to follow link');
-		}
-		if (platform.isMacintosh) {
-			return nls.localize('terminalLinkHandler.followLinkCmd', 'Cmd + click to follow link');
 		}
 		return nls.localize('terminalLinkHandler.followLinkCtrl', 'Ctrl + click to follow link');
 	}


### PR DESCRIPTION
This pull request provides users on linux and mac who have enabled "editor.multiCursorModifier": "ctrlCmd" with the correct hyperlink or command tooltip text.

New localization key "links.navigate.al.mac" and "terminalLinkHandler.followLinkAltMac" are added, however I would suggest renaming them.