### PR TITLE
supporting backslash in quoted path names under linux

### DIFF
--- a/src/vs/base/common/paths.ts
+++ b/src/vs/base/common/paths.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { isWindows } from 'vs/base/common/platform';
+import { isWindows, isLinux } from 'vs/base/common/platform';
 import { startsWithIgnoreCase, equalsIgnoreCase } from 'vs/base/common/strings';
 import { CharCode } from 'vs/base/common/charCode';
 
@@ -293,7 +293,15 @@ export function isValidBasename(name: string): boolean {
 
 	INVALID_FILE_CHARS.lastIndex = 0; // the holy grail of software development
 	if (INVALID_FILE_CHARS.test(name)) {
-		return false; // check for certain invalid file characters
+		let isValid = false;
+		if (isLinux && name.indexOf('/') === -1) {	// forward slashes are not allowed
+			if (name.search(/^['"].+?\\.+?['"]$/) === 0) {	// name starts & ends with a quote and contains a backslash
+				isValid = true;	// linux allows names with backslashes as long as they are in quotes. e.g 'file1\name'
+			}
+		}
+		if (!isValid) {
+			return false; // check for certain invalid file characters
+		}
 	}
 
 	if (isWindows && WINDOWS_FORBIDDEN_NAMES.test(name)) {

--- a/src/vs/workbench/parts/files/common/explorerModel.ts
+++ b/src/vs/workbench/parts/files/common/explorerModel.ts
@@ -18,6 +18,8 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { getPathLabel } from 'vs/base/common/labels';
 import { Schemas } from 'vs/base/common/network';
 import { startsWith, startsWithIgnoreCase, rtrim } from 'vs/base/common/strings';
+// tslint:disable-next-line:import-patterns
+import * as path from 'path';
 
 export class Model {
 
@@ -304,7 +306,7 @@ export class ExplorerItem {
 	}
 
 	private updateResource(recursive: boolean): void {
-		this.resource = this.parent.resource.with({ path: paths.join(this.parent.resource.path, this.name) });
+		this.resource = this.parent.resource.with({ path: path.join(this.parent.resource.path, this.name) });
 
 		if (recursive) {
 			if (this.isDirectory && this.children) {

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -1056,12 +1056,12 @@ export class FileDragAndDrop extends SimpleFileResourceDragAndDrop {
 
 				// If the dirty file itself got moved, just reparent it to the target folder
 				if (source.resource.toString() === d.toString()) {
-					moved = target.resource.with({ path: paths.join(target.resource.path, source.name) });
+					moved = target.resource.with({ path: path.join(target.resource.path, source.name) });
 				}
 
 				// Otherwise, a parent of the dirty resource got moved, so we have to reparent more complicated. Example:
 				else {
-					moved = target.resource.with({ path: paths.join(target.resource.path, d.path.substr(source.parent.resource.path.length + 1)) });
+					moved = target.resource.with({ path: path.join(target.resource.path, d.path.substr(source.parent.resource.path.length + 1)) });
 				}
 
 				dirtyMoved.push(moved);
@@ -1076,7 +1076,7 @@ export class FileDragAndDrop extends SimpleFileResourceDragAndDrop {
 
 				// 3.) run the move operation
 				.then(() => {
-					const targetResource = target.resource.with({ path: paths.join(target.resource.path, source.name) });
+					const targetResource = target.resource.with({ path: path.join(target.resource.path, source.name) });
 
 					return this.fileService.moveFile(source.resource, targetResource).then(null, error => {
 

--- a/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
+++ b/src/vs/workbench/parts/files/test/electron-browser/explorerModel.test.ts
@@ -10,7 +10,7 @@ import { isUndefinedOrNull } from 'vs/base/common/types';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 import URI from 'vs/base/common/uri';
 import { join } from 'vs/base/common/paths';
-import { validateFileName } from 'vs/workbench/parts/files/electron-browser/fileActions';
+import { validateFileName, extractPathSegments } from 'vs/workbench/parts/files/electron-browser/fileActions';
 import { ExplorerItem } from 'vs/workbench/parts/files/common/explorerModel';
 
 function createStat(path: string, name: string, isFolder: boolean, hasChildren: boolean, size: number, mtime: number): ExplorerItem {
@@ -262,6 +262,21 @@ suite('Files - View Model', () => {
 		// detect if path already exists
 		assert(validateFileName(wsFolder, '/path/to/stat/fileNested') !== null);
 		assert(validateFileName(wsFolder, '/path/to/stat/') !== null);
+	});
+
+	test('Split Multi-Path OS-Specific', function () {
+		const isLinux = true;
+		const notLinux = false;
+		// basic tests
+		assert.deepStrictEqual(extractPathSegments('folder1', isLinux), ['folder1']);
+		assert.deepStrictEqual(extractPathSegments('folder1/', isLinux), ['folder1']);
+		assert.deepStrictEqual(extractPathSegments('folder1/folder2//', notLinux), ['folder1', 'folder2']);
+		assert.deepStrictEqual(extractPathSegments('folder1\\folder2', isLinux), ['folder1', 'folder2']);
+
+		// quoted path segments
+		assert.deepStrictEqual(extractPathSegments('"folder1\\folder2"', isLinux), ['"folder1\\folder2"']);
+		assert.deepStrictEqual(extractPathSegments('"folder1//folder2"', isLinux), ['"folder1', 'folder2"']);
+		assert.deepStrictEqual(extractPathSegments('"folder1\\folder2"', notLinux), ['"folder1', 'folder2"']);
 	});
 
 	test('Merge Local with Disk', function () {


### PR DESCRIPTION
This is a first take at enabling the explorer to create and handle folders with backslashes in their names under linux.
This was requested while testing in #44693 and #44694
@isidorn This feature requires quite a lot of changes. It's up to you to decide, whether we want to include it just yet or wait for more request from the users.

The initial commit is not yet merge-ready:
1. To make this feature work, I had to replace paths.join with path.join. In explorerModel.ts this import is not allowed. I temporarily fixed it with ```// tslint:disable-next-line:import-patterns```
2. The message while creating the folder is not yet reflecting correctly where the folder will be created.
3. The user needs to use the forward slash in all other places to make multi-path creation work. Example:
'a\b'/d works. 'a\b'\d not.
