### PR TITLE
Tilde expansion for files to include and exclude (fixes #36792)

### DIFF
--- a/src/vs/workbench/parts/search/common/queryBuilder.ts
+++ b/src/vs/workbench/parts/search/common/queryBuilder.ts
@@ -12,9 +12,11 @@ import * as glob from 'vs/base/common/glob';
 import * as paths from 'vs/base/common/paths';
 import * as strings from 'vs/base/common/strings';
 import uri from 'vs/base/common/uri';
+import { untildify } from 'vs/base/common/labels';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IPatternInfo, IQueryOptions, IFolderQuery, ISearchQuery, QueryType, ISearchConfiguration, getExcludes, pathIncludedInQuery } from 'vs/platform/search/common/search';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 
 export interface ISearchPathPattern {
 	searchPath: uri;
@@ -30,8 +32,9 @@ export class QueryBuilder {
 
 	constructor(
 		@IConfigurationService private configurationService: IConfigurationService,
-		@IWorkspaceContextService private workspaceContextService: IWorkspaceContextService) {
-	}
+		@IWorkspaceContextService private workspaceContextService: IWorkspaceContextService,
+		@IEnvironmentService private environmentService: IEnvironmentService
+	) { }
 
 	public text(contentPattern: IPatternInfo, folderResources?: uri[], options?: IQueryOptions): ISearchQuery {
 		return this.query(QueryType.Text, contentPattern, folderResources, options);
@@ -105,7 +108,8 @@ export class QueryBuilder {
 			return paths.isAbsolute(segment) || strings.startsWith(segment, './') || strings.startsWith(segment, '.\\');
 		};
 
-		const segments = splitGlobPattern(pattern);
+		const segments = splitGlobPattern(pattern)
+			.map(segment => untildify(segment, this.environmentService.userHome));
 		const groups = collections.groupBy(segments,
 			segment => isSearchPath(segment) ? 'searchPaths' : 'exprSegments');
 

--- a/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
+++ b/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
@@ -14,7 +14,9 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IWorkspaceContextService, Workspace, toWorkspaceFolders } from 'vs/platform/workspace/common/workspace';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { QueryBuilder, ISearchPathsResult } from 'vs/workbench/parts/search/common/queryBuilder';
-import { TestContextService } from 'vs/workbench/test/workbenchTestServices';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { TestContextService, TestEnvironmentService } from 'vs/workbench/test/workbenchTestServices';
+
 
 import { ISearchQuery, QueryType, IPatternInfo, IFolderQuery } from 'vs/platform/search/common/search';
 
@@ -43,6 +45,8 @@ suite('QueryBuilder', () => {
 		mockWorkspace = new Workspace('workspace', 'workspace', toWorkspaceFolders([{ path: ROOT_1_URI.fsPath }]));
 		mockContextService.setWorkspace(mockWorkspace);
 		instantiationService.stub(IWorkspaceContextService, mockContextService);
+
+		instantiationService.stub(IEnvironmentService, TestEnvironmentService);
 
 		queryBuilder = instantiationService.createInstance(QueryBuilder);
 	});


### PR DESCRIPTION
Fixes issue #36792. Uses the untildify method added in PR #39122 to expand paths that start with ~ to their absolute path.