### PR TITLE
Add ability to zoom in/out on all images

### DIFF
--- a/src/vs/base/browser/ui/resourceviewer/resourceviewer.css
+++ b/src/vs/base/browser/ui/resourceviewer/resourceviewer.css
@@ -16,6 +16,7 @@
 	padding: 10px 10px 0 10px;
 	background-position: 0 0, 8px 8px;
 	background-size: 16px 16px;
+	display: grid;
 }
 
 .monaco-resource-viewer.image.full-size {
@@ -34,23 +35,24 @@
 		linear-gradient(45deg, rgb(20, 20, 20) 25%, transparent 25%, transparent 75%, rgb(20, 20, 20) 75%, rgb(20, 20, 20));
 }
 
-.monaco-resource-viewer img {
+.monaco-resource-viewer img.untouched {
 	max-width: 100%;
-	max-height: calc(100% - 10px); /* somehow this prevents scrollbars from showing up */
-	transform-origin: left top;
+	object-fit: contain;
 }
 
 .monaco-resource-viewer img.pixelated {
 	image-rendering: pixelated;
 }
 
-.monaco-resource-viewer.oversized img {
+.monaco-resource-viewer img {
+	margin: auto; /* centers the image */
+}
+
+.monaco-resource-viewer.zoom-in {
 	cursor: zoom-in;
 }
 
-.monaco-resource-viewer.full-size img {
-	max-width: initial;
-	max-height: initial;
+.monaco-resource-viewer.zoom-out {
 	cursor: zoom-out;
 }
 

--- a/src/vs/base/browser/ui/resourceviewer/resourceviewer.css
+++ b/src/vs/base/browser/ui/resourceviewer/resourceviewer.css
@@ -37,6 +37,11 @@
 .monaco-resource-viewer img {
 	max-width: 100%;
 	max-height: calc(100% - 10px); /* somehow this prevents scrollbars from showing up */
+	transform-origin: left top;
+}
+
+.monaco-resource-viewer img.pixelated {
+	image-rendering: pixelated;
 }
 
 .monaco-resource-viewer.oversized img {

--- a/src/vs/workbench/browser/parts/editor/binaryEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/binaryEditor.ts
@@ -10,7 +10,7 @@ import Event, { Emitter } from 'vs/base/common/event';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { Dimension, Builder, $ } from 'vs/base/browser/builder';
-import { ResourceViewer } from 'vs/base/browser/ui/resourceviewer/resourceViewer';
+import { ResourceViewer, ResourceViewerContext } from 'vs/base/browser/ui/resourceviewer/resourceViewer';
 import { EditorModel, EditorInput, EditorOptions } from 'vs/workbench/common/editor';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel';
@@ -29,6 +29,7 @@ export abstract class BaseBinaryResourceEditor extends BaseEditor {
 
 	private binaryContainer: Builder;
 	private scrollbar: DomScrollableElement;
+	private resourceViewerContext: ResourceViewerContext;
 
 	constructor(
 		id: string,
@@ -87,7 +88,7 @@ export abstract class BaseBinaryResourceEditor extends BaseEditor {
 
 				// Render Input
 				const model = <BinaryEditorModel>resolvedModel;
-				ResourceViewer.show(
+				this.resourceViewerContext = ResourceViewer.show(
 					{ name: model.getName(), resource: model.getResource(), size: model.getSize(), etag: model.getETag(), mime: model.getMime() },
 					this.binaryContainer,
 					this.scrollbar,
@@ -132,6 +133,9 @@ export abstract class BaseBinaryResourceEditor extends BaseEditor {
 		// Pass on to Binary Container
 		this.binaryContainer.size(dimension.width, dimension.height);
 		this.scrollbar.scanDomNode();
+		if (this.resourceViewerContext) {
+			this.resourceViewerContext.layout(dimension);
+		}
 	}
 
 	public focus(): void {


### PR DESCRIPTION
Allows smaller images to be scaled up when viewing, either by pinching the trackpad, or holding ctrl while scrolling. Adds image-rendering: pixelated to the css if the image size is below a threshold.