### PR TITLE
Enable clear search even if there are no results found

### DIFF
--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -393,7 +393,7 @@ export class ClearSearchResultsAction extends Action {
 
 	update(): void {
 		const searchView = getSearchView(this.viewletService, this.panelService);
-		this.enabled = searchView && searchView.hasSearchResults();
+		this.enabled = searchView && searchView.isSearchSubmitted();
 	}
 
 	public run(): TPromise<void> {


### PR DESCRIPTION
For the clear button it shouldn't matter whether there are
search results found or not. The clear button gets now enabled
after every search.