### PR TITLE
pass --no-use flag when sourcing nvm in build script 

### DIFF
--- a/build/tfs/common/node.sh
+++ b/build/tfs/common/node.sh
@@ -4,9 +4,9 @@ set -e
 # setup nvm
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	export NVM_DIR=~/.nvm
-	source $(brew --prefix nvm)/nvm.sh
+	source $(brew --prefix nvm)/nvm.sh --no-use
 else
-	source $NVM_DIR/nvm.sh
+	source $NVM_DIR/nvm.sh --no-use
 fi
 
 # install node


### PR DESCRIPTION
The command that sources `nvm.sh` discovers the `.nvmrc` file in the repository. It will then try to `nvm use 8.9.2` (at this time of writing), but a fresh build agent won't have installed any node version yet (chicken and egg problem). This issue causes the command to silently fail. The fix is to pass the `--no-use` flag to `nvm.sh`, which will skip this discovery process. This allows the build to proceed normally. 