### PR TITLE
handle multi-line messages in multi-line patterns

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -208,7 +208,7 @@ abstract class AbstractLineMatcher implements ILineMatcher {
 
 	protected fillProblemData(data: ProblemData, pattern: ProblemPattern, matches: RegExpExecArray): void {
 		this.fillProperty(data, 'file', pattern, matches, true);
-		this.fillProperty(data, 'message', pattern, matches, true);
+		this.appendProperty(data, 'message', pattern, matches, true);
 		this.fillProperty(data, 'code', pattern, matches, true);
 		this.fillProperty(data, 'severity', pattern, matches, true);
 		this.fillProperty(data, 'location', pattern, matches, true);
@@ -216,6 +216,19 @@ abstract class AbstractLineMatcher implements ILineMatcher {
 		this.fillProperty(data, 'character', pattern, matches);
 		this.fillProperty(data, 'endLine', pattern, matches);
 		this.fillProperty(data, 'endCharacter', pattern, matches);
+	}
+
+	private appendProperty(data: ProblemData, property: keyof ProblemData, pattern: ProblemPattern, matches: RegExpExecArray, trim: boolean = false): void {
+		if (Types.isUndefined(data[property])) {
+			this.fillProperty(data, property, pattern, matches, trim);
+		}
+		else if (!Types.isUndefined(pattern[property]) && pattern[property] < matches.length) {
+			let value = matches[pattern[property]];
+			if (trim) {
+				value = Strings.trim(value);
+			}
+			data[property] += '\n' + value;
+		}
 	}
 
 	private fillProperty(data: ProblemData, property: keyof ProblemData, pattern: ProblemPattern, matches: RegExpExecArray, trim: boolean = false): void {

--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -12,6 +12,7 @@ import * as Assert from 'vs/base/common/assert';
 import * as Paths from 'vs/base/common/paths';
 import * as Types from 'vs/base/common/types';
 import * as UUID from 'vs/base/common/uuid';
+import * as Platform from 'vs/base/common/platform';
 import Severity from 'vs/base/common/severity';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -189,6 +190,8 @@ export function createLineMatcher(matcher: ProblemMatcher): ILineMatcher {
 	}
 }
 
+const endOfLine: string = Platform.OS === Platform.OperatingSystem.Windows ? '\r\n' : '\n';
+
 abstract class AbstractLineMatcher implements ILineMatcher {
 	private matcher: ProblemMatcher;
 
@@ -227,7 +230,7 @@ abstract class AbstractLineMatcher implements ILineMatcher {
 			if (trim) {
 				value = Strings.trim(value);
 			}
-			data[property] += '\n' + value;
+			data[property] += endOfLine + value;
 		}
 	}
 


### PR DESCRIPTION
This modifies the handling of multiline message reporters, where more than one pattern have a message field.

For instance

~~~
{
  "regexp": "^\\(\\d+\\) .+\\(([^\\)]+)\\): (failed in .* phase)$",
  "file": 1,
  "message": 2
},
{
  "regexp": "^    (.*)",
  "message": 1,
  "loop": true
}
~~~

The existing behaviour was to use the first matching message. This PR changes this by appending to an existing message instead (retaining newlines). 

One obvious question is whether the new behaviour should be made optional or not.