### PR TITLE
Fix #34057 - Allow default config exporter to access platform-specific configurations that don't apply on the build machine

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -613,7 +613,7 @@ const editorConfiguration: IConfigurationNode = {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.contribInfo.selectionClipboard,
 			'description': nls.localize('selectionClipboard', "Controls if the Linux primary clipboard should be supported."),
-			'excluded': !platform.isLinux
+			'included': platform.isLinux
 		},
 		'diffEditor.renderSideBySide': {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -609,6 +609,12 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.contribInfo.lightbulbEnabled,
 			'description': nls.localize('codeActions', "Enables the code action lightbulb")
 		},
+		'editor.selectionClipboard': {
+			'type': 'boolean',
+			'default': EDITOR_DEFAULTS.contribInfo.selectionClipboard,
+			'description': nls.localize('selectionClipboard', "Controls if the Linux primary clipboard should be supported."),
+			'excluded': !platform.isLinux
+		},
 		'diffEditor.renderSideBySide': {
 			'type': 'boolean',
 			'default': true,
@@ -626,13 +632,5 @@ const editorConfiguration: IConfigurationNode = {
 		}
 	}
 };
-
-if (platform.isLinux) {
-	editorConfiguration['properties']['editor.selectionClipboard'] = {
-		'type': 'boolean',
-		'default': EDITOR_DEFAULTS.contribInfo.selectionClipboard,
-		'description': nls.localize('selectionClipboard', "Controls if the Linux primary clipboard should be supported.")
-	};
-}
 
 configurationRegistry.registerConfiguration(editorConfiguration);

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -72,7 +72,7 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	isExecutable?: boolean;
 	scope?: ConfigurationScope;
 	notMultiRootAdopted?: boolean;
-	excluded?: boolean;
+	included?: boolean;
 }
 
 export interface IConfigurationNode {
@@ -200,8 +200,9 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 					property.scope = scope;
 				}
 
-				// add to properties maps
-				if (properties[key].excluded) {
+				// Add to properties maps
+				// Property is included by default if 'included' is unspecified
+				if (properties[key].hasOwnProperty('included') && !properties[key].included) {
 					this.excludedConfigurationProperties[key] = properties[key];
 					delete properties[key];
 					continue;

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -52,6 +52,11 @@ export interface IConfigurationRegistry {
 	getConfigurationProperties(): { [qualifiedKey: string]: IConfigurationPropertySchema };
 
 	/**
+	 * Returns all excluded configurations settings of all configuration nodes contributed to this registry.
+	 */
+	getExcludedConfigurationProperties(): { [qualifiedKey: string]: IConfigurationPropertySchema };
+
+	/**
 	 * Register the identifiers for editor configurations
 	 */
 	registerOverrideIdentifiers(identifiers: string[]): void;
@@ -67,6 +72,7 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	isExecutable?: boolean;
 	scope?: ConfigurationScope;
 	notMultiRootAdopted?: boolean;
+	excluded?: boolean;
 }
 
 export interface IConfigurationNode {
@@ -97,6 +103,7 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 
 	private configurationContributors: IConfigurationNode[];
 	private configurationProperties: { [qualifiedKey: string]: IJSONSchema };
+	private excludedConfigurationProperties: { [qualifiedKey: string]: IJSONSchema };
 	private editorConfigurationSchema: IJSONSchema;
 	private overrideIdentifiers: string[] = [];
 	private overridePropertyPattern: string;
@@ -108,6 +115,7 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 		this.configurationContributors = [];
 		this.editorConfigurationSchema = { properties: {}, patternProperties: {}, additionalProperties: false, errorMessage: 'Unknown editor configuration setting' };
 		this.configurationProperties = {};
+		this.excludedConfigurationProperties = {};
 		this.computeOverridePropertyPattern();
 
 		contributionRegistry.registerSchema(editorConfigurationSchemaId, this.editorConfigurationSchema);
@@ -191,8 +199,16 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 				if (property.scope === void 0) {
 					property.scope = scope;
 				}
-				// add to properties map
-				this.configurationProperties[key] = properties[key];
+
+				// add to properties maps
+				if (properties[key].excluded) {
+					this.excludedConfigurationProperties[key] = properties[key];
+					delete properties[key];
+					continue;
+				} else {
+					this.configurationProperties[key] = properties[key];
+				}
+
 				propertyKeys.push(key);
 			}
 		}
@@ -211,6 +227,10 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 
 	getConfigurationProperties(): { [qualifiedKey: string]: IConfigurationPropertySchema } {
 		return this.configurationProperties;
+	}
+
+	getExcludedConfigurationProperties(): { [qualifiedKey: string]: IConfigurationPropertySchema } {
+		return this.excludedConfigurationProperties;
 	}
 
 	private registerJSONConfiguration(configuration: IConfigurationNode) {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -10,7 +10,7 @@ import nls = require('vs/nls');
 import product from 'vs/platform/node/product';
 import * as os from 'os';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationPropertySchema } from 'vs/platform/configuration/common/configurationRegistry';
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
@@ -272,130 +272,121 @@ configurationRegistry.registerConfiguration({
 
 
 // Configuration: Window
-let properties: { [path: string]: IJSONSchema; } = {
-	'window.openFilesInNewWindow': {
-		'type': 'string',
-		'enum': ['on', 'off', 'default'],
-		'enumDescriptions': [
-			nls.localize('window.openFilesInNewWindow.on', "Files will open in a new window"),
-			nls.localize('window.openFilesInNewWindow.off', "Files will open in the window with the files' folder open or the last active window"),
-			nls.localize('window.openFilesInNewWindow.default', "Files will open in the window with the files' folder open or the last active window unless opened via the dock or from finder (macOS only)")
-		],
-		'default': 'off',
-		'description':
-			nls.localize('openFilesInNewWindow', "Controls if files should open in a new window.\n- default: files will open in the window with the files' folder open or the last active window unless opened via the dock or from finder (macOS only)\n- on: files will open in a new window\n- off: files will open in the window with the files' folder open or the last active window\nNote that there can still be cases where this setting is ignored (e.g. when using the -new-window or -reuse-window command line option).")
-	},
-	'window.openFoldersInNewWindow': {
-		'type': 'string',
-		'enum': ['on', 'off', 'default'],
-		'enumDescriptions': [
-			nls.localize('window.openFoldersInNewWindow.on', "Folders will open in a new window"),
-			nls.localize('window.openFoldersInNewWindow.off', "Folders will replace the last active window"),
-			nls.localize('window.openFoldersInNewWindow.default', "Folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu)")
-		],
-		'default': 'default',
-		'description': nls.localize('openFoldersInNewWindow', "Controls if folders should open in a new window or replace the last active window.\n- default: folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu)\n- on: folders will open in a new window\n- off: folders will replace the last active window\nNote that there can still be cases where this setting is ignored (e.g. when using the -new-window or -reuse-window command line option)."
-		)
-	},
-	'window.restoreWindows': {
-		'type': 'string',
-		'enum': ['all', 'folders', 'one', 'none'],
-		'enumDescriptions': [
-			nls.localize('window.reopenFolders.all', "Reopen all windows."),
-			nls.localize('window.reopenFolders.folders', "Reopen all folders. Empty workspaces will not be restored."),
-			nls.localize('window.reopenFolders.one', "Reopen the last active window."),
-			nls.localize('window.reopenFolders.none', "Never reopen a window. Always start with an empty one.")
-		],
-		'default': 'one',
-		'description': nls.localize('restoreWindows', "Controls how windows are being reopened after a restart. Select 'none' to always start with an empty workspace, 'one' to reopen the last window you worked on, 'folders' to reopen all windows that had folders opened or 'all' to reopen all windows of your last session.")
-	},
-	'window.restoreFullscreen': {
-		'type': 'boolean',
-		'default': false,
-		'description': nls.localize('restoreFullscreen', "Controls if a window should restore to full screen mode if it was exited in full screen mode.")
-	},
-	'window.zoomLevel': {
-		'type': 'number',
-		'default': 0,
-		'description': nls.localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.")
-	},
-	'window.title': {
-		'type': 'string',
-		'default': isMacintosh ? '${activeEditorShort}${separator}${rootName}' : '${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}',
-		'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by parenthesis are not to be translated.'], key: 'title' },
-			"Controls the window title based on the active editor. Variables are substituted based on the context:\n\${activeEditorShort}: the file name (e.g. myFile.txt)\n\${activeEditorMedium}: the path of the file relative to the workspace folder (e.g. myFolder/myFile.txt)\n\${activeEditorLong}: the full path of the file (e.g. /Users/Development/myProject/myFolder/myFile.txt)\n\${folderName}: name of the workspace folder the file is contained in (e.g. myFolder)\n\${folderPath}: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder)\n\${rootName}: name of the workspace (e.g. myFolder or myWorkspace)\n\${rootPath}: file path of the workspace (e.g. /Users/Development/myWorkspace)\n\${appName}: e.g. VS Code\n\${dirty}: a dirty indicator if the active editor is dirty\n\${separator}: a conditional separator (\" - \") that only shows when surrounded by variables with values")
-	},
-	'window.newWindowDimensions': {
-		'type': 'string',
-		'enum': ['default', 'inherit', 'maximized', 'fullscreen'],
-		'enumDescriptions': [
-			nls.localize('window.newWindowDimensions.default', "Open new windows in the center of the screen."),
-			nls.localize('window.newWindowDimensions.inherit', "Open new windows with same dimension as last active one."),
-			nls.localize('window.newWindowDimensions.maximized', "Open new windows maximized."),
-			nls.localize('window.newWindowDimensions.fullscreen', "Open new windows in full screen mode.")
-		],
-		'default': 'default',
-		'description': nls.localize('newWindowDimensions', "Controls the dimensions of opening a new window when at least one window is already opened. By default, a new window will open in the center of the screen with small dimensions. When set to 'inherit', the window will get the same dimensions as the last window that was active. When set to 'maximized', the window will open maximized and fullscreen if configured to 'fullscreen'. Note that this setting does not have an impact on the first window that is opened. The first window will always restore the size and location as you left it before closing.")
-	},
-	'window.closeWhenEmpty': {
-		'type': 'boolean',
-		'default': false,
-		'description': nls.localize('closeWhenEmpty', "Controls if closing the last editor should also close the window. This setting only applies for windows that do not show folders.")
-	}
-};
-
-if (isWindows || isLinux) {
-	properties['window.menuBarVisibility'] = {
-		'type': 'string',
-		'enum': ['default', 'visible', 'toggle', 'hidden'],
-		'enumDescriptions': [
-			nls.localize('window.menuBarVisibility.default', "Menu is only hidden in full screen mode."),
-			nls.localize('window.menuBarVisibility.visible', "Menu is always visible even in full screen mode."),
-			nls.localize('window.menuBarVisibility.toggle', "Menu is hidden but can be displayed via Alt key."),
-			nls.localize('window.menuBarVisibility.hidden', "Menu is always hidden.")
-		],
-		'default': 'default',
-		'description': nls.localize('menuBarVisibility', "Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen.")
-	};
-	properties['window.enableMenuBarMnemonics'] = {
-		'type': 'boolean',
-		'default': true,
-		'description': nls.localize('enableMenuBarMnemonics', "If enabled, the main menus can be opened via Alt-key shortcuts. Disabling mnemonics allows to bind these Alt-key shortcuts to editor commands instead.")
-	};
-}
-
-if (isWindows) {
-	properties['window.autoDetectHighContrast'] = {
-		'type': 'boolean',
-		'default': true,
-		'description': nls.localize('autoDetectHighContrast', "If enabled, will automatically change to high contrast theme if Windows is using a high contrast theme, and to dark theme when switching away from a Windows high contrast theme."),
-	};
-}
-
-if (isMacintosh) {
-	properties['window.titleBarStyle'] = {
-		'type': 'string',
-		'enum': ['native', 'custom'],
-		'default': 'custom',
-		'description': nls.localize('titleBarStyle', "Adjust the appearance of the window title bar. Changes require a full restart to apply.")
-	};
-
-	// Minimum: macOS Sierra (10.12.x = darwin 16.x)
-	if (parseFloat(os.release()) >= 16) {
-		properties['window.nativeTabs'] = {
-			'type': 'boolean',
-			'default': false,
-			'description': nls.localize('window.nativeTabs', "Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured.")
-		};
-	}
-}
 
 configurationRegistry.registerConfiguration({
 	'id': 'window',
 	'order': 8,
 	'title': nls.localize('windowConfigurationTitle', "Window"),
 	'type': 'object',
-	'properties': properties
+	'properties': {
+		'window.openFilesInNewWindow': {
+			'type': 'string',
+			'enum': ['on', 'off', 'default'],
+			'enumDescriptions': [
+				nls.localize('window.openFilesInNewWindow.on', "Files will open in a new window"),
+				nls.localize('window.openFilesInNewWindow.off', "Files will open in the window with the files' folder open or the last active window"),
+				nls.localize('window.openFilesInNewWindow.default', "Files will open in the window with the files' folder open or the last active window unless opened via the dock or from finder (macOS only)")
+			],
+			'default': 'off',
+			'description':
+				nls.localize('openFilesInNewWindow', "Controls if files should open in a new window.\n- default: files will open in the window with the files' folder open or the last active window unless opened via the dock or from finder (macOS only)\n- on: files will open in a new window\n- off: files will open in the window with the files' folder open or the last active window\nNote that there can still be cases where this setting is ignored (e.g. when using the -new-window or -reuse-window command line option).")
+		},
+		'window.openFoldersInNewWindow': {
+			'type': 'string',
+			'enum': ['on', 'off', 'default'],
+			'enumDescriptions': [
+				nls.localize('window.openFoldersInNewWindow.on', "Folders will open in a new window"),
+				nls.localize('window.openFoldersInNewWindow.off', "Folders will replace the last active window"),
+				nls.localize('window.openFoldersInNewWindow.default', "Folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu)")
+			],
+			'default': 'default',
+			'description': nls.localize('openFoldersInNewWindow', "Controls if folders should open in a new window or replace the last active window.\n- default: folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu)\n- on: folders will open in a new window\n- off: folders will replace the last active window\nNote that there can still be cases where this setting is ignored (e.g. when using the -new-window or -reuse-window command line option)."
+			)
+		},
+		'window.restoreWindows': {
+			'type': 'string',
+			'enum': ['all', 'folders', 'one', 'none'],
+			'enumDescriptions': [
+				nls.localize('window.reopenFolders.all', "Reopen all windows."),
+				nls.localize('window.reopenFolders.folders', "Reopen all folders. Empty workspaces will not be restored."),
+				nls.localize('window.reopenFolders.one', "Reopen the last active window."),
+				nls.localize('window.reopenFolders.none', "Never reopen a window. Always start with an empty one.")
+			],
+			'default': 'one',
+			'description': nls.localize('restoreWindows', "Controls how windows are being reopened after a restart. Select 'none' to always start with an empty workspace, 'one' to reopen the last window you worked on, 'folders' to reopen all windows that had folders opened or 'all' to reopen all windows of your last session.")
+		},
+		'window.restoreFullscreen': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('restoreFullscreen', "Controls if a window should restore to full screen mode if it was exited in full screen mode.")
+		},
+		'window.zoomLevel': {
+			'type': 'number',
+			'default': 0,
+			'description': nls.localize('zoomLevel', "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.")
+		},
+		'window.title': {
+			'type': 'string',
+			'default': isMacintosh ? '${activeEditorShort}${separator}${rootName}' : '${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}',
+			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by parenthesis are not to be translated.'], key: 'title' },
+				"Controls the window title based on the active editor. Variables are substituted based on the context:\n\${activeEditorShort}: the file name (e.g. myFile.txt)\n\${activeEditorMedium}: the path of the file relative to the workspace folder (e.g. myFolder/myFile.txt)\n\${activeEditorLong}: the full path of the file (e.g. /Users/Development/myProject/myFolder/myFile.txt)\n\${folderName}: name of the workspace folder the file is contained in (e.g. myFolder)\n\${folderPath}: file path of the workspace folder the file is contained in (e.g. /Users/Development/myFolder)\n\${rootName}: name of the workspace (e.g. myFolder or myWorkspace)\n\${rootPath}: file path of the workspace (e.g. /Users/Development/myWorkspace)\n\${appName}: e.g. VS Code\n\${dirty}: a dirty indicator if the active editor is dirty\n\${separator}: a conditional separator (\" - \") that only shows when surrounded by variables with values")
+		},
+		'window.newWindowDimensions': {
+			'type': 'string',
+			'enum': ['default', 'inherit', 'maximized', 'fullscreen'],
+			'enumDescriptions': [
+				nls.localize('window.newWindowDimensions.default', "Open new windows in the center of the screen."),
+				nls.localize('window.newWindowDimensions.inherit', "Open new windows with same dimension as last active one."),
+				nls.localize('window.newWindowDimensions.maximized', "Open new windows maximized."),
+				nls.localize('window.newWindowDimensions.fullscreen', "Open new windows in full screen mode.")
+			],
+			'default': 'default',
+			'description': nls.localize('newWindowDimensions', "Controls the dimensions of opening a new window when at least one window is already opened. By default, a new window will open in the center of the screen with small dimensions. When set to 'inherit', the window will get the same dimensions as the last window that was active. When set to 'maximized', the window will open maximized and fullscreen if configured to 'fullscreen'. Note that this setting does not have an impact on the first window that is opened. The first window will always restore the size and location as you left it before closing.")
+		},
+		'window.closeWhenEmpty': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('closeWhenEmpty', "Controls if closing the last editor should also close the window. This setting only applies for windows that do not show folders.")
+		},
+		'window.menuBarVisibility': {
+			'type': 'string',
+			'enum': ['default', 'visible', 'toggle', 'hidden'],
+			'enumDescriptions': [
+				nls.localize('window.menuBarVisibility.default', "Menu is only hidden in full screen mode."),
+				nls.localize('window.menuBarVisibility.visible', "Menu is always visible even in full screen mode."),
+				nls.localize('window.menuBarVisibility.toggle', "Menu is hidden but can be displayed via Alt key."),
+				nls.localize('window.menuBarVisibility.hidden', "Menu is always hidden.")
+			],
+			'default': 'default',
+			'description': nls.localize('menuBarVisibility', "Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen."),
+			'excluded': !isWindows && !isLinux
+		},
+		'window.enableMenuBarMnemonics': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('enableMenuBarMnemonics', "If enabled, the main menus can be opened via Alt-key shortcuts. Disabling mnemonics allows to bind these Alt-key shortcuts to editor commands instead."),
+			'excluded': !isWindows && !isLinux
+		},
+		'window.autoDetectHighContrast': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('autoDetectHighContrast', "If enabled, will automatically change to high contrast theme if Windows is using a high contrast theme, and to dark theme when switching away from a Windows high contrast theme."),
+			'excluded': !isWindows
+		},
+		'window.titleBarStyle': {
+			'type': 'string',
+			'enum': ['native', 'custom'],
+			'default': 'custom',
+			'description': nls.localize('titleBarStyle', "Adjust the appearance of the window title bar. Changes require a full restart to apply."),
+			'excluded': !isMacintosh
+		},
+		'window.nativeTabs': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('window.nativeTabs', "Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured."),
+			'excluded': !isMacintosh || parseFloat(os.release()) < 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
+		}
+	}
 });
 
 // Configuration: Zen Mode

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -10,7 +10,7 @@ import nls = require('vs/nls');
 import product from 'vs/platform/node/product';
 import * as os from 'os';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationPropertySchema } from 'vs/platform/configuration/common/configurationRegistry';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -359,32 +359,32 @@ configurationRegistry.registerConfiguration({
 			],
 			'default': 'default',
 			'description': nls.localize('menuBarVisibility', "Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. By default, the menu bar will be visible, unless the window is full screen."),
-			'excluded': !isWindows && !isLinux
+			'included': isWindows || isLinux
 		},
 		'window.enableMenuBarMnemonics': {
 			'type': 'boolean',
 			'default': true,
 			'description': nls.localize('enableMenuBarMnemonics', "If enabled, the main menus can be opened via Alt-key shortcuts. Disabling mnemonics allows to bind these Alt-key shortcuts to editor commands instead."),
-			'excluded': !isWindows && !isLinux
+			'included': isWindows || isLinux
 		},
 		'window.autoDetectHighContrast': {
 			'type': 'boolean',
 			'default': true,
 			'description': nls.localize('autoDetectHighContrast', "If enabled, will automatically change to high contrast theme if Windows is using a high contrast theme, and to dark theme when switching away from a Windows high contrast theme."),
-			'excluded': !isWindows
+			'included': !isWindows
 		},
 		'window.titleBarStyle': {
 			'type': 'string',
 			'enum': ['native', 'custom'],
 			'default': 'custom',
 			'description': nls.localize('titleBarStyle', "Adjust the appearance of the window title bar. Changes require a full restart to apply."),
-			'excluded': !isMacintosh
+			'included': isMacintosh
 		},
 		'window.nativeTabs': {
 			'type': 'boolean',
 			'default': false,
 			'description': nls.localize('window.nativeTabs', "Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured."),
-			'excluded': !isMacintosh || parseFloat(os.release()) < 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
+			'included': isMacintosh && parseFloat(os.release()) >= 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
 		}
 	}
 });

--- a/src/vs/workbench/services/configuration/node/configurationService.ts
+++ b/src/vs/workbench/services/configuration/node/configurationService.ts
@@ -25,7 +25,7 @@ import { IConfigurationChangeEvent, ConfigurationTarget, IConfigurationOverrides
 import { Configuration, WorkspaceConfigurationChangeEvent, AllKeysConfigurationChangeEvent } from 'vs/workbench/services/configuration/common/configurationModels';
 import { IWorkspaceConfigurationService, FOLDER_CONFIG_FOLDER_NAME, defaultSettingsSchemaId, userSettingsSchemaId, workspaceSettingsSchemaId, folderSettingsSchemaId } from 'vs/workbench/services/configuration/common/configuration';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { IConfigurationNode, IConfigurationRegistry, Extensions, settingsSchema, resourceSettingsSchema } from 'vs/platform/configuration/common/configurationRegistry';
+import { IConfigurationNode, IConfigurationRegistry, Extensions, settingsSchema, resourceSettingsSchema, IConfigurationPropertySchema } from 'vs/platform/configuration/common/configurationRegistry';
 import { createHash } from 'crypto';
 import { getWorkspaceLabel, IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier, IStoredWorkspaceFolder, isStoredWorkspaceFolder, IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
 import { IWindowConfiguration } from 'vs/platform/windows/common/windows';
@@ -717,28 +717,33 @@ export class DefaultConfigurationExportHelper {
 	}
 
 	private getConfigModel(): IConfigurationExport {
-		const configurations = Registry.as<IConfigurationRegistry>(Extensions.Configuration).getConfigurations().slice();
+		const configRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+		const configurations = configRegistry.getConfigurations().slice();
 		const settings: IExportedConfigurationNode[] = [];
+
+		const processProperty = (name: string, prop: IConfigurationPropertySchema) => {
+			const propDetails: IExportedConfigurationNode = {
+				name,
+				description: prop.description,
+				default: prop.default,
+				type: prop.type
+			};
+
+			if (prop.enum) {
+				propDetails.enum = prop.enum;
+			}
+
+			if (prop.enumDescriptions) {
+				propDetails.enumDescriptions = prop.enumDescriptions;
+			}
+
+			settings.push(propDetails);
+		};
+
 		const processConfig = (config: IConfigurationNode) => {
 			if (config.properties) {
 				for (let name in config.properties) {
-					const prop = config.properties[name];
-					const propDetails: IExportedConfigurationNode = {
-						name,
-						description: prop.description,
-						default: prop.default,
-						type: prop.type
-					};
-
-					if (prop.enum) {
-						propDetails.enum = prop.enum;
-					}
-
-					if (prop.enumDescriptions) {
-						propDetails.enumDescriptions = prop.enumDescriptions;
-					}
-
-					settings.push(propDetails);
+					processProperty(name, config.properties[name]);
 				}
 			}
 
@@ -748,6 +753,11 @@ export class DefaultConfigurationExportHelper {
 		};
 
 		configurations.forEach(processConfig);
+
+		const excludedProps = configRegistry.getExcludedConfigurationProperties();
+		for (let name in excludedProps) {
+			processProperty(name, excludedProps[name]);
+		}
 
 		const result: IConfigurationExport = {
 			settings: settings.sort((a, b) => a.name.localeCompare(b.name)),

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -582,7 +582,7 @@ const keyboardConfiguration: IConfigurationNode = {
 			'enum': ['code', 'keyCode'],
 			'default': 'code',
 			'description': nls.localize('dispatch', "Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`."),
-			'excluded': OS !== OperatingSystem.Macintosh && OS !== OperatingSystem.Linux
+			'included': OS === OperatingSystem.Macintosh || OS === OperatingSystem.Linux
 		}
 	}
 };

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -569,25 +569,22 @@ let schema: IJSONSchema = {
 let schemaRegistry = <IJSONContributionRegistry>Registry.as(Extensions.JSONContribution);
 schemaRegistry.registerSchema(schemaId, schema);
 
-if (OS === OperatingSystem.Macintosh || OS === OperatingSystem.Linux) {
-
-	const configurationRegistry = <IConfigurationRegistry>Registry.as(ConfigExtensions.Configuration);
-	const keyboardConfiguration: IConfigurationNode = {
-		'id': 'keyboard',
-		'order': 15,
-		'type': 'object',
-		'title': nls.localize('keyboardConfigurationTitle', "Keyboard"),
-		'overridable': true,
-		'properties': {
-			'keyboard.dispatch': {
-				'type': 'string',
-				'enum': ['code', 'keyCode'],
-				'default': 'code',
-				'description': nls.localize('dispatch', "Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`.")
-			}
+const configurationRegistry = <IConfigurationRegistry>Registry.as(ConfigExtensions.Configuration);
+const keyboardConfiguration: IConfigurationNode = {
+	'id': 'keyboard',
+	'order': 15,
+	'type': 'object',
+	'title': nls.localize('keyboardConfigurationTitle', "Keyboard"),
+	'overridable': true,
+	'properties': {
+		'keyboard.dispatch': {
+			'type': 'string',
+			'enum': ['code', 'keyCode'],
+			'default': 'code',
+			'description': nls.localize('dispatch', "Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`."),
+			'excluded': OS !== OperatingSystem.Macintosh && OS !== OperatingSystem.Linux
 		}
-	};
+	}
+};
 
-	configurationRegistry.registerConfiguration(keyboardConfiguration);
-
-}
+configurationRegistry.registerConfiguration(keyboardConfiguration);


### PR DESCRIPTION
Let me know what you think - this isn't enabled for extensions yet.

In core, we need a flexible mechanism because we check the OS version and may want to check something else arbitrarily. Extensions probably would only be allowed to set the OS version declaratively.