### PR TITLE
implement push success notification for issue #39039

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -966,6 +966,11 @@
           "default": true,
           "description": "%config.showInlineOpenFileAction%"
         },
+        "git.showPushSuccessNotification": {
+          "type": "boolean",
+          "description": "%config.showPushSuccessNotification%",
+          "default": false
+        },
         "git.inputValidation": {
           "type": "string",
           "enum": [

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -68,6 +68,7 @@
 	"config.decorations.enabled": "Controls if Git contributes colors and badges to the explorer and the open editors view.",
 	"config.promptToSaveFilesBeforeCommit": "Controls whether Git should check for unsaved files before committing.",
 	"config.showInlineOpenFileAction": "Controls whether to show an inline Open File action in the Git changes view.",
+	"config.showPushSuccessNotification": "Controls whether to show a notification when a push is successful.",
 	"config.inputValidation": "Controls when to show commit message input validation.",
 	"config.detectSubmodules": "Controls whether to automatically detect git submodules.",
 	"config.detectSubmodulesLimit": "Controls the limit of git submodules detected.",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1376,6 +1376,10 @@ export class CommandCenter {
 
 		try {
 			await repository.push(repository.HEAD);
+			const gitConfig = workspace.getConfiguration('git');
+			if (gitConfig.get<boolean>('showPushSuccessNotification')) {
+				window.showInformationMessage(localize('push success', "Successfully pushed."));
+			}
 		} catch (err) {
 			if (err.gitErrorCode !== GitErrorCodes.NoUpstreamBranch) {
 				throw err;


### PR DESCRIPTION
My friend (@ylingene) and I worked on issue #39039.  We didn't implement anything to show if the push failed because error messages already show on failure.

Test plan:
1. Set git.showPushSuccessNotification to true in settings
![push_1](https://user-images.githubusercontent.com/15807050/38711389-61eb8d14-3e93-11e8-91d6-66e80f6d3661.PNG)

2. Make changes to file, commit the file, and push
![push_2](https://user-images.githubusercontent.com/15807050/38711402-7778f23e-3e93-11e8-8ef3-620e5f1b0566.PNG)

3. Delete git.showPushSuccessNotification from settings (default value is false, as shown in step 1 screenshot)
![push_3](https://user-images.githubusercontent.com/15807050/38711416-8db05e98-3e93-11e8-8259-77a0b25cd8fb.PNG)

4. Make changes to file, commit the file, and push (no notification)
![push_4](https://user-images.githubusercontent.com/15807050/38711425-99a741da-3e93-11e8-805e-0b88d88173b7.PNG)

5. Change file in remote to cause merge conflict

6. Set git.showPushSuccessNotification to true in settings, make changes to file, commit the file, and push (no notification)
![push_5](https://user-images.githubusercontent.com/15807050/38711452-c309f0fe-3e93-11e8-87b2-631c727640a5.PNG)
