### PR TITLE
add support for ignored repositories list #46763

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -987,6 +987,15 @@
           "scope": "resource",
           "default": 10,
           "description": "%config.detectSubmodulesLimit%"
+        },
+        "git.ignoreRepositories": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "scope": "resource",
+          "description": "%config.ignoreRepositories%"
         }
       }
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -71,6 +71,7 @@
 	"config.inputValidation": "Controls when to show commit message input validation.",
 	"config.detectSubmodules": "Controls whether to automatically detect git submodules.",
 	"config.detectSubmodulesLimit": "Controls the limit of git submodules detected.",
+	"config.ignoreRepositories": "List of git repositories to ignore",
 	"colors.modified": "Color for modified resources.",
 	"colors.deleted": "Color for deleted resources.",
 	"colors.untracked": "Color for untracked resources.",

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -190,6 +190,7 @@ export class Model {
 
 		const config = workspace.getConfiguration('git', Uri.file(path));
 		const enabled = config.get<boolean>('enabled') === true;
+		const ignoredRepos = new Set(config.get<Array<string>>('ignoreRepositories'));
 
 		if (!enabled) {
 			return;
@@ -204,6 +205,10 @@ export class Model {
 			const repositoryRoot = Uri.file(rawRoot).fsPath;
 
 			if (this.getRepository(repositoryRoot)) {
+				return;
+			}
+
+			if (ignoredRepos.has(rawRoot)) {
 				return;
 			}
 


### PR DESCRIPTION
Issue #46763 
I added a new configuration property that takes in an array of repo path strings and ignores those repositories, if they exist. A reload is required after editing the settings file for the repo to be ignored.

In the example below, I initially have two repositories open: settings and vscode. Changing the ignoreRepositories property to an array containing the path to the settings repo and then reloading causes it to disappear from the sidebar, leaving only the vscode repo. Changing this back to null (or anything else) brings the settings repo back into view.
![example](https://user-images.githubusercontent.com/17259750/38774791-1715e558-403e-11e8-9b9e-3779315c8496.gif)


