### PR TITLE
Set the minimum height of the xterm scrollbar thumb to 35px

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/media/scrollbar.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/scrollbar.css
@@ -19,7 +19,7 @@
 }
 
 .monaco-workbench .panel.integrated-terminal .xterm-viewport::-webkit-scrollbar-thumb {
-	min-height: 35px;
+	min-height: 20px;
 	background-color: inherit;
 }
 

--- a/src/vs/workbench/parts/terminal/electron-browser/media/scrollbar.css
+++ b/src/vs/workbench/parts/terminal/electron-browser/media/scrollbar.css
@@ -19,6 +19,7 @@
 }
 
 .monaco-workbench .panel.integrated-terminal .xterm-viewport::-webkit-scrollbar-thumb {
+	min-height: 35px;
 	background-color: inherit;
 }
 


### PR DESCRIPTION
Closes #35116.

Changes are minimal, testing performed was manual. I basically eye-balled a couple of minimum heights and 35px seems like a decent height.