### PR TITLE
Keep item expanded after rename

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -525,7 +525,6 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 				modelElements.forEach(modelElement => {
 					//Check if element is expanded
 					isExpanded = this.explorerViewer.isExpanded(modelElement);
-
 					// Rename File (Model)
 					modelElement.rename(newElement);
 
@@ -537,7 +536,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 							this.explorerViewer.setFocus(modelElement);
 						}
 						//Expand the element again
-						if(isExpanded){
+						if (isExpanded) {
 							this.explorerViewer.expand(modelElement);
 						}
 					}, errors.onUnexpectedError);

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -518,10 +518,14 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 				restoreFocus = true;
 			}
 
+			let isExpanded = false;
 			// Handle Rename
 			if (oldParentResource && newParentResource && oldParentResource.toString() === newParentResource.toString()) {
 				const modelElements = this.model.findAll(oldResource);
 				modelElements.forEach(modelElement => {
+					//Check if element is expanded
+					isExpanded = this.explorerViewer.isExpanded(modelElement);
+
 					// Rename File (Model)
 					modelElement.rename(newElement);
 
@@ -531,6 +535,10 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 						// Select in Viewer if set
 						if (restoreFocus) {
 							this.explorerViewer.setFocus(modelElement);
+						}
+						//Expand the element again
+						if(isExpanded){
+							this.explorerViewer.expand(modelElement);
 						}
 					}, errors.onUnexpectedError);
 				});


### PR DESCRIPTION
Fixes #44230

Checks if the item is expanded and expanding it again after the rename.