### PR TITLE
Allow class names to begin with an underscore in textModel.ts 

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -2757,7 +2757,7 @@ class DecorationsTrees {
 }
 
 function cleanClassName(className: string): string {
-	return className.replace(/[^a-z0-9\-]/gi, ' ');
+	return className.replace(/[^a-z0-9\-_]/gi, ' ');
 }
 
 export class ModelDecorationOverviewRulerOptions implements model.IModelDecorationOverviewRulerOptions {


### PR DESCRIPTION
As per https://github.com/Microsoft/monaco-editor/issues/869 class names that begin with an underscore are being cleaned of the underscore even though it is a valid identifier.

This stops underscores being cleaned, which allows WebPack generated css classnames to be used as decorations. 