### PR TITLE
Simple implementation of drag and drop installation for VSIX extensions

### DIFF
--- a/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
@@ -66,3 +66,7 @@
 .vs-dark .extensions-viewlet>.extensions .extension>.details>.footer>.monaco-action-bar .action-item .action-label.extension-action.manage {
 	background: url('manage-inverse.svg') center center no-repeat;
 }
+
+.extensions-viewlet.dragged-over {
+	background-color: rgba(255, 255, 255, 0.5);
+}


### PR DESCRIPTION
- This allows for (one or) multiple VSIX files to be dropped onto the extension viewlet to be installed.
- This will display an error message if there was an issue installing one extension while still successfully installing the other extensions.
Refactor DelayedDragHandler into DragHandler.
- This allows the implementation of DnD handlers that can be disposed.

Targets #12090.

Note that this is not finished, in that it doesn't support Light/Dark themes styling (the dragged-over color is currently hard coded in the CSS).

I'm also unsure as how to proceed regarding the messages to display on success/failure. A few cases (with the current message being displayed):
- One good VSIX file (current: success message)
- Multiple good VSIX files (current: success message)
- One bad VSIX file (missing package.json)  (current: error message)
- One non-VSIX file (current: no message)
- VSIX+non-VSIX files (current: success message)
