### PR TITLE
Allow css emmet completions when abbr contains period or errors in css blocks in html files 

### DIFF
--- a/extensions/css/server/package.json
+++ b/extensions/css/server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "vscode-css-languageservice": "^3.0.7",
-    "vscode-emmet-helper": "^1.1.38",
+    "vscode-emmet-helper": "^1.2.0",
     "vscode-languageserver": "4.0.0-next.4"
   },
   "devDependencies": {

--- a/extensions/css/server/yarn.lock
+++ b/extensions/css/server/yarn.lock
@@ -25,9 +25,9 @@ vscode-css-languageservice@^3.0.7:
     vscode-languageserver-types "^3.6.0-next.1"
     vscode-nls "^2.0.1"
 
-vscode-emmet-helper@^1.1.38:
-  version "1.1.38"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.1.38.tgz#6b7de1abe39f8b41d4713c4e85ace4a7261ef0d8"
+vscode-emmet-helper@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.2.0.tgz#6b9311be065c9c99d5de2dae18ea0730d9cfb734"
   dependencies:
     "@emmetio/extract-abbreviation" "0.1.6"
     jsonc-parser "^1.0.0"

--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -337,7 +337,7 @@
         "@emmetio/html-matcher": "^0.3.3",
         "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",
         "@emmetio/math-expression": "^0.1.1",
-        "vscode-emmet-helper": "^1.1.38",
+        "vscode-emmet-helper": "^1.2.0",
         "vscode-languageserver-types": "^3.5.0",
         "image-size": "^0.5.2",
         "vscode-nls": "3.2.1"

--- a/extensions/emmet/yarn.lock
+++ b/extensions/emmet/yarn.lock
@@ -2052,9 +2052,9 @@ vinyl@~2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-emmet-helper@^1.1.38:
-  version "1.1.38"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.1.38.tgz#6b7de1abe39f8b41d4713c4e85ace4a7261ef0d8"
+vscode-emmet-helper@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.2.0.tgz#6b9311be065c9c99d5de2dae18ea0730d9cfb734"
   dependencies:
     "@emmetio/extract-abbreviation" "0.1.6"
     jsonc-parser "^1.0.0"

--- a/extensions/html/server/package.json
+++ b/extensions/html/server/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "vscode-css-languageservice": "^3.0.6",
-    "vscode-emmet-helper": "1.1.38",
+    "vscode-emmet-helper": "1.2.0",
     "vscode-html-languageservice": "^2.0.17-next.3",
     "vscode-languageserver": "4.0.0-next.4",
     "vscode-languageserver-types": "^3.6.0-next.1",

--- a/extensions/html/server/src/htmlServerMain.ts
+++ b/extensions/html/server/src/htmlServerMain.ts
@@ -17,7 +17,7 @@ import { pushAll } from './utils/arrays';
 import { getDocumentContext } from './utils/documentContext';
 import uri from 'vscode-uri';
 import { formatError, runSafe } from './utils/errors';
-import { doComplete as emmetDoComplete, updateExtensionsPath as updateEmmetExtensionsPath, getEmmetCompletionParticipants, extractAbbreviation } from 'vscode-emmet-helper';
+import { doComplete as emmetDoComplete, updateExtensionsPath as updateEmmetExtensionsPath, getEmmetCompletionParticipants } from 'vscode-emmet-helper';
 import { getPathCompletionParticipant } from './modes/pathCompletion';
 
 import { FoldingRangesRequest, FoldingProviderServerCapabilities } from './protocol/foldingProvider.proposed';
@@ -285,34 +285,18 @@ connection.onCompletion(async textDocumentPosition => {
 		};
 
 		const emmetCompletionParticipant = getEmmetCompletionParticipants(document, textDocumentPosition.position, mode.getId(), emmetSettings, emmetCompletionList);
-		if (mode.setCompletionParticipants) {
-			// Ideally, fix this in the Language Service side
-			// Check participants' methods before calling them
-			if (mode.getId() === 'html') {
-				const pathCompletionParticipant = getPathCompletionParticipant(document, workspaceFolders, pathCompletionList);
-				mode.setCompletionParticipants([emmetCompletionParticipant, pathCompletionParticipant]);
-			} else {
-				mode.setCompletionParticipants([emmetCompletionParticipant]);
-			}
+		const completionParticipants = [emmetCompletionParticipant];
+		// Ideally, fix this in the Language Service side
+		// Check participants' methods before calling them
+		if (mode.getId() === 'html') {
+			const pathCompletionParticipant = getPathCompletionParticipant(document, workspaceFolders, pathCompletionList);
+			completionParticipants.push(pathCompletionParticipant);
 		}
 
 		let settings = await getDocumentSettings(document, () => mode.doComplete.length > 2);
-		let result = mode.doComplete(document, textDocumentPosition.position, settings);
+		let result = mode.doComplete(document, textDocumentPosition.position, settings, completionParticipants);
 		result.items = [...pathCompletionList.items, ...result.items];
 		if (emmetCompletionList && emmetCompletionList.items) {
-			if (mode.getId() === 'css') {
-				// Workaround for https://github.com/Microsoft/vscode-css-languageservice/issues/69
-				const stylesheet = mode.getEmbeddedParsedDocument(document);
-				if (!emmetCompletionList.items.length
-					&& typeof stylesheet['end'] === 'number'
-					&& document.offsetAt(textDocumentPosition.position) > stylesheet['end']) {
-					const extractedResults = extractAbbreviation(document, textDocumentPosition.position, { lookAhead: false, syntax: 'css' });
-					if (extractedResults && /\.\d+$/.test(extractedResults.abbreviation)) {
-						emmetCompletionParticipant.onCssProperty({ propertyName: extractedResults.abbreviation, range: extractedResults.abbreviationRange });
-					}
-				}
-			}
-
 			cachedCompletionList = result;
 			if (emmetCompletionList.items.length && hexColorRegex.test(emmetCompletionList.items[0].label) && result.items.some(x => x.label === emmetCompletionList.items[0].label)) {
 				emmetCompletionList.items.shift();

--- a/extensions/html/server/src/modes/cssMode.ts
+++ b/extensions/html/server/src/modes/cssMode.ts
@@ -82,10 +82,6 @@ export function getCSSMode(documentRegions: LanguageModelCache<HTMLDocumentRegio
 			let embedded = embeddedCSSDocuments.get(document);
 			return cssLanguageService.getColorPresentations(embedded, cssStylesheets.get(embedded), color, range);
 		},
-		getEmbeddedParsedDocument(document: TextDocument) {
-			let embedded = embeddedCSSDocuments.get(document);
-			return cssStylesheets.get(embedded);
-		},
 		onDocumentRemoved(document: TextDocument) {
 			embeddedCSSDocuments.onDocumentRemoved(document);
 			cssStylesheets.onDocumentRemoved(document);

--- a/extensions/html/server/src/modes/cssMode.ts
+++ b/extensions/html/server/src/modes/cssMode.ts
@@ -62,6 +62,10 @@ export function getCSSMode(documentRegions: LanguageModelCache<HTMLDocumentRegio
 			let embedded = embeddedCSSDocuments.get(document);
 			return cssLanguageService.getColorPresentations(embedded, cssStylesheets.get(embedded), color, range);
 		},
+		getEmbeddedParsedDocument(document: TextDocument) {
+			let embedded = embeddedCSSDocuments.get(document);
+			return cssStylesheets.get(embedded);
+		},
 		onDocumentRemoved(document: TextDocument) {
 			embeddedCSSDocuments.onDocumentRemoved(document);
 			cssStylesheets.onDocumentRemoved(document);

--- a/extensions/html/server/src/modes/htmlMode.ts
+++ b/extensions/html/server/src/modes/htmlMode.ts
@@ -22,7 +22,10 @@ export function getHTMLMode(htmlLanguageService: HTMLLanguageService): LanguageM
 		configure(options: any) {
 			globalSettings = options;
 		},
-		doComplete(document: TextDocument, position: Position, settings: Settings = globalSettings) {
+		doComplete(document: TextDocument, position: Position, settings: Settings = globalSettings, registeredCompletionParticipants: any[]) {
+			if (registeredCompletionParticipants) {
+				completionParticipants = registeredCompletionParticipants;
+			}
 			let options = settings && settings.html && settings.html.suggest;
 			let doAutoComplete = settings && settings.html && settings.html.autoClosingTags;
 			if (doAutoComplete) {

--- a/extensions/html/server/src/modes/languageModes.ts
+++ b/extensions/html/server/src/modes/languageModes.ts
@@ -37,7 +37,7 @@ export interface LanguageMode {
 	getId(): string;
 	configure?: (options: Settings) => void;
 	doValidation?: (document: TextDocument, settings?: Settings) => Diagnostic[];
-	doComplete?: (document: TextDocument, position: Position, settings?: Settings) => CompletionList | null;
+	doComplete?: (document: TextDocument, position: Position, settings?: Settings, registeredCompletionParticipants?: any[]) => CompletionList | null;
 	setCompletionParticipants?: (registeredCompletionParticipants: any[]) => void;
 	doResolve?: (document: TextDocument, item: CompletionItem) => CompletionItem | null;
 	doHover?: (document: TextDocument, position: Position) => Hover | null;

--- a/extensions/html/server/src/modes/languageModes.ts
+++ b/extensions/html/server/src/modes/languageModes.ts
@@ -52,7 +52,6 @@ export interface LanguageMode {
 	getColorPresentations?: (document: TextDocument, color: Color, range: Range) => ColorPresentation[];
 	doAutoClose?: (document: TextDocument, position: Position) => string | null;
 	getFoldingRanges?: (document: TextDocument) => FoldingRangeList | null;
-	getEmbeddedParsedDocument?: (document: TextDocument) => any;
 	onDocumentRemoved(document: TextDocument): void;
 	dispose(): void;
 }

--- a/extensions/html/server/src/modes/languageModes.ts
+++ b/extensions/html/server/src/modes/languageModes.ts
@@ -52,6 +52,7 @@ export interface LanguageMode {
 	getColorPresentations?: (document: TextDocument, color: Color, range: Range) => ColorPresentation[];
 	doAutoClose?: (document: TextDocument, position: Position) => string | null;
 	getFoldingRanges?: (document: TextDocument) => FoldingRangeList | null;
+	getEmbeddedParsedDocument?: (document: TextDocument) => any;
 	onDocumentRemoved(document: TextDocument): void;
 	dispose(): void;
 }

--- a/extensions/html/server/yarn.lock
+++ b/extensions/html/server/yarn.lock
@@ -25,9 +25,9 @@ vscode-css-languageservice@^3.0.6:
     vscode-languageserver-types "^3.6.0-next.1"
     vscode-nls "^2.0.1"
 
-vscode-emmet-helper@1.1.38:
-  version "1.1.38"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.1.38.tgz#6b7de1abe39f8b41d4713c4e85ace4a7261ef0d8"
+vscode-emmet-helper@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.2.0.tgz#6b9311be065c9c99d5de2dae18ea0730d9cfb734"
   dependencies:
     "@emmetio/extract-abbreviation" "0.1.6"
     jsonc-parser "^1.0.0"


### PR DESCRIPTION
Fixes #44352

Due to https://github.com/Microsoft/vscode-css-languageservice/issues/69, css files do not get parsed after encountering an emmet abbreviation that has a `.`

This PR has workaround for such cases. 

**Update**

Reverted the move of emmet to css extension. See #44840

- Emmet completions in css/scss/less files will come from the Emmet extension like they did in 1.20
- Emmet completions in html files will come from Html extension 
- Each mode (htmlmode, cssmode) in the Html extension is responsible for Emmet in their respective modes.
- HtmlMode will ensure to trigger emmet only inside Html content area (`onHtmlContent`)
- CssMode will trigger emmet regardless of the position (this mimics what the Emmet extension does for css in html files today in 1.20)

