### PR TITLE
Prevent scrollbar to be considered as a drop target for drag-and-drop

### DIFF
--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -1645,7 +1645,7 @@ export class TreeView extends HeightMap {
 				return candidate;
 			}
 
-			if (element === document.body) {
+			if (element === this.scrollableElement.getDomNode() || element === document.body) {
 				return null;
 			}
 		} while (element = element.parentElement);


### PR DESCRIPTION
Fixes: #48929

The approach here is to prevent scrollbar to be not considered a drop target when searching on `dragover` or `dragleave`. This behaviour is similar to how MacOS handles drag and drop while hovering on the scrollbar in Finder.

Another approach is basically to add `drop` event listener on the `domNode` instead of `wrapper` which will allow the user to drop any item on the scrollbar but the file will be dropped on the top level of the folder structure instead of in the scrolled position.

Let me know if you want another approach instead of the one in this PR.