### PR TITLE
allow for problem patterns without a line

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -42,8 +42,29 @@ export module FileLocationKind {
 	}
 }
 
+
+export enum ProblemLocationKind {
+	File,
+	Location
+}
+
+export module ProblemLocationKind {
+	export function fromString(value: string): ProblemLocationKind {
+		value = value.toLowerCase();
+		if (value === 'file') {
+			return ProblemLocationKind.File;
+		} else if (value === 'location') {
+			return ProblemLocationKind.Location;
+		} else {
+			return undefined;
+		}
+	}
+}
+
 export interface ProblemPattern {
 	regexp: RegExp;
+
+	kind?: ProblemLocationKind;
 
 	file?: number;
 
@@ -138,6 +159,7 @@ interface Location {
 }
 
 interface ProblemData {
+	kind?: ProblemLocationKind;
 	file?: string;
 	location?: string;
 	line?: string;
@@ -353,6 +375,9 @@ class SingleLineMatcher extends AbstractLineMatcher {
 	public handle(lines: string[], start: number = 0): HandleResult {
 		Assert.ok(lines.length - start === 1);
 		let data: ProblemData = Object.create(null);
+		if (this.pattern.kind) {
+			data.kind = this.pattern.kind;
+		}
 		let matches = this.pattern.regexp.exec(lines[start]);
 		if (matches) {
 			this.fillProblemData(data, this.pattern, matches);
@@ -387,6 +412,7 @@ class MultiLineMatcher extends AbstractLineMatcher {
 		Assert.ok(lines.length - start === this.patterns.length);
 		this.data = Object.create(null);
 		let data = this.data;
+		data.kind = this.patterns[0].kind;
 		for (let i = 0; i < this.patterns.length; i++) {
 			let pattern = this.patterns[i];
 			let matches = pattern.regexp.exec(lines[i + start]);
@@ -430,6 +456,14 @@ export namespace Config {
 		* executed task.
 		*/
 		regexp?: string;
+
+		/**
+		* Whether the pattern matches a whole file, or a location (file/line)
+		*
+		* The default is to match for a location. Only valid on the
+		* first problem pattern in a multi line problem matcher.
+		*/
+		kind?: string;
 
 		/**
 		* The match group index of the filename.
@@ -696,7 +730,7 @@ export namespace Config {
 	}
 }
 
-class ProblemPatternParser extends Parser {
+export class ProblemPatternParser extends Parser {
 
 	constructor(logger: IProblemReporter) {
 		super(logger);
@@ -724,6 +758,9 @@ class ProblemPatternParser extends Parser {
 
 	private createSingleProblemPattern(value: Config.ProblemPattern): ProblemPattern {
 		let result = this.doCreateSingleProblemPattern(value, true);
+		if (result.kind === undefined) {
+			result.kind = ProblemLocationKind.Location;
+		}
 		return this.validateProblemPattern([result]) ? result : null;
 	}
 
@@ -748,13 +785,19 @@ class ProblemPatternParser extends Parser {
 			}
 			result.push(pattern);
 		}
+		if (result[0].kind === undefined) {
+			result[0].kind = ProblemLocationKind.Location;
+		}
 		return this.validateProblemPattern(result) ? result : null;
 	}
 
 	private doCreateSingleProblemPattern(value: Config.ProblemPattern, setDefaults: boolean): ProblemPattern {
 		let result: ProblemPattern = {
-			regexp: this.createRegularExpression(value.regexp)
+			regexp: this.createRegularExpression(value.regexp),
 		};
+		if (value.kind) {
+			result.kind = ProblemLocationKind.fromString(value.kind);
+		}
 
 		function copyProperty(result: ProblemPattern, source: Config.ProblemPattern, resultKey: keyof ProblemPattern, sourceKey: keyof Config.ProblemPattern) {
 			let value = source[sourceKey];
@@ -775,7 +818,7 @@ class ProblemPatternParser extends Parser {
 			result.loop = value.loop;
 		}
 		if (setDefaults) {
-			if (result.location) {
+			if (result.location || result.kind === ProblemLocationKind.File) {
 				let defaultValue: Partial<ProblemPattern> = {
 					file: 1,
 					message: 0
@@ -797,7 +840,12 @@ class ProblemPatternParser extends Parser {
 	private validateProblemPattern(values: ProblemPattern[]): boolean {
 		let file: boolean, message: boolean, location: boolean, line: boolean;
 		let regexp: number = 0;
-		values.forEach(pattern => {
+		let locationKind = (values[0].kind === undefined) ? ProblemLocationKind.Location : values[0].kind;
+
+		values.forEach((pattern, i) => {
+			if (i !== 0 && pattern.kind) {
+				this.error(localize('ProblemPatternParser.problemPattern.kindProperty.notFirst', 'The problem pattern is invalid. The kind property must be provided only in the first element'));
+			}
 			file = file || !Types.isUndefined(pattern.file);
 			message = message || !Types.isUndefined(pattern.message);
 			location = location || !Types.isUndefined(pattern.location);
@@ -810,8 +858,12 @@ class ProblemPatternParser extends Parser {
 			this.error(localize('ProblemPatternParser.problemPattern.missingRegExp', 'The problem pattern is missing a regular expression.'));
 			return false;
 		}
-		if (!(file && message && (location || line))) {
-			this.error(localize('ProblemPatternParser.problemPattern.missingProperty', 'The problem pattern is invalid. It must have at least a file, message and line or location match group.'));
+		if (!(file && message)) {
+			this.error(localize('ProblemPatternParser.problemPattern.missingProperty', 'The problem pattern is invalid. It must have at least have a file and a message.'));
+			return false;
+		}
+		if (locationKind === ProblemLocationKind.Location && !(location || line)) {
+			this.error(localize('ProblemPatternParser.problemPattern.missingLocation', 'The problem pattern is invalid. It must either have kind: "file" or have a line or location match group.'));
 			return false;
 		}
 		return true;
@@ -875,6 +927,10 @@ export namespace Schemas {
 			regexp: {
 				type: 'string',
 				description: localize('ProblemPatternSchema.regexp', 'The regular expression to find an error, warning or info in the output.')
+			},
+			kind: {
+				type: 'string',
+				description: localize('ProblemPatternSchema.kind', 'whether the pattern matches a location (file and line) or only a file.')
 			},
 			file: {
 				type: 'integer',
@@ -1026,6 +1082,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 	private fillDefaults(): void {
 		this.add('msCompile', {
 			regexp: /^(?:\s+\d+\>)?([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\)\s*:\s+(error|warning|info)\s+(\w{1,2}\d+)\s*:\s*(.*)$/,
+			kind: ProblemLocationKind.Location,
 			file: 1,
 			location: 2,
 			severity: 3,
@@ -1034,6 +1091,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		});
 		this.add('gulp-tsc', {
 			regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(\d+)\s+(.*)$/,
+			kind: ProblemLocationKind.Location,
 			file: 1,
 			location: 2,
 			code: 3,
@@ -1041,6 +1099,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		});
 		this.add('cpp', {
 			regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(error|warning|info)\s+(C\d+)\s*:\s*(.*)$/,
+			kind: ProblemLocationKind.Location,
 			file: 1,
 			location: 2,
 			severity: 3,
@@ -1049,6 +1108,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		});
 		this.add('csc', {
 			regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(error|warning|info)\s+(CS\d+)\s*:\s*(.*)$/,
+			kind: ProblemLocationKind.Location,
 			file: 1,
 			location: 2,
 			severity: 3,
@@ -1057,6 +1117,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		});
 		this.add('vb', {
 			regexp: /^([^\s].*)\((\d+|\d+,\d+|\d+,\d+,\d+,\d+)\):\s+(error|warning|info)\s+(BC\d+)\s*:\s*(.*)$/,
+			kind: ProblemLocationKind.Location,
 			file: 1,
 			location: 2,
 			severity: 3,
@@ -1065,12 +1126,14 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		});
 		this.add('lessCompile', {
 			regexp: /^\s*(.*) in file (.*) line no. (\d+)$/,
+			kind: ProblemLocationKind.Location,
 			message: 1,
 			file: 2,
 			line: 3
 		});
 		this.add('jshint', {
 			regexp: /^(.*):\s+line\s+(\d+),\s+col\s+(\d+),\s(.+?)(?:\s+\((\w)(\d+)\))?$/,
+			kind: ProblemLocationKind.Location,
 			file: 1,
 			line: 2,
 			character: 3,
@@ -1081,6 +1144,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		this.add('jshint-stylish', [
 			{
 				regexp: /^(.+)$/,
+				kind: ProblemLocationKind.Location,
 				file: 1
 			},
 			{
@@ -1096,6 +1160,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		this.add('eslint-compact', {
 			regexp: /^(.+):\sline\s(\d+),\scol\s(\d+),\s(Error|Warning|Info)\s-\s(.+)\s\((.+)\)$/,
 			file: 1,
+			kind: ProblemLocationKind.Location,
 			line: 2,
 			character: 3,
 			severity: 4,
@@ -1105,6 +1170,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		this.add('eslint-stylish', [
 			{
 				regexp: /^([^\s].*)$/,
+				kind: ProblemLocationKind.Location,
 				file: 1
 			},
 			{
@@ -1119,6 +1185,7 @@ class ProblemPatternRegistryImpl implements IProblemPatternRegistry {
 		]);
 		this.add('go', {
 			regexp: /^([^:]*: )?((.:)?[^:]*):(\d+)(:(\d+))?: (.*)$/,
+			kind: ProblemLocationKind.Location,
 			file: 2,
 			line: 4,
 			character: 6,
@@ -1369,7 +1436,7 @@ export namespace Schemas {
 				description: localize('PatternTypeSchema.name', 'The name of a contributed or predefined pattern')
 			},
 			Schemas.ProblemPattern,
-			Schemas.MultLileProblemPattern
+			Schemas.MultiLineProblemPattern
 		],
 		description: localize('PatternTypeSchema.description', 'A problem pattern or the name of a contributed or predefined problem pattern. Can be omitted if base is specified.')
 	};

--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -927,7 +927,7 @@ export namespace Schemas {
 	};
 
 
-	export const MultLileProblemPattern: IJSONSchema = {
+	export const MultiLineProblemPattern: IJSONSchema = {
 		type: 'array',
 		items: ProblemPattern
 	};

--- a/src/vs/platform/markers/test/common/problemMatcher.test.ts
+++ b/src/vs/platform/markers/test/common/problemMatcher.test.ts
@@ -1,0 +1,260 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as matchers from 'vs/platform/markers/common/problemMatcher';
+
+import assert = require('assert');
+import { ValidationState, IProblemReporter, ValidationStatus } from 'vs/base/common/parsers';
+
+class ProblemReporter implements IProblemReporter {
+	private _validationStatus: ValidationStatus;
+	private _messages: string[];
+
+	constructor() {
+		this._validationStatus = new ValidationStatus();
+		this._messages = [];
+	}
+
+	public info(message: string): void {
+		this._messages.push(message);
+		this._validationStatus.state = ValidationState.Info;
+	}
+
+	public warn(message: string): void {
+		this._messages.push(message);
+		this._validationStatus.state = ValidationState.Warning;
+	}
+
+	public error(message: string): void {
+		this._messages.push(message);
+		this._validationStatus.state = ValidationState.Error;
+	}
+
+	public fatal(message: string): void {
+		this._messages.push(message);
+		this._validationStatus.state = ValidationState.Fatal;
+	}
+
+	public hasMessage(message: string): boolean {
+		return this._messages.indexOf(message) !== null;
+	}
+	public get messages(): string[] {
+		return this._messages;
+	}
+	public get state(): ValidationState {
+		return this._validationStatus.state;
+	}
+
+	public isOK(): boolean {
+		return this._validationStatus.isOK();
+	}
+
+	public get status(): ValidationStatus {
+		return this._validationStatus;
+	}
+}
+
+suite('ProblemPatternParser', () => {
+	let reporter: ProblemReporter;
+	let parser: matchers.ProblemPatternParser;
+	const testRegexp = new RegExp('test');
+
+	setup(() => {
+		reporter = new ProblemReporter();
+		parser = new matchers.ProblemPatternParser(reporter);
+	});
+
+	suite('single-pattern definitions', () => {
+		test('parses a pattern defined by only a regexp', () => {
+			let problemPattern: matchers.Config.ProblemPattern = {
+				regexp: 'test'
+			};
+			let parsed = parser.parse(problemPattern);
+			assert(reporter.isOK());
+			assert.deepEqual(parsed, {
+				regexp: testRegexp,
+				kind: matchers.ProblemLocationKind.Location,
+				file: 1,
+				line: 2,
+				character: 3,
+				message: 0
+			});
+		});
+		test('does not sets defaults for line and character if kind is File', () => {
+			let problemPattern: matchers.Config.ProblemPattern = {
+				regexp: 'test',
+				kind: 'file'
+			};
+			let parsed = parser.parse(problemPattern);
+			assert.deepEqual(parsed, {
+				regexp: testRegexp,
+				kind: matchers.ProblemLocationKind.File,
+				file: 1,
+				message: 0
+			});
+		});
+	});
+
+	suite('multi-pattern definitions', () => {
+		test('defines a pattern based on regexp and property fields, with file/line location', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 3, line: 4, column: 5, message: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert(reporter.isOK());
+			assert.deepEqual(parsed,
+				[{
+					regexp: testRegexp,
+					kind: matchers.ProblemLocationKind.Location,
+					file: 3,
+					line: 4,
+					character: 5,
+					message: 6
+				}]
+			);
+		});
+		test('defines a pattern bsaed on regexp and property fields, with location', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 3, location: 4, message: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert(reporter.isOK());
+			assert.deepEqual(parsed,
+				[{
+					regexp: testRegexp,
+					kind: matchers.ProblemLocationKind.Location,
+					file: 3,
+					location: 4,
+					message: 6
+				}]
+			);
+		});
+		test('accepts a pattern that provides the fields from multiple entries', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 3 },
+				{ regexp: 'test1', line: 4 },
+				{ regexp: 'test2', column: 5 },
+				{ regexp: 'test3', message: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert(reporter.isOK());
+			assert.deepEqual(parsed, [
+				{ regexp: testRegexp, kind: matchers.ProblemLocationKind.Location, file: 3 },
+				{ regexp: new RegExp('test1'), line: 4 },
+				{ regexp: new RegExp('test2'), character: 5 },
+				{ regexp: new RegExp('test3'), message: 6 }
+			]);
+		});
+		test('forbids setting the loop flag outside of the last element in the array', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 3, loop: true },
+				{ regexp: 'test1', line: 4 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The loop property is only supported on the last line matcher.'));
+		});
+		test('forbids setting the kind outside of the first element of the array', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 3 },
+				{ regexp: 'test1', kind: 'file', line: 4 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is invalid. The kind property must be provided only in the first element'));
+		});
+
+		test('kind: Location requires a regexp', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ file: 0, line: 1, column: 20, message: 0 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is missing a regular expression.'));
+		});
+		test('kind: Location requires a regexp on every entry', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 3 },
+				{ line: 4 },
+				{ regexp: 'test2', column: 5 },
+				{ regexp: 'test3', message: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is missing a regular expression.'));
+		});
+		test('kind: Location requires a message', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 0, line: 1, column: 20 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is invalid. It must have at least have a file and a message.'));
+		});
+
+		test('kind: Location requires a file', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', line: 1, column: 20, message: 0 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is invalid. It must either have kind: "file" or have a line or location match group.'));
+		});
+
+		test('kind: Location requires either a line or location', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 1, column: 20, message: 0 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is invalid. It must either have kind: "file" or have a line or location match group.'));
+		});
+
+		test('kind: File accepts a regexp, file and message', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', file: 2, kind: 'file', message: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			console.log(reporter.messages);
+			assert(reporter.isOK());
+			assert.deepEqual(parsed,
+				[{
+					regexp: testRegexp,
+					kind: matchers.ProblemLocationKind.File,
+					file: 2,
+					message: 6
+				}]
+			);
+		});
+
+		test('kind: File requires a file', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', kind: 'file', message: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is invalid. It must have at least have a file and a message.'));
+		});
+
+		test('kind: File requires a message', () => {
+			let problemPattern: matchers.Config.MultiLineProblemPattern = [
+				{ regexp: 'test', kind: 'file', file: 6 }
+			];
+			let parsed = parser.parse(problemPattern);
+			assert.equal(null, parsed);
+			assert.equal(ValidationState.Error, reporter.state);
+			assert(reporter.hasMessage('The problem pattern is invalid. It must have at least have a file and a message.'));
+		});
+	});
+});


### PR DESCRIPTION
Problem matchers currently must provide a line (and will be ignored if they don't). There's however sometimes problems that have no lines.

In these cases, using the matcher, assuming a line of 1, would be IMO a lot more useful than ignoring it.

Closes #39919