### PR TITLE
Apply suggestion additionalTextEdits after main insertion

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/suggestController.ts
@@ -203,12 +203,6 @@ export class SuggestController implements IEditorContribution {
 		const editorColumn = this._editor.getPosition().column;
 		const columnDelta = editorColumn - position.column;
 
-		if (Array.isArray(suggestion.additionalTextEdits)) {
-			this._editor.pushUndoStop();
-			this._editor.executeEdits('suggestController.additionalTextEdits', suggestion.additionalTextEdits.map(edit => EditOperation.replace(Range.lift(edit.range), edit.text)));
-			this._editor.pushUndoStop();
-		}
-
 		// remember this word for future invocations
 		this._memory.remember(this._editor.getModel().getLanguageIdentifier(), item);
 
@@ -222,6 +216,12 @@ export class SuggestController implements IEditorContribution {
 			suggestion.overwriteBefore + columnDelta,
 			suggestion.overwriteAfter
 		);
+
+		if (Array.isArray(suggestion.additionalTextEdits)) {
+			this._editor.pushUndoStop();
+			this._editor.executeEdits('suggestController.additionalTextEdits', suggestion.additionalTextEdits.map(edit => EditOperation.replace(Range.lift(edit.range), edit.text)));
+			this._editor.pushUndoStop();
+		}
 
 		if (!suggestion.command) {
 			// done


### PR DESCRIPTION
Fixes #39947

**Problem**
Investigating using the `additionalTextEdits` property to add auto insert completeions for TS as part of #39893. We currently use a command for this

Current suggest controller behavior is:

- Apply additionalTextEdits with undo stops
- Apply main insertion
- Apply command

This creates the following undo sequnce:

- Undo any changes from command
- Undo main insertion
- Then undo additionalTextEdits

This ordering feels wrong

**Proposed fix**
Apply the `additionalTextEdits` after the main insertion. This results in the correct undo behavior when using `additionalTextEdits`