### PR TITLE
Make Horizontal Slider Taller #32192

### DIFF
--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -11,7 +11,7 @@
 
 .monaco-workbench > .part > .title,
 .monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title {
-	height: 35px;
+	height: 48px;   /* 35px for default plus 13px of the horizontal scroll bar */
 	display: flex;
 	box-sizing:	border-box;
 	overflow: hidden;

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -164,11 +164,11 @@ export class TabsTitleControl extends TitleControl {
 
 		// Custom Scrollbar
 		this.scrollbar = new ScrollableElement(this.tabsContainer, {
-			horizontal: ScrollbarVisibility.Auto,
-			vertical: ScrollbarVisibility.Hidden,
+			horizontal: ScrollbarVisibility.Visible,
+			vertical: ScrollbarVisibility.Visible,
 			scrollYToX: true,
 			useShadows: false,
-			horizontalScrollbarSize: 3
+			horizontalScrollbarSize: 13
 		});
 
 		this.scrollbar.onScroll(e => {


### PR DESCRIPTION
Closes #32192

1. horizontalScrollbarSize changed to 13.
2. Changed ScrollbarVisibility to visible because as the bar now has its own space it can be always visible like the other bars.

