### PR TITLE
Better readable highlighted line for kimbie-dark-theme

### DIFF
--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -15,7 +15,7 @@
 		"pickerGroup.border": "#e3b583",
 		"inputOption.activeBorder": "#a57a4c",
 		"selection.background": "#84613daa",
-		"editor.selectionBackground": "#84613daa",
+		"editor.selectionBackground": "#003629ee",
 		"editorWidget.background": "#131510",
 		"editorHoverWidget.background": "#221a14",
 		"editorGroupHeader.tabsBackground": "#131510",
@@ -48,7 +48,6 @@
 		"progressBar.background": "#7f5d38",
 		"editor.wordHighlightBackground": "#220b00",
 		"editor.wordHighlightStrongBackground": "#3b0e00",
-		"editor.selectionBackground": "#003629ee",
 		"activityBarBadge.background": "#00805e"
 		
 	},

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -47,7 +47,8 @@
 		"badge.background": "#7f5d38",
 		"progressBar.background": "#7f5d38",
 		"editor.wordHighlightBackground": "#220b00",
-		"editor.wordHighlightStrongBackground": "#3b0e00"
+		"editor.wordHighlightStrongBackground": "#3b0e00",
+		"editor.selectionBackground": "#003629ee"
 		
 	},
 	"tokenColors": [

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -28,7 +28,7 @@
 		"activityBar.background": "#221a0f",
 		"activityBar.foreground": "#d3af86",
 		"sideBar.background": "#362712",
-		"editor.lineHighlightBackground": "#5e452b",
+		"editor.lineHighlightBackground": "#553f2a56",
 		"editorCursor.foreground": "#d3af86",
 		"editorWhitespace.foreground": "#a57a4c",
 		"peekViewTitle.background": "#362712",

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -48,7 +48,8 @@
 		"progressBar.background": "#7f5d38",
 		"editor.wordHighlightBackground": "#220b00",
 		"editor.wordHighlightStrongBackground": "#3b0e00",
-		"editor.selectionBackground": "#003629ee"
+		"editor.selectionBackground": "#003629ee",
+		"activityBarBadge.background": "#00805e"
 		
 	},
 	"tokenColors": [

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -45,7 +45,10 @@
 		"inputValidation.errorBackground": "#5f0d0d",
 		"inputValidation.errorBorder": "#9d2f23",
 		"badge.background": "#7f5d38",
-		"progressBar.background": "#7f5d38"
+		"progressBar.background": "#7f5d38",
+		"editor.wordHighlightBackground": "#220b00",
+		"editor.wordHighlightStrongBackground": "#3b0e00"
+		
 	},
 	"tokenColors": [
 		{


### PR DESCRIPTION
modifies `editor.lineHighlightBackground` for better readable highlighted line. :art: 
## before
![theme-before](https://user-images.githubusercontent.com/12165822/32884040-12cfa0da-cadf-11e7-954a-7a90afde78db.png)
## now
![theme-now](https://user-images.githubusercontent.com/12165822/32884052-1acb2d72-cadf-11e7-876a-87b7cbe1e1c7.png)
