### PR TITLE
Option to disable Touch Bar controls and leave control strip (#38333)

### DIFF
--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -220,7 +220,7 @@ export interface IWindowSettings {
 	nativeTabs: boolean;
 	enableMenuBarMnemonics: boolean;
 	closeWhenEmpty: boolean;
-	touchbarSupport: boolean;
+	touchbarEnabled: boolean;
 }
 
 export enum OpenContext {

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -220,6 +220,7 @@ export interface IWindowSettings {
 	nativeTabs: boolean;
 	enableMenuBarMnemonics: boolean;
 	closeWhenEmpty: boolean;
+	touchbarSupport: boolean;
 }
 
 export enum OpenContext {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -386,6 +386,12 @@ configurationRegistry.registerConfiguration({
 			'default': false,
 			'description': nls.localize('window.nativeTabs', "Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured."),
 			'included': isMacintosh && parseFloat(os.release()) >= 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
+		},
+		'window.touchbarSupport': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('window.touchbarSupport', "Enables macOS tocuhbar buttons."),
+			'included': isMacintosh && parseFloat(os.release()) >= 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
 		}
 	}
 });

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -386,12 +386,6 @@ configurationRegistry.registerConfiguration({
 			'default': false,
 			'description': nls.localize('window.nativeTabs', "Enables macOS Sierra window tabs. Note that changes require a full restart to apply and that native tabs will disable a custom title bar style if configured."),
 			'included': isMacintosh && parseFloat(os.release()) >= 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
-		},
-		'window.touchbarSupport': {
-			'type': 'boolean',
-			'default': true,
-			'description': nls.localize('window.touchbarSupport', "Enables macOS tocuhbar buttons."),
-			'included': isMacintosh && parseFloat(os.release()) >= 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
 		}
 	}
 });

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -350,10 +350,12 @@ export class ElectronWindow extends Themable {
 		if (!isMacintosh) {
 			return; // macOS only
 		}
-		const windowConfig = this.configurationService.getValue<IWindowSettings>('window');
-		if (windowConfig && windowConfig.touchbarSupport === false) {
-			return; // tocuhbar support disabled
+
+		const touchbarEnabled = this.configurationService.getValue<boolean>('keyboard.touchbar.enabled');
+		if (touchbarEnabled === false) {
+			return;
 		}
+
 		// Dispose old
 		this.touchBarDisposables = dispose(this.touchBarDisposables);
 

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -350,7 +350,10 @@ export class ElectronWindow extends Themable {
 		if (!isMacintosh) {
 			return; // macOS only
 		}
-
+		const windowConfig = this.configurationService.getValue<IWindowSettings>('window');
+		if (windowConfig && windowConfig.touchbarSupport === false) {
+			return; // tocuhbar support disabled
+		}
 		// Dispose old
 		this.touchBarDisposables = dispose(this.touchBarDisposables);
 

--- a/src/vs/workbench/parts/relauncher/electron-browser/relauncher.contribution.ts
+++ b/src/vs/workbench/parts/relauncher/electron-browser/relauncher.contribution.ts
@@ -34,6 +34,7 @@ export class SettingsChangeRelauncher implements IWorkbenchContribution {
 	private nativeTabs: boolean;
 	private updateChannel: string;
 	private enableCrashReporter: boolean;
+	private touchbarSupport: boolean;
 
 	private firstFolderResource: URI;
 	private extensionHostRestarter: RunOnceScheduler;
@@ -76,6 +77,12 @@ export class SettingsChangeRelauncher implements IWorkbenchContribution {
 		// Native tabs
 		if (config.window && typeof config.window.nativeTabs === 'boolean' && config.window.nativeTabs !== this.nativeTabs) {
 			this.nativeTabs = config.window.nativeTabs;
+			changed = true;
+		}
+
+		// TouchBar support
+		if (config.window && typeof config.window.touchbarSupport === 'boolean' && config.window.touchbarSupport !== this.touchbarSupport) {
+			this.touchbarSupport = config.window.touchbarSupport;
 			changed = true;
 		}
 

--- a/src/vs/workbench/parts/relauncher/electron-browser/relauncher.contribution.ts
+++ b/src/vs/workbench/parts/relauncher/electron-browser/relauncher.contribution.ts
@@ -24,6 +24,7 @@ import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 interface IConfiguration extends IWindowsConfiguration {
 	update: { channel: string; };
 	telemetry: { enableCrashReporter: boolean };
+	keyboard: { touchbar: { enabled: boolean } };
 }
 
 export class SettingsChangeRelauncher implements IWorkbenchContribution {
@@ -34,7 +35,7 @@ export class SettingsChangeRelauncher implements IWorkbenchContribution {
 	private nativeTabs: boolean;
 	private updateChannel: string;
 	private enableCrashReporter: boolean;
-	private touchbarSupport: boolean;
+	private touchbarEnabled: boolean;
 
 	private firstFolderResource: URI;
 	private extensionHostRestarter: RunOnceScheduler;
@@ -80,12 +81,6 @@ export class SettingsChangeRelauncher implements IWorkbenchContribution {
 			changed = true;
 		}
 
-		// TouchBar support
-		if (config.window && typeof config.window.touchbarSupport === 'boolean' && config.window.touchbarSupport !== this.touchbarSupport) {
-			this.touchbarSupport = config.window.touchbarSupport;
-			changed = true;
-		}
-
 		// Update channel
 		if (config.update && typeof config.update.channel === 'string' && config.update.channel !== this.updateChannel) {
 			this.updateChannel = config.update.channel;
@@ -95,6 +90,12 @@ export class SettingsChangeRelauncher implements IWorkbenchContribution {
 		// Crash reporter
 		if (config.telemetry && typeof config.telemetry.enableCrashReporter === 'boolean' && config.telemetry.enableCrashReporter !== this.enableCrashReporter) {
 			this.enableCrashReporter = config.telemetry.enableCrashReporter;
+			changed = true;
+		}
+
+		// Touchbar config
+		if (config.keyboard && typeof config.keyboard.touchbar.enabled === 'boolean' && config.keyboard.touchbar.enabled !== this.touchbarEnabled) {
+			this.touchbarEnabled = config.keyboard.touchbar.enabled;
 			changed = true;
 		}
 

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -36,6 +36,7 @@ import Event, { Emitter } from 'vs/base/common/event';
 import { Extensions as ConfigExtensions, IConfigurationRegistry, IConfigurationNode } from 'vs/platform/configuration/common/configurationRegistry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { onUnexpectedError } from 'vs/base/common/errors';
+import { release } from 'os';
 
 export class KeyboardMapperFactory {
 	public static readonly INSTANCE = new KeyboardMapperFactory();
@@ -583,6 +584,12 @@ const keyboardConfiguration: IConfigurationNode = {
 			'default': 'code',
 			'description': nls.localize('dispatch', "Controls the dispatching logic for key presses to use either `code` (recommended) or `keyCode`."),
 			'included': OS === OperatingSystem.Macintosh || OS === OperatingSystem.Linux
+		},
+		'keyboard.touchbar.enabled': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('window.touchbar.enabled', "Enables macOS tocuhbar buttons."),
+			'included': OS === OperatingSystem.Macintosh && parseFloat(release()) >= 16 // Minimum: macOS Sierra (10.12.x = darwin 16.x)
 		}
 	}
 };


### PR DESCRIPTION
An attempt to add config option to disable rendering Touch Bar buttons at all issue #38333 
This is my first PR to vscode repo.