### PR TITLE
typescript.experimental.syntaxFolding

### DIFF
--- a/extensions/typescript/package.json
+++ b/extensions/typescript/package.json
@@ -395,6 +395,11 @@
           "default": null,
           "description": "%typescript.locale%",
           "scope": "window"
+        },
+        "typescript.experimental.syntaxFolding": {
+          "type": "boolean",
+          "default": false,
+          "description": "%typescript.experimental.syntaxFolding%"
         }
       }
     },
@@ -454,7 +459,8 @@
           "value": "%typescript.restartTsServer%"
         },
         "category": "TypeScript"
-      }
+      },
+
     ],
     "menus": {
       "commandPalette": [

--- a/extensions/typescript/package.nls.json
+++ b/extensions/typescript/package.nls.json
@@ -48,5 +48,6 @@
 	"typescript.quickSuggestionsForPaths": "Enable/disable quick suggestions when typing out an import path.",
 	"typescript.locale": "Sets the locale used to report TypeScript errors. Requires TypeScript >= 2.6.0. Default of 'null' uses VS Code's locale for TypeScript errors.",
 	"javascript.implicitProjectConfig.experimentalDecorators": "Enable/disable 'experimentalDecorators' for JavaScript files that are not part of a project. Existing jsconfig.json or tsconfig.json files override this setting. Requires TypeScript >=2.3.1.",
-	"typescript.autoImportSuggestions.enabled": "Enable/disable auto import suggestions. Requires TypeScript >=2.6.1"
+	"typescript.autoImportSuggestions.enabled": "Enable/disable auto import suggestions. Requires TypeScript >=2.6.1",
+	"typescript.experimental.syntaxFolding": "Enables/disables syntax aware folding markers.",
 }


### PR DESCRIPTION
- Renames the setting `typeScript.enableExperimentalFolding` to be consistent with the html and json settings: `typescript.experimental.syntaxFolding`
- Makes the setting visible for testing
- Dynamic enabled/disabled-ment