### PR TITLE
Add emoji fonts to default font families

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2212,9 +2212,9 @@ export class EditorLayoutProvider {
 	}
 }
 
-const DEFAULT_WINDOWS_FONT_FAMILY = 'Consolas, \'Courier New\', monospace';
-const DEFAULT_MAC_FONT_FAMILY = 'Menlo, Monaco, \'Courier New\', monospace';
-const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', \'monospace\', monospace, \'Droid Sans Fallback\'';
+const DEFAULT_WINDOWS_FONT_FAMILY = 'Consolas, \'Courier New\', monospace, \'Segoe UI Emoji\'';
+const DEFAULT_MAC_FONT_FAMILY = 'Menlo, Monaco, \'Courier New\', monospace, \'Apple Color Emoji\'';
+const DEFAULT_LINUX_FONT_FAMILY = '\'Droid Sans Mono\', \'monospace\', monospace, \'Droid Sans Fallback\', \'Noto Color Emoji\'';
 
 /**
  * @internal


### PR DESCRIPTION
This makes most emoji (like 😃 for example) render correctly in the editor, fixing #32840.

However, it doesn't support zero width joiners, since these glyphs are handled by the normal, non-emoji fonts and don't get rendered by the emoji fonts. Thus emoji like 🙋‍♂️ still don't render correctly, although most others do.

Also for Linux I only have the Ubuntu emoji font (Noto). If anyone knows which fonts other operating systems use these should get added.