### PR TITLE
Validate workspace recommended extensions against the marketplace

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
@@ -114,13 +114,13 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 			let countBadRecommendations = 0;
 			let badRecommendationsString = '';
 			let filteredRecommendations = extensionsContent.recommendations.filter((element, position) => {
-				if (!regEx.test(element)) {
+				if (extensionsContent.recommendations.indexOf(element) !== position) {
+					// This is a duplicate entry, it doesn't hurt anybody
+					// but it shouldn't be sent in the gallery query
+					return false;
+				} else if (!regEx.test(element)) {
 					countBadRecommendations++;
 					badRecommendationsString += `${element} (bad format) Expected: <provider>.<name>\n`;
-					return false;
-				} else if (extensionsContent.recommendations.indexOf(element) !== position) {
-					countBadRecommendations++;
-					badRecommendationsString += `${element} (duplicate)\n`;
 					return false;
 				}
 
@@ -137,7 +137,7 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 					filteredRecommendations.forEach(element => {
 						if (validRecommendations.indexOf(element.toLowerCase()) === -1) {
 							countBadRecommendations++;
-							badRecommendationsString += `${element} (not found in gallery)\n`;
+							badRecommendationsString += `${element} (not found in marketplace)\n`;
 						}
 					});
 				}

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsTipsService.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsTipsService.test.ts
@@ -12,7 +12,7 @@ import * as os from 'os';
 import { TPromise } from 'vs/base/common/winjs.base';
 import uuid = require('vs/base/common/uuid');
 import { mkdirp } from 'vs/base/node/pfs';
-import { IExtensionManagementService, IExtensionGalleryService, IExtensionTipsService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IExtensionManagementService, IExtensionGalleryService, IExtensionTipsService, IGalleryExtensionAssets, IGalleryExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionManagementService } from 'vs/platform/extensionManagement/node/extensionManagementService';
 import { ExtensionTipsService } from 'vs/workbench/parts/extensions/electron-browser/extensionTipsService';
 import { ExtensionGalleryService } from 'vs/platform/extensionManagement/node/extensionGalleryService';
@@ -32,12 +32,90 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { FileService } from 'vs/workbench/services/files/node/fileService';
 import extfs = require('vs/base/node/extfs');
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { IPager } from 'vs/base/common/paging';
+import { assign } from 'vs/base/common/objects';
+import { getGalleryExtensionId } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
+import { generateUuid } from 'vs/base/common/uuid';
 
-const expectedWorkspaceRecommendations = [
-	'eg2.tslint',
-	'dbaeumer.vscode-eslint',
-	'msjsdiag.debugger-for-chrome'
+const mockExtensionGallery: IGalleryExtension[] = [
+	aGalleryExtension('MockExtension1', {
+		displayName: 'Mock Extension 1',
+		version: '1.5',
+		publisherId: 'mockPublisher1Id',
+		publisher: 'mockPublisher1',
+		publisherDisplayName: 'Mock Publisher 1',
+		description: 'Mock Description',
+		installCount: 1000,
+		rating: 4,
+		ratingCount: 100
+	}, {
+			dependencies: ['pub.1'],
+		}, {
+			manifest: { uri: 'uri:manifest', fallbackUri: 'fallback:manifest' },
+			readme: { uri: 'uri:readme', fallbackUri: 'fallback:readme' },
+			changelog: { uri: 'uri:changelog', fallbackUri: 'fallback:changlog' },
+			download: { uri: 'uri:download', fallbackUri: 'fallback:download' },
+			icon: { uri: 'uri:icon', fallbackUri: 'fallback:icon' },
+			license: { uri: 'uri:license', fallbackUri: 'fallback:license' },
+			repository: { uri: 'uri:repository', fallbackUri: 'fallback:repository' },
+		}),
+	aGalleryExtension('MockExtension2', {
+		displayName: 'Mock Extension 2',
+		version: '1.5',
+		publisherId: 'mockPublisher2Id',
+		publisher: 'mockPublisher2',
+		publisherDisplayName: 'Mock Publisher 2',
+		description: 'Mock Description',
+		installCount: 1000,
+		rating: 4,
+		ratingCount: 100
+	}, {
+			dependencies: ['pub.1', 'pub.2'],
+		}, {
+			manifest: { uri: 'uri:manifest', fallbackUri: 'fallback:manifest' },
+			readme: { uri: 'uri:readme', fallbackUri: 'fallback:readme' },
+			changelog: { uri: 'uri:changelog', fallbackUri: 'fallback:changlog' },
+			download: { uri: 'uri:download', fallbackUri: 'fallback:download' },
+			icon: { uri: 'uri:icon', fallbackUri: 'fallback:icon' },
+			license: { uri: 'uri:license', fallbackUri: 'fallback:license' },
+			repository: { uri: 'uri:repository', fallbackUri: 'fallback:repository' },
+		})
 ];
+
+const mockRecommendedExtensions = [
+	'mockPublisher1.mockExtension1',
+	'MOCKPUBLISHER2.mockextension2',
+	'badlyformattedextension',
+	'unknown.extension'
+];
+
+const mockValidRecommendedExtensions = [
+	'mockPublisher1.mockExtension1',
+	'MOCKPUBLISHER2.mockextension2'
+];
+
+function aPage<T>(...objects: T[]): IPager<T> {
+	return { firstPage: objects, total: objects.length, pageSize: objects.length, getPage: () => null };
+}
+
+const noAssets: IGalleryExtensionAssets = {
+	changelog: null,
+	download: null,
+	icon: null,
+	license: null,
+	manifest: null,
+	readme: null,
+	repository: null
+};
+
+function aGalleryExtension(name: string, properties: any = {}, galleryExtensionProperties: any = {}, assets: IGalleryExtensionAssets = noAssets): IGalleryExtension {
+	const galleryExtension = <IGalleryExtension>Object.create({});
+	assign(galleryExtension, { name, publisher: 'pub', version: '1.0.0', properties: {}, assets: {} }, properties);
+	assign(galleryExtension.properties, { dependencies: [] }, galleryExtensionProperties);
+	assign(galleryExtension.assets, assets);
+	galleryExtension.identifier = { id: getGalleryExtensionId(galleryExtension.publisher, galleryExtension.name), uuid: generateUuid() };
+	return <IGalleryExtension>galleryExtension;
+}
 
 function setUpFolderWorkspace(folderName: string): TPromise<{ parentDir: string, folderDir: string }> {
 	const id = uuid.generateUuid();
@@ -51,7 +129,7 @@ function setUpFolder(folderName: string, parentDir: string): TPromise<string> {
 	return mkdirp(workspaceSettingsDir, 493).then(() => {
 		const configPath = path.join(workspaceSettingsDir, 'extensions.json');
 		fs.writeFileSync(configPath, JSON.stringify({
-			'recommendations': expectedWorkspaceRecommendations
+			'recommendations': mockRecommendedExtensions
 		}, null, '\t'));
 		return folderDir;
 	});
@@ -104,6 +182,7 @@ suite('ExtensionsTipsService Test', () => {
 			workspaceService = new TestContextService(myWorkspace);
 			instantiationService.stub(IWorkspaceContextService, workspaceService);
 			instantiationService.stub(IFileService, new FileService(workspaceService, new TestTextResourceConfigurationService(), new TestConfigurationService(), new TestLifecycleService(), { disableWatcher: true }));
+			instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage<IGalleryExtension>(...mockExtensionGallery));
 
 			testObject = instantiationService.createInstance(ExtensionTipsService);
 
@@ -120,8 +199,13 @@ suite('ExtensionsTipsService Test', () => {
 
 	test('test workspace folder recommendations', () => {
 		return testObject.getWorkspaceRecommendations().then(recommendations => {
-			assert.equal(recommendations.length, expectedWorkspaceRecommendations.length);
-			recommendations.forEach(x => assert.equal(expectedWorkspaceRecommendations.indexOf(x) > -1, true));
+			assert.equal(recommendations.length, mockValidRecommendedExtensions.length);
+			let lowerRecommendations = recommendations.map(x => x.toLowerCase());
+			let lowerValidRecommendations = mockValidRecommendedExtensions.map(x => x.toLowerCase());
+
+			lowerRecommendations.forEach(x => {
+				assert.equal(lowerValidRecommendations.indexOf(x) > -1, true);
+			});
 		});
 	});
 });


### PR DESCRIPTION
Don't show message about workspace recommended extensions if none of the recommended extensions are valid (i.e. they are badly formatted or don't exist in the marketplace)