### PR TITLE
Fixed typos

### DIFF
--- a/extensions/typescript/syntaxes/Readme.md
+++ b/extensions/typescript/syntaxes/Readme.md
@@ -7,7 +7,7 @@ To update to the latest version:
 Migration notes and todos:
 
 - differentiate variable and function declarations from references
-	- I suggest we use a new scope segment 'function-call' to sigmal a function references, and 'definition' to the declaration. Alternative is to use 'support.function' everywhere.
+  - I suggest we use a new scope segment 'function-call' to signal a function reference, and 'definition' to the declaration. An alternative is to use 'support.function' everywhere.
   - I suggest we use a new scope segment 'definition' to the variable declarations. Haven't yet found a scope for references that other grammars use.
 
 - rename scope to return.type to return-type, which is already used in other grammars


### PR DESCRIPTION
Fixed typos in [Readme.md](../blob/master/extensions/typescript/syntaxes/Readme.md):
`to sigmal a function references` => `to signal a function reference`
`Alternative is to...` => `An alternative is to...`