### PR TITLE
Dont do async work on process.on('exit') 

### DIFF
--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -64,20 +64,21 @@ class Main {
 	run(argv: ParsedArgs): TPromise<any> {
 		// TODO@joao - make this contributable
 
+		let returnPromise: TPromise<any>;
 		if (argv['install-source']) {
-			return this.setInstallSource(argv['install-source']);
+			returnPromise = this.setInstallSource(argv['install-source']);
 		} else if (argv['list-extensions']) {
-			return this.listExtensions(argv['show-versions']);
+			returnPromise = this.listExtensions(argv['show-versions']);
 		} else if (argv['install-extension']) {
 			const arg = argv['install-extension'];
 			const args: string[] = typeof arg === 'string' ? [arg] : arg;
-			return this.installExtension(args);
+			returnPromise = this.installExtension(args);
 		} else if (argv['uninstall-extension']) {
 			const arg = argv['uninstall-extension'];
 			const ids: string[] = typeof arg === 'string' ? [arg] : arg;
-			return this.uninstallExtension(ids);
+			returnPromise = this.uninstallExtension(ids);
 		}
-		return undefined;
+		return returnPromise || TPromise.as(null);
 	}
 
 	private setInstallSource(installSource: string): TPromise<any> {
@@ -242,7 +243,7 @@ export function main(argv: ParsedArgs): TPromise<void> {
 			const instantiationService2 = instantiationService.createChild(services);
 			const main = instantiationService2.createInstance(Main);
 
-			return (main.run(argv) || TPromise.as(null)).then(() => {
+			return main.run(argv).then(() => {
 				// Dispose the AI adapter so that remaining data gets flushed.
 				return combinedAppender(...appenders).dispose();
 			});

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -30,13 +30,17 @@ export const NullTelemetryService = new class implements ITelemetryService {
 
 export interface ITelemetryAppender {
 	log(eventName: string, data: any): void;
+	dispose(): TPromise<any>;
 }
 
 export function combinedAppender(...appenders: ITelemetryAppender[]): ITelemetryAppender {
-	return { log: (e, d) => appenders.forEach(a => a.log(e, d)) };
+	return {
+		log: (e, d) => appenders.forEach(a => a.log(e, d)),
+		dispose: () => TPromise.join(appenders.map(a => a.dispose()))
+	};
 }
 
-export const NullAppender: ITelemetryAppender = { log: () => null };
+export const NullAppender: ITelemetryAppender = { log: () => null, dispose: () => null };
 
 /* __GDPR__FRAGMENT__
 	"URIDescriptor" : {

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -40,7 +40,7 @@ export function combinedAppender(...appenders: ITelemetryAppender[]): ITelemetry
 	};
 }
 
-export const NullAppender: ITelemetryAppender = { log: () => null, dispose: () => null };
+export const NullAppender: ITelemetryAppender = { log: () => null, dispose: () => TPromise.as(null) };
 
 /* __GDPR__FRAGMENT__
 	"URIDescriptor" : {

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -34,8 +34,9 @@ class TestTelemetryAppender implements ITelemetryAppender {
 		return this.events.length;
 	}
 
-	public dispose() {
+	public dispose(): TPromise<any> {
 		this.isDisposed = true;
+		return TPromise.as(null);
 	}
 }
 


### PR DESCRIPTION
From https://nodejs.org/api/process.html#process_event_exit about use of `process.on('exit')`

> Listener functions must only perform synchronous operations. The Node.js process will exit immediately after calling the 'exit' event listeners causing any additional work still queued in the event loop to be abandoned

This PR fixes #47180

All pending telemetry events get flushed out when appInsightsAppender is disposed. Since the dispose call was made from `process.once('exit')`, the appender never got disposed and so the events never really got fired.

