### PR TITLE
Make npm logs less verbose in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ before_install:
       sh -e /etc/init.d/xvfb start;
       sleep 3;
     fi
+  # Make npm logs less verbose
+  - npm config set depth 0
+  - npm config set loglevel warn
 
 install:
   - ./scripts/npm.sh install


### PR DESCRIPTION
This configures npm to not dump the full dependency tree for every `npm install`, but only the flat direct dependencies. It's impossible to fully disable the output in npm 4 (it's not printed by npm 5).

Before npm install caused >5000 log lines, which made Travis hang for multiple seconds while parsing the log in the browser. Now it's ~800, which makes the logs load significantly faster and makes Travis not hang.

Before:

![image](https://user-images.githubusercontent.com/10532611/32355845-73f1201a-bfee-11e7-9486-791b4090fd6b.png)


After:

![image](https://user-images.githubusercontent.com/10532611/32355830-5d76d6d6-bfee-11e7-95f9-a91532ec43ab.png)

This does not change any install behaviour.
