### PR TITLE
Fix for Emmet's wrap with abbreviation inserting extra spaces

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -337,7 +337,7 @@
         "@emmetio/html-matcher": "^0.3.3",
         "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",
         "@emmetio/math-expression": "^0.1.1",
-        "vscode-emmet-helper": "^1.1.32",
+        "vscode-emmet-helper": "^1.1.36",
         "vscode-languageserver-types": "^3.5.0",
         "image-size": "^0.5.2",
         "vscode-nls": "3.2.1"

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -62,7 +62,8 @@ export function wrapWithAbbreviation(args: any) {
 			const preceedingWhiteSpace = matches ? matches[1].length : 0;
 
 			rangeToReplace = new vscode.Range(rangeToReplace.start.line, rangeToReplace.start.character + preceedingWhiteSpace, rangeToReplace.end.line, rangeToReplace.end.character);
-			expandAbbrList.push({ syntax, abbreviation, rangeToReplace, textToWrap: ['\n\t$TM_SELECTED_TEXT\n'], filter });
+			let textToWrap = rangeToReplace.end.line === rangeToReplace.start.line ? ['$TM_SELECTED_TEXT'] : ['\n\t$TM_SELECTED_TEXT\n'];
+			expandAbbrList.push({ syntax, abbreviation, rangeToReplace, textToWrap, filter });
 		});
 
 		return expandAbbreviationInRange(editor, expandAbbrList, true);
@@ -441,11 +442,6 @@ function expandAbbr(input: ExpandAbbreviationInput): string | undefined {
 			// All $anyword would have been escaped by the emmet helper.
 			// Remove the escaping backslash from $TM_SELECTED_TEXT so that VS Code Snippet controller can treat it as a variable
 			expandedText = expandedText.replace('\\$TM_SELECTED_TEXT', '$TM_SELECTED_TEXT');
-
-			// If the expanded text is single line then we dont need the \t and \n we added to $TM_SELECTED_TEXT earlier
-			if (input.textToWrap.length === 1 && expandedText.indexOf('\n') === -1) {
-				expandedText = expandedText.replace(/\s*\$TM_SELECTED_TEXT\s*/, '$TM_SELECTED_TEXT');
-			}
 		}
 
 		return expandedText;

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -448,15 +448,13 @@ function expandAbbr(input: ExpandAbbreviationInput): string | undefined {
 			if (input.rangeToReplace.isSingleLine) {
 
 				// Fetch innermost element in the expanded abbreviation
-				let tagRegexp = /\$TM_SELECTED_TEXT\s*<\/([a-z,A-Z]*)/;
+				let tagRegexp = /\$TM_SELECTED_TEXT<\/([a-z,A-Z,:,-]*)>/;
 				let tagName = expandedText.match(tagRegexp)[1];
 
 				// If wrapping with a block element, insert newline and expand again
+				// We need to expand again because emmet module can't know if the text being wrapped is multiline.
 				if (inlineElements.indexOf(tagName) === -1 && input.textToWrap.length === 1) {
-					if (expandOptions['text'][0].indexOf('\n') === -1) {
-						expandOptions['text'][0] = '\n\t' + expandOptions['text'][0] + '\n';
-					}
-					// We need to expand again because emmet module can't know if the text being wrapped is multiline.
+					expandOptions['text'][0] = '\n\t' + expandOptions['text'][0] + '\n';
 					expandedText = helper.expandAbbreviation(input.abbreviation, expandOptions);
 				}
 			}

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -446,20 +446,18 @@ function expandAbbr(input: ExpandAbbreviationInput): string | undefined {
 
 		if (input.textToWrap) {
 			let parsedAbbr = helper.parseAbbreviation(input.abbreviation, expandOptions);
-			if (input.rangeToReplace.isSingleLine) {
+			if (input.rangeToReplace.isSingleLine && input.textToWrap.length === 1) {
 
-				// Fetch innermost element in the expanded abbreviation
-				let lastNode = parsedAbbr;
-				let tagName = parsedAbbr.name || '';
-				while (lastNode.children && lastNode.children.length > 0) {
-					lastNode = lastNode.children[lastNode.children.length - 1];
-					tagName = lastNode.name;
+				// Fetch rightmost element in the parsed abbreviation (i.e the element that will contain the wrapped text).
+				let wrappingNode = parsedAbbr;
+				while (wrappingNode.children && wrappingNode.children.length > 0) {
+					wrappingNode = wrappingNode.children[wrappingNode.children.length - 1];
 				}
+				let tagName = wrappingNode.name;
 
-				// If wrapping with a block element, insert newline and expand again
-				// We need to expand again because emmet module can't know if the text being wrapped is multiline.
-				if (inlineElements.indexOf(tagName) === -1 && input.textToWrap.length === 1) {
-					lastNode.value = '\n\t' + lastNode.value + '\n';
+				// If wrapping with a block element, insert newline in the text to wrap.
+				if (inlineElements.indexOf(tagName) === -1) {
+					wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
 				}
 			}
 			expandedText = helper.expandAbbreviation(parsedAbbr, expandOptions);

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -448,8 +448,8 @@ function expandAbbr(input: ExpandAbbreviationInput): string | undefined {
 			if (input.rangeToReplace.isSingleLine) {
 
 				// Fetch innermost element in the expanded abbreviation
-				let wrappingEnd = expandedText.substring(expandedText.indexOf('$TM_SELECTED_TEXT'));
-				let tagName = wrappingEnd.substring(wrappingEnd.indexOf('/') + 1, wrappingEnd.indexOf('>'));
+				let tagRegexp = /\$TM_SELECTED_TEXT\s*<\/([a-z,A-Z]*)/;
+				let tagName = expandedText.match(tagRegexp)[1];
 
 				// If wrapping with a block element, insert newline and expand again
 				if (inlineElements.indexOf(tagName) === -1 && input.textToWrap.length === 1) {

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -450,13 +450,12 @@ function expandAbbr(input: ExpandAbbreviationInput): string | undefined {
 
 				// Fetch rightmost element in the parsed abbreviation (i.e the element that will contain the wrapped text).
 				let wrappingNode = parsedAbbr;
-				while (wrappingNode.children && wrappingNode.children.length > 0) {
+				while (wrappingNode && wrappingNode.children && wrappingNode.children.length > 0) {
 					wrappingNode = wrappingNode.children[wrappingNode.children.length - 1];
 				}
-				let tagName = wrappingNode.name;
 
 				// If wrapping with a block element, insert newline in the text to wrap.
-				if (inlineElements.indexOf(tagName) === -1) {
+				if (wrappingNode && inlineElements.indexOf(wrappingNode.name) === -1) {
 					wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
 				}
 			}

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -197,6 +197,30 @@ suite('Tests for Wrap with Abbreviations', () => {
 		});
 	});
 
+	test('Wrap with multiline abbreviation doesnt add extra spaces', () => {
+		const contents = `
+	hello
+	`;
+		const expectedContents = `
+	<ul>
+		<li><a href="">hello</a></li>
+	</ul>
+	`;
+
+		return withRandomFileEditor(contents, 'html', (editor, doc) => {
+			editor.selections = [new Selection(1, 2, 1, 2)];
+			const promise = wrapWithAbbreviation({ abbreviation: 'ul>li>a' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap returned undefined instead of promise.');
+				return Promise.resolve();
+			}
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), expectedContents);
+				return Promise.resolve();
+			});
+		});
+	});
+
 	test('Wrap individual lines with abbreviation', () => {
 		const contents = `
 	<ul class="nav main">

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -198,6 +198,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 	});
 
 	test('Wrap with multiline abbreviation doesnt add extra spaces', () => {
+		// Issue #29898
 		const contents = `
 	hello
 	`;

--- a/extensions/emmet/yarn.lock
+++ b/extensions/emmet/yarn.lock
@@ -2052,17 +2052,21 @@ vinyl@~2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-emmet-helper@^1.1.32:
-  version "1.1.32"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.1.32.tgz#5a67c6aa34255129d8b6564f5182f016a2b5b0da"
+vscode-emmet-helper@^1.1.36:
+  version "1.1.36"
+  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.1.36.tgz#537cbf91041a3d426f6f24dd9834550a26e61685"
   dependencies:
     "@emmetio/extract-abbreviation" "^0.1.4"
     jsonc-parser "^1.0.0"
-    vscode-languageserver-types "^3.5.0"
+    vscode-languageserver-types "^3.6.0-next.1"
 
 vscode-languageserver-types@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz#e48d79962f0b8e02de955e3f524908e2b19c0374"
+
+vscode-languageserver-types@^3.6.0-next.1:
+  version "3.6.0-next.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.6.0-next.1.tgz#98e488d3f87b666b4ee1a3d89f0023e246d358f3"
 
 vscode-nls@3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Fix for https://github.com/Microsoft/vscode/issues/29898
Now, when wrapping text with a multiline abbreviation such as `ul>li>a`, no extra spaces are added.

Added a unit test to keep track of this issue.