### PR TITLE
NPM Scripts: Added configuration option to change default click action

### DIFF
--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -1,6 +1,6 @@
 # Node npm
 
-**Notice** This is a an extension that is bundled with Visual Studio Code. 
+**Notice** This is a an extension that is bundled with Visual Studio Code.
 
 This extension supports running npm scripts defined in the `package.json` as [tasks](https://code.visualstudio.com/docs/editor/tasks). Scripts with the name 'build', 'compile', or 'watch'
 are treated as build tasks.
@@ -15,3 +15,4 @@ For more information about auto detection of Tasks pls see the [documentation](h
 - `npm.packageManager` the package manager used to run the scripts: `npm` or `yarn`, the default is `npm`.
 - `npm.exclude` glob patterns for folders that should be excluded from automatic script detection. The pattern is matched against the **absolute path** of the package.json. For example, to exclude all test folders use '&ast;&ast;/test/&ast;&ast;'.
 - `npm.enableScriptExplorer` enable an explorer view for npm scripts.
+- `npm.scriptExplorerAction` choose default click action

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -151,7 +151,18 @@
           "default": false,
           "scope": "resource",
           "description": "%config.npm.enableScriptExplorer%"
-        }
+        },
+				"npm.scriptExplorerAction": {
+					"type": "string",
+					"enum": [
+						"open",
+						"run",
+						"debug"
+					],
+					"description": "%config.npm.scriptExplorerAction%",
+					"scope": "resource",
+					"default": "open"
+				}
       }
     },
     "jsonValidation": [

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -6,6 +6,7 @@
 	"config.npm.packageManager": "The package manager used to run scripts.",
 	"config.npm.exclude": "Configure glob patterns for folders that should be excluded from automatic script detection.",
 	"config.npm.enableScriptExplorer": "Enable an explorer view for npm scripts.",
+	"config.npm.scriptExplorerAction": "Define default click action.",
 	"npm.parseError": "Npm task detection: failed to parse the file {0}",
 	"taskdef.script": "The npm script to customize.",
 	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be ommitted.",

--- a/extensions/npm/src/npmView.ts
+++ b/extensions/npm/src/npmView.ts
@@ -65,20 +65,38 @@ class PackageJSON extends TreeItem {
 	}
 }
 
+type NpmActions = 'open' | 'run' | 'debug';
+
 class NpmScript extends TreeItem {
 	task: Task;
 	package: PackageJSON;
 
 	constructor(context: ExtensionContext, packageJson: PackageJSON, task: Task) {
 		super(task.name, TreeItemCollapsibleState.None);
+		const config = workspace.getConfiguration();
+		const action: NpmActions = config.get('npm.scriptExplorerAction') || 'open';
+		const commandList = {
+			'open': {
+				title: 'Configure Script',
+				command: 'npm.openScript',
+				arguments: [this]
+			},
+			'run': {
+				title: 'Run Script',
+				command: 'npm.runScript',
+				arguments: [this]
+			},
+			'debug': {
+				title: 'Debug Script',
+				command: 'npm.debugScript',
+				arguments: [this]
+			}
+		};
+
 		this.contextValue = 'script';
 		this.package = packageJson;
 		this.task = task;
-		this.command = {
-			title: 'Run Script',
-			command: 'npm.openScript',
-			arguments: [this]
-		};
+		this.command = commandList[action];
 		this.iconPath = {
 			light: context.asAbsolutePath(path.join('resources', 'light', 'script.svg')),
 			dark: context.asAbsolutePath(path.join('resources', 'dark', 'script.svg'))


### PR DESCRIPTION
This allows users to choose what the default operation is going to be when clicking on a task in the npm scripts view. 

 #49204 
