### PR TITLE
Allowed preceding spaces in fileActions.ts file names

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.ts
@@ -1414,13 +1414,12 @@ export function getWellFormedFileName(filename: string): string {
 		return filename;
 	}
 
-	// Trim whitespaces
-	filename = strings.trim(strings.trim(filename, ' '), '\t');
+	// Trim tabs
+	filename = strings.trim(filename, '\t');
 
-	// Remove trailing dots
+	// Remove trailing dots, slashes, and spaces
 	filename = strings.rtrim(filename, '.');
-
-	// Remove trailing slashes
+	filename = strings.rtrim(filename, ' ');
 	filename = strings.rtrim(filename, '/');
 	filename = strings.rtrim(filename, '\\');
 


### PR DESCRIPTION
Fixes #47416

Technically, tabs aren't allowed _anywhere_ in names [[source](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
)]. Unless there's a strong opinion during this PR I'll file a followup issue.