### PR TITLE
Align GIT light colored check icon with dark

### DIFF
--- a/extensions/git/resources/icons/light/check.svg
+++ b/extensions/git/resources/icons/light/check.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><polygon points="5.382,13 2.382,7 6.618,7 7,7.764 9.382,3 13.618,3 8.618,13" fill="#F6F6F6"/><path d="M12 4l-4 8h-2l-2-4h2l1 2 3-6h2z" fill="#424242"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="-2 -2 16 16" enable-background="new -2 -2 16 16"><polygon fill="#424242" points="9,0 4.5,9 3,6 0,6 3,12 6,12 12,0"/></svg>


### PR DESCRIPTION
I noticed the GIT extension light and dark Check icons were mismatched in size and style; the dark icon looks more consistent with the rest of the VS Code style.

I have replaced the Light Check with the Dark Check and updated the colour to the standard `#424242`.

References
- [Dark Icon](https://github.com/Microsoft/vscode/blob/4eaf58348b51e601877c360f59c3ca82f45691ad/extensions/git/resources/icons/dark/check.svg)
- [Light Icon](https://github.com/Microsoft/vscode/blob/4eaf58348b51e601877c360f59c3ca82f45691ad/extensions/git/resources/icons/light/check.svg)