### PR TITLE
fixes #36854 folder picker api

### DIFF
--- a/src/vs/workbench/api/node/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/node/extHostQuickOpen.ts
@@ -128,12 +128,12 @@ export class ExtHostQuickOpen implements ExtHostQuickOpenShape {
 	// ---- workspace folder picker
 
 	showWorkspaceFolderPick(options?: WorkspaceFolderPickOptions, token = CancellationToken.None): Thenable<WorkspaceFolder> {
-		return this._commands.executeCommand('_workbench.pickWorkspaceFolder', [options]).then((folder: WorkspaceFolder) => {
-			if (!folder) {
+		return this._commands.executeCommand('_workbench.pickWorkspaceFolder', [options]).then((selectedFolder: WorkspaceFolder) => {
+			if (!selectedFolder) {
 				return undefined;
 			}
 
-			return this._workspace.getWorkspaceFolders().filter(folder => folder.uri.toString() === folder.uri.toString())[0];
+			return this._workspace.getWorkspaceFolders().filter(folder => folder.uri.toString() === selectedFolder.uri.toString())[0];
 		});
 	}
 }


### PR DESCRIPTION
fixes https://github.com/Microsoft/vscode/issues/36854
Rename variable to ensure inner filter function doesn't use same parameter name as existing outer variable name.