### PR TITLE
Add V8 version to about dialog and prettify it

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -460,13 +460,14 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		const lastActiveWindow = this.windowsMainService.getFocusedWindow() || this.windowsMainService.getLastActiveWindow();
 
 		const detail = nls.localize('aboutDetail',
-			"Version {0}\nCommit {1}\nDate {2}\nShell {3}\nRenderer {4}\nNode {5}\nArchitecture {6}",
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nChrome: {4}\nNode: {5}\nV8: {6}\nArchitecture: {7}",
 			app.getVersion(),
 			product.commit || 'Unknown',
 			product.date || 'Unknown',
 			process.versions['electron'],
 			process.versions['chrome'],
 			process.versions['node'],
+			process.versions['v8'],
 			process.arch
 		);
 


### PR DESCRIPTION
This PR makes the following small changes to the About dialog (Help -> About):
- Adds the V8 version to the list
- Renames "Shell" -> "Electron"
- Renames "Renderer" -> "Chrome"
- Adds colons between the labels and versions

I think the renames make it more clear what exactly the versions are referring to, and the colons are just to visually separate the labels from the versions better. As for the V8 version, I think it's worth noting independently (since Node already is as well, even though it can also typically be assumed by the Electron version).

I looked into the localisation changes necessary for these text changes, but am not sure exactly what procedure needs to be followed to associate the changes with this PR (if any). Please correct me if you find any issues with this PR. Thanks!