### PR TITLE
Add gitignore language

### DIFF
--- a/extensions/git/languages/ignore.language-configuration.json
+++ b/extensions/git/languages/ignore.language-configuration.json
@@ -1,0 +1,5 @@
+{
+	"comments": {
+		"lineComment": "#",
+	}
+}

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1082,6 +1082,17 @@
           ".rej"
         ],
         "configuration": "./languages/diff.language-configuration.json"
+      },
+      {
+        "id": "ignore",
+        "aliases": [
+          "Ignore",
+          "ignore"
+        ],
+        "filenames": [
+          ".gitignore"
+        ],
+        "configuration": "./languages/ignore.language-configuration.json"
       }
     ],
     "grammars": [
@@ -1099,6 +1110,11 @@
         "language": "diff",
         "scopeName": "source.diff",
         "path": "./syntaxes/diff.tmLanguage.json"
+      },
+      {
+        "language": "ignore",
+        "scopeName": "source.ignore",
+        "path": "./syntaxes/ignore.tmLanguage.json"
       }
     ],
     "configurationDefaults": {

--- a/extensions/git/syntaxes/ignore.tmLanguage.json
+++ b/extensions/git/syntaxes/ignore.tmLanguage.json
@@ -1,0 +1,10 @@
+{
+	"name": "Ignore",
+	"scopeName": "source.ignore",
+	"patterns": [
+		{
+			"match": "^#.*",
+			"name": "comment.line.number-sign.ignore"
+		}
+	]
+}


### PR DESCRIPTION
See https://github.com/Microsoft/vscode-eslint/pull/473
@aeschli, @dbaeumer 
This only adds the Ignore-language and assigns it to `.gitignore`.
I would like to add a reference to it in [`extensions/npm`](https://github.com/Microsoft/vscode/tree/master/extensions/npm) for `.npmignore`. Is it possible to add that file association as contribution in the `package.json` or how would you propose to do it?