### PR TITLE
Allow a space between # and `region` for folding in Python

### DIFF
--- a/extensions/python/language-configuration.json
+++ b/extensions/python/language-configuration.json
@@ -43,8 +43,8 @@
 	"folding": {
 		"offSide": true,
 		"markers": {
-			"start": "^\\s*#region\\b",
-			"end": "^\\s*#endregion\\b"
+			"start": "^\\s*#\\s*region\\b",
+			"end": "^\\s*#\\s*endregion\\b"
 		}
 	}
 }


### PR DESCRIPTION
Automatic formatting inserts a space between the comment marker `#` and text in the Python extension, so without the allowance for whitespace then `"editor.formatOnType": true` breaks all region markers.

Closes Microsoft/vscode-python#1073 and Microsoft/vscode-python#33