### PR TITLE
enable CLI when invoked from WSL on modern (RS4) hosts

### DIFF
--- a/resources/win32/bin/code.sh
+++ b/resources/win32/bin/code.sh
@@ -7,14 +7,20 @@ NAME="@@NAME@@"
 VSCODE_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
 ELECTRON="$VSCODE_PATH/$NAME.exe"
 if grep -q Microsoft /proc/version; then
-	# If running under WSL don't pass cli.js to Electron as environment vars
-	# cannot be transferred from WSL to Windows
-	# See: https://github.com/Microsoft/BashOnWindows/issues/1363
-	#      https://github.com/Microsoft/BashOnWindows/issues/1494
-	"$ELECTRON" "$@"
-	exit $?
-fi
-if [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
+	if [ -x /bin/wslpath ]; then
+		# On recent WSL builds, we just need to set WSLENV so that
+		# ELECTRON_RUN_AS_NODE is visible to the win32 process
+		export WSLENV=ELECTRON_RUN_AS_NODE/w:$WSLENV
+		CLI=$(wslpath -m "$VSCODE_PATH/resources/app/out/cli.js")
+	else
+		# If running under older WSL, don't pass cli.js to Electron as
+		# environment vars cannot be transferred from WSL to Windows
+		# See: https://github.com/Microsoft/BashOnWindows/issues/1363
+		#      https://github.com/Microsoft/BashOnWindows/issues/1494
+		"$ELECTRON" "$@"
+		exit $?
+	fi
+elif [ "$(expr substr $(uname -s) 1 9)" == "CYGWIN_NT" ]; then
 	CLI=$(cygpath -m "$VSCODE_PATH/resources/app/out/cli.js")
 else
 	CLI="$VSCODE_PATH/resources/app/out/cli.js"


### PR DESCRIPTION
Fixes issue #39892

There's one minor gotchya: this script tests for a modern WSL release
(which supports the WSLENV feature) using the existence of
/bin/wslpath. Per https://docs.microsoft.com/en-us/windows/wsl/release-notes,
wslpath was added in build 17046 but WSLENV is only supported in
the subsequent build (17063). Both those builds were only shipped as
Windows insider builds, so this test should be safe enough.