### PR TITLE
Fit promise error in fileServices

### DIFF
--- a/src/vs/workbench/services/files/node/fileService.ts
+++ b/src/vs/workbench/services/files/node/fileService.ts
@@ -449,7 +449,7 @@ export class FileService implements IFileService {
 						} else {
 							// when receiving the first chunk of data we need to create the
 							// decoding stream which is then used to drive the string stream.
-							Promise.resolve(detectMimeAndEncodingFromBuffer(
+							TPromise.as(detectMimeAndEncodingFromBuffer(
 								{ buffer: chunkBuffer, bytesRead },
 								options && options.autoGuessEncoding || this.configuredAutoGuessEncoding(resource)
 							)).then(value => {
@@ -468,7 +468,7 @@ export class FileService implements IFileService {
 									handleChunk(bytesRead);
 								}
 
-							}).catch(err => {
+							}).then(undefined, err => {
 								// failed to get encoding
 								finish(err);
 							});


### PR DESCRIPTION
Fixes #38360

`detectMimeAndEncodingFromBuffer` returns a `TPromise<X> | X`. Seems we need to use `TPromise.resolve`to wrap this instead