### PR TITLE
[WIP]: Move Debug Actions Widget to the Debug Viewlet

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugActionsWidget.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActionsWidget.ts
@@ -47,7 +47,6 @@ export const debugToolBarBorder = registerColor('debugToolBar.border', {
 export class DebugActionsWidget extends Themable implements IWorkbenchContribution {
 
 	private $el: Builder;
-	private dragArea: Builder;
 	private actionBar: ActionBar;
 	private allActions: AbstractDebugAction[];
 	private activeActions: AbstractDebugAction[];
@@ -71,8 +70,6 @@ export class DebugActionsWidget extends Themable implements IWorkbenchContributi
 		super(themeService);
 
 		this.$el = $().div().addClass('debug-actions-widget').style('top', `${partService.getTitleBarOffset()}px`);
-		this.dragArea = $().div().addClass('drag-area');
-		this.$el.append(this.dragArea);
 
 		const actionBarContainter = $().div().addClass('.action-bar-container');
 		this.$el.append(actionBarContainter);
@@ -136,40 +133,8 @@ export class DebugActionsWidget extends Themable implements IWorkbenchContributi
 		}));
 		$(window).on(dom.EventType.RESIZE, () => this.setXCoordinate(), this.toUnbind);
 
-		this.dragArea.on(dom.EventType.MOUSE_UP, (event: MouseEvent) => {
-			const mouseClickEvent = new StandardMouseEvent(event);
-			if (mouseClickEvent.detail === 2) {
-				// double click on debug bar centers it again #8250
-				const widgetWidth = this.$el.getHTMLElement().clientWidth;
-				this.setXCoordinate(0.5 * window.innerWidth - 0.5 * widgetWidth);
-				this.storePosition();
-			}
-		});
-
-		this.dragArea.on(dom.EventType.MOUSE_DOWN, (event: MouseEvent) => {
-			const $window = $(window);
-			this.dragArea.addClass('dragged');
-
-			$window.on('mousemove', (e: MouseEvent) => {
-				const mouseMoveEvent = new StandardMouseEvent(e);
-				// Prevent default to stop editor selecting text #8524
-				mouseMoveEvent.preventDefault();
-				// Reduce x by width of drag handle to reduce jarring #16604
-				this.setXCoordinate(mouseMoveEvent.posx - 14);
-			}).once('mouseup', (e: MouseEvent) => {
-				this.storePosition();
-				this.dragArea.removeClass('dragged');
-				$window.off('mousemove');
-			});
-		});
-
 		this.toUnbind.push(this.partService.onTitleBarVisibilityChange(() => this.positionDebugWidget()));
 		this.toUnbind.push(browser.onDidChangeZoomLevel(() => this.positionDebugWidget()));
-	}
-
-	private storePosition(): void {
-		const position = parseFloat(this.$el.getComputedStyle().left) / window.innerWidth;
-		this.storageService.store(DEBUG_ACTIONS_WIDGET_POSITION_KEY, position, StorageScope.WORKSPACE);
 	}
 
 	protected updateStyles(): void {


### PR DESCRIPTION
This PR is one of two solutions that I propose in which fixes #2513. The other PR is #49097.

At the time of writing, this PR was created before the work was implemented to open discussion about the design for this. While #49097 is a simple fix to mitigate #2513, I believe it is ugly from a UX perspective, and the debug actions widget needs to be moved to a more permanent place.

Many solutions have been proposed in #2513.
- Move to the navigation bar
    - I believe this solution is somewhat odd in terms of expected placement
    - Further, the process selection drop down would need to be a button which then pops up a drop down for selection. I think this would just look funky and not get approved by VS Code maintainers
- Pin it to the title bar (left or right side) and the scrollable region for title tabs will be less
    - While this seemed promising at first, this solution breaks down when you do split windows. Each window gets its own tabs and title action, and it would be non-intuitive as to which window the widget was placed. Further, with 3 split windows and the side panel open, there could be very little space for a debug actions widget without making the file names inexistent/small
- Move it to the debug viewlet
    - This would put the debug actions viewlet below the header and above the views container (see the below picture). I feel this is the strongest place to put the debug action widget as it's exactly where you'd expect to find it. Users don't need to see the widget all the time if they use shortcuts, but it would be available in the first place they'd look.

![image](https://user-images.githubusercontent.com/549323/39564295-9b61b246-4e81-11e8-8c7d-256c34d388e9.png)

Unfortunately, putting this in a viewlet does bring up a couple of questions: is it a view like variables/call stack/watch/breakpoints? If so, does it still have a header, is collapsible, and could be reordered? I think that this should always be at the top or bottom of the viewlet. I think it's redundant to show a header, and I think it should always show in the viewlet.

This means it should be a static div outside of the `split-view-container`. We could make a "hack" and just get the element in the `debugActionsWidget.ts` file and append a div in the right spot. However, I could see that we would want to standardize this a little for posterity's sake. This would pose that a viewlet should be able to have a sub-header or something along those lines to display content. Should you only be able to have one div or maybe an array? Should you be able to add div(s) to both above and below the `split-view-container`.

A lot of questions to answer. I'm totally fine with doing the "hack", and I'm fine with figuring out a forward-thinking solution. However, I think we should solve this one way or another in a timely fashion, even if it means implementing a less-than-perfect solution.

Tagging @isidorn on this for discussion