### PR TITLE
global is undefined while polyfilling the native promise

### DIFF
--- a/src/vs/editor/editor.main.ts
+++ b/src/vs/editor/editor.main.ts
@@ -19,6 +19,9 @@ import { createMonacoEditorAPI } from 'vs/editor/standalone/browser/standaloneEd
 import { createMonacoLanguagesAPI } from 'vs/editor/standalone/browser/standaloneLanguages';
 import { EDITOR_DEFAULTS, WrappingIndent } from 'vs/editor/common/config/editorOptions';
 
+var global: any = self;
+global.monaco = exports;
+
 // When missing, polyfill the native promise
 // with our winjs-based polyfill
 import { PolyfillPromise } from 'vs/base/common/winjs.polyfill.promise';
@@ -40,9 +43,6 @@ for (let prop in base) {
 }
 exports.editor = createMonacoEditorAPI();
 exports.languages = createMonacoLanguagesAPI();
-
-var global: any = self;
-global.monaco = exports;
 
 if (typeof global.require !== 'undefined' && typeof global.require.config === 'function') {
 	global.require.config({


### PR DESCRIPTION
For some reason,  I have to compile the monaco-editor by myself.
Recently I update the monaco and found that the editor crash while loading the monaco.
It seems that we need polyfill the `promise` after we set the `global`.

<img width="540" alt="2017-10-27 11 45 47" src="https://user-images.githubusercontent.com/12891758/32087135-6fa9c114-ba9f-11e7-83ca-030e75b18772.png">

