### PR TITLE
Fix #39306 - allow tab to change file currently being renamed

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -369,21 +369,36 @@ export class FileRenderer implements IRenderer {
 		inputBox.select({ start: 0, end: lastDot > 0 && !stat.isDirectory ? lastDot : value.length });
 		inputBox.focus();
 
-		const done = once((commit: boolean) => {
-			tree.clearHighlight();
-
-			if (commit && inputBox.value) {
-				this.state.actionProvider.runAction(tree, stat, editableData.action, { value: inputBox.value });
+		const done = once((commit: boolean, renameNext?: boolean) => {
+			const renameNextSet = typeof renameNext === 'boolean';
+			var renameItem = tree.getFocus();
+			if (renameNextSet) {
+				const nav = tree.getNavigator(renameItem, false);
+				if (renameNext) {
+					renameItem = nav.next() || renameItem;
+				} else {
+					renameItem = nav.previous() || renameItem;
+				}
 			}
 
+			tree.clearHighlight();
+
 			const restoreFocus = document.activeElement === inputBox.inputElement; // https://github.com/Microsoft/vscode/issues/20269
-			setTimeout(() => {
-				if (restoreFocus) {
-					tree.DOMFocus();
-				}
-				lifecycle.dispose(toDispose);
-				container.removeChild(label.element);
-			}, 0);
+			const donePromise = commit && inputBox.value ? this.state.actionProvider.runAction(tree, stat, editableData.action, { value: inputBox.value }) : TPromise.as(null);
+			donePromise.then(() => {
+				setTimeout(() => {
+					if (restoreFocus) {
+						tree.DOMFocus();
+					}
+					lifecycle.dispose(toDispose);
+					container.removeChild(label.element);
+
+					if (renameNextSet) {
+						tree.setFocus(renameItem);
+						this.state.actionProvider.runAction(tree, renameItem, 'renameFile', null).done(null, errors.onUnexpectedError);
+					}
+				}, 0);
+			});
 		});
 
 		const toDispose = [
@@ -392,6 +407,10 @@ export class FileRenderer implements IRenderer {
 				if (e.equals(KeyCode.Enter)) {
 					if (inputBox.validate()) {
 						done(true);
+					}
+				} else if (e.keyCode === KeyCode.Tab) {
+					if (inputBox.validate()) {
+						done(true, !e.shiftKey);
 					}
 				} else if (e.equals(KeyCode.Escape)) {
 					done(false);


### PR DESCRIPTION
So I've added a check for tab/shift tab to rename the next or previous file.Focusing has to happen after the rename action has fired, otherwise the renaming seems to cause the current file to be refocused again. The renaming can cause files to move as they are sorted by name, so I couldn't use `focusNext` and `focusPrevious`, because tabbing could then cause the file being renamed to jump around as the renamed file moves. I didn't see an easier way to get the next/previous element in the tree, is there one? I also had to move `const restoreFocus` because the rename action seemed to change `document.activeElement`, so after a rename focus was never restored.