### PR TITLE
Remove hard-coded zebra in running extensions Fixes #40432

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/media/runtimeExtensionsEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/runtimeExtensionsEditor.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd {
-	background-color: #f5f5f5;
+	background-color: rgba(130, 130, 130, 0.1);
 }
 
 .runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row:hover:not(.odd) {
@@ -88,7 +88,7 @@
 
 .vs-dark .runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd,
 .hc-black .runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd {
-	background-color: #262829;
+	background-color: rgba(130, 130, 130, 0.1);
 }
 
 .runtime-extensions-editor .monaco-action-bar {

--- a/src/vs/workbench/parts/extensions/electron-browser/media/runtimeExtensionsEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/runtimeExtensionsEditor.css
@@ -3,12 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd {
-	background-color: rgba(130, 130, 130, 0.1);
-}
-
-.runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row:hover:not(.odd) {
-	background-color: transparent;
+.runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row:nth-child(even):not(:hover):not(.focused) {
+	background-color: rgba(130, 130, 130, 0.08);
 }
 
 .runtime-extensions-editor .extension {
@@ -84,11 +80,6 @@
 .vs-dark .monaco-action-bar .save-extension-host-profile,
 .hc-black .monaco-action-bar .save-extension-host-profile {
 	background: url('save-inverse.svg') center center no-repeat;
-}
-
-.vs-dark .runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd,
-.hc-black .runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd {
-	background-color: rgba(130, 130, 130, 0.1);
 }
 
 .runtime-extensions-editor .monaco-action-bar {

--- a/src/vs/workbench/parts/extensions/electron-browser/runtimeExtensionsEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/runtimeExtensionsEditor.ts
@@ -294,8 +294,6 @@ export class RuntimeExtensionsEditor extends BaseEditor {
 
 				data.elementDisposables = dispose(data.elementDisposables);
 
-				toggleClass(data.root, 'odd', index % 2 === 1);
-
 				data.name.textContent = element.marketplaceInfo ? element.marketplaceInfo.displayName : element.description.displayName;
 
 				const activationTimes = element.status.activationTimes;

--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -644,7 +644,6 @@ class KeybindingItemRenderer implements IRenderer<IKeybindingItemEntry, Keybindi
 	}
 
 	renderElement(keybindingEntry: IKeybindingItemEntry, index: number, template: KeybindingItemTemplate): void {
-		DOM.toggleClass(template.parent, 'even', index % 2 === 0);
 		template.actions.render(keybindingEntry);
 		template.command.render(keybindingEntry);
 		template.keybinding.render(keybindingEntry);

--- a/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
@@ -68,9 +68,9 @@
 	display: flex;
 }
 
-.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row.even:not(.focused):not(.selected):not(:hover),
-.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list:not(:focus) .monaco-list-row.focused.even:not(.selected):not(:hover),
-.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list:not(.focused) .monaco-list-row.focused.even:not(.selected):not(:hover) {
+.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row:nth-child(even):not(.focused):not(.selected):not(:hover),
+.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list:not(:focus) .monaco-list-row.focused:nth-child(even):not(.selected):not(:hover),
+.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list:not(.focused) .monaco-list-row.focused:nth-child(even):not(.selected):not(:hover) {
 	background-color: rgba(130, 130, 130, 0.04);
 }
 


### PR DESCRIPTION
#40432

The same way it's already done in keybindings editor.

Also, there is another issue in "running extensions": `.focused` selector not overwriting `.odd` in dark and high contrast themes - it was broken before me.