### PR TITLE
CodeActionScope

### DIFF
--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -108,10 +108,14 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 	public async provideCodeActions(
 		document: vscode.TextDocument,
 		_range: vscode.Range,
-		_context: vscode.CodeActionContext,
+		context: vscode.CodeActionContext,
 		token: vscode.CancellationToken
 	): Promise<vscode.CodeAction[]> {
 		if (!this.client.apiVersion.has240Features()) {
+			return [];
+		}
+
+		if (context.requestedScope && !vscode.CodeActionScope.Refactor.contains(context.requestedScope)) {
 			return [];
 		}
 

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -158,7 +158,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 								command: ApplyRefactoringCommand.ID,
 								arguments: [document, file, info.name, action.name, range]
 							},
-							scope: vscode.CodeActionScope.Refactor
+							scope: TypeScriptRefactorProvider.getScope(action)
 						});
 					}
 				}
@@ -167,5 +167,12 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 		} catch {
 			return [];
 		}
+	}
+
+	private static getScope(refactor: Proto.RefactorActionInfo) {
+		if (refactor.name.startsWith('function_')) {
+			return vscode.CodeActionScope.RefactorExtract.add('function');
+		}
+		return vscode.CodeActionScope.Refactor;
 	}
 }

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -146,7 +146,8 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 							title: info.description,
 							command: SelectRefactorCommand.ID,
 							arguments: [document, file, info, range]
-						}
+						},
+						scope: vscode.CodeActionScope.Refactor
 					});
 				} else {
 					for (const action of info.actions) {
@@ -156,7 +157,8 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 								title: action.description,
 								command: ApplyRefactoringCommand.ID,
 								arguments: [document, file, info.name, action.name, range]
-							}
+							},
+							scope: vscode.CodeActionScope.Refactor
 						});
 					}
 				}

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -115,7 +115,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 			return [];
 		}
 
-		if (context.requestedScope && !vscode.CodeActionScope.Refactor.contains(context.requestedScope)) {
+		if (context.only && !vscode.CodeActionKind.Refactor.contains(context.only)) {
 			return [];
 		}
 
@@ -151,7 +151,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 							command: SelectRefactorCommand.ID,
 							arguments: [document, file, info, range]
 						},
-						scope: vscode.CodeActionScope.Refactor
+						kind: vscode.CodeActionKind.Refactor
 					});
 				} else {
 					for (const action of info.actions) {
@@ -162,7 +162,7 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 								command: ApplyRefactoringCommand.ID,
 								arguments: [document, file, info.name, action.name, range]
 							},
-							scope: TypeScriptRefactorProvider.getScope(action)
+							kind: TypeScriptRefactorProvider.getKind(action)
 						});
 					}
 				}
@@ -173,10 +173,10 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 		}
 	}
 
-	private static getScope(refactor: Proto.RefactorActionInfo) {
+	private static getKind(refactor: Proto.RefactorActionInfo) {
 		if (refactor.name.startsWith('function_')) {
-			return vscode.CodeActionScope.RefactorExtract.add('function');
+			return vscode.CodeActionKind.RefactorExtract.append('function');
 		}
-		return vscode.CodeActionScope.Refactor;
+		return vscode.CodeActionKind.Refactor;
 	}
 }

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -347,6 +347,13 @@ export interface CodeAction {
 }
 
 /**
+ * @internal
+ */
+export interface CodeActionContext {
+	scope?: string;
+}
+
+/**
  * The code action interface defines the contract between extensions and
  * the [light bulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action) feature.
  * @internal
@@ -355,7 +362,7 @@ export interface CodeActionProvider {
 	/**
 	 * Provide commands for the given document and range.
 	 */
-	provideCodeActions(model: model.ITextModel, range: Range, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
+	provideCodeActions(model: model.ITextModel, range: Range, context: CodeActionContext, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -350,7 +350,7 @@ export interface CodeAction {
  * @internal
  */
 export interface CodeActionContext {
-	scope: string | undefined;
+	requestedScope?: string;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -343,14 +343,14 @@ export interface CodeAction {
 	command?: Command;
 	edit?: WorkspaceEdit;
 	diagnostics?: IMarkerData[];
-	scope?: string;
+	kind?: string;
 }
 
 /**
  * @internal
  */
 export interface CodeActionContext {
-	requestedScope: string;
+	only?: string;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -350,7 +350,7 @@ export interface CodeAction {
  * @internal
  */
 export interface CodeActionContext {
-	requestedScope?: string;
+	requestedScope: string;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -343,6 +343,7 @@ export interface CodeAction {
 	command?: Command;
 	edit?: WorkspaceEdit;
 	diagnostics?: IMarkerData[];
+	scope?: string;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -350,7 +350,7 @@ export interface CodeAction {
  * @internal
  */
 export interface CodeActionContext {
-	scope?: string;
+	scope: string | undefined;
 }
 
 /**

--- a/src/vs/editor/contrib/quickFix/codeActionScope.ts
+++ b/src/vs/editor/contrib/quickFix/codeActionScope.ts
@@ -20,6 +20,7 @@ export class CodeActionScope {
 }
 
 export interface CodeActionTrigger {
-	scope: CodeActionScope;
+	type: 'auto' | 'manual';
+	scope?: CodeActionScope;
 	autoApply?: boolean;
 }

--- a/src/vs/editor/contrib/quickFix/codeActionScope.ts
+++ b/src/vs/editor/contrib/quickFix/codeActionScope.ts
@@ -8,6 +8,8 @@ import { startsWith } from 'vs/base/common/strings';
 export class CodeActionScope {
 	private static readonly sep = '.';
 
+	public static readonly Empty = new CodeActionScope('');
+
 	constructor(
 		public readonly value: string
 	) { }
@@ -15,4 +17,9 @@ export class CodeActionScope {
 	public contains(other: string): boolean {
 		return this.value === other || startsWith(other, this.value + CodeActionScope.sep);
 	}
+}
+
+export interface CodeActionTrigger {
+	scope: CodeActionScope;
+	autoApply?: boolean;
 }

--- a/src/vs/editor/contrib/quickFix/codeActionScope.ts
+++ b/src/vs/editor/contrib/quickFix/codeActionScope.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { startsWith } from 'vs/base/common/strings';
+
+export class CodeActionScope {
+	private static readonly sep = '.';
+
+	constructor(
+		public readonly value: string
+	) { }
+
+	public contains(other: string): boolean {
+		return this.value === other || startsWith(other, this.value + CodeActionScope.sep);
+	}
+}

--- a/src/vs/editor/contrib/quickFix/codeActionTrigger.ts
+++ b/src/vs/editor/contrib/quickFix/codeActionTrigger.ts
@@ -19,8 +19,14 @@ export class CodeActionKind {
 	}
 }
 
+export enum CodeActionAutoApply {
+	IfSingle = 1,
+	First = 2,
+	Never = 3
+}
+
 export interface CodeActionTrigger {
 	type: 'auto' | 'manual';
-	scope?: CodeActionKind;
-	autoApply?: boolean;
+	kind?: CodeActionKind;
+	autoApply?: CodeActionAutoApply;
 }

--- a/src/vs/editor/contrib/quickFix/codeActionTrigger.ts
+++ b/src/vs/editor/contrib/quickFix/codeActionTrigger.ts
@@ -5,22 +5,22 @@
 
 import { startsWith } from 'vs/base/common/strings';
 
-export class CodeActionScope {
+export class CodeActionKind {
 	private static readonly sep = '.';
 
-	public static readonly Empty = new CodeActionScope('');
+	public static readonly Empty = new CodeActionKind('');
 
 	constructor(
 		public readonly value: string
 	) { }
 
 	public contains(other: string): boolean {
-		return this.value === other || startsWith(other, this.value + CodeActionScope.sep);
+		return this.value === other || startsWith(other, this.value + CodeActionKind.sep);
 	}
 }
 
 export interface CodeActionTrigger {
 	type: 'auto' | 'manual';
-	scope?: CodeActionScope;
+	scope?: CodeActionKind;
 	autoApply?: boolean;
 }

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -20,7 +20,7 @@ export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActi
 
 	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
-		return asWinJsPromise(token => support.provideCodeActions(model, range, { scope: scope ? scope.value : undefined }, token)).then(result => {
+		return asWinJsPromise(token => support.provideCodeActions(model, range, { requestedScope: scope ? scope.value : undefined }, token)).then(result => {
 			if (Array.isArray(result)) {
 				for (const quickFix of result) {
 					if (quickFix) {

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -23,8 +23,10 @@ export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActi
 		return asWinJsPromise(token => support.provideCodeActions(model, range, { scope: scope ? scope.value : undefined }, token)).then(result => {
 			if (Array.isArray(result)) {
 				for (const quickFix of result) {
-					if (quickFix && (!scope || quickFix.scope && scope.contains(quickFix.scope))) {
-						allResults.push(quickFix);
+					if (quickFix) {
+						if (!scope || (quickFix.scope && scope.contains(quickFix.scope))) {
+							allResults.push(quickFix);
+						}
 					}
 				}
 			}

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -14,15 +14,16 @@ import { onUnexpectedExternalError, illegalArgument } from 'vs/base/common/error
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { registerLanguageCommand } from 'vs/editor/browser/editorExtensions';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
+import { CodeActionScope } from './codeActionScope';
 
-export function getCodeActions(model: ITextModel, range: Range): TPromise<CodeAction[]> {
+export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActionScope): TPromise<CodeAction[]> {
 
 	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
 		return asWinJsPromise(token => support.provideCodeActions(model, range, token)).then(result => {
 			if (Array.isArray(result)) {
 				for (const quickFix of result) {
-					if (quickFix) {
+					if (quickFix && (!scope || quickFix.scope && scope.contains(quickFix.scope))) {
 						allResults.push(quickFix);
 					}
 				}

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -20,7 +20,7 @@ export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActi
 
 	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
-		return asWinJsPromise(token => support.provideCodeActions(model, range, token)).then(result => {
+		return asWinJsPromise(token => support.provideCodeActions(model, range, { scope: scope ? scope.value : undefined }, token)).then(result => {
 			if (Array.isArray(result)) {
 				for (const quickFix of result) {
 					if (quickFix && (!scope || quickFix.scope && scope.contains(quickFix.scope))) {

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -20,11 +20,11 @@ export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActi
 
 	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {
-		return asWinJsPromise(token => support.provideCodeActions(model, range, { requestedScope: scope ? scope.value : undefined }, token)).then(result => {
+		return asWinJsPromise(token => support.provideCodeActions(model, range, { only: scope ? scope.value : undefined }, token)).then(result => {
 			if (Array.isArray(result)) {
 				for (const quickFix of result) {
 					if (quickFix) {
-						if (!scope || (quickFix.scope && scope.contains(quickFix.scope))) {
+						if (!scope || (quickFix.kind && scope.contains(quickFix.kind))) {
 							allResults.push(quickFix);
 						}
 					}

--- a/src/vs/editor/contrib/quickFix/quickFix.ts
+++ b/src/vs/editor/contrib/quickFix/quickFix.ts
@@ -14,9 +14,9 @@ import { onUnexpectedExternalError, illegalArgument } from 'vs/base/common/error
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { registerLanguageCommand } from 'vs/editor/browser/editorExtensions';
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
-import { CodeActionScope } from './codeActionScope';
+import { CodeActionKind } from './codeActionTrigger';
 
-export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActionScope): TPromise<CodeAction[]> {
+export function getCodeActions(model: ITextModel, range: Range, scope?: CodeActionKind): TPromise<CodeAction[]> {
 
 	const allResults: CodeAction[] = [];
 	const promises = CodeActionProviderRegistry.all(model).map(support => {

--- a/src/vs/editor/contrib/quickFix/quickFixCommands.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixCommands.ts
@@ -20,7 +20,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { QuickFixContextMenu } from './quickFixWidget';
 import { LightBulbWidget } from './lightBulbWidget';
 import { QuickFixModel, QuickFixComputeEvent } from './quickFixModel';
-import { CodeActionScope } from './codeActionScope';
+import { CodeActionKind } from './codeActionTrigger';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { CodeAction } from 'vs/editor/common/modes';
 import { createBulkEdit } from 'vs/editor/browser/services/bulkEdit';
@@ -112,7 +112,7 @@ export class QuickFixController implements IEditorContribution {
 		this._model.trigger({ type: 'manual' });
 	}
 
-	public triggerCodeActionFromEditorSelection(scope?: CodeActionScope, autoApply?: boolean): void {
+	public triggerCodeActionFromEditorSelection(scope?: CodeActionKind, autoApply?: boolean): void {
 		this._model.trigger({ type: 'manual', scope, autoApply });
 	}
 
@@ -183,7 +183,7 @@ export class CodeActionCommand extends EditorCommand {
 	public runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor, args: any) {
 		let controller = QuickFixController.get(editor);
 		if (controller) {
-			const scope = args && typeof args[0] === 'string' ? new CodeActionScope(args[0]) : CodeActionScope.Empty;
+			const scope = args && typeof args[0] === 'string' ? new CodeActionKind(args[0]) : CodeActionKind.Empty;
 			const argsSettings: CodeActionCommandOptions = (args && args[1]) || {};
 			controller.triggerCodeActionFromEditorSelection(scope, argsSettings.autoApply);
 		}

--- a/src/vs/editor/contrib/quickFix/quickFixCommands.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixCommands.ts
@@ -19,7 +19,8 @@ import { registerEditorAction, registerEditorContribution, ServicesAccessor, Edi
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { QuickFixContextMenu } from './quickFixWidget';
 import { LightBulbWidget } from './lightBulbWidget';
-import { QuickFixModel, QuickFixComputeEvent, CodeActionScope } from './quickFixModel';
+import { QuickFixModel, QuickFixComputeEvent } from './quickFixModel';
+import { CodeActionScope } from './codeActionScope';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { CodeAction } from 'vs/editor/common/modes';
 import { createBulkEdit } from 'vs/editor/browser/services/bulkEdit';

--- a/src/vs/editor/contrib/quickFix/quickFixCommands.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixCommands.ts
@@ -19,7 +19,7 @@ import { registerEditorAction, registerEditorContribution, ServicesAccessor, Edi
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { QuickFixContextMenu } from './quickFixWidget';
 import { LightBulbWidget } from './lightBulbWidget';
-import { QuickFixModel, QuickFixComputeEvent } from './quickFixModel';
+import { QuickFixModel, QuickFixComputeEvent, CodeActionScope } from './quickFixModel';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { CodeAction } from 'vs/editor/common/modes';
 import { createBulkEdit } from 'vs/editor/browser/services/bulkEdit';
@@ -72,7 +72,6 @@ export class QuickFixController implements IEditorContribution {
 	private _onQuickFixEvent(e: QuickFixComputeEvent): void {
 		if (e && e.type === 'manual') {
 			this._quickFixContextMenu.show(e.fixes, e.position);
-
 		} else if (e && e.fixes) {
 			// auto magically triggered
 			// * update an existing list of code actions
@@ -95,8 +94,8 @@ export class QuickFixController implements IEditorContribution {
 		this._quickFixContextMenu.show(this._lightBulbWidget.model.fixes, coords);
 	}
 
-	public triggerFromEditorSelection(): void {
-		this._model.trigger('manual');
+	public triggerFromEditorSelection(scope?: CodeActionScope): void {
+		this._model.trigger('manual', scope);
 	}
 
 	private _updateLightBulbTitle(): void {
@@ -140,10 +139,10 @@ export class QuickFixAction extends EditorAction {
 		});
 	}
 
-	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+	public run(accessor: ServicesAccessor, editor: ICodeEditor, args?: any[]): void {
 		let controller = QuickFixController.get(editor);
 		if (controller) {
-			controller.triggerFromEditorSelection();
+			controller.triggerFromEditorSelection(args && typeof args[0] === 'string' ? new CodeActionScope(args[0]) : undefined);
 		}
 	}
 }

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -113,7 +113,7 @@ export class QuickFixOracle {
 			const model = this._editor.getModel();
 			const range = model.validateRange(rangeOrSelection);
 			const position = rangeOrSelection instanceof Selection ? rangeOrSelection.getPosition() : rangeOrSelection.getStartPosition();
-			const fixes = getCodeActions(model, range, trigger && trigger.scope);
+			const fixes = getCodeActions(model, range, trigger && trigger.kind);
 
 			this._signalChange({
 				trigger,

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -24,8 +24,8 @@ export class CodeActionScope {
 		public readonly value: string
 	) { }
 
-	public matches(other: CodeActionScope): boolean {
-		return this.value === other.value || (startsWith(this.value, other.value) && other.value[this.value + 1] === CodeActionScope.sep);
+	public contains(other: CodeActionScope): boolean {
+		return this.value === other.value || startsWith(other.value, this.value + CodeActionScope.sep);
 	}
 }
 
@@ -131,7 +131,7 @@ export class QuickFixOracle {
 				if (!scope) {
 					return actions;
 				}
-				return actions.filter(action => action.scope && new CodeActionScope(action.scope).matches(scope));
+				return actions.filter(action => action.scope && scope.contains(new CodeActionScope(action.scope)));
 			});
 
 			this._signalChange({

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -13,22 +13,9 @@ import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
 import { getCodeActions } from './quickFix';
+import { CodeActionScope } from './codeActionScope';
 import { Position } from 'vs/editor/common/core/position';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { startsWith } from 'vs/base/common/strings';
-
-export class CodeActionScope {
-	private static readonly sep = '.';
-
-	constructor(
-		public readonly value: string
-	) { }
-
-	public contains(other: CodeActionScope): boolean {
-		return this.value === other.value || startsWith(other.value, this.value + CodeActionScope.sep);
-	}
-}
-
 
 export class QuickFixOracle {
 
@@ -127,12 +114,7 @@ export class QuickFixOracle {
 			const model = this._editor.getModel();
 			const range = model.validateRange(rangeOrSelection);
 			const position = rangeOrSelection instanceof Selection ? rangeOrSelection.getPosition() : rangeOrSelection.getStartPosition();
-			const fixes = getCodeActions(model, range).then(actions => {
-				if (!scope) {
-					return actions;
-				}
-				return actions.filter(action => action.scope && scope.contains(new CodeActionScope(action.scope)));
-			});
+			const fixes = getCodeActions(model, range, scope);
 
 			this._signalChange({
 				type,

--- a/src/vs/editor/contrib/quickFix/quickFixModel.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixModel.ts
@@ -13,7 +13,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { CodeActionProviderRegistry, CodeAction } from 'vs/editor/common/modes';
 import { getCodeActions } from './quickFix';
-import { CodeActionTrigger } from './codeActionScope';
+import { CodeActionTrigger } from './codeActionTrigger';
 import { Position } from 'vs/editor/common/core/position';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 

--- a/src/vs/editor/contrib/quickFix/test/quickFix.test.ts
+++ b/src/vs/editor/contrib/quickFix/test/quickFix.test.ts
@@ -12,7 +12,7 @@ import { CodeActionProviderRegistry, LanguageIdentifier, CodeActionProvider, Com
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { Range } from 'vs/editor/common/core/range';
 import { getCodeActions } from 'vs/editor/contrib/quickFix/quickFix';
-import { CodeActionScope } from 'vs/editor/contrib/quickFix/codeActionScope';
+import { CodeActionKind } from 'vs/editor/contrib/quickFix/codeActionTrigger';
 
 suite('QuickFix', () => {
 
@@ -136,20 +136,20 @@ suite('QuickFix', () => {
 		disposables.push(CodeActionProviderRegistry.register('fooLang', provider));
 
 		{
-			const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionScope('a'));
+			const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionKind('a'));
 			assert.equal(actions.length, 2);
 			assert.strictEqual(actions[0].title, 'a');
 			assert.strictEqual(actions[1].title, 'a.b');
 		}
 
 		{
-			const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionScope('a.b'));
+			const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionKind('a.b'));
 			assert.equal(actions.length, 1);
 			assert.strictEqual(actions[0].title, 'a.b');
 		}
 
 		{
-			const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionScope('a.b.c'));
+			const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionKind('a.b.c'));
 			assert.equal(actions.length, 0);
 		}
 	});
@@ -165,7 +165,7 @@ suite('QuickFix', () => {
 
 		disposables.push(CodeActionProviderRegistry.register('fooLang', provider));
 
-		const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionScope('a'));
+		const actions = await getCodeActions(model, new Range(1, 1, 2, 1), new CodeActionKind('a'));
 		assert.equal(actions.length, 1);
 		assert.strictEqual(actions[0].title, 'a');
 	});

--- a/src/vs/editor/contrib/quickFix/test/quickFix.test.ts
+++ b/src/vs/editor/contrib/quickFix/test/quickFix.test.ts
@@ -126,9 +126,9 @@ suite('QuickFix', () => {
 		const provider = new class implements CodeActionProvider {
 			provideCodeActions(): CodeAction[] {
 				return [
-					{ title: 'a', scope: 'a' },
-					{ title: 'b', scope: 'b' },
-					{ title: 'a.b', scope: 'a.b' }
+					{ title: 'a', kind: 'a' },
+					{ title: 'b', kind: 'b' },
+					{ title: 'a.b', kind: 'a.b' }
 				];
 			}
 		};
@@ -158,7 +158,7 @@ suite('QuickFix', () => {
 		const provider = new class implements CodeActionProvider {
 			provideCodeActions(_model: any, _range: Range, context: CodeActionContext, _token: any): CodeAction[] {
 				return [
-					{ title: context.requestedScope, scope: context.requestedScope }
+					{ title: context.only, kind: context.only }
 				];
 			}
 		};

--- a/src/vs/editor/contrib/quickFix/test/quickFixModel.test.ts
+++ b/src/vs/editor/contrib/quickFix/test/quickFixModel.test.ts
@@ -47,7 +47,7 @@ suite('QuickFix', () => {
 	test('Orcale -> marker added', done => {
 
 		const oracle = new QuickFixOracle(editor, markerService, e => {
-			assert.equal(e.type, 'auto');
+			assert.equal(e.trigger.type, 'auto');
 			assert.ok(e.fixes);
 
 			e.fixes.then(fixes => {
@@ -83,7 +83,7 @@ suite('QuickFix', () => {
 		return new Promise((resolve, reject) => {
 
 			const oracle = new QuickFixOracle(editor, markerService, e => {
-				assert.equal(e.type, 'auto');
+				assert.equal(e.trigger.type, 'auto');
 				assert.ok(e.fixes);
 				e.fixes.then(fixes => {
 					oracle.dispose();
@@ -160,7 +160,7 @@ suite('QuickFix', () => {
 		await new Promise(resolve => {
 
 			let oracle = new QuickFixOracle(editor, markerService, e => {
-				assert.equal(e.type, 'auto');
+				assert.equal(e.trigger.type, 'auto');
 				assert.deepEqual(e.range, { startLineNumber: 3, startColumn: 1, endLineNumber: 3, endColumn: 4 });
 				assert.deepEqual(e.position, { lineNumber: 3, column: 1 });
 

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -333,7 +333,7 @@ export function registerCodeActionProvider(languageId: string, provider: CodeAct
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
 			});
-			return provider.provideCodeActions(model, range, { markers, scope: context.scope }, token);
+			return provider.provideCodeActions(model, range, { markers, scope: context.requestedScope }, token);
 		}
 	});
 }

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -333,7 +333,7 @@ export function registerCodeActionProvider(languageId: string, provider: CodeAct
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
 			});
-			return provider.provideCodeActions(model, range, { markers, scope: context.requestedScope }, token);
+			return provider.provideCodeActions(model, range, { markers, scope: context.only }, token);
 		}
 	});
 }

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -329,11 +329,11 @@ export function registerCodeLensProvider(languageId: string, provider: modes.Cod
  */
 export function registerCodeActionProvider(languageId: string, provider: CodeActionProvider): IDisposable {
 	return modes.CodeActionProviderRegistry.register(languageId, {
-		provideCodeActions: (model: model.ITextModel, range: Range, token: CancellationToken): (modes.Command | modes.CodeAction)[] | Thenable<(modes.Command | modes.CodeAction)[]> => {
+		provideCodeActions: (model: model.ITextModel, range: Range, context: modes.CodeActionContext, token: CancellationToken): (modes.Command | modes.CodeAction)[] | Thenable<(modes.Command | modes.CodeAction)[]> => {
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
 			});
-			return provider.provideCodeActions(model, range, { markers }, token);
+			return provider.provideCodeActions(model, range, { markers, scope: context.scope }, token);
 		}
 	});
 }
@@ -401,6 +401,8 @@ export interface CodeActionContext {
 	 * @readonly
 	 */
 	readonly markers: IMarkerData[];
+
+	readonly scope?: string;
 }
 
 /**

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -333,7 +333,7 @@ export function registerCodeActionProvider(languageId: string, provider: CodeAct
 			let markers = StaticServices.markerService.get().read({ resource: model.uri }).filter(m => {
 				return Range.areIntersectingOrTouching(m, range);
 			});
-			return provider.provideCodeActions(model, range, { markers, scope: context.only }, token);
+			return provider.provideCodeActions(model, range, { markers, only: context.only }, token);
 		}
 	});
 }
@@ -402,7 +402,10 @@ export interface CodeActionContext {
 	 */
 	readonly markers: IMarkerData[];
 
-	readonly scope?: string;
+	/**
+	 * Requested kind of actions to return.
+	 */
+	readonly only?: string;
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4496,7 +4496,7 @@ declare module monaco.languages {
 		command?: Command;
 		edit?: WorkspaceEdit;
 		diagnostics?: editor.IMarkerData[];
-		scope?: string;
+		kind?: string;
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4043,6 +4043,7 @@ declare module monaco.languages {
 		 * @readonly
 		 */
 		readonly markers: editor.IMarkerData[];
+		readonly scope?: string;
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4495,6 +4495,7 @@ declare module monaco.languages {
 		command?: Command;
 		edit?: WorkspaceEdit;
 		diagnostics?: editor.IMarkerData[];
+		scope?: string;
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4043,7 +4043,10 @@ declare module monaco.languages {
 		 * @readonly
 		 */
 		readonly markers: editor.IMarkerData[];
-		readonly scope?: string;
+		/**
+		 * Requested kind of actions to return.
+		 */
+		readonly only?: string;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1815,7 +1815,7 @@ declare module 'vscode' {
 	/**
 	 * Kind of a code action.
 	 *
-	 * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactoring.extract.function"`.
+	 * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
 	 */
 	export class CodeActionKind {
 		/**
@@ -1851,7 +1851,7 @@ declare module 'vscode' {
 		private constructor(value: string);
 
 		/**
-		 * String value of the kind, e.g. `"refactoring.extract.function"`.
+		 * String value of the kind, e.g. `"refactor.extract.function"`.
 		 */
 		readonly value?: string;
 
@@ -1865,7 +1865,7 @@ declare module 'vscode' {
 		/**
 		 * Does this kind contain `other`?
 		 *
-		 * The kind `"refactoring"` for example contains `"refactoring.extract"` and ``"refactoring.extract.function"`, but not `"unicorn.refactor.extract"` or `"refactory.extract"`
+		 * The kind `"refactor"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`, but not `"unicorn.refactor.extract"` or `"refactory.extract"`
 		 *
 		 * @param other Kind to check.
 		 */

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1812,6 +1812,22 @@ declare module 'vscode' {
 	 */
 	export type ProviderResult<T> = T | undefined | null | Thenable<T | undefined | null>;
 
+	export class CodeActionScope {
+		public static readonly Empty: CodeActionScope;
+		public static readonly Refactor: CodeActionScope;
+		public static readonly RefactorExtract: CodeActionScope;
+		public static readonly RefactorInline: CodeActionScope;
+
+		private constructor(value: string);
+
+		readonly value?: string;
+
+		public add(parts: string): CodeActionScope;
+
+		public matches(other: CodeActionScope): boolean;
+
+	}
+
 	/**
 	 * Contains additional diagnostic information about the context in which
 	 * a [code action](#CodeActionProvider.provideCodeActions) is run.
@@ -1821,6 +1837,8 @@ declare module 'vscode' {
 		 * An array of diagnostics.
 		 */
 		readonly diagnostics: Diagnostic[];
+
+		readonly requestedScope?: CodeActionScope;
 	}
 
 	/**
@@ -1852,6 +1870,13 @@ declare module 'vscode' {
 		 * *Note* that either an [`edit`](CodeAction#edit) or a [`command`](CodeAction#command) must be supplied.
 		 */
 		command?: Command;
+
+		/**
+		 * Scope of the code action.
+		 *
+		 * Used to filter code actions.
+		 */
+		readonly scope?: CodeActionScope;
 
 		/**
 		 * Creates a new code action.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1813,30 +1813,35 @@ declare module 'vscode' {
 	export type ProviderResult<T> = T | undefined | null | Thenable<T | undefined | null>;
 
 	/**
-	 * Scope of a code action.
+	 * Kind of a code action.
 	 *
-	 * Specifies the type of a code action. A scope is a hierarchical list of identifiers separated by `.`, e.g. `"refactoring.extract.function"`.
+	 * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactoring.extract.function"`.
 	 */
-	export class CodeActionScope {
+	export class CodeActionKind {
 		/**
-		 * Empty scope.
+		 * Empty kind.
 		 */
-		public static readonly Empty: CodeActionScope;
+		static readonly Empty: CodeActionKind;
 
 		/**
-		 * Base scope for refactoring actions.
+		 * Base kind for refactoring actions.
 		 */
-		public static readonly Refactor: CodeActionScope;
+		static readonly Refactor: CodeActionKind;
 
 		/**
-		 * Base scope for refactoring extraction actions.
+		 * Base kind for refactoring extraction actions.
 		 */
-		public static readonly RefactorExtract: CodeActionScope;
+		static readonly RefactorExtract: CodeActionKind;
 
 		/**
-		 * Base scope for refactoring extraction inline.
+		 * Base kind for refactoring rewite actions.
 		 */
-		public static readonly RefactorInline: CodeActionScope;
+		static readonly RefactorRewrite: CodeActionKind;
+
+		/**
+		 * Base kind for refactoring extraction inline.
+		 */
+		static readonly RefactorInline: CodeActionKind;
 
 		private constructor(value: string);
 
@@ -1846,11 +1851,11 @@ declare module 'vscode' {
 		readonly value?: string;
 
 		/**
-		 * Create a new scope by appending a more specific selector to the current scope.
+		 * Create a new kind by appending a more specific selector to the current kind.
 		 *
-		 * Does not modify the current scope object.
+		 * Does not modify the current object.
 		 */
-		public add(parts: string): CodeActionScope;
+		append(parts: string): CodeActionKind;
 
 		/**
 		 * Does this scope contain scope `other`?
@@ -1859,7 +1864,7 @@ declare module 'vscode' {
 		 *
 		 * @param other Scope to check.
 		 */
-		public contains(other: CodeActionScope): boolean;
+		contains(other: CodeActionKind): boolean;
 	}
 
 	/**
@@ -1873,11 +1878,11 @@ declare module 'vscode' {
 		readonly diagnostics: Diagnostic[];
 
 		/**
-		 * Requested scope of actions to return.
+		 * Requested kind of actions to return.
 		 *
-		 * Actions not within this scope are filtered out before being shown by the lightbulb.
+		 * Actions not of this kind are filtered out before being shown by the lightbulb.
 		 */
-		readonly requestedScope?: CodeActionScope;
+		readonly only?: CodeActionKind;
 	}
 
 	/**
@@ -1911,11 +1916,11 @@ declare module 'vscode' {
 		command?: Command;
 
 		/**
-		 * Scope of the code action.
+		 * Kind of the code action.
 		 *
 		 * Used to filter code actions.
 		 */
-		readonly scope?: CodeActionScope;
+		readonly kind?: CodeActionKind;
 
 		/**
 		 * Creates a new code action.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1877,7 +1877,7 @@ declare module 'vscode' {
 		 *
 		 * Actions not within this scope are filtered out before being shown by the lightbulb.
 		 */
-		readonly requestedScope: CodeActionScope;
+		readonly requestedScope?: CodeActionScope;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1815,7 +1815,7 @@ declare module 'vscode' {
 	/**
 	 * Scope of a code action.
 	 *
-	 * Specifies the type of a code action. Scopes are
+	 * Specifies the type of a code action. A scope is a hierarchical list of identifiers separated by `.`, e.g. `"refactoring.extract.function"`.
 	 */
 	export class CodeActionScope {
 		/**
@@ -1849,8 +1849,6 @@ declare module 'vscode' {
 		 * Create a new scope by appending a more specific selector to the current scope.
 		 *
 		 * Does not modify the current scope object.
-		 *
-		 * TODO: Should we allow `add('a.b.c')` or require `add('a').add('b').add('c')`?
 		 */
 		public add(parts: string): CodeActionScope;
 
@@ -1879,7 +1877,7 @@ declare module 'vscode' {
 		 *
 		 * Actions not within this scope are filtered out before being shown by the lightbulb.
 		 */
-		readonly requestedScope?: CodeActionScope;
+		readonly requestedScope: CodeActionScope;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1812,20 +1812,56 @@ declare module 'vscode' {
 	 */
 	export type ProviderResult<T> = T | undefined | null | Thenable<T | undefined | null>;
 
+	/**
+	 * Scope of a code action.
+	 *
+	 * Specifies the type of a code action. Scopes are
+	 */
 	export class CodeActionScope {
+		/**
+		 * Empty scope.
+		 */
 		public static readonly Empty: CodeActionScope;
+
+		/**
+		 * Base scope for refactoring actions.
+		 */
 		public static readonly Refactor: CodeActionScope;
+
+		/**
+		 * Base scope for refactoring extraction actions.
+		 */
 		public static readonly RefactorExtract: CodeActionScope;
+
+		/**
+		 * Base scope for refactoring extraction inline.
+		 */
 		public static readonly RefactorInline: CodeActionScope;
 
 		private constructor(value: string);
 
+		/**
+		 * TODO: should this be exposed?
+		 */
 		readonly value?: string;
 
+		/**
+		 * Create a new scope by appending a more specific selector to the current scope.
+		 *
+		 * Does not modify the current scope object.
+		 *
+		 * TODO: Should we allow `add('a.b.c')` or require `add('a').add('b').add('c')`?
+		 */
 		public add(parts: string): CodeActionScope;
 
+		/**
+		 * Does this scope contain scope `other`?
+		 *
+		 * Another way of saying: is `other` within this scope?
+		 *
+		 * @param other Scope to check.
+		 */
 		public contains(other: CodeActionScope): boolean;
-
 	}
 
 	/**
@@ -1838,6 +1874,11 @@ declare module 'vscode' {
 		 */
 		readonly diagnostics: Diagnostic[];
 
+		/**
+		 * Requested scope of actions to return.
+		 *
+		 * Actions not within this scope are filtered out before being shown by the lightbulb.
+		 */
 		readonly requestedScope?: CodeActionScope;
 	}
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1851,23 +1851,23 @@ declare module 'vscode' {
 		private constructor(value: string);
 
 		/**
-		 * TODO: should this be exposed?
+		 * String value of the kind, e.g. `"refactoring.extract.function"`.
 		 */
 		readonly value?: string;
 
 		/**
 		 * Create a new kind by appending a more specific selector to the current kind.
 		 *
-		 * Does not modify the current object.
+		 * Does not modify the current kind.
 		 */
 		append(parts: string): CodeActionKind;
 
 		/**
-		 * Does this scope contain scope `other`?
+		 * Does this kind contain `other`?
 		 *
-		 * Another way of saying: is `other` within this scope?
+		 * The kind `"refactoring"` for example contains `"refactoring.extract"` and ``"refactoring.extract.function"`, but not `"unicorn.refactor.extract"` or `"refactory.extract"`
 		 *
-		 * @param other Scope to check.
+		 * @param other Kind to check.
 		 */
 		contains(other: CodeActionKind): boolean;
 	}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1824,6 +1824,11 @@ declare module 'vscode' {
 		static readonly Empty: CodeActionKind;
 
 		/**
+		 * Base kind for quickfix actions.
+		 */
+		static readonly QuickFix: CodeActionKind;
+
+		/**
 		 * Base kind for refactoring actions.
 		 */
 		static readonly Refactor: CodeActionKind;
@@ -1834,14 +1839,14 @@ declare module 'vscode' {
 		static readonly RefactorExtract: CodeActionKind;
 
 		/**
+		 * Base kind for refactoring inline actions.
+		 */
+		static readonly RefactorInline: CodeActionKind;
+
+		/**
 		 * Base kind for refactoring rewite actions.
 		 */
 		static readonly RefactorRewrite: CodeActionKind;
-
-		/**
-		 * Base kind for refactoring extraction inline.
-		 */
-		static readonly RefactorInline: CodeActionKind;
 
 		private constructor(value: string);
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1824,7 +1824,7 @@ declare module 'vscode' {
 
 		public add(parts: string): CodeActionScope;
 
-		public matches(other: CodeActionScope): boolean;
+		public contains(other: CodeActionScope): boolean;
 
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -206,7 +206,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	$registerQuickFixSupport(handle: number, selector: vscode.DocumentSelector): void {
 		this._registrations[handle] = modes.CodeActionProviderRegistry.register(toLanguageSelector(selector), <modes.CodeActionProvider>{
-			provideCodeActions: (model: ITextModel, range: EditorRange, token: CancellationToken): Thenable<modes.CodeAction[]> => {
+			provideCodeActions: (model: ITextModel, range: EditorRange, scope: any, token: CancellationToken): Thenable<modes.CodeAction[]> => {
 				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range))).then(MainThreadLanguageFeatures._reviveCodeActionDto);
 			}
 		});

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -206,8 +206,8 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	$registerQuickFixSupport(handle: number, selector: vscode.DocumentSelector): void {
 		this._registrations[handle] = modes.CodeActionProviderRegistry.register(toLanguageSelector(selector), <modes.CodeActionProvider>{
-			provideCodeActions: (model: ITextModel, range: EditorRange, scope: any, token: CancellationToken): Thenable<modes.CodeAction[]> => {
-				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range))).then(MainThreadLanguageFeatures._reviveCodeActionDto);
+			provideCodeActions: (model: ITextModel, range: EditorRange, context: modes.CodeActionContext, token: CancellationToken): Thenable<modes.CodeAction[]> => {
+				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range, context))).then(MainThreadLanguageFeatures._reviveCodeActionDto);
 			}
 		});
 	}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -556,7 +556,7 @@ export function createApiFactory(
 			Breakpoint: extHostTypes.Breakpoint,
 			CancellationTokenSource: CancellationTokenSource,
 			CodeAction: extHostTypes.CodeAction,
-			CodeActionScope: extHostTypes.CodeActionScope,
+			CodeActionKind: extHostTypes.CodeActionKind,
 			CodeLens: extHostTypes.CodeLens,
 			Color: extHostTypes.Color,
 			ColorPresentation: extHostTypes.ColorPresentation,

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -556,6 +556,7 @@ export function createApiFactory(
 			Breakpoint: extHostTypes.Breakpoint,
 			CancellationTokenSource: CancellationTokenSource,
 			CodeAction: extHostTypes.CodeAction,
+			CodeActionScope: extHostTypes.CodeActionScope,
 			CodeLens: extHostTypes.CodeLens,
 			Color: extHostTypes.Color,
 			ColorPresentation: extHostTypes.ColorPresentation,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -639,6 +639,7 @@ export interface CodeActionDto {
 	edit?: WorkspaceEditDto;
 	diagnostics?: IMarkerData[];
 	command?: modes.Command;
+	scope?: string;
 }
 
 export interface ExtHostLanguageFeaturesShape {
@@ -651,7 +652,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideHover(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.Hover>;
 	$provideDocumentHighlights(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.DocumentHighlight[]>;
 	$provideReferences(handle: number, resource: UriComponents, position: IPosition, context: modes.ReferenceContext): TPromise<LocationDto[]>;
-	$provideCodeActions(handle: number, resource: UriComponents, range: IRange): TPromise<CodeActionDto[]>;
+	$provideCodeActions(handle: number, resource: UriComponents, range: IRange, context: modes.CodeActionContext): TPromise<CodeActionDto[]>;
 	$provideDocumentFormattingEdits(handle: number, resource: UriComponents, options: modes.FormattingOptions): TPromise<ISingleEditOperation[]>;
 	$provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: IRange, options: modes.FormattingOptions): TPromise<ISingleEditOperation[]>;
 	$provideOnTypeFormattingEdits(handle: number, resource: UriComponents, position: IPosition, ch: string, options: modes.FormattingOptions): TPromise<ISingleEditOperation[]>;

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -419,8 +419,8 @@ export class ExtHostApiCommands {
 						codeAction.title,
 						typeConverters.WorkspaceEdit.to(codeAction.edit)
 					);
-					if (codeAction.scope) {
-						ret.scope = new types.CodeActionScope(codeAction.scope);
+					if (codeAction.kind) {
+						ret.scope = new types.CodeActionKind(codeAction.kind);
 					}
 					return ret;
 				}

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -419,6 +419,9 @@ export class ExtHostApiCommands {
 						codeAction.title,
 						typeConverters.WorkspaceEdit.to(codeAction.edit)
 					);
+					if (codeAction.scope) {
+						ret.scope = new types.CodeActionScope(codeAction.scope);
+					}
 					return ret;
 				}
 			});

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -289,7 +289,7 @@ class CodeActionAdapter {
 			}
 		});
 
-		const codeActionContext = {
+		const codeActionContext: vscode.CodeActionContext = {
 			diagnostics: allDiagnostics,
 			requestedScope: context.requestedScope ? new CodeActionScope(context.requestedScope) : undefined
 		};

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -9,7 +9,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { mixin } from 'vs/base/common/objects';
 import * as vscode from 'vscode';
 import * as TypeConverters from 'vs/workbench/api/node/extHostTypeConverters';
-import { Range, Disposable, CompletionList, SnippetString, Color, CodeActionScope } from 'vs/workbench/api/node/extHostTypes';
+import { Range, Disposable, CompletionList, SnippetString, Color, CodeActionKind } from 'vs/workbench/api/node/extHostTypes';
 import { ISingleEditOperation } from 'vs/editor/common/model';
 import * as modes from 'vs/editor/common/modes';
 import { ExtHostHeapService } from 'vs/workbench/api/node/extHostHeapService';
@@ -291,7 +291,7 @@ class CodeActionAdapter {
 
 		const codeActionContext: vscode.CodeActionContext = {
 			diagnostics: allDiagnostics,
-			requestedScope: context.requestedScope ? new CodeActionScope(context.requestedScope) : undefined
+			only: context.only ? new CodeActionKind(context.only) : undefined
 		};
 		return asWinJsPromise(token =>
 			this._provider.provideCodeActions(doc, ran, codeActionContext, token)
@@ -318,7 +318,7 @@ class CodeActionAdapter {
 						command: candidate.command && this._commands.toInternal(candidate.command),
 						diagnostics: candidate.diagnostics && candidate.diagnostics.map(DiagnosticCollection.toMarkerData),
 						edit: candidate.edit && TypeConverters.WorkspaceEdit.from(candidate.edit),
-						scope: candidate.scope && candidate.scope.value
+						kind: candidate.kind && candidate.kind.value
 					});
 				}
 			}

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -9,7 +9,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { mixin } from 'vs/base/common/objects';
 import * as vscode from 'vscode';
 import * as TypeConverters from 'vs/workbench/api/node/extHostTypeConverters';
-import { Range, Disposable, CompletionList, SnippetString, Color } from 'vs/workbench/api/node/extHostTypes';
+import { Range, Disposable, CompletionList, SnippetString, Color, CodeActionScope } from 'vs/workbench/api/node/extHostTypes';
 import { ISingleEditOperation } from 'vs/editor/common/model';
 import * as modes from 'vs/editor/common/modes';
 import { ExtHostHeapService } from 'vs/workbench/api/node/extHostHeapService';
@@ -273,7 +273,7 @@ class CodeActionAdapter {
 		this._provider = provider;
 	}
 
-	provideCodeActions(resource: URI, range: IRange): TPromise<modes.CodeAction[]> {
+	provideCodeActions(resource: URI, range: IRange, context: modes.CodeActionContext): TPromise<modes.CodeAction[]> {
 
 		const doc = this._documents.getDocumentData(resource).document;
 		const ran = <vscode.Range>TypeConverters.toRange(range);
@@ -289,8 +289,12 @@ class CodeActionAdapter {
 			}
 		});
 
+		const codeActionContext = {
+			diagnostics: allDiagnostics,
+			requestedScope: context.requestedScope ? new CodeActionScope(context.requestedScope) : undefined
+		};
 		return asWinJsPromise(token =>
-			this._provider.provideCodeActions(doc, ran, { diagnostics: allDiagnostics }, token)
+			this._provider.provideCodeActions(doc, ran, codeActionContext, token)
 		).then(commandsOrActions => {
 			if (isFalsyOrEmpty(commandsOrActions)) {
 				return undefined;
@@ -944,8 +948,8 @@ export class ExtHostLanguageFeatures implements ExtHostLanguageFeaturesShape {
 		return this._createDisposable(handle);
 	}
 
-	$provideCodeActions(handle: number, resource: UriComponents, range: IRange): TPromise<modes.CodeAction[]> {
-		return this._withAdapter(handle, CodeActionAdapter, adapter => adapter.provideCodeActions(URI.revive(resource), range));
+	$provideCodeActions(handle: number, resource: UriComponents, range: IRange, context: modes.CodeActionContext): TPromise<modes.CodeAction[]> {
+		return this._withAdapter(handle, CodeActionAdapter, adapter => adapter.provideCodeActions(URI.revive(resource), range, context));
 	}
 
 	// --- formatting

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -314,6 +314,7 @@ class CodeActionAdapter {
 						command: candidate.command && this._commands.toInternal(candidate.command),
 						diagnostics: candidate.diagnostics && candidate.diagnostics.map(DiagnosticCollection.toMarkerData),
 						edit: candidate.edit && TypeConverters.WorkspaceEdit.from(candidate.edit),
+						scope: candidate.scope && candidate.scope.value
 					});
 				}
 			}

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -844,8 +844,8 @@ export class CodeActionScope {
 		return new CodeActionScope(this.value + CodeActionScope.sep + scopes);
 	}
 
-	public matches(other: CodeActionScope): boolean {
-		return this.value === other.value || (startsWith(this.value, other.value) && other.value[this.value + 1] === CodeActionScope.sep);
+	public contains(other: CodeActionScope): boolean {
+		return this.value === other.value || startsWith(other.value, this.value + CodeActionScope.sep);
 	}
 }
 

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -12,6 +12,7 @@ import * as vscode from 'vscode';
 import { isMarkdownString } from 'vs/base/common/htmlContent';
 import { IRelativePattern } from 'vs/base/common/glob';
 import { relative } from 'path';
+import { startsWith } from 'vs/base/common/strings';
 
 export class Disposable {
 
@@ -818,11 +819,36 @@ export class CodeAction {
 
 	dianostics?: Diagnostic[];
 
+	scope?: CodeActionScope;
+
 	constructor(title: string, edit?: WorkspaceEdit) {
 		this.title = title;
 		this.edit = edit;
 	}
 }
+
+
+export class CodeActionScope {
+	private static readonly sep = '.';
+
+	public static readonly Empty = new CodeActionScope('');
+	public static readonly Refactor = new CodeActionScope('refactor');
+	public static readonly RefactorExtract = CodeActionScope.Refactor.add('extract');
+	public static readonly RefactorInline = CodeActionScope.Refactor.add('inline');
+
+	constructor(
+		public readonly value: string
+	) { }
+
+	public add(scopes: string): CodeActionScope {
+		return new CodeActionScope(this.value + CodeActionScope.sep + scopes);
+	}
+
+	public matches(other: CodeActionScope): boolean {
+		return this.value === other.value || (startsWith(this.value, other.value) && other.value[this.value + 1] === CodeActionScope.sep);
+	}
+}
+
 
 export class CodeLens {
 

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -841,7 +841,7 @@ export class CodeActionScope {
 	) { }
 
 	public add(scopes: string): CodeActionScope {
-		return new CodeActionScope(this.value + CodeActionScope.sep + scopes);
+		return new CodeActionScope(this.value ? this.value + CodeActionScope.sep + scopes : scopes);
 	}
 
 	public contains(other: CodeActionScope): boolean {

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -819,7 +819,7 @@ export class CodeAction {
 
 	dianostics?: Diagnostic[];
 
-	scope?: CodeActionScope;
+	scope?: CodeActionKind;
 
 	constructor(title: string, edit?: WorkspaceEdit) {
 		this.title = title;
@@ -828,24 +828,25 @@ export class CodeAction {
 }
 
 
-export class CodeActionScope {
+export class CodeActionKind {
 	private static readonly sep = '.';
 
-	public static readonly Empty = new CodeActionScope('');
-	public static readonly Refactor = new CodeActionScope('refactor');
-	public static readonly RefactorExtract = CodeActionScope.Refactor.add('extract');
-	public static readonly RefactorInline = CodeActionScope.Refactor.add('inline');
+	public static readonly Empty = new CodeActionKind('');
+	public static readonly Refactor = new CodeActionKind('refactor');
+	public static readonly RefactorExtract = CodeActionKind.Refactor.append('extract');
+	public static readonly RefactorInline = CodeActionKind.Refactor.append('inline');
+	public static readonly RefactorRewrite = CodeActionKind.Refactor.append('rewrite');
 
 	constructor(
 		public readonly value: string
 	) { }
 
-	public add(scopes: string): CodeActionScope {
-		return new CodeActionScope(this.value ? this.value + CodeActionScope.sep + scopes : scopes);
+	public append(parts: string): CodeActionKind {
+		return new CodeActionKind(this.value ? this.value + CodeActionKind.sep + parts : parts);
 	}
 
-	public contains(other: CodeActionScope): boolean {
-		return this.value === other.value || startsWith(other.value, this.value + CodeActionScope.sep);
+	public contains(other: CodeActionKind): boolean {
+		return this.value === other.value || startsWith(other.value, this.value + CodeActionKind.sep);
 	}
 }
 

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -832,6 +832,7 @@ export class CodeActionKind {
 	private static readonly sep = '.';
 
 	public static readonly Empty = new CodeActionKind('');
+	public static readonly QuickFix = new CodeActionKind('quickfix');
 	public static readonly Refactor = new CodeActionKind('refactor');
 	public static readonly RefactorExtract = CodeActionKind.Refactor.append('extract');
 	public static readonly RefactorInline = CodeActionKind.Refactor.append('inline');

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -641,7 +641,7 @@ suite('ExtHostLanguageFeatures', function () {
 
 	// --- quick fix
 
-	test('Quick Fix, data conversion', function () {
+	test('Quick Fix, command data conversion', function () {
 
 		disposables.push(extHost.registerCodeActionProvider(defaultSelector, {
 			provideCodeActions(): vscode.Command[] {
@@ -664,6 +664,34 @@ suite('ExtHostLanguageFeatures', function () {
 			});
 		});
 	});
+
+	test('Quick Fix, code action data conversion', function () {
+
+		disposables.push(extHost.registerCodeActionProvider(defaultSelector, {
+			provideCodeActions(): vscode.CodeAction[] {
+				return [
+					{
+						title: 'Testing1',
+						command: { title: 'Testing1Command', command: 'test1' },
+						scope: types.CodeActionScope.Empty.add('test.scope')
+					}
+				];
+			}
+		}));
+
+		return rpcProtocol.sync().then(() => {
+			return getCodeActions(model, model.getFullModelRange()).then(value => {
+				assert.equal(value.length, 1);
+
+				const [first] = value;
+				assert.equal(first.title, 'Testing1');
+				assert.equal(first.command.title, 'Testing1Command');
+				assert.equal(first.command.id, 'test1');
+				assert.equal(first.scope, 'test.scope');
+			});
+		});
+	});
+
 
 	test('Cannot read property \'id\' of undefined, #29469', function () {
 

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -673,7 +673,7 @@ suite('ExtHostLanguageFeatures', function () {
 					{
 						title: 'Testing1',
 						command: { title: 'Testing1Command', command: 'test1' },
-						scope: types.CodeActionScope.Empty.add('test.scope')
+						kind: types.CodeActionKind.Empty.append('test.scope')
 					}
 				];
 			}
@@ -687,7 +687,7 @@ suite('ExtHostLanguageFeatures', function () {
 				assert.equal(first.title, 'Testing1');
 				assert.equal(first.command.title, 'Testing1Command');
 				assert.equal(first.command.id, 'test1');
-				assert.equal(first.scope, 'test.scope');
+				assert.equal(first.kind, 'test.scope');
 			});
 		});
 	});


### PR DESCRIPTION
Fixes #41048

**Problem**
We'd like to improve the UX for refactorings. Two specific ideas:

- A refactorings context menu
- Allow a keybinding to a specific refactoring, such as extract method

**Proposal**
Introduce a new `CodeActionScope` type. This identifies the class/type of a given refactoring. All refactoring code actions for example would have a scope of `refactor.*`, with an extract method refactoring action having a scope of `refactor.extract.method`

- For the refactoring context menu, we use `CodeActionScope` to filter out any code actions that are not refactorings. The `CodeActionContext` will also have a scope field on it that a `CodeActionProvider` can use to determine which code actions to compute and return

- For keybindings, we can setup a keybinding such as:

    ```json
	{
		"key": "ctrl+shift+.",
		"command": "editor.action.codeAction",
		"args": [
			"refactor.extract"
		]
	}
    ```

    where `"refactor"` is treated as the code action scope. Only code actions of the type `"refactor.*"` should be shown

**Todo**
Still a lot to do on this PR

- [x] Tests
- [x] Hookup scope for `CodeActionContext`
- [x] Create an new `editor.action.codeAction` command instead of overloading the existing `editor.action.quickFix` command

