### PR TITLE
adding suggestion to search for extension for files are of unknown mime type

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
@@ -31,6 +31,7 @@ import { flatten, distinct } from 'vs/base/common/arrays';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { guessMimeTypes, MIME_UNKNOWN } from 'vs/base/common/mime';
 import { ShowLanguageExtensionsAction } from 'vs/workbench/browser/parts/editor/editorStatus';
+import { ILifecycleService, LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 
 interface IExtensionsContent {
 	recommendations: string[];
@@ -63,7 +64,8 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IMessageService private messageService: IMessageService,
 		@ITelemetryService private telemetryService: ITelemetryService,
-		@IEnvironmentService private environmentService: IEnvironmentService
+		@IEnvironmentService private environmentService: IEnvironmentService,
+		@ILifecycleService lifecycleService: ILifecycleService
 	) {
 		super();
 
@@ -71,7 +73,10 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 			return;
 		}
 
-		this._suggestFileBasedRecommendations();
+		lifecycleService.when(LifecyclePhase.Eventually).then(() => {
+			this._suggestFileBasedRecommendations();
+		});
+
 		this.promptWorkspaceRecommendationsPromise = this._suggestWorkspaceRecommendations();
 
 		// Executable based recommendations carry out a lot of file stats, so run them after 10 secs

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
@@ -398,9 +398,16 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 						localize('close', "Close")
 					];
 
-					this.choiceService.choose(Severity.Info, message, options, 3).done(choice => {
+					this.choiceService.choose(Severity.Info, message, options, 2).done(choice => {
 						switch (choice) {
 							case 0:
+								/* __GDPR__
+									"fileExtensionSuggestion:popup" : {
+										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+										"extensionId": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+									}
+								*/
+								this.telemetryService.publicLog('fileExtensionSuggestion:popup', { userReaction: 'ok', fileExtension: fileExtension });
 								return searchMarketplaceAction.run();
 							case 1:
 								fileExtensionSuggestionIgnoreList.push(fileExtension);
@@ -409,13 +416,34 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 									JSON.stringify(fileExtensionSuggestionIgnoreList),
 									StorageScope.GLOBAL
 								);
+								/* __GDPR__
+									"fileExtensionSuggestion:popup" : {
+										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+										"extensionId": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+									}
+								*/
+								this.telemetryService.publicLog('fileExtensionSuggestion:popup', { userReaction: 'neverShowAgain', fileExtension: fileExtension });
+
 								return this.ignoreExtensionRecommendations();
 							case 2:
-								return TPromise.as(null);
-						}
+								/* __GDPR__
+									"fileExtensionSuggestion:popup" : {
+										"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+										"extensionId": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+									}
+								*/
+								this.telemetryService.publicLog('fileExtensionSuggestion:popup', { userReaction: 'close', fileExtension: fileExtension });
 
-						return TPromise.as(null);
-					}, () => { return TPromise.as(null); });
+						}
+					}, () => {
+						/* __GDPR__
+							"fileExtensionSuggestion:popup" : {
+								"userReaction" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+								"extensionId": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" }
+							}
+						*/
+						this.telemetryService.publicLog('fileExtensionSuggestion:popup', { userReaction: 'cancelled', fileExtension: fileExtension });
+					});
 				}
 			});
 		});

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsTipsService.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsTipsService.test.ts
@@ -46,6 +46,7 @@ import { IChoiceService } from 'vs/platform/message/common/message';
 import product from 'vs/platform/node/product';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/modelService';
+import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 
 const mockExtensionGallery: IGalleryExtension[] = [
 	aGalleryExtension('MockExtension1', {
@@ -179,7 +180,7 @@ suite('ExtensionsTipsService Test', () => {
 		uninstallEvent = new Emitter<IExtensionIdentifier>();
 		didUninstallEvent = new Emitter<DidUninstallExtensionEvent>();
 		instantiationService.stub(IExtensionGalleryService, ExtensionGalleryService);
-
+		instantiationService.stub(ILifecycleService, new TestLifecycleService());
 		testConfigurationService = new TestConfigurationService();
 		instantiationService.stub(IConfigurationService, testConfigurationService);
 		instantiationService.stub(IExtensionManagementService, ExtensionManagementService);


### PR DESCRIPTION
When user loads a file of unknown mime type in the editor, suggest searching for an extension in the marketplace supporting that file extension.