### PR TITLE
Fix Markdown quote syntax highlight(fix #38523)

### DIFF
--- a/extensions/markdown/syntaxes/markdown.tmLanguage
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage
@@ -478,7 +478,7 @@
 				<key>list_paragraph</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)(?=\S)(?![*+-]\s|[0-9]+\.\s)</string>
+					<string>(^|\G)(?=\S)(?![*+-&gt;]\s|[0-9]+\.\s)</string>
 					<key>name</key>
 					<string>meta.paragraph.markdown</string>
 					<key>patterns</key>
@@ -497,7 +497,7 @@
 						</dict>
 					</array>
 					<key>while</key>
-					<string>(^|\G)(?!\s*$|#|[ ]{0,3}([-*_][ ]{2,}){3,}[ \t]*$\n?|&gt;|[ ]{0,3}[*+-]|[ ]{0,3}[0-9]+\.)</string>
+					<string>(^|\G)(?!\s*$|#|[ ]{0,3}([-*_&gt;][ ]{2,}){3,}[ \t]*$\n?|[ ]{0,3}[*+-&gt;]|[ ]{0,3}[0-9]+\.)</string>
 				</dict>
 				<key>lists</key>
 				<dict>

--- a/extensions/markdown/syntaxes/markdown.tmLanguage.base
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage.base
@@ -303,7 +303,7 @@
 				<key>list_paragraph</key>
 				<dict>
 					<key>begin</key>
-					<string>(^|\G)(?=\S)(?![*+-]\s|[0-9]+\.\s)</string>
+					<string>(^|\G)(?=\S)(?![*+-&gt;]\s|[0-9]+\.\s)</string>
 					<key>name</key>
 					<string>meta.paragraph.markdown</string>
 					<key>patterns</key>
@@ -322,7 +322,7 @@
 						</dict>
 					</array>
 					<key>while</key>
-					<string>(^|\G)(?!\s*$|#|[ ]{0,3}([-*_][ ]{2,}){3,}[ \t]*$\n?|&gt;|[ ]{0,3}[*+-]|[ ]{0,3}[0-9]+\.)</string>
+					<string>(^|\G)(?!\s*$|#|[ ]{0,3}([-*_&gt;][ ]{2,}){3,}[ \t]*$\n?|[ ]{0,3}[*+-&gt;]|[ ]{0,3}[0-9]+\.)</string>
 				</dict>
 				<key>lists</key>
 				<dict>

--- a/extensions/markdown/test/colorize-fixtures/test.md
+++ b/extensions/markdown/test/colorize-fixtures/test.md
@@ -47,6 +47,7 @@ in_words_are ignored.
 >> And, they can be nested
 
 1. A numbered list
+    > Block quotes in list
 2. Which is numbered
 3. With periods and a space
 

--- a/extensions/markdown/test/colorize-results/test_md.json
+++ b/extensions/markdown/test/colorize-results/test_md.json
@@ -1793,6 +1793,50 @@
 		}
 	},
 	{
+		"c": "    ",
+		"t": "text.html.markdown markup.list.numbered.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ">",
+		"t": "text.html.markdown markup.list.numbered.markdown markup.quote.markdown beginning.punctuation.definition.quote.markdown",
+		"r": {
+			"dark_plus": "beginning.punctuation.definition.quote.markdown: #608B4E",
+			"light_plus": "beginning.punctuation.definition.quote.markdown: #0451A5",
+			"dark_vs": "beginning.punctuation.definition.quote.markdown: #608B4E",
+			"light_vs": "beginning.punctuation.definition.quote.markdown: #0451A5",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": " ",
+		"t": "text.html.markdown markup.list.numbered.markdown markup.quote.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Block quotes in list",
+		"t": "text.html.markdown markup.list.numbered.markdown markup.quote.markdown meta.paragraph.markdown",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
 		"c": "2.",
 		"t": "text.html.markdown markup.list.numbered.markdown beginning.punctuation.definition.list.markdown",
 		"r": {


### PR DESCRIPTION
Fix #38523
before
<img width="349" alt="before" src="https://user-images.githubusercontent.com/834235/32897112-0bbb365a-cae5-11e7-82ca-238bcf2a95cb.png">

after
<img width="349" alt="screen shot 2017-12-03 at 16 42 09" src="https://user-images.githubusercontent.com/8369346/33523435-c77b4200-d84a-11e7-8cd7-8ecee54a80e4.png">
