### PR TITLE
Resolve completion items on click

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -498,7 +498,9 @@ export class SuggestWidget implements IContentWidget, IDelegate<ICompletionItem>
 		}
 
 		const item = e.elements[0];
-		this.onDidSelectEmitter.fire(item);
+		item.resolve().then(() => {
+			this.onDidSelectEmitter.fire(item);
+		});
 
 		alert(nls.localize('suggestionAriaAccepted', "{0}, accepted", item.suggestion.label));
 


### PR DESCRIPTION
Fixes #38636

**Bug**
When clicking on a suggestion to accept it, it may not have been resolved yet.

**Fix**
Make sure we resolve it after the click