### PR TITLE
Add a function return type for typescript snippets.

### DIFF
--- a/extensions/typescript/snippets/typescript.json
+++ b/extensions/typescript/snippets/typescript.json
@@ -192,7 +192,7 @@
 	"Function Statement": {
 		"prefix": "function",
 		"body": [
-			"function ${1:name}(${2:params}:${3:type}) {",
+			"function ${1:name}(${2:params}:${3:type}): ${4:return} {",
 			"\t$0",
 			"}"
 		],


### PR DESCRIPTION
I think it should be a best practice for the TypeScript that to always specify the function return type. So I add this snippet. Thanks.