### PR TITLE
added Center Mode (#15684)

### DIFF
--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -688,6 +688,7 @@ export class CodeMenu {
 
 		const fullscreen = new MenuItem(this.withKeybinding('workbench.action.toggleFullScreen', { label: this.mnemonicLabel(nls.localize({ key: 'miToggleFullScreen', comment: ['&& denotes a mnemonic'] }, "Toggle &&Full Screen")), click: () => this.windowsMainService.getLastActiveWindow().toggleFullScreen(), enabled: this.windowsMainService.getWindowCount() > 0 }));
 		const toggleZenMode = this.createMenuItem(nls.localize('miToggleZenMode', "Toggle Zen Mode"), 'workbench.action.toggleZenMode');
+		const toggleCenteredLayout = this.createMenuItem(nls.localize('miToggleCenteredLayout', "Toggle centered Layout"), 'workbench.action.toggleCenteredLayout');
 		const toggleMenuBar = this.createMenuItem(nls.localize({ key: 'miToggleMenuBar', comment: ['&& denotes a mnemonic'] }, "Toggle Menu &&Bar"), 'workbench.action.toggleMenuBar');
 		const splitEditor = this.createMenuItem(nls.localize({ key: 'miSplitEditor', comment: ['&& denotes a mnemonic'] }, "Split &&Editor"), 'workbench.action.splitEditor');
 		const toggleEditorLayout = this.createMenuItem(nls.localize({ key: 'miToggleEditorLayout', comment: ['&& denotes a mnemonic'] }, "Toggle Editor Group &&Layout"), 'workbench.action.toggleEditorGroupLayout');
@@ -747,6 +748,7 @@ export class CodeMenu {
 			__separator__(),
 			fullscreen,
 			toggleZenMode,
+			toggleCenteredLayout,
 			isWindows || isLinux ? toggleMenuBar : void 0,
 			__separator__(),
 			splitEditor,

--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -688,7 +688,7 @@ export class CodeMenu {
 
 		const fullscreen = new MenuItem(this.withKeybinding('workbench.action.toggleFullScreen', { label: this.mnemonicLabel(nls.localize({ key: 'miToggleFullScreen', comment: ['&& denotes a mnemonic'] }, "Toggle &&Full Screen")), click: () => this.windowsMainService.getLastActiveWindow().toggleFullScreen(), enabled: this.windowsMainService.getWindowCount() > 0 }));
 		const toggleZenMode = this.createMenuItem(nls.localize('miToggleZenMode', "Toggle Zen Mode"), 'workbench.action.toggleZenMode');
-		const toggleCenteredLayout = this.createMenuItem(nls.localize('miToggleCenteredLayout', "Toggle centered Layout"), 'workbench.action.toggleCenteredLayout');
+		const toggleCenteredLayout = this.createMenuItem(nls.localize('miToggleCenteredLayout', "Toggle Centered Layout"), 'workbench.action.toggleCenteredLayout');
 		const toggleMenuBar = this.createMenuItem(nls.localize({ key: 'miToggleMenuBar', comment: ['&& denotes a mnemonic'] }, "Toggle Menu &&Bar"), 'workbench.action.toggleMenuBar');
 		const splitEditor = this.createMenuItem(nls.localize({ key: 'miSplitEditor', comment: ['&& denotes a mnemonic'] }, "Split &&Editor"), 'workbench.action.splitEditor');
 		const toggleEditorLayout = this.createMenuItem(nls.localize({ key: 'miToggleEditorLayout', comment: ['&& denotes a mnemonic'] }, "Toggle Editor Group &&Layout"), 'workbench.action.toggleEditorGroupLayout');

--- a/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
+++ b/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
@@ -6,7 +6,6 @@
 import { TPromise } from 'vs/base/common/winjs.base';
 import nls = require('vs/nls');
 import { Action } from 'vs/base/common/actions';
-import { KeyCode, KeyMod, KeyChord } from 'vs/base/common/keyCodes';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';

--- a/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
+++ b/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TPromise } from 'vs/base/common/winjs.base';
+import nls = require('vs/nls');
+import { Action } from 'vs/base/common/actions';
+import { KeyCode, KeyMod, KeyChord } from 'vs/base/common/keyCodes';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
+import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
+import { IPartService } from 'vs/workbench/services/part/common/partService';
+
+class ToggleCenteredLayout extends Action {
+
+	public static readonly ID = 'workbench.action.toggleCenteredLayout';
+	public static readonly LABEL = nls.localize('toggleCenteredLayout', "Toggle Centered Layout");
+
+	constructor(
+		id: string,
+		label: string,
+		@IPartService private partService: IPartService
+	) {
+		super(id, label);
+		this.enabled = !!this.partService;
+	}
+
+	public run(): TPromise<any> {
+		this.partService.toggleCenteredLayout();
+		return TPromise.as(null);
+	}
+}
+
+const registry = Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions);
+registry.registerWorkbenchAction(new SyncActionDescriptor(ToggleCenteredLayout, ToggleCenteredLayout.ID, ToggleCenteredLayout.LABEL, { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_T) }), 'View: Toggle Centered Layout', nls.localize('view', "View"));

--- a/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
+++ b/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
@@ -33,4 +33,4 @@ class ToggleCenteredLayout extends Action {
 }
 
 const registry = Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions);
-registry.registerWorkbenchAction(new SyncActionDescriptor(ToggleCenteredLayout, ToggleCenteredLayout.ID, ToggleCenteredLayout.LABEL, { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_T) }), 'View: Toggle Centered Layout', nls.localize('view', "View"));
+registry.registerWorkbenchAction(new SyncActionDescriptor(ToggleCenteredLayout, ToggleCenteredLayout.ID, ToggleCenteredLayout.LABEL), 'View: Toggle Centered Layout', nls.localize('view', "View"));

--- a/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
+++ b/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
@@ -26,7 +26,8 @@ class ToggleCenteredLayout extends Action {
 	}
 
 	public run(): TPromise<any> {
-		this.partService.toggleCenteredLayout();
+		this.partService.toggleCenteredEditorLayout();
+
 		return TPromise.as(null);
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -214,10 +214,6 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		return this.layoutVertically ? EditorGroupsControl.MIN_EDITOR_WIDTH : EditorGroupsControl.MIN_EDITOR_HEIGHT;
 	}
 
-	private get visibleSilos(): number {
-		return this.visibleEditors.reduce((acc, min) => min ? acc + 1 : acc, 0);
-	}
-
 	private isSiloMinimized(position: number): boolean {
 		return this.silosSize[position] === this.minSize && this.silosMinimized[position];
 	}
@@ -2132,7 +2128,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		// Layout centered Editor
 		const doCentering =
 			this.layoutVertically &&
-			this.visibleSilos === 1 &&
+			this.editorGroupService.getStacksModel().groups.length === 1 &&
 			this.partService.isLayoutCentered() &&
 			this.visibleEditors[Position.ONE] instanceof TextResourceEditor;
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -1989,8 +1989,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			case this.centeredEditorSashLeft:
 				return this.centeredEditorPosition;
 			case this.centeredEditorSashRight:
-				// the border indicating the sash is 1px right to the end position
-				return this.centeredEditorEndPosition + 1;
+				return this.centeredEditorEndPosition;
 			default:
 				return 0;
 		}
@@ -2153,12 +2152,6 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			this.centeredEditorSashLeft.show();
 			this.centeredEditorSashRight.show();
 
-			const centeredEditor = this.visibleEditors[Position.ONE];
-			// TODO: replace the color
-			centeredEditor.getContainer().style('border-color', '#383838');
-			centeredEditor.getContainer().style('border-left-width', '1px');
-			centeredEditor.getContainer().style('border-right-width', '1px');
-
 			// no size set yet. Calculate a default value
 			if (this.centeredEditorPreferedSize === -1) {
 				this.resetCenteredEditor(false);
@@ -2202,9 +2195,6 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			if (this.centeredEditorActive) {
 				editorWidth = this.centeredEditorSize;
 				editorPosition = this.centeredEditorPosition;
-
-				// adjust the position because of the border
-				editorPosition--;
 			}
 
 			if (position !== Position.ONE) {
@@ -2215,8 +2205,6 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 				}
 			}
 
-			editor.getContainer().style('border-left-style', this.centeredEditorActive ? 'solid' : 'none');
-			editor.getContainer().style('border-right-style', this.centeredEditorActive ? 'solid' : 'none');
 			editor.getContainer().style({ 'margin-left': editorPosition + 'px', 'width': editorWidth + 'px' });
 			editor.layout(new Dimension(editorWidth, editorHeight));
 		}

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -1989,7 +1989,8 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			case this.centeredEditorSashLeft:
 				return this.centeredEditorPosition;
 			case this.centeredEditorSashRight:
-				return this.centeredEditorEndPosition;
+				// the border indicating the sash is 1px right to the end position
+				return this.centeredEditorEndPosition + 1;
 			default:
 				return 0;
 		}
@@ -2152,6 +2153,12 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			this.centeredEditorSashLeft.show();
 			this.centeredEditorSashRight.show();
 
+			const centeredEditor = this.visibleEditors[Position.ONE];
+			// TODO: replace the color
+			centeredEditor.getContainer().style('border-color', '#383838');
+			centeredEditor.getContainer().style('border-left-width', '1px');
+			centeredEditor.getContainer().style('border-right-width', '1px');
+
 			// no size set yet. Calculate a default value
 			if (this.centeredEditorPreferedSize === -1) {
 				this.resetCenteredEditor(false);
@@ -2195,6 +2202,9 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			if (this.centeredEditorActive) {
 				editorWidth = this.centeredEditorSize;
 				editorPosition = this.centeredEditorPosition;
+
+				// adjust the position because of the border
+				editorPosition--;
 			}
 
 			if (position !== Position.ONE) {
@@ -2205,6 +2215,8 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 				}
 			}
 
+			editor.getContainer().style('border-left-style', this.centeredEditorActive ? 'solid' : 'none');
+			editor.getContainer().style('border-right-style', this.centeredEditorActive ? 'solid' : 'none');
 			editor.getContainer().style({ 'margin-left': editorPosition + 'px', 'width': editorWidth + 'px' });
 			editor.layout(new Dimension(editorWidth, editorHeight));
 		}

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -1938,7 +1938,6 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 	}
 
 	private onCenterSashLeftDragEnd(): void {
-		this.layoutContainers();
 	}
 
 	private onCenterSashRightDragStart(): void {

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -39,7 +39,6 @@ import { IDisposable, combinedDisposable } from 'vs/base/common/lifecycle';
 import { ResourcesDropHandler, LocalSelectionTransfer, DraggedEditorIdentifier } from 'vs/workbench/browser/dnd';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
-import { TextResourceEditor } from 'vs/workbench/browser/parts/editor/textResourceEditor';
 
 export enum Rochade {
 	NONE,

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -37,6 +37,8 @@ import { attachProgressBarStyler } from 'vs/platform/theme/common/styler';
 import { IDisposable, combinedDisposable } from 'vs/base/common/lifecycle';
 import { ResourcesDropHandler, LocalSelectionTransfer, DraggedEditorIdentifier } from 'vs/workbench/browser/dnd';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IPartService } from 'vs/workbench/services/part/common/partService';
+import { TextResourceEditor } from 'vs/workbench/browser/parts/editor/textResourceEditor';
 
 export enum Rochade {
 	NONE,
@@ -101,6 +103,8 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 
 	private static readonly EDITOR_TITLE_HEIGHT = 35;
 
+	private static readonly CENTERED_EDITOR_MIN_MARGIN = 10;
+
 	private static readonly SNAP_TO_MINIMIZED_THRESHOLD_WIDTH = 50;
 	private static readonly SNAP_TO_MINIMIZED_THRESHOLD_HEIGHT = 20;
 
@@ -125,6 +129,22 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 	private sashTwo: Sash;
 	private startSiloThreeSize: number;
 
+	// if the centered layout is activated, the editor inside of silo ONE is centered
+	// the silo will then contain:
+	// [left margin]|[editor]|[right margin]
+	// - The size of the editor is defined by centeredEditorSize
+	// - The position is defined by the ratio centeredEditorLeftMarginRatio = left-margin/(left-margin + editor + right-margin).
+	// - The two sashes can be used to control the size and position of the editor inside of the silo.
+	// - In order to seperate the two sashes from the sashes that control the size of bordering widgets
+	//   CENTERED_EDITOR_MIN_MARGIN is forced as a minimum size for the two margins.
+	private centeredEditorActive: boolean;
+	private centeredEditorSashLeft: Sash;
+	private centeredEditorSashRight: Sash;
+	private centeredEditorPreferedSize: number;
+	private centeredEditorLeftMarginRatio: number;
+	private centeredEditorDragStartPosition: number;
+	private centeredEditorDragStartSize: number;
+
 	private visibleEditors: BaseEditor[];
 
 	private lastActiveEditor: BaseEditor;
@@ -144,6 +164,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		groupOrientation: GroupOrientation,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
 		@IEditorGroupService private editorGroupService: IEditorGroupService,
+		@IPartService private partService: IPartService,
 		@IContextKeyService private contextKeyService: IContextKeyService,
 		@IExtensionService private extensionService: IExtensionService,
 		@IInstantiationService private instantiationService: IInstantiationService,
@@ -193,6 +214,10 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		return this.layoutVertically ? EditorGroupsControl.MIN_EDITOR_WIDTH : EditorGroupsControl.MIN_EDITOR_HEIGHT;
 	}
 
+	private get visibleSilos(): number {
+		return this.visibleEditors.reduce((acc, min) => min ? acc + 1 : acc, 0);
+	}
+
 	private isSiloMinimized(position: number): boolean {
 		return this.silosSize[position] === this.minSize && this.silosMinimized[position];
 	}
@@ -207,6 +232,22 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 				this.silosMinimized[p] = false; // release silo from minimized state if it was sized large enough
 			}
 		});
+	}
+
+	private get centeredEditorAvailableSize(): number {
+		return this.silosSize[0] - EditorGroupsControl.CENTERED_EDITOR_MIN_MARGIN * 2;
+	}
+
+	private get centeredEditorSize(): number {
+		return Math.min(this.centeredEditorAvailableSize, this.centeredEditorPreferedSize);
+	}
+
+	private get centeredEditorPosition(): number {
+		return EditorGroupsControl.CENTERED_EDITOR_MIN_MARGIN + this.centeredEditorLeftMarginRatio * (this.centeredEditorAvailableSize - this.centeredEditorSize);
+	}
+
+	private get centeredEditorEndPosition(): number {
+		return this.centeredEditorPosition + this.centeredEditorSize;
 	}
 
 	private get snapToMinimizeThresholdSize(): number {
@@ -968,6 +1009,23 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 
 		// Silo Three
 		this.silos[Position.THREE] = $(this.parent).div({ class: 'one-editor-silo editor-three' });
+
+		// Center Layout stuff
+		this.centeredEditorSashLeft = new Sash(this.parent.getHTMLElement(), this, { baseSize: 5, orientation: Orientation.VERTICAL });
+		this.toUnbind.push(this.centeredEditorSashLeft.onDidStart(() => this.onCenterSashLeftDragStart()));
+		this.toUnbind.push(this.centeredEditorSashLeft.onDidChange((e: ISashEvent) => this.onCenterSashLeftDrag(e)));
+		this.toUnbind.push(this.centeredEditorSashLeft.onDidEnd(() => this.onCenterSashLeftDragEnd()));
+		this.toUnbind.push(this.centeredEditorSashLeft.onDidReset(() => this.resetCenteredEditor()));
+
+		this.centeredEditorSashRight = new Sash(this.parent.getHTMLElement(), this, { baseSize: 5, orientation: Orientation.VERTICAL });
+		this.toUnbind.push(this.centeredEditorSashRight.onDidStart(() => this.onCenterSashRightDragStart()));
+		this.toUnbind.push(this.centeredEditorSashRight.onDidChange((e: ISashEvent) => this.onCenterSashRightDrag(e)));
+		this.toUnbind.push(this.centeredEditorSashRight.onDidEnd(() => this.onCenterSashRightDragEnd()));
+		this.toUnbind.push(this.centeredEditorSashRight.onDidReset(() => this.resetCenteredEditor()));
+
+		this.centeredEditorActive = false;
+		this.centeredEditorLeftMarginRatio = 0.5;
+		this.centeredEditorPreferedSize = -1; // set this later if we know the container size
 
 		// For each position
 		POSITIONS.forEach(position => {
@@ -1858,12 +1916,70 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		this.sashTwo.layout();
 	}
 
+	private setCenteredEditorPositionAndSize(pos: number, size: number): void {
+		this.centeredEditorPreferedSize = Math.max(this.minSize, size);
+		pos -= EditorGroupsControl.CENTERED_EDITOR_MIN_MARGIN;
+		pos = Math.min(pos, this.centeredEditorAvailableSize - this.centeredEditorSize);
+		pos = Math.max(0, pos);
+		this.centeredEditorLeftMarginRatio = pos / (this.centeredEditorAvailableSize - this.centeredEditorSize);
+
+		this.layoutContainers();
+	}
+
+	private onCenterSashLeftDragStart(): void {
+		this.centeredEditorDragStartPosition = this.centeredEditorPosition;
+		this.centeredEditorDragStartSize = this.centeredEditorSize;
+	}
+
+	private onCenterSashLeftDrag(e: ISashEvent): void {
+		const minMargin = EditorGroupsControl.CENTERED_EDITOR_MIN_MARGIN;
+		const diffPos = e.currentX - e.startX;
+		const diffSize = -diffPos;
+
+		const pos = this.centeredEditorDragStartPosition + diffPos;
+		const size = this.centeredEditorDragStartSize + diffSize;
+		this.setCenteredEditorPositionAndSize(pos, pos <= minMargin ? size + pos - minMargin : size);
+	}
+
+	private onCenterSashLeftDragEnd(): void {
+		this.layoutContainers();
+	}
+
+	private onCenterSashRightDragStart(): void {
+		this.centeredEditorDragStartPosition = this.centeredEditorPosition;
+		this.centeredEditorDragStartSize = this.centeredEditorSize;
+	}
+
+	private onCenterSashRightDrag(e: ISashEvent): void {
+		const diffPos = e.currentX - e.startX;
+		const diffSize = diffPos;
+
+		const pos = this.centeredEditorDragStartPosition;
+		const maxSize = this.centeredEditorAvailableSize - this.centeredEditorDragStartPosition;
+		const size = Math.min(maxSize, this.centeredEditorDragStartSize + diffSize);
+		this.setCenteredEditorPositionAndSize(size < this.minSize ? pos + (size - this.minSize) : pos, size);
+	}
+
+	private onCenterSashRightDragEnd(): void {
+	}
+
 	public getVerticalSashTop(sash: Sash): number {
 		return 0;
 	}
 
 	public getVerticalSashLeft(sash: Sash): number {
-		return sash === this.sashOne ? this.silosSize[Position.ONE] : this.silosSize[Position.TWO] + this.silosSize[Position.ONE];
+		switch (sash) {
+			case this.sashOne:
+				return this.silosSize[Position.ONE];
+			case this.sashTwo:
+				return this.silosSize[Position.TWO] + this.silosSize[Position.ONE];
+			case this.centeredEditorSashLeft:
+				return this.centeredEditorPosition;
+			case this.centeredEditorSashRight:
+				return this.centeredEditorEndPosition;
+			default:
+				return 0;
+		}
 	}
 
 	public getVerticalSashHeight(sash: Sash): number {
@@ -2013,6 +2129,32 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 			}
 		});
 
+		// Layout centered Editor
+		const doCentering =
+			this.layoutVertically &&
+			this.visibleSilos === 1 &&
+			this.partService.isCenteredLayoutActive() &&
+			this.visibleEditors[Position.ONE] instanceof TextResourceEditor;
+
+		if (doCentering && !this.centeredEditorActive) {
+			this.centeredEditorSashLeft.show();
+			this.centeredEditorSashRight.show();
+
+			// no size set yet. Calculate a default value
+			if (this.centeredEditorPreferedSize === -1) {
+				this.resetCenteredEditor(false);
+			}
+		} else if (!doCentering && this.centeredEditorActive) {
+			this.centeredEditorSashLeft.hide();
+			this.centeredEditorSashRight.hide();
+		}
+		this.centeredEditorActive = doCentering;
+
+		if (this.centeredEditorActive) {
+			this.centeredEditorSashLeft.layout();
+			this.centeredEditorSashRight.layout();
+		}
+
 		// Layout visible editors
 		POSITIONS.forEach(position => {
 			this.layoutEditor(position);
@@ -2031,9 +2173,17 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 
 	private layoutEditor(position: Position): void {
 		const editorSize = this.silosSize[position];
-		if (editorSize && this.visibleEditors[position]) {
+		const editor = this.visibleEditors[position];
+		if (editorSize && editor) {
 			let editorWidth = this.layoutVertically ? editorSize : this.dimension.width;
 			let editorHeight = (this.layoutVertically ? this.dimension.height : this.silosSize[position]) - EditorGroupsControl.EDITOR_TITLE_HEIGHT;
+
+			let editorPosition = 0;
+
+			if (this.centeredEditorActive) {
+				editorWidth = this.centeredEditorSize;
+				editorPosition = this.centeredEditorPosition;
+			}
 
 			if (position !== Position.ONE) {
 				if (this.layoutVertically) {
@@ -2043,7 +2193,16 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 				}
 			}
 
-			this.visibleEditors[position].layout(new Dimension(editorWidth, editorHeight));
+			editor.getContainer().style({ 'margin-left': editorPosition + 'px', 'width': editorWidth + 'px' });
+			editor.layout(new Dimension(editorWidth, editorHeight));
+		}
+	}
+
+	private resetCenteredEditor(layout: boolean = true) {
+		this.centeredEditorLeftMarginRatio = 0.5;
+		this.centeredEditorPreferedSize = Math.floor(this.dimension.width * 0.5);
+		if (layout) {
+			this.layoutContainers();
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -2195,7 +2195,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 
 	private resetCenteredEditor(layout: boolean = true) {
 		this.centeredEditorLeftMarginRatio = 0.5;
-		this.centeredEditorPreferedSize = Math.floor(this.dimension.width * 0.5);
+		this.centeredEditorPreferedSize = Math.floor(this.dimension.width * 0.61);
 		if (layout) {
 			this.layoutContainers();
 		}

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -100,7 +100,7 @@ interface CenteredLayoutData {
  */
 export class EditorGroupsControl extends Themable implements IEditorGroupsControl, IVerticalSashLayoutProvider, IHorizontalSashLayoutProvider {
 
-	private static readonly CENTERED_LAYOUT_DATA_STORAGE_KEY = 'centeredLayoutData';
+	private static readonly CENTERED_LAYOUT_DATA_STORAGE_KEY = 'workbench.centeredlayout.layoutData';
 
 	private static readonly TITLE_AREA_CONTROL_KEY = '__titleAreaControl';
 	private static readonly PROGRESS_BAR_CONTROL_KEY = '__progressBar';

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -1019,13 +1019,13 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		this.centeredEditorSashLeft = new Sash(this.parent.getHTMLElement(), this, { baseSize: 5, orientation: Orientation.VERTICAL });
 		this.toUnbind.push(this.centeredEditorSashLeft.onDidStart(() => this.onCenterSashLeftDragStart()));
 		this.toUnbind.push(this.centeredEditorSashLeft.onDidChange((e: ISashEvent) => this.onCenterSashLeftDrag(e)));
-		this.toUnbind.push(this.centeredEditorSashLeft.onDidEnd(() => this.saveCenterdLayoutData()));
+		this.toUnbind.push(this.centeredEditorSashLeft.onDidEnd(() => this.storeCenteredLayoutData()));
 		this.toUnbind.push(this.centeredEditorSashLeft.onDidReset(() => this.resetCenteredEditor()));
 
 		this.centeredEditorSashRight = new Sash(this.parent.getHTMLElement(), this, { baseSize: 5, orientation: Orientation.VERTICAL });
 		this.toUnbind.push(this.centeredEditorSashRight.onDidStart(() => this.onCenterSashRightDragStart()));
 		this.toUnbind.push(this.centeredEditorSashRight.onDidChange((e: ISashEvent) => this.onCenterSashRightDrag(e)));
-		this.toUnbind.push(this.centeredEditorSashRight.onDidEnd(() => this.saveCenterdLayoutData()));
+		this.toUnbind.push(this.centeredEditorSashRight.onDidEnd(() => this.storeCenteredLayoutData()));
 		this.toUnbind.push(this.centeredEditorSashRight.onDidReset(() => this.resetCenteredEditor()));
 
 		this.centeredEditorActive = false;
@@ -1969,7 +1969,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		this.setCenteredEditorPositionAndSize(size < this.minSize ? pos + (size - this.minSize) : pos, size);
 	}
 
-	private saveCenterdLayoutData(): void {
+	private storeCenteredLayoutData(): void {
 		const data: CenteredLayoutData = {
 			leftMarginRatio: this.centeredEditorLeftMarginRatio,
 			size: this.centeredEditorSize

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -2133,7 +2133,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		const doCentering =
 			this.layoutVertically &&
 			this.visibleSilos === 1 &&
-			this.partService.isCenteredLayoutActive() &&
+			this.partService.isLayoutCentered() &&
 			this.visibleEditors[Position.ONE] instanceof TextResourceEditor;
 
 		if (doCentering && !this.centeredEditorActive) {

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -2147,8 +2147,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		const doCentering =
 			this.layoutVertically &&
 			this.editorGroupService.getStacksModel().groups.length === 1 &&
-			this.partService.isLayoutCentered() &&
-			this.visibleEditors[Position.ONE] instanceof TextResourceEditor;
+			this.partService.isLayoutCentered();
 
 		if (doCentering && !this.centeredEditorActive) {
 			this.centeredEditorSashLeft.show();

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -155,6 +155,7 @@ export class Workbench implements IPartService {
 	private static readonly sidebarRestoreStorageKey = 'workbench.sidebar.restore';
 	private static readonly panelHiddenStorageKey = 'workbench.panel.hidden';
 	private static readonly zenModeActiveStorageKey = 'workbench.zenmode.active';
+	private static readonly centeredLayoutActiveStorageKey = 'workbench.centeredlayout.active';
 	private static readonly panelPositionStorageKey = 'workbench.panel.location';
 	private static readonly defaultPanelPositionStorageKey = 'workbench.panel.defaultLocation';
 
@@ -213,6 +214,7 @@ export class Workbench implements IPartService {
 		wasSideBarVisible: boolean;
 		wasPanelVisible: boolean;
 	};
+	private centeredLayoutActive: boolean;
 
 	constructor(
 		parent: HTMLElement,
@@ -377,6 +379,11 @@ export class Workbench implements IPartService {
 		// Restore Zen Mode if active
 		if (this.storageService.getBoolean(Workbench.zenModeActiveStorageKey, StorageScope.WORKSPACE, false)) {
 			this.toggleZenMode(true);
+		}
+
+		// Restore Forced Center Mode
+		if (this.storageService.getBoolean(Workbench.centeredLayoutActiveStorageKey, StorageScope.GLOBAL, false)) {
+			this.centeredLayoutActive = true;
 		}
 
 		const onRestored = (error?: Error): IWorkbenchStartedInfo => {
@@ -660,6 +667,9 @@ export class Workbench implements IPartService {
 			wasSideBarVisible: false,
 			wasPanelVisible: false
 		};
+
+		// Centered Layout
+		this.centeredLayoutActive = false;
 	}
 
 	private setPanelPositionFromStorageOrConfig() {
@@ -1311,6 +1321,22 @@ export class Workbench implements IPartService {
 		if (toggleFullScreen) {
 			this.windowService.toggleFullScreen().done(void 0, errors.onUnexpectedError);
 		}
+	}
+
+	public isCenteredLayoutActive(): boolean {
+		return this.centeredLayoutActive;
+	}
+
+	public toggleCenteredLayout(): void {
+		this.centeredLayoutActive = !this.centeredLayoutActive;
+
+		if (this.centeredLayoutActive) {
+			this.storageService.store(Workbench.centeredLayoutActiveStorageKey, 'true', StorageScope.GLOBAL);
+		} else {
+			this.storageService.remove(Workbench.centeredLayoutActiveStorageKey, StorageScope.GLOBAL);
+		}
+
+		this.layout();
 	}
 
 	// Resize requested part along the main axis

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -155,7 +155,7 @@ export class Workbench implements IPartService {
 	private static readonly sidebarRestoreStorageKey = 'workbench.sidebar.restore';
 	private static readonly panelHiddenStorageKey = 'workbench.panel.hidden';
 	private static readonly zenModeActiveStorageKey = 'workbench.zenmode.active';
-	private static readonly centeredLayoutActiveStorageKey = 'workbench.centeredlayout.active';
+	private static readonly centeredEditorLayoutActiveStorageKey = 'workbench.centered.editorlayout.active';
 	private static readonly panelPositionStorageKey = 'workbench.panel.location';
 	private static readonly defaultPanelPositionStorageKey = 'workbench.panel.defaultLocation';
 
@@ -208,13 +208,13 @@ export class Workbench implements IPartService {
 	private sideBarVisibleContext: IContextKey<boolean>;
 	private hasFilesToCreateOpenOrDiff: boolean;
 	private fontAliasing: FontAliasingOption;
+	private centeredEditorLayoutActive: boolean;
 	private zenMode: {
 		active: boolean;
 		transitionedToFullScreen: boolean;
 		wasSideBarVisible: boolean;
 		wasPanelVisible: boolean;
 	};
-	private centeredLayoutActive: boolean;
 
 	constructor(
 		parent: HTMLElement,
@@ -381,9 +381,9 @@ export class Workbench implements IPartService {
 			this.toggleZenMode(true);
 		}
 
-		// Restore Forced Center Mode
-		if (this.storageService.getBoolean(Workbench.centeredLayoutActiveStorageKey, StorageScope.GLOBAL, false)) {
-			this.centeredLayoutActive = true;
+		// Restore Forced Editor Center Mode
+		if (this.storageService.getBoolean(Workbench.centeredEditorLayoutActiveStorageKey, StorageScope.GLOBAL, false)) {
+			this.centeredEditorLayoutActive = true;
 		}
 
 		const onRestored = (error?: Error): IWorkbenchStartedInfo => {
@@ -668,8 +668,8 @@ export class Workbench implements IPartService {
 			wasPanelVisible: false
 		};
 
-		// Centered Layout
-		this.centeredLayoutActive = false;
+		// Centered Editor Layout
+		this.centeredEditorLayoutActive = false;
 	}
 
 	private setPanelPositionFromStorageOrConfig() {
@@ -1323,13 +1323,14 @@ export class Workbench implements IPartService {
 		}
 	}
 
-	public isLayoutCentered(): boolean {
-		return this.centeredLayoutActive;
+	public isEditorLayoutCentered(): boolean {
+		return this.centeredEditorLayoutActive;
 	}
 
-	public toggleCenteredLayout(): void {
-		this.centeredLayoutActive = !this.centeredLayoutActive;
-		this.storageService.store(Workbench.centeredLayoutActiveStorageKey, this.centeredLayoutActive, StorageScope.GLOBAL);
+	public toggleCenteredEditorLayout(): void {
+		this.centeredEditorLayoutActive = !this.centeredEditorLayoutActive;
+		this.storageService.store(Workbench.centeredEditorLayoutActiveStorageKey, this.centeredEditorLayoutActive, StorageScope.GLOBAL);
+
 		this.layout();
 	}
 

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -1323,7 +1323,7 @@ export class Workbench implements IPartService {
 		}
 	}
 
-	public isCenteredLayoutActive(): boolean {
+	public isLayoutCentered(): boolean {
 		return this.centeredLayoutActive;
 	}
 

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -1329,13 +1329,7 @@ export class Workbench implements IPartService {
 
 	public toggleCenteredLayout(): void {
 		this.centeredLayoutActive = !this.centeredLayoutActive;
-
-		if (this.centeredLayoutActive) {
-			this.storageService.store(Workbench.centeredLayoutActiveStorageKey, 'true', StorageScope.GLOBAL);
-		} else {
-			this.storageService.remove(Workbench.centeredLayoutActiveStorageKey, StorageScope.GLOBAL);
-		}
-
+		this.storageService.store(Workbench.centeredLayoutActiveStorageKey, this.centeredLayoutActive, StorageScope.GLOBAL);
 		this.layout();
 	}
 

--- a/src/vs/workbench/services/part/common/partService.ts
+++ b/src/vs/workbench/services/part/common/partService.ts
@@ -132,7 +132,7 @@ export interface IPartService {
 	/**
 	 * Returns whether the centered layout is active.
 	 */
-	isCenteredLayoutActive(): boolean;
+	isLayoutCentered(): boolean;
 
 	/**
 	 * Toggles the workbench in and out of centered layout.

--- a/src/vs/workbench/services/part/common/partService.ts
+++ b/src/vs/workbench/services/part/common/partService.ts
@@ -130,14 +130,14 @@ export interface IPartService {
 	toggleZenMode(): void;
 
 	/**
-	 * Returns whether the centered layout is active.
+	 * Returns whether the centered editor layout is active.
 	 */
-	isLayoutCentered(): boolean;
+	isEditorLayoutCentered(): boolean;
 
 	/**
-	 * Toggles the workbench in and out of centered layout.
+	 * Toggles the workbench in and out of centered editor layout.
 	 */
-	toggleCenteredLayout(): void;
+	toggleCenteredEditorLayout(): void;
 
 	/**
 	 * Resizes currently focused part on main access

--- a/src/vs/workbench/services/part/common/partService.ts
+++ b/src/vs/workbench/services/part/common/partService.ts
@@ -130,6 +130,16 @@ export interface IPartService {
 	toggleZenMode(): void;
 
 	/**
+	 * Returns whether the centered layout is active.
+	 */
+	isCenteredLayoutActive(): boolean;
+
+	/**
+	 * Toggles the workbench in and out of centered layout.
+	 */
+	toggleCenteredLayout(): void;
+
+	/**
 	 * Resizes currently focused part on main access
 	 */
 	resizePart(part: Parts, sizeChange: number): void;

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -429,6 +429,10 @@ export class TestPartService implements IPartService {
 
 	public toggleZenMode(): void { }
 
+	public isCenteredLayoutActive(): boolean { return false; }
+	public toggleCenteredLayout(): void { }
+
+
 	public resizePart(part: Parts, sizeChange: number): void { }
 }
 

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -429,7 +429,7 @@ export class TestPartService implements IPartService {
 
 	public toggleZenMode(): void { }
 
-	public isCenteredLayoutActive(): boolean { return false; }
+	public isLayoutCentered(): boolean { return false; }
 	public toggleCenteredLayout(): void { }
 
 

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -429,8 +429,8 @@ export class TestPartService implements IPartService {
 
 	public toggleZenMode(): void { }
 
-	public isLayoutCentered(): boolean { return false; }
-	public toggleCenteredLayout(): void { }
+	public isEditorLayoutCentered(): boolean { return false; }
+	public toggleCenteredEditorLayout(): void { }
 
 
 	public resizePart(part: Parts, sizeChange: number): void { }

--- a/src/vs/workbench/workbench.main.ts
+++ b/src/vs/workbench/workbench.main.ts
@@ -31,6 +31,7 @@ import 'vs/workbench/browser/actions/toggleSidebarVisibility';
 import 'vs/workbench/browser/actions/toggleSidebarPosition';
 import 'vs/workbench/browser/actions/toggleEditorLayout';
 import 'vs/workbench/browser/actions/toggleZenMode';
+import 'vs/workbench/browser/actions/toggleCenteredLayout';
 import 'vs/workbench/browser/actions/toggleTabsVisibility';
 import 'vs/workbench/parts/preferences/electron-browser/preferences.contribution';
 import 'vs/workbench/parts/preferences/browser/keybindingsEditorContribution';


### PR DESCRIPTION
As described in #15684 this adds editor centering for the zen mode. I added two options:
- `zenMode.centerEditor` controls if the centering should be used
- `zenMode.centerEditorSize` controls the size of the centered editor. you can either specify the size using a size string (e.g. `"60%"` or `"600px"`) or you can specify the size of the two halfs of the editor (seen from the center)

```
"zenMode.centerEditorSize": {
  "left": "30%",
  "right": "100%"
}
```
With this the editor would occupy 30% of the left side of the window and 100% of the right side.

![preview](https://github.com/SrTobi-Forks/vscode/blob/SrTobi/center-zen-preview/resources/center-zen-preview.gif?raw=true)