### PR TITLE
Fix #42741 - remoteSearchThrottle should not be waiting on the search…

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -265,7 +265,10 @@ export class PreferencesEditor extends BaseEditor {
 		if (query) {
 			return TPromise.join([
 				this.localSearchDelayer.trigger(() => this.preferencesRenderers.localFilterPreferences(query)),
-				this.remoteSearchThrottle.trigger(() => this.progressService.showWhile(this.preferencesRenderers.remoteSearchPreferences(query), 500))
+				this.remoteSearchThrottle.trigger(() => {
+					this.progressService.showWhile(this.preferencesRenderers.remoteSearchPreferences(query), 500);
+					return TPromise.wrap(null);
+				})
 			]) as TPromise;
 		} else {
 			// When clearing the input, update immediately to clear it


### PR DESCRIPTION
…. It should simply debounce the remote search, each new instance cancelling the previous if it hasn't completed