### PR TITLE
Fix circular/infinite dispose Fixes: #40465

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -66,9 +66,9 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 
 		// Instantiate select implementation based on platform
 		if (isMacintosh) {
-			this.selectBoxDelegate = new SelectBoxNative(options, selected, styles, this.toDispose);
+			this.selectBoxDelegate = new SelectBoxNative(options, selected, styles);
 		} else {
-			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, styles, this.toDispose);
+			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, styles);
 		}
 
 		this.toDispose.push(this.selectBoxDelegate);
@@ -112,7 +112,6 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 
 	public dispose(): void {
 		this.toDispose = dispose(this.toDispose);
-
 		super.dispose();
 	}
 }

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -88,10 +88,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	private selectDropDownListContainer: HTMLElement;
 	private widthControlElement: HTMLElement;
 
-	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles, toDispose: IDisposable[]) {
+	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles) {
 
-		// Disposables handled by caller
-		this.toDispose = toDispose;
+		this.toDispose = [];
 
 		this.selectElement = document.createElement('select');
 		this.selectElement.className = 'select-box';

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -20,12 +20,13 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 	private toDispose: IDisposable[];
 	private styles: ISelectBoxStyles;
 
-	constructor(options: string[], selected: number, styles: ISelectBoxStyles, toDispose: IDisposable[]) {
+	constructor(options: string[], selected: number, styles: ISelectBoxStyles) {
+
+		this.toDispose = [];
 
 		this.selectElement = document.createElement('select');
 		this.selectElement.className = 'select-box';
 
-		this.toDispose = toDispose;
 		this._onDidSelect = new Emitter<ISelectData>();
 
 		this.styles = styles;


### PR DESCRIPTION
Fixes: #40465 

Both SelectBox and SelectBox Delegate classes call dispose on the same list creating an infinite dispose Loop.

@bpasero 
Given that this crashes the panel,  would you like me to merge things like this on my own?