### PR TITLE
Update C# TextMate grammar with latest bug fixes

### DIFF
--- a/extensions/csharp/syntaxes/csharp.tmLanguage.json
+++ b/extensions/csharp/syntaxes/csharp.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/dotnet/csharp-tmLanguage/commit/ca22c5211b87a6a1a8fd5356895237bb821df728",
+	"version": "https://github.com/dotnet/csharp-tmLanguage/commit/7689494edad006eafb9025aa6d72f8a634011a00",
 	"name": "C#",
 	"scopeName": "source.cs",
 	"patterns": [
@@ -2050,6 +2050,9 @@
 			"patterns": [
 				{
 					"include": "#block"
+				},
+				{
+					"include": "#comment"
 				}
 			]
 		},
@@ -3670,7 +3673,7 @@
 			}
 		},
 		"type-builtin": {
-			"match": "\\b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void)\\b",
+			"match": "\\b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void|dynamic)\\b",
 			"captures": {
 				"1": {
 					"name": "keyword.type.cs"
@@ -4131,7 +4134,7 @@
 						},
 						{
 							"name": "comment.line.double-slash.cs",
-							"begin": "(?<!/)//(?!/)",
+							"begin": "(?<!/)//(?:(?!/)|(?=//))",
 							"beginCaptures": {
 								"0": {
 									"name": "punctuation.definition.comment.cs"


### PR DESCRIPTION
This PR includes the following fixes for the C# TextMate grammar:

* Comments are now allowed after checked and unchecked statements
(https://github.com/dotnet/csharp-tmLanguage/issues/104)
* 'dynamic' is now highlighted as a built-in type keyword (https://github.com/dotnet/csharp-tmLanguage/issues/26)
* Single-line comments with four slashes (i.e. ////) are now highlighted properly
(https://github.com/dotnet/csharp-tmLanguage/issues/100)

Thanks to @Muchiachio for contributing these fixes!