### PR TITLE
Handle special characters in markdown slugify

### DIFF
--- a/extensions/markdown/src/tableOfContentsProvider.ts
+++ b/extensions/markdown/src/tableOfContentsProvider.ts
@@ -8,13 +8,18 @@ import * as vscode from 'vscode';
 import { MarkdownEngine } from './markdownEngine';
 
 export class Slug {
+	private static specialChars: any = { 'à': 'a', 'ä': 'a', 'ã': 'a', 'á': 'a', 'â': 'a', 'æ': 'a', 'å': 'a', 'ë': 'e', 'è': 'e', 'é': 'e', 'ê': 'e', 'î': 'i', 'ï': 'i', 'ì': 'i', 'í': 'i', 'ò': 'o', 'ó': 'o', 'ö': 'o', 'ô': 'o', 'ø': 'o', 'ù': 'o', 'ú': 'u', 'ü': 'u', 'û': 'u', 'ñ': 'n', 'ç': 'c', 'ß': 's', 'ÿ': 'y', 'œ': 'o', 'ŕ': 'r', 'ś': 's', 'ń': 'n', 'ṕ': 'p', 'ẃ': 'w', 'ǵ': 'g', 'ǹ': 'n', 'ḿ': 'm', 'ǘ': 'u', 'ẍ': 'x', 'ź': 'z', 'ḧ': 'h', '·': '-', '/': '-', '_': '-', ',': '-', ':': '-', ';': '-' };
+
 	public static fromHeading(heading: string): Slug {
 		const slugifiedHeading = encodeURI(heading.trim()
 			.toLowerCase()
-			.replace(/[\]\[\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`]/g, '')
-			.replace(/\s+/g, '-')
-			.replace(/^\-+/, '')
-			.replace(/\-+$/, ''));
+			.replace(/./g, c => Slug.specialChars[c] || c)
+			.replace(/[\]\[\!\'\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\\\^\_\{\|\}\~\`]/g, '')
+			.replace(/\s+/g, '-') // Replace whitespace with -
+			.replace(/[^\w\-]+/g, '') // Remove remaining non-word chars
+			.replace(/^\-+/, '') // Remove leading -
+			.replace(/\-+$/, '') // Remove trailing -
+		);
 
 		return new Slug(slugifiedHeading);
 	}

--- a/extensions/markdown/src/test/tableOfContentsProvider.test.ts
+++ b/extensions/markdown/src/test/tableOfContentsProvider.test.ts
@@ -73,6 +73,13 @@ suite('markdown.TableOfContentsProvider', () => {
 		assert.strictEqual(await provider.lookup('foo'), undefined);
 		assert.strictEqual(await provider.lookup('fo o'), undefined);
 	});
+
+	test('should normalize special characters #44779', async () => {
+		const doc = new InMemoryDocument(testFileName, `# Indentação\n`);
+		const provider = new TableOfContentsProvider(new MarkdownEngine(), doc);
+
+		assert.strictEqual((await provider.lookup('indentacao'))!.line, 0);
+	});
 });
 
 class InMemoryDocument implements vscode.TextDocument {


### PR DESCRIPTION
Fixes #44779 

Does a simple replacement of some unicode characters, then strips out any remaining unrecognized characters