### PR TITLE
Move away from lineWarningLength into validationProvider

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -946,6 +946,16 @@
           "type": "boolean",
           "default": true,
           "description": "%config.showInlineOpenFileAction%"
+        },
+        "git.inputValidation": {
+          "type": "string",
+          "enum": [
+            "always",
+            "warn",
+            "off"
+          ],
+          "default": "warn",
+          "description": "%config.inputValidation%"
         }
       }
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -66,6 +66,7 @@
 	"config.decorations.enabled": "Controls if Git contributes colors and badges to the explorer and the open editors view.",
 	"config.promptToSaveFilesBeforeCommit": "Controls whether Git should check for unsaved files before committing.",
 	"config.showInlineOpenFileAction": "Controls whether to show an inline Open File action in the Git changes view.",
+	"config.inputValidation": "Controls when to show input validation the input counter.",
 	"colors.modified": "Color for modified resources.",
 	"colors.deleted": "Color for deleted resources.",
 	"colors.untracked": "Color for untracked resources.",

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -523,7 +523,7 @@ export class Repository implements Disposable {
 		this._sourceControl.inputBox.placeholder = localize('commitMessage', "Message (press {0} to commit)");
 		this._sourceControl.acceptInputCommand = { command: 'git.commitWithInput', title: localize('commit', "Commit"), arguments: [this._sourceControl] };
 		this._sourceControl.quickDiffProvider = this;
-		this._sourceControl.inputBox.validationProvider = this;
+		this._sourceControl.inputBox.validateInput = this.validateInput.bind(this);
 		this.disposables.push(this._sourceControl);
 
 		this._mergeGroup = this._sourceControl.createResourceGroup('merge', localize('merge changes', "Merge Changes"));

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5987,6 +5987,56 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Represents the validation type of the Source Control input.
+	 */
+	export enum SourceControlInputBoxValidationType {
+
+		/**
+		 * Something not allowed by the rules of a language or other means.
+		 */
+		Error = 0,
+
+		/**
+		 * Something suspicious but allowed.
+		 */
+		Warning = 1,
+
+		/**
+		 * Something to inform about but not a problem.
+		 */
+		Information = 2
+	}
+
+	export interface SourceControlInputBoxValidation {
+
+		/**
+		 * The validation message to display.
+		 */
+		readonly message: string;
+
+		/**
+		 * The validation type.
+		 */
+		readonly type: SourceControlInputBoxValidationType;
+	}
+
+	/**
+	 * A validation provider which can validate Source Control input.
+	 */
+	export interface SourceControlInputBoxValidationProvider {
+
+		/**
+		 * A function that will be called to validate input and give a hint to the user.
+		 *
+		 * @param value The current value of the input box.
+		 * @param cursorPosition The cusror position within the input box.
+		 * @return A human readable string which is presented as diagnostic message.
+		 * Return `undefined`, `null`, or the empty string when 'value' is valid.
+		 */
+		validateInput(value: string, cursorPosition: number): ProviderResult<SourceControlInputBoxValidation | undefined | null>;
+	}
+
+	/**
 	 * Represents the input box in the Source Control viewlet.
 	 */
 	export interface SourceControlInputBox {
@@ -6002,9 +6052,10 @@ declare module 'vscode' {
 		placeholder: string;
 
 		/**
-		 * The warning threshold for lines in the input box.
+		 * A validation provider for the input box. It's possible to change
+		 * the validation provider simply by setting this property to a different value.
 		 */
-		lineWarningLength: number | undefined;
+		validationProvider: SourceControlInputBoxValidationProvider;
 	}
 
 	interface QuickDiffProvider {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5987,56 +5987,6 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Represents the validation type of the Source Control input.
-	 */
-	export enum SourceControlInputBoxValidationType {
-
-		/**
-		 * Something not allowed by the rules of a language or other means.
-		 */
-		Error = 0,
-
-		/**
-		 * Something suspicious but allowed.
-		 */
-		Warning = 1,
-
-		/**
-		 * Something to inform about but not a problem.
-		 */
-		Information = 2
-	}
-
-	export interface SourceControlInputBoxValidation {
-
-		/**
-		 * The validation message to display.
-		 */
-		readonly message: string;
-
-		/**
-		 * The validation type.
-		 */
-		readonly type: SourceControlInputBoxValidationType;
-	}
-
-	/**
-	 * A validation provider which can validate Source Control input.
-	 */
-	export interface SourceControlInputBoxValidationProvider {
-
-		/**
-		 * A function that will be called to validate input and give a hint to the user.
-		 *
-		 * @param value The current value of the input box.
-		 * @param cursorPosition The cusror position within the input box.
-		 * @return A human readable string which is presented as diagnostic message.
-		 * Return `undefined`, `null`, or the empty string when 'value' is valid.
-		 */
-		validateInput(value: string, cursorPosition: number): ProviderResult<SourceControlInputBoxValidation | undefined | null>;
-	}
-
-	/**
 	 * Represents the input box in the Source Control viewlet.
 	 */
 	export interface SourceControlInputBox {
@@ -6050,12 +6000,6 @@ declare module 'vscode' {
 		 * A string to show as place holder in the input box to guide the user.
 		 */
 		placeholder: string;
-
-		/**
-		 * A validation provider for the input box. It's possible to change
-		 * the validation provider simply by setting this property to a different value.
-		 */
-		validationProvider: SourceControlInputBoxValidationProvider;
 	}
 
 	interface QuickDiffProvider {

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -394,4 +394,50 @@ declare module 'vscode' {
 		 */
 		logger: Logger;
 	}
+
+	/**
+	 * Represents the validation type of the Source Control input.
+	 */
+	export enum SourceControlInputBoxValidationType {
+
+		/**
+		 * Something not allowed by the rules of a language or other means.
+		 */
+		Error = 0,
+
+		/**
+		 * Something suspicious but allowed.
+		 */
+		Warning = 1,
+
+		/**
+		 * Something to inform about but not a problem.
+		 */
+		Information = 2
+	}
+
+	export interface SourceControlInputBoxValidation {
+
+		/**
+		 * The validation message to display.
+		 */
+		readonly message: string;
+
+		/**
+		 * The validation type.
+		 */
+		readonly type: SourceControlInputBoxValidationType;
+	}
+
+	/**
+	 * Represents the input box in the Source Control viewlet.
+	 */
+	export interface SourceControlInputBox {
+
+		/**
+		 * A validation function for the input box. It's possible to change
+		 * the validation provider simply by setting this property to a different function.
+		 */
+		validateInput?(value: string, cursorPosition: number): ProviderResult<SourceControlInputBoxValidation | undefined | null>;
+	}
 }

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -601,6 +601,7 @@ export function createApiFactory(
 			StatusBarAlignment: extHostTypes.StatusBarAlignment,
 			SymbolInformation: extHostTypes.SymbolInformation,
 			SymbolKind: extHostTypes.SymbolKind,
+			SourceControlInputBoxValidationType: extHostTypes.SourceControlInputBoxValidationType,
 			TextDocumentSaveReason: extHostTypes.TextDocumentSaveReason,
 			TextEdit: extHostTypes.TextEdit,
 			TextEditorCursorStyle: TextEditorCursorStyle,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -431,7 +431,7 @@ export interface MainThreadSCMShape extends IDisposable {
 
 	$setInputBoxValue(sourceControlHandle: number, value: string): void;
 	$setInputBoxPlaceholder(sourceControlHandle: number, placeholder: string): void;
-	$setLineWarningLength(sourceControlHandle: number, lineWarningLength: number): void;
+	$setValidationProviderIsEnabled(sourceControlHandle: number, enabled: boolean): void;
 }
 
 export type DebugSessionUUID = string;
@@ -693,6 +693,7 @@ export interface ExtHostSCMShape {
 	$provideOriginalResource(sourceControlHandle: number, uri: string): TPromise<string>;
 	$onInputBoxValueChange(sourceControlHandle: number, value: string): TPromise<void>;
 	$executeResourceCommand(sourceControlHandle: number, groupHandle: number, handle: number): TPromise<void>;
+	$validateInput(sourceControlHandle: number, value: string, cursorPosition: number): TPromise<[string, number] | undefined>;
 }
 
 export interface ExtHostTaskShape {

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1200,6 +1200,12 @@ export enum ColorFormat {
 	HSL = 2
 }
 
+export enum SourceControlInputBoxValidationType {
+	Error = 0,
+	Warning = 1,
+	Information = 2
+}
+
 export enum TaskRevealKind {
 	Always = 1,
 

--- a/src/vs/workbench/parts/scm/electron-browser/scm.contribution.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scm.contribution.ts
@@ -79,12 +79,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			enum: ['all', 'gutter', 'overview', 'none'],
 			default: 'all',
 			description: localize('diffDecorations', "Controls diff decorations in the editor.")
-		},
-		'scm.inputCounter': {
-			type: 'string',
-			enum: ['always', 'warn', 'off'],
-			default: 'warn',
-			description: localize('inputCounter', "Controls when to display the input counter.")
 		}
 	}
 });

--- a/src/vs/workbench/services/scm/common/scm.ts
+++ b/src/vs/workbench/services/scm/common/scm.ts
@@ -68,6 +68,21 @@ export interface ISCMProvider extends IDisposable {
 	getOriginalResource(uri: URI): TPromise<URI>;
 }
 
+export enum InputValidationType {
+	Error = 0,
+	Warning = 1,
+	Information = 2
+}
+
+export interface IInputValidation {
+	message: string;
+	type: InputValidationType;
+}
+
+export interface IInputValidator {
+	(value: string, cursorPosition: number): TPromise<IInputValidation | undefined>;
+}
+
 export interface ISCMInput {
 	value: string;
 	readonly onDidChange: Event<string>;
@@ -75,7 +90,8 @@ export interface ISCMInput {
 	placeholder: string;
 	readonly onDidChangePlaceholder: Event<string>;
 
-	lineWarningLength: number | undefined;
+	validateInput: IInputValidator;
+	readonly onDidChangeValidateInput: Event<void>;
 }
 
 export interface ISCMRepository extends IDisposable {

--- a/src/vs/workbench/services/scm/common/scmService.ts
+++ b/src/vs/workbench/services/scm/common/scmService.ts
@@ -7,8 +7,9 @@
 
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import Event, { Emitter } from 'vs/base/common/event';
-import { ISCMService, ISCMProvider, ISCMInput, ISCMRepository } from './scm';
+import { ISCMService, ISCMProvider, ISCMInput, ISCMRepository, IInputValidator } from './scm';
 import { ILogService } from 'vs/platform/log/common/log';
+import { TPromise } from 'vs/base/common/winjs.base';
 
 class SCMInput implements ISCMInput {
 
@@ -40,7 +41,19 @@ class SCMInput implements ISCMInput {
 	private _onDidChangePlaceholder = new Emitter<string>();
 	get onDidChangePlaceholder(): Event<string> { return this._onDidChangePlaceholder.event; }
 
-	public lineWarningLength: number | undefined = undefined;
+	private _validateInput: IInputValidator = () => TPromise.as(undefined);
+
+	get validateInput(): IInputValidator {
+		return this._validateInput;
+	}
+
+	set validateInput(validateInput: IInputValidator) {
+		this._validateInput = validateInput;
+		this._onDidChangeValidateInput.fire();
+	}
+
+	private _onDidChangeValidateInput = new Emitter<void>();
+	get onDidChangeValidateInput(): Event<void> { return this._onDidChangeValidateInput.event; }
 }
 
 class SCMRepository implements ISCMRepository {


### PR DESCRIPTION
As discussed, here's another approach to fix https://github.com/Microsoft/vscode/issues/21144

This solution exposes a `validationProvider` on the SCM input, instead of relying on a very specific `lineWarningLength` property. It is a more general solution to the problem, which feels better on the API side of things.

There are a few drawbacks, though:

- It requires renderer <-> ext host communication while there is interaction with the scm input (though debounced).
- The overall feeling isn't great. The UI seems slow, given the debouncing.
- Opens up quite a bit more API.

@jrieken Please review the approach in the API and, given the drawbacks, let me know if this is still your preferred approach.