### PR TITLE
CodeActionProvider.providedKinds

### DIFF
--- a/extensions/typescript-language-features/src/features/organizeImports.ts
+++ b/extensions/typescript-language-features/src/features/organizeImports.ts
@@ -91,10 +91,15 @@ export class OrganizeImportsContextManager {
 
 
 export class OrganizeImportsCodeActionProvider implements vscode.CodeActionProvider {
+	private static readonly organizeImportsKind = vscode.CodeActionKind.Source.append('organizeImports');
 
 	public constructor(
 		private readonly client: ITypeScriptServiceClient
 	) { }
+
+	public readonly metadata: vscode.CodeActionProviderMetadata = {
+		providedCodeActionKinds: [OrganizeImportsCodeActionProvider.organizeImportsKind]
+	};
 
 	public provideCodeActions(
 		document: vscode.TextDocument,
@@ -110,7 +115,7 @@ export class OrganizeImportsCodeActionProvider implements vscode.CodeActionProvi
 			return [];
 		}
 
-		const action = new vscode.CodeAction(localize('oraganizeImportsAction.title', "Organize Imports"), vscode.CodeActionKind.Source.append('organizeImports'));
+		const action = new vscode.CodeAction(localize('oraganizeImportsAction.title', "Organize Imports"), OrganizeImportsCodeActionProvider.organizeImportsKind);
 		action.command = { title: '', command: OrganizeImportsCommand.Ids[0] };
 		return [action];
 	}

--- a/extensions/typescript-language-features/src/features/refactorProvider.ts
+++ b/extensions/typescript-language-features/src/features/refactorProvider.ts
@@ -96,7 +96,9 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 		commandManager.register(new SelectRefactorCommand(doRefactoringCommand));
 	}
 
-	public readonly providedKinds = [vscode.CodeActionKind.Refactor];
+	public readonly metadata: vscode.CodeActionProviderMetadata = {
+		providedCodeActionKinds: [vscode.CodeActionKind.Refactor]
+	};
 
 	public async provideCodeActions(
 		document: vscode.TextDocument,

--- a/extensions/typescript-language-features/src/features/refactorProvider.ts
+++ b/extensions/typescript-language-features/src/features/refactorProvider.ts
@@ -96,6 +96,8 @@ export default class TypeScriptRefactorProvider implements vscode.CodeActionProv
 		commandManager.register(new SelectRefactorCommand(doRefactoringCommand));
 	}
 
+	public readonly providedKinds = [vscode.CodeActionKind.Refactor];
+
 	public async provideCodeActions(
 		document: vscode.TextDocument,
 		_range: vscode.Range,

--- a/extensions/typescript-language-features/src/languageProvider.ts
+++ b/extensions/typescript-language-features/src/languageProvider.ts
@@ -119,8 +119,12 @@ export default class LanguageProvider {
 		this.disposables.push(languages.registerSignatureHelpProvider(selector, new (await import('./features/signatureHelpProvider')).default(client), '(', ','));
 		this.disposables.push(languages.registerRenameProvider(selector, new (await import('./features/renameProvider')).default(client)));
 		this.disposables.push(languages.registerCodeActionsProvider(selector, new (await import('./features/quickFixProvider')).default(client, this.formattingOptionsManager, commandManager, this.diagnosticsManager, this.bufferSyncSupport)));
-		this.disposables.push(languages.registerCodeActionsProvider(selector, new (await import('./features/refactorProvider')).default(client, this.formattingOptionsManager, commandManager)));
-		this.disposables.push(languages.registerCodeActionsProvider(selector, new (await import('./features/organizeImports')).OrganizeImportsCodeActionProvider(client)));
+
+		const refactorProvider = new (await import('./features/refactorProvider')).default(client, this.formattingOptionsManager, commandManager);
+		this.disposables.push(languages.registerCodeActionsProvider(selector, refactorProvider, refactorProvider.metadata));
+
+		const organizeImportsProvider = new (await import('./features/organizeImports')).OrganizeImportsCodeActionProvider(client);
+		this.disposables.push(languages.registerCodeActionsProvider(selector, organizeImportsProvider, organizeImportsProvider.metadata));
 
 		await this.initFoldingProvider();
 		this.disposables.push(workspace.onDidChangeConfiguration(c => {

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -368,7 +368,7 @@ export interface CodeActionProvider {
 	/**
 	 * Optional list of of CodeActionKinds that this provider returns.
 	 */
-	providedKinds?: string[];
+	providedCodeActionKinds?: string[];
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -364,6 +364,11 @@ export interface CodeActionProvider {
 	 * Provide commands for the given document and range.
 	 */
 	provideCodeActions(model: model.ITextModel, range: Range, context: CodeActionContext, token: CancellationToken): CodeAction[] | Thenable<CodeAction[]>;
+
+	/**
+	 * Optional list of of CodeActionKinds that this provider returns.
+	 */
+	providedKinds?: string[];
 }
 
 /**

--- a/src/vs/editor/contrib/quickFix/quickFixCommands.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixCommands.ts
@@ -25,7 +25,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { CodeActionAutoApply, CodeActionFilter, CodeActionKind } from './codeActionTrigger';
 import { LightBulbWidget } from './lightBulbWidget';
-import { QuickFixComputeEvent, QuickFixModel, HAS_REFACTOR_PROVIDER } from './quickFixModel';
+import { QuickFixComputeEvent, QuickFixModel, HAS_REFACTOR_PROVIDER, HAS_SOURCE_ACTION_PROVIDER } from './quickFixModel';
 import { QuickFixContextMenu } from './quickFixWidget';
 
 export class QuickFixController implements IEditorContribution {
@@ -274,7 +274,9 @@ export class SourceAction extends EditorAction {
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider),
 			menuOpts: {
 				group: '1_modification',
-				order: 2.1
+				order: 2.1,
+				when: ContextKeyExpr.and(EditorContextKeys.writable, HAS_SOURCE_ACTION_PROVIDER),
+
 			}
 		});
 	}

--- a/src/vs/editor/contrib/quickFix/quickFixCommands.ts
+++ b/src/vs/editor/contrib/quickFix/quickFixCommands.ts
@@ -25,7 +25,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { CodeActionAutoApply, CodeActionFilter, CodeActionKind } from './codeActionTrigger';
 import { LightBulbWidget } from './lightBulbWidget';
-import { QuickFixComputeEvent, QuickFixModel } from './quickFixModel';
+import { QuickFixComputeEvent, QuickFixModel, HAS_REFACTOR_PROVIDER } from './quickFixModel';
 import { QuickFixContextMenu } from './quickFixWidget';
 
 export class QuickFixController implements IEditorContribution {
@@ -52,7 +52,7 @@ export class QuickFixController implements IEditorContribution {
 		@optional(IFileService) private _fileService: IFileService
 	) {
 		this._editor = editor;
-		this._model = new QuickFixModel(this._editor, markerService);
+		this._model = new QuickFixModel(this._editor, markerService, contextKeyService);
 		this._quickFixContextMenu = new QuickFixContextMenu(editor, contextMenuService, action => this._onApplyCodeAction(action));
 		this._lightBulbWidget = new LightBulbWidget(editor);
 
@@ -247,7 +247,8 @@ export class RefactorAction extends EditorAction {
 			},
 			menuOpts: {
 				group: '1_modification',
-				order: 2
+				order: 2,
+				when: ContextKeyExpr.and(EditorContextKeys.writable, HAS_REFACTOR_PROVIDER),
 			}
 		});
 	}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2034,7 +2034,6 @@ declare module 'vscode' {
 	 * A code action can be any command that is [known](#commands.getCommands) to the system.
 	 */
 	export interface CodeActionProvider {
-
 		/**
 		 * Provide commands for the given document and range.
 		 *
@@ -2046,6 +2045,14 @@ declare module 'vscode' {
 		 * signaled by returning `undefined`, `null`, or an empty array.
 		 */
 		provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | CodeAction)[]>;
+
+		/**
+		 * [CodeActionKinds](#CodeActionKind) that this provider may return.
+		 *
+		 * The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the provider
+		 * may list our every specific kind they provide, such as `CodeActionKind.Refactor.Extract.append('function`)`
+		 */
+		readonly providedKinds?: CodeActionKind[];
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2045,14 +2045,19 @@ declare module 'vscode' {
 		 * signaled by returning `undefined`, `null`, or an empty array.
 		 */
 		provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken): ProviderResult<(Command | CodeAction)[]>;
+	}
 
+	/**
+	 * Metadata about the type of code actions that a [CodeActionProvider](#CodeActionProvider) providers
+	 */
+	export interface CodeActionProviderMetadata {
 		/**
 		 * [CodeActionKinds](#CodeActionKind) that this provider may return.
 		 *
 		 * The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the provider
 		 * may list our every specific kind they provide, such as `CodeActionKind.Refactor.Extract.append('function`)`
 		 */
-		readonly providedKinds?: CodeActionKind[];
+		readonly providedCodeActionKinds?: CodeActionKind[];
 	}
 
 	/**
@@ -6130,9 +6135,10 @@ declare module 'vscode' {
 		 *
 		 * @param selector A selector that defines the documents this provider is applicable to.
 		 * @param provider A code action provider.
+		 * @param metadata Metadata about the kind of code actions the provider providers.
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
-		export function registerCodeActionsProvider(selector: DocumentSelector, provider: CodeActionProvider): Disposable;
+		export function registerCodeActionsProvider(selector: DocumentSelector, provider: CodeActionProvider, metadata?: CodeActionProviderMetadata): Disposable;
 
 		/**
 		 * Register a code lens provider.

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -191,11 +191,12 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	// --- quick fix
 
-	$registerQuickFixSupport(handle: number, selector: ISerializedDocumentFilter[]): void {
+	$registerQuickFixSupport(handle: number, selector: ISerializedDocumentFilter[], providedKinds?: string[]): void {
 		this._registrations[handle] = modes.CodeActionProviderRegistry.register(toLanguageSelector(selector), <modes.CodeActionProvider>{
 			provideCodeActions: (model: ITextModel, range: EditorRange, context: modes.CodeActionContext, token: CancellationToken): Thenable<modes.CodeAction[]> => {
 				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range, context))).then(MainThreadLanguageFeatures._reviveCodeActionDto);
-			}
+			},
+			providedKinds
 		});
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -191,12 +191,12 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 
 	// --- quick fix
 
-	$registerQuickFixSupport(handle: number, selector: ISerializedDocumentFilter[], providedKinds?: string[]): void {
+	$registerQuickFixSupport(handle: number, selector: ISerializedDocumentFilter[], providedCodeActionKinds?: string[]): void {
 		this._registrations[handle] = modes.CodeActionProviderRegistry.register(toLanguageSelector(selector), <modes.CodeActionProvider>{
 			provideCodeActions: (model: ITextModel, range: EditorRange, context: modes.CodeActionContext, token: CancellationToken): Thenable<modes.CodeAction[]> => {
 				return this._heapService.trackRecursive(wireCancellationToken(token, this._proxy.$provideCodeActions(handle, model.uri, range, context))).then(MainThreadLanguageFeatures._reviveCodeActionDto);
 			},
-			providedKinds
+			providedCodeActionKinds
 		});
 	}
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -271,8 +271,8 @@ export function createApiFactory(
 			match(selector: vscode.DocumentSelector, document: vscode.TextDocument): number {
 				return score(toLanguageSelector(selector), document.uri, document.languageId, true);
 			},
-			registerCodeActionsProvider(selector: vscode.DocumentSelector, provider: vscode.CodeActionProvider): vscode.Disposable {
-				return extHostLanguageFeatures.registerCodeActionProvider(checkSelector(selector), provider);
+			registerCodeActionsProvider(selector: vscode.DocumentSelector, provider: vscode.CodeActionProvider, metadata?: vscode.CodeActionProviderMetadata): vscode.Disposable {
+				return extHostLanguageFeatures.registerCodeActionProvider(checkSelector(selector), provider, metadata);
 			},
 			registerCodeLensProvider(selector: vscode.DocumentSelector, provider: vscode.CodeLensProvider): vscode.Disposable {
 				return extHostLanguageFeatures.registerCodeLensProvider(checkSelector(selector), provider);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -273,7 +273,7 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerHoverProvider(handle: number, selector: ISerializedDocumentFilter[]): void;
 	$registerDocumentHighlightProvider(handle: number, selector: ISerializedDocumentFilter[]): void;
 	$registerReferenceSupport(handle: number, selector: ISerializedDocumentFilter[]): void;
-	$registerQuickFixSupport(handle: number, selector: ISerializedDocumentFilter[]): void;
+	$registerQuickFixSupport(handle: number, selector: ISerializedDocumentFilter[], supportedKinds?: string[]): void;
 	$registerDocumentFormattingSupport(handle: number, selector: ISerializedDocumentFilter[]): void;
 	$registerRangeFormattingSupport(handle: number, selector: ISerializedDocumentFilter[]): void;
 	$registerOnTypeFormattingSupport(handle: number, selector: ISerializedDocumentFilter[], autoFormatTriggerCharacters: string[]): void;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -1015,7 +1015,7 @@ export class ExtHostLanguageFeatures implements ExtHostLanguageFeaturesShape {
 
 	registerCodeActionProvider(selector: vscode.DocumentSelector, provider: vscode.CodeActionProvider): vscode.Disposable {
 		const handle = this._addNewAdapter(new CodeActionAdapter(this._documents, this._commands.converter, this._diagnostics, provider));
-		this._proxy.$registerQuickFixSupport(handle, this._transformDocumentSelector(selector));
+		this._proxy.$registerQuickFixSupport(handle, this._transformDocumentSelector(selector), provider.providedKinds ? provider.providedKinds.map(kind => kind.value) : undefined);
 		return this._createDisposable(handle);
 	}
 

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -1013,9 +1013,9 @@ export class ExtHostLanguageFeatures implements ExtHostLanguageFeaturesShape {
 
 	// --- quick fix
 
-	registerCodeActionProvider(selector: vscode.DocumentSelector, provider: vscode.CodeActionProvider): vscode.Disposable {
+	registerCodeActionProvider(selector: vscode.DocumentSelector, provider: vscode.CodeActionProvider, metadata?: vscode.CodeActionProviderMetadata): vscode.Disposable {
 		const handle = this._addNewAdapter(new CodeActionAdapter(this._documents, this._commands.converter, this._diagnostics, provider));
-		this._proxy.$registerQuickFixSupport(handle, this._transformDocumentSelector(selector), provider.providedKinds ? provider.providedKinds.map(kind => kind.value) : undefined);
+		this._proxy.$registerQuickFixSupport(handle, this._transformDocumentSelector(selector), metadata && metadata.providedCodeActionKinds ? metadata.providedCodeActionKinds.map(kind => kind.value) : undefined);
 		return this._createDisposable(handle);
 	}
 


### PR DESCRIPTION
Adds a new optinal `providedKinds` property on `CodeActionProvider`. This is a list of `CodeActionKinds` that the provider may return. The list will be used for deciding when to show the `refactor` and `source action` context menus. It is not used for filtering the returned code actions

Possibly helps address #45383