### PR TITLE
Use em dash instead of hyphen in name

### DIFF
--- a/product.json
+++ b/product.json
@@ -1,6 +1,6 @@
 {
-	"nameShort": "Code - OSS",
-	"nameLong": "Code - OSS",
+	"nameShort": "Code—OSS",
+	"nameLong": "Code—OSS",
 	"applicationName": "code-oss",
 	"dataFolderName": ".vscode-oss",
 	"win32MutexName": "vscodeoss",


### PR DESCRIPTION
Besides looking a lot better, it is now correct. Yay Unicode.

Note: I daren’t touch the Win32 stuff, I have no idea if there’s Unicode support there.