### PR TITLE
Move log level API to env

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -406,9 +406,6 @@ declare module 'vscode' {
 	 * A logger for writing to an extension's log file, and accessing its dedicated log directory.
 	 */
 	export interface Logger {
-		readonly onDidChangeLogLevel: Event<LogLevel>;
-		readonly currentLevel: LogLevel;
-
 		trace(message: string, ...args: any[]): void;
 		debug(message: string, ...args: any[]): void;
 		info(message: string, ...args: any[]): void;
@@ -429,6 +426,15 @@ declare module 'vscode' {
 		 * Extensions must create this directory before writing to it. The parent directory will always exist.
 		 */
 		readonly logDirectory: string;
+	}
+
+	export namespace env {
+		/**
+		 * Current logging level.
+		 *
+		 * @readonly
+		 */
+		export const logLevel: LogLevel;
 	}
 
 	//#endregion

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -211,6 +211,7 @@ export function createApiFactory(
 			get language() { return Platform.language; },
 			get appName() { return product.nameLong; },
 			get appRoot() { return initData.environment.appRoot; },
+			get logLevel() { return extHostLogService.getLevel(); }
 		});
 
 		// namespace: extensions

--- a/src/vs/workbench/api/node/extHostLogService.ts
+++ b/src/vs/workbench/api/node/extHostLogService.ts
@@ -6,7 +6,6 @@
 
 import * as vscode from 'vscode';
 import { join } from 'vs/base/common/paths';
-import { Event } from 'vs/base/common/event';
 import { LogLevel } from 'vs/workbench/api/node/extHostTypes';
 import { ILogService, DelegatedLogService } from 'vs/platform/log/common/log';
 import { createSpdLogService } from 'vs/platform/log/node/spdlogService';
@@ -56,12 +55,6 @@ export class ExtHostLogger implements vscode.Logger {
 	constructor(
 		private readonly _logService: ILogService
 	) { }
-
-	get onDidChangeLogLevel(): Event<LogLevel> {
-		return this._logService.onDidChangeLogLevel;
-	}
-
-	get currentLevel(): LogLevel { return this._logService.getLevel(); }
 
 	trace(message: string, ...args: any[]): void {
 		return this._logService.trace(message, ...args);


### PR DESCRIPTION
Moves the log level API to env. Also removes the `onDidChangeLogLevel` API