### PR TITLE
Removing unnecessary lines in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ addons:
 before_install:
   - export GITHUB_TOKEN=$PUBLIC_GITHUB_TOKEN
   - git submodule update --init --recursive
-  - git clone --depth 1 https://github.com/creationix/nvm.git ./.nvm
-  - source ./.nvm/nvm.sh
   - nvm install 8.9.1
   - nvm use 8.9.1
   - npm i -g yarn


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/46043

As Travis CI have `nvm` shipped in their images, there is no need to install `nvm` again