### PR TITLE
Add cwd to createTerminal via TerminalOptions for extension API  Addresses: #37709

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4986,6 +4986,12 @@ declare module 'vscode' {
 		 * Args for the custom shell executable, this does not work on Windows (see #8429)
 		 */
 		shellArgs?: string[];
+
+		/**
+		 * A path for the current working directory to be used for the terminal.
+		 */
+		cwd?: string;
+
 		/**
 		 * Object with environment variables that will be added to the VS Code process.
 		 */

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -38,7 +38,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			name,
 			executable: shellPath,
 			args: shellArgs,
-			cwd: cwd,
+			cwd,
 			waitOnExit,
 			ignoreConfigurationCwd: true,
 			env

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -33,11 +33,12 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 		// when the extension host process goes down ?
 	}
 
-	public $createTerminal(name?: string, shellPath?: string, shellArgs?: string[], env?: { [key: string]: string }, waitOnExit?: boolean): TPromise<number> {
+	public $createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, env?: { [key: string]: string }, waitOnExit?: boolean): TPromise<number> {
 		const shellLaunchConfig: IShellLaunchConfig = {
 			name,
 			executable: shellPath,
 			args: shellArgs,
+			cwd: cwd,
 			waitOnExit,
 			ignoreConfigurationCwd: true,
 			env

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -296,7 +296,7 @@ export interface MainThreadProgressShape extends IDisposable {
 }
 
 export interface MainThreadTerminalServiceShape extends IDisposable {
-	$createTerminal(name?: string, shellPath?: string, shellArgs?: string[], env?: { [key: string]: string }, waitOnExit?: boolean): TPromise<number>;
+	$createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, env?: { [key: string]: string }, waitOnExit?: boolean): TPromise<number>;
 	$dispose(terminalId: number): void;
 	$hide(terminalId: number): void;
 	$sendText(terminalId: number, text: string, addNewLine: boolean): void;

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -24,6 +24,7 @@ export class ExtHostTerminal implements vscode.Terminal {
 		name?: string,
 		shellPath?: string,
 		shellArgs?: string[],
+		cwd?: string,
 		env?: { [key: string]: string },
 		waitOnExit?: boolean
 	) {
@@ -33,7 +34,8 @@ export class ExtHostTerminal implements vscode.Terminal {
 		this._pidPromise = new TPromise<number>(c => {
 			this._pidPromiseComplete = c;
 		});
-		this._proxy.$createTerminal(name, shellPath, shellArgs, env, waitOnExit).then((id) => {
+
+		this._proxy.$createTerminal(name, shellPath, shellArgs, cwd, env, waitOnExit).then((id) => {
 			this._id = id;
 			this._queuedRequests.forEach((r) => {
 				r.run(this._proxy, this._id);
@@ -114,7 +116,7 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 	}
 
 	public createTerminalFromOptions(options: vscode.TerminalOptions): vscode.Terminal {
-		let terminal = new ExtHostTerminal(this._proxy, options.name, options.shellPath, options.shellArgs, options.env/*, options.waitOnExit*/);
+		let terminal = new ExtHostTerminal(this._proxy, options.name, options.shellPath, options.shellArgs, options.cwd, options.env /*, options.waitOnExit*/);
 		this._terminals.push(terminal);
 		return terminal;
 	}


### PR DESCRIPTION
Adds an optional cwd argument to TerminalOptions for the extension API
to define the current working directory.  

Addresses: #37709