### PR TITLE
Add logging snippets for Javascript & typescript

### DIFF
--- a/extensions/javascript/snippets/javascript.json
+++ b/extensions/javascript/snippets/javascript.json
@@ -160,5 +160,29 @@
 			"//#endregion"
 		],
 		"description": "Folding Region End"
+	},
+	"Log to the console": {
+		"prefix": "log",
+		"body": [
+			"console.log($1);",
+			"$0"
+		],
+		"description": "Log to the console"
+	},
+	"Log warning to console": {
+		"prefix": "warn",
+		"body": [
+			"console.warn($1);",
+			"$0"
+		],
+		"description": "Log warning to the console"
+	},
+	"Log error to console": {
+		"prefix": "error",
+		"body": [
+			"console.error($1);",
+			"$0"
+		],
+		"description": "Log error to the console"
 	}
 }

--- a/extensions/typescript/snippets/typescript.json
+++ b/extensions/typescript/snippets/typescript.json
@@ -70,6 +70,22 @@
 		],
 		"description": "Log to the console"
 	},
+	"Log warning to console": {
+		"prefix": "warn",
+		"body": [
+			"console.warn($1);",
+			"$0"
+		],
+		"description": "Log warning to the console"
+	},
+	"Log error to console": {
+		"prefix": "error",
+		"body": [
+			"console.error($1);",
+			"$0"
+		],
+		"description": "Log error to the console"
+	},
 	"Define a full property": {
 		"prefix": "prop",
 		"body": [


### PR DESCRIPTION
# Add logging snippets for Javascript & Typescript

This PR addresses https://github.com/Microsoft/vscode/issues/37839 😄 

## Context

One nifty set of snippets that I *do* miss from my time with Atom are the `log`, `warn` and `error` snippets for Javascript.

`log`  => `console.log()`
`warn` => `console.warn()`
`error` => `console.error()`

![atom-log-snippets](https://user-images.githubusercontent.com/6417910/32565352-d415fc7a-c4dc-11e7-84e6-aa07ffc9b905.gif)

## Changes

- Added new `log`, `warn` and `error` snippets to `extensions/javascript/snippets/javascript.json`
- Added new `warn` and `error` snippets to `extensions/typescript/snippets/typescript.json`

### After Changes

![code-logging-snippet](https://user-images.githubusercontent.com/6417910/32593266-4a6fd948-c54d-11e7-98b1-d8b1410a1306.gif)
