### PR TITLE
Fix spelling mistake in NPM task tooltip

### DIFF
--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -8,7 +8,7 @@
 	"config.npm.enableScriptExplorer": "Enable an explorer view for npm scripts.",
 	"npm.parseError": "Npm task detection: failed to parse the file {0}",
 	"taskdef.script": "The npm script to customize.",
-	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be ommitted.",
+	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be omitted.",
 	"view.name": "Npm Scripts",
 	"command.refresh": "Refresh",
 	"command.run": "Run",


### PR DESCRIPTION
Noticed this when mousing over a key when setting up an npm task.
ommitted -> omitted