### PR TITLE
Change Hover#range to be optional

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -230,7 +230,7 @@ export interface Hover {
 	 * editor will use the range at the current position or the
 	 * current position itself.
 	 */
-	range: IRange;
+	range?: IRange;
 }
 
 /**


### PR DESCRIPTION
The docs of `Hover#range` in [monaco.d.ts](https://github.com/Microsoft/vscode/blob/master/src/vs/monaco.d.ts#L4554-L4559) and [modes.ts](https://github.com/Microsoft/vscode/blob/master/src/vs/editor/common/modes.ts#L228-L233) state:

> When missing, the editor will use the range at the current position or the current position itself.

This implies that the `range` field should be optional as it can be missing. When looking at the references to `Hover#range`, we find out that there might pop up warnings in `modesContentHover.ts` when vscode is compiled with `strictNullChecks` later.