### PR TITLE
"Clear Recently Opened" now clears editor history

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1055,13 +1055,16 @@ export class ClearRecentFilesAction extends Action {
 	constructor(
 		id: string,
 		label: string,
-		@IWindowsService private windowsService: IWindowsService
+		@IWindowsService private windowsService: IWindowsService,
+		@IHistoryService private historyService: IHistoryService
 	) {
 		super(id, label);
 	}
 
 	public run(): TPromise<any> {
 		this.windowsService.clearRecentlyOpened();
+
+		this.historyService.clear();
 
 		return TPromise.as(false);
 	}


### PR DESCRIPTION
This commit resolves [Issue #35935](https://github.com/Microsoft/vscode/issues/35935).

I resolved the issue by clearing the editor history whenever the "Clear Recently Opened" command is executed. This is my first time working with this repository so any feedback is appreciated. 