### PR TITLE
Update NumberBadge to show hundreds in full, show thousands with k

### DIFF
--- a/src/vs/workbench/browser/parts/compositebar/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositebar/compositeBarActions.ts
@@ -207,13 +207,11 @@ export class ActivityActionItem extends BaseActionItem {
 			// Number
 			if (badge instanceof NumberBadge) {
 				if (badge.number) {
-					let number;
+					let number = badge.number.toString();
 					if (badge.number > 9999) {
 						number = '10k+';
 					} else if (badge.number > 999) {
-						number = (badge.number / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
-					} else {
-						number = badge.number.toString();
+						number = number.charAt(0) + 'k';
 					}
 					this.$badgeContent.text(number);
 					this.$badge.show();

--- a/src/vs/workbench/browser/parts/compositebar/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositebar/compositeBarActions.ts
@@ -207,7 +207,15 @@ export class ActivityActionItem extends BaseActionItem {
 			// Number
 			if (badge instanceof NumberBadge) {
 				if (badge.number) {
-					this.$badgeContent.text(badge.number > 99 ? '99+' : badge.number.toString());
+					let number;
+					if (badge.number > 9999) {
+						number = '10k+';
+					} else if (badge.number > 999) {
+						number = (badge.number / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+					} else {
+						number = badge.number.toString();
+					}
+					this.$badgeContent.text(number);
 					this.$badge.show();
 				}
 			}

--- a/src/vs/workbench/browser/parts/compositebar/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositebar/compositeBarActions.ts
@@ -209,7 +209,7 @@ export class ActivityActionItem extends BaseActionItem {
 				if (badge.number) {
 					let number = badge.number.toString();
 					if (badge.number > 9999) {
-						number = '10k+';
+						number = nls.localize('largeNumberBadge', '10k+');
 					} else if (badge.number > 999) {
 						number = number.charAt(0) + 'k';
 					}


### PR DESCRIPTION
Fixes #38524

If the 'k' thing isn't acceptable we have the option to ditch that and show something else for 1000 or more. This fix is mainly to make it so that when there are 100-200 changes in a SCM workspace, which can happen, it's more clear to the user that there are that many changes.