### PR TITLE
Fixes #39750

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -157,7 +157,11 @@ export class TrimFinalNewLinesParticipant implements ISaveParticipant {
 			currentLine = model.getLineContent(currentLineNumber);
 			currentLineIsEmptyOrWhitespace = strings.lastNonWhitespaceIndex(currentLine) === -1;
 		}
-		model.pushEditOperations(prevSelection, [EditOperation.delete(new Range(currentLineNumber + 1, 1, lineCount + 1, 1))], edits => prevSelection);
+
+		const deletionRange = new Range(currentLineNumber + 1, 1, lineCount + 1, 1);
+		if (!deletionRange.isEmpty()) {
+			model.pushEditOperations(prevSelection, [EditOperation.delete(deletionRange)], edits => prevSelection);
+		}
 
 		if (editor) {
 			editor.setSelections(prevSelection);


### PR DESCRIPTION
Doesn't edit the model unless an edit is required, which means the undo stack is updated properly. Behaviour should be similar to `files.trimTrailingWhitespace`. I'm not sure how to test the behaviour to prevent a future regression though, if someone could clarify?

Closed #39844 because the commit provided the wrong issue number.