### PR TITLE
"tag_classes" will be treated as css classes

### DIFF
--- a/extensions/pug/syntaxes/pug.tmLanguage.json
+++ b/extensions/pug/syntaxes/pug.tmLanguage.json
@@ -894,7 +894,7 @@
 				}
 			},
 			"match": "\\.([^\\w-])?[\\w-]*",
-			"name": "entity.other.attribute-name.class.jade"
+			"name": "entity.other.attribute-name.class.css.jade"
 		},
 		"tag_id": {
 			"match": "#[\\w-]+",


### PR DESCRIPTION
Syntax of Pug for classes was not treated as css classes but as attributes.  
It is not good because difference occured between css meta languages.