### PR TITLE
Make extension disablement persistent only one load

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -494,7 +494,7 @@ export class CodeWindow implements ICodeWindow {
 		});
 	}
 
-	public load(config: IWindowConfiguration, isReload?: boolean): void {
+	public load(config: IWindowConfiguration, isReload?: boolean, temporaryArgs?: ParsedArgs): void {
 
 		// If this is the first time the window is loaded, we associate the paths
 		// directly with the window because we assume the loading will just work
@@ -509,6 +509,13 @@ export class CodeWindow implements ICodeWindow {
 		else {
 			this.pendingLoadConfig = config;
 			this._readyState = ReadyState.NAVIGATING;
+		}
+
+		// Add args to the config, but do not preserve them on currentConfig or
+		// pendingLoadConfig so that they are applied only on this load
+		const configuration = objects.assign({}, config);
+		if (temporaryArgs) {
+			configuration['disable-extensions'] = temporaryArgs['disable-extensions'];
 		}
 
 		// Clear Document Edited if needed
@@ -529,7 +536,7 @@ export class CodeWindow implements ICodeWindow {
 
 		// Load URL
 		mark('main:loadWindow');
-		this._win.loadURL(this.getUrl(config));
+		this._win.loadURL(this.getUrl(configuration));
 
 		// Make window visible if it did not open in N seconds because this indicates an error
 		// Only do this when running out of sources and not when running tests
@@ -567,14 +574,10 @@ export class CodeWindow implements ICodeWindow {
 			configuration['extensions-dir'] = cli['extensions-dir'];
 		}
 
-		if (cli) {
-			configuration['disable-extensions'] = cli['disable-extensions'];
-		}
-
 		configuration.isInitialStartup = false; // since this is a reload
 
 		// Load config
-		this.load(configuration, true);
+		this.load(configuration, true, cli);
 	}
 
 	private getUrl(windowConfiguration: IWindowConfiguration): string {

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -494,7 +494,7 @@ export class CodeWindow implements ICodeWindow {
 		});
 	}
 
-	public load(config: IWindowConfiguration, isReload?: boolean, temporaryArgs?: ParsedArgs): void {
+	public load(config: IWindowConfiguration, isReload?: boolean, disableExtensions?: boolean): void {
 
 		// If this is the first time the window is loaded, we associate the paths
 		// directly with the window because we assume the loading will just work
@@ -511,11 +511,11 @@ export class CodeWindow implements ICodeWindow {
 			this._readyState = ReadyState.NAVIGATING;
 		}
 
-		// Add args to the config, but do not preserve them on currentConfig or
-		// pendingLoadConfig so that they are applied only on this load
+		// Add disable-extensions to the config, but do not preserve it on currentConfig or
+		// pendingLoadConfig so that it is applied only on this load
 		const configuration = objects.assign({}, config);
-		if (temporaryArgs) {
-			configuration['disable-extensions'] = temporaryArgs['disable-extensions'];
+		if (disableExtensions !== undefined) {
+			configuration['disable-extensions'] = disableExtensions['disable-extensions'];
 		}
 
 		// Clear Document Edited if needed
@@ -577,7 +577,8 @@ export class CodeWindow implements ICodeWindow {
 		configuration.isInitialStartup = false; // since this is a reload
 
 		// Load config
-		this.load(configuration, true, cli);
+		const disableExtensions = cli ? cli['disable-extensions'] : undefined;
+		this.load(configuration, true, disableExtensions);
 	}
 
 	private getUrl(windowConfiguration: IWindowConfiguration): string {

--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -515,7 +515,7 @@ export class CodeWindow implements ICodeWindow {
 		// pendingLoadConfig so that it is applied only on this load
 		const configuration = objects.assign({}, config);
 		if (disableExtensions !== undefined) {
-			configuration['disable-extensions'] = disableExtensions['disable-extensions'];
+			configuration['disable-extensions'] = disableExtensions;
 		}
 
 		// Clear Document Edited if needed

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -47,7 +47,7 @@ export interface ICodeWindow {
 	readyState: ReadyState;
 	ready(): TPromise<ICodeWindow>;
 
-	load(config: IWindowConfiguration, isReload?: boolean): void;
+	load(config: IWindowConfiguration, isReload?: boolean, temporaryArgs?: ParsedArgs): void;
 	reload(configuration?: IWindowConfiguration, cli?: ParsedArgs): void;
 
 	focus(): void;

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -47,7 +47,7 @@ export interface ICodeWindow {
 	readyState: ReadyState;
 	ready(): TPromise<ICodeWindow>;
 
-	load(config: IWindowConfiguration, isReload?: boolean, temporaryArgs?: ParsedArgs): void;
+	load(config: IWindowConfiguration, isReload?: boolean, disableExtensions?: boolean): void;
 	reload(configuration?: IWindowConfiguration, cli?: ParsedArgs): void;
 
 	focus(): void;


### PR DESCRIPTION
The current behavior of the `Reload Window with Extensions Disabled` command is that after running it, on subsequent window reloads extensions will remain disabled, which is unexpected.

This changes the load so that the 'disable-extensions' arg is not preserved on the config.