### PR TITLE
explorer: set the directory to not resolved when can not merge local …

### DIFF
--- a/src/vs/workbench/parts/files/common/explorerModel.ts
+++ b/src/vs/workbench/parts/files/common/explorerModel.ts
@@ -168,6 +168,7 @@ export class ExplorerItem {
 		// Stop merging when a folder is not resolved to avoid loosing local data
 		const mergingDirectories = disk.isDirectory || local.isDirectory;
 		if (mergingDirectories && local.isDirectoryResolved && !disk.isDirectoryResolved) {
+			local.isDirectoryResolved = false;
 			return;
 		}
 


### PR DESCRIPTION
File events sometimes lead to explorer items not updating because their `isDirectoryResolved` is wrongly set to `true`. This PR is an attempt to fix that by setting the `ExplorerItem.isDirectoryResolved` to false when trying to merge an `ExplorerItem` with a `ExplorerItem` that is not yet resolved.
For exact repro steps please ping me on slack.

fyi @jrieken 