### PR TITLE
Adding 'editor.sameCursorStyle' preference setting

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursor.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursor.ts
@@ -65,7 +65,7 @@ export class ViewCursor {
 
 		// Create the dom node
 		this._domNode = createFastDomNode(document.createElement('div'));
-		if (this._isSecondary) {
+		if (this._isSecondary && !this._context.configuration.editor.sameCursorStyle) {
 			this._domNode.setClassName('cursor secondary');
 		} else {
 			this._domNode.setClassName('cursor');

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -259,6 +259,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.viewInfo.smoothScrolling,
 			'description': nls.localize('smoothScrolling', "Controls if the editor will scroll using an animation")
 		},
+		'editor.sameCursorStyle': {
+			'type': 'boolean',
+			'default': EDITOR_DEFAULTS.sameCursorStyle,
+			'description': nls.localize('sameCursorStyle', "Disable difference between first and secondary cursors if true")
+		},
 		'editor.minimap.enabled': {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.viewInfo.minimap.enabled,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -283,6 +283,11 @@ export interface IEditorOptions {
 	 */
 	smoothScrolling?: boolean;
 	/**
+	 * Disable difference between first and secondary cursors if true
+	 * Defaults to false.
+	 */
+	sameCursorStyle?: boolean;
+	/**
 	 * Enable that the editor will install an interval to check if its container dom node size has changed.
 	 * Enabling this might have a severe performance impact.
 	 * Defaults to false.
@@ -846,6 +851,7 @@ export interface IValidatedEditorOptions {
 	readonly dragAndDrop: boolean;
 	readonly emptySelectionClipboard: boolean;
 	readonly useTabStops: boolean;
+	readonly sameCursorStyle: boolean;
 	readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
 	readonly accessibilitySupport: 'auto' | 'off' | 'on';
 
@@ -869,6 +875,7 @@ export class InternalEditorOptions {
 	 */
 	readonly accessibilitySupport: platform.AccessibilitySupport;
 	readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+	readonly sameCursorStyle: boolean;
 
 	// ---- cursor options
 	readonly wordSeparators: string;
@@ -904,6 +911,7 @@ export class InternalEditorOptions {
 		tabFocusMode: boolean;
 		dragAndDrop: boolean;
 		emptySelectionClipboard: boolean;
+		sameCursorStyle: boolean;
 		layoutInfo: EditorLayoutInfo;
 		fontInfo: FontInfo;
 		viewInfo: InternalEditorViewOptions;
@@ -917,6 +925,7 @@ export class InternalEditorOptions {
 		this.readOnly = source.readOnly;
 		this.accessibilitySupport = source.accessibilitySupport;
 		this.multiCursorModifier = source.multiCursorModifier;
+		this.sameCursorStyle = source.sameCursorStyle;
 		this.wordSeparators = source.wordSeparators;
 		this.autoClosingBrackets = source.autoClosingBrackets;
 		this.autoIndent = source.autoIndent;
@@ -943,6 +952,7 @@ export class InternalEditorOptions {
 			&& this.readOnly === other.readOnly
 			&& this.accessibilitySupport === other.accessibilitySupport
 			&& this.multiCursorModifier === other.multiCursorModifier
+			&& this.sameCursorStyle === other.sameCursorStyle
 			&& this.wordSeparators === other.wordSeparators
 			&& this.autoClosingBrackets === other.autoClosingBrackets
 			&& this.autoIndent === other.autoIndent
@@ -970,6 +980,7 @@ export class InternalEditorOptions {
 			readOnly: (this.readOnly !== newOpts.readOnly),
 			accessibilitySupport: (this.accessibilitySupport !== newOpts.accessibilitySupport),
 			multiCursorModifier: (this.multiCursorModifier !== newOpts.multiCursorModifier),
+			sameCursorStyle: (this.sameCursorStyle !== newOpts.sameCursorStyle),
 			wordSeparators: (this.wordSeparators !== newOpts.wordSeparators),
 			autoClosingBrackets: (this.autoClosingBrackets !== newOpts.autoClosingBrackets),
 			autoIndent: (this.autoIndent !== newOpts.autoIndent),
@@ -1313,6 +1324,7 @@ export interface IConfigurationChangedEvent {
 	readonly readOnly: boolean;
 	readonly accessibilitySupport: boolean;
 	readonly multiCursorModifier: boolean;
+	readonly sameCursorStyle: boolean;
 	readonly wordSeparators: boolean;
 	readonly autoClosingBrackets: boolean;
 	readonly autoIndent: boolean;
@@ -1498,6 +1510,7 @@ export class EditorOptionsValidator {
 			emptySelectionClipboard: _boolean(opts.emptySelectionClipboard, defaults.emptySelectionClipboard),
 			useTabStops: _boolean(opts.useTabStops, defaults.useTabStops),
 			multiCursorModifier: multiCursorModifier,
+			sameCursorStyle: _boolean(opts.sameCursorStyle, defaults.sameCursorStyle),
 			accessibilitySupport: _stringSet<'auto' | 'on' | 'off'>(opts.accessibilitySupport, defaults.accessibilitySupport, ['auto', 'on', 'off']),
 			viewInfo: viewInfo,
 			contribInfo: contribInfo,
@@ -1720,6 +1733,7 @@ export class InternalEditorOptionsFactory {
 			emptySelectionClipboard: opts.emptySelectionClipboard,
 			useTabStops: opts.useTabStops,
 			multiCursorModifier: opts.multiCursorModifier,
+			sameCursorStyle: opts.sameCursorStyle,
 			accessibilitySupport: opts.accessibilitySupport,
 
 			viewInfo: {
@@ -1922,6 +1936,7 @@ export class InternalEditorOptionsFactory {
 			readOnly: opts.readOnly,
 			accessibilitySupport: accessibilitySupport,
 			multiCursorModifier: opts.multiCursorModifier,
+			sameCursorStyle: opts.sameCursorStyle,
 			wordSeparators: opts.wordSeparators,
 			autoClosingBrackets: opts.autoClosingBrackets,
 			autoIndent: opts.autoIndent,
@@ -2142,6 +2157,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 	dragAndDrop: true,
 	emptySelectionClipboard: true,
 	useTabStops: true,
+	sameCursorStyle: false,
 	multiCursorModifier: 'altKey',
 	accessibilitySupport: 'auto',
 

--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -77,6 +77,7 @@ export class CursorConfiguration {
 	public readonly useTabStops: boolean;
 	public readonly wordSeparators: string;
 	public readonly emptySelectionClipboard: boolean;
+	public readonly sameCursorStyle: boolean;
 	public readonly autoClosingBrackets: boolean;
 	public readonly autoIndent: boolean;
 	public readonly autoClosingPairsOpen: CharacterMap;
@@ -113,6 +114,7 @@ export class CursorConfiguration {
 		this.useTabStops = c.useTabStops;
 		this.wordSeparators = c.wordSeparators;
 		this.emptySelectionClipboard = c.emptySelectionClipboard;
+		this.sameCursorStyle = c.sameCursorStyle;
 		this.autoClosingBrackets = c.autoClosingBrackets;
 		this.autoIndent = c.autoIndent;
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2606,6 +2606,11 @@ declare module monaco.editor {
 		 */
 		smoothScrolling?: boolean;
 		/**
+		 * Disable difference between first and secondary cursors if true
+		 * Defaults to false.
+		 */
+		sameCursorStyle?: boolean;
+		/**
 		 * Enable that the editor will install an interval to check if its container dom node size has changed.
 		 * Enabling this might have a severe performance impact.
 		 * Defaults to false.
@@ -3097,6 +3102,7 @@ declare module monaco.editor {
 		readonly lineHeight: number;
 		readonly readOnly: boolean;
 		readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+		readonly sameCursorStyle: boolean;
 		readonly wordSeparators: string;
 		readonly autoClosingBrackets: boolean;
 		readonly autoIndent: boolean;
@@ -3230,6 +3236,7 @@ declare module monaco.editor {
 		readonly readOnly: boolean;
 		readonly accessibilitySupport: boolean;
 		readonly multiCursorModifier: boolean;
+		readonly sameCursorStyle: boolean;
 		readonly wordSeparators: boolean;
 		readonly autoClosingBrackets: boolean;
 		readonly autoIndent: boolean;


### PR DESCRIPTION
Adding `editor.sameCursorStyle` preference setting.

If this preference set to true then difference between multiple cursors (transparency) will be disabled.
