### PR TITLE
Show warning when git commit input box only contains whitespaces

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -559,6 +559,15 @@ export class Repository implements Disposable {
 			return;
 		}
 
+		const whitespacesOnly = text.length && !text.replace(/\s/g, '');
+
+		if (whitespacesOnly) {
+			return {
+				message: localize('commitMessageWhitespacesOnlyWarning', "Current commit message only contains whitespaces"),
+				type: SourceControlInputBoxValidationType.Warning
+			};
+		}
+
 		let start = 0, end;
 		let match: RegExpExecArray | null;
 		const regex = /\r?\n/g;


### PR DESCRIPTION
fixes #45031. 
A warning message 'Current commit message only contains line breaks' will be shown when `git.inputValidation` is not set to 'off' and all the user has entered in the commit message box are line breaks.