### PR TITLE
[WIP] Implement a window.captureScreenshot extension API method

### DIFF
--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -115,6 +115,7 @@ export interface IWindowsService {
 
 	reloadWindow(windowId: number, args?: ParsedArgs): TPromise<void>;
 	openDevTools(windowId: number, options?: IDevToolsOptions): TPromise<void>;
+	captureScreenshot(windowId: number): TPromise<string>;
 	toggleDevTools(windowId: number): TPromise<void>;
 	closeWorkspace(windowId: number): TPromise<void>;
 	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult>;
@@ -201,6 +202,7 @@ export interface IWindowService {
 	focusWindow(): TPromise<void>;
 	closeWindow(): TPromise<void>;
 	isFocused(): TPromise<boolean>;
+	captureScreenshot(): TPromise<string>;
 	setDocumentEdited(flag: boolean): TPromise<void>;
 	onWindowTitleDoubleClick(): TPromise<void>;
 	show(): TPromise<void>;

--- a/src/vs/platform/windows/common/windowsIpc.ts
+++ b/src/vs/platform/windows/common/windowsIpc.ts
@@ -197,6 +197,10 @@ export class WindowsChannelClient implements IWindowsService {
 		return this.channel.call('reloadWindow', [windowId, args]);
 	}
 
+	captureScreenshot(windowId: number): TPromise<string> {
+		return this.channel.call('captureScreenshot');
+	}
+
 	openDevTools(windowId: number, options?: IDevToolsOptions): TPromise<void> {
 		return this.channel.call('openDevTools', [windowId, options]);
 	}

--- a/src/vs/platform/windows/electron-browser/windowService.ts
+++ b/src/vs/platform/windows/electron-browser/windowService.ts
@@ -69,6 +69,10 @@ export class WindowService implements IWindowService {
 		return this.windowsService.openDevTools(this.windowId, options);
 	}
 
+	captureScreenshot(): TPromise<string> {
+		return this.windowsService.captureScreenshot(this.windowId);
+	}
+
 	toggleDevTools(): TPromise<void> {
 		return this.windowsService.toggleDevTools(this.windowId);
 	}

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -112,6 +112,17 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		return TPromise.as(null);
 	}
 
+	captureScreenshot(windowId: number): TPromise<string | null> {
+		const codeWindow = this.windowsMainService.getWindowById(windowId);
+		if (codeWindow) {
+			codeWindow.win.webContents.capturePage(image => {
+				return TPromise.as(image.toDataURL());
+			});
+		}
+
+		return TPromise.as(null);
+	}
+
 	openDevTools(windowId: number, options?: IDevToolsOptions): TPromise<void> {
 		this.logService.trace('windowsService#openDevTools', windowId);
 		const codeWindow = this.windowsMainService.getWindowById(windowId);

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5653,6 +5653,13 @@ declare module 'vscode' {
 		export function showErrorMessage<T extends MessageItem>(message: string, options: MessageOptions, ...items: T[]): Thenable<T | undefined>;
 
 		/**
+		 * Captures a screenshot of the window.
+		 *
+		 * @return A Base64 encoded string of the PNG image of the screenshot.
+		 */
+		export function captureScreenshot(): Thenable<string | null>;
+
+		/**
 		 * Shows a selection list allowing multiple selections.
 		 *
 		 * @param items An array of strings, or a promise that resolves to an array of strings.

--- a/src/vs/workbench/api/electron-browser/mainThreadWindow.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWindow.ts
@@ -31,6 +31,10 @@ export class MainThreadWindow implements MainThreadWindowShape {
 		return this.windowService.isFocused();
 	}
 
+	$captureScreenshot(): TPromise<string | null> {
+		return this.windowService.captureScreenshot();
+	}
+
 	dispose(): void {
 		this.disposables = dispose(this.disposables);
 	}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -385,6 +385,9 @@ export function createApiFactory(
 			showErrorMessage(message, first, ...rest) {
 				return extHostMessageService.showMessage(extension, Severity.Error, message, first, rest);
 			},
+			captureScreenshot() {
+				return extHostWindow.captureScreenshot();
+			},
 			showQuickPick(items: any, options: vscode.QuickPickOptions, token?: vscode.CancellationToken): any {
 				return extHostQuickOpen.showQuickPick(undefined, items, options, token);
 			},

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -496,6 +496,7 @@ export interface MainThreadDebugServiceShape extends IDisposable {
 
 export interface MainThreadWindowShape extends IDisposable {
 	$getWindowVisibility(): TPromise<boolean>;
+	$captureScreenshot(): TPromise<string | null>;
 }
 
 // -- extension host

--- a/src/vs/workbench/api/node/extHostWindow.ts
+++ b/src/vs/workbench/api/node/extHostWindow.ts
@@ -7,6 +7,7 @@
 import { Event, Emitter } from 'vs/base/common/event';
 import { ExtHostWindowShape, MainContext, MainThreadWindowShape, IMainContext } from './extHost.protocol';
 import { WindowState } from 'vscode';
+import { TPromise } from '../../../base/common/winjs.base';
 
 export class ExtHostWindow implements ExtHostWindowShape {
 
@@ -34,5 +35,9 @@ export class ExtHostWindow implements ExtHostWindowShape {
 
 		this._state = { ...this._state, focused };
 		this._onDidChangeWindowState.fire(this._state);
+	}
+
+	captureScreenshot(): TPromise<string | null> {
+		return this._proxy.$captureScreenshot();
 	}
 }

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -902,6 +902,10 @@ export class TestWindowService implements IWindowService {
 		return TPromise.as(void 0);
 	}
 
+	captureScreenshot(): TPromise<string> {
+		return TPromise.as(void 0);
+	}
+
 	openDevTools(): TPromise<void> {
 		return TPromise.as(void 0);
 	}
@@ -1033,6 +1037,10 @@ export class TestWindowsService implements IWindowsService {
 	}
 
 	reloadWindow(windowId: number): TPromise<void> {
+		return TPromise.as(void 0);
+	}
+
+	captureScreenshot(): TPromise<string> {
 		return TPromise.as(void 0);
 	}
 


### PR DESCRIPTION
This is my attempt to implement #49959. I am having a problem running VS Code from source, F5 gets stuck in Gulp, figuring that out… This code so far is my trying to use my intuition and TypeScript typings to grasp the architecture and follow established methods. I was successful in getting at the Electron window  in order to call it's `capturePage` method, but I was not able to test this yet, will do once I have fixed my run from source issue.

I cannot claim to fully grasp the architecture, so if you see a glaring issue, please point it out so I can improve my understanding.