### PR TITLE
find in folder adopt to multi select in explorer

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -328,7 +328,7 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: 'navigation',
 	order: 10,
 	command: openToSideCommand,
-	when: ExplorerFolderContext.toNegated()
+	when: ContextKeyExpr.and(ExplorerFolderContext.toNegated(), ResourceContextKey.HasResource)
 });
 
 MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -97,7 +97,7 @@ export function getResourceForCommand(resource: URI, listService: IListService, 
 	return toResource(editorService.getActiveEditorInput(), { supportSideBySide: true });
 }
 
-function getResourcesForCommand(resource: URI, listService: IListService, editorService: IWorkbenchEditorService): URI[] {
+export function getResourcesForCommand(resource: URI, listService: IListService, editorService: IWorkbenchEditorService): URI[] {
 	const list = listService.lastFocusedList;
 	if (list && list.isDOMFocused() && list instanceof Tree) {
 		const selection = list.getSelection();

--- a/src/vs/workbench/parts/search/browser/searchViewlet.ts
+++ b/src/vs/workbench/parts/search/browser/searchViewlet.ts
@@ -908,33 +908,38 @@ export class SearchViewlet extends Viewlet {
 		}
 	}
 
-	public searchInFolder(resource: URI, pathToRelative: (from: string, to: string) => string): void {
-		let folderPath = null;
+	public searchInFolders(resources: URI[], pathToRelative: (from: string, to: string) => string): void {
+		const folderPaths: string[] = [];
 		const workspace = this.contextService.getWorkspace();
-		if (resource) {
+		if (resources && resources.length) {
 			if (this.contextService.getWorkbenchState() === WorkbenchState.FOLDER) {
 				// Show relative path from the root for single-root mode
-				folderPath = paths.normalize(pathToRelative(workspace.folders[0].uri.fsPath, resource.fsPath));
-				if (folderPath && folderPath !== '.') {
-					folderPath = './' + folderPath;
-				}
-			} else {
-				const owningFolder = this.contextService.getWorkspaceFolder(resource);
-				if (owningFolder) {
-					const owningRootBasename = paths.basename(owningFolder.uri.fsPath);
-
-					// If this root is the only one with its basename, use a relative ./ path. If there is another, use an absolute path
-					const isUniqueFolder = workspace.folders.filter(folder => paths.basename(folder.uri.fsPath) === owningRootBasename).length === 1;
-					if (isUniqueFolder) {
-						folderPath = `./${owningRootBasename}/${paths.normalize(pathToRelative(owningFolder.uri.fsPath, resource.fsPath))}`;
-					} else {
-						folderPath = resource.fsPath;
+				resources.forEach(r => {
+					let folderPath = paths.normalize(pathToRelative(workspace.folders[0].uri.fsPath, r.fsPath));
+					if (folderPath && folderPath !== '.') {
+						folderPath = './' + folderPath;
 					}
-				}
+					folderPaths.push(folderPath);
+				});
+			} else {
+				resources.forEach(r => {
+					const owningFolder = this.contextService.getWorkspaceFolder(r);
+					if (owningFolder) {
+						const owningRootBasename = paths.basename(owningFolder.uri.fsPath);
+
+						// If this root is the only one with its basename, use a relative ./ path. If there is another, use an absolute path
+						const isUniqueFolder = workspace.folders.filter(folder => paths.basename(folder.uri.fsPath) === owningRootBasename).length === 1;
+						if (isUniqueFolder) {
+							folderPaths.push(`./${owningRootBasename}/${paths.normalize(pathToRelative(owningFolder.uri.fsPath, r.fsPath))}`);
+						} else {
+							folderPaths.push(r.fsPath);
+						}
+					}
+				});
 			}
 		}
 
-		if (!folderPath || folderPath === '.') {
+		if (folderPaths.length === 0 || folderPaths.length === 1 && folderPaths[0] === '.') {
 			this.inputPatternIncludes.setValue('');
 			this.searchWidget.focus();
 			return;
@@ -945,7 +950,7 @@ export class SearchViewlet extends Viewlet {
 			this.toggleQueryDetails(true, true);
 		}
 
-		this.inputPatternIncludes.setValue(folderPath);
+		this.inputPatternIncludes.setValue(folderPaths.join(', '));
 		this.searchWidget.focus(false);
 	}
 


### PR DESCRIPTION
Hi @roblourens this PR updates the find in folder explorer actions such that it works with multiple selections.
Apart from that I have removed the `fs.stat` check to see if the resource is a folder since currently this command is only available for folders.
I tested this out and it works nicely, appending each folder path in the search

Corner case (not unique for this command but can happen for others). First select a file and secondly select a folde and trigger this command on it. It will actually put the file and folder as input in search. To fix this we could do multiple fs.stats in parallel for each resource to check if they are folders, but I did not go that far until somebody actually complains.

Let me know what you think

fyi @bpasero 