### PR TITLE
Add workbench.fontAliasing.auto option

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -256,14 +256,15 @@ configurationRegistry.registerConfiguration({
 		},
 		'workbench.fontAliasing': {
 			'type': 'string',
-			'enum': ['default', 'antialiased', 'none'],
+			'enum': ['default', 'antialiased', 'none', 'auto'],
 			'default': 'default',
 			'description':
-				nls.localize('fontAliasing', "Controls font aliasing method in the workbench.\n- default: Sub-pixel font smoothing. On most non-retina displays this will give the sharpest text\n- antialiased: Smooth the font on the level of the pixel, as opposed to the subpixel. Can make the font appear lighter overall\n- none: Disables font smoothing. Text will show with jagged sharp edges"),
+				nls.localize('fontAliasing', "Controls font aliasing method in the workbench.\n- default: Sub-pixel font smoothing. On most non-retina displays this will give the sharpest text\n- antialiased: Smooth the font on the level of the pixel, as opposed to the subpixel. Can make the font appear lighter overall\n- none: Disables font smoothing. Text will show with jagged sharp edges\n- auto: Applies `default` or `antialiased` automatically based on the DPI of displays."),
 			'enumDescriptions': [
 				nls.localize('workbench.fontAliasing.default', "Sub-pixel font smoothing. On most non-retina displays this will give the sharpest text."),
 				nls.localize('workbench.fontAliasing.antialiased', "Smooth the font on the level of the pixel, as opposed to the subpixel. Can make the font appear lighter overall."),
-				nls.localize('workbench.fontAliasing.none', "Disables font smoothing. Text will show with jagged sharp edges.")
+				nls.localize('workbench.fontAliasing.none', "Disables font smoothing. Text will show with jagged sharp edges."),
+				nls.localize('workbench.fontAliasing.auto', "Applies `default` or `antialiased` automatically based on the DPI of displays.")
 			],
 			'included': isMacintosh
 		},

--- a/src/vs/workbench/electron-browser/media/workbench.css
+++ b/src/vs/workbench/electron-browser/media/workbench.css
@@ -36,10 +36,6 @@
 	-webkit-font-smoothing: none;
 }
 
-.monaco-font-aliasing-auto {
-	-webkit-font-smoothing: subpixel-antialiased;
-}
-
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 	.monaco-font-aliasing-auto {
 		-webkit-font-smoothing: antialiased;

--- a/src/vs/workbench/electron-browser/media/workbench.css
+++ b/src/vs/workbench/electron-browser/media/workbench.css
@@ -28,10 +28,6 @@
 	margin-top: 7px; /* Center the select box */
 }
 
-.monaco-font-aliasing-default {
-	-webkit-font-smoothing: subpixel-antialiased;
-}
-
 .monaco-font-aliasing-antialiased {
 	-webkit-font-smoothing: antialiased;
 }

--- a/src/vs/workbench/electron-browser/media/workbench.css
+++ b/src/vs/workbench/electron-browser/media/workbench.css
@@ -27,3 +27,25 @@
 .monaco-workbench.windows .monaco-action-bar .select-box {
 	margin-top: 7px; /* Center the select box */
 }
+
+.monaco-font-aliasing-default {
+	-webkit-font-smoothing: subpixel-antialiased;
+}
+
+.monaco-font-aliasing-antialiased {
+	-webkit-font-smoothing: antialiased;
+}
+
+.monaco-font-aliasing-none {
+	-webkit-font-smoothing: none;
+}
+
+.monaco-font-aliasing-auto {
+	-webkit-font-smoothing: subpixel-antialiased;
+}
+
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+	.monaco-font-aliasing-auto {
+		-webkit-font-smoothing: antialiased;
+	}
+}

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -124,6 +124,8 @@ export interface IWorkbenchStartedInfo {
 	restoredEditors: string[];
 }
 
+type FontAliasingOption = 'default' | 'antialiased' | 'none' | 'auto';
+
 const Identifiers = {
 	WORKBENCH_CONTAINER: 'workbench.main.container',
 	TITLEBAR_PART: 'workbench.parts.titlebar',
@@ -202,7 +204,7 @@ export class Workbench implements IPartService {
 	private inZenMode: IContextKey<boolean>;
 	private sideBarVisibleContext: IContextKey<boolean>;
 	private hasFilesToCreateOpenOrDiff: boolean;
-	private fontAliasing: string;
+	private fontAliasing: FontAliasingOption;
 	private zenMode: {
 		active: boolean;
 		transitionedToFullScreen: boolean;
@@ -643,7 +645,7 @@ export class Workbench implements IPartService {
 		this.activityBarHidden = !activityBarVisible;
 
 		// Font aliasing
-		this.fontAliasing = this.configurationService.getValue<string>(Workbench.fontAliasingConfigurationKey);
+		this.fontAliasing = this.configurationService.getValue<FontAliasingOption>(Workbench.fontAliasingConfigurationKey);
 
 		// Zen mode
 		this.zenMode = {
@@ -937,10 +939,16 @@ export class Workbench implements IPartService {
 		});
 	}
 
-	private setFontAliasing(aliasing: string) {
+	private setFontAliasing(aliasing: FontAliasingOption) {
 		this.fontAliasing = aliasing;
-
-		document.body.style['-webkit-font-smoothing'] = (aliasing === 'default' ? '' : aliasing);
+		const fontAliasingClassNames = [
+			'monaco-font-aliasing-default',
+			'monaco-font-aliasing-antialiased',
+			'monaco-font-aliasing-none',
+			'monaco-font-aliasing-auto'
+		];
+		document.body.classList.remove(...fontAliasingClassNames);
+		document.body.classList.add(`monaco-font-aliasing-${aliasing}`);
 	}
 
 	public dispose(reason = ShutdownReason.QUIT): void {
@@ -1088,7 +1096,7 @@ export class Workbench implements IPartService {
 
 		this.setPanelPositionFromStorageOrConfig();
 
-		const fontAliasing = this.configurationService.getValue<string>(Workbench.fontAliasingConfigurationKey);
+		const fontAliasing = this.configurationService.getValue<FontAliasingOption>(Workbench.fontAliasingConfigurationKey);
 		if (fontAliasing !== this.fontAliasing) {
 			this.setFontAliasing(fontAliasing);
 		}

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -942,13 +942,14 @@ export class Workbench implements IPartService {
 	private setFontAliasing(aliasing: FontAliasingOption) {
 		this.fontAliasing = aliasing;
 		const fontAliasingClassNames = [
-			'monaco-font-aliasing-default',
 			'monaco-font-aliasing-antialiased',
 			'monaco-font-aliasing-none',
 			'monaco-font-aliasing-auto'
 		];
 		document.body.classList.remove(...fontAliasingClassNames);
-		document.body.classList.add(`monaco-font-aliasing-${aliasing}`);
+		if (aliasing !== 'default') {
+			document.body.classList.add(`monaco-font-aliasing-${aliasing}`);
+		}
 	}
 
 	public dispose(reason = ShutdownReason.QUIT): void {


### PR DESCRIPTION
Add `workbench.fontAliasing.auto` option, which applies `default` on non-retina displays and `antialiased` on retina displays automatically, adding some pleasure when moving `vscode` around multiple displays.