### PR TITLE
make sure yml extesion is default for yaml files

### DIFF
--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -19,10 +19,10 @@
 					"yaml"
 				],
 				"extensions": [
+					".yml",
 					".eyaml",
 					".eyml",
-					".yaml",
-					".yml"
+					".yaml"
 				],
 				"filenames": [
 					"yarn.lock"


### PR DESCRIPTION
Moving .yml extension to the top. This is to make sure .yml extension is selected by default when saving yaml file. At the moment .eyaml is selected, and it's not really used for yaml files except of some special cases.