### PR TITLE
Allow specifying number of scrolled lines in args

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -1139,7 +1139,7 @@ export namespace CoreNavigationCommands {
 			EditorScroll._runEditorScroll(cursors, args.source, {
 				direction: EditorScroll_.Direction.Up,
 				unit: EditorScroll_.Unit.WrappedLine,
-				value: 1,
+				value: args.value || 1,
 				revealCursor: false,
 				select: false
 			});
@@ -1190,7 +1190,7 @@ export namespace CoreNavigationCommands {
 			EditorScroll._runEditorScroll(cursors, args.source, {
 				direction: EditorScroll_.Direction.Down,
 				unit: EditorScroll_.Unit.WrappedLine,
-				value: 1,
+				value: args.value || 1,
 				revealCursor: false,
 				select: false
 			});


### PR DESCRIPTION
This will allow to scroll multiple lines from `keybindings.json` without using extensions:
```json
{
    "key": "alt+down",
    "command": "scrollLineDown",
    "when": "editorTextFocus && !editorReadOnly",
    "args": {
        "value": 15
    }
},
{
    "key": "alt+up",
    "command": "scrollLineUp",
    "when": "editorTextFocus && !editorReadOnly",
    "args": {
        "value": 15
    }
}
```