### PR TITLE
Explorer multiple selection

### DIFF
--- a/src/vs/base/browser/dnd.ts
+++ b/src/vs/base/browser/dnd.ts
@@ -50,6 +50,11 @@ export const DataTransfers = {
 	URL: 'URL',
 
 	/**
+	 * Application specific resource transfer type when multiple resources are being dragged.
+	 */
+	URLS: 'URLS',
+
+	/**
 	 * Browser specific transfer type to download.
 	 */
 	DOWNLOAD_URL: 'DownloadURL',

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -662,7 +662,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	private eventBufferer = new EventBufferer();
 	private view: ListView<T>;
 	private spliceable: ISpliceable<T>;
-	private disposables: IDisposable[];
+	protected disposables: IDisposable[];
 	private styleElement: HTMLStyleElement;
 
 	@memoize get onFocusChange(): Event<IListEvent<T>> {

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -74,6 +74,7 @@ export class ListService implements IListService {
 const RawWorkbenchListFocusContextKey = new RawContextKey<boolean>('listFocus', true);
 export const WorkbenchListSupportsMultiSelectContextKey = new RawContextKey<boolean>('listSupportsMultiselect', true);
 export const WorkbenchListFocusContextKey = ContextKeyExpr.and(RawWorkbenchListFocusContextKey, ContextKeyExpr.not(InputFocusedContextKey));
+export const WorkbenchListDoubleSelection = new RawContextKey<boolean>('listDoubleSelection', false);
 
 export type Widget = List<any> | PagedList<any> | ITree;
 
@@ -91,7 +92,7 @@ function createScopedContextKeyService(contextKeyService: IContextKeyService, wi
 export class WorkbenchList<T> extends List<T> {
 
 	readonly contextKeyService: IContextKeyService;
-	private disposable: IDisposable;
+	private listDoubleSelection: IContextKey<boolean>;
 
 	constructor(
 		container: HTMLElement,
@@ -103,17 +104,18 @@ export class WorkbenchList<T> extends List<T> {
 		@IThemeService themeService: IThemeService
 	) {
 		super(container, delegate, renderers, options);
+		this.listDoubleSelection = WorkbenchListDoubleSelection.bindTo(contextKeyService);
 		this.contextKeyService = createScopedContextKeyService(contextKeyService, this);
 
-		this.disposable = combinedDisposable([
+		this.disposables.push(combinedDisposable([
 			this.contextKeyService,
 			(listService as ListService).register(this),
 			attachListStyler(this, themeService)
-		]);
-	}
-
-	dispose(): void {
-		this.disposable.dispose();
+		]));
+		this.disposables.push(this.onSelectionChange(() => {
+			const selection = this.getSelection();
+			this.listDoubleSelection.set(selection && selection.length === 2);
+		}));
 	}
 }
 
@@ -150,6 +152,7 @@ export class WorkbenchTree extends Tree {
 
 	readonly contextKeyService: IContextKeyService;
 	private disposables: IDisposable[] = [];
+	private listDoubleSelection: IContextKey<boolean>;
 
 	constructor(
 		container: HTMLElement,
@@ -161,6 +164,7 @@ export class WorkbenchTree extends Tree {
 	) {
 		super(container, configuration, options);
 
+		this.listDoubleSelection = WorkbenchListDoubleSelection.bindTo(contextKeyService);
 		this.contextKeyService = createScopedContextKeyService(contextKeyService, this);
 
 		this.disposables.push(
@@ -168,6 +172,10 @@ export class WorkbenchTree extends Tree {
 			(listService as ListService).register(this),
 			attachListStyler(this, themeService)
 		);
+		this.disposables.push(this.onDidChangeSelection(() => {
+			const selection = this.getSelection();
+			this.listDoubleSelection.set(selection && selection.length === 2);
+		}));
 	}
 
 	dispose(): void {

--- a/src/vs/platform/message/common/message.ts
+++ b/src/vs/platform/message/common/message.ts
@@ -5,6 +5,8 @@
 'use strict';
 
 import nls = require('vs/nls');
+import uri from 'vs/base/common/uri';
+import paths = require('vs/base/common/paths');
 import { TPromise } from 'vs/base/common/winjs.base';
 import Severity from 'vs/base/common/severity';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -34,6 +36,24 @@ export const LaterAction = new Action('later.message', nls.localize('later', "La
 export const CancelAction = new Action('cancel.message', nls.localize('cancel', "Cancel"), null, true, () => TPromise.as(true));
 
 export const IMessageService = createDecorator<IMessageService>('messageService');
+
+const MAX_CONFIRM_FILES = 10;
+export function getConfirmMessage(start: string, resourcesToConfirm: uri[]): string {
+	const message = [start];
+	message.push('');
+	message.push(...resourcesToConfirm.slice(0, MAX_CONFIRM_FILES).map(r => paths.basename(r.fsPath)));
+
+	if (resourcesToConfirm.length > MAX_CONFIRM_FILES) {
+		if (resourcesToConfirm.length - MAX_CONFIRM_FILES === 1) {
+			message.push(nls.localize('moreFile', "...1 additional file not shown"));
+		} else {
+			message.push(nls.localize('moreFiles', "...{0} additional files not shown", resourcesToConfirm.length - MAX_CONFIRM_FILES));
+		}
+	}
+
+	message.push('');
+	return message.join('\n');
+}
 
 export interface IConfirmationResult {
 	confirmed: boolean;

--- a/src/vs/workbench/browser/editor.ts
+++ b/src/vs/workbench/browser/editor.ts
@@ -241,13 +241,19 @@ export function extractResources(e: DragEvent, externalOnly?: boolean): (IDragge
 
 			// Data Transfer: URL
 			else {
-				const rawURLData = e.dataTransfer.getData(DataTransfers.URL);
-				if (rawURLData) {
-					try {
-						resources.push({ resource: URI.parse(rawURLData), isExternal: false });
-					} catch (error) {
-						// Invalid URI
+				try {
+					const rawURLsData = e.dataTransfer.getData(DataTransfers.URLS);
+					if (rawURLsData) {
+						const uriStrArray: string[] = JSON.parse(rawURLsData);
+						resources.push(...uriStrArray.map(uriStr => ({ resource: URI.parse(uriStr), isExternal: false })));
+					} else {
+						const rawURLData = e.dataTransfer.getData(DataTransfers.URL);
+						if (rawURLData) {
+							resources.push({ resource: URI.parse(rawURLData), isExternal: false });
+						}
 					}
+				} catch (error) {
+					// Invalid URI
 				}
 			}
 		}

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -11,7 +11,7 @@ import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTI
 import { SyncActionDescriptor, MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
-import { openWindowCommand, REVEAL_IN_OS_COMMAND_ID, COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, REVEAL_IN_OS_LABEL, DirtyEditorContext } from 'vs/workbench/parts/files/electron-browser/fileCommands';
+import { openWindowCommand, REVEAL_IN_OS_COMMAND_ID, COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, REVEAL_IN_OS_LABEL, DirtyEditorContext, COMPARE_SELECTED_COMMAND_ID } from 'vs/workbench/parts/files/electron-browser/fileCommands';
 import { CommandsRegistry, ICommandHandler } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -22,6 +22,7 @@ import { CLOSE_UNMODIFIED_EDITORS_COMMAND_ID, CLOSE_EDITORS_IN_GROUP_COMMAND_ID,
 import { OPEN_FOLDER_SETTINGS_COMMAND, OPEN_FOLDER_SETTINGS_LABEL } from 'vs/workbench/parts/preferences/browser/preferencesActions';
 import { AutoSaveContext } from 'vs/workbench/services/textfile/common/textfiles';
 import { ResourceContextKey } from 'vs/workbench/common/resources';
+import { WorkbenchListDoubleSelection } from 'vs/platform/list/browser/listService';
 
 
 // Contribute Global Actions
@@ -341,14 +342,24 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: '3_compare',
 	order: 20,
 	command: compareResourceCommand,
-	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.IsFile, ResourceSelectedForCompareContext)
+	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.IsFile, ResourceSelectedForCompareContext, WorkbenchListDoubleSelection.toNegated())
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: '3_compare',
 	order: 30,
 	command: selectForCompareCommand,
-	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.IsFile)
+	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.IsFile, WorkbenchListDoubleSelection.toNegated())
+});
+
+MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
+	group: '3_compare',
+	order: 30,
+	command: {
+		id: COMPARE_SELECTED_COMMAND_ID,
+		title: nls.localize('compareSelected', "Compare Selected")
+	},
+	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.IsFile, WorkbenchListDoubleSelection)
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.ts
@@ -37,7 +37,7 @@ import { IQuickOpenService } from 'vs/platform/quickOpen/common/quickOpen';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IUntitledResourceInput } from 'vs/platform/editor/common/editor';
 import { IInstantiationService, IConstructorSignature2, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { IMessageService, IMessageWithAction, IConfirmation, Severity, CancelAction, IConfirmationResult } from 'vs/platform/message/common/message';
+import { IMessageService, IMessageWithAction, IConfirmation, Severity, CancelAction, IConfirmationResult, getConfirmMessage } from 'vs/platform/message/common/message';
 import { ITextModel } from 'vs/editor/common/model';
 import { IBackupFileService } from 'vs/workbench/services/backup/common/backup';
 import { IWindowsService } from 'vs/platform/windows/common/windows';
@@ -706,7 +706,7 @@ class BaseDeleteFileAction extends BaseFileAction {
 
 			// Confirm for moving to trash
 			else if (this.useTrash) {
-				const message = this.elements.length > 1 ? nls.localize('confirmMoveTrashMessageMultiple', "Are you sure you want to delete '{0}' resources?", this.elements.length)
+				const message = this.elements.length > 1 ? getConfirmMessage(nls.localize('confirmMoveTrashMessageMultiple', "Are you sure you want to delete the following {0} files?", this.elements.length), this.elements.map(e => e.resource))
 					: this.elements[0].isDirectory ? nls.localize('confirmMoveTrashMessageFolder', "Are you sure you want to delete '{0}' and its contents?", this.elements[0].name)
 						: nls.localize('confirmMoveTrashMessageFile', "Are you sure you want to delete '{0}'?", this.elements[0].name);
 				confirmDeletePromise = this.messageService.confirmWithCheckbox({
@@ -722,7 +722,7 @@ class BaseDeleteFileAction extends BaseFileAction {
 
 			// Confirm for deleting permanently
 			else {
-				const message = this.elements.length > 1 ? nls.localize('confirmDeleteMessageMultiple', "Are you sure you want to permanently delete '{0}' resources?", this.elements.length)
+				const message = this.elements.length > 1 ? getConfirmMessage(nls.localize('confirmDeleteMessageMultiple', "Are you sure you want to permanently delete the following {0} files?", this.elements.length), this.elements.map(e => e.resource))
 					: this.elements[0].isDirectory ? nls.localize('confirmDeleteMessageFolder', "Are you sure you want to permanently delete '{0}' and its contents?", this.elements[0].name)
 						: nls.localize('confirmDeleteMessageFile', "Are you sure you want to permanently delete '{0}'?", this.elements[0].name);
 				confirmDeletePromise = this.messageService.confirmWithCheckbox({

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -49,6 +49,8 @@ export const REVEAL_IN_EXPLORER_COMMAND_ID = 'workbench.command.files.revealInEx
 export const REVERT_FILE_COMMAND_ID = 'workbench.action.files.revert';
 export const OPEN_TO_SIDE_COMMAND_ID = 'explorer.openToSide';
 export const SELECT_FOR_COMPARE_COMMAND_ID = 'workbench.files.command.selectForCompare';
+
+export const COMPARE_SELECTED_COMMAND_ID = 'compareSelected';
 export const COMPARE_RESOURCE_COMMAND_ID = 'workbench.files.command.compareFiles';
 export const COMPARE_WITH_SAVED_COMMAND_ID = 'workbench.files.action.compareWithSaved';
 export const COPY_PATH_COMMAND_ID = 'copyFilePath';
@@ -364,6 +366,19 @@ CommandsRegistry.registerCommand({
 			resourceSelectedForCompareContext = ResourceSelectedForCompareContext.bindTo(accessor.get(IContextKeyService));
 		}
 		resourceSelectedForCompareContext.set(true);
+	}
+});
+
+CommandsRegistry.registerCommand({
+	id: COMPARE_SELECTED_COMMAND_ID,
+	handler: (accessor, resource: URI) => {
+		const editorService = accessor.get(IWorkbenchEditorService);
+		const resources = getResourcesForCommand(resource, accessor.get(IListService), editorService);
+
+		return editorService.openEditor({
+			leftResource: resources[0],
+			rightResource: resources[1]
+		});
 	}
 });
 

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -104,7 +104,8 @@ function getResourcesForCommand(resource: URI, listService: IListService, editor
 		}
 	}
 
-	return [getResourceForCommand(resource, listService, editorService)];
+	const result = getResourceForCommand(resource, listService, editorService);
+	return !!result ? [result] : [];
 }
 
 function save(resource: URI, isSaveAs: boolean, editorService: IWorkbenchEditorService, fileService: IFileService, untitledEditorService: IUntitledEditorService,
@@ -293,7 +294,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const editorService = accessor.get(IWorkbenchEditorService);
 		const listService = accessor.get(IListService);
 		const tree = listService.lastFocusedList;
-		resource = getResourceForCommand(resource, listService, editorService);
+		const resources = getResourcesForCommand(resource, listService, editorService);
 
 		// Remove highlight
 		if (tree instanceof Tree) {
@@ -301,8 +302,16 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		}
 
 		// Set side input
-		if (URI.isUri(resource)) {
-			return editorService.openEditor({ resource, options: { preserveFocus: false } }, true);
+		if (resources.length) {
+			return editorService.openEditors(resources.map(resource => {
+				return {
+					input: {
+						resource,
+						options: { preserveFocus: false }
+					},
+					position: Position.THREE
+				};
+			}));
 		}
 
 		return TPromise.as(true);

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -308,10 +308,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 					input: {
 						resource,
 						options: { preserveFocus: false }
-					},
-					position: Position.THREE
+					}
 				};
-			}));
+			}), true);
 		}
 
 		return TPromise.as(true);

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -726,13 +726,14 @@ export class FileDragAndDrop extends SimpleFileResourceDragAndDrop {
 			});
 
 			// Apply some datatransfer types to allow for dragging the element outside of the application
-			// TODO@Isidor check this
 			if (sources.length === 1) {
 				if (!sources[0].isDirectory) {
 					originalEvent.dataTransfer.setData(DataTransfers.DOWNLOAD_URL, [MIME_BINARY, sources[0].name, sources[0].resource.toString()].join(':'));
 				}
 
 				originalEvent.dataTransfer.setData(DataTransfers.TEXT, getPathLabel(sources[0].resource));
+			} else {
+				originalEvent.dataTransfer.setData(DataTransfers.URLS, JSON.stringify(sources.map(s => s.resource.toString())));
 			}
 		}
 	}

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -735,7 +735,7 @@ export class FileDragAndDrop extends SimpleFileResourceDragAndDrop {
 
 				originalEvent.dataTransfer.setData(DataTransfers.TEXT, getPathLabel(sources[0].resource));
 			} else {
-				originalEvent.dataTransfer.setData(DataTransfers.URLS, JSON.stringify(sources.map(s => s.resource.toString())));
+				originalEvent.dataTransfer.setData(DataTransfers.URLS, JSON.stringify(sources.filter(s => !s.isDirectory).map(s => s.resource.toString())));
 			}
 		}
 	}

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -459,6 +459,7 @@ export class FileController extends DefaultController implements IDisposable {
 		tree.setFocus(stat);
 
 		const anchor = { x: event.posx, y: event.posy };
+		const selection = tree.getSelection();
 		this.contextMenuService.showContextMenu({
 			getAnchor: () => anchor,
 			getActions: () => {
@@ -470,7 +471,8 @@ export class FileController extends DefaultController implements IDisposable {
 				if (wasCancelled) {
 					tree.DOMFocus();
 				}
-			}
+			},
+			getActionsContext: () => selection ? selection.map((fs: FileStat) => fs.resource) : undefined
 		});
 
 		return true;

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -342,7 +342,6 @@ export class FileController extends DefaultController implements IDisposable {
 		this.toDispose = [];
 		this.contributedContextMenu = menuService.createMenu(MenuId.ExplorerContext, contextKeyService);
 		this.toDispose.push(this.contributedContextMenu);
-
 	}
 
 	public onLeftClick(tree: ITree, stat: FileStat | Model, event: IMouseEvent, origin: string = 'mouse'): boolean {
@@ -426,6 +425,27 @@ export class FileController extends DefaultController implements IDisposable {
 		}
 
 		return true;
+	}
+
+	public onKeyDown(tree: ITree, event: IKeyboardEvent): boolean {
+		if (event.shiftKey && (event.keyCode === KeyCode.DownArrow || event.keyCode === KeyCode.UpArrow)) {
+			const previousFocus = tree.getFocus();
+			if (event.keyCode === KeyCode.DownArrow) {
+				tree.focusNext();
+			} else {
+				tree.focusPrevious();
+			}
+
+			const focus = tree.getFocus();
+			const selection = tree.getSelection();
+			if (selection && selection.indexOf(focus) >= 0) {
+				tree.setSelection(selection.filter(s => s !== previousFocus));
+			} else {
+				tree.setSelection(selection.concat(focus));
+			}
+		}
+
+		return super.onKeyDown(tree, event);
 	}
 
 	public onContextMenu(tree: ITree, stat: FileStat | Model, event: ContextMenuEvent): boolean {

--- a/src/vs/workbench/services/textfile/electron-browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/electron-browser/textFileService.ts
@@ -24,7 +24,7 @@ import { createTextBufferFactoryFromStream } from 'vs/editor/common/model/textMo
 import product from 'vs/platform/node/product';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IMessageService } from 'vs/platform/message/common/message';
+import { IMessageService, getConfirmMessage } from 'vs/platform/message/common/message';
 import { IBackupFileService } from 'vs/workbench/services/backup/common/backup';
 import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
@@ -32,8 +32,6 @@ import { mnemonicButtonLabel } from 'vs/base/common/labels';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export class TextFileService extends AbstractTextFileService {
-
-	private static readonly MAX_CONFIRM_FILES = 10;
 
 	constructor(
 		@IWorkspaceContextService contextService: IWorkspaceContextService,
@@ -80,24 +78,8 @@ export class TextFileService extends AbstractTextFileService {
 			return TPromise.wrap(ConfirmResult.DONT_SAVE);
 		}
 
-		const message = [
-			resourcesToConfirm.length === 1 ? nls.localize('saveChangesMessage', "Do you want to save the changes you made to {0}?", paths.basename(resourcesToConfirm[0].fsPath)) : nls.localize('saveChangesMessages', "Do you want to save the changes to the following {0} files?", resourcesToConfirm.length)
-		];
-
-		if (resourcesToConfirm.length > 1) {
-			message.push('');
-			message.push(...resourcesToConfirm.slice(0, TextFileService.MAX_CONFIRM_FILES).map(r => paths.basename(r.fsPath)));
-
-			if (resourcesToConfirm.length > TextFileService.MAX_CONFIRM_FILES) {
-				if (resourcesToConfirm.length - TextFileService.MAX_CONFIRM_FILES === 1) {
-					message.push(nls.localize('moreFile', "...1 additional file not shown"));
-				} else {
-					message.push(nls.localize('moreFiles', "...{0} additional files not shown", resourcesToConfirm.length - TextFileService.MAX_CONFIRM_FILES));
-				}
-			}
-
-			message.push('');
-		}
+		const message = resourcesToConfirm.length === 1 ? nls.localize('saveChangesMessage', "Do you want to save the changes you made to {0}?", paths.basename(resourcesToConfirm[0].fsPath))
+			: getConfirmMessage(nls.localize('saveChangesMessages', "Do you want to save the changes to the following {0} files?", resourcesToConfirm.length), resourcesToConfirm);
 
 		// Button order
 		// Windows: Save | Don't Save | Cancel
@@ -119,7 +101,7 @@ export class TextFileService extends AbstractTextFileService {
 
 		const opts: Electron.MessageBoxOptions = {
 			title: product.nameLong,
-			message: message.join('\n'),
+			message,
 			type: 'warning',
 			detail: nls.localize('saveChangesDetail', "Your changes will be lost if you don't save them."),
 			buttons: buttons.map(b => b.label),


### PR DESCRIPTION
fixes #1023

After discussing with @bpasero we came to the following conclusions regarding extension commands in the explorer:

#### Pass the selected resources as an additional array
We would continue to pass the focused resource as the first argument, however if there is a multi selection we would pass those resources as an additional argument. We would only pass them if the focused element is part of the selection since that means the user triggered the action on the selection.
`resource, [selected_resources]` 
This also means that the first argument is containted in the array,

#### Option 1: show all extension commands for multiple selection
Commands from extensions would always still show up even if multi select is on. And we would still continue passing the same argument so nothing would break. Only the users might find surprising that extension commands only work on the actual focused element, not on all. But extension can adopt to the new arguments over time.

#### Option 2:  no extension command shows up for multi-select unless they opt-in

Basically for each extension command we actually add to the when condition: `when-single-selection` and we provide a mechanism for commands to opt into this.
If we decide to go down this path do we still show those command but disabled or not show them at all? For me it makes most sense to show them disabled.

@jrieken looking forward to your feedback

Edit: After discussion in the standup we have decided to go with Option 1.