### PR TITLE
Add editor.codeActionsOnSave

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -653,12 +653,18 @@ const editorConfiguration: IConfigurationNode = {
 			'description': nls.localize('codeActions', "Enables the code action lightbulb")
 		},
 		'editor.codeActionsOnSave': {
-			'type': 'array',
-			'items': {
-				'type': 'string'
+			'type': 'object',
+			'properties': {
+				'source.organizeImports': {
+					'type': 'boolean',
+					'description': nls.localize('codeActionsOnSave.organizeImports', "Run organize imports on save?")
+				}
+			},
+			'additionalProperties': {
+				'type': 'boolean'
 			},
 			'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSave,
-			'description': nls.localize('codeActionsOnSave', "List of code actions kinds to be run on save.")
+			'description': nls.localize('codeActionsOnSave', "Code actions kinds to be run on save.")
 		},
 		'editor.selectionClipboard': {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -669,7 +669,7 @@ const editorConfiguration: IConfigurationNode = {
 		'editor.codeActionsOnSaveTimeout': {
 			'type': 'number',
 			'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSaveTimeout,
-			'description': nls.localize('codeActionsOnSaveTimeout', "Timeout for code actions kinds to be run on save.")
+			'description': nls.localize('codeActionsOnSaveTimeout', "Timeout for code actions run on save.")
 		},
 		'editor.selectionClipboard': {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -652,6 +652,14 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.contribInfo.lightbulbEnabled,
 			'description': nls.localize('codeActions', "Enables the code action lightbulb")
 		},
+		'editor.codeActionsOnSave': {
+			'type': 'array',
+			'items': {
+				'type': 'string'
+			},
+			'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSave,
+			'description': nls.localize('codeActionsOnSave', "List of code actions kinds to be run on save.")
+		},
 		'editor.selectionClipboard': {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.contribInfo.selectionClipboard,

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -666,6 +666,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSave,
 			'description': nls.localize('codeActionsOnSave', "Code actions kinds to be run on save.")
 		},
+		'editor.codeActionsOnSaveTimeout': {
+			'type': 'number',
+			'default': EDITOR_DEFAULTS.contribInfo.codeActionsOnSaveTimeout,
+			'description': nls.localize('codeActionsOnSaveTimeout', "Timeout for code actions kinds to be run on save.")
+		},
 		'editor.selectionClipboard': {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.contribInfo.selectionClipboard,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -497,6 +497,10 @@ export interface IEditorOptions {
 	 */
 	lightbulb?: IEditorLightbulbOptions;
 	/**
+	 * Code action kinds to be run on save.
+	 */
+	codeActionsOnSave?: string[];
+	/**
 	 * Enable code folding
 	 * Defaults to true.
 	 */
@@ -850,6 +854,7 @@ export interface EditorContribOptions {
 	readonly find: InternalEditorFindOptions;
 	readonly colorDecorators: boolean;
 	readonly lightbulbEnabled: boolean;
+	readonly codeActionsOnSave: string[];
 }
 
 /**
@@ -1194,6 +1199,7 @@ export class InternalEditorOptions {
 			&& a.matchBrackets === b.matchBrackets
 			&& this._equalFindOptions(a.find, b.find)
 			&& a.colorDecorators === b.colorDecorators
+			&& arrays.equals(a.codeActionsOnSave, b.codeActionsOnSave)
 			&& a.lightbulbEnabled === b.lightbulbEnabled
 		);
 	}
@@ -1406,6 +1412,13 @@ function _stringSet<T>(value: T, defaultValue: T, allowedValues: T[]): T {
 		return defaultValue;
 	}
 	return value;
+}
+
+function _stringArray(value: any, defaultValue: string[]): string[] {
+	if (!Array.isArray(value)) {
+		return defaultValue;
+	}
+	return value.filter(x => typeof x === 'string');
 }
 
 function _clampedInt(value: any, defaultValue: number, minimum: number, maximum: number): number {
@@ -1736,7 +1749,8 @@ export class EditorOptionsValidator {
 			matchBrackets: _boolean(opts.matchBrackets, defaults.matchBrackets),
 			find: find,
 			colorDecorators: _boolean(opts.colorDecorators, defaults.colorDecorators),
-			lightbulbEnabled: _boolean(opts.lightbulb ? opts.lightbulb.enabled : false, defaults.lightbulbEnabled)
+			lightbulbEnabled: _boolean(opts.lightbulb ? opts.lightbulb.enabled : false, defaults.lightbulbEnabled),
+			codeActionsOnSave: _stringArray(opts.codeActionsOnSave, [])
 		};
 	}
 }
@@ -1839,7 +1853,8 @@ export class InternalEditorOptionsFactory {
 				matchBrackets: (accessibilityIsOn ? false : opts.contribInfo.matchBrackets), // DISABLED WHEN SCREEN READER IS ATTACHED
 				find: opts.contribInfo.find,
 				colorDecorators: opts.contribInfo.colorDecorators,
-				lightbulbEnabled: opts.contribInfo.lightbulbEnabled
+				lightbulbEnabled: opts.contribInfo.lightbulbEnabled,
+				codeActionsOnSave: opts.contribInfo.codeActionsOnSave
 			}
 		};
 	}
@@ -2305,6 +2320,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 			globalFindClipboard: false
 		},
 		colorDecorators: true,
-		lightbulbEnabled: true
+		lightbulbEnabled: true,
+		codeActionsOnSave: []
 	},
 };

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -509,6 +509,10 @@ export interface IEditorOptions {
 	 */
 	codeActionsOnSave?: ICodeActionsOnSaveOptions;
 	/**
+	 * Timeout for running code actions on save.
+	 */
+	codeActionsOnSaveTimeout?: number;
+	/**
 	 * Enable code folding
 	 * Defaults to true.
 	 */
@@ -863,6 +867,7 @@ export interface EditorContribOptions {
 	readonly colorDecorators: boolean;
 	readonly lightbulbEnabled: boolean;
 	readonly codeActionsOnSave: ICodeActionsOnSaveOptions;
+	readonly codeActionsOnSaveTimeout: number;
 }
 
 /**
@@ -1208,6 +1213,7 @@ export class InternalEditorOptions {
 			&& this._equalFindOptions(a.find, b.find)
 			&& a.colorDecorators === b.colorDecorators
 			&& objects.equals(a.codeActionsOnSave, b.codeActionsOnSave)
+			&& a.codeActionsOnSaveTimeout === b.codeActionsOnSaveTimeout
 			&& a.lightbulbEnabled === b.lightbulbEnabled
 		);
 	}
@@ -1766,7 +1772,8 @@ export class EditorOptionsValidator {
 			find: find,
 			colorDecorators: _boolean(opts.colorDecorators, defaults.colorDecorators),
 			lightbulbEnabled: _boolean(opts.lightbulb ? opts.lightbulb.enabled : false, defaults.lightbulbEnabled),
-			codeActionsOnSave: _booleanMap(opts.codeActionsOnSave, {})
+			codeActionsOnSave: _booleanMap(opts.codeActionsOnSave, {}),
+			codeActionsOnSaveTimeout: _clampedInt(opts.codeActionsOnSaveTimeout, defaults.codeActionsOnSaveTimeout, 1, 10000)
 		};
 	}
 }
@@ -1870,7 +1877,8 @@ export class InternalEditorOptionsFactory {
 				find: opts.contribInfo.find,
 				colorDecorators: opts.contribInfo.colorDecorators,
 				lightbulbEnabled: opts.contribInfo.lightbulbEnabled,
-				codeActionsOnSave: opts.contribInfo.codeActionsOnSave
+				codeActionsOnSave: opts.contribInfo.codeActionsOnSave,
+				codeActionsOnSaveTimeout: opts.contribInfo.codeActionsOnSaveTimeout
 			}
 		};
 	}
@@ -2337,6 +2345,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 		},
 		colorDecorators: true,
 		lightbulbEnabled: true,
-		codeActionsOnSave: {}
+		codeActionsOnSave: {},
+		codeActionsOnSaveTimeout: 750
 	},
 };

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -11,6 +11,7 @@ import { FontInfo } from 'vs/editor/common/config/fontInfo';
 import { Constants } from 'vs/editor/common/core/uint';
 import { USUAL_WORD_SEPARATORS } from 'vs/editor/common/model/wordHelper';
 import * as arrays from 'vs/base/common/arrays';
+import * as objects from 'vs/base/common/objects';
 
 /**
  * Configuration options for editor scrollbars
@@ -134,6 +135,13 @@ export interface IEditorLightbulbOptions {
 	 * Defaults to true.
 	 */
 	enabled?: boolean;
+}
+
+/**
+ * Configuration map for codeActionsOnSave
+ */
+export interface ICodeActionsOnSaveOptions {
+	[kind: string]: boolean;
 }
 
 /**
@@ -499,7 +507,7 @@ export interface IEditorOptions {
 	/**
 	 * Code action kinds to be run on save.
 	 */
-	codeActionsOnSave?: string[];
+	codeActionsOnSave?: ICodeActionsOnSaveOptions;
 	/**
 	 * Enable code folding
 	 * Defaults to true.
@@ -854,7 +862,7 @@ export interface EditorContribOptions {
 	readonly find: InternalEditorFindOptions;
 	readonly colorDecorators: boolean;
 	readonly lightbulbEnabled: boolean;
-	readonly codeActionsOnSave: string[];
+	readonly codeActionsOnSave: ICodeActionsOnSaveOptions;
 }
 
 /**
@@ -1199,7 +1207,7 @@ export class InternalEditorOptions {
 			&& a.matchBrackets === b.matchBrackets
 			&& this._equalFindOptions(a.find, b.find)
 			&& a.colorDecorators === b.colorDecorators
-			&& arrays.equals(a.codeActionsOnSave, b.codeActionsOnSave)
+			&& objects.equals(a.codeActionsOnSave, b.codeActionsOnSave)
 			&& a.lightbulbEnabled === b.lightbulbEnabled
 		);
 	}
@@ -1397,6 +1405,21 @@ function _boolean<T>(value: any, defaultValue: T): boolean | T {
 	return Boolean(value);
 }
 
+function _booleanMap(value: { [key: string]: boolean }, defaultValue: { [key: string]: boolean }): { [key: string]: boolean } {
+	if (!value) {
+		return defaultValue;
+	}
+
+	const out = Object.create(null);
+	for (const k of Object.keys(value)) {
+		const v = value[k];
+		if (typeof v === 'boolean') {
+			out[k] = v;
+		}
+	}
+	return out;
+}
+
 function _string(value: any, defaultValue: string): string {
 	if (typeof value !== 'string') {
 		return defaultValue;
@@ -1412,13 +1435,6 @@ function _stringSet<T>(value: T, defaultValue: T, allowedValues: T[]): T {
 		return defaultValue;
 	}
 	return value;
-}
-
-function _stringArray(value: any, defaultValue: string[]): string[] {
-	if (!Array.isArray(value)) {
-		return defaultValue;
-	}
-	return value.filter(x => typeof x === 'string');
 }
 
 function _clampedInt(value: any, defaultValue: number, minimum: number, maximum: number): number {
@@ -1750,7 +1766,7 @@ export class EditorOptionsValidator {
 			find: find,
 			colorDecorators: _boolean(opts.colorDecorators, defaults.colorDecorators),
 			lightbulbEnabled: _boolean(opts.lightbulb ? opts.lightbulb.enabled : false, defaults.lightbulbEnabled),
-			codeActionsOnSave: _stringArray(opts.codeActionsOnSave, [])
+			codeActionsOnSave: _booleanMap(opts.codeActionsOnSave, {})
 		};
 	}
 }
@@ -2321,6 +2337,6 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 		},
 		colorDecorators: true,
 		lightbulbEnabled: true,
-		codeActionsOnSave: []
+		codeActionsOnSave: {}
 	},
 };

--- a/src/vs/editor/contrib/codeAction/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionCommands.ts
@@ -131,13 +131,22 @@ export class QuickFixController implements IEditorContribution {
 	}
 
 	private async _onApplyCodeAction(action: CodeAction): TPromise<void> {
-		if (action.edit) {
-			await BulkEdit.perform(action.edit.edits, this._textModelService, this._fileService, this._editor);
-		}
+		await applyCodeAction(action, this._textModelService, this._fileService, this._commandService, this._editor);
+	}
+}
 
-		if (action.command) {
-			await this._commandService.executeCommand(action.command.id, ...action.command.arguments);
-		}
+export async function applyCodeAction(
+	action: CodeAction,
+	textModelService: ITextModelService,
+	fileService: IFileService,
+	commandService: ICommandService,
+	editor: ICodeEditor,
+) {
+	if (action.edit) {
+		await BulkEdit.perform(action.edit.edits, textModelService, fileService, editor);
+	}
+	if (action.command) {
+		await commandService.executeCommand(action.command.id, ...action.command.arguments);
 	}
 }
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2472,6 +2472,13 @@ declare namespace monaco.editor {
 	}
 
 	/**
+	 * Configuration map for codeActionsOnSave
+	 */
+	export interface ICodeActionsOnSaveOptions {
+		[kind: string]: boolean;
+	}
+
+	/**
 	 * Configuration options for the editor.
 	 */
 	export interface IEditorOptions {
@@ -2826,7 +2833,11 @@ declare namespace monaco.editor {
 		/**
 		 * Code action kinds to be run on save.
 		 */
-		codeActionsOnSave?: string[];
+		codeActionsOnSave?: ICodeActionsOnSaveOptions;
+		/**
+		 * Timeout for running code actions on save.
+		 */
+		codeActionsOnSaveTimeout?: number;
 		/**
 		 * Enable code folding
 		 * Defaults to true.
@@ -3122,7 +3133,8 @@ declare namespace monaco.editor {
 		readonly find: InternalEditorFindOptions;
 		readonly colorDecorators: boolean;
 		readonly lightbulbEnabled: boolean;
-		readonly codeActionsOnSave: string[];
+		readonly codeActionsOnSave: ICodeActionsOnSaveOptions;
+		readonly codeActionsOnSaveTimeout: number;
 	}
 
 	/**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2824,6 +2824,10 @@ declare namespace monaco.editor {
 		 */
 		lightbulb?: IEditorLightbulbOptions;
 		/**
+		 * Code action kinds to be run on save.
+		 */
+		codeActionsOnSave?: string[];
+		/**
 		 * Enable code folding
 		 * Defaults to true.
 		 */
@@ -3118,6 +3122,7 @@ declare namespace monaco.editor {
 		readonly find: InternalEditorFindOptions;
 		readonly colorDecorators: boolean;
 		readonly lightbulbEnabled: boolean;
+		readonly codeActionsOnSave: string[];
 	}
 
 	/**

--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -37,7 +37,7 @@ import { CodeActionKind } from 'vs/editor/contrib/codeAction/codeActionTrigger';
 import { CodeAction } from 'vs/editor/common/modes';
 import { applyCodeAction } from 'vs/editor/contrib/codeAction/codeActionCommands';
 import { getCodeActions } from 'vs/editor/contrib/codeAction/codeAction';
-import { ICodeActionsOnSaveOptions } from '../../../editor/common/config/editorOptions';
+import { ICodeActionsOnSaveOptions } from 'vs/editor/common/config/editorOptions';
 
 export interface ISaveParticipantParticipant extends ISaveParticipant {
 	// progressMessage: string;

--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -33,6 +33,11 @@ import { SnippetController2 } from 'vs/editor/contrib/snippet/snippetController2
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IFileService } from 'vs/platform/files/common/files';
+import { CodeActionKind } from 'vs/editor/contrib/codeAction/codeActionTrigger';
+import { CodeAction } from 'vs/editor/common/modes';
+import { applyCodeAction } from 'vs/editor/contrib/codeAction/codeActionCommands';
+import { getCodeActions } from 'vs/editor/contrib/codeAction/codeAction';
+import { ICodeActionsOnSaveOptions } from '../../../editor/common/config/editorOptions';
 
 export interface ISaveParticipantParticipant extends ISaveParticipant {
 	// progressMessage: string;
@@ -283,7 +288,12 @@ class CodeActionOnParticipant implements ISaveParticipant {
 			return undefined;
 		}
 
-		const codeActionsOnSave = this._configurationService.getValue<string[]>('editor.codeActionsOnSave', { overrideIdentifier: model.getLanguageIdentifier().language, resource: editorModel.getResource() }).map(x => new CodeActionKind(x));
+		const setting = this._configurationService.getValue<ICodeActionsOnSaveOptions>('editor.codeActionsOnSave', { overrideIdentifier: model.getLanguageIdentifier().language, resource: editorModel.getResource() });
+		if (!setting) {
+			return undefined;
+		}
+
+		const codeActionsOnSave = Object.keys(setting).filter(x => setting[x]).map(x => new CodeActionKind(x));
 		if (!codeActionsOnSave.length) {
 			return undefined;
 		}


### PR DESCRIPTION
Fixes #42092

Adds a way to run code actions on save using the `editor.codeActionsOnSave` setting. This setting lists code action kinds to be executed automatically when  the document is saved.

TODO / Questions: 

- [X] TODO: Add timeout
- [X] Q: Is the order correct? Currently code actions are run before format: **A: Yes, this order seems expected**
- [X] Q: How to handle multiple code actions? **A: Run sequentially**
- [X] Q: How should we handle edit conflicts for the code actions? What do we do for format on save? **A: format on save currently picks a formatter to run. We'll try running all the code actions **
- [X] Q: What should the default setting for this be?: **A: Default = off. Extensions can now contribute language specific overrides that would enable this**
- [ ] Q: Current behavior creates two undo stops (one for the action and one for the format). Is this expected?
- [X] Q: Should we restrict this to `source.` code actions? (This is what it is doing currently actually) **A: yes i still think this makes the most sense. We pass the entire document range when requesting these code actions. We can relax this restriction if it causes problems for extension authors**