### PR TITLE
Don't use code annotations unconditionally for related diagnostics

### DIFF
--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -174,8 +174,10 @@ class ModelMarkerHandler {
 				hoverMessage.appendMarkdown('\n');
 				for (const { message, resource, startLineNumber, startColumn } of relatedInformation) {
 					hoverMessage.appendMarkdown(
-						`* [${basename(resource.path)}(${startLineNumber}, ${startColumn})](${resource.toString(false)}#${startLineNumber},${startColumn}): ${message} \n`
+						`* [${basename(resource.path)}(${startLineNumber}, ${startColumn})](${resource.toString(false)}#${startLineNumber},${startColumn}): `
 					);
+					hoverMessage.appendText(`${message}`);
+					hoverMessage.appendMarkdown('\n');
 				}
 				hoverMessage.appendMarkdown('\n');
 			}

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -174,7 +174,7 @@ class ModelMarkerHandler {
 				hoverMessage.appendMarkdown('\n');
 				for (const { message, resource, startLineNumber, startColumn } of relatedInformation) {
 					hoverMessage.appendMarkdown(
-						`* [${basename(resource.path)}(${startLineNumber}, ${startColumn})](${resource.toString(false)}#${startLineNumber},${startColumn}): \`${message}\` \n`
+						`* [${basename(resource.path)}(${startLineNumber}, ${startColumn})](${resource.toString(false)}#${startLineNumber},${startColumn}): ${message} \n`
 					);
 				}
 				hoverMessage.appendMarkdown('\n');


### PR DESCRIPTION
Apparently fixes #46713.

First of all, thank you for your work on related information! That seems like a huge boon for Rust users, where the diagnostics emitted by the compiler often have multiple spans. It's nifty to see them logically grouped in VSCode!

I noticed that the related information messages unconditionally use code formatting. That doesn't seem consistent with regular diagnostic messages and also `rustc` emits messages containing backticks when referring to code, which would benefit further from using the message verbatim.

I tried to nail it down, the effects can be seen here:

Before:
![before_change](https://user-images.githubusercontent.com/3093213/39677201-36ed3882-5177-11e8-938c-ab5d0fd03791.png)

After:
![after_change](https://user-images.githubusercontent.com/3093213/39677205-401be66a-5177-11e8-8209-63dd4d2a1748.png)

Is the fix good or should we sanitize and disable markdown rendering for related information, like it's done for primary diagnostic message? (It'd be great to opt-in into primary diagnostic message rendered as markdown as well, but that's another thing)