### PR TITLE
Remove needless check for array in ContextKeyChangeEvent

### DIFF
--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -169,11 +169,7 @@ export class ContextKeyChangeEvent implements IContextKeyChangeEvent {
 	private _keys: string[] = [];
 
 	collect(oneOrManyKeys: string | string[]): void {
-		if (Array.isArray(oneOrManyKeys)) {
-			this._keys = this._keys.concat(oneOrManyKeys);
-		} else {
-			this._keys.push(oneOrManyKeys);
-		}
+		this._keys = this._keys.concat(oneOrManyKeys);
 	}
 
 	affectsSome(keys: Set<string>): boolean {


### PR DESCRIPTION
Removed check `isArray` and use `concat` for both cases, because concat works correct with array and not array as argument.
```js
['mike', 'bob'].concat('alex'); // ['mike', 'bob', 'alex']
['mike', 'bob'].concat(['alex', 'bill']); // ['mike', 'bob', 'alex', 'bill']
```