### PR TITLE
Update gulp-atom-electron to 1.16.0 to fix duplicated icns issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "express": "^4.13.1",
     "glob": "^5.0.13",
     "gulp": "^3.8.9",
-    "gulp-atom-electron": "1.15.1",
+    "gulp-atom-electron": "1.16.0",
     "gulp-azure-storage": "^0.7.0",
     "gulp-bom": "^1.0.0",
     "gulp-buffer": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,9 +2212,9 @@ grunt@0.4:
     underscore.string "~2.2.1"
     which "~1.0.5"
 
-gulp-atom-electron@1.15.1:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/gulp-atom-electron/-/gulp-atom-electron-1.15.1.tgz#ae13a4107a52e249d3335f584794981f5dcbf9be"
+gulp-atom-electron@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/gulp-atom-electron/-/gulp-atom-electron-1.16.0.tgz#7900d854689db3f5d6821c645d4693d5af22fa05"
   dependencies:
     event-stream "^3.1.7"
     github-releases "^0.2.0"


### PR DESCRIPTION
Brings in changes from `gulp-atom-electron` specified in [this PR](https://github.com/joaomoreno/gulp-atom-electron/pull/49), related to the duplicated `icns` file in macOS builds.