### PR TITLE
Fix typo in MergeDecorator class name

### DIFF
--- a/extensions/merge-conflict/src/mergeDecorator.ts
+++ b/extensions/merge-conflict/src/mergeDecorator.ts
@@ -7,7 +7,7 @@ import * as interfaces from './interfaces';
 import { loadMessageBundle } from 'vscode-nls';
 const localize = loadMessageBundle();
 
-export default class MergeDectorator implements vscode.Disposable {
+export default class MergeDecorator implements vscode.Disposable {
 
 	private decorations: { [key: string]: vscode.TextEditorDecorationType } = {};
 


### PR DESCRIPTION
Also, newline added to the end of the file  