### PR TITLE
Change to prevent fakeFireContinued when initiating time-travel

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/rawDebugSession.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/rawDebugSession.ts
@@ -372,14 +372,18 @@ export class RawDebugSession extends V8Protocol implements debug.ISession {
 
 	public stepBack(args: DebugProtocol.StepBackArguments): TPromise<DebugProtocol.StepBackResponse> {
 		return this.send('stepBack', args).then(response => {
-			this.fireFakeContinued(args.threadId);
+			if (response.body === undefined) {
+				this.fireFakeContinued(args.threadId);
+			}
 			return response;
 		});
 	}
 
 	public reverseContinue(args: DebugProtocol.ReverseContinueArguments): TPromise<DebugProtocol.ReverseContinueResponse> {
 		return this.send('reverseContinue', args).then(response => {
-			this.fireFakeContinued(args.threadId);
+			if (response.body === undefined) {
+				this.fireFakeContinued(args.threadId);
+			}
 			return response;
 		});
 	}


### PR DESCRIPTION
Based on discussion in [issue #42384](https://github.com/Microsoft/vscode/issues/42383) I have heavily refactored the code to work almost entirely as an extension. 

In this implementation clicking the step-back button when in "live" debug mode will launch a time-travel session. However, a `fireFakeContinued` still occurs and leaves the live session in an ill-defined state. This PR adds a check for these 2 cases and simply suppresses the fake event when needed. This is backward compatible with previous uses and only impacts the TTD specific code paths.