### PR TITLE
in Chinese users most understanding mind, repository should better be `托管库`

### DIFF
--- a/i18n/chs/src/vs/workbench/parts/extensions/browser/extensionEditor.i18n.json
+++ b/i18n/chs/src/vs/workbench/parts/extensions/browser/extensionEditor.i18n.json
@@ -10,7 +10,7 @@
 	"publisher": "发布服务器名称",
 	"install count": "安装计数",
 	"rating": "评级",
-	"repository": "存储库",
+	"repository": "托管库",
 	"license": "许可证",
 	"details": "详细信息",
 	"contributions": "发布内容",


### PR DESCRIPTION
in Chinese users most understanding mind, repository should better be `托管库`