### PR TITLE
limit Uri.toJSON to object instead of any

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1253,7 +1253,7 @@ declare module 'vscode' {
 		 *
 		 * @return An object.
 		 */
-		toJSON(): any;
+		toJSON(): object;
 	}
 
 	/**


### PR DESCRIPTION
It would be really nice to see the null/unknowns removed from vscode.d.ts as much as possible by avoiding use of `any`. The documentation says that this returns object. 

https://blog.mariusschulz.com/2017/02/24/typescript-2-2-the-object-type