### PR TITLE
Prompt recommendations only when uri schema is file #37569

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
@@ -221,11 +221,7 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 	private _suggest(model: IModel): void {
 		const uri = model.uri;
 
-		if (!uri) {
-			return;
-		}
-
-		if (uri.scheme === Schemas.inMemory || uri.scheme === Schemas.internal || uri.scheme === Schemas.vscode) {
+		if (!uri || uri.scheme !== Schemas.file) {
 			return;
 		}
 


### PR DESCRIPTION
Partially fixes #37569 

@sandy081  @joaomoreno Any idea why we show the recommendation prompt for all uri schemes other than `Schemas.inMemory`, `Schemas.internal` and `Schemas.vscode`, instead of showing the prompt for just the file schema?