### PR TITLE
Center viewport for nextChange/previousChange using keybinding

### DIFF
--- a/src/vs/workbench/parts/scm/electron-browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/dirtydiffDecorator.ts
@@ -469,7 +469,7 @@ export class MoveToPreviousChangeAction extends EditorAction {
 
 		const position = new Position(change.modifiedStartLineNumber, 1);
 		outerEditor.setPosition(position);
-		outerEditor.revealPosition(position);
+		outerEditor.revealPositionInCenter(position);
 	}
 }
 registerEditorAction(MoveToPreviousChangeAction);

--- a/src/vs/workbench/parts/scm/electron-browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/dirtydiffDecorator.ts
@@ -511,7 +511,7 @@ export class MoveToNextChangeAction extends EditorAction {
 
 		const position = new Position(change.modifiedStartLineNumber, 1);
 		outerEditor.setPosition(position);
-		outerEditor.revealPosition(position);
+		outerEditor.revealPositionInCenter(position);
 	}
 }
 registerEditorAction(MoveToNextChangeAction);


### PR DESCRIPTION
Fixes #51031
cc: @joaomoreno 