### PR TITLE
Take kind instead of edit in CodeAction ctor

### DIFF
--- a/extensions/typescript/src/features/quickFixProvider.ts
+++ b/extensions/typescript/src/features/quickFixProvider.ts
@@ -131,10 +131,8 @@ export default class TypeScriptQuickFixProvider implements vscode.CodeActionProv
 		diagnostic: vscode.Diagnostic,
 		tsAction: Proto.CodeFixAction
 	): vscode.CodeAction {
-		const codeAction = new vscode.CodeAction(
-			tsAction.description,
-			getEditForCodeAction(this.client, tsAction));
-
+		const codeAction = new vscode.CodeAction(tsAction.description, vscode.CodeActionKind.QuickFix);
+		codeAction.edit = getEditForCodeAction(this.client, tsAction);
 		codeAction.diagnostics = [diagnostic];
 		if (tsAction.commands) {
 			codeAction.command = {
@@ -172,7 +170,8 @@ export default class TypeScriptQuickFixProvider implements vscode.CodeActionProv
 
 			const codeAction = new vscode.CodeAction(
 				localize('fixAllInFileLabel', '{0} (Fix all in file)', tsAction.description),
-				createWorkspaceEditFromFileCodeEdits(this.client, combinedCodeFixesResponse.body.changes));
+				vscode.CodeActionKind.QuickFix);
+			codeAction.edit = createWorkspaceEditFromFileCodeEdits(this.client, combinedCodeFixesResponse.body.changes);
 			codeAction.diagnostics = [diagnostic];
 			if (tsAction.commands) {
 				codeAction.command = {

--- a/extensions/typescript/src/features/refactorProvider.ts
+++ b/extensions/typescript/src/features/refactorProvider.ts
@@ -144,26 +144,22 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 			const actions: vscode.CodeAction[] = [];
 			for (const info of response.body) {
 				if (info.inlineable === false) {
-					actions.push({
+					const codeAction = new vscode.CodeAction(info.description, vscode.CodeActionKind.Refactor);
+					codeAction.command = {
 						title: info.description,
-						command: {
-							title: info.description,
-							command: SelectRefactorCommand.ID,
-							arguments: [document, file, info, range]
-						},
-						kind: vscode.CodeActionKind.Refactor
-					});
+						command: SelectRefactorCommand.ID,
+						arguments: [document, file, info, range]
+					};
+					actions.push(codeAction);
 				} else {
 					for (const action of info.actions) {
-						actions.push({
+						const codeAction = new vscode.CodeAction(action.description, TypeScriptRefactorProvider.getKind(action));
+						codeAction.command = {
 							title: action.description,
-							command: {
-								title: action.description,
-								command: ApplyRefactoringCommand.ID,
-								arguments: [document, file, info.name, action.name, range]
-							},
-							kind: TypeScriptRefactorProvider.getKind(action)
-						});
+							command: ApplyRefactoringCommand.ID,
+							arguments: [document, file, info.name, action.name, range]
+						};
+						actions.push(codeAction);
 					}
 				}
 			}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1897,7 +1897,7 @@ declare module 'vscode' {
 	export class CodeAction {
 
 		/**
-		 * A short, human-readanle, title for this code action.
+		 * A short, human-readable, title for this code action.
 		 */
 		title: string;
 
@@ -1925,7 +1925,7 @@ declare module 'vscode' {
 		 *
 		 * Used to filter code actions.
 		 */
-		readonly kind?: CodeActionKind;
+		kind?: CodeActionKind;
 
 		/**
 		 * Creates a new code action.
@@ -1934,9 +1934,9 @@ declare module 'vscode' {
 		 * or a [command](#CodeAction.command).
 		 *
 		 * @param title The title of the code action.
-		 * @param edits The edit of the code action.
+		 * @param kind The kind of the code action.
 		 */
-		constructor(title: string, edit?: WorkspaceEdit);
+		constructor(title: string, kind?: CodeActionKind);
 	}
 
 	/**

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -417,10 +417,10 @@ export class ExtHostApiCommands {
 				} else {
 					const ret = new types.CodeAction(
 						codeAction.title,
-						typeConverters.WorkspaceEdit.to(codeAction.edit)
+						codeAction.kind ? new types.CodeActionKind(codeAction.kind) : undefined
 					);
-					if (codeAction.kind) {
-						ret.scope = new types.CodeActionKind(codeAction.kind);
+					if (codeAction.edit) {
+						ret.edit = typeConverters.WorkspaceEdit.to(codeAction.edit);
 					}
 					return ret;
 				}

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -819,11 +819,11 @@ export class CodeAction {
 
 	dianostics?: Diagnostic[];
 
-	scope?: CodeActionKind;
+	kind?: CodeActionKind;
 
-	constructor(title: string, edit?: WorkspaceEdit) {
+	constructor(title: string, kind?: CodeActionKind) {
 		this.title = title;
-		this.edit = edit;
+		this.kind = kind;
 	}
 }
 


### PR DESCRIPTION
Changes the `CodeAction` constructor to take a kind instead of an edit. This makes the API more consistent IMO, as now both `edit` and `command` on `CodeAction` are set the same way

The `CodeAction` class is new for VS Code 1.20 so this is not an breaking API change