### PR TITLE
Promise with no error log error.stack

### DIFF
--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -50,6 +50,9 @@ function promiseErrorHandler(e: IPromiseError): void {
 				if (error.exception) {
 					console.log(error.exception.stack);
 				}
+				if (error.error) {
+					console.log(error.error.stack);
+				}
 			});
 		}, 0);
 	}

--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -51,7 +51,7 @@ function promiseErrorHandler(e: IPromiseError): void {
 					console.log(error.exception.stack);
 				}
 				if (error.error) {
-					console.log(error.error.stack);
+					console.log(error.error);
 				}
 			});
 		}, 0);


### PR DESCRIPTION
Some non handled promises are not logged at all (so was impossible to know where the error happened). One example is calling`TreeView.reveal()` with `TreeDataProvider` that doesn't implement `getParent()` : In that case I expect to see at least the following message (and a stack if possible):

`Required registered `TreeDataProvider` to implement 'getParent' method to access 'reveal' method`

Actual behavior: nothing is shown, just the message "WARNING: Promise with no error callback" 

 I was able to reproduce this in vscode master  creating a very simple extension that just did that. Don't know / don't have the time to investigate if the real issue is when the promise is created instead of in this part of the code. Notice I don't want only to print just the stack but also the message, logging error.error did the trick

Thanks