### PR TITLE
FIXED: issue window opened as modal/child, fixes #42024

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -198,7 +198,7 @@ const hygiene = exports.hygiene = (some, options) => {
 		tsfmt.processString(file.path, file.contents.toString('utf8'), {
 			verify: true,
 			tsfmt: true,
-			// verbose: true
+			verbose: true
 		}).then(result => {
 			if (result.error) {
 				console.error(result.message);

--- a/src/vs/platform/issue/electron-main/issueService.ts
+++ b/src/vs/platform/issue/electron-main/issueService.ts
@@ -36,12 +36,14 @@ export class IssueService implements IIssueService {
 			});
 		}
 
+		// focusedWindow can be null (eg. using the Help menu in macOS)
+		const focusedWindow = BrowserWindow.getFocusedWindow();
 		this._issueWindow = new BrowserWindow({
 			width: 800,
 			height: 900,
 			title: 'Issue Reporter',
-			modal: true,
-			parent: BrowserWindow.getFocusedWindow()
+			modal: focusedWindow !== null ? true : false,
+			parent: focusedWindow
 		});
 
 		this._issueWindow.setMenuBarVisibility(false); // workaround for now, until a menu is implemented

--- a/src/vs/platform/issue/electron-main/issueService.ts
+++ b/src/vs/platform/issue/electron-main/issueService.ts
@@ -36,14 +36,11 @@ export class IssueService implements IIssueService {
 			});
 		}
 
-		// focusedWindow can be null (eg. using the Help menu in macOS)
-		const focusedWindow = BrowserWindow.getFocusedWindow();
 		this._issueWindow = new BrowserWindow({
 			width: 800,
 			height: 900,
 			title: 'Issue Reporter',
-			modal: focusedWindow !== null ? true : false,
-			parent: focusedWindow
+			parent: BrowserWindow.getFocusedWindow()
 		});
 
 		this._issueWindow.setMenuBarVisibility(false); // workaround for now, until a menu is implemented

--- a/src/vs/platform/issue/electron-main/issueService.ts
+++ b/src/vs/platform/issue/electron-main/issueService.ts
@@ -40,7 +40,8 @@ export class IssueService implements IIssueService {
 			width: 800,
 			height: 900,
 			title: 'Issue Reporter',
-			alwaysOnTop: true
+			modal: true,
+			parent: BrowserWindow.getFocusedWindow()
 		});
 
 		this._issueWindow.setMenuBarVisibility(false); // workaround for now, until a menu is implemented


### PR DESCRIPTION
I think the issue reporter window shouldn't be opened as `always on top`. This PR opens it as modal instead.

See #42024.