### PR TITLE
Multi-Select Quick-Pick API

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1549,6 +1549,7 @@ declare module 'vscode' {
 
 		/**
 		 * An optional function that is invoked whenever an item is selected.
+		 * (Only honored when the picker does not allow multiple selections.)
 		 */
 		onDidSelectItem?(item: QuickPickItem | string): any;
 	}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1535,9 +1535,28 @@ declare module 'vscode' {
 		ignoreFocusOut?: boolean;
 
 		/**
+		 * An optional flag to make the picker multi-select, if true the result is an array of picks.
+		 */
+		multiSelect?: boolean;
+
+		/**
 		 * An optional function that is invoked whenever an item is selected.
 		 */
 		onDidSelectItem?(item: QuickPickItem | string): any;
+	}
+
+	/**
+	 * Represents an item that can be selected in a multi-select quick pick UI.
+	 */
+	export interface MultiSelectQuickPickItem extends QuickPickItem {
+		selected?: boolean;
+	}
+
+	/**
+	 * Options to configure the behavior of the multi-select quick pick UI. (Marker type.)
+	 */
+	export interface MultiSelectQuickPickOptions extends QuickPickOptions {
+		multiSelect: true;
 	}
 
 	/**
@@ -5042,8 +5061,9 @@ declare module 'vscode' {
 		 * @param items An array of strings, or a promise that resolves to an array of strings.
 		 * @param options Configures the behavior of the selection list.
 		 * @param token A token that can be used to signal cancellation.
-		 * @return A promise that resolves to the selection or `undefined`.
+		 * @return A promise that resolves to the selected item(s) or `undefined`.
 		 */
+		export function showQuickPick(items: string[] | Thenable<string[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<string[] | undefined>;
 		export function showQuickPick(items: string[] | Thenable<string[]>, options?: QuickPickOptions, token?: CancellationToken): Thenable<string | undefined>;
 
 		/**
@@ -5052,8 +5072,9 @@ declare module 'vscode' {
 		 * @param items An array of items, or a promise that resolves to an array of items.
 		 * @param options Configures the behavior of the selection list.
 		 * @param token A token that can be used to signal cancellation.
-		 * @return A promise that resolves to the selected item or `undefined`.
+		 * @return A promise that resolves to the selected item(s) or `undefined`.
 		 */
+		export function showQuickPick<T extends MultiSelectQuickPickItem>(items: T[] | Thenable<T[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<T[] | undefined>;
 		export function showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options?: QuickPickOptions, token?: CancellationToken): Thenable<T | undefined>;
 
 		/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1554,16 +1554,6 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Options to configure the behavior of the multi-select quick pick UI. (Marker type.)
-	 */
-	export interface MultiSelectQuickPickOptions extends QuickPickOptions {
-		/**
-		 * Indicates that the pick allows multiple selections. Must be true for this interface.
-		 */
-		canSelectMany: true;
-	}
-
-	/**
 	 * Options to configure the behaviour of the [workspace folder](#WorkspaceFolder) pick UI.
 	 */
 	export interface WorkspaceFolderPickOptions {
@@ -5067,7 +5057,7 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation.
 		 * @return A promise that resolves to the selected items or `undefined`.
 		 */
-		export function showQuickPick(items: string[] | Thenable<string[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<string[] | undefined>;
+		export function showQuickPick(items: string[] | Thenable<string[]>, options: QuickPickOptions & { canSelectMany: true; }, token?: CancellationToken): Thenable<string[] | undefined>;
 
 		/**
 		 * Shows a selection list.
@@ -5087,7 +5077,7 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation.
 		 * @return A promise that resolves to the selected items or `undefined`.
 		 */
-		export function showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<T[] | undefined>;
+		export function showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: QuickPickOptions & { canSelectMany: true; }, token?: CancellationToken): Thenable<T[] | undefined>;
 
 		/**
 		 * Shows a selection list.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1508,6 +1508,14 @@ declare module 'vscode' {
 		 * A human readable string which is rendered less prominent.
 		 */
 		detail?: string;
+
+		/**
+		 * Optional flag indicating if this item is selected initially.
+		 * (Only honored when the picker allows multiple selections.)
+		 *
+		 * @see [QuickPickOptions.canSelectMany](#QuickPickOptions.canSelectMany)
+		 */
+		selected?: boolean;
 	}
 
 	/**
@@ -1535,9 +1543,9 @@ declare module 'vscode' {
 		ignoreFocusOut?: boolean;
 
 		/**
-		 * An optional flag to make the picker multi-select, if true the result is an array of picks.
+		 * An optional flag to make the picker accept multiple selections, if true the result is an array of picks.
 		 */
-		multiSelect?: boolean;
+		canSelectMany?: boolean;
 
 		/**
 		 * An optional function that is invoked whenever an item is selected.
@@ -1546,17 +1554,13 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Represents an item that can be selected in a multi-select quick pick UI.
-	 */
-	export interface MultiSelectQuickPickItem extends QuickPickItem {
-		selected?: boolean;
-	}
-
-	/**
 	 * Options to configure the behavior of the multi-select quick pick UI. (Marker type.)
 	 */
 	export interface MultiSelectQuickPickOptions extends QuickPickOptions {
-		multiSelect: true;
+		/**
+		 * Indicates that the pick allows multiple selections. Must be true for this interface.
+		 */
+		canSelectMany: true;
 	}
 
 	/**
@@ -5056,15 +5060,34 @@ declare module 'vscode' {
 		export function showErrorMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Thenable<T | undefined>;
 
 		/**
+		 * Shows a selection list allowing multiple selections.
+		 *
+		 * @param items An array of strings, or a promise that resolves to an array of strings.
+		 * @param options Configures the behavior of the selection list.
+		 * @param token A token that can be used to signal cancellation.
+		 * @return A promise that resolves to the selected items or `undefined`.
+		 */
+		export function showQuickPick(items: string[] | Thenable<string[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<string[] | undefined>;
+
+		/**
 		 * Shows a selection list.
 		 *
 		 * @param items An array of strings, or a promise that resolves to an array of strings.
 		 * @param options Configures the behavior of the selection list.
 		 * @param token A token that can be used to signal cancellation.
-		 * @return A promise that resolves to the selected item(s) or `undefined`.
+		 * @return A promise that resolves to the selection or `undefined`.
 		 */
-		export function showQuickPick(items: string[] | Thenable<string[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<string[] | undefined>;
 		export function showQuickPick(items: string[] | Thenable<string[]>, options?: QuickPickOptions, token?: CancellationToken): Thenable<string | undefined>;
+
+		/**
+		 * Shows a selection list allowing multiple selections.
+		 *
+		 * @param items An array of items, or a promise that resolves to an array of items.
+		 * @param options Configures the behavior of the selection list.
+		 * @param token A token that can be used to signal cancellation.
+		 * @return A promise that resolves to the selected items or `undefined`.
+		 */
+		export function showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<T[] | undefined>;
 
 		/**
 		 * Shows a selection list.
@@ -5072,9 +5095,8 @@ declare module 'vscode' {
 		 * @param items An array of items, or a promise that resolves to an array of items.
 		 * @param options Configures the behavior of the selection list.
 		 * @param token A token that can be used to signal cancellation.
-		 * @return A promise that resolves to the selected item(s) or `undefined`.
+		 * @return A promise that resolves to the selected item or `undefined`.
 		 */
-		export function showQuickPick<T extends MultiSelectQuickPickItem>(items: T[] | Thenable<T[]>, options: MultiSelectQuickPickOptions, token?: CancellationToken): Thenable<T[] | undefined>;
 		export function showQuickPick<T extends QuickPickItem>(items: T[] | Thenable<T[]>, options?: QuickPickOptions, token?: CancellationToken): Thenable<T | undefined>;
 
 		/**


### PR DESCRIPTION
A minimal API change to include the multi-select picker in the API.

The Azure Account extension is the first customer for this API. I would like to include it in the stable API because it is a simple increment on the existing API. (This will also allow the Azure Account extension, which couldn't depend on proposed API, to use it.)

Implementation is currently done in chrmarti/richerquickpick2.

/fyi @bpasero 