### PR TITLE
Enabled 'Open to the side' command only for files

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -175,7 +175,7 @@ MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: 'navigation',
 	order: 10,
 	command: openToSideCommand,
-	when: ResourceContextKey.HasResource && ResourceContextKey.IsFile
+	when: ContextKeyExpr.and(ResourceContextKey.HasResource, ResourceContextKey.IsFile)
 });
 
 const revealInOsCommand = {

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -175,7 +175,7 @@ MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: 'navigation',
 	order: 10,
 	command: openToSideCommand,
-	when: ResourceContextKey.HasResource
+	when: ResourceContextKey.HasResource && ResourceContextKey.IsFile
 });
 
 const revealInOsCommand = {


### PR DESCRIPTION
I'm not totally sure if that's the optimal solution, but it works for markdown preview files (as stated in the issue) and for the Welcome page (which acts the same).

resolves #44676