### PR TITLE
Remove onCommand:type from activation events

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -15,7 +15,6 @@
         "url": "https://github.com/Microsoft/vscode-emmet"
     },
     "activationEvents": [
-        "onCommand:type",
         "onCommand:emmet.expandAbbreviation",
         "onLanguage:html",
         "onLanguage:css",


### PR DESCRIPTION
Addresses #36575

Activating `"onCommand:type"` means that all typing in any editor will wait for emmet to activate before proceeding. I suggest emmet removes this activation event. If this doesn't work, activating on `*` is actually better than on `onCommand:type`. `onCommand:type` should be something used by the vim extension which literally wants to block all editor input until it comes up.