### PR TITLE
50190

### DIFF
--- a/src/vs/workbench/common/notifications.ts
+++ b/src/vs/workbench/common/notifications.ts
@@ -315,6 +315,7 @@ export class NotificationViewItemProgress implements INotificationViewItemProgre
 
 	public worked(value: number): void {
 		if (this._state.worked === value) {
+			this._onDidChange.fire();
 			return;
 		}
 

--- a/src/vs/workbench/services/progress/browser/progressService2.ts
+++ b/src/vs/workbench/services/progress/browser/progressService2.ts
@@ -221,6 +221,9 @@ export class ProgressService2 implements IProgressService2 {
 
 		let handle: INotificationHandle;
 		const updateNotification = (message?: string, increment?: number): void => {
+			if (!message) {
+				message = ' ';
+			}
 			if (!handle) {
 				handle = createNotification(message, increment);
 			} else {

--- a/src/vs/workbench/services/progress/browser/progressService2.ts
+++ b/src/vs/workbench/services/progress/browser/progressService2.ts
@@ -221,9 +221,6 @@ export class ProgressService2 implements IProgressService2 {
 
 		let handle: INotificationHandle;
 		const updateNotification = (message?: string, increment?: number): void => {
-			if (!message) {
-				message = ' ';
-			}
 			if (!handle) {
 				handle = createNotification(message, increment);
 			} else {


### PR DESCRIPTION
Fix for #50190. 

Was a little unclear about the desired action that a blank message should have. Should it only update the progress bar and keep the previous message or should it update the progress bar and display no message? 

I assumed the former would be desired.

The issue seems to be that when all increments are the same AND the messages are all blank they are seen as exactly the same and thus not updated.

The few solutions I could think of would be to a) force blank messages to include a whitespace. b) Force increment to change by 1 every time. c) update even if they are the same. 