### PR TITLE
Update coding information for GBK and GB18030

### DIFF
--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -834,12 +834,12 @@ export const SUPPORTED_ENCODINGS: { [encoding: string]: { labelLong: string; lab
 		order: 33
 	},
 	gbk: {
-		labelLong: 'Chinese (GBK)',
+		labelLong: 'Simplified Chinese (GBK)',
 		labelShort: 'GBK',
 		order: 34
 	},
 	gb18030: {
-		labelLong: 'Chinese (GB18030)',
+		labelLong: 'Simplified Chinese (GB18030)',
 		labelShort: 'GB18030',
 		order: 35
 	},


### PR DESCRIPTION
I edited this file to clarify the coding information for GBK and GB18030 as they're Chinese Government standards and are mainly used for simplified Chinese characters coding.
Ref:
https://en.wikipedia.org/wiki/GBK_(character_encoding)
https://en.wikipedia.org/wiki/GB_18030