### PR TITLE
Add defining span to definition provider API

### DIFF
--- a/extensions/typescript/src/features/definitionProvider.ts
+++ b/extensions/typescript/src/features/definitionProvider.ts
@@ -3,12 +3,38 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DefinitionProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
+import { DefinitionProvider, TextDocument, Position, CancellationToken, Definition, DefinitionContext } from 'vscode';
 
 import DefinitionProviderBase from './definitionProviderBase';
+import { vsPositionToTsFileLocation, tsTextSpanToVsRange } from '../utils/convert';
 
 export default class TypeScriptDefinitionProvider extends DefinitionProviderBase implements DefinitionProvider {
 	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | undefined> {
 		return this.getSymbolLocations('definition', document, position, token);
+	}
+
+	async resolveDefinitionContext(
+		document: TextDocument,
+		position: Position,
+		token: CancellationToken
+	): Promise<DefinitionContext | undefined> {
+		const filepath = this.client.normalizePath(document.uri);
+		if (!filepath) {
+			return undefined;
+		}
+
+		const args = vsPositionToTsFileLocation(filepath, position);
+		try {
+			const response = await this.client.execute('definitionAndBoundSpan', args, token);
+			if (response && response.body && response.body.textSpan) {
+				return {
+					definingSymbolRange: tsTextSpanToVsRange(response.body.textSpan)
+				};
+			}
+		} catch {
+			// noop
+		}
+
+		return undefined;
 	}
 }

--- a/extensions/typescript/src/features/definitionProviderBase.ts
+++ b/extensions/typescript/src/features/definitionProviderBase.ts
@@ -11,7 +11,7 @@ import { tsTextSpanToVsRange, vsPositionToTsFileLocation } from '../utils/conver
 
 export default class TypeScriptDefinitionProviderBase {
 	constructor(
-		private client: ITypeScriptServiceClient
+		protected client: ITypeScriptServiceClient
 	) { }
 
 	protected async getSymbolLocations(

--- a/extensions/typescript/src/typescriptService.ts
+++ b/extensions/typescript/src/typescriptService.ts
@@ -45,6 +45,7 @@ export interface ITypeScriptServiceClient {
 	execute(command: 'completionEntryDetails', args: Proto.CompletionDetailsRequestArgs, token?: CancellationToken): Promise<Proto.CompletionDetailsResponse>;
 	execute(command: 'signatureHelp', args: Proto.SignatureHelpRequestArgs, token?: CancellationToken): Promise<Proto.SignatureHelpResponse>;
 	execute(command: 'definition', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DefinitionResponse>;
+	execute(command: 'definitionAndBoundSpan', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DefinitionInfoAndBoundSpanReponse>;
 	execute(command: 'implementation', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ImplementationResponse>;
 	execute(command: 'typeDefinition', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.TypeDefinitionResponse>;
 	execute(command: 'references', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ReferencesResponse>;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -522,6 +522,10 @@ export interface Location {
  */
 export type Definition = Location | Location[];
 
+export interface DefinitionContext {
+	definingSymbolRange?: IRange;
+}
+
 /**
  * The definition provider interface defines the contract between extensions and
  * the [go to definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
@@ -532,6 +536,11 @@ export interface DefinitionProvider {
 	 * Provide the definition of the symbol at the given position and document.
 	 */
 	provideDefinition(model: model.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+
+	/**
+	 * Resolve additional information about the definition.
+	 */
+	resolveDefinitionContext?(model: model.ITextModel, position: Position, token: CancellationToken): DefinitionContext | Thenable<DefinitionContext>;
 }
 
 /**

--- a/src/vs/editor/contrib/goToDeclaration/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/goToDeclaration.ts
@@ -10,53 +10,75 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { ITextModel } from 'vs/editor/common/model';
 import { registerDefaultLanguageCommand } from 'vs/editor/browser/editorExtensions';
 import LanguageFeatureRegistry from 'vs/editor/common/modes/languageFeatureRegistry';
-import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location, DefinitionProvider, ImplementationProvider, TypeDefinitionProvider } from 'vs/editor/common/modes';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
 import { flatten } from 'vs/base/common/arrays';
+
+export interface DefintionsResult<T> {
+	firstProvider: T | undefined;
+	definitions: Location[];
+}
 
 function getDefinitions<T>(
 	model: ITextModel,
 	position: Position,
 	registry: LanguageFeatureRegistry<T>,
 	provide: (provider: T, model: ITextModel, position: Position, token: CancellationToken) => Location | Location[] | Thenable<Location | Location[]>
-): TPromise<Location[]> {
+): TPromise<DefintionsResult<T>> {
 	const provider = registry.ordered(model);
+	let firstProvider: T;
 
 	// get results
-	const promises = provider.map((provider, idx): TPromise<Location | Location[]> => {
+	const promises = provider.map((provider, idx) => {
 		return asWinJsPromise((token) => {
 			return provide(provider, model, position, token);
-		}).then(undefined, err => {
-			onUnexpectedExternalError(err);
-			return null;
-		});
+		})
+			.then<Location | Location[]>(undefined, err => {
+				onUnexpectedExternalError(err);
+				return null;
+			}).then(locations => {
+				if (!firstProvider) {
+					if ((Array.isArray(locations) && locations.length) || locations) {
+						firstProvider = provider;
+					}
+				}
+				return locations;
+			});
 	});
 	return TPromise.join(promises)
 		.then(flatten)
-		.then(references => references.filter(x => !!x));
+		.then(locations => locations.filter(x => !!x))
+		.then(locations => ({
+			definitions: locations,
+			firstProvider
+		}));
 }
 
-
-export function getDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<DefintionsResult<DefinitionProvider>> {
 	return getDefinitions(model, position, DefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideDefinition(model, position, token);
 	});
 }
 
-export function getImplementationsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getImplementationsAtPosition(model: ITextModel, position: Position): TPromise<DefintionsResult<ImplementationProvider>> {
 	return getDefinitions(model, position, ImplementationProviderRegistry, (provider, model, position, token) => {
 		return provider.provideImplementation(model, position, token);
 	});
 }
 
-export function getTypeDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getTypeDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<DefintionsResult<TypeDefinitionProvider>> {
 	return getDefinitions(model, position, TypeDefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideTypeDefinition(model, position, token);
 	});
 }
 
-registerDefaultLanguageCommand('_executeDefinitionProvider', getDefinitionsAtPosition);
-registerDefaultLanguageCommand('_executeImplementationProvider', getImplementationsAtPosition);
-registerDefaultLanguageCommand('_executeTypeDefinitionProvider', getTypeDefinitionsAtPosition);
+registerDefaultLanguageCommand('_executeDefinitionProvider', (model: ITextModel, position: Position) =>
+	getDefinitionsAtPosition(model, position).then(result => result.definitions));
+
+registerDefaultLanguageCommand('_executeImplementationProvider', (model: ITextModel, position: Position) =>
+	getImplementationsAtPosition(model, position).then(result => result.definitions));
+
+registerDefaultLanguageCommand('_executeTypeDefinitionProvider', (model: ITextModel, position: Position) =>
+	getTypeDefinitionsAtPosition(model, position).then(result => result.definitions));

--- a/src/vs/editor/contrib/goToDeclaration/goToDeclarationCommands.ts
+++ b/src/vs/editor/contrib/goToDeclaration/goToDeclarationCommands.ts
@@ -112,7 +112,7 @@ export class DefinitionAction extends EditorAction {
 	}
 
 	protected _getDeclarationsAtPosition(model: ITextModel, position: corePosition.Position): TPromise<Location[]> {
-		return getDefinitionsAtPosition(model, position);
+		return getDefinitionsAtPosition(model, position).then(result => result.definitions);
 	}
 
 	protected _getNoResultFoundMessage(info?: IWordAtPosition): string {
@@ -249,7 +249,7 @@ export class PeekDefinitionAction extends DefinitionAction {
 
 export class ImplementationAction extends DefinitionAction {
 	protected _getDeclarationsAtPosition(model: ITextModel, position: corePosition.Position): TPromise<Location[]> {
-		return getImplementationsAtPosition(model, position);
+		return getImplementationsAtPosition(model, position).then(result => result.definitions);
 	}
 
 	protected _getNoResultFoundMessage(info?: IWordAtPosition): string {
@@ -305,7 +305,7 @@ export class PeekImplementationAction extends ImplementationAction {
 
 export class TypeDefinitionAction extends DefinitionAction {
 	protected _getDeclarationsAtPosition(model: ITextModel, position: corePosition.Position): TPromise<Location[]> {
-		return getTypeDefinitionsAtPosition(model, position);
+		return getTypeDefinitionsAtPosition(model, position).then(result => result.definitions);
 	}
 
 	protected _getNoResultFoundMessage(info?: IWordAtPosition): string {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4698,6 +4698,10 @@ declare module monaco.languages {
 	 */
 	export type Definition = Location | Location[];
 
+	export interface DefinitionContext {
+		definingSymbolRange?: IRange;
+	}
+
 	/**
 	 * The definition provider interface defines the contract between extensions and
 	 * the [go to definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
@@ -4708,6 +4712,10 @@ declare module monaco.languages {
 		 * Provide the definition of the symbol at the given position and document.
 		 */
 		provideDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+		/**
+		 * Resolve additional information about the definition.
+		 */
+		resolveDefinitionContext?(model: editor.ITextModel, position: Position, token: CancellationToken): DefinitionContext | Thenable<DefinitionContext>;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -353,6 +353,10 @@ declare module 'vscode' {
 		text?: string;
 	}
 
+	export interface DefinitionContext {
+		definingSymbolRange?: Range;
+	}
+
 	export namespace languages {
 
 		/**
@@ -371,7 +375,16 @@ declare module 'vscode' {
 		export interface RenameProvider2 extends RenameProvider {
 			resolveInitialRenameValue?(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<RenameInitialValue>;
 		}
+
+		export interface DefinitionProvider2 extends DefinitionProvider {
+
+			/**
+			 * Provides additional information about a definition.
+			 */
+			resolveDefinitionContext?(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<DefinitionContext>;
+		}
 	}
+
 	export interface FoldingProvider {
 		provideFoldingRanges(document: TextDocument, token: CancellationToken): ProviderResult<FoldingRangeList>;
 	}

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -140,6 +140,9 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 		this._registrations[handle] = modes.DefinitionProviderRegistry.register(toLanguageSelector(selector), <modes.DefinitionProvider>{
 			provideDefinition: (model, position, token): Thenable<modes.Definition> => {
 				return wireCancellationToken(token, this._proxy.$provideDefinition(handle, model.uri, position)).then(MainThreadLanguageFeatures._reviveLocationDto);
+			},
+			resolveDefinitionContext: (model, position, token): Thenable<modes.DefinitionContext> => {
+				return wireCancellationToken(token, this._proxy.$resolveDefinitionContext(handle, model.uri, position));
 			}
 		});
 	}

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -679,6 +679,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideCodeLenses(handle: number, resource: UriComponents): TPromise<modes.ICodeLensSymbol[]>;
 	$resolveCodeLens(handle: number, resource: UriComponents, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol>;
 	$provideDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
+	$resolveDefinitionContext(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.DefinitionContext>;
 	$provideImplementation(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
 	$provideTypeDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
 	$provideHover(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.Hover>;

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -324,8 +324,8 @@ suite('ExtHostLanguageFeatures', function () {
 				assert.equal(value.definitions.length, 2);
 				// let [first, second] = value;
 
-				assert.equal(value[0].uri.authority, 'second');
-				assert.equal(value[1].uri.authority, 'first');
+				assert.equal(value.definitions[0].uri.authority, 'second');
+				assert.equal(value.definitions[1].uri.authority, 'first');
 			});
 		});
 	});
@@ -372,16 +372,18 @@ suite('ExtHostLanguageFeatures', function () {
 			},
 			resolveDefinitionContext() {
 				return {
-					definingSymbolRange: new types.Range(1, 2, 1, 3)
+					definingSymbolRange: new types.Range(1, 3, 1, 4)
 				};
 			}
 		};
 		disposables.push(extHost.registerDefinitionProvider(defaultSelector, provider2));
 
 		return rpcProtocol.sync().then(() => {
-
-			return getDefinitionsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.firstProvider, provider1);
+			const pos = new EditorPosition(1, 1);
+			return getDefinitionsAtPosition(model, pos).then(value => {
+				return asWinJsPromise(token => value.firstProvider.resolveDefinitionContext(model, pos, token)).then(context => {
+					assert.equal(context.definingSymbolRange.endColumn, 5);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Supersedes #40045

**Problem**
See #10037

**Proposal**
Adds a new `resolveDefinitionContext` to `DefinitionProvider`. This allows a definition provider to return the defining symbol span.