### PR TITLE
git: Throw fetch error

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -626,11 +626,7 @@ export class Repository implements Disposable {
 
 	@throttle
 	async fetch(): Promise<void> {
-		try {
-			await this.run(Operation.Fetch, () => this.repository.fetch());
-		} catch (err) {
-			// noop
-		}
+		await this.run(Operation.Fetch, () => this.repository.fetch());
 	}
 
 	@throttle


### PR DESCRIPTION
The only place that calls `fetch` will handle the error correctly. So this should fix a bug were we don't disable autofetch when fetch fails due to auth issues.

https://github.com/Microsoft/vscode/blob/3f4bb73cb98e6b4dcd5da6ddff74024ce71bd493/extensions/git/src/autofetch.ts#L62-L68