### PR TITLE
Simplify check lang.mimetypes

### DIFF
--- a/src/vs/editor/common/services/languagesRegistry.ts
+++ b/src/vs/editor/common/services/languagesRegistry.ts
@@ -111,13 +111,9 @@ export class LanguagesRegistry {
 
 		let primaryMime: string = null;
 
-		if (typeof lang.mimetypes !== 'undefined' && Array.isArray(lang.mimetypes)) {
-			for (let i = 0; i < lang.mimetypes.length; i++) {
-				if (!primaryMime) {
-					primaryMime = lang.mimetypes[i];
-				}
-				resolvedLanguage.mimetypes.push(lang.mimetypes[i]);
-			}
+		if (Array.isArray(lang.mimetypes) && lang.mimetypes.length) {
+			resolvedLanguage.mimetypes.push(...lang.mimetypes);
+			primaryMime = lang.mimetypes[0];
 		}
 
 		if (!primaryMime) {


### PR DESCRIPTION
This PR simplify mergeLanguage

1) Remove needless check for type `undefined`, because `Array.isArray` doesn't pass `undefined`, `null`, etc.
2) Get rid of `for loop` and use native push + spread
3) Don't check `primaryMime` in each step. Just pull from first element.