### PR TITLE
make the timeout for formatOnSave configurable

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -197,8 +197,10 @@ class FormatOnSaveParticipant implements ISaveParticipantParticipant {
 		const versionNow = model.getVersionId();
 		const { tabSize, insertSpaces } = model.getOptions();
 
+		const timeout = this._configurationService.getValue('editor.formatOnSaveTimeout', { overrideIdentifier: model.getLanguageIdentifier().language, resource: editorModel.getResource() });
+
 		return new Promise<ISingleEditOperation[]>((resolve, reject) => {
-			setTimeout(reject, 750);
+			setTimeout(reject, timeout);
 			getDocumentFormattingEdits(model, { tabSize, insertSpaces })
 				.then(edits => this._editorWorkerService.computeMoreMinimalEdits(model.uri, edits))
 				.then(resolve, err => {

--- a/src/vs/workbench/parts/files/electron-browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/files.contribution.ts
@@ -303,6 +303,7 @@ configurationRegistry.registerConfiguration({
 			'type': 'number',
 			'default': 750,
 			'description': nls.localize('formatOnSaveTimeout', "Format on save timeout. Specifies a time limit in milliseconds for formatOnSave-commands. Commands taking longer than the specified timeout will be cancelled."),
+			'overridable': true,
 			'scope': ConfigurationScope.RESOURCE
 		}
 	}

--- a/src/vs/workbench/parts/files/electron-browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/files.contribution.ts
@@ -298,6 +298,12 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('formatOnSave', "Format a file on save. A formatter must be available, the file must not be auto-saved, and editor must not be shutting down."),
 			'overridable': true,
 			'scope': ConfigurationScope.RESOURCE
+		},
+		'editor.formatOnSaveTimeout': {
+			'type': 'number',
+			'default': 750,
+			'description': nls.localize('formatOnSaveTimeout', "Format on save timeout. Specifies a time limit in milliseconds for formatOnSave-commands. Commands taking longer than the specified timeout will be cancelled."),
+			'scope': ConfigurationScope.RESOURCE
 		}
 	}
 });


### PR DESCRIPTION
Fixes #41194 

As reported by users of extensions for `TypeScript`, `Python`, `ruby` and `go` `formatOnSave`-commands can take longer than the hard coded `750 ms`, e.g. for large projects or complex commands.

This removes the hardcoded value and instead makes it user configurable.