### PR TITLE
Fixing integrated terminal font-size overflow

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalConfigHelper.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalConfigHelper.ts
@@ -29,6 +29,7 @@ interface IFullTerminalConfiguration {
 const DEFAULT_LINE_HEIGHT = 1.0;
 
 const MINIMUM_FONT_SIZE = 6;
+const MAXIMUM_FONT_SIZE = 25;
 
 /**
  * Encapsulates terminal configuration logic, the primary purpose of this file is so that platform
@@ -101,7 +102,7 @@ export class TerminalConfigHelper implements ITerminalConfigHelper {
 			}
 		}
 
-		let fontSize = this._toInteger(terminalConfig.fontSize, MINIMUM_FONT_SIZE, EDITOR_FONT_DEFAULTS.fontSize);
+		let fontSize = this._toInteger(terminalConfig.fontSize, MINIMUM_FONT_SIZE, MAXIMUM_FONT_SIZE, EDITOR_FONT_DEFAULTS.fontSize);
 		const lineHeight = terminalConfig.lineHeight ? Math.max(terminalConfig.lineHeight, 1) : DEFAULT_LINE_HEIGHT;
 
 		if (excludeDimensions) {
@@ -179,13 +180,16 @@ export class TerminalConfigHelper implements ITerminalConfigHelper {
 		}
 	}
 
-	private _toInteger(source: any, minimum: number, fallback: number): number {
+	private _toInteger(source: any, minimum: number, maximum: number, fallback: number): number {
 		let r = parseInt(source, 10);
 		if (isNaN(r)) {
 			return fallback;
 		}
 		if (typeof minimum === 'number') {
 			r = Math.max(minimum, r);
+		}
+		if (typeof maximum === 'number') {
+			r = Math.min(maximum, r);
 		}
 		return r;
 	}


### PR DESCRIPTION
This puts a maximum limit to allowed font-size for integrated terminal in VSCode.

#### Checklist
- [x] No errors in build on local (```npm run watch```)
- [x] Tried putting large value such as ```"terminal.integrated.fontSize" : 1500``` in OSS Dev VSCode.


Fixes #37455 