### PR TITLE
Add character countdown to commit message input

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -484,6 +484,7 @@ export class Repository implements Disposable {
 		this._sourceControl.inputBox.placeholder = localize('commitMessage', "Message (press {0} to commit)");
 		this._sourceControl.acceptInputCommand = { command: 'git.commitWithInput', title: localize('commit', "Commit"), arguments: [this._sourceControl] };
 		this._sourceControl.quickDiffProvider = this;
+		this._sourceControl.inputBox.warningLength = 72;
 		this.disposables.push(this._sourceControl);
 
 		this._mergeGroup = this._sourceControl.createResourceGroup('merge', localize('merge changes', "Merge Changes"));

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5782,6 +5782,11 @@ declare module 'vscode' {
 		 * A string to show as place holder in the input box to guide the user.
 		 */
 		placeholder: string;
+
+		/**
+		 * The warning threshold for commit messages.
+		 */
+		warningLength: number | undefined;
 	}
 
 	interface QuickDiffProvider {

--- a/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSCM.ts
@@ -391,4 +391,14 @@ export class MainThreadSCM implements MainThreadSCMShape {
 
 		repository.input.placeholder = placeholder;
 	}
+
+	$setWarningLength(sourceControlHandle: number, warningLength: number): void {
+		const repository = this._repositories[sourceControlHandle];
+
+		if (!repository) {
+			return;
+		}
+
+		repository.input.warningLength = warningLength;
+	}
 }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -410,6 +410,7 @@ export interface MainThreadSCMShape extends IDisposable {
 
 	$setInputBoxValue(sourceControlHandle: number, value: string): void;
 	$setInputBoxPlaceholder(sourceControlHandle: number, placeholder: string): void;
+	$setWarningLength(sourceControlHandle: number, warningLength: number): void;
 }
 
 export type DebugSessionUUID = string;

--- a/src/vs/workbench/api/node/extHostSCM.ts
+++ b/src/vs/workbench/api/node/extHostSCM.ts
@@ -110,7 +110,7 @@ function compareResourceStates(a: vscode.SourceControlResourceState, b: vscode.S
 	return result;
 }
 
-export class ExtHostSCMInputBox {
+export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
 
 	private _value: string = '';
 
@@ -138,6 +138,17 @@ export class ExtHostSCMInputBox {
 	set placeholder(placeholder: string) {
 		this._proxy.$setInputBoxPlaceholder(this._sourceControlHandle, placeholder);
 		this._placeholder = placeholder;
+	}
+
+	private _warningLength: number | undefined;
+
+	get warningLength(): number | undefined {
+		return this._warningLength;
+	}
+
+	set warningLength(warningLength: number) {
+		this._proxy.$setWarningLength(this._sourceControlHandle, warningLength);
+		this._warningLength = warningLength;
 	}
 
 	constructor(private _proxy: MainThreadSCMShape, private _sourceControlHandle: number) {

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -45,7 +45,7 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IExtensionsViewlet, VIEWLET_ID as EXTENSIONS_VIEWLET_ID } from 'vs/workbench/parts/extensions/common/extensions';
-import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
+import { InputBox, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { Command } from 'vs/editor/common/modes';
@@ -753,7 +753,21 @@ export class RepositoryPanel extends ViewletPanel {
 			this.inputBox.setPlaceHolder(placeholder);
 		};
 
-		this.inputBox = new InputBox(this.inputBoxContainer, this.contextViewService, { flexibleHeight: true });
+		this.inputBox = new InputBox(this.inputBoxContainer, this.contextViewService, {
+			flexibleHeight: true,
+			validationOptions: {
+				validation: (text: string) => {
+					const charactersLeft = 72 - text.length;
+					if (text.length > 72) {
+						return { content: `${charactersLeft} characters left`, type: MessageType.ERROR };
+					} else if (text.length > 55) {
+						return { content: `${charactersLeft} characters left`, type: MessageType.WARNING };
+					} else {
+						return { content: `${charactersLeft} characters left`, type: MessageType.INFO };
+					}
+				}
+			}
+		});
 		this.disposables.push(attachInputBoxStyler(this.inputBox, this.themeService));
 		this.disposables.push(this.inputBox);
 

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -45,7 +45,7 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IExtensionsViewlet, VIEWLET_ID as EXTENSIONS_VIEWLET_ID } from 'vs/workbench/parts/extensions/common/extensions';
-import { InputBox, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
+import { IMessage, InputBox, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { Command } from 'vs/editor/common/modes';
@@ -753,20 +753,32 @@ export class RepositoryPanel extends ViewletPanel {
 			this.inputBox.setPlaceHolder(placeholder);
 		};
 
+		const validation = (text: string): IMessage => {
+			const warningLength = this.repository.input.warningLength;
+			if (warningLength === undefined) {
+				return {
+					content: localize('commitMessageInfo', "{0} characters", text.length),
+					type: MessageType.INFO
+				};
+			}
+
+			const charactersLeft = warningLength - text.length;
+			if (charactersLeft > 0) {
+				return {
+					content: localize('commitMessageCountdown', "{0} characters left", text.length),
+					type: MessageType.INFO
+				};
+			} else {
+				return {
+					content: localize('commitMessageWarning', "{0} characters over", text.length),
+					type: MessageType.WARNING
+				};
+			}
+		};
+
 		this.inputBox = new InputBox(this.inputBoxContainer, this.contextViewService, {
 			flexibleHeight: true,
-			validationOptions: {
-				validation: (text: string) => {
-					const charactersLeft = 72 - text.length;
-					if (text.length > 72) {
-						return { content: `${charactersLeft} characters left`, type: MessageType.ERROR };
-					} else if (text.length > 55) {
-						return { content: `${charactersLeft} characters left`, type: MessageType.WARNING };
-					} else {
-						return { content: `${charactersLeft} characters left`, type: MessageType.INFO };
-					}
-				}
-			}
+			validationOptions: { validation: validation }
 		});
 		this.disposables.push(attachInputBoxStyler(this.inputBox, this.themeService));
 		this.disposables.push(this.inputBox);

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -74,6 +74,8 @@ export interface ISCMInput {
 
 	placeholder: string;
 	readonly onDidChangePlaceholder: Event<string>;
+
+	warningLength: number | undefined;
 }
 
 export interface ISCMRepository extends IDisposable {

--- a/src/vs/workbench/services/scm/common/scmService.ts
+++ b/src/vs/workbench/services/scm/common/scmService.ts
@@ -39,6 +39,16 @@ class SCMInput implements ISCMInput {
 
 	private _onDidChangePlaceholder = new Emitter<string>();
 	get onDidChangePlaceholder(): Event<string> { return this._onDidChangePlaceholder.event; }
+
+	private _warningLength: number | undefined;
+
+	get warningLength(): number | undefined {
+		return this._warningLength;
+	}
+
+	set warningLength(warningLength: number) {
+		this._warningLength = warningLength;
+	}
 }
 
 class SCMRepository implements ISCMRepository {


### PR DESCRIPTION
See #21144.

I miss warnings against long commit messages. I like Atom’s way of showing a persistent character countdown. It’s subtle and easy to ignore.

![31976595-0f44f22e-b96b-11e7-9519-5fbe554a2818](https://user-images.githubusercontent.com/4433966/31994603-d055b672-b9b3-11e7-8484-037cd7c55cc2.png)

Knocked something up quickly using `InputBox`’s built-in validation box.

![thvugwdgsf](https://user-images.githubusercontent.com/4433966/31993829-06bb7948-b9b1-11e7-829d-f2175261c02e.gif)

Haven’t put much thought into the UI. Happy to hear more ideas!