### PR TITLE
Add user setting that hides/shows release notes on Code update #44020

### DIFF
--- a/src/vs/platform/update/node/update.config.contribution.ts
+++ b/src/vs/platform/update/node/update.config.contribution.ts
@@ -28,6 +28,12 @@ configurationRegistry.registerConfiguration({
 			'default': true,
 			'scope': ConfigurationScope.APPLICATION,
 			'description': nls.localize('enableWindowsBackgroundUpdates', "Enables Windows background updates.")
+		},
+		'update.showReleaseNotes': {
+			'type': 'boolean',
+			'default': true,
+			'scope': ConfigurationScope.APPLICATION,
+			'description': nls.localize('showReleaseNotes', 'Show release notes after updating.')
 		}
 	}
 });

--- a/src/vs/workbench/parts/update/electron-browser/update.ts
+++ b/src/vs/workbench/parts/update/electron-browser/update.ts
@@ -30,6 +30,7 @@ import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IWindowService } from 'vs/platform/windows/common/windows';
 import { ReleaseNotesManager } from './releaseNotesEditor';
 import { isWindows } from 'vs/base/common/platform';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 let releaseNotesManager: ReleaseNotesManager | undefined = undefined;
 
@@ -115,12 +116,14 @@ export class ProductContribution implements IWorkbenchContribution {
 		@INotificationService notificationService: INotificationService,
 		@IWorkbenchEditorService editorService: IWorkbenchEditorService,
 		@IEnvironmentService environmentService: IEnvironmentService,
-		@IOpenerService openerService: IOpenerService
+		@IOpenerService openerService: IOpenerService,
+		@IConfigurationService protected configurationService: IConfigurationService
 	) {
 		const lastVersion = storageService.get(ProductContribution.KEY, StorageScope.GLOBAL, '');
+		const showReleaseNotesConfig = configurationService.getValue<boolean>('update.showReleaseNotes');
 
 		// was there an update? if so, open release notes
-		if (!environmentService.skipReleaseNotes && product.releaseNotesUrl && lastVersion && pkg.version !== lastVersion) {
+		if (!environmentService.skipReleaseNotes && showReleaseNotesConfig && product.releaseNotesUrl && lastVersion && pkg.version !== lastVersion) {
 			showReleaseNotes(instantiationService, pkg.version)
 				.then(undefined, () => {
 					notificationService.prompt(


### PR DESCRIPTION
In response to issue #44020, this adds a user setting `update.showReleaseNotes` that determines whether or not an update will trigger the release notes to be shown.