### PR TITLE
Fix C++ synatx highlighting error in macros with extern "C"

### DIFF
--- a/extensions/cpp/syntaxes/cpp.tmLanguage.json
+++ b/extensions/cpp/syntaxes/cpp.tmLanguage.json
@@ -338,13 +338,13 @@
 					]
 				},
 				{
-					"begin": "\\b(extern)(?=\\s*\")",
+					"begin": "\\b(extern)(?=\\s*\"\\w+\"\\b)",
 					"beginCaptures": {
 						"1": {
 							"name": "storage.modifier.cpp"
 						}
 					},
-					"end": "(?<=\\})|(?=\\w)|(?=\\s*#\\s*endif\\b)",
+					"end": "(?<=\\})|(?=\\w)|(?=\\s*#\\s*(?:else|elseif|endif)\\b)",
 					"name": "meta.extern-block.cpp",
 					"patterns": [
 						{
@@ -354,7 +354,7 @@
 									"name": "punctuation.section.block.begin.bracket.curly.c"
 								}
 							},
-							"end": "\\}|(?=\\s*#\\s*endif\\b)",
+							"end": "\\}|(?=\\s*#\\s*(?:else|elseif|endif\\b)",
 							"endCaptures": {
 								"0": {
 									"name": "punctuation.section.block.end.bracket.curly.c"


### PR DESCRIPTION
Before this change:

![screenshot from 2018-04-11 20-42-11](https://user-images.githubusercontent.com/4525736/38624232-6ef611b6-3dc9-11e8-9a91-e47ecba08b5d.png)

After:

![screenshot from 2018-04-11 20-42-36](https://user-images.githubusercontent.com/4525736/38624245-77dba304-3dc9-11e8-9ca4-a6581cfbc028.png)

The changes in `"end"` parts are not required for this fix to work, I just added support for `#else` and `#elseif` because `#endif` is already there. I don't know why `#endif` is there in the first place to be honest.

Edit:

Forgot the "n" in the second `extern` on the screenshots but this doesn't affect anything.

```c++
#ifdef __cplusplus
    #define FOO_EXTERN extern "C"
#else
    #define FOO_EXTERN extern
#endif
```

Edit2:

Hmm, it looks like GitHub also has a bug related to this 😃 