### PR TITLE
Add terminal move to line start/end commands

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -18,7 +18,7 @@ import { TERMINAL_DEFAULT_SHELL_UNIX_LIKE, TERMINAL_DEFAULT_SHELL_WINDOWS } from
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { KillTerminalAction, CopyTerminalSelectionAction, CreateNewTerminalAction, CreateNewInActiveWorkspaceTerminalAction, FocusActiveTerminalAction, FocusNextTerminalAction, FocusPreviousTerminalAction, SelectDefaultShellWindowsTerminalAction, RunSelectedTextInTerminalAction, RunActiveFileInTerminalAction, ScrollDownTerminalAction, ScrollDownPageTerminalAction, ScrollToBottomTerminalAction, ScrollUpTerminalAction, ScrollUpPageTerminalAction, ScrollToTopTerminalAction, TerminalPasteAction, ToggleTerminalAction, ClearTerminalAction, AllowWorkspaceShellTerminalCommand, DisallowWorkspaceShellTerminalCommand, RenameTerminalAction, SelectAllTerminalAction, FocusTerminalFindWidgetAction, HideTerminalFindWidgetAction, ShowNextFindTermTerminalFindWidgetAction, ShowPreviousFindTermTerminalFindWidgetAction, DeleteWordLeftTerminalAction, DeleteWordRightTerminalAction, QuickOpenActionTermContributor, QuickOpenTermAction, TERMINAL_PICKER_PREFIX } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
+import { KillTerminalAction, CopyTerminalSelectionAction, CreateNewTerminalAction, CreateNewInActiveWorkspaceTerminalAction, FocusActiveTerminalAction, FocusNextTerminalAction, FocusPreviousTerminalAction, SelectDefaultShellWindowsTerminalAction, RunSelectedTextInTerminalAction, RunActiveFileInTerminalAction, ScrollDownTerminalAction, ScrollDownPageTerminalAction, ScrollToBottomTerminalAction, ScrollUpTerminalAction, ScrollUpPageTerminalAction, ScrollToTopTerminalAction, TerminalPasteAction, ToggleTerminalAction, ClearTerminalAction, AllowWorkspaceShellTerminalCommand, DisallowWorkspaceShellTerminalCommand, RenameTerminalAction, SelectAllTerminalAction, FocusTerminalFindWidgetAction, HideTerminalFindWidgetAction, ShowNextFindTermTerminalFindWidgetAction, ShowPreviousFindTermTerminalFindWidgetAction, DeleteWordLeftTerminalAction, DeleteWordRightTerminalAction, QuickOpenActionTermContributor, QuickOpenTermAction, TERMINAL_PICKER_PREFIX, MoveToLineStartTerminalAction, MoveToLineEndTerminalAction } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ShowAllCommandsAction } from 'vs/workbench/parts/quickopen/browser/commandsHandler';
 import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
@@ -268,6 +268,8 @@ configurationRegistry.registerConfiguration({
 				NavigateLeftAction.ID,
 				DeleteWordLeftTerminalAction.ID,
 				DeleteWordRightTerminalAction.ID,
+				MoveToLineStartTerminalAction.ID,
+				MoveToLineEndTerminalAction.ID,
 				TogglePanelAction.ID,
 				'workbench.action.quickOpenView'
 			].sort()
@@ -398,6 +400,14 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DeleteWordRightT
 	primary: KeyMod.CtrlCmd | KeyCode.Delete,
 	mac: { primary: KeyMod.Alt | KeyCode.Delete }
 }, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Delete Word Right', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(MoveToLineStartTerminalAction, MoveToLineStartTerminalAction.ID, MoveToLineStartTerminalAction.LABEL, {
+	primary: null,
+	mac: { primary: KeyMod.CtrlCmd | KeyCode.LeftArrow }
+}, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Move To Line Start', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(MoveToLineEndTerminalAction, MoveToLineEndTerminalAction.ID, MoveToLineEndTerminalAction.LABEL, {
+	primary: null,
+	mac: { primary: KeyMod.CtrlCmd | KeyCode.RightArrow }
+}, KEYBINDING_CONTEXT_TERMINAL_FOCUS), 'Terminal: Move To Line End', category);
 
 terminalCommands.setup();
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -152,47 +152,50 @@ export class SelectAllTerminalAction extends Action {
 	}
 }
 
-export class DeleteWordLeftTerminalAction extends Action {
-
-	public static readonly ID = 'workbench.action.terminal.deleteWordLeft';
-	public static readonly LABEL = nls.localize('workbench.action.terminal.deleteWordLeft', "Delete Word Left");
-
+export abstract class BaseSendTextTerminalAction extends Action {
 	constructor(
-		id: string, label: string,
-		@ITerminalService private terminalService: ITerminalService
+		id: string,
+		label: string,
+		private _text: string,
+		@ITerminalService private _terminalService: ITerminalService
 	) {
 		super(id, label);
 	}
 
 	public run(event?: any): TPromise<any> {
-		let terminalInstance = this.terminalService.getActiveInstance();
+		let terminalInstance = this._terminalService.getActiveInstance();
 		if (terminalInstance) {
-			// Send ctrl+W
-			terminalInstance.sendText(String.fromCharCode('W'.charCodeAt(0) - 64), false);
+			terminalInstance.sendText(this._text, false);
 		}
 		return TPromise.as(void 0);
 	}
 }
 
-export class DeleteWordRightTerminalAction extends Action {
+export class DeleteWordLeftTerminalAction extends BaseSendTextTerminalAction {
+	public static readonly ID = 'workbench.action.terminal.deleteWordLeft';
+	public static readonly LABEL = nls.localize('workbench.action.terminal.deleteWordLeft', "Delete Word Left");
 
+	constructor(
+		id: string,
+		label: string,
+		@ITerminalService terminalService: ITerminalService
+	) {
+		// Send ctrl+W
+		super(id, label, String.fromCharCode('W'.charCodeAt(0) - 64), terminalService);
+	}
+}
+
+export class DeleteWordRightTerminalAction extends BaseSendTextTerminalAction {
 	public static readonly ID = 'workbench.action.terminal.deleteWordRight';
 	public static readonly LABEL = nls.localize('workbench.action.terminal.deleteWordRight', "Delete Word Right");
 
 	constructor(
-		id: string, label: string,
-		@ITerminalService private terminalService: ITerminalService
+		id: string,
+		label: string,
+		@ITerminalService terminalService: ITerminalService
 	) {
-		super(id, label);
-	}
-
-	public run(event?: any): TPromise<any> {
-		let terminalInstance = this.terminalService.getActiveInstance();
-		if (terminalInstance) {
-			// Send alt+D
-			terminalInstance.sendText('\x1bD', false);
-		}
-		return TPromise.as(void 0);
+		// Send alt+D
+		super(id, label, '\x1bD', terminalService);
 	}
 }
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -199,6 +199,34 @@ export class DeleteWordRightTerminalAction extends BaseSendTextTerminalAction {
 	}
 }
 
+export class MoveToLineStartTerminalAction extends BaseSendTextTerminalAction {
+	public static readonly ID = 'workbench.action.terminal.moveToLineStart';
+	public static readonly LABEL = nls.localize('workbench.action.terminal.moveToLineStart', "Move To Line Start");
+
+	constructor(
+		id: string,
+		label: string,
+		@ITerminalService terminalService: ITerminalService
+	) {
+		// Send ctrl+A
+		super(id, label, String.fromCharCode('A'.charCodeAt(0) - 64), terminalService);
+	}
+}
+
+export class MoveToLineEndTerminalAction extends BaseSendTextTerminalAction {
+	public static readonly ID = 'workbench.action.terminal.moveToLineEnd';
+	public static readonly LABEL = nls.localize('workbench.action.terminal.moveToLineEnd', "Move To Line End");
+
+	constructor(
+		id: string,
+		label: string,
+		@ITerminalService terminalService: ITerminalService
+	) {
+		// Send ctrl+A
+		super(id, label, String.fromCharCode('E'.charCodeAt(0) - 64), terminalService);
+	}
+}
+
 export class CreateNewTerminalAction extends Action {
 
 	public static readonly ID = 'workbench.action.terminal.new';

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -222,7 +222,7 @@ export class MoveToLineEndTerminalAction extends BaseSendTextTerminalAction {
 		label: string,
 		@ITerminalService terminalService: ITerminalService
 	) {
-		// Send ctrl+A
+		// Send ctrl+E
 		super(id, label, String.fromCharCode('E'.charCodeAt(0) - 64), terminalService);
 	}
 }


### PR DESCRIPTION
Defaults to command+left/right arrow on macOS only.

Fixes #42216