### PR TITLE
Prototype update import paths on file rename/move for JS/TS

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -482,6 +482,28 @@
           "default": true,
           "description": "%typescript.showUnused.enabled%",
           "scope": "resource"
+        },
+        "typescript.updateImportsOnFileMove.enabled": {
+          "type": "string",
+          "enum": [
+            "prompt",
+            "always",
+            "never"
+          ],
+          "default": "prompt",
+          "description": "%typescript.updateImportsOnFileMove.enabled%",
+          "scope": "resource"
+        },
+        "javascript.updateImportsOnFileMove.enabled": {
+          "type": "string",
+          "enum": [
+            "prompt",
+            "always",
+            "never"
+          ],
+          "default": "prompt",
+          "description": "%typescript.updateImportsOnFileMove.enabled%",
+          "scope": "resource"
         }
       }
     },

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -520,11 +520,6 @@
         "command": "typescript.restartTsServer",
         "title": "%typescript.restartTsServer%",
         "category": "TypeScript"
-      },
-      {
-        "command": "typescript.renameFileAndUpdatePaths",
-        "title": "Rename file and update paths",
-        "category": "TypeScript"
       }
     ],
     "menus": {
@@ -572,16 +567,6 @@
         {
           "command": "typescript.restartTsServer",
           "when": "typescript.isManagedFile"
-        },
-        {
-          "command": "typescript.renameFileAndUpdatePaths",
-          "when": ""
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "typescript.renameFileAndUpdatePaths",
-          "when": "resourceLangId == typescript"
         }
       ]
     },

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -520,6 +520,11 @@
         "command": "typescript.restartTsServer",
         "title": "%typescript.restartTsServer%",
         "category": "TypeScript"
+      },
+      {
+        "command": "typescript.renameFileAndUpdatePaths",
+        "title": "Rename file and update paths",
+        "category": "TypeScript"
       }
     ],
     "menus": {
@@ -567,6 +572,16 @@
         {
           "command": "typescript.restartTsServer",
           "when": "typescript.isManagedFile"
+        },
+        {
+          "command": "typescript.renameFileAndUpdatePaths",
+          "when": ""
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "typescript.renameFileAndUpdatePaths",
+          "when": "resourceLangId == typescript"
         }
       ]
     },

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -57,5 +57,6 @@
 	"typescript.suggestionActions.enabled": "Enable/disable suggestion diagnostics for TypeScript files in the editor. Requires TypeScript >= 2.8",
 	"typescript.preferences.quoteStyle": "Preferred quote style to use for quick fixes: 'single' quotes, 'double' quotes, or 'auto' infer quote type from existing imports. Requires TS >= 2.9",
 	"typescript.preferences.importModuleSpecifier": "Preferred path style for auto imports: 'relative' paths, 'non-relative' paths, or 'auto' infer the shortest path type. Requires TS >= 2.9",
-	"typescript.showUnused.enabled": "Enable/disable highlighting of unused variables in code. Requires TypeScript >= 2.9"
+	"typescript.showUnused.enabled": "Enable/disable highlighting of unused variables in code. Requires TypeScript >= 2.9",
+	"typescript.updateImportsOnFileMove.enabled": "Enable/disable automatic updating of import paths when you rename or move a file in VS Code. Possible values are: 'prompt' on each rename, 'always' update paths automatically, and 'never' rename paths and don't prompt me. Requires TypeScript >= 2.9"
 }

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -19,7 +19,6 @@ import ManagedFileContextManager from './utils/managedFileContext';
 import { lazy, Lazy } from './utils/lazy';
 import * as fileSchemes from './utils/fileSchemes';
 import LogDirectoryProvider from './utils/logDirectoryProvider';
-import { RenameFileAndUpdatePathsCommand } from './features/updatePathsOnRename';
 
 export function activate(
 	context: vscode.ExtensionContext
@@ -75,7 +74,6 @@ function createLazyClientHost(
 		context.subscriptions.push(clientHost);
 
 		clientHost.serviceClient.onReady(() => {
-			commandManager.register(new RenameFileAndUpdatePathsCommand(clientHost.serviceClient));
 			context.subscriptions.push(
 				ProjectStatus.create(
 					clientHost.serviceClient,

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -19,6 +19,7 @@ import ManagedFileContextManager from './utils/managedFileContext';
 import { lazy, Lazy } from './utils/lazy';
 import * as fileSchemes from './utils/fileSchemes';
 import LogDirectoryProvider from './utils/logDirectoryProvider';
+import { RenameFileAndUpdatePathsCommand } from './features/updatePathsOnRename';
 
 export function activate(
 	context: vscode.ExtensionContext
@@ -74,6 +75,7 @@ function createLazyClientHost(
 		context.subscriptions.push(clientHost);
 
 		clientHost.serviceClient.onReady(() => {
+			commandManager.register(new RenameFileAndUpdatePathsCommand(clientHost.serviceClient));
 			context.subscriptions.push(
 				ProjectStatus.create(
 					clientHost.serviceClient,

--- a/extensions/typescript-language-features/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript-language-features/src/features/bufferSyncSupport.ts
@@ -172,10 +172,10 @@ export default class BufferSyncSupport {
 	}
 
 	public listen(): void {
-		workspace.onDidOpenTextDocument(this.onDidOpenTextDocument, this, this.disposables);
+		workspace.onDidOpenTextDocument(this.openTextDocument, this, this.disposables);
 		workspace.onDidCloseTextDocument(this.onDidCloseTextDocument, this, this.disposables);
 		workspace.onDidChangeTextDocument(this.onDidChangeTextDocument, this, this.disposables);
-		workspace.textDocuments.forEach(this.onDidOpenTextDocument, this);
+		workspace.textDocuments.forEach(this.openTextDocument, this);
 	}
 
 	public set validate(value: boolean) {
@@ -196,7 +196,7 @@ export default class BufferSyncSupport {
 		disposeAll(this.disposables);
 	}
 
-	private onDidOpenTextDocument(document: TextDocument): void {
+	public openTextDocument(document: TextDocument): void {
 		if (!this.modeIds.has(document.languageId)) {
 			return;
 		}

--- a/extensions/typescript-language-features/src/features/updatePathsOnRename.ts
+++ b/extensions/typescript-language-features/src/features/updatePathsOnRename.ts
@@ -10,7 +10,6 @@ import * as Proto from '../protocol';
 import { ITypeScriptServiceClient } from '../typescriptService';
 import { Command } from '../utils/commandManager';
 import * as typeConverters from '../utils/typeConverters';
-import { isPrimitive } from 'util';
 
 export class RenameFileAndUpdatePathsCommand implements Command {
 
@@ -51,7 +50,7 @@ export class RenameFileAndUpdatePathsCommand implements Command {
 			return;
 		}
 
-		const edit = typeConverters.WorkspaceEdit.fromFromFileCodeEdits(this.client, response.body.edits);
+		const edit = typeConverters.WorkspaceEdit.fromFromFileCodeEdits(this.client, response.body);
 		await vscode.workspace.applyEdit(edit);
 	}
 }

--- a/extensions/typescript-language-features/src/features/updatePathsOnRename.ts
+++ b/extensions/typescript-language-features/src/features/updatePathsOnRename.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as Proto from '../protocol';
+import { ITypeScriptServiceClient } from '../typescriptService';
+import { Command } from '../utils/commandManager';
+import * as typeConverters from '../utils/typeConverters';
+import { isPrimitive } from 'util';
+
+export class RenameFileAndUpdatePathsCommand implements Command {
+
+	id = 'typescript.renameFileAndUpdatePaths';
+
+	public constructor(
+		private readonly client: ITypeScriptServiceClient
+	) { }
+
+	async execute(resource: vscode.Uri): Promise<void> {
+		if (!resource) {
+			return;
+		}
+
+		const newFileName = await vscode.window.showInputBox({ prompt: 'Enter new file name...', value: path.basename(resource.fsPath) });
+		if (!newFileName) {
+			return;
+		}
+
+		const newFilePath = path.join(path.dirname(resource.fsPath), newFileName);
+		if (fs.existsSync(newFilePath)) {
+			return;
+		}
+
+		// Do rename
+		fs.renameSync(resource.fsPath, newFilePath);
+		vscode.window.showTextDocument(vscode.Uri.file(newFilePath));
+		const args: Proto.GetEditsForFileRenameRequestArgs = {
+			file: newFilePath,
+			oldFilePath: resource.fsPath,
+			newFilePath: newFilePath
+		};
+
+		await new Promise(resolve => setTimeout(resolve, 1000));
+
+		const response = await this.client.execute('getEditsForFileRename', args);
+		if (!response || !response.body) {
+			return;
+		}
+
+		const edit = typeConverters.WorkspaceEdit.fromFromFileCodeEdits(this.client, response.body.edits);
+		await vscode.workspace.applyEdit(edit);
+	}
+}

--- a/extensions/typescript-language-features/src/languageProvider.ts
+++ b/extensions/typescript-language-features/src/languageProvider.ts
@@ -21,6 +21,7 @@ import { CachedNavTreeResponse } from './features/baseCodeLensProvider';
 import { memoize } from './utils/memoize';
 import { disposeAll } from './utils/dispose';
 import TelemetryReporter from './utils/telemetry';
+import { UpdatePathsOnFileRenameHandler } from './features/updatePathsOnRename';
 
 const validateSetting = 'validate.enable';
 const suggestionSetting = 'suggestionActions.enabled';
@@ -40,6 +41,7 @@ export default class LanguageProvider {
 	private readonly versionDependentDisposables: Disposable[] = [];
 
 	private foldingProviderRegistration: Disposable | undefined = void 0;
+	private readonly renameHandler: UpdatePathsOnFileRenameHandler;
 
 	constructor(
 		private readonly client: TypeScriptServiceClient,
@@ -64,6 +66,15 @@ export default class LanguageProvider {
 			await this.registerProviders(client, commandManager, typingsStatus);
 			this.bufferSyncSupport.listen();
 		});
+
+		this.renameHandler = new UpdatePathsOnFileRenameHandler(this.client, this.bufferSyncSupport, this.fileConfigurationManager, async uri => {
+			try {
+				const doc = await workspace.openTextDocument(uri);
+				return this.handles(uri, doc);
+			} catch {
+				return false;
+			}
+		});
 	}
 
 	public dispose(): void {
@@ -73,6 +84,7 @@ export default class LanguageProvider {
 		this.diagnosticsManager.dispose();
 		this.bufferSyncSupport.dispose();
 		this.fileConfigurationManager.dispose();
+		this.renameHandler.dispose();
 	}
 
 	@memoize

--- a/extensions/typescript-language-features/src/languageProvider.ts
+++ b/extensions/typescript-language-features/src/languageProvider.ts
@@ -21,7 +21,7 @@ import { CachedNavTreeResponse } from './features/baseCodeLensProvider';
 import { memoize } from './utils/memoize';
 import { disposeAll } from './utils/dispose';
 import TelemetryReporter from './utils/telemetry';
-import { UpdatePathsOnFileRenameHandler } from './features/updatePathsOnRename';
+import { UpdateImportsOnFileRenameHandler } from './features/updatePathsOnRename';
 
 const validateSetting = 'validate.enable';
 const suggestionSetting = 'suggestionActions.enabled';
@@ -41,7 +41,7 @@ export default class LanguageProvider {
 	private readonly versionDependentDisposables: Disposable[] = [];
 
 	private foldingProviderRegistration: Disposable | undefined = void 0;
-	private readonly renameHandler: UpdatePathsOnFileRenameHandler;
+	private readonly renameHandler: UpdateImportsOnFileRenameHandler;
 
 	constructor(
 		private readonly client: TypeScriptServiceClient,
@@ -67,7 +67,7 @@ export default class LanguageProvider {
 			this.bufferSyncSupport.listen();
 		});
 
-		this.renameHandler = new UpdatePathsOnFileRenameHandler(this.client, this.bufferSyncSupport, this.fileConfigurationManager, async uri => {
+		this.renameHandler = new UpdateImportsOnFileRenameHandler(this.client, this.bufferSyncSupport, this.fileConfigurationManager, async uri => {
 			try {
 				const doc = await workspace.openTextDocument(uri);
 				return this.handles(uri, doc);

--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -45,7 +45,6 @@ export default class TypeScriptServiceClientHost {
 	private readonly languagePerId = new Map<string, LanguageProvider>();
 	private readonly disposables: Disposable[] = [];
 	private readonly versionStatus: VersionStatus;
-	private readonly renameHandler: UpdatePathsOnFileRenameHandler;
 	private reportStyleCheckAsWarnings: boolean = true;
 
 	constructor(
@@ -126,15 +125,12 @@ export default class TypeScriptServiceClientHost {
 
 		workspace.onDidChangeConfiguration(this.configurationChanged, this, this.disposables);
 		this.configurationChanged();
-
-		this.renameHandler = new UpdatePathsOnFileRenameHandler(this.client, uri => this.handles(uri));
 	}
 
 	public dispose(): void {
 		disposeAll(this.disposables);
 		this.typingsStatus.dispose();
 		this.ataProgressReporter.dispose();
-		this.renameHandler.dispose();
 	}
 
 	public get serviceClient(): TypeScriptServiceClient {

--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -25,6 +25,7 @@ import { LanguageDescription } from './utils/languageDescription';
 import LogDirectoryProvider from './utils/logDirectoryProvider';
 import { disposeAll } from './utils/dispose';
 import { DiagnosticKind } from './features/diagnostics';
+import { UpdatePathsOnFileRenameHandler } from './features/updatePathsOnRename';
 
 // Style check diagnostics that can be reported as warnings
 const styleCheckDiagnostics = [
@@ -44,6 +45,7 @@ export default class TypeScriptServiceClientHost {
 	private readonly languagePerId = new Map<string, LanguageProvider>();
 	private readonly disposables: Disposable[] = [];
 	private readonly versionStatus: VersionStatus;
+	private readonly renameHandler: UpdatePathsOnFileRenameHandler;
 	private reportStyleCheckAsWarnings: boolean = true;
 
 	constructor(
@@ -124,12 +126,15 @@ export default class TypeScriptServiceClientHost {
 
 		workspace.onDidChangeConfiguration(this.configurationChanged, this, this.disposables);
 		this.configurationChanged();
+
+		this.renameHandler = new UpdatePathsOnFileRenameHandler(this.client, uri => this.handles(uri));
 	}
 
 	public dispose(): void {
 		disposeAll(this.disposables);
 		this.typingsStatus.dispose();
 		this.ataProgressReporter.dispose();
+		this.renameHandler.dispose();
 	}
 
 	public get serviceClient(): TypeScriptServiceClient {

--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -25,7 +25,7 @@ import { LanguageDescription } from './utils/languageDescription';
 import LogDirectoryProvider from './utils/logDirectoryProvider';
 import { disposeAll } from './utils/dispose';
 import { DiagnosticKind } from './features/diagnostics';
-import { UpdatePathsOnFileRenameHandler } from './features/updatePathsOnRename';
+import { UpdateImportsOnFileRenameHandler } from './features/updatePathsOnRename';
 
 // Style check diagnostics that can be reported as warnings
 const styleCheckDiagnostics = [

--- a/extensions/typescript-language-features/src/typescriptService.ts
+++ b/extensions/typescript-language-features/src/typescriptService.ts
@@ -58,6 +58,7 @@ export interface ITypeScriptServiceClient {
 	execute(command: 'applyCodeActionCommand', args: Proto.ApplyCodeActionCommandRequestArgs, token?: CancellationToken): Promise<Proto.ApplyCodeActionCommandResponse>;
 	execute(command: 'organizeImports', args: Proto.OrganizeImportsRequestArgs, token?: CancellationToken): Promise<Proto.OrganizeImportsResponse>;
 	execute(command: 'getOutliningSpans', args: Proto.FileRequestArgs, token: CancellationToken): Promise<Proto.OutliningSpansResponse>;
+	execute(command: 'getEditsForFileRename', args: Proto.GetEditsForFileRenameRequestArgs): Promise<Proto.GetEditsForFileRenameResponse>;
 	execute(command: string, args: any, expectedResult: boolean | CancellationToken, token?: CancellationToken): Promise<any>;
 
 	executeAsync(command: 'geterr', args: Proto.GeterrRequestArgs, token: CancellationToken): Promise<any>;

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -640,4 +640,15 @@ declare module 'vscode' {
 	}
 
 	//#endregion
+
+	//#region mjbvz: File rename events
+	export interface ResourceRenamedEvent {
+		readonly oldResource: Uri;
+		readonly newResource: Uri;
+	}
+
+	export namespace workspace {
+		export const onDidRenameResource: Event<ResourceRenamedEvent>;
+	}
+	//#endregion
 }

--- a/src/vs/workbench/api/electron-browser/mainThreadDocuments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDocuments.ts
@@ -10,7 +10,7 @@ import { IModelService, shouldSynchronizeModel } from 'vs/editor/common/services
 import { IDisposable, dispose, IReference } from 'vs/base/common/lifecycle';
 import { TextFileModelChangeEvent, ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { TPromise } from 'vs/base/common/winjs.base';
-import { IFileService } from 'vs/platform/files/common/files';
+import { IFileService, FileOperation } from 'vs/platform/files/common/files';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { ExtHostContext, MainThreadDocumentsShape, ExtHostDocumentsShape, IExtHostContext } from '../node/extHost.protocol';
@@ -116,6 +116,12 @@ export class MainThreadDocuments implements MainThreadDocumentsShape {
 		this._toDispose.push(textFileService.models.onModelDirty(e => {
 			if (this._shouldHandleFileEvent(e)) {
 				this._proxy.$acceptDirtyStateChanged(e.resource, true);
+			}
+		}));
+
+		this._toDispose.push(fileService.onAfterOperation(e => {
+			if (e.operation === FileOperation.MOVE) {
+				this._proxy.$onDidRename(e.resource, e.target.resource);
 			}
 		}));
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -568,7 +568,10 @@ export function createApiFactory(
 			}),
 			registerSearchProvider: proposedApiFunction(extension, (scheme, provider) => {
 				return extHostSearch.registerSearchProvider(scheme, provider);
-			})
+			}),
+			onDidRenameResource: proposedApiFunction(extension, (listener, thisArg?, disposables?) => {
+				return extHostDocuments.onDidRenameResource(listener, thisArg, disposables);
+			}),
 		};
 
 		// namespace: scm

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -530,6 +530,7 @@ export interface ExtHostDocumentsShape {
 	$acceptModelSaved(strURL: UriComponents): void;
 	$acceptDirtyStateChanged(strURL: UriComponents, isDirty: boolean): void;
 	$acceptModelChanged(strURL: UriComponents, e: IModelChangedEvent, isDirty: boolean): void;
+	$onDidRename(oldURL: UriComponents, newURL: UriComponents): void;
 }
 
 export interface ExtHostDocumentSaveParticipantShape {

--- a/src/vs/workbench/api/node/extHostDocuments.ts
+++ b/src/vs/workbench/api/node/extHostDocuments.ts
@@ -21,11 +21,13 @@ export class ExtHostDocuments implements ExtHostDocumentsShape {
 	private _onDidRemoveDocument = new Emitter<vscode.TextDocument>();
 	private _onDidChangeDocument = new Emitter<vscode.TextDocumentChangeEvent>();
 	private _onDidSaveDocument = new Emitter<vscode.TextDocument>();
+	private _onDidRenameResource = new Emitter<vscode.ResourceRenamedEvent>();
 
 	readonly onDidAddDocument: Event<vscode.TextDocument> = this._onDidAddDocument.event;
 	readonly onDidRemoveDocument: Event<vscode.TextDocument> = this._onDidRemoveDocument.event;
 	readonly onDidChangeDocument: Event<vscode.TextDocumentChangeEvent> = this._onDidChangeDocument.event;
 	readonly onDidSaveDocument: Event<vscode.TextDocument> = this._onDidSaveDocument.event;
+	readonly onDidRenameResource: Event<vscode.ResourceRenamedEvent> = this._onDidRenameResource.event;
 
 	private _toDispose: IDisposable[];
 	private _proxy: MainThreadDocumentsShape;
@@ -148,4 +150,11 @@ export class ExtHostDocuments implements ExtHostDocumentsShape {
 	public setWordDefinitionFor(modeId: string, wordDefinition: RegExp): void {
 		setWordDefinitionFor(modeId, wordDefinition);
 	}
+
+	public $onDidRename(oldURL: UriComponents, newURL: UriComponents): void {
+		const oldResource = URI.revive(oldURL);
+		const newResource = URI.revive(newURL);
+		this._onDidRenameResource.fire({ oldResource, newResource });
+	}
+
 }

--- a/src/vs/workbench/test/electron-browser/api/mainThreadDocumentsAndEditors.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadDocumentsAndEditors.test.ts
@@ -21,6 +21,7 @@ import { Event } from 'vs/base/common/event';
 import { ITextModel } from 'vs/editor/common/model';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IFileService } from 'vs/platform/files/common/files';
 
 suite('MainThreadDocumentsAndEditors', () => {
 
@@ -63,6 +64,10 @@ suite('MainThreadDocumentsAndEditors', () => {
 			onEditorGroupMoved = Event.None;
 		};
 
+		const fileService = new class extends mock<IFileService>() {
+			onAfterOperation = Event.None;
+		};
+
 		/* tslint:disable */
 		new MainThreadDocumentsAndEditors(
 			SingleProxyRPCProtocol(new class extends mock<ExtHostDocumentsAndEditorsShape>() {
@@ -73,7 +78,7 @@ suite('MainThreadDocumentsAndEditors', () => {
 			workbenchEditorService,
 			codeEditorService,
 			null,
-			null,
+			fileService,
 			null,
 			null,
 			editorGroupService,


### PR DESCRIPTION
#19439

Adds a prototype that updates import paths when you rename or move a js/ts file. This is accomplished by introducing a new proposed VS Code API for understanding when a resource has been renamed or rename (we don't try detecting renames/moves that happen outside of vscode). The new proposed API is rough and needs more thought, see #43768

**TODO**:
- [X] Remove `setTimeout` and replace with proper handler for when TS opens file.
- [X] Add prompt to update paths on rename? Only should fire if there are changes
- [X] Add setting to always update paths on rename (if we add a prompt)

