### PR TITLE
ensure all switch cases are handled

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -184,7 +184,7 @@ export class Resource implements SourceControlResourceState {
 		return { strikeThrough, faded, tooltip, light, dark, letter, color, source: 'git.resource' /*todo@joh*/ };
 	}
 
-	get letter(): string | undefined {
+	get letter(): string {
 		switch (this.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.MODIFIED:
@@ -209,12 +209,10 @@ export class Resource implements SourceControlResourceState {
 			case Status.BOTH_ADDED:
 			case Status.BOTH_MODIFIED:
 				return 'C';
-			default:
-				return undefined;
 		}
 	}
 
-	get color(): ThemeColor | undefined {
+	get color(): ThemeColor {
 		switch (this.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.MODIFIED:
@@ -237,8 +235,6 @@ export class Resource implements SourceControlResourceState {
 			case Status.BOTH_ADDED:
 			case Status.BOTH_MODIFIED:
 				return new ThemeColor('gitDecoration.conflictingResourceForeground');
-			default:
-				return undefined;
 		}
 	}
 
@@ -263,7 +259,7 @@ export class Resource implements SourceControlResourceState {
 		}
 	}
 
-	get resourceDecoration(): DecorationData | undefined {
+	get resourceDecoration(): DecorationData {
 		const title = this.tooltip;
 		const abbreviation = this.letter;
 		const color = this.color;


### PR DESCRIPTION
By removing the default case and undefined from the return type, the type system can ensure that all cases are handled.