### PR TITLE
`{ "editor.wrappingIndent": "deepIndent" }` for 2 additional tabs on continuation lines

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -353,9 +353,9 @@ const editorConfiguration: IConfigurationNode = {
 		},
 		'editor.wrappingIndent': {
 			'type': 'string',
-			'enum': ['none', 'same', 'indent'],
+			'enum': ['none', 'same', 'indent', 'deepIndent'],
 			'default': 'same',
-			'description': nls.localize('wrappingIndent', "Controls the indentation of wrapped lines. Can be one of 'none', 'same' or 'indent'.")
+			'description': nls.localize('wrappingIndent', "Controls the indentation of wrapped lines. Can be one of 'none', 'same', 'indent' or 'deepIndent'.")
 		},
 		'editor.mouseWheelScrollSensitivity': {
 			'type': 'number',

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -340,7 +340,7 @@ export interface IEditorOptions {
 	 */
 	wordWrapMinified?: boolean;
 	/**
-	 * Control indentation of wrapped lines. Can be: 'none', 'same' or 'indent'.
+	 * Control indentation of wrapped lines. Can be: 'none', 'same', 'indent' or 'deepIndent'.
 	 * Defaults to 'same' in vscode and to 'none' in monaco-editor.
 	 */
 	wrappingIndent?: string;
@@ -635,9 +635,13 @@ export enum WrappingIndent {
 	 */
 	Same = 1,
 	/**
-	 * Indent => wrapped lines get +1 indentation as the parent.
+	 * Indent => wrapped lines get +1 indentation toward the parent.
 	 */
-	Indent = 2
+	Indent = 2,
+	/**
+	 * DeepIndent => wrapped lines get +2 indentation toward the parent.
+	 */
+	DeepIndent = 3
 }
 
 /**
@@ -1477,10 +1481,12 @@ function _wrappingIndentFromString(wrappingIndent: string, defaultValue: Wrappin
 	if (typeof wrappingIndent !== 'string') {
 		return defaultValue;
 	}
-	if (wrappingIndent === 'indent') {
-		return WrappingIndent.Indent;
-	} else if (wrappingIndent === 'same') {
+	if (wrappingIndent === 'same') {
 		return WrappingIndent.Same;
+	} else if (wrappingIndent === 'indent') {
+		return WrappingIndent.Indent;
+	} else if (wrappingIndent === 'deepIndent') {
+		return WrappingIndent.DeepIndent;
 	} else {
 		return WrappingIndent.None;
 	}

--- a/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
+++ b/src/vs/editor/common/viewModel/characterHardWrappingLineMapper.ts
@@ -92,14 +92,24 @@ export class CharacterHardWrappingLineMapperFactory implements ILineMapperFactor
 		if (hardWrappingIndent !== WrappingIndent.None) {
 			firstNonWhitespaceIndex = strings.firstNonWhitespaceIndex(lineText);
 			if (firstNonWhitespaceIndex !== -1) {
+				// Track existing indent
 				wrappedTextIndent = lineText.substring(0, firstNonWhitespaceIndex);
 				for (let i = 0; i < firstNonWhitespaceIndex; i++) {
 					wrappedTextIndentVisibleColumn = CharacterHardWrappingLineMapperFactory.nextVisibleColumn(wrappedTextIndentVisibleColumn, tabSize, lineText.charCodeAt(i) === CharCode.Tab, 1);
 				}
+
+				// Increase indent of continuation lines, if desired
+				let numberOfAdditionalTabs = 0;
 				if (hardWrappingIndent === WrappingIndent.Indent) {
+					numberOfAdditionalTabs = 1;
+				} else if (hardWrappingIndent === WrappingIndent.DeepIndent) {
+					numberOfAdditionalTabs = 2;
+				}
+				for (let i = 0; i < numberOfAdditionalTabs; i++) {
 					wrappedTextIndent += '\t';
 					wrappedTextIndentVisibleColumn = CharacterHardWrappingLineMapperFactory.nextVisibleColumn(wrappedTextIndentVisibleColumn, tabSize, true, 1);
 				}
+
 				// Force sticking to beginning of line if no character would fit except for the indentation
 				if (wrappedTextIndentVisibleColumn + columnsForFullWidthChar > breakingColumn) {
 					wrappedTextIndent = '';

--- a/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
+++ b/src/vs/editor/test/common/viewModel/characterHardWrappingLineMapper.test.ts
@@ -10,7 +10,7 @@ import { CharacterHardWrappingLineMapperFactory } from 'vs/editor/common/viewMod
 import { ILineMapperFactory, ILineMapping } from 'vs/editor/common/viewModel/splitLinesCollection';
 
 function assertLineMapping(factory: ILineMapperFactory, tabSize: number, breakAfter: number, annotatedText: string, wrappingIndent = WrappingIndent.None): ILineMapping {
-
+	// Create version of `annotatedText` with line break markers removed
 	let rawText = '';
 	let currentLineIndex = 0;
 	let lineIndices: number[] = [];
@@ -25,6 +25,7 @@ function assertLineMapping(factory: ILineMapperFactory, tabSize: number, breakAf
 
 	let mapper = factory.createLineMapping(rawText, tabSize, breakAfter, 2, wrappingIndent);
 
+	// Insert line break markers again, according to algorithm
 	let actualAnnotatedText = '';
 	if (mapper) {
 		let previousLineIndex = 0;
@@ -113,5 +114,11 @@ suite('Editor ViewModel - CharacterHardWrappingLineMapper', () => {
 		let factory = new CharacterHardWrappingLineMapperFactory('', ' ', '');
 		let mapper = assertLineMapping(factory, 4, 24, '                t h i s |i s |a l |o n |g l |i n |e', WrappingIndent.Indent);
 		assert.equal(mapper.getWrappedLinesIndent(), '                \t');
+	});
+
+	test('CharacterHardWrappingLineMapper - WrappingIndent.DeepIndent', () => {
+		let factory = new CharacterHardWrappingLineMapperFactory('', ' ', '');
+		let mapper = assertLineMapping(factory, 4, 26, '        W e A r e T e s t |i n g D e |e p I n d |e n t a t |i o n', WrappingIndent.DeepIndent);
+		assert.equal(mapper.getWrappedLinesIndent(), '        \t\t');
 	});
 });

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2679,7 +2679,7 @@ declare namespace monaco.editor {
 		 */
 		wordWrapMinified?: boolean;
 		/**
-		 * Control indentation of wrapped lines. Can be: 'none', 'same' or 'indent'.
+		 * Control indentation of wrapped lines. Can be: 'none', 'same', 'indent' or 'deepIndent'.
 		 * Defaults to 'same' in vscode and to 'none' in monaco-editor.
 		 */
 		wrappingIndent?: string;
@@ -2977,9 +2977,13 @@ declare namespace monaco.editor {
 		 */
 		Same = 1,
 		/**
-		 * Indent => wrapped lines get +1 indentation as the parent.
+		 * Indent => wrapped lines get +1 indentation toward the parent.
 		 */
 		Indent = 2,
+		/**
+		 * DeepIndent => wrapped lines get +2 indentation toward the parent.
+		 */
+		DeepIndent = 3,
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces the `deepIndent` preference value.

Here's an example from the VS Code codebase with an `editor.wrappingIndent` value of `indent` which, at first, confused me regarding the opening brace in `ILineMapping {`:

![`indent`](https://user-images.githubusercontent.com/13482553/40592839-f953a96c-6223-11e8-827b-6bbec0e3aacc.png)

Here's the same code with a preference value of `deepIndent`:

![`deepIndent`](https://user-images.githubusercontent.com/13482553/40592842-0132271c-6224-11e8-8f59-af756f81ffc5.png)

Here's some proof of manual indentation that other people also like this style:

- https://github.com/rg3/youtube-dl/blob/master/youtube_dl/YoutubeDL.py#L399
- https://github.com/Microsoft/vscode/issues/29285#issuecomment-310541379
- https://eev.ee/blog/2015/02/28/sylph-the-programming-language-i-want/#operators
- http://linux-kernel.vger.kernel.narkive.com/TwwLehIS/coding-style#post35
- https://github.com/YosysHQ/yosys/blob/master/CodingReadme#L223
- Search "additional": [NASA Style Guide](https://archive.li/qmf22)

The overwhelming advantage is in the context of block headers when lines follow that are indented deeper by one level. But even in the context of lines all on the same indentation level, it's totally okay in my opinion.