### PR TITLE
Fix windowOpenNoOpener not opening new window

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1063,9 +1063,5 @@ export function computeScreenAwareSize(cssPx: number): number {
  * See https://mathiasbynens.github.io/rel-noopener/
  */
 export function windowOpenNoOpener(url: string): void {
-	let newTab = window.open();
-	if (newTab) {
-		newTab.opener = null;
-		newTab.location.href = url;
-	}
+	window.open(url, '_blank', 'noopener');
 }

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import * as platform from 'vs/base/common/platform';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { TimeoutTimer } from 'vs/base/common/async';
 import { onUnexpectedError } from 'vs/base/common/errors';
@@ -1063,5 +1064,14 @@ export function computeScreenAwareSize(cssPx: number): number {
  * See https://mathiasbynens.github.io/rel-noopener/
  */
 export function windowOpenNoOpener(url: string): void {
-	window.open(url, '_blank', 'noopener');
+	if (platform.isNative) {
+		// In VSCode, window.open() always returns null...
+		window.open(url);
+	} else {
+		let newTab = window.open();
+		if (newTab) {
+			newTab.opener = null;
+			newTab.location.href = url;
+		}
+	}
 }


### PR DESCRIPTION
Fix `newTab` returning `null` and not opening new window in [`windowOpenNoOpener`](https://github.com/Microsoft/vscode/blob/914c81ec277b4eaad1ef1e9df8af062d6cc497d9/src/vs/base/browser/dom.ts#L1066)
Encountered while testing PR #36795
@alexandrudima It would be best if you could take a look since it seems that this code was introduced on the commit 914c81ec277b4eaad1ef1e9df8af062d6cc497d9
Thank you :)