### PR TITLE
Issue #39269

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.css
+++ b/src/vs/editor/contrib/find/findWidget.css
@@ -312,7 +312,8 @@
 }
 
 .monaco-editor.vs-dark .find-widget .monaco-checkbox .checkbox:checked + .label {
-	background-color: rgba(255, 255, 255, 0.1);
+	background-image: url('images/cancelSelectionFind-inverseSelected.svg');
+	background-color: rgba(197, 197, 197, 1);
 }
 
 .monaco-editor.hc-black .find-widget .close-fw,

--- a/src/vs/editor/contrib/find/images/cancelSelectionFind-inverseSelected.svg
+++ b/src/vs/editor/contrib/find/images/cancelSelectionFind-inverseSelected.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+<g transform="translate(0,-1032.3622)">
+  <rect width="15" height="2" x="2" y="1046.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect width="13" height="2" x="2" y="1043.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect width="6" height="2" x="2" y="1040.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect width="12" height="2" x="2" y="1037.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
+</g>
+</svg>

--- a/src/vs/editor/contrib/find/images/cancelSelectionFind-inverseSelected.svg
+++ b/src/vs/editor/contrib/find/images/cancelSelectionFind-inverseSelected.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
 <g transform="translate(0,-1032.3622)">
-  <rect width="15" height="2" x="2" y="1046.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
+  <rect width="9" height="2" x="2" y="1046.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
   <rect width="13" height="2" x="2" y="1043.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
   <rect width="6" height="2" x="2" y="1040.3622" style="fill:#000000;fill-opacity:1;stroke:none" />
   <rect width="12" height="2" x="2" y="1037.3622" style="fill:#000000;fill-opacity:1;stroke:none" />


### PR DESCRIPTION
Issue #39269 

This makes it easier to differenciate the selected / not selected state of the "Find in selection" button of the find/replace dialog in the dark theme.

To actually solve the issue, the "editor.find.autoFindInSelection" must be set to true.