### PR TITLE
Issue Reporter: Checkbox for 'reproduces without extensions'

### DIFF
--- a/src/vs/code/electron-browser/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterMain.ts
@@ -70,7 +70,8 @@ export class IssueReporter extends Disposable {
 				vscodeVersion: `${pkg.name} ${pkg.version} (${product.commit || 'Commit unknown'}, ${product.date || 'Date unknown'})`,
 				os: `${os.type()} ${os.arch()} ${os.release()}`
 			},
-			extensionsDisabled: this.environmentService.disableExtensions
+			extensionsDisabled: this.environmentService.disableExtensions,
+			reprosWithoutExtensions: true
 		});
 
 		ipcRenderer.on('issueInfoResponse', (event, info) => {
@@ -132,11 +133,11 @@ export class IssueReporter extends Disposable {
 		}
 
 		if (styles.inputActiveBorder) {
-			content.push(`input[type='text']:focus, textarea:focus, select:focus, summary:focus  { border: 1px solid ${styles.inputActiveBorder}; outline-style: none; }`);
+			content.push(`input[type='text']:focus, textarea:focus, select:focus, summary:focus, button:focus  { border: 1px solid ${styles.inputActiveBorder}; outline-style: none; }`);
 		}
 
 		if (styles.textLinkColor) {
-			content.push(`a { color: ${styles.textLinkColor}; }`);
+			content.push(`a, .workbenchCommand { color: ${styles.textLinkColor}; }`);
 		}
 
 		if (styles.buttonBackground) {
@@ -148,7 +149,7 @@ export class IssueReporter extends Disposable {
 		}
 
 		if (styles.buttonHoverBackground) {
-			content.push(`button:hover:enabled { background-color: ${styles.buttonHoverBackground}; }`);
+			content.push(`#github-submit-btn:hover:enabled, #github-submit-btn:focus:enabled { background-color: ${styles.buttonHoverBackground}; }`);
 		}
 
 		if (styles.textLinkColor) {
@@ -206,7 +207,7 @@ export class IssueReporter extends Disposable {
 			this.render();
 		});
 
-		['includeSystemInfo', 'includeProcessInfo', 'includeWorkspaceInfo', 'includeExtensions'].forEach(elementId => {
+		['includeSystemInfo', 'includeProcessInfo', 'includeWorkspaceInfo', 'includeExtensions', 'reprosWithoutExtensions'].forEach(elementId => {
 			document.getElementById(elementId).addEventListener('click', (event: Event) => {
 				event.stopPropagation();
 				this.issueReporterModel.update({ [elementId]: !this.issueReporterModel.getData()[elementId] });
@@ -220,6 +221,15 @@ export class IssueReporter extends Disposable {
 		document.getElementById('issue-title').addEventListener('input', this.searchGitHub);
 
 		document.getElementById('github-submit-btn').addEventListener('click', () => this.createIssue());
+
+		document.getElementById('disableExtensions').addEventListener('click', () => {
+			ipcRenderer.send('workbenchCommand', 'workbench.extensions.action.disableAll');
+			ipcRenderer.send('workbenchCommand', 'workbench.action.reloadWindow');
+		});
+
+		document.getElementById('showRunning').addEventListener('click', () => {
+			ipcRenderer.send('workbenchCommand', 'workbench.action.showRuntimeExtensions');
+		});
 
 		document.onkeydown = (e: KeyboardEvent) => {
 			if (e.shiftKey && e.keyCode === 13) {

--- a/src/vs/code/electron-browser/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterMain.ts
@@ -171,6 +171,10 @@ export class IssueReporter extends Disposable {
 		const numberOfThemeExtesions = themes && themes.length;
 		this.issueReporterModel.update({ numberOfThemeExtesions, enabledNonThemeExtesions: nonThemes });
 		this.updateExtensionTable(nonThemes, numberOfThemeExtesions);
+
+		if (this.environmentService.disableExtensions || extensions.length === 0) {
+			(<HTMLButtonElement>document.getElementById('disableExtensions')).disabled = true;
+		}
 	}
 
 	private initServices(configuration: IWindowConfiguration): void {

--- a/src/vs/code/electron-browser/issue/issueReporterModel.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterModel.ts
@@ -17,17 +17,21 @@ export enum IssueType {
 export interface IssueReporterData {
 	issueType?: IssueType;
 	issueDescription?: string;
+
 	versionInfo?: any;
 	systemInfo?: any;
 	processInfo?: any;
 	workspaceInfo?: any;
+
 	includeSystemInfo?: boolean;
 	includeWorkspaceInfo?: boolean;
 	includeProcessInfo?: boolean;
 	includeExtensions?: boolean;
+
 	numberOfThemeExtesions?: number;
 	enabledNonThemeExtesions?: ILocalExtension[];
 	extensionsDisabled?: boolean;
+	reprosWithoutExtensions?: boolean;
 }
 
 export class IssueReporterModel {
@@ -82,12 +86,6 @@ ${this.getInfos()}
 			info += this.generateSystemInfoMd();
 		}
 
-		if (this._data.issueType === IssueType.Bug) {
-			if (this._data.includeExtensions) {
-				info += this.generateExtensionsMd();
-			}
-		}
-
 		if (this._data.issueType === IssueType.PerformanceIssue) {
 
 			if (this._data.includeProcessInfo) {
@@ -97,10 +95,14 @@ ${this.getInfos()}
 			if (this._data.includeWorkspaceInfo) {
 				info += this.generateWorkspaceInfoMd();
 			}
+		}
 
+		if (this._data.issueType === IssueType.Bug || this._data.issueType === IssueType.PerformanceIssue) {
 			if (this._data.includeExtensions) {
 				info += this.generateExtensionsMd();
 			}
+
+			info += this._data.reprosWithoutExtensions ? '\nReproduces without extensions' : '\nReproduces only with extensions';
 		}
 
 		return info;

--- a/src/vs/code/electron-browser/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterPage.ts
@@ -92,6 +92,12 @@ export default (): string => `
 					<!-- To be dynamically filled -->
 				</div>
 			</details>
+			<div>
+				<label for="reprosWithoutExtensions">${escape(localize('tryDisablingExtensions', "Is the problem reproducible when extensions are disabled?"))}</label>
+				<input type="checkbox" id="reprosWithoutExtensions" checked>
+				<button id="disableExtensions" class="workbenchCommand">${escape(localize('disableExtensions', "Disable Extensions and Reload"))}</button>
+				<button id="showRunning" class="workbenchCommand">${escape(localize('showRunningExtensions', "Show Running Extensions"))}</button>
+			</div>
 		</div>
 	</div>
 

--- a/src/vs/code/electron-browser/issue/media/issueReporter.css
+++ b/src/vs/code/electron-browser/issue/media/issueReporter.css
@@ -72,6 +72,7 @@ button {
 	font-size: 1rem;
 	border-radius: .25rem;
 	background: none;
+	border: 1px solid transparent;
 }
 
 select {
@@ -140,7 +141,6 @@ button:disabled {
 	float: right;
 	margin-top: 10px;
 	margin-bottom: 10px;
-
 }
 
 .two-col {
@@ -197,6 +197,16 @@ input:disabled {
 	margin-left: 1em;
 }
 
+.workbenchCommand {
+	display: block;
+	font-size: 12px;
+	background: transparent;
+}
+
+.block-extensions .block-info {
+	margin-bottom: 1.5em;
+}
+
 /* Default styles, overwritten if a theme is provided */
 input, select, textarea {
 	background-color: #3c3c3c;
@@ -219,5 +229,4 @@ a {
 button {
 	background-color: #007ACC;
 	color: #fff;
-	border: none;
 }

--- a/src/vs/code/electron-browser/issue/media/issueReporter.css
+++ b/src/vs/code/electron-browser/issue/media/issueReporter.css
@@ -203,6 +203,10 @@ input:disabled {
 	background: transparent;
 }
 
+.workbenchCommand:disabled {
+	color: #868e96;
+}
+
 .block-extensions .block-info {
 	margin-bottom: 1.5em;
 }

--- a/src/vs/platform/issue/electron-main/issueService.ts
+++ b/src/vs/platform/issue/electron-main/issueService.ts
@@ -34,9 +34,13 @@ export class IssueService implements IIssueService {
 			});
 		});
 
+		ipcMain.on('workbenchCommand', (event, arg) => {
+			this._issueWindow.getParentWindow().webContents.send('vscode:runAction', { id: arg });
+		});
+
 		this._issueWindow = new BrowserWindow({
 			width: 800,
-			height: 1000,
+			height: 1100,
 			title: localize('issueReporter', "Issue Reporter"),
 			parent: BrowserWindow.getFocusedWindow(),
 			backgroundColor: data.styles.backgroundColor || DEFAULT_BACKGROUND_COLOR


### PR DESCRIPTION
Adds a checkbox for indicating if the problem only happens when extensions are enabled. This section shows up for 'Bug Report' and 'Performance Issue' types. Also adds buttons that trigger workbench commands, one to disable extensions and reload the workbench, and one to show running extensions.

![image](https://user-images.githubusercontent.com/3672607/35419970-dbc97dd4-01ef-11e8-9a55-bbbdadfc27d0.png)
