### PR TITLE
Dropdown: Restore original selection on escape exit Fixes: #42487

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -520,6 +520,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 				index: this.selectElement.selectedIndex,
 				selected: this.selectElement.title
 			});
+
+			// Reset Selection Handler
+			this._currentSelection = -1;
 			this.hideSelectDropDown(true);
 		}
 		dom.EventHelper.stop(e);
@@ -527,6 +530,10 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 	// List Exit - passive - hide drop-down, fire onDidSelect
 	private onListBlur(): void {
+
+		if (this._currentSelection >= 0) {
+			this.select(this._currentSelection);
+		}
 
 		this._onDidSelect.fire({
 			index: this.selectElement.selectedIndex,
@@ -553,6 +560,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	// List exit - active - hide ContextView dropdown, return focus to parent select, fire onDidSelect
 	private onEnter(e: StandardKeyboardEvent): void {
 		dom.EventHelper.stop(e);
+
+		// Reset current selection
+		this._currentSelection = -1;
 
 		this.hideSelectDropDown(true);
 		this._onDidSelect.fire({

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -88,6 +88,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	private selectList: List<ISelectOptionItem>;
 	private selectDropDownListContainer: HTMLElement;
 	private widthControlElement: HTMLElement;
+	private _onOriginalSelect: ISelectData;
 
 	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles) {
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -88,7 +88,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	private selectList: List<ISelectOptionItem>;
 	private selectDropDownListContainer: HTMLElement;
 	private widthControlElement: HTMLElement;
-	private _onOriginalSelect: ISelectData;
+	private _onOriginalSelect: number;
 
 	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles) {
 
@@ -358,6 +358,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 				dom.toggleClass(this.selectElement, 'synthetic-focus', false);
 			}
 		});
+		this._onOriginalSelect = this.selected;
 	}
 
 	private hideSelectDropDown(focusSelect: boolean) {
@@ -539,6 +540,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	// List exit - active - hide ContextView dropdown, return focus to parent select, fire onDidSelect
 	private onEscape(e: StandardKeyboardEvent): void {
 		dom.EventHelper.stop(e);
+		this.selectElement.selected = this.select(this._onOriginalSelect);
 
 		this.hideSelectDropDown(true);
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -527,7 +527,6 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 	// List Exit - passive - hide drop-down, fire onDidSelect
 	private onListBlur(): void {
-		this.select(this._currentSelection);
 
 		this._onDidSelect.fire({
 			index: this.selectElement.selectedIndex,

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -88,7 +88,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	private selectList: List<ISelectOptionItem>;
 	private selectDropDownListContainer: HTMLElement;
 	private widthControlElement: HTMLElement;
-	private _onOriginalSelect: number;
+	private _currentSelection: number;
 
 	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles) {
 
@@ -358,7 +358,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 				dom.toggleClass(this.selectElement, 'synthetic-focus', false);
 			}
 		});
-		this._onOriginalSelect = this.selected;
+		this._currentSelection = this.selected;
 	}
 
 	private hideSelectDropDown(focusSelect: boolean) {
@@ -527,6 +527,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 	// List Exit - passive - hide drop-down, fire onDidSelect
 	private onListBlur(): void {
+		this.select(this._currentSelection);
 
 		this._onDidSelect.fire({
 			index: this.selectElement.selectedIndex,
@@ -540,7 +541,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	// List exit - active - hide ContextView dropdown, return focus to parent select, fire onDidSelect
 	private onEscape(e: StandardKeyboardEvent): void {
 		dom.EventHelper.stop(e);
-		this.selectElement.selected = this.select(this._onOriginalSelect);
+		this.select(this._currentSelection);
 
 		this.hideSelectDropDown(true);
 


### PR DESCRIPTION
Fixes #42487 

Change new custom select (dropdown) to revert to current selection if user presses Escape or
blurs focus by pressing the mouse outside the drop-down.

The native select behavior remains unchanged by design.