### PR TITLE
Highlight escaped characters in default Light+ (Fix #48638)

### DIFF
--- a/extensions/theme-defaults/themes/light_plus.json
+++ b/extensions/theme-defaults/themes/light_plus.json
@@ -156,7 +156,7 @@
 		{
 			"scope": "constant.character.escape",
 			"settings": {
-				"foreground": "#a31515"
+				"foreground": "#800000"
 			}
 		}
 

--- a/extensions/theme-defaults/themes/light_plus.json
+++ b/extensions/theme-defaults/themes/light_plus.json
@@ -156,7 +156,7 @@
 		{
 			"scope": "constant.character.escape",
 			"settings": {
-				"foreground": "#000000"
+				"foreground": "#ff0000"
 			}
 		}
 

--- a/extensions/theme-defaults/themes/light_plus.json
+++ b/extensions/theme-defaults/themes/light_plus.json
@@ -156,7 +156,7 @@
 		{
 			"scope": "constant.character.escape",
 			"settings": {
-				"foreground": "#800000"
+				"foreground": "#000000"
 			}
 		}
 


### PR DESCRIPTION
Fixed #48638
Before
![before](https://user-images.githubusercontent.com/15185258/39226711-f7263c98-4808-11e8-95bf-26d37c52d70d.png)
After
![after](https://user-images.githubusercontent.com/8369346/39297497-a468b7c0-497e-11e8-8e91-8fbdbf278483.png)

These issue is cause of `string` and `constant.character.escape` is same(`#a31515`).

This new color(`#800000`) looks not so changed. I referenced dark-theme 
https://github.com/Microsoft/vscode/blob/master/extensions/theme-defaults/themes/dark_plus.json#L159
use same color from
https://github.com/Microsoft/vscode/blob/master/extensions/theme-defaults/themes/dark_vs.json#L90
and
https://github.com/Microsoft/vscode/blob/master/extensions/theme-defaults/themes/dark_vs.json#L164

So this `#800000` is used from
https://github.com/Microsoft/vscode/blob/master/extensions/theme-defaults/themes/light_vs.json#L88
and
https://github.com/Microsoft/vscode/blob/master/extensions/theme-defaults/themes/light_vs.json#L66
