### PR TITLE
Fixed cht translation for Node.js in about dialog

### DIFF
--- a/i18n/cht/src/vs/code/electron-main/menus.i18n.json
+++ b/i18n/cht/src/vs/code/electron-main/menus.i18n.json
@@ -184,6 +184,6 @@
 	"miDownloadingUpdate": "正在下載更新...",
 	"miInstallingUpdate": "正在安裝更新...",
 	"miCheckForUpdates": "查看是否有更新",
-	"aboutDetail": "\n版本 {0}\n認可 {1}\n日期 {2}\nShell {3}\n轉譯器 {4}\n節點 {5}\n架構 {6}",
+	"aboutDetail": "\n版本 {0}\n認可 {1}\n日期 {2}\nShell {3}\n轉譯器 {4}\nNode {5}\n架構 {6}",
 	"okButton": "確定"
 }


### PR DESCRIPTION
"Node" should not translated to "節點", since it is stand for "Node.js"
![photo_2017-11-15_00-08-28](https://user-images.githubusercontent.com/5138409/32790365-3356fde0-c999-11e7-9e0a-9276910c65a7.jpg)
