### PR TITLE
eslint-compact to use absolute pathnames

### DIFF
--- a/src/vs/platform/markers/common/problemMatcher.ts
+++ b/src/vs/platform/markers/common/problemMatcher.ts
@@ -1598,7 +1598,7 @@ class ProblemMatcherRegistryImpl implements IProblemMatcherRegistry {
 			label: localize('eslint-compact', 'ESLint compact problems'),
 			owner: 'eslint',
 			applyTo: ApplyToKind.allDocuments,
-			fileLocation: FileLocationKind.Relative,
+			fileLocation: FileLocationKind.Absolute,
 			filePrefix: '${workspaceFolder}',
 			pattern: ProblemPatternRegistry.get('eslint-compact')
 		});


### PR DESCRIPTION
eslint compact now uses absolute pathnames for files