### PR TITLE
Add log uploader command line util

### DIFF
--- a/src/vs/code/electron-main/launch.ts
+++ b/src/vs/code/electron-main/launch.ts
@@ -10,7 +10,7 @@ import { IChannel } from 'vs/base/parts/ipc/common/ipc';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IURLService } from 'vs/platform/url/common/url';
 import { IProcessEnvironment } from 'vs/base/common/platform';
-import { ParsedArgs } from 'vs/platform/environment/common/environment';
+import { ParsedArgs, IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { OpenContext } from 'vs/platform/windows/common/windows';
 import { IWindowsMainService, ICodeWindow } from 'vs/platform/windows/electron-main/windows';
@@ -42,12 +42,14 @@ export interface ILaunchService {
 	start(args: ParsedArgs, userEnv: IProcessEnvironment): TPromise<void>;
 	getMainProcessId(): TPromise<number>;
 	getMainProcessInfo(): TPromise<IMainProcessInfo>;
+	getLogsPath(): TPromise<string>;
 }
 
 export interface ILaunchChannel extends IChannel {
 	call(command: 'start', arg: IStartArguments): TPromise<void>;
 	call(command: 'get-main-process-id', arg: null): TPromise<any>;
 	call(command: 'get-main-process-info', arg: null): TPromise<any>;
+	call(command: 'get-logs-path', arg: null): TPromise<string>;
 	call(command: string, arg: any): TPromise<any>;
 }
 
@@ -66,6 +68,9 @@ export class LaunchChannel implements ILaunchChannel {
 
 			case 'get-main-process-info':
 				return this.service.getMainProcessInfo();
+
+			case 'get-logs-path':
+				return this.service.getLogsPath();
 		}
 
 		return undefined;
@@ -89,6 +94,10 @@ export class LaunchChannelClient implements ILaunchService {
 	public getMainProcessInfo(): TPromise<IMainProcessInfo> {
 		return this.channel.call('get-main-process-info', null);
 	}
+
+	public getLogsPath(): TPromise<string> {
+		return this.channel.call('get-logs-path', null);
+	}
 }
 
 export class LaunchService implements ILaunchService {
@@ -99,7 +108,8 @@ export class LaunchService implements ILaunchService {
 		@ILogService private logService: ILogService,
 		@IWindowsMainService private windowsMainService: IWindowsMainService,
 		@IURLService private urlService: IURLService,
-		@IWorkspacesMainService private workspacesMainService: IWorkspacesMainService
+		@IWorkspacesMainService private workspacesMainService: IWorkspacesMainService,
+		@IEnvironmentService private readonly environmentService: IEnvironmentService
 	) { }
 
 	public start(args: ParsedArgs, userEnv: IProcessEnvironment): TPromise<void> {
@@ -178,6 +188,11 @@ export class LaunchService implements ILaunchService {
 				return this.getWindowInfo(window);
 			})
 		} as IMainProcessInfo);
+	}
+
+	public getLogsPath(): TPromise<string> {
+		this.logService.trace('Received request for logs path from other instance.');
+		return TPromise.as(this.environmentService.logsPath);
 	}
 
 	private getWindowInfo(window: ICodeWindow): IWindowInfo {

--- a/src/vs/code/electron-main/logUploader.ts
+++ b/src/vs/code/electron-main/logUploader.ts
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import * as os from 'os';
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as https from 'https';
+import * as path from 'path';
+import * as url from 'url';
+import * as readline from 'readline';
+
+import { localize } from 'vs/nls';
+import { ILaunchChannel } from 'vs/code/electron-main/launch';
+import { TPromise } from 'vs/base/common/winjs.base';
+import product from 'vs/platform/node/product';
+
+interface PostResult {
+	readonly blob_id: string;
+}
+
+class Endpoint {
+	private constructor(
+		public readonly host: string,
+		public readonly path: string
+	) { }
+
+	public static getFromProduct(): Endpoint | undefined {
+		const logUploaderUrl = product.logUploaderUrl;
+		if (!logUploaderUrl) {
+			return undefined;
+		}
+
+		try {
+			const parsed = url.parse(logUploaderUrl);
+			return new Endpoint(parsed.host, parsed.path);
+		} catch {
+			return undefined;
+		}
+	}
+}
+
+export async function uploadLogs(
+	channel: ILaunchChannel
+): TPromise<any> {
+	const endpoint = Endpoint.getFromProduct();
+	if (!endpoint) {
+		console.error(localize('invalidEndpoint', 'Invalid log uploader endpoint'));
+		return;
+	}
+
+	const logsPath = await channel.call('get-logs-path', null);
+
+	if (await promptUserToConfirmLogUplod(logsPath)) {
+		const outZip = await zipLogs(logsPath);
+		const result = await postLogs(endpoint, logsPath, outZip);
+		console.log(localize('didUploadLogs', 'Uploaded logs ID: {0}', result.blob_id));
+	} else {
+		console.log(localize('userDeniedUpload', 'Canceled upload'));
+	}
+}
+
+async function promptUserToConfirmLogUplod(
+	logsPath: string
+): Promise<boolean> {
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
+
+	return new Promise<boolean>(resolve =>
+		rl.question(
+			localize('logUploadPromptHeader', 'Upload session logs to secure endpoint?')
+			+ '\n\n' + localize('logUploadPromptBody', 'Please review your log files: \'{0}\'', logsPath)
+			+ '\n\n' + localize('logUploadPromptKey', 'Enter \'y\' to confirm upload...'),
+			(answer: string) => {
+				rl.close();
+				resolve(answer && answer.trim()[0].toLowerCase() === 'y');
+			}));
+}
+
+function postLogs(
+	endpoint: Endpoint,
+	logsPath: string,
+	outZip: string
+): TPromise<PostResult> {
+	return new TPromise((resolve, reject) => {
+		const req = https.request({
+			host: endpoint.host,
+			path: endpoint.path,
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/zip',
+				'Content-Length': fs.statSync(logsPath).size
+			}
+		}, res => {
+			const chunks: (Buffer)[] = [];
+			res.on('data', (chunk: Buffer) => {
+				chunks.push(chunk);
+			});
+			res.on('end', () => {
+				const body = Buffer.concat(chunks);
+				try {
+					resolve(JSON.parse(body.toString()));
+				} catch (e) {
+					console.log(localize('parseError', 'Error parsing response'));
+					reject(e);
+				}
+			});
+			res.on('error', (e) => {
+				console.log(localize('postError', 'Error posting logs: {0}', e));
+				reject(e);
+			});
+		});
+		fs.createReadStream(outZip).pipe(req);
+	});
+}
+
+function zipLogs(
+	logsPath: string
+): TPromise<string> {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-log-upload'));
+	const outZip = path.join(tempDir, 'logs.zip');
+	return new TPromise<string>((resolve, reject) => {
+		doZip(logsPath, outZip, (err, stdout, stderr) => {
+			if (err) {
+				console.error(localize('zipError', 'Error zipping logs: {0}', err));
+				reject(err);
+			} else {
+				resolve(outZip);
+			}
+		});
+	});
+}
+
+function doZip(
+	logsPath: string,
+	outZip: string,
+	callback: (error: Error, stdout: string, stderr: string) => void
+) {
+	switch (os.platform()) {
+		case 'win32':
+			return cp.execFile('powershell', ['-Command', `Compress-Archive -Path "${logsPath}" -DestinationPath ${outZip}`], { cwd: logsPath }, callback);
+
+		default:
+			return cp.execFile('zip', ['-r', outZip, '.'], { cwd: logsPath }, callback);
+	}
+}

--- a/src/vs/code/electron-main/logUploader.ts
+++ b/src/vs/code/electron-main/logUploader.ts
@@ -54,7 +54,7 @@ export async function uploadLogs(
 
 	const logsPath = await channel.call('get-logs-path', null);
 
-	if (await promptUserToConfirmLogUplod(logsPath)) {
+	if (await promptUserToConfirmLogUpload(logsPath)) {
 		const outZip = await zipLogs(logsPath);
 		const result = await postLogs(endpoint, logsPath, outZip);
 		console.log(localize('didUploadLogs', 'Uploaded logs ID: {0}', result.blob_id));
@@ -63,7 +63,7 @@ export async function uploadLogs(
 	}
 }
 
-async function promptUserToConfirmLogUplod(
+async function promptUserToConfirmLogUpload(
 	logsPath: string
 ): Promise<boolean> {
 	const rl = readline.createInterface({

--- a/src/vs/code/electron-main/logUploader.ts
+++ b/src/vs/code/electron-main/logUploader.ts
@@ -71,7 +71,7 @@ async function promptUserToConfirmLogUplod(
 		output: process.stdout
 	});
 
-	return new Promise<boolean>(resolve =>
+	return new TPromise<boolean>(resolve =>
 		rl.question(
 			localize('logUploadPromptHeader', 'Upload session logs to secure endpoint?')
 			+ '\n\n' + localize('logUploadPromptBody', 'Please review your log files: \'{0}\'', logsPath)

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -104,6 +104,7 @@ class ExpectedError extends Error {
 function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 	const logService = accessor.get(ILogService);
 	const environmentService = accessor.get(IEnvironmentService);
+	const requestService = accessor.get(IRequestService);
 
 	function allowSetForegroundWindow(service: LaunchChannelClient): TPromise<void> {
 		let promise = TPromise.wrap<void>(void 0);
@@ -176,7 +177,7 @@ function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 					// Skip this if we are running with --wait where it is expected that we wait for a while.
 					// Also skip when gathering diagnostics (--status) which can take a longer time.
 					let startupWarningDialogHandle: number;
-					if (!environmentService.wait && !environmentService.status && !environmentService['upload-logs']) {
+					if (!environmentService.wait && !environmentService.status && !environmentService.args['upload-logs']) {
 						startupWarningDialogHandle = setTimeout(() => {
 							showStartupWarningDialog(
 								localize('secondInstanceNoResponse', "Another instance of {0} is running but not responding", product.nameShort),
@@ -198,7 +199,7 @@ function setupIPC(accessor: ServicesAccessor): TPromise<Server> {
 					// Log uploader
 					if (environmentService.args['upload-logs']) {
 						return import('vs/code/electron-main/logUploader')
-							.then(logUploader => logUploader.uploadLogs(channel))
+							.then(logUploader => logUploader.uploadLogs(channel, requestService))
 							.then(() => TPromise.wrapError(new ExpectedError()));
 					}
 

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -54,6 +54,7 @@ export interface ParsedArgs {
 	'skip-add-to-recently-opened'?: boolean;
 	'file-write'?: boolean;
 	'file-chmod'?: boolean;
+	'upload-logs'?: boolean;
 }
 
 export const IEnvironmentService = createDecorator<IEnvironmentService>('environmentService');

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -164,7 +164,7 @@ const troubleshootingHelp: { [name: string]: string; } = {
 	'--inspect-extensions': localize('inspect-extensions', "Allow debugging and profiling of extensions. Check the developer tools for the connection uri."),
 	'--inspect-brk-extensions': localize('inspect-brk-extensions', "Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection uri."),
 	'--disable-gpu': localize('disableGPU', "Disable GPU hardware acceleration."),
-	'--upload-logs': localize('uploadLogs', "Upload logs.")
+	'--upload-logs': localize('uploadLogs', "Uploads logs from current session to a secure endpoint.")
 };
 
 export function formatOptions(options: { [name: string]: string; }, columns: number): string {

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -58,7 +58,8 @@ const options: minimist.Opts = {
 		'skip-add-to-recently-opened',
 		'status',
 		'file-write',
-		'file-chmod'
+		'file-chmod',
+		'upload-logs'
 	],
 	alias: {
 		add: 'a',
@@ -162,7 +163,8 @@ const troubleshootingHelp: { [name: string]: string; } = {
 	'--disable-extensions': localize('disableExtensions', "Disable all installed extensions."),
 	'--inspect-extensions': localize('inspect-extensions', "Allow debugging and profiling of extensions. Check the developer tools for the connection uri."),
 	'--inspect-brk-extensions': localize('inspect-brk-extensions', "Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection uri."),
-	'--disable-gpu': localize('disableGPU', "Disable GPU hardware acceleration.")
+	'--disable-gpu': localize('disableGPU', "Disable GPU hardware acceleration."),
+	'--upload-logs': localize('uploadLogs', "Upload logs.")
 };
 
 export function formatOptions(options: { [name: string]: string; }, columns: number): string {

--- a/src/vs/platform/node/product.ts
+++ b/src/vs/platform/node/product.ts
@@ -69,6 +69,7 @@ export interface IProductConfiguration {
 		'linux-x64': string;
 		'darwin': string;
 	};
+	logUploaderUrl: string;
 }
 
 export interface ISurveyData {


### PR DESCRIPTION
Adds a new --upload-logs command line flag that allows users to upload log files from their current session to a secure endpoint.

These logs will only be uploaded after the user reviews them and confirms the upload. After confirmation, the uploaded logs will be zipped up and uploaded to a secure store that only vscode core team members have access to. When a user shares their log file id, we can then find their log files in order to investigate an issue
  