### PR TITLE
DropDown: Remove prior option-disabled class.  Fixes: #46011

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -62,8 +62,7 @@ class SelectListRenderer implements IRenderer<ISelectOptionItem, ISelectListTemp
 		if (optionDisabled) {
 			dom.addClass((<HTMLElement>data.root), 'option-disabled');
 		} else {
-			// TODO: verify if there is a list issue with old classes on rows
-			// This class removal should not be necessary
+			// Make sure we do class removal from prior template rendering
 			dom.removeClass((<HTMLElement>data.root), 'option-disabled');
 		}
 	}


### PR DESCRIPTION
Fixes: #46011 
(remove TODO/finalize)

Required to remove old class additions to templates.

@bpasero - good to understand better/have to know what you're doing ;-)