### PR TITLE
enable checkJS for the build folder

### DIFF
--- a/build/builtin/browser-main.js
+++ b/build/builtin/browser-main.js
@@ -13,6 +13,7 @@ const builtInExtensionsPath = path.join(__dirname, '..', 'builtInExtensions.json
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 
 function readJson(filePath) {
+	//@ts-ignore review
 	return JSON.parse(fs.readFileSync(filePath));
 }
 

--- a/build/builtin/browser-main.js
+++ b/build/builtin/browser-main.js
@@ -6,6 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+// @ts-ignore review
 const { remote } = require('electron');
 const dialog = remote.dialog;
 

--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -12,6 +12,7 @@ var File = require('vinyl');
 
 var root = path.dirname(__dirname);
 var sha1 = util.getVersion(root);
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 var semver = require('./monaco/package.json').version;
 var headerVersion = semver + '(' + sha1 + ')';
 
@@ -79,7 +80,8 @@ gulp.task('optimize-editor', ['clean-optimized-editor', 'compile-client-build'],
 	bundleLoader: false,
 	header: BUNDLED_FILE_HEADER,
 	bundleInfo: true,
-	out: 'out-editor'
+	out: 'out-editor',
+	languages: undefined
 }));
 
 gulp.task('clean-minified-editor', util.rimraf('out-editor-min'));
@@ -155,6 +157,7 @@ gulp.task('editor-distro', ['clean-editor-distro', 'minify-editor', 'optimize-ed
 });
 
 gulp.task('analyze-editor-distro', function() {
+	// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 	var bundleInfo = require('../out-editor/bundleInfo.json');
 	var graph = bundleInfo.graph;
 	var bundles = bundleInfo.bundles;

--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -94,8 +94,11 @@ const tasks = compilations.map(function (tsconfigFile) {
 					sourceRoot: '../src'
 				}))
 				.pipe(tsFilter.restore)
+				// @ts-ignore review
 				.pipe(build ? nlsDev.createAdditionalLanguageFiles(languages, i18nPath, out) : es.through())
+				// @ts-ignore review
 				.pipe(build ? nlsDev.bundleMetaDataFiles(headerId, headerOut) : es.through())
+				// @ts-ignore review
 				.pipe(build ? nlsDev.bundleLanguageFiles() : es.through())
 				.pipe(reporter.end(emitError));
 
@@ -143,6 +146,7 @@ const tasks = compilations.map(function (tsconfigFile) {
 		const watchInput = watcher(src, srcOpts);
 
 		return watchInput
+			// @ts-ignore review
 			.pipe(util.incremental(() => pipeline(true), input))
 			.pipe(gulp.dest(out));
 	});

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -151,8 +151,8 @@ gulp.task('tslint', () => {
 
 	return vfs.src(all, { base: '.', follow: true, allowEmpty: true })
 		.pipe(filter(tslintFilter))
-		.pipe(gulptslint({ rulesDirectory: 'build/lib/tslint' }))
-		.pipe(gulptslint.report(options));
+		.pipe(gulptslint.default({ rulesDirectory: 'build/lib/tslint' }))
+		.pipe(gulptslint.default.report(options));
 });
 
 const hygiene = exports.hygiene = (some, options) => {
@@ -202,6 +202,11 @@ const hygiene = exports.hygiene = (some, options) => {
 			verify: true,
 			tsfmt: true,
 			// verbose: true
+			// keep checkJS happy
+			editorconfig: undefined,
+			replace: undefined,
+			tsconfig: undefined,
+			tslint: undefined
 		}).then(result => {
 			if (result.error) {
 				console.error(result.message);
@@ -227,9 +232,9 @@ const hygiene = exports.hygiene = (some, options) => {
 
 	const tsl = es.through(function (file) {
 		const configuration = tslint.Configuration.findConfiguration(null, '.');
-		const options = { formatter: 'json', rulesDirectory: 'build/lib/tslint' };
+		const linterOptions = { fix: false, formatter: 'json', rulesDirectory: 'build/lib/tslint' };
 		const contents = file.contents.toString('utf8');
-		const linter = new tslint.Linter(options);
+		const linter = new tslint.Linter(linterOptions);
 		linter.lint(file.relative, contents, configuration.results);
 		const result = linter.getResult();
 

--- a/build/gulpfile.mixin.js
+++ b/build/gulpfile.mixin.js
@@ -14,6 +14,8 @@ const util = require('./lib/util');
 const remote = require('gulp-remote-src');
 const zip = require('gulp-vinyl-zip');
 const assign = require('object-assign');
+
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const pkg = require('../package.json');
 
 gulp.task('mixin', function () {
@@ -54,6 +56,7 @@ gulp.task('mixin', function () {
 			.pipe(util.rebase(2))
 			.pipe(productJsonFilter)
 			.pipe(buffer())
+			// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 			.pipe(json(o => assign({}, require('../product.json'), o)))
 			.pipe(productJsonFilter.restore);
 

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -27,7 +27,9 @@ const common = require('./lib/optimize');
 const nlsDev = require('vscode-nls-dev');
 const root = path.dirname(__dirname);
 const commit = util.getVersion(root);
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const packageJson = require('../package.json');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const product = require('../product.json');
 const crypto = require('crypto');
 const i18n = require('./lib/i18n');
@@ -37,6 +39,7 @@ const getElectronVersion = require('./lib/electron').getElectronVersion;
 // const createAsar = require('./lib/asar').createAsar;
 
 const productionDependencies = deps.getProductionDependencies(path.dirname(__dirname));
+//@ts-ignore review
 const baseModules = Object.keys(process.binding('natives')).filter(n => !/^_|\//.test(n));
 const nodeModules = ['electron', 'original-fs']
 	.concat(Object.keys(product.dependencies || {}))
@@ -44,8 +47,8 @@ const nodeModules = ['electron', 'original-fs']
 	.concat(baseModules);
 
 // Build
-
-const builtInExtensions = require('./builtInExtensions');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
+const builtInExtensions = require('./builtInExtensions.json');
 
 const excludedExtensions = [
 	'vscode-api-tests',
@@ -104,6 +107,8 @@ gulp.task('optimize-vscode', ['clean-optimized-vscode', 'compile-build', 'compil
 	header: BUNDLED_FILE_HEADER,
 	out: 'out-vscode',
 	languages: languages,
+	// @ts-ignore review
+	bundleInfo: undefined
 }));
 
 
@@ -245,6 +250,7 @@ function packageTask(platform, arch, opts) {
 				// 	// TODO@Dirk: this filter / buffer is here to make sure the nls.json files are buffered
 				.pipe(nlsFilter)
 				.pipe(buffer())
+				//@ts-ignore review
 				.pipe(nlsDev.createAdditionalLanguageFiles(languages, path.join(__dirname, '..', 'i18n')))
 				.pipe(nlsFilter.restore);
 		}));
@@ -297,6 +303,7 @@ function packageTask(platform, arch, opts) {
 			.pipe(util.cleanNodeModule('native-is-elevated', ['binding.gyp', 'build/**', 'src/**', 'deps/**'], ['**/*.node']))
 			.pipe(util.cleanNodeModule('native-watchdog', ['binding.gyp', 'build/**', 'src/**'], ['**/*.node']))
 			.pipe(util.cleanNodeModule('spdlog', ['binding.gyp', 'build/**', 'deps/**', 'src/**', 'test/**'], ['**/*.node']))
+			//@ts-ignore review
 			.pipe(util.cleanNodeModule('jschardet', ['dist/**']))
 			.pipe(util.cleanNodeModule('windows-foreground-love', ['binding.gyp', 'build/**', 'src/**'], ['**/*.node']))
 			.pipe(util.cleanNodeModule('windows-process-tree', ['binding.gyp', 'build/**', 'src/**'], ['**/*.node']))
@@ -439,6 +446,7 @@ gulp.task('vscode-translations-pull', function () {
 gulp.task('vscode-translations-import', function () {
 	[...i18n.defaultLanguages, ...i18n.extraLanguages].forEach(language => {
 		gulp.src(`../vscode-localization/${language.id}/build/*/*.xlf`)
+			//@ts-ignore review
 			.pipe(i18n.prepareI18nFiles(language))
 			.pipe(vfs.dest(`./i18n/${language.folderName}`));
 		gulp.src(`../vscode-localization/${language.id}/setup/*/*.xlf`)
@@ -470,6 +478,7 @@ gulp.task('upload-vscode-sourcemaps', ['minify-vscode'], () => {
 const allConfigDetailsPath = path.join(os.tmpdir(), 'configuration.json');
 gulp.task('upload-vscode-configuration', ['generate-vscode-configuration'], () => {
 	const branch = process.env.BUILD_SOURCEBRANCH;
+	//@ts-ignore review
 	if (!branch.endsWith('/master') && branch.indexOf('/release/') < 0) {
 		console.log(`Only runs on master and release branches, not ${branch}`);
 		return;

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -12,9 +12,12 @@ const shell = require('gulp-shell');
 const es = require('event-stream');
 const vfs = require('vinyl-fs');
 const util = require('./lib/util');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const packageJson = require('../package.json');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const product = require('../product.json');
-const rpmDependencies = require('../resources/linux/rpm/dependencies');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
+const rpmDependencies = require('../resources/linux/rpm/dependencies.json');
 
 const linuxPackageRevision = Math.floor(new Date().getTime() / 1000);
 

--- a/build/gulpfile.vscode.win32.js
+++ b/build/gulpfile.vscode.win32.js
@@ -11,7 +11,9 @@ const assert = require('assert');
 const cp = require('child_process');
 const _7z = require('7zip')['7z'];
 const util = require('./lib/util');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const pkg = require('../package.json');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const product = require('../product.json');
 const vfs = require('vinyl-fs');
 

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -17,7 +17,8 @@ const ext = require('./extensions');
 const util = require('gulp-util');
 
 const root = path.dirname(path.dirname(__dirname));
-const builtInExtensions = require('../builtInExtensions');
+// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
+const builtInExtensions = require('../builtInExtensions.json');
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 
 function getExtensionPath(extension) {
@@ -34,6 +35,7 @@ function isUpToDate(extension) {
 	const packageContents = fs.readFileSync(packagePath);
 
 	try {
+		//@ts-ignore review
 		const diskVersion = JSON.parse(packageContents).version;
 		return (diskVersion === extension.version);
 	} catch (err) {

--- a/build/lib/bundle.ts
+++ b/build/lib/bundle.ts
@@ -44,11 +44,11 @@ interface ILoaderPluginReqFunc {
 
 export interface IEntryPoint {
 	name: string;
-	include: string[];
-	exclude: string[];
+	include?: string[];
+	exclude?: string[];
 	prepend: string[];
-	append: string[];
-	dest: string;
+	append?: string[];
+	dest?: string;
 }
 
 interface IEntryPointMap {

--- a/build/lib/optimize.ts
+++ b/build/lib/optimize.ts
@@ -30,7 +30,7 @@ function log(prefix: string, message: string): void {
 	gulpUtil.log(gulpUtil.colors.cyan('[' + prefix + ']'), message);
 }
 
-export function loaderConfig(emptyPaths: string[]) {
+export function loaderConfig(emptyPaths?: string[]) {
 	const result = {
 		paths: {
 			'vs': 'out-build/vs',
@@ -293,7 +293,7 @@ function uglifyWithCopyrights(): NodeJS.ReadWriteStream {
 	return es.duplex(input, output);
 }
 
-export function minifyTask(src: string, sourceMapBaseUrl: string): (cb: any) => void {
+export function minifyTask(src: string, sourceMapBaseUrl?: string): (cb: any) => void {
 	const sourceMappingURL = sourceMapBaseUrl && (f => `${sourceMapBaseUrl}/${f.relative}.map`);
 
 	return cb => {

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -173,7 +173,6 @@ function rimraf(dir) {
             if (!err) {
                 return cb();
             }
-            ;
             if (err.code === 'ENOTEMPTY' && ++retries < 5) {
                 return setTimeout(function () { return retry(cb); }, 10);
             }

--- a/build/lib/util.ts
+++ b/build/lib/util.ts
@@ -28,7 +28,7 @@ export interface IStreamProvider {
 	(cancellationToken?: ICancellationToken): NodeJS.ReadWriteStream;
 }
 
-export function incremental(streamProvider: IStreamProvider, initial: NodeJS.ReadWriteStream, supportsCancellation: boolean): NodeJS.ReadWriteStream {
+export function incremental(streamProvider: IStreamProvider, initial: NodeJS.ReadWriteStream, supportsCancellation?: boolean): NodeJS.ReadWriteStream {
 	const input = es.through();
 	const output = es.through();
 	let state = 'idle';
@@ -223,7 +223,7 @@ export function rimraf(dir: string): (cb: any) => void {
 		_rimraf(dir, { maxBusyTries: 1 }, (err: any) => {
 			if (!err) {
 				return cb();
-			};
+			}
 
 			if (err.code === 'ENOTEMPTY' && ++retries < 5) {
 				return setTimeout(() => retry(cb), 10);

--- a/build/lib/watch/watch-nsfw.js
+++ b/build/lib/watch/watch-nsfw.js
@@ -30,7 +30,7 @@ function watch(root) {
             path: path,
             base: root
         });
-
+        //@ts-ignore review
         file.event = type;
         result.emit('data', file);
     }

--- a/build/lib/watch/watch-win32.js
+++ b/build/lib/watch/watch-win32.js
@@ -25,6 +25,7 @@ function watch(root) {
 	var child = cp.spawn(watcherPath, [root]);
 
 	child.stdout.on('data', function(data) {
+		//@ts-ignore review
 		var lines = data.toString('utf8').split('\n');
 		for (var i = 0; i < lines.length; i++) {
 			var line = lines[i].trim();
@@ -46,7 +47,7 @@ function watch(root) {
 				path: changePathFull,
 				base: root
 			});
-
+			//@ts-ignore review
 			file.event = toChangeType(changeType);
 			result.emit('data', file);
 		}

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -49,6 +49,7 @@ extensions.forEach(extension => yarnInstall(`extensions/${extension}`));
 function yarnInstallBuildDependencies() {
 	// make sure we install the deps of build/lib/watch for the system installed
 	// node, since that is the driver of gulp
+	//@ts-ignore review
 	const env = Object.assign({}, process.env);
 	const watchPath = path.join(path.dirname(__dirname), 'lib', 'watch');
 	const yarnrcPath = path.join(watchPath, '.yarnrc');

--- a/build/npm/update-localization-extension.js
+++ b/build/npm/update-localization-extension.js
@@ -15,7 +15,6 @@ let rimraf = require('rimraf');
 function update(idOrPath) {
 	if (!idOrPath) {
 		throw new Error('Argument must be the location of the localization extension.');
-		return;
 	}
 	let locExtFolder = idOrPath;
 	if (/^\w{2}(-\w+)?$/.test(idOrPath)) {

--- a/build/package.json
+++ b/build/package.json
@@ -17,8 +17,9 @@
     "xml2js": "^0.4.17"
   },
   "scripts": {
-    "compile": "tsc",
-    "watch": "tsc --watch",
-    "postinstall": "npm run compile"
+    "compile": "tsc -p tsconfig.build.json",
+    "watch": "tsc -p tsconfig.build.json --watch",
+    "postinstall": "npm run compile",
+    "npmCheckJs": "tsc --noEmit"
   }
 }

--- a/build/tsconfig.build.json
+++ b/build/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"allowJs": false,
+		"checkJs": false
+	}
+}

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -7,7 +7,12 @@
 		"preserveConstEnums": true,
 		"sourceMap": false,
 		"experimentalDecorators": true,
-		"newLine": "LF"
+		"newLine": "LF",
+		// enable JavaScript type checking for the language service
+		// use the tsconfig.build.json for compiling wich disable JavaScript
+		// type checking so that JavaScript file are not transpiled
+		"allowJs": true,
+		"checkJs": true
 	},
 	"exclude": [
 		"node_modules/**"

--- a/src/buildfile.js
+++ b/src/buildfile.js
@@ -10,6 +10,7 @@ exports.base = [{
 	append: [ 'vs/base/worker/workerMain' ],
 	dest: 'vs/base/worker/workerMain.js'
 }];
+//@ts-ignore review
 exports.workbench = require('./vs/workbench/buildfile').collectModules(['vs/workbench/workbench.main']);
 exports.code = require('./vs/code/buildfile').collectModules();
 


### PR DESCRIPTION
Enabled checkJS for the build folder.

Errors that need a review a commented with `//@ts-ignore review`. 
