### PR TITLE
Add webview restoration api proposal

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -22,7 +22,8 @@
 		"onCommand:markdown.showPreviewToSide",
 		"onCommand:markdown.showLockedPreviewToSide",
 		"onCommand:markdown.showSource",
-		"onCommand:markdown.showPreviewSecuritySelector"
+		"onCommand:markdown.showPreviewSecuritySelector",
+		"onView:markdown.preview"
 	],
 	"contributes": {
 		"commands": [

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -88,12 +88,10 @@ export class MarkdownPreviewManager implements vscode.WebviewSerializer {
 		}
 	}
 
-	public deserializeWebview(
+	public async deserializeWebview(
 		webview: vscode.Webview,
 		state: any
-	): void {
-		console.log('It\'s close to midnight...');
-
+	): Promise<boolean> {
 		const preview = MarkdownPreview.revive(
 			webview,
 			state,
@@ -104,13 +102,14 @@ export class MarkdownPreviewManager implements vscode.WebviewSerializer {
 
 		this.registerPreview(preview);
 		preview.refresh();
+		return true;
 	}
 
-	public serializeWebview(
+	public async serializeWebview(
 		webview: vscode.Webview,
-	): any {
+	): Promise<any> {
 		const preview = this.previews.find(preview => preview.isWebviewOf(webview));
-		return preview ? preview.state : {};
+		return preview ? preview.state : undefined;
 	}
 
 	private getExistingPreview(

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -14,7 +14,7 @@ import { isMarkdownFile } from '../util/file';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { MarkdownContributions } from '../markdownExtensions';
 
-export class MarkdownPreviewManager implements vscode.WebviewReviver {
+export class MarkdownPreviewManager implements vscode.WebviewSerializer {
 	private static readonly markdownPreviewActiveContextKey = 'markdownPreviewFocus';
 
 	private readonly topmostLineMonitor = new MarkdownFileTopmostLineMonitor();
@@ -36,7 +36,7 @@ export class MarkdownPreviewManager implements vscode.WebviewReviver {
 			}
 		}, null, this.disposables);
 
-		this.disposables.push(vscode.window.registerWebviewReviver(MarkdownPreview.viewType, this));
+		this.disposables.push(vscode.window.registerWebviewSerializer(MarkdownPreview.viewType, this));
 	}
 
 	public dispose(): void {
@@ -88,13 +88,15 @@ export class MarkdownPreviewManager implements vscode.WebviewReviver {
 		}
 	}
 
-	public reviveWebview(
-		webview: vscode.Webview
+	public deserializeWebview(
+		webview: vscode.Webview,
+		state: any
 	): void {
 		console.log('It\'s close to midnight...');
 
 		const preview = MarkdownPreview.revive(
 			webview,
+			state,
 			this.contentProvider,
 			this.previewConfigurations,
 			this.logger,
@@ -102,6 +104,13 @@ export class MarkdownPreviewManager implements vscode.WebviewReviver {
 
 		this.registerPreview(preview);
 		preview.refresh();
+	}
+
+	public serializeWebview(
+		webview: vscode.Webview,
+	): any {
+		const preview = this.previews.find(preview => preview.isWebviewOf(webview));
+		return preview ? preview.state : {};
 	}
 
 	private getExistingPreview(

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -14,7 +14,7 @@ import { isMarkdownFile } from '../util/file';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { MarkdownContributions } from '../markdownExtensions';
 
-export class MarkdownPreviewManager {
+export class MarkdownPreviewManager implements vscode.WebviewReviver {
 	private static readonly markdownPreviewActiveContextKey = 'markdownPreviewFocus';
 
 	private readonly topmostLineMonitor = new MarkdownFileTopmostLineMonitor();
@@ -29,15 +29,14 @@ export class MarkdownPreviewManager {
 		private readonly contributions: MarkdownContributions
 	) {
 		vscode.window.onDidChangeActiveTextEditor(editor => {
-			if (editor) {
-				if (isMarkdownFile(editor.document)) {
-					for (const preview of this.previews.filter(preview => !preview.locked)) {
-						preview.update(editor.document.uri);
-					}
+			if (editor && isMarkdownFile(editor.document)) {
+				for (const preview of this.previews.filter(preview => !preview.locked)) {
+					preview.update(editor.document.uri);
 				}
 			}
 		}, null, this.disposables);
 
+		this.disposables.push(vscode.window.registerWebviewReviver(MarkdownPreview.viewType, this));
 	}
 
 	public dispose(): void {
@@ -66,7 +65,6 @@ export class MarkdownPreviewManager {
 			preview.reveal(previewSettings.previewColumn);
 		} else {
 			preview = this.createNewPreview(resource, previewSettings);
-			this.previews.push(preview);
 		}
 
 		preview.update(resource);
@@ -90,6 +88,22 @@ export class MarkdownPreviewManager {
 		}
 	}
 
+	public reviveWebview(
+		webview: vscode.Webview
+	): void {
+		console.log('It\'s close to midnight...');
+
+		const preview = MarkdownPreview.revive(
+			webview,
+			this.contentProvider,
+			this.previewConfigurations,
+			this.logger,
+			this.topmostLineMonitor);
+
+		this.registerPreview(preview);
+		preview.refresh();
+	}
+
 	private getExistingPreview(
 		resource: vscode.Uri,
 		previewSettings: PreviewSettings
@@ -101,8 +115,8 @@ export class MarkdownPreviewManager {
 	private createNewPreview(
 		resource: vscode.Uri,
 		previewSettings: PreviewSettings
-	) {
-		const preview = new MarkdownPreview(
+	): MarkdownPreview {
+		const preview = MarkdownPreview.create(
 			resource,
 			previewSettings.previewColumn,
 			previewSettings.locked,
@@ -111,6 +125,14 @@ export class MarkdownPreviewManager {
 			this.logger,
 			this.topmostLineMonitor,
 			this.contributions);
+
+		return this.registerPreview(preview);
+	}
+
+	private registerPreview(
+		preview: MarkdownPreview
+	): MarkdownPreview {
+		this.previews.push(preview);
 
 		preview.onDispose(() => {
 			const existing = this.previews.indexOf(preview!);

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -637,27 +637,26 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * Restores webviews that have been persisted when vscode shuts down.
+	 * Save and restore webviews that have been persisted when vscode shuts down.
 	 */
 	interface WebviewSerializer {
 		/**
 		 * Save a webview's `state`.
 		 *
-		 * Called when a webview is about to be hidden
+		 * Called before shutdown. Webview may or may not be visible.
 		 *
-		 * @param webview Webview to revive.
+		 * @param webview Webview to serialize.
 		 *
-		 * @returns state JSON serializable blob.
+		 * @returns JSON serializable state blob.
 		 */
 		serializeWebview(webview: Webview): any;
 
-
 		/**
-		 * Restore a webview's `html` from its `state`.
+		 * Restore a webview from its `state`.
 		 *
 		 * Called when a serialized webview first becomes active.
 		 *
-		 * @param webview Webview to revive.
+		 * @param webview Webview to restore. The serializer should take ownership of this webview.
 		 * @param state Persisted state.
 		 */
 		deserializeWebview(webview: Webview, state: any): void;
@@ -680,10 +679,10 @@ declare module 'vscode' {
 		 * Extensions that support reviving should have an `"onView:viewType"` activation method and
 		 * make sure that `registerWebviewSerializer` is called during activation.
 		 *
-		 * Only a single reviver may be registered at a time for a given `viewType`.
+		 * Only a single serializer may be registered at a time for a given `viewType`.
 		 *
-		 * @param viewType Type of the webview that can be revived.
-		 * @param reviver Webview revivier.
+		 * @param viewType Type of the webview that can be serialized.
+		 * @param reviver Webview serializer.
 		 */
 		export function registerWebviewSerializer(viewType: string, reviver: WebviewSerializer): Disposable;
 	}

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -649,7 +649,7 @@ declare module 'vscode' {
 		 *
 		 * @returns JSON serializable state blob.
 		 */
-		serializeWebview(webview: Webview): any;
+		serializeWebview(webview: Webview): Thenable<any>;
 
 		/**
 		 * Restore a webview from its `state`.
@@ -658,8 +658,10 @@ declare module 'vscode' {
 		 *
 		 * @param webview Webview to restore. The serializer should take ownership of this webview.
 		 * @param state Persisted state.
+		 *
+		 * @return Was deserialization successful?
 		 */
-		deserializeWebview(webview: Webview, state: any): void;
+		deserializeWebview(webview: Webview, state: any): Thenable<boolean>;
 	}
 
 	namespace window {

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -568,7 +568,7 @@ declare module 'vscode' {
 	 */
 	export interface Webview {
 		/**
-		 * The type of the webview, such as `'markdownw.preview'`
+		 * The type of the webview, such as `'markdown.preview'`
 		 */
 		readonly viewType: string;
 
@@ -588,6 +588,11 @@ declare module 'vscode' {
 		 * Should be a complete html document.
 		 */
 		html: string;
+
+		/**
+		 * JSON serializable blob of data saved on webviews for revival.
+		 */
+		state: any;
 
 		/**
 		 * The column in which the webview is showing.
@@ -636,16 +641,43 @@ declare module 'vscode' {
 		dispose(): any;
 	}
 
+	/**
+	 * Restores webviews that have been persisted when vscode shuts down.
+	 */
+	interface WebviewReviver {
+		/**
+		 * Restore a webview's `html` from its `state`.
+		 *
+		 * Called when a serialized webview first becomes active.
+		 *
+		 * @param webview Webview to revive.
+		 */
+		reviveWebview(webview: Webview): void;
+	}
+
 	namespace window {
 		/**
 		 * Create and show a new webview.
 		 *
-		 * @param viewType Identifier the type of the webview.
+		 * @param viewType Identifies the type of the webview.
 		 * @param title Title of the webview.
 		 * @param column Editor column to show the new webview in.
 		 * @param options Content settings for the webview.
 		 */
 		export function createWebview(viewType: string, title: string, column: ViewColumn, options: WebviewOptions): Webview;
+
+		/**
+		 * Registers a webview reviver.
+		 *
+		 * Extensions that support reviving should have an `"onView:viewType"` activation method and
+		 * make sure that `registerWebviewReviver` is called during activation.
+		 *
+		 * Only a single reviver may be registered at a time for a given `viewType`.
+		 *
+		 * @param viewType Type of the webview that can be revived.
+		 * @param reviver Webview revivier.
+		 */
+		export function registerWebviewReviver(viewType: string, reviver: WebviewReviver): Disposable;
 	}
 
 	//#endregion

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -590,11 +590,6 @@ declare module 'vscode' {
 		html: string;
 
 		/**
-		 * JSON serializable blob of data saved on webviews for revival.
-		 */
-		state: any;
-
-		/**
 		 * The column in which the webview is showing.
 		 */
 		readonly viewColumn?: ViewColumn;
@@ -644,15 +639,28 @@ declare module 'vscode' {
 	/**
 	 * Restores webviews that have been persisted when vscode shuts down.
 	 */
-	interface WebviewReviver {
+	interface WebviewSerializer {
+		/**
+		 * Save a webview's `state`.
+		 *
+		 * Called when a webview is about to be hidden
+		 *
+		 * @param webview Webview to revive.
+		 *
+		 * @returns state JSON serializable blob.
+		 */
+		serializeWebview(webview: Webview): any;
+
+
 		/**
 		 * Restore a webview's `html` from its `state`.
 		 *
 		 * Called when a serialized webview first becomes active.
 		 *
 		 * @param webview Webview to revive.
+		 * @param state Persisted state.
 		 */
-		reviveWebview(webview: Webview): void;
+		deserializeWebview(webview: Webview, state: any): void;
 	}
 
 	namespace window {
@@ -667,17 +675,17 @@ declare module 'vscode' {
 		export function createWebview(viewType: string, title: string, column: ViewColumn, options: WebviewOptions): Webview;
 
 		/**
-		 * Registers a webview reviver.
+		 * Registers a webview serializer.
 		 *
 		 * Extensions that support reviving should have an `"onView:viewType"` activation method and
-		 * make sure that `registerWebviewReviver` is called during activation.
+		 * make sure that `registerWebviewSerializer` is called during activation.
 		 *
 		 * Only a single reviver may be registered at a time for a given `viewType`.
 		 *
 		 * @param viewType Type of the webview that can be revived.
 		 * @param reviver Webview revivier.
 		 */
-		export function registerWebviewReviver(viewType: string, reviver: WebviewReviver): Disposable;
+		export function registerWebviewSerializer(viewType: string, reviver: WebviewSerializer): Disposable;
 	}
 
 	//#endregion

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -129,7 +129,7 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 		this._revivers.delete(viewType);
 	}
 
-	reviveWebview(webview: WebviewEditorInput): boolean {
+	reviveWebview(webview: WebviewEditorInput) {
 		this._extensionService.activateByEvent(`onView:${webview.state.viewType}`).then(() => {
 			const handle = 'revival-' + MainThreadWebviews.revivalPool++;
 			this._webviews.set(handle, webview);
@@ -147,8 +147,6 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 
 			this._proxy.$reviveWebview(handle, webview.state.viewType, webview.state.state, webview.position, webview.options);
 		});
-
-		return true;
 	}
 
 	canRevive(webview: WebviewEditorInput): boolean {
@@ -199,5 +197,4 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 			this._openerService.open(link);
 		}
 	}
-
 }

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -2,24 +2,22 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
+import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import * as map from 'vs/base/common/map';
-import { MainThreadWebviewsShape, MainContext, IExtHostContext, ExtHostContext, ExtHostWebviewsShape, WebviewHandle } from 'vs/workbench/api/node/extHost.protocol';
-import { dispose, IDisposable } from 'vs/base/common/lifecycle';
-import { extHostNamedCustomer } from './extHostCustomers';
-import { Position } from 'vs/platform/editor/common/editor';
-import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import * as vscode from 'vscode';
-import { WebviewEditorInput } from 'vs/workbench/parts/webview/electron-browser/webviewInput';
-import { WebviewEditor } from 'vs/workbench/parts/webview/electron-browser/webviewEditor';
-import { IWebviewService, WebviewReviver } from 'vs/workbench/parts/webview/electron-browser/webviewService';
-import { IEditorGroupService } from '../../services/group/common/groupService';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
 import URI from 'vs/base/common/uri';
-import { IExtensionService } from '../../services/extensions/common/extensions';
-import { ILifecycleService } from '../../../platform/lifecycle/common/lifecycle';
-import { TPromise } from '../../../base/common/winjs.base';
+import { TPromise } from 'vs/base/common/winjs.base';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { Position } from 'vs/platform/editor/common/editor';
+import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { ExtHostContext, ExtHostWebviewsShape, IExtHostContext, MainContext, MainThreadWebviewsShape, WebviewHandle } from 'vs/workbench/api/node/extHost.protocol';
+import { WebviewEditor } from 'vs/workbench/parts/webview/electron-browser/webviewEditor';
+import { WebviewEditorInput } from 'vs/workbench/parts/webview/electron-browser/webviewInput';
+import { IWebviewService, WebviewInputOptions, WebviewReviver } from 'vs/workbench/parts/webview/electron-browser/webviewService';
+import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
+import { extHostNamedCustomer } from './extHostCustomers';
 
 @extHostNamedCustomer(MainContext.MainThreadWebviews)
 export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviver {
@@ -67,7 +65,7 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 		viewType: string,
 		title: string,
 		column: Position,
-		options: vscode.WebviewOptions,
+		options: WebviewInputOptions,
 		extensionFolderPath: string
 	): void {
 		const webview = this._webviewService.createWebview(MainThreadWebviews.viewType, title, column, options, extensionFolderPath, {

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -166,9 +166,11 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 
 		return TPromise.join(reviveResponses).then(results => {
 			for (const result of results) {
-				const view = this._webviews.get(result.handle);
-				if (view) {
-					view.state.state = result.state;
+				if (result.state) {
+					const view = this._webviews.get(result.handle);
+					if (view) {
+						view.state.state = result.state;
+					}
 				}
 			}
 			return false; // Don't veto shutdown
@@ -209,7 +211,7 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 		}
 	}
 
-	private onDidClickLink(link: URI, options: vscode.WebviewOptions): void {
+	private onDidClickLink(link: URI, options: WebviewInputOptions): void {
 		if (!link) {
 			return;
 		}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -419,8 +419,8 @@ export function createApiFactory(
 			createWebview: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, options: vscode.WebviewOptions) => {
 				return extHostWebviews.createWebview(viewType, title, column, options, extension.extensionFolderPath);
 			}),
-			registerWebviewSerializer: proposedApiFunction(extension, (viewType: string, reviver: vscode.WebviewSerializer) => {
-				return extHostWebviews.registerWebviewSerializer(viewType, reviver);
+			registerWebviewSerializer: proposedApiFunction(extension, (viewType: string, serializer: vscode.WebviewSerializer) => {
+				return extHostWebviews.registerWebviewSerializer(viewType, serializer);
 			})
 		};
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -418,6 +418,9 @@ export function createApiFactory(
 			}),
 			createWebview: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, options: vscode.WebviewOptions) => {
 				return extHostWebviews.createWebview(viewType, title, column, options, extension.extensionFolderPath);
+			}),
+			registerWebviewReviver: proposedApiFunction(extension, (viewType: string, reviver: vscode.WebviewReviver) => {
+				return extHostWebviews.registerWebviewReviver(viewType, reviver);
 			})
 		};
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -419,8 +419,8 @@ export function createApiFactory(
 			createWebview: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, options: vscode.WebviewOptions) => {
 				return extHostWebviews.createWebview(viewType, title, column, options, extension.extensionFolderPath);
 			}),
-			registerWebviewReviver: proposedApiFunction(extension, (viewType: string, reviver: vscode.WebviewReviver) => {
-				return extHostWebviews.registerWebviewReviver(viewType, reviver);
+			registerWebviewSerializer: proposedApiFunction(extension, (viewType: string, reviver: vscode.WebviewSerializer) => {
+				return extHostWebviews.registerWebviewSerializer(viewType, reviver);
 			})
 		};
 

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -347,7 +347,7 @@ export interface MainThreadTelemetryShape extends IDisposable {
 	$publicLog(eventName: string, data?: any): void;
 }
 
-export type WebviewHandle = number;
+export type WebviewHandle = string;
 
 export interface MainThreadWebviewsShape extends IDisposable {
 	$createWebview(handle: WebviewHandle, viewType: string, title: string, column: EditorPosition, options: vscode.WebviewOptions, extensionFolderPath: string): void;
@@ -355,13 +355,19 @@ export interface MainThreadWebviewsShape extends IDisposable {
 	$reveal(handle: WebviewHandle, column: EditorPosition): void;
 	$setTitle(handle: WebviewHandle, value: string): void;
 	$setHtml(handle: WebviewHandle, value: string): void;
+	$setState(handle: WebviewHandle, value: any): void;
 	$sendMessage(handle: WebviewHandle, value: any): Thenable<boolean>;
+
+	$registerReviver(viewType: string): void;
+	$unregisterReviver(viewType: string): void;
 }
+
 export interface ExtHostWebviewsShape {
 	$onMessage(handle: WebviewHandle, message: any): void;
 	$onDidChangeActiveWeview(handle: WebviewHandle | undefined): void;
 	$onDidDisposeWeview(handle: WebviewHandle): Thenable<void>;
 	$onDidChangePosition(handle: WebviewHandle, newPosition: EditorPosition): void;
+	$reviveWebview(newWebviewHandle: WebviewHandle, viewType: string, state: any, position: EditorPosition, options: vscode.WebviewOptions): void;
 }
 
 export interface MainThreadWorkspaceShape extends IDisposable {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -355,11 +355,10 @@ export interface MainThreadWebviewsShape extends IDisposable {
 	$reveal(handle: WebviewHandle, column: EditorPosition): void;
 	$setTitle(handle: WebviewHandle, value: string): void;
 	$setHtml(handle: WebviewHandle, value: string): void;
-	$setState(handle: WebviewHandle, value: any): void;
 	$sendMessage(handle: WebviewHandle, value: any): Thenable<boolean>;
 
-	$registerReviver(viewType: string): void;
-	$unregisterReviver(viewType: string): void;
+	$registerSerializer(viewType: string): void;
+	$unregisterSerializer(viewType: string): void;
 }
 
 export interface ExtHostWebviewsShape {
@@ -367,7 +366,8 @@ export interface ExtHostWebviewsShape {
 	$onDidChangeActiveWeview(handle: WebviewHandle | undefined): void;
 	$onDidDisposeWeview(handle: WebviewHandle): Thenable<void>;
 	$onDidChangePosition(handle: WebviewHandle, newPosition: EditorPosition): void;
-	$reviveWebview(newWebviewHandle: WebviewHandle, viewType: string, state: any, position: EditorPosition, options: vscode.WebviewOptions): void;
+	$deserializeWebview(newWebviewHandle: WebviewHandle, viewType: string, state: any, position: EditorPosition, options: vscode.WebviewOptions): void;
+	$serializeWebview(webviewHandle: WebviewHandle): Thenable<any>;
 }
 
 export interface MainThreadWorkspaceShape extends IDisposable {

--- a/src/vs/workbench/api/node/extHostWebview.ts
+++ b/src/vs/workbench/api/node/extHostWebview.ts
@@ -250,12 +250,12 @@ export class ExtHostWebviews implements ExtHostWebviewsShape {
 
 	$serializeWebview(
 		webviewHandle: WebviewHandle
-	): any {
+	): Thenable<any> {
 		const webview = this.getWebview(webviewHandle);
 
 		const serialzer = this._serializers.get(webview.viewType);
 		if (!serialzer) {
-			return {};
+			return TPromise.as(undefined);
 		}
 
 		return serialzer.serializeWebview(webview);

--- a/src/vs/workbench/api/node/extHostWebview.ts
+++ b/src/vs/workbench/api/node/extHostWebview.ts
@@ -9,6 +9,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import * as typeConverters from 'vs/workbench/api/node/extHostTypeConverters';
 import { Position } from 'vs/platform/editor/common/editor';
 import { TPromise } from 'vs/base/common/winjs.base';
+import { Disposable } from './extHostTypes';
 
 export class ExtHostWebview implements vscode.Webview {
 
@@ -19,6 +20,7 @@ export class ExtHostWebview implements vscode.Webview {
 	private _isDisposed: boolean = false;
 	private _viewColumn: vscode.ViewColumn;
 	private _active: boolean;
+	private _state: any;
 
 	public readonly onMessageEmitter = new Emitter<any>();
 	public readonly onDidReceiveMessage: Event<any> = this.onMessageEmitter.event;
@@ -85,6 +87,17 @@ export class ExtHostWebview implements vscode.Webview {
 		}
 	}
 
+	get state(): any {
+		this.assertNotDisposed();
+		return this._state;
+	}
+
+	set state(value: any) {
+		this.assertNotDisposed();
+		this._state = value;
+		this._proxy.$setState(this._handle, value);
+	}
+
 	get options(): vscode.WebviewOptions {
 		this.assertNotDisposed();
 		return this._options;
@@ -128,11 +141,12 @@ export class ExtHostWebview implements vscode.Webview {
 }
 
 export class ExtHostWebviews implements ExtHostWebviewsShape {
-	private static handlePool = 1;
+	private static webviewHandlePool = 1;
 
 	private readonly _proxy: MainThreadWebviewsShape;
 
 	private readonly _webviews = new Map<WebviewHandle, ExtHostWebview>();
+	private readonly _revivers = new Map<string, vscode.WebviewReviver>();
 
 	private _activeWebview: ExtHostWebview | undefined;
 
@@ -149,12 +163,29 @@ export class ExtHostWebviews implements ExtHostWebviewsShape {
 		options: vscode.WebviewOptions,
 		extensionFolderPath: string
 	): vscode.Webview {
-		const handle = ExtHostWebviews.handlePool++;
+		const handle = ExtHostWebviews.webviewHandlePool++ + '';
 		this._proxy.$createWebview(handle, viewType, title, typeConverters.fromViewColumn(viewColumn), options, extensionFolderPath);
 
 		const webview = new ExtHostWebview(handle, this._proxy, viewType, viewColumn, options);
 		this._webviews.set(handle, webview);
 		return webview;
+	}
+
+	registerWebviewReviver(
+		viewType: string,
+		reviver: vscode.WebviewReviver
+	): vscode.Disposable {
+		if (this._revivers.has(viewType)) {
+			throw new Error(`Reviver for '${viewType}' already registered`);
+		}
+
+		this._revivers.set(viewType, reviver);
+		this._proxy.$registerReviver(viewType);
+
+		return new Disposable(() => {
+			this._revivers.delete(viewType);
+			this._proxy.$unregisterReviver(viewType);
+		});
 	}
 
 	$onMessage(handle: WebviewHandle, message: any): void {
@@ -206,8 +237,24 @@ export class ExtHostWebviews implements ExtHostWebviewsShape {
 		}
 	}
 
-	private readonly _onDidChangeActiveWebview = new Emitter<ExtHostWebview | undefined>();
-	public readonly onDidChangeActiveWebview = this._onDidChangeActiveWebview.event;
+	$reviveWebview(
+		webviewHandle: WebviewHandle,
+		viewType: string,
+		state: any,
+		position: Position,
+		options: vscode.WebviewOptions
+	): void {
+		const reviver = this._revivers.get(viewType);
+		if (!reviver) {
+			return;
+		}
+
+		const webview = new ExtHostWebview(webviewHandle, this._proxy, viewType, typeConverters.toViewColumn(position), options);
+		webview.state = state;
+
+		this._webviews.set(webviewHandle, webview);
+		reviver.reviveWebview(webview);
+	}
 
 	private getWebview(handle: WebviewHandle) {
 		return this._webviews.get(handle);

--- a/src/vs/workbench/api/node/extHostWebview.ts
+++ b/src/vs/workbench/api/node/extHostWebview.ts
@@ -167,13 +167,13 @@ export class ExtHostWebviews implements ExtHostWebviewsShape {
 
 	registerWebviewSerializer(
 		viewType: string,
-		reviver: vscode.WebviewSerializer
+		serializer: vscode.WebviewSerializer
 	): vscode.Disposable {
 		if (this._serializers.has(viewType)) {
 			throw new Error(`Serializer for '${viewType}' already registered`);
 		}
 
-		this._serializers.set(viewType, reviver);
+		this._serializers.set(viewType, serializer);
 		this._proxy.$registerSerializer(viewType);
 
 		return new Disposable(() => {
@@ -238,14 +238,14 @@ export class ExtHostWebviews implements ExtHostWebviewsShape {
 		position: Position,
 		options: vscode.WebviewOptions
 	): void {
-		const reviver = this._serializers.get(viewType);
-		if (!reviver) {
+		const serializer = this._serializers.get(viewType);
+		if (!serializer) {
 			return;
 		}
 
 		const revivedWebview = new ExtHostWebview(webviewHandle, this._proxy, viewType, typeConverters.toViewColumn(position), options);
 		this._webviews.set(webviewHandle, revivedWebview);
-		reviver.deserializeWebview(revivedWebview, state);
+		serializer.deserializeWebview(revivedWebview, state);
 	}
 
 	$serializeWebview(
@@ -253,12 +253,12 @@ export class ExtHostWebviews implements ExtHostWebviewsShape {
 	): any {
 		const webview = this.getWebview(webviewHandle);
 
-		const reviver = this._serializers.get(webview.viewType);
-		if (!reviver) {
+		const serialzer = this._serializers.get(webview.viewType);
+		if (!serialzer) {
 			return {};
 		}
 
-		return reviver.serializeWebview(webview);
+		return serialzer.serializeWebview(webview);
 	}
 
 	private getWebview(handle: WebviewHandle) {

--- a/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/parts/update/electron-browser/releaseNotesEditor.ts
@@ -5,29 +5,29 @@
 
 'use strict';
 
-import { TPromise } from 'vs/base/common/winjs.base';
+import { onUnexpectedError } from 'vs/base/common/errors';
 import { marked } from 'vs/base/common/marked/marked';
-import { IModeService } from 'vs/editor/common/services/modeService';
-import { tokenizeToString } from 'vs/editor/common/modes/textToHtmlTokenizer';
+import { OS } from 'vs/base/common/platform';
+import URI from 'vs/base/common/uri';
+import { TPromise } from 'vs/base/common/winjs.base';
+import { asText } from 'vs/base/node/request';
 import { IMode, TokenizationRegistry } from 'vs/editor/common/modes';
 import { generateTokensCSSForColorMap } from 'vs/editor/common/modes/supports/tokenization';
-import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { KeybindingIO } from 'vs/workbench/services/keybinding/common/keybindingIO';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IRequestService } from 'vs/platform/request/node/request';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { IPartService } from 'vs/workbench/services/part/common/partService';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { WebviewInput } from 'vs/workbench/parts/webview/electron-browser/webviewInput';
-import { onUnexpectedError } from 'vs/base/common/errors';
-import { addGAParameters } from 'vs/platform/telemetry/node/telemetryNodeUtils';
-import URI from 'vs/base/common/uri';
-import { asText } from 'vs/base/node/request';
+import { tokenizeToString } from 'vs/editor/common/modes/textToHtmlTokenizer';
+import { IModeService } from 'vs/editor/common/services/modeService';
 import * as nls from 'vs/nls';
-import { OS } from 'vs/base/common/platform';
-import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IRequestService } from 'vs/platform/request/node/request';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { addGAParameters } from 'vs/platform/telemetry/node/telemetryNodeUtils';
+import { IWebviewService } from 'vs/workbench/parts/webview/electron-browser/webviewService';
+import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { KeybindingIO } from 'vs/workbench/services/keybinding/common/keybindingIO';
+import { Position } from 'vs/platform/editor/common/editor';
+import { WebviewEditorInput } from 'vs/workbench/parts/webview/electron-browser/webviewInput';
 
 function renderBody(
 	body: string,
@@ -51,18 +51,17 @@ export class ReleaseNotesManager {
 
 	private _releaseNotesCache: { [version: string]: TPromise<string>; } = Object.create(null);
 
-	private _currentReleaseNotes: WebviewInput | undefined = undefined;
+	private _currentReleaseNotes: WebviewEditorInput | undefined = undefined;
 
 	public constructor(
-		@IEditorGroupService private readonly _editorGroupService: IEditorGroupService,
 		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@IModeService private readonly _modeService: IModeService,
 		@IOpenerService private readonly _openerService: IOpenerService,
-		@IPartService private readonly _partService: IPartService,
 		@IRequestService private readonly _requestService: IRequestService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IWorkbenchEditorService private readonly _editorService: IWorkbenchEditorService,
+		@IWebviewService private readonly _webviewService: IWebviewService,
 	) { }
 
 	public async show(
@@ -73,21 +72,23 @@ export class ReleaseNotesManager {
 		const html = await this.renderBody(releaseNoteText);
 		const title = nls.localize('releaseNotesInputName', "Release Notes: {0}", version);
 
+		const activeEditor = this._editorService.getActiveEditor();
 		if (this._currentReleaseNotes) {
 			this._currentReleaseNotes.setName(title);
-			this._currentReleaseNotes.setHtml(html);
-			const activeEditor = this._editorService.getActiveEditor();
-			if (activeEditor && activeEditor.position !== this._currentReleaseNotes.position) {
-				this._editorGroupService.moveEditor(this._currentReleaseNotes, this._currentReleaseNotes.position, activeEditor.position, { preserveFocus: true });
-			} else {
-				this._editorService.openEditor(this._currentReleaseNotes, { preserveFocus: true });
-			}
+			this._currentReleaseNotes.html = html;
+			this._webviewService.revealWebview(this._currentReleaseNotes, activeEditor ? activeEditor.position : undefined);
 		} else {
-			this._currentReleaseNotes = new WebviewInput(title, { tryRestoreScrollPosition: true, enableFindWidget: true }, html, {
-				onDidClickLink: uri => this.onDidClickLink(uri),
-				onDispose: () => { this._currentReleaseNotes = undefined; }
-			}, this._partService);
-			await this._editorService.openEditor(this._currentReleaseNotes, { pinned: true });
+			this._currentReleaseNotes = this._webviewService.createWebview(
+				'releaseNotes',
+				title,
+				activeEditor ? activeEditor.position : Position.ONE,
+				{ tryRestoreScrollPosition: true, enableFindWidget: true },
+				undefined, {
+					onDidClickLink: uri => this.onDidClickLink(uri),
+					onDispose: () => { this._currentReleaseNotes = undefined; }
+				});
+
+			this._currentReleaseNotes.html = html;
 		}
 
 		return true;

--- a/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
@@ -7,11 +7,21 @@ import { IEditorRegistry, EditorDescriptor, Extensions as EditorExtensions } fro
 import { WebviewEditor } from './webviewEditor';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { WebviewInput } from './webviewInput';
+import { WebviewEditorInput } from './webviewInput';
 import { localize } from 'vs/nls';
+import { IEditorInputFactoryRegistry, Extensions as EditorInputExtensions } from 'vs/workbench/common/editor';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { IWebviewService, WebviewService } from './webviewService';
+import { WebviewInputFactory } from 'vs/workbench/parts/webview/electron-browser/webviewInputFactory';
 
 (Registry.as<IEditorRegistry>(EditorExtensions.Editors)).registerEditor(new EditorDescriptor(
 	WebviewEditor,
 	WebviewEditor.ID,
 	localize('webview.editor.label', "webview editor")),
-	[new SyncDescriptor(WebviewInput)]);
+	[new SyncDescriptor(WebviewEditorInput)]);
+
+Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories).registerEditorInputFactory(
+	WebviewInputFactory.ID,
+	WebviewInputFactory);
+
+registerSingleton(IWebviewService, WebviewService);

--- a/src/vs/workbench/parts/webview/electron-browser/webviewInputFactory.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewInputFactory.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IEditorInputFactory } from 'vs/workbench/common/editor';
+import { IWebviewService, WebviewInputOptions } from './webviewService';
+import { WebviewEditorInput } from './webviewInput';
+
+interface SerializedWebview {
+	readonly viewType: string;
+	readonly title: string;
+	readonly options: WebviewInputOptions;
+	readonly extensionFolderPath: string;
+	readonly state: any;
+}
+
+export class WebviewInputFactory implements IEditorInputFactory {
+
+	public static readonly ID = WebviewEditorInput.typeId;
+
+	public constructor(
+		@IWebviewService private readonly _webviewService: IWebviewService
+	) { }
+
+	public serialize(
+		input: WebviewEditorInput
+	): string {
+		// Only attempt revival if we may have a reviver
+		if (!this._webviewService.canRevive(input) && !input.reviver) {
+			return null;
+		}
+
+		const data: SerializedWebview = {
+			viewType: input.viewType,
+			title: input.getName(),
+			options: input.options,
+			extensionFolderPath: input.extensionFolderPath.fsPath,
+			state: input.state
+		};
+		return JSON.stringify(data);
+	}
+
+	public deserialize(
+		instantiationService: IInstantiationService,
+		serializedEditorInput: string
+	): WebviewEditorInput {
+		const data: SerializedWebview = JSON.parse(serializedEditorInput);
+		return this._webviewService.createRevivableWebview(data.viewType, data.title, data.state, data.options, data.extensionFolderPath);
+	}
+}

--- a/src/vs/workbench/parts/webview/electron-browser/webviewService.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewService.ts
@@ -55,7 +55,7 @@ export interface WebviewReviver {
 
 	reviveWebview(
 		webview: WebviewEditorInput
-	): boolean;
+	): void;
 }
 
 export interface WebviewEvents {

--- a/src/vs/workbench/parts/webview/electron-browser/webviewService.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewService.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import URI from 'vs/base/common/uri';
+import { Position } from 'vs/platform/editor/common/editor';
+import { IInstantiationService, createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
+import * as vscode from 'vscode';
+import { WebviewEditorInput } from './webviewInput';
+
+export const IWebviewService = createDecorator<IWebviewService>('webviewService');
+
+export interface IWebviewService {
+	_serviceBrand: any;
+
+	createWebview(
+		viewType: string,
+		title: string,
+		column: Position,
+		options: WebviewInputOptions,
+		extensionFolderPath: string,
+		events: WebviewEvents
+	): WebviewEditorInput;
+
+	createRevivableWebview(
+		viewType: string,
+		title: string,
+		state: any,
+		options: WebviewInputOptions,
+		extensionFolderPath: string
+	): WebviewEditorInput;
+
+	revealWebview(
+		webview: WebviewEditorInput,
+		column: Position | undefined
+	): void;
+
+	registerReviver(
+		viewType: string,
+		reviver: WebviewReviver
+	): IDisposable;
+
+	canRevive(
+		input: WebviewEditorInput
+	): boolean;
+}
+
+export interface WebviewReviver {
+	canRevive(
+		webview: WebviewEditorInput
+	): boolean;
+
+	reviveWebview(
+		webview: WebviewEditorInput
+	): boolean;
+}
+
+export interface WebviewEvents {
+	onMessage?(message: any): void;
+	onDidChangePosition?(newPosition: Position): void;
+	onDispose?(): void;
+	onDidClickLink?(link: URI, options: vscode.WebviewOptions): void;
+}
+
+export interface WebviewInputOptions extends vscode.WebviewOptions {
+	tryRestoreScrollPosition?: boolean;
+}
+
+export class WebviewService implements IWebviewService {
+	_serviceBrand: any;
+
+	private readonly _revivers = new Map<string, WebviewReviver>();
+	private readonly _needingRevival = new Map<string, WebviewEditorInput[]>();
+
+	constructor(
+		@IWorkbenchEditorService private readonly _editorService: IWorkbenchEditorService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IEditorGroupService private readonly _editorGroupService: IEditorGroupService,
+	) { }
+
+	createWebview(
+		viewType: string,
+		title: string,
+		column: Position,
+		options: vscode.WebviewOptions,
+		extensionFolderPath: string,
+		events: WebviewEvents
+	): WebviewEditorInput {
+		const webviewInput = this._instantiationService.createInstance(WebviewEditorInput, viewType, title, options, {}, events, extensionFolderPath, undefined);
+		this._editorService.openEditor(webviewInput, { pinned: true }, column);
+		return webviewInput;
+	}
+
+	revealWebview(
+		webview: WebviewEditorInput,
+		column: Position | undefined
+	): void {
+		if (typeof column === 'undefined') {
+			column = webview.position;
+		}
+
+		if (webview.position === column) {
+			this._editorService.openEditor(webview, { preserveFocus: true }, column);
+		} else {
+			this._editorGroupService.moveEditor(webview, webview.position, column, { preserveFocus: true });
+		}
+	}
+
+	createRevivableWebview(
+		viewType: string,
+		title: string,
+		state: any,
+		options: WebviewInputOptions,
+		extensionFolderPath: string
+	): WebviewEditorInput {
+		const webviewInput = this._instantiationService.createInstance(WebviewEditorInput, viewType, title, options, state, {}, extensionFolderPath, {
+			canRevive: (webview) => {
+				return true;
+			},
+			reviveWebview: (webview) => {
+				if (!this._needingRevival.has(viewType)) {
+					this._needingRevival.set(viewType, []);
+				}
+				this._needingRevival.get(viewType).push(webviewInput);
+				this.tryRevive(viewType);
+			}
+		});
+
+		return webviewInput;
+	}
+
+	registerReviver(
+		viewType: string,
+		reviver: WebviewReviver
+	): IDisposable {
+		if (this._revivers.has(viewType)) {
+			throw new Error(`Reveriver for 'viewType' already registered`);
+		}
+
+		this._revivers.set(viewType, reviver);
+		this.tryRevive(viewType);
+
+		return toDisposable(() => {
+			this._revivers.delete(viewType);
+		});
+	}
+
+	canRevive(
+		webview: WebviewEditorInput
+	): boolean {
+		const viewType = webview.viewType;
+		return this._revivers.has(viewType) && this._revivers.get(viewType).canRevive(webview);
+	}
+
+	tryRevive(
+		viewType: string
+	) {
+		const reviver = this._revivers.get(viewType);
+		if (!reviver) {
+			return;
+		}
+
+		const toRevive = this._needingRevival.get(viewType);
+		if (!toRevive) {
+			return;
+		}
+
+		for (const webview of toRevive) {
+			reviver.reviveWebview(webview);
+		}
+	}
+}


### PR DESCRIPTION
From #45994

Adds an experimental API that allows extensions to persist webviews and restore them after vscode restarts. Uses this api to restore markdown previews.

This is done by:

- Adding a new `state` field on webviews. This is a json serializable blob of data

- Adds a new `WebviewReviver` interface (name will probably change). This binds a specific viewType to a provider that can restore a webview's contents from its `state`

- In VS Code core, persist webview editors. When we restart and need to show a webview, activate all extensions that may have revivers using the `onView:viewType` activation event.

Current implementation is sort of a mess. Will try to clean things up