### PR TITLE
Unsaved tracked files warning Addresses: #37337

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -866,6 +866,11 @@
           "description": "%config.enableSmartCommit%",
           "default": false
         },
+        "git.enableUnsavedResourceCheck": {
+          "type": "boolean",
+          "description": "%config.enableUnsavedResourceCheck%",
+          "default": true
+        },
         "git.enableCommitSigning": {
           "type": "boolean",
           "description": "%config.enableCommitSigning%",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -59,6 +59,7 @@
 	"config.defaultCloneDirectory": "The default location where to clone a git repository",
 	"config.enableSmartCommit": "Commit all changes when there are no staged changes.",
 	"config.enableCommitSigning": "Enables commit signing with GPG.",
+	"config.enableUnsavedResourceCheck": "Enables commit warning for unsaved files.",
 	"config.discardAllScope": "Controls what changes are discarded by the `Discard all changes` command. `all` discards all changes. `tracked` discards only tracked files. `prompt` shows a prompt dialog every time the action is run.",
 	"config.decorations.enabled": "Controls if Git contributes colors and badges to the explorer and the open editors view.",
 	"colors.modified": "Color for modified resources.",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -924,8 +924,21 @@ export class CommandCenter {
 		const config = workspace.getConfiguration('git');
 		const enableSmartCommit = config.get<boolean>('enableSmartCommit') === true;
 		const enableCommitSigning = config.get<boolean>('enableCommitSigning') === true;
+		const enableUnsavedResourceCheck = config.get<boolean>('enableUnsavedResourceCheck', true);
 		const noStagedChanges = repository.indexGroup.resourceStates.length === 0;
 		const noUnstagedChanges = repository.workingTreeGroup.resourceStates.length === 0;
+
+		// Flag if user has unsaved, tracked files
+		if (enableUnsavedResourceCheck) {
+			const continueCommit = await this.unsavedResourceCheck(repository);
+
+			if (continueCommit === 'no') {
+				return false;
+			}
+			if (continueCommit === 'disable-warning') {
+				config.update('enableUnsavedResourceCheck', false, true);
+			}
+		}
 
 		// no changes, and the user has not configured to commit all in this case
 		if (!noUnstagedChanges && noStagedChanges && !enableSmartCommit) {
@@ -1631,6 +1644,56 @@ export class CommandCenter {
 			.map(({ repository, resources }) => fn(repository as Repository, isSingleResource ? resources[0] : resources));
 
 		return Promise.all(promises);
+	}
+
+	private async unsavedResourceCheck(repository: Repository): Promise<string> {
+
+		// Filter all dirty, not untitled
+		// Check results for ignored files
+		// Remove ignored files from list
+		// If length > 0, flag unsaved warning
+
+		let dirtyFilePaths = Array.from(workspace.textDocuments.filter(r => {
+			return r.isDirty && r.uri.scheme === 'file' && !r.isUntitled &&
+				!path.relative(repository.root, r.uri.fsPath).startsWith('..');
+		}), r => {
+			return r.uri.fsPath;
+		});
+
+		let ignoreSet = new Set<string>();
+		try {
+			ignoreSet = await repository.checkIgnore(dirtyFilePaths);
+		} catch (err) {
+			console.error(err);
+			window.showErrorMessage(err, { modal: false });
+			return 'no';
+		}
+
+		if (ignoreSet.size) {
+			ignoreSet.forEach(i => {
+				if (i !== undefined && (dirtyFilePaths.indexOf(eval(i)) >= 0)) {
+					dirtyFilePaths.splice(dirtyFilePaths.indexOf(eval(i)), 1);
+				}
+			});
+		}
+
+		if (dirtyFilePaths.length) {
+			const message = localize('unsavedResourcesMessage', "There {0} ({1}) Unsaved, Tracked {2}.\n\nDo you want to continue with the commit ? ", (dirtyFilePaths.length < 2 ? 'is' : 'are'), dirtyFilePaths.length, (dirtyFilePaths.length < 2 ? 'file' : 'files'));
+			const yes = localize('yes', "Yes");
+			const no = localize('no', "No");
+			const disableWarning = localize('disableWarning', "Disable Warning");
+
+			const pick = await window.showWarningMessage(message, { modal: true }, yes, disableWarning);
+
+			if (pick === yes) {
+				return 'yes';
+			} else if (pick === disableWarning) {
+				return 'disable-warning';
+			} else {
+				return 'no';
+			}
+		}
+		return 'yes';
 	}
 
 	dispose(): void {


### PR DESCRIPTION
@joaomoreno 
@jrieken 

Addresses: #37337

This PR addition will fail with the recent change in checkIgnore which I use to filter out
non- tracked files.

The invalid token error occurs if the -z option is used with the command.  I did a lot of experiments
but I could not track where the error is thrown.  It is not generated within checkIgnore which succeeds
successfully.  It appears to be related to what is passed within the promise set.

- Using cp.spawn as opposed to repository.spawn with both -z and --stdin does not exhibit the problem
- dropping -z also works this is what I remained in the code
- a Python check also works and eliminated any questions about my repository

I did not want to do an issue since this cannot be reproduced without a function like my new one
I only see one other use of the checkIgnore and it is not done within the user command structure
so I would not expect it to have the same problem.