### PR TITLE
Added support for multiple selections in Open Link action

### DIFF
--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -399,13 +399,13 @@ class OpenLinkAction extends EditorAction {
 		let selections = editor.getSelections();
 
 		for (let sel of selections) {
-			let link = linkDetector.getLinkOccurrence(sel.getEndPosition());
+				let link = linkDetector.getLinkOccurrence(sel.getEndPosition());
 
-		if (link) {
-			linkDetector.openLinkOccurrence(link, false);
+			if (link) {
+				linkDetector.openLinkOccurrence(link, false);
+			}
 		}
 	}
-}
 }
 
 registerEditorContribution(LinkDetector);

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -396,11 +396,16 @@ class OpenLinkAction extends EditorAction {
 			return;
 		}
 
-		let link = linkDetector.getLinkOccurrence(editor.getPosition());
+		let selections = editor.getSelections();
+
+		for (let sel of selections) {
+			let link = linkDetector.getLinkOccurrence(sel.getEndPosition());
+
 		if (link) {
 			linkDetector.openLinkOccurrence(link, false);
 		}
 	}
+}
 }
 
 registerEditorContribution(LinkDetector);

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -399,7 +399,7 @@ class OpenLinkAction extends EditorAction {
 		let selections = editor.getSelections();
 
 		for (let sel of selections) {
-				let link = linkDetector.getLinkOccurrence(sel.getEndPosition());
+			let link = linkDetector.getLinkOccurrence(sel.getEndPosition());
 
 			if (link) {
 				linkDetector.openLinkOccurrence(link, false);


### PR DESCRIPTION
Fixes #41231.

It checks for links in each selection, rather than limiting to a single one.

## Unit Tests

**tl;dr** Unfortunately I was unable to integrate all deps to make tests together.

I'm a fan of TDD, however I had to gave up during unit tests development. As there were many dependencies going on there.

Based on other tests I was able to somehow register `LinkDetector` contribution to the editor, but that wasn't enough, as it relies on [`currentOccurrences`](https://github.com/Microsoft/vscode/blob/8e0baed/src/vs/editor/contrib/links/links.ts#L293) which is set in [updateDecorations](https://github.com/Microsoft/vscode/blob/8e0baed/src/vs/editor/contrib/links/links.ts#L265-L270) and I wasn't able to figure out api to hook it up to the editor. I guess I should try to hook `LinkProviderRegistry` but I wasn't able to.

Then as a last resort I wanted to stub these dependencies using Sinon, but again, even stubbed methods had quite a few dependencies (`getLinkOccurrence` method), which would require me to manually create ILink compatible instances - and I don't think this is the best idea.

All the work is available at [my `open-link-multi-selections-tests`](https://github.com/mlewand/vscode/tree/open-link-multi-selections-tests) branch. Feel free to pull it if you find it helpful to do final touches, or you could point me to how to make it work together.