### PR TITLE
Ts suggest diagnostics

### DIFF
--- a/extensions/typescript/src/features/diagnostics.ts
+++ b/extensions/typescript/src/features/diagnostics.ts
@@ -34,6 +34,7 @@ export default class DiagnosticsManager {
 
 	private readonly syntaxDiagnostics: DiagnosticSet;
 	private readonly semanticDiagnostics: DiagnosticSet;
+	private readonly suggestionDiagnostics: DiagnosticSet;
 	private readonly currentDiagnostics: DiagnosticCollection;
 	private _validate: boolean = true;
 
@@ -42,6 +43,7 @@ export default class DiagnosticsManager {
 	) {
 		this.syntaxDiagnostics = new DiagnosticSet();
 		this.semanticDiagnostics = new DiagnosticSet();
+		this.suggestionDiagnostics = new DiagnosticSet();
 		this.currentDiagnostics = languages.createDiagnosticCollection(language);
 	}
 
@@ -75,6 +77,11 @@ export default class DiagnosticsManager {
 		this.updateCurrentDiagnostics(file);
 	}
 
+	public suggestionDiagnosticsReceived(file: Uri, suggestionDiagnostics: Diagnostic[]): void {
+		this.semanticDiagnostics.set(file, suggestionDiagnostics);
+		this.updateCurrentDiagnostics(file);
+	}
+
 	public configFileDiagnosticsReceived(file: Uri, diagnostics: Diagnostic[]): void {
 		this.currentDiagnostics.set(file, diagnostics);
 	}
@@ -90,7 +97,8 @@ export default class DiagnosticsManager {
 
 		const semanticDiagnostics = this.semanticDiagnostics.get(file);
 		const syntaxDiagnostics = this.syntaxDiagnostics.get(file);
-		this.currentDiagnostics.set(file, semanticDiagnostics.concat(syntaxDiagnostics));
+		const suggestionDiagnostics = this.suggestionDiagnostics.get(file);
+		this.currentDiagnostics.set(file, semanticDiagnostics.concat(syntaxDiagnostics, suggestionDiagnostics));
 	}
 
 	public getDiagnostics(file: Uri): Diagnostic[] {

--- a/extensions/typescript/src/features/quickFixProvider.ts
+++ b/extensions/typescript/src/features/quickFixProvider.ts
@@ -11,7 +11,7 @@ import * as typeConverters from '../utils/typeConverters';
 import FormattingConfigurationManager from './formattingConfigurationManager';
 import { getEditForCodeAction, applyCodeActionCommands } from '../utils/codeAction';
 import { Command, CommandManager } from '../utils/commandManager';
-import DiagnosticsManager from './diagnostics';
+import { DiagnosticsManager } from './diagnostics';
 
 import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();

--- a/extensions/typescript/src/languageProvider.ts
+++ b/extensions/typescript/src/languageProvider.ts
@@ -14,7 +14,7 @@ import TypingsStatus from './utils/typingsStatus';
 import FormattingConfigurationManager from './features/formattingConfigurationManager';
 import * as languageConfigurations from './utils/languageConfigurations';
 import { CommandManager } from './utils/commandManager';
-import DiagnosticsManager from './features/diagnostics';
+import { DiagnosticsManager, DiagnosticKind } from './features/diagnostics';
 import { LanguageDescription } from './utils/languageDescription';
 import * as fileSchemes from './utils/fileSchemes';
 import { CachedNavTreeResponse } from './features/baseCodeLensProvider';
@@ -233,16 +233,8 @@ export default class LanguageProvider {
 		this.bufferSyncSupport.requestAllDiagnostics();
 	}
 
-	public syntaxDiagnosticsReceived(file: Uri, syntaxDiagnostics: Diagnostic[]): void {
-		this.diagnosticsManager.syntaxDiagnosticsReceived(file, syntaxDiagnostics);
-	}
-
-	public semanticDiagnosticsReceived(file: Uri, semanticDiagnostics: Diagnostic[]): void {
-		this.diagnosticsManager.semanticDiagnosticsReceived(file, semanticDiagnostics);
-	}
-
-	public suggestionDiagnosticsRecieved(file: Uri, semanticDiagnostics: Diagnostic[]): void {
-		this.diagnosticsManager.suggestionDiagnosticsReceived(file, semanticDiagnostics);
+	public diagnosticsReceived(diagnosticsKind: DiagnosticKind, file: Uri, syntaxDiagnostics: Diagnostic[]): void {
+		this.diagnosticsManager.diagnosticsReceived(diagnosticsKind, file, syntaxDiagnostics);
 	}
 
 	public configFileDiagnosticsReceived(file: Uri, diagnostics: Diagnostic[]): void {

--- a/extensions/typescript/src/languageProvider.ts
+++ b/extensions/typescript/src/languageProvider.ts
@@ -241,6 +241,10 @@ export default class LanguageProvider {
 		this.diagnosticsManager.semanticDiagnosticsReceived(file, semanticDiagnostics);
 	}
 
+	public suggestionDiagnosticsRecieved(file: Uri, semanticDiagnostics: Diagnostic[]): void {
+		this.diagnosticsManager.suggestionDiagnosticsReceived(file, semanticDiagnostics);
+	}
+
 	public configFileDiagnosticsReceived(file: Uri, diagnostics: Diagnostic[]): void {
 		this.diagnosticsManager.configFileDiagnosticsReceived(file, diagnostics);
 	}

--- a/extensions/typescript/src/protocol.const.ts
+++ b/extensions/typescript/src/protocol.const.ts
@@ -36,6 +36,6 @@ export class Kind {
 
 export class DiagnosticCategory {
 	public static readonly error = 'error';
-
 	public static readonly warning = 'warning';
+	public static readonly suggestion = 'suggestion';
 }

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -243,6 +243,9 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 	private _onSemanticDiagnosticsReceived = new EventEmitter<TsDiagnostics>();
 	public get onSemanticDiagnosticsReceived(): Event<TsDiagnostics> { return this._onSemanticDiagnosticsReceived.event; }
 
+	private _onSuggestionDiagnosticsReceived = new EventEmitter<TsDiagnostics>();
+	public get onSuggestionDiagnosticsReceived(): Event<TsDiagnostics> { return this._onSuggestionDiagnosticsReceived.event; }
+
 	private _onConfigDiagnosticsReceived = new EventEmitter<Proto.ConfigFileDiagnosticEvent>();
 	public get onConfigDiagnosticsReceived(): Event<Proto.ConfigFileDiagnosticEvent> { return this._onConfigDiagnosticsReceived.event; }
 
@@ -813,6 +816,17 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 					const diagnosticEvent: Proto.DiagnosticEvent = event;
 					if (diagnosticEvent.body && diagnosticEvent.body.diagnostics) {
 						this._onSemanticDiagnosticsReceived.fire({
+							resource: this.asUrl(diagnosticEvent.body.file),
+							diagnostics: diagnosticEvent.body.diagnostics
+						});
+					}
+					break;
+				}
+			case 'suggestionDiag':
+				{
+					const diagnosticEvent: Proto.DiagnosticEvent = event;
+					if (diagnosticEvent.body && diagnosticEvent.body.diagnostics) {
+						this._onSuggestionDiagnosticsReceived.fire({
 							resource: this.asUrl(diagnosticEvent.body.file),
 							diagnostics: diagnosticEvent.body.diagnostics
 						});

--- a/extensions/typescript/src/typescriptServiceClient.ts
+++ b/extensions/typescript/src/typescriptServiceClient.ts
@@ -29,6 +29,7 @@ import * as fileSchemes from './utils/fileSchemes';
 import { inferredProjectConfig } from './utils/tsconfig';
 import LogDirectoryProvider from './utils/logDirectoryProvider';
 import { disposeAll } from './utils/dipose';
+import { DiagnosticKind } from './features/diagnostics';
 
 const localize = nls.loadMessageBundle();
 
@@ -140,6 +141,7 @@ class ForkedTsServerProcess {
 }
 
 export interface TsDiagnostics {
+	readonly kind: DiagnosticKind;
 	readonly resource: Uri;
 	readonly diagnostics: Proto.Diagnostic[];
 }
@@ -237,14 +239,8 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 		this.disposables.push(this.telemetryReporter);
 	}
 
-	private _onSyntaxDiagnosticsReceived = new EventEmitter<TsDiagnostics>();
-	public get onSyntaxDiagnosticsReceived(): Event<TsDiagnostics> { return this._onSyntaxDiagnosticsReceived.event; }
-
-	private _onSemanticDiagnosticsReceived = new EventEmitter<TsDiagnostics>();
-	public get onSemanticDiagnosticsReceived(): Event<TsDiagnostics> { return this._onSemanticDiagnosticsReceived.event; }
-
-	private _onSuggestionDiagnosticsReceived = new EventEmitter<TsDiagnostics>();
-	public get onSuggestionDiagnosticsReceived(): Event<TsDiagnostics> { return this._onSuggestionDiagnosticsReceived.event; }
+	private _onDiagnosticsReceived = new EventEmitter<TsDiagnostics>();
+	public get onDiagnosticsReceived(): Event<TsDiagnostics> { return this._onDiagnosticsReceived.event; }
 
 	private _onConfigDiagnosticsReceived = new EventEmitter<Proto.ConfigFileDiagnosticEvent>();
 	public get onConfigDiagnosticsReceived(): Event<Proto.ConfigFileDiagnosticEvent> { return this._onConfigDiagnosticsReceived.event; }
@@ -264,8 +260,7 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 		}
 
 		disposeAll(this.disposables);
-		this._onSyntaxDiagnosticsReceived.dispose();
-		this._onSemanticDiagnosticsReceived.dispose();
+		this._onDiagnosticsReceived.dispose();
 		this._onConfigDiagnosticsReceived.dispose();
 		this._onResendModelsRequested.dispose();
 	}
@@ -801,38 +796,18 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
 	private dispatchEvent(event: Proto.Event) {
 		switch (event.event) {
 			case 'syntaxDiag':
-				{
-					const diagnosticEvent: Proto.DiagnosticEvent = event;
-					if (diagnosticEvent.body && diagnosticEvent.body.diagnostics) {
-						this._onSyntaxDiagnosticsReceived.fire({
-							resource: this.asUrl(diagnosticEvent.body.file),
-							diagnostics: diagnosticEvent.body.diagnostics
-						});
-					}
-					break;
-				}
 			case 'semanticDiag':
-				{
-					const diagnosticEvent: Proto.DiagnosticEvent = event;
-					if (diagnosticEvent.body && diagnosticEvent.body.diagnostics) {
-						this._onSemanticDiagnosticsReceived.fire({
-							resource: this.asUrl(diagnosticEvent.body.file),
-							diagnostics: diagnosticEvent.body.diagnostics
-						});
-					}
-					break;
-				}
 			case 'suggestionDiag':
-				{
-					const diagnosticEvent: Proto.DiagnosticEvent = event;
-					if (diagnosticEvent.body && diagnosticEvent.body.diagnostics) {
-						this._onSuggestionDiagnosticsReceived.fire({
-							resource: this.asUrl(diagnosticEvent.body.file),
-							diagnostics: diagnosticEvent.body.diagnostics
-						});
-					}
-					break;
+				const diagnosticEvent: Proto.DiagnosticEvent = event;
+				if (diagnosticEvent.body && diagnosticEvent.body.diagnostics) {
+					this._onDiagnosticsReceived.fire({
+						kind: getDignosticsKind(event),
+						resource: this.asUrl(diagnosticEvent.body.file),
+						diagnostics: diagnosticEvent.body.diagnostics
+					});
 				}
+				break;
+
 			case 'configFileDiag':
 				this._onConfigDiagnosticsReceived.fire(event as Proto.ConfigFileDiagnosticEvent);
 				break;
@@ -1004,3 +979,12 @@ const getTsLocale = (configuration: TypeScriptServiceConfiguration): string | un
 	(configuration.locale
 		? configuration.locale
 		: env.language);
+
+function getDignosticsKind(event: Proto.Event) {
+	switch (event.event) {
+		case 'syntaxDiag': return DiagnosticKind.Syntax;
+		case 'semanticDiag': return DiagnosticKind.Semantic;
+		case 'suggestionDiag': return DiagnosticKind.Suggestion;
+	}
+	throw new Error('Unknown dignostics kind');
+}


### PR DESCRIPTION
#45378

Picks up initial support for TypeScript's suggest diagnostics. This PR is blocked on a few things:

- [x] Pick up TS 2.8 insiders build
- [x] Understand the UX for these diagnostics. They currently still show up in the problems view