### PR TITLE
Focus terminal after toggling via `workbench.action.terminal.toggleTerminal`

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -46,11 +46,11 @@ export class ToggleTerminalAction extends TogglePanelAction {
 		if (this.terminalService.terminalInstances.length === 0) {
 			// If there is not yet an instance attempt to create it here so that we can suggest a
 			// new shell on Windows (and not do so when the panel is restored on reload).
-			const toDispose = this.terminalService.onInstanceProcessIdReady(() => {
-				this.terminalService.getActiveInstance().focus();
+			const newTerminalInstance = this.terminalService.createInstance(undefined, true);
+			const toDispose = newTerminalInstance.onProcessIdReady(() => {
+				newTerminalInstance.focus();
 				toDispose.dispose();
 			});
-			this.terminalService.createInstance(undefined, true);
 		}
 		return super.run();
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -46,6 +46,10 @@ export class ToggleTerminalAction extends TogglePanelAction {
 		if (this.terminalService.terminalInstances.length === 0) {
 			// If there is not yet an instance attempt to create it here so that we can suggest a
 			// new shell on Windows (and not do so when the panel is restored on reload).
+			const toDispose = this.terminalService.onInstanceProcessIdReady(() => {
+				this.terminalService.getActiveInstance().focus();
+				toDispose.dispose();
+			});
 			this.terminalService.createInstance(undefined, true);
 		}
 		return super.run();


### PR DESCRIPTION
Partly mitigates #40416 (only for the command). 2 items left:

* First mouse click on terminal label does not focus the terminal
* Focus not preserved for terminal after window reload

This is not a WIP, I am only interested in the command fix, as of now.

cc @Tyriar 