### PR TITLE
Fix #35709. If there is onEnter rule matching

### DIFF
--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -360,6 +360,12 @@ export class LanguageConfigurationRegistryImpl {
 
 		let precedingUnIgnoredLineContent = model.getLineContent(precedingUnIgnoredLine);
 
+		let onEnterSupport = this._getOnEnterSupport(model.getLanguageIdentifier().id);
+
+		if (onEnterSupport && onEnterSupport.onEnter('', precedingUnIgnoredLineContent, '')) {
+			return null;
+		}
+
 		if (indentRulesSupport.shouldIncrease(precedingUnIgnoredLineContent) || indentRulesSupport.shouldIndentNextLine(precedingUnIgnoredLineContent)) {
 			return {
 				indentation: strings.getLeadingWhitespace(precedingUnIgnoredLineContent),


### PR DESCRIPTION
no longer try to calculate indentation from above lines.