### PR TITLE
Open File Handler now untildifies. Fixes #32736

### DIFF
--- a/src/vs/base/common/labels.ts
+++ b/src/vs/base/common/labels.ts
@@ -106,6 +106,14 @@ export function tildify(path: string, userHome: string): string {
 	return path;
 }
 
+export function untildify(path: string, userHome: string): string {
+	if (platform.isMacintosh || platform.isLinux) {
+		path = path.replace(/^~($|\/|\\)/, `${userHome}$1`);
+	}
+
+	return path;
+}
+
 /**
  * Shortens the paths but keeps them easy to distinguish.
  * Replaces not important parts with ellipsis.

--- a/src/vs/base/common/labels.ts
+++ b/src/vs/base/common/labels.ts
@@ -107,11 +107,7 @@ export function tildify(path: string, userHome: string): string {
 }
 
 export function untildify(path: string, userHome: string): string {
-	if (platform.isMacintosh || platform.isLinux) {
-		path = path.replace(/^~($|\/|\\)/, `${userHome}$1`);
-	}
-
-	return path;
+	return path.replace(/^~($|\/|\\)/, `${userHome}$1`);
 }
 
 /**

--- a/src/vs/workbench/parts/search/browser/openFileHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openFileHandler.ts
@@ -142,6 +142,9 @@ export class OpenFileHandler extends QuickOpenHandler {
 			return TPromise.as(new FileQuickOpenModel([]));
 		}
 
+		// Untildify file pattern
+		searchValue = labels.untildify(searchValue, this.environmentService.userHome);
+
 		// Do find results
 		return this.doFindResults(searchValue, this.cacheState.cacheKey, maxSortedResults);
 	}


### PR DESCRIPTION
This fixes issue #32736. 

`~/file.txt` should now expand for Mac and Linux (e.g. to `/Users/moorejs/file.txt`), allowing you to quick open files by absolute filepath.

I believe I made the change in the best way, but feedback would be appreciated.