### PR TITLE
Skip quick picker when there is only one task to select from

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -276,6 +276,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'description': nls.localize('enableNaturalLanguageSettingsSearch', "Controls whether to enable the natural language search mode for settings."),
 			'default': true
+		},
+		'workbench.quickOpen.skipTaskQuickOpen': {
+			'type': 'boolean',
+			'description': nls.localize('skipTaskQuickOpen', "Controls whether the quick panel is skipped in conditions when there is only one (build, test, etc...) task to pick from."),
+			'default': false
 		}
 	}
 });

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -276,11 +276,6 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'description': nls.localize('enableNaturalLanguageSettingsSearch', "Controls whether to enable the natural language search mode for settings."),
 			'default': true
-		},
-		'workbench.quickOpen.skipTaskQuickOpen': {
-			'type': 'boolean',
-			'description': nls.localize('skipTaskQuickOpen', "Controls whether the quick panel is skipped in conditions when there is only one (build, test, etc...) task to pick from."),
-			'default': false
 		}
 	}
 });

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1876,23 +1876,27 @@ class TaskService implements ITaskService {
 
 	private doRunTaskCommand(tasks?: Task[]): void {
 		this.showIgnoredFoldersMessage().then(() => {
-			this.showQuickPick(tasks ? tasks : this.tasks(),
-				nls.localize('TaskService.pickRunTask', 'Select the task to run'),
-				{
-					label: nls.localize('TaslService.noEntryToRun', 'No task to run found. Configure Tasks...'),
-					task: null
-				},
-				true).
-				then((task) => {
-					if (task === void 0) {
-						return;
-					}
-					if (task === null) {
-						this.runConfigureTasks();
-					} else {
-						this.run(task, { attachProblemMatcher: true });
-					}
-				});
+			if (tasks && tasks.length === 1) {
+				this.run(tasks[0], { attachProblemMatcher: true });
+			} else {
+				this.showQuickPick(tasks ? tasks : this.tasks(),
+					nls.localize('TaskService.pickRunTask', 'Select the task to run'),
+					{
+						label: nls.localize('TaslService.noEntryToRun', 'No task to run found. Configure Tasks...'),
+						task: null
+					},
+					true).
+					then((task) => {
+						if (task === void 0) {
+							return;
+						}
+						if (task === null) {
+							this.runConfigureTasks();
+						} else {
+							this.run(task, { attachProblemMatcher: true });
+						}
+					});
+			}
 		});
 	}
 
@@ -1935,22 +1939,27 @@ class TaskService implements ITaskService {
 				}
 			}
 			this.showIgnoredFoldersMessage().then(() => {
-				this.showQuickPick(tasks,
-					nls.localize('TaskService.pickBuildTask', 'Select the build task to run'),
-					{
-						label: nls.localize('TaskService.noBuildTask', 'No build task to run found. Configure Build Task...'),
-						task: null
-					},
-					true).then((task) => {
-						if (task === void 0) {
-							return;
-						}
-						if (task === null) {
-							this.runConfigureDefaultBuildTask();
-							return;
-						}
-						this.run(task, { attachProblemMatcher: true });
-					});
+				if (tasks.length === 1) {
+					this.run(tasks[0], { attachProblemMatcher: true });
+				} else {
+					this.showQuickPick(tasks,
+						nls.localize('TaskService.pickBuildTask', 'Select the build task to run'),
+						{
+							label: nls.localize('TaskService.noBuildTask', 'No build task to run found. Configure Build Task...'),
+							task: null
+						},
+						true)
+						.then((task) => {
+							if (task === void 0) {
+								return;
+							}
+							if (task === null) {
+								this.runConfigureDefaultBuildTask();
+								return;
+							}
+							this.run(task, { attachProblemMatcher: true });
+						});
+				}
 			});
 		});
 		this.progressService.withProgress(options, () => promise);
@@ -1979,22 +1988,27 @@ class TaskService implements ITaskService {
 				}
 			}
 			this.showIgnoredFoldersMessage().then(() => {
-				this.showQuickPick(tasks,
-					nls.localize('TaskService.pickTestTask', 'Select the test task to run'),
-					{
-						label: nls.localize('TaskService.noTestTaskTerminal', 'No test task to run found. Configure Tasks...'),
-						task: null
-					}, true
-				).then((task) => {
-					if (task === void 0) {
-						return;
-					}
-					if (task === null) {
-						this.runConfigureTasks();
-						return;
-					}
-					this.run(task);
-				});
+				if (tasks.length === 1) {
+					this.run(tasks[0]);
+				} else {
+					this.showQuickPick(tasks,
+						nls.localize('TaskService.pickTestTask', 'Select the test task to run'),
+						{
+							label: nls.localize('TaskService.noTestTaskTerminal', 'No test task to run found. Configure Tasks...'),
+							task: null
+						},
+						true)
+						.then((task) => {
+							if (task === void 0) {
+								return;
+							}
+							if (task === null) {
+								this.runConfigureTasks();
+								return;
+							}
+							this.run(task);
+						});
+				}
 			});
 		});
 		this.progressService.withProgress(options, () => promise);
@@ -2043,18 +2057,24 @@ class TaskService implements ITaskService {
 			return;
 		}
 		if (this.inTerminal()) {
-			this.showQuickPick(this.getActiveTasks(),
-				nls.localize('TaskService.tastToRestart', 'Select the task to restart'),
-				{
-					label: nls.localize('TaskService.noTaskToRestart', 'No task to restart'),
-					task: null
-				},
-				false, true
-			).then(task => {
-				if (task === void 0 || task === null) {
-					return;
+			this.getActiveTasks().then((tasks) => {
+				if (tasks.length === 1) {
+					this.restart(tasks[0]);
+				} else {
+					this.showQuickPick(tasks,
+						nls.localize('TaskService.tastToRestart', 'Select the task to restart'),
+						{
+							label: nls.localize('TaskService.noTaskToRestart', 'No task to restart'),
+							task: null
+						},
+						false, true)
+						.then(task => {
+							if (task === void 0 || task === null) {
+								return;
+							}
+							this.restart(task);
+						});
 				}
-				this.restart(task);
 			});
 		} else {
 			this.getActiveTasks().then((activeTasks) => {
@@ -2291,18 +2311,24 @@ class TaskService implements ITaskService {
 		if (!this.canRunCommand()) {
 			return;
 		}
-		this.showQuickPick(this.getActiveTasks(),
-			nls.localize('TaskService.pickShowTask', 'Select the task to show its output'),
-			{
-				label: nls.localize('TaskService.noTaskIsRunning', 'No task is running'),
-				task: null
-			},
-			false, true
-		).then((task) => {
-			if (task === void 0 || task === null) {
-				return;
+		this.getActiveTasks().then((tasks) => {
+			if (tasks.length === 1) {
+				this._taskSystem.revealTask(tasks[0]);
+			} else {
+				this.showQuickPick(tasks,
+					nls.localize('TaskService.pickShowTask', 'Select the task to show its output'),
+					{
+						label: nls.localize('TaskService.noTaskIsRunning', 'No task is running'),
+						task: null
+					},
+					false, true)
+					.then((task) => {
+						if (task === void 0 || task === null) {
+							return;
+						}
+						this._taskSystem.revealTask(task);
+					});
 			}
-			this._taskSystem.revealTask(task);
 		});
 	}
 }

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1815,7 +1815,7 @@ class TaskService implements ITaskService {
 	}
 
 	private canSkipPicker(): boolean {
-		return this.configurationService.getValue<any>().tasks.skipPicker;
+		return this.configurationService.getValue<any>().task.skipPicker;
 	}
 
 	private showQuickPick(tasks: TPromise<Task[]> | Task[], placeHolder: string, defaultEntry?: TaskQuickPickEntry, group: boolean = false, sort: boolean = false): TPromise<Task> {
@@ -2367,12 +2367,12 @@ registerSingleton(ITaskService, TaskService);
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
-	id: 'tasks',
+	id: 'task',
 	order: 25,
 	title: nls.localize('tasksConfigurationTitle', "Tasks"),
 	type: 'object',
 	properties: {
-		'tasks.skipPicker': {
+		'task.skipPicker': {
 			'type': 'boolean',
 			'description': nls.localize('skipTaskPicker', "Controls whether the quick panel is skipped in conditions when there is only one (build, test, etc...) task to pick from."),
 			'default': false

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -34,6 +34,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IMarkerService, MarkerStatistics } from 'vs/platform/markers/common/markers';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { IFileService, IFileStat } from 'vs/platform/files/common/files';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
@@ -1814,7 +1815,7 @@ class TaskService implements ITaskService {
 	}
 
 	private canSkipPicker(): boolean {
-		return this.configurationService.getValue<any>().workbench.quickOpen.skipTaskQuickOpen;
+		return this.configurationService.getValue<any>().tasks.skipPicker;
 	}
 
 	private showQuickPick(tasks: TPromise<Task[]> | Task[], placeHolder: string, defaultEntry?: TaskQuickPickEntry, group: boolean = false, sort: boolean = false): TPromise<Task> {
@@ -2362,6 +2363,22 @@ outputChannelRegistry.registerChannel(TaskService.OutputChannelId, TaskService.O
 
 // Task Service
 registerSingleton(ITaskService, TaskService);
+
+// Register configuration
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	id: 'tasks',
+	order: 25,
+	title: nls.localize('tasksConfigurationTitle', "Tasks"),
+	type: 'object',
+	properties: {
+		'tasks.skipPicker': {
+			'type': 'boolean',
+			'description': nls.localize('skipTaskPicker', "Controls whether the quick panel is skipped in conditions when there is only one (build, test, etc...) task to pick from."),
+			'default': false
+		}
+	}
+});
 
 // Register Quick Open
 const quickOpenRegistry = (Registry.as<IQuickOpenRegistry>(QuickOpenExtensions.Quickopen));


### PR DESCRIPTION
I find it particularly annoying when it asks me what to select from when there's only one choice. This skips the quick picker and proceeds directly when there is only one task to choose from.