### PR TITLE
terminal scroll cursor set to default

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/media/scrollbar.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/scrollbar.css
@@ -26,6 +26,7 @@
 .monaco-workbench .panel.integrated-terminal .xterm:focus .xterm-viewport,
 .monaco-workbench .panel.integrated-terminal .xterm:hover .xterm-viewport {
 	transition: opacity 100ms linear;
+	cursor: default;
 }
 
 .monaco-workbench .panel.integrated-terminal .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
Based on issue https://github.com/Microsoft/vscode/issues/38632, fixed the type of cursor when hovering the scroll bar of the terminal being text to default.

Fixes https://github.com/Microsoft/vscode/issues/36397