### PR TITLE
Fixed #4375 - Multiple Cursors now go to the next logical line 

### DIFF
--- a/src/vs/editor/common/controller/cursorMoveCommands.ts
+++ b/src/vs/editor/common/controller/cursorMoveCommands.ts
@@ -12,15 +12,26 @@ import { WordOperations } from 'vs/editor/common/controller/cursorWordOperations
 import * as types from 'vs/base/common/types';
 import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
 import { Selection } from 'vs/editor/common/core/selection';
+import { ITextModel } from 'vs/editor/common/model';
 
 export class CursorMoveCommands {
 
-	public static addCursorDown(context: CursorContext, cursors: CursorState[]): CursorState[] {
+	public static addCursorDown(context: CursorContext, cursors: CursorState[], model: ITextModel = null): CursorState[] {
 		let result: CursorState[] = [], resultLen = 0;
-		for (let i = 0, len = cursors.length; i < len; i++) {
-			const cursor = cursors[i];
-			result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
-			result[resultLen++] = CursorState.fromViewState(MoveOperations.translateDown(context.config, context.viewModel, cursor.viewState));
+		if (model) {
+			for (let i = 0, len = cursors.length; i < len; i++) {
+				const cursor = cursors[i];
+				let lineContent = model.getLineContent(cursor.modelState.selection.startLineNumber + 1);
+				let additionalLine = model.findNextMatch(lineContent, cursor.modelState.position, false, true, null, false).range;
+				result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
+				result[resultLen++] = CursorState.fromModelSelection(new Selection(additionalLine.startLineNumber, cursor.viewState.selection.startColumn, additionalLine.endLineNumber, cursor.viewState.selection.endColumn));
+			}
+		} else {
+			for (let i = 0, len = cursors.length; i < len; i++) {
+				const cursor = cursors[i];
+				result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
+				result[resultLen++] = CursorState.fromViewState(MoveOperations.translateDown(context.config, context.viewModel, cursor.viewState));
+			}
 		}
 		return result;
 	}
@@ -31,12 +42,22 @@ export class CursorMoveCommands {
 		return result;
 	}
 
-	public static addCursorUp(context: CursorContext, cursors: CursorState[]): CursorState[] {
+	public static addCursorUp(context: CursorContext, cursors: CursorState[], model: ITextModel = null): CursorState[] {
 		let result: CursorState[] = [], resultLen = 0;
-		for (let i = 0, len = cursors.length; i < len; i++) {
-			const cursor = cursors[i];
-			result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
-			result[resultLen++] = CursorState.fromViewState(MoveOperations.translateUp(context.config, context.viewModel, cursor.viewState));
+		if (model) {
+			for (let i = 0, len = cursors.length; i < len; i++) {
+				const cursor = cursors[i];
+				let lineContent = model.getLineContent(cursor.modelState.selection.startLineNumber - 1);
+				let additionalLine = model.findPreviousMatch(lineContent, cursor.modelState.position, false, true, null, false).range;
+				result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
+				result[resultLen++] = CursorState.fromModelSelection(new Selection(additionalLine.startLineNumber, cursor.viewState.selection.startColumn, additionalLine.endLineNumber, cursor.viewState.selection.endColumn));
+			}
+		} else {
+			for (let i = 0, len = cursors.length; i < len; i++) {
+				const cursor = cursors[i];
+				result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
+				result[resultLen++] = CursorState.fromViewState(MoveOperations.translateUp(context.config, context.viewModel, cursor.viewState));
+			}
 		}
 		return result;
 	}

--- a/src/vs/editor/common/controller/cursorMoveCommands.ts
+++ b/src/vs/editor/common/controller/cursorMoveCommands.ts
@@ -11,6 +11,7 @@ import { MoveOperations } from 'vs/editor/common/controller/cursorMoveOperations
 import { WordOperations } from 'vs/editor/common/controller/cursorWordOperations';
 import * as types from 'vs/base/common/types';
 import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { Selection } from 'vs/editor/common/core/selection';
 
 export class CursorMoveCommands {
 
@@ -21,6 +22,12 @@ export class CursorMoveCommands {
 			result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
 			result[resultLen++] = CursorState.fromViewState(MoveOperations.translateDown(context.config, context.viewModel, cursor.viewState));
 		}
+		return result;
+	}
+
+	public static addCursorSelect(context: CursorContext, selections: Selection[]): CursorState[] {
+		let result: CursorState[] = [];
+		result = CursorState.fromModelSelections(selections);
 		return result;
 	}
 

--- a/src/vs/editor/common/controller/cursorMoveCommands.ts
+++ b/src/vs/editor/common/controller/cursorMoveCommands.ts
@@ -11,20 +11,16 @@ import { MoveOperations } from 'vs/editor/common/controller/cursorMoveOperations
 import { WordOperations } from 'vs/editor/common/controller/cursorWordOperations';
 import * as types from 'vs/base/common/types';
 import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
-import { Selection } from 'vs/editor/common/core/selection';
-import { ITextModel } from 'vs/editor/common/model';
 
 export class CursorMoveCommands {
 
-	public static addCursorDown(context: CursorContext, cursors: CursorState[], model: ITextModel = null): CursorState[] {
+	public static addCursorDown(context: CursorContext, cursors: CursorState[], useLogicalLine: boolean): CursorState[] {
 		let result: CursorState[] = [], resultLen = 0;
-		if (model) {
+		if (useLogicalLine) {
 			for (let i = 0, len = cursors.length; i < len; i++) {
 				const cursor = cursors[i];
-				let lineContent = model.getLineContent(cursor.modelState.selection.startLineNumber + 1);
-				let additionalLine = model.findNextMatch(lineContent, cursor.modelState.position, false, true, null, false).range;
 				result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
-				result[resultLen++] = CursorState.fromModelSelection(new Selection(additionalLine.startLineNumber, cursor.viewState.selection.startColumn, additionalLine.endLineNumber, cursor.viewState.selection.endColumn));
+				result[resultLen++] = CursorState.fromModelState(MoveOperations.translateDown(context.config, context.model, cursor.modelState));
 			}
 		} else {
 			for (let i = 0, len = cursors.length; i < len; i++) {
@@ -36,21 +32,13 @@ export class CursorMoveCommands {
 		return result;
 	}
 
-	public static addCursorSelect(context: CursorContext, selections: Selection[]): CursorState[] {
-		let result: CursorState[] = [];
-		result = CursorState.fromModelSelections(selections);
-		return result;
-	}
-
-	public static addCursorUp(context: CursorContext, cursors: CursorState[], model: ITextModel = null): CursorState[] {
+	public static addCursorUp(context: CursorContext, cursors: CursorState[], useLogicalLine: boolean): CursorState[] {
 		let result: CursorState[] = [], resultLen = 0;
-		if (model) {
+		if (useLogicalLine) {
 			for (let i = 0, len = cursors.length; i < len; i++) {
 				const cursor = cursors[i];
-				let lineContent = model.getLineContent(cursor.modelState.selection.startLineNumber - 1);
-				let additionalLine = model.findPreviousMatch(lineContent, cursor.modelState.position, false, true, null, false).range;
 				result[resultLen++] = new CursorState(cursor.modelState, cursor.viewState);
-				result[resultLen++] = CursorState.fromModelSelection(new Selection(additionalLine.startLineNumber, cursor.viewState.selection.startColumn, additionalLine.endLineNumber, cursor.viewState.selection.endColumn));
+				result[resultLen++] = CursorState.fromModelState(MoveOperations.translateUp(context.config, context.model, cursor.modelState));
 			}
 		} else {
 			for (let i = 0, len = cursors.length; i < len; i++) {

--- a/src/vs/editor/contrib/multicursor/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/multicursor.ts
@@ -28,8 +28,6 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 
 export class InsertCursorAbove extends EditorAction {
 
-	private logicalLine: boolean;
-
 	constructor() {
 		super({
 			id: 'editor.action.insertCursorAbove',
@@ -45,11 +43,10 @@ export class InsertCursorAbove extends EditorAction {
 				}
 			}
 		});
-		this.logicalLine = true;
 	}
 
-
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
+		const useLogicalLine = (args && args.logicalLine === true);
 		const cursors = editor._getCursors();
 		const context = cursors.context;
 
@@ -57,23 +54,17 @@ export class InsertCursorAbove extends EditorAction {
 			return;
 		}
 
-		if (editor.getSelections[0].startLineNumber === 1) {
-			return;
-		}
-
 		context.model.pushStackElement();
 		cursors.setStates(
 			args.source,
 			CursorChangeReason.Explicit,
-			CursorMoveCommands.addCursorUp(context, cursors.getAll(), (this.logicalLine) ? editor.getModel() : null)
+			CursorMoveCommands.addCursorUp(context, cursors.getAll(), useLogicalLine)
 		);
 		cursors.reveal(true, RevealTarget.TopMost, ScrollType.Smooth);
 	}
 }
 
 export class InsertCursorBelow extends EditorAction {
-
-	private logicalLine: boolean;
 
 	constructor() {
 		super({
@@ -90,10 +81,10 @@ export class InsertCursorBelow extends EditorAction {
 				}
 			}
 		});
-		this.logicalLine = true;
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
+		const useLogicalLine = (args && args.logicalLine === true);
 		const cursors = editor._getCursors();
 		const context = cursors.context;
 
@@ -101,15 +92,11 @@ export class InsertCursorBelow extends EditorAction {
 			return;
 		}
 
-		if (editor.getSelections()[editor.getSelections().length - 1].startLineNumber >= editor.getModel().getLineCount()) {
-			return;
-		}
-
 		context.model.pushStackElement();
 		cursors.setStates(
 			args.source,
 			CursorChangeReason.Explicit,
-			CursorMoveCommands.addCursorDown(context, cursors.getAll(), (this.logicalLine) ? editor.getModel() : null)
+			CursorMoveCommands.addCursorDown(context, cursors.getAll(), useLogicalLine)
 		);
 		cursors.reveal(true, RevealTarget.BottomMost, ScrollType.Smooth);
 	}

--- a/src/vs/editor/contrib/multicursor/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/multicursor.ts
@@ -27,6 +27,9 @@ import { INewFindReplaceState, FindOptionOverride } from 'vs/editor/contrib/find
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 
 export class InsertCursorAbove extends EditorAction {
+
+	private logicalLine: boolean;
+
 	constructor() {
 		super({
 			id: 'editor.action.insertCursorAbove',
@@ -42,38 +45,36 @@ export class InsertCursorAbove extends EditorAction {
 				}
 			}
 		});
+		this.logicalLine = true;
 	}
+
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
 		const cursors = editor._getCursors();
 		const context = cursors.context;
-		const model = editor.getModel();
 
 		if (context.config.readOnly) {
 			return;
 		}
 
-		let selects = editor.getSelections();
-
-		if (selects[0].startLineNumber === 1) {
+		if (editor.getSelections[0].startLineNumber === 1) {
 			return;
 		}
-
-		let additionalLine = editor.getModel().findPreviousMatch(model.getLineContent(selects[0].selectionStartLineNumber - 1), editor.getPosition(), false, true, null, false).range;
-
-		selects.unshift(new Selection(additionalLine.startLineNumber, selects[selects.length - 1].startColumn, additionalLine.endLineNumber, selects[selects.length - 1].startColumn));
 
 		context.model.pushStackElement();
 		cursors.setStates(
 			args.source,
 			CursorChangeReason.Explicit,
-			CursorMoveCommands.addCursorSelect(context, selects)
+			CursorMoveCommands.addCursorUp(context, cursors.getAll(), (this.logicalLine) ? editor.getModel() : null)
 		);
 		cursors.reveal(true, RevealTarget.TopMost, ScrollType.Smooth);
 	}
 }
 
 export class InsertCursorBelow extends EditorAction {
+
+	private logicalLine: boolean;
+
 	constructor() {
 		super({
 			id: 'editor.action.insertCursorBelow',
@@ -89,32 +90,26 @@ export class InsertCursorBelow extends EditorAction {
 				}
 			}
 		});
+		this.logicalLine = true;
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
 		const cursors = editor._getCursors();
 		const context = cursors.context;
-		const model = editor.getModel();
 
 		if (context.config.readOnly) {
 			return;
 		}
 
-		let selects = editor.getSelections();
-
-		if (selects[selects.length - 1].startLineNumber >= model.getLineCount()) {
+		if (editor.getSelections()[editor.getSelections().length - 1].startLineNumber >= editor.getModel().getLineCount()) {
 			return;
 		}
-
-		let additionalLine = editor.getModel().findNextMatch(model.getLineContent(selects[selects.length - 1].selectionStartLineNumber + 1), editor.getPosition(), false, true, null, false).range;
-
-		selects.push(new Selection(additionalLine.startLineNumber, selects[0].startColumn, additionalLine.endLineNumber, selects[0].startColumn));
 
 		context.model.pushStackElement();
 		cursors.setStates(
 			args.source,
 			CursorChangeReason.Explicit,
-			CursorMoveCommands.addCursorSelect(context, selects)
+			CursorMoveCommands.addCursorDown(context, cursors.getAll(), (this.logicalLine) ? editor.getModel() : null)
 		);
 		cursors.reveal(true, RevealTarget.BottomMost, ScrollType.Smooth);
 	}


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/4375.

When adding multiple cursors it now only creates cursors for logical lines instead of visual lines.

Adding Cursors Down:
![movedown](https://user-images.githubusercontent.com/16523071/39676457-3f403b08-5139-11e8-8656-09be5ce1a1ee.gif)

Adding Cursors Up:
![moveup](https://user-images.githubusercontent.com/16523071/39676463-4cd4aede-5139-11e8-870e-4aa45e8da01d.gif)

Thanks for considering this PR.