### PR TITLE
Added focus to quick fix widget click

### DIFF
--- a/src/vs/editor/contrib/quickFix/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/quickFix/lightBulbWidget.ts
@@ -39,6 +39,8 @@ export class LightBulbWidget implements IDisposable, IContentWidget {
 		this._disposables.push(this._editor.onDidChangeModel(_ => this._futureFixes.cancel()));
 		this._disposables.push(this._editor.onDidChangeModelLanguage(_ => this._futureFixes.cancel()));
 		this._disposables.push(dom.addStandardDisposableListener(this._domNode, 'click', e => {
+			// Make sure that focus / cursor location is not lost when clicking widget icon
+			this._editor.focus();
 			// a bit of extra work to make sure the menu
 			// doesn't cover the line-text
 			const { top, height } = dom.getDomNodePagePosition(this._domNode);


### PR DESCRIPTION
Fixes #43002

Added a focus to the quick fix widget icon click so that editor / cursor remain present during fix selection and after fix has been applied. 

The addition of the focus now making clicking the widget mirror the behavior of pressing `CMD`+`.`

