### PR TITLE
Treat Xamarin .workbook files as markdown

### DIFF
--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -19,7 +19,8 @@
 					".md",
 					".mdown",
 					".markdown",
-					".markdn"
+					".markdn",
+					".workbook"
 				],
 				"configuration": "./language-configuration.json"
 			}


### PR DESCRIPTION
Xamarin Workbooks are interactive coding documents that are saved as
straight-forward markdown files with a YAML front matter header block.

Here is a sample: https://github.com/xamarin/Workbooks/blob/master/csharp/csharp6/csharp6.workbook

Github has been treating them as markdown files for over a year now
(https://github.com/github/linguist/pull/3500).