### PR TITLE
 Adding support for project level validation in json extension

### DIFF
--- a/extensions/json/server/src/jsonServerMain.ts
+++ b/extensions/json/server/src/jsonServerMain.ts
@@ -239,7 +239,11 @@ function updateConfiguration() {
 	languageService.configure(languageSettings);
 
 	// Revalidate any open text documents
-	documents.all().forEach(triggerValidation);
+	if (JsonProjectDocuments) {
+        JsonProjectDocuments.forEach(validateTextDocument);
+	}else{
+		documents.all().forEach(triggerValidation);
+	}
 }
 
 // The content of a text document has changed. This event is emitted
@@ -305,6 +309,10 @@ connection.onDidChangeWatchedFiles((change) => {
 			hasChanges = true;
 		}
 	});
+	
+	if (hasChanges && JsonProjectDocuments) {
+        JsonProjectDocuments.forEach(validateTextDocument);
+	}
 	if (hasChanges) {
 		documents.all().forEach(validateTextDocument);
 	}


### PR DESCRIPTION
Adding property- `initializationOptions.projectValidation` to initalization params enables project level validation.
The code goes over all json files in the project and sends diagnostic notification for each one.