### PR TITLE
listService: forget about disposed lists

### DIFF
--- a/src/vs/base/browser/ui/list/listPaging.ts
+++ b/src/vs/base/browser/ui/list/listPaging.ts
@@ -97,6 +97,10 @@ export class PagedList<T> implements IDisposable {
 		return this.list;
 	}
 
+	get onDidDispose(): Event<void> {
+		return this.list.onDidDispose;
+	}
+
 	get onFocusChange(): Event<IListEvent<T>> {
 		return mapEvent(this.list.onFocusChange, ({ elements, indexes }) => ({ elements: elements.map(e => this._model.get(e)), indexes }));
 	}

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1059,7 +1059,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	}
 
 	isDOMFocused(): boolean {
-		return this.view && this.view.domNode === document.activeElement;
+		return this.view.domNode === document.activeElement;
 	}
 
 	getHTMLElement(): HTMLElement {

--- a/src/vs/base/parts/tree/browser/treeImpl.ts
+++ b/src/vs/base/parts/tree/browser/treeImpl.ts
@@ -131,7 +131,7 @@ export class Tree implements _.ITree {
 	}
 
 	public isDOMFocused(): boolean {
-		return this.view && this.view.isFocused();
+		return this.view.isFocused();
 	}
 
 	public domBlur(): void {

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -73,7 +73,13 @@ export class ListService implements IListService {
 
 		const result = combinedDisposable([
 			widget.onDidFocus(() => this._lastFocusedWidget = widget),
-			toDisposable(() => this.lists.splice(this.lists.indexOf(registeredList), 1))
+			toDisposable(() => this.lists.splice(this.lists.indexOf(registeredList), 1)),
+			widget.onDidDispose(() => {
+				this.lists = this.lists.filter(l => l !== registeredList);
+				if (this._lastFocusedWidget === widget) {
+					this._lastFocusedWidget = undefined;
+				}
+			})
 		]);
 
 		return result;


### PR DESCRIPTION
João Moreno: https://github.com/Microsoft/vscode/commit/ce745369d0cb68ab9f07ba9bff4cbf2ae8080134

brah!
the issue happens because the list service keep holding on to disposed trees/lists
this fix is bad since it only covers the `isDOMFocused` method
the real fix is for the list service to forget about the tree/list when it detects that it gets disposed
both widgets have the `onDidDispose` event


fyi @bpasero 