### PR TITLE
Emmet strict compile part 2

### DIFF
--- a/extensions/emmet/src/bufferStream.ts
+++ b/extensions/emmet/src/bufferStream.ts
@@ -20,11 +20,6 @@ export class DocumentStreamReader {
 	public pos: Position;
 	private _eol: string;
 
-	/**
-	 * @param  {TextDocument} buffer
-	 * @param  {Position}      pos
-	 * @param  {Range}        limit
-	 */
 	constructor(document: TextDocument, pos?: Position, limit?: Range) {
 
 		this.document = document;
@@ -35,9 +30,8 @@ export class DocumentStreamReader {
 
 	/**
 	 * Returns true only if the stream is at the end of the file.
-	 * @returns {Boolean}
 	 */
-	eof() {
+	eof(): boolean {
 		return this.pos.isAfterOrEqual(this._eof);
 	}
 

--- a/extensions/emmet/src/defaultCompletionProvider.ts
+++ b/extensions/emmet/src/defaultCompletionProvider.ts
@@ -52,15 +52,15 @@ export class DefaultCompletionItemProvider implements vscode.CompletionItemProvi
 			}
 		}
 
-		return noiseCheckPromise.then(noise => {
+		return noiseCheckPromise.then((noise): vscode.CompletionList | undefined => {
 			if (noise) {
 				return;
 			}
 
-			let result = helper.doComplete(document, position, syntax, getEmmetConfiguration(syntax));
+			let result = helper.doComplete(document, position, syntax, getEmmetConfiguration(syntax!));
 			let newItems: vscode.CompletionItem[] = [];
 			if (result && result.items) {
-				result.items.forEach(item => {
+				result.items.forEach((item: any) => {
 					let newItem = new vscode.CompletionItem(item.label);
 					newItem.documentation = item.documentation;
 					newItem.detail = item.detail;
@@ -78,7 +78,7 @@ export class DefaultCompletionItemProvider implements vscode.CompletionItemProvi
 				});
 			}
 
-			return Promise.resolve(new vscode.CompletionList(newItems, true));
+			return new vscode.CompletionList(newItems, true);
 		});
 	}
 
@@ -101,23 +101,24 @@ export class DefaultCompletionItemProvider implements vscode.CompletionItemProvi
 
 		if (!isStyleSheet(syntax)) {
 			const currentHtmlNode = <HtmlNode>currentNode;
-			if (currentHtmlNode
-				&& currentHtmlNode.close
-				&& getInnerRange(currentHtmlNode).contains(position)) {
-				if (currentHtmlNode.name === 'style') {
-					return 'css';
-				}
-				if (currentHtmlNode.name === 'script') {
-					if (currentHtmlNode.attributes
-						&& currentHtmlNode.attributes.some(x => x.name.toString() === 'type' && allowedMimeTypesInScriptTag.indexOf(x.value.toString()) > -1)) {
-						return syntax;
+			if (currentHtmlNode && currentHtmlNode.close) {
+				const innerRange = getInnerRange(currentHtmlNode);
+				if (innerRange && innerRange.contains(position)) {
+					if (currentHtmlNode.name === 'style') {
+						return 'css';
 					}
-					return;
+					if (currentHtmlNode.name === 'script') {
+						if (currentHtmlNode.attributes
+							&& currentHtmlNode.attributes.some(x => x.name.toString() === 'type' && allowedMimeTypesInScriptTag.indexOf(x.value.toString()) > -1)) {
+							return syntax;
+						}
+						return;
+					}
 				}
 			}
 		}
 
-		if (!isValidLocationForEmmetAbbreviation(currentNode, syntax, position)) {
+		if (!currentNode || !isValidLocationForEmmetAbbreviation(currentNode, syntax, position)) {
 			return;
 		}
 		return syntax;

--- a/extensions/emmet/src/extension.ts
+++ b/extensions/emmet/src/extension.ts
@@ -45,7 +45,11 @@ export function activate(context: vscode.ExtensionContext) {
 			return updateTag(inputTag);
 		}
 		return vscode.window.showInputBox({ prompt: 'Enter Tag' }).then(tagName => {
-			return updateTag(tagName);
+			if (tagName) {
+				const update = updateTag(tagName);
+				return update ? update : false;
+			}
+			return false;
 		});
 	}));
 
@@ -149,7 +153,10 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
 		}
 
 		if (languageMappingForCompletionProviders.has(language)) {
-			completionProvidersMapping.get(language).dispose();
+			const mapping = completionProvidersMapping.get(language);
+			if (mapping) {
+				mapping.dispose();
+			}
 			languageMappingForCompletionProviders.delete(language);
 			completionProvidersMapping.delete(language);
 		}

--- a/extensions/emmet/src/imageSizeHelper.ts
+++ b/extensions/emmet/src/imageSizeHelper.ts
@@ -61,10 +61,10 @@ function getImageSizeFromURL(urlStr: string) {
 		const getTransport = url.protocol === 'https:' ? https.get : http.get;
 
 		getTransport(url as any, resp => {
-			const chunks = [];
+			const chunks: Buffer[] = [];
 			let bufSize = 0;
 
-			const trySize = chunks => {
+			const trySize = (chunks: Buffer[]) => {
 				try {
 					const size = sizeOf(Buffer.concat(chunks, bufSize));
 					resp.removeListener('data', onData);
@@ -75,7 +75,7 @@ function getImageSizeFromURL(urlStr: string) {
 				}
 			};
 
-			const onData = chunk => {
+			const onData = (chunk: Buffer) => {
 				bufSize += chunk.length;
 				chunks.push(chunk);
 				trySize(chunks);

--- a/extensions/emmet/src/incrementDecrement.ts
+++ b/extensions/emmet/src/incrementDecrement.ts
@@ -11,14 +11,13 @@ const reNumber = /[0-9]/;
 
 /**
  * Incerement number under caret of given editor
- * @param  {Number}     delta
  */
-export function incrementDecrement(delta: number): Thenable<boolean> {
-	let editor = vscode.window.activeTextEditor;
-	if (!editor) {
+export function incrementDecrement(delta: number): Thenable<boolean> | undefined {
+	if (!vscode.window.activeTextEditor) {
 		vscode.window.showInformationMessage('No editor is active');
 		return;
 	}
+	const editor = vscode.window.activeTextEditor;
 
 	return editor.edit(editBuilder => {
 		editor.selections.forEach(selection => {
@@ -38,19 +37,16 @@ export function incrementDecrement(delta: number): Thenable<boolean> {
 /**
  * Updates given number with `delta` and returns string formatted according
  * to original string format
- * @param  {String} numString
- * @param  {Number} delta
- * @return {String}
  */
-export function update(numString, delta): string {
-	let m;
+export function update(numString: string, delta: number): string {
+	let m: RegExpMatchArray | null;
 	let decimals = (m = numString.match(/\.(\d+)$/)) ? m[1].length : 1;
 	let output = String((parseFloat(numString) + delta).toFixed(decimals)).replace(/\.0+$/, '');
 
 	if (m = numString.match(/^\-?(0\d+)/)) {
 		// padded number: preserve padding
 		output = output.replace(/^(\-?)(\d+)/, (str, minus, prefix) =>
-			minus + '0'.repeat(Math.max(0, m[1].length - prefix.length)) + prefix);
+			minus + '0'.repeat(Math.max(0, (m ? m[1].length : 0) - prefix.length)) + prefix);
 	}
 
 	if (/^\-?\./.test(numString)) {
@@ -63,11 +59,10 @@ export function update(numString, delta): string {
 
 /**
  * Locates number from given position in the document
- * @param  {document} Textdocument
- * @param  {Point}      pos
- * @return {Range}      Range of number or `undefined` if not found
+ *
+ * @return Range of number or `undefined` if not found
  */
-export function locate(document: vscode.TextDocument, pos: vscode.Position): vscode.Range {
+export function locate(document: vscode.TextDocument, pos: vscode.Position): vscode.Range | undefined {
 
 	const line = document.lineAt(pos.line).text;
 	let start = pos.character;
@@ -111,9 +106,7 @@ export function locate(document: vscode.TextDocument, pos: vscode.Position): vsc
 
 /**
  * Check if given string contains valid number
- * @param  {String}  str
- * @return {Boolean}
  */
-function isValidNumber(str): boolean {
-	return str && !isNaN(parseFloat(str));
+function isValidNumber(str: string): boolean {
+	return str ? !isNaN(parseFloat(str)) : false;
 }

--- a/extensions/emmet/src/locateFile.ts
+++ b/extensions/emmet/src/locateFile.ts
@@ -15,9 +15,8 @@ const reAbsolute = /^\/+/;
 /**
  * Locates given `filePath` on user’s file system and returns absolute path to it.
  * This method expects either URL, or relative/absolute path to resource
- * @param  {String} basePath Base path to use if filePath is not absoulte
- * @param  {String} filePath File to locate. 
- * @return {Promise}
+ * @param basePath Base path to use if filePath is not absoulte
+ * @param filePath File to locate.
  */
 export function locateFile(base: string, filePath: string): Promise<string> {
 	if (/^\w+:/.test(filePath)) {
@@ -34,26 +33,20 @@ export function locateFile(base: string, filePath: string): Promise<string> {
 
 /**
  * Resolves relative file path
- * @param  {TextEditor|String} base
- * @param  {String}            filePath
- * @return {Promise}
  */
-function resolveRelative(basePath, filePath): Promise<string> {
+function resolveRelative(basePath: string, filePath: string): Promise<string> {
 	return tryFile(path.resolve(basePath, filePath));
 }
 
 /**
  * Resolves absolute file path agaist given editor: tries to find file in every
  * parent of editor’s file
- * @param  {TextEditor|String} base
- * @param  {String}            filePath
- * @return {Promise}
  */
-function resolveAbsolute(basePath, filePath): Promise<string> {
+function resolveAbsolute(basePath: string, filePath: string): Promise<string> {
 	return new Promise((resolve, reject) => {
 		filePath = filePath.replace(reAbsolute, '');
 
-		const next = ctx => {
+		const next = (ctx: string) => {
 			tryFile(path.resolve(ctx, filePath))
 				.then(resolve, err => {
 					const dir = path.dirname(ctx);
@@ -71,10 +64,8 @@ function resolveAbsolute(basePath, filePath): Promise<string> {
 
 /**
  * Check if given file exists and it’s a file, not directory
- * @param  {String} file
- * @return {Promise}
  */
-function tryFile(file): Promise<string> {
+function tryFile(file: string): Promise<string> {
 	return new Promise((resolve, reject) => {
 		fs.stat(file, (err, stat) => {
 			if (err) {

--- a/extensions/emmet/src/matchTag.ts
+++ b/extensions/emmet/src/matchTag.ts
@@ -8,17 +8,17 @@ import { HtmlNode } from 'EmmetNode';
 import { getNode, parseDocument, validate } from './util';
 
 export function matchTag() {
-	let editor = vscode.window.activeTextEditor;
-	if (!validate(false)) {
+	if (!validate(false) || !vscode.window.activeTextEditor) {
 		return;
 	}
+	const editor = vscode.window.activeTextEditor;
 
 	let rootNode = <HtmlNode>parseDocument(editor.document);
 	if (!rootNode) {
 		return;
 	}
 
-	let updatedSelections = [];
+	let updatedSelections: vscode.Selection[] = [];
 	editor.selections.forEach(selection => {
 		let updatedSelection = getUpdatedSelections(editor, selection.start, rootNode);
 		if (updatedSelection) {
@@ -31,7 +31,7 @@ export function matchTag() {
 	}
 }
 
-function getUpdatedSelections(editor: vscode.TextEditor, position: vscode.Position, rootNode: HtmlNode): vscode.Selection {
+function getUpdatedSelections(editor: vscode.TextEditor, position: vscode.Position, rootNode: HtmlNode): vscode.Selection | undefined {
 	let currentNode = <HtmlNode>getNode(rootNode, position, true);
 	if (!currentNode) {
 		return;

--- a/extensions/emmet/src/mergeLines.ts
+++ b/extensions/emmet/src/mergeLines.ts
@@ -8,10 +8,11 @@ import { Node } from 'EmmetNode';
 import { getNode, parseDocument, validate } from './util';
 
 export function mergeLines() {
-	let editor = vscode.window.activeTextEditor;
-	if (!validate(false)) {
+	if (!validate(false) || !vscode.window.activeTextEditor) {
 		return;
 	}
+
+	const editor = vscode.window.activeTextEditor;
 
 	let rootNode = parseDocument(editor.document);
 	if (!rootNode) {
@@ -20,7 +21,7 @@ export function mergeLines() {
 
 	return editor.edit(editBuilder => {
 		editor.selections.reverse().forEach(selection => {
-			let textEdit = getRangesToReplace(editor.document, selection, rootNode);
+			let textEdit = getRangesToReplace(editor.document, selection, rootNode!);
 			if (textEdit) {
 				editBuilder.replace(textEdit.range, textEdit.newText);
 			}
@@ -28,9 +29,9 @@ export function mergeLines() {
 	});
 }
 
-function getRangesToReplace(document: vscode.TextDocument, selection: vscode.Selection, rootNode: Node): vscode.TextEdit {
-	let startNodeToUpdate: Node;
-	let endNodeToUpdate: Node;
+function getRangesToReplace(document: vscode.TextDocument, selection: vscode.Selection, rootNode: Node): vscode.TextEdit | undefined {
+	let startNodeToUpdate: Node | null;
+	let endNodeToUpdate: Node | null;
 
 	if (selection.isEmpty) {
 		startNodeToUpdate = endNodeToUpdate = getNode(rootNode, selection.start);

--- a/extensions/emmet/src/reflectCssValue.ts
+++ b/extensions/emmet/src/reflectCssValue.ts
@@ -9,7 +9,7 @@ import { Property, Rule } from 'EmmetNode';
 
 const vendorPrefixes = ['-webkit-', '-moz-', '-ms-', '-o-', ''];
 
-export function reflectCssValue(): Thenable<boolean> {
+export function reflectCssValue(): Thenable<boolean> | undefined {
 	let editor = window.activeTextEditor;
 	if (!editor) {
 		window.showInformationMessage('No editor is active.');

--- a/extensions/emmet/src/removeTag.ts
+++ b/extensions/emmet/src/removeTag.ts
@@ -8,10 +8,10 @@ import { parseDocument, validate, getNode } from './util';
 import { HtmlNode } from 'EmmetNode';
 
 export function removeTag() {
-	let editor = vscode.window.activeTextEditor;
-	if (!validate(false)) {
+	if (!validate(false) || !vscode.window.activeTextEditor) {
 		return;
 	}
+	const editor = vscode.window.activeTextEditor;
 
 	let rootNode = <HtmlNode>parseDocument(editor.document);
 	if (!rootNode) {
@@ -23,7 +23,7 @@ export function removeTag() {
 		indentInSpaces += ' ';
 	}
 
-	let rangesToRemove = [];
+	let rangesToRemove: vscode.Range[] = [];
 	editor.selections.reverse().forEach(selection => {
 		rangesToRemove = rangesToRemove.concat(getRangeToRemove(editor, rootNode, selection, indentInSpaces));
 	});

--- a/extensions/emmet/src/selectItem.ts
+++ b/extensions/emmet/src/selectItem.ts
@@ -9,13 +9,13 @@ import { nextItemHTML, prevItemHTML } from './selectItemHTML';
 import { nextItemStylesheet, prevItemStylesheet } from './selectItemStylesheet';
 
 export function fetchSelectItem(direction: string): void {
-	let editor = vscode.window.activeTextEditor;
-	if (!validate()) {
+	if (!validate() || !vscode.window.activeTextEditor) {
 		return;
 	}
+	const editor = vscode.window.activeTextEditor;
 
-	let nextItem;
-	let prevItem;
+	let nextItem: any;
+	let prevItem: any;
 
 	if (isStyleSheet(editor.document.languageId)) {
 		nextItem = nextItemStylesheet;

--- a/extensions/emmet/src/selectItemStylesheet.ts
+++ b/extensions/emmet/src/selectItemStylesheet.ts
@@ -111,7 +111,7 @@ function getSelectionFromProperty(node: Node, document: vscode.TextDocument, sel
 		return new vscode.Selection(propertyNode.valueToken.start, propertyNode.valueToken.end);
 	}
 
-	let pos;
+	let pos: number = -1;
 	if (direction === 'prev') {
 		if (selectionStart.isEqual(propertyNode.valueToken.start)) {
 			return;


### PR DESCRIPTION
Continue moving emmet extension to strict mode. This change does the following:

- Remove jsdoc types. These are unused in ts files and can easily get out of date
- Annotate when something can return undefined
- Add null checks for when something can be undefined
- Add explicit types when something can be any
