### PR TITLE
Add theme-specific color customizations. Fix #36860

### DIFF
--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -153,6 +153,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 		this.colorThemeStore.onDidChange(themes => {
 			const colorThemeSettingSchemaEnum = [];
 			const colorThemeSettingSchemaEnumDescriptions = [];
+			const enumDescription = themeData.description || '';
 			const themeSpecificEditorColorProperties = {};
 			const themeSpecificWorkbenchColorProperties = {};
 			const copyColorCustomizationsSchema = { ...colorCustomizationsSchema };
@@ -162,7 +163,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 
 			themes.forEach(t => {
 				colorThemeSettingSchemaEnum.push(t.settingsId);
-				colorThemeSettingSchemaEnumDescriptions.push(themeData.description || '');
+				colorThemeSettingSchemaEnumDescriptions.push(enumDescription);
 				const themeId = `[${t.settingsId}]`;
 				themeSpecificWorkbenchColorProperties[themeId] = copyColorCustomizationsSchema;
 				themeSpecificEditorColorProperties[themeId] = copyCustomEditorColorSchema;

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -151,8 +151,6 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 
 		// update settings schema setting
 		this.colorThemeStore.onDidChange(themes => {
-			const colorThemeSettingSchemaEnum = [];
-			const colorThemeSettingSchemaEnumDescriptions = [];
 			const enumDescription = themeData.description || '';
 			const themeSpecificEditorColorProperties = {};
 			const themeSpecificWorkbenchColorProperties = {};
@@ -162,15 +160,13 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 			copyCustomEditorColorSchema.properties = customEditorColorConfigurationProperties;
 
 			themes.forEach(t => {
-				colorThemeSettingSchemaEnum.push(t.settingsId);
-				colorThemeSettingSchemaEnumDescriptions.push(enumDescription);
+				colorThemeSettingSchema.enum.push(t.settingsId);
+				colorThemeSettingSchema.enumDescriptions.push(enumDescription);
 				const themeId = `[${t.settingsId}]`;
 				themeSpecificWorkbenchColorProperties[themeId] = copyColorCustomizationsSchema;
 				themeSpecificEditorColorProperties[themeId] = copyCustomEditorColorSchema;
 			});
 
-			colorThemeSettingSchema.enum = colorThemeSettingSchemaEnum;
-			colorThemeSettingSchema.enumDescriptions = colorThemeSettingSchemaEnumDescriptions;
 			colorCustomizationsSchema.properties = {
 				...colorThemeSchema.colorsSchema.properties,
 				...themeSpecificWorkbenchColorProperties

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -168,11 +168,11 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 
 			colorThemeSettingSchema.enum = colorThemeSettingSchemaEnum;
 			colorThemeSettingSchema.enumDescriptions = colorThemeSettingSchemaEnumDescriptions;
-			themeSettingsConfiguration.properties[CUSTOM_WORKBENCH_COLORS_SETTING].properties = {
+			colorCustomizationsSchema.properties = {
 				...colorThemeSchema.colorsSchema.properties,
 				...themeSpecificWorkbenchColorProperties
 			};
-			customEditorColorConfiguration.properties[CUSTOM_EDITOR_COLORS_SETTING].properties = {
+			customEditorColorSetting.properties = {
 				...customEditorColorConfigurationProperties,
 				...themeSpecificEditorColorProperties
 			};

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -155,15 +155,17 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 			const colorThemeSettingSchemaEnumDescriptions = [];
 			const themeSpecificEditorColorProperties = {};
 			const themeSpecificWorkbenchColorProperties = {};
-			const copyColorCustomizationsSchema = JSON.parse(JSON.stringify(colorCustomizationsSchema));
-			const copyColorConfigurationProperties = JSON.parse(JSON.stringify(customEditorColorSetting));
+			const copyColorCustomizationsSchema = { ...colorCustomizationsSchema };
+			copyColorCustomizationsSchema.properties = colorThemeSchema.colorsSchema.properties;
+			const copyCustomEditorColorSchema = { ...customEditorColorSetting };
+			copyCustomEditorColorSchema.properties = customEditorColorConfigurationProperties;
 
 			themes.forEach(t => {
 				colorThemeSettingSchemaEnum.push(t.settingsId);
 				colorThemeSettingSchemaEnumDescriptions.push(themeData.description || '');
 				const themeId = `[${t.settingsId}]`;
 				themeSpecificWorkbenchColorProperties[themeId] = copyColorCustomizationsSchema;
-				themeSpecificEditorColorProperties[themeId] = copyColorConfigurationProperties;
+				themeSpecificEditorColorProperties[themeId] = copyCustomEditorColorSchema;
 			});
 
 			colorThemeSettingSchema.enum = colorThemeSettingSchemaEnum;
@@ -510,7 +512,7 @@ const iconThemeSettingSchema: IConfigurationPropertySchema = {
 const colorCustomizationsSchema: IConfigurationPropertySchema = {
 	type: 'object',
 	description: nls.localize('workbenchColors', "Overrides colors from the currently selected color theme."),
-	properties: colorThemeSchema.colorsSchema.properties,
+	properties: {},
 	additionalProperties: false,
 	default: {},
 	defaultSnippets: [{
@@ -562,7 +564,7 @@ const customEditorColorSetting = {
 	description: nls.localize('editorColors', "Overrides editor colors and font style from the currently selected color theme."),
 	default: {},
 	additionalProperties: false,
-	properties: customEditorColorConfigurationProperties
+	properties: {}
 };
 const customEditorColorConfiguration: IConfigurationNode = {
 	id: 'editor',

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -159,7 +159,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 
 			customEditorColorSchema.properties = customEditorColorConfigurationProperties;
 			const copyCustomEditorColorSchema = { ...customEditorColorSchema };
-			copyCustomEditorColorSchema.properties = { ...customEditorColorSchema.properties };
+			copyCustomEditorColorSchema.properties = { ...customEditorColorConfigurationProperties };
 
 			themes.forEach(t => {
 				colorThemeSettingSchema.enum.push(t.settingsId);

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -157,7 +157,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 			const themeSpecificWorkbenchColorProperties = {};
 			const copyColorCustomizationsSchema = { ...colorCustomizationsSchema };
 			copyColorCustomizationsSchema.properties = colorThemeSchema.colorsSchema.properties;
-			const copyCustomEditorColorSchema = { ...customEditorColorSetting };
+			const copyCustomEditorColorSchema = { ...customEditorColorSchema };
 			copyCustomEditorColorSchema.properties = customEditorColorConfigurationProperties;
 
 			themes.forEach(t => {
@@ -174,7 +174,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 				...colorThemeSchema.colorsSchema.properties,
 				...themeSpecificWorkbenchColorProperties
 			};
-			customEditorColorSetting.properties = {
+			customEditorColorSchema.properties = {
 				...customEditorColorConfigurationProperties,
 				...themeSpecificEditorColorProperties
 			};
@@ -560,7 +560,7 @@ const customEditorColorConfigurationProperties = {
 	variables: tokenGroupSettings(nls.localize('editorColors.variables', "Sets the colors and styles for variables declarations and references.")),
 	[CUSTOM_EDITOR_SCOPE_COLORS_SETTING]: colorThemeSchema.tokenColorsSchema(nls.localize('editorColors.textMateRules', 'Sets colors and styles using textmate theming rules (advanced).'))
 };
-const customEditorColorSetting = {
+const customEditorColorSchema: IConfigurationPropertySchema = {
 	description: nls.localize('editorColors', "Overrides editor colors and font style from the currently selected color theme."),
 	default: {},
 	additionalProperties: false,
@@ -571,7 +571,7 @@ const customEditorColorConfiguration: IConfigurationNode = {
 	order: 7.2,
 	type: 'object',
 	properties: {
-		[CUSTOM_EDITOR_COLORS_SETTING]: customEditorColorSetting
+		[CUSTOM_EDITOR_COLORS_SETTING]: customEditorColorSchema
 	}
 };
 configurationRegistry.registerConfiguration(customEditorColorConfiguration);

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -152,29 +152,22 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 		// update settings schema setting
 		this.colorThemeStore.onDidChange(themes => {
 			const enumDescription = themeData.description || '';
-			const themeSpecificEditorColorProperties = {};
-			const themeSpecificWorkbenchColorProperties = {};
+
+			colorCustomizationsSchema.properties = colorThemeSchema.colorsSchema.properties;
 			const copyColorCustomizationsSchema = { ...colorCustomizationsSchema };
-			copyColorCustomizationsSchema.properties = colorThemeSchema.colorsSchema.properties;
+			copyColorCustomizationsSchema.properties = { ...colorThemeSchema.colorsSchema.properties };
+
+			customEditorColorSchema.properties = customEditorColorConfigurationProperties;
 			const copyCustomEditorColorSchema = { ...customEditorColorSchema };
-			copyCustomEditorColorSchema.properties = customEditorColorConfigurationProperties;
+			copyCustomEditorColorSchema.properties = { ...customEditorColorSchema.properties };
 
 			themes.forEach(t => {
 				colorThemeSettingSchema.enum.push(t.settingsId);
 				colorThemeSettingSchema.enumDescriptions.push(enumDescription);
 				const themeId = `[${t.settingsId}]`;
-				themeSpecificWorkbenchColorProperties[themeId] = copyColorCustomizationsSchema;
-				themeSpecificEditorColorProperties[themeId] = copyCustomEditorColorSchema;
+				colorCustomizationsSchema.properties[themeId] = copyColorCustomizationsSchema;
+				customEditorColorSchema.properties[themeId] = copyCustomEditorColorSchema;
 			});
-
-			colorCustomizationsSchema.properties = {
-				...colorThemeSchema.colorsSchema.properties,
-				...themeSpecificWorkbenchColorProperties
-			};
-			customEditorColorSchema.properties = {
-				...customEditorColorConfigurationProperties,
-				...themeSpecificEditorColorProperties
-			};
 
 			configurationRegistry.notifyConfigurationSchemaUpdated(themeSettingsConfiguration);
 			configurationRegistry.notifyConfigurationSchemaUpdated(customEditorColorConfiguration);


### PR DESCRIPTION
My attempt at implementing theme-scoped color customizations #36860 .

![update_theme](https://user-images.githubusercontent.com/9638156/34192106-011e03d4-e55d-11e7-8c22-78faac39a64c.gif)
![intellisense](https://user-images.githubusercontent.com/9638156/34192118-0fcb295c-e55d-11e7-96fe-de719bd97c2b.png)

- [x] IntelliSense in settings
- [x] Colors update on settings change
- [x] Colors update on theme change
- [x] Priority `scoped` => `customized` => `theme`

---
Settings example:
```json
"workbench.colorCustomizations": {
    "[Monokai Dimmed]": {
        "activityBar.background": "#66F",
    },
    "activityBar.background": "#ddd",
    "[Monokai]": {
        "activityBar.background": "#F66"
    }
},
"editor.tokenColorCustomizations": {
    "[Monokai Dimmed]": {
        "comments": "#66F",
    },
    "comments": "#ddd",
    "[Monokai]": {
        "textMateRules": [{
            "scope": "comment",
            "settings": {
                "foreground": "#F66"
            },   
        }]
    },
},
```

cc @aeschli 