### PR TITLE
Fixed the case where a notification was purged too soon

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -185,6 +185,9 @@ export class NotificationsToasts extends Themable {
 			let timeoutHandle: number;
 			const hideAfterTimeout = () => {
 				timeoutHandle = setTimeout(() => {
+					if (item.progress.state.infinite) {
+						return;
+					}
 					if (!notificationList.hasFocus() && !item.expanded && !isMouseOverToast) {
 						this.removeToast(item);
 					} else {


### PR DESCRIPTION
ProgressService2 creates a notification and marks it as infinite (`progressService2.ts:218`). But the hideAfterTimeout() function (`notificationToasts:186`) removes it after a timeout based on the notification severity (info, warning, error).

This adds a check inside the `hideAfterTimeout()` function. When the infinite state flag is set to true, the notification is not removed, and the `hideAfterTimeout()` function doesn't get called again. Adding the check before calling `hideAfterTimeout()` the first time doesn't work correctly, because the infinite flag is set after the notification handle is created.