### PR TITLE
Increase visibility of Install buton focus. #50883

### DIFF
--- a/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
@@ -5,8 +5,8 @@
 
 .monaco-action-bar .action-item .action-label.extension-action {
 	padding: 0 5px;
-	outline-offset: 1px;
-	outline-width: 1.5px;
+	outline-offset: 2px;
+	outline-width: 2px;
 	line-height: initial;
 }
 
@@ -62,6 +62,7 @@
 	width: 10px;
 	border: none;
 	background: url('manage.svg') center center no-repeat;
+	outline-offset: -1.5px;
 }
 
 .hc-black .extensions-viewlet>.extensions .extension>.details>.footer>.monaco-action-bar .action-item .action-label.extension-action.manage,

--- a/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
@@ -5,6 +5,8 @@
 
 .monaco-action-bar .action-item .action-label.extension-action {
 	padding: 0 5px;
+	outline-offset: 1px;
+	outline-width: 1.5px;
 	line-height: initial;
 }
 

--- a/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/parts/extensions/browser/media/extensionActions.css
@@ -62,7 +62,8 @@
 	width: 10px;
 	border: none;
 	background: url('manage.svg') center center no-repeat;
-	outline-offset: -1.5px;
+	outline-offset: 0px;
+	margin-top: 0.15em
 }
 
 .hc-black .extensions-viewlet>.extensions .extension>.details>.footer>.monaco-action-bar .action-item .action-label.extension-action.manage,

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
@@ -124,7 +124,7 @@
 
 .extension-editor > .header > .details > .actions > .monaco-action-bar > .actions-container > .action-item > .action-label {
 	font-weight: 600;
-	margin: 2px;
+	margin: 4px;
 	padding: 1px 6px;
 }
 
@@ -134,7 +134,7 @@
 
 .extension-editor > .header.recommended > .details > .recommendation {
 	display: block;
-	margin-top: 10px;
+	margin-top: 2px;
 	font-size: 13px;
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
@@ -124,6 +124,7 @@
 
 .extension-editor > .header > .details > .actions > .monaco-action-bar > .actions-container > .action-item > .action-label {
 	font-weight: 600;
+	margin: 2px;
 	padding: 1px 6px;
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -165,7 +165,7 @@
 .extensions-viewlet > .extensions .extension > .details > .footer {
 	display: flex;
 	justify-content: flex-end;
-	height: 20px;
+	height: 24px;
 	overflow: hidden;
 }
 
@@ -182,9 +182,9 @@
 }
 
 .extensions-viewlet > .extensions .extension > .details > .footer > .monaco-action-bar .action-label {
-	margin-right: 0.3em;
+	margin-top: 0.3em;
 	margin-left: 0.3em;
-	line-height: 15px;
+	line-height: 14px;
 }
 
 .extensions-viewlet > .extensions .extension > .details > .footer > .monaco-action-bar .action-label:not(:empty) {

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -165,7 +165,7 @@
 .extensions-viewlet > .extensions .extension > .details > .footer {
 	display: flex;
 	justify-content: flex-end;
-	height: 18px;
+	height: 20px;
 	overflow: hidden;
 }
 
@@ -182,7 +182,7 @@
 }
 
 .extensions-viewlet > .extensions .extension > .details > .footer > .monaco-action-bar .action-label {
-	margin-right: 0;
+	margin-right: 0.3em;
 	margin-left: 0.3em;
 	line-height: 15px;
 }

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -182,6 +182,7 @@
 }
 
 .extensions-viewlet > .extensions .extension > .details > .footer > .monaco-action-bar .action-label {
+	margin-right: 0;
 	margin-top: 0.3em;
 	margin-left: 0.3em;
 	line-height: 14px;


### PR DESCRIPTION
Needed to change some margins around because the outline was getting clipped. A possible better solution would be to use a border, which affects layout, but I think outline is standard for accessibility?