### PR TITLE
Revert - move striping logic back to javascript for running extensions

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/media/runtimeExtensionsEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/runtimeExtensionsEditor.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row:nth-child(even):not(:hover):not(.focused) {
+.runtime-extensions-editor .monaco-list .monaco-list-rows > .monaco-list-row.odd:not(:hover):not(.focused) {
 	background-color: rgba(130, 130, 130, 0.08);
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/runtimeExtensionsEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/runtimeExtensionsEditor.ts
@@ -291,6 +291,8 @@ export class RuntimeExtensionsEditor extends BaseEditor {
 
 				data.elementDisposables = dispose(data.elementDisposables);
 
+				toggleClass(data.root, 'odd', index % 2 === 1);
+
 				data.name.textContent = element.marketplaceInfo ? element.marketplaceInfo.displayName : element.description.displayName;
 
 				const activationTimes = element.status.activationTimes;


### PR DESCRIPTION
I haven't had a list long enough to test it on OSS Dev, so...
When you scroll down and then up (or vice versa) you'll get 2 consecutive rows with the same color:
![running_extensions](https://user-images.githubusercontent.com/9638156/35267710-3b186cfa-0038-11e8-8bf3-20f6d5e8f041.png)

cc @isidorn 