### PR TITLE
DropDown: Remove old-duplicates option-disabled class. Addresses: #46011

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -61,6 +61,10 @@ class SelectListRenderer implements IRenderer<ISelectOptionItem, ISelectListTemp
 		// pseudo-select disabled option
 		if (optionDisabled) {
 			dom.addClass((<HTMLElement>data.root), 'option-disabled');
+		} else {
+			// TODO: verify if there is a list issue with old classes on rows
+			// This class removal should not be necessary
+			dom.removeClass((<HTMLElement>data.root), 'option-disabled');
 		}
 	}
 


### PR DESCRIPTION
Addresses: #46011 

@isidorn 
@bpasero 

This may be a workaround for an issue in the list widget.  It may also be a misuse of adding classes
to a list row.  

The issue found is that the HTML element for a row in the drop-down appears to sometimes
retain an added class specifically 'option-disabled'  which is added for disabled options
to disable the hover rule.  This occurs within the table render function which should not have
any old class assignments.  I added an class removal clause.  This appears to solve the problem
, but this shouldn't really be necessary assuming I'm doing things correctly adding the class.

Would like your guys thoughts...

From selectBoxCustom.ts:

	renderElement(element: ISelectOptionItem, index: number, templateData: ISelectListTemplateData): void {
		const data = <ISelectListTemplateData>templateData;
		const optionText = (<ISelectOptionItem>element).optionText;
		const optionDisabled = (<ISelectOptionItem>element).optionDisabled;

		data.optionText.textContent = optionText;
		data.root.setAttribute('aria-label', nls.localize('selectAriaOption', "{0}", optionText));

		// pseudo-select disabled option
		if (optionDisabled) {
			dom.addClass((<HTMLElement>data.root), 'option-disabled');
		} else {
			// TODO: verify if there is a list issue with old classes on rows
			// This class removal should not be necessary
			dom.removeClass((<HTMLElement>data.root), 'option-disabled');
		}
	}

