### PR TITLE
List: Prevent double context-menu events Fixes: #31850

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -338,6 +338,10 @@ class MouseController<T> implements IDisposable {
 			.filter(e => this.list.getFocus().length > 0)
 			.filter(e => e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
 			.map(e => {
+				e.stopPropagation();
+				e.preventDefault();
+			})
+			.map(e => {
 				const index = this.list.getFocus()[0];
 				const element = this.view.element(index);
 				const anchor = this.view.domElement(index);

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -338,16 +338,17 @@ class MouseController<T> implements IDisposable {
 			.filter(e => this.list.getFocus().length > 0)
 			.filter(e => e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
 			.map(e => {
-				e.stopPropagation();
-				e.preventDefault();
-			})
-			.map(e => {
 				const index = this.list.getFocus()[0];
 				const element = this.view.element(index);
 				const anchor = this.view.domElement(index);
-				return { index, element, anchor };
+				return { e, index, element, anchor };
 			})
-			.filter(({ anchor }) => !!anchor)
+			.filter(({ e, anchor }) => !!anchor)
+			.map(o => {
+				o.e.preventDefault();
+				o.e.preventDefault();
+				return o;
+			})
 			.event;
 
 		const fromMouse = chain(fromCallback(handler => this.view.addListener('contextmenu', handler)))


### PR DESCRIPTION
Add stopPropagation and preventDefault in list onContextMenu to prevent
double event and double popUps.

Update: finally figured out syntax to move pD/sP to end of event chain...

Fixes: #31850 