### PR TITLE
Use html on enter rules in php 

### DIFF
--- a/extensions/php/src/phpMain.ts
+++ b/extensions/php/src/phpMain.ts
@@ -55,4 +55,19 @@ export function activate(context: vscode.ExtensionContext): any {
 			}
 		]
 	});
+
+	const EMPTY_ELEMENTS: string[] = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'];
+	vscode.languages.setLanguageConfiguration('html', {
+		onEnterRules: [
+			{
+				beforeText: new RegExp(`<(?!(?:${EMPTY_ELEMENTS.join('|')}))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+				afterText: /^<\/([_:\w][_:\w-.\d]*)\s*>/i,
+				action: { indentAction: vscode.IndentAction.IndentOutdent }
+			},
+			{
+				beforeText: new RegExp(`<(?!(?:${EMPTY_ELEMENTS.join('|')}))(\\w[\\w\\d]*)([^/>]*(?!/)>)[^<]*$`, 'i'),
+				action: { indentAction: vscode.IndentAction.Indent }
+			}
+		],
+	});
 }


### PR DESCRIPTION
Fixes #39142

The onEnterRules of html come into play in the html parts of a php file only if the html extension has been activated. So in a case where there is no html file open, the onEnterRules of html doesnt get applied in a php file causing #39142

One way to fix this is to activate html extension when a php file is opened. But that feels like an overhead.
This PR covers another way which is to set the onEnterRules for html in the php extension.

@aeschli @rebornix I am not sure if doing this would cause any issues to html files

cc @roblourens 