### PR TITLE
Add markdown header based folding

### DIFF
--- a/extensions/markdown/src/extension.ts
+++ b/extensions/markdown/src/extension.ts
@@ -16,6 +16,7 @@ import LinkProvider from './features/documentLinkProvider';
 import MDDocumentSymbolProvider from './features/documentSymbolProvider';
 import { MarkdownContentProvider } from './features/previewContentProvider';
 import { MarkdownPreviewManager } from './features/previewManager';
+import MarkdownFoldingProvider from './features/foldingProvider';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -36,6 +37,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new MDDocumentSymbolProvider(engine)));
 	context.subscriptions.push(vscode.languages.registerDocumentLinkProvider(selector, new LinkProvider()));
+	context.subscriptions.push(vscode.languages.registerFoldingProvider(selector, new MarkdownFoldingProvider(engine)));
 
 	const previewSecuritySelector = new PreviewSecuritySelector(cspArbiter, previewManager);
 

--- a/extensions/markdown/src/features/foldingProvider.ts
+++ b/extensions/markdown/src/features/foldingProvider.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+import { MarkdownEngine } from '../markdownEngine';
+import { TableOfContentsProvider } from '../tableOfContentsProvider';
+
+export default class MarkdownFoldingProvider implements vscode.FoldingProvider {
+
+	constructor(
+		private readonly engine: MarkdownEngine
+	) { }
+
+	public async provideFoldingRanges(
+		document: vscode.TextDocument,
+		_token: vscode.CancellationToken
+	): Promise<vscode.FoldingRangeList> {
+		const tocProvider = new TableOfContentsProvider(this.engine, document);
+		const toc = await tocProvider.getToc();
+
+		const foldingRanges = toc.map((entry, startIndex) => {
+			const start = entry.line;
+			let end: number | undefined = undefined;
+			for (let i = startIndex + 1; i < toc.length; ++i) {
+				if (toc[i].level <= entry.level) {
+					end = toc[i].line - 1;
+					break;
+				}
+			}
+			return new vscode.FoldingRange(
+				start,
+				typeof end === 'number' ? end : document.lineCount - 1);
+		});
+
+		return new vscode.FoldingRangeList(foldingRanges);
+	}
+}


### PR DESCRIPTION
Fixes #3347

Adds folding based on markdown heading level. Headers fold to the next header of <= level