### PR TITLE
explorer: use map for ExplorerItem children to reduce isEqualOrParent calls

### DIFF
--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -7,7 +7,7 @@
 
 import { WORKSPACE_EXTENSION, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { extname, basename } from 'vs/base/common/paths';
-import { IFileService, IFileStat } from 'vs/platform/files/common/files';
+import { IFileService } from 'vs/platform/files/common/files';
 import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
 import URI from 'vs/base/common/uri';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
@@ -348,7 +348,7 @@ export class SimpleFileResourceDragAndDrop extends DefaultDragAndDrop {
 	}
 }
 
-export function fillResourceDataTransfers(accessor: ServicesAccessor, resources: (URI | IFileStat)[], event: DragMouseEvent | DragEvent): void {
+export function fillResourceDataTransfers(accessor: ServicesAccessor, resources: (URI | { resource: URI, isDirectory: boolean })[], event: DragMouseEvent | DragEvent): void {
 	if (resources.length === 0) {
 		return;
 	}

--- a/src/vs/workbench/parts/files/browser/files.ts
+++ b/src/vs/workbench/parts/files/browser/files.ts
@@ -8,7 +8,7 @@
 import URI from 'vs/base/common/uri';
 import { IListService } from 'vs/platform/list/browser/listService';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { FileStat, OpenEditor } from 'vs/workbench/parts/files/common/explorerModel';
+import { ExplorerItem, OpenEditor } from 'vs/workbench/parts/files/common/explorerModel';
 import { toResource } from 'vs/workbench/common/editor';
 import { Tree } from 'vs/base/parts/tree/browser/treeImpl';
 import { List } from 'vs/base/browser/ui/list/listWidget';
@@ -24,7 +24,7 @@ export function getResourceForCommand(resource: URI | object, listService: IList
 	let list = listService.lastFocusedList;
 	if (list && list.isDOMFocused()) {
 		const focus = list.getFocus();
-		if (focus instanceof FileStat) {
+		if (focus instanceof ExplorerItem) {
 			return focus.resource;
 		} else if (focus instanceof OpenEditor) {
 			return focus.getResource();

--- a/src/vs/workbench/parts/files/common/explorerModel.ts
+++ b/src/vs/workbench/parts/files/common/explorerModel.ts
@@ -17,7 +17,7 @@ import { IEditorGroup, toResource, IEditorIdentifier } from 'vs/workbench/common
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { getPathLabel } from 'vs/base/common/labels';
 import { Schemas } from 'vs/base/common/network';
-import { startsWith } from 'vs/base/common/strings';
+import { startsWith, beginsWithIgnoreCase } from 'vs/base/common/strings';
 
 export class Model {
 
@@ -222,7 +222,7 @@ export class ExplorerItem {
 		child.parent = this;
 		child.updateResource(false);
 
-		this.children[this.lowercaseOnCaseInsensitivePlatforms(child.name)] = child;
+		this.children[this.getPlatformAwareName(child.name)] = child;
 	}
 
 	public getChild(name: string): ExplorerItem {
@@ -230,7 +230,7 @@ export class ExplorerItem {
 			return undefined;
 		}
 
-		return this.children[this.lowercaseOnCaseInsensitivePlatforms(name)];
+		return this.children[this.getPlatformAwareName(name)];
 	}
 
 	/**
@@ -256,10 +256,10 @@ export class ExplorerItem {
 	 * Removes a child element from this folder.
 	 */
 	public removeChild(child: ExplorerItem): void {
-		delete this.children[this.lowercaseOnCaseInsensitivePlatforms(child.name)];
+		delete this.children[this.getPlatformAwareName(child.name)];
 	}
 
-	private lowercaseOnCaseInsensitivePlatforms(name: string): string {
+	private getPlatformAwareName(name: string): string {
 		return isLinux ? name : name.toLowerCase();
 	}
 
@@ -316,7 +316,7 @@ export class ExplorerItem {
 	public find(resource: URI): ExplorerItem {
 		// Return if path found
 		if (resource && this.resource.scheme === resource.scheme && this.resource.authority === resource.authority &&
-			startsWith(this.lowercaseOnCaseInsensitivePlatforms(resource.path), this.lowercaseOnCaseInsensitivePlatforms(this.resource.path))
+			(isLinux ? startsWith(resource.path, this.resource.path) : beginsWithIgnoreCase(resource.path, this.resource.path))
 		) {
 			return this.findByPath(resource.path, this.resource.path.length);
 		}
@@ -343,7 +343,7 @@ export class ExplorerItem {
 			// The name to search is between two separators
 			const name = path.substring(index, indexOfNextSep);
 
-			const child = this.children[this.lowercaseOnCaseInsensitivePlatforms(name)];
+			const child = this.children[this.getPlatformAwareName(name)];
 
 			if (child) {
 				// We found a child with the given name, search inside it

--- a/src/vs/workbench/parts/files/common/explorerModel.ts
+++ b/src/vs/workbench/parts/files/common/explorerModel.ts
@@ -302,17 +302,18 @@ export class FileStat implements IFileStat {
 		if (paths.isEqual(this.resource.path, path, !isLinux)) {
 			return this;
 		}
-		while (index < path.length && path[index] === paths.sep) {
-			index++;
-		}
 
-		let indexOfNextSep = path.indexOf(paths.sep, index);
-		if (indexOfNextSep === -1) {
-			indexOfNextSep = path.length - 1;
-		}
-
-		const name = path.substring(index, indexOfNextSep);
 		if (this.children) {
+			while (index < path.length && path[index] === paths.sep) {
+				index++;
+			}
+
+			let indexOfNextSep = path.indexOf(paths.sep, index);
+			if (indexOfNextSep === -1) {
+				indexOfNextSep = path.length - 1;
+			}
+
+			const name = path.substring(index, indexOfNextSep);
 			const found = binarySearch(this.children.map(c => c.name), name, (first, second) => isLinux ? compare(first, second) : compareIgnoreCase(first, second));
 
 			if (found >= 0 && found < this.children.length) {

--- a/src/vs/workbench/parts/files/common/files.ts
+++ b/src/vs/workbench/parts/files/common/files.ts
@@ -8,7 +8,7 @@ import URI from 'vs/base/common/uri';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IWorkbenchEditorConfiguration } from 'vs/workbench/common/editor';
 import { IFilesConfiguration, FileChangeType, IFileService } from 'vs/platform/files/common/files';
-import { FileStat, OpenEditor } from 'vs/workbench/parts/files/common/explorerModel';
+import { ExplorerItem, OpenEditor } from 'vs/workbench/parts/files/common/explorerModel';
 import { ContextKeyExpr, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { ITextModelContentProvider } from 'vs/editor/common/services/resolverService';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -98,9 +98,9 @@ export interface IFileResource {
 /**
  * Helper to get an explorer item from an object.
  */
-export function explorerItemToFileResource(obj: FileStat | OpenEditor): IFileResource {
-	if (obj instanceof FileStat) {
-		const stat = obj as FileStat;
+export function explorerItemToFileResource(obj: ExplorerItem | OpenEditor): IFileResource {
+	if (obj instanceof ExplorerItem) {
+		const stat = obj as ExplorerItem;
 
 		return {
 			resource: stat.resource,

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.ts
@@ -1392,8 +1392,8 @@ export function validateFileName(parent: ExplorerItem, name: string, allowOverwr
 function alreadyExists(parent: ExplorerItem, name: string): { exists: boolean, child: ExplorerItem | undefined } {
 	let duplicateChild: ExplorerItem;
 
-	if (parent.children) {
-		duplicateChild = parent.children[isLinux ? name : name.toLowerCase()];
+	if (parent && parent.isDirectory) {
+		duplicateChild = parent.getChild(name);
 		return { exists: !!duplicateChild, child: duplicateChild };
 	}
 

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.ts
@@ -25,7 +25,7 @@ import { VIEWLET_ID } from 'vs/workbench/parts/files/common/files';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IFileService, IFileStat } from 'vs/platform/files/common/files';
 import { toResource } from 'vs/workbench/common/editor';
-import { FileStat, Model, NewStatPlaceholder } from 'vs/workbench/parts/files/common/explorerModel';
+import { ExplorerItem, Model, NewStatPlaceholder } from 'vs/workbench/parts/files/common/explorerModel';
 import { ExplorerView } from 'vs/workbench/parts/files/electron-browser/views/explorerView';
 import { ExplorerViewlet } from 'vs/workbench/parts/files/electron-browser/explorerViewlet';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
@@ -112,7 +112,7 @@ export class BaseErrorReportingAction extends Action {
 }
 
 export class BaseFileAction extends BaseErrorReportingAction {
-	public element: FileStat;
+	public element: ExplorerItem;
 
 	constructor(
 		id: string,
@@ -144,7 +144,7 @@ class TriggerRenameFileAction extends BaseFileAction {
 
 	constructor(
 		tree: ITree,
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -215,7 +215,7 @@ export abstract class BaseRenameAction extends BaseFileAction {
 	constructor(
 		id: string,
 		label: string,
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService
@@ -276,7 +276,7 @@ class RenameFileAction extends BaseRenameAction {
 	public static readonly ID = 'workbench.files.action.renameFile';
 
 	constructor(
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -330,7 +330,7 @@ class RenameFileAction extends BaseRenameAction {
 
 /* Base New File/Folder Action */
 export class BaseNewAction extends BaseFileAction {
-	private presetFolder: FileStat;
+	private presetFolder: ExplorerItem;
 	private tree: ITree;
 	private isFile: boolean;
 	private renameAction: BaseRenameAction;
@@ -341,7 +341,7 @@ export class BaseNewAction extends BaseFileAction {
 		tree: ITree,
 		isFile: boolean,
 		editableAction: BaseRenameAction,
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService
@@ -369,11 +369,11 @@ export class BaseNewAction extends BaseFileAction {
 
 		let folder = this.presetFolder;
 		if (!folder) {
-			const focus = <FileStat>this.tree.getFocus();
+			const focus = <ExplorerItem>this.tree.getFocus();
 			if (focus) {
 				folder = focus.isDirectory ? focus : focus.parent;
 			} else {
-				const input: FileStat | Model = this.tree.getInput();
+				const input: ExplorerItem | Model = this.tree.getInput();
 				folder = input instanceof Model ? input.roots[0] : input;
 			}
 		}
@@ -430,7 +430,7 @@ export class NewFileAction extends BaseNewAction {
 
 	constructor(
 		tree: ITree,
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -448,7 +448,7 @@ export class NewFolderAction extends BaseNewAction {
 
 	constructor(
 		tree: ITree,
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -498,7 +498,7 @@ class CreateFileAction extends BaseCreateAction {
 	public static readonly LABEL = nls.localize('createNewFile', "New File");
 
 	constructor(
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
 		@INotificationService notificationService: INotificationService,
@@ -526,7 +526,7 @@ class CreateFolderAction extends BaseCreateAction {
 	public static readonly LABEL = nls.localize('createNewFolder', "New Folder");
 
 	constructor(
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService
@@ -552,7 +552,7 @@ class BaseDeleteFileAction extends BaseFileAction {
 
 	constructor(
 		private tree: ITree,
-		private elements: FileStat[],
+		private elements: ExplorerItem[],
 		private useTrash: boolean,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
@@ -731,7 +731,7 @@ export class ImportFileAction extends BaseFileAction {
 
 	constructor(
 		tree: ITree,
-		element: FileStat,
+		element: ExplorerItem,
 		clazz: string,
 		@IFileService fileService: IFileService,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
@@ -756,11 +756,11 @@ export class ImportFileAction extends BaseFileAction {
 			if (resources && resources.length > 0) {
 
 				// Find parent for import
-				let targetElement: FileStat;
+				let targetElement: ExplorerItem;
 				if (this.element) {
 					targetElement = this.element;
 				} else {
-					const input: FileStat | Model = this.tree.getInput();
+					const input: ExplorerItem | Model = this.tree.getInput();
 					targetElement = this.tree.getFocus() || (input instanceof Model ? input.roots[0] : input);
 				}
 
@@ -846,7 +846,7 @@ class CopyFileAction extends BaseFileAction {
 	private tree: ITree;
 	constructor(
 		tree: ITree,
-		private elements: FileStat[],
+		private elements: ExplorerItem[],
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -884,7 +884,7 @@ class PasteFileAction extends BaseFileAction {
 
 	constructor(
 		tree: ITree,
-		element: FileStat,
+		element: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ITextFileService textFileService: ITextFileService,
@@ -895,7 +895,7 @@ class PasteFileAction extends BaseFileAction {
 		this.tree = tree;
 		this.element = element;
 		if (!this.element) {
-			const input: FileStat | Model = this.tree.getInput();
+			const input: ExplorerItem | Model = this.tree.getInput();
 			this.element = input instanceof Model ? input.roots[0] : input;
 		}
 		this._updateEnablement();
@@ -916,7 +916,7 @@ class PasteFileAction extends BaseFileAction {
 			}
 
 			// Find target
-			let target: FileStat;
+			let target: ExplorerItem;
 			if (this.element.resource.toString() === fileToPaste.toString()) {
 				target = this.element.parent;
 			} else {
@@ -944,12 +944,12 @@ class PasteFileAction extends BaseFileAction {
 // Duplicate File/Folder
 export class DuplicateFileAction extends BaseFileAction {
 	private tree: ITree;
-	private target: FileStat;
+	private target: ExplorerItem;
 
 	constructor(
 		tree: ITree,
-		fileToDuplicate: FileStat,
-		target: FileStat,
+		fileToDuplicate: ExplorerItem,
+		target: ExplorerItem,
 		@IFileService fileService: IFileService,
 		@IWorkbenchEditorService private editorService: IWorkbenchEditorService,
 		@INotificationService notificationService: INotificationService,
@@ -983,7 +983,7 @@ export class DuplicateFileAction extends BaseFileAction {
 	}
 }
 
-function findValidPasteFileTarget(targetFolder: FileStat, fileToPaste: { resource: URI, isDirectory?: boolean }): URI {
+function findValidPasteFileTarget(targetFolder: ExplorerItem, fileToPaste: { resource: URI, isDirectory?: boolean }): URI {
 	let name = resources.basenameOrAuthority(fileToPaste.resource);
 
 	let candidate = targetFolder.resource.with({ path: paths.join(targetFolder.resource.path, name) });
@@ -1511,8 +1511,8 @@ if (!diag) {
 
 interface IExplorerContext {
 	viewletState: IFileViewletState;
-	stat: FileStat;
-	selection: FileStat[];
+	stat: ExplorerItem;
+	selection: ExplorerItem[];
 }
 
 function getContext(listWidget: ListWidget, viewletService: IViewletService): IExplorerContext {

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -25,7 +25,7 @@ import { IEditorGroupService } from 'vs/workbench/services/group/common/groupSer
 import * as DOM from 'vs/base/browser/dom';
 import { CollapseAction } from 'vs/workbench/browser/viewlet';
 import { IViewletViewOptions, IViewOptions, TreeViewsViewletPanel, FileIconThemableWorkbenchTree } from 'vs/workbench/browser/parts/views/viewsViewlet';
-import { FileStat, Model } from 'vs/workbench/parts/files/common/explorerModel';
+import { ExplorerItem, Model } from 'vs/workbench/parts/files/common/explorerModel';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { ExplorerDecorationsProvider } from 'vs/workbench/parts/files/electron-browser/views/explorerDecorationsProvider';
@@ -364,7 +364,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 	}
 
 	private openFocusedElement(preserveFocus?: boolean): void {
-		const stat: FileStat = this.explorerViewer.getFocus();
+		const stat: ExplorerItem = this.explorerViewer.getFocus();
 		if (stat && !stat.isDirectory) {
 			this.editorService.openEditor({ resource: stat.resource, options: { preserveFocus, revealIfVisible: true } }).done(null, errors.onUnexpectedError);
 		}
@@ -428,7 +428,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		this.disposables.push(this.fileService.onFileChanges(e => this.onFileChanges(e)));
 
 		// Update resource context based on focused element
-		this.disposables.push(this.explorerViewer.onDidChangeFocus((e: { focus: FileStat }) => {
+		this.disposables.push(this.explorerViewer.onDidChangeFocus((e: { focus: ExplorerItem }) => {
 			const isSingleFolder = this.contextService.getWorkbenchState() === WorkbenchState.FOLDER;
 			const resource = e.focus ? e.focus.resource : isSingleFolder ? this.contextService.getWorkspace().folders[0].uri : undefined;
 			this.resourceContext.set(resource);
@@ -441,7 +441,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			if (event && event.payload && event.payload.origin === 'keyboard') {
 				const element = this.tree.getSelection();
 
-				if (Array.isArray(element) && element[0] instanceof FileStat) {
+				if (Array.isArray(element) && element[0] instanceof ExplorerItem) {
 					if (element[0].isDirectory) {
 						this.explorerViewer.toggleExpansion(element[0]);
 					}
@@ -483,11 +483,11 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 					// We have to check if the parent is resolved #29177
 					(p.isDirectoryResolved ? TPromise.as(null) : this.fileService.resolveFile(p.resource)).then(stat => {
 						if (stat) {
-							const modelStat = FileStat.create(stat, p.root);
-							FileStat.mergeLocalWithDisk(modelStat, p);
+							const modelStat = ExplorerItem.create(stat, p.root);
+							ExplorerItem.mergeLocalWithDisk(modelStat, p);
 						}
 
-						const childElement = FileStat.create(addedElement, p.root);
+						const childElement = ExplorerItem.create(addedElement, p.root);
 						p.removeChild(childElement); // make sure to remove any previous version of the file if any
 						p.addChild(childElement);
 						// Refresh the Parent (View)
@@ -513,7 +513,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 
 			// Only update focus if renamed/moved element is selected
 			let restoreFocus = false;
-			const focus: FileStat = this.explorerViewer.getFocus();
+			const focus: ExplorerItem = this.explorerViewer.getFocus();
 			if (focus && focus.resource && focus.resource.toString() === oldResource.toString()) {
 				restoreFocus = true;
 			}
@@ -738,7 +738,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			if (!resourceToFocus) {
 				const selection = this.explorerViewer.getSelection();
 				if (selection && selection.length === 1) {
-					resourceToFocus = (<FileStat>selection[0]).resource;
+					resourceToFocus = (<ExplorerItem>selection[0]).resource;
 				}
 			}
 		}
@@ -788,11 +788,11 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		return promise;
 	}
 
-	private resolveRoots(targetsToResolve: { root: FileStat, resource: URI, options: { resolveTo: any[] } }[], targetsToExpand: URI[]): TPromise<any> {
+	private resolveRoots(targetsToResolve: { root: ExplorerItem, resource: URI, options: { resolveTo: any[] } }[], targetsToExpand: URI[]): TPromise<any> {
 
 		// Display roots only when multi folder workspace
 		const input = this.contextService.getWorkbenchState() === WorkbenchState.FOLDER ? this.model.roots[0] : this.model;
-		const errorFileStat = (resource: URI, root: FileStat) => FileStat.create({
+		const errorFileStat = (resource: URI, root: ExplorerItem) => ExplorerItem.create({
 			resource: resource,
 			name: paths.basename(resource.fsPath),
 			mtime: 0,
@@ -800,7 +800,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			isDirectory: true
 		}, root);
 
-		const setInputAndExpand = (input: FileStat | Model, statsToExpand: FileStat[]) => {
+		const setInputAndExpand = (input: ExplorerItem | Model, statsToExpand: ExplorerItem[]) => {
 			// Make sure to expand all folders that where expanded in the previous session
 			// Special case: we are switching to multi workspace view, thus expand all the roots (they might just be added)
 			if (input === this.model && statsToExpand.every(fs => fs && !fs.isRoot)) {
@@ -816,7 +816,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 				// Convert to model
 				const modelStats = results.map((result, index) => {
 					if (result.success && result.stat.isDirectory) {
-						return FileStat.create(result.stat, targetsToResolve[index].root, targetsToResolve[index].options.resolveTo);
+						return ExplorerItem.create(result.stat, targetsToResolve[index].root, targetsToResolve[index].options.resolveTo);
 					}
 
 					return errorFileStat(targetsToResolve[index].resource, targetsToResolve[index].root);
@@ -824,11 +824,11 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 				// Subsequent refresh: Merge stat into our local model and refresh tree
 				modelStats.forEach((modelStat, index) => {
 					if (index < this.model.roots.length) {
-						FileStat.mergeLocalWithDisk(modelStat, this.model.roots[index]);
+						ExplorerItem.mergeLocalWithDisk(modelStat, this.model.roots[index]);
 					}
 				});
 
-				const statsToExpand: FileStat[] = this.explorerViewer.getExpandedElements().concat(targetsToExpand.map(expand => this.model.findClosest(expand)));
+				const statsToExpand: ExplorerItem[] = this.explorerViewer.getExpandedElements().concat(targetsToExpand.map(expand => this.model.findClosest(expand)));
 				if (input === this.explorerViewer.getInput()) {
 					return this.explorerViewer.refresh().then(() => this.explorerViewer.expandAll(statsToExpand));
 				}
@@ -838,18 +838,18 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		}
 
 		// There is a remote root, resolve the roots sequantally
-		let statsToExpand: FileStat[] = [];
+		let statsToExpand: ExplorerItem[] = [];
 		let delayer = new Delayer(100);
 		let delayerPromise: TPromise;
 		return TPromise.join(targetsToResolve.map((target, index) => this.fileService.resolveFile(target.resource, target.options)
-			.then(result => result.isDirectory ? FileStat.create(result, target.root, target.options.resolveTo) : errorFileStat(target.resource, target.root), err => errorFileStat(target.resource, target.root))
+			.then(result => result.isDirectory ? ExplorerItem.create(result, target.root, target.options.resolveTo) : errorFileStat(target.resource, target.root), err => errorFileStat(target.resource, target.root))
 			.then(modelStat => {
 				// Subsequent refresh: Merge stat into our local model and refresh tree
 				if (index < this.model.roots.length) {
-					FileStat.mergeLocalWithDisk(modelStat, this.model.roots[index]);
+					ExplorerItem.mergeLocalWithDisk(modelStat, this.model.roots[index]);
 				}
 
-				let toExpand: FileStat[] = this.explorerViewer.getExpandedElements().concat(targetsToExpand.map(target => this.model.findClosest(target)));
+				let toExpand: ExplorerItem[] = this.explorerViewer.getExpandedElements().concat(targetsToExpand.map(target => this.model.findClosest(target)));
 				if (input === this.explorerViewer.getInput()) {
 					statsToExpand = statsToExpand.concat(toExpand);
 					if (!delayer.isTriggered()) {
@@ -869,7 +869,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 	/**
 	 * Given a stat, fills an array of path that make all folders below the stat that are resolved directories.
 	 */
-	private getResolvedDirectories(stat: FileStat, resolvedDirectories: URI[]): void {
+	private getResolvedDirectories(stat: ExplorerItem, resolvedDirectories: URI[]): void {
 		if (stat.isDirectoryResolved) {
 			if (!stat.isRoot) {
 
@@ -928,9 +928,9 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 
 			// Convert to model
 			const root = this.model.roots.filter(r => r.resource.toString() === rootUri.toString()).pop();
-			const modelStat = FileStat.create(stat, root, options.resolveTo);
+			const modelStat = ExplorerItem.create(stat, root, options.resolveTo);
 			// Update Input with disk Stat
-			FileStat.mergeLocalWithDisk(modelStat, root);
+			ExplorerItem.mergeLocalWithDisk(modelStat, root);
 
 			// Select and Reveal
 			return this.explorerViewer.refresh(root).then(() => this.doSelect(root.find(resource), reveal));
@@ -938,14 +938,14 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		}, e => { this.notificationService.error(e); });
 	}
 
-	private hasSingleSelection(resource: URI): FileStat {
-		const currentSelection: FileStat[] = this.explorerViewer.getSelection();
+	private hasSingleSelection(resource: URI): ExplorerItem {
+		const currentSelection: ExplorerItem[] = this.explorerViewer.getSelection();
 		return currentSelection.length === 1 && currentSelection[0].resource.toString() === resource.toString()
 			? currentSelection[0]
 			: undefined;
 	}
 
-	private doSelect(fileStat: FileStat, reveal: boolean): TPromise<void> {
+	private doSelect(fileStat: ExplorerItem, reveal: boolean): TPromise<void> {
 		if (!fileStat) {
 			return TPromise.as(null);
 		}
@@ -988,8 +988,8 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		// Keep list of expanded folders to restore on next load
 		if (this.isCreated) {
 			const expanded = this.explorerViewer.getExpandedElements()
-				.filter(e => e instanceof FileStat)
-				.map((e: FileStat) => e.resource.toString());
+				.filter(e => e instanceof ExplorerItem)
+				.map((e: ExplorerItem) => e.resource.toString());
 
 			if (expanded.length) {
 				this.settings[ExplorerView.MEMENTO_EXPANDED_FOLDER_RESOURCES] = expanded;

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -886,9 +886,8 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			}
 
 			// Recurse into children
-			for (let i = 0; i < stat.children.length; i++) {
-				const child = stat.children[i];
-				this.getResolvedDirectories(child, resolvedDirectories);
+			for (let childName in stat.children) {
+				this.getResolvedDirectories(stat.children[childName], resolvedDirectories);
 			}
 		}
 	}

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -886,8 +886,8 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			}
 
 			// Recurse into children
-			stat.getChildrenNames().forEach(name => {
-				this.getResolvedDirectories(stat.getChild(name), resolvedDirectories);
+			stat.getChildrenArray().forEach(child => {
+				this.getResolvedDirectories(child, resolvedDirectories);
 			});
 		}
 	}

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -886,9 +886,9 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			}
 
 			// Recurse into children
-			for (let childName in stat.children) {
-				this.getResolvedDirectories(stat.children[childName], resolvedDirectories);
-			}
+			stat.getChildrenNames().forEach(name => {
+				this.getResolvedDirectories(stat.getChild(name), resolvedDirectories);
+			});
 		}
 	}
 

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -86,7 +86,7 @@ export class FileDataSource implements IDataSource {
 
 		// Return early if stat is already resolved
 		if (stat.isDirectoryResolved) {
-			return TPromise.as(Object.keys(stat.children).map(name => stat.children[name]));
+			return TPromise.as(stat.getChildrenArray());
 		}
 
 		// Resolve children and add to fileStat for future lookup
@@ -99,13 +99,13 @@ export class FileDataSource implements IDataSource {
 				const modelDirStat = ExplorerItem.create(dirStat, stat.root);
 
 				// Add children to folder
-				for (let childName in modelDirStat.children) {
-					stat.addChild(modelDirStat.children[childName]);
-				}
+				modelDirStat.getChildrenArray().forEach(child => {
+					stat.addChild(child);
+				});
 
 				stat.isDirectoryResolved = true;
 
-				return Object.keys(stat.children).map(name => stat.children[name]);
+				return stat.getChildrenArray();
 			}, (e: any) => {
 				// Do not show error for roots since we already use an explorer decoration to notify user
 				if (!(stat instanceof ExplorerItem && stat.isRoot)) {
@@ -693,7 +693,7 @@ export class FileFilter implements IFilter {
 		}
 
 		// Workaround for O(N^2) complexity (https://github.com/Microsoft/vscode/issues/9962)
-		let siblingNames = stat.parent && Object.keys(stat.parent.children);
+		let siblingNames = stat.parent && stat.parent.getChildrenNames();
 		if (siblingNames && siblingNames.length > FileFilter.MAX_SIBLINGS_FILTER_THRESHOLD) {
 			siblingNames = void 0;
 		}

--- a/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
+++ b/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
@@ -11,10 +11,10 @@ import { isLinux, isWindows } from 'vs/base/common/platform';
 import URI from 'vs/base/common/uri';
 import { join } from 'vs/base/common/paths';
 import { validateFileName } from 'vs/workbench/parts/files/electron-browser/fileActions';
-import { FileStat } from 'vs/workbench/parts/files/common/explorerModel';
+import { ExplorerItem } from 'vs/workbench/parts/files/common/explorerModel';
 
-function createStat(path: string, name: string, isFolder: boolean, hasChildren: boolean, size: number, mtime: number): FileStat {
-	return new FileStat(toResource(path), undefined, false, isFolder, name, mtime);
+function createStat(path: string, name: string, isFolder: boolean, hasChildren: boolean, size: number, mtime: number): ExplorerItem {
+	return new ExplorerItem(toResource(path), undefined, false, isFolder, name, mtime);
 }
 
 function toResource(path) {
@@ -239,31 +239,31 @@ suite('Files - View Model', () => {
 	test('Merge Local with Disk', function () {
 		const d = new Date().toUTCString();
 
-		const merge1 = new FileStat(URI.file(join('C:\\', '/path/to')), undefined, false, true, 'to', Date.now(), d);
-		const merge2 = new FileStat(URI.file(join('C:\\', '/path/to')), undefined, false, true, 'to', Date.now(), new Date(0).toUTCString());
+		const merge1 = new ExplorerItem(URI.file(join('C:\\', '/path/to')), undefined, false, true, 'to', Date.now(), d);
+		const merge2 = new ExplorerItem(URI.file(join('C:\\', '/path/to')), undefined, false, true, 'to', Date.now(), new Date(0).toUTCString());
 
 		// Merge Properties
-		FileStat.mergeLocalWithDisk(merge2, merge1);
+		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
 		assert.strictEqual(merge1.mtime, merge2.mtime);
 
 		// Merge Child when isDirectoryResolved=false is a no-op
-		merge2.addChild(new FileStat(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d));
-		FileStat.mergeLocalWithDisk(merge2, merge1);
+		merge2.addChild(new ExplorerItem(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d));
+		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
 		assert.strictEqual(merge1.children.length, 0);
 
 		// Merge Child with isDirectoryResolved=true
-		const child = new FileStat(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d);
+		const child = new ExplorerItem(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d);
 		merge2.removeChild(child);
 		merge2.addChild(child);
 		merge2.isDirectoryResolved = true;
-		FileStat.mergeLocalWithDisk(merge2, merge1);
+		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
 		assert.strictEqual(merge1.children.length, 1);
 		assert.strictEqual(merge1.children[0].name, 'foo.html');
 		assert.deepEqual(merge1.children[0].parent, merge1, 'Check parent');
 
 		// Verify that merge does not replace existing children, but updates properties in that case
 		const existingChild = merge1.children[0];
-		FileStat.mergeLocalWithDisk(merge2, merge1);
+		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
 		assert.ok(existingChild === merge1.children[0]);
 	});
 });

--- a/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
+++ b/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
@@ -32,10 +32,10 @@ suite('Files - View Model', () => {
 		assert.strictEqual(s.name, 'sName');
 		assert.strictEqual(s.isDirectory, true);
 		assert.strictEqual(s.mtime, new Date(d).getTime());
-		assert.strictEqual(Object.keys(s.children).length, 0);
+		assert.strictEqual(s.getChildrenArray().length, 0);
 
 		s = createStat('/path/to/stat', 'sName', false, false, 8096, d);
-		assert(isUndefinedOrNull(s.children));
+		assert(isUndefinedOrNull(s.getChildrenArray()));
 	});
 
 	test('Add and Remove Child, check for hasChild', function () {
@@ -47,14 +47,14 @@ suite('Files - View Model', () => {
 
 		s.addChild(child1);
 
-		assert(Object.keys(s.children).length === 1);
+		assert(s.getChildrenArray().length === 1);
 
 		s.removeChild(child1);
 		s.addChild(child1);
-		assert(Object.keys(s.children).length === 1);
+		assert(s.getChildrenArray().length === 1);
 
 		s.removeChild(child1);
-		assert(Object.keys(s.children).length === 0);
+		assert(s.getChildrenArray().length === 0);
 
 		// Assert that adding a child updates its path properly
 		s.addChild(child4);
@@ -75,9 +75,9 @@ suite('Files - View Model', () => {
 
 		s4.move(s1);
 
-		assert.strictEqual(Object.keys(s3.children).length, 0);
+		assert.strictEqual(s3.getChildrenArray().length, 0);
 
-		assert.strictEqual(Object.keys(s1.children).length, 2);
+		assert.strictEqual(s1.getChildrenArray().length, 2);
 
 		// Assert the new path of the moved element
 		assert.strictEqual(s4.resource.fsPath, toResource('/' + s4.name).fsPath);
@@ -249,7 +249,7 @@ suite('Files - View Model', () => {
 		// Merge Child when isDirectoryResolved=false is a no-op
 		merge2.addChild(new ExplorerItem(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d));
 		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
-		assert.strictEqual(Object.keys(merge1.children).length, 0);
+		assert.strictEqual(merge1.getChildrenArray().length, 0);
 
 		// Merge Child with isDirectoryResolved=true
 		const child = new ExplorerItem(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d);
@@ -257,13 +257,13 @@ suite('Files - View Model', () => {
 		merge2.addChild(child);
 		merge2.isDirectoryResolved = true;
 		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
-		assert.strictEqual(Object.keys(merge1.children).length, 1);
-		assert.strictEqual(merge1.children['foo.html'].name, 'foo.html');
-		assert.deepEqual(merge1.children['foo.html'].parent, merge1, 'Check parent');
+		assert.strictEqual(merge1.getChildrenArray().length, 1);
+		assert.strictEqual(merge1.getChild('foo.html').name, 'foo.html');
+		assert.deepEqual(merge1.getChild('foo.html').parent, merge1, 'Check parent');
 
 		// Verify that merge does not replace existing children, but updates properties in that case
-		const existingChild = merge1.children['foo.html'];
+		const existingChild = merge1.getChild('foo.html');
 		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
-		assert.ok(existingChild === merge1.children[existingChild.name]);
+		assert.ok(existingChild === merge1.getChild(existingChild.name));
 	});
 });

--- a/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
+++ b/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import * as assert from 'assert';
-import { isUndefinedOrNull, isArray } from 'vs/base/common/types';
+import { isUndefinedOrNull } from 'vs/base/common/types';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 import URI from 'vs/base/common/uri';
 import { join } from 'vs/base/common/paths';
@@ -32,7 +32,7 @@ suite('Files - View Model', () => {
 		assert.strictEqual(s.name, 'sName');
 		assert.strictEqual(s.isDirectory, true);
 		assert.strictEqual(s.mtime, new Date(d).getTime());
-		assert(isArray(s.children) && s.children.length === 0);
+		assert.strictEqual(Object.keys(s.children).length, 0);
 
 		s = createStat('/path/to/stat', 'sName', false, false, 8096, d);
 		assert(isUndefinedOrNull(s.children));
@@ -47,14 +47,14 @@ suite('Files - View Model', () => {
 
 		s.addChild(child1);
 
-		assert(s.children.length === 1);
+		assert(Object.keys(s.children).length === 1);
 
 		s.removeChild(child1);
 		s.addChild(child1);
-		assert(s.children.length === 1);
+		assert(Object.keys(s.children).length === 1);
 
 		s.removeChild(child1);
-		assert(s.children.length === 0);
+		assert(Object.keys(s.children).length === 0);
 
 		// Assert that adding a child updates its path properly
 		s.addChild(child4);
@@ -75,9 +75,9 @@ suite('Files - View Model', () => {
 
 		s4.move(s1);
 
-		assert.strictEqual(s3.children.length, 0);
+		assert.strictEqual(Object.keys(s3.children).length, 0);
 
-		assert.strictEqual(s1.children.length, 2);
+		assert.strictEqual(Object.keys(s1.children).length, 2);
 
 		// Assert the new path of the moved element
 		assert.strictEqual(s4.resource.fsPath, toResource('/' + s4.name).fsPath);
@@ -249,7 +249,7 @@ suite('Files - View Model', () => {
 		// Merge Child when isDirectoryResolved=false is a no-op
 		merge2.addChild(new ExplorerItem(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d));
 		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
-		assert.strictEqual(merge1.children.length, 0);
+		assert.strictEqual(Object.keys(merge1.children).length, 0);
 
 		// Merge Child with isDirectoryResolved=true
 		const child = new ExplorerItem(URI.file(join('C:\\', '/path/to/foo.html')), undefined, false, true, 'foo.html', Date.now(), d);
@@ -257,13 +257,13 @@ suite('Files - View Model', () => {
 		merge2.addChild(child);
 		merge2.isDirectoryResolved = true;
 		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
-		assert.strictEqual(merge1.children.length, 1);
-		assert.strictEqual(merge1.children[0].name, 'foo.html');
-		assert.deepEqual(merge1.children[0].parent, merge1, 'Check parent');
+		assert.strictEqual(Object.keys(merge1.children).length, 1);
+		assert.strictEqual(merge1.children['foo.html'].name, 'foo.html');
+		assert.deepEqual(merge1.children['foo.html'].parent, merge1, 'Check parent');
 
 		// Verify that merge does not replace existing children, but updates properties in that case
-		const existingChild = merge1.children[0];
+		const existingChild = merge1.children['foo.html'];
 		ExplorerItem.mergeLocalWithDisk(merge2, merge1);
-		assert.ok(existingChild === merge1.children[0]);
+		assert.ok(existingChild === merge1.children[existingChild.name]);
 	});
 });


### PR DESCRIPTION
Fixes #45972

This is my attempt to remove all calls to `isEqualOrParent` from the explorer.
This PR takes advantage of the children array being already alhabetically sorted by names ( I am not 100% sure this is a fair assumption to take, but it is always sorted on my os x).
I decided to take this suggestion from @jrieken as it compared to others seemed to require the least amount of changes. (keeping children in a map would require to change all the method but we can do that as well).

I tried this out and seems to work, also all the explorer tests are passing.

Note that this is not thoroughly tested and just wanted to get some feedback if this approach makes sense thus I created this PR.
Also note that I did not measure performance which I could do in case we decide to take this route.

Let me know what you think

fyi @bpasero 