### PR TITLE
Focus xterm on first startup. fix #40416

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -110,6 +110,9 @@ export class TerminalPanel extends Panel {
 						if (instance) {
 							this._updateFont();
 							this._updateTheme();
+							setTimeout(() => {
+								instance.focus();
+							}, 0);
 						}
 					}, 0);
 					return TPromise.as(void 0);


### PR DESCRIPTION
Call terminalInstances's focus in the next tick to fix #40416.