### PR TITLE
Suggested menu toggle fix. Solves #41070 #35010 #37724

### DIFF
--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -137,7 +137,8 @@ export class ToggleMenuBarAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IConfigurationService private configurationService: IConfigurationService
+		@IConfigurationService private configurationService: IConfigurationService,
+		@IKeybindingService private keybindingService: IKeybindingService
 	) {
 		super(id, label);
 	}
@@ -150,7 +151,7 @@ export class ToggleMenuBarAction extends Action {
 
 		let newVisibilityValue: string;
 		if (currentVisibilityValue === 'visible' || currentVisibilityValue === 'default') {
-			newVisibilityValue = 'toggle';
+			newVisibilityValue = this.keybindingService.lookupKeybindings(this.id)[0] ? 'hidden' : 'toggle';
 		} else {
 			newVisibilityValue = 'default';
 		}

--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -133,12 +133,12 @@ export class ToggleMenuBarAction extends Action {
 	static LABEL = nls.localize('toggleMenuBar', "Toggle Menu Bar");
 
 	private static readonly menuBarVisibilityKey = 'window.menuBarVisibility';
+	private static hiddenVisibilityValue = 'toggle';
 
 	constructor(
 		id: string,
 		label: string,
-		@IConfigurationService private configurationService: IConfigurationService,
-		@IKeybindingService private keybindingService: IKeybindingService
+		@IConfigurationService private configurationService: IConfigurationService
 	) {
 		super(id, label);
 	}
@@ -151,8 +151,9 @@ export class ToggleMenuBarAction extends Action {
 
 		let newVisibilityValue: string;
 		if (currentVisibilityValue === 'visible' || currentVisibilityValue === 'default') {
-			newVisibilityValue = this.keybindingService.lookupKeybindings(this.id)[0] ? 'hidden' : 'toggle';
+			newVisibilityValue = ToggleMenuBarAction.hiddenVisibilityValue;
 		} else {
+			ToggleMenuBarAction.hiddenVisibilityValue = currentVisibilityValue;
 			newVisibilityValue = 'default';
 		}
 


### PR DESCRIPTION
This is a fix I described in [this comment](https://github.com/Microsoft/vscode/issues/35010#issuecomment-370993391)

> If a user has explicity set a keybinding to toggleMenuBar then that should override the built-in Alt toggle, since that's obviously the user's intention by setting their own key. So toggleMenuBar should change behaviour and toggle between default and hidden