### PR TITLE
Add open editors context menu contribution point

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -115,6 +115,13 @@
 					"group": "navigation"
 				}
 			],
+			"explorer/openEditors/context": [
+				{
+					"command": "markdown.showPreview",
+					"when": "resourceLangId == markdown",
+					"group": "navigation"
+				}
+			],
 			"editor/title/context": [
 				{
 					"command": "markdown.showPreview",

--- a/src/vs/workbench/services/actions/electron-browser/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/electron-browser/menusExtensionPoint.ts
@@ -31,6 +31,7 @@ namespace schema {
 			case 'editor/title': return MenuId.EditorTitle;
 			case 'editor/context': return MenuId.EditorContext;
 			case 'explorer/context': return MenuId.ExplorerContext;
+			case 'explorer/openEditors/context': return MenuId.OpenEditorsContext;
 			case 'editor/title/context': return MenuId.EditorTitleContext;
 			case 'debug/callstack/context': return MenuId.DebugCallStackContext;
 			case 'scm/title': return MenuId.SCMTitle;
@@ -121,6 +122,11 @@ namespace schema {
 			},
 			'explorer/context': {
 				description: localize('menus.explorerContext', "The file explorer context menu"),
+				type: 'array',
+				items: menuItem
+			},
+			'explorer/openEditors/context': {
+				description: localize('menus.openEditorsContext', "The explorer open editors context menu"),
 				type: 'array',
 				items: menuItem
 			},


### PR DESCRIPTION
Allows extensions to contribute to the open editors context menu

Fixes #37045
Fixes #48981