### PR TITLE
Update Quiet Light theme's JSX

### DIFF
--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -460,7 +460,25 @@
 				"background": "#DDFFDD",
 				"foreground": "#434343"
 			}
-		}
+		},
+		{
+			"name": "JSX: Tags",
+			"scope": [
+				"punctuation.definition.tag.js",
+				"punctuation.definition.tag.begin.js",
+				"punctuation.definition.tag.end.js"
+			],
+			"settings": {
+			  "foreground": "#91B3E0"
+			}
+      },
+      {
+			"name": "JSX: InnerText",
+			"scope": "meta.jsx.children.js",
+			"settings": {
+			  "foreground": "#333333ff"
+			}
+      }
 	],
 	"colors": {
 		"focusBorder": "#A6B39B",

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -245,7 +245,7 @@
 			],
 			"settings": {
 				"fontStyle": "italic",
-				"foreground": "#91B3E0"
+				"foreground": "#7C98BB"
 			}
 		},
 		{

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -471,14 +471,14 @@
 			"settings": {
 			  "foreground": "#91B3E0"
 			}
-      },
-      {
+      	},
+      	{
 			"name": "JSX: InnerText",
 			"scope": "meta.jsx.children.js",
 			"settings": {
 			  "foreground": "#333333ff"
 			}
-      }
+      	}
 	],
 	"colors": {
 		"focusBorder": "#A6B39B",

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -245,7 +245,7 @@
 			],
 			"settings": {
 				"fontStyle": "italic",
-				"foreground": "#7C98BB"
+				"foreground": "#8190A0"
 			}
 		},
 		{


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/39449 and https://github.com/Microsoft/vscode/issues/39460
This PR makes JSX to match with HTML colors and changes attribute color of HTML for visibility

JSX-HTML matching ->
Earlier:
![33511050-6ab4ad92-d73a-11e7-866a-8f46975120fa](https://user-images.githubusercontent.com/26769888/33511437-e245d6c8-d740-11e7-9246-260cf4452fbb.png)

Now:
![screenshot from 2017-12-02 09-10-33](https://user-images.githubusercontent.com/26769888/33511442-f095d6c4-d740-11e7-8321-4d2603ca2659.png)

HTML:
![html](https://user-images.githubusercontent.com/26769888/33511447-0624c8c4-d741-11e7-95c0-496237cb9b11.png)

Attribute color improvement->
Earlier
![screenshot from 2017-12-02 15-14-24](https://user-images.githubusercontent.com/26769888/33514250-80fe30aa-d776-11e7-9a27-eee830f02ac8.png)

Now
![screenshot from 2017-12-02 15-20-15](https://user-images.githubusercontent.com/26769888/33514252-8a77c5e2-d776-11e7-8c5f-670f0ac92111.png)


