### PR TITLE
add tooltips to extension navbar

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -101,9 +101,13 @@ class NavBar {
 		this.actionbar = new ActionBar(element, { animated: false });
 	}
 
-	push(id: string, label: string): void {
+	push(id: string, label: string, tooltip: string): void {
 		const run = () => this._update(id);
 		const action = new Action(id, label, null, true, run);
+
+		if (!action.tooltip) {
+			action.tooltip = tooltip;
+		}
 
 		this.actions.push(action);
 		this.actionbar.push(action);
@@ -374,10 +378,10 @@ export class ExtensionEditor extends BaseEditor {
 
 		this.navbar.clear();
 		this.navbar.onChange(this.onNavbarChange.bind(this, extension), this, this.transientDisposables);
-		this.navbar.push(NavbarSection.Readme, localize('details', "Details"));
-		this.navbar.push(NavbarSection.Contributions, localize('contributions', "Contributions"));
-		this.navbar.push(NavbarSection.Changelog, localize('changelog', "Changelog"));
-		this.navbar.push(NavbarSection.Dependencies, localize('dependencies', "Dependencies"));
+		this.navbar.push(NavbarSection.Readme, localize('details', "Details"), localize("detailstooltip", "Extension details"));
+		this.navbar.push(NavbarSection.Contributions, localize('contributions', "Contributions"), localize("contributionstooltip", "Extension modifications"));
+		this.navbar.push(NavbarSection.Changelog, localize('changelog', "Changelog"), localize("changelogtooltip", "Extension change history"));
+		this.navbar.push(NavbarSection.Dependencies, localize('dependencies', "Dependencies"), localize("dependenciestooltip", "Extension dependencies"));
 
 		return super.setInput(input, options);
 	}


### PR DESCRIPTION
Adds tooltips to extension pane navbar, per [#47586](https://github.com/Microsoft/vscode/issues/47586)
![image](https://user-images.githubusercontent.com/25020493/38718440-22b5bd2c-3ebb-11e8-8709-3d5485901f18.png)
