### PR TITLE
Adding test for integrated terminal font-size overflow

### DIFF
--- a/src/vs/workbench/parts/terminal/test/electron-browser/terminalConfigHelper.test.ts
+++ b/src/vs/workbench/parts/terminal/test/electron-browser/terminalConfigHelper.test.ts
@@ -106,6 +106,21 @@ suite('Workbench - TerminalConfigHelper', () => {
 
 		configurationService = new MockConfigurationService({
 			editor: {
+				fontFamily: 'foo'
+			},
+			terminal: {
+				integrated: {
+					fontFamily: 0,
+					fontSize: 1500
+				}
+			}
+		});
+		configHelper = new TerminalConfigHelper(configurationService, null, null, null);
+		configHelper.panelContainer = fixture;
+		assert.equal(configHelper.getFont().fontSize, 25, 'The maximum terminal font size should be used when terminal.integrated.fontSize more than it');
+
+		configurationService = new MockConfigurationService({
+			editor: {
 				fontFamily: 'foo',
 			},
 			terminal: {


### PR DESCRIPTION
This extends the tests for `terminalConfigHelper`.
Adds case when terminal font-size is more than max defined.

Fixes #37455
Refs #37636