### PR TITLE
Add fixed sized workbench tabs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/tabstitle.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitle.css
@@ -66,6 +66,17 @@
 	min-width: 80px; /* make more room for close button when it shows to the left */
 }
 
+.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.sizing-fixed {
+	min-width: 160px;
+	flex-basis: 0; /* all tabs are even */
+	flex-grow: 1; /* all tabs grow even */
+	max-width: 160px;
+}
+
+.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.sizing-fixed.close-button-left {
+	min-width: 160px; /* make more room for close button when it shows to the left */
+}
+
 .monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.dragged {
 	will-change: transform; /* forces tab to be drawn on a separate layer (fixes https://github.com/Microsoft/vscode/issues/18733) */
 }
@@ -111,6 +122,16 @@
 
 .monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.dirty.close-button-right.sizing-shrink > .tab-close,
 .monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.close-button-right.sizing-shrink:hover > .tab-close {
+	overflow: visible; /* ...but still show the close button on hover and when dirty */
+}
+
+.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.close-button-right.sizing-fixed > .tab-close {
+	flex: 0;
+	overflow: hidden; /* let the close button be pushed out of view when sizing is set to shrink to make more room... */
+}
+
+.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.dirty.close-button-right.sizing-fixed > .tab-close,
+.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.close-button-right.sizing-fixed:hover > .tab-close {
 	overflow: visible; /* ...but still show the close button on hover and when dirty */
 }
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -321,7 +321,7 @@ export class TabsTitleControl extends TitleControl {
 				domAction(tabContainer, `close-button-${option}`);
 			});
 
-			['fit', 'shrink'].forEach(option => {
+			['fit', 'shrink', 'fixed'].forEach(option => {
 				const domAction = tabOptions.tabSizing === option ? DOM.addClass : DOM.removeClass;
 				domAction(tabContainer, `sizing-${option}`);
 			});

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -812,7 +812,7 @@ export interface IWorkbenchEditorConfiguration {
 		editor: {
 			showTabs: boolean;
 			tabCloseButton: 'left' | 'right' | 'off';
-			tabSizing: 'fit' | 'shrink';
+			tabSizing: 'fit' | 'shrink' | 'fixed';
 			showIcons: boolean;
 			enablePreview: boolean;
 			enablePreviewFromQuickOpen: boolean;

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -165,9 +165,9 @@ configurationRegistry.registerConfiguration({
 		},
 		'workbench.editor.tabSizing': {
 			'type': 'string',
-			'enum': ['fit', 'shrink'],
+			'enum': ['fit', 'shrink', 'fixed'],
 			'default': 'fit',
-			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'tabSizing' }, "Controls the sizing of editor tabs. Set to 'fit' to keep tabs always large enough to show the full editor label. Set to 'shrink' to allow tabs to get smaller when the available space is not enough to show all tabs at once.")
+			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'tabSizing' }, "Controls the sizing of editor tabs. Set to 'fit' to keep tabs always large enough to show the full editor label. Set to 'shrink' to allow tabs to get smaller when the available space is not enough to show all tabs at once. Set to 'fixed' to always have same size for all tabs.")
 		},
 		'workbench.editor.showIcons': {
 			'type': 'boolean',

--- a/src/vs/workbench/services/group/common/groupService.ts
+++ b/src/vs/workbench/services/group/common/groupService.ts
@@ -22,7 +22,7 @@ export const IEditorGroupService = createDecorator<IEditorGroupService>('editorG
 export interface IEditorTabOptions {
 	showTabs?: boolean;
 	tabCloseButton?: 'left' | 'right' | 'off';
-	tabSizing?: 'fit' | 'shrink';
+	tabSizing?: 'fit' | 'shrink' | 'fixed';
 	showIcons?: boolean;
 	previewEditors?: boolean;
 	labelFormat?: 'default' | 'short' | 'medium' | 'long';


### PR DESCRIPTION
This is a PoC for #38594 to have fixed tab sizes so that someone can close multiple tabs by pushing close button multiple times at the same mouse position.

Following #39176 I added a `fixed` setting for `workbench.editor.tabSizing` 

This is how it looks like:

![vscode-editor-tabsizing-fixed](https://user-images.githubusercontent.com/207759/34319170-8a92e97e-e7db-11e7-8dc9-089cc569da1b.gif)

I'm not fully happy with this as the tabs could be resized to fit after some seconds of inactivity. This is how browsers do that. 

I've also played with `width` and `min-width` which shrinks the tabs if many tabs are open:

```css
.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title .tabs-container > .tab.sizing-fixed {
	min-width: 60px;
	width: 160px;
	flex-basis: 0; /* all tabs are even */
	flex-grow: 1; /* all tabs grow even */
	max-width: 160px;
}
```

But this immediatelly increases them when closing one tab. So the user will miss the close button after closing one tab.

So is there a way to add some kind of timer to do that resizing?