### PR TITLE
Allowing to use 'window.title': '' for SCM files

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -311,7 +311,13 @@ export class CommandCenter {
 	}
 
 	private getTitle(resource: Resource): string {
-		const basename = path.basename(resource.resourceUri.fsPath);
+		let basename = path.basename(resource.resourceUri.fsPath);
+		const config = workspace.getConfiguration('window');
+		let windowTitle = config.get<string>('title');
+
+		if (windowTitle === '${activeEditorLong}') {
+			basename = resource.resourceUri.fsPath;
+		}
 
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:


### PR DESCRIPTION
This fixes https://github.com/Microsoft/vscode/issues/45848.

I'm still having the issue that this is also changing the tab title as you can see below:
![image](https://user-images.githubusercontent.com/4671080/40947598-7faa68e4-6831-11e8-84cd-b68f1ece25d2.png)

and it doesn't look good but I'm not sure how to discriminate this (to only change the window's title). Any hint?

Also, should I check all possible values of `window.title` and act accordingly?

cc: @bpasero @joaomoreno 