### PR TITLE
Move new CodeAction Api from proposed to vscode.d.ts

### DIFF
--- a/extensions/typescript/src/features/quickFixProvider.ts
+++ b/extensions/typescript/src/features/quickFixProvider.ts
@@ -42,17 +42,7 @@ export default class TypeScriptQuickFixProvider implements vscode.CodeActionProv
 		commandManager.register(new ApplyCodeActionCommand(client));
 	}
 
-	public provideCodeActions(
-		_document: vscode.TextDocument,
-		_range: vscode.Range,
-		_context: vscode.CodeActionContext,
-		_token: vscode.CancellationToken
-	) {
-		// Uses provideCodeActions2 instead
-		return [];
-	}
-
-	public async provideCodeActions2(
+	public async provideCodeActions(
 		document: vscode.TextDocument,
 		range: vscode.Range,
 		context: vscode.CodeActionContext,

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -106,12 +106,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 		commandManager.register(new SelectRefactorCommand(doRefactoringCommand));
 	}
 
-	public async provideCodeActions() {
-		// Uses provideCodeActions2 instead
-		return [];
-	}
-
-	public async provideCodeActions2(
+	public async provideCodeActions(
 		document: vscode.TextDocument,
 		_range: vscode.Range,
 		_context: vscode.CodeActionContext,

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1824,6 +1824,48 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * A code action represents a change that can be performed in code, e.g. to fix a problem or
+	 * to refactor code.
+	 */
+	export class CodeAction {
+
+		/**
+		 * A short, human-readanle, title for this code action.
+		 */
+		title: string;
+
+		/**
+		 * A workspace edit this code action performs.
+		 *
+		 * *Note* that either an [`edit`](CodeAction#edit) or a [`command`](CodeAction#command) must be supplied.
+		 */
+		edit?: WorkspaceEdit;
+
+		/**
+		 * Diagnostics that this code action resolves.
+		 */
+		diagnostics?: Diagnostic[];
+
+		/**
+		 * A command this code action performs.
+		 *
+		 * *Note* that either an [`edit`](CodeAction#edit) or a [`command`](CodeAction#command) must be supplied.
+		 */
+		command?: Command;
+
+		/**
+		 * Creates a new code action.
+		 *
+		 * A code action must have at least a [title](#CodeAction.title) and either [edits](#CodeAction.edits)
+		 * or a [command](#CodeAction.command).
+		 *
+		 * @param title The title of the code action.
+		 * @param edits The edit of the code action.
+		 */
+		constructor(title: string, edit?: WorkspaceEdit);
+	}
+
+	/**
 	 * The code action interface defines the contract between extensions and
 	 * the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action) feature.
 	 *
@@ -1838,10 +1880,10 @@ declare module 'vscode' {
 		 * @param range The range for which the command was invoked.
 		 * @param context Context carrying additional information.
 		 * @param token A cancellation token.
-		 * @return An array of commands or a thenable of such. The lack of a result can be
+		 * @return An array of commands, quick fixes, or refactorings or a thenable of such. The lack of a result can be
 		 * signaled by returning `undefined`, `null`, or an empty array.
 		 */
-		provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<Command[]>;
+		provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | CodeAction)[]>;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -198,65 +198,6 @@ declare module 'vscode' {
 
 	//#endregion
 
-	/**
-	 * A code action represents a change that can be performed in code, e.g. to fix a problem or
-	 * to refactor code.
-	 */
-	export class CodeAction {
-
-		/**
-		 * A short, human-readanle, title for this code action.
-		 */
-		title: string;
-
-		/**
-		 * A workspace edit this code action performs.
-		 *
-		 * *Note* that either an [`edit`](CodeAction#edit) or a [`command`](CodeAction#command) must be supplied.
-		 */
-		edit?: WorkspaceEdit;
-
-		/**
-		 * Diagnostics that this code action resolves.
-		 */
-		diagnostics?: Diagnostic[];
-
-		/**
-		 * A command this code action performs.
-		 *
-		 * *Note* that either an [`edit`](CodeAction#edit) or a [`command`](CodeAction#command) must be supplied.
-		 */
-		command?: Command;
-
-		/**
-		 * Creates a new code action.
-		 *
-		 * A code action must have at least a [title](#CodeAction.title) and either [edits](#CodeAction.edits)
-		 * or a [command](#CodeAction.command).
-		 *
-		 * @param title The title of the code action.
-		 * @param edits The edit of the code action.
-		 */
-		constructor(title: string, edit?: WorkspaceEdit);
-	}
-
-	export interface CodeActionProvider {
-
-		/**
-		 * Provide commands for the given document and range.
-		 *
-		 * If implemented, overrides `provideCodeActions`
-		 *
-		 * @param document The document in which the command was invoked.
-		 * @param range The range for which the command was invoked.
-		 * @param context Context carrying additional information.
-		 * @param token A cancellation token.
-		 * @return An array of commands, quick fixes, or refactorings or a thenable of such. The lack of a result can be
-		 * signaled by returning `undefined`, `null`, or an empty array.
-		 */
-		provideCodeActions2?(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | CodeAction)[]>;
-	}
-
 	export namespace debug {
 
 		/**

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -289,9 +289,8 @@ class CodeActionAdapter {
 			}
 		});
 
-		return asWinJsPromise(token => this._provider.provideCodeActions2
-			? this._provider.provideCodeActions2(doc, ran, { diagnostics: allDiagnostics }, token)
-			: this._provider.provideCodeActions(doc, ran, { diagnostics: allDiagnostics }, token)
+		return asWinJsPromise(token =>
+			this._provider.provideCodeActions(doc, ran, { diagnostics: allDiagnostics }, token)
 		).then(commandsOrActions => {
 			if (isFalsyOrEmpty(commandsOrActions)) {
 				return undefined;


### PR DESCRIPTION
Moves the `provideCodeActions2` api from proposed to the offical VS Code api. This new API allows code action providers to return  `CodeAction` objects