### PR TITLE
Fix stray space in editor config

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -410,7 +410,7 @@ const editorConfiguration: IConfigurationNode = {
 		'editor.autoIndent': {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.autoIndent,
-			'description': nls.localize('autoIndent', "Controls if the editor should automatically adjust the indentation when users type, paste or move lines. Indentation rules of the language must be available. ")
+			'description': nls.localize('autoIndent', "Controls if the editor should automatically adjust the indentation when users type, paste or move lines. Indentation rules of the language must be available.")
 		},
 		'editor.suggestOnTriggerCharacters': {
 			'type': 'boolean',


### PR DESCRIPTION
This shows up as bright red on my screen:

![image](https://user-images.githubusercontent.com/551184/32080425-2505a670-ba75-11e7-9e12-e90b8bafde13.png)

(I've had the trailing-whitespace plugin ever since that eslint bug that made it stop detecting trailing whitespace.)

I hope this isn't too frivolous or something...