### PR TITLE
Allow to filter keyBindings by 'Source'.

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -51,7 +51,7 @@ export class KeybindingsEditorInput extends EditorInput {
 	public static readonly ID: string = 'workbench.input.keybindings';
 	public readonly keybindingsModel: KeybindingsEditorModel;
 
-	constructor(@IInstantiationService instantiationService: IInstantiationService) {
+	constructor( @IInstantiationService instantiationService: IInstantiationService) {
 		super();
 		this.keybindingsModel = instantiationService.createInstance(KeybindingsEditorModel, OS);
 	}
@@ -245,10 +245,10 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 			this.reportKeybindingAction(KEYBINDINGS_EDITOR_COMMAND_REMOVE, keybindingEntry.keybindingItem.command, keybindingEntry.keybindingItem.keybinding);
 			return this.keybindingEditingService.removeKeybinding(keybindingEntry.keybindingItem.keybindingItem)
 				.then(() => this.focus(),
-					error => {
-						this.onKeybindingEditingError(error);
-						this.selectEntry(keybindingEntry);
-					});
+				error => {
+					this.onKeybindingEditingError(error);
+					this.selectEntry(keybindingEntry);
+				});
 		}
 		return TPromise.as(null);
 	}
@@ -263,10 +263,10 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 				}
 				this.selectEntry(keybindingEntry);
 			},
-				error => {
-					this.onKeybindingEditingError(error);
-					this.selectEntry(keybindingEntry);
-				});
+			error => {
+				this.onKeybindingEditingError(error);
+				this.selectEntry(keybindingEntry);
+			});
 	}
 
 	copyKeybinding(keybinding: IKeybindingItemEntry): TPromise<any> {

--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -234,10 +234,10 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 			this.reportKeybindingAction(KEYBINDINGS_EDITOR_COMMAND_REMOVE, keybindingEntry.keybindingItem.command, keybindingEntry.keybindingItem.keybinding);
 			return this.keybindingEditingService.removeKeybinding(keybindingEntry.keybindingItem.keybindingItem)
 				.then(() => this.focus(),
-					error => {
-						this.onKeybindingEditingError(error);
-						this.selectEntry(keybindingEntry);
-					});
+				error => {
+					this.onKeybindingEditingError(error);
+					this.selectEntry(keybindingEntry);
+				});
 		}
 		return TPromise.as(null);
 	}
@@ -252,10 +252,10 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 				}
 				this.selectEntry(keybindingEntry);
 			},
-				error => {
-					this.onKeybindingEditingError(error);
-					this.selectEntry(keybindingEntry);
-				});
+			error => {
+				this.onKeybindingEditingError(error);
+				this.selectEntry(keybindingEntry);
+			});
 	}
 
 	copyKeybinding(keybinding: IKeybindingItemEntry): TPromise<any> {

--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -98,7 +98,6 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 	private keybindingFocusContextKey: IContextKey<boolean>;
 	private searchFocusContextKey: IContextKey<boolean>;
 	private sortByPrecedence: Checkbox;
-	private secondaryActions: IAction[];
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -178,37 +177,27 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 		return focusedElement && focusedElement.templateId === KEYBINDING_ENTRY_TEMPLATE_ID ? <IKeybindingItemEntry>focusedElement : null;
 	}
 
-	setKeybindingSource(searchString: string): TPromise<any> {
-		this.searchWidget.setValue(searchString);
-		return TPromise.as(null);
-	}
-
-	showDefaultKeyBindings(): IAction {
-		return <IAction>{
-			label: localize('showDefaultKeybindings', "Show Default Keybindings"),
-			enabled: true,
-			id: KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS,
-			run: () => this.setKeybindingSource('source: default')
-		};
-	}
-
-	showUserKeyBindings(): IAction {
-		return <IAction>{
-			label: localize('showUserKeybindings', "Show User Keybindings"),
-			enabled: true,
-			id: KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS,
-			run: () => this.setKeybindingSource('source: user')
-		};
-	}
-
 	getSecondaryActions(): IAction[] {
-		if (!this.secondaryActions) {
-			this.secondaryActions = [
-				this.showDefaultKeyBindings(),
-				this.showUserKeyBindings(),
-			];
-		}
-		return this.secondaryActions;
+		return <IAction[]>[
+			<IAction>{
+				label: localize('showDefaultKeybindings', "Show Default Keybindings"),
+				enabled: true,
+				id: KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS,
+				run: (): TPromise<any> => {
+					this.searchWidget.setValue('@source: default');
+					return TPromise.as(null);
+				}
+			},
+			<IAction>{
+				label: localize('showUserKeybindings', "Show User Keybindings"),
+				enabled: true,
+				id: KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS,
+				run: (): TPromise<any> => {
+					this.searchWidget.setValue('@source: user');
+					return TPromise.as(null);
+				}
+			}
+		];
 	}
 
 	defineKeybinding(keybindingEntry: IKeybindingItemEntry): TPromise<any> {
@@ -245,10 +234,10 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 			this.reportKeybindingAction(KEYBINDINGS_EDITOR_COMMAND_REMOVE, keybindingEntry.keybindingItem.command, keybindingEntry.keybindingItem.keybinding);
 			return this.keybindingEditingService.removeKeybinding(keybindingEntry.keybindingItem.keybindingItem)
 				.then(() => this.focus(),
-				error => {
-					this.onKeybindingEditingError(error);
-					this.selectEntry(keybindingEntry);
-				});
+					error => {
+						this.onKeybindingEditingError(error);
+						this.selectEntry(keybindingEntry);
+					});
 		}
 		return TPromise.as(null);
 	}
@@ -263,10 +252,10 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 				}
 				this.selectEntry(keybindingEntry);
 			},
-			error => {
-				this.onKeybindingEditingError(error);
-				this.selectEntry(keybindingEntry);
-			});
+				error => {
+					this.onKeybindingEditingError(error);
+					this.selectEntry(keybindingEntry);
+				});
 	}
 
 	copyKeybinding(keybinding: IKeybindingItemEntry): TPromise<any> {

--- a/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
@@ -121,27 +121,20 @@ export class KeybindingsEditorModel extends EditorModel {
 		return searchValue.split('@source:')[1].trim() || '';
 	}
 
+	private matchSource(itemSource: string, searchValue: string): boolean {
+		return itemSource.toLowerCase() === searchValue.toLowerCase();
+	}
+
 	private filterBySource(keybindingItems: IKeybindingItem[], searchValue: string, completeMatch: boolean): IKeybindingItemEntry[] {
-		const result: IKeybindingItemEntry[] = [];
-		const words = searchValue.split(' ');
-		const keybindingWords = this.splitKeybindingWords(words);
-		for (const keybindingItem of keybindingItems) {
-			let keybindingMatches = new KeybindingItemMatches(this.modifierLabels, keybindingItem, searchValue, words, keybindingWords, completeMatch);
-			if (keybindingMatches.sourceMatches) {
-				result.push({
+		return <IKeybindingItemEntry[]>keybindingItems
+			.filter((keybindingItem: IKeybindingItem) => this.matchSource(keybindingItem.source, searchValue))
+			.map((keybindingItem: IKeybindingItem) => (
+				{
 					id: KeybindingsEditorModel.getId(keybindingItem),
 					templateId: KEYBINDING_ENTRY_TEMPLATE_ID,
-					commandLabelMatches: keybindingMatches.commandLabelMatches,
-					commandDefaultLabelMatches: keybindingMatches.commandDefaultLabelMatches,
 					keybindingItem,
-					keybindingMatches: keybindingMatches.keybindingMatches,
-					commandIdMatches: keybindingMatches.commandIdMatches,
-					sourceMatches: keybindingMatches.sourceMatches,
-					whenMatches: keybindingMatches.whenMatches
-				});
-			}
-		}
-		return result;
+				}
+			));
 	}
 
 	private filterByText(keybindingItems: IKeybindingItem[], searchValue: string, completeMatch: boolean): IKeybindingItemEntry[] {

--- a/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
@@ -243,9 +243,16 @@ class KeybindingItemMatches {
 		this.commandIdMatches = this.matches(searchValue, keybindingItem.command, or(matchesWords, matchesCamelCase), words);
 		this.commandLabelMatches = keybindingItem.commandLabel ? this.matches(searchValue, keybindingItem.commandLabel, (word, wordToMatchAgainst) => matchesWords(word, keybindingItem.commandLabel, true), words) : null;
 		this.commandDefaultLabelMatches = keybindingItem.commandDefaultLabel ? this.matches(searchValue, keybindingItem.commandDefaultLabel, (word, wordToMatchAgainst) => matchesWords(word, keybindingItem.commandDefaultLabel, true), words) : null;
-		this.sourceMatches = this.matches(searchValue, keybindingItem.source, (word, wordToMatchAgainst) => matchesWords(word, keybindingItem.source, true), words);
+		this.sourceMatches = this.matches(this.checkForSourceFilter(searchValue), keybindingItem.source, (word, wordToMatchAgainst) => matchesWords(word, keybindingItem.source, true), words);
 		this.whenMatches = keybindingItem.when ? this.matches(searchValue, keybindingItem.when, or(matchesWords, matchesCamelCase), words) : null;
 		this.keybindingMatches = keybindingItem.keybinding ? this.matchesKeybinding(keybindingItem.keybinding, searchValue, keybindingWords) : null;
+	}
+
+	private checkForSourceFilter(searchValue: string) {
+		const words = searchValue.split(':');
+		return (words[0].trim().toLowerCase() === 'source') ?
+			words[1].trim() :
+			searchValue;
 	}
 
 	private matches(searchValue: string, wordToMatchAgainst: string, wordMatchesFilter: IFilter, words: string[]): IMatch[] {

--- a/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
@@ -250,7 +250,7 @@ class KeybindingItemMatches {
 
 	private checkForSourceFilter(searchValue: string) {
 		const words = searchValue.split(':');
-		return (words.length) && (words[0].trim().toLowerCase() === 'source') ?
+		return (words.length) && (words[0].trim().toLowerCase() === '@source') ?
 			words[1].trim() :
 			searchValue;
 	}

--- a/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/parts/preferences/common/keybindingsEditorModel.ts
@@ -250,7 +250,7 @@ class KeybindingItemMatches {
 
 	private checkForSourceFilter(searchValue: string) {
 		const words = searchValue.split(':');
-		return (words[0].trim().toLowerCase() === 'source') ?
+		return (words.length) && (words[0].trim().toLowerCase() === 'source') ?
 			words[1].trim() :
 			searchValue;
 	}

--- a/src/vs/workbench/parts/preferences/common/preferences.ts
+++ b/src/vs/workbench/parts/preferences/common/preferences.ts
@@ -230,6 +230,8 @@ export const KEYBINDINGS_EDITOR_COMMAND_COPY = 'keybindings.editor.copyKeybindin
 export const KEYBINDINGS_EDITOR_COMMAND_COPY_COMMAND = 'keybindings.editor.copyCommandKeybindingEntry';
 export const KEYBINDINGS_EDITOR_COMMAND_SHOW_SIMILAR = 'keybindings.editor.showConflicts';
 export const KEYBINDINGS_EDITOR_COMMAND_FOCUS_KEYBINDINGS = 'keybindings.editor.focusKeybindings';
+export const KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS = 'keybindings.editor.showDefaultKeybindings';
+export const KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS = 'keybindings.editor.showUserKeybindings';
 
 export const FOLDER_SETTINGS_PATH = join('.vscode', 'settings.json');
 export const DEFAULT_SETTINGS_EDITOR_SETTING = 'workbench.settings.openDefaultSettings';

--- a/src/vs/workbench/parts/preferences/test/common/keybindingsEditorModel.test.ts
+++ b/src/vs/workbench/parts/preferences/test/common/keybindingsEditorModel.test.ts
@@ -258,24 +258,24 @@ suite('Keybindings Editor Model test', () => {
 		});
 	});
 
-	test('filter by default source with "source: " prefix', () => {
+	test('filter by default source with "@source: " prefix', () => {
 		const command = 'a' + uuid.generateUuid();
 		const expected = aResolvedKeybindingItem({ command, firstPart: { keyCode: KeyCode.Escape }, when: 'context1 && context2', isDefault: true });
 		prepareKeybindingService(expected);
 
 		return testObject.resolve({}).then(() => {
-			const actual = testObject.fetch('source: default').filter(element => element.keybindingItem.command === command)[0];
+			const actual = testObject.fetch('@source: default').filter(element => element.keybindingItem.command === command)[0];
 			assert.ok(actual);
 		});
 	});
 
-	test('filter by user source with "source: " prefix', () => {
+	test('filter by user source with "@source: " prefix', () => {
 		const command = 'a' + uuid.generateUuid();
 		const expected = aResolvedKeybindingItem({ command, firstPart: { keyCode: KeyCode.Escape }, when: 'context1 && context2', isDefault: false });
 		prepareKeybindingService(expected);
 
 		return testObject.resolve({}).then(() => {
-			const actual = testObject.fetch('source: user').filter(element => element.keybindingItem.command === command)[0];
+			const actual = testObject.fetch('@source: user').filter(element => element.keybindingItem.command === command)[0];
 			assert.ok(actual);
 		});
 	});

--- a/src/vs/workbench/parts/preferences/test/common/keybindingsEditorModel.test.ts
+++ b/src/vs/workbench/parts/preferences/test/common/keybindingsEditorModel.test.ts
@@ -258,15 +258,24 @@ suite('Keybindings Editor Model test', () => {
 		});
 	});
 
-	test('filter by source: filter', () => {
+	test('filter by default source with "source: " prefix', () => {
+		const command = 'a' + uuid.generateUuid();
+		const expected = aResolvedKeybindingItem({ command, firstPart: { keyCode: KeyCode.Escape }, when: 'context1 && context2', isDefault: true });
+		prepareKeybindingService(expected);
+
+		return testObject.resolve({}).then(() => {
+			const actual = testObject.fetch('source: default').filter(element => element.keybindingItem.command === command)[0];
+			assert.ok(actual);
+		});
+	});
+
+	test('filter by user source with "source: " prefix', () => {
 		const command = 'a' + uuid.generateUuid();
 		const expected = aResolvedKeybindingItem({ command, firstPart: { keyCode: KeyCode.Escape }, when: 'context1 && context2', isDefault: false });
 		prepareKeybindingService(expected);
 
 		return testObject.resolve({}).then(() => {
-			let actual = testObject.fetch('source: user').filter(element => element.keybindingItem.command === command)[0];
-			assert.ok(actual);
-			actual = testObject.fetch('source: default').filter(element => element.keybindingItem.command === command)[0];
+			const actual = testObject.fetch('source: user').filter(element => element.keybindingItem.command === command)[0];
 			assert.ok(actual);
 		});
 	});

--- a/src/vs/workbench/parts/preferences/test/common/keybindingsEditorModel.test.ts
+++ b/src/vs/workbench/parts/preferences/test/common/keybindingsEditorModel.test.ts
@@ -258,6 +258,19 @@ suite('Keybindings Editor Model test', () => {
 		});
 	});
 
+	test('filter by source: filter', () => {
+		const command = 'a' + uuid.generateUuid();
+		const expected = aResolvedKeybindingItem({ command, firstPart: { keyCode: KeyCode.Escape }, when: 'context1 && context2', isDefault: false });
+		prepareKeybindingService(expected);
+
+		return testObject.resolve({}).then(() => {
+			let actual = testObject.fetch('source: user').filter(element => element.keybindingItem.command === command)[0];
+			assert.ok(actual);
+			actual = testObject.fetch('source: default').filter(element => element.keybindingItem.command === command)[0];
+			assert.ok(actual);
+		});
+	});
+
 	test('filter by when context', () => {
 		const command = 'a' + uuid.generateUuid();
 		const expected = aResolvedKeybindingItem({ command, firstPart: { keyCode: KeyCode.Escape }, when: 'whenContext1 && whenContext2', isDefault: false });


### PR DESCRIPTION
This adds a source filter to the Key Bindings Editor View.
Usage: `source: user`   |   `source: default`

Tasks - 
- [x] source filter working
- [x] Tests passing
- [x] Update the test for the file changes


Closes: #43037