### PR TITLE
Configure output panel editor word wrap

### DIFF
--- a/src/vs/workbench/parts/output/browser/outputPanel.ts
+++ b/src/vs/workbench/parts/output/browser/outputPanel.ts
@@ -91,8 +91,13 @@ export class OutputPanel extends AbstractTextResourceEditor {
 		options.minimap = { enabled: false };
 
 		const outputConfig = this.baseConfigurationService.getValue('[Log]');
-		if (outputConfig && outputConfig['editor.minimap.enabled']) {
-			options.minimap = { enabled: true };
+		if (outputConfig) {
+			if (outputConfig['editor.minimap.enabled']) {
+				options.minimap = { enabled: true };
+			}
+			if ('editor.wordWrap' in outputConfig) {
+				options.wordWrap = outputConfig['editor.wordWrap'];
+			}
 		}
 
 		return options;


### PR DESCRIPTION
Can be configured through preferences:

"[Log]": {
  "editor.wordWrap": "on|off|bounded|wordWrapColumn"
}

Fixes #21468.