### PR TITLE
Revert "bump electron to 1.7.13"

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "1.7.13"
+target "1.7.12"
 runtime "electron"


### PR DESCRIPTION
This reverts commit d6bdff7f77fac972c7d17d9b237d26451a39df4f.