### PR TITLE
Allow extensions to access all terminals

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -769,4 +769,12 @@ declare module 'vscode' {
 	}
 
 	//#endregion
+
+	//#region Terminal
+
+	export namespace window {
+		export const onDidOpenTerminal: Event<Terminal>;
+	}
+
+	//#endregion
 }

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -774,10 +774,16 @@ declare module 'vscode' {
 
 	export namespace window {
 		/**
+		 * The currently active terminals or an empty array.
+		 *
 		 * @readonly
 		 */
 		export let terminals: Terminal[];
 
+		/**
+		 * An [event](#Event) which fires when a terminal has been created, either through the
+		 * [createTerminal](#window.createTerminal) API or commands.
+		 */
 		export const onDidOpenTerminal: Event<Terminal>;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -773,6 +773,11 @@ declare module 'vscode' {
 	//#region Terminal
 
 	export namespace window {
+		/**
+		 * @readonly
+		 */
+		export let terminals: Terminal[];
+
 		export const onDidOpenTerminal: Event<Terminal>;
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -22,6 +22,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTerminalService);
 		this._toDispose = [];
+		this._toDispose.push(terminalService.onInstanceCreated((terminalInstance) => this._onTerminalOpened(terminalInstance)));
 		this._toDispose.push(terminalService.onInstanceDisposed((terminalInstance) => this._onTerminalDisposed(terminalInstance)));
 		this._toDispose.push(terminalService.onInstanceProcessIdReady((terminalInstance) => this._onTerminalProcessIdReady(terminalInstance)));
 	}
@@ -76,6 +77,10 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 
 	private _onTerminalDisposed(terminalInstance: ITerminalInstance): void {
 		this._proxy.$acceptTerminalClosed(terminalInstance.id);
+	}
+
+	private _onTerminalOpened(terminalInstance: ITerminalInstance): void {
+		this._proxy.$acceptTerminalOpened(terminalInstance.id, terminalInstance.title);
 	}
 
 	private _onTerminalProcessIdReady(terminalInstance: ITerminalInstance): void {

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -23,13 +23,19 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTerminalService);
 		this._toDispose = [];
 		this._toDispose.push(terminalService.onInstanceCreated((terminalInstance) => {
-			// Delay this message so the TerminalInstance constructor has a change to finish and
+			// Delay this message so the TerminalInstance constructor has a chance to finish and
 			// return the ID normally to the extension host. The ID that is passed here will be used
 			// to register non-extension API terminals in the extension host.
 			setTimeout(() => this._onTerminalOpened(terminalInstance), 100);
 		}));
 		this._toDispose.push(terminalService.onInstanceDisposed((terminalInstance) => this._onTerminalDisposed(terminalInstance)));
 		this._toDispose.push(terminalService.onInstanceProcessIdReady((terminalInstance) => this._onTerminalProcessIdReady(terminalInstance)));
+
+		// Set initial ext host state
+		this.terminalService.terminalInstances.forEach(t => {
+			this._onTerminalOpened(t);
+			t.processReady.then(() => this._onTerminalProcessIdReady(t));
+		});
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -22,7 +22,12 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostTerminalService);
 		this._toDispose = [];
-		this._toDispose.push(terminalService.onInstanceCreated((terminalInstance) => this._onTerminalOpened(terminalInstance)));
+		this._toDispose.push(terminalService.onInstanceCreated((terminalInstance) => {
+			// Delay this message so the TerminalInstance constructor has a change to finish and
+			// return the ID normally to the extension host. The ID that is passed here will be used
+			// to register non-extension API terminals in the extension host.
+			setTimeout(() => this._onTerminalOpened(terminalInstance), 100);
+		}));
 		this._toDispose.push(terminalService.onInstanceDisposed((terminalInstance) => this._onTerminalDisposed(terminalInstance)));
 		this._toDispose.push(terminalService.onInstanceProcessIdReady((terminalInstance) => this._onTerminalProcessIdReady(terminalInstance)));
 	}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -316,6 +316,9 @@ export function createApiFactory(
 			get visibleTextEditors() {
 				return extHostEditors.getVisibleTextEditors();
 			},
+			get terminals() {
+				return extHostTerminalService.terminals;
+			},
 			showTextDocument(documentOrUri: vscode.TextDocument | vscode.Uri, columnOrOptions?: vscode.ViewColumn | vscode.TextDocumentShowOptions, preserveFocus?: boolean): TPromise<vscode.TextEditor> {
 				let documentPromise: TPromise<vscode.TextDocument>;
 				if (URI.isUri(documentOrUri)) {

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -351,6 +351,9 @@ export function createApiFactory(
 			onDidCloseTerminal(listener, thisArg?, disposables?) {
 				return extHostTerminalService.onDidCloseTerminal(listener, thisArg, disposables);
 			},
+			onDidOpenTerminal(listener, thisArg?, disposables?) {
+				return extHostTerminalService.onDidOpenTerminal(listener, thisArg, disposables);
+			},
 			get state() {
 				return extHostWindow.state;
 			},

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -728,6 +728,7 @@ export interface ExtHostQuickOpenShape {
 
 export interface ExtHostTerminalServiceShape {
 	$acceptTerminalClosed(id: number): void;
+	$acceptTerminalOpened(id: number, name: string): void;
 	$acceptTerminalProcessId(id: number, processId: number): void;
 }
 

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -106,6 +106,8 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 	private _proxy: MainThreadTerminalServiceShape;
 	private _terminals: ExtHostTerminal[];
 
+	public get terminals(): ExtHostTerminal[] { return this._terminals; }
+
 	constructor(mainContext: IMainContext) {
 		this._onDidCloseTerminal = new Emitter<vscode.Terminal>();
 		this._onDidOpenTerminal = new Emitter<vscode.Terminal>();

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -149,9 +149,6 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 		this._onDidCloseTerminal.fire(terminal);
 	}
 
-	// TOOD: How do we set PID
-	// TODO: Make sure both API terminals and non-API terminals are created correctly
-	// TODO: Ensure the terminal that is opened when first launched gets added, I think it's set before the ext host is ready for it
 	public $acceptTerminalOpened(id: number, name: string): void {
 		let index = this._getTerminalIndexById(id);
 		if (index !== null) {
@@ -159,7 +156,6 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 			this._onDidOpenTerminal.fire(this.terminals[index]);
 			return;
 		}
-		// TODO: Only create a terminal if it doesn't already exist for the ID
 		let terminal = new ExtHostTerminal(this._proxy, name, id);
 		this._terminals.push(terminal);
 		this._onDidOpenTerminal.fire(terminal);

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -51,12 +51,10 @@ export class ExtHostTerminal implements vscode.Terminal {
 	}
 
 	public get name(): string {
-		this._checkDisposed();
 		return this._name;
 	}
 
 	public get processId(): Thenable<number> {
-		this._checkDisposed();
 		return this._pidPromise;
 	}
 

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -20,12 +20,7 @@ export class ExtHostTerminal implements vscode.Terminal {
 
 	constructor(
 		proxy: MainThreadTerminalServiceShape,
-		name?: string,
-		shellPath?: string,
-		shellArgs?: string[],
-		cwd?: string,
-		env?: { [key: string]: string },
-		waitOnExit?: boolean
+		name?: string
 	) {
 		this._name = name;
 		this._queuedRequests = [];
@@ -33,8 +28,16 @@ export class ExtHostTerminal implements vscode.Terminal {
 		this._pidPromise = new Promise<number>(c => {
 			this._pidPromiseComplete = c;
 		});
+	}
 
-		this._proxy.$createTerminal(name, shellPath, shellArgs, cwd, env, waitOnExit).then((id) => {
+	public create(
+		shellPath?: string,
+		shellArgs?: string[],
+		cwd?: string,
+		env?: { [key: string]: string },
+		waitOnExit?: boolean
+	): void {
+		this._proxy.$createTerminal(this._name, shellPath, shellArgs, cwd, env, waitOnExit).then((id) => {
 			this._id = id;
 			this._queuedRequests.forEach((r) => {
 				r.run(this._proxy, this._id);
@@ -99,29 +102,37 @@ export class ExtHostTerminal implements vscode.Terminal {
 export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 
 	private readonly _onDidCloseTerminal: Emitter<vscode.Terminal>;
+	private readonly _onDidOpenTerminal: Emitter<vscode.Terminal>;
 	private _proxy: MainThreadTerminalServiceShape;
 	private _terminals: ExtHostTerminal[];
 
 	constructor(mainContext: IMainContext) {
 		this._onDidCloseTerminal = new Emitter<vscode.Terminal>();
+		this._onDidOpenTerminal = new Emitter<vscode.Terminal>();
 		this._proxy = mainContext.getProxy(MainContext.MainThreadTerminalService);
 		this._terminals = [];
 	}
 
 	public createTerminal(name?: string, shellPath?: string, shellArgs?: string[]): vscode.Terminal {
-		let terminal = new ExtHostTerminal(this._proxy, name, shellPath, shellArgs);
+		let terminal = new ExtHostTerminal(this._proxy, name);
+		terminal.create(shellPath, shellArgs);
 		this._terminals.push(terminal);
 		return terminal;
 	}
 
 	public createTerminalFromOptions(options: vscode.TerminalOptions): vscode.Terminal {
-		let terminal = new ExtHostTerminal(this._proxy, options.name, options.shellPath, options.shellArgs, options.cwd, options.env /*, options.waitOnExit*/);
+		let terminal = new ExtHostTerminal(this._proxy, options.name);
+		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.env /*, options.waitOnExit*/);
 		this._terminals.push(terminal);
 		return terminal;
 	}
 
 	public get onDidCloseTerminal(): Event<vscode.Terminal> {
 		return this._onDidCloseTerminal && this._onDidCloseTerminal.event;
+	}
+
+	public get onDidOpenTerminal(): Event<vscode.Terminal> {
+		return this._onDidOpenTerminal && this._onDidOpenTerminal.event;
 	}
 
 	public $acceptTerminalClosed(id: number): void {
@@ -132,6 +143,15 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 		}
 		let terminal = this._terminals.splice(index, 1)[0];
 		this._onDidCloseTerminal.fire(terminal);
+	}
+
+	// TOOD: How do we set PID
+	// TODO: Make sure both API terminals and non-API terminals are created correctly
+	public $acceptTerminalOpened(id: number, name: string): void {
+		// TODO: Only create a terminal if it doesn't already exist for the ID
+		let terminal = new ExtHostTerminal(this._proxy, name);
+		this._terminals.push(terminal);
+		this._onDidOpenTerminal.fire(terminal);
 	}
 
 	public $acceptTerminalProcessId(id: number, processId: number): void {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -149,6 +149,7 @@ export interface ITerminalService {
 	configHelper: ITerminalConfigHelper;
 	onActiveTabChanged: Event<void>;
 	onTabDisposed: Event<ITerminalTab>;
+	onInstanceCreated: Event<ITerminalInstance>;
 	onInstanceDisposed: Event<ITerminalInstance>;
 	onInstanceProcessIdReady: Event<ITerminalInstance>;
 	onInstancesChanged: Event<void>;

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -235,6 +235,8 @@ export interface ITerminalInstance {
 
 	onProcessIdReady: Event<ITerminalInstance>;
 
+	processReady: TPromise<void>;
+
 	/**
 	 * The title of the terminal. This is either title or the process currently running or an
 	 * explicit name given to the terminal instance through the extension API.

--- a/src/vs/workbench/parts/terminal/common/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/common/terminalService.ts
@@ -24,6 +24,7 @@ export abstract class TerminalService implements ITerminalService {
 	protected _terminalContainer: HTMLElement;
 	protected _onInstancesChanged: Emitter<void>;
 	protected _onTabDisposed: Emitter<ITerminalTab>;
+	protected _onInstanceCreated: Emitter<ITerminalInstance>;
 	protected _onInstanceDisposed: Emitter<ITerminalInstance>;
 	protected _onInstanceProcessIdReady: Emitter<ITerminalInstance>;
 	protected _onInstanceTitleChanged: Emitter<string>;
@@ -36,6 +37,7 @@ export abstract class TerminalService implements ITerminalService {
 	public get activeTabIndex(): number { return this._activeTabIndex; }
 	public get onActiveTabChanged(): Event<void> { return this._onActiveTabChanged.event; }
 	public get onTabDisposed(): Event<ITerminalTab> { return this._onTabDisposed.event; }
+	public get onInstanceCreated(): Event<ITerminalInstance> { return this._onInstanceCreated.event; }
 	public get onInstanceDisposed(): Event<ITerminalInstance> { return this._onInstanceDisposed.event; }
 	public get onInstanceProcessIdReady(): Event<ITerminalInstance> { return this._onInstanceProcessIdReady.event; }
 	public get onInstanceTitleChanged(): Event<string> { return this._onInstanceTitleChanged.event; }
@@ -57,6 +59,7 @@ export abstract class TerminalService implements ITerminalService {
 
 		this._onActiveTabChanged = new Emitter<void>();
 		this._onTabDisposed = new Emitter<ITerminalTab>();
+		this._onInstanceCreated = new Emitter<ITerminalInstance>();
 		this._onInstanceDisposed = new Emitter<ITerminalInstance>();
 		this._onInstanceProcessIdReady = new Emitter<ITerminalInstance>();
 		this._onInstanceTitleChanged = new Emitter<string>();

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -107,7 +107,9 @@ export class TerminalInstance implements ITerminalInstance {
 
 	public disableLayout: boolean;
 	public get id(): number { return this._id; }
+	// TODO: Ideally processId would be merged into processReady
 	public get processId(): number { return this._processId; }
+	public get processReady(): TPromise<void> { return this._processReady; }
 	public get onDisposed(): Event<ITerminalInstance> { return this._onDisposed.event; }
 	public get onFocused(): Event<ITerminalInstance> { return this._onFocused.event; }
 	public get onProcessIdReady(): Event<ITerminalInstance> { return this._onProcessIdReady.event; }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -82,6 +82,7 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 			// It's the first instance so it should be made active automatically
 			this.setActiveInstanceByIndex(0);
 		}
+		this._onInstanceCreated.fire(instance);
 		this._onInstancesChanged.fire();
 		this._suggestShellChange(wasNewTerminalAction);
 		return instance;

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalTab.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalTab.ts
@@ -402,8 +402,6 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 			shellLaunchConfig);
 		this._terminalInstances.splice(this._activeInstanceIndex + 1, 0, instance);
 		this._initInstanceListeners(instance);
-		// TODO: Ensure change event is fired
-		// TODO: Fire create event on service
 		this._setActiveInstance(instance);
 
 		if (this._splitPaneContainer) {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalTab.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalTab.ts
@@ -402,6 +402,8 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 			shellLaunchConfig);
 		this._terminalInstances.splice(this._activeInstanceIndex + 1, 0, instance);
 		this._initInstanceListeners(instance);
+		// TODO: Ensure change event is fired
+		// TODO: Fire create event on service
 		this._setActiveInstance(instance);
 
 		if (this._splitPaneContainer) {


### PR DESCRIPTION
New proposed APIs:

```ts
export namespace window {
	/**
	 * The currently active terminals or an empty array.
	 *
	 * @readonly
	 */
	export let terminals: Terminal[];

	/**
	 * An [event](#Event) which fires when a terminal has been created, either through the
	 * [createTerminal](#window.createTerminal) API or commands.
	 */
	export const onDidOpenTerminal: Event<Terminal>;
}
```

Changes to existing behavior:

- `Terminal.name` and `Terminal.processId` can be accessed on a disposed terminal

See usage example at https://github.com/Microsoft/vscode-extension-samples/blob/master/terminal-sample/src/extension.ts

Fixes #13267
Part of #46192

/cc @dbaeumer @weinand @IlyaBiryukov @alpaix