### PR TITLE
Run Active File In Active Terminal - make file path WSL Bash friendly

### DIFF
--- a/extensions/typescript-basics/test/colorize-fixtures/test-issue5566.ts
+++ b/extensions/typescript-basics/test/colorize-fixtures/test-issue5566.ts
@@ -1,3 +1,3 @@
 function foo3() {
-	const foo = (): any => ({ 'bar': 'baz' })
+	const foo = (): any => ({ 'bar': 'baz' });
 }

--- a/extensions/typescript-basics/test/colorize-fixtures/test.ts
+++ b/extensions/typescript-basics/test/colorize-fixtures/test.ts
@@ -13,7 +13,7 @@ module Conway {
 		constructor(row: number, col: number, live: boolean) {
 			this.row = row;
 			this.col = col;
-			this.live = live
+			this.live = live;
 		}
 	}
 
@@ -43,35 +43,35 @@ module Conway {
 		}
 
 		public createWorld() {
-			return this.travelWorld( (cell : Cell) =>  {
+			return this.travelWorld((cell: Cell) => {
 				cell.live = Math.random() < this.initialLifeProbability;
 				return cell;
 			});
 		}
 
-		public circleOfLife() : void {
-			this.world = this.travelWorld( (cell: Cell) => {
+		public circleOfLife(): void {
+			this.world = this.travelWorld((cell: Cell) => {
 				cell = this.world[cell.row][cell.col];
 				this.draw(cell);
 				return this.resolveNextGeneration(cell);
 			});
-			setTimeout( () => {this.circleOfLife()}, this.animationRate);
+			setTimeout(() => { this.circleOfLife(); }, this.animationRate);
 		}
 
-		public resolveNextGeneration(cell : Cell) {
+		public resolveNextGeneration(cell: Cell) {
 			var count = this.countNeighbors(cell);
 			var newCell = new Cell(cell.row, cell.col, cell.live);
-			if(count < 2 || count > 3) newCell.live = false;
-			else if(count == 3) newCell.live = true;
+			if (count < 2 || count > 3) { newCell.live = false; }
+			else if (count === 3) { newCell.live = true; }
 			return newCell;
 		}
 
-		public countNeighbors(cell : Cell) {
+		public countNeighbors(cell: Cell) {
 			var neighbors = 0;
-			for(var row = -1; row <=1; row++) {
-				for(var col = -1; col <= 1; col++) {
-					if(row == 0 && col == 0) continue;
-					if(this.isAlive(cell.row + row, cell.col + col)) {
+			for (var row = -1; row <= 1; row++) {
+				for (var col = -1; col <= 1; col++) {
+					if (row === 0 && col === 0) { continue; }
+					if (this.isAlive(cell.row + row, cell.col + col)) {
 						neighbors++;
 					}
 				}
@@ -79,16 +79,16 @@ module Conway {
 			return neighbors;
 		}
 
-		public isAlive(row : number, col : number) {
-			if(row < 0 || col < 0 || row >= this.gridSize || col >= this.gridSize) return false;
+		public isAlive(row: number, col: number) {
+			if (row < 0 || col < 0 || row >= this.gridSize || col >= this.gridSize) { return false; }
 			return this.world[row][col].live;
 		}
 
 		public travelWorld(callback) {
 			var result = [];
-			for(var row = 0; row < this.gridSize; row++) {
+			for (var row = 0; row < this.gridSize; row++) {
 				var rowData = [];
-				for(var col = 0; col < this.gridSize; col++) {
+				for (var col = 0; col < this.gridSize; col++) {
 					rowData.push(callback(new Cell(row, col, false)));
 				}
 				result.push(rowData);
@@ -96,13 +96,13 @@ module Conway {
 			return result;
 		}
 
-		public draw(cell : Cell) {
-			if(this.cellSize == 0) this.cellSize = this.canvasSize/this.gridSize;
+		public draw(cell: Cell) {
+			if (this.cellSize === 0) { this.cellSize = this.canvasSize / this.gridSize; }
 
 			this.context.strokeStyle = this.lineColor;
-			this.context.strokeRect(cell.row * this.cellSize, cell.col*this.cellSize, this.cellSize, this.cellSize);
+			this.context.strokeRect(cell.row * this.cellSize, cell.col * this.cellSize, this.cellSize, this.cellSize);
 			this.context.fillStyle = cell.live ? this.liveColor : this.deadColor;
-			this.context.fillRect(cell.row * this.cellSize, cell.col*this.cellSize, this.cellSize, this.cellSize);
+			this.context.fillRect(cell.row * this.cellSize, cell.col * this.cellSize, this.cellSize, this.cellSize);
 		}
 
 	}

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -181,8 +181,6 @@ export interface ITerminalService {
 	setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): void;
 	selectDefaultWindowsShell(): TPromise<string>;
 	setWorkspaceShellAllowed(isAllowed: boolean): void;
-
-	isWslBashTerminal(terminalInstance: ITerminalInstance): boolean;
 }
 
 export const enum Direction {
@@ -338,6 +336,14 @@ export interface ITerminalInstance {
 	 * Focuses and pastes the contents of the clipboard into the terminal instance.
 	 */
 	paste(): void;
+
+	/**
+	 * Send file to the terminal instance. The file is run by the underlying pty
+	 * process (shell) of the terminal instance.
+	 *
+	 * @param filePath Path of file to run.
+	 */
+	sendFile(filePath: string, addNewLine: boolean): void;
 
 	/**
 	 * Send text to the terminal instance. The text is written to the stdin of the underlying pty

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -181,6 +181,8 @@ export interface ITerminalService {
 	setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): void;
 	selectDefaultWindowsShell(): TPromise<string>;
 	setWorkspaceShellAllowed(isAllowed: boolean): void;
+
+	isWslBashDefaultTerminal(): boolean;
 }
 
 export const enum Direction {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -182,7 +182,7 @@ export interface ITerminalService {
 	selectDefaultWindowsShell(): TPromise<string>;
 	setWorkspaceShellAllowed(isAllowed: boolean): void;
 
-	isWslBashDefaultTerminal(): boolean;
+	isWslBashTerminal(terminalInstance: ITerminalInstance): boolean;
 }
 
 export const enum Direction {

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -76,6 +76,7 @@ export abstract class TerminalService implements ITerminalService {
 	public abstract getActiveOrCreateInstance(wasNewTerminalAction?: boolean): ITerminalInstance;
 	public abstract selectDefaultWindowsShell(): TPromise<string>;
 	public abstract setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): void;
+	public abstract isWslBashDefaultTerminal(): boolean;
 
 	private _restoreTabs(): void {
 		if (!this.configHelper.config.experimentalRestore) {

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -76,7 +76,6 @@ export abstract class TerminalService implements ITerminalService {
 	public abstract getActiveOrCreateInstance(wasNewTerminalAction?: boolean): ITerminalInstance;
 	public abstract selectDefaultWindowsShell(): TPromise<string>;
 	public abstract setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): void;
-	public abstract isWslBashTerminal(terminalInstance: ITerminalInstance): boolean;
 
 	private _restoreTabs(): void {
 		if (!this.configHelper.config.experimentalRestore) {

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -76,7 +76,7 @@ export abstract class TerminalService implements ITerminalService {
 	public abstract getActiveOrCreateInstance(wasNewTerminalAction?: boolean): ITerminalInstance;
 	public abstract selectDefaultWindowsShell(): TPromise<string>;
 	public abstract setContainers(panelContainer: HTMLElement, terminalContainer: HTMLElement): void;
-	public abstract isWslBashDefaultTerminal(): boolean;
+	public abstract isWslBashTerminal(terminalInstance: ITerminalInstance): boolean;
 
 	private _restoreTabs(): void {
 		if (!this.configHelper.config.experimentalRestore) {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -581,12 +581,10 @@ export class RunActiveFileInTerminalAction extends Action {
 			this.notificationService.warn(nls.localize('workbench.action.terminal.runActiveFile.noFile', 'Only files on disk can be run in the terminal'));
 			return TPromise.as(void 0);
 		}
-		if (true) {
-			let filePath = uri.path.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`);
-			instance.sendText(`"${filePath}"`, true);
-		} else {
-			instance.sendText(uri.fsPath, true);
-		}
+
+		let filePath = this.terminalService.isWslBashDefaultTerminal() ? uri.path.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`) : uri.fsPath;
+		instance.sendText(`"${filePath}"`, true);
+
 		return this.terminalService.showPanel();
 	}
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -581,7 +581,12 @@ export class RunActiveFileInTerminalAction extends Action {
 			this.notificationService.warn(nls.localize('workbench.action.terminal.runActiveFile.noFile', 'Only files on disk can be run in the terminal'));
 			return TPromise.as(void 0);
 		}
-		instance.sendText(uri.fsPath, true);
+		if (true) {
+			let filePath = uri.path.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`);
+			instance.sendText(`"${filePath}"`, true);
+		} else {
+			instance.sendText(uri.fsPath, true);
+		}
 		return this.terminalService.showPanel();
 	}
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -582,10 +582,7 @@ export class RunActiveFileInTerminalAction extends Action {
 			return TPromise.as(void 0);
 		}
 
-		const filePath = this.terminalService.isWslBashTerminal(instance) ?
-			uri.path.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`) :
-			uri.fsPath;
-		instance.sendText(`"${filePath}"`, true);
+		instance.sendFile(uri.path, true);
 		return this.terminalService.showPanel();
 	}
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -582,9 +582,10 @@ export class RunActiveFileInTerminalAction extends Action {
 			return TPromise.as(void 0);
 		}
 
-		let filePath = this.terminalService.isWslBashDefaultTerminal() ? uri.path.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`) : uri.fsPath;
+		const filePath = this.terminalService.isWslBashTerminal(instance) ?
+			uri.path.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`) :
+			uri.fsPath;
 		instance.sendText(`"${filePath}"`, true);
-
 		return this.terminalService.showPanel();
 	}
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -557,6 +557,24 @@ export class TerminalInstance implements ITerminalInstance {
 		document.execCommand('paste');
 	}
 
+	public sendFile(filePath: string, addNewLine: boolean): void {
+		this._processReady.then(() => {
+			let path: string;
+			if (/(System32|Sysnative)\\(bash.exe|wsl.exe)/i.exec(this._shellLaunchConfig.executable)) {
+				path = `"${filePath.replace(/([A-Za-z]):/, (m, g) => `mnt/${g.toLocaleLowerCase()}`)}"`;
+			} else {
+				path = `"${filePath.replace(/^\//, '')}"`;
+			}
+			if (addNewLine) {
+				path += '\r';
+			}
+			this._process.send({
+				event: 'input',
+				data: path
+			});
+		});
+	}
+
 	public sendText(text: string, addNewLine: boolean): void {
 		this._processReady.then(() => {
 			// Normalize line endings to 'enter' press.

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -25,6 +25,7 @@ import { TerminalTab } from 'vs/workbench/parts/terminal/electron-browser/termin
 import { IChoiceService, IConfirmationService, Choice } from 'vs/platform/dialogs/common/dialogs';
 
 export class TerminalService extends AbstractTerminalService implements ITerminalService {
+	private WSL_BASH = 'WSL Bash';
 	private _configHelper: TerminalConfigHelper;
 	public get configHelper(): ITerminalConfigHelper { return this._configHelper; }
 
@@ -69,6 +70,13 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 		this._onInstancesChanged.fire();
 		this._suggestShellChange(wasNewTerminalAction);
 		return instance;
+	}
+
+	public isWslBashDefaultTerminal(): boolean {
+		let shell: IShellLaunchConfig = {};
+		this._configHelper.mergeDefaultShellPathAndArgs(shell);
+		const expectedLocations = this._getExpectedLocations();
+		return shell.executable === expectedLocations[this.WSL_BASH][0];
 	}
 
 	public focusFindWidget(): TPromise<void> {
@@ -169,24 +177,7 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 	}
 
 	private _detectWindowsShells(): TPromise<IPickOpenEntry[]> {
-		// Determine the correct System32 path. We want to point to Sysnative
-		// when the 32-bit version of VS Code is running on a 64-bit machine.
-		// The reason for this is because PowerShell's important PSReadline
-		// module doesn't work if this is not the case. See #27915.
-		const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
-		const system32Path = `${process.env['windir']}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}`;
-		const expectedLocations = {
-			'Command Prompt': [`${system32Path}\\cmd.exe`],
-			PowerShell: [`${system32Path}\\WindowsPowerShell\\v1.0\\powershell.exe`],
-			'WSL Bash': [`${system32Path}\\bash.exe`],
-			'Git Bash': [
-				`${process.env['ProgramW6432']}\\Git\\bin\\bash.exe`,
-				`${process.env['ProgramW6432']}\\Git\\usr\\bin\\bash.exe`,
-				`${process.env['ProgramFiles']}\\Git\\bin\\bash.exe`,
-				`${process.env['ProgramFiles']}\\Git\\usr\\bin\\bash.exe`,
-				`${process.env['LocalAppData']}\\Programs\\Git\\bin\\bash.exe`,
-			]
-		};
+		const expectedLocations = this._getExpectedLocations();
 		const promises: TPromise<[string, string]>[] = [];
 		Object.keys(expectedLocations).forEach(key => promises.push(this._validateShellPaths(key, expectedLocations[key])));
 		return TPromise.join(promises).then(results => {
@@ -197,6 +188,28 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 				};
 			});
 		});
+	}
+
+	private _getExpectedLocations(): { [key: string]: string[] } {
+		// Determine the correct System32 path. We want to point to Sysnative
+		// when the 32-bit version of VS Code is running on a 64-bit machine.
+		// The reason for this is because PowerShell's important PSReadline
+		// module doesn't work if this is not the case. See #27915.
+		const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
+		const system32Path = `${process.env['windir']}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}`;
+		const expectedLocations = {
+			'Command Prompt': [`${system32Path}\\cmd.exe`],
+			PowerShell: [`${system32Path}\\WindowsPowerShell\\v1.0\\powershell.exe`],
+			[this.WSL_BASH]: [`${system32Path}\\bash.exe`],
+			'Git Bash': [
+				`${process.env['ProgramW6432']}\\Git\\bin\\bash.exe`,
+				`${process.env['ProgramW6432']}\\Git\\usr\\bin\\bash.exe`,
+				`${process.env['ProgramFiles']}\\Git\\bin\\bash.exe`,
+				`${process.env['ProgramFiles']}\\Git\\usr\\bin\\bash.exe`,
+				`${process.env['LocalAppData']}\\Programs\\Git\\bin\\bash.exe`,
+			]
+		};
+		return expectedLocations;
 	}
 
 	private _validateShellPaths(label: string, potentialPaths: string[]): TPromise<[string, string]> {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -72,11 +72,12 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 		return instance;
 	}
 
-	public isWslBashDefaultTerminal(): boolean {
-		let shell: IShellLaunchConfig = {};
-		this._configHelper.mergeDefaultShellPathAndArgs(shell);
+	public isWslBashTerminal(terminalInstance: ITerminalInstance): boolean {
+		// let shell: IShellLaunchConfig = {};
+		// this._configHelper.mergeDefaultShellPathAndArgs(shell);
 		const expectedLocations = this._getExpectedLocations();
-		return shell.executable === expectedLocations[this.WSL_BASH][0];
+		// return shell.executable === expectedLocations[this.WSL_BASH][0];
+		return terminalInstance.shellLaunchConfig.executable === expectedLocations[this.WSL_BASH][0];
 	}
 
 	public focusFindWidget(): TPromise<void> {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -73,10 +73,7 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 	}
 
 	public isWslBashTerminal(terminalInstance: ITerminalInstance): boolean {
-		// let shell: IShellLaunchConfig = {};
-		// this._configHelper.mergeDefaultShellPathAndArgs(shell);
 		const expectedLocations = this._getExpectedLocations();
-		// return shell.executable === expectedLocations[this.WSL_BASH][0];
 		return terminalInstance.shellLaunchConfig.executable === expectedLocations[this.WSL_BASH][0];
 	}
 


### PR DESCRIPTION
I didn't see any unit tests for [src/vs/workbench/parts/terminal/common/terminalService.ts](https://github.com/captainrdubb/vscode/blob/8f985b0be7645a6d3180088d88d862be167b1059/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts) or [src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts](https://github.com/captainrdubb/vscode/blob/8f985b0be7645a6d3180088d88d862be167b1059/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts). If needed, please advise.