### PR TITLE
 set background-color explicitly instead of shorthand declaration #47752

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -925,7 +925,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	if (tabHoverBackground) {
 		collector.addRule(`
 			.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title.active .tabs-container > .tab:hover  {
-				background: ${tabHoverBackground} !important;
+				background-color: ${tabHoverBackground} !important;
 			}
 		`);
 	}
@@ -934,7 +934,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	if (tabUnfocusedHoverBackground) {
 		collector.addRule(`
 			.monaco-workbench > .part.editor > .content > .one-editor-silo > .container > .title.inactive .tabs-container > .tab:hover  {
-				background: ${tabUnfocusedHoverBackground} !important;
+				background-color: ${tabUnfocusedHoverBackground} !important;
 			}
 		`);
 	}


### PR DESCRIPTION
see #47752. `background` shorthand has a side effect of setting all `background` properties including resetting `background-image`, which is set for dirty tabs.

Before:
<img width="860" alt="screen shot 2018-04-13 at 00 08 07" src="https://user-images.githubusercontent.com/927591/38707380-73cdfc38-3eb1-11e8-8615-b1cd59c0386c.png">

After: 
<img width="846" alt="screen shot 2018-04-13 at 00 08 46" src="https://user-images.githubusercontent.com/927591/38707385-76506e00-3eb1-11e8-9f18-bc4381c793b1.png">