### PR TITLE
Setting to center the layout when turning on the zen mode

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -408,6 +408,11 @@ configurationRegistry.registerConfiguration({
 			'default': true,
 			'description': nls.localize('zenMode.fullScreen', "Controls if turning on Zen Mode also puts the workbench into full screen mode.")
 		},
+		'zenMode.centeredLayout': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('zenMode.centeredLayout', "Controls if turning on Zen Mode also centers the layout.")
+		},
 		'zenMode.hideTabs': {
 			'type': 'boolean',
 			'default': true,


### PR DESCRIPTION
@isidorn as discussed in #40757 this PR adds a setting to centered the layout when activating the zenmode