### PR TITLE
Simple widget editor that is hidden from extensions

### DIFF
--- a/src/vs/editor/browser/codeEditor.ts
+++ b/src/vs/editor/browser/codeEditor.ts
@@ -24,7 +24,7 @@ export class CodeEditor extends CodeEditorWidget {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService
 	) {
-		super(domElement, options, instantiationService, codeEditorService, commandService, contextKeyService, themeService);
+		super(domElement, options, false, instantiationService, codeEditorService, commandService, contextKeyService, themeService);
 	}
 
 	protected _getContributions(): IEditorContributionCtor[] {

--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -7,9 +7,7 @@
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { Position } from 'vs/editor/common/core/position';
 import { Selection } from 'vs/editor/common/core/selection';
-import * as editorCommon from 'vs/editor/common/editorCommon';
 import { IEditorMouseEvent } from 'vs/editor/browser/editorBrowser';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IViewModel } from 'vs/editor/common/viewModel/viewModel';
 import { ViewOutgoingEvents } from 'vs/editor/browser/view/viewOutgoingEvents';
 import { CoreNavigationCommands, CoreEditorCommand } from 'vs/editor/browser/controller/coreCommands';
@@ -35,26 +33,35 @@ export interface IMouseDispatchData {
 	shiftKey: boolean;
 }
 
+export interface ICommandDelegate {
+	paste(source: string, text: string, pasteOnNewLine: boolean, multicursorText: string[]): void;
+	type(source: string, text: string): void;
+	replacePreviousChar(source: string, text: string, replaceCharCnt: number): void;
+	compositionStart(source: string): void;
+	compositionEnd(source: string): void;
+	cut(source: string): void;
+}
+
 export class ViewController {
 
 	private readonly configuration: Configuration;
 	private readonly viewModel: IViewModel;
 	private readonly _execCoreEditorCommandFunc: ExecCoreEditorCommandFunc;
 	private readonly outgoingEvents: ViewOutgoingEvents;
-	private readonly commandService: ICommandService;
+	private readonly commandDelegate: ICommandDelegate;
 
 	constructor(
 		configuration: Configuration,
 		viewModel: IViewModel,
 		execCommandFunc: ExecCoreEditorCommandFunc,
 		outgoingEvents: ViewOutgoingEvents,
-		commandService: ICommandService
+		commandDelegate: ICommandDelegate
 	) {
 		this.configuration = configuration;
 		this.viewModel = viewModel;
 		this._execCoreEditorCommandFunc = execCommandFunc;
 		this.outgoingEvents = outgoingEvents;
-		this.commandService = commandService;
+		this.commandDelegate = commandDelegate;
 	}
 
 	private _execMouseCommand(editorCommand: CoreEditorCommand, args: any): void {
@@ -63,36 +70,27 @@ export class ViewController {
 	}
 
 	public paste(source: string, text: string, pasteOnNewLine: boolean, multicursorText: string[]): void {
-		this.commandService.executeCommand(editorCommon.Handler.Paste, {
-			text: text,
-			pasteOnNewLine: pasteOnNewLine,
-			multicursorText: multicursorText
-		});
+		this.commandDelegate.paste(source, text, pasteOnNewLine, multicursorText);
 	}
 
 	public type(source: string, text: string): void {
-		this.commandService.executeCommand(editorCommon.Handler.Type, {
-			text: text
-		});
+		this.commandDelegate.type(source, text);
 	}
 
 	public replacePreviousChar(source: string, text: string, replaceCharCnt: number): void {
-		this.commandService.executeCommand(editorCommon.Handler.ReplacePreviousChar, {
-			text: text,
-			replaceCharCnt: replaceCharCnt
-		});
+		this.commandDelegate.replacePreviousChar(source, text, replaceCharCnt);
 	}
 
 	public compositionStart(source: string): void {
-		this.commandService.executeCommand(editorCommon.Handler.CompositionStart, {});
+		this.commandDelegate.compositionStart(source);
 	}
 
 	public compositionEnd(source: string): void {
-		this.commandService.executeCommand(editorCommon.Handler.CompositionEnd, {});
+		this.commandDelegate.compositionEnd(source);
 	}
 
 	public cut(source: string): void {
-		this.commandService.executeCommand(editorCommon.Handler.Cut, {});
+		this.commandDelegate.cut(source);
 	}
 
 	public setSelection(source: string, modelSelection: Selection): void {

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -8,14 +8,13 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import * as dom from 'vs/base/browser/dom';
 import { FastDomNode, createFastDomNode } from 'vs/base/browser/fastDomNode';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { Range } from 'vs/editor/common/core/range';
 import { ViewEventHandler } from 'vs/editor/common/viewModel/viewEventHandler';
 import { Configuration } from 'vs/editor/browser/config/configuration';
 import { TextAreaHandler, ITextAreaHandlerHelper } from 'vs/editor/browser/controller/textAreaHandler';
 import { PointerHandler } from 'vs/editor/browser/controller/pointerHandler';
 import * as editorBrowser from 'vs/editor/browser/editorBrowser';
-import { ViewController, ExecCoreEditorCommandFunc } from 'vs/editor/browser/view/viewController';
+import { ViewController, ExecCoreEditorCommandFunc, ICommandDelegate } from 'vs/editor/browser/view/viewController';
 import { ViewEventDispatcher } from 'vs/editor/common/view/viewEventDispatcher';
 import { ContentViewOverlays, MarginViewOverlays } from 'vs/editor/browser/view/viewOverlays';
 import { ViewContentWidgets } from 'vs/editor/browser/viewParts/contentWidgets/contentWidgets';
@@ -93,7 +92,7 @@ export class View extends ViewEventHandler {
 	private _renderAnimationFrame: IDisposable;
 
 	constructor(
-		commandService: ICommandService,
+		commandDelegate: ICommandDelegate,
 		configuration: Configuration,
 		themeService: IThemeService,
 		model: IViewModel,
@@ -105,7 +104,7 @@ export class View extends ViewEventHandler {
 		this._renderAnimationFrame = null;
 		this.outgoingEvents = new ViewOutgoingEvents(model);
 
-		let viewController = new ViewController(configuration, model, execCoreEditorCommandFunc, this.outgoingEvents, commandService);
+		let viewController = new ViewController(configuration, model, execCoreEditorCommandFunc, this.outgoingEvents, commandDelegate);
 
 		// The event dispatcher will always go through _renderOnce before dispatching any events
 		this.eventDispatcher = new ViewEventDispatcher((callback: () => void) => this._renderOnce(callback));

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -33,7 +33,7 @@ import { Color } from 'vs/base/common/color';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { ClassName } from 'vs/editor/common/model/intervalTree';
 import { ITextModel, IModelDecorationOptions } from 'vs/editor/common/model';
-import { ICommandDelegate } from '../view/viewController';
+import { ICommandDelegate } from 'vs/editor/browser/view/viewController';
 
 export abstract class CodeEditorWidget extends CommonCodeEditor implements editorBrowser.ICodeEditor {
 

--- a/src/vs/editor/common/commonCodeEditor.ts
+++ b/src/vs/editor/common/commonCodeEditor.ts
@@ -1051,7 +1051,7 @@ class EditorContextKeysManager extends Disposable {
 
 	private _editor: CommonCodeEditor;
 	private _editorFocus: IContextKey<boolean>;
-	private _inputFocus: IContextKey<boolean>;
+	private _textInputFocus: IContextKey<boolean>;
 	private _editorTextFocus: IContextKey<boolean>;
 	private _editorTabMovesFocus: IContextKey<boolean>;
 	private _editorReadonly: IContextKey<boolean>;
@@ -1068,7 +1068,7 @@ class EditorContextKeysManager extends Disposable {
 
 		contextKeyService.createKey('editorId', editor.getId());
 		this._editorFocus = EditorContextKeys.focus.bindTo(contextKeyService);
-		this._inputFocus = EditorContextKeys.inputFocus.bindTo(contextKeyService);
+		this._textInputFocus = EditorContextKeys.textInputFocus.bindTo(contextKeyService);
 		this._editorTextFocus = EditorContextKeys.textFocus.bindTo(contextKeyService);
 		this._editorTabMovesFocus = EditorContextKeys.tabMovesFocus.bindTo(contextKeyService);
 		this._editorReadonly = EditorContextKeys.readOnly.bindTo(contextKeyService);
@@ -1108,7 +1108,7 @@ class EditorContextKeysManager extends Disposable {
 	private _updateFromFocus(): void {
 		this._editorFocus.set(this._editor.hasWidgetFocus() && !this._editor.isSimpleWidget);
 		this._editorTextFocus.set(this._editor.isFocused() && !this._editor.isSimpleWidget);
-		this._inputFocus.set(this._editor.isFocused());
+		this._textInputFocus.set(this._editor.isFocused());
 	}
 }
 

--- a/src/vs/editor/common/commonCodeEditor.ts
+++ b/src/vs/editor/common/commonCodeEditor.ts
@@ -93,6 +93,7 @@ export abstract class CommonCodeEditor extends Disposable {
 	protected readonly domElement: IContextKeyServiceTarget;
 	protected readonly id: number;
 	protected readonly _configuration: CommonEditorConfiguration;
+	protected readonly isSimpleWidget: boolean;
 
 	protected _contributions: { [key: string]: editorCommon.IEditorContribution; };
 	protected _actions: { [key: string]: editorCommon.IEditorAction; };
@@ -118,6 +119,7 @@ export abstract class CommonCodeEditor extends Disposable {
 	constructor(
 		domElement: IContextKeyServiceTarget,
 		options: editorOptions.IEditorOptions,
+		isSimpleWidget: boolean,
 		instantiationService: IInstantiationService,
 		contextKeyService: IContextKeyService
 	) {
@@ -126,6 +128,7 @@ export abstract class CommonCodeEditor extends Disposable {
 		this.id = (++EDITOR_ID);
 		this._decorationTypeKeysToIds = {};
 		this._decorationTypeSubtypes = {};
+		this.isSimpleWidget = isSimpleWidget;
 
 		options = options || {};
 		this._configuration = this._register(this._createConfiguration(options));

--- a/src/vs/editor/common/commonCodeEditor.ts
+++ b/src/vs/editor/common/commonCodeEditor.ts
@@ -89,11 +89,11 @@ export abstract class CommonCodeEditor extends Disposable {
 	private readonly _onDidPaste: Emitter<Range> = this._register(new Emitter<Range>());
 	public readonly onDidPaste = this._onDidPaste.event;
 
+	public readonly isSimpleWidget: boolean;
 
 	protected readonly domElement: IContextKeyServiceTarget;
 	protected readonly id: number;
 	protected readonly _configuration: CommonEditorConfiguration;
-	protected readonly isSimpleWidget: boolean;
 
 	protected _contributions: { [key: string]: editorCommon.IEditorContribution; };
 	protected _actions: { [key: string]: editorCommon.IEditorAction; };
@@ -1051,6 +1051,7 @@ class EditorContextKeysManager extends Disposable {
 
 	private _editor: CommonCodeEditor;
 	private _editorFocus: IContextKey<boolean>;
+	private _inputFocus: IContextKey<boolean>;
 	private _editorTextFocus: IContextKey<boolean>;
 	private _editorTabMovesFocus: IContextKey<boolean>;
 	private _editorReadonly: IContextKey<boolean>;
@@ -1067,6 +1068,7 @@ class EditorContextKeysManager extends Disposable {
 
 		contextKeyService.createKey('editorId', editor.getId());
 		this._editorFocus = EditorContextKeys.focus.bindTo(contextKeyService);
+		this._inputFocus = EditorContextKeys.inputFocus.bindTo(contextKeyService);
 		this._editorTextFocus = EditorContextKeys.textFocus.bindTo(contextKeyService);
 		this._editorTabMovesFocus = EditorContextKeys.tabMovesFocus.bindTo(contextKeyService);
 		this._editorReadonly = EditorContextKeys.readOnly.bindTo(contextKeyService);
@@ -1104,8 +1106,9 @@ class EditorContextKeysManager extends Disposable {
 	}
 
 	private _updateFromFocus(): void {
-		this._editorFocus.set(this._editor.hasWidgetFocus());
-		this._editorTextFocus.set(this._editor.isFocused());
+		this._editorFocus.set(this._editor.hasWidgetFocus() && !this._editor.isSimpleWidget);
+		this._editorTextFocus.set(this._editor.isFocused() && !this._editor.isSimpleWidget);
+		this._inputFocus.set(this._editor.isFocused());
 	}
 }
 

--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -19,7 +19,7 @@ export namespace EditorContextKeys {
 	/**
 	 * A context key that is set when any editor input has focus (regular editor, repl input...).
 	 */
-	export const inputFocus = new RawContextKey<boolean>('inputFocus', false);
+	export const textInputFocus = new RawContextKey<boolean>('textInputFocus', false);
 
 	export const readOnly = new RawContextKey<boolean>('editorReadonly', false);
 	export const writable: ContextKeyExpr = readOnly.toNegated();

--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -16,6 +16,11 @@ export namespace EditorContextKeys {
 	 */
 	export const focus = new RawContextKey<boolean>('editorFocus', false);
 
+	/**
+	 * A context key that is set when any editor input has focus (regular editor, repl input...).
+	 */
+	export const inputFocus = new RawContextKey<boolean>('inputFocus', false);
+
 	export const readOnly = new RawContextKey<boolean>('editorReadonly', false);
 	export const writable: ContextKeyExpr = readOnly.toNegated();
 	export const hasNonEmptySelection = new RawContextKey<boolean>('editorHasSelection', false);

--- a/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/suggestModel.test.ts
@@ -37,7 +37,7 @@ function createMockEditor(model: TextModel): TestCodeEditor {
 		[IStorageService, NullStorageService]
 	));
 
-	const editor = new TestCodeEditor(new MockScopeLocation(), {}, instantiationService, contextKeyService);
+	const editor = new TestCodeEditor(new MockScopeLocation(), {}, false, instantiationService, contextKeyService);
 	editor.setModel(model);
 	return editor;
 }

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -173,7 +173,7 @@ function _createTestCodeEditor(options: TestCodeEditorCreationOptions): TestCode
 	services.set(IContextKeyService, contextKeyService);
 	let instantiationService = new InstantiationService(services);
 
-	let editor = new TestCodeEditor(new MockScopeLocation(), options, instantiationService, contextKeyService);
+	let editor = new TestCodeEditor(new MockScopeLocation(), options, false, instantiationService, contextKeyService);
 	editor.setModel(options.model);
 	return editor;
 }

--- a/src/vs/workbench/parts/debug/electron-browser/replEditor.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replEditor.ts
@@ -30,7 +30,7 @@ export class ReplInputEditor extends CodeEditorWidget {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService
 	) {
-		super(domElement, options, instantiationService, codeEditorService, commandService, contextKeyService, themeService);
+		super(domElement, options, true, instantiationService, codeEditorService, commandService, contextKeyService, themeService);
 	}
 
 	protected _getContributions(): IEditorContributionCtor[] {

--- a/src/vs/workbench/parts/debug/electron-browser/replEditor.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replEditor.ts
@@ -30,7 +30,7 @@ export class ReplInputEditor extends CodeEditorWidget {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService
 	) {
-		super(domElement, options, true, instantiationService, codeEditorService, commandService, contextKeyService, themeService);
+		super(domElement, options, false, instantiationService, codeEditorService, commandService, contextKeyService, themeService);
 	}
 
 	protected _getContributions(): IEditorContributionCtor[] {


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/46112

Introduces a new "type" of editor that will not be sent to extensions. Work that needs to be done:
- [x] introduce `isSimpleWdiget` flag such that basic commands are not sent via command service so extensions can not intercept
- [x] refine `editorTextFocus` to not be set for simple editors
- [x] introduce new context `inputFocus` which will be set for both simple and regular editors
- [x] update context of fitting  commands  to the new `textFocus` (probably will not be a part of this PR due to large number of files touched)
- [ ] add if statement in extension host to not send simple editors

