### PR TITLE
Support to report TS style checks as warnings

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -166,6 +166,12 @@
           "description": "%typescript.useCodeSnippetsOnMethodSuggest.dec%",
           "scope": "resource"
         },
+        "typescript.reportStyleChecksAsWarnings": {
+          "type": "boolean",
+          "default": true,
+          "description": "%typescript.reportStyleChecksAsWarnings%",
+          "scope": "window"
+        },
         "typescript.validate.enable": {
           "type": "boolean",
           "default": true,

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -34,6 +34,7 @@
 	"typescript.openTsServerLog.title": "Open TS Server log",
 	"typescript.restartTsServer": "Restart TS server",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version",
+	"typescript.reportStyleChecksAsWarnings": "Report style checks as warnings",
 	"jsDocCompletion.enabled": "Enable/disable auto JSDoc comments",
 	"javascript.implicitProjectConfig.checkJs": "Enable/disable semantic checking of JavaScript files. Existing jsconfig.json or tsconfig.json files override this setting. Requires TypeScript >=2.3.1.",
 	"typescript.npm": "Specifies the path to the NPM executable used for Automatic Type Acquisition. Requires TypeScript >= 2.3.4.",

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -425,11 +425,11 @@ class LanguageProvider {
 // Style check diagnostics that can be reported as warnings
 const styleCheckDiagnostics = [
 	6133, 	// variable is declared but never used
-	6138, 	// property is declared but is value is never read
+	6138, 	// property is declared but its value is never read
 	7027,	// unreachable code detected
 	7028,	// unused label
-	7029,	// fallthrough case in switch
-	7030	// not call code paths return a value
+	7029,	// fall through case in switch
+	7030	// not all code paths return a value
 ];
 
 class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {

--- a/extensions/typescript/src/typescriptMain.ts
+++ b/extensions/typescript/src/typescriptMain.ts
@@ -422,6 +422,16 @@ class LanguageProvider {
 	}
 }
 
+// Style check diagnostics that can be reported as warnings
+const styleCheckDiagnostics = [
+	6133, 	// variable is declared but never used
+	6138, 	// property is declared but is value is never read
+	7027,	// unreachable code detected
+	7028,	// unused label
+	7029,	// fallthrough case in switch
+	7030	// not call code paths return a value
+];
+
 class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	private client: TypeScriptServiceClient;
 	private languages: LanguageProvider[] = [];
@@ -701,6 +711,11 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 	}
 
 	private getDiagnosticSeverity(diagnostic: Proto.Diagnostic): DiagnosticSeverity {
+
+		if (this.reportStyleCheckAsWarnings() && this.isStyleCheckDiagnostic(diagnostic.code)) {
+			return DiagnosticSeverity.Warning;
+		}
+
 		switch (diagnostic.category) {
 			case PConst.DiagnosticCategory.error:
 				return DiagnosticSeverity.Error;
@@ -711,5 +726,14 @@ class TypeScriptServiceClientHost implements ITypescriptServiceClientHost {
 			default:
 				return DiagnosticSeverity.Error;
 		}
+	}
+
+	private isStyleCheckDiagnostic(code: number | undefined): boolean {
+		return code ? styleCheckDiagnostics.indexOf(code) !== -1 : false;
+	}
+
+	private reportStyleCheckAsWarnings() {
+		const config = workspace.getConfiguration('typescript');
+		return config.get('reportStyleChecksAsWarnings', true);
 	}
 }


### PR DESCRIPTION
This PR adds a setting `typescript.reportStyleChecksAsWarnings`. If the setting is true, then diagnostics created by the compiler options below are reported as warnings:

* `--noUnusedLocals`
* `--noUnusedParameters`
* `--noImplicitReturns`
* `--noFallthroughCasesInSwitch`
* `--allowUnusedLabels`
* `--allowUnreachableCode`

See also https://github.com/Microsoft/TypeScript/issues/13408