### PR TITLE
monaco-editor: web ide app `worksapce/symbol` Reuse document/symbol s…

### DIFF
--- a/src/vs/editor/standalone/browser/quickOpen/quickOutline.ts
+++ b/src/vs/editor/standalone/browser/quickOpen/quickOutline.ts
@@ -167,6 +167,10 @@ export class QuickOutlineAction extends BaseEditorQuickOpenAction {
 		});
 	}
 
+	private symbolEntry(name: string, type: string, description: string, range: Range, highlights: IHighlight[], editor: ICodeEditor, decorator: IDecorator): SymbolEntry {
+		return new SymbolEntry(name, type, description, range, highlights, editor, decorator);
+	}
+
 	private toQuickOpenEntries(editor: ICodeEditor, flattened: SymbolInformation[], searchValue: string): SymbolEntry[] {
 		const controller = this.getController(editor);
 
@@ -193,7 +197,7 @@ export class QuickOutlineAction extends BaseEditorQuickOpenAction {
 				}
 
 				// Add
-				results.push(new SymbolEntry(label, symbolKindToCssClass(element.kind), description, Range.lift(element.location.range), highlights, editor, controller));
+				results.push(this.symbolEntry(label, symbolKindToCssClass(element.kind), description, Range.lift(element.location.range), highlights, editor, controller));
 			}
 		}
 

--- a/src/vs/editor/standalone/browser/quickOpen/quickOutline.ts
+++ b/src/vs/editor/standalone/browser/quickOpen/quickOutline.ts
@@ -15,7 +15,7 @@ import { IContext, IHighlight, QuickOpenEntryGroup, QuickOpenModel } from 'vs/ba
 import { IAutoFocus, Mode } from 'vs/base/parts/quickopen/common/quickOpen';
 import { ScrollType } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { SymbolInformation, DocumentSymbolProviderRegistry, symbolKindToCssClass, IOutline } from 'vs/editor/common/modes';
+import { SymbolInformation, DocumentSymbolProviderRegistry, symbolKindToCssClass, IOutline, Location } from 'vs/editor/common/modes';
 import { BaseEditorQuickOpenAction, IDecorator } from './editorQuickOpen';
 import { getDocumentSymbols } from 'vs/editor/contrib/quickOpen/quickOpen';
 import { registerEditorAction, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
@@ -167,8 +167,8 @@ export class QuickOutlineAction extends BaseEditorQuickOpenAction {
 		});
 	}
 
-	private symbolEntry(name: string, type: string, description: string, range: Range, highlights: IHighlight[], editor: ICodeEditor, decorator: IDecorator): SymbolEntry {
-		return new SymbolEntry(name, type, description, range, highlights, editor, decorator);
+	private symbolEntry(name: string, type: string, description: string, location: Location, highlights: IHighlight[], editor: ICodeEditor, decorator: IDecorator): SymbolEntry {
+		return new SymbolEntry(name, type, description, Range.lift(location.range), highlights, editor, decorator);
 	}
 
 	private toQuickOpenEntries(editor: ICodeEditor, flattened: SymbolInformation[], searchValue: string): SymbolEntry[] {
@@ -197,7 +197,7 @@ export class QuickOutlineAction extends BaseEditorQuickOpenAction {
 				}
 
 				// Add
-				results.push(this.symbolEntry(label, symbolKindToCssClass(element.kind), description, Range.lift(element.location.range), highlights, editor, controller));
+				results.push(this.symbolEntry(label, symbolKindToCssClass(element.kind), description, element.location, highlights, editor, controller));
 			}
 		}
 

--- a/src/vs/editor/standalone/browser/quickOpen/quickOutline.ts
+++ b/src/vs/editor/standalone/browser/quickOpen/quickOutline.ts
@@ -25,7 +25,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 
 let SCOPE_PREFIX = ':';
 
-class SymbolEntry extends QuickOpenEntryGroup {
+export class SymbolEntry extends QuickOpenEntryGroup {
 	private name: string;
 	private type: string;
 	private description: string;


### PR DESCRIPTION
monaco-editor don't support `workspace/symbol`

Now, we are developing an web ide base on monaco-editor,
and we want to realize the `workspace/symbol` feature which can make multi files switch(cmd + p), just like:
<img width="676" alt="2018-04-10 12 03 59" src="https://user-images.githubusercontent.com/10772305/38535683-484a9ec8-3cb7-11e8-89e3-4e35c51d243c.png">

However, monaco-editor only support `document/symbol` (cmd + shift + O).

We want to reuse the `document/symbol` ui Widget to realize `workspace/symbol` feature, but we meet an problew:

```ts
// class SymbolEntry extends QuickOpenEntryGroup {
// change to 
export class SymbolEntry extends QuickOpenEntryGroup {
	private name: string;
	private type: string;
        ...

        // selected action
	public run(mode: Mode, context: IContext): boolean {
		if (mode === Mode.OPEN) {
			return this.runOpen(context);
		}

		return this.runPreview();
	}

```

`SymbolEntry` was not export in `quickOutline.ts`, that I cannot change the action after select an item.

~~if we export SymbolEntry, I can overwrite the `SymbolEntry.prototype.run` method in my code, like:~~

~~```js~~
~~import { QuickOutlineAction, SymbolEntry } from 'monaco-editor/esm/vs/editor/standalone/browser/quickOpen/quickOutline';~~


~~editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_P, () => {~~
    ~~SymbolEntry.prototype.customType = 'workspace';~~
    ~~SymbolEntry.prototype.webideRun = SymbolEntry.prototype.run;~~
    ~~SymbolEntry.prototype.run = function(...args) {~~
        ~~if (this.customType !== 'workspace') {~~
            ~~return this.webideRun(...args);~~
        ~~}~~
        ~~this.customType = '';~~
        ~~// do something for workspace/symbol~~
    ~~}~~
    ~~(new QuickOutlineAction()).run('', eiditor);~~
~~})~~



