### PR TITLE
Terminal Find: Add Find Next/Previous WIP Fixes: #29661

### DIFF
--- a/src/vs/editor/contrib/find/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/simpleFindWidget.ts
@@ -104,13 +104,6 @@ export abstract class SimpleFindWidget extends Widget {
 		this._domNode.classList.add('simple-find-part-wrapper');
 		this._domNode.appendChild(this._innerDomNode);
 
-		this.onkeyup(this._innerDomNode, e => {
-			if (e.equals(KeyCode.Escape)) {
-				this.hide();
-				e.preventDefault();
-				return;
-			}
-		});
 
 		this._focusTracker = this._register(dom.trackFocus(this._innerDomNode));
 		this._register(this._focusTracker.onDidFocus(this.onFocusTrackerFocus.bind(this)));
@@ -156,12 +149,12 @@ export abstract class SimpleFindWidget extends Widget {
 		return this._domNode;
 	}
 
-	public reveal(initialInput?: string): void {
+	public reveal(initialInput?: string, focusFindInput = true): void {
 		if (initialInput) {
 			this._findInput.setValue(initialInput);
 		}
 
-		if (this._isVisible) {
+		if (this._isVisible && focusFindInput) {
 			this._findInput.select();
 			return;
 		}
@@ -176,7 +169,9 @@ export abstract class SimpleFindWidget extends Widget {
 			}
 			setTimeout(() => {
 				dom.removeClass(this._innerDomNode, 'noanimation');
-				this._findInput.select();
+				if (focusFindInput) {
+					this._findInput.select();
+				}
 			}, 200);
 		}, 0);
 	}

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -17,6 +17,9 @@ export const TERMINAL_SERVICE_ID = 'terminalService';
 
 export const TERMINAL_DEFAULT_RIGHT_CLICK_COPY_PASTE = platform.isWindows;
 
+/**  A context key that is set when the integrated terminal OR the terminal FindWidget has focus. */
+export const KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS = new RawContextKey<boolean>('terminalComponentsFocus', undefined);
+
 /**  A context key that is set when the integrated terminal has focus. */
 export const KEYBINDING_CONTEXT_TERMINAL_FOCUS = new RawContextKey<boolean>('terminalFocus', undefined);
 /**  A context key that is set when the integrated terminal does not have focus. */
@@ -164,6 +167,8 @@ export interface ITerminalService {
 	hidePanel(): void;
 	focusFindWidget(): TPromise<void>;
 	hideFindWidget(): void;
+	nextMatchFindWidget(): void;
+	previousMatchFindWidget(): void;
 	showNextFindTermFindWidget(): void;
 	showPreviousFindTermFindWidget(): void;
 

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -10,15 +10,15 @@ import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ITerminalService, ITerminalInstance, IShellLaunchConfig, ITerminalConfigHelper, KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE, TERMINAL_PANEL_ID } from 'vs/workbench/parts/terminal/common/terminal';
+import { ITerminalService, ITerminalInstance, IShellLaunchConfig, ITerminalConfigHelper, KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FOCUS, TERMINAL_PANEL_ID } from 'vs/workbench/parts/terminal/common/terminal';
 import { TPromise } from 'vs/base/common/winjs.base';
 
 export abstract class TerminalService implements ITerminalService {
 	public _serviceBrand: any;
 
 	protected _isShuttingDown: boolean;
+	protected _terminalComponentsFocusContextKey: IContextKey<boolean>;
 	protected _terminalFocusContextKey: IContextKey<boolean>;
-	protected _findWidgetVisible: IContextKey<boolean>;
 	protected _terminalContainer: HTMLElement;
 	protected _onInstancesChanged: Emitter<string>;
 	protected _onInstanceDisposed: Emitter<ITerminalInstance>;
@@ -66,8 +66,10 @@ export abstract class TerminalService implements ITerminalService {
 		});
 		lifecycleService.onWillShutdown(event => event.veto(this._onWillShutdown()));
 		lifecycleService.onShutdown(() => this._onShutdown());
+
+		this._terminalComponentsFocusContextKey = KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS.bindTo(this._contextKeyService);
 		this._terminalFocusContextKey = KEYBINDING_CONTEXT_TERMINAL_FOCUS.bindTo(this._contextKeyService);
-		this._findWidgetVisible = KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE.bindTo(this._contextKeyService);
+
 		this.onInstanceDisposed((terminalInstance) => { this._removeInstance(terminalInstance); });
 	}
 
@@ -220,6 +222,8 @@ export abstract class TerminalService implements ITerminalService {
 
 	public abstract focusFindWidget(): TPromise<void>;
 	public abstract hideFindWidget(): void;
+	public abstract nextMatchFindWidget(): void;
+	public abstract previousMatchFindWidget(): void;
 	public abstract showNextFindTermFindWidget(): void;
 	public abstract showPreviousFindTermFindWidget(): void;
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -13,12 +13,12 @@ import * as panel from 'vs/workbench/browser/panel';
 import * as platform from 'vs/base/common/platform';
 import * as terminalCommands from 'vs/workbench/parts/terminal/electron-browser/terminalCommands';
 import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
-import { ITerminalService, KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_INPUT_FOCUSED, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, TERMINAL_PANEL_ID, TERMINAL_DEFAULT_RIGHT_CLICK_COPY_PASTE, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE, TerminalCursorStyle } from 'vs/workbench/parts/terminal/common/terminal';
+import { ITerminalService, KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_INPUT_FOCUSED, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, TERMINAL_PANEL_ID, TERMINAL_DEFAULT_RIGHT_CLICK_COPY_PASTE, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE, TerminalCursorStyle } from 'vs/workbench/parts/terminal/common/terminal';
 import { TERMINAL_DEFAULT_SHELL_UNIX_LIKE, TERMINAL_DEFAULT_SHELL_WINDOWS } from 'vs/workbench/parts/terminal/electron-browser/terminal';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { KillTerminalAction, CopyTerminalSelectionAction, CreateNewTerminalAction, CreateNewInActiveWorkspaceTerminalAction, FocusActiveTerminalAction, FocusNextTerminalAction, FocusPreviousTerminalAction, SelectDefaultShellWindowsTerminalAction, RunSelectedTextInTerminalAction, RunActiveFileInTerminalAction, ScrollDownTerminalAction, ScrollDownPageTerminalAction, ScrollToBottomTerminalAction, ScrollUpTerminalAction, ScrollUpPageTerminalAction, ScrollToTopTerminalAction, TerminalPasteAction, ToggleTerminalAction, ClearTerminalAction, AllowWorkspaceShellTerminalCommand, DisallowWorkspaceShellTerminalCommand, RenameTerminalAction, SelectAllTerminalAction, FocusTerminalFindWidgetAction, HideTerminalFindWidgetAction, ShowNextFindTermTerminalFindWidgetAction, ShowPreviousFindTermTerminalFindWidgetAction, DeleteWordLeftTerminalAction, DeleteWordRightTerminalAction, QuickOpenActionTermContributor, QuickOpenTermAction, TERMINAL_PICKER_PREFIX } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
+import { KillTerminalAction, CopyTerminalSelectionAction, CreateNewTerminalAction, CreateNewInActiveWorkspaceTerminalAction, FocusActiveTerminalAction, FocusNextTerminalAction, FocusPreviousTerminalAction, SelectDefaultShellWindowsTerminalAction, RunSelectedTextInTerminalAction, RunActiveFileInTerminalAction, ScrollDownTerminalAction, ScrollDownPageTerminalAction, ScrollToBottomTerminalAction, ScrollUpTerminalAction, ScrollUpPageTerminalAction, ScrollToTopTerminalAction, TerminalPasteAction, ToggleTerminalAction, ClearTerminalAction, AllowWorkspaceShellTerminalCommand, DisallowWorkspaceShellTerminalCommand, RenameTerminalAction, SelectAllTerminalAction, FocusTerminalFindWidgetAction, HideTerminalFindWidgetAction, PreviousMatchTerminalFindWidgetAction, NextMatchTerminalFindWidgetAction, ShowNextFindTermTerminalFindWidgetAction, ShowPreviousFindTermTerminalFindWidgetAction, DeleteWordLeftTerminalAction, DeleteWordRightTerminalAction, QuickOpenActionTermContributor, QuickOpenTermAction, TERMINAL_PICKER_PREFIX } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ShowAllCommandsAction } from 'vs/workbench/parts/quickopen/browser/commandsHandler';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
@@ -243,6 +243,8 @@ configurationRegistry.registerConfiguration({
 				SelectAllTerminalAction.ID,
 				FocusTerminalFindWidgetAction.ID,
 				HideTerminalFindWidgetAction.ID,
+				NextMatchTerminalFindWidgetAction.ID,
+				PreviousMatchTerminalFindWidgetAction.ID,
 				ShowPreviousFindTermTerminalFindWidgetAction.ID,
 				ShowNextFindTermTerminalFindWidgetAction.ID,
 				NavigateUpAction.ID,
@@ -361,7 +363,15 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(FocusTerminalFin
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(HideTerminalFindWidgetAction, HideTerminalFindWidgetAction.ID, HideTerminalFindWidgetAction.LABEL, {
 	primary: KeyCode.Escape,
 	secondary: [KeyMod.Shift | KeyCode.Escape]
-}, ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE)), 'Terminal: Hide Find Widget', category);
+}, ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE)), 'Terminal: Hide Find Widget', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(NextMatchTerminalFindWidgetAction, NextMatchTerminalFindWidgetAction.ID, NextMatchTerminalFindWidgetAction.LABEL, {
+	primary: KeyCode.F3,
+	mac: { primary: KeyMod.CtrlCmd | KeyCode.KEY_G, secondary: [KeyCode.F3] }
+}, KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS), 'Terminal: Find Next', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(PreviousMatchTerminalFindWidgetAction, PreviousMatchTerminalFindWidgetAction.ID, PreviousMatchTerminalFindWidgetAction.LABEL, {
+	primary: KeyMod.Shift | KeyCode.F3,
+	mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_G, secondary: [KeyMod.Shift | KeyCode.F3] }
+}, KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS), 'Terminal: Find Previous', category);
 actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(ShowNextFindTermTerminalFindWidgetAction, ShowNextFindTermTerminalFindWidgetAction.ID, ShowNextFindTermTerminalFindWidgetAction.LABEL, {
 	primary: KeyMod.Alt | KeyCode.DownArrow
 }, ContextKeyExpr.and(KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_INPUT_FOCUSED, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE)), 'Terminal: Show Next Find Term', category);

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -718,6 +718,40 @@ export class HideTerminalFindWidgetAction extends Action {
 	}
 }
 
+export class NextMatchTerminalFindWidgetAction extends Action {
+
+	public static ID = 'workbench.action.terminal.findWidget.nextMatch';
+	public static LABEL = nls.localize('terminalFindNext', "Terminal: Find Next");
+
+	constructor(
+		id: string, label: string,
+		@ITerminalService private terminalService: ITerminalService
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<any> {
+		return TPromise.as(this.terminalService.nextMatchFindWidget());
+	}
+}
+
+export class PreviousMatchTerminalFindWidgetAction extends Action {
+
+	public static ID = 'workbench.action.terminal.findWidget.previousMatch';
+	public static LABEL = nls.localize('terminalFindPrevious', "Terminal: Find Previous");
+
+	constructor(
+		id: string, label: string,
+		@ITerminalService private terminalService: ITerminalService
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<any> {
+		return TPromise.as(this.terminalService.previousMatchFindWidget());
+	}
+}
+
 export class ShowNextFindTermTerminalFindWidgetAction extends Action {
 
 	public static readonly ID = 'workbench.action.terminal.findWidget.history.showNext';

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalFindWidget.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalFindWidget.ts
@@ -5,10 +5,11 @@
 
 import { SimpleFindWidget } from 'vs/editor/contrib/find/simpleFindWidget';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
-import { ITerminalService, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_INPUT_FOCUSED } from 'vs/workbench/parts/terminal/common/terminal';
+import { ITerminalService, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE, KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_INPUT_FOCUSED } from 'vs/workbench/parts/terminal/common/terminal';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 export class TerminalFindWidget extends SimpleFindWidget {
+	protected _findWidgetVisible: IContextKey<boolean>;
 	protected _findInputFocused: IContextKey<boolean>;
 
 	constructor(
@@ -17,6 +18,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		@ITerminalService private _terminalService: ITerminalService
 	) {
 		super(_contextViewService);
+		this._findWidgetVisible = KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_VISIBLE.bindTo(this._contextKeyService);
 		this._findInputFocused = KEYBINDING_CONTEXT_TERMINAL_FIND_WIDGET_INPUT_FOCUSED.bindTo(this._contextKeyService);
 	}
 
@@ -24,6 +26,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		let val = this.inputValue;
 		let instance = this._terminalService.getActiveInstance();
 		if (instance !== null) {
+			this.reveal(undefined, false);
 			if (previous) {
 				instance.findPrevious(val);
 			} else {
@@ -32,8 +35,14 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		}
 	}
 
+	public reveal(initialInput?: string, focusFindInput = true): void {
+		super.reveal(initialInput, focusFindInput);
+		this._findWidgetVisible.set(true);
+	}
+
 	public hide() {
 		super.hide();
+		this._findWidgetVisible.reset();
 		this._terminalService.getActiveInstance().focus();
 	}
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -112,6 +112,7 @@ export class TerminalInstance implements ITerminalInstance {
 	public get isTitleSetByProcess(): boolean { return !!this._messageTitleListener; }
 
 	public constructor(
+		private _terminalComponentsFocusContextKey: IContextKey<boolean>,
 		private _terminalFocusContextKey: IContextKey<boolean>,
 		private _configHelper: TerminalConfigHelper,
 		private _container: HTMLElement,
@@ -365,16 +366,20 @@ export class TerminalInstance implements ITerminalInstance {
 
 			this._instanceDisposables.push(dom.addDisposableListener(this._xterm.textarea, 'focus', (event: KeyboardEvent) => {
 				this._terminalFocusContextKey.set(true);
+				this._terminalComponentsFocusContextKey.set(true);
 			}));
 			this._instanceDisposables.push(dom.addDisposableListener(this._xterm.textarea, 'blur', (event: KeyboardEvent) => {
 				this._terminalFocusContextKey.reset();
+				this._terminalComponentsFocusContextKey.reset();
 				this._refreshSelectionContextKey();
 			}));
 			this._instanceDisposables.push(dom.addDisposableListener(this._xterm.element, 'focus', (event: KeyboardEvent) => {
 				this._terminalFocusContextKey.set(true);
+				this._terminalComponentsFocusContextKey.set(true);
 			}));
 			this._instanceDisposables.push(dom.addDisposableListener(this._xterm.element, 'blur', (event: KeyboardEvent) => {
 				this._terminalFocusContextKey.reset();
+				this._terminalComponentsFocusContextKey.reset();
 				this._refreshSelectionContextKey();
 			}));
 
@@ -443,6 +448,12 @@ export class TerminalInstance implements ITerminalInstance {
 	public notifyFindWidgetFocusChanged(isFocused: boolean): void {
 		const terminalFocused = !isFocused && (document.activeElement === this._xterm.textarea || document.activeElement === this._xterm.element);
 		this._terminalFocusContextKey.set(terminalFocused);
+
+		if (!isFocused && !(document.activeElement === this._xterm.textarea || document.activeElement === this._xterm.element)) {
+			this._terminalComponentsFocusContextKey.reset();
+		} else if (isFocused) {
+			this._terminalComponentsFocusContextKey.set(true);
+		}
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -182,6 +182,14 @@ export class TerminalPanel extends Panel {
 		this._findWidget.hide();
 	}
 
+	public nextMatchFindWidget(): void {
+		this._findWidget.find(false);
+	}
+
+	public previousMatchFindWidget(): void {
+		this._findWidget.find(true);
+	}
+
 	public showNextFindTermFindWidget(): void {
 		this._findWidget.showNextFindTerm();
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -47,6 +47,7 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 
 	public createInstance(shell: IShellLaunchConfig = {}, wasNewTerminalAction?: boolean): ITerminalInstance {
 		let terminalInstance = this._instantiationService.createInstance(TerminalInstance,
+			this._terminalComponentsFocusContextKey,
 			this._terminalFocusContextKey,
 			this._configHelper,
 			this._terminalContainer,
@@ -69,7 +70,7 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 		return this.showPanel(false).then(() => {
 			let panel = this._panelService.getActivePanel() as TerminalPanel;
 			panel.focusFindWidget();
-			this._findWidgetVisible.set(true);
+			this._terminalComponentsFocusContextKey.set(true);
 		});
 	}
 
@@ -77,8 +78,21 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 		const panel = this._panelService.getActivePanel() as TerminalPanel;
 		if (panel && panel.getId() === TERMINAL_PANEL_ID) {
 			panel.hideFindWidget();
-			this._findWidgetVisible.reset();
 			panel.focus();
+		}
+	}
+
+	public nextMatchFindWidget(): void {
+		const panel = this._panelService.getActivePanel() as TerminalPanel;
+		if (panel && panel.getId() === TERMINAL_PANEL_ID) {
+			panel.nextMatchFindWidget();
+		}
+	}
+
+	public previousMatchFindWidget(): void {
+		const panel = this._panelService.getActivePanel() as TerminalPanel;
+		if (panel && panel.getId() === TERMINAL_PANEL_ID) {
+			panel.previousMatchFindWidget();
 		}
 	}
 


### PR DESCRIPTION
Fixes: #29661

@Tyriar 
cc:/ @rebornix 
A bit trickier than anticipated.  I marked this as WIP as I want to make sure you get to do a close look. I don't want to mess up like this summer ;-)

- Added context key essentially an OR of terminal focus and find widget is to focus.
- Moved _findWidgetVisible into terminalFindWidget

/**  A context key that is set when the integrated terminal OR the terminal FindWidget has focus. */
export const KEYBINDING_CONTEXT_TERMINAL_COMPONENTS_FOCUS = new RawContextKey<boolean>('terminalComponentsFocus', undefined);

- I believe all paths adjust context keys correctly, but I want a second pair of eyes to check on this.
- Removed hardwired Escape handling within SimpleFind , make sure key binding command is called.
- If this looks good, I will do a separate issue/PR for the markdown editors.
  