### PR TITLE
Exclude yarn-error from hygiene

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -61,6 +61,7 @@ const indentationFilter = [
 	// except multiple specific files
 	'!**/package.json',
 	'!**/yarn.lock',
+	'!**/yarn-error.log',
 
 	// except multiple specific folders
 	'!**/octicons/**',


### PR DESCRIPTION
@joaomoreno Just fyi. The hygiene checking was failing due to `yarn-error.log` in my Workspace, but it's already excluded from .gitignore.