### PR TITLE
Add more time-based variables for snippets

### DIFF
--- a/src/vs/editor/contrib/snippet/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/snippetVariables.ts
@@ -5,6 +5,7 @@
 
 'use strict';
 
+import * as nls from 'vs/nls';
 import { basename, dirname } from 'vs/base/common/paths';
 import { ITextModel } from 'vs/editor/common/model';
 import { Selection } from 'vs/editor/common/core/selection';
@@ -186,8 +187,10 @@ export class TimeBasedVariableResolver implements VariableResolver {
 
 	resolve(variable: Variable): string {
 		const { name } = variable;
-		const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-		const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+		const dayNames = [nls.localize('Sunday', "Sunday"), nls.localize('Monday', "Monday"), nls.localize('Tuesday', "Tuesday"), nls.localize('Wednesday', "Wednesday"), nls.localize('Thursday', "Thursday"), nls.localize('Friday', "Friday"), nls.localize('Saturday', "Saturday")];
+		const dayNamesShort = [nls.localize('SundayShort', "Sun"), nls.localize('MondayShort', "Mon"), nls.localize('TuesdayShort', "Tue"), nls.localize('WednesdayShort', "Wed"), nls.localize('ThursdayShort', "Thu"), nls.localize('FridayShort', "Fri"), nls.localize('SaturdayShort', "Sat")];
+		const monthNames = [nls.localize('January', "January"), nls.localize('February', "February"), nls.localize('March', "March"), nls.localize('April', "April"), nls.localize('May', "May"), nls.localize('June', "June"), nls.localize('July', "July"), nls.localize('August', "August"), nls.localize('September', "September"), nls.localize('October', "October"), nls.localize('November', "November"), nls.localize('December', "December")];
+		const monthNamesShort = [nls.localize('JanuaryShort', "Jan"), nls.localize('FebruaryShort', "Feb"), nls.localize('MarchShort', "Mar"), nls.localize('AprilShort', "Apr"), nls.localize('MayShort', "May"), nls.localize('JuneShort', "Jun"), nls.localize('JulyShort', "Jul"), nls.localize('AugustShort', "Aug"), nls.localize('SeptemberShort', "Sep"), nls.localize('OctoberShort', "Oct"), nls.localize('NovemberShort', "Nov"), nls.localize('DecemberShort', "Dec")];
 
 		if (name === 'CURRENT_YEAR') {
 			return String(new Date().getFullYear());
@@ -206,11 +209,11 @@ export class TimeBasedVariableResolver implements VariableResolver {
 		} else if (name === 'CURRENT_DAY_NAME') {
 			return dayNames[new Date().getDay()];
 		} else if (name === 'CURRENT_DAY_NAME_SHORT') {
-			return dayNames[new Date().getDay()].slice(0, 3);
+			return dayNamesShort[new Date().getDay()];
 		} else if (name === 'CURRENT_MONTH_NAME') {
 			return monthNames[new Date().getMonth()];
 		} else if (name === 'CURRENT_MONTH_NAME_SHORT') {
-			return monthNames[new Date().getMonth()].slice(0, 3);
+			return monthNamesShort[new Date().getMonth()];
 		}
 
 		return undefined;

--- a/src/vs/editor/contrib/snippet/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/snippetVariables.ts
@@ -185,12 +185,13 @@ export class ClipboardBasedVariableResolver implements VariableResolver {
 
 export class TimeBasedVariableResolver implements VariableResolver {
 
+	private static readonly dayNames = [nls.localize('Sunday', "Sunday"), nls.localize('Monday', "Monday"), nls.localize('Tuesday', "Tuesday"), nls.localize('Wednesday', "Wednesday"), nls.localize('Thursday', "Thursday"), nls.localize('Friday', "Friday"), nls.localize('Saturday', "Saturday")];
+	private static readonly dayNamesShort = [nls.localize('SundayShort', "Sun"), nls.localize('MondayShort', "Mon"), nls.localize('TuesdayShort', "Tue"), nls.localize('WednesdayShort', "Wed"), nls.localize('ThursdayShort', "Thu"), nls.localize('FridayShort', "Fri"), nls.localize('SaturdayShort', "Sat")];
+	private static readonly monthNames = [nls.localize('January', "January"), nls.localize('February', "February"), nls.localize('March', "March"), nls.localize('April', "April"), nls.localize('May', "May"), nls.localize('June', "June"), nls.localize('July', "July"), nls.localize('August', "August"), nls.localize('September', "September"), nls.localize('October', "October"), nls.localize('November', "November"), nls.localize('December', "December")];
+	private static readonly monthNamesShort = [nls.localize('JanuaryShort', "Jan"), nls.localize('FebruaryShort', "Feb"), nls.localize('MarchShort', "Mar"), nls.localize('AprilShort', "Apr"), nls.localize('MayShort', "May"), nls.localize('JuneShort', "Jun"), nls.localize('JulyShort', "Jul"), nls.localize('AugustShort', "Aug"), nls.localize('SeptemberShort', "Sep"), nls.localize('OctoberShort', "Oct"), nls.localize('NovemberShort', "Nov"), nls.localize('DecemberShort', "Dec")];
+
 	resolve(variable: Variable): string {
 		const { name } = variable;
-		const dayNames = [nls.localize('Sunday', "Sunday"), nls.localize('Monday', "Monday"), nls.localize('Tuesday', "Tuesday"), nls.localize('Wednesday', "Wednesday"), nls.localize('Thursday', "Thursday"), nls.localize('Friday', "Friday"), nls.localize('Saturday', "Saturday")];
-		const dayNamesShort = [nls.localize('SundayShort', "Sun"), nls.localize('MondayShort', "Mon"), nls.localize('TuesdayShort', "Tue"), nls.localize('WednesdayShort', "Wed"), nls.localize('ThursdayShort', "Thu"), nls.localize('FridayShort', "Fri"), nls.localize('SaturdayShort', "Sat")];
-		const monthNames = [nls.localize('January', "January"), nls.localize('February', "February"), nls.localize('March', "March"), nls.localize('April', "April"), nls.localize('May', "May"), nls.localize('June', "June"), nls.localize('July', "July"), nls.localize('August', "August"), nls.localize('September', "September"), nls.localize('October', "October"), nls.localize('November', "November"), nls.localize('December', "December")];
-		const monthNamesShort = [nls.localize('JanuaryShort', "Jan"), nls.localize('FebruaryShort', "Feb"), nls.localize('MarchShort', "Mar"), nls.localize('AprilShort', "Apr"), nls.localize('MayShort', "May"), nls.localize('JuneShort', "Jun"), nls.localize('JulyShort', "Jul"), nls.localize('AugustShort', "Aug"), nls.localize('SeptemberShort', "Sep"), nls.localize('OctoberShort', "Oct"), nls.localize('NovemberShort', "Nov"), nls.localize('DecemberShort', "Dec")];
 
 		if (name === 'CURRENT_YEAR') {
 			return String(new Date().getFullYear());
@@ -207,13 +208,13 @@ export class TimeBasedVariableResolver implements VariableResolver {
 		} else if (name === 'CURRENT_SECOND') {
 			return pad(new Date().getSeconds().valueOf(), 2);
 		} else if (name === 'CURRENT_DAY_NAME') {
-			return dayNames[new Date().getDay()];
+			return TimeBasedVariableResolver.dayNames[new Date().getDay()];
 		} else if (name === 'CURRENT_DAY_NAME_SHORT') {
-			return dayNamesShort[new Date().getDay()];
+			return TimeBasedVariableResolver.dayNamesShort[new Date().getDay()];
 		} else if (name === 'CURRENT_MONTH_NAME') {
-			return monthNames[new Date().getMonth()];
+			return TimeBasedVariableResolver.monthNames[new Date().getMonth()];
 		} else if (name === 'CURRENT_MONTH_NAME_SHORT') {
-			return monthNamesShort[new Date().getMonth()];
+			return TimeBasedVariableResolver.monthNamesShort[new Date().getMonth()];
 		}
 
 		return undefined;

--- a/src/vs/editor/contrib/snippet/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/snippetVariables.ts
@@ -20,6 +20,10 @@ export const KnownSnippetVariableNames = Object.freeze({
 	'CURRENT_HOUR': true,
 	'CURRENT_MINUTE': true,
 	'CURRENT_SECOND': true,
+	'CURRENT_DAY_NAME': true,
+	'CURRENT_DAY_NAME_SHORT': true,
+	'CURRENT_MONTH_NAME': true,
+	'CURRENT_MONTH_NAME_SHORT': true,
 	'SELECTION': true,
 	'CLIPBOARD': true,
 	'TM_SELECTED_TEXT': true,
@@ -182,6 +186,8 @@ export class TimeBasedVariableResolver implements VariableResolver {
 
 	resolve(variable: Variable): string {
 		const { name } = variable;
+		const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+		const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
 		if (name === 'CURRENT_YEAR') {
 			return String(new Date().getFullYear());
@@ -197,6 +203,14 @@ export class TimeBasedVariableResolver implements VariableResolver {
 			return pad(new Date().getMinutes().valueOf(), 2);
 		} else if (name === 'CURRENT_SECOND') {
 			return pad(new Date().getSeconds().valueOf(), 2);
+		} else if (name === 'CURRENT_DAY_NAME') {
+			return dayNames[new Date().getDay()];
+		} else if (name === 'CURRENT_DAY_NAME_SHORT') {
+			return dayNames[new Date().getDay()].slice(0, 3);
+		} else if (name === 'CURRENT_MONTH_NAME') {
+			return monthNames[new Date().getMonth()];
+		} else if (name === 'CURRENT_MONTH_NAME_SHORT') {
+			return monthNames[new Date().getMonth()].slice(0, 3);
 		}
 
 		return undefined;

--- a/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
@@ -276,7 +276,7 @@ suite('Snippet Variables Resolver', function () {
 		assert.equal(variable.resolve(resolver), true, `${varName} failed to resolve`);
 	}
 
-	test('Add time variables for snippets #41631', function () {
+	test('Add time variables for snippets #41631, #43140', function () {
 
 		const resolver = new TimeBasedVariableResolver;
 
@@ -287,5 +287,9 @@ suite('Snippet Variables Resolver', function () {
 		assertVariableResolve3(resolver, 'CURRENT_HOUR');
 		assertVariableResolve3(resolver, 'CURRENT_MINUTE');
 		assertVariableResolve3(resolver, 'CURRENT_SECOND');
+		assertVariableResolve3(resolver, 'CURRENT_DAY_NAME');
+		assertVariableResolve3(resolver, 'CURRENT_DAY_NAME_SHORT');
+		assertVariableResolve3(resolver, 'CURRENT_MONTH_NAME');
+		assertVariableResolve3(resolver, 'CURRENT_MONTH_NAME_SHORT');
 	});
 });


### PR DESCRIPTION
Fixes #43140

Not 100% sure about short months: `Sep` vs `Sept`. They currently all 3-letter abbreviations and can be easily aligned:
```javascript
17 Aug 2018
06 Jul 1999

Sep 20,2015
Jun 19,2000
```
If it's critical it can be changed to `Sept`. In that case `Jun` & `Jul` would be `June` & `July`, I guess...

If someone wants localized versions - <b>`New issue`</b> button awaits.