### PR TITLE
Fixes #42726 fixing file name space issues

### DIFF
--- a/src/vs/base/parts/quickopen/common/quickOpenScorer.ts
+++ b/src/vs/base/parts/quickopen/common/quickOpenScorer.ts
@@ -311,7 +311,8 @@ export function prepareQuery(original: string): IPreparedQuery {
 	let value: string;
 
 	if (original) {
-		value = stripWildcards(original).replace(/\s/g, ''); // get rid of all wildcards and whitespace
+		value = stripWildcards(original).trim().replace(/\s/g, '\ '); // get rid of all wildcards and whitespace
+
 		if (isWindows) {
 			value = value.replace(/\//g, nativeSep); // Help Windows users to search for paths when using slash
 		}

--- a/src/vs/base/parts/quickopen/test/common/quickOpenScorer.test.ts
+++ b/src/vs/base/parts/quickopen/test/common/quickOpenScorer.test.ts
@@ -814,9 +814,11 @@ suite('Quick Open Scorer', () => {
 
 	test('prepareSearchForScoring', function () {
 		assert.equal(scorer.prepareQuery(' f*a ').value, 'fa');
-		assert.equal(scorer.prepareQuery('model Tester.ts').value, 'modelTester.ts');
-		assert.equal(scorer.prepareQuery('Model Tester.ts').lowercase, 'modeltester.ts');
+		assert.equal(scorer.prepareQuery('model Tester.ts').value, 'model Tester.ts');
+		assert.equal(scorer.prepareQuery('Model Tester.ts').lowercase, 'model tester.ts');
 		assert.equal(scorer.prepareQuery('ModelTester.ts').containsPathSeparator, false);
 		assert.equal(scorer.prepareQuery('Model' + nativeSep + 'Tester.ts').containsPathSeparator, true);
+		assert.equal(scorer.prepareQuery('dir' + nativeSep + 'tester.ts').value, 'dir' + nativeSep + 'tester.ts');
+		assert.equal(scorer.prepareQuery('dir' + nativeSep + 'model tester.ts').value, 'dir' + nativeSep + 'model tester.ts');
 	});
 });


### PR DESCRIPTION
This PR fixes using quick open to search for files and directories with a space in the file path.

I have tested this on a Windows 7 machine and on Fedora 25, and quick open works for files with spaces.  

I have also added 2 additional tests in quickOpenScorer.test.js to test for cases with spaces in the filepath.

 