### PR TITLE
fixes #29553 preserve quick open input on escape

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -118,6 +118,7 @@ export class QuickOpenWidget implements IModelProvider {
 	private inputChangingTimeoutHandle: number;
 	private styles: IQuickOpenStyles;
 	private renderer: Renderer;
+	private lastValue: string;
 
 	constructor(container: HTMLElement, callbacks: IQuickOpenCallbacks, options: IQuickOpenOptions) {
 		this.isDisposed = false;
@@ -150,7 +151,7 @@ export class QuickOpenWidget implements IModelProvider {
 				const keyboardEvent: StandardKeyboardEvent = new StandardKeyboardEvent(e as KeyboardEvent);
 				if (keyboardEvent.keyCode === KeyCode.Escape) {
 					DOM.EventHelper.stop(e, true);
-
+					this.lastValue = this.inputBox.inputElement.value;
 					this.hide(HideReason.CANCELED);
 				}
 			})
@@ -554,6 +555,8 @@ export class QuickOpenWidget implements IModelProvider {
 		this.visible = true;
 		this.isLoosingFocus = false;
 		this.quickNavigateConfiguration = options ? options.quickNavigateConfiguration : void 0;
+		this.inputBox.inputElement.value = (this.lastValue) || '';
+		this.inputBox.inputElement.select();
 
 		// Adjust UI for quick navigate mode
 		if (this.quickNavigateConfiguration) {
@@ -792,6 +795,7 @@ export class QuickOpenWidget implements IModelProvider {
 		// Callbacks
 		if (reason === HideReason.ELEMENT_SELECTED) {
 			this.callbacks.onOk();
+			this.lastValue = '';
 		} else {
 			this.callbacks.onCancel();
 		}


### PR DESCRIPTION
This fixes #29553 by preserving the quick open input when the escape key is pressed. The input box value is saved and loaded in when quick open shows again. I chose to highlight the input box value to make easier for deleting what was there and entering something new.

![Alt Text](https://i.imgur.com/TFQzmpv.gif)
