### PR TITLE
Call shellscript files just "Shell Script"

### DIFF
--- a/extensions/shellscript/syntaxes/Shell-Unix-Bash.tmLanguage.json
+++ b/extensions/shellscript/syntaxes/Shell-Unix-Bash.tmLanguage.json
@@ -18,7 +18,7 @@
 	],
 	"firstLineMatch": "^#!.*\\b(bash|zsh|sh|tcsh)|^#.*-\\*-.*\\bshell-script\\b.*-\\*-",
 	"keyEquivalent": "^~S",
-	"name": "Shell Script (Bash)",
+	"name": "Shell Script",
 	"patterns": [
 		{
 			"include": "#comment"


### PR DESCRIPTION
Currently VSCode displays filetype "Shell Script (Bash)" for all shell script files, including ones that are quite obviously not Bash or even Bash-compatible. Change the UI text to just "Shell Script" to be more accurate.

Here's what the footer looks like when editing `.zshrc`:
![Image of footer when editing .zshrc. Includes text "Shell Script (Bash)"](https://i.imgur.com/dRglsPd.png)