### PR TITLE
Properly set electron version in env scripts

### DIFF
--- a/scripts/env.ps1
+++ b/scripts/env.ps1
@@ -1,3 +1,3 @@
 $env:npm_config_disturl="https://atom.io/download/electron"
-$env:npm_config_target=(node "build/lib/electron.js")
+$env:npm_config_target=(node -p "require('./build/lib/electron').getElectronVersion();")
 $env:npm_config_runtime="electron"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export npm_config_disturl=https://atom.io/download/electron
-export npm_config_target=$(node "build/lib/electron.js")
+export npm_config_target=$(node -p "require('./build/lib/electron').getElectronVersion();")
 export npm_config_runtime=electron
 export npm_config_cache="$HOME/.npm-electron"
 mkdir -p "$npm_config_cache"


### PR DESCRIPTION
Since the `console.log()` got removed from `build/lib/electron.js`, the `npm_config_target` environment variable wasn't getting set to anything.

This PR updates the scripts to call the `getElectronVersion()` method on `build/lib/electron.js`.