### PR TITLE
[WIP] git: Detect conflict markets in BOTH_ADDED files when staging

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -624,12 +624,13 @@ export class CommandCenter {
 
 		const selection = resourceStates.filter(s => s instanceof Resource) as Resource[];
 		const merge = selection.filter(s => s.resourceGroupType === ResourceGroupType.Merge);
-		const bothModified = merge.filter(s => s.type === Status.BOTH_MODIFIED);
+		const isBothAddedOrModified = (s: Resource) => s.type === Status.BOTH_MODIFIED || s.type === Status.BOTH_ADDED;
+		const bothModified = merge.filter(isBothAddedOrModified);
 		const promises = bothModified.map(s => grep(s.resourceUri.fsPath, /^<{7}|^={7}|^>{7}/));
 		const unresolvedBothModified = await Promise.all<boolean>(promises);
 		const resolvedConflicts = bothModified.filter((s, i) => !unresolvedBothModified[i]);
 		const unresolvedConflicts = [
-			...merge.filter(s => s.type !== Status.BOTH_MODIFIED),
+			...merge.filter(s => !isBothAddedOrModified(s)),
 			...bothModified.filter((s, i) => unresolvedBothModified[i])
 		];
 


### PR DESCRIPTION
The existing code only checked for conflict markers for files with BOTH_MODIFIED status; files with BOTH_ADDED status were always detected as conflicting even after conflicts are resolved.

This fixes #44106.

---
I have only tested this against [this testcase in the original issue](https://github.com/Microsoft/vscode/issues/44106#issuecomment-367292376) . I have not tested to see if this breaks existing conflict detection: are there any Git testcases I can run to make sure that I've fixed the issue and that I didn't introduce regressions?