### PR TITLE
Fix #36924. PowerShell Extension Comment Highlighting Error

### DIFF
--- a/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
+++ b/extensions/powershell/syntaxes/PowershellSyntax.tmLanguage
@@ -45,7 +45,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;![\\-])#</string>
+			<string>(?&lt;![`\\-])#</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>


### PR DESCRIPTION
Fixes issue #36924 to correct a comment highlighting error in the PowerShell extension. Now when the `#` is escaped with a backtick, therefore not creating a comment, the remainder of the line will not be highlighted as though it were a comment.

# Code to reproduce
```
(($message.description | Select-Object -ExpandProperty `#cdata-section) -replace '(<\/*\w+?>){1,}','').trim()
```

# Result before applying this change
![image](https://user-images.githubusercontent.com/13203965/32015382-2e049fb2-b97e-11e7-9e04-bb61124a9013.png)
This line has incorrect syntax highlighting. The backtick should escape the `#` and negate the syntax highlighting that colors the remainder of the line green.

# Result after applying this change
![image](https://user-images.githubusercontent.com/13203965/32015529-981866fe-b97e-11e7-8a7b-66f5e4ab5aba.png)