### PR TITLE
added workspace statistics to '--ps'

### DIFF
--- a/src/vs/base/node/workspaceStats.ts
+++ b/src/vs/base/node/workspaceStats.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { readdirSync, statSync } from 'fs';
+
+export interface WorkspaceStatItem {
+	name: string;
+	value: number;
+}
+export interface WorkspaceStats {
+	fileTypes: WorkspaceStatItem[];
+	configFiles: WorkspaceStatItem[];
+}
+
+export function collectWorkspaceStats(folder: string, filter: string[]): WorkspaceStats {
+	const configFilePatterns = [
+		{ 'tag': 'grunt.js', 'pattern': /^gruntfile\.js$/i },
+		{ 'tag': 'gulp.js', 'pattern': /^gulpfile\.js$/i },
+		{ 'tag': 'tsconfig.json', 'pattern': /^tsconfig\.json$/i },
+		{ 'tag': 'package.json', 'pattern': /^package\.json$/i },
+		{ 'tag': 'jsconfig.json', 'pattern': /^jsconfig\.json$/i },
+		{ 'tag': 'tslint.json', 'pattern': /^tslint\.json$/i },
+		{ 'tag': 'eslint.json', 'pattern': /^eslint\.json$/i },
+		{ 'tag': 'tasks.json', 'pattern': /^tasks\.json$/i },
+		{ 'tag': 'launch.json', 'pattern': /^launch\.json$/i },
+		{ 'tag': 'settings.json', 'pattern': /^settings\.json$/i },
+		{ 'tag': 'webpack.config.js', 'pattern': /^webpack\.config\.js$/i },
+		{ 'tag': 'project.json', 'pattern': /^project\.json$/i },
+		{ 'tag': 'makefile', 'pattern': /^makefile$/i },
+		{ 'tag': 'sln', 'pattern': /^.+\.sln$/i },
+		{ 'tag': 'csproj', 'pattern': /^.+\.csproj$/i },
+		{ 'tag': 'cmake', 'pattern': /^.+\.cmake$/i }
+	];
+
+	let fileTypes = new Map<string, number>();
+	let configFiles = new Map<string, number>();
+
+	let walkSync = (dir: string, acceptFile: (fileName: string) => void, filter: string[]) => {
+		let files = readdirSync(dir);
+		for (const file of files) {
+			if (statSync(dir + '/' + file).isDirectory()) {
+				if (filter.indexOf(file) === -1) {
+					walkSync(dir + '/' + file, acceptFile, filter);
+				}
+			}
+			else {
+				acceptFile(file);
+			}
+		}
+	};
+
+	let addFileType = (fileType: string) => {
+		if (fileTypes.has(fileType)) {
+			fileTypes.set(fileType, fileTypes.get(fileType) + 1);
+		}
+		else {
+			fileTypes.set(fileType, 1);
+		}
+	};
+
+	let addConfigFiles = (fileName: string) => {
+		for (const each of configFilePatterns) {
+			if (each.pattern.test(fileName)) {
+				if (configFiles.has(each.tag)) {
+					configFiles.set(each.tag, configFiles.get(each.tag) + 1);
+				} else {
+					configFiles.set(each.tag, 1);
+				}
+			}
+		}
+	};
+
+	let acceptFile = (name: string) => {
+		if (name.lastIndexOf('.') >= 0) {
+			let suffix: string | undefined = name.split('.').pop();
+			if (suffix) {
+				addFileType(suffix);
+			}
+		}
+		addConfigFiles(name);
+	};
+
+	let asSortedItems = (map: Map<string, number>): WorkspaceStatItem[] => {
+		let a: WorkspaceStatItem[] = [];
+		map.forEach((value, index) => a.push({ name: index, value: value }));
+		return a.sort((a, b) => b.value - a.value);
+	};
+
+	walkSync(folder, acceptFile, filter);
+
+	let result = {
+		'configFiles': asSortedItems(configFiles),
+		'fileTypes': asSortedItems(fileTypes)
+	};
+	return result;
+}

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -156,7 +156,9 @@ function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 						return service.getMainProcessInfo().then(info => {
 							return listProcesses(info.mainPID).then(rootProcess => {
 								console.log(formatProcessList(info, rootProcess));
-								console.log();
+
+								console.log('\n');
+								console.log('\n');
 
 								let stats = collectWorkspaceStats('.', ['node_modules', '.git']); // TODO call for each root folder
 								console.log(formatWorkspaceStats(stats));
@@ -228,20 +230,22 @@ function formatWorkspaceStats(workspaceStats: WorkspaceStats): string {
 		line += item;
 	};
 
-	output.push('Workspace statistics');
+	output.push('Workspace:');
 	const lineLength = 60;
-	let line = '  Configuration files:';
+
+	let line = '  File types:';
 	let col = 0;
-	workspaceStats.configFiles.forEach((item) => {
-		appendAndWrap(item.name, item.value);
-	});
-	output.push(line);
-	line = '  File Types:';
-	col = 0;
 	workspaceStats.fileTypes.forEach((item) => {
 		if (item.value > 20) {
 			appendAndWrap(item.name, item.value);
 		}
+	});
+	output.push(line);
+	output.push('');
+	line = '  Configuration files:';
+	col = 0;
+	workspaceStats.configFiles.forEach((item) => {
+		appendAndWrap(item.name, item.value);
 	});
 	output.push(line);
 	return output.join('\n');


### PR DESCRIPTION
I've tried to come up with a compact presentation. 
- I'll only show a file type if the number of instances > 10
- wrap the lines

The collector is currently called on the current working directory.

This is how it looks
```
code-oss main
   gpu-process
   shared-process
   renderer-9
     watcherService
     extensionHost

Workspace statistics
  Configuration files: package.json(76) tsconfig.json(27) launch.json(14)
     tasks.json(13) settings.json(4) tslint.json(2) gulp.js(2) makefile(1)
  File Types: json(6625) ts(3143) js(1850) map(1614) svg(763) css(310)
     h(210) pak(165) txt(71) vscodeignore(53) html(42) png(37)
     sh(28) lock(27) md(23)
```