### PR TITLE
Fix #39867 fix git popStash type check

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -977,7 +977,7 @@ export class Repository {
 		try {
 			const args = ['stash', 'pop'];
 
-			if (typeof index === 'string') {
+			if (typeof index === 'number') {
 				args.push(`stash@{${index}}`);
 			}
 


### PR DESCRIPTION
This fixes #39867 by changing the type check to be that of the function signature