### PR TITLE
Added indentation rules for cpp

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -1,4 +1,9 @@
 {
+	"indentationRules": {
+        "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$|^\\s*(public|private|protected):\\s*$|^\\s*@(public|private|protected)\\s*$|^\\s*\\{\\}$",
+        "decreaseIndentPattern": "^\\s*(\\s*/[*].*[*]/\\s*)*\\}|^\\s*(\\s*/[*].*[*]/\\s*)*\\)|^\\s*(public|private|protected):\\s*$|^\\s*@(public|private|protected)\\s*$",
+        "indentNextLinePattern": "^(?!.*;\\s*//).*[^\\s;{}]\\s*$"
+    },
 	"comments": {
 		"lineComment": "//",
 		"blockComment": ["/*", "*/"]

--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -1,9 +1,9 @@
 {
 	"indentationRules": {
-        "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$|^\\s*(public|private|protected):\\s*$|^\\s*@(public|private|protected)\\s*$|^\\s*\\{\\}$",
-        "decreaseIndentPattern": "^\\s*(\\s*/[*].*[*]/\\s*)*\\}|^\\s*(\\s*/[*].*[*]/\\s*)*\\)|^\\s*(public|private|protected):\\s*$|^\\s*@(public|private|protected)\\s*$",
-        "indentNextLinePattern": "^(?!.*;\\s*//).*[^\\s;{}]\\s*$"
-    },
+		"increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$|^\\s*(public|private|protected):\\s*$|^\\s*@(public|private|protected)\\s*$|^\\s*\\{\\}$",
+		"decreaseIndentPattern": "^\\s*(\\s*/[*].*[*]/\\s*)*\\}|^\\s*(\\s*/[*].*[*]/\\s*)*\\)|^\\s*(public|private|protected):\\s*$|^\\s*@(public|private|protected)\\s*$",
+		"indentNextLinePattern": "^(?!.*;\\s*//).*[^\\s;{}]\\s*$"
+	},
 	"comments": {
 		"lineComment": "//",
 		"blockComment": ["/*", "*/"]


### PR DESCRIPTION
Reformatted from Atom language-c extension (https://github.com/atom/language-c/blob/master/settings/language-c.cson)

Related to https://github.com/Microsoft/vscode-cpptools/issues/883