### PR TITLE
[themes] font-weigth => font-weight

### DIFF
--- a/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
@@ -300,7 +300,7 @@ function _processIconThemeDocument(id: string, iconThemeDocumentPath: string, ic
 	if (Array.isArray(fonts)) {
 		fonts.forEach(font => {
 			let src = font.src.map(l => `url('${resolvePath(l.path)}') format('${l.format}')`).join(', ');
-			cssRules.push(`@font-face { src: ${src}; font-family: '${font.id}'; font-weigth: ${font.weight}; font-style: ${font.style}; }`);
+			cssRules.push(`@font-face { src: ${src}; font-family: '${font.id}'; font-weight: ${font.weight}; font-style: ${font.style}; }`);
 		});
 		cssRules.push(`.show-file-icons .file-icon::before, .show-file-icons .folder-icon::before, .show-file-icons .rootfolder-icon::before { font-family: '${fonts[0].id}'; font-size: ${fonts[0].size || '150%'}}`);
 	}


### PR DESCRIPTION
There is a spell error in src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts

font-weigth => font-weight