### PR TITLE
NPM Scripts: Add configuration option to toggle visibility of pre/post scripts

### DIFF
--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -1,6 +1,6 @@
 # Node npm
 
-**Notice** This is a an extension that is bundled with Visual Studio Code. 
+**Notice** This is a an extension that is bundled with Visual Studio Code.
 
 This extension supports running npm scripts defined in the `package.json` as [tasks](https://code.visualstudio.com/docs/editor/tasks). Scripts with the name 'build', 'compile', or 'watch'
 are treated as build tasks.
@@ -15,3 +15,4 @@ For more information about auto detection of Tasks pls see the [documentation](h
 - `npm.packageManager` the package manager used to run the scripts: `npm` or `yarn`, the default is `npm`.
 - `npm.exclude` glob patterns for folders that should be excluded from automatic script detection. The pattern is matched against the **absolute path** of the package.json. For example, to exclude all test folders use '&ast;&ast;/test/&ast;&ast;'.
 - `npm.enableScriptExplorer` enable an explorer view for npm scripts.
+- `npm.showPrePostScripts` show pre/post scripts. Hidden by default.

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -151,7 +151,13 @@
           "default": false,
           "scope": "resource",
           "description": "%config.npm.enableScriptExplorer%"
-        }
+        },
+        "npm.showPrePostScripts": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+					"description": "%config.npm.showPrePostScripts%"
+				}
       }
     },
     "jsonValidation": [

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -6,6 +6,7 @@
 	"config.npm.packageManager": "The package manager used to run scripts.",
 	"config.npm.exclude": "Configure glob patterns for folders that should be excluded from automatic script detection.",
 	"config.npm.enableScriptExplorer": "Enable an explorer view for npm scripts.",
+	"config.npm.showPrePostScripts": "Enable visibility of pre/post scripts.",
 	"npm.parseError": "Npm task detection: failed to parse the file {0}",
 	"taskdef.script": "The npm script to customize.",
 	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be omitted.",

--- a/extensions/npm/src/main.ts
+++ b/extensions/npm/src/main.ts
@@ -34,6 +34,8 @@ function registerTaskProvider(context: vscode.ExtensionContext): vscode.Disposab
 		watcher.onDidCreate((_e) => flushCache());
 		context.subscriptions.push(watcher);
 
+		vscode.workspace.onDidChangeConfiguration(flushCache);
+
 		let provider: vscode.TaskProvider = {
 			provideTasks: async () => {
 				if (!cachedTasks) {

--- a/extensions/npm/src/tasks.ts
+++ b/extensions/npm/src/tasks.ts
@@ -40,8 +40,16 @@ function isTestTask(name: string): boolean {
 	return false;
 }
 
+function scriptsVisibility(script: string): boolean {
+	return isShowPrePostScripts() || isNotPreOrPostScript(script);
+}
+
 function isNotPreOrPostScript(script: string): boolean {
 	return !(script.startsWith('pre') || script.startsWith('post'));
+}
+
+function isShowPrePostScripts(): boolean {
+	return workspace.getConfiguration('npm', null).get<boolean>('showPrePostScripts') === true;
 }
 
 export function isWorkspaceFolder(value: any): value is WorkspaceFolder {
@@ -140,7 +148,7 @@ async function provideNpmScriptsForFolder(packageJsonUri: Uri): Promise<Task[]> 
 	}
 
 	const result: Task[] = [];
-	Object.keys(scripts).filter(isNotPreOrPostScript).forEach(each => {
+	Object.keys(scripts).filter(scriptsVisibility).forEach(each => {
 		const task = createTask(each, `run ${each}`, folder!, packageJsonUri);
 		const lowerCaseTaskName = each.toLowerCase();
 		if (isBuildTask(lowerCaseTaskName)) {


### PR DESCRIPTION
```
{
    "npm.enableScriptExplorer": true,
    "npm.showPrePostScripts": true
}
```

My use case: I have two npm scripts, one named `precommit` and one `prettier-all` that are hidden in the npm scripts panel [because of this line](https://github.com/Microsoft/vscode/blob/master/extensions/npm/src/tasks.ts#L143).

This PR add an option to prevent the filtering.
