### PR TITLE
Resolve machine ID in main side and pass through

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess.js
+++ b/src/vs/code/electron-browser/sharedProcess.js
@@ -89,7 +89,11 @@ function main() {
 			});
 		}
 
-		require(['vs/code/electron-browser/sharedProcessMain'], function () { });
+		require(['vs/code/electron-browser/sharedProcessMain'], function (sharedProcess) {
+			sharedProcess.startup({
+				machineId: configuration.machineId
+			});
+		});
 	});
 }
 

--- a/src/vs/code/electron-browser/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcessMain.ts
@@ -24,7 +24,7 @@ import { IRequestService } from 'vs/platform/request/node/request';
 import { RequestService } from 'vs/platform/request/electron-browser/requestService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { combinedAppender, NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
-import { resolveCommonProperties, machineIdStorageKey } from 'vs/platform/telemetry/node/commonProperties';
+import { resolveCommonProperties } from 'vs/platform/telemetry/node/commonProperties';
 import { TelemetryAppenderChannel } from 'vs/platform/telemetry/common/telemetryIpc';
 import { TelemetryService, ITelemetryServiceConfig } from 'vs/platform/telemetry/common/telemetryService';
 import { AppInsightsAppender } from 'vs/platform/telemetry/node/appInsightsAppender';
@@ -34,8 +34,15 @@ import { IWindowsService } from 'vs/platform/windows/common/windows';
 import { WindowsChannelClient } from 'vs/platform/windows/common/windowsIpc';
 import { ipcRenderer } from 'electron';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
-import { StorageService, inMemoryLocalStorageInstance } from 'vs/platform/storage/common/storageService';
 import { createSharedProcessContributions } from 'vs/code/electron-browser/contrib/contributions';
+
+export interface ISharedProcessConfiguration {
+	machineId: string;
+}
+
+export function startup(configuration: ISharedProcessConfiguration) {
+	handshake(configuration);
+}
 
 interface ISharedProcessInitData {
 	sharedIPCHandle: string;
@@ -66,7 +73,7 @@ class ActiveWindowManager implements IDisposable {
 
 const eventPrefix = 'monacoworkbench';
 
-function main(server: Server, initData: ISharedProcessInitData): void {
+function main(server: Server, initData: ISharedProcessInitData, configuration: ISharedProcessConfiguration): void {
 	const services = new ServiceCollection();
 
 	services.set(IEnvironmentService, new SyncDescriptor(EnvironmentService, initData.args, process.execPath));
@@ -100,21 +107,12 @@ function main(server: Server, initData: ISharedProcessInitData): void {
 
 		const services = new ServiceCollection();
 		const environmentService = accessor.get(IEnvironmentService);
-		const { appRoot, extensionsPath, extensionDevelopmentPath, isBuilt, extensionTestsPath, installSource } = environmentService;
+		const { appRoot, extensionsPath, extensionDevelopmentPath, isBuilt, installSource } = environmentService;
 
 		if (isBuilt && !extensionDevelopmentPath && !environmentService.args['disable-telemetry'] && product.enableTelemetry) {
-			const disableStorage = !!extensionTestsPath; // never keep any state when running extension tests!
-			const storage = disableStorage ? inMemoryLocalStorageInstance : window.localStorage;
-			const storageService = new StorageService(storage, storage);
-
 			const config: ITelemetryServiceConfig = {
 				appender,
-				commonProperties: resolveCommonProperties(product.commit, pkg.version, installSource)
-					// __GDPR__COMMON__ "common.machineId" : { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
-					.then(result => Object.defineProperty(result, 'common.machineId', {
-						get: () => storageService.get(machineIdStorageKey),
-						enumerable: true
-					})),
+				commonProperties: resolveCommonProperties(product.commit, pkg.version, installSource, configuration.machineId),
 				piiPaths: [appRoot, extensionsPath]
 			};
 
@@ -182,10 +180,8 @@ function startHandshake(): TPromise<ISharedProcessInitData> {
 	});
 }
 
-function handshake(): TPromise<void> {
+function handshake(configuration: ISharedProcessConfiguration): TPromise<void> {
 	return startHandshake()
-		.then((data) => setupIPC(data.sharedIPCHandle).then(server => main(server, data)))
+		.then(data => setupIPC(data.sharedIPCHandle).then(server => main(server, data, configuration)))
 		.then(() => ipcRenderer.send('handshake:im ready'));
 }
-
-handshake();

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -249,10 +249,7 @@ function main() {
 		// Startup
 		return instantiationService.invokeFunction(a => createPaths(a.get(IEnvironmentService)))
 			.then(() => instantiationService.invokeFunction(setupIPC))
-			.then(mainIpcServer => {
-				const app = instantiationService.createInstance(CodeApplication, mainIpcServer, instanceEnv);
-				app.startup();
-			});
+			.then(mainIpcServer => instantiationService.createInstance(CodeApplication, mainIpcServer, instanceEnv).startup());
 	}).done(null, err => instantiationService.invokeFunction(quit, err));
 }
 

--- a/src/vs/code/electron-main/sharedProcess.ts
+++ b/src/vs/code/electron-main/sharedProcess.ts
@@ -32,6 +32,7 @@ export class SharedProcess implements ISharedProcess {
 		});
 		const config = assign({
 			appRoot: this.environmentService.appRoot,
+			machineId: this.machineId,
 			nodeCachedDataDir: this.environmentService.nodeCachedDataDir,
 			userEnv: this.userEnv
 		});
@@ -78,6 +79,7 @@ export class SharedProcess implements ISharedProcess {
 
 	constructor(
 		private environmentService: IEnvironmentService,
+		private machineId: string,
 		private userEnv: IProcessEnvironment
 	) { }
 

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -138,6 +138,7 @@ export class WindowsManager implements IWindowsMainService {
 	onWindowsCountChanged: CommonEvent<IWindowsCountChangedEvent> = this._onWindowsCountChanged.event;
 
 	constructor(
+		private machineId: string,
 		@ILogService private logService: ILogService,
 		@IStorageMainService private storageMainService: IStorageMainService,
 		@IEnvironmentService private environmentService: IEnvironmentService,
@@ -1065,6 +1066,7 @@ export class WindowsManager implements IWindowsMainService {
 		// Build IWindowConfiguration from config and options
 		const configuration: IWindowConfiguration = mixin({}, options.cli); // inherit all properties from CLI
 		configuration.appRoot = this.environmentService.appRoot;
+		configuration.machineId = this.machineId;
 		configuration.execPath = process.execPath;
 		configuration.userEnv = assign({}, this.initialUserEnv, options.userEnv || {});
 		configuration.isInitialStartup = options.initialStartup;

--- a/src/vs/platform/telemetry/node/commonProperties.ts
+++ b/src/vs/platform/telemetry/node/commonProperties.ts
@@ -8,12 +8,12 @@ import * as os from 'os';
 import { TPromise } from 'vs/base/common/winjs.base';
 import * as uuid from 'vs/base/common/uuid';
 
-export const machineIdStorageKey = 'telemetry.machineId';
-export const machineIdIpcChannel = 'vscode:machineId';
-
-export function resolveCommonProperties(commit: string, version: string, source: string): TPromise<{ [name: string]: string; }> {
+export function resolveCommonProperties(commit: string, version: string, source: string, machineId?: string): TPromise<{ [name: string]: string; }> {
 	const result: { [name: string]: string; } = Object.create(null);
-
+	// __GDPR__COMMON__ "common.machineId" : { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
+	if (typeof machineId === 'string') {
+		result['common.machineId'] = machineId;
+	}
 	// __GDPR__COMMON__ "sessionID" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['sessionID'] = uuid.generateUuid() + Date.now();
 	// __GDPR__COMMON__ "commitHash" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }

--- a/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
@@ -7,12 +7,10 @@ import * as os from 'os';
 import { TPromise } from 'vs/base/common/winjs.base';
 import * as uuid from 'vs/base/common/uuid';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { getMachineId } from 'vs/base/node/id';
-import { resolveCommonProperties, machineIdStorageKey } from '../node/commonProperties';
+import { resolveCommonProperties } from '../node/commonProperties';
 
-
-export function resolveWorkbenchCommonProperties(storageService: IStorageService, commit: string, version: string, source: string): TPromise<{ [name: string]: string }> {
-	return resolveCommonProperties(commit, version, source).then(result => {
+export function resolveWorkbenchCommonProperties(storageService: IStorageService, commit: string, version: string, source: string, machineId: string): TPromise<{ [name: string]: string }> {
+	return resolveCommonProperties(commit, version, source, machineId).then(result => {
 		// __GDPR__COMMON__ "common.version.shell" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 		result['common.version.shell'] = process.versions && (<any>process).versions['electron'];
 		// __GDPR__COMMON__ "common.version.renderer" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
@@ -31,32 +29,16 @@ export function resolveWorkbenchCommonProperties(storageService: IStorageService
 		result['common.lastSessionDate'] = lastSessionDate;
 		// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 		result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
-
-		const promises: TPromise<any>[] = [];
 		// __GDPR__COMMON__ "common.instanceId" : { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
-		promises.push(getOrCreateInstanceId(storageService).then(value => result['common.instanceId'] = value));
-		// __GDPR__COMMON__ "common.machineId" : { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
-		promises.push(getOrCreateMachineId(storageService).then(value => result['common.machineId'] = value));
+		result['common.instanceId'] = getOrCreateInstanceId(storageService);
 
-		return TPromise.join(promises).then(() => result);
-	});
-}
-
-function getOrCreateInstanceId(storageService: IStorageService): TPromise<string> {
-	let result = storageService.get('telemetry.instanceId') || uuid.generateUuid();
-	storageService.store('telemetry.instanceId', result);
-	return TPromise.as(result);
-}
-
-export function getOrCreateMachineId(storageService: IStorageService): TPromise<string> {
-	let result = storageService.get(machineIdStorageKey);
-
-	if (result) {
-		return TPromise.as(result);
-	}
-
-	return getMachineId().then(result => {
-		storageService.store(machineIdStorageKey, result);
 		return result;
 	});
+}
+
+function getOrCreateInstanceId(storageService: IStorageService): string {
+	const result = storageService.get('telemetry.instanceId') || uuid.generateUuid();
+	storageService.store('telemetry.instanceId', result);
+
+	return result;
 }

--- a/src/vs/platform/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/commonProperties.test.ts
@@ -23,7 +23,7 @@ suite('Telemetry - common properties', function () {
 
 	test('default', function () {
 
-		return resolveWorkbenchCommonProperties(storageService, commit, version, source).then(props => {
+		return resolveWorkbenchCommonProperties(storageService, commit, version, source, 'someMachineId').then(props => {
 
 			assert.ok('commitHash' in props);
 			assert.ok('sessionID' in props);
@@ -55,7 +55,7 @@ suite('Telemetry - common properties', function () {
 
 		storageService.store('telemetry.lastSessionDate', new Date().toUTCString());
 
-		return resolveWorkbenchCommonProperties(storageService, commit, version, source).then(props => {
+		return resolveWorkbenchCommonProperties(storageService, commit, version, source, 'someMachineId').then(props => {
 
 			assert.ok('common.lastSessionDate' in props); // conditional, see below
 			assert.ok('common.isNewSession' in props);
@@ -64,7 +64,7 @@ suite('Telemetry - common properties', function () {
 	});
 
 	test('values chance on ask', function () {
-		return resolveWorkbenchCommonProperties(storageService, commit, version, source).then(props => {
+		return resolveWorkbenchCommonProperties(storageService, commit, version, source, 'someMachineId').then(props => {
 			let value1 = props['common.sequence'];
 			let value2 = props['common.sequence'];
 			assert.ok(value1 !== value2, 'seq');

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -292,6 +292,8 @@ export interface IAddFoldersRequest {
 }
 
 export interface IWindowConfiguration extends ParsedArgs, IOpenFileRequest {
+	machineId: string;
+
 	appRoot: string;
 	execPath: string;
 	isInitialStartup?: boolean;


### PR DESCRIPTION
@chrmarti this is a clean-up of how we get the machine identifier. Previously the dance was quite crazy as you know (main => renderer => getmac => renderer => main => shared process => local storage). And I also think there was a chance that the shared process would use the machine identifier when it was not yet stored in local storage.

My attempt now is to resolve it once in main on startup unless it is already stored in our main `storage.json` file. And then pass that value around to the shared process as well as the renderer for usage. 