### PR TITLE
Adding Emmet preference for changing fuzzySearchMinScore

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -199,6 +199,11 @@
                             "type": "string",
                             "default": null,
                             "description": "%emmetPreferencesCssMsProperties%"
+                        },
+                        "fuzzySearchMinScore": {
+                            "type": "number",
+                            "default": 0.3,
+                            "description": "%emmetPreferencesFuzzySearchMinScore%"
                         }
                     }
                 },

--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -343,7 +343,7 @@
         "@emmetio/html-matcher": "^0.3.3",
         "@emmetio/css-parser": "ramya-rao-a/css-parser#vscode",
         "@emmetio/math-expression": "^0.1.1",
-        "vscode-emmet-helper": "^1.2.0",
+        "vscode-emmet-helper": "^1.2.1",
         "vscode-languageserver-types": "^3.5.0",
         "image-size": "^0.5.2",
         "vscode-nls": "3.2.1"

--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -200,10 +200,10 @@
                             "default": null,
                             "description": "%emmetPreferencesCssMsProperties%"
                         },
-                        "fuzzySearchMinScore": {
+                        "css.fuzzySearchMinScore": {
                             "type": "number",
                             "default": 0.3,
-                            "description": "%emmetPreferencesFuzzySearchMinScore%"
+                            "description": "%emmetPreferencesCssFuzzySearchMinScore%"
                         }
                     }
                 },

--- a/extensions/emmet/package.nls.json
+++ b/extensions/emmet/package.nls.json
@@ -53,5 +53,5 @@
 	"emmetPreferencesCssMozProperties": "Comma separated CSS properties that get the 'moz' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'moz' prefix.",
 	"emmetPreferencesCssOProperties": "Comma separated CSS properties that get the 'o' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'o' prefix.",
 	"emmetPreferencesCssMsProperties": "Comma separated CSS properties that get the 'ms' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'ms' prefix.",
-	"emmetPreferencesFuzzySearchMinScore": "Number between 0 and 1 defining the minimum score a match should get in order to be shown as suggestion."
+	"emmetPreferencesCssFuzzySearchMinScore": "The minimum score (from 0 to 1) that fuzzy-matched abbreviation should achieve. Lower values may produce many false-positive matches, higher values may reduce possible matches."
 }

--- a/extensions/emmet/package.nls.json
+++ b/extensions/emmet/package.nls.json
@@ -52,5 +52,6 @@
 	"emmetPreferencesCssWebkitProperties": "Comma separated CSS properties that get the 'webkit' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'webkit' prefix.",
 	"emmetPreferencesCssMozProperties": "Comma separated CSS properties that get the 'moz' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'moz' prefix.",
 	"emmetPreferencesCssOProperties": "Comma separated CSS properties that get the 'o' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'o' prefix.",
-	"emmetPreferencesCssMsProperties": "Comma separated CSS properties that get the 'ms' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'ms' prefix."
+	"emmetPreferencesCssMsProperties": "Comma separated CSS properties that get the 'ms' vendor prefix when used in Emmet abbreviation that starts with `-`. Set to empty string to always avoid the 'ms' prefix.",
+	"emmetPreferencesFuzzySearchMinScore": "Number between 0 and 1 defining the minimum score a match should get in order to be shown as suggestion."
 }

--- a/extensions/emmet/yarn.lock
+++ b/extensions/emmet/yarn.lock
@@ -2052,9 +2052,9 @@ vinyl@~2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-emmet-helper@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.2.0.tgz#6b9311be065c9c99d5de2dae18ea0730d9cfb734"
+vscode-emmet-helper@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/vscode-emmet-helper/-/vscode-emmet-helper-1.2.1.tgz#dc4a3c83a3f1d48f4e9e1a5cce0e63f24b6eb843"
   dependencies:
     "@emmetio/extract-abbreviation" "0.1.6"
     jsonc-parser "^1.0.0"


### PR DESCRIPTION
This has been requested in https://github.com/Microsoft/vscode/issues/44568
See also https://github.com/Microsoft/vscode-emmet-helper/pull/25

This new preference will define how good should be a match in order to be shown by Emmet. Higher numbers are better matches, so setting this preference to a number closer to 1 should prevent emmet suggestions to appear as often.
Setting it by default to 0.3