### PR TITLE
paths: isEqual and isEqualOrParent trim trailing slash from path

### DIFF
--- a/src/vs/base/common/paths.ts
+++ b/src/vs/base/common/paths.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import { isWindows } from 'vs/base/common/platform';
-import { beginsWithIgnoreCase, equalsIgnoreCase } from 'vs/base/common/strings';
+import { beginsWithIgnoreCase, equalsIgnoreCase, rtrim } from 'vs/base/common/strings';
 import { CharCode } from 'vs/base/common/charCode';
 
 /**
@@ -323,7 +323,7 @@ export function isEqual(pathA: string, pathB: string, ignoreCase?: boolean): boo
 		return false;
 	}
 
-	return equalsIgnoreCase(pathA, pathB);
+	return equalsIgnoreCase(rtrim(pathA, sep), rtrim(pathB, sep));
 }
 
 export function isEqualOrParent(path: string, candidate: string, ignoreCase?: boolean): boolean {
@@ -339,6 +339,8 @@ export function isEqualOrParent(path: string, candidate: string, ignoreCase?: bo
 		return false;
 	}
 
+	path = rtrim(path, sep);
+	candidate = rtrim(candidate, sep);
 	if (ignoreCase) {
 		const beginsWith = beginsWithIgnoreCase(path, candidate);
 		if (!beginsWith) {


### PR DESCRIPTION
fixes #36946

@bpasero can you please code review and if we merge I will lit the candles so we please the gods and the whole world does not break 🕯

After the change I opened the workbench and nothings seems to be breaking.
Unit tests also pass

I will add unit tests covering this case if we decide to merge this in.