### PR TITLE
TSLint: Fixed Syntax Warning

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
 		"curly": true,
 		"class-name": true,
 		"semicolon": [
+			true,
 			"always"
 		],
 		"triple-equals": true,


### PR DESCRIPTION
Fixed incorrect syntax in the semicolon setting. TSlint does give a warning, if you set the set "always" as the first parameter. It expects a boolean as the first and "always" as the second.
More information you will find here: https://palantir.github.io/tslint/rules/semicolon/
![image](https://user-images.githubusercontent.com/17984549/32102486-d63aec1e-bb1c-11e7-809f-60795ba29b7f.png)
