### PR TITLE
Use ReadonlyArray for diagnostics returned from new getDiagnostics api

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3728,7 +3728,7 @@ declare module 'vscode' {
 		/**
 		 * An array of resources for which diagnostics have changed.
 		 */
-		readonly uris: Uri[];
+		readonly uris: ReadonlyArray<Uri>;
 	}
 
 	/**
@@ -6108,7 +6108,7 @@ declare module 'vscode' {
 		 * @param resource A resource
 		 * @returns An arrary of [diagnostics](#Diagnostic) objects or an empty array.
 		 */
-		export function getDiagnostics(resource: Uri): Diagnostic[];
+		export function getDiagnostics(resource: Uri): ReadonlyArray<Diagnostic>;
 
 		/**
 		 * Get all diagnostics. *Note* that this includes diagnostics from
@@ -6116,7 +6116,7 @@ declare module 'vscode' {
 		 *
 		 * @returns An array of uri-diagnostics tuples or an empty array.
 		 */
-		export function getDiagnostics(): [Uri, Diagnostic[]][];
+		export function getDiagnostics(): [Uri, ReadonlyArray<Diagnostic>][];
 
 		/**
 		 * Create a diagnostics collection.

--- a/src/vs/workbench/api/node/extHostDiagnostics.ts
+++ b/src/vs/workbench/api/node/extHostDiagnostics.ts
@@ -262,9 +262,9 @@ export class ExtHostDiagnostics implements ExtHostDiagnosticsShape {
 		return result;
 	}
 
-	getDiagnostics(resource: vscode.Uri): vscode.Diagnostic[];
-	getDiagnostics(): [vscode.Uri, vscode.Diagnostic[]][];
-	getDiagnostics(resource?: vscode.Uri): vscode.Diagnostic[] | [vscode.Uri, vscode.Diagnostic[]][] {
+	getDiagnostics(resource: vscode.Uri): ReadonlyArray<vscode.Diagnostic>;
+	getDiagnostics(): [vscode.Uri, ReadonlyArray<vscode.Diagnostic>][];
+	getDiagnostics(resource?: vscode.Uri): ReadonlyArray<vscode.Diagnostic> | [vscode.Uri, ReadonlyArray<vscode.Diagnostic>][] {
 		if (resource) {
 			return this._getDiagnostics(resource);
 		} else {


### PR DESCRIPTION
Just marking these arrays as read only. I believe we freeze them so the results are readonly at runtime