### PR TITLE
Fix #43240 - Fix triple click on extension id selecting extra info

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
@@ -34,6 +34,7 @@
 	flex: 1;
 	padding-left: 20px;
 	overflow: hidden;
+	user-select: text;
 }
 
 .extension-editor > .header > .details > .title {
@@ -77,6 +78,7 @@
 	margin-left: 10px;
 	padding: 0px 4px;
 	border-radius: 4px;
+	user-select: none;
 }
 
 .extension-editor > .header > .details > .subtitle {


### PR DESCRIPTION
Fixes #43240

This PR fixes the the bug where triple clicking on the extension id and copy-pasting it pastes everything after the extension id along with the id.