### PR TITLE
Fixes #45848 Long file paths for window.title": "${activeEditorLong}" 

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -311,8 +311,21 @@ export class CommandCenter {
 	}
 
 	private getTitle(resource: Resource): string {
-		const basename = path.basename(resource.resourceUri.fsPath);
+		var basename = path.basename(resource.resourceUri.fsPath);
+		var fullPath = '';
+		var title = '';
 
+		var regexLong = /^(([A-Z]:)|(\/))/;
+		var regexShort = /[/\\]/g;
+		if (regexLong.test(title)) {
+			//is long
+			fullPath = path.join(resource.resourceUri.fsPath);
+			basename = fullPath;
+		} else if (regexShort.test(title)) {
+			//is short
+		} else {
+			//is medium
+		}
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_RENAMED:
@@ -320,6 +333,7 @@ export class CommandCenter {
 				return `${basename} (Index)`;
 
 			case Status.MODIFIED:
+				return `${fullPath} (modified1)`;
 			case Status.BOTH_ADDED:
 			case Status.BOTH_MODIFIED:
 				return `${basename} (Working Tree)`;

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -312,28 +312,13 @@ export class CommandCenter {
 
 	private getTitle(resource: Resource): string {
 		var basename = path.basename(resource.resourceUri.fsPath);
-		var fullPath = '';
-		var title = '';
 
-		var regexLong = /^(([A-Z]:)|(\/))/;
-		var regexShort = /[/\\]/g;
-		if (regexLong.test(title)) {
-			//is long
-			fullPath = path.join(resource.resourceUri.fsPath);
-			basename = fullPath;
-		} else if (regexShort.test(title)) {
-			//is short
-		} else {
-			//is medium
-		}
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_RENAMED:
 			case Status.DELETED_BY_THEM:
 				return `${basename} (Index)`;
-
 			case Status.MODIFIED:
-				return `${fullPath} (modified1)`;
 			case Status.BOTH_ADDED:
 			case Status.BOTH_MODIFIED:
 				return `${basename} (Working Tree)`;

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -211,8 +211,9 @@ export class TitlebarPart extends Part implements ITitleService {
 		const appName = this.environmentService.appNameLong;
 		const separator = TitlebarPart.TITLE_SEPARATOR;
 		const titleTemplate = this.configurationService.getValue<string>('window.title');
+		console.log(process.platform);
+		if (titleTemplate === '${activeEditorLong}' && process.platform !== 'win32') {
 
-		if (titleTemplate === '${activeEditorLong}') {
 			var shortRegex = /[/\\]/g;
 			if (!shortRegex.test(labels.template(titleTemplate, {
 				activeEditorShort,
@@ -226,7 +227,8 @@ export class TitlebarPart extends Part implements ITitleService {
 				appName,
 				separator: { label: separator }
 			}))) {
-				return `${folderPath}`;
+
+				return `${folderPath}/${activeEditorMedium}`;
 
 			}
 		}

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -211,9 +211,8 @@ export class TitlebarPart extends Part implements ITitleService {
 		const appName = this.environmentService.appNameLong;
 		const separator = TitlebarPart.TITLE_SEPARATOR;
 		const titleTemplate = this.configurationService.getValue<string>('window.title');
-		console.log(process.platform);
-		if (titleTemplate === '${activeEditorLong}' && process.platform !== 'win32') {
 
+		if (titleTemplate === '${activeEditorLong}' && process.platform !== 'win32') {
 			var shortRegex = /[/\\]/g;
 			if (!shortRegex.test(labels.template(titleTemplate, {
 				activeEditorShort,
@@ -227,11 +226,10 @@ export class TitlebarPart extends Part implements ITitleService {
 				appName,
 				separator: { label: separator }
 			}))) {
-
 				return `${folderPath}/${activeEditorMedium}`;
-
 			}
 		}
+
 		return labels.template(titleTemplate, {
 			activeEditorShort,
 			activeEditorLong,

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -212,6 +212,24 @@ export class TitlebarPart extends Part implements ITitleService {
 		const separator = TitlebarPart.TITLE_SEPARATOR;
 		const titleTemplate = this.configurationService.getValue<string>('window.title');
 
+		if (titleTemplate === '${activeEditorLong}') {
+			var shortRegex = /[/\\]/g;
+			if (!shortRegex.test(labels.template(titleTemplate, {
+				activeEditorShort,
+				activeEditorLong,
+				activeEditorMedium,
+				rootName,
+				rootPath,
+				folderName,
+				folderPath,
+				dirty,
+				appName,
+				separator: { label: separator }
+			}))) {
+				return `${folderPath}`;
+
+			}
+		}
 		return labels.template(titleTemplate, {
 			activeEditorShort,
 			activeEditorLong,


### PR DESCRIPTION
This PR fixes issue#[45848](https://github.com/Microsoft/vscode/issues/45848)  and allows users with the setting window.title": "${activeEditorLong}" to view their file long paths in the title bar.

The title bar will also display a relative path for users in linux as per screenshot below.

![image](https://user-images.githubusercontent.com/25869561/37866543-68ecdb9e-2f62-11e8-8fe7-3d85f7a98d01.png)

