### PR TITLE
Fixes #21423 | Add ANSI colour tokens as children of existing tokens

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -352,7 +352,13 @@ export class ReplExpressionsRenderer implements IRenderer {
 						}
 
 						currentToken = token;
-						tokensContainer.appendChild(token);
+
+						// get child until deepest nested node is found
+						let childPointer: Node = tokensContainer;
+						while (childPointer.hasChildNodes() && childPointer.firstChild.nodeName !== '#text') {
+							childPointer = childPointer.firstChild;
+						}
+						childPointer.appendChild(token);
 
 						i = index;
 					}


### PR DESCRIPTION
#21423 

Previous implementation was appending new `<span>` elements to the same node, rather than finding the deepest node each time and appending to that. I added a loop to find the deepest child and append, ensuring that new tokens are nested as desired.