### PR TITLE
git: Include GitErrorData in GitError.toString

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -251,7 +251,7 @@ export class GitError {
 			gitCommand: this.gitCommand,
 			stdout: this.stdout,
 			stderr: this.stderr
-		}, [], 2);
+		}, null, 2);
 
 		if (this.error) {
 			result += (<any>this.error).stack;


### PR DESCRIPTION
We are passing `GitErrorData` to `JSON.stringify` to include in the string
generated by `GitError.toString`. However, we set `replacer` to `[]` which
means `JSON.stringify` will _always_ serialize to `{ }`. After this change
`GitError` messages should be more understandable, and not just say `Failed to
execute git { }`.