### PR TITLE
Use case-insensitive environment vars on Windows

### DIFF
--- a/src/vs/workbench/services/configurationResolver/electron-browser/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/electron-browser/configurationResolverService.ts
@@ -18,6 +18,7 @@ import { toResource } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { relative } from 'path';
+import { IProcessEnvironment, isWindows } from 'vs/base/common/platform';
 
 export class ConfigurationResolverService implements IConfigurationResolverService {
 	_serviceBrand: any;
@@ -25,7 +26,7 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 	private _lastWorkspaceFolder: IWorkspaceFolder;
 
 	constructor(
-		envVariables: { [key: string]: string },
+		envVariables: IProcessEnvironment,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
 		@IEnvironmentService environmentService: IEnvironmentService,
 		@IConfigurationService private configurationService: IConfigurationService,
@@ -33,7 +34,8 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 	) {
 		this._execPath = environmentService.execPath;
 		Object.keys(envVariables).forEach(key => {
-			this[`env:${key}`] = envVariables[key];
+			const name = isWindows ? key.toLowerCase() : key;
+			this[`env:${name}`] = envVariables[key];
 		});
 	}
 
@@ -159,7 +161,8 @@ export class ConfigurationResolverService implements IConfigurationResolverServi
 		let regexp = /\$\{(.*?)\}/g;
 		const originalValue = value;
 		const resolvedString = value.replace(regexp, (match: string, name: string) => {
-			let newValue = (<any>this)[name];
+			const key = (isWindows && match.indexOf('env:') > 0) ? name.toLowerCase() : name;
+			let newValue = (<any>this)[key];
 			if (types.isString(newValue)) {
 				return newValue;
 			} else {

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -84,7 +84,7 @@ suite('Configuration Resolver Service', () => {
 		if (platform.isWindows) {
 			assert.strictEqual(configurationResolverService.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - Value for key1');
 		} else {
-			assert.strictEqual(configurationResolverService.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - ${env:Key1}');
+			assert.strictEqual(configurationResolverService.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - ');
 		}
 	});
 

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -17,7 +17,7 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 
 suite('Configuration Resolver Service', () => {
 	let configurationResolverService: IConfigurationResolverService;
-	let envVariables: { [key: string]: string } = { key1: 'Value for Key1', key2: 'Value for Key2' };
+	let envVariables: { [key: string]: string } = { key1: 'Value for key1', key2: 'Value for key2' };
 	let mockCommandService: MockCommandService;
 	let editorService: TestEditorService;
 	let workspace: IWorkspaceFolder;
@@ -66,17 +66,25 @@ suite('Configuration Resolver Service', () => {
 
 	test('substitute one env variable', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService.resolve(workspace, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc \\VSCode\\workspaceLocation Value for Key1 xyz');
+			assert.strictEqual(configurationResolverService.resolve(workspace, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc \\VSCode\\workspaceLocation Value for key1 xyz');
 		} else {
-			assert.strictEqual(configurationResolverService.resolve(workspace, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc /VSCode/workspaceLocation Value for Key1 xyz');
+			assert.strictEqual(configurationResolverService.resolve(workspace, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc /VSCode/workspaceLocation Value for key1 xyz');
 		}
 	});
 
 	test('substitute many env variable', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService.resolve(workspace, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for Key1 - Value for Key2');
+			assert.strictEqual(configurationResolverService.resolve(workspace, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
 		} else {
-			assert.strictEqual(configurationResolverService.resolve(workspace, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '/VSCode/workspaceLocation - /VSCode/workspaceLocation Value for Key1 - Value for Key2');
+			assert.strictEqual(configurationResolverService.resolve(workspace, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '/VSCode/workspaceLocation - /VSCode/workspaceLocation Value for key1 - Value for key2');
+		}
+	});
+
+	test('substitute one env variable using platform case sensitivity', () => {
+		if (platform.isWindows) {
+			assert.strictEqual(configurationResolverService.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - Value for key1');
+		} else {
+			assert.strictEqual(configurationResolverService.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - ${env:Key1}');
 		}
 	});
 
@@ -171,9 +179,9 @@ suite('Configuration Resolver Service', () => {
 
 		let service = new ConfigurationResolverService(envVariables, new TestEditorService(), TestEnvironmentService, configurationService, mockCommandService);
 		if (platform.isWindows) {
-			assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo \\VSCode\\workspaceLocation Value for Key1 xyz');
+			assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo \\VSCode\\workspaceLocation Value for key1 xyz');
 		} else {
-			assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo /VSCode/workspaceLocation Value for Key1 xyz');
+			assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo /VSCode/workspaceLocation Value for key1 xyz');
 		}
 	});
 
@@ -192,9 +200,9 @@ suite('Configuration Resolver Service', () => {
 
 		let service = new ConfigurationResolverService(envVariables, new TestEditorService(), TestEnvironmentService, configurationService, mockCommandService);
 		if (platform.isWindows) {
-			assert.strictEqual(service.resolve(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar \\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for Key1 - Value for Key2');
+			assert.strictEqual(service.resolve(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar \\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
 		} else {
-			assert.strictEqual(service.resolve(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar /VSCode/workspaceLocation - /VSCode/workspaceLocation Value for Key1 - Value for Key2');
+			assert.strictEqual(service.resolve(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar /VSCode/workspaceLocation - /VSCode/workspaceLocation Value for key1 - Value for key2');
 		}
 	});
 


### PR DESCRIPTION
Fixes #4895