### PR TITLE
Webview Api Prototype

### DIFF
--- a/extensions/markdown/media/loading.js
+++ b/extensions/markdown/media/loading.js
@@ -31,6 +31,6 @@
 		window.parent.postMessage({
 			command: 'did-click-link',
 			data: `command:_markdown.onPreviewStyleLoadError?${encodeURIComponent(JSON.stringify(args))}`
-		}, 'file://');
+		}, '*');
 	});
 }());

--- a/extensions/markdown/media/main.js
+++ b/extensions/markdown/media/main.js
@@ -35,9 +35,9 @@
 	 */
 	function postMessage(command, args) {
 		window.parent.postMessage({
-			command: 'did-click-link',
-			data: `command:${command}?${encodeURIComponent(JSON.stringify(args))}`
-		}, 'file://');
+			command,
+			args
+		}, '*');
 	}
 
 	/**

--- a/extensions/markdown/package.json
+++ b/extensions/markdown/package.json
@@ -2,6 +2,7 @@
 	"name": "vscode-markdown",
 	"displayName": "VS Code Markdown",
 	"description": "Markdown for VS Code",
+	"enableProposedApi": true,
 	"version": "0.2.0",
 	"publisher": "Microsoft",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -39,8 +39,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const commandManager = new CommandManager();
 	context.subscriptions.push(commandManager);
-	commandManager.register(new commands.ShowPreviewCommand(cspArbiter, telemetryReporter));
-	commandManager.register(new commands.ShowPreviewToSideCommand(cspArbiter, telemetryReporter));
+	commandManager.register(new commands.ShowPreviewCommand(contentProvider, cspArbiter, telemetryReporter));
+	commandManager.register(new commands.ShowPreviewToSideCommand(contentProvider, cspArbiter, telemetryReporter));
 	commandManager.register(new commands.ShowSourceCommand());
 	commandManager.register(new commands.RefreshPreviewCommand(contentProvider));
 	commandManager.register(new commands.RevealLineCommand(logger));

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -33,6 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
 	loadMarkdownExtensions(contentProvider, engine);
 
 	const webviewManager = new MarkdownPreviewWebviewManager(contentProvider);
+	context.subscriptions.push(webviewManager);
 
 	context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new MDDocumentSymbolProvider(engine)));
 	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()));
@@ -51,20 +52,6 @@ export function activate(context: vscode.ExtensionContext) {
 	commandManager.register(new commands.OnPreviewStyleLoadErrorCommand());
 	commandManager.register(new commands.DidClickCommand());
 	commandManager.register(new commands.OpenDocumentLinkCommand(engine));
-
-	context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(document => {
-		if (isMarkdownFile(document)) {
-			const uri = getMarkdownUri(document.uri);
-			contentProvider.update(uri);
-		}
-	}));
-
-	context.subscriptions.push(vscode.workspace.onDidChangeTextDocument(event => {
-		if (isMarkdownFile(event.document)) {
-			const uri = getMarkdownUri(event.document.uri);
-			contentProvider.update(uri);
-		}
-	}));
 
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
 		logger.updateConfiguration();

--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -14,7 +14,7 @@ import { loadDefaultTelemetryReporter } from './telemetryReporter';
 import { loadMarkdownExtensions } from './markdownExtensions';
 import LinkProvider from './features/documentLinkProvider';
 import MDDocumentSymbolProvider from './features/documentSymbolProvider';
-import { MDDocumentContentProvider, getMarkdownUri, isMarkdownFile } from './features/previewContentProvider';
+import { MDDocumentContentProvider, getMarkdownUri, isMarkdownFile, MarkdownPreviewWebviewManager } from './features/previewContentProvider';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -32,6 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	loadMarkdownExtensions(contentProvider, engine);
 
+	const webviewManager = new MarkdownPreviewWebviewManager(contentProvider);
+
 	context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new MDDocumentSymbolProvider(engine)));
 	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()));
 
@@ -39,8 +41,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const commandManager = new CommandManager();
 	context.subscriptions.push(commandManager);
-	commandManager.register(new commands.ShowPreviewCommand(contentProvider, cspArbiter, telemetryReporter));
-	commandManager.register(new commands.ShowPreviewToSideCommand(contentProvider, cspArbiter, telemetryReporter));
+	commandManager.register(new commands.ShowPreviewCommand(webviewManager, telemetryReporter));
+	commandManager.register(new commands.ShowPreviewToSideCommand(webviewManager, telemetryReporter));
 	commandManager.register(new commands.ShowSourceCommand());
 	commandManager.register(new commands.RefreshPreviewCommand(contentProvider));
 	commandManager.register(new commands.RevealLineCommand(logger));

--- a/extensions/markdown/src/features/previewContentProvider.ts
+++ b/extensions/markdown/src/features/previewContentProvider.ts
@@ -164,7 +164,7 @@ export class MDDocumentContentProvider implements vscode.TextDocumentContentProv
 	}
 
 	private getMediaPath(mediaFile: string): string {
-		return vscode.Uri.file(this.context.asAbsolutePath(path.join('media', mediaFile))).toString();
+		return vscode.Uri.file(this.context.asAbsolutePath(path.join('media', mediaFile))).with({ scheme: 'vscode-extension-resource' }).toString();
 	}
 
 	private fixHref(resource: vscode.Uri, href: string): string {
@@ -307,14 +307,14 @@ export class MDDocumentContentProvider implements vscode.TextDocumentContentProv
 	private getCspForResource(resource: vscode.Uri, nonce: string): string {
 		switch (this.cspArbiter.getSecurityLevelForResource(resource)) {
 			case MarkdownPreviewSecurityLevel.AllowInsecureContent:
-				return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' http: https: data:; media-src 'self' http: https: data:; script-src 'nonce-${nonce}'; style-src 'self' 'unsafe-inline' http: https: data:; font-src 'self' http: https: data:;">`;
+				return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' http: https: data:; media-src 'self' http: https: data:; script-src 'nonce-${nonce}'; style-src 'self' 'unsafe-inline' http: https: data: vscode-extension-resource:; font-src 'self' http: https: data:;">`;
 
 			case MarkdownPreviewSecurityLevel.AllowScriptsAndAllContent:
 				return '';
 
 			case MarkdownPreviewSecurityLevel.Strict:
 			default:
-				return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' https: data:; media-src 'self' https: data:; script-src 'nonce-${nonce}'; style-src 'self' 'unsafe-inline' https: data:; font-src 'self' https: data:;">`;
+				return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self' https: data:; media-src 'self' https: data:; script-src 'nonce-${nonce}'; style-src 'self' 'unsafe-inline' https: data: vscode-extension-resource:; font-src 'self' https: data:;">`;
 		}
 	}
 }

--- a/extensions/markdown/src/features/previewContentProvider.ts
+++ b/extensions/markdown/src/features/previewContentProvider.ts
@@ -318,3 +318,31 @@ export class MDDocumentContentProvider implements vscode.TextDocumentContentProv
 		}
 	}
 }
+
+export class MarkdownPreviewWebviewManager {
+	public constructor(
+		private readonly contentProvider: MDDocumentContentProvider
+	) { }
+
+	public update(uri: vscode.Uri) {
+		this.contentProvider.update(uri);
+	}
+
+	public create(
+		resource: vscode.Uri,
+		viewColumn: vscode.ViewColumn
+	) {
+		const view = vscode.window.createWebview(
+			localize('previewTitle', 'Preview {0}', path.basename(resource.fsPath)),
+			viewColumn,
+			{ enableScripts: true });
+
+		this.contentProvider.provideTextDocumentContent(getMarkdownUri(resource)).then(x => view.html = x);
+
+		view.onMessage(e => {
+			vscode.commands.executeCommand(e.command, ...e.args);
+		});
+
+		return view;
+	}
+}

--- a/extensions/markdown/src/typings/ref.d.ts
+++ b/extensions/markdown/src/typings/ref.d.ts
@@ -4,4 +4,5 @@
  *--------------------------------------------------------------------------------------------*/
 
 /// <reference path='../../../../src/vs/vscode.d.ts'/>
+/// <reference path='../../../../src/vs/vscode.proposed.d.ts'/>
 /// <reference types='@types/node'/>

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -336,4 +336,70 @@ declare module 'vscode' {
 		 */
 		logger: Logger;
 	}
+
+	/**
+	 * Content settings for a webview.
+	 */
+	export interface WebviewOptions {
+		/**
+		 * Should scripts be enabled in the webview?
+		 *
+		 * Defaults to false (scripts-disabled).
+		 */
+		enableScripts?: boolean;
+
+		/**
+		 * Should command uris be enabled?
+		 *
+		 * Defaults to false.
+		 */
+		enableCommandUris?: boolean;
+	}
+
+	/**
+	 *
+	 */
+	export interface Webview {
+		/**
+		 * Title of the webview.
+		 */
+		title: string;
+
+		/**
+		 * Contents of the webview.
+		 */
+		html: string;
+
+		/**
+		 * Content settings for the webview.
+		 */
+		options: WebviewOptions;
+
+		/**
+		 * Fixed when the webview posts a message.
+		 */
+		readonly onMessage: Event<any>;
+
+		/**
+		 * Post a message to the webview.
+		 *
+		 * @param message Body of the message.
+		 */
+		postMessage(message: any): Thenable<any>;
+	}
+
+	namespace window {
+		/**
+		 * Create and show a new webview.
+		 *
+		 * @param title Title of the webview
+		 * @param column Editor column to show the new webview in
+		 * @param options Webview options
+		 */
+		export function createWebview(
+			title: string,
+			column: ViewColumn,
+			options: WebviewOptions
+		): Webview;
+	}
 }

--- a/src/vs/workbench/api/electron-browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/electron-browser/extensionHost.contribution.ts
@@ -46,6 +46,7 @@ import './mainThreadTask';
 import './mainThreadTelemetry';
 import './mainThreadTerminalService';
 import './mainThreadTreeViews';
+import './mainThreadWebview';
 import './mainThreadWindow';
 import './mainThreadWorkspace';
 

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -1,0 +1,238 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { TPromise } from 'vs/base/common/winjs.base';
+import { MainThreadWebviewShape, MainContext, IExtHostContext, ExtHostContext, ExtHostWebviewsShape } from 'vs/workbench/api/node/extHost.protocol';
+import { IDisposable, dispose, toDisposable } from 'vs/base/common/lifecycle';
+import { extHostNamedCustomer } from './extHostCustomers';
+import { EditorInput, EditorModel, EditorOptions } from 'vs/workbench/common/editor';
+import { IEditorModel, Position } from 'vs/platform/editor/common/editor';
+import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { WebviewEditor as BaseWebviewEditor } from 'vs/workbench/parts/html/browser/webviewEditor';
+import { Builder, Dimension } from 'vs/base/browser/builder';
+import { append, $ } from 'vs/base/browser/dom';
+import WebView from 'vs/workbench/parts/html/browser/webview';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IPartService, Parts } from 'vs/workbench/services/part/common/partService';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { IEditorRegistry, EditorDescriptor, Extensions as EditorExtensions } from 'vs/workbench/browser/editor';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { localize } from 'vs/nls';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import * as vscode from 'vscode';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+
+
+class WebviewInput extends EditorInput {
+	private _name: string;
+	private _options: vscode.WebviewOptions;
+	private _html: string;
+
+	constructor(
+		name: string,
+		options: vscode.WebviewOptions,
+		html: string,
+		public readonly onMessage: (message: any) => void
+	) {
+		super();
+		this._name = name;
+		this._options = options;
+		this._html = html;
+	}
+
+	public getName(): string {
+		return this._name;
+	}
+
+	public setName(value: string): void {
+		this._name = value;
+		this._onDidChangeLabel.fire();
+	}
+
+	public get html(): string {
+		return this._html;
+	}
+
+	public set html(value: string) {
+		this._html = value;
+	}
+
+
+	public get options(): vscode.WebviewOptions {
+		return this._options;
+	}
+
+	public set options(value: vscode.WebviewOptions) {
+		this._options = value;
+	}
+
+
+	public getTypeId(): string {
+		return 'webview';
+	}
+
+	public resolve(refresh?: boolean): TPromise<IEditorModel, any> {
+		return TPromise.as(new EditorModel());
+	}
+}
+
+class WebviewEditor extends BaseWebviewEditor {
+	static ID = 'WebviewEditor';
+
+	private contentDisposables: IDisposable[] = [];
+
+	constructor(
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IStorageService storageService: IStorageService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IThemeService themeService: IThemeService,
+		@IPartService private partService: IPartService,
+		@IContextViewService private _contextViewService: IContextViewService,
+		@IEnvironmentService private _environmentService: IEnvironmentService,
+		@IOpenerService private _openerService: IOpenerService
+
+	) {
+		super(WebviewEditor.ID, telemetryService, themeService, storageService, contextKeyService);
+	}
+
+	protected createEditor(parent: Builder): void {
+		const container = parent.getHTMLElement();
+		this.content = append(container, $('.release-notes', { 'style': 'height: 100%; position: relative; overflow: hidden;' }));
+	}
+
+	public layout(dimension: Dimension): void {
+		if (this._webview) {
+			this._webview.layout();
+		}
+	}
+
+	public sendMessage(data: any): void {
+		if (this._webview) {
+			this._webview.sendMessage(data);
+		}
+	}
+
+	async setInput(input: WebviewInput, options: EditorOptions): TPromise<void> {
+		if (this.input && this.input.matches(input)) {
+			return undefined;
+		}
+
+		this.contentDisposables = dispose(this.contentDisposables);
+		this.content.innerHTML = '';
+
+		await super.setInput(input, options);
+
+		this._webview = new WebView(
+			this.content,
+			this.partService.getContainer(Parts.EDITOR_PART),
+			this._environmentService,
+			this._contextViewService,
+			this.contextKey,
+			this.findInputFocusContextKey,
+			{ allowScripts: true },
+			false);
+
+		this._webview.options = {
+			allowScripts: input.options.enableScripts,
+			enableWrappedPostMessage: true
+		};
+
+		this._webview.style(this.themeService.getTheme());
+		this._webview.contents = [input.html];
+
+		this._webview.onDidClickLink(link => {
+			// Whitelist supported schemes for links
+			if (link && ['http', 'https', 'mailto'].indexOf(link.scheme) >= 0) {
+				this._openerService.open(link);
+			}
+		}, null, this.contentDisposables);
+		this._webview.onMessage(message => {
+			input.onMessage(message);
+		});
+		this.themeService.onThemeChange(theme => this._webview.style(theme), null, this.contentDisposables);
+
+		this.contentDisposables.push(this._webview);
+		this.contentDisposables.push(toDisposable(() => this._webview = null));
+	}
+}
+
+
+@extHostNamedCustomer(MainContext.MainThreadWebview)
+export class MainThreadWebview implements MainThreadWebviewShape {
+	private readonly _proxy: ExtHostWebviewsShape;
+	private readonly _webviews = new Map<number, WebviewInput>();
+
+	constructor(
+		context: IExtHostContext,
+		@IWorkbenchEditorService private readonly _editorService: IWorkbenchEditorService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService
+	) {
+		this._proxy = context.getProxy(ExtHostContext.ExtHostWebviews);
+	}
+
+	dispose(): void {
+		throw new Error('Method not implemented.');
+	}
+
+	$createWebview(handle: number): void {
+		const webview = new WebviewInput('', {}, '', message => this._proxy.$onMessage(handle, message));
+		this._webviews.set(handle, webview);
+	}
+
+	$disposeWebview(handle: number): void {
+		const webview = this._webviews.get(handle);
+		this._editorService.closeEditor(Position.ONE, webview);
+	}
+
+	$setTitle(handle: number, value: string): void {
+		const webview = this._webviews.get(handle);
+		webview.setName(value);
+	}
+
+	$setHtml(handle: number, value: string): void {
+		const existingInput = this._webviews.get(handle);
+		const newInput = this._instantiationService.createInstance(WebviewInput, existingInput.getName(), existingInput.options, value, existingInput.onMessage);
+		this._webviews.set(handle, newInput);
+		this._editorService.replaceEditors([{ toReplace: existingInput, replaceWith: newInput }]);
+	}
+
+	$setOptions(handle: number, newOptions: vscode.WebviewOptions): void {
+		const existingInput = this._webviews.get(handle);
+		const newInput = this._instantiationService.createInstance(WebviewInput, existingInput.getName(), newOptions, existingInput.html, existingInput.onMessage);
+		this._webviews.set(handle, newInput);
+		this._editorService.replaceEditors([{ toReplace: existingInput, replaceWith: newInput }]);
+	}
+
+	$show(handle: number, column: Position): void {
+		const webviewInput = this._webviews.get(handle);
+		this._editorService.openEditor(webviewInput, { pinned: true }, column);
+	}
+
+	async $sendMessage(handle: number, message: any): Promise<boolean> {
+		const webviewInput = this._webviews.get(handle);
+		const editors = this._editorService.getVisibleEditors()
+			.filter(e => e instanceof WebviewInput)
+			.map(e => e as WebviewEditor)
+			.filter(e => e.input.matches(webviewInput));
+
+		for (const editor of editors) {
+			editor.sendMessage(message);
+		}
+
+		return (editors.length > 0);
+	}
+}
+
+(<IEditorRegistry>Registry.as(EditorExtensions.Editors)).registerEditor(new EditorDescriptor(
+	WebviewEditor,
+	WebviewEditor.ID,
+	localize('webview.editor.label', "webview editor")),
+	[new SyncDescriptor(WebviewInput)]);

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -57,6 +57,7 @@ import { ExtensionActivatedByAPI } from 'vs/workbench/api/node/extHostExtensionA
 import { isFalsyOrEmpty } from 'vs/base/common/arrays';
 import { ILogService } from 'vs/platform/log/common/log';
 import { OverviewRulerLane } from 'vs/editor/common/model';
+import { ExtHostWebviews } from 'vs/workbench/api/node/extHostWebview';
 
 export interface IExtensionApiFactory {
 	(extension: IExtensionDescription): typeof vscode;
@@ -115,6 +116,7 @@ export function createApiFactory(
 	const extHostTask = rpcProtocol.set(ExtHostContext.ExtHostTask, new ExtHostTask(rpcProtocol, extHostWorkspace));
 	const extHostWindow = rpcProtocol.set(ExtHostContext.ExtHostWindow, new ExtHostWindow(rpcProtocol));
 	rpcProtocol.set(ExtHostContext.ExtHostExtensionService, extensionService);
+	const extHostWebviews = rpcProtocol.set(ExtHostContext.ExtHostWebviews, new ExtHostWebviews(rpcProtocol));
 
 	// Check that no named customers are missing
 	const expected: ProxyIdentifier<any>[] = Object.keys(ExtHostContext).map((key) => ExtHostContext[key]);
@@ -395,6 +397,9 @@ export function createApiFactory(
 			}),
 			registerDecorationProvider: proposedApiFunction(extension, (provider: vscode.DecorationProvider) => {
 				return extHostDecorations.registerDecorationProvider(provider, extension.id);
+			}),
+			createWebview: proposedApiFunction(extension, (name: string, column: vscode.ViewColumn, options: vscode.WebviewOptions) => {
+				return extHostWebviews.createWebview(name, column, options);
 			})
 		};
 

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -360,6 +360,19 @@ export interface MainThreadTelemetryShape extends IDisposable {
 	$publicLog(eventName: string, data?: any): void;
 }
 
+export interface MainThreadWebviewShape extends IDisposable {
+	$createWebview(handle: number): void;
+	$disposeWebview(handle: number): void;
+	$show(handle: number, column: EditorPosition): void;
+	$setTitle(handle: number, value: string): void;
+	$setHtml(handle: number, value: string): void;
+	$setOptions(handle: number, value: vscode.WebviewOptions): void;
+	$sendMessage(handle: number, value: any): Thenable<boolean>;
+}
+export interface ExtHostWebviewsShape {
+	$onMessage(handle: number, message: any): void;
+}
+
 export interface MainThreadWorkspaceShape extends IDisposable {
 	$startSearch(includePattern: string, includeFolder: string, excludePattern: string, maxResults: number, requestId: number): Thenable<UriComponents[]>;
 	$cancelSearch(requestId: number): Thenable<boolean>;
@@ -767,6 +780,7 @@ export const MainContext = {
 	MainThreadStorage: createMainId<MainThreadStorageShape>('MainThreadStorage'),
 	MainThreadTelemetry: createMainId<MainThreadTelemetryShape>('MainThreadTelemetry'),
 	MainThreadTerminalService: createMainId<MainThreadTerminalServiceShape>('MainThreadTerminalService'),
+	MainThreadWebview: createMainId<MainThreadWebviewShape>('MainThreadWebview'),
 	MainThreadWorkspace: createMainId<MainThreadWorkspaceShape>('MainThreadWorkspace'),
 	MainThreadFileSystem: createMainId<MainThreadFileSystemShape>('MainThreadFileSystem'),
 	MainThreadExtensionService: createMainId<MainThreadExtensionServiceShape>('MainThreadExtensionService'),
@@ -799,4 +813,5 @@ export const ExtHostContext = {
 	ExtHostTask: createExtId<ExtHostTaskShape>('ExtHostTask', ProxyType.CustomMarshaller),
 	ExtHostWorkspace: createExtId<ExtHostWorkspaceShape>('ExtHostWorkspace'),
 	ExtHostWindow: createExtId<ExtHostWindowShape>('ExtHostWindow'),
+	ExtHostWebviews: createExtId<ExtHostWebviewsShape>('ExtHostWebviews')
 };

--- a/src/vs/workbench/api/node/extHostWebview.ts
+++ b/src/vs/workbench/api/node/extHostWebview.ts
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { MainContext, MainThreadWebviewShape, IMainContext, ExtHostWebviewsShape } from './extHost.protocol';
+import * as vscode from 'vscode';
+import { Emitter } from 'vs/base/common/event';
+import * as typeConverters from 'vs/workbench/api/node/extHostTypeConverters';
+
+class ExtHostWebview implements vscode.Webview {
+	private _title: string;
+	private _html: string;
+	private _options: vscode.WebviewOptions;
+	public onMessageEmitter = new Emitter<any>();
+
+	constructor(
+		private readonly _proxy: MainThreadWebviewShape,
+		private readonly _handle: number,
+	) { }
+
+	get title(): string {
+		return this._title;
+	}
+
+	set title(value: string) {
+		if (this._title !== value) {
+			this._title = value;
+			this._proxy.$setTitle(this._handle, value);
+		}
+	}
+
+	get html(): string {
+		return this._html;
+	}
+
+	set html(value: string) {
+		if (this._html !== value) {
+			this._html = value;
+			this._proxy.$setHtml(this._handle, value);
+		}
+	}
+
+	get options(): vscode.WebviewOptions {
+		return this._options;
+	}
+
+	set options(value: vscode.WebviewOptions) {
+		this._proxy.$setOptions(this._handle, value);
+	}
+
+	public postMessage(message: any): Thenable<any> {
+		return this._proxy.$sendMessage(this._handle, message);
+	}
+
+	public get onMessage(): vscode.Event<any> {
+		return this.onMessageEmitter.event;
+	}
+}
+
+export class ExtHostWebviews implements ExtHostWebviewsShape {
+	private static _handlePool = 0;
+
+	private readonly _proxy: MainThreadWebviewShape;
+
+	private readonly _webviews = new Map<number, ExtHostWebview>();
+
+	constructor(
+		mainContext: IMainContext
+	) {
+		this._proxy = mainContext.getProxy(MainContext.MainThreadWebview);
+	}
+
+	createWebview(
+		title: string,
+		column: vscode.ViewColumn,
+		options: vscode.WebviewOptions
+	): vscode.Webview {
+		const handle = ExtHostWebviews._handlePool++;
+		this._proxy.$createWebview(handle);
+
+		const webview = new ExtHostWebview(this._proxy, handle);
+		this._webviews.set(handle, webview);
+		webview.title = title;
+		webview.options = options;
+		this._proxy.$show(handle, typeConverters.fromViewColumn(column));
+		return webview;
+	}
+
+	$onMessage(handle: number, message: any): void {
+		const webview = this._webviews.get(handle);
+		webview.onMessageEmitter.fire(message);
+	}
+}

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -39,6 +39,7 @@ export interface WebviewOptions {
 	allowScripts?: boolean;
 	allowSvgs?: boolean;
 	svgWhiteList?: string[];
+	enableWrappedPostMessage?: boolean;
 }
 
 export default class Webview {
@@ -49,6 +50,7 @@ export default class Webview {
 
 	private _onDidScroll = new Emitter<{ scrollYPercentage: number }>();
 	private _onFoundInPageResults = new Emitter<FoundInPageResults>();
+	private _onMessage = new Emitter<any>();
 
 	private _webviewFindWidget: WebviewFindWidget;
 	private _findStarted: boolean = false;
@@ -103,6 +105,7 @@ export default class Webview {
 				const contents = this._webview.getWebContents();
 				if (contents && !contents.isDestroyed()) {
 					registerFileProtocol(contents, 'vscode-core-resource', [this._environmentService.appRoot]);
+					registerFileProtocol(contents, 'vscode-extension-resource', [this._environmentService.extensionsPath, this._environmentService.appRoot, this._environmentService.extensionDevelopmentPath]);
 				}
 			}));
 		}
@@ -157,6 +160,12 @@ export default class Webview {
 			}),
 			addDisposableListener(this._webview, 'ipc-message', (event) => {
 				switch (event.channel) {
+					case 'onmessage':
+						if (this._options.enableWrappedPostMessage && event.args && event.args.length) {
+							this._onMessage.fire(event.args[0]);
+						}
+						return;
+
 					case 'did-click-link':
 						let [uri] = event.args;
 						this._onDidClickLink.fire(URI.parse(uri));
@@ -233,6 +242,10 @@ export default class Webview {
 
 	get onFindResults(): Event<FoundInPageResults> {
 		return this._onFoundInPageResults.event;
+	}
+
+	get onMessage(): Event<any> {
+		return this._onMessage.event;
 	}
 
 	private _send(channel: string, ...args: any[]): void {

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -440,6 +440,7 @@ function registerFileProtocol(
 				callback({ path: normalizedPath });
 				return;
 			}
+
 		}
 		callback({ error: 'Cannot load resource outside of protocol root' });
 	}, (error) => {


### PR DESCRIPTION
#41047

Proposes a new Api for webviews. This API aims to make the current html preview api more usable, safer, and more extensible for the future.

Besides the new API, the new webviews also differ in several important ways:

- They are no longer loaded in the `file://` origin so they can't read files on disk (you have to use the new protocols for this)
- Scripts are disabled by default
- Command uris are disabled by default
- `postMessage` inside of webviews now posts back to vscode directly (no more weird click faking required)

**TODO**
- [ ] Discuss and finalize API
- [ ] Add `onFocus` and `onBlur` to the webview object
- [ ] See if implementation can be cleaned up
- [ ] Add dispose method on webview
- [ ] Add editorColumn property on webview
- [ ] Make `enableCommandUris` option actually enable command uris
- [ ] Add a new protocol for accessing a resource inside of a workspace folder (markdown loading a local image for example)
- [ ] Finish moving markdown extension to use the new API
