### PR TITLE
Fix backspace in IME composition on iOS Safari

### DIFF
--- a/src/vs/editor/browser/controller/textAreaInput.ts
+++ b/src/vs/editor/browser/controller/textAreaInput.ts
@@ -111,7 +111,8 @@ export class TextAreaInput extends Disposable {
 		this._nextCommand = ReadFromTextArea.Type;
 
 		this._register(dom.addStandardDisposableListener(textArea.domNode, 'keydown', (e: IKeyboardEvent) => {
-			if (this._isDoingComposition && e.keyCode === KeyCode.KEY_IN_COMPOSITION) {
+			if (this._isDoingComposition &&
+				(e.keyCode === KeyCode.KEY_IN_COMPOSITION || e.keyCode === KeyCode.Backspace)) {
 				// Stop propagation for keyDown events if the IME is processing key input
 				e.stopPropagation();
 			}


### PR DESCRIPTION
This should fix Microsoft/monaco-editor#529

## Current Behavior

![ezgif-3-ce5762380b](https://user-images.githubusercontent.com/4230968/34190161-39f38d9c-e57a-11e7-8be9-9277d0137818.gif)

Hitting <kbd>backspace</kbd> deletes text.

## After

![ezgif-3-0401591e24](https://user-images.githubusercontent.com/4230968/34190169-412ad37c-e57a-11e7-89d4-9a6482433f8e.gif)

IME handles correctly.