### PR TITLE
Middle vertical align for icons in status bar

### DIFF
--- a/src/vs/workbench/parts/tasks/electron-browser/media/task.contribution.css
+++ b/src/vs/workbench/parts/tasks/electron-browser/media/task.contribution.css
@@ -47,7 +47,7 @@
 
 .task-statusbar-item-label > .task-statusbar-item-label-counter {
 	display: inline-block;
-	vertical-align: top;
+	vertical-align: middle;
 	padding-left: 2px;
 	padding-right: 2px;
 }
@@ -56,9 +56,10 @@
 .task-statusbar-item-label > .task-statusbar-item-label-warning,
 .task-statusbar-item-label > .task-statusbar-item-label-info {
 	display: inline-block;
+	vertical-align: middle;
 	padding-right: 8px;
 	width: 8px;
-	height: 22px;
+	height: 11px;
 }
 
 .task-statusbar-item-label > .task-statusbar-item-label-error {


### PR DESCRIPTION
Hi, I know it sounds strange, but there is one thing that looks a little bit imperfect and always catches my eye. And this is icons in status bar on my Mac. Counters looks like they are aligned higher

<img width="140" alt="before" src="https://user-images.githubusercontent.com/1119630/41062498-a6534700-69de-11e8-8d6e-59f86768ba6c.png">

I did some changes and aligned them with `vertical-align: middle` and I think they looks better with this change

<img width="142" alt="after" src="https://user-images.githubusercontent.com/1119630/41062572-e6ce8b3c-69de-11e8-97cf-870709cdeb95.png">