### PR TITLE
Allow customization of the viewlets in the default Extensions view

### DIFF
--- a/src/vs/workbench/browser/parts/views/views.ts
+++ b/src/vs/workbench/browser/parts/views/views.ts
@@ -320,26 +320,17 @@ export class ContributableViewsModel extends Disposable {
 	}
 
 	private compareViewDescriptors(a: IViewDescriptor, b: IViewDescriptor): number {
-		const viewStateA = this.viewStates.get(a.id);
-		const viewStateB = this.viewStates.get(b.id);
-
-		let orderA = viewStateA && viewStateA.order;
-		orderA = typeof orderA === 'number' ? orderA : a.order;
-		orderA = typeof orderA === 'number' ? orderA : Number.POSITIVE_INFINITY;
-
-		let orderB = viewStateB && viewStateB.order;
-		orderB = typeof orderB === 'number' ? orderB : b.order;
-		orderB = typeof orderB === 'number' ? orderB : Number.POSITIVE_INFINITY;
-
-		if (orderA !== orderB) {
-			return orderA - orderB;
-		}
-
 		if (a.id === b.id) {
 			return 0;
 		}
 
-		return a.id < b.id ? -1 : 1;
+		return (this.getViewOrder(a) - this.getViewOrder(b)) || (a.id < b.id ? -1 : 1);
+	}
+
+	private getViewOrder(viewDescriptor: IViewDescriptor): number {
+		const viewState = this.viewStates.get(viewDescriptor.id);
+		const viewOrder = viewState && typeof viewState.order === 'number' ? viewState.order : viewDescriptor.order;
+		return typeof viewOrder === 'number' ? viewOrder : Number.MAX_VALUE;
 	}
 
 	private onDidChangeViewDescriptors(viewDescriptors: IViewDescriptor[]): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -32,7 +32,7 @@ import {
 } from 'vs/workbench/parts/extensions/browser/extensionsActions';
 import { LocalExtensionType, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionsInput } from 'vs/workbench/parts/extensions/common/extensionsInput';
-import { ExtensionsListView, InstalledExtensionsView, RecommendedExtensionsView, WorkspaceRecommendedExtensionsView, BuiltInExtensionsView, BuiltInThemesExtensionsView, BuiltInBasicsExtensionsView } from './extensionsViews';
+import { ExtensionsListView, InstalledExtensionsView, EnabledExtensionsView, DisabledExtensionsView, RecommendedExtensionsView, WorkspaceRecommendedExtensionsView, BuiltInExtensionsView, BuiltInThemesExtensionsView, BuiltInBasicsExtensionsView } from './extensionsViews';
 import { OpenGlobalSettingsAction } from 'vs/workbench/parts/preferences/browser/preferencesActions';
 import { IProgressService } from 'vs/platform/progress/common/progress';
 import { IEditorGroupsService } from 'vs/workbench/services/group/common/editorGroupsService';
@@ -78,6 +78,8 @@ export class ExtensionsViewletViewsContribution implements IWorkbenchContributio
 		let viewDescriptors = [];
 		viewDescriptors.push(this.createMarketPlaceExtensionsListViewDescriptor());
 		viewDescriptors.push(this.createInstalledExtensionsListViewDescriptor());
+		viewDescriptors.push(this.createEnabledExtensionsListViewDescriptor());
+		viewDescriptors.push(this.createDisabledExtensionsListViewDescriptor());
 		viewDescriptors.push(this.createSearchInstalledExtensionsListViewDescriptor());
 		viewDescriptors.push(this.createSearchBuiltInExtensionsListViewDescriptor());
 		viewDescriptors.push(this.createSearchBuiltInBasicsExtensionsListViewDescriptor());
@@ -108,6 +110,34 @@ export class ExtensionsViewletViewsContribution implements IWorkbenchContributio
 			when: ContextKeyExpr.and(ContextKeyExpr.not('donotshowExtensions'), ContextKeyExpr.not('searchExtensions')),
 			order: 1,
 			weight: 30
+		};
+	}
+
+	private createEnabledExtensionsListViewDescriptor(): IViewDescriptor {
+		return {
+			id: 'extensions.enabledList',
+			name: localize('enabledExtensions', "Enabled"),
+			container: VIEW_CONTAINER,
+			ctor: EnabledExtensionsView,
+			when: ContextKeyExpr.and(ContextKeyExpr.not('searchExtensions')),
+			weight: 30,
+			canToggleVisibility: true,
+			order: 30,
+			collapsed: true
+		};
+	}
+
+	private createDisabledExtensionsListViewDescriptor(): IViewDescriptor {
+		return {
+			id: 'extensions.disabledList',
+			name: localize('disabledExtensions', "Disabled"),
+			container: VIEW_CONTAINER,
+			ctor: DisabledExtensionsView,
+			when: ContextKeyExpr.and(ContextKeyExpr.not('searchExtensions')),
+			weight: 30,
+			canToggleVisibility: true,
+			order: 40,
+			collapsed: true
 		};
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -109,7 +109,8 @@ export class ExtensionsViewletViewsContribution implements IWorkbenchContributio
 			ctor: InstalledExtensionsView,
 			when: ContextKeyExpr.and(ContextKeyExpr.not('donotshowExtensions'), ContextKeyExpr.not('searchExtensions')),
 			order: 1,
-			weight: 30
+			weight: 30,
+			canToggleVisibility: true
 		};
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -598,22 +598,14 @@ export class InstalledExtensionsView extends ExtensionsListView {
 export class EnabledExtensionsView extends ExtensionsListView {
 
 	async show(query: string): TPromise<IPagedModel<IExtension>> {
-		const queryEnabled = '@enabled';
-		if (!query || ExtensionsListView.isEnabledExtensionsQuery(query)) {
-			return super.show(queryEnabled);
-		}
-		return super.show(queryEnabled + ' ' + query);
+		return super.show('@enabled');
 	}
 }
 
 export class DisabledExtensionsView extends ExtensionsListView {
 
 	async show(query: string): TPromise<IPagedModel<IExtension>> {
-		const queryDisabled = '@disabled';
-		if (!query || ExtensionsListView.isDisabledExtensionsQuery(query)) {
-			return super.show(queryDisabled);
-		}
-		return super.show(queryDisabled + ' ' + query);
+		return super.show('@disabled');
 	}
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -597,33 +597,23 @@ export class InstalledExtensionsView extends ExtensionsListView {
 
 export class EnabledExtensionsView extends ExtensionsListView {
 
-	public static isEnabledExtensionsQuery(query: string): boolean {
-		return ExtensionsListView.isEnabledExtensionsQuery(query);
-	}
-
 	async show(query: string): TPromise<IPagedModel<IExtension>> {
-		if (EnabledExtensionsView.isEnabledExtensionsQuery(query)) {
-			return super.show(query);
+		const queryEnabled = '@enabled';
+		if (!query || ExtensionsListView.isEnabledExtensionsQuery(query)) {
+			return super.show(queryEnabled);
 		}
-		let searchEnabledQuery = '@enabled';
-		searchEnabledQuery = query ? searchEnabledQuery + ' ' + query : searchEnabledQuery;
-		return super.show(searchEnabledQuery);
+		return super.show(queryEnabled + ' ' + query);
 	}
 }
 
 export class DisabledExtensionsView extends ExtensionsListView {
 
-	public static isDisabledExtensionsQuery(query: string): boolean {
-		return ExtensionsListView.isDisabledExtensionsQuery(query);
-	}
-
 	async show(query: string): TPromise<IPagedModel<IExtension>> {
-		if (DisabledExtensionsView.isDisabledExtensionsQuery(query)) {
-			return super.show(query);
+		const queryDisabled = '@disabled';
+		if (!query || ExtensionsListView.isDisabledExtensionsQuery(query)) {
+			return super.show(queryDisabled);
 		}
-		let searchDisabledQuery = '@disabled';
-		searchDisabledQuery = query ? searchDisabledQuery + ' ' + query : searchDisabledQuery;
-		return super.show(searchDisabledQuery);
+		return super.show(queryDisabled + ' ' + query);
 	}
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -236,9 +236,7 @@ export class ExtensionsListView extends ViewletPanel {
 
 			const result = local
 				.sort((e1, e2) => e1.displayName.localeCompare(e2.displayName))
-				.filter(e => e.type === LocalExtensionType.User	// exclude disabled builtin extensions
-					&& runningExtensions.every(r => !areSameExtensions(r, e))
-					&& (e.name.toLowerCase().indexOf(value) > -1 || e.displayName.toLowerCase().indexOf(value) > -1));
+				.filter(e => runningExtensions.every(r => !areSameExtensions(r, e)) && (e.name.toLowerCase().indexOf(value) > -1 || e.displayName.toLowerCase().indexOf(value) > -1));
 
 			return new PagedModel(this.sortExtensions(result, options));
 		}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -236,7 +236,9 @@ export class ExtensionsListView extends ViewletPanel {
 
 			const result = local
 				.sort((e1, e2) => e1.displayName.localeCompare(e2.displayName))
-				.filter(e => runningExtensions.every(r => !areSameExtensions(r, e)) && (e.name.toLowerCase().indexOf(value) > -1 || e.displayName.toLowerCase().indexOf(value) > -1));
+				.filter(e => e.type === LocalExtensionType.User	// exclude disabled builtin extensions
+					&& runningExtensions.every(r => !areSameExtensions(r, e))
+					&& (e.name.toLowerCase().indexOf(value) > -1 || e.displayName.toLowerCase().indexOf(value) > -1));
 
 			return new PagedModel(this.sortExtensions(result, options));
 		}
@@ -590,6 +592,38 @@ export class InstalledExtensionsView extends ExtensionsListView {
 		let searchInstalledQuery = '@installed';
 		searchInstalledQuery = query ? searchInstalledQuery + ' ' + query : searchInstalledQuery;
 		return super.show(searchInstalledQuery);
+	}
+}
+
+export class EnabledExtensionsView extends ExtensionsListView {
+
+	public static isEnabledExtensionsQuery(query: string): boolean {
+		return ExtensionsListView.isEnabledExtensionsQuery(query);
+	}
+
+	async show(query: string): TPromise<IPagedModel<IExtension>> {
+		if (EnabledExtensionsView.isEnabledExtensionsQuery(query)) {
+			return super.show(query);
+		}
+		let searchEnabledQuery = '@enabled';
+		searchEnabledQuery = query ? searchEnabledQuery + ' ' + query : searchEnabledQuery;
+		return super.show(searchEnabledQuery);
+	}
+}
+
+export class DisabledExtensionsView extends ExtensionsListView {
+
+	public static isDisabledExtensionsQuery(query: string): boolean {
+		return ExtensionsListView.isDisabledExtensionsQuery(query);
+	}
+
+	async show(query: string): TPromise<IPagedModel<IExtension>> {
+		if (DisabledExtensionsView.isDisabledExtensionsQuery(query)) {
+			return super.show(query);
+		}
+		let searchDisabledQuery = '@disabled';
+		searchDisabledQuery = query ? searchDisabledQuery + ' ' + query : searchDisabledQuery;
+		return super.show(searchDisabledQuery);
 	}
 }
 


### PR DESCRIPTION
When there're lots of extensions installed, and many of them disabled, it's kinda messy to have all the enabled/disabled extensions mixed in one list.

It's more clean to separate the disabled extensions into a dedicated list view:

<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img src="https://user-images.githubusercontent.com/610161/38725878-2f9ee5c4-3f3b-11e8-898e-dafd535bb5b4.png" width="300px"/></td>
<td><img src="https://user-images.githubusercontent.com/610161/38725747-e42fd6f2-3f3a-11e8-9ec9-76e1823e5630.png" width="300px"/>
</td></tr></table>