### PR TITLE
Monokai: Use new  dropdown.listBackground to correct contrast Fixes: #42480

### DIFF
--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -9,7 +9,7 @@
 	"colors": {
 		"dropdown.background": "#414339",
 		"list.activeSelectionBackground": "#75715E",
-		"list.focusBackground": "#414339",
+		"list.focusBackground": "#75715E",
 		"list.inactiveSelectionBackground": "#414339",
 		"list.hoverBackground": "#272822",
 		"list.dropBackground": "#414339",

--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -9,7 +9,8 @@
 	"colors": {
 		"dropdown.background": "#414339",
 		"list.activeSelectionBackground": "#75715E",
-		"list.focusBackground": "#75715E",
+		"list.focusBackground": "#414339",
+		"dropdown.listBackground": "#1e1f1c",
 		"list.inactiveSelectionBackground": "#414339",
 		"list.hoverBackground": "#272822",
 		"list.dropBackground": "#414339",


### PR DESCRIPTION
Fixes #42480, the drop down widget now accommodates the Monokai theme on Windows and Linux platforms better for currently active list item!

Currently using color `#75715E` for active item, which looks like this: 
![monokaidropdownfix](https://user-images.githubusercontent.com/14265337/35763199-c2eccc9a-0874-11e8-997a-137f7efa5513.png)
 
If you have a preferred color from the theme, I'd be happy to switch out the current 👍 