### PR TITLE
Split out `Webview` from `WebviewEditor` in proposed API

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -20,7 +20,7 @@ export class MarkdownPreview {
 
 	public static viewType = 'markdown.preview';
 
-	private readonly webview: vscode.WebviewEditor;
+	private readonly editor: vscode.WebviewEditor;
 	private throttleTimer: any;
 	private line: number | undefined = undefined;
 	private readonly disposables: vscode.Disposable[] = [];
@@ -98,17 +98,17 @@ export class MarkdownPreview {
 		private readonly logger: Logger,
 		topmostLineMonitor: MarkdownFileTopmostLineMonitor
 	) {
-		this.webview = webview;
+		this.editor = webview;
 
-		this.webview.onDidDispose(() => {
+		this.editor.onDidDispose(() => {
 			this.dispose();
 		}, null, this.disposables);
 
-		this.webview.onDidChangeViewState(e => {
+		this.editor.onDidChangeViewState(e => {
 			this._onDidChangeViewStateEmitter.fire(e);
 		}, null, this.disposables);
 
-		this.webview.webview.onDidReceiveMessage(e => {
+		this.editor.webview.onDidReceiveMessage(e => {
 			if (e.source !== this._resource.toString()) {
 				return;
 			}
@@ -180,7 +180,7 @@ export class MarkdownPreview {
 
 		this._onDisposeEmitter.dispose();
 		this._onDidChangeViewStateEmitter.dispose();
-		this.webview.dispose();
+		this.editor.dispose();
 
 		disposeAll(this.disposables);
 	}
@@ -224,7 +224,7 @@ export class MarkdownPreview {
 	}
 
 	public get viewColumn(): vscode.ViewColumn | undefined {
-		return this.webview.viewColumn;
+		return this.editor.viewColumn;
 	}
 
 	public isPreviewOf(resource: vscode.Uri): boolean {
@@ -232,7 +232,7 @@ export class MarkdownPreview {
 	}
 
 	public isWebviewOf(webview: vscode.WebviewEditor): boolean {
-		return this.webview === webview;
+		return this.editor === webview;
 	}
 
 	public matchesResource(
@@ -256,12 +256,12 @@ export class MarkdownPreview {
 	}
 
 	public reveal(viewColumn: vscode.ViewColumn) {
-		this.webview.reveal(viewColumn);
+		this.editor.reveal(viewColumn);
 	}
 
 	public toggleLock() {
 		this.locked = !this.locked;
-		this.webview.title = MarkdownPreview.getPreviewTitle(this._resource, this.locked);
+		this.editor.webview.title = MarkdownPreview.getPreviewTitle(this._resource, this.locked);
 	}
 
 	private static getPreviewTitle(resource: vscode.Uri, locked: boolean): string {
@@ -293,7 +293,7 @@ export class MarkdownPreview {
 
 	private postMessage(msg: any) {
 		if (!this._disposed) {
-			this.webview.webview.postMessage(msg);
+			this.editor.webview.postMessage(msg);
 		}
 	}
 
@@ -315,8 +315,8 @@ export class MarkdownPreview {
 		this.currentVersion = { resource, version: document.version };
 		const content = await this.contentProvider.provideTextDocumentContent(document, this.previewConfigurations, this.line);
 		if (this._resource === resource) {
-			this.webview.title = MarkdownPreview.getPreviewTitle(this._resource, this.locked);
-			this.webview.webview.html = content;
+			this.editor.webview.title = MarkdownPreview.getPreviewTitle(this._resource, this.locked);
+			this.editor.webview.html = content;
 		}
 	}
 

--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -20,7 +20,7 @@ export class MarkdownPreview {
 
 	public static viewType = 'markdown.preview';
 
-	private readonly webview: vscode.Webview;
+	private readonly webview: vscode.WebviewEditor;
 	private throttleTimer: any;
 	private line: number | undefined = undefined;
 	private readonly disposables: vscode.Disposable[] = [];
@@ -32,7 +32,7 @@ export class MarkdownPreview {
 
 
 	public static async revive(
-		webview: vscode.Webview,
+		webview: vscode.WebviewEditor,
 		state: any,
 		contentProvider: MarkdownContentProvider,
 		previewConfigurations: MarkdownPreviewConfigurationManager,
@@ -69,7 +69,7 @@ export class MarkdownPreview {
 		topmostLineMonitor: MarkdownFileTopmostLineMonitor,
 		contributions: MarkdownContributions
 	): MarkdownPreview {
-		const webview = vscode.window.createWebview(
+		const webview = vscode.window.createWebviewEditor(
 			MarkdownPreview.viewType,
 			MarkdownPreview.getPreviewTitle(resource, locked),
 			previewColumn, {
@@ -90,7 +90,7 @@ export class MarkdownPreview {
 	}
 
 	private constructor(
-		webview: vscode.Webview,
+		webview: vscode.WebviewEditor,
 		private _resource: vscode.Uri,
 		public locked: boolean,
 		private readonly contentProvider: MarkdownContentProvider,
@@ -108,7 +108,7 @@ export class MarkdownPreview {
 			this._onDidChangeViewStateEmitter.fire(e);
 		}, null, this.disposables);
 
-		this.webview.onDidReceiveMessage(e => {
+		this.webview.webview.onDidReceiveMessage(e => {
 			if (e.source !== this._resource.toString()) {
 				return;
 			}
@@ -155,7 +155,7 @@ export class MarkdownPreview {
 	private readonly _onDisposeEmitter = new vscode.EventEmitter<void>();
 	public readonly onDispose = this._onDisposeEmitter.event;
 
-	private readonly _onDidChangeViewStateEmitter = new vscode.EventEmitter<vscode.WebviewOnDidChangeViewStateEvent>();
+	private readonly _onDidChangeViewStateEmitter = new vscode.EventEmitter<vscode.WebviewEditorOnDidChangeViewStateEvent>();
 	public readonly onDidChangeViewState = this._onDidChangeViewStateEmitter.event;
 
 	public get resource(): vscode.Uri {
@@ -231,7 +231,7 @@ export class MarkdownPreview {
 		return this._resource.fsPath === resource.fsPath;
 	}
 
-	public isWebviewOf(webview: vscode.Webview): boolean {
+	public isWebviewOf(webview: vscode.WebviewEditor): boolean {
 		return this.webview === webview;
 	}
 
@@ -293,7 +293,7 @@ export class MarkdownPreview {
 
 	private postMessage(msg: any) {
 		if (!this._disposed) {
-			this.webview.postMessage(msg);
+			this.webview.webview.postMessage(msg);
 		}
 	}
 
@@ -316,7 +316,7 @@ export class MarkdownPreview {
 		const content = await this.contentProvider.provideTextDocumentContent(document, this.previewConfigurations, this.line);
 		if (this._resource === resource) {
 			this.webview.title = MarkdownPreview.getPreviewTitle(this._resource, this.locked);
-			this.webview.html = content;
+			this.webview.webview.html = content;
 		}
 	}
 

--- a/extensions/markdown-language-features/src/features/previewManager.ts
+++ b/extensions/markdown-language-features/src/features/previewManager.ts
@@ -14,7 +14,7 @@ import { isMarkdownFile } from '../util/file';
 import { MarkdownPreviewConfigurationManager } from './previewConfig';
 import { MarkdownContributions } from '../markdownExtensions';
 
-export class MarkdownPreviewManager implements vscode.WebviewSerializer {
+export class MarkdownPreviewManager implements vscode.WebviewEditorSerializer {
 	private static readonly markdownPreviewActiveContextKey = 'markdownPreviewFocus';
 
 	private readonly topmostLineMonitor = new MarkdownFileTopmostLineMonitor();
@@ -36,7 +36,7 @@ export class MarkdownPreviewManager implements vscode.WebviewSerializer {
 			}
 		}, null, this.disposables);
 
-		this.disposables.push(vscode.window.registerWebviewSerializer(MarkdownPreview.viewType, this));
+		this.disposables.push(vscode.window.registerWebviewEditorSerializer(MarkdownPreview.viewType, this));
 	}
 
 	public dispose(): void {
@@ -88,8 +88,8 @@ export class MarkdownPreviewManager implements vscode.WebviewSerializer {
 		}
 	}
 
-	public async deserializeWebview(
-		webview: vscode.Webview,
+	public async deserializeWebviewEditor(
+		webview: vscode.WebviewEditor,
 		state: any
 	): Promise<void> {
 		const preview = await MarkdownPreview.revive(
@@ -103,8 +103,8 @@ export class MarkdownPreviewManager implements vscode.WebviewSerializer {
 		this.registerPreview(preview);
 	}
 
-	public async serializeWebview(
-		webview: vscode.Webview,
+	public async serializeWebviewEditor(
+		webview: vscode.WebviewEditor,
 	): Promise<any> {
 		const preview = this.previews.find(preview => preview.isWebviewOf(webview));
 		return preview ? preview.state : undefined;

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -574,6 +574,11 @@ declare module 'vscode' {
 		readonly options: WebviewOptions;
 
 		/**
+		 * Title of the webview shown in UI.
+		 */
+		title: string;
+
+		/**
 		 * Contents of the webview.
 		 *
 		 * Should be a complete html document.
@@ -600,17 +605,17 @@ declare module 'vscode' {
 	 */
 	export interface WebviewEditorOptions {
 		/**
-		 * Should the find widget be enabled in the webview?
+		 * Should the find widget be enabled in the editor?
 		 *
 		 * Defaults to false.
 		 */
 		readonly enableFindWidget?: boolean;
 
 		/**
-		 * Should the webview editor's webview content be kept around even when the webview
+		 * Should the webview editor's content (iframe) be kept around even when the editor
 		 * is no longer visible?
 		 *
-		 * Normally a webview context is created when the editor becomes visible
+		 * Normally the editors html context is created when the editor becomes visible
 		 * and destroyed when the webview is hidden. Apps that have complex state
 		 * or UI can set the `retainContextWhenHidden` to make VS Code keep the webview
 		 * context around, even when the webview moves to a background tab. When
@@ -632,17 +637,15 @@ declare module 'vscode' {
 		 */
 		readonly viewType: string;
 
-		readonly options: WebviewEditorOptions;
-
-		/**
-		 * Title of the editor shown in UI.
-		 */
-		title: string;
-
 		/**
 		 * The webview belonging to the editor.
 		 */
 		readonly webview: Webview;
+
+		/**
+		 * Content settings for the webview editor.
+		 */
+		readonly options: WebviewEditorOptions;
 
 		/**
 		 * The column in which the webview is showing.
@@ -650,7 +653,17 @@ declare module 'vscode' {
 		readonly viewColumn?: ViewColumn;
 
 		/**
-		 * Shows the webview in a given column.
+		 * Fired when the webview's view state changes.
+		 */
+		readonly onDidChangeViewState: Event<WebviewEditorOnDidChangeViewStateEvent>;
+
+		/**
+		 * Fired when the webview is disposed.
+		 */
+		readonly onDidDispose: Event<void>;
+
+		/**
+		 * Shows the webview editor in a given column.
 		 *
 		 * A webview may only be in a single column at a time. If it is already showing, this
 		 * command moves it to a new column.
@@ -658,23 +671,13 @@ declare module 'vscode' {
 		reveal(viewColumn: ViewColumn): void;
 
 		/**
-		 * Fired when the webview's view state changes.
-		 */
-		readonly onDidChangeViewState: Event<WebviewEditorOnDidChangeViewStateEvent>;
-
-		/**
-		 * Dispose of the the webview.
+		 * Dispose of the the webview editor.
 		 *
 		 * This closes the webview if it showing and disposes of the resources owned by the webview.
 		 * Webview are also disposed when the user closes the webview editor. Both cases fire `onDispose`
 		 * event. Trying to use the webview after it has been disposed throws an exception.
 		 */
 		dispose(): any;
-
-		/**
-		 * Fired when the webview is disposed.
-		 */
-		readonly onDidDispose: Event<void>;
 	}
 
 	export interface WebviewEditorOnDidChangeViewStateEvent {
@@ -691,21 +694,21 @@ declare module 'vscode' {
 		 *
 		 * Called before shutdown. Webview editor may or may not be visible.
 		 *
-		 * @param webview Webview editor to serialize.
+		 * @param webviewEditor Webview editor to serialize.
 		 *
 		 * @returns JSON serializable state blob.
 		 */
-		serializeWebviewEditor(webview: WebviewEditor): Thenable<any>;
+		serializeWebviewEditor(webviewEditor: WebviewEditor): Thenable<any>;
 
 		/**
-		 * Restore a webview from its `state`.
+		 * Restore a webview editor from its `state`.
 		 *
 		 * Called when a serialized webview first becomes active.
 		 *
-		 * @param webview Webview to restore. The serializer should take ownership of this webview.
+		 * @param webviewEditor Webview editor to restore. The serializer should take ownership of this editor.
 		 * @param state Persisted state.
 		 */
-		deserializeWebviewEditor(webview: WebviewEditor, state: any): Thenable<void>;
+		deserializeWebviewEditor(webviewEditor: WebviewEditor, state: any): Thenable<void>;
 	}
 
 	namespace window {
@@ -715,10 +718,9 @@ declare module 'vscode' {
 		 * @param viewType Identifies the type of the webview.
 		 * @param title Title of the webview.
 		 * @param column Editor column to show the new webview in.
-		 * @param editorOptions Content settings for the webview editor.
-		 * @param webviewOptions Content settings for the webview.
+		 * @param editorOptions Settings for the webview editor.
 		 */
-		export function createWebviewEditor(viewType: string, title: string, column: ViewColumn, editorOptions: WebviewEditorOptions, webviewOptions: WebviewOptions): WebviewEditor;
+		export function createWebviewEditor(viewType: string, title: string, column: ViewColumn, options: WebviewEditorOptions & WebviewOptions): WebviewEditor;
 
 		/**
 		 * Registers a webview editor serializer.

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -555,6 +555,51 @@ declare module 'vscode' {
 		readonly enableCommandUris?: boolean;
 
 		/**
+		 * Root paths from which the webview can load local (filesystem) resources using the `vscode-resource:` scheme.
+		 *
+		 * Default to the root folders of the current workspace plus the extension's install directory.
+		 *
+		 * Pass in an empty array to disallow access to any local resources.
+		 */
+		readonly localResourceRoots?: Uri[];
+	}
+
+	/**
+	 * A webview displays html content, like an iframe.
+	 */
+	export interface Webview {
+		/**
+		 * Content settings for the webview.
+		 */
+		readonly options: WebviewOptions;
+
+		/**
+		 * Contents of the webview.
+		 *
+		 * Should be a complete html document.
+		 */
+		html: string;
+
+		/**
+		 * Fired when the webview content posts a message.
+		 */
+		readonly onDidReceiveMessage: Event<any>;
+
+		/**
+		 * Post a message to the webview content.
+		 *
+		 * Messages are only develivered if the webview is visible.
+		 *
+		 * @param message Body of the message.
+		 */
+		postMessage(message: any): Thenable<boolean>;
+	}
+
+	/**
+	 * Content settings for a webview editor.
+	 */
+	export interface WebviewEditorOptions {
+		/**
 		 * Should the find widget be enabled in the webview?
 		 *
 		 * Defaults to false.
@@ -562,9 +607,10 @@ declare module 'vscode' {
 		readonly enableFindWidget?: boolean;
 
 		/**
-		 * Should the webview's context be kept around even when the webview is no longer visible?
+		 * Should the webview editor's webview content be kept around even when the webview
+		 * is no longer visible?
 		 *
-		 * Normally a webview's context is created when the webview becomes visible
+		 * Normally a webview context is created when the editor becomes visible
 		 * and destroyed when the webview is hidden. Apps that have complex state
 		 * or UI can set the `retainContextWhenHidden` to make VS Code keep the webview
 		 * context around, even when the webview moves to a background tab. When
@@ -575,76 +621,33 @@ declare module 'vscode' {
 		 * your webview's context cannot be quickly saved and restored.
 		 */
 		readonly retainContextWhenHidden?: boolean;
-
-		/**
-		 * Root paths from which the webview can load local (filesystem) resources using the `vscode-resource:` scheme.
-		 *
-		 * Default to the root folders of the current workspace plus the extension's install directory.
-		 *
-		 * Pass in an empty array to disallow access to any local resources.
-		 */
-		readonly localResourceRoots?: Uri[];
-	}
-
-	export interface WebviewOnDidChangeViewStateEvent {
-		readonly viewColumn: ViewColumn;
-		readonly active: boolean;
 	}
 
 	/**
-	 * A webview displays html content, like an iframe.
+	 * An editor that contains a webview.
 	 */
-	export interface Webview {
+	interface WebviewEditor {
 		/**
-		 * The type of the webview, such as `'markdown.preview'`
+		 * The type of the webview editor, such as `'markdown.preview'`
 		 */
 		readonly viewType: string;
 
-		/**
-		 * Content settings for the webview.
-		 */
-		readonly options: WebviewOptions;
+		readonly options: WebviewEditorOptions;
 
 		/**
-		 * Title of the webview shown in UI.
+		 * Title of the editor shown in UI.
 		 */
 		title: string;
 
 		/**
-		 * Contents of the webview.
-		 *
-		 * Should be a complete html document.
+		 * The webview belonging to the editor.
 		 */
-		html: string;
+		readonly webview: Webview;
 
 		/**
 		 * The column in which the webview is showing.
 		 */
 		readonly viewColumn?: ViewColumn;
-
-		/**
-		 * Fired when the webview content posts a message.
-		 */
-		readonly onDidReceiveMessage: Event<any>;
-
-		/**
-		 * Fired when the webview is disposed.
-		 */
-		readonly onDidDispose: Event<void>;
-
-		/**
-		 * Fired when the webview's view state changes.
-		 */
-		readonly onDidChangeViewState: Event<WebviewOnDidChangeViewStateEvent>;
-
-		/**
-		 * Post a message to the webview content.
-		 *
-		 * Messages are only develivered if the webview is visible.
-		 *
-		 * @param message Body of the message.
-		 */
-		postMessage(message: any): Thenable<boolean>;
 
 		/**
 		 * Shows the webview in a given column.
@@ -655,6 +658,11 @@ declare module 'vscode' {
 		reveal(viewColumn: ViewColumn): void;
 
 		/**
+		 * Fired when the webview's view state changes.
+		 */
+		readonly onDidChangeViewState: Event<WebviewEditorOnDidChangeViewStateEvent>;
+
+		/**
 		 * Dispose of the the webview.
 		 *
 		 * This closes the webview if it showing and disposes of the resources owned by the webview.
@@ -662,22 +670,32 @@ declare module 'vscode' {
 		 * event. Trying to use the webview after it has been disposed throws an exception.
 		 */
 		dispose(): any;
+
+		/**
+		 * Fired when the webview is disposed.
+		 */
+		readonly onDidDispose: Event<void>;
+	}
+
+	export interface WebviewEditorOnDidChangeViewStateEvent {
+		readonly viewColumn: ViewColumn;
+		readonly active: boolean;
 	}
 
 	/**
-	 * Save and restore webviews that have been persisted when vscode shuts down.
+	 * Save and restore webview editors that have been persisted when vscode shuts down.
 	 */
-	interface WebviewSerializer {
+	interface WebviewEditorSerializer {
 		/**
-		 * Save a webview's `state`.
+		 * Save a webview editors's `state`.
 		 *
-		 * Called before shutdown. Webview may or may not be visible.
+		 * Called before shutdown. Webview editor may or may not be visible.
 		 *
-		 * @param webview Webview to serialize.
+		 * @param webview Webview editor to serialize.
 		 *
 		 * @returns JSON serializable state blob.
 		 */
-		serializeWebview(webview: Webview): Thenable<any>;
+		serializeWebviewEditor(webview: WebviewEditor): Thenable<any>;
 
 		/**
 		 * Restore a webview from its `state`.
@@ -687,32 +705,33 @@ declare module 'vscode' {
 		 * @param webview Webview to restore. The serializer should take ownership of this webview.
 		 * @param state Persisted state.
 		 */
-		deserializeWebview(webview: Webview, state: any): Thenable<void>;
+		deserializeWebviewEditor(webview: WebviewEditor, state: any): Thenable<void>;
 	}
 
 	namespace window {
 		/**
-		 * Create and show a new webview.
+		 * Create and show a new webview editor.
 		 *
 		 * @param viewType Identifies the type of the webview.
 		 * @param title Title of the webview.
 		 * @param column Editor column to show the new webview in.
-		 * @param options Content settings for the webview.
+		 * @param editorOptions Content settings for the webview editor.
+		 * @param webviewOptions Content settings for the webview.
 		 */
-		export function createWebview(viewType: string, title: string, column: ViewColumn, options: WebviewOptions): Webview;
+		export function createWebviewEditor(viewType: string, title: string, column: ViewColumn, editorOptions: WebviewEditorOptions, webviewOptions: WebviewOptions): WebviewEditor;
 
 		/**
-		 * Registers a webview serializer.
+		 * Registers a webview editor serializer.
 		 *
 		 * Extensions that support reviving should have an `"onView:viewType"` activation method and
-		 * make sure that `registerWebviewSerializer` is called during activation.
+		 * make sure that `registerWebviewEditorSerializer` is called during activation.
 		 *
 		 * Only a single serializer may be registered at a time for a given `viewType`.
 		 *
-		 * @param viewType Type of the webview that can be serialized.
+		 * @param viewType Type of the webview editor that can be serialized.
 		 * @param reviver Webview serializer.
 		 */
-		export function registerWebviewSerializer(viewType: string, reviver: WebviewSerializer): Disposable;
+		export function registerWebviewEditorSerializer(viewType: string, reviver: WebviewEditorSerializer): Disposable;
 	}
 
 	//#endregion

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -615,15 +615,15 @@ declare module 'vscode' {
 		 * Should the webview editor's content (iframe) be kept around even when the editor
 		 * is no longer visible?
 		 *
-		 * Normally the editors html context is created when the editor becomes visible
-		 * and destroyed when the webview is hidden. Apps that have complex state
+		 * Normally the editor's html context is created when the editor becomes visible
+		 * and destroyed when it is is hidden. Apps that have complex state
 		 * or UI can set the `retainContextWhenHidden` to make VS Code keep the webview
 		 * context around, even when the webview moves to a background tab. When
-		 * the webview becomes visible again, the context is automatically restored
+		 * the editor becomes visible again, the context is automatically restored
 		 * in the exact same state it was in originally.
 		 *
 		 * `retainContextWhenHidden` has a high memory overhead and should only be used if
-		 * your webview's context cannot be quickly saved and restored.
+		 * your editor's context cannot be quickly saved and restored.
 		 */
 		readonly retainContextWhenHidden?: boolean;
 	}
@@ -633,7 +633,7 @@ declare module 'vscode' {
 	 */
 	interface WebviewEditor {
 		/**
-		 * The type of the webview editor, such as `'markdown.preview'`
+		 * The type of the webview editor, such as `'markdown.preview'`.
 		 */
 		readonly viewType: string;
 
@@ -648,17 +648,22 @@ declare module 'vscode' {
 		readonly options: WebviewEditorOptions;
 
 		/**
-		 * The column in which the webview is showing.
+		 * The column in which the editor is showing.
 		 */
 		readonly viewColumn?: ViewColumn;
 
 		/**
-		 * Fired when the webview's view state changes.
+		 * Fired when the editor's view state changes.
 		 */
 		readonly onDidChangeViewState: Event<WebviewEditorOnDidChangeViewStateEvent>;
 
 		/**
-		 * Fired when the webview is disposed.
+		 * Fired when the editor is disposed.
+		 *
+		 * This may be because the user closed the editor or because `.dispose()` was
+		 * called on it.
+		 *
+		 * Trying to use the webview after it has been disposed throws an exception.
 		 */
 		readonly onDidDispose: Event<void>;
 
@@ -671,11 +676,11 @@ declare module 'vscode' {
 		reveal(viewColumn: ViewColumn): void;
 
 		/**
-		 * Dispose of the the webview editor.
+		 * Dispose of the webview editor.
 		 *
 		 * This closes the webview if it showing and disposes of the resources owned by the webview.
 		 * Webview are also disposed when the user closes the webview editor. Both cases fire `onDispose`
-		 * event. Trying to use the webview after it has been disposed throws an exception.
+		 * event.
 		 */
 		dispose(): any;
 	}
@@ -715,9 +720,9 @@ declare module 'vscode' {
 		/**
 		 * Create and show a new webview editor.
 		 *
-		 * @param viewType Identifies the type of the webview.
+		 * @param viewType Identifies the type of the webview editor.
 		 * @param title Title of the webview.
-		 * @param column Editor column to show the new webview in.
+		 * @param column Editor column to show the new webview editor in.
 		 * @param editorOptions Settings for the webview editor.
 		 */
 		export function createWebviewEditor(viewType: string, title: string, column: ViewColumn, options: WebviewEditorOptions & WebviewOptions): WebviewEditor;

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -129,7 +129,7 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 			this._webviews.set(handle, webview);
 			webview._events = this.createWebviewEventDelegate(handle);
 
-			return this._proxy.$deserializeWebview(handle, webview.state.viewType, webview.state.state, webview.position, webview.options)
+			return this._proxy.$deserializeWebview(handle, webview.state.viewType, webview.getTitle(), webview.state.state, webview.position, webview.options)
 				.then(undefined, () => {
 					webview.html = MainThreadWebviews.getDeserializationFailedContents(viewType);
 				});

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -416,8 +416,8 @@ export function createApiFactory(
 			registerDecorationProvider: proposedApiFunction(extension, (provider: vscode.DecorationProvider) => {
 				return extHostDecorations.registerDecorationProvider(provider, extension.id);
 			}),
-			createWebviewEditor: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, editorOptions: vscode.WebviewEditorOptions, webviewOptions: vscode.WebviewOptions) => {
-				return extHostWebviews.createWebview(viewType, title, column, editorOptions, webviewOptions, extension.extensionFolderPath);
+			createWebviewEditor: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, options: vscode.WebviewEditorOptions & vscode.WebviewOptions) => {
+				return extHostWebviews.createWebview(viewType, title, column, options, extension.extensionFolderPath);
 			}),
 			registerWebviewEditorSerializer: proposedApiFunction(extension, (viewType: string, serializer: vscode.WebviewEditorSerializer) => {
 				return extHostWebviews.registerWebviewEditorSerializer(viewType, serializer);

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -416,11 +416,11 @@ export function createApiFactory(
 			registerDecorationProvider: proposedApiFunction(extension, (provider: vscode.DecorationProvider) => {
 				return extHostDecorations.registerDecorationProvider(provider, extension.id);
 			}),
-			createWebview: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, options: vscode.WebviewOptions) => {
-				return extHostWebviews.createWebview(viewType, title, column, options, extension.extensionFolderPath);
+			createWebviewEditor: proposedApiFunction(extension, (viewType: string, title: string, column: vscode.ViewColumn, editorOptions: vscode.WebviewEditorOptions, webviewOptions: vscode.WebviewOptions) => {
+				return extHostWebviews.createWebview(viewType, title, column, editorOptions, webviewOptions, extension.extensionFolderPath);
 			}),
-			registerWebviewSerializer: proposedApiFunction(extension, (viewType: string, serializer: vscode.WebviewSerializer) => {
-				return extHostWebviews.registerWebviewSerializer(viewType, serializer);
+			registerWebviewEditorSerializer: proposedApiFunction(extension, (viewType: string, serializer: vscode.WebviewEditorSerializer) => {
+				return extHostWebviews.registerWebviewEditorSerializer(viewType, serializer);
 			})
 		};
 

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -350,7 +350,7 @@ export interface MainThreadTelemetryShape extends IDisposable {
 export type WebviewHandle = string;
 
 export interface MainThreadWebviewsShape extends IDisposable {
-	$createWebview(handle: WebviewHandle, viewType: string, title: string, column: EditorPosition, options: vscode.WebviewOptions, extensionFolderPath: string): void;
+	$createWebview(handle: WebviewHandle, viewType: string, title: string, column: EditorPosition, options: vscode.WebviewEditorOptions & vscode.WebviewOptions, extensionFolderPath: string): void;
 	$disposeWebview(handle: WebviewHandle): void;
 	$reveal(handle: WebviewHandle, column: EditorPosition): void;
 	$setTitle(handle: WebviewHandle, value: string): void;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -365,7 +365,7 @@ export interface ExtHostWebviewsShape {
 	$onMessage(handle: WebviewHandle, message: any): void;
 	$onDidChangeWeviewViewState(handle: WebviewHandle, active: boolean, position: EditorPosition): void;
 	$onDidDisposeWeview(handle: WebviewHandle): Thenable<void>;
-	$deserializeWebview(newWebviewHandle: WebviewHandle, viewType: string, state: any, position: EditorPosition, options: vscode.WebviewOptions): Thenable<void>;
+	$deserializeWebview(newWebviewHandle: WebviewHandle, viewType: string, title: string, state: any, position: EditorPosition, options: vscode.WebviewOptions): Thenable<void>;
 	$serializeWebview(webviewHandle: WebviewHandle): Thenable<any>;
 }
 

--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditorService.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditorService.ts
@@ -67,7 +67,7 @@ export interface WebviewEvents {
 	onDidClickLink?(link: URI, options: vscode.WebviewOptions): void;
 }
 
-export interface WebviewInputOptions extends vscode.WebviewOptions {
+export interface WebviewInputOptions extends vscode.WebviewOptions, vscode.WebviewEditorOptions {
 	tryRestoreScrollPosition?: boolean;
 }
 

--- a/src/vs/workbench/test/electron-browser/api/extHostWebview.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostWebview.test.ts
@@ -21,12 +21,12 @@ suite('ExtHostWebview', function () {
 		const shape = createNoopMainThreadWebviews();
 		const extHostWebviews = new ExtHostWebviews(SingleProxyRPCProtocol(shape));
 
-		let lastInvokedDeserializer: vscode.WebviewSerializer | undefined = undefined;
+		let lastInvokedDeserializer: vscode.WebviewEditorSerializer | undefined = undefined;
 
-		class NoopSerializer implements vscode.WebviewSerializer {
-			async serializeWebview(webview: vscode.Webview): Promise<any> { /* noop */ }
+		class NoopSerializer implements vscode.WebviewEditorSerializer {
+			async serializeWebviewEditor(webview: vscode.WebviewEditor): Promise<any> { /* noop */ }
 
-			async deserializeWebview(webview: vscode.Webview, state: any): Promise<void> {
+			async deserializeWebviewEditor(webview: vscode.WebviewEditor, state: any): Promise<void> {
 				lastInvokedDeserializer = this;
 			}
 		}
@@ -34,18 +34,18 @@ suite('ExtHostWebview', function () {
 		const serializerA = new NoopSerializer();
 		const serializerB = new NoopSerializer();
 
-		const serializerARegistration = extHostWebviews.registerWebviewSerializer(viewType, serializerA);
+		const serializerARegistration = extHostWebviews.registerWebviewEditorSerializer(viewType, serializerA);
 
 		await extHostWebviews.$deserializeWebview('x', viewType, {}, EditorPosition.ONE, {});
 		assert.strictEqual(lastInvokedDeserializer, serializerA);
 
 		assert.throws(
-			() => extHostWebviews.registerWebviewSerializer(viewType, serializerB),
+			() => extHostWebviews.registerWebviewEditorSerializer(viewType, serializerB),
 			'Should throw when registering two serializers for the same view');
 
 		serializerARegistration.dispose();
 
-		extHostWebviews.registerWebviewSerializer(viewType, serializerB);
+		extHostWebviews.registerWebviewEditorSerializer(viewType, serializerB);
 
 		await extHostWebviews.$deserializeWebview('x', viewType, {}, EditorPosition.ONE, {});
 		assert.strictEqual(lastInvokedDeserializer, serializerB);

--- a/src/vs/workbench/test/electron-browser/api/extHostWebview.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostWebview.test.ts
@@ -36,7 +36,7 @@ suite('ExtHostWebview', function () {
 
 		const serializerARegistration = extHostWebviews.registerWebviewEditorSerializer(viewType, serializerA);
 
-		await extHostWebviews.$deserializeWebview('x', viewType, {}, EditorPosition.ONE, {});
+		await extHostWebviews.$deserializeWebview('x', viewType, 'title', {}, EditorPosition.ONE, {});
 		assert.strictEqual(lastInvokedDeserializer, serializerA);
 
 		assert.throws(
@@ -47,7 +47,7 @@ suite('ExtHostWebview', function () {
 
 		extHostWebviews.registerWebviewEditorSerializer(viewType, serializerB);
 
-		await extHostWebviews.$deserializeWebview('x', viewType, {}, EditorPosition.ONE, {});
+		await extHostWebviews.$deserializeWebview('x', viewType, 'title', {}, EditorPosition.ONE, {});
 		assert.strictEqual(lastInvokedDeserializer, serializerB);
 	});
 });


### PR DESCRIPTION
**Problem**
The current proposed `Webview` interface has a few methods and properties that are editor specific, such as `.reveal` and `.onDidChangeViewState`. These properies will not make sense if we ever allow webview to be displayed in other locations, such as in widgets

**Proposal**
Split the concepts of a `Webview` and of a `WebveiwEditor`. A webview is the html content itself. A `WebviewEditor` is an editor that displays a `Webview`

This would allow us to easily add other types of `Webview` owning objects in the future without having to document that some methods only apply when a webview is used as an editor and now when a webview is used as a widget

To add some context, this came out of my exploration with displaying webviews in widgets: https://github.com/Microsoft/vscode/tree/mjbvz/webviewWidgetProto We are not commit to ever supporting that but it was helpful for thinking about the API design

The main points where we've considered adding webviews:

- As editors - Covered by `webviewEditor`
- As panels - Also mostly covered by `webviewEditor` (with some teaks)
- In the side bar - Requires new api to register view provider. Would require `viewType` stored on `Webview` unless we introduce a class called something like `SideBarWebview`
- In widgets - Requires new API to show the webview. Could also possibly benefit from  storing the `title` and `viewType` on the `Webview` 

**Open questions**
- Should `Webview` own the `viewType` property instead of setting it on the `webviewEditor`?
- Same for `title`?
- Should webview also have a `dispose` / `onDidDispose` method?
- How could we serialize a webview that is not an editor? Would we need to?

// cc @kieferrm 