### PR TITLE
Fix moveSelectionToPreviousFindMatch accidentally mapped to addSelectionToPreviousFindMatch

### DIFF
--- a/src/vs/editor/contrib/multicursor/common/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/common/multicursor.ts
@@ -457,7 +457,7 @@ export class MultiCursorSelectionController extends Disposable implements IEdito
 	public moveSelectionToPreviousFindMatch(findController: CommonFindController): void {
 		this._beginSessionIfNeeded(findController);
 		if (this._session) {
-			this._applySessionResult(this._session.addSelectionToPreviousFindMatch());
+			this._applySessionResult(this._session.moveSelectionToPreviousFindMatch());
 		}
 	}
 


### PR DESCRIPTION
Currently when moveSelectionToPreviousFindMatch executes, instead of moving the selection it actually adds to the selection.  This clearly is typo that accidentally snuck in with https://github.com/Microsoft/vscode/pull/36682

https://github.com/Microsoft/vscode/blob/d02a9cd78391205524889ce591e1a28d8928a2dd/src/vs/editor/contrib/multicursor/common/multicursor.ts#L471-L474

/cc @alexandrudima 