### PR TITLE
Use keydown instead of keypress to close terminal

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -714,7 +714,7 @@ export class TerminalInstance implements ITerminalInstance {
 	}
 
 	private _attachPressAnyKeyToCloseListener() {
-		this._processDisposables.push(dom.addDisposableListener(this._xterm.textarea, 'keypress', (event: KeyboardEvent) => {
+		this._processDisposables.push(dom.addDisposableListener(this._xterm.textarea, 'keydown', (event: KeyboardEvent) => {
 			this.dispose();
 			event.preventDefault();
 		}));


### PR DESCRIPTION
This allows the terminal to be closed using the arrow keys. https://github.com/Microsoft/vscode/issues/37983