### PR TITLE
Add link to package homepage in package.json files

### DIFF
--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -288,6 +288,9 @@ export class PackageJSONContribution implements IJSONContribution {
 					if (latest) {
 						result.push(localize('json.npm.version.hover', 'Latest version: {0}', latest));
 					}
+					if (obj.homepage) {
+						result.push(obj.homepage);
+					}
 					return result;
 				}
 			} catch (e) {


### PR DESCRIPTION
Displayed at the bottom of the box that appears when hovering over a package name