### PR TITLE
Change default shortcut search history navigation

### DIFF
--- a/src/vs/editor/contrib/find/findModel.ts
+++ b/src/vs/editor/contrib/find/findModel.ts
@@ -45,10 +45,10 @@ export const ToggleSearchScopeKeybinding: IKeybindings = {
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_L }
 };
 export const ShowPreviousFindTermKeybinding: IKeybindings = {
-	primary: KeyMod.Alt | KeyCode.UpArrow
+	primary: KeyCode.UpArrow
 };
 export const ShowNextFindTermKeybinding: IKeybindings = {
-	primary: KeyMod.Alt | KeyCode.DownArrow
+	primary: KeyCode.DownArrow
 };
 
 export const FIND_IDS = {

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -69,7 +69,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: Constants.FocusSearchFromResults,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
 	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.FirstMatchFocusKey),
-	primary: KeyCode.UpArrow,
+	primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
 	handler: (accessor, args: any) => {
 		const searchViewlet: SearchViewlet = <SearchViewlet>accessor.get(IViewletService).getActiveViewlet();
 		searchViewlet.focusPreviousInputBox();
@@ -167,7 +167,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: searchActions.FocusNextInputAction.ID,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
 	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.InputBoxFocusedKey),
-	primary: KeyCode.DownArrow,
+	primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
 	handler: (accessor, args: any) => {
 		accessor.get(IInstantiationService).createInstance(searchActions.FocusNextInputAction, searchActions.FocusNextInputAction.ID, '').run();
 	}
@@ -177,7 +177,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: searchActions.FocusPreviousInputAction.ID,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
 	when: ContextKeyExpr.and(Constants.SearchViewletVisibleKey, Constants.InputBoxFocusedKey, Constants.SearchInputBoxFocusedKey.toNegated()),
-	primary: KeyCode.UpArrow,
+	primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
 	handler: (accessor, args: any) => {
 		accessor.get(IInstantiationService).createInstance(searchActions.FocusPreviousInputAction, searchActions.FocusPreviousInputAction.ID, '').run();
 	}


### PR DESCRIPTION
Previous and next in history is now up and down arrows.
Navigate search fields is now Ctrl/Cmd + up and down arrows.

https://github.com/Microsoft/vscode/issues/12645

@sandy081 comments?