### PR TITLE
Run hygiene in a dedicated Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ install:
   - yarn
 
 script:
-  - node_modules/.bin/gulp hygiene
   - node_modules/.bin/gulp electron --silent
   - node_modules/.bin/tsc -p ./src/tsconfig.monaco.json --noEmit
   - node_modules/.bin/gulp compile --silent --max_old_space_size=4096
@@ -62,3 +61,10 @@ script:
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then node_modules/.bin/coveralls < .build/coverage/lcov.info; fi
+
+matrix:
+  include:
+    - os: linux
+      env: label=hygiene
+      script: node_modules/.bin/gulp hygiene
+      after_success: skip


### PR DESCRIPTION
Back again with some build speedups.

Biggest time sink atm is hygiene with 164.90s, which is an operation that does not depend on the project being compiled before and is the same on macOS and Linux - so it makes sense to run it in a parallel job, only on Linux.

Potentially other jobs could be run in parallel too but I am not sure - what's the relation between `compile`, `optimize` and test? Does `optimize` depend on `compile`, and `test` depend on `optimize`? What about tsc monaco?
Given AppVeyor does not run `optimize` at all I assume that could be in a parallel job too?