### PR TITLE
[powershell] Update PowerShell Editor Syntax.

### DIFF
--- a/extensions/powershell/syntaxes/powershell.tmLanguage.json
+++ b/extensions/powershell/syntaxes/powershell.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/PowerShell/EditorSyntax/commit/e6e207044299a7121b4ed92c9762f51e1c23d0dd",
+	"version": "https://github.com/PowerShell/EditorSyntax/commit/529562fbe4ba9abde22282ee8b00141284968f4b",
 	"name": "PowerShell",
 	"scopeName": "source.powershell",
 	"patterns": [
@@ -12,13 +12,13 @@
 			"begin": "<#",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.start.definition.comment.block.powershell"
+					"name": "punctuation.definition.comment.block.begin.powershell"
 				}
 			},
 			"end": "#>",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.end.definition.comment.block.powershell"
+					"name": "punctuation.definition.comment.block.end.powershell"
 				}
 			},
 			"name": "comment.block.powershell",
@@ -29,24 +29,14 @@
 			]
 		},
 		{
-			"begin": "(?<![`\\\\-])#",
-			"end": "$",
-			"name": "comment.line.number-sign.powershell",
-			"patterns": [
-				{
-					"include": "#commentEmbeddedDocs"
-				},
-				{
-					"include": "#RequiresDirective"
-				}
-			]
-		},
-		{
 			"match": "[2-6]>&1|>>|>|<<|<|>|>\\||[1-6]>|[1-6]>>",
 			"name": "keyword.operator.redirection.powershell"
 		},
 		{
 			"include": "#commands"
+		},
+		{
+			"include": "#commentLine"
 		},
 		{
 			"include": "#variable"
@@ -70,24 +60,10 @@
 			"include": "#hashtable"
 		},
 		{
-			"begin": "(?<!(?<!`)\")\"",
-			"end": "\"(?!\")",
-			"name": "string.quoted.double.powershell",
-			"patterns": [
-				{
-					"include": "#variableNoProperty"
-				},
-				{
-					"include": "#doubleQuotedStringEscapes"
-				},
-				{
-					"include": "#interpolation"
-				},
-				{
-					"match": "`\\s*$",
-					"name": "keyword.other.powershell"
-				}
-			]
+			"include": "#doubleQuotedString"
+		},
+		{
+			"include": "#scriptblock"
 		},
 		{
 			"comment": "Needed to parse stuff correctly in 'argument mode'. (See about_parsing.)",
@@ -135,13 +111,21 @@
 			"include": "#numericConstant"
 		},
 		{
-			"begin": "@\\(",
-			"captures": {
-				"0": {
-					"name": "keyword.other.powershell"
+			"begin": "(@)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.array.begin.powershell"
+				},
+				"2": {
+					"name": "punctuation.section.group.begin.powershell"
 				}
 			},
 			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.group.end.powershell"
+				}
+			},
 			"name": "meta.group.array-expression.powershell",
 			"patterns": [
 				{
@@ -150,14 +134,22 @@
 			]
 		},
 		{
-			"begin": "\\$\\(",
-			"captures": {
-				"0": {
-					"name": "keyword.other.powershell"
+			"begin": "(\\$)(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.other.variable.definition.powershell"
+				},
+				"2": {
+					"name": "punctuation.section.group.begin.powershell"
 				}
 			},
 			"comment": "TODO: move to repo; make recursive.",
 			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.group.end.powershell"
+				}
+			},
 			"name": "meta.group.complex.subexpression.powershell",
 			"patterns": [
 				{
@@ -174,7 +166,11 @@
 			"name": "support.function.powershell"
 		},
 		{
-			"match": "(?<!\\w)((?i:begin|break|catch|continue|data|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\\?)(?!\\w)",
+			"match": "(?<!\\w|-)((?i:begin|break|catch|continue|data|default|define|do|dynamicparam|else|elseif|end|exit|finally|for|foreach(?!-object)|from|if|in|inlinescript|parallel|param|process|return|switch|throw|trap|try|until|var|where(?!-object)|while)|%|\\?)(?!\\w)",
+			"name": "keyword.control.powershell"
+		},
+		{
+			"match": "(?<!\\w)(--%)(?!\\w)",
 			"name": "keyword.control.powershell"
 		},
 		{
@@ -232,51 +228,112 @@
 		},
 		{
 			"comment": "This is very imprecise, is there a syntax for 'must come after...' ",
-			"match": "(?<!\\s|^)\\.\\.(?=\\d|\\(|\\$)",
+			"match": "(?<!\\s|^)\\.\\.(?=\\-?\\d|\\(|\\$)",
 			"name": "keyword.operator.range.powershell"
 		}
 	],
 	"repository": {
-		"attribute": {
-			"begin": "\\[(\\p{L}|\\.|``\\d+)+(?=\\()",
-			"beginCaptures": {
+		"commentLine": {
+			"begin": "(?<![`\\\\-])#",
+			"captures": {
 				"0": {
-					"name": "entity.name.tag"
+					"name": "punctuation.definition.comment.powershell"
+				}
+			},
+			"end": "$",
+			"name": "comment.line.powershell",
+			"patterns": [
+				{
+					"include": "#commentEmbeddedDocs"
 				},
+				{
+					"include": "#RequiresDirective"
+				}
+			]
+		},
+		"attribute": {
+			"begin": "(\\[)\\s*\\b(?i)(cmdletbinding|alias|outputtype|parameter|validatenotnull|validatenotnullorempty|validatecount|validateset|allownull|allowemptycollection|allowemptystring|validatescript|validaterange|validatepattern|validatelength)\\b",
+			"beginCaptures": {
 				"1": {
-					"name": "entity.name.tag"
+					"name": "punctuation.section.bracket.begin.powershell"
+				},
+				"2": {
+					"name": "support.function.attribute.powershell"
 				}
 			},
-			"end": "\\]",
+			"end": "(\\])",
 			"endCaptures": {
-				"0": {
-					"name": "entity.name.tag"
+				"1": {
+					"name": "punctuation.section.bracket.end.powershell"
 				}
 			},
+			"name": "meta.attribute.powershell",
 			"patterns": [
 				{
 					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.section.group.begin.powershell"
+						}
+					},
 					"end": "\\)",
-					"name": "entity.other.attribute-name",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.section.group.end.powershell"
+						}
+					},
 					"patterns": [
 						{
-							"captures": {
-								"0": {
-									"name": "entity.other.attribute.parameter.powershell"
-								},
-								"1": {
-									"name": "constant.language.powershell"
-								},
-								"2": {
-									"name": "variable.other.powershell"
-								}
-							},
-							"comment": "really we should match the known attributes first",
-							"match": "(\\w+)\\s*=?([^\"']*?|'[^']*?'|\"[^\"]*?\")?(?=,|\\))",
-							"name": "entity.other.attribute-name.powershell"
+							"include": "#variable"
 						},
 						{
-							"include": "#variable"
+							"include": "#variableNoProperty"
+						},
+						{
+							"include": "#hashtable"
+						},
+						{
+							"include": "#scriptblock"
+						},
+						{
+							"include": "#doubleQuotedStringEscapes"
+						},
+						{
+							"include": "#doubleQuotedString"
+						},
+						{
+							"include": "#type"
+						},
+						{
+							"include": "#numericConstant"
+						},
+						{
+							"include": "#doubleQuotedString"
+						},
+						{
+							"include": "$self"
+						},
+						{
+							"match": "(?i)\\b(mandatory|valuefrompipeline|valuefrompipelinebypropertyname|valuefromremainingarguments|position|parametersetname|defaultparametersetname|supportsshouldprocess|positionalbinding|helpuri|confirmimpact|helpmessage)\\b(?:\\s+)?(=)",
+							"captures": {
+								"1": {
+									"name": "variable.parameter.attribute.powershell"
+								},
+								"2": {
+									"name": "keyword.operator.assignment.powershell"
+								}
+							}
+						},
+						{
+							"begin": "(?<!')'",
+							"end": "'(?!')",
+							"name": "string.quoted.single.powershell",
+							"patterns": [
+								{
+									"match": "''",
+									"name": "constant.character.escape.powershell"
+								}
+							]
 						}
 					]
 				}
@@ -358,10 +415,10 @@
 			"begin": "^(?:\\s*+)(?i)(function|filter|configuration|workflow)\\s+(?:(global|local|script|private):)?((?:\\p{L}|\\d|_|-|\\.)+)",
 			"beginCaptures": {
 				"0": {
-					"name": "meta.function"
+					"name": "meta.function.powershell"
 				},
 				"1": {
-					"name": "storage.type"
+					"name": "storage.type.powershell"
 				},
 				"2": {
 					"name": "storage.modifier.scope.powershell"
@@ -370,20 +427,25 @@
 					"name": "entity.name.function.powershell"
 				}
 			},
-			"end": "\\{|\\("
+			"end": "(?=\\{|\\()",
+			"patterns": [
+				{
+					"include": "#commentLine"
+				}
+			]
 		},
 		"interpolatedStringContent": {
 			"begin": "\\(",
 			"beginCaptures": {
 				"0": {
-					"name": "keyword.other.powershell"
+					"name": "punctuation.section.group.begin.powershell"
 				}
 			},
 			"contentName": "interpolated.simple.source.powershell",
 			"end": "\\)",
 			"endCaptures": {
 				"0": {
-					"name": "keyword.other.powershell"
+					"name": "punctuation.section.group.end.powershell"
 				}
 			},
 			"patterns": [
@@ -399,17 +461,20 @@
 			]
 		},
 		"interpolation": {
-			"begin": "(\\$)\\(",
+			"begin": "(\\$)(\\()",
 			"beginCaptures": {
-				"0": {
-					"name": "keyword.other.powershell"
+				"1": {
+					"name": "keyword.other.variable.definition.powershell"
+				},
+				"2": {
+					"name": "punctuation.section.group.begin.powershell"
 				}
 			},
 			"contentName": "interpolated.complex.source.powershell",
 			"end": "\\)",
 			"endCaptures": {
 				"0": {
-					"name": "keyword.other.powershell"
+					"name": "punctuation.section.group.end.powershell"
 				}
 			},
 			"patterns": [
@@ -429,92 +494,95 @@
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.hexadecimal.powershell"
+							"name": "constant.numeric.hex.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.hexadecimal.powershell"
+					"match": "(?<!\\w)([-+]?0(?:x|X)[0-9a-fA-F_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\\b"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.scientific.powershell"
+							"name": "constant.numeric.integer.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?(?:[0-9_]+)?\\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.scientific.powershell"
+					"match": "(?<!\\w)([-+]?(?:[0-9_]+)?\\.[0-9_]+(?:(?:e|E)[0-9]+)?(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\\b"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.binary.powershell"
+							"name": "constant.numeric.octal.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.binary.powershell"
+					"match": "(?<!\\w)([-+]?0(?:b|B)[01_]+(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\\b"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.decimal.powershell"
+							"name": "constant.numeric.integer.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?[0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.decimal.powershell"
+					"match": "(?<!\\w)([-+]?[0-9_]+(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\\b"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.decimal.powershell"
+							"name": "constant.numeric.integer.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?[0-9_]+\\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.decimal.powershell"
+					"match": "(?<!\\w)([-+]?[0-9_]+\\.(?:e|E)(?:[0-9_])?+(?:F|f|D|d|M|m)?)((?i:[kmgtp]b)?)\\b"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.decimal.powershell"
+							"name": "constant.numeric.integer.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?[0-9_]+[\\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.decimal.powershell"
+					"match": "(?<!\\w)([-+]?[0-9_]+[\\.]?(?:F|f|D|d|M|m))((?i:[kmgtp]b)?)\\b"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "constant.numeric.decimal.powershell"
+							"name": "constant.numeric.integer.powershell"
 						},
 						"2": {
 							"name": "keyword.other.powershell"
 						}
 					},
-					"match": "(?<!\\w)([-+]?[0-9_]+[\\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\\b",
-					"name": "constant.numeric.decimal.powershell"
+					"match": "(?<!\\w)([-+]?[0-9_]+[\\.]?(?:U|u|L|l|UL|Ul|uL|ul|LU|Lu|lU|lu)?)((?i:[kmgtp]b)?)\\b"
 				}
 			]
 		},
 		"scriptblock": {
 			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.braces.begin.powershell"
+				}
+			},
 			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.braces.end.powershell"
+				}
+			},
 			"name": "meta.scriptblock.powershell",
 			"patterns": [
 				{
@@ -526,20 +594,19 @@
 			"begin": "\\[",
 			"beginCaptures": {
 				"0": {
-					"name": "entity.other.attribute-name"
+					"name": "punctuation.section.bracket.begin.powershell"
 				}
 			},
-			"comment": "name should be entity.name.type but default schema doesn't have a good color for it",
 			"end": "\\]",
 			"endCaptures": {
 				"0": {
-					"name": "entity.other.attribute-name"
+					"name": "punctuation.section.bracket.end.powershell"
 				}
 			},
 			"patterns": [
 				{
-					"match": "(\\p{L}|\\.|``\\d+)+?",
-					"name": "entity.other.attribute-name"
+					"match": "(?!\\d+|\\.)(?:\\p{L}|\\p{N}|\\.)+",
+					"name": "storage.type.powershell"
 				},
 				{
 					"include": "$self"
@@ -551,7 +618,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "constant.language.powershell"
@@ -563,7 +630,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "support.constant.variable.powershell"
@@ -578,7 +645,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "support.constant.automatic.powershell"
@@ -593,7 +660,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "variable.language.powershell"
@@ -608,13 +675,13 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "storage.modifier.scope.powershell"
 						},
 						"3": {
-							"name": "variable.other.normal.powershell"
+							"name": "variable.other.readwrite.powershell"
 						},
 						"4": {
 							"name": "entity.name.function.invocation.powershell"
@@ -625,27 +692,30 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
-							"name": "storage.modifier.scope.powershell"
+							"name": "punctuation.section.braces.begin.powershell"
 						},
 						"3": {
-							"name": "variable.other.readwrite.powershell"
+							"name": "storage.modifier.scope.powershell"
 						},
 						"4": {
-							"name": "keyword.other.powershell"
+							"name": "variable.other.readwrite.powershell"
 						},
 						"5": {
+							"name": "punctuation.section.braces.end.powershell"
+						},
+						"6": {
 							"name": "entity.name.function.invocation.powershell"
 						}
 					},
-					"match": "(?i:(\\$\\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\\}))((?:\\.(?:\\p{L}|\\d|_)+)*\\b)?"
+					"match": "(?i:(\\$)(\\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\\}))((?:\\.(?:\\p{L}|\\d|_)+)*\\b)?"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "support.variable.drive.powershell"
@@ -662,22 +732,25 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
-							"name": "support.variable.drive.powershell"
+							"name": "punctuation.section.braces.begin.powershell"
 						},
 						"3": {
-							"name": "variable.other.readwrite.powershell"
+							"name": "support.variable.drive.powershell"
 						},
 						"4": {
-							"name": "keyword.other.powershell"
+							"name": "variable.other.readwrite.powershell"
 						},
 						"5": {
+							"name": "punctuation.section.braces.end.powershell"
+						},
+						"6": {
 							"name": "entity.name.function.invocation.powershell"
 						}
 					},
-					"match": "(?i:(\\$\\{)((?:\\p{L}|\\d|_)+:)?([^}]*[^}`])(\\}))((?:\\.(?:\\p{L}|\\d|_)+)*\\b)?"
+					"match": "(?i:(\\$)(\\{)((?:\\p{L}|\\d|_)+:)?([^}]*[^}`])(\\}))((?:\\.(?:\\p{L}|\\d|_)+)*\\b)?"
 				}
 			]
 		},
@@ -723,7 +796,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "constant.language.powershell"
@@ -735,7 +808,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "support.constant.variable.powershell"
@@ -750,7 +823,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "support.variable.automatic.powershell"
@@ -765,7 +838,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "variable.language.powershell"
@@ -780,13 +853,13 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "storage.modifier.scope.powershell"
 						},
 						"3": {
-							"name": "variable.other.normal.powershell"
+							"name": "variable.other.readwrite.powershell"
 						},
 						"4": {
 							"name": "entity.name.function.invocation.powershell"
@@ -797,7 +870,7 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "storage.modifier.scope.powershell"
@@ -812,12 +885,12 @@
 							"name": "entity.name.function.invocation.powershell"
 						}
 					},
-					"match": "(?i:(\\$\\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\\}))"
+					"match": "(?i:(\\$)(\\{)(global|local|private|script|using|workflow):([^}]*[^}`])(\\}))"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
 							"name": "support.variable.drive.powershell"
@@ -834,36 +907,39 @@
 				{
 					"captures": {
 						"1": {
-							"name": "keyword.other.powershell"
+							"name": "keyword.other.variable.definition.powershell"
 						},
 						"2": {
-							"name": "support.variable.drive.powershell"
+							"name": "punctuation.section.braces.begin"
 						},
 						"3": {
-							"name": "variable.other.readwrite.powershell"
+							"name": "support.variable.drive.powershell"
 						},
 						"4": {
-							"name": "keyword.other.powershell"
+							"name": "variable.other.readwrite.powershell"
 						},
 						"5": {
-							"name": "entity.name.function.invocation.powershell"
+							"name": "punctuation.section.braces.end"
 						}
 					},
-					"match": "(?i:(\\$\\{)((?:\\p{L}|\\d|_)+:)?([^}]*[^}`])(\\}))"
+					"match": "(?i:(\\$)(\\{)((?:\\p{L}|\\d|_)+:)?([^}]*[^}`])(\\}))"
 				}
 			]
 		},
 		"hashtable": {
-			"begin": "(@\\{)",
+			"begin": "(@)(\\{)",
 			"beginCaptures": {
 				"1": {
-					"name": "punctuation.section.braces.begin"
+					"name": "keyword.other.hashtable.begin.powershell"
+				},
+				"2": {
+					"name": "punctuation.section.braces.begin.powershell"
 				}
 			},
 			"end": "(\\})",
 			"endCaptures": {
 				"1": {
-					"name": "punctuation.section.braces.end"
+					"name": "punctuation.section.braces.end.powershell"
 				}
 			},
 			"name": "meta.hashtable.powershell",
@@ -871,13 +947,13 @@
 				{
 					"captures": {
 						"1": {
-							"name": "punctuation.definition.string.begin"
+							"name": "punctuation.definition.string.begin.powershell"
 						},
 						"2": {
 							"name": "variable.other.readwrite.powershell"
 						},
 						"3": {
-							"name": "punctuation.definition.string.end"
+							"name": "punctuation.definition.string.end.powershell"
 						},
 						"4": {
 							"name": "keyword.operator.assignment.powershell"
@@ -891,6 +967,32 @@
 				},
 				{
 					"include": "$self"
+				}
+			]
+		},
+		"doubleQuotedString": {
+			"begin": "(?<!(?<!`)\")\"",
+			"end": "\"(?!\")",
+			"name": "string.quoted.double.powershell",
+			"patterns": [
+				{
+					"match": "(?i)\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,64}\\b"
+				},
+				{
+					"include": "#variableNoProperty"
+				},
+				{
+					"include": "#variable"
+				},
+				{
+					"include": "#doubleQuotedStringEscapes"
+				},
+				{
+					"include": "#interpolation"
+				},
+				{
+					"match": "`\\s*$",
+					"name": "keyword.other.powershell"
 				}
 			]
 		}


### PR DESCRIPTION
Updating PowerShell syntax to [PowerShell/EditorSyntax](https://github.com/PowerShell/EditorSyntax) commit [529562f](https://github.com/PowerShell/EditorSyntax/commit/529562fbe4ba9abde22282ee8b00141284968f4b).

Includes multiple fixes detailed in https://github.com/PowerShell/EditorSyntax/pull/94 and https://github.com/PowerShell/EditorSyntax/pull/96 

> Build status & tests: https://ci.appveyor.com/project/powershell/editorsyntax/branch/master
> 359 tests, 3459 assertions, **0 failures**, 0 skipped