### PR TITLE
mistyped pattern name in css syntax

### DIFF
--- a/extensions/css/syntaxes/css.tmLanguage.json
+++ b/extensions/css/syntaxes/css.tmLanguage.json
@@ -1058,7 +1058,7 @@
 							"name": "support.constant.text-direction.css"
 						},
 						{
-							"include": "#property-value"
+							"include": "#property-values"
 						}
 					]
 				},


### PR DESCRIPTION
It's trivial but it should be fixed.