### PR TITLE
Fix paths in scripts/code*.sh

### DIFF
--- a/scripts/code-cli.sh
+++ b/scripts/code-cli.sh
@@ -8,7 +8,7 @@ else
 fi
 
 function code() {
-	cd $ROOT
+	pushd $ROOT >/dev/null
 
 	if [[ "$OSTYPE" == "darwin"* ]]; then
 		NAME=`node -p "require('./product.json').nameLong"`
@@ -27,12 +27,14 @@ function code() {
 	# Build
 	test -d out || ./node_modules/.bin/gulp compile
 
+	popd >/dev/null
+
 	ELECTRON_RUN_AS_NODE=1 \
 	NODE_ENV=development \
 	VSCODE_DEV=1 \
 	ELECTRON_ENABLE_LOGGING=1 \
 	ELECTRON_ENABLE_STACK_DUMPING=1 \
-	"$CODE" --debug=5874 "$ROOT/out/cli.js" . "$@"
+	"$ROOT/$CODE" --debug=5874 "$ROOT/out/cli.js" "$ROOT" "$@"
 }
 
 code "$@"

--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -8,7 +8,7 @@ else
 fi
 
 function code() {
-	cd "$ROOT"
+	pushd $ROOT >/dev/null
 
 	if [[ "$OSTYPE" == "darwin"* ]]; then
 		NAME=`node -p "require('./product.json').nameLong"`
@@ -27,6 +27,8 @@ function code() {
 	# Build
 	test -d out || ./node_modules/.bin/gulp compile
 
+	popd >/dev/null
+
 	# Configuration
 	export NODE_ENV=development
 	export VSCODE_DEV=1
@@ -35,7 +37,7 @@ function code() {
 	export ELECTRON_ENABLE_STACK_DUMPING=1
 
 	# Launch Code
-	exec "$CODE" . "$@"
+	exec "$ROOT/$CODE" "$ROOT" "$@"
 }
 
 # Use the following to get v8 tracing:


### PR DESCRIPTION
Running "./scripts/code.sh <filename>" with a relative path from any folder other than the vscode source root fails.

I believe `pushd`/`popd` is compatible among platforms. Ideally I'd get rid of the `cd` command but that is a riskier change.