### PR TITLE
SelectBox Custom: Hide Drop-down on Dispose.  Fixes: #40962

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -675,6 +675,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	}
 
 	public dispose(): void {
+		this.hideSelectDropDown(false);
 		this.toDispose = dispose(this.toDispose);
 	}
 }


### PR DESCRIPTION
@bpasero 
@Tyriar 
@isidorn 
Happy New Years !  :fireworks:  :confetti_ball: 

Been great working with you guys this year, look forward to the next :+1: 

When the panel is closed while the Drop-down is open it does not receive a blur event which is how the Drop-down is usually closed.  I tried using a MutationObserver without luck, had to do the hide within the dispose.

public dispose(): void {
		this.hideSelectDropDown(false);
		this.toDispose = dispose(this.toDispose);
	}


Seems indirect,  anything more appropriate?

Cheers