### PR TITLE
Automatically select type in generated snippet

### DIFF
--- a/extensions/typescript/src/features/jsDocCompletionProvider.ts
+++ b/extensions/typescript/src/features/jsDocCompletionProvider.ts
@@ -182,7 +182,7 @@ class TryCompleteJsDocCommand implements Command {
 		template = template.replace(/\* @param([ ]\{\S+\})?\s+(\S+)\s*$/gm, (_param, type, post) => {
 			let out = '* @param ';
 			if (type === ' {any}' || type === ' {*}') {
-				out += `{*\$\{${snippetIndex++}\}} `;
+				out += `{\$\{${snippetIndex++}:*\}} `;
 			} else if (type) {
 				out += type + ' ';
 			}


### PR DESCRIPTION
This is a very small usability change to the automatically generated jsdoc.

Currently, when generating the jsdoc, the snippet will place the cursor after the `*` (for unknown parameter types), causing the user to press backspace before entering a type. This modification will select that `*` so typing will automatically remove it without having to press backspace first. Tabbing to skip an item will still leave the `*` as it previously did.

Thanks for your time!