### PR TITLE
Fix #40011: Tweak overflow behaviour when setting tab is narrow

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/parts/preferences/browser/media/preferences.css
@@ -48,6 +48,11 @@
 	text-overflow: ellipsis;
 }
 
+.default-preferences-editor-container > .preferences-header-container > .default-preferences-header,
+.settings-tabs-widget > .monaco-action-bar .action-item .action-label:not([aria-haspopup]) {
+ 	display: block;
+}
+
 .settings-tabs-widget > .monaco-action-bar .actions-container {
 	justify-content: flex-start;
 }


### PR DESCRIPTION
Show ellipsis when the setting tab is narrow, as issue described in #40011

![image](https://user-images.githubusercontent.com/12627024/34131754-caf18a5c-e4b1-11e7-925c-04d31470953e.png)
