### PR TITLE
SymbolDefinition API

### DIFF
--- a/extensions/typescript-language-features/src/features/definitionProvider.ts
+++ b/extensions/typescript-language-features/src/features/definitionProvider.ts
@@ -3,12 +3,56 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DefinitionProvider, TextDocument, Position, CancellationToken, Definition } from 'vscode';
+import { DefinitionProvider, TextDocument, Position, CancellationToken, Location, SymbolDefinition } from 'vscode';
+import * as Proto from '../protocol';
 
 import DefinitionProviderBase from './definitionProviderBase';
+import { ITypeScriptServiceClient } from '../typescriptService';
+import * as typeConverters from '../utils/typeConverters';
 
 export default class TypeScriptDefinitionProvider extends DefinitionProviderBase implements DefinitionProvider {
-	public provideDefinition(document: TextDocument, position: Position, token: CancellationToken | boolean): Promise<Definition | undefined> {
+	constructor(
+		client: ITypeScriptServiceClient
+	) {
+		super(client);
+	}
+
+	public async provideDefinition() {
+		// Implemented by provideDefinition2
+		return undefined;
+	}
+
+	public async provideDefinition2(
+		document: TextDocument,
+		position: Position,
+		token: CancellationToken | boolean
+	): Promise<SymbolDefinition | Location[] | undefined> {
+		if (this.client.apiVersion.has270Features()) {
+			const filepath = this.client.normalizePath(document.uri);
+			if (!filepath) {
+				return undefined;
+			}
+
+			const args = typeConverters.Position.toFileLocationRequestArgs(filepath, position);
+			try {
+				const response = await this.client.execute('definitionAndBoundSpan', args, token);
+				const locations: Proto.FileSpan[] = (response && response.body && response.body.definitions) || [];
+				if (!locations) {
+					return [];
+				}
+
+				const span = response.body.textSpan ? typeConverters.Location.fromTextSpan(document.uri, response.body.textSpan) : undefined;
+				return {
+					definingSpan: span,
+					definitions: locations
+						.map(location => typeConverters.Location.fromTextSpan(this.client.asUrl(location.file), location))
+						.filter(x => x) as Location[]
+				};
+			} catch {
+				return [];
+			}
+		}
+
 		return this.getSymbolLocations('definition', document, position, token);
 	}
 }

--- a/extensions/typescript-language-features/src/features/definitionProviderBase.ts
+++ b/extensions/typescript-language-features/src/features/definitionProviderBase.ts
@@ -11,7 +11,7 @@ import * as typeConverters from '../utils/typeConverters';
 
 export default class TypeScriptDefinitionProviderBase {
 	constructor(
-		private readonly client: ITypeScriptServiceClient
+		protected client: ITypeScriptServiceClient
 	) { }
 
 	protected async getSymbolLocations(

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -520,6 +520,10 @@ export interface Location {
 	 */
 	range: IRange;
 }
+export interface SymbolDefinition {
+	definingSpan?: Location;
+	definitions: Location[];
+}
 /**
  * The definition of a symbol represented as one or many [locations](#Location).
  * For most programming languages there is only one location at which a symbol is
@@ -536,7 +540,7 @@ export interface DefinitionProvider {
 	/**
 	 * Provide the definition of the symbol at the given position and document.
 	 */
-	provideDefinition(model: model.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideDefinition(model: model.ITextModel, position: Position, token: CancellationToken): Definition | SymbolDefinition | Thenable<Definition | SymbolDefinition>;
 }
 
 /**

--- a/src/vs/editor/contrib/goToDeclaration/goToDeclaration.ts
+++ b/src/vs/editor/contrib/goToDeclaration/goToDeclaration.ts
@@ -10,7 +10,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { ITextModel } from 'vs/editor/common/model';
 import { registerDefaultLanguageCommand } from 'vs/editor/browser/editorExtensions';
 import LanguageFeatureRegistry from 'vs/editor/common/modes/languageFeatureRegistry';
-import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location, SymbolDefinition } from 'vs/editor/common/modes';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
@@ -20,38 +20,49 @@ function getDefinitions<T>(
 	model: ITextModel,
 	position: Position,
 	registry: LanguageFeatureRegistry<T>,
-	provide: (provider: T, model: ITextModel, position: Position, token: CancellationToken) => Location | Location[] | Thenable<Location | Location[]>
-): TPromise<Location[]> {
+	provide: (provider: T, model: ITextModel, position: Position, token: CancellationToken) => Location | Location[] | SymbolDefinition | Thenable<Location | Location[] | SymbolDefinition>
+): TPromise<SymbolDefinition> {
 	const provider = registry.ordered(model);
+
+	let definingSpan: Location | undefined = undefined;
 
 	// get results
 	const promises = provider.map((provider, idx): TPromise<Location | Location[]> => {
 		return asWinJsPromise((token) => {
 			return provide(provider, model, position, token);
-		}).then(undefined, err => {
+		}).then(result => {
+			if (result && (result as any).definitions) {
+				definingSpan = definingSpan || (result as any).definingSpan;
+				return (result as any).definitions;
+			}
+			return result;
+		}, err => {
 			onUnexpectedExternalError(err);
 			return null;
 		});
 	});
+
 	return TPromise.join(promises)
 		.then(flatten)
-		.then(references => references.filter(x => !!x));
+		.then(references => references.filter(x => !!x))
+		.then((definitions): SymbolDefinition => {
+			return { definingSpan, definitions };
+		});
 }
 
-
-export function getDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<SymbolDefinition> {
 	return getDefinitions(model, position, DefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideDefinition(model, position, token);
 	});
 }
 
-export function getImplementationsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getImplementationsAtPosition(model: ITextModel, position: Position): TPromise<SymbolDefinition> {
 	return getDefinitions(model, position, ImplementationProviderRegistry, (provider, model, position, token) => {
 		return provider.provideImplementation(model, position, token);
 	});
 }
 
-export function getTypeDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getTypeDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<SymbolDefinition> {
 	return getDefinitions(model, position, TypeDefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideTypeDefinition(model, position, token);
 	});

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4743,6 +4743,11 @@ declare namespace monaco.languages {
 		range: IRange;
 	}
 
+	export interface SymbolDefinition {
+		definingSpan?: Location;
+		definitions: Location[];
+	}
+
 	/**
 	 * The definition of a symbol represented as one or many [locations](#Location).
 	 * For most programming languages there is only one location at which a symbol is
@@ -4759,7 +4764,7 @@ declare namespace monaco.languages {
 		/**
 		 * Provide the definition of the symbol at the given position and document.
 		 */
-		provideDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+		provideDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): Definition | SymbolDefinition | Thenable<Definition | SymbolDefinition>;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -870,4 +870,19 @@ declare module 'vscode' {
 	}
 
 	//#endregion
+
+	//#region Defintion symbol range: mjbvz
+
+	export interface SymbolDefinition {
+		definingSpan?: Location;
+
+		definitions: Location[];
+	}
+
+	export interface DefinitionProvider {
+
+		provideDefinition2?(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | SymbolDefinition>;
+	}
+
+	//#endregion
 }

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -649,6 +649,7 @@ export function createApiFactory(
 			CompletionList: extHostTypes.CompletionList,
 			CompletionTriggerKind: extHostTypes.CompletionTriggerKind,
 			DebugAdapterExecutable: extHostTypes.DebugAdapterExecutable,
+			SymbolDefinition: extHostTypes.SymbolDefinition,
 			Diagnostic: extHostTypes.Diagnostic,
 			DiagnosticRelatedInformation: extHostTypes.DiagnosticRelatedInformation,
 			DiagnosticSeverity: extHostTypes.DiagnosticSeverity,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -641,6 +641,11 @@ export interface LocationDto {
 	range: IRange;
 }
 
+export interface SymbolDefinitionDto {
+	definingSpan?: LocationDto;
+	definitions: LocationDto[];
+}
+
 export interface SymbolInformationDto extends IdObject {
 	name: string;
 	containerName?: string;
@@ -696,7 +701,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideDocumentSymbols(handle: number, resource: UriComponents): TPromise<SymbolInformationDto[]>;
 	$provideCodeLenses(handle: number, resource: UriComponents): TPromise<modes.ICodeLensSymbol[]>;
 	$resolveCodeLens(handle: number, resource: UriComponents, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol>;
-	$provideDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
+	$provideDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[] | SymbolDefinitionDto>;
 	$provideImplementation(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
 	$provideTypeDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
 	$provideHover(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.Hover>;

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -4,23 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import * as modes from 'vs/editor/common/modes';
-import * as types from './extHostTypes';
-import { Position as EditorPosition, ITextEditorOptions } from 'vs/platform/editor/common/editor';
-import { IDecorationOptions } from 'vs/editor/common/editorCommon';
-import { EndOfLineSequence } from 'vs/editor/common/model';
-import * as vscode from 'vscode';
+import { IRelativePattern } from 'vs/base/common/glob';
+import * as htmlContent from 'vs/base/common/htmlContent';
 import URI from 'vs/base/common/uri';
-import { ProgressLocation as MainProgressLocation } from 'vs/platform/progress/common/progress';
-import { SaveReason } from 'vs/workbench/services/textfile/common/textfiles';
 import { IPosition } from 'vs/editor/common/core/position';
 import { IRange } from 'vs/editor/common/core/range';
 import { ISelection } from 'vs/editor/common/core/selection';
-import * as htmlContent from 'vs/base/common/htmlContent';
-import { IRelativePattern } from 'vs/base/common/glob';
-import { LanguageSelector, LanguageFilter } from 'vs/editor/common/modes/languageSelector';
-import { WorkspaceEditDto, ResourceTextEditDto } from 'vs/workbench/api/node/extHost.protocol';
-import { MarkerSeverity, IRelatedInformation, IMarkerData } from 'vs/platform/markers/common/markers';
+import { IDecorationOptions } from 'vs/editor/common/editorCommon';
+import { EndOfLineSequence } from 'vs/editor/common/model';
+import * as modes from 'vs/editor/common/modes';
+import { LanguageFilter, LanguageSelector } from 'vs/editor/common/modes/languageSelector';
+import { ITextEditorOptions, Position as EditorPosition } from 'vs/platform/editor/common/editor';
+import { IMarkerData, IRelatedInformation, MarkerSeverity } from 'vs/platform/markers/common/markers';
+import { ProgressLocation as MainProgressLocation } from 'vs/platform/progress/common/progress';
+import { ResourceTextEditDto, WorkspaceEditDto } from 'vs/workbench/api/node/extHost.protocol';
+import { SaveReason } from 'vs/workbench/services/textfile/common/textfiles';
+import * as vscode from 'vscode';
+import * as types from './extHostTypes';
 
 export interface PositionLike {
 	line: number;
@@ -363,6 +363,16 @@ export const location = {
 		return new types.Location(value.uri, toRange(value.range));
 	}
 };
+
+export namespace SymbolDefinition {
+	export function from(value: vscode.SymbolDefinition): modes.SymbolDefinition {
+		const span = value.definingSpan ? location.from(value.definingSpan) : undefined;
+		return {
+			definingSpan: span,
+			definitions: value.definitions.map(location.from)
+		};
+	}
+}
 
 export function fromHover(hover: vscode.Hover): modes.Hover {
 	return <modes.Hover>{

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -739,6 +739,23 @@ export class DiagnosticRelatedInformation {
 	}
 }
 
+export class SymbolDefinition {
+	span: Location;
+	definitions: Location[];
+
+	constructor(span: Location, definitions: Location[]) {
+		this.span = span;
+
+		if (!definitions) {
+			// skip
+		} else if (Array.isArray(definitions)) {
+			this.definitions = definitions;
+		} else {
+			throw new Error('Illegal argument');
+		}
+	}
+}
+
 export class Diagnostic {
 
 	range: Range;

--- a/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostLanguageFeatures.test.ts
@@ -276,8 +276,8 @@ suite('ExtHostLanguageFeatures', function () {
 		return rpcProtocol.sync().then(() => {
 
 			return getDefinitionsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.length, 1);
-				let [entry] = value;
+				assert.equal(value.definitions.length, 1);
+				let [entry] = value.definitions;
 				assert.deepEqual(entry.range, { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 });
 				assert.equal(entry.uri.toString(), model.uri.toString());
 			});
@@ -300,7 +300,7 @@ suite('ExtHostLanguageFeatures', function () {
 		return rpcProtocol.sync().then(() => {
 
 			return getDefinitionsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.length, 2);
+				assert.equal(value.definitions.length, 2);
 			});
 		});
 	});
@@ -322,7 +322,7 @@ suite('ExtHostLanguageFeatures', function () {
 		return rpcProtocol.sync().then(() => {
 
 			return getDefinitionsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.length, 2);
+				assert.equal(value.definitions.length, 2);
 				// let [first, second] = value;
 
 				assert.equal(value[0].uri.authority, 'second');
@@ -347,7 +347,7 @@ suite('ExtHostLanguageFeatures', function () {
 		return rpcProtocol.sync().then(() => {
 
 			return getDefinitionsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.length, 1);
+				assert.equal(value.definitions.length, 1);
 			});
 		});
 	});
@@ -364,8 +364,8 @@ suite('ExtHostLanguageFeatures', function () {
 
 		return rpcProtocol.sync().then(() => {
 			return getImplementationsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.length, 1);
-				let [entry] = value;
+				assert.equal(value.definitions.length, 1);
+				let [entry] = value.definitions;
 				assert.deepEqual(entry.range, { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 });
 				assert.equal(entry.uri.toString(), model.uri.toString());
 			});
@@ -384,8 +384,8 @@ suite('ExtHostLanguageFeatures', function () {
 
 		return rpcProtocol.sync().then(() => {
 			return getTypeDefinitionsAtPosition(model, new EditorPosition(1, 1)).then(value => {
-				assert.equal(value.length, 1);
-				let [entry] = value;
+				assert.equal(value.definitions.length, 1);
+				let [entry] = value.definitions;
 				assert.deepEqual(entry.range, { startLineNumber: 2, startColumn: 3, endLineNumber: 4, endColumn: 5 });
 				assert.equal(entry.uri.toString(), model.uri.toString());
 			});


### PR DESCRIPTION
**Problem**
 #10037  again. 

**Proposal**
Add a new `SymbolDefinition` type to the VSCode API. This bundles up set of definitions and the span of the defining symbol

This PR supersedes #45249 and returns to the approach from #40045
