### PR TITLE
Update SCSS syntax extension

### DIFF
--- a/extensions/scss/package.json
+++ b/extensions/scss/package.json
@@ -1,12 +1,12 @@
 {
     "name": "scss",
     "displayName": "%displayName%",
-	"description": "%description%",
+	  "description": "%description%",
     "version": "1.0.0",
     "publisher": "vscode",
     "engines": { "vscode": "*" },
     "scripts": {
-        "update-grammar": "node ../../build/npm/update-grammar.js atom/language-sass grammars/scss.cson ./syntaxes/scss.tmLanguage.json"
+        "update-grammar": "node ../../build/npm/update-grammar.js atom/language-sass grammars/scss.cson ./syntaxes/scss.tmLanguage.json grammars/sassdoc.cson ./syntaxes/sassdoc.tmLanguage.json"
     },
     "contributes": {
         "languages": [{
@@ -20,6 +20,9 @@
             "language": "scss",
             "scopeName": "source.css.scss",
             "path": "./syntaxes/scss.tmLanguage.json"
+        }, {
+            "scopeName": "source.sassdoc",
+            "path": "./syntaxes/sassdoc.tmLanguage.json"
         }],
         "problemMatchers": [{
             "name": "node-sass",

--- a/extensions/scss/syntaxes/sassdoc.tmLanguage.json
+++ b/extensions/scss/syntaxes/sassdoc.tmLanguage.json
@@ -1,0 +1,354 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/atom/language-sass/blob/master/grammars/sassdoc.cson",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/atom/language-sass/commit/303bbf0c250fe380b9e57375598cfd916110758b",
+	"name": "SassDoc",
+	"scopeName": "source.sassdoc",
+	"patterns": [
+		{
+			"match": "(?x)\n((@)(?:access))\n\\s+\n(private|public)\n\\b",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "constant.language.access-type.sassdoc"
+				}
+			}
+		},
+		{
+			"match": "(?x)\n((@)author)\n\\s+\n(\n  [^@\\s<>*/]\n  (?:[^@<>*/]|\\*[^/])*\n)\n(?:\n  \\s*\n  (<)\n  ([^>\\s]+)\n  (>)\n)?",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "entity.name.type.instance.sassdoc"
+				},
+				"4": {
+					"name": "punctuation.definition.bracket.angle.begin.sassdoc"
+				},
+				"5": {
+					"name": "constant.other.email.link.underline.sassdoc"
+				},
+				"6": {
+					"name": "punctuation.definition.bracket.angle.end.sassdoc"
+				}
+			}
+		},
+		{
+			"name": "meta.example.css.scss.sassdoc",
+			"begin": "(?x)\n((@)example)\n\\s+\n(css|scss)",
+			"end": "(?=@|///$)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "variable.other.sassdoc"
+				}
+			},
+			"patterns": [
+				{
+					"match": "^///\\s+"
+				},
+				{
+					"match": "[^\\s@*](?:[^*]|\\*[^/])*",
+					"captures": {
+						"0": {
+							"name": "source.embedded.css.scss",
+							"patterns": [
+								{
+									"include": "source.css.scss"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "meta.example.html.sassdoc",
+			"begin": "(?x)\n((@)example)\n\\s+\n(markup)",
+			"end": "(?=@|///$)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "variable.other.sassdoc"
+				}
+			},
+			"patterns": [
+				{
+					"match": "^///\\s+"
+				},
+				{
+					"match": "[^\\s@*](?:[^*]|\\*[^/])*",
+					"captures": {
+						"0": {
+							"name": "source.embedded.html",
+							"patterns": [
+								{
+									"include": "source.html"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "meta.example.js.sassdoc",
+			"begin": "(?x)\n((@)example)\n\\s+\n(javascript)",
+			"end": "(?=@|///$)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "variable.other.sassdoc"
+				}
+			},
+			"patterns": [
+				{
+					"match": "^///\\s+"
+				},
+				{
+					"match": "[^\\s@*](?:[^*]|\\*[^/])*",
+					"captures": {
+						"0": {
+							"name": "source.embedded.js",
+							"patterns": [
+								{
+									"include": "source.js"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		{
+			"match": "(?x)\n((@)link)\n\\s+\n(?:\n  # URL\n  (\n    (?=https?://)\n    (?:[^\\s*]|\\*[^/])+\n  )\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "variable.other.link.underline.sassdoc"
+				},
+				"4": {
+					"name": "entity.name.type.instance.sassdoc"
+				}
+			}
+		},
+		{
+			"match": "(?x)\n(\n  (@)\n  (?:arg|argument|param|parameter|requires?|see|colors?|fonts?|ratios?|sizes?)\n)\n\\s+\n(\n  [A-Za-z_$%]\n  [\\-\\w$.\\[\\]]*\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "variable.other.sassdoc"
+				}
+			}
+		},
+		{
+			"begin": "((@)(?:arg|argument|param|parameter|prop|property|requires?|see|sizes?))\\s+(?={)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				}
+			},
+			"end": "(?=\\s|\\*/|[^{}\\[\\]A-Za-z_$])",
+			"patterns": [
+				{
+					"include": "#sassdoctype"
+				},
+				{
+					"match": "([A-Za-z_$%][\\-\\w$.\\[\\]]*)",
+					"name": "variable.other.sassdoc"
+				},
+				{
+					"name": "variable.other.sassdoc",
+					"match": "(?x)\n(\\[)\\s*\n[\\w$]+\n(?:\n  (?:\\[\\])?                                        # Foo[].bar properties within an array\n  \\.                                                # Foo.Bar namespaced parameter\n  [\\w$]+\n)*\n(?:\n  \\s*\n  (=)                                                # [foo=bar] Default parameter value\n  \\s*\n  (\n    # The inner regexes are to stop the match early at */ and to not stop at escaped quotes\n    (?>\n      \"(?:(?:\\*(?!/))|(?:\\\\(?!\"))|[^*\\\\])*?\" |  # [foo=\"bar\"] Double-quoted\n      '(?:(?:\\*(?!/))|(?:\\\\(?!'))|[^*\\\\])*?' |  # [foo='bar'] Single-quoted\n      \\[ (?:(?:\\*(?!/))|[^*])*? \\] |              # [foo=[1,2]] Array literal\n      (?:(?:\\*(?!/))|\\s(?!\\s*\\])|\\[.*?(?:\\]|(?=\\*/))|[^*\\s\\[\\]])* # Everything else (sorry)\n    )*\n  )\n)?\n\\s*(?:(\\])((?:[^*\\s]|\\*[^\\s/])+)?|(?=\\*/))",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.optional-value.begin.bracket.square.sassdoc"
+						},
+						"2": {
+							"name": "keyword.operator.assignment.sassdoc"
+						},
+						"3": {
+							"name": "source.embedded.js",
+							"patterns": [
+								{
+									"include": "source.js"
+								}
+							]
+						},
+						"4": {
+							"name": "punctuation.definition.optional-value.end.bracket.square.sassdoc"
+						},
+						"5": {
+							"name": "invalid.illegal.syntax.sassdoc"
+						}
+					}
+				}
+			]
+		},
+		{
+			"begin": "(?x)\n(\n  (@)\n  (?:returns?|throws?|exception|outputs?)\n)\n\\s+(?={)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				}
+			},
+			"end": "(?=\\s|[^{}\\[\\]A-Za-z_$])",
+			"patterns": [
+				{
+					"include": "#sassdoctype"
+				}
+			]
+		},
+		{
+			"match": "(?x)\n(\n  (@)\n  (?:type)\n)\n\\s+\n(\n  (?:\n    [A-Za-z |]+\n  )\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "entity.name.type.instance.sassdoc",
+					"patterns": [
+						{
+							"include": "#sassdoctypedelimiter"
+						}
+					]
+				}
+			}
+		},
+		{
+			"match": "(?x)\n(\n  (@)\n  (?:alias|group|name|requires?|see|icons?)\n)\n\\s+\n(\n  (?:\n    [^{}@\\s*] | \\*[^/]\n  )+\n)",
+			"captures": {
+				"1": {
+					"name": "storage.type.class.sassdoc"
+				},
+				"2": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				},
+				"3": {
+					"name": "entity.name.type.instance.sassdoc"
+				}
+			}
+		},
+		{
+			"name": "storage.type.class.sassdoc",
+			"match": "(?x)\n(@)\n(?:access|alias|author|content|deprecated|example|exception|group\n|ignore|name|prop|property|requires?|returns?|see|since|throws?|todo\n|type|outputs?)\n\\b",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.block.tag.sassdoc"
+				}
+			}
+		}
+	],
+	"repository": {
+		"brackets": {
+			"patterns": [
+				{
+					"begin": "{",
+					"end": "}|(?=$)",
+					"patterns": [
+						{
+							"include": "#brackets"
+						}
+					]
+				},
+				{
+					"begin": "\\[",
+					"end": "\\]|(?=$)",
+					"patterns": [
+						{
+							"include": "#brackets"
+						}
+					]
+				}
+			]
+		},
+		"sassdoctypedelimiter": {
+			"match": "(\\|)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.delimiter.sassdoc"
+				}
+			}
+		},
+		"sassdoctype": {
+			"patterns": [
+				{
+					"name": "invalid.illegal.type.sassdoc",
+					"match": "\\G{(?:[^}*]|\\*[^/}])+$"
+				},
+				{
+					"begin": "\\G({)",
+					"beginCaptures": {
+						"0": {
+							"name": "entity.name.type.instance.sassdoc"
+						},
+						"1": {
+							"name": "punctuation.definition.bracket.curly.begin.sassdoc"
+						}
+					},
+					"contentName": "entity.name.type.instance.sassdoc",
+					"end": "((}))\\s*|(?=$)",
+					"endCaptures": {
+						"1": {
+							"name": "entity.name.type.instance.sassdoc"
+						},
+						"2": {
+							"name": "punctuation.definition.bracket.curly.end.sassdoc"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#brackets"
+						}
+					]
+				}
+			]
+		}
+	}
+}

--- a/extensions/scss/syntaxes/scss.tmLanguage.json
+++ b/extensions/scss/syntaxes/scss.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/atom/language-sass/commit/a07688bd078f420f56df6221e9263d80e738869b",
+	"version": "https://github.com/atom/language-sass/commit/804a935ea1d50504e14a7f602e2bb133fee8450c",
 	"name": "SCSS",
 	"scopeName": "source.css.scss",
 	"patterns": [
@@ -506,6 +506,9 @@
 					"name": "meta.at-rule.media.scss",
 					"patterns": [
 						{
+							"include": "#comment_docblock"
+						},
+						{
 							"include": "#comment_block"
 						},
 						{
@@ -842,6 +845,21 @@
 				}
 			]
 		},
+		"comment_docblock": {
+			"name": "comment.block.documentation.scss",
+			"begin": "///",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.comment.scss"
+				}
+			},
+			"end": "(?=$)",
+			"patterns": [
+				{
+					"include": "source.sassdoc"
+				}
+			]
+		},
 		"comment_block": {
 			"begin": "/\\*",
 			"beginCaptures": {
@@ -1006,6 +1024,9 @@
 					"include": "#variable"
 				},
 				{
+					"include": "#comment_docblock"
+				},
+				{
 					"include": "#comment_block"
 				},
 				{
@@ -1069,6 +1090,9 @@
 			},
 			"name": "meta.definition.variable.map.scss",
 			"patterns": [
+				{
+					"include": "#comment_docblock"
+				},
 				{
 					"include": "#comment_block"
 				},
@@ -1672,6 +1696,9 @@
 					},
 					"end": "(?=;)",
 					"patterns": [
+						{
+							"include": "#comment_docblock"
+						},
 						{
 							"include": "#comment_block"
 						},


### PR DESCRIPTION
Rebuilds the SCSS syntax from the source repo (https://github.com/atom/language-sass).

The latest version of the syntax includes a separate file for SassDoc comment blocks, so
I've modified the scripts and grammars in `package.json` to account for that.

Closes #49071