### PR TITLE
Fail the TravisCI build if a dependency isn't shrinkwrapped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_install:
 
 install:
   - ./scripts/npm.sh install
+  # Fail the build early if dependencies aren't shrinkwrapped correctly
+  - ./scripts/npm.sh ls --depth=Infinity
 
 script:
   - node_modules/.bin/gulp hygiene


### PR DESCRIPTION
I ran into an issue earlier that was ultimately caused by me forgetting to add new dependency to a `npm-shrinkwrap.json` file. Adding this line to the TravisCI build script marks the build as failed if someone forgets to do this in the future, so I thought it'd be useful for y'all as well. 