### PR TITLE
Update Ruby indent pattern

### DIFF
--- a/extensions/ruby/language-configuration.json
+++ b/extensions/ruby/language-configuration.json
@@ -23,7 +23,7 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|(.*\\sdo\\b)|(.*=\\s*(case|if|unless)))\\b[^\\{;]*$",
+		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^\\{;]|(\"|'|\/).*\\4)*$",
 		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)"
 	}
 }

--- a/extensions/ruby/language-configuration.json
+++ b/extensions/ruby/language-configuration.json
@@ -23,7 +23,7 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^\\{;]|(\"|'|\/).*\\4)*$",
+		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|\/).*\\4)*(#.*)?$",
 		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif|when)\\b)"
 	}
 }


### PR DESCRIPTION
I didn't bother to make an issue for this one but here are the problems:
1. While I can see why it doesn't auto-indent when theres a `{` or `;` character on the line, this behavior is not something we want when those characters are inside a string or regular expression.

2. Some keywords are detected inside comments, leading to an auto-indent, which is also not something we want.

Current behavior:
![current](https://a.safe.moe/YIflX.gif)

Updated behavior:
![updated](https://a.safe.moe/i7Z1d.gif)

This PR makes auto-indent ignore characters/keywords inside strings, regular expressions and comments.
@rebornix 

P.S. please take a look at my PR for the vscode-ruby extension since it overwrites this default behavior and is not yet patched.