### PR TITLE
Standardize transpose logic. Add basic support for transposing multibyte characters.

### DIFF
--- a/src/vs/editor/contrib/caretOperations/transpose.ts
+++ b/src/vs/editor/contrib/caretOperations/transpose.ts
@@ -6,14 +6,55 @@
 
 import * as nls from 'vs/nls';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { isLowSurrogate, isHighSurrogate } from 'vs/base/common/strings';
 import { Range } from 'vs/editor/common/core/range';
+import { Position, IPosition } from 'vs/editor/common/core/position';
 import { ICommand } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { registerEditorAction, EditorAction, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ReplaceCommand } from 'vs/editor/common/commands/replaceCommand';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { ITextModel } from 'vs/editor/common/model';
 
 class TransposeLettersAction extends EditorAction {
+
+	private positionLeftOf(start: IPosition, model: ITextModel): Position {
+		let column = start.column;
+		let lineNumber = start.lineNumber;
+
+		if (column > model.getLineMinColumn(lineNumber)) {
+			if (isLowSurrogate(model.getLineContent(lineNumber).charCodeAt(column - 2))) {
+				// character before column is a low surrogate
+				column = column - 2;
+			} else {
+				column = column - 1;
+			}
+		} else if (lineNumber > 1) {
+			lineNumber = lineNumber - 1;
+			column = model.getLineMaxColumn(lineNumber);
+		}
+
+		return new Position(lineNumber, column);
+	}
+
+	private positionRightOf(start: IPosition, model: ITextModel): Position {
+		let column = start.column;
+		let lineNumber = start.lineNumber;
+
+		if (column < model.getLineMaxColumn(lineNumber)) {
+			if (isHighSurrogate(model.getLineContent(lineNumber).charCodeAt(column - 1))) {
+				// character after column is a high surrogate
+				column = column + 2;
+			} else {
+				column = column + 1;
+			}
+		} else if (lineNumber < model.getLineCount()) {
+			lineNumber = lineNumber + 1;
+			column = 0;
+		}
+
+		return new Position(lineNumber, column);
+	}
 
 	constructor() {
 		super({
@@ -36,30 +77,35 @@ class TransposeLettersAction extends EditorAction {
 		let commands: ICommand[] = [];
 		let selections = editor.getSelections();
 
-		for (let i = 0; i < selections.length; i++) {
-			let selection = selections[i];
+		for (let selection of selections) {
 			if (!selection.isEmpty()) {
 				continue;
 			}
+
 			let lineNumber = selection.startLineNumber;
 			let column = selection.startColumn;
-			if (column === 1) {
-				// at the beginning of line
+
+			let lastColumn = model.getLineMaxColumn(lineNumber);
+
+			if (lineNumber === 1 && (column === 1 || (column === 2 && lastColumn === 2))) {
+				// at beginning of file, nothing to do
 				continue;
 			}
-			let maxColumn = model.getLineMaxColumn(lineNumber);
-			if (column === maxColumn) {
-				// at the end of line
-				continue;
-			}
 
-			let lineContent = model.getLineContent(lineNumber);
-			let charToTheLeft = lineContent.charAt(column - 2);
-			let charToTheRight = lineContent.charAt(column - 1);
+			// handle special case: when at end of line, transpose left two chars
+			// otherwise, transpose left and right chars
+			let endPosition = (column === lastColumn) ?
+				selection.getPosition() :
+				this.positionRightOf(selection.getPosition(), model);
 
-			let replaceRange = new Range(lineNumber, column - 1, lineNumber, column + 1);
+			let middlePosition = this.positionLeftOf(endPosition, model);
+			let beginPosition = this.positionLeftOf(middlePosition, model);
 
-			commands.push(new ReplaceCommand(replaceRange, charToTheRight + charToTheLeft));
+			let leftChar = model.getValueInRange(Range.fromPositions(beginPosition, middlePosition));
+			let rightChar = model.getValueInRange(Range.fromPositions(middlePosition, endPosition));
+
+			let replaceRange = Range.fromPositions(beginPosition, endPosition);
+			commands.push(new ReplaceCommand(replaceRange, rightChar + leftChar));
 		}
 
 		if (commands.length > 0) {


### PR DESCRIPTION
This fixes #8574 by standardizing "editor.action.transposeLetters" to match standard emacs/MacOS behavior.