### PR TITLE
Explorer: multi select

### DIFF
--- a/extensions/merge-conflict/src/contentProvider.ts
+++ b/extensions/merge-conflict/src/contentProvider.ts
@@ -9,6 +9,15 @@ export default class MergeConflictContentProvider implements vscode.TextDocument
 
 	static scheme = 'merge-conflict.conflict-diff';
 
+	constructor(private context: vscode.ExtensionContext) {
+	}
+
+	begin() {
+		this.context.subscriptions.push(
+			vscode.workspace.registerTextDocumentContentProvider(MergeConflictContentProvider.scheme, this)
+		);
+	}
+
 	dispose() {
 	}
 

--- a/extensions/merge-conflict/src/services.ts
+++ b/extensions/merge-conflict/src/services.ts
@@ -28,7 +28,7 @@ export default class ServiceWrapper implements vscode.Disposable {
 			documentTracker,
 			new CommandHandler(documentTracker),
 			new CodeLensProvider(documentTracker),
-			new ContentProvider(),
+			new ContentProvider(this.context),
 			new Decorator(this.context, documentTracker),
 		);
 

--- a/src/vs/code/electron-main/launch.ts
+++ b/src/vs/code/electron-main/launch.ts
@@ -106,25 +106,24 @@ export class LaunchService implements ILaunchService {
 		this.logService.trace('Received data from other instance: ', args, userEnv);
 
 		// Check early for open-url which is handled in URL service
-		const openUrl = this.startOpenUrl(args);
-		if (openUrl) {
-			return openUrl;
+		if (this.shouldOpenUrl(args)) {
+			return TPromise.as(null);
 		}
 
 		// Otherwise handle in windows service
 		return this.startOpenWindow(args, userEnv);
 	}
 
-	private startOpenUrl(args: ParsedArgs): TPromise<void> {
+	private shouldOpenUrl(args: ParsedArgs): boolean {
 		if (args['open-url'] && args._urls && args._urls.length > 0) {
 			// --open-url must contain -- followed by the url(s)
 			// process.argv is used over args._ as args._ are resolved to file paths at this point
 			args._urls.forEach(url => this.urlService.open(url));
 
-			return TPromise.as(null);
+			return true;
 		}
 
-		return void 0;
+		return false;
 	}
 
 	private startOpenWindow(args: ParsedArgs, userEnv: IProcessEnvironment): TPromise<void> {

--- a/src/vs/code/electron-main/launch.ts
+++ b/src/vs/code/electron-main/launch.ts
@@ -116,8 +116,7 @@ export class LaunchService implements ILaunchService {
 	}
 
 	private startOpenUrl(args: ParsedArgs): TPromise<void> {
-		const openUrlArg = args['open-url'] || [];
-		if (openUrlArg && args._urls && args._urls.length) {
+		if (args['open-url'] && args._urls && args._urls.length > 0) {
 			// --open-url must contain -- followed by the url(s)
 			// process.argv is used over args._ as args._ are resolved to file paths at this point
 			args._urls.forEach(url => this.urlService.open(url));

--- a/src/vs/code/electron-main/launch.ts
+++ b/src/vs/code/electron-main/launch.ts
@@ -117,13 +117,10 @@ export class LaunchService implements ILaunchService {
 
 	private startOpenUrl(args: ParsedArgs): TPromise<void> {
 		const openUrlArg = args['open-url'] || [];
-		if (openUrlArg) {
+		if (openUrlArg && args._urls && args._urls.length) {
 			// --open-url must contain -- followed by the url(s)
-			// process.argv is used over args._ as args._ are resolved to file paths on disk at this point
-			const dashDashIndex = process.argv.indexOf('--');
-			for (let i = dashDashIndex + 1; i < process.argv.length; i++) {
-				this.urlService.open(process.argv[i]);
-			}
+			// process.argv is used over args._ as args._ are resolved to file paths at this point
+			args._urls.forEach(url => this.urlService.open(url));
 
 			return TPromise.as(null);
 		}

--- a/src/vs/code/electron-main/launch.ts
+++ b/src/vs/code/electron-main/launch.ts
@@ -117,9 +117,13 @@ export class LaunchService implements ILaunchService {
 
 	private startOpenUrl(args: ParsedArgs): TPromise<void> {
 		const openUrlArg = args['open-url'] || [];
-		const openUrl = typeof openUrlArg === 'string' ? [openUrlArg] : openUrlArg;
-		if (openUrl.length > 0) {
-			openUrl.forEach(url => this.urlService.open(url));
+		if (openUrlArg) {
+			// --open-url must contain -- followed by the url(s)
+			// process.argv is used over args._ as args._ are resolved to file paths on disk at this point
+			const dashDashIndex = process.argv.indexOf('--');
+			for (let i = dashDashIndex + 1; i < process.argv.length; i++) {
+				this.urlService.open(process.argv[i]);
+			}
 
 			return TPromise.as(null);
 		}

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -66,7 +66,7 @@ function createServices(args: ParsedArgs, bufferLogService: BufferLogService): I
 	services.set(IStateService, new SyncDescriptor(StateService));
 	services.set(IConfigurationService, new SyncDescriptor(ConfigurationService));
 	services.set(IRequestService, new SyncDescriptor(RequestService));
-	services.set(IURLService, new SyncDescriptor(URLService, args['open-url'] ? args._urls : ''));
+	services.set(IURLService, new SyncDescriptor(URLService, args['open-url'] ? args._urls : []));
 	services.set(IBackupMainService, new SyncDescriptor(BackupMainService));
 
 	return new InstantiationService(services, true);

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -66,7 +66,7 @@ function createServices(args: ParsedArgs, bufferLogService: BufferLogService): I
 	services.set(IStateService, new SyncDescriptor(StateService));
 	services.set(IConfigurationService, new SyncDescriptor(ConfigurationService));
 	services.set(IRequestService, new SyncDescriptor(RequestService));
-	services.set(IURLService, new SyncDescriptor(URLService, args['open-url']));
+	services.set(IURLService, new SyncDescriptor(URLService, args['open-url'] ? args._urls : ''));
 	services.set(IBackupMainService, new SyncDescriptor(BackupMainService));
 
 	return new InstantiationService(services, true);

--- a/src/vs/code/node/paths.ts
+++ b/src/vs/code/node/paths.ts
@@ -15,6 +15,10 @@ import { ParsedArgs } from 'vs/platform/environment/common/environment';
 import { realpathSync } from 'vs/base/node/extfs';
 
 export function validatePaths(args: ParsedArgs): ParsedArgs {
+	// Track URLs if they're going to be used
+	if (args['open-url']) {
+		args._urls = args._;
+	}
 
 	// Realpath/normalize paths and watch out for goto line mode
 	const paths = doValidatePaths(args._, args.goto);

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -9,6 +9,7 @@ import { LogLevel } from 'vs/platform/log/common/log';
 export interface ParsedArgs {
 	[arg: string]: any;
 	_: string[];
+	_urls?: string[];
 	help?: boolean;
 	version?: boolean;
 	status?: boolean;

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -42,7 +42,7 @@ export interface ParsedArgs {
 	'install-extension'?: string | string[];
 	'uninstall-extension'?: string | string[];
 	'enable-proposed-api'?: string | string[];
-	'open-url'?: string | string[];
+	'open-url'?: boolean;
 	'skip-getting-started'?: boolean;
 	'skip-release-notes'?: boolean;
 	'sticky-quickopen'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -26,7 +26,6 @@ const options: minimist.Opts = {
 		'debugBrkPluginHost',
 		'debugSearch',
 		'debugBrkSearch',
-		'open-url',
 		'enable-proposed-api',
 		'export-default-configuration',
 		'install-source'
@@ -41,6 +40,7 @@ const options: minimist.Opts = {
 		'new-window',
 		'unity-launch',
 		'reuse-window',
+		'open-url',
 		'performance',
 		'prof-startup',
 		'verbose',

--- a/src/vs/platform/message/common/message.ts
+++ b/src/vs/platform/message/common/message.ts
@@ -5,6 +5,8 @@
 'use strict';
 
 import nls = require('vs/nls');
+import uri from 'vs/base/common/uri';
+import paths = require('vs/base/common/paths');
 import { TPromise } from 'vs/base/common/winjs.base';
 import Severity from 'vs/base/common/severity';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -34,6 +36,24 @@ export const LaterAction = new Action('later.message', nls.localize('later', "La
 export const CancelAction = new Action('cancel.message', nls.localize('cancel', "Cancel"), null, true, () => TPromise.as(true));
 
 export const IMessageService = createDecorator<IMessageService>('messageService');
+
+const MAX_CONFIRM_FILES = 10;
+export function getConfirmMessage(start: string, resourcesToConfirm: uri[]): string {
+	const message = [start];
+	message.push('');
+	message.push(...resourcesToConfirm.slice(0, MAX_CONFIRM_FILES).map(r => paths.basename(r.fsPath)));
+
+	if (resourcesToConfirm.length > MAX_CONFIRM_FILES) {
+		if (resourcesToConfirm.length - MAX_CONFIRM_FILES === 1) {
+			message.push(nls.localize('moreFile', "...1 additional file not shown"));
+		} else {
+			message.push(nls.localize('moreFiles', "...{0} additional files not shown", resourcesToConfirm.length - MAX_CONFIRM_FILES));
+		}
+	}
+
+	message.push('');
+	return message.join('\n');
+}
 
 export interface IConfirmationResult {
 	confirmed: boolean;

--- a/src/vs/platform/url/electron-main/urlService.ts
+++ b/src/vs/platform/url/electron-main/urlService.ts
@@ -25,7 +25,7 @@ export class URLService implements IURLService {
 			...globalBuffer
 		];
 
-		app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--open-url', '--']);
+		app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--protocol-launcher', '--']);
 
 		const rawOnOpenUrl = fromNodeEventEmitter(app, 'open-url', (event: Electron.Event, url: string) => ({ event, url }));
 

--- a/src/vs/platform/url/electron-main/urlService.ts
+++ b/src/vs/platform/url/electron-main/urlService.ts
@@ -25,7 +25,7 @@ export class URLService implements IURLService {
 			...globalBuffer
 		];
 
-		app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--open-url']);
+		app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--open-url', '--']);
 
 		const rawOnOpenUrl = fromNodeEventEmitter(app, 'open-url', (event: Electron.Event, url: string) => ({ event, url }));
 

--- a/src/vs/platform/url/electron-main/urlService.ts
+++ b/src/vs/platform/url/electron-main/urlService.ts
@@ -25,7 +25,7 @@ export class URLService implements IURLService {
 			...globalBuffer
 		];
 
-		app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--protocol-launcher', '--']);
+		app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--open-url', '--']);
 
 		const rawOnOpenUrl = fromNodeEventEmitter(app, 'open-url', (event: Electron.Event, url: string) => ({ event, url }));
 

--- a/src/vs/workbench/api/node/extHostTreeViews.ts
+++ b/src/vs/workbench/api/node/extHostTreeViews.ts
@@ -77,7 +77,7 @@ interface TreeNode {
 
 class ExtHostTreeView<T> extends Disposable {
 
-	private static ROOT_HANDLE = '0';
+	private _itemHandlePool = 0;
 	private elements: Map<TreeItemHandle, T> = new Map<TreeItemHandle, T>();
 	private nodes: Map<T, TreeNode> = new Map<T, TreeNode>();
 
@@ -103,12 +103,10 @@ class ExtHostTreeView<T> extends Disposable {
 				elements = coalesce(elements || []);
 				return TPromise.join(elements.map((element, index) => {
 					const node = this.nodes.get(element);
-					const currentHandle = node && node.parentHandle === parentHandle ? node.handle : void 0;
-					return this.resolveElement(element, currentHandle ? currentHandle : index, parentHandle)
+					return this.resolveElement(element, node ? node.handle : `${++this._itemHandlePool}`, parentHandle)
 						.then(treeItem => {
 							if (treeItem) {
-								if (!currentHandle) {
-									// update the caches if current handle is not used
+								if (!node) {
 									this.nodes.set(element, {
 										handle: treeItem.handle,
 										parentHandle,
@@ -139,38 +137,27 @@ class ExtHostTreeView<T> extends Disposable {
 		}
 	}
 
-	private resolveElement(element: T, handleOrIndex: TreeItemHandle | number, parentHandle: TreeItemHandle): TPromise<ITreeItem> {
+	private resolveElement(element: T, handle: TreeItemHandle, parentHandle: TreeItemHandle): TPromise<ITreeItem> {
 		return asWinJsPromise(() => this.dataProvider.getTreeItem(element))
-			.then(extTreeItem => this.massageTreeItem(element, extTreeItem, handleOrIndex, parentHandle));
+			.then(extTreeItem => this.massageTreeItem(element, extTreeItem, handle, parentHandle));
 	}
 
-	private massageTreeItem(element: T, extensionTreeItem: vscode.TreeItem, handleOrIndex: TreeItemHandle | number, parentHandle: TreeItemHandle): ITreeItem {
+	private massageTreeItem(element: T, extensionTreeItem: vscode.TreeItem, handle: TreeItemHandle, parentHandle: TreeItemHandle): ITreeItem {
 		if (!extensionTreeItem) {
 			return null;
 		}
 
 		const icon = this.getLightIconPath(extensionTreeItem);
-		const label = extensionTreeItem.label;
-		const handle = typeof handleOrIndex === 'number' ?
-			this.generateHandle(label, handleOrIndex, parentHandle) // create the handle
-			: handleOrIndex; // reuse the passed handle
-
 		return {
 			handle,
 			parentHandle,
-			label,
+			label: extensionTreeItem.label,
 			command: extensionTreeItem.command ? this.commands.toInternal(extensionTreeItem.command) : void 0,
 			contextValue: extensionTreeItem.contextValue,
 			icon,
 			iconDark: this.getDarkIconPath(extensionTreeItem) || icon,
 			collapsibleState: extensionTreeItem.collapsibleState
 		};
-	}
-
-	private generateHandle(label: string, index: number, parentHandle: TreeItemHandle): TreeItemHandle {
-		parentHandle = parentHandle ? parentHandle : ExtHostTreeView.ROOT_HANDLE;
-		label = label.indexOf('/') !== -1 ? label.replace('/', '//') : label;
-		return `${parentHandle}/${index}:${label}`;
 	}
 
 	private getLightIconPath(extensionTreeItem: vscode.TreeItem): string {

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -187,7 +187,7 @@ MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: 'navigation',
 	order: 40,
 	command: copyPathCommand,
-	when: ResourceContextKey.HasResource
+	when: ResourceContextKey.IsFile
 });
 
 MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
@@ -334,7 +334,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: 'navigation',
 	order: 20,
 	command: revealInOsCommand,
-	when: ResourceContextKey.HasResource
+	when: ResourceContextKey.Scheme.isEqualTo('file')
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
@@ -376,7 +376,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: '5_cutcopypaste',
 	order: 30,
 	command: copyPathCommand,
-	when: ResourceContextKey.HasResource
+	when: ResourceContextKey.IsFile
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -102,16 +102,16 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 // Editor Title Context Menu
-appendEditorTitleContextMenuItem(REVEAL_IN_OS_COMMAND_ID, REVEAL_IN_OS_LABEL);
-appendEditorTitleContextMenuItem(COPY_PATH_COMMAND_ID, CopyPathAction.LABEL);
-appendEditorTitleContextMenuItem(REVEAL_IN_EXPLORER_COMMAND_ID, nls.localize('revealInSideBar', "Reveal in Side Bar"));
+appendEditorTitleContextMenuItem(REVEAL_IN_OS_COMMAND_ID, REVEAL_IN_OS_LABEL, ResourceContextKey.Scheme.isEqualTo('file'));
+appendEditorTitleContextMenuItem(COPY_PATH_COMMAND_ID, CopyPathAction.LABEL, ResourceContextKey.IsFile);
+appendEditorTitleContextMenuItem(REVEAL_IN_EXPLORER_COMMAND_ID, nls.localize('revealInSideBar', "Reveal in Side Bar"), ResourceContextKey.IsFile);
 
-function appendEditorTitleContextMenuItem(id: string, title: string): void {
+function appendEditorTitleContextMenuItem(id: string, title: string, when: ContextKeyExpr): void {
 
 	// Menu
 	MenuRegistry.appendMenuItem(MenuId.EditorTitleContext, {
 		command: { id, title },
-		when: ContextKeyExpr.equals('resourceScheme', 'file'),
+		when,
 		group: '2_files'
 	});
 }

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.ts
@@ -37,7 +37,7 @@ import { IQuickOpenService } from 'vs/platform/quickOpen/common/quickOpen';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IUntitledResourceInput } from 'vs/platform/editor/common/editor';
 import { IInstantiationService, IConstructorSignature2, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { IMessageService, IMessageWithAction, IConfirmation, Severity, CancelAction, IConfirmationResult } from 'vs/platform/message/common/message';
+import { IMessageService, IMessageWithAction, IConfirmation, Severity, CancelAction, IConfirmationResult, getConfirmMessage } from 'vs/platform/message/common/message';
 import { ITextModel } from 'vs/editor/common/model';
 import { IBackupFileService } from 'vs/workbench/services/backup/common/backup';
 import { IWindowsService } from 'vs/platform/windows/common/windows';
@@ -706,7 +706,7 @@ class BaseDeleteFileAction extends BaseFileAction {
 
 			// Confirm for moving to trash
 			else if (this.useTrash) {
-				const message = this.elements.length > 1 ? nls.localize('confirmMoveTrashMessageMultiple', "Are you sure you want to delete '{0}' resources?", this.elements.length)
+				const message = this.elements.length > 1 ? getConfirmMessage(nls.localize('confirmMoveTrashMessageMultiple', "Are you sure you want to delete the following {0} files?", this.elements.length), this.elements.map(e => e.resource))
 					: this.elements[0].isDirectory ? nls.localize('confirmMoveTrashMessageFolder', "Are you sure you want to delete '{0}' and its contents?", this.elements[0].name)
 						: nls.localize('confirmMoveTrashMessageFile', "Are you sure you want to delete '{0}'?", this.elements[0].name);
 				confirmDeletePromise = this.messageService.confirmWithCheckbox({
@@ -722,7 +722,7 @@ class BaseDeleteFileAction extends BaseFileAction {
 
 			// Confirm for deleting permanently
 			else {
-				const message = this.elements.length > 1 ? nls.localize('confirmDeleteMessageMultiple', "Are you sure you want to permanently delete '{0}' resources?", this.elements.length)
+				const message = this.elements.length > 1 ? getConfirmMessage(nls.localize('confirmDeleteMessageMultiple', "Are you sure you want to permanently delete the following {0} files?", this.elements.length), this.elements.map(e => e.resource))
 					: this.elements[0].isDirectory ? nls.localize('confirmDeleteMessageFolder', "Are you sure you want to permanently delete '{0}' and its contents?", this.elements[0].name)
 						: nls.localize('confirmDeleteMessageFile', "Are you sure you want to permanently delete '{0}'?", this.elements[0].name);
 				confirmDeletePromise = this.messageService.confirmWithCheckbox({

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -104,7 +104,8 @@ function getResourcesForCommand(resource: URI, listService: IListService, editor
 		}
 	}
 
-	return [getResourceForCommand(resource, listService, editorService)];
+	const result = getResourceForCommand(resource, listService, editorService);
+	return !!result ? [result] : [];
 }
 
 function save(resource: URI, isSaveAs: boolean, editorService: IWorkbenchEditorService, fileService: IFileService, untitledEditorService: IUntitledEditorService,
@@ -293,7 +294,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const editorService = accessor.get(IWorkbenchEditorService);
 		const listService = accessor.get(IListService);
 		const tree = listService.lastFocusedList;
-		resource = getResourceForCommand(resource, listService, editorService);
+		const resources = getResourcesForCommand(resource, listService, editorService);
 
 		// Remove highlight
 		if (tree instanceof Tree) {
@@ -301,8 +302,16 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		}
 
 		// Set side input
-		if (URI.isUri(resource)) {
-			return editorService.openEditor({ resource, options: { preserveFocus: false } }, true);
+		if (resources.length) {
+			return editorService.openEditors(resources.map(resource => {
+				return {
+					input: {
+						resource,
+						options: { preserveFocus: false }
+					},
+					position: Position.THREE
+				};
+			}));
 		}
 
 		return TPromise.as(true);

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -342,7 +342,6 @@ export class FileController extends DefaultController implements IDisposable {
 		this.toDispose = [];
 		this.contributedContextMenu = menuService.createMenu(MenuId.ExplorerContext, contextKeyService);
 		this.toDispose.push(this.contributedContextMenu);
-
 	}
 
 	public onLeftClick(tree: ITree, stat: FileStat | Model, event: IMouseEvent, origin: string = 'mouse'): boolean {
@@ -426,6 +425,27 @@ export class FileController extends DefaultController implements IDisposable {
 		}
 
 		return true;
+	}
+
+	public onKeyDown(tree: ITree, event: IKeyboardEvent): boolean {
+		if (event.shiftKey && (event.keyCode === KeyCode.DownArrow || event.keyCode === KeyCode.UpArrow)) {
+			const previousFocus = tree.getFocus();
+			if (event.keyCode === KeyCode.DownArrow) {
+				tree.focusNext();
+			} else {
+				tree.focusPrevious();
+			}
+
+			const focus = tree.getFocus();
+			const selection = tree.getSelection();
+			if (selection && selection.indexOf(focus) >= 0) {
+				tree.setSelection(selection.filter(s => s !== previousFocus));
+			} else {
+				tree.setSelection(selection.concat(focus));
+			}
+		}
+
+		return super.onKeyDown(tree, event);
 	}
 
 	public onContextMenu(tree: ITree, stat: FileStat | Model, event: ContextMenuEvent): boolean {

--- a/src/vs/workbench/services/textfile/electron-browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/electron-browser/textFileService.ts
@@ -24,7 +24,7 @@ import { createTextBufferFactoryFromStream } from 'vs/editor/common/model/textMo
 import product from 'vs/platform/node/product';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IMessageService } from 'vs/platform/message/common/message';
+import { IMessageService, getConfirmMessage } from 'vs/platform/message/common/message';
 import { IBackupFileService } from 'vs/workbench/services/backup/common/backup';
 import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
@@ -32,8 +32,6 @@ import { mnemonicButtonLabel } from 'vs/base/common/labels';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export class TextFileService extends AbstractTextFileService {
-
-	private static readonly MAX_CONFIRM_FILES = 10;
 
 	constructor(
 		@IWorkspaceContextService contextService: IWorkspaceContextService,
@@ -80,24 +78,8 @@ export class TextFileService extends AbstractTextFileService {
 			return TPromise.wrap(ConfirmResult.DONT_SAVE);
 		}
 
-		const message = [
-			resourcesToConfirm.length === 1 ? nls.localize('saveChangesMessage', "Do you want to save the changes you made to {0}?", paths.basename(resourcesToConfirm[0].fsPath)) : nls.localize('saveChangesMessages', "Do you want to save the changes to the following {0} files?", resourcesToConfirm.length)
-		];
-
-		if (resourcesToConfirm.length > 1) {
-			message.push('');
-			message.push(...resourcesToConfirm.slice(0, TextFileService.MAX_CONFIRM_FILES).map(r => paths.basename(r.fsPath)));
-
-			if (resourcesToConfirm.length > TextFileService.MAX_CONFIRM_FILES) {
-				if (resourcesToConfirm.length - TextFileService.MAX_CONFIRM_FILES === 1) {
-					message.push(nls.localize('moreFile', "...1 additional file not shown"));
-				} else {
-					message.push(nls.localize('moreFiles', "...{0} additional files not shown", resourcesToConfirm.length - TextFileService.MAX_CONFIRM_FILES));
-				}
-			}
-
-			message.push('');
-		}
+		const message = resourcesToConfirm.length === 1 ? nls.localize('saveChangesMessage', "Do you want to save the changes you made to {0}?", paths.basename(resourcesToConfirm[0].fsPath))
+			: getConfirmMessage(nls.localize('saveChangesMessages', "Do you want to save the changes to the following {0} files?", resourcesToConfirm.length), resourcesToConfirm);
 
 		// Button order
 		// Windows: Save | Don't Save | Cancel
@@ -119,7 +101,7 @@ export class TextFileService extends AbstractTextFileService {
 
 		const opts: Electron.MessageBoxOptions = {
 			title: product.nameLong,
-			message: message.join('\n'),
+			message,
 			type: 'warning',
 			detail: nls.localize('saveChangesDetail', "Your changes will be lost if you don't save them."),
 			buttons: buttons.map(b => b.label),

--- a/src/vs/workbench/test/electron-browser/api/extHostTreeViews.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostTreeViews.test.ts
@@ -83,24 +83,24 @@ suite('ExtHostTreeView', function () {
 		return testObject.$getElements('testNodeTreeProvider')
 			.then(elements => {
 				const actuals = elements.map(e => e.handle);
-				assert.deepEqual(actuals, ['0/0:a', '0/1:b']);
+				assert.deepEqual(actuals, ['1', '2']);
 				return TPromise.join([
-					testObject.$getChildren('testNodeTreeProvider', '0/0:a')
+					testObject.$getChildren('testNodeTreeProvider', '1')
 						.then(children => {
 							const actuals = children.map(e => e.handle);
-							assert.deepEqual(actuals, ['0/0:a/0:aa', '0/0:a/1:ab']);
+							assert.deepEqual(actuals, ['3', '4']);
 							return TPromise.join([
-								testObject.$getChildren('testNodeTreeProvider', '0/0:a/0:aa').then(children => assert.equal(children.length, 0)),
-								testObject.$getChildren('testNodeTreeProvider', '0/0:a/1:ab').then(children => assert.equal(children.length, 0))
+								testObject.$getChildren('testNodeTreeProvider', '3').then(children => assert.equal(children.length, 0)),
+								testObject.$getChildren('testNodeTreeProvider', '4').then(children => assert.equal(children.length, 0))
 							]);
 						}),
-					testObject.$getChildren('testNodeTreeProvider', '0/1:b')
+					testObject.$getChildren('testNodeTreeProvider', '2')
 						.then(children => {
 							const actuals = children.map(e => e.handle);
-							assert.deepEqual(actuals, ['0/1:b/0:ba', '0/1:b/1:bb']);
+							assert.deepEqual(actuals, ['5', '6']);
 							return TPromise.join([
-								testObject.$getChildren('testNodeTreeProvider', '0/1:b/0:ba').then(children => assert.equal(children.length, 0)),
-								testObject.$getChildren('testNodeTreeProvider', '0/1:b/1:bb').then(children => assert.equal(children.length, 0))
+								testObject.$getChildren('testNodeTreeProvider', '5').then(children => assert.equal(children.length, 0)),
+								testObject.$getChildren('testNodeTreeProvider', '6').then(children => assert.equal(children.length, 0))
 							]);
 						})
 				]);
@@ -111,24 +111,24 @@ suite('ExtHostTreeView', function () {
 		return testObject.$getElements('testStringTreeProvider')
 			.then(elements => {
 				const actuals = elements.map(e => e.handle);
-				assert.deepEqual(actuals, ['0/0:a', '0/1:b']);
+				assert.deepEqual(actuals, ['1', '2']);
 				return TPromise.join([
-					testObject.$getChildren('testStringTreeProvider', '0/0:a')
+					testObject.$getChildren('testStringTreeProvider', '1')
 						.then(children => {
 							const actuals = children.map(e => e.handle);
-							assert.deepEqual(actuals, ['0/0:a/0:aa', '0/0:a/1:ab']);
+							assert.deepEqual(actuals, ['3', '4']);
 							return TPromise.join([
-								testObject.$getChildren('testStringTreeProvider', '0/0:a/0:aa').then(children => assert.equal(children.length, 0)),
-								testObject.$getChildren('testStringTreeProvider', '0/0:a/1:ab').then(children => assert.equal(children.length, 0))
+								testObject.$getChildren('testStringTreeProvider', '3').then(children => assert.equal(children.length, 0)),
+								testObject.$getChildren('testStringTreeProvider', '4').then(children => assert.equal(children.length, 0))
 							]);
 						}),
-					testObject.$getChildren('testStringTreeProvider', '0/1:b')
+					testObject.$getChildren('testStringTreeProvider', '2')
 						.then(children => {
 							const actuals = children.map(e => e.handle);
-							assert.deepEqual(actuals, ['0/1:b/0:ba', '0/1:b/1:bb']);
+							assert.deepEqual(actuals, ['5', '6']);
 							return TPromise.join([
-								testObject.$getChildren('testStringTreeProvider', '0/1:b/0:ba').then(children => assert.equal(children.length, 0)),
-								testObject.$getChildren('testStringTreeProvider', '0/1:b/1:bb').then(children => assert.equal(children.length, 0))
+								testObject.$getChildren('testStringTreeProvider', '5').then(children => assert.equal(children.length, 0)),
+								testObject.$getChildren('testStringTreeProvider', '6').then(children => assert.equal(children.length, 0))
 							]);
 						})
 				]);
@@ -146,9 +146,9 @@ suite('ExtHostTreeView', function () {
 	test('refresh a parent node', () => {
 		return new TPromise((c, e) => {
 			target.onRefresh.event(actuals => {
-				assert.deepEqual(['0/1:b'], Object.keys(actuals));
-				assert.deepEqual(removeUnsetKeys(actuals['0/1:b']), {
-					handle: '0/1:b',
+				assert.deepEqual(['2'], Object.keys(actuals));
+				assert.deepEqual(removeUnsetKeys(actuals['2']), {
+					handle: '2',
 					label: 'b',
 				});
 				c(null);
@@ -159,10 +159,10 @@ suite('ExtHostTreeView', function () {
 
 	test('refresh a leaf node', function (done) {
 		target.onRefresh.event(actuals => {
-			assert.deepEqual(['0/1:b/1:bb'], Object.keys(actuals));
-			assert.deepEqual(removeUnsetKeys(actuals['0/1:b/1:bb']), {
-				handle: '0/1:b/1:bb',
-				parentHandle: '0/1:b',
+			assert.deepEqual(['6'], Object.keys(actuals));
+			assert.deepEqual(removeUnsetKeys(actuals['6']), {
+				handle: '6',
+				parentHandle: '2',
 				label: 'bb'
 			});
 			done();
@@ -172,14 +172,14 @@ suite('ExtHostTreeView', function () {
 
 	test('refresh parent and child node trigger refresh only on parent - scenario 1', function (done) {
 		target.onRefresh.event(actuals => {
-			assert.deepEqual(['0/1:b', '0/0:a/0:aa'], Object.keys(actuals));
-			assert.deepEqual(removeUnsetKeys(actuals['0/1:b']), {
-				handle: '0/1:b',
+			assert.deepEqual(['2', '3'], Object.keys(actuals));
+			assert.deepEqual(removeUnsetKeys(actuals['2']), {
+				handle: '2',
 				label: 'b',
 			});
-			assert.deepEqual(removeUnsetKeys(actuals['0/0:a/0:aa']), {
-				handle: '0/0:a/0:aa',
-				parentHandle: '0/0:a',
+			assert.deepEqual(removeUnsetKeys(actuals['3']), {
+				handle: '3',
+				parentHandle: '1',
 				label: 'aa',
 			});
 			done();
@@ -191,14 +191,14 @@ suite('ExtHostTreeView', function () {
 
 	test('refresh parent and child node trigger refresh only on parent - scenario 2', function (done) {
 		target.onRefresh.event(actuals => {
-			assert.deepEqual(['0/0:a/0:aa', '0/1:b'], Object.keys(actuals));
-			assert.deepEqual(removeUnsetKeys(actuals['0/1:b']), {
-				handle: '0/1:b',
+			assert.deepEqual(['2', '3'], Object.keys(actuals));
+			assert.deepEqual(removeUnsetKeys(actuals['2']), {
+				handle: '2',
 				label: 'b',
 			});
-			assert.deepEqual(removeUnsetKeys(actuals['0/0:a/0:aa']), {
-				handle: '0/0:a/0:aa',
-				parentHandle: '0/0:a',
+			assert.deepEqual(removeUnsetKeys(actuals['3']), {
+				handle: '3',
+				parentHandle: '1',
 				label: 'aa',
 			});
 			done();
@@ -211,9 +211,9 @@ suite('ExtHostTreeView', function () {
 	test('refresh an element for label change', function (done) {
 		labels['a'] = 'aa';
 		target.onRefresh.event(actuals => {
-			assert.deepEqual(['0/0:a'], Object.keys(actuals));
-			assert.deepEqual(removeUnsetKeys(actuals['0/0:a']), {
-				handle: '0/0:a',
+			assert.deepEqual(['1'], Object.keys(actuals));
+			assert.deepEqual(removeUnsetKeys(actuals['1']), {
+				handle: '1',
 				label: 'aa',
 			});
 			done();
@@ -234,7 +234,7 @@ suite('ExtHostTreeView', function () {
 
 	test('refresh calls are throttled on elements', function (done) {
 		target.onRefresh.event(actuals => {
-			assert.deepEqual(['0/0:a', '0/1:b'], Object.keys(actuals));
+			assert.deepEqual(['1', '2'], Object.keys(actuals));
 			done();
 		});
 
@@ -246,7 +246,7 @@ suite('ExtHostTreeView', function () {
 
 	test('refresh calls are throttled on unknown elements', function (done) {
 		target.onRefresh.event(actuals => {
-			assert.deepEqual(['0/0:a', '0/1:b'], Object.keys(actuals));
+			assert.deepEqual(['1', '2'], Object.keys(actuals));
 			done();
 		});
 
@@ -278,19 +278,6 @@ suite('ExtHostTreeView', function () {
 		onDidChangeTreeNode.fire(getNode('b'));
 		onDidChangeTreeNode.fire();
 		onDidChangeTreeNode.fire(getNode('a'));
-	});
-
-	test('generate unique handles from labels by escaping them', () => {
-		tree = {
-			'a/0:b': {}
-		};
-
-		onDidChangeTreeNode.fire();
-
-		return testObject.$getElements('testNodeTreeProvider')
-			.then(elements => {
-				assert.deepEqual(elements.map(e => e.handle), ['0/0:a//0:b']);
-			});
 	});
 
 	function removeUnsetKeys(obj: any): any {


### PR DESCRIPTION
After discussing with @bpasero we came to the following conclusions regarding extension commands in the explorer:

#### Pass the selected resources as an additional array
We would continue to pass the focused resource as the first argument, however if there is a multi selection we would pass those resources as an additional argument. We would only pass them if the focused element is part of the selection since that means the user triggered the action on the selection.
`resource, [selected_resources]` 
This also means that the first argument is containted in the array,

#### Option 1: show all extension commands for multiple selection
Commands from extensions would always still show up even if multi select is on. And we would still continue passing the same argument so nothing would break. Only the users might find surprising that extension commands only work on the actual focused element, not on all. But extension can adopt to the new arguments over time.

#### Option 2:  no extension command shows up for multi-select unless they opt-in

Basically for each extension command we actually add to the when condition: `when-single-selection` and we provide a mechanism for commands to opt into this.
If we decide to go down this path do we still show those command but disabled or not show them at all? For me it makes most sense to show them disabled.

@jrieken looking forward to your feedback