### PR TITLE
[openWindowCommand handler]: pass window id to make sure the current window is reloaded

### DIFF
--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -96,6 +96,21 @@ export interface IDevToolsOptions {
 	mode: 'right' | 'bottom' | 'undocked' | 'detach';
 }
 
+export interface IOpenWindowOptions {
+	forceNewWindow?: boolean;
+	forceReuseWindow?: boolean;
+	forceOpenWorkspaceAsFile?: boolean;
+	targetWindowId?: number;
+}
+
+export interface IOpenOptions {
+	cli?: ParsedArgs;
+	userEnv?: IProcessEnvironment;
+	targetWindowId?: number;
+	initialStartup?: boolean;
+	forceNewWindow?: boolean;
+}
+
 export interface IWindowsService {
 
 	_serviceBrand: any;
@@ -151,7 +166,7 @@ export interface IWindowsService {
 	toggleSharedProcess(): TPromise<void>;
 
 	// Global methods
-	openWindow(paths: string[], options?: { forceNewWindow?: boolean, forceReuseWindow?: boolean, forceOpenWorkspaceAsFile?: boolean; }): TPromise<void>;
+	openWindow(paths: string[], options?: IOpenWindowOptions): TPromise<void>;
 	openNewWindow(): TPromise<void>;
 	showWindow(windowId: number): TPromise<void>;
 	getWindows(): TPromise<{ id: number; workspace?: IWorkspaceIdentifier; folderPath?: string; title: string; filename?: string; }[]>;

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import { TPromise } from 'vs/base/common/winjs.base';
-import { OpenContext, IWindowConfiguration, ReadyState, INativeOpenDialogOptions, IEnterWorkspaceResult, IMessageBoxResult } from 'vs/platform/windows/common/windows';
+import { OpenContext, IWindowConfiguration, ReadyState, INativeOpenDialogOptions, IEnterWorkspaceResult, IMessageBoxResult, IOpenOptions } from 'vs/platform/windows/common/windows';
 import { ParsedArgs } from 'vs/platform/environment/common/environment';
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -117,20 +117,17 @@ export interface IWindowsMainService {
 	quit(): void;
 }
 
-export interface IOpenConfiguration {
+export interface IOpenConfiguration extends IOpenOptions {
 	context: OpenContext;
-	cli: ParsedArgs;
-	userEnv?: IProcessEnvironment;
 	pathsToOpen?: string[];
 	preferNewWindow?: boolean;
-	forceNewWindow?: boolean;
 	forceReuseWindow?: boolean;
 	forceEmpty?: boolean;
 	diffMode?: boolean;
 	addMode?: boolean;
 	forceOpenWorkspaceAsFile?: boolean;
-	initialStartup?: boolean;
 }
+
 
 export interface ISharedProcess {
 	whenReady(): TPromise<void>;

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -11,7 +11,7 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { assign } from 'vs/base/common/objects';
 import URI from 'vs/base/common/uri';
 import product from 'vs/platform/node/product';
-import { IWindowsService, OpenContext, INativeOpenDialogOptions, IEnterWorkspaceResult, IMessageBoxResult, IDevToolsOptions } from 'vs/platform/windows/common/windows';
+import { IWindowsService, OpenContext, INativeOpenDialogOptions, IEnterWorkspaceResult, IMessageBoxResult, IDevToolsOptions, IOpenWindowOptions } from 'vs/platform/windows/common/windows';
 import { IEnvironmentService, ParsedArgs } from 'vs/platform/environment/common/environment';
 import { shell, crashReporter, app, Menu, clipboard } from 'electron';
 import { Event, fromNodeEventEmitter, mapEvent, filterEvent, anyEvent } from 'vs/base/common/event';
@@ -360,7 +360,7 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		return TPromise.as(null);
 	}
 
-	openWindow(paths: string[], options?: { forceNewWindow?: boolean, forceReuseWindow?: boolean, forceOpenWorkspaceAsFile?: boolean }): TPromise<void> {
+	openWindow(paths: string[], options: IOpenWindowOptions = {}): TPromise<void> {
 		this.logService.trace('windowsService#openWindow');
 		if (!paths || !paths.length) {
 			return TPromise.as(null);
@@ -370,9 +370,7 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 			context: OpenContext.API,
 			cli: this.environmentService.args,
 			pathsToOpen: paths,
-			forceNewWindow: options && options.forceNewWindow,
-			forceReuseWindow: options && options.forceReuseWindow,
-			forceOpenWorkspaceAsFile: options && options.forceOpenWorkspaceAsFile
+			...options
 		});
 
 		return TPromise.as(null);

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -10,6 +10,7 @@ import * as paths from 'vs/base/common/paths';
 import { TPromise } from 'vs/base/common/winjs.base';
 import * as labels from 'vs/base/common/labels';
 import URI from 'vs/base/common/uri';
+import { remote } from 'electron';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { toResource, IEditorCommandsContext } from 'vs/workbench/common/editor';
 import { IWindowsService } from 'vs/platform/windows/common/windows';
@@ -78,7 +79,10 @@ export const REMOVE_ROOT_FOLDER_LABEL = nls.localize('removeFolderFromWorkspace'
 
 export const openWindowCommand = (accessor: ServicesAccessor, paths: string[], forceNewWindow: boolean) => {
 	const windowsService = accessor.get(IWindowsService);
-	windowsService.openWindow(paths, { forceNewWindow });
+	const currentWindow = remote.getCurrentWindow();
+	const targetWindowId = currentWindow && currentWindow.id;
+
+	windowsService.openWindow(paths, { forceNewWindow, targetWindowId });
 };
 
 function save(resource: URI, isSaveAs: boolean, editorService: IWorkbenchEditorService, fileService: IFileService, untitledEditorService: IUntitledEditorService,


### PR DESCRIPTION
[Bug](https://github.com/Microsoft/vscode/pull/49730#pullrequestreview-119613744).

The PR updates the `openWindowCommand` handler to pass down the current window id. This allows using the current window to reload to a folder as appose to the last active one [[video](https://monosnap.com/file/Bv3qw3tuTf1zoBB2cgQQ9AnqlZGO2s)].

![image](https://user-images.githubusercontent.com/1478800/39952507-ec7f588c-554c-11e8-8b90-0c78591998eb.png)
