### PR TITLE
debug: debug.hideNonDebugHovers

### DIFF
--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -351,7 +351,7 @@ export interface IDebugConfiguration {
 	showInStatusBar: 'never' | 'always' | 'onFirstSessionStart';
 	internalConsoleOptions: 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart';
 	extensionHostDebugAdapter: boolean;
-	hideNonDebugHovers: boolean;
+	enableAllHovers: boolean;
 }
 
 export interface IGlobalConfig {

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -351,6 +351,7 @@ export interface IDebugConfiguration {
 	showInStatusBar: 'never' | 'always' | 'onFirstSessionStart';
 	internalConsoleOptions: 'neverOpen' | 'openOnSessionStart' | 'openOnFirstSessionStart';
 	extensionHostDebugAdapter: boolean;
+	hideNonDebugHovers: boolean;
 }
 
 export interface IGlobalConfig {

--- a/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
@@ -205,6 +205,11 @@ configurationRegistry.registerConfiguration({
 			default: 'openOnFirstSessionStart',
 			description: nls.localize('openDebug', "Controls whether debug view should be open on debugging session start.")
 		},
+		'debug.hideNonDebugHovers': {
+			type: 'boolean',
+			description: nls.localize({ comment: ['This is the description for a setting'], key: 'hideNonDebugHovers' }, "Controls if the non debug hovers should be hidden while debugging. If false the hover providers will be called to provide a hover. Regular hovers will not be shown even if this setting is false."),
+			default: true
+		},
 		'launch': {
 			type: 'object',
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces"),

--- a/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
@@ -205,10 +205,10 @@ configurationRegistry.registerConfiguration({
 			default: 'openOnFirstSessionStart',
 			description: nls.localize('openDebug', "Controls whether debug view should be open on debugging session start.")
 		},
-		'debug.hideNonDebugHovers': {
+		'debug.enableAllHovers': {
 			type: 'boolean',
-			description: nls.localize({ comment: ['This is the description for a setting'], key: 'hideNonDebugHovers' }, "Controls if the non debug hovers should be hidden while debugging. If false the hover providers will be called to provide a hover. Regular hovers will not be shown even if this setting is false."),
-			default: true
+			description: nls.localize({ comment: ['This is the description for a setting'], key: 'enableAllHovers' }, "Controls if the non debug hovers should be enabled while debugging. If true the hover providers will be called to provide a hover. Regular hovers will not be shown even if this setting is true."),
+			default: false
 		},
 		'launch': {
 			type: 'object',


### PR DESCRIPTION
fixes #48733

Introduces a settings `debug.hideNonDebugHovers`. Feedback on the name and description are very welcome.

@alexandrudima as you gave me the pointer I am simply `provideHover` with a 300 ms delay so it does not get spammed. Note that I do not do anything if debug is not active and in a stopped state since then I do not hide the regular hover.