### PR TITLE
Add unique build number per build to support fuzzy settings search

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -274,8 +274,9 @@ function packageTask(platform, arch, opts) {
 			.pipe(json({ name, version }));
 
 		const date = new Date().toISOString();
+		const buildNumber = getBuildNumber();
 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
-			.pipe(json({ commit, date, checksums }));
+			.pipe(json({ commit, date, checksums, buildNumber }));
 
 		const license = gulp.src(['LICENSES.chromium.html', 'LICENSE.txt', 'ThirdPartyNotices.txt', 'licenses/**'], { base: '.' });
 
@@ -465,9 +466,63 @@ gulp.task('upload-vscode-configuration', ['generate-vscode-configuration'], () =
 			account: process.env.AZURE_STORAGE_ACCOUNT,
 			key: process.env.AZURE_STORAGE_ACCESS_KEY,
 			container: 'configuration',
-			prefix: `${versionStringToNumber(packageJson.version)}/${commit}/`
+			prefix: `${getBuildNumber()}/${commit}/`
 		}));
 });
+
+function getBuildNumber() {
+	const previous = getPreviousVersion(packageJson.version);
+	try {
+		const out = cp.execSync(`git rev-list ${previous}..HEAD --count`);
+		const count = parseInt(out.toString());
+		return versionStringToNumber(packageJson.version) * 1e4 + count;
+	} catch (e) {
+		console.error('Could not determine build number: ' + e.toString());
+		return 0;
+	}
+}
+
+/**
+ * Given 1.17.2, return 1.17.1
+ * 1.18.0 => 1.17.2.
+ * 2.0.0 => 1.18.0 (or the highest 1.x)
+ */
+function getPreviousVersion(versionStr) {
+	function tagExists(tagName) {
+		try {
+			cp.execSync(`git rev-parse ${tagName}`);
+			return true;
+		} catch (e) {
+			return false;
+		}
+	}
+
+	function getLastTagFromBase(semverArr, componentToTest) {
+		if (!tagExists(semverArr.join('.'))) {
+			return null;
+		}
+
+		let goodTag;
+		do {
+			goodTag = semverArr.join('.');
+			semverArr[componentToTest]++;
+		} while (tagExists(semverArr.join('.')))
+
+		return goodTag;
+	}
+
+	const semverArr = versionStr.split('.');
+	if (semverArr[2] > 0) {
+		semverArr[2]--;
+		return semverArr.join('.');
+	} else if (semverArr[1] > 0) {
+		semverArr[1]--;
+		return getLastTagFromBase(semverArr, 2);
+	} else {
+		semverArr[0]--;
+		return getLastTagFromBase(semverArr, 1);
+	}
+}
 
 function versionStringToNumber(versionStr) {
 	const semverRegex = /(\d+)\.(\d+)\.(\d+)/;
@@ -476,7 +531,7 @@ function versionStringToNumber(versionStr) {
 		return 0;
 	}
 
-	return parseInt(match[1], 10) * 10000 + parseInt(match[2], 10) * 100 + parseInt(match[3], 10);
+	return parseInt(match[1], 10) * 1e4 + parseInt(match[2], 10) * 1e2 + parseInt(match[3], 10);
 }
 
 gulp.task('generate-vscode-configuration', () => {

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -461,6 +461,11 @@ gulp.task('upload-vscode-configuration', ['generate-vscode-configuration'], () =
 		return;
 	}
 
+	if (!buildNumber) {
+		console.error('Failed to compute build number');
+		return;
+	}
+
 	return gulp.src(allConfigDetailsPath)
 		.pipe(azure.upload({
 			account: process.env.AZURE_STORAGE_ACCOUNT,
@@ -472,6 +477,10 @@ gulp.task('upload-vscode-configuration', ['generate-vscode-configuration'], () =
 
 function getBuildNumber() {
 	const previous = getPreviousVersion(packageJson.version);
+	if (!previous) {
+		return 0;
+	}
+
 	try {
 		const out = cp.execSync(`git rev-list ${previous}..HEAD --count`);
 		const count = parseInt(out.toString());
@@ -498,7 +507,9 @@ function getPreviousVersion(versionStr) {
 	}
 
 	function getLastTagFromBase(semverArr, componentToTest) {
-		if (!tagExists(semverArr.join('.'))) {
+		const baseVersion = semverArr.join('.');
+		if (!tagExists(baseVersion)) {
+			console.error('Failed to find tag for base version, ' + baseVersion);
 			return null;
 		}
 

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -209,6 +209,7 @@ function computeChecksum(filename) {
 	return hash;
 }
 
+const buildNumber = getBuildNumber();
 function packageTask(platform, arch, opts) {
 	opts = opts || {};
 
@@ -274,7 +275,6 @@ function packageTask(platform, arch, opts) {
 			.pipe(json({ name, version }));
 
 		const date = new Date().toISOString();
-		const buildNumber = getBuildNumber();
 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
 			.pipe(json({ commit, date, checksums, buildNumber }));
 
@@ -466,7 +466,7 @@ gulp.task('upload-vscode-configuration', ['generate-vscode-configuration'], () =
 			account: process.env.AZURE_STORAGE_ACCOUNT,
 			key: process.env.AZURE_STORAGE_ACCESS_KEY,
 			container: 'configuration',
-			prefix: `${getBuildNumber()}/${commit}/`
+			prefix: `${buildNumber}/${commit}/`
 		}));
 });
 
@@ -506,7 +506,7 @@ function getPreviousVersion(versionStr) {
 		do {
 			goodTag = semverArr.join('.');
 			semverArr[componentToTest]++;
-		} while (tagExists(semverArr.join('.')))
+		} while (tagExists(semverArr.join('.')));
 
 		return goodTag;
 	}


### PR DESCRIPTION
@joaomoreno I wanted to give a heads up on this change.

I'm adding a new build number which is unique for the commit built. It's based on the version number (e.g. 1.18) and the number of commits since the last tag. So if this is 1.18 and there have been 532 commits since the 1.17.0 tag, the build number will be 11800532. It goes into the product.json and the exported settings file.

I'm adding it for a couple reasons. Previously we would treat any new 1.18.0 build as the latest authoritative set, and any 1.18.0 client would get settings from that build. Not usually a big problem since this would only affect people running old versions of insiders. But this lets us serve settings for the exact build.

It also gives the remote endpoint flexibility. For example if it indexes a new build, and there is some problem with the indexing process, we can disable that new build and serve settings from the previous new build.