### PR TITLE
reset focus context key when the webview is disposed

### DIFF
--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -196,6 +196,10 @@ export default class Webview {
 		this._onDidClickLink.dispose();
 		this._disposables = dispose(this._disposables);
 
+		if (this._contextKey) {
+			this._contextKey.reset();
+		}
+
 		if (this._webview.parentElement) {
 			this._webview.parentElement.removeChild(this._webview);
 			const findWidgetDomNode = this._webviewFindWidget.getDomNode();


### PR DESCRIPTION
Otherwise, commands that depend on the the focus may still be active after it is disposed.