### PR TITLE
Markdown Security Policy to allow local HTTP content

### DIFF
--- a/extensions/markdown-language-features/src/features/previewContentProvider.ts
+++ b/extensions/markdown-language-features/src/features/previewContentProvider.ts
@@ -164,6 +164,9 @@ export class MarkdownContentProvider {
 			case MarkdownPreviewSecurityLevel.AllowInsecureContent:
 				return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: http: https: data:; media-src vscode-resource: http: https: data:; script-src 'nonce-${nonce}'; style-src vscode-resource: 'unsafe-inline' http: https: data:; font-src vscode-resource: http: https: data:;">`;
 
+			case MarkdownPreviewSecurityLevel.AllowInsecureLocalContent:
+				return `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https: data: http://localhost:* http://127.0.0.1:*; media-src vscode-resource: https: data: http://localhost:* http://127.0.0.1:*; script-src 'nonce-${nonce}'; style-src vscode-resource: 'unsafe-inline' https: data: http://localhost:* http://127.0.0.1:*; font-src vscode-resource: https: data: http://localhost:* http://127.0.0.1:*;">`;
+
 			case MarkdownPreviewSecurityLevel.AllowScriptsAndAllContent:
 				return '';
 

--- a/extensions/markdown-language-features/src/security.ts
+++ b/extensions/markdown-language-features/src/security.ts
@@ -14,7 +14,8 @@ const localize = nls.loadMessageBundle();
 export enum MarkdownPreviewSecurityLevel {
 	Strict = 0,
 	AllowInsecureContent = 1,
-	AllowScriptsAndAllContent = 2
+	AllowScriptsAndAllContent = 2,
+	AllowInsecureLocalContent = 3
 }
 
 export interface ContentSecurityPolicyArbiter {
@@ -110,6 +111,10 @@ export class PreviewSecuritySelector {
 					label: markActiveWhen(currentSecurityLevel === MarkdownPreviewSecurityLevel.Strict) + localize('strict.title', 'Strict'),
 					description: localize('strict.description', 'Only load secure content'),
 				}, {
+					type: MarkdownPreviewSecurityLevel.AllowInsecureLocalContent,
+					label: markActiveWhen(currentSecurityLevel === MarkdownPreviewSecurityLevel.AllowInsecureLocalContent) + localize('insecureLocalContent.title', 'Allow insecure local content'),
+					description: localize('insecureLocalContent.description', 'Enable loading content over http served from localhost'),
+				}, {
 					type: MarkdownPreviewSecurityLevel.AllowInsecureContent,
 					label: markActiveWhen(currentSecurityLevel === MarkdownPreviewSecurityLevel.AllowInsecureContent) + localize('insecureContent.title', 'Allow insecure content'),
 					description: localize('insecureContent.description', 'Enable loading content over http'),
@@ -133,7 +138,6 @@ export class PreviewSecuritySelector {
 					'preview.showPreviewSecuritySelector.title',
 					'Select security settings for Markdown previews in this workspace'),
 			});
-
 		if (!selection) {
 			return;
 		}


### PR DESCRIPTION
fixes #46418 

Added another Security Policy option that allows image, media, style and font data to be loaded via (unsafe) http from `localhost` and `127.0.0.1`. Even though [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/) recommends adding `object-src` to prevent injection I refrained from adding it would deviate from the standard set by the existing policies. Maybe worth updating all of them in one PR?

![screen shot 2018-03-24 at 12 37 07](https://user-images.githubusercontent.com/7142618/37869055-0f47ecf6-2fb1-11e8-9d8c-1ec1e9d64c42.png)

Steps taken to test:
- ran tests: `3934 passing`
- successful local build for darwin
- tested new policy that it won't load http:// from www but will load from localhost web server