### PR TITLE
Point to correct keybinding in smoketest

### DIFF
--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -151,7 +151,7 @@ async function setup(): Promise<void> {
 	console.log('*** Test data:', testDataPath);
 	console.log('*** Preparing smoketest setup...');
 
-	const keybindingsUrl = `https://raw.githubusercontent.com/Microsoft/vscode-docs/master/scripts/keybindings/doc.keybindings.${getKeybindingPlatform()}.json`;
+	const keybindingsUrl = `https://raw.githubusercontent.com/Microsoft/vscode-docs/master/build/keybindings/doc.keybindings.${getKeybindingPlatform()}.json`;
 	console.log('*** Fetching keybindings...');
 
 	await new Promise((c, e) => {


### PR DESCRIPTION
Fixes Microsoft/vscode-docs/issues/1234

We'll remove the `/scripts` folder after the next release. These keybindings will live in `/build/keybindings`.

FYI @gregvanl 