### PR TITLE
fix: #41516 (wrap with abbrevation)

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -24,6 +24,7 @@ export function wrapWithAbbreviation(args: any) {
 	}
 
 	const editor = vscode.window.activeTextEditor;
+	let rootNode = parseDocument(editor.document, false);
 
 	const syntax = getSyntaxFromArgs({ language: editor.document.languageId });
 	if (!syntax) {
@@ -47,7 +48,13 @@ export function wrapWithAbbreviation(args: any) {
 		editor.selections.forEach(selection => {
 			let rangeToReplace: vscode.Range = selection.isReversed ? new vscode.Range(selection.active, selection.anchor) : selection;
 			if (rangeToReplace.isEmpty) {
-				rangeToReplace = new vscode.Range(rangeToReplace.start.line, 0, rangeToReplace.start.line, editor.document.lineAt(rangeToReplace.start.line).text.length);
+				let { active } = selection;
+				let currentNode = getNode(rootNode, active, true);
+				if (currentNode && (currentNode.start.line === active.line || currentNode.end.line === active.line)) {
+					rangeToReplace = new vscode.Range(currentNode.start, currentNode.end);
+				} else {
+					rangeToReplace = new vscode.Range(rangeToReplace.start.line, 0, rangeToReplace.start.line, editor.document.lineAt(rangeToReplace.start.line).text.length);
+				}
 			}
 
 			const firstLineOfSelection = editor.document.lineAt(rangeToReplace.start).text.substr(rangeToReplace.start.character);

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -131,7 +131,63 @@ suite('Tests for Wrap with Abbreviations', () => {
 			editor.selections = [new Selection(2, 0, 2, 0)];
 			const promise = wrapWithAbbreviation({ abbreviation: 'li.hello|c' });
 			if (!promise) {
-				assert.equal(1, 2, 'Wrap returned udnefined instead of promise.');
+				assert.equal(1, 2, 'Wrap returned undefined instead of promise.');
+				return Promise.resolve();
+			}
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), expectedContents);
+				return Promise.resolve();
+			});
+		});
+	});
+
+	test('Wrap with abbreviation entire node when cursor is on opening tag', () => {
+		const contents = `
+	<div class="nav main">
+		hello
+	</div>
+	`;
+		const expectedContents = `
+	<div>
+		<div class="nav main">
+			hello
+		</div>
+	</div>
+	`;
+
+		return withRandomFileEditor(contents, 'html', (editor, doc) => {
+			editor.selections = [new Selection(1, 1, 1, 1)];
+			const promise = wrapWithAbbreviation({ abbreviation: 'div' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap returned undefined instead of promise.');
+				return Promise.resolve();
+			}
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), expectedContents);
+				return Promise.resolve();
+			});
+		});
+	});
+
+	test('Wrap with abbreviation entire node when cursor is on closing tag', () => {
+		const contents = `
+	<div class="nav main">
+		hello
+	</div>
+	`;
+		const expectedContents = `
+	<div>
+		<div class="nav main">
+			hello
+		</div>
+	</div>
+	`;
+
+		return withRandomFileEditor(contents, 'html', (editor, doc) => {
+			editor.selections = [new Selection(3, 1, 3, 1)];
+			const promise = wrapWithAbbreviation({ abbreviation: 'div' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap returned undefined instead of promise.');
 				return Promise.resolve();
 			}
 			return promise.then(() => {
@@ -160,7 +216,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 			editor.selections = [new Selection(2, 2, 3, 33)];
 			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'ul>li.hello$*' });
 			if (!promise) {
-				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned udnefined.');
+				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');
 				return Promise.resolve();
 			}
 			return promise.then(() => {
@@ -191,7 +247,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 			editor.selections = [new Selection(2, 2, 3, 33)];
 			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'ul>li.hello*|c' });
 			if (!promise) {
-				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned udnefined.');
+				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');
 				return Promise.resolve();
 			}
 			return promise.then(() => {
@@ -220,7 +276,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 			editor.selections = [new Selection(2, 3, 3, 16)];
 			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'ul>li.hello$*|t' });
 			if (!promise) {
-				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned udnefined.');
+				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');
 				return Promise.resolve();
 			}
 
@@ -238,7 +294,7 @@ function testWrapWithAbbreviation(selections: Selection[], abbreviation: string,
 		editor.selections = selections;
 		const promise = wrapWithAbbreviation({ abbreviation });
 		if (!promise) {
-			assert.equal(1, 2, 'Wrap  with Abbreviation returned udnefined.');
+			assert.equal(1, 2, 'Wrap  with Abbreviation returned undefined.');
 			return Promise.resolve();
 		}
 


### PR DESCRIPTION
Fixes issue #41516:
Wraps current node when no selection and cursor on opening or closing tag