### PR TITLE
Update link color when theme changes. Fixes #40353

### DIFF
--- a/src/vs/workbench/parts/html/browser/webview-pre.js
+++ b/src/vs/workbench/parts/html/browser/webview-pre.js
@@ -109,8 +109,8 @@
 			styleBody(body[0]);
 
 			// iframe
-			Object.keys(variables).forEach(function(variable) {
-				target.contentDocument.documentElement.style.setProperty(`--${variable}`,variables[variable]);
+			Object.keys(variables).forEach(function (variable) {
+				target.contentDocument.documentElement.style.setProperty(`--${variable}`, variables[variable]);
 			});
 		});
 
@@ -139,7 +139,7 @@
 			const defaultStyles = newDocument.createElement('style');
 			defaultStyles.id = '_defaultStyles';
 
-			const vars = Object.keys(initData.styles).map(function(variable) {
+			const vars = Object.keys(initData.styles).map(function (variable) {
 				return `--${variable}: ${initData.styles[variable]};`;
 			});
 			defaultStyles.innerHTML = `
@@ -159,6 +159,11 @@
 				max-width: 100%;
 				max-height: 100%;
 			}
+
+			body a {
+				color: var(--link-color);
+			}
+
 			a:focus,
 			input:focus,
 			select:focus,
@@ -252,7 +257,7 @@
 					newFrame.style.visibility = 'visible';
 					contentWindow.addEventListener('scroll', handleInnerScroll);
 
-					pendingMessages.forEach(function(data) {
+					pendingMessages.forEach(function (data) {
 						contentWindow.postMessage(data, document.location.origin);
 					});
 					pendingMessages = [];

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -9,7 +9,7 @@ import URI from 'vs/base/common/uri';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import Event, { Emitter } from 'vs/base/common/event';
 import { addDisposableListener, addClass } from 'vs/base/browser/dom';
-import { editorBackground, editorForeground } from 'vs/platform/theme/common/colorRegistry';
+import { editorBackground, editorForeground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
 import { ITheme, LIGHT, DARK } from 'vs/platform/theme/common/themeService';
 import { WebviewFindWidget } from './webviewFindWidget';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
@@ -268,6 +268,7 @@ export default class Webview {
 			'font-family': fontFamily,
 			'font-weight': fontWeight,
 			'font-size': fontSize,
+			'link-color': theme.getColor(textLinkForeground).toString()
 		};
 
 		let activeTheme: ApiThemeClassName;


### PR DESCRIPTION
The link colors in web view do not change when theme changes causing accessibility issues in light themes. This PR applies the link color from theme