### PR TITLE
Selectbox: Remove workbench css ref, add min bottom margin.  Fixes: #44915

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -36,7 +36,6 @@ export interface ISelectBoxDelegate {
 
 export interface ISelectBoxOptions {
 	minBottomMargin?: number;
-
 }
 
 export interface ISelectBoxStyles extends IListStyles {

--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -34,6 +34,11 @@ export interface ISelectBoxDelegate {
 	applyStyles(): void;
 }
 
+export interface ISelectBoxOptions {
+	minBottomMargin?: number;
+
+}
+
 export interface ISelectBoxStyles extends IListStyles {
 	selectBackground?: Color;
 	selectListBackground?: Color;
@@ -58,7 +63,7 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 	private styles: ISelectBoxStyles;
 	private selectBoxDelegate: ISelectBoxDelegate;
 
-	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles = deepClone(defaultStyles)) {
+	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles = deepClone(defaultStyles), selectBoxOptions?: ISelectBoxOptions) {
 		super();
 
 		this.toDispose = [];
@@ -69,7 +74,7 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 		if (isMacintosh) {
 			this.selectBoxDelegate = new SelectBoxNative(options, selected, styles);
 		} else {
-			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, styles);
+			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, styles, selectBoxOptions);
 		}
 
 		this.toDispose.push(this.selectBoxDelegate);

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -98,11 +98,12 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 		this.toDispose = [];
 		this._isVisible = false;
+		this.selectBoxOptions = selectBoxOptions || Object.create(null);
 
-		this.selectBoxOptions = selectBoxOptions;
 		if (!this.selectBoxOptions.minBottomMargin) {
 			this.selectBoxOptions.minBottomMargin = SelectBoxList.DEFAULT_DROPDOWN_MINIMUM_BOTTOM_MARGIN;
 		}
+
 		this.selectElement = document.createElement('select');
 		this.selectElement.className = 'monaco-select-box';
 
@@ -409,13 +410,16 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 		const selectWidth = dom.getTotalWidth(this.selectElement);
 		const selectPosition = dom.getDomNodePagePosition(this.selectElement);
 
-		// Set container height to max from select bottom to margin above status bar
+		// Set container height to max from select bottom to margin (default/minBottomMargin)
+		if (this.selectBoxOptions.minBottomMargin < 0) {
+			this.selectBoxOptions.minBottomMargin = 0;
+		}
 
-		// const statusBarHeight = dom.getTotalHeight(document.getElementById('workbench.parts.statusbar'));
-		console.debug('status bar height ' + this.selectBoxOptions.minBottomMargin);
+		let maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin);
 
-
-		const maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin);
+		if (maxSelectDropDownHeight < 0) {
+			maxSelectDropDownHeight = 0;
+		}
 
 		// SetUp list dimensions and layout - account for container padding
 		if (this.selectList) {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -17,7 +17,7 @@ import { List } from 'vs/base/browser/ui/list/listWidget';
 import { IDelegate, IRenderer } from 'vs/base/browser/ui/list/list';
 import { domEvent } from 'vs/base/browser/event';
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
-import { ISelectBoxDelegate, ISelectBoxStyles, ISelectData } from 'vs/base/browser/ui/selectBox/selectBox';
+import { ISelectBoxDelegate, ISelectBoxOptions, ISelectBoxStyles, ISelectData } from 'vs/base/browser/ui/selectBox/selectBox';
 import { isMacintosh } from 'vs/base/common/platform';
 
 const $ = dom.$;
@@ -74,9 +74,10 @@ class SelectListRenderer implements IRenderer<ISelectOptionItem, ISelectListTemp
 
 export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptionItem> {
 
-	private static SELECT_DROPDOWN_BOTTOM_MARGIN = 10;
+	private static readonly DEFAULT_DROPDOWN_MINIMUM_BOTTOM_MARGIN = 32;
 
 	private _isVisible: boolean;
+	private selectBoxOptions: ISelectBoxOptions;
 	private selectElement: HTMLSelectElement;
 	private options: string[];
 	private selected: number;
@@ -93,11 +94,15 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 	private widthControlElement: HTMLElement;
 	private _currentSelection: number;
 
-	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles) {
+	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles, selectBoxOptions?: ISelectBoxOptions) {
 
 		this.toDispose = [];
 		this._isVisible = false;
 
+		this.selectBoxOptions = selectBoxOptions;
+		if (!this.selectBoxOptions.minBottomMargin) {
+			this.selectBoxOptions.minBottomMargin = SelectBoxList.DEFAULT_DROPDOWN_MINIMUM_BOTTOM_MARGIN;
+		}
 		this.selectElement = document.createElement('select');
 		this.selectElement.className = 'monaco-select-box';
 
@@ -405,8 +410,12 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 		const selectPosition = dom.getDomNodePagePosition(this.selectElement);
 
 		// Set container height to max from select bottom to margin above status bar
-		const statusBarHeight = dom.getTotalHeight(document.getElementById('workbench.parts.statusbar'));
-		const maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - statusBarHeight - SelectBoxList.SELECT_DROPDOWN_BOTTOM_MARGIN);
+
+		// const statusBarHeight = dom.getTotalHeight(document.getElementById('workbench.parts.statusbar'));
+		console.debug('status bar height ' + this.selectBoxOptions.minBottomMargin);
+
+
+		const maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin);
 
 		// SetUp list dimensions and layout - account for container padding
 		if (this.selectList) {


### PR DESCRIPTION
Fixes: #44915 

@bpasero 
finally catching up...

- remove workbench CSS reference
- add default margin of 32 - 10 above current status bar
- add selectBoxOptions optional parameter/interface with minBottomMargin

FYI: I know the interface has only one element, but I assume we probably will add more in the future better to do it now with an interface then a single dangling parameter.