### PR TITLE
Fix for "Cannot read property size of "undefined"" when navigate up/d…

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -231,6 +231,9 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 	}
 
 	elementHeight(index: number): number {
+		if (index === null || index === undefined) {
+			return 0;
+		}
 		return this.items[index].size;
 	}
 


### PR DESCRIPTION
Fixes #44309

Check for null or undefined index when navigating up/down on explorer list. 
Fixes the exception when explorer list is empty.