### PR TITLE
Allow white-spaces after # for region folding in python

### DIFF
--- a/extensions/python/language-configuration.json
+++ b/extensions/python/language-configuration.json
@@ -41,8 +41,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*#region\\b",
-			"end": "^\\s*#endregion\\b"
+			"start": "^\\s*#\\s*region\\b",
+			"end": "^\\s*#\\s*endregion\\b"
 		}
 	}
 }


### PR DESCRIPTION
It is impossible to use region folding in python with auto-format enabled as it adds space after # automatically. This PR allows one or more whitespace characters between `#` and `region` so that region folding can be used with auto-format enabled.