### PR TITLE
Don't prompt to save an untitled workspace with a single folder

### DIFF
--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -1364,6 +1364,11 @@ export class WindowsManager implements IWindowsMainService {
 			return; // Windows/Linux: quits when last window is closed, so do not ask then
 		}
 
+		if (windowClosing && this.workspacesService.resolveWorkspaceSync(workspace.configPath).folders.length <= 1) {
+			this.workspacesService.deleteUntitledWorkspaceSync(workspace);
+			return; // don't bother saving a workspace with only a single folder inside
+		}
+
 		// Handle untitled workspaces with prompt as needed
 		this.workspacesManager.promptToSaveUntitledWorkspace(e, workspace);
 	}


### PR DESCRIPTION
When closing a window (hitting the `x` button, not quitting), I find it annoying that I'm asked to save an untitled workspace that only has one folder. 

This PR changes this behavior to mirror the behavior in the single-folder mode. It'll skip prompting you if you're closing a window that has an untitled workspace with 1 or fewer folders inside of it.