### PR TITLE
Avoid accessing vsWorker of undefined / null value

### DIFF
--- a/src/vs/base/common/worker/simpleWorker.ts
+++ b/src/vs/base/common/worker/simpleWorker.ts
@@ -116,7 +116,7 @@ class SimpleWorkerProtocol {
 		} catch (e) {
 			// nothing
 		}
-		if (!message.vsWorker) {
+		if (!message || !message.vsWorker) {
 			return;
 		}
 		if (this._workerId !== -1 && message.vsWorker !== this._workerId) {


### PR DESCRIPTION
According to Microsoft/monaco-editor#766, I made small changes to the code. The `message ` might be `null` if `serializedMessage === 'null'` or `undefined` if the `JSON.parse` throws a `SyntaxError`. So the code should check the nullity first.

Monaco editor itself, I think, will not make invalid messages like this. But other message source(like webpack) which is not intended for monaco editor may lead to this error.