### PR TITLE
Display enabled extension information in Issue Reporter

### DIFF
--- a/src/vs/code/electron-browser/issue/issueReporterModel.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterModel.ts
@@ -6,9 +6,16 @@
 'use strict';
 
 import { assign } from 'vs/base/common/objects';
+import { ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
+
+export enum IssueType {
+	Bug,
+	PerformanceIssue,
+	FeatureRequest
+}
 
 export interface IssueReporterData {
-	issueType?: number;
+	issueType?: IssueType;
 	issueDescription?: string;
 	versionInfo?: any;
 	systemInfo?: any;
@@ -17,6 +24,9 @@ export interface IssueReporterData {
 	includeSystemInfo?: boolean;
 	includeWorkspaceInfo?: boolean;
 	includeProcessInfo?: boolean;
+	includeExtensions?: boolean;
+	numberOfThemeExtesions?: number;
+	enabledNonThemeExtesions?: ILocalExtension[];
 }
 
 export class IssueReporterModel {
@@ -55,9 +65,9 @@ ${this.getInfos()}
 	}
 
 	private getIssueTypeTitle(): string {
-		if (this._data.issueType === 0) {
+		if (this._data.issueType === IssueType.Bug) {
 			return 'Bug';
-		} else if (this._data.issueType === 1) {
+		} else if (this._data.issueType === IssueType.PerformanceIssue) {
 			return 'Performance Issue';
 		} else {
 			return 'Feature Request';
@@ -71,8 +81,13 @@ ${this.getInfos()}
 			info += this.generateSystemInfoMd();
 		}
 
-		// For perf issue, add process info and workspace info too
-		if (this._data.issueType === 1) {
+		if (this._data.issueType === IssueType.Bug) {
+			if (this._data.includeExtensions) {
+				info += this.generateExtensionsMd();
+			}
+		}
+
+		if (this._data.issueType === IssueType.PerformanceIssue) {
 
 			if (this._data.includeProcessInfo) {
 				info += this.generateProcessInfoMd();
@@ -80,6 +95,10 @@ ${this.getInfos()}
 
 			if (this._data.includeWorkspaceInfo) {
 				info += this.generateWorkspaceInfoMd();
+			}
+
+			if (this._data.includeExtensions) {
+				info += this.generateExtensionsMd();
 			}
 		}
 
@@ -130,5 +149,35 @@ ${this._data.workspaceInfo};
 
 </details>
 `;
+	}
+
+	private generateExtensionsMd(): string {
+		const themeExclusionStr = this._data.numberOfThemeExtesions ? `\n(${this._data.numberOfThemeExtesions} theme extensions excluded)` : '';
+
+		if (!this._data.enabledNonThemeExtesions) {
+			return 'Extensions: none' + themeExclusionStr;
+		}
+
+		let tableHeader = `Extension|Author (truncated)|Version
+---|---|---`;
+		const table = this._data.enabledNonThemeExtesions.map(e => {
+			return `${e.manifest.name}|${e.manifest.publisher.substr(0, 3)}|${e.manifest.version}`;
+		}).join('\n');
+
+		const extensionTable = `<details><summary>Extensions (${this._data.enabledNonThemeExtesions.length})</summary>
+
+${tableHeader}
+${table}
+${themeExclusionStr}
+
+</details>`;
+
+		// 2000 chars is browsers de-facto limit for URLs, 400 chars are allowed for other string parts of the issue URL
+		// http://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+		if (encodeURIComponent(extensionTable).length > 1600) {
+			return 'the listing length exceeds browsers\' URL characters limit';
+		}
+
+		return extensionTable;
 	}
 }

--- a/src/vs/code/electron-browser/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterPage.ts
@@ -81,6 +81,18 @@ export default (): string => `
 				</pre>
 			</details>
 		</div>
+		<div class="block block-extensions">
+			<details>
+				<summary>${escape(localize('extensions', "Extensions"))}
+					<input type="checkbox" id="includeExtensions" checked>
+						<label class="caption" for="includeExtensions">${escape(localize('sendData', "Send my data"))}</label>
+					</input>
+				</summary>
+				<div class="block-info">
+					<!-- To be dynamically filled -->
+				</div>
+			</details>
+		</div>
 	</div>
 
 	<div class="input-group">

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -452,12 +452,6 @@ export class CodeApplication {
 
 		// Start shared process here
 		this.sharedProcess.spawn();
-
-		// Launch Issue BrowserWindow if --issue is specified
-		if (this.environmentService.args.issue) {
-			const issueService = accessor.get(IIssueService);
-			issueService.openReporter();
-		}
 	}
 
 	private dispose(): void {

--- a/src/vs/code/electron-main/diagnostics.ts
+++ b/src/vs/code/electron-main/diagnostics.ts
@@ -215,7 +215,6 @@ function getProcessList(info: IMainProcessInfo, rootProcess: ProcessItem): Proce
 	info.windows.forEach(window => mapPidToWindowTitle.set(window.pid, window.title));
 
 	const processes: ProcessInfo[] = [];
-	getProcessItem(mapPidToWindowTitle, processes, rootProcess, 0);
 
 	if (rootProcess) {
 		getProcessItem(mapPidToWindowTitle, processes, rootProcess, 0);

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -12,7 +12,6 @@ export interface ParsedArgs {
 	help?: boolean;
 	version?: boolean;
 	status?: boolean;
-	issue?: boolean;
 	wait?: boolean;
 	waitMarkerFilePath?: string;
 	diff?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -74,7 +74,6 @@ const options: minimist.Opts = {
 		'new-window': 'n',
 		'reuse-window': 'r',
 		performance: 'p',
-		'issue': 'i',
 		'disable-extensions': 'disableExtensions',
 		'extensions-dir': 'extensionHomePath',
 		'debugPluginHost': 'inspect-extensions',
@@ -168,7 +167,6 @@ const troubleshootingHelp: { [name: string]: string; } = {
 	'--inspect-brk-extensions': localize('inspect-brk-extensions', "Allow debugging and profiling of extensions with the extension host being paused after start. Check the developer tools for the connection uri."),
 	'--disable-gpu': localize('disableGPU', "Disable GPU hardware acceleration."),
 	'--upload-logs': localize('uploadLogs', "Uploads logs from current session to a secure endpoint."),
-	'-i, --issue': localize('issue', "Report an issue."),
 };
 
 export function formatOptions(options: { [name: string]: string; }, columns: number): string {

--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -156,7 +156,6 @@ export class EnvironmentService implements IEnvironmentService {
 
 	get performance(): boolean { return this._args.performance; }
 	get status(): boolean { return this._args.status; }
-	get issue(): boolean { return this._args.issue; }
 
 	@memoize
 	get mainIPCHandle(): string { return getIPCHandle(this.userDataPath, 'main'); }

--- a/src/vs/platform/issue/common/issue.ts
+++ b/src/vs/platform/issue/common/issue.ts
@@ -7,6 +7,7 @@
 
 import { TPromise } from 'vs/base/common/winjs.base';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 
 export const ID = 'issueService';
 export const IIssueService = createDecorator<IIssueService>(ID);
@@ -23,10 +24,15 @@ export interface IssueReporterStyles {
 	buttonBackground: string;
 	buttonForeground: string;
 	buttonHoverBackground: string;
+}
+
+export interface IssueReporterData {
+	styles: IssueReporterStyles;
 	zoomLevel: number;
+	enabledExtensions: ILocalExtension[];
 }
 
 export interface IIssueService {
 	_serviceBrand: any;
-	openReporter(theme?: IssueReporterStyles): TPromise<void>;
+	openReporter(data: IssueReporterData): TPromise<void>;
 }

--- a/src/vs/platform/issue/common/issueIpc.ts
+++ b/src/vs/platform/issue/common/issueIpc.ts
@@ -7,10 +7,10 @@
 
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IChannel } from 'vs/base/parts/ipc/common/ipc';
-import { IIssueService, IssueReporterStyles } from './issue';
+import { IIssueService, IssueReporterData } from './issue';
 
 export interface IIssueChannel extends IChannel {
-	call(command: 'openIssueReporter', arg: IssueReporterStyles): TPromise<void>;
+	call(command: 'openIssueReporter', arg: IssueReporterData): TPromise<void>;
 	call(command: 'getStatusInfo'): TPromise<any>;
 	call(command: string, arg?: any): TPromise<any>;
 }
@@ -34,7 +34,7 @@ export class IssueChannelClient implements IIssueService {
 
 	constructor(private channel: IIssueChannel) { }
 
-	openReporter(theme: IssueReporterStyles): TPromise<void> {
-		return this.channel.call('openIssueReporter', theme);
+	openReporter(data: IssueReporterData): TPromise<void> {
+		return this.channel.call('openIssueReporter', data);
 	}
 }

--- a/src/vs/platform/issue/electron-main/issueService.ts
+++ b/src/vs/platform/issue/electron-main/issueService.ts
@@ -7,7 +7,7 @@
 
 import { TPromise, Promise } from 'vs/base/common/winjs.base';
 import { localize } from 'vs/nls';
-import { IIssueService, IssueReporterStyles } from 'vs/platform/issue/common/issue';
+import { IIssueService, IssueReporterData } from 'vs/platform/issue/common/issue';
 import { BrowserWindow, ipcMain } from 'electron';
 import { ILaunchService } from 'vs/code/electron-main/launch';
 import { buildDiagnostics, DiagnosticInfo } from 'vs/code/electron-main/diagnostics';
@@ -25,31 +25,24 @@ export class IssueService implements IIssueService {
 		@ILaunchService private launchService: ILaunchService
 	) { }
 
-	openReporter(theme?: IssueReporterStyles): TPromise<void> {
+	openReporter(data: IssueReporterData): TPromise<void> {
 		ipcMain.on('issueInfoRequest', event => {
 			this.getStatusInfo().then(msg => {
 				event.sender.send('issueInfoResponse', msg);
 			});
 		});
 
-		// When launching from cli, no theme is provided. Match theme if passed from workbench.
-		if (theme) {
-			ipcMain.on('issueStyleRequest', event => {
-				event.sender.send('issueStyleResponse', theme);
-			});
-		}
-
 		this._issueWindow = new BrowserWindow({
 			width: 800,
 			height: 900,
 			title: localize('issueReporter', "Issue Reporter"),
 			parent: BrowserWindow.getFocusedWindow(),
-			backgroundColor: theme && theme.backgroundColor || DEFAULT_BACKGROUND_COLOR
+			backgroundColor: data.styles.backgroundColor || DEFAULT_BACKGROUND_COLOR
 		});
 
 		this._issueWindow.setMenuBarVisibility(false); // workaround for now, until a menu is implemented
 
-		this._issueWindow.loadURL(this.getIssueReporterPath());
+		this._issueWindow.loadURL(this.getIssueReporterPath(data));
 
 		return TPromise.as(null);
 	}
@@ -68,12 +61,13 @@ export class IssueService implements IIssueService {
 		});
 	}
 
-	private getIssueReporterPath() {
+	private getIssueReporterPath(data: IssueReporterData) {
 		const config = {
 			appRoot: this.environmentService.appRoot,
 			nodeCachedDataDir: this.environmentService.nodeCachedDataDir,
 			windowId: this._issueWindow.id,
-			machineId: this.machineId
+			machineId: this.machineId,
+			data
 		};
 		return `${require.toUrl('vs/code/electron-browser/issue/issueReporter.html')}?config=${encodeURIComponent(JSON.stringify(config))}`;
 	}

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -755,29 +755,41 @@ export class OpenIssueReporterAction extends Action {
 		id: string,
 		label: string,
 		@IIssueService private issueService: IIssueService,
-		@IThemeService private themeService: IThemeService
+		@IThemeService private themeService: IThemeService,
+		@IExtensionManagementService private extensionManagementService: IExtensionManagementService,
+		@IExtensionEnablementService private extensionEnablementService: IExtensionEnablementService
 	) {
 		super(id, label);
 	}
 
 	public run(): TPromise<boolean> {
-		const theme = this.themeService.getTheme();
-		const style = {
-			backgroundColor: theme.getColor(SIDE_BAR_BACKGROUND) && theme.getColor(SIDE_BAR_BACKGROUND).toString(),
-			color: theme.getColor(foreground).toString(),
-			textLinkColor: theme.getColor(textLinkForeground) && theme.getColor(textLinkForeground).toString(),
-			inputBackground: theme.getColor(inputBackground) && theme.getColor(inputBackground).toString(),
-			inputForeground: theme.getColor(inputForeground) && theme.getColor(inputForeground).toString(),
-			inputBorder: theme.getColor(inputBorder) && theme.getColor(inputBorder).toString(),
-			inputActiveBorder: theme.getColor(inputActiveOptionBorder) && theme.getColor(inputActiveOptionBorder).toString(),
-			inputErrorBorder: theme.getColor(inputValidationErrorBorder) && theme.getColor(inputValidationErrorBorder).toString(),
-			buttonBackground: theme.getColor(buttonBackground) && theme.getColor(buttonBackground).toString(),
-			buttonForeground: theme.getColor(buttonForeground) && theme.getColor(buttonForeground).toString(),
-			buttonHoverBackground: theme.getColor(buttonHoverBackground) && theme.getColor(buttonHoverBackground).toString(),
-			zoomLevel: webFrame.getZoomLevel()
-		};
-		return this.issueService.openReporter(style).then(() => {
-			return TPromise.as(true);
+		return this.extensionManagementService.getInstalled(LocalExtensionType.User).then(extensions => {
+			const enabledExtensions = extensions.filter(extension => this.extensionEnablementService.isEnabled(extension.identifier));
+			const theme = this.themeService.getTheme();
+			const styles = {
+				backgroundColor: theme.getColor(SIDE_BAR_BACKGROUND) && theme.getColor(SIDE_BAR_BACKGROUND).toString(),
+				color: theme.getColor(foreground).toString(),
+				textLinkColor: theme.getColor(textLinkForeground) && theme.getColor(textLinkForeground).toString(),
+				inputBackground: theme.getColor(inputBackground) && theme.getColor(inputBackground).toString(),
+				inputForeground: theme.getColor(inputForeground) && theme.getColor(inputForeground).toString(),
+				inputBorder: theme.getColor(inputBorder) && theme.getColor(inputBorder).toString(),
+				inputActiveBorder: theme.getColor(inputActiveOptionBorder) && theme.getColor(inputActiveOptionBorder).toString(),
+				inputErrorBorder: theme.getColor(inputValidationErrorBorder) && theme.getColor(inputValidationErrorBorder).toString(),
+				buttonBackground: theme.getColor(buttonBackground) && theme.getColor(buttonBackground).toString(),
+				buttonForeground: theme.getColor(buttonForeground) && theme.getColor(buttonForeground).toString(),
+				buttonHoverBackground: theme.getColor(buttonHoverBackground) && theme.getColor(buttonHoverBackground).toString(),
+				zoomLevel: webFrame.getZoomLevel(),
+				extensions
+			};
+			const issueReporterData = {
+				styles,
+				zoomLevel: webFrame.getZoomLevel(),
+				enabledExtensions
+			};
+
+			return this.issueService.openReporter(issueReporterData).then(() => {
+				return TPromise.as(true);
+			});
 		});
 	}
 }


### PR DESCRIPTION
Display and send the same info about extensions as `'Help: Report Issue'` in the Issue Reporter

![image](https://user-images.githubusercontent.com/3672607/35363533-40f85b70-011f-11e8-9757-b7fe1fbcabdd.png)

This also removes the CLI support for launching the issue reporter - the idea there was that if there were problems with the workbench renderer, the reporter could be launched independently. I think this is something that should be returned to, but for now its simplifying to not have this.
