### PR TITLE
Normalize file paths before comparing them

### DIFF
--- a/src/vs/base/common/paths.ts
+++ b/src/vs/base/common/paths.ts
@@ -314,6 +314,9 @@ export function isValidBasename(name: string): boolean {
 }
 
 export function isEqual(pathA: string, pathB: string, ignoreCase?: boolean): boolean {
+	pathA = normalize(pathA);
+	pathB = normalize(pathB);
+
 	const identityEquals = (pathA === pathB);
 	if (!ignoreCase || identityEquals) {
 		return identityEquals;
@@ -338,6 +341,9 @@ export function isEqualOrParent(path: string, candidate: string, ignoreCase?: bo
 	if (candidate.length > path.length) {
 		return false;
 	}
+
+	path = normalize(path);
+	candidate = normalize(candidate);
 
 	if (ignoreCase) {
 		const beginsWith = startsWithIgnoreCase(path, candidate);

--- a/src/vs/base/common/resources.ts
+++ b/src/vs/base/common/resources.ts
@@ -6,7 +6,6 @@
 
 import * as paths from 'vs/base/common/paths';
 import uri from 'vs/base/common/uri';
-import { equalsIgnoreCase } from 'vs/base/common/strings';
 
 export function basenameOrAuthority(resource: uri): string {
 	return paths.basename(resource.path) || resource.authority;
@@ -34,11 +33,11 @@ export function isEqual(first: uri, second: uri, ignoreCase?: boolean): boolean 
 		return false;
 	}
 
-	if (ignoreCase) {
-		return equalsIgnoreCase(first.toString(), second.toString());
+	if (first.scheme === second.scheme && first.authority === second.authority) {
+		return paths.isEqual(first.path, second.path, ignoreCase);
 	}
 
-	return first.toString() === second.toString();
+	return false;
 }
 
 export function dirname(resource: uri): uri {

--- a/src/vs/workbench/parts/files/common/explorerModel.ts
+++ b/src/vs/workbench/parts/files/common/explorerModel.ts
@@ -7,7 +7,6 @@
 
 import URI from 'vs/base/common/uri';
 import * as paths from 'vs/base/common/paths';
-import * as resources from 'vs/base/common/resources';
 import { ResourceMap } from 'vs/base/common/map';
 import { isLinux } from 'vs/base/common/platform';
 import { IFileStat } from 'vs/platform/files/common/files';
@@ -139,7 +138,7 @@ export class ExplorerItem {
 			// the folder is fully resolved if either it has a list of children or the client requested this by using the resolveTo
 			// array of resource path to resolve.
 			stat.isDirectoryResolved = !!raw.children || (!!resolveTo && resolveTo.some((r) => {
-				return resources.isEqualOrParent(r, stat.resource, !isLinux /* ignorecase */);
+				return !!stat.find(r);
 			}));
 
 			// Recurse into children

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -43,6 +43,7 @@ import { WorkbenchTree } from 'vs/platform/list/browser/listService';
 import { DelayedDragHandler } from 'vs/base/browser/dnd';
 import { Schemas } from 'vs/base/common/network';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { equalsIgnoreCase } from 'vs/base/common/strings';
 
 export interface IExplorerViewOptions extends IViewletViewOptions {
 	viewletState: FileViewletState;
@@ -868,11 +869,15 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 	private getResolvedDirectories(stat: ExplorerItem, resolvedDirectories: URI[]): void {
 		if (stat.isDirectoryResolved) {
 			if (!stat.isRoot) {
-
+				const areEqual = (first: string, second: string) => isLinux ? first === second : equalsIgnoreCase(first, second);
 				// Drop those path which are parents of the current one
 				for (let i = resolvedDirectories.length - 1; i >= 0; i--) {
-					const resource = resolvedDirectories[i];
-					if (resources.isEqualOrParent(stat.resource, resource, !isLinux /* ignorecase */)) {
+					const resourceStr = resolvedDirectories[i].toString();
+					let statToCompare = stat;
+					while (statToCompare && !areEqual(statToCompare.resource.toString(), resourceStr)) {
+						statToCompare = statToCompare.parent;
+					}
+					if (statToCompare) {
 						resolvedDirectories.splice(i);
 					}
 				}


### PR DESCRIPTION
These PR does the following:
* Removes the usage of `isEqualOrParent` in the explorer. In one location I simply use the `ExplorerItem.find` (which should be fast) and in the other I use a reverse logic of looking up the parents
* Normalize the paths before comparing the in `isEqual` and `isEqualOrParent` calls

I did not thoroughly test this. I also did not check the performance.
In case you like the approach I can do both these things tomorrow.

LiveShare team just informed me that they will need this in the april stable version. So assigning to April so we discuss and check how far away are we from merging this in.

fixes #46549
fixes #36946