### PR TITLE
Build VS Code with TS 2.7

### DIFF
--- a/build/monaco/api.js
+++ b/build/monaco/api.js
@@ -171,9 +171,7 @@ function format(text) {
     function getRuleProvider(options) {
         // Share this between multiple formatters using the same options.
         // This represents the bulk of the space the formatter uses.
-        var ruleProvider = new ts.formatting.RulesProvider();
-        ruleProvider.ensureUpToDate(options);
-        return ruleProvider;
+        return ts.formatting.getFormatContext(options);
     }
     function applyEdits(text, edits) {
         // Apply edits in reverse on the existing text

--- a/build/monaco/api.ts
+++ b/build/monaco/api.ts
@@ -196,9 +196,7 @@ function format(text:string): string {
 	function getRuleProvider(options: ts.FormatCodeSettings) {
 		// Share this between multiple formatters using the same options.
 		// This represents the bulk of the space the formatter uses.
-		let ruleProvider = new (<any>ts).formatting.RulesProvider();
-		ruleProvider.ensureUpToDate(options);
-		return ruleProvider;
+		return (ts as any).formatting.getFormatContext(options);
 	}
 
 	function applyEdits(text: string, edits: ts.TextChange[]): string {

--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "documentdb": "1.13.0",
     "mime": "^1.3.4",
     "minimist": "^1.2.0",
-    "typescript": "2.6.1",
+    "typescript": "2.7.1",
     "xml2js": "^0.4.17"
   },
   "scripts": {

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -427,9 +427,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-typescript@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 underscore@1.8.3, underscore@~1.8.3:
   version "1.8.3"

--- a/extensions/markdown/syntaxes/markdown.tmLanguage.json
+++ b/extensions/markdown/syntaxes/markdown.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/microsoft/vscode-markdown-tm-grammar/commit/cdfdaf47163809791dfcb324472b0830a3153efe",
+	"version": "https://github.com/microsoft/vscode-markdown-tm-grammar/commit/1ba9efd21c29c70dd87d8402a92ef64666dcb25e",
 	"fileTypes": [
 		"md",
 		"mdown",
@@ -623,13 +623,13 @@
 					"name": "meta.image.reference.markdown"
 				},
 				"italic": {
-					"begin": "(?x) \\b(\\*|_)(?=\\S)\t\t\t\t\t\t\t\t# Open\n  (?=\n    (\n      <[^>]*+>\t\t\t\t\t\t\t# HTML tags\n      | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n                        # Raw\n      | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+\t\t\t# Escapes\n      | \\[\n      (\n          (?<square>\t\t\t\t\t# Named group\n            [^\\[\\]\\\\]\t\t\t\t# Match most chars\n            | \\\\.\t\t\t\t\t\t# Escaped chars\n            | \\[ \\g<square>*+ \\]\t\t# Nested brackets\n          )*+\n        \\]\n        (\n          (\t\t\t\t\t\t\t# Reference Link\n            [ ]?\t\t\t\t\t# Optional space\n            \\[[^\\]]*+\\]\t\t\t\t# Ref name\n          )\n          | (\t\t\t\t\t\t\t# Inline Link\n            \\(\t\t\t\t\t\t# Opening paren\n              [ \\t]*+\t\t\t\t# Optional whtiespace\n              <?(.*?)>?\t\t\t# URL\n              [ \\t]*+\t\t\t\t# Optional whtiespace\n              (\t\t\t\t\t# Optional Title\n                (?<title>['\"])\n                (.*?)\n                \\k<title>\n              )?\n            \\)\n          )\n        )\n      )\n      | \\1\\1\t\t\t\t\t\t\t\t# Must be bold closer\n      | (?!(?<=\\S)\\1).\t\t\t\t\t\t# Everything besides\n                        # style closer\n    )++\n    (?<=\\S)\\1\t\t\t\t\t\t\t\t# Close\n  )\n",
+					"begin": "(?x) (\\*\\b|\\b_)(?=\\S)\t\t\t\t\t\t\t\t# Open\n  (?=\n    (\n      <[^>]*+>\t\t\t\t\t\t\t# HTML tags\n      | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n                        # Raw\n      | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+\t\t\t# Escapes\n      | \\[\n      (\n          (?<square>\t\t\t\t\t# Named group\n            [^\\[\\]\\\\]\t\t\t\t# Match most chars\n            | \\\\.\t\t\t\t\t\t# Escaped chars\n            | \\[ \\g<square>*+ \\]\t\t# Nested brackets\n          )*+\n        \\]\n        (\n          (\t\t\t\t\t\t\t# Reference Link\n            [ ]?\t\t\t\t\t# Optional space\n            \\[[^\\]]*+\\]\t\t\t\t# Ref name\n          )\n          | (\t\t\t\t\t\t\t# Inline Link\n            \\(\t\t\t\t\t\t# Opening paren\n              [ \\t]*+\t\t\t\t# Optional whtiespace\n              <?(.*?)>?\t\t\t# URL\n              [ \\t]*+\t\t\t\t# Optional whtiespace\n              (\t\t\t\t\t# Optional Title\n                (?<title>['\"])\n                (.*?)\n                \\k<title>\n              )?\n            \\)\n          )\n        )\n      )\n      | \\1\\1\t\t\t\t\t\t\t\t# Must be bold closer\n      | (?!(?<=\\S)\\1).\t\t\t\t\t\t# Everything besides\n                        # style closer\n    )++\n    (?<=\\S)\\1\t\t\t\t\t\t\t\t# Close\n  )\n",
 					"captures": {
 						"1": {
 							"name": "punctuation.definition.italic.markdown"
 						}
 					},
-					"end": "(?<=\\S)(\\1)((?!\\1)|(?=\\1\\1))\\b",
+					"end": "(?<=\\S)(\\1)((?!\\1)|(?=\\1\\1))",
 					"name": "markup.italic.markdown",
 					"patterns": [
 						{

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "sinon": "^1.17.2",
     "source-map": "^0.4.4",
     "tslint": "^5.8.0",
-    "typescript": "2.6.1",
+    "typescript": "2.7.1",
     "typescript-formatter": "4.0.1",
     "uglify-es": "^3.0.18",
     "underscore": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5653,9 +5653,9 @@ typescript-formatter@4.0.1:
     editorconfig "^0.13.2"
     glob-expand "^0.2.1"
 
-typescript@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 typescript@^2.6.2:
   version "2.6.2"


### PR DESCRIPTION
Fixes #43136 

Updates VS Code to build with TS 2.7

Mostly just adding casts/type modifiers. Please take a look through your files to make sure things look ok. Let me know if you have a better fix in mind.

Current blocked by a tslint error on format in the git pre-commit hook. 