### PR TITLE
fixed #38232

### DIFF
--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -228,6 +228,9 @@ export class CommonFindController extends Disposable implements editorCommon.IEd
 	}
 
 	public setSearchString(searchString: string): void {
+		if (this._state.isRegex) {
+			searchString = strings.escapeRegExpCharacters(searchString);
+		}
 		this._state.change({ searchString: searchString }, false);
 	}
 

--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -538,7 +538,7 @@ export abstract class SelectionMatchFindAction extends EditorAction {
 		if (!this._run(controller)) {
 			controller.start({
 				forceRevealReplace: false,
-				seedSearchStringFromSelection: false,
+				seedSearchStringFromSelection: editor.getConfiguration().contribInfo.find.seedSearchStringFromSelection,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.NoFocusChange,
 				shouldAnimate: true


### PR DESCRIPTION
This fixes https://github.com/Microsoft/vscode/issues/38232 which allows for Find Next Selection to have escaped characters in Find Window. Thanks for considering this request. 