### PR TITLE
SelectBox: Bounds check/adjust selected option (Fix2). Addresses: #43475, #44309

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -237,6 +237,10 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 		if (index >= 0 && index < this.options.length) {
 			this.selected = index;
+		} else if (index > this.options.length - 1) {
+			// Adjust index to end of list
+			// This could make client out of sync with the select
+			this.select(this.options.length - 1);
 		} else if (this.selected < 0) {
 			this.selected = 0;
 		}

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -91,6 +91,10 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 	public select(index: number): void {
 		if (index >= 0 && index < this.options.length) {
 			this.selected = index;
+		} else if (index > this.options.length - 1) {
+			// Adjust index to end of list
+			// This could make client out of sync with the select
+			this.select(this.options.length - 1);
 		} else if (this.selected < 0) {
 			this.selected = 0;
 		}


### PR DESCRIPTION
Addresses: #43475, #44309

Do bounds checking in select()
This is a partial fix for these problems.  There is a root cause issue when terminals get instantiated and disposed.  The activeTabIndex can get out of bounds when _update() from terminal.

@bpasero 
Should I create an issue to resolve the non-atomic issues with the terminal dispose?