### PR TITLE
Include spaceship operator in PHP snippet autocomplete

### DIFF
--- a/extensions/php/snippets/php.snippets.json
+++ b/extensions/php/snippets/php.snippets.json
@@ -193,6 +193,11 @@
 		"body": "'$1' => $2${3:,} $0",
 		"description": "Key-Value initializer"
 	},
+	"… <=> …": {
+		"prefix": "spaceship",
+		"body": "$1 <=> $2",
+		"description": "Spaceship operator initializer"
+	},
 	"switch …": {
 		"prefix": "switch",
 		"body": [


### PR DESCRIPTION
While in vscode's PHP context, allows the user to begin typing `spaceship` to complete to PHP's combined comparison, "spaceship," operator, `$1 <=> $2` 

http://php.net/manual/en/language.operators.comparison.php
https://wiki.php.net/rfc/combined-comparison-operator