### PR TITLE
Fix #38321 -- Provide navigation through git merge conflicts with codelens

### DIFF
--- a/extensions/merge-conflict/src/codelensProvider.ts
+++ b/extensions/merge-conflict/src/codelensProvider.ts
@@ -91,6 +91,27 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 2 })), acceptBothCommand),
 				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 3 })), diffCommand)
 			);
+
+			// if there is more than 1 conflict, add a 'next conflict' and 'previous conflict' button
+			if (conflicts.length > 1) {
+
+				let previousConflictCommand: vscode.Command = {
+					command: 'merge-conflict.previous',
+					title: localize('previousConflict', 'Previous Conflict'),
+					arguments: [conflict]
+				};
+
+				let nextConflictCommand: vscode.Command = {
+					command: 'merge-conflict.next',
+					title: localize('nextConflict', 'Next Conflict'),
+					arguments: [conflict]
+				};
+
+				items.push(
+					new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 4 })), previousConflictCommand),
+					new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 5 })), nextConflictCommand)
+				);
+			}
 		});
 
 		return items;


### PR DESCRIPTION
#38321 
It should first be noted that the "next conflict" and "previous conflict" buttons will not be present if there is only **1 merge conflict** in the current file.

It should also be noted that this navigation does not go between files.  For example, if there are 2 conflicts in file **A** and 2 conflicts in file **B**, the **"next conflict"** button will not ever switch between the two files.