### PR TITLE
Correct "branchs" to "branches" typo

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -55,7 +55,7 @@
 	"config.enableLongCommitWarning": "Whether long commit messages should be warned about",
 	"config.confirmSync": "Confirm before synchronizing git repositories",
 	"config.countBadge": "Controls the git badge counter. `all` counts all changes. `tracked` counts only the tracked changes. `off` turns it off.",
-	"config.checkoutType": "Controls what type of branches are listed when running `Checkout to...`. `all` shows all refs, `local` shows only the local branchs, `tags` shows only tags and `remote` shows only remote branches.",
+	"config.checkoutType": "Controls what type of branches are listed when running `Checkout to...`. `all` shows all refs, `local` shows only the local branches, `tags` shows only tags and `remote` shows only remote branches.",
 	"config.ignoreLegacyWarning": "Ignores the legacy Git warning",
 	"config.ignoreMissingGitWarning": "Ignores the warning when Git is missing",
 	"config.ignoreLimitWarning": "Ignores the warning when there are too many changes in a repository",


### PR DESCRIPTION
I noticed this when scrolling through the Git settings. Clearly low-priority but I thought I'd submit anyway.

A search for "branchs" in this repository turned up only this result, and I didn't notice any other typos in this file.

The GitHub online editor added the newline at the end of the file. I can remove it if it's necessary -- it looks like at least one other `package.nls.json` file doesn't have the same newline at the end, so I'll defer to the standard if it exists.