### PR TITLE
Config Tests - Check Filename

### DIFF
--- a/src/vs/base/node/config.ts
+++ b/src/vs/base/node/config.ts
@@ -165,8 +165,8 @@ export class ConfigWatcher<T> implements IConfigWatcher<T>, IDisposable {
 	}
 
 	private onConfigFileChange(eventType: string, filename: string, isParentFolder: boolean): void {
-
-		if (isParentFolder && filename.indexOf(this.configName, filename.length - this.configName.length) !== filename.length - this.configName.length) {
+		const pattern = new RegExp(`\\${this.configName}$|/${this.configName}$|^${this.configName}$`);
+		if (isParentFolder && !pattern.test(filename)) {
 			return; // a change to a sibling file that is not our config file
 		}
 

--- a/src/vs/base/node/config.ts
+++ b/src/vs/base/node/config.ts
@@ -165,7 +165,8 @@ export class ConfigWatcher<T> implements IConfigWatcher<T>, IDisposable {
 	}
 
 	private onConfigFileChange(eventType: string, filename: string, isParentFolder: boolean): void {
-		if (isParentFolder && filename !== this.configName) {
+
+		if (isParentFolder && filename.indexOf(this.configName, filename.length - this.configName.length) !== filename.length - this.configName.length) {
 			return; // a change to a sibling file that is not our config file
 		}
 

--- a/src/vs/base/node/config.ts
+++ b/src/vs/base/node/config.ts
@@ -165,7 +165,7 @@ export class ConfigWatcher<T> implements IConfigWatcher<T>, IDisposable {
 	}
 
 	private onConfigFileChange(eventType: string, filename: string, isParentFolder: boolean): void {
-		const pattern = new RegExp(`\\${this.configName}$|/${this.configName}$|^${this.configName}$`);
+		const pattern = new RegExp(`\\\\${this.configName}$|/${this.configName}$|^${this.configName}$`);
 		if (isParentFolder && !pattern.test(filename)) {
 			return; // a change to a sibling file that is not our config file
 		}


### PR DESCRIPTION
fixes  #44957 ConfigWatcher.onFileChange event incorrectly returns early when comparing filename of actual changed file to expected config filename