### PR TITLE
Fix php grammar update script

### DIFF
--- a/extensions/php/build/update-grammar.js
+++ b/extensions/php/build/update-grammar.js
@@ -27,7 +27,7 @@ function fixBadRegex(grammar) {
 	if (scopeResolution) {
 		const match = scopeResolution.patterns[0].match;
 		if (match === '(?i)([a-z_\\x{7f}-\\x{7fffffff}\\\\][a-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(?=\\s*::)') {
-			scopeResolution.patterns[0].match = '([A-Za-z_\\x{7f}-\\x{7fffffff}\\\\][A_Za-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(?=\\s*::)';
+			scopeResolution.patterns[0].match = '([A-Za-z_\\x{7f}-\\x{7fffffff}\\\\][A-Za-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(?=\\s*::)';
 			return;
 		}
 	}

--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -2430,7 +2430,7 @@
 		"scope-resolution": {
 			"patterns": [
 				{
-					"match": "([A-Za-z_\\x{7f}-\\x{7fffffff}\\\\][A_Za-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(?=\\s*::)",
+					"match": "([A-Za-z_\\x{7f}-\\x{7fffffff}\\\\][A-Za-z0-9_\\x{7f}-\\x{7fffffff}\\\\]*)(?=\\s*::)",
 					"captures": {
 						"1": {
 							"patterns": [


### PR DESCRIPTION
This PR fixes #44032.

On a side note: I don't think we need the workaround applied in the `update-grammar.js` file anymore. I've opened some PHP files and it worked perfectly with Atom's regex (different from what was reported on #59 and #40279).

However, as I didn't test further, I decided to keep the workaround and just fix its regex.