### PR TITLE
Modify hygiene pre-commit checks for users with git autocrlf set

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -132,7 +132,7 @@ const copyrightHeader = [
 	' *  Copyright (c) Microsoft Corporation. All rights reserved.',
 	' *  Licensed under the MIT License. See License.txt in the project root for license information.',
 	' *--------------------------------------------------------------------------------------------*/'
-].join('\n');
+];
 
 gulp.task('eslint', () => {
 	return vfs.src(all, { base: '.', follow: true, allowEmpty: true })
@@ -185,7 +185,8 @@ const hygiene = exports.hygiene = (some, options) => {
 	});
 
 	const copyrights = es.through(function (file) {
-		if (file.contents.toString('utf8').indexOf(copyrightHeader) !== 0) {
+		const fullCopyrightHeader = options.usingAutoCRLF ? copyrightHeader.join('\r\n') : copyrightHeader.join('\n');
+		if (file.contents.toString('utf8').indexOf(fullCopyrightHeader) !== 0) {
 			console.error(file.relative + ': Missing or bad copyright statement');
 			errorCount++;
 		}
@@ -194,7 +195,8 @@ const hygiene = exports.hygiene = (some, options) => {
 	});
 
 	const formatting = es.map(function (file, cb) {
-		tsfmt.processString(file.path, file.contents.toString('utf8'), {
+		const fileContents = options.usingAutoCRLF ? file.contents.toString('utf8').replace(/\r\n/g, '\n') : file.contents.toString('utf8');
+		tsfmt.processString(file.path, fileContents, {
 			verify: true,
 			tsfmt: true,
 			// verbose: true
@@ -240,7 +242,7 @@ const hygiene = exports.hygiene = (some, options) => {
 	const result = vfs.src(some || all, { base: '.', follow: true, allowEmpty: true })
 		.pipe(filter(f => !f.stat.isDirectory()))
 		.pipe(filter(eolFilter))
-		.pipe(options.skipEOL ? es.through() : eol)
+		.pipe(options.usingAutoCRLF ? es.through() : eol)
 		.pipe(filter(indentationFilter))
 		.pipe(indentation)
 		.pipe(filter(copyrightFilter))
@@ -287,10 +289,10 @@ if (require.main === module) {
 	});
 
 	cp.exec('git config core.autocrlf', (err, out) => {
-		const skipEOL = out.trim() === 'true';
+		const usingAutoCRLF = out.trim() === 'true';
 
 		if (process.argv.length > 2) {
-			return hygiene(process.argv.slice(2), { skipEOL: skipEOL }).on('error', err => {
+			return hygiene(process.argv.slice(2), { usingAutoCRLF: usingAutoCRLF }).on('error', err => {
 				console.error();
 				console.error(err);
 				process.exit(1);
@@ -309,7 +311,7 @@ if (require.main === module) {
 				.filter(l => !!l);
 
 			if (some.length > 0) {
-				hygiene(some, { skipEOL: skipEOL }).on('error', err => {
+				hygiene(some, { usingAutoCRLF: usingAutoCRLF }).on('error', err => {
 					console.error();
 					console.error(err);
 					process.exit(1);


### PR DESCRIPTION
For Windows users with core.autocrlf set, the hygiene precommit hook fails right now with messages that files are missing copyright statements and are not formatted. When autocrlf is set, the check that all line endings are '\n' is skipped, but the checks for copyright statement being present and the typescript-formatter both still look for LF line endings.

This commit changes the behavior of both of these checks to pivot on autocrlf being set so that Windows users do not have to change their git settings before cloning the repo.