### PR TITLE
Fixes markdown link syntax highlighting bug

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -3266,7 +3266,6 @@
 					<string>(?x:
 						(\!\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])
 													# Match the link text.
-						([ ])?						# Space not allowed
 						(\()						# Opening paren for url
 							(&lt;?)(\S+?)(&gt;?)			# The url
 							[ \t]*					# Optional whitespace
@@ -3578,7 +3577,6 @@
 					<string>(?x:
 						(\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])
 													# Match the link text.
-						([ ])?						# Space not allowed
 						(\()						# Opening paren for url
 							(&lt;?)(.*?)(&gt;?)			# The url
 							[ \t]*					# Optional whitespace

--- a/extensions/markdown/syntaxes/markdown.tmLanguage.base
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage.base
@@ -756,7 +756,6 @@
 					<string>(?x:
 						(\!\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])
 													# Match the link text.
-						([ ])?						# Space not allowed
 						(\()						# Opening paren for url
 							(&lt;?)(\S+?)(&gt;?)			# The url
 							[ \t]*					# Optional whitespace
@@ -1068,7 +1067,6 @@
 					<string>(?x:
 						(\[)((?&lt;square&gt;[^\[\]\\]|\\.|\[\g&lt;square&gt;*+\])*+)(\])
 													# Match the link text.
-						([ ])?						# Space not allowed
 						(\()						# Opening paren for url
 							(&lt;?)(.*?)(&gt;?)			# The url
 							[ \t]*					# Optional whitespace


### PR DESCRIPTION
Fixes Issue: #38049 

Removed the optional space in regexp for the link markdown