### PR TITLE
Resize the 'Extensions' icon to make it pixel-perfect

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensions.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensions.css
@@ -5,5 +5,5 @@
 
 .monaco-workbench > .activitybar > .content .monaco-action-bar .action-label.extensions {
 	-webkit-mask: url('extensions-dark.svg') no-repeat 50% 50%;
-	-webkit-mask-size: 22px;
+	-webkit-mask-size: 21px;
 }


### PR DESCRIPTION
Seems like reducing just 1px to the size of the Extensions icon makes it pixel-perfect on 2x screens (like the MacBook Retina), and maybe other high-DPI screens. I'd like to see this in master because that slightly blurry icon makes me sad.

![untitled-1](https://user-images.githubusercontent.com/3427344/39961151-2b6bace2-55fe-11e8-8b3d-75e7ad0b1362.png)

😄 