### PR TITLE
Fixes #46509 - Added key binding to disable a single breakpoint

### DIFF
--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -850,6 +850,7 @@ export class CodeMenu {
 		const continueAction = this.createMenuItem(nls.localize({ key: 'miContinue', comment: ['&& denotes a mnemonic'] }, "&&Continue"), 'workbench.action.debug.continue');
 
 		const toggleBreakpoint = this.createMenuItem(nls.localize({ key: 'miToggleBreakpoint', comment: ['&& denotes a mnemonic'] }, "Toggle &&Breakpoint"), 'editor.debug.action.toggleBreakpoint');
+		const disableBreakpoint = this.createMenuItem(nls.localize({ key: 'miDisableBreakpoint', comment: ['&& denotes a mnemonic'] }, "Disable &&Breakpoint"), 'debug.disableBreakpoint');
 		const breakpointsMenu = new Menu();
 		breakpointsMenu.append(this.createMenuItem(nls.localize({ key: 'miConditionalBreakpoint', comment: ['&& denotes a mnemonic'] }, "&&Conditional Breakpoint..."), 'editor.debug.action.conditionalBreakpoint'));
 		breakpointsMenu.append(this.createMenuItem(nls.localize({ key: 'miColumnBreakpoint', comment: ['&& denotes a mnemonic'] }, "C&&olumn Breakpoint"), 'editor.debug.action.toggleColumnBreakpoint'));
@@ -875,6 +876,7 @@ export class CodeMenu {
 			continueAction,
 			__separator__(),
 			toggleBreakpoint,
+			disableBreakpoint,
 			newBreakpoints,
 			enableAllBreakpoints,
 			disableAllBreakpoints,

--- a/src/vs/code/electron-main/menus.ts
+++ b/src/vs/code/electron-main/menus.ts
@@ -850,7 +850,6 @@ export class CodeMenu {
 		const continueAction = this.createMenuItem(nls.localize({ key: 'miContinue', comment: ['&& denotes a mnemonic'] }, "&&Continue"), 'workbench.action.debug.continue');
 
 		const toggleBreakpoint = this.createMenuItem(nls.localize({ key: 'miToggleBreakpoint', comment: ['&& denotes a mnemonic'] }, "Toggle &&Breakpoint"), 'editor.debug.action.toggleBreakpoint');
-		const disableBreakpoint = this.createMenuItem(nls.localize({ key: 'miDisableBreakpoint', comment: ['&& denotes a mnemonic'] }, "Disable &&Breakpoint"), 'debug.disableBreakpoint');
 		const breakpointsMenu = new Menu();
 		breakpointsMenu.append(this.createMenuItem(nls.localize({ key: 'miConditionalBreakpoint', comment: ['&& denotes a mnemonic'] }, "&&Conditional Breakpoint..."), 'editor.debug.action.conditionalBreakpoint'));
 		breakpointsMenu.append(this.createMenuItem(nls.localize({ key: 'miColumnBreakpoint', comment: ['&& denotes a mnemonic'] }, "C&&olumn Breakpoint"), 'editor.debug.action.toggleColumnBreakpoint'));
@@ -876,7 +875,6 @@ export class CodeMenu {
 			continueAction,
 			__separator__(),
 			toggleBreakpoint,
-			disableBreakpoint,
 			newBreakpoints,
 			enableAllBreakpoints,
 			disableAllBreakpoints,

--- a/src/vs/workbench/parts/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/parts/debug/browser/debugCommands.ts
@@ -45,6 +45,29 @@ export function registerCommands(): void {
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
+		id: 'debug.disableBreakpoint',
+		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
+		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_D,
+		when: EditorContextKeys.editorTextFocus,
+		handler: (accessor) => {
+			const debugService = accessor.get(IDebugService);
+			const editorService = accessor.get(IWorkbenchEditorService);
+			const editor = editorService.getActiveEditor();
+			const control = <ICodeEditor>editor.getControl();
+
+			if (control) {
+				const position = control.getPosition();
+				const modelUri = control.getModel().uri;
+				const bp = debugService.getModel().getBreakpoints()
+					.filter(bp => bp.lineNumber === position.lineNumber, bp => bp.column === position.column && bp.uri.toString() === modelUri.toString()).pop();
+				if (bp && bp.enabled) {
+					debugService.enableOrDisableBreakpoints(!bp.enabled, bp).done(null, errors.onUnexpectedError);
+				}
+			}
+		}
+	});
+
+	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: 'debug.renameWatchExpression',
 		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(5),
 		when: CONTEXT_WATCH_EXPRESSIONS_FOCUSED,

--- a/src/vs/workbench/parts/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/parts/debug/browser/debugCommands.ts
@@ -45,9 +45,9 @@ export function registerCommands(): void {
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
-		id: 'debug.disableBreakpoint',
+		id: 'debug.enableOrDisableBreakpoint',
 		weight: KeybindingsRegistry.WEIGHT.workbenchContrib(),
-		primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_D,
+		primary: undefined,
 		when: EditorContextKeys.editorTextFocus,
 		handler: (accessor) => {
 			const debugService = accessor.get(IDebugService);
@@ -60,7 +60,7 @@ export function registerCommands(): void {
 				const modelUri = control.getModel().uri;
 				const bp = debugService.getModel().getBreakpoints()
 					.filter(bp => bp.lineNumber === position.lineNumber, bp => bp.column === position.column && bp.uri.toString() === modelUri.toString()).pop();
-				if (bp && bp.enabled) {
+				if (bp) {
 					debugService.enableOrDisableBreakpoints(!bp.enabled, bp).done(null, errors.onUnexpectedError);
 				}
 			}


### PR DESCRIPTION
## Fixes #46509 

This PR includes support to enable/disable a single breakpoint ~~using the quick open menu or the `Ctrl+Alt+D`~~ keyboard shortcut.

**NOTE**
- This feature only enables/disables an active line with an enabled breakpoint


---