### PR TITLE
Add win32x64AppId to product.json

### DIFF
--- a/product.json
+++ b/product.json
@@ -10,6 +10,7 @@
 	"win32NameVersion": "Microsoft Code OSS",
 	"win32RegValueName": "CodeOSS",
 	"win32AppId": "{{E34003BB-9E10-4501-8C11-BE3FAA83F23F}",
+	"win32x64AppId": "{{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}",
 	"win32AppUserModelId": "Microsoft.CodeOSS",
 	"win32ShellNameShort": "C&ode - OSS",
 	"darwinBundleIdentifier": "com.visualstudio.code.oss",


### PR DESCRIPTION
This allows building the OSS version of the 64-bit windows installer