### PR TITLE
enclose git option (revision name) in apostrophes

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1160,7 +1160,7 @@ export class Repository {
 	}
 
 	async getRefs(): Promise<Ref[]> {
-		const result = await this.run(['for-each-ref', '--format', '%(refname) %(objectname)', '--sort', '-committerdate']);
+		const result = await this.run(['for-each-ref', '--format', '\'%(refname) %(objectname)\'', '--sort', '-committerdate']);
 
 		const fn = (line: string): Ref | null => {
 			let match: RegExpExecArray | null;
@@ -1220,7 +1220,7 @@ export class Repository {
 		const commit = result.stdout.trim();
 
 		try {
-			const res2 = await this.run(['rev-parse', '--symbolic-full-name', '--abbrev-ref', name + '@{u}']);
+			const res2 = await this.run(['rev-parse', '--symbolic-full-name', '--abbrev-ref', '\'' + name + '@{u}' + '\'']);
 			const upstream = res2.stdout.trim();
 
 			const res3 = await this.run(['rev-list', '--left-right', name + '...' + upstream]);


### PR DESCRIPTION
related to https://github.com/Microsoft/vscode/issues/41636#issuecomment-359954268, https://github.com/Microsoft/vscode/issues/41896#issuecomment-365209525
I know vscode does not support msys2 git, but with this modification, at least for me, vscode looks working well.
I still need .bat file shown in https://github.com/Microsoft/vscode/issues/4651, though.
```bat
@echo off
setlocal

rem If you don't add path for msys2 into %PATH%, enable following line.
set HOME=%~d0/home/MY_USERNAME
set PATH=%~dp0usr/bin;%PATH%

if "%1 %2" equ "rev-parse --show-toplevel" goto rev_parse
git %*
goto :eof
:rev_parse
for /f %%1 in ('git %*') do cygpath -w %%1
```