### PR TITLE
Address VSCode issue 45679

### DIFF
--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -13,6 +13,9 @@ import { Event } from 'vs/base/common/event';
 
 export interface IUserFriendlyKeybinding {
 	key: string;
+	win?: string;
+	mac?: string;
+	linux?: string;
 	command: string;
 	args?: any;
 	when?: string;

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -39,7 +39,7 @@ export class KeybindingIO {
 	}
 
 	public static readUserKeybindingItem(input: IUserFriendlyKeybinding, OS: OperatingSystem): IUserKeybindingItem {
-		const [firstPart, chordPart] = (typeof input.key === 'string' ? this._readUserBinding(input.key) : [null, null]);
+		const [firstPart, chordPart] = this._readUserPlatformBinding(input, OS);
 		const when = (typeof input.when === 'string' ? ContextKeyExpr.deserialize(input.when) : null);
 		const command = (typeof input.command === 'string' ? input.command : null);
 		const commandArgs = (typeof input.args !== 'undefined' ? input.args : null);
@@ -150,6 +150,27 @@ export class KeybindingIO {
 		}
 		const keyCode = KeyCodeUtils.fromUserSettings(mods.key);
 		return [new SimpleKeybinding(mods.ctrl, mods.shift, mods.alt, mods.meta, keyCode), mods.remains];
+	}
+
+	private static _platformKeyFromBinding(binding: IUserFriendlyKeybinding, OS: OperatingSystem): string {
+		if (!binding) {
+			return null;
+		}
+
+		let platformKey: string = binding.key;
+		if (OS === OperatingSystem.Windows && binding.win) {
+			platformKey = binding.win;
+		} else if (OS === OperatingSystem.Macintosh && binding.mac) {
+			platformKey = binding.mac;
+		} else if (OS === OperatingSystem.Linux && binding.linux) {
+			platformKey = binding.linux;
+		}
+		return typeof platformKey === 'string' ? platformKey : null;
+	}
+
+	private static _readUserPlatformBinding(input: IUserFriendlyKeybinding, OS: OperatingSystem): [SimpleKeybinding | ScanCodeBinding, SimpleKeybinding | ScanCodeBinding] {
+		let platformKey = this._platformKeyFromBinding(input, OS);
+		return platformKey ? this._readUserBinding(platformKey) : [null, null];
 	}
 
 	static _readUserBinding(input: string): [SimpleKeybinding | ScanCodeBinding, SimpleKeybinding | ScanCodeBinding] {

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -553,6 +553,18 @@ let schema: IJSONSchema = {
 				'type': 'string',
 				'description': nls.localize('keybindings.json.key', "Key or key sequence (separated by space)"),
 			},
+			'linux': {
+				'type': 'string',
+				'description': nls.localize('keybindings.json.linux', "Linux specific key or key sequence"),
+			},
+			'mac': {
+				'type': 'string',
+				'description': nls.localize('keybindings.json.mac', "Mac specific key or key sequence"),
+			},
+			'win': {
+				'type': 'string',
+				'description': nls.localize('keybindings.json.win', "Windows specific key or key sequence"),
+			},
 			'command': {
 				'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
 			},

--- a/src/vs/workbench/services/keybinding/test/keybindingIO.test.ts
+++ b/src/vs/workbench/services/keybinding/test/keybindingIO.test.ts
@@ -160,4 +160,21 @@ suite('keybindingIO', () => {
 		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OS);
 		assert.equal(keybindingItem.commandArgs.text, 'theText');
 	});
+
+	test('issue #45679 - platform specific user keybinding', () => {
+		const strJSON = `[{ "key": "ctrl+k ctrl+f", "mac": "cmd+k cmd+f", "win": "alt+k alt+f", "command": "firstcommand", "when": [], "args": { "text": "theText" } }]`;
+		const userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
+		const macKeybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OperatingSystem.Macintosh);
+		const winKeybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OperatingSystem.Windows);
+		const linuxKeyBindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OperatingSystem.Linux);
+
+		assert.equal(macKeybindingItem.firstPart.metaKey, true); // override
+		assert.equal(macKeybindingItem.chordPart.metaKey, true);
+
+		assert.equal(winKeybindingItem.firstPart.altKey, true); // override
+		assert.equal(winKeybindingItem.chordPart.altKey, true);
+
+		assert.equal(linuxKeyBindingItem.firstPart.ctrlKey, true); // default
+		assert.equal(linuxKeyBindingItem.chordPart.ctrlKey, true);
+	});
 });


### PR DESCRIPTION
#45679 
 - Accept mac/linux/win overrides in user keybindings
 - Behave same as extension contributed keys
 - Add tests
