### PR TITLE
Fix 37385 by introducing addition configuration setting

### DIFF
--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -50,7 +50,7 @@ export const INTERNAL_CONSOLE_OPTIONS_SCHEMA = {
 export const OPEN_DEBUG_OPTIONS_SCHEMA = {
 	enum: ['neverOpen', 'openOnSessionStart', 'openOnFirstSessionStart'],
 	default: 'openOnFirstSessionStart',
-	description: nls.localize('openDebugOnStart', "Controls whether debug viewlet should be open on debugging session start.")
+	description: nls.localize('openDebug', "Controls whether debug viewlet should be open on debugging session start.")
 };
 
 // raw
@@ -324,7 +324,7 @@ export enum State {
 
 export interface IDebugConfiguration {
 	allowBreakpointsEverywhere: boolean;
-	openDebugOnStart: string;
+	openDebug: string;
 	openExplorerOnEnd: boolean;
 	inlineValues: boolean;
 	hideActionBar: boolean;

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -47,10 +47,10 @@ export const INTERNAL_CONSOLE_OPTIONS_SCHEMA = {
 	default: 'openOnFirstSessionStart',
 	description: nls.localize('internalConsoleOptions', "Controls behavior of the internal debug console.")
 };
-export const DEBUG_VIEWLET_OPTIONS_SCHEMA = {
+export const OPEN_DEBUG_OPTIONS_SCHEMA = {
 	enum: ['neverOpen', 'openOnSessionStart', 'openOnFirstSessionStart'],
 	default: 'openOnFirstSessionStart',
-	description: nls.localize('debugViewletOptions', "Controls whether debug viewlet should be open on debugging session start.")
+	description: nls.localize('openDebugOnStart', "Controls whether debug viewlet should be open on debugging session start.")
 };
 
 // raw
@@ -324,11 +324,11 @@ export enum State {
 
 export interface IDebugConfiguration {
 	allowBreakpointsEverywhere: boolean;
+	openDebugOnStart: string;
 	openExplorerOnEnd: boolean;
 	inlineValues: boolean;
 	hideActionBar: boolean;
 	internalConsoleOptions: string;
-	debugViewletOptions: string;
 }
 
 export interface IGlobalConfig {
@@ -342,7 +342,6 @@ export interface IEnvConfig {
 	type: string;
 	request: string;
 	internalConsoleOptions?: string;
-	debugViewletOptions?: string;
 	preLaunchTask?: string;
 	__restart?: any;
 	__sessionId?: string;

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -47,6 +47,11 @@ export const INTERNAL_CONSOLE_OPTIONS_SCHEMA = {
 	default: 'openOnFirstSessionStart',
 	description: nls.localize('internalConsoleOptions', "Controls behavior of the internal debug console.")
 };
+export const DEBUG_VIEWLET_OPTIONS_SCHEMA = {
+	enum: ['neverOpen', 'openOnSessionStart', 'openOnFirstSessionStart'],
+	default: 'openOnFirstSessionStart',
+	description: nls.localize('debugViewletOptions', "Controls whether debug viewlet should be open on debugging session start.")
+};
 
 // raw
 
@@ -323,6 +328,7 @@ export interface IDebugConfiguration {
 	inlineValues: boolean;
 	hideActionBar: boolean;
 	internalConsoleOptions: string;
+	debugViewletOptions: string;
 }
 
 export interface IGlobalConfig {
@@ -336,6 +342,7 @@ export interface IEnvConfig {
 	type: string;
 	request: string;
 	internalConsoleOptions?: string;
+	debugViewletOptions?: string;
 	preLaunchTask?: string;
 	__restart?: any;
 	__sessionId?: string;

--- a/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
@@ -20,7 +20,7 @@ import { VariablesView, WatchExpressionsView, CallStackView, BreakpointsView } f
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import {
 	IDebugService, VIEWLET_ID, REPL_ID, CONTEXT_NOT_IN_DEBUG_MODE, CONTEXT_IN_DEBUG_MODE, INTERNAL_CONSOLE_OPTIONS_SCHEMA,
-	CONTEXT_DEBUG_STATE, VARIABLES_VIEW_ID, CALLSTACK_VIEW_ID, WATCH_VIEW_ID, BREAKPOINTS_VIEW_ID
+	CONTEXT_DEBUG_STATE, VARIABLES_VIEW_ID, CALLSTACK_VIEW_ID, WATCH_VIEW_ID, BREAKPOINTS_VIEW_ID, DEBUG_VIEWLET_OPTIONS_SCHEMA
 } from 'vs/workbench/parts/debug/common/debug';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
@@ -188,6 +188,7 @@ configurationRegistry.registerConfiguration({
 			default: false
 		},
 		'debug.internalConsoleOptions': INTERNAL_CONSOLE_OPTIONS_SCHEMA,
+		'debug.debugViewletOptions': DEBUG_VIEWLET_OPTIONS_SCHEMA,
 		'launch': {
 			type: 'object',
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces"),

--- a/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
@@ -20,7 +20,7 @@ import { VariablesView, WatchExpressionsView, CallStackView, BreakpointsView } f
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import {
 	IDebugService, VIEWLET_ID, REPL_ID, CONTEXT_NOT_IN_DEBUG_MODE, CONTEXT_IN_DEBUG_MODE, INTERNAL_CONSOLE_OPTIONS_SCHEMA,
-	CONTEXT_DEBUG_STATE, VARIABLES_VIEW_ID, CALLSTACK_VIEW_ID, WATCH_VIEW_ID, BREAKPOINTS_VIEW_ID, DEBUG_VIEWLET_OPTIONS_SCHEMA
+	CONTEXT_DEBUG_STATE, VARIABLES_VIEW_ID, CALLSTACK_VIEW_ID, WATCH_VIEW_ID, BREAKPOINTS_VIEW_ID, OPEN_DEBUG_OPTIONS_SCHEMA
 } from 'vs/workbench/parts/debug/common/debug';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
@@ -188,7 +188,7 @@ configurationRegistry.registerConfiguration({
 			default: false
 		},
 		'debug.internalConsoleOptions': INTERNAL_CONSOLE_OPTIONS_SCHEMA,
-		'debug.debugViewletOptions': DEBUG_VIEWLET_OPTIONS_SCHEMA,
+		'debug.openDebugOnStart': OPEN_DEBUG_OPTIONS_SCHEMA,
 		'launch': {
 			type: 'object',
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces"),

--- a/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
@@ -188,7 +188,7 @@ configurationRegistry.registerConfiguration({
 			default: false
 		},
 		'debug.internalConsoleOptions': INTERNAL_CONSOLE_OPTIONS_SCHEMA,
-		'debug.openDebugOnStart': OPEN_DEBUG_OPTIONS_SCHEMA,
+		'debug.openDebug': OPEN_DEBUG_OPTIONS_SCHEMA,
 		'launch': {
 			type: 'object',
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces"),

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -876,7 +876,7 @@ export class DebugService implements debug.IDebugService {
 				// Open debug viewlet based on the visibility of the side bar and debugViewletOptions setting
 				if ((this.partService.isVisible(Parts.SIDEBAR_PART) || this.contextService.getWorkbenchState() === WorkbenchState.EMPTY)
 					&& ((debugViewletOptions === 'openOnSessionStart')
-						|| ((debugViewletOptions === 'openOnFirstSessionStart' && !this.viewModel.changedWorkbenchViewState)) {
+						|| (debugViewletOptions === 'openOnFirstSessionStart' && !this.viewModel.changedWorkbenchViewState))) {
 					this.viewModel.changedWorkbenchViewState = true;
 					this.viewletService.openViewlet(debug.VIEWLET_ID);
 				}

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -872,11 +872,11 @@ export class DebugService implements debug.IDebugService {
 					this.panelService.openPanel(debug.REPL_ID, false).done(undefined, errors.onUnexpectedError);
 				}
 
-				const debugViewletOptions = configuration.debugViewletOptions || this.configurationService.getConfiguration<debug.IDebugConfiguration>('debug').debugViewletOptions;
-				// Open debug viewlet based on the visibility of the side bar and debugViewletOptions setting
+				const openDebugOptions = this.configurationService.getConfiguration<debug.IDebugConfiguration>('debug').openDebugOnStart;
+				// Open debug viewlet based on the visibility of the side bar and openDebugOnStart setting
 				if ((this.partService.isVisible(Parts.SIDEBAR_PART) || this.contextService.getWorkbenchState() === WorkbenchState.EMPTY)
-					&& ((debugViewletOptions === 'openOnSessionStart')
-						|| (debugViewletOptions === 'openOnFirstSessionStart' && !this.viewModel.changedWorkbenchViewState))) {
+					&& ((openDebugOptions === 'openOnSessionStart')
+						|| (openDebugOptions === 'openOnFirstSessionStart' && !this.viewModel.changedWorkbenchViewState))) {
 					this.viewModel.changedWorkbenchViewState = true;
 					this.viewletService.openViewlet(debug.VIEWLET_ID);
 				}

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -872,8 +872,8 @@ export class DebugService implements debug.IDebugService {
 					this.panelService.openPanel(debug.REPL_ID, false).done(undefined, errors.onUnexpectedError);
 				}
 
-				const openDebugOptions = this.configurationService.getConfiguration<debug.IDebugConfiguration>('debug').openDebugOnStart;
-				// Open debug viewlet based on the visibility of the side bar and openDebugOnStart setting
+				const openDebugOptions = this.configurationService.getConfiguration<debug.IDebugConfiguration>('debug').openDebug;
+				// Open debug viewlet based on the visibility of the side bar and openDebug setting
 				if ((this.partService.isVisible(Parts.SIDEBAR_PART) || this.contextService.getWorkbenchState() === WorkbenchState.EMPTY)
 					&& ((openDebugOptions === 'openOnSessionStart')
 						|| (openDebugOptions === 'openOnFirstSessionStart' && !this.viewModel.changedWorkbenchViewState))) {

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -872,8 +872,11 @@ export class DebugService implements debug.IDebugService {
 					this.panelService.openPanel(debug.REPL_ID, false).done(undefined, errors.onUnexpectedError);
 				}
 
-				if (!this.viewModel.changedWorkbenchViewState && (this.partService.isVisible(Parts.SIDEBAR_PART) || this.contextService.getWorkbenchState() === WorkbenchState.EMPTY)) {
-					// We only want to change the workbench view state on the first debug session #5738 and if the side bar is not hidden
+				const debugViewletOptions = configuration.debugViewletOptions || this.configurationService.getConfiguration<debug.IDebugConfiguration>('debug').debugViewletOptions;
+				// Open debug viewlet based on the visibility of the side bar and debugViewletOptions setting
+				if ((this.partService.isVisible(Parts.SIDEBAR_PART) || this.contextService.getWorkbenchState() === WorkbenchState.EMPTY)
+					&& ((debugViewletOptions === 'openOnSessionStart')
+						|| ((debugViewletOptions === 'openOnFirstSessionStart' && !this.viewModel.changedWorkbenchViewState)) {
 					this.viewModel.changedWorkbenchViewState = true;
 					this.viewletService.openViewlet(debug.VIEWLET_ID);
 				}


### PR DESCRIPTION
Fixing the issue #37385
Adding configuration parameter that allows the user to control if s(he) wants to open debug viewlet on every debug session, on the first only or never.
