### PR TITLE
SelectBox convert to WorkbenchList WIP

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -143,6 +143,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/parts/selectbox",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/services/configuration",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -659,6 +659,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 
 	private focus: Trait<T>;
 	private selection: Trait<T>;
+	private disabled: Trait<T>;
 	private eventBufferer = new EventBufferer();
 	private view: ListView<T>;
 	private spliceable: ISpliceable<T>;
@@ -714,6 +715,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		const aria = new Aria();
 		this.focus = new FocusTrait(i => this.getElementDomId(i));
 		this.selection = new Trait('selected');
+		this.disabled = new Trait('disabled');
 
 		mixin(options, defaultStyles, false);
 
@@ -830,7 +832,28 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		if (this.length === 0) { return; }
 		const focus = this.focus.get();
 		let index = focus.length > 0 ? focus[0] + n : 0;
-		this.setFocus(loop ? [index % this.length] : [Math.min(index, this.length - 1)]);
+
+		index = (loop ? index % this.length : Math.min(index, this.length - 1));
+
+		const adjustedIndex = this.ajustFocusForDisabled(index, 1);
+		this.setFocus([adjustedIndex]);
+	}
+
+	private ajustFocusForDisabled(optionIndex: number, adjDelta = 1): number {
+		const disabled = this.getDisabled();
+		if (!disabled.length) {
+			return optionIndex;
+		}
+
+		let adjOptionIndex = optionIndex;
+
+		for (let i = 0; i < this.length; i++) {
+			adjOptionIndex = (i * adjDelta + optionIndex) % this.length;
+			if (disabled.indexOf(adjOptionIndex) < 0) {
+				break;
+			}
+		}
+		return (adjOptionIndex);
 	}
 
 	focusPrevious(n = 1, loop = false): void {
@@ -838,7 +861,10 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		const focus = this.focus.get();
 		let index = focus.length > 0 ? focus[0] - n : 0;
 		if (loop && index < 0) { index = (this.length + (index % this.length)) % this.length; }
-		this.setFocus([Math.max(index, 0)]);
+
+		index = Math.max(index, 0);
+		const adjustedIndex = this.ajustFocusForDisabled(index, -1);
+		this.setFocus([adjustedIndex]);
 	}
 
 	focusNextPage(): void {
@@ -848,7 +874,8 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		const currentlyFocusedElement = this.getFocusedElements()[0];
 
 		if (currentlyFocusedElement !== lastPageElement) {
-			this.setFocus([lastPageIndex]);
+			const adjustedIndex = this.ajustFocusForDisabled(lastPageIndex, 1);
+			this.setFocus([adjustedIndex]);
 		} else {
 			const previousScrollTop = this.view.getScrollTop();
 			this.view.setScrollTop(previousScrollTop + this.view.renderHeight - this.view.elementHeight(lastPageIndex));
@@ -874,7 +901,8 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		const currentlyFocusedElement = this.getFocusedElements()[0];
 
 		if (currentlyFocusedElement !== firstPageElement) {
-			this.setFocus([firstPageIndex]);
+			const adjustedIndex = this.ajustFocusForDisabled(firstPageIndex, -1);
+			this.setFocus([adjustedIndex]);
 		} else {
 			const previousScrollTop = scrollTop;
 			this.view.setScrollTop(scrollTop - this.view.renderHeight);
@@ -888,12 +916,15 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 
 	focusLast(): void {
 		if (this.length === 0) { return; }
-		this.setFocus([this.length - 1]);
+		const adjustedIndex = this.ajustFocusForDisabled(this.length - 1, -1);
+		this.setFocus([adjustedIndex]);
 	}
 
 	focusFirst(): void {
 		if (this.length === 0) { return; }
-		this.setFocus([0]);
+		const adjustedIndex = this.ajustFocusForDisabled(0, 1);
+		this.setFocus([adjustedIndex]);
+
 	}
 
 	getFocus(): number[] {
@@ -946,6 +977,15 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 
 	pin(indexes: number[]): void {
 		this._onPin.fire(indexes);
+	}
+
+	setDisabled(indexes: number[]): void {
+		indexes = indexes.sort(numericSort);
+		this.disabled.set(indexes);
+	}
+
+	getDisabled(): number[] {
+		return this.disabled.get();
 	}
 
 	style(styles: IListStyles): void {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -25,6 +25,7 @@ const $ = dom.$;
 const SELECT_OPTION_ENTRY_TEMPLATE_ID = 'selectOption.entry.template';
 
 export interface ISelectOptionItem {
+	id: string;
 	optionText: string;
 	optionDisabled: boolean;
 }
@@ -217,7 +218,8 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 					const element = this.options[index];
 					let optionDisabled: boolean;
 					index === this.disabledOptionIndex ? optionDisabled = true : optionDisabled = false;
-					listEntries.push({ optionText: element, optionDisabled: optionDisabled });
+					// listEntries.push({ optionText: element, optionDisabled: optionDisabled });
+					listEntries.push({ id: SELECT_OPTION_ENTRY_TEMPLATE_ID, optionText: element, optionDisabled: optionDisabled });
 				}
 
 				this.selectList.splice(0, this.selectList.length, listEntries);

--- a/src/vs/workbench/parts/debug/browser/debugActionItems.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActionItems.ts
@@ -9,8 +9,7 @@ import * as errors from 'vs/base/common/errors';
 import { IAction, IActionRunner } from 'vs/base/common/actions';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import * as dom from 'vs/base/browser/dom';
-import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
-import { SelectBox } from 'vs/base/browser/ui/selectBox/selectBox';
+import { SelectBox } from 'vs/workbench/parts/selectBox/browser/selectBox';
 import { SelectActionItem, IActionItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -20,6 +19,9 @@ import { attachSelectBoxStyler, attachStylerCallback } from 'vs/platform/theme/c
 import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { selectBorder } from 'vs/platform/theme/common/colorRegistry';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { IListService } from 'vs/platform/list/browser/listService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 const $ = dom.$;
 
@@ -43,9 +45,11 @@ export class StartDebugActionItem implements IActionItem {
 		@IConfigurationService private configurationService: IConfigurationService,
 		@ICommandService private commandService: ICommandService,
 		@IContextViewService contextViewService: IContextViewService,
+		@IListService listService: IListService,
+		@IContextKeyService contextKeyService: IContextKeyService
 	) {
 		this.toDispose = [];
-		this.selectBox = new SelectBox([], -1, contextViewService);
+		this.selectBox = new SelectBox([], -1, contextViewService, contextKeyService, listService, themeService);
 		this.toDispose.push(attachSelectBoxStyler(this.selectBox, themeService, {
 			selectBackground: SIDE_BAR_BACKGROUND
 		}));

--- a/src/vs/workbench/parts/selectbox/browser/selectBox.css
+++ b/src/vs/workbench/parts/selectbox/browser/selectBox.css
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.monaco-workbench .select-box {
+	width: 100%;
+	height: 20px;
+}

--- a/src/vs/workbench/parts/selectbox/browser/selectBox.ts
+++ b/src/vs/workbench/parts/selectbox/browser/selectBox.ts
@@ -1,0 +1,131 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./selectBox';
+
+import { IDisposable, dispose } from 'vs/base/common/lifecycle';
+import Event from 'vs/base/common/event';
+import { Widget } from 'vs/base/browser/ui/widget';
+import { Color } from 'vs/base/common/color';
+import { deepClone, mixin } from 'vs/base/common/objects';
+import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
+import { IListStyles } from 'vs/base/browser/ui/list/listWidget';
+import { SelectBoxNative } from 'vs/base/browser/ui/selectBox/selectBoxNative';
+// import { SelectBoxList } from 'vs/base/browser/ui/selectBox/selectBoxCustom';
+import { SelectBoxList } from 'vs/workbench/parts/selectBox/browser/selectBoxCustom';
+import { isMacintosh } from 'vs/base/common/platform';
+// import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IListService } from 'vs/platform/list/browser/listService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+
+// Public SelectBox interface - Calls routed to appropriate select implementation class
+
+export interface ISelectBoxDelegate {
+
+	// Public SelectBox Interface
+	readonly onDidSelect: Event<ISelectData>;
+	setOptions(options: string[], selected?: number, disabled?: number): void;
+	select(index: number): void;
+	focus(): void;
+	blur(): void;
+	dispose(): void;
+
+	// Delegated Widget interface
+	render(container: HTMLElement): void;
+	style(styles: ISelectBoxStyles): void;
+	applyStyles(): void;
+}
+
+export interface ISelectBoxStyles extends IListStyles {
+	selectBackground?: Color;
+	selectForeground?: Color;
+	selectBorder?: Color;
+	focusBorder?: Color;
+}
+
+export const defaultStyles = {
+	selectBackground: Color.fromHex('#3C3C3C'),
+	selectForeground: Color.fromHex('#F0F0F0'),
+	selectBorder: Color.fromHex('#3C3C3C')
+};
+
+export interface ISelectData {
+	selected: string;
+	index: number;
+}
+
+export class SelectBox extends Widget implements ISelectBoxDelegate {
+	private toDispose: IDisposable[];
+	private styles: ISelectBoxStyles;
+	private selectBoxDelegate: ISelectBoxDelegate;
+
+	constructor(
+		options: string[],
+		selected: number,
+		contextViewProvider: IContextViewProvider,
+		// instaniationService: IInstantiationService,
+		contextKeyService: IContextKeyService,
+		listService: IListService,
+		themeService: IThemeService,
+		styles: ISelectBoxStyles = deepClone(defaultStyles)
+	) {
+		super();
+
+		this.toDispose = [];
+
+		mixin(this.styles, defaultStyles, false);
+
+		// Instantiate select implementation based on platform
+		if (isMacintosh) {
+			this.selectBoxDelegate = new SelectBoxNative(options, selected, styles);
+		} else {
+			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, contextKeyService, listService, themeService, this.styles);
+		}
+
+		this.toDispose.push(this.selectBoxDelegate);
+	}
+
+	// Public SelectBox Methods - routed through delegate interface
+
+	public get onDidSelect(): Event<ISelectData> {
+		return this.selectBoxDelegate.onDidSelect;
+	}
+
+	public setOptions(options: string[], selected?: number, disabled?: number): void {
+		this.selectBoxDelegate.setOptions(options, selected, disabled);
+	}
+
+	public select(index: number): void {
+		this.selectBoxDelegate.select(index);
+	}
+
+	public focus(): void {
+		this.selectBoxDelegate.focus();
+	}
+
+	public blur(): void {
+		this.selectBoxDelegate.blur();
+	}
+
+	// Public Widget Methods - routed through delegate interface
+
+	public render(container: HTMLElement): void {
+		this.selectBoxDelegate.render(container);
+	}
+
+	public style(styles: ISelectBoxStyles): void {
+		this.selectBoxDelegate.style(styles);
+	}
+
+	public applyStyles(): void {
+		this.selectBoxDelegate.applyStyles();
+	}
+
+	public dispose(): void {
+		this.toDispose = dispose(this.toDispose);
+		super.dispose();
+	}
+}

--- a/src/vs/workbench/parts/selectbox/browser/selectBox.ts
+++ b/src/vs/workbench/parts/selectbox/browser/selectBox.ts
@@ -11,15 +11,11 @@ import { Widget } from 'vs/base/browser/ui/widget';
 import { Color } from 'vs/base/common/color';
 import { deepClone, mixin } from 'vs/base/common/objects';
 import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
-import { IListStyles } from 'vs/base/browser/ui/list/listWidget';
+import { List, IListStyles } from 'vs/base/browser/ui/list/listWidget';
 import { SelectBoxNative } from 'vs/base/browser/ui/selectBox/selectBoxNative';
-// import { SelectBoxList } from 'vs/base/browser/ui/selectBox/selectBoxCustom';
-import { SelectBoxList } from 'vs/workbench/parts/selectBox/browser/selectBoxCustom';
+import { SelectBoxList, SelectListDelegate, SelectListRenderer } from 'vs/workbench/parts/selectBox/browser/selectBoxCustom';
 import { isMacintosh } from 'vs/base/common/platform';
-// import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IListService } from 'vs/platform/list/browser/listService';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ISelectOptionItem } from 'vs/base/browser/ui/selectBox/selectBoxCustom';
 
 // Public SelectBox interface - Calls routed to appropriate select implementation class
 
@@ -66,11 +62,8 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 		options: string[],
 		selected: number,
 		contextViewProvider: IContextViewProvider,
-		// instaniationService: IInstantiationService,
-		contextKeyService: IContextKeyService,
-		listService: IListService,
-		themeService: IThemeService,
-		styles: ISelectBoxStyles = deepClone(defaultStyles)
+		styles: ISelectBoxStyles = deepClone(defaultStyles),
+		listCreator?: { container: HTMLElement, list: List<ISelectOptionItem>, delegate: SelectListDelegate, renderer: SelectListRenderer }
 	) {
 		super();
 
@@ -82,7 +75,8 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 		if (isMacintosh) {
 			this.selectBoxDelegate = new SelectBoxNative(options, selected, styles);
 		} else {
-			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, contextKeyService, listService, themeService, this.styles);
+			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, this.styles, listCreator);
+
 		}
 
 		this.toDispose.push(this.selectBoxDelegate);

--- a/src/vs/workbench/parts/selectbox/browser/selectBoxCustom.css
+++ b/src/vs/workbench/parts/selectbox/browser/selectBoxCustom.css
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Require .monaco-shell for ContextView dropdown */
+
+.monaco-shell .select-box-dropdown-container {
+	display: none;
+}
+
+.monaco-shell .select-box-dropdown-container.visible {
+	display: flex;
+	flex-direction: column;
+	text-align: left;
+	width: 1px;
+	overflow: hidden;
+}
+
+.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container {
+	flex: 0 0 auto;
+	align-self: flex-start;
+	padding-bottom: 1px;
+	padding-top: 1px;
+	padding-left: 1px;
+	padding-right: 1px;
+	width: 100%;
+	overflow: hidden;
+	-webkit-box-sizing:	border-box;
+	-o-box-sizing:		border-box;
+	-moz-box-sizing:	border-box;
+	-ms-box-sizing:		border-box;
+	box-sizing:			border-box;
+}
+
+.monaco-shell.hc-black .select-box-dropdown-container > .select-box-dropdown-list-container {
+	padding-bottom: 4px;
+	padding-top: 3px;
+}
+
+.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row > .option-text {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	padding-left: 3.5px;
+	white-space: nowrap;
+}
+
+.monaco-shell .select-box-dropdown-container > .select-box-dropdown-container-width-control {
+	flex: 1 1 auto;
+	align-self: flex-start;
+	opacity: 0;
+}
+
+.monaco-shell .select-box-dropdown-container > .select-box-dropdown-container-width-control > .width-control-div {
+	overflow: hidden;
+	max-height: 0px;
+}
+
+.monaco-shell .select-box-dropdown-container > .select-box-dropdown-container-width-control > .width-control-div > .option-text-width-control {
+	padding-left: 4px;
+	padding-right: 8px;
+	white-space: nowrap;
+}

--- a/src/vs/workbench/parts/selectbox/browser/selectBoxCustom.ts
+++ b/src/vs/workbench/parts/selectbox/browser/selectBoxCustom.ts
@@ -1,0 +1,615 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./selectBoxCustom';
+
+import * as nls from 'vs/nls';
+import { IDisposable, dispose } from 'vs/base/common/lifecycle';
+import Event, { Emitter, chain } from 'vs/base/common/event';
+import { KeyCode, KeyCodeUtils } from 'vs/base/common/keyCodes';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import * as dom from 'vs/base/browser/dom';
+import * as arrays from 'vs/base/common/arrays';
+import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
+import { IListEvent, IDelegate, IRenderer } from 'vs/base/browser/ui/list/list';
+import { domEvent } from 'vs/base/browser/event';
+import { ScrollbarVisibility } from 'vs/base/common/scrollable';
+import { ISelectBoxDelegate, ISelectBoxStyles, ISelectData } from 'vs/base/browser/ui/selectBox/selectBox';
+import { isMacintosh } from 'vs/base/common/platform';
+import { IListService, WorkbenchList } from 'vs/platform/list/browser/listService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+
+const $ = dom.$;
+
+const SELECT_OPTION_ENTRY_TEMPLATE_ID = 'selectOption.entry.template';
+
+export interface ISelectOptionItem {
+	id: string;
+	optionText: string;
+	optionDisabled: boolean;
+}
+
+interface ISelectListTemplateData {
+	root: HTMLElement;
+	optionText: HTMLElement;
+	disposables: IDisposable[];
+}
+
+class SelectListRenderer implements IRenderer<ISelectOptionItem, ISelectListTemplateData> {
+	public templateId = SELECT_OPTION_ENTRY_TEMPLATE_ID;
+
+	get getHeight(): number {
+		return 18;
+	}
+
+	get getTemplateId(): string { return SELECT_OPTION_ENTRY_TEMPLATE_ID; }
+
+	constructor() { }
+
+	renderTemplate(container: HTMLElement): any {
+		const data = <ISelectListTemplateData>Object.create(null);
+		data.disposables = [];
+		data.root = container;
+		data.optionText = dom.append(container, $('.option-text'));
+
+		return data;
+	}
+
+	renderElement(element: ISelectOptionItem, index: number, templateData: ISelectListTemplateData): void {
+		const data = <ISelectListTemplateData>templateData;
+		const optionText = (<ISelectOptionItem>element).optionText;
+		const optionDisabled = (<ISelectOptionItem>element).optionDisabled;
+
+		data.optionText.textContent = optionText;
+		data.root.setAttribute('aria-label', nls.localize('selectAriaOption', "{0}", optionText));
+
+		// pseudo-select disabled option
+		if (optionDisabled) {
+			dom.addClass((<HTMLElement>data.root), 'option-disabled');
+		}
+	}
+
+	disposeTemplate(templateData: ISelectListTemplateData): void {
+		templateData.disposables = dispose(templateData.disposables);
+	}
+}
+
+export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptionItem> {
+
+	private static SELECT_DROPDOWN_BOTTOM_MARGIN = 10;
+
+	private _isVisible: boolean;
+	private selectElement: HTMLSelectElement;
+	private options: string[];
+	private selected: number;
+	private disabledOptionIndex: number;
+	private _onDidSelect: Emitter<ISelectData>;
+	private toDispose: IDisposable[];
+	private styles: ISelectBoxStyles;
+	private listRenderer: SelectListRenderer;
+	private contextViewProvider: IContextViewProvider;
+	private selectDropDownContainer: HTMLElement;
+	private styleElement: HTMLStyleElement;
+	// private selectList: List<ISelectOptionItem>;
+	private selectDropDownListContainer: HTMLElement;
+	private widthControlElement: HTMLElement;
+
+	private selectList: WorkbenchList<ISelectOptionItem>;
+	// instaniationService: IInstantiationService,
+	private contextKeyService: IContextKeyService;
+	private listService: IListService;
+	private themeService: IThemeService;
+
+	// private instantiationService: IInstantiationService;
+	// private _tree: Tree;
+	// private _themeService:
+
+	constructor(
+		options: string[],
+		selected: number,
+		contextViewProvider: IContextViewProvider,
+		contextKeyService: IContextKeyService,
+		listService: IListService,
+		themeService: IThemeService,
+		styles: ISelectBoxStyles
+	) {
+		this.toDispose = [];
+		this._isVisible = false;
+
+		this.contextKeyService = contextKeyService;
+		this.listService = listService;
+		this.themeService = themeService;
+
+		this.selectElement = document.createElement('select');
+		this.selectElement.className = 'select-box';
+
+		this._onDidSelect = new Emitter<ISelectData>();
+		this.styles = styles;
+
+		this.registerListeners();
+		this.constructSelectDropDown(contextViewProvider);
+
+		this.setOptions(options, selected);
+
+	}
+
+	// IDelegate - List renderer
+
+	getHeight(): number {
+		return 18;
+	}
+
+	getTemplateId(): string {
+		return SELECT_OPTION_ENTRY_TEMPLATE_ID;
+	}
+
+
+	private createSelectWorkbenchList(parent: HTMLElement): void {
+
+		this.selectDropDownListContainer = dom.append(parent, $('.select-box-dropdown-list-container'));
+
+		this.listRenderer = new SelectListRenderer();
+
+
+		this.selectList = new WorkbenchList<ISelectOptionItem>(this.selectDropDownListContainer, this, [this.listRenderer], {
+			identityProvider: e => e.id,
+			useShadows: false,
+			selectOnMouseDown: false,
+			verticalScrollMode: ScrollbarVisibility.Visible,
+			keyboardSupport: false,
+			mouseSupport: false
+
+		}, this.contextKeyService, this.listService, this.themeService);
+
+		const onSelectDropDownKeyDown = chain(domEvent(this.selectDropDownListContainer, 'keydown'))
+			.filter(() => this.selectList.length > 0)
+			.map(e => new StandardKeyboardEvent(e));
+
+		onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.Escape).on(e => this.onEscape(e), this, this.toDispose);
+		onSelectDropDownKeyDown.filter(e => (e.keyCode >= KeyCode.KEY_0 && e.keyCode <= KeyCode.KEY_Z) || (e.keyCode >= KeyCode.US_SEMICOLON && e.keyCode <= KeyCode.NUMPAD_DIVIDE)).on(this.onCharacter, this, this.toDispose);
+
+		this.toDispose.push(this.selectList.onOpen(e => this.onEnter(e.elements[0])));
+
+		this.toDispose.push(this.selectList.onFocusChange(e => this.onFocusChange(e)));
+
+		// SetUp list mouse controller - control navigation, disabled items, focus
+
+		chain(domEvent(this.selectList.getHTMLElement(), 'mouseup'))
+			.filter(() => this.selectList.length > 0)
+			.on(e => this.onMouseUp(e), this, this.toDispose);
+
+		this.toDispose.push(this.selectList.onDidBlur(e => this.onListBlur()));
+
+	}
+
+	private constructSelectDropDown(contextViewProvider: IContextViewProvider) {
+
+		// SetUp ContextView container to hold select Dropdown
+		this.contextViewProvider = contextViewProvider;
+		this.selectDropDownContainer = dom.$('.select-box-dropdown-container');
+
+		// Setup list for drop-down select
+		this.createSelectWorkbenchList(this.selectDropDownContainer);
+
+		// Create span flex box item/div we can measure and control
+		let widthControlOuterDiv = dom.append(this.selectDropDownContainer, $('.select-box-dropdown-container-width-control'));
+		let widthControlInnerDiv = dom.append(widthControlOuterDiv, $('.width-control-div'));
+		this.widthControlElement = document.createElement('span');
+		this.widthControlElement.className = 'option-text-width-control';
+		dom.append(widthControlInnerDiv, this.widthControlElement);
+
+		// Inline stylesheet for themes
+		this.styleElement = dom.createStyleSheet(this.selectDropDownContainer);
+	}
+
+	private registerListeners() {
+
+		// Parent native select keyboard listeners
+
+		this.toDispose.push(dom.addStandardDisposableListener(this.selectElement, 'change', (e) => {
+			this.selectElement.title = e.target.value;
+			this._onDidSelect.fire({
+				index: e.target.selectedIndex,
+				selected: e.target.value
+			});
+		}));
+
+		// Have to implement both keyboard and mouse controllers to handle disabled options
+		// Intercept mouse events to override normal select actions on parents
+
+		this.toDispose.push(dom.addDisposableListener(this.selectElement, dom.EventType.CLICK, (e) => {
+			dom.EventHelper.stop(e);
+
+			if (this._isVisible) {
+				this.hideSelectDropDown(true);
+			} else {
+				this.showSelectDropDown();
+			}
+		}));
+
+		this.toDispose.push(dom.addDisposableListener(this.selectElement, dom.EventType.MOUSE_DOWN, (e) => {
+			dom.EventHelper.stop(e);
+		}));
+
+		// Intercept keyboard handling
+
+		this.toDispose.push(dom.addDisposableListener(this.selectElement, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+			const event = new StandardKeyboardEvent(e);
+			let showDropDown = false;
+
+			// Create and drop down select list on keyboard select
+			if (isMacintosh) {
+				if (event.keyCode === KeyCode.DownArrow || event.keyCode === KeyCode.UpArrow || event.keyCode === KeyCode.Space || event.keyCode === KeyCode.Enter) {
+					showDropDown = true;
+				}
+			} else {
+				if (event.keyCode === KeyCode.DownArrow && event.altKey || event.keyCode === KeyCode.UpArrow && event.altKey || event.keyCode === KeyCode.Space || event.keyCode === KeyCode.Enter) {
+					showDropDown = true;
+				}
+			}
+
+			if (showDropDown) {
+				this.showSelectDropDown();
+				dom.EventHelper.stop(e);
+			}
+		}));
+	}
+
+	public get onDidSelect(): Event<ISelectData> {
+		return this._onDidSelect.event;
+	}
+
+	public setOptions(options: string[], selected?: number, disabled?: number): void {
+
+		if (!this.options || !arrays.equals(this.options, options)) {
+			this.options = options;
+			this.selectElement.options.length = 0;
+
+			let i = 0;
+			this.options.forEach((option) => {
+				this.selectElement.add(this.createOption(option, i, disabled === i++));
+			});
+
+			// Mirror options in drop-down
+			// Populate select list for non-native select mode
+			if (this.selectList && !!this.options) {
+				let listEntries: ISelectOptionItem[];
+
+				listEntries = [];
+				if (disabled !== undefined) {
+					this.disabledOptionIndex = disabled;
+				}
+				for (let index = 0; index < this.options.length; index++) {
+					const element = this.options[index];
+					let optionDisabled: boolean;
+					index === this.disabledOptionIndex ? optionDisabled = true : optionDisabled = false;
+					listEntries.push({ id: SELECT_OPTION_ENTRY_TEMPLATE_ID, optionText: element, optionDisabled: optionDisabled });
+				}
+
+				this.selectList.setDisabled([this.disabledOptionIndex]);
+				this.selectList.splice(0, this.selectList.length, listEntries);
+
+				if (selected !== undefined) {
+					this.select(selected);
+				}
+			}
+		}
+	}
+
+	public select(index: number): void {
+
+		if (index >= 0 && index < this.options.length) {
+			this.selected = index;
+		} else if (this.selected < 0) {
+			this.selected = 0;
+		}
+
+		this.selectElement.selectedIndex = this.selected;
+		this.selectElement.title = this.options[this.selected];
+	}
+
+
+	public focus(): void {
+		if (this.selectElement) {
+			this.selectElement.focus();
+		}
+
+	}
+	public blur(): void {
+		if (this.selectElement) {
+			this.selectElement.blur();
+		}
+	}
+
+	public render(container: HTMLElement): void {
+		dom.addClass(container, 'select-container');
+		ontainer.appendChild(this.selectElement);
+		this.setOptions(this.options, this.selected);
+		this.applyStyles();
+	}
+
+	public style(styles: ISelectBoxStyles): void {
+
+		const content: string[] = [];
+
+		this.styles = styles;
+
+		// Style non-native select mode
+
+		if (this.styles.listFocusBackground) {
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.focused { background-color: ${this.styles.listFocusBackground} !important; }`);
+		}
+
+		if (this.styles.listFocusForeground) {
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.focused:not(:hover) { color: ${this.styles.listFocusForeground} !important; }`);
+		}
+
+		// Hover foreground - ignore for disabled options
+		if (this.styles.listHoverForeground) {
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row:hover { color: ${this.styles.listHoverForeground} !important; }`);
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.option-disabled:hover { background-color: ${this.styles.listActiveSelectionForeground} !important; }`);
+		}
+
+		// Hover background - ignore for disabled options
+		if (this.styles.listHoverBackground) {
+			cntent.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row:not(.option-disabled):not(.focused):hover { background-color: ${this.styles.listHoverBackground} !important; }`);
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.option-disabled:hover { background-color: ${this.styles.selectBackground} !important; }`);
+		}
+
+		// Match quickOpen outline styles - ignore for disabled options
+		if (this.styles.listFocusOutline) {
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.focused { outline: 1.6px dotted ${this.styles.listFocusOutline} !important; outline-offset: -1.6px !important; }`);
+		}
+
+		if (this.styles.listHoverOutline) {
+			content.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row:hover:not(.focused) { outline: 1.6px dashed ${this.styles.listHoverOutline} !important; outline-offset: -1.6px !important; }`);
+			cntent.push(`.monaco-shell .select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.option-disabled:hover { outline: none !important; }`);
+		}
+
+		this.styleElement.innerHTML = content.join('\n');
+
+		this.applyStyles();
+	}
+
+	public applyStyles(): void {
+
+		//Style parent select
+		if (this.selectElement) {
+			const background = this.styles.selectBackground ? this.styles.selectBackground.toString() : null;
+			const foreground = this.styles.selectForeground ? this.styles.selectForeground.toString() : null;
+			const border = this.styles.selectBorder ? this.styles.selectBorder.toString() : null;
+
+			this.selectElement.style.backgroundColor = background;
+			this.selectElement.style.color = foreground;
+			this.selectElement.style.borderColor = border;
+		}
+
+		// Style drop down select list (non-native mode only)
+
+		if (this.selectList) {
+			this.selectList.style({});
+
+			const background = this.styles.selectBackground ? this.styles.selectBackground.toString() : null;
+			this.selectDropDownListContainer.style.backgroundColor = background;
+			const optionsBorder = this.styles.focusBorder ? this.styles.focusBorder.toString() : null;
+			this.selectDropDownContainer.style.outlineColor = optionsBorder;
+			this.selectDropDownContainer.style.outlineOffset = '-1px';
+		}
+	}
+
+	private createOption(value: string, index: number, disabled?: boolean): HTMLOptionElement {
+		let option = document.createElement('option');
+		ption.value = value;
+		option.text = value;
+		option.disabled = disabled;
+
+		return option;
+	}
+
+	// ContextView dropdown methods
+
+	private showSelectDropDown() {
+		if (!this.contextViewProvider || this._isVisible) {
+			return;
+		}
+
+		this._isVisible = true;
+		this.cloneElementFont(this.selectElement, this.selectDropDownContainer);
+		this.contextViewProvider.showContextView({
+			getAnchor: () => this.selectElement,
+			render: (container: HTMLElement) => { return this.renderSelectDropDown(container); },
+			layout: () => this.layoutSelectDropDown(),
+			onHide: () => {
+				dom.toggleClass(this.selectDropDownContainer, 'visible', false);
+				dom.toggleClass(this.selectElement, 'synthetic-focus', false);
+			}
+		});
+	}
+
+	private hideSelectDropDown(focusSelect: boolean) {
+		if (!this.contextViewProvider || !this._isVisible) {
+			return;
+		}
+
+		this._isVisible = false;
+
+		if (focusSelect) {
+			this.selectElement.focus();
+		}
+		this.contextViewProvider.hideContextView();
+	}
+
+	private renderSelectDropDown(container: HTMLElement) {
+		dom.append(container, this.selectDropDownContainer);
+		this.layoutSelectDropDown();
+		return null;
+	}
+
+	private layoutSelectDropDown() {
+
+		// Layout ContextView drop down select list and container
+		// Have to manage our vertical overflow, sizing
+		// Need to be visible to measure
+
+		dom.toggleClass(this.selectDropDownContainer, 'visible', true);
+
+		const selectWidth = dom.getTotalWidth(this.selectElement);
+		const selectPosition = dom.getDomNodePagePosition(this.selectElement);
+
+		// Set container height to max from select bottom to margin above status bar
+		const statusBarHeight = dom.getTotalHeight(document.getElementById('workbench.parts.statusbar'));
+		const maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - statusBarHeight - SelectBoxList.SELECT_DROPDOWN_BOTTOM_MARGIN);
+
+		// SetUp list dimensions and layout - account for container padding
+		if (this.selectList) {
+			this.selectList.layout();
+			let listHeight = this.selectList.contentHeight;
+			const listContainerHeight = dom.getTotalHeight(this.selectDropDownListContainer);
+			const totalVerticalListPadding = listContainerHeight - listHeight;
+
+			// Always show complete list items - never more than Max available vertical height
+			if (listContainerHeight > maxSelectDropDownHeight) {
+				listHeight = ((Math.floor((maxSelectDropDownHeight - totalVerticalListPadding) / this.getHeight())) * this.getHeight());
+			}
+
+			this.selectList.layout(listHeight);
+			this.selectList.domFocus();
+
+			// Finally set focus on selected item
+			this.selectList.setFocus([this.selected]);
+			this.selectList.reveal(this.selectList.getFocus()[0]);
+
+			// Set final container height after adjustments
+			this.selectDropDownContainer.style.height = (listHeight + totalVerticalListPadding) + 'px';
+
+			// Determine optimal width - min(longest option), opt(parent select), max(ContextView controlled)
+			const selectMinWidth = this.setWidthControlElement(this.widthControlElement);
+			const selectOptimalWidth = Math.max(selectMinWidth, Math.round(selectWidth)).toString() + 'px';
+
+			this.selectDropDownContainer.style.minWidth = selectOptimalWidth;
+
+			// Maintain focus outline on parent select as well as list container - tabindex for focus
+			this.selectDropDownListContainer.setAttribute('ta bindex', '0');
+			dom.toggleClass(this.selectElement, 'synthetic-focus', true);
+			dom.toggleClass(this.selectDropDownContainer, 'synthetic-focus', true);
+
+		}
+	}
+	private setWidthControlElement(container: HTMLElement): number {
+		let elementWidth = 0;
+
+		if (container && !!this.options) {
+			let longest = 0;
+
+			for (let index = 0; index < this.options.length; index++) {
+				if (this.options[index].length > this.options[longest].length) {
+					longest = index;
+				}
+			}
+
+			container.innerHTML = this.options[longest];
+			elementWidth = dom.getTotalWidth(container);
+		}
+
+		return elementWidth;
+	}
+
+	private cloneElementFont(source: HTMLElement, target: HTMLElement) {
+		const fontSize = window.getComputedStyle(source, null).getPropertyValue('font-size');
+		const fontFamily = window.getComputedStyle(source, null).getPropertyValue('font-family');
+		target.style.fontFamily = fontFamily;
+		target.style.fontSize = fontSize;
+	}
+
+	// List methods
+
+	// List mouse controller - active exit, select option, fire onDidSelect, return focus to parent select
+	private onMouseUp(e: MouseEvent): void {
+
+		// Check our mouse event is on an option (not scrollbar)
+		if (!e.toElement.classList.contains('option-text')) {
+			return;
+		}
+
+		const listRowElement = e.toElement.parentElement;
+		const index = Number(listRowElement.getAttribute('data-index'));
+		const disabled = listRowElement.classList.contains('option-disabled');
+
+		// Ignore mouse selection of disabled options
+		if (index >= 0 && index < this.options.length && !disabled) {
+			this.selected = index;
+			this.select(this.selected);
+
+			this.selectList.setFocus([this.selected]);
+			this.selectList.reveal(this.selectList.getFocus()[0]);
+			this._onDidSelect.fire({
+				index: this.selectElement.selectedIndex,
+				selected: this.selectElement.title
+			});
+			this.hideSelectDropDown(true);
+		}
+		dom.EventHelper.stop(e);
+	}
+
+	private onFocusChange(e: IListEvent<ISelectOptionItem>): void {
+		const index = e.indexes[0];
+		this.select(index);
+	}
+
+	// List Exit - passive - hide drop - down, fire onDidSelect
+	private onListBlur(): void {
+
+		this._onDidSelect.fire({
+			index: this.selectElement.selectedIndex,
+			selected: this.selectElement.title
+		});
+
+		this.hideSelectDropDown(false);
+	}
+
+	// List keyboard controller
+	// List exit - active - hide ContextView dropdown, return focus to parent select, fire onDidSelect
+	private onEscape(e: StandardKeyboardEvent): void {
+		dom.EventHelper.stop(e);
+
+		this.hideSelectDropDown(true);
+
+		this._onDidSelect.fire({
+			index: this.selectElement.selectedIndex,
+			selected: this.selectElement.title
+		});
+	}
+
+	// List exit - active - hide ContextView dropdown, return focus to parent select, fire onDidSelect
+	private onEnter(e: ISelectOptionItem): void {
+		this.hideSelectDropDown(true);
+		this._onDidSelect.fire({
+			index: this.selectElement.selectedIndex,
+			selected: this.selectElement.title
+		});
+	}
+	// Mimic option first character navigation of native select
+	private onCharacter(e: StandardKeyboardEvent): void {
+		const ch = KeyCodeUtils.toString(e.keyCode);
+		let optionIndex = -1;
+
+		for (let i = 0; i < this.options.length - 1; i++) {
+			optionIndex = (i + this.selected + 1) % this.options.length;
+			if (this.options[optionIndex].charAt(0).toUpperCase() === ch) {
+				this.select(optionIndex);
+				this.selectList.setFocus([optionIndex]);
+				this.selectList.reveal(this.selectList.getFocus()[0]);
+				dom.EventHelper.stop(e);
+				break;
+			}
+		}
+	}
+
+	public dispose(): void {
+		this.hideSelectDropDown(false);
+		this.toDispose = dispose(this.toDispose);
+	}
+

--- a/src/vs/workbench/parts/selectbox/browser/selectBoxNative.ts
+++ b/src/vs/workbench/parts/selectbox/browser/selectBoxNative.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable, dispose } from 'vs/base/common/lifecycle';
+import Event, { Emitter } from 'vs/base/common/event';
+import { KeyCode } from 'vs/base/common/keyCodes';
+import * as dom from 'vs/base/browser/dom';
+import * as arrays from 'vs/base/common/arrays';
+import { ISelectBoxDelegate, ISelectBoxStyles, ISelectData } from 'vs/base/browser/ui/selectBox/selectBox';
+import { isMacintosh } from 'vs/base/common/platform';
+
+export class SelectBoxNative implements ISelectBoxDelegate {
+
+	private selectElement: HTMLSelectElement;
+	private options: string[];
+	private selected: number;
+	private _onDidSelect: Emitter<ISelectData>;
+	private toDispose: IDisposable[];
+	private styles: ISelectBoxStyles;
+
+	constructor(options: string[], selected: number, styles: ISelectBoxStyles) {
+
+		this.toDispose = [];
+
+		this.selectElement = document.createElement('select');
+		this.selectElement.className = 'select-box';
+
+		this._onDidSelect = new Emitter<ISelectData>();
+
+		this.styles = styles;
+
+		this.registerListeners();
+
+		this.setOptions(options, selected);
+	}
+
+	private registerListeners() {
+
+		this.toDispose.push(dom.addStandardDisposableListener(this.selectElement, 'change', (e) => {
+			this.selectElement.title = e.target.value;
+			this._onDidSelect.fire({
+				index: e.target.selectedIndex,
+				selected: e.target.value
+			});
+		}));
+
+		this.toDispose.push(dom.addStandardDisposableListener(this.selectElement, 'keydown', (e) => {
+			let showSelect = false;
+
+			if (isMacintosh) {
+				if (e.keyCode === KeyCode.DownArrow || e.keyCode === KeyCode.UpArrow || e.keyCode === KeyCode.Space) {
+					showSelect = true;
+				}
+			} else {
+				if (e.keyCode === KeyCode.DownArrow && e.altKey || e.keyCode === KeyCode.Space || e.keyCode === KeyCode.Enter) {
+					showSelect = true;
+				}
+			}
+
+			if (showSelect) {
+				// Space, Enter, is used to expand select box, do not propagate it (prevent action bar action run)
+				e.stopPropagation();
+			}
+		}));
+	}
+
+	public get onDidSelect(): Event<ISelectData> {
+		return this._onDidSelect.event;
+	}
+
+	public setOptions(options: string[], selected?: number, disabled?: number): void {
+
+		if (!this.options || !arrays.equals(this.options, options)) {
+			this.options = options;
+			this.selectElement.options.length = 0;
+
+			let i = 0;
+			this.options.forEach((option) => {
+				this.selectElement.add(this.createOption(option, i, disabled === i++));
+			});
+
+		}
+
+		if (selected !== undefined) {
+			this.select(selected);
+		}
+	}
+
+	public select(index: number): void {
+		if (index >= 0 && index < this.options.length) {
+			this.selected = index;
+		} else if (this.selected < 0) {
+			this.selected = 0;
+		}
+
+		this.selectElement.selectedIndex = this.selected;
+		this.selectElement.title = this.options[this.selected];
+	}
+
+	public focus(): void {
+		if (this.selectElement) {
+			this.selectElement.focus();
+		}
+	}
+
+	public blur(): void {
+		if (this.selectElement) {
+			this.selectElement.blur();
+		}
+	}
+
+	public render(container: HTMLElement): void {
+		dom.addClass(container, 'select-container');
+		container.appendChild(this.selectElement);
+		this.setOptions(this.options, this.selected);
+		this.applyStyles();
+	}
+
+	public style(styles: ISelectBoxStyles): void {
+		this.styles = styles;
+		this.applyStyles();
+	}
+
+	public applyStyles(): void {
+
+		// Style native select
+		if (this.selectElement) {
+			const background = this.styles.selectBackground ? this.styles.selectBackground.toString() : null;
+			const foreground = this.styles.selectForeground ? this.styles.selectForeground.toString() : null;
+			const border = this.styles.selectBorder ? this.styles.selectBorder.toString() : null;
+
+			this.selectElement.style.backgroundColor = background;
+			this.selectElement.style.color = foreground;
+			this.selectElement.style.borderColor = border;
+		}
+
+	}
+
+	private createOption(value: string, index: number, disabled?: boolean): HTMLOptionElement {
+		let option = document.createElement('option');
+		option.value = value;
+		option.text = value;
+		option.disabled = disabled;
+
+		return option;
+	}
+
+	public dispose(): void {
+		this.toDispose = dispose(this.toDispose);
+	}
+}


### PR DESCRIPTION
@bpasero 
- in progress, just wanted to see if this is what you want
- Moved selectBox to workbench/parts/selectbox  - to allow imports - could also be elsewhere
- Debug configurations uses new select box 
- converted to workbenchList - instantiated inside select box - could instantiate in caller - will do next
- Note: if we have caller instantiate workbench list, I have to instantiate renderer also AND
we would have to add platform switch in each caller
- kind of ugly IMHO - I prefer things as I have them fully encapsulated
- Utilize Global list commands 
- Added disabled trait and disabled list entry handling inside listWidget