### PR TITLE
Fix OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - ./scripts/npm.sh install
 
 script:
-  - node_modules/.bin/gulp hygiene --silent
+  - node_modules/.bin/gulp hygiene
   - node_modules/.bin/gulp electron --silent
   - node_modules/.bin/gulp compile --silent --max_old_space_size=4096
   - node_modules/.bin/gulp optimize-vscode --silent --max_old_space_size=4096

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -256,8 +256,16 @@ const hygiene = exports.hygiene = (some, options) => {
 		.pipe(gulpeslint.formatEach('compact'))
 		.pipe(gulpeslint.failAfterError());
 
+	let count = 0;
 	return es.merge(typescript, javascript)
-		.pipe(es.through(null, function () {
+		.pipe(es.through(function (data) {
+			count++;
+			if (count % 10 === 0) {
+				process.stdout.write('.');
+			}
+			this.emit('data', data);
+		}, function () {
+			process.stdout.write('\n');
 			if (errorCount > 0) {
 				this.emit('error', 'Hygiene failed with ' + errorCount + ' errors. Check \'build/gulpfile.hygiene.js\'.');
 			} else {


### PR DESCRIPTION
I noticed Travis often fails on OSX because it doesn't receive output from `gulp hygiene` for a long time. This adds some small progress indication to keep the build alive.

![2017-11-02 4 17 48 pm](https://user-images.githubusercontent.com/10532611/32355564-a49bd0fe-bfec-11e7-9a87-0907885ae63c.gif)

![image](https://user-images.githubusercontent.com/10532611/32355576-b0a78e60-bfec-11e7-93d7-9aa5f02ad1ea.png)
