### PR TITLE
try to fix search file with ./

### DIFF
--- a/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/parts/search/browser/openAnythingHandler.ts
@@ -176,6 +176,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 		let range: IRange = null;
 
 		// Find Line/Column number from search value using RegExp
+		value = value.replace('./', '');
 		const patternMatch = OpenAnythingHandler.LINE_COLON_PATTERN.exec(value);
 		if (patternMatch && patternMatch.length > 1) {
 			const startLineNumber = parseInt(patternMatch[1], 10);


### PR DESCRIPTION
I'm trying fix issue #26956, which can't find files starting with `./` on MacOS. I try to remove './' if it is found in search path. For example, to find 'controller.js' in current directory, if I input './controller.js', it will search like 'controller.js'. So I use "value.replace('./', '')" to remove './'.