### PR TITLE
Update package.json to support PowerShell Core shebang lines.

### DIFF
--- a/extensions/powershell/package.json
+++ b/extensions/powershell/package.json
@@ -10,6 +10,7 @@
 			"id": "powershell",
 			"extensions": [ ".ps1", ".psm1", ".psd1", ".pssc", ".psrc" ],
 			"aliases": [ "PowerShell", "powershell", "ps", "ps1" ],
+			"firstLine": "^#!/.*\\bpwsh\\b",
 			"configuration": "./language-configuration.json"
 		}],
 		"grammars": [{


### PR DESCRIPTION
PowerShell Core, whose executable filename is `pwsh`, supports shebang lines on Unix platforms. This change would make VSCode properly recognize extension-less PowerShell Core scripts that have a shebang line.