### PR TITLE
Rename logPoint action to match other breakpoint actions

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
@@ -74,7 +74,7 @@ class LogPointAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.debug.action.logPoint',
+			id: 'editor.debug.action.toggleLogPoint',
 			label: nls.localize('logPointEditorAction', "Debug: Add Log Point..."),
 			alias: 'Debug: Add Log Point...',
 			precondition: null


### PR DESCRIPTION
Our existing breakpoint type actions are named
```
editor.debug.action.toggleColumnBreakpoint
editor.debug.action.toggleBreakpoint
```

This change renames `editor.debug.action.logPoint` to `editor.debug.action.toggleLogPoint`

https://github.com/Microsoft/vscode/commit/14249ad9df0ab4807b994ab931c1ee23cc790922