### PR TITLE
Moved action FindInFileActionId from constants file to a static const…

### DIFF
--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -316,6 +316,7 @@ export abstract class FindOrReplaceInFilesAction extends Action {
 
 export class FindInFilesAction extends FindOrReplaceInFilesAction {
 
+	public static readonly ID = 'workbench.action.findInFiles';
 	public static readonly LABEL = nls.localize('findInFiles', "Find in Files");
 
 	constructor(id: string, label: string,

--- a/src/vs/workbench/parts/search/common/constants.ts
+++ b/src/vs/workbench/parts/search/common/constants.ts
@@ -5,7 +5,6 @@
 
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
-export const FindInFilesActionId = 'workbench.action.findInFiles';
 export const FocusActiveEditorCommandId = 'search.action.focusActiveEditor';
 
 export const FocusSearchFromResults = 'search.action.focusSearchFromResults';

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -452,7 +452,7 @@ const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.Workbenc
 
 registry.registerWorkbenchAction(new SyncActionDescriptor(FindInFilesAction, VIEW_ID, nls.localize('showSearchViewl', "Show Search"), { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F },
 	Constants.SearchViewVisibleKey.toNegated()), 'View: Show Search', nls.localize('view', "View"));
-registry.registerWorkbenchAction(new SyncActionDescriptor(FindInFilesAction, Constants.FindInFilesActionId, nls.localize('findInFiles', "Find in Files"), { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F },
+registry.registerWorkbenchAction(new SyncActionDescriptor(FindInFilesAction, FindInFilesAction.ID, nls.localize('findInFiles', "Find in Files"), { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_F },
 	Constants.SearchInputBoxFocusedKey.toNegated()), 'Find in Files', category);
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/parts/watermark/electron-browser/watermark.ts
+++ b/src/vs/workbench/parts/watermark/electron-browser/watermark.ts
@@ -23,7 +23,7 @@ import { OpenFolderAction, OpenFileFolderAction, OpenFileAction } from 'vs/workb
 import { ShowAllCommandsAction } from 'vs/workbench/parts/quickopen/browser/commandsHandler';
 import { Parts, IPartService, IDimension } from 'vs/workbench/services/part/common/partService';
 import { StartAction } from 'vs/workbench/parts/debug/browser/debugActions';
-import { FindInFilesActionId } from 'vs/workbench/parts/search/common/constants';
+import { FindInFilesAction } from 'vs/workbench/parts/search/browser/searchActions';
 import { ToggleTerminalAction } from 'vs/workbench/parts/terminal/electron-browser/terminalActions';
 import { escape } from 'vs/base/common/strings';
 import { QUICKOPEN_ACTION_ID } from 'vs/workbench/browser/parts/quickopen/quickopen';
@@ -73,7 +73,7 @@ const toggleTerminal: WatermarkEntry = {
 
 const findInFiles: WatermarkEntry = {
 	text: nls.localize('watermark.findInFiles', "Find in Files"),
-	ids: [FindInFilesActionId]
+	ids: [FindInFilesAction.ID]
 };
 const startDebugging: WatermarkEntry = {
 	text: nls.localize('watermark.startDebugging', "Start Debugging"),


### PR DESCRIPTION
- Moved the FindInFilesActionId to static variable FindInFilesAction.ID in order to preserve consistency (every class has a static ID and LABEL value) within the classes of SearchActions.ts