### PR TITLE
Keeping find input value unchanged on replace if find input is active, fixes #41027

### DIFF
--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -636,20 +636,27 @@ export class StartFindReplaceAction extends EditorAction {
 
 		let controller = CommonFindController.get(editor);
 		let currentSelection = editor.getSelection();
-		// we only seed search string from selection when the current selection is single line and not empty.
-		let seedSearchStringFromSelection = !currentSelection.isEmpty() &&
-			currentSelection.startLineNumber === currentSelection.endLineNumber && editor.getConfiguration().contribInfo.find.seedSearchStringFromSelection;
-		// if the existing search string in find widget is empty and we don't seed search string from selection, it means the Find Input
-		// is still empty, so we should focus the Find Input instead of Replace Input.
-		let shouldFocus = seedSearchStringFromSelection ?
+		let findInputFocused = controller.isFindInputFocused();
+		// we only seed search string from selection when the current selection is single line and not empty,
+		// + the find input is not focused
+		let seedSearchStringFromSelection = !currentSelection.isEmpty()
+			&& currentSelection.startLineNumber === currentSelection.endLineNumber && editor.getConfiguration().contribInfo.find.seedSearchStringFromSelection
+			&& !findInputFocused;
+		/*
+		 * if the existing search string in find widget is empty and we don't seed search string from selection, it means the Find Input is still empty, so we should focus the Find Input instead of Replace Input.
+
+		 * findInputFocused true -> seedSearchStringFromSelection false, FocusReplaceInput
+		 * findInputFocused false, seedSearchStringFromSelection true FocusReplaceInput
+		 * findInputFocused false seedSearchStringFromSelection false FocusFindInput
+		 */
+		let shouldFocus = (findInputFocused || seedSearchStringFromSelection) ?
 			FindStartFocusAction.FocusReplaceInput : FindStartFocusAction.FocusFindInput;
 
-		let findInputFocused = controller.isFindInputFocused();
 
 		if (controller) {
 			controller.start({
 				forceRevealReplace: true,
-				seedSearchStringFromSelection: seedSearchStringFromSelection && !findInputFocused,
+				seedSearchStringFromSelection: seedSearchStringFromSelection,
 				seedSearchStringFromGlobalClipboard: editor.getConfiguration().contribInfo.find.seedSearchStringFromSelection,
 				shouldFocus: shouldFocus,
 				shouldAnimate: true,

--- a/src/vs/editor/contrib/find/test/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/findController.test.ts
@@ -11,9 +11,10 @@ import { Position } from 'vs/editor/common/core/position';
 import { Selection } from 'vs/editor/common/core/selection';
 import { Range } from 'vs/editor/common/core/range';
 import * as platform from 'vs/base/common/platform';
-import { CommonFindController, FindStartFocusAction, IFindStartOptions, NextMatchFindAction, StartFindAction, NextSelectionMatchFindAction } from 'vs/editor/contrib/find/findController';
+import { CommonFindController, FindStartFocusAction, IFindStartOptions, NextMatchFindAction, StartFindAction, NextSelectionMatchFindAction, StartFindReplaceAction } from 'vs/editor/contrib/find/findController';
+import { CONTEXT_FIND_INPUT_FOCUSED } from 'vs/editor/contrib/find/findModel';
 import { withTestCodeEditor } from 'vs/editor/test/browser/testCodeEditor';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -26,6 +27,8 @@ export class TestFindController extends CommonFindController {
 	public delayUpdateHistory: boolean = false;
 	public delayedUpdateHistoryPromise: TPromise<void>;
 
+	private _findInputFocused: IContextKey<boolean>;
+
 	constructor(
 		editor: ICodeEditor,
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -33,6 +36,7 @@ export class TestFindController extends CommonFindController {
 		@IClipboardService clipboardService: IClipboardService
 	) {
 		super(editor, contextKeyService, storageService, clipboardService);
+		this._findInputFocused = CONTEXT_FIND_INPUT_FOCUSED.bindTo(contextKeyService);
 		this._updateHistoryDelayer = new Delayer<void>(50);
 	}
 
@@ -42,6 +46,9 @@ export class TestFindController extends CommonFindController {
 		if (opts.shouldFocus !== FindStartFocusAction.NoFocusChange) {
 			this.hasFocus = true;
 		}
+
+		let inputFocused = opts.shouldFocus === FindStartFocusAction.FocusFindInput;
+		this._findInputFocused.set(inputFocused);
 	}
 }
 
@@ -243,6 +250,33 @@ suite('FindController', () => {
 
 			nextMatchFindAction.run(null, editor);
 			assert.deepEqual(fromRange(editor.getSelection()), [1, 9, 1, 13]);
+
+			findController.dispose();
+		});
+	});
+
+	test('issue #41027: Don\'t replace find input value on replace action if find input is active', () => {
+		withTestCodeEditor([
+			'test',
+		], { serviceCollection: serviceCollection }, (editor, cursor) => {
+			let testRegexString = 'tes.';
+			let findController = editor.registerAndInstantiateContribution<TestFindController>(TestFindController);
+			let nextMatchFindAction = new NextMatchFindAction();
+			let startFindReplaceAction = new StartFindReplaceAction();
+
+			findController.toggleRegex();
+			findController.setSearchString(testRegexString);
+			findController.start({
+				forceRevealReplace: false,
+				seedSearchStringFromSelection: false,
+				seedSearchStringFromGlobalClipboard: false,
+				shouldFocus: FindStartFocusAction.FocusFindInput,
+				shouldAnimate: false
+			});
+			nextMatchFindAction.run(null, editor);
+			startFindReplaceAction.run(null, editor);
+
+			assert.equal(findController.getState().searchString, testRegexString);
 
 			findController.dispose();
 		});

--- a/src/vs/editor/contrib/find/test/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/findController.test.ts
@@ -271,7 +271,8 @@ suite('FindController', () => {
 				seedSearchStringFromSelection: false,
 				seedSearchStringFromGlobalClipboard: false,
 				shouldFocus: FindStartFocusAction.FocusFindInput,
-				shouldAnimate: false
+				shouldAnimate: false,
+				updateSearchScope: false
 			});
 			nextMatchFindAction.run(null, editor);
 			startFindReplaceAction.run(null, editor);


### PR DESCRIPTION
Currently when replace action occurs editor text selection replaces find input. That causes problems because regexes get replaced "tes." => "test".
This pull request prevent replacing find input value by editor text selection on replace action when find input is active.