### PR TITLE
Fix incorrect tokenization of SCSS class extensions

### DIFF
--- a/extensions/scss/syntaxes/scss.json
+++ b/extensions/scss/syntaxes/scss.json
@@ -1712,7 +1712,7 @@
 			]
 		},
 		"variables": {
-			"match": "(\\$|\\-\\-)[A-Za-z0-9_-]+\\b",
+			"match": "(\\$|(?<!&)\\-\\-)[A-Za-z0-9_-]+\\b",
 			"name": "variable.scss"
 		}
 	}


### PR DESCRIPTION
In the snippet below, `--modifier` would be incorrectly tokenized as `variable.scss` since it begins with 2 (or more) hyphens.

```scss
.block {
    &__element {
    }
    &--modifier {
    }
}
```

Fix for #37444