### PR TITLE
👌 IMPROVE: Lingo for terminal font notification

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -87,7 +87,7 @@ export class TerminalPanel extends Panel {
 							label: nls.localize('terminal.useMonospace', "Use 'monospace' font"),
 							run: () => this._configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),
 						}];
-						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. The font you are using is not supported."), choices);
+						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts (the font you are using is not supported."), choices);
 					}
 				}
 			}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -87,7 +87,7 @@ export class TerminalPanel extends Panel {
 							label: nls.localize('terminal.useMonospace', "Use 'monospace' font"),
 							run: () => this._configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),
 						}];
-						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. "), choices);
+						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. The font you are using is not supported."), choices);
 					}
 				}
 			}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -87,7 +87,7 @@ export class TerminalPanel extends Panel {
 							label: nls.localize('terminal.useMonospace', "Use 'monospace' font"),
 							run: () => this._configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),
 						}];
-						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts (the font you are using is not supported."), choices);
+						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts (the font you are using is not supported)."), choices);
 					}
 				}
 			}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -84,10 +84,10 @@ export class TerminalPanel extends Panel {
 				if (configHelper instanceof TerminalConfigHelper) {
 					if (!configHelper.configFontIsMonospace()) {
 						const choices: IPromptChoice[] = [{
-							label: nls.localize('terminal.useMonospace', "Use 'monospace' font"),
+							label: nls.localize('terminal.useMonospace', "Use 'monospace'"),
 							run: () => this._configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),
 						}];
-						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts (the font you are using is not supported). "), choices);
+						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. "), choices);
 					}
 				}
 			}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -84,7 +84,7 @@ export class TerminalPanel extends Panel {
 				if (configHelper instanceof TerminalConfigHelper) {
 					if (!configHelper.configFontIsMonospace()) {
 						const choices: IPromptChoice[] = [{
-							label: nls.localize('terminal.useMonospace', "Use 'monospace'"),
+							label: nls.localize('terminal.useMonospace', "Use 'monospace' font"),
 							run: () => this._configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),
 						}];
 						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts. "), choices);

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalPanel.ts
@@ -84,10 +84,10 @@ export class TerminalPanel extends Panel {
 				if (configHelper instanceof TerminalConfigHelper) {
 					if (!configHelper.configFontIsMonospace()) {
 						const choices: IPromptChoice[] = [{
-							label: nls.localize('terminal.useMonospace', "Use 'monospace'"),
+							label: nls.localize('terminal.useMonospace', "Use 'monospace' font"),
 							run: () => this._configurationService.updateValue('terminal.integrated.fontFamily', 'monospace'),
 						}];
-						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts."), choices);
+						this._notificationService.prompt(Severity.Warning, nls.localize('terminal.monospaceOnly', "The terminal only supports monospace fonts (the font you are using is not supported). "), choices);
 					}
 				}
 			}


### PR DESCRIPTION
When warning the user about non-monospace font, the notification lacks context. This PR addresses that by giving user a bit more context about what went wrong. 

For Issue #45226