### PR TITLE
add 'commits' checkoutType to exclude tags

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -916,7 +916,8 @@
             "all",
             "local",
             "tags",
-            "remote"
+            "remote",
+            "commits"
           ],
           "description": "%config.checkoutType%",
           "default": "all"

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -57,7 +57,7 @@
 	"config.enableLongCommitWarning": "Whether long commit messages should be warned about",
 	"config.confirmSync": "Confirm before synchronizing git repositories",
 	"config.countBadge": "Controls the git badge counter. `all` counts all changes. `tracked` counts only the tracked changes. `off` turns it off.",
-	"config.checkoutType": "Controls what type of branches are listed when running `Checkout to...`. `all` shows all refs, `local` shows only the local branches, `tags` shows only tags and `remote` shows only remote branches.",
+	"config.checkoutType": "Controls what type of branches are listed when running `Checkout to...`. `all` shows all refs, `local` shows only the local branches, `tags` shows only tags, `remote` shows only remote branches and `commits` show only remote and local branches",
 	"config.ignoreLegacyWarning": "Ignores the legacy Git warning",
 	"config.ignoreMissingGitWarning": "Ignores the warning when Git is missing",
 	"config.ignoreLimitWarning": "Ignores the warning when there are too many changes in a repository",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1146,7 +1146,7 @@ export class CommandCenter {
 
 		const config = workspace.getConfiguration('git');
 		const checkoutType = config.get<string>('checkoutType') || 'all';
-		const includeTags = checkoutType !== 'commits' && (checkoutType === 'all' || checkoutType === 'tags');
+		const includeTags = checkoutType === 'all' || checkoutType === 'tags';
 		const includeRemotes = checkoutType === 'all' || checkoutType === 'remote' || checkoutType === 'commits';
 
 		const createBranch = new CreateBranchItem(this);

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1146,8 +1146,8 @@ export class CommandCenter {
 
 		const config = workspace.getConfiguration('git');
 		const checkoutType = config.get<string>('checkoutType') || 'all';
-		const includeTags = checkoutType === 'all' || checkoutType === 'tags';
-		const includeRemotes = checkoutType === 'all' || checkoutType === 'remote';
+		const includeTags = checkoutType !== 'commits' && (checkoutType === 'all' || checkoutType === 'tags');
+		const includeRemotes = checkoutType === 'all' || checkoutType === 'remote' || checkoutType === 'commits';
 
 		const createBranch = new CreateBranchItem(this);
 


### PR DESCRIPTION
This is a pull request for issue: #49868

Add `commits` setting to `git.checkoutType` to only list local and remote branches, excluding tags