### PR TITLE
Defer RichEditBrackets creation

### DIFF
--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -82,7 +82,9 @@ export class CursorConfiguration {
 	public readonly autoClosingPairsOpen: CharacterMap;
 	public readonly autoClosingPairsClose: CharacterMap;
 	public readonly surroundingPairs: CharacterMap;
-	public readonly electricChars: { [key: string]: boolean; };
+
+	private readonly _languageIdentifier: LanguageIdentifier;
+	private _electricChars: { [key: string]: boolean; };
 
 	public static shouldRecreate(e: IConfigurationChangedEvent): boolean {
 		return (
@@ -102,6 +104,8 @@ export class CursorConfiguration {
 		modelOptions: TextModelResolvedOptions,
 		configuration: IConfiguration
 	) {
+		this._languageIdentifier = languageIdentifier;
+
 		let c = configuration.editor;
 
 		this.readOnly = c.readOnly;
@@ -119,14 +123,6 @@ export class CursorConfiguration {
 		this.autoClosingPairsOpen = {};
 		this.autoClosingPairsClose = {};
 		this.surroundingPairs = {};
-		this.electricChars = {};
-
-		let electricChars = CursorConfiguration._getElectricCharacters(languageIdentifier);
-		if (electricChars) {
-			for (let i = 0; i < electricChars.length; i++) {
-				this.electricChars[electricChars[i]] = true;
-			}
-		}
 
 		let autoClosingPairs = CursorConfiguration._getAutoClosingPairs(languageIdentifier);
 		if (autoClosingPairs) {
@@ -142,6 +138,19 @@ export class CursorConfiguration {
 				this.surroundingPairs[surroundingPairs[i].open] = surroundingPairs[i].close;
 			}
 		}
+	}
+
+	public get electricChars() {
+		if (!this._electricChars) {
+			this._electricChars = {};
+			let electricChars = CursorConfiguration._getElectricCharacters(this._languageIdentifier);
+			if (electricChars) {
+				for (let i = 0; i < electricChars.length; i++) {
+					this._electricChars[electricChars[i]] = true;
+				}
+			}
+		}
+		return this._electricChars;
 	}
 
 	public normalizeIndentation(str: string): string {

--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -123,6 +123,7 @@ export class CursorConfiguration {
 		this.autoClosingPairsOpen = {};
 		this.autoClosingPairsClose = {};
 		this.surroundingPairs = {};
+		this._electricChars = null;
 
 		let autoClosingPairs = CursorConfiguration._getAutoClosingPairs(languageIdentifier);
 		if (autoClosingPairs) {

--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -61,6 +61,9 @@ export class RichEditSupport {
 	constructor(languageIdentifier: LanguageIdentifier, previous: RichEditSupport, rawConf: LanguageConfiguration) {
 		this._languageIdentifier = languageIdentifier;
 
+		this._brackets = null;
+		this._electricCharacter = null;
+
 		let prev: LanguageConfiguration = null;
 		if (previous) {
 			prev = previous._conf;

--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -46,18 +46,20 @@ export interface IIndentConverter {
 export class RichEditSupport {
 
 	private readonly _conf: LanguageConfiguration;
+	private readonly _languageIdentifier: LanguageIdentifier;
+	private _brackets: RichEditBrackets;
+	private _electricCharacter: BracketElectricCharacterSupport;
 
-	public readonly electricCharacter: BracketElectricCharacterSupport;
 	public readonly comments: ICommentsConfiguration;
 	public readonly characterPair: CharacterPairSupport;
 	public readonly wordDefinition: RegExp;
 	public readonly onEnter: OnEnterSupport;
 	public readonly indentRulesSupport: IndentRulesSupport;
-	public readonly brackets: RichEditBrackets;
 	public readonly indentationRules: IndentationRule;
 	public readonly foldingRules: FoldingRules;
 
 	constructor(languageIdentifier: LanguageIdentifier, previous: RichEditSupport, rawConf: LanguageConfiguration) {
+		this._languageIdentifier = languageIdentifier;
 
 		let prev: LanguageConfiguration = null;
 		if (previous) {
@@ -66,16 +68,11 @@ export class RichEditSupport {
 
 		this._conf = RichEditSupport._mergeConf(prev, rawConf);
 
-		if (this._conf.brackets) {
-			this.brackets = new RichEditBrackets(languageIdentifier, this._conf.brackets);
-		}
-
 		this.onEnter = RichEditSupport._handleOnEnter(this._conf);
 
 		this.comments = RichEditSupport._handleComments(this._conf);
 
 		this.characterPair = new CharacterPairSupport(this._conf);
-		this.electricCharacter = new BracketElectricCharacterSupport(this.brackets, this.characterPair.getAutoClosingPairs(), this._conf.__electricCharacterSupport);
 
 		this.wordDefinition = this._conf.wordPattern || DEFAULT_WORD_REGEXP;
 
@@ -85,6 +82,20 @@ export class RichEditSupport {
 		}
 
 		this.foldingRules = this._conf.folding || {};
+	}
+
+	public get brackets(): RichEditBrackets {
+		if (!this._brackets && this._conf.brackets) {
+			this._brackets = new RichEditBrackets(this._languageIdentifier, this._conf.brackets);
+		}
+		return this._brackets;
+	}
+
+	public get electricCharacter(): BracketElectricCharacterSupport {
+		if (!this._electricCharacter) {
+			this._electricCharacter = new BracketElectricCharacterSupport(this.brackets, this.characterPair.getAutoClosingPairs(), this._conf.__electricCharacterSupport);
+		}
+		return this._electricCharacter;
 	}
 
 	private static _mergeConf(prev: LanguageConfiguration, current: LanguageConfiguration): LanguageConfiguration {


### PR DESCRIPTION
**Bug**
`RichEditBrackets` are currently created eagerly pretty early in startup

**fix**
Lazily create `RichEditBrackets` instead