### PR TITLE
Use special prefix to tell TS that a resource is in-memory only

### DIFF
--- a/extensions/typescript/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript/src/features/bufferSyncSupport.ts
@@ -48,11 +48,8 @@ class SyncedBuffer {
 			}
 		}
 
-		if (this.client.apiVersion.has230Features() && this.document.uri.scheme === fileSchemes.file) {
-			const root = this.client.getWorkspaceRootForResource(this.document.uri);
-			if (root) {
-				args.projectRootPath = root;
-			}
+		if (this.client.apiVersion.has230Features()) {
+			args.projectRootPath = this.client.getWorkspaceRootForResource(this.document.uri);
 		}
 
 		if (this.client.apiVersion.has240Features()) {

--- a/extensions/typescript/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript/src/features/bufferSyncSupport.ts
@@ -10,6 +10,7 @@ import * as Proto from '../protocol';
 import { ITypeScriptServiceClient } from '../typescriptService';
 import { Delayer } from '../utils/async';
 import * as languageModeIds from '../utils/languageModeIds';
+import * as fileSchemes from '../utils/fileSchemes';
 
 interface IDiagnosticRequestor {
 	requestDiagnostic(filepath: string): void;
@@ -47,7 +48,7 @@ class SyncedBuffer {
 			}
 		}
 
-		if (this.client.apiVersion.has230Features()) {
+		if (this.client.apiVersion.has230Features() && this.document.uri.scheme === fileSchemes.file) {
 			const root = this.client.getWorkspaceRootForResource(this.document.uri);
 			if (root) {
 				args.projectRootPath = root;

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -633,8 +633,10 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 					return root.uri.fsPath;
 				}
 			}
+			return roots[0].uri.fsPath;
 		}
-		return roots[0].uri.fsPath;
+
+		return undefined;
 	}
 
 	public execute(command: string, args: any, expectsResultOrToken?: boolean | CancellationToken): Promise<any> {

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -578,12 +578,12 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 	}
 
 	public normalizePath(resource: Uri): string | null {
-		if (resource.scheme === fileSchemes.walkThroughSnippet) {
-			return resource.toString();
-		}
-
-		if (resource.scheme === fileSchemes.untitled && this._apiVersion.has213Features()) {
-			return resource.toString();
+		if (this._apiVersion.has213Features()) {
+			if (resource.scheme === fileSchemes.walkThroughSnippet || resource.scheme === fileSchemes.untitled) {
+				const dirName = path.dirname(resource.path);
+				const fileName = this.inMemoryResourcePrefix + path.basename(resource.path);
+				return resource.with({ path: path.join(dirName, fileName) }).toString(true);
+			}
 		}
 
 		if (resource.scheme !== fileSchemes.file) {
@@ -599,11 +599,24 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 		return result.replace(new RegExp('\\' + this.pathSeparator, 'g'), '/');
 	}
 
+	private get inMemoryResourcePrefix(): string {
+		return this._apiVersion.has270Features() ? '^' : '';
+	}
+
 	public asUrl(filepath: string): Uri {
-		if (filepath.startsWith(TypeScriptServiceClient.WALK_THROUGH_SNIPPET_SCHEME_COLON)
-			|| (filepath.startsWith(fileSchemes.untitled + ':') && this._apiVersion.has213Features())
-		) {
-			return Uri.parse(filepath);
+		if (this._apiVersion.has213Features()) {
+			if (filepath.startsWith(TypeScriptServiceClient.WALK_THROUGH_SNIPPET_SCHEME_COLON) || (filepath.startsWith(fileSchemes.untitled + ':'))
+			) {
+				let resource = Uri.parse(filepath);
+				if (this.inMemoryResourcePrefix) {
+					const dirName = path.dirname(resource.path);
+					const fileName = path.basename(resource.path);
+					if (fileName.startsWith(this.inMemoryResourcePrefix)) {
+						resource = resource.with({ path: path.join(dirName, fileName.slice(this.inMemoryResourcePrefix.length)) });
+					}
+				}
+				return resource;
+			}
 		}
 		return Uri.file(filepath);
 	}


### PR DESCRIPTION
Fixes #40915

See https://github.com/Microsoft/TypeScript/issues/21204 for background. TypeScript requests that we mark in-memory files with `^`.
