### PR TITLE
Add firstline match for Makefile

### DIFF
--- a/extensions/make/package.json
+++ b/extensions/make/package.json
@@ -13,6 +13,7 @@
 			"aliases": ["Makefile", "makefile"],
 			"extensions": [ ".mk" ],
 			"filenames": [ "Makefile", "makefile", "GNUmakefile", "OCamlMakefile" ],
+      "firstLine": "^#!/usr/bin/make",
 			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{


### PR DESCRIPTION
Some makefiles don't have a file extension and are not named "*Makefile*" but have a shebang that can be used to identify it as a makefile. Example: `debian/rules` in all Debian packages.