### PR TITLE
Emmet in Interactive Playground

### DIFF
--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -330,7 +330,103 @@
                 "title": "%command.reflectCSSValue%",
                 "category": "Emmet"
             }
-        ]
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "editor.emmet.action.wrapIndividualLinesWithAbbreviation",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.wrapWithAbbreviation",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.removeTag",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.updateTag",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.matchTag",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.balanceIn",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.balanceOut",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.prevEditPoint",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.nextEditPoint",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.mergeLines",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.selectPrevItem",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.selectNextItem",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.splitJoinTag",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.toggleComment",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.evaluateMathExpression",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.updateImageSize",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.incrementNumberByOneTenth",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.incrementNumberByOne",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.incrementNumberByTen",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.decrementNumberByOneTenth",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.decrementNumberByOne",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.decrementNumberByTen",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                },
+                {
+                    "command": "editor.emmet.action.reflectCSSValue",
+                    "when": "resourceScheme =~ /^untitled$|^file$/"
+                }
+            ]
+        }
     },
     "scripts": {
         "compile": "gulp compile-extension:emmet"

--- a/src/vs/workbench/parts/welcome/walkThrough/electron-browser/editor/vs_code_editor_walkthrough.md
+++ b/src/vs/workbench/parts/welcome/walkThrough/electron-browser/editor/vs_code_editor_walkthrough.md
@@ -161,7 +161,7 @@ You can greatly accelerate your editing through the use of snippets.  Simply sta
 
 
 ### Emmet
-Emmet takes the snippets idea to a whole new level: you can type CSS-like expressions that can be dynamically parsed, and produce output depending on what you type in the abbreviation. To use Emmet simply run the command `Emmet: Expand Abbreviation` with the cursor at the end of a valid Emmet abbreviation or snippet and the expansion will occur.
+Emmet takes the snippets idea to a whole new level: you can type CSS-like expressions that can be dynamically parsed, and produce output depending on what you type in the abbreviation. Try it by selecting `Emmet: Expand Abbreviation` from the `Edit` menu with the cursor at the end of a valid Emmet abbreviation or snippet and the expansion will occur.
 
 ```html
 ul>li.item$*5


### PR DESCRIPTION
Fixing description so it points to a way of using emmet that works in the context of the Interactive Playground.
Removed Emmet commands from the Command Palette when not in an editor context.