### PR TITLE
Prototype definition and span API

### DIFF
--- a/extensions/typescript/src/features/completionItemProvider.ts
+++ b/extensions/typescript/src/features/completionItemProvider.ts
@@ -181,7 +181,6 @@ namespace Configuration {
 	export const nameSuggestions = 'nameSuggestions';
 	export const quickSuggestionsForPaths = 'quickSuggestionsForPaths';
 	export const autoImportSuggestions = 'autoImportSuggestions.enabled';
-
 }
 
 export default class TypeScriptCompletionItemProvider implements CompletionItemProvider {

--- a/extensions/typescript/src/features/definitionProvider.ts
+++ b/extensions/typescript/src/features/definitionProvider.ts
@@ -3,12 +3,53 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DefinitionProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
+import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, DefinitionAndSpan } from 'vscode';
+import * as Proto from '../protocol';
 
 import DefinitionProviderBase from './definitionProviderBase';
+import { ITypeScriptServiceClient } from '../typescriptService';
+import { vsPositionToTsFileLocation, tsFileSpanToVsLocation, tsTextSpanToVsRange } from '../utils/convert';
 
 export default class TypeScriptDefinitionProvider extends DefinitionProviderBase implements DefinitionProvider {
-	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | undefined> {
+	constructor(
+		client: ITypeScriptServiceClient
+	) {
+		super(client);
+	}
+
+	public async provideDefinition(
+		document: TextDocument,
+		position: Position,
+		token: CancellationToken | boolean
+	): Promise<DefinitionAndSpan | Location[] | undefined> {
+		if (this.client.apiVersion.has270Features()) {
+			const filepath = this.client.normalizePath(document.uri);
+			if (!filepath) {
+				return undefined;
+			}
+
+			const args = vsPositionToTsFileLocation(filepath, position);
+			try {
+				const response = await this.client.execute('definitionAndBoundSpan', args, token);
+				const locations: Proto.FileSpan[] = (response && response.body && response.body.definitions) || [];
+				if (!locations) {
+					return [];
+				}
+				const span = new Location(document.uri, tsTextSpanToVsRange(response.body.textSpan));
+
+				if (!span) {
+					return [];
+				}
+
+				return new DefinitionAndSpan(span,
+					locations
+						.map(location => tsFileSpanToVsLocation(this.client, location))
+						.filter(x => x) as Location[]);
+			} catch {
+				return [];
+			}
+		}
+
 		return this.getSymbolLocations('definition', document, position, token);
 	}
 }

--- a/extensions/typescript/src/utils/api.ts
+++ b/extensions/typescript/src/utils/api.ts
@@ -76,4 +76,8 @@ export default class API {
 	public has262Features(): boolean {
 		return semver.gte(this.version, '2.6.2');
 	}
+
+	public has270Features(): boolean {
+		return semver.gte(this.version, '2.7.0');
+	}
 }

--- a/extensions/typescript/src/utils/convert.ts
+++ b/extensions/typescript/src/utils/convert.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as Proto from '../protocol';
-
+import { ITypeScriptServiceClient } from '../typescriptService';
 
 export const tsTextSpanToVsRange = (span: Proto.TextSpan) =>
 	new vscode.Range(
@@ -28,3 +28,10 @@ export const vsRangeToTsFileRange = (file: string, range: vscode.Range): Proto.F
 	endLine: range.end.line + 1,
 	endOffset: range.end.character + 1
 });
+
+export const tsFileSpanToVsLocation = (client: ITypeScriptServiceClient, span: Proto.FileSpan): vscode.Location | undefined => {
+	const resource = client.asUrl(span.file);
+	return resource
+		? new vscode.Location(resource, tsTextSpanToVsRange(span))
+		: undefined;
+};

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -444,6 +444,10 @@ export interface Location {
 	 */
 	range: IRange;
 }
+export interface DefinitionAndSpan {
+	span?: Location;
+	definition: Location;
+}
 /**
  * The definition of a symbol represented as one or many [locations](#Location).
  * For most programming languages there is only one location at which a symbol is
@@ -460,7 +464,7 @@ export interface DefinitionProvider {
 	/**
 	 * Provide the definition of the symbol at the given position and document.
 	 */
-	provideDefinition(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideDefinition(model: editorCommon.IReadOnlyModel, position: Position, token: CancellationToken): Definition | DefinitionAndSpan | Thenable<Definition | DefinitionAndSpan>;
 }
 
 /**

--- a/src/vs/editor/contrib/goToDeclaration/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/goToDeclaration.ts
@@ -10,19 +10,35 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
 import { registerDefaultLanguageCommand } from 'vs/editor/browser/editorExtensions';
 import LanguageFeatureRegistry from 'vs/editor/common/modes/languageFeatureRegistry';
-import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location, DefinitionAndSpan } from 'vs/editor/common/modes';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
 
-function outputResults(promises: TPromise<Location | Location[]>[]) {
+function locationToDefinitionAndSpan(location: Location): DefinitionAndSpan {
+	return {
+		definition: location
+	};
+}
+
+function outputResults(promises: TPromise<Location | Location[] | DefinitionAndSpan[]>[]): TPromise<DefinitionAndSpan[]> {
 	return TPromise.join(promises).then(allReferences => {
-		let result: Location[] = [];
+		let result: DefinitionAndSpan[] = [];
 		for (let references of allReferences) {
+			if (!references) {
+				continue;
+			}
+
 			if (Array.isArray(references)) {
-				result.push(...references);
-			} else if (references) {
-				result.push(references);
+				for (const item of references) {
+					if ((item as DefinitionAndSpan).definition) {
+						result.push(item as DefinitionAndSpan);
+					} else {
+						result.push(locationToDefinitionAndSpan(item as Location));
+					}
+				}
+			} else {
+				result.push(locationToDefinitionAndSpan(references as Location));
 			}
 		}
 		return result;
@@ -33,8 +49,8 @@ function getDefinitions<T>(
 	model: IReadOnlyModel,
 	position: Position,
 	registry: LanguageFeatureRegistry<T>,
-	provide: (provider: T, model: IReadOnlyModel, position: Position, token: CancellationToken) => Location | Location[] | Thenable<Location | Location[]>
-): TPromise<Location[]> {
+	provide: (provider: T, model: IReadOnlyModel, position: Position, token: CancellationToken) => Location | Location[] | DefinitionAndSpan | Thenable<Location | Location[] | DefinitionAndSpan>
+): TPromise<DefinitionAndSpan[]> {
 	const provider = registry.ordered(model);
 
 	// get results
@@ -50,19 +66,19 @@ function getDefinitions<T>(
 }
 
 
-export function getDefinitionsAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+export function getDefinitionsAtPosition(model: IReadOnlyModel, position: Position): TPromise<DefinitionAndSpan[]> {
 	return getDefinitions(model, position, DefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideDefinition(model, position, token);
 	});
 }
 
-export function getImplementationsAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+export function getImplementationsAtPosition(model: IReadOnlyModel, position: Position): TPromise<DefinitionAndSpan[]> {
 	return getDefinitions(model, position, ImplementationProviderRegistry, (provider, model, position, token) => {
 		return provider.provideImplementation(model, position, token);
 	});
 }
 
-export function getTypeDefinitionsAtPosition(model: IReadOnlyModel, position: Position): TPromise<Location[]> {
+export function getTypeDefinitionsAtPosition(model: IReadOnlyModel, position: Position): TPromise<DefinitionAndSpan[]> {
 	return getDefinitions(model, position, TypeDefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideTypeDefinition(model, position, token);
 	});

--- a/src/vs/editor/contrib/goToDeclaration/goToDeclarationCommands.ts
+++ b/src/vs/editor/contrib/goToDeclaration/goToDeclarationCommands.ts
@@ -16,7 +16,7 @@ import { IMessageService } from 'vs/platform/message/common/message';
 import { Range } from 'vs/editor/common/core/range';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { registerEditorAction, IActionOptions, ServicesAccessor, EditorAction } from 'vs/editor/browser/editorExtensions';
-import { Location } from 'vs/editor/common/modes';
+import { Location, DefinitionAndSpan } from 'vs/editor/common/modes';
 import { getDefinitionsAtPosition, getImplementationsAtPosition, getTypeDefinitionsAtPosition } from './goToDeclaration';
 import { ReferencesController } from 'vs/editor/contrib/referenceSearch/referencesController';
 import { ReferencesModel } from 'vs/editor/contrib/referenceSearch/referencesModel';
@@ -68,12 +68,12 @@ export class DefinitionAction extends EditorAction {
 			// * find reference at the current pos
 			let idxOfCurrent = -1;
 			let result: Location[] = [];
-			for (let i = 0; i < references.length; i++) {
-				let reference = references[i];
-				if (!reference || !reference.range) {
+			for (const reference of references) {
+				let location = reference.definition;
+				if (!reference || !location.range) {
 					continue;
 				}
-				let { uri, range } = reference;
+				let { uri, range } = location;
 				let newLen = result.push({
 					uri,
 					range
@@ -112,7 +112,7 @@ export class DefinitionAction extends EditorAction {
 		return definitionPromise;
 	}
 
-	protected _getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
+	protected _getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<DefinitionAndSpan[]> {
 		return getDefinitionsAtPosition(model, position);
 	}
 
@@ -249,7 +249,7 @@ export class PeekDefinitionAction extends DefinitionAction {
 }
 
 export class ImplementationAction extends DefinitionAction {
-	protected _getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
+	protected _getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<DefinitionAndSpan[]> {
 		return getImplementationsAtPosition(model, position);
 	}
 
@@ -305,7 +305,7 @@ export class PeekImplementationAction extends ImplementationAction {
 }
 
 export class TypeDefinitionAction extends DefinitionAction {
-	protected _getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<Location[]> {
+	protected _getDeclarationsAtPosition(model: editorCommon.IModel, position: corePosition.Position): TPromise<DefinitionAndSpan[]> {
 		return getTypeDefinitionsAtPosition(model, position);
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4677,6 +4677,11 @@ declare module monaco.languages {
 		range: IRange;
 	}
 
+	export interface DefinitionAndSpan {
+		span?: Location;
+		definition: Location;
+	}
+
 	/**
 	 * The definition of a symbol represented as one or many [locations](#Location).
 	 * For most programming languages there is only one location at which a symbol is
@@ -4693,7 +4698,7 @@ declare module monaco.languages {
 		/**
 		 * Provide the definition of the symbol at the given position and document.
 		 */
-		provideDefinition(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+		provideDefinition(model: editor.IReadOnlyModel, position: Position, token: CancellationToken): Definition | DefinitionAndSpan | Thenable<Definition | DefinitionAndSpan>;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1896,6 +1896,13 @@ declare module 'vscode' {
 		resolveCodeLens?(codeLens: CodeLens, token: CancellationToken): ProviderResult<CodeLens>;
 	}
 
+	export class DefinitionAndSpan {
+		span: Location;
+		definitions: Location[];
+
+		constructor(span: Location, definitions: Location[]);
+	}
+
 	/**
 	 * The definition of a symbol represented as one or many [locations](#Location).
 	 * For most programming languages there is only one location at which a symbol is
@@ -1919,7 +1926,7 @@ declare module 'vscode' {
 		 * @return A definition or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+		provideDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | DefinitionAndSpan>;
 	}
 
 	/**

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -102,7 +102,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	$registerDeclaractionSupport(handle: number, selector: vscode.DocumentSelector): TPromise<any> {
 		this._registrations[handle] = modes.DefinitionProviderRegistry.register(toLanguageSelector(selector), <modes.DefinitionProvider>{
-			provideDefinition: (model, position, token): Thenable<modes.Definition> => {
+			provideDefinition: (model, position, token): Thenable<modes.Definition | modes.DefinitionAndSpan[]> => {
 				return wireCancellationToken(token, this._proxy.$provideDefinition(handle, model.uri, position));
 			}
 		});

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -566,6 +566,7 @@ export function createApiFactory(
 			CompletionItemKind: extHostTypes.CompletionItemKind,
 			CompletionList: extHostTypes.CompletionList,
 			CompletionTriggerKind: extHostTypes.CompletionTriggerKind,
+			DefinitionAndSpan: extHostTypes.DefinitionAndSpan,
 			Diagnostic: extHostTypes.Diagnostic,
 			DiagnosticSeverity: extHostTypes.DiagnosticSeverity,
 			Disposable: extHostTypes.Disposable,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -581,7 +581,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideDocumentSymbols(handle: number, resource: URI): TPromise<modes.SymbolInformation[]>;
 	$provideCodeLenses(handle: number, resource: URI): TPromise<modes.ICodeLensSymbol[]>;
 	$resolveCodeLens(handle: number, resource: URI, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol>;
-	$provideDefinition(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition>;
+	$provideDefinition(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition | modes.DefinitionAndSpan[]>;
 	$provideImplementation(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition>;
 	$provideTypeDefinition(handle: number, resource: URI, position: IPosition): TPromise<modes.Definition>;
 	$provideHover(handle: number, resource: URI, position: IPosition): TPromise<modes.Hover>;

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -338,6 +338,20 @@ export const location = {
 	}
 };
 
+export namespace DefinitionAndSpan {
+	export function from(value: vscode.DefinitionAndSpan): modes.DefinitionAndSpan[] {
+		if (!Array.isArray(value.definitions)) {
+			return undefined;
+		}
+
+		const span = value.span ? location.from(value.span) : undefined;
+		return value.definitions.map(loc => ({
+			definition: location.from(loc),
+			span
+		}));
+	}
+}
+
 export function fromHover(hover: vscode.Hover): modes.Hover {
 	return <modes.Hover>{
 		range: fromRange(hover.range),

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -673,6 +673,23 @@ export class Location {
 	}
 }
 
+export class DefinitionAndSpan {
+	span: Location;
+	definitions: Location[];
+
+	constructor(span: Location, definitions: Location[]) {
+		this.span = span;
+
+		if (!definitions) {
+			// skip
+		} else if (Array.isArray(definitions)) {
+			this.definitions = definitions;
+		} else {
+			throw new Error('Illegal argument');
+		}
+	}
+}
+
 export class Diagnostic {
 
 	range: Range;


### PR DESCRIPTION
**Problem**
See #10037

**Proposal**
Add a new `DefinitionAndSpan` class to the VSCode API. This bundles up a location and the span of the defining symbol. Allow definition providers to return either a `Location` or a `DefinitionAndSpan`