### PR TITLE
Allow alt+F4 to close window in integrated terminal on Windows Fixes #35646

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -329,7 +329,7 @@ export class TerminalInstance implements ITerminalInstance {
 					return false;
 				}
 				// Skip alt+F4
-				if (platform.isWindows && event.altKey && event.keyCode === 115 && !event.ctrlKey) {
+				if (platform.isWindows && event.altKey && event.key === 'F4' && !event.ctrlKey) {
 					return false;
 				}
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -328,6 +328,10 @@ export class TerminalInstance implements ITerminalInstance {
 				if (TabFocus.getTabFocusMode() && event.keyCode === 9) {
 					return false;
 				}
+				// Skip alt+F4
+				if (platform.isWindows && event.altKey && event.keyCode === 115 && !event.ctrlKey) {
+					return false;
+				}
 
 				return undefined;
 			});


### PR DESCRIPTION
Fixes #35646
@Tyriar 