### PR TITLE
SelectBox: Add bounds checking on selected option.  Addresses: #43475, #44309

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -229,7 +229,17 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 		}
 
 		if (selected !== undefined) {
-			this.select(selected);
+			// Guard against out of bounds selected values
+			// Cannot currently return error, set selected within range
+			if (selected >= 0 && selected < this.options.length) {
+				this.select(selected);
+			} else if (selected > this.options.length - 1) {
+				// This could make client out of sync with the select
+				this.select(this.options.length - 1);
+				console.error('selectBoxCustom: setOptions selected exceeds options length');
+			} else if (selected < 0) {
+				this.selected = 0;
+			}
 		}
 	}
 
@@ -350,6 +360,12 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 	private showSelectDropDown() {
 		if (!this.contextViewProvider || this._isVisible) {
+			return;
+		}
+
+		// Bounds check selected/list before attempting to show
+		if (this.selected < 0 || this.selected > this.options.length - 1 || !this.selectList.length) {
+			console.error('selectBoxCustom: showSelectDropDown this.select exceeds options length or empty list');
 			return;
 		}
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -84,7 +84,17 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 		}
 
 		if (selected !== undefined) {
-			this.select(selected);
+			// Guard against out of bounds selected values
+			// Cannot currently return error, set selected within range
+			if (selected >= 0 && selected < this.options.length) {
+				this.select(selected);
+			} else if (selected > this.options.length - 1) {
+				// This could make client out of sync with the select
+				this.select(this.options.length - 1);
+				console.error('selectBoxNative: setOptions selected exceeds options length');
+			} else if (selected < 0) {
+				this.selected = 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses: #43475, #44309

This is a partial fix for these problems.  There is a root cause issue when terminals get instantiated and disposed.  The activeTabIndex can get out of bounds when _update() from terminal.

I added the bounds checking , but I just return and issue a console error.  The index does appear to be updated correctly before the Drop-down is shown except in the case of an extension call.  If I getting out of balance selected I set it to the top.  My concern is that there would be scenarios where the client gets out of sync with the drop-down.

I know where the problem is within the terminal code but I'm not confident enough to fix yet.