### PR TITLE
Prevent the same problem matcher beginning twice

### DIFF
--- a/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts
@@ -251,6 +251,9 @@ export class TerminalTaskSystem implements ITaskSystem {
 						eventCounter++;
 						this._onDidStateChange.fire(TaskEvent.create(TaskEventKind.Active, task));
 					} else if (event.kind === ProblemCollectorEventKind.BackgroundProcessingEnds) {
+						if (eventCounter === 0) {
+							return;
+						}
 						eventCounter--;
 						this._onDidStateChange.fire(TaskEvent.create(TaskEventKind.Inactive, task));
 					}


### PR DESCRIPTION
Fixes #44192

---

The change prevents 2 begins to run in successive if the lines were identical. I couldn't think of a case where the lines would be the same as typically they would be labelled something different (eg. "compiling sass", "compiling typescript"), they also often contain a timestamp which is even better. I think this should work to fix the problem and makes a good defensive guard as well as this could potentially happen on Linux and mac as well.

As for why no workaround in the terminal; I don't see how I could detect something like this and know that it's "incorrect" to prevent the line send. Also `TerminalInstance._sendLineData` call tells you what lines change in the terminal, messing with that would add complexity that belongs in tasks imo.

Something else that could be done to know more about where you are within the terminal is expose [`lineIndex`](https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts#L960) on the `TerminalInstance.onLineData` event as that can pretty clearly tell you when the terminal moves the cursor back and overwrites lines.