### PR TITLE
Fixes #34449 - checking for relative paths

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -258,7 +258,15 @@ export default class URI implements UriComponents {
 			// tricky -> makes invalid paths
 			// but otherwise we have to stop
 			// allowing relative paths...
-			path = _slash + path;
+			const _isRelative = /^([~\.]\/|^[a-zA-Z]+\/)/;
+			if (platform.isWindows) {
+				console.log('2');
+				path = _slash + path;
+			} else {
+				if (!_isRelative.test(path)) {
+					path = _slash + path;
+				}
+			}
 		}
 
 		return new _URI('file', authority, path, _empty, _empty);

--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -56,6 +56,7 @@ const _regexp = /^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
 const _driveLetterPath = /^\/[a-zA-Z]:/;
 const _upperCaseDrive = /^(\/)?([A-Z]:)/;
 const _driveLetter = /^[a-zA-Z]:/;
+const _isRelative = /^([~\.]\/|^[a-zA-Z]+\/)/;
 
 /**
  * Uniform Resource Identifier (URI) http://tools.ietf.org/html/rfc3986.
@@ -253,14 +254,11 @@ export default class URI implements UriComponents {
 		// or that it is at least a slash
 		if (_driveLetter.test(path)) {
 			path = _slash + path;
-
 		} else if (path[0] !== _slash) {
 			// tricky -> makes invalid paths
 			// but otherwise we have to stop
 			// allowing relative paths...
-			const _isRelative = /^([~\.]\/|^[a-zA-Z]+\/)/;
 			if (platform.isWindows) {
-				console.log('2');
 				path = _slash + path;
 			} else {
 				if (!_isRelative.test(path)) {
@@ -393,7 +391,12 @@ function _makeFsPath(uri: URI): string {
 		value = uri.path[1].toLowerCase() + uri.path.substr(2);
 	} else {
 		// other path
-		value = uri.path;
+		// required check because '.' means relative paths in non-Windows platform
+		if (uri.path[0] === '.') {
+			value = _slash + uri.path;
+		} else {
+			value = uri.path;
+		}
 	}
 	if (platform.isWindows) {
 		value = value.replace(/\//g, '\\');

--- a/src/vs/base/parts/quickopen/common/quickOpenScorer.ts
+++ b/src/vs/base/parts/quickopen/common/quickOpenScorer.ts
@@ -311,7 +311,8 @@ export function prepareQuery(original: string): IPreparedQuery {
 	let value: string;
 
 	if (original) {
-		value = stripWildcards(original).replace(/\s/g, ''); // get rid of all wildcards and whitespace
+		value = stripWildcards(original).trim().replace(/\s/g, '\ '); // get rid of all wildcards and whitespace
+
 		if (isWindows) {
 			value = value.replace(/\//g, nativeSep); // Help Windows users to search for paths when using slash
 		}

--- a/src/vs/base/parts/quickopen/test/common/quickOpenScorer.test.ts
+++ b/src/vs/base/parts/quickopen/test/common/quickOpenScorer.test.ts
@@ -814,9 +814,11 @@ suite('Quick Open Scorer', () => {
 
 	test('prepareSearchForScoring', function () {
 		assert.equal(scorer.prepareQuery(' f*a ').value, 'fa');
-		assert.equal(scorer.prepareQuery('model Tester.ts').value, 'modelTester.ts');
-		assert.equal(scorer.prepareQuery('Model Tester.ts').lowercase, 'modeltester.ts');
+		assert.equal(scorer.prepareQuery('model Tester.ts').value, 'model Tester.ts');
+		assert.equal(scorer.prepareQuery('Model Tester.ts').lowercase, 'model tester.ts');
 		assert.equal(scorer.prepareQuery('ModelTester.ts').containsPathSeparator, false);
 		assert.equal(scorer.prepareQuery('Model' + nativeSep + 'Tester.ts').containsPathSeparator, true);
+		assert.equal(scorer.prepareQuery('dir' + nativeSep + 'tester.ts').value, 'dir' + nativeSep + 'tester.ts');
+		assert.equal(scorer.prepareQuery('dir' + nativeSep + 'model tester.ts').value, 'dir' + nativeSep + 'model tester.ts');
 	});
 });

--- a/src/vs/base/test/common/uri.test.ts
+++ b/src/vs/base/test/common/uri.test.ts
@@ -466,6 +466,13 @@ suite('URI', () => {
 		test('relative path', function () {
 			const path = 'foo/bar';
 			assert.equal(URI.file(path).path, path);
+			const fileUri1 = URI.parse(`file:foo/bar`);
+			assert.equal(fileUri1.path, 'foo/bar');
+			const uri = fileUri1.toString();
+			assert.equal(uri, 'file://foo/bar');
+			const fileUri2 = URI.parse(uri);
+			assert.equal(fileUri2.path, '/bar');
+			assert.equal(fileUri2.authority, 'foo');
 		});
 
 		test('relative path with dot', function () {

--- a/src/vs/base/test/common/uri.test.ts
+++ b/src/vs/base/test/common/uri.test.ts
@@ -457,4 +457,20 @@ suite('URI', () => {
 		// }
 		// console.profileEnd();
 	});
+	if (!isWindows) {
+		test('absolute path', function () {
+			const path = '/foo/bar';
+			assert.equal(URI.file(path).path, path);
+		});
+
+		test('relative path', function () {
+			const path = 'foo/bar';
+			assert.equal(URI.file(path).path, path);
+		});
+
+		test('relative path with dot', function () {
+			const path = './foo/bar';
+			assert.equal(URI.file(path).path, path);
+		});
+	}
 });


### PR DESCRIPTION
This PR adds logic to check for relative paths and ensure the additional '/' are not added for relative paths.
It includes the additional test cases from the previous comments to ensure the path checking is accurate.