### PR TITLE
Fix typings for electron.WebviewTag.executeJavaScript

### DIFF
--- a/src/typings/electron.d.ts
+++ b/src/typings/electron.d.ts
@@ -5613,7 +5613,7 @@ declare namespace Electron {
 		 * context in the page. HTML APIs like requestFullScreen, which require user
 		 * action, can take advantage of this option for automation.
 		 */
-		executeJavaScript(code: string, userGesture: boolean, callback?: (result: any) => void): void;
+		executeJavaScript(code: string, userGesture?: boolean, callback?: (result: any) => void): void;
 		/**
 		 * Starts a request to find all matches for the text in the web page and returns an
 		 * Integer representing the request id used for the request. The result of the


### PR DESCRIPTION
According to documentation of [`<webview>`][1], second parameter
`userGesture` has a default value. This means that it is an optional
parameter.

[1]: https://electronjs.org/docs/api/webview-tag#webviewexecutejavascriptcode-usergesture-callback