### PR TITLE
git: fix includeIf on Windows by uppercasing drive letter (#40354)

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -365,6 +365,14 @@ function getGitErrorCode(stderr: string): string | undefined {
 	return void 0;
 }
 
+function sanitizeCwd(cwd: string): string {
+	// Make the drive letter uppercase on Windows for includeIf (#40354)
+	if (os.platform() === 'win32' && cwd && cwd[1] === ':') {
+		return cwd[0].toUpperCase() + cwd.substr(1);
+	}
+	return cwd;
+}
+
 export class Git {
 
 	readonly path: string;
@@ -420,11 +428,13 @@ export class Git {
 	}
 
 	async exec(cwd: string, args: string[], options: SpawnOptions = {}): Promise<IExecutionResult<string>> {
+		cwd = sanitizeCwd(cwd);
 		options = assign({ cwd }, options || {});
 		return await this._exec(args, options);
 	}
 
 	stream(cwd: string, args: string[], options: SpawnOptions = {}): cp.ChildProcess {
+		cwd = sanitizeCwd(cwd);
 		options = assign({ cwd }, options || {});
 		return this.spawn(args, options);
 	}


### PR DESCRIPTION
This fixes #40354.

Git's includeIf feature by default matches the path against the current working directory in a case sensitive manner.

VS Code launches Git using a current working directory with a lowercase drive letter, while everything else uses an uppercase drive letter, so includeIf directives that work everywhere else don't work in VS Code.

This commit borrows the fix from #9448, which manually uppercases the drive letter for Windows.