### PR TITLE
Add code.ps1 for Windows PowerShell

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -345,6 +345,10 @@ function packageTask(platform, arch, opts) {
 				.pipe(replace('@@NAME@@', product.nameShort))
 				.pipe(rename(function (f) { f.basename = product.applicationName; })));
 
+			result = es.merge(result, gulp.src('resources/win32/bin/code.ps1', { base: 'resources/win32' })
+				.pipe(replace('@@NAME@@', product.nameShort))
+				.pipe(rename(function (f) { f.basename = product.applicationName; })));
+
 			result = es.merge(result, gulp.src('resources/win32/bin/code.sh', { base: 'resources/win32' })
 				.pipe(replace('@@NAME@@', product.nameShort))
 				.pipe(rename(function (f) { f.basename = product.applicationName; f.extname = ''; })));

--- a/resources/win32/bin/code.ps1
+++ b/resources/win32/bin/code.ps1
@@ -1,0 +1,6 @@
+# %~dp0.. in CMD
+$tilde_dp0_parent = Split-Path -Parent (Split-Path -Parent $MyInvocation.Mycommand.Path)
+
+$env:VSCODE_DEV = ""
+$env:ELECTRON_RUN_AS_NODE = "1"
+&(Join-Path $tilde_dp0_parent "@@NAME@@.exe") (Join-Path $tilde_dp0_parent "resources" | Join-Path -ChildPath "app" | Join-Path -ChildPath "out" | Join-Path -ChildPath "cli.js") $args


### PR DESCRIPTION
This will fix #38587.

However, you have to change the execution policy to other than `Restricted` after installing VSCode by the following commandlet for example (this requires the administrator's privilege):

```powershell
Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
```

I know this process must corrupt users who run VSCode in Windows 10, use PowerShell as the default shell, which is opened from the context menu that appears after you right-click the start button or press `Win + X`, and are not used to the shell so much.

This PR doesn't concern users who use Windows 8.1 or earlier (because most of they use only CMD instead) and another OS than Windows.