### PR TITLE
Fix broken regex of OR condition for fold marker.

### DIFF
--- a/extensions/java/language-configuration.json
+++ b/extensions/java/language-configuration.json
@@ -26,8 +26,8 @@
 	],
 	"folding": {
 		"markers": {
-			"start": "^\\s*//\\s*(#?region\\b)|(<editor-fold\\b)",
-			"end": "^\\s*//\\s*(#?endregion\\b)|(</editor-fold>)"
+			"start": "^\\s*//\\s*(#?region\\b)",
+			"end": "^\\s*//\\s*(#?endregion\\b)"
 		}
 	}
 }


### PR DESCRIPTION
Fixed broken regex of OR condition for folding marker. Before the inner block in the example below would fold.
``` java
// #region hello!
public static void main(String[] args)
{
    System.out.println("<editor-fold>");
    System.out.println("Hello, world");
    System.out.println("</editor-fold>");
}
// #endregion
```
We should work on making **`{line-comment-leader}<editor-fold>`**  **`{line-comment-leader}</editor-fold>`**  more of a universal check/feature.