### PR TITLE
Emmet: when wrapping, skip lines with no characters selected

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -521,7 +521,7 @@ function expandAbbreviationInRange(editor: vscode.TextEditor, expandAbbrList: Ex
 	// We will not be able to maintain multiple cursors after snippet insertion
 	let insertPromises: Thenable<boolean>[] = [];
 	if (!insertSameSnippet) {
-		expandAbbrList.forEach((expandAbbrInput: ExpandAbbreviationInput) => {
+		expandAbbrList.sort((a: ExpandAbbreviationInput, b: ExpandAbbreviationInput) => { return b.rangeToReplace.start.compareTo(a.rangeToReplace.start); }).forEach((expandAbbrInput: ExpandAbbreviationInput) => {
 			let expandedText = expandAbbr(expandAbbrInput);
 			if (expandedText) {
 				insertPromises.push(editor.insertSnippet(new vscode.SnippetString(expandedText), expandAbbrInput.rangeToReplace, { undoStopBefore: false, undoStopAfter: false }));

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -184,6 +184,14 @@ export function wrapIndividualLinesWithAbbreviation(args: any) {
 	}
 
 	const editor = vscode.window.activeTextEditor;
+	if (editor.selections.length === 1 && editor.selection.isEmpty) {
+		vscode.window.showInformationMessage('Select more than 1 line and try again.');
+		return;
+	}
+	if (editor.selections.find(x => x.isEmpty)) {
+		vscode.window.showInformationMessage('Select more than 1 line in each selection and try again.');
+		return;
+	}
 	let rangesToReplace: vscode.Range[] = [];
 	editor.selections.forEach(selection => {
 		let rangeToReplace: vscode.Range = selection.isReversed ? new vscode.Range(selection.active, selection.anchor) : selection;
@@ -191,10 +199,6 @@ export function wrapIndividualLinesWithAbbreviation(args: any) {
 			let previousLine = rangeToReplace.end.line - 1;
 			let lastChar = editor.document.lineAt(previousLine).text.length;
 			rangeToReplace = new vscode.Range(rangeToReplace.start, new vscode.Position(previousLine, lastChar));
-		}
-		if (rangeToReplace.isEmpty) {
-			vscode.window.showInformationMessage('Select more than 1 line and try again.');
-			return;
 		}
 
 		rangeToReplace = ignoreExtraWhitespaceSelected(rangeToReplace, editor.document);

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -184,19 +184,22 @@ export function wrapIndividualLinesWithAbbreviation(args: any) {
 	}
 
 	const editor = vscode.window.activeTextEditor;
-	const selection = editor.selection;
-	let rangeToReplace: vscode.Range = selection.isReversed ? new vscode.Range(selection.active, selection.anchor) : selection;
-	if (!rangeToReplace.isSingleLine && rangeToReplace.end.character === 0) {
-		let previousLine = rangeToReplace.end.line - 1;
-		let lastChar = editor.document.lineAt(previousLine).text.length;
-		rangeToReplace = new vscode.Range(rangeToReplace.start, new vscode.Position(previousLine, lastChar));
-	}
-	if (rangeToReplace.isEmpty) {
-		vscode.window.showInformationMessage('Select more than 1 line and try again.');
-		return;
-	}
+	let rangesToReplace: vscode.Range[] = [];
+	editor.selections.forEach(selection => {
+		let rangeToReplace: vscode.Range = selection.isReversed ? new vscode.Range(selection.active, selection.anchor) : selection;
+		if (!rangeToReplace.isSingleLine && rangeToReplace.end.character === 0) {
+			let previousLine = rangeToReplace.end.line - 1;
+			let lastChar = editor.document.lineAt(previousLine).text.length;
+			rangeToReplace = new vscode.Range(rangeToReplace.start, new vscode.Position(previousLine, lastChar));
+		}
+		if (rangeToReplace.isEmpty) {
+			vscode.window.showInformationMessage('Select more than 1 line and try again.');
+			return;
+		}
 
-	rangeToReplace = ignoreExtraWhitespaceSelected(rangeToReplace, editor.document);
+		rangeToReplace = ignoreExtraWhitespaceSelected(rangeToReplace, editor.document);
+		rangesToReplace.push(rangeToReplace);
+	});
 
 	const syntax = getSyntaxFromArgs({ language: editor.document.languageId });
 	if (!syntax) {
@@ -204,27 +207,31 @@ export function wrapIndividualLinesWithAbbreviation(args: any) {
 	}
 
 	const abbreviationPromise = (args && args['abbreviation']) ? Promise.resolve(args['abbreviation']) : vscode.window.showInputBox({ prompt: 'Enter Abbreviation' });
-	const lines = editor.document.getText(rangeToReplace).split('\n').map(x => x.trim());
 	const helper = getEmmetHelper();
 
 	return abbreviationPromise.then(inputAbbreviation => {
+		let expandAbbrInput: ExpandAbbreviationInput[] = [];
 		if (!inputAbbreviation || !inputAbbreviation.trim() || !helper.isAbbreviationValid(syntax, inputAbbreviation)) { return false; }
 
 		let extractedResults = helper.extractAbbreviationFromText(inputAbbreviation);
 		if (!extractedResults) {
 			return false;
 		}
+		rangesToReplace.forEach(rangeToReplace => {
+			let lines = editor.document.getText(rangeToReplace).split('\n').map(x => x.trim());
 
-		let { abbreviation, filter } = extractedResults;
-		let input: ExpandAbbreviationInput = {
-			syntax,
-			abbreviation,
-			rangeToReplace,
-			textToWrap: lines,
-			filter
-		};
+			let { abbreviation, filter } = extractedResults;
+			let input: ExpandAbbreviationInput = {
+				syntax,
+				abbreviation,
+				rangeToReplace,
+				textToWrap: lines,
+				filter
+			};
+			expandAbbrInput.push(input);
+		});
 
-		return expandAbbreviationInRange(editor, [input], true);
+		return expandAbbreviationInRange(editor, expandAbbrInput, false);
 	});
 
 }
@@ -513,7 +520,7 @@ function expandAbbreviationInRange(editor: vscode.TextEditor, expandAbbrList: Ex
 		expandAbbrList.forEach((expandAbbrInput: ExpandAbbreviationInput) => {
 			let expandedText = expandAbbr(expandAbbrInput);
 			if (expandedText) {
-				insertPromises.push(editor.insertSnippet(new vscode.SnippetString(expandedText), expandAbbrInput.rangeToReplace));
+				insertPromises.push(editor.insertSnippet(new vscode.SnippetString(expandedText), expandAbbrInput.rangeToReplace, { undoStopBefore: false, undoStopAfter: false }));
 			}
 		});
 		if (insertPromises.length === 0) {

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -61,7 +61,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 
 	const multiCursors = [new Selection(2, 6, 2, 6), new Selection(3, 6, 3, 6)];
 	const multiCursorsWithSelection = [new Selection(2, 2, 2, 28), new Selection(3, 2, 3, 33)];
-	const multiCursorsWithFullLineSelection = [new Selection(2, 0, 2, 28), new Selection(3, 0, 3, 33)];
+	const multiCursorsWithFullLineSelection = [new Selection(2, 0, 2, 28), new Selection(3, 0, 4, 0)];
 
 
 	test('Wrap with block element using multi cursor', () => {
@@ -239,6 +239,35 @@ suite('Tests for Wrap with Abbreviations', () => {
 `;
 		return withRandomFileEditor(contents, 'html', (editor, doc) => {
 			editor.selections = [new Selection(2, 2, 3, 33)];
+			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'ul>li.hello$*' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');
+				return Promise.resolve();
+			}
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), wrapIndividualLinesExpected);
+				return Promise.resolve();
+			});
+		});
+	});
+
+	test('Wrap individual lines with abbreviation with extra space selected', () => {
+		const contents = `
+	<ul class="nav main">
+		<li class="item1">img</li>
+		<li class="item2">hi.there</li>
+	</ul>
+`;
+		const wrapIndividualLinesExpected = `
+	<ul class="nav main">
+		<ul>
+			<li class="hello1"><li class="item1">img</li></li>
+			<li class="hello2"><li class="item2">hi.there</li></li>
+		</ul>
+	</ul>
+`;
+		return withRandomFileEditor(contents, 'html', (editor, doc) => {
+			editor.selections = [new Selection(2, 1, 4, 0)];
 			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'ul>li.hello$*' });
 			if (!promise) {
 				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');


### PR DESCRIPTION
This fixes https://github.com/Microsoft/vscode/issues/44833
Also solved an issue whit the `wrapIndividualLinesWithAbbreviation` that was causing wrong indentation in the final text.

#### Tests
Modified `wrapWithAbbreviation` tests so that they take in consideration both cases of "Full line selection" (one being `from (line, 0) to (line, line.length)`, and the other `from (line, 0) to (line+1, 0)`).

Added a test for both fixes on `wrapIndividualLinesWithAbbreviation`.