### PR TITLE
Add transformations for placeholders

### DIFF
--- a/src/vs/editor/contrib/snippet/snippet.md
+++ b/src/vs/editor/contrib/snippet/snippet.md
@@ -53,6 +53,26 @@ ${TM_FILENAME/(.*)\..+$/$1/}
   |-> resolves to the filename
 ```
 
+Placeholder-Transform
+--
+
+Like a Variable-Transform, a transformation of a placeholder allows changing the inserted text for the placeholder when moving to the next tab stop.
+The inserted text is matched with the regular expression and the match or matches - depending on the options - are replaced with the specified replacement format text.
+Every occurrence of a placeholder can define its own transformation independently using the value of the first placeholder.
+The format for Placeholder-Transforms is the same as for Variable-Transforms.
+
+The following sample removes an underscore at the beginning of the text. `_transform` becomes `transform`.
+
+```
+${1/^_(.*)/$1/}
+  |   |    |  |-> No options
+  |   |    |
+  |   |    |-> Replace it with the first capture group
+  |   |
+  |   |-> Regular expression to capture everything after the underscore
+  |
+  |-> Placeholder Index
+```
 
 Grammar
 --
@@ -61,12 +81,17 @@ Below is the EBNF for snippets. With `\` (backslash) you can escape `$`, `}` and
 
 ```
 any         ::= tabstop | placeholder | choice | variable | text
-tabstop     ::= '$' int | '${' int '}'
+tabstop     ::= '$' int
+                | '${' int '}'
+                | '${' int  transform '}'
 placeholder ::= '${' int ':' any '}'
+                | '${' int ':' any transform '}'
 choice      ::= '${' int '|' text (',' text)* '|}'
+                | '${' int '|' text (',' text)* '|' transform '}'
 variable    ::= '$' var | '${' var }'
                 | '${' var ':' any '}'
-                | '${' var '/' regex '/' (format | text)+ '/' options '}'
+                | '${' var transform '}'
+transform   ::= '/' regex '/' (format | text)+ '/' options
 format      ::= '$' int | '${' int '}'
                 | '${' int ':' '/upcase' | '/downcase' | '/capitalize' '}'
                 | '${' int ':+' if '}'
@@ -78,3 +103,5 @@ var         ::= [_a-zA-Z] [_a-zA-Z0-9]*
 int         ::= [0-9]+
 text        ::= .*
 ```
+
+Transformations for placeholders and choices are an extension to the TextMate snippet grammar and only support by Visual Studio Code.

--- a/src/vs/editor/contrib/snippet/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/snippetParser.ts
@@ -712,17 +712,21 @@ export class SnippetParser {
 			// ${1:<children>}
 			while (true) {
 
-
+				// ...} -> done
 				if (this._accept(TokenType.CurlyClose)) {
-					// ...} -> done
 					parent.appendChild(placeholder);
 					return true;
-				} else if (this._accept(TokenType.Forwardslash)) {
-					//../<regex>/<format>/<options>} -> transform
+				}
+
+				//../<regex>/<format>/<options>} -> transform
+				if (this._accept(TokenType.Forwardslash)) {
 					if (this._parseTransform(placeholder)) {
 						parent.appendChild(placeholder);
 						return true;
 					}
+
+					this._backTo(token);
+					return false;
 				}
 
 				if (this._parse(placeholder)) {
@@ -746,16 +750,19 @@ export class SnippetParser {
 						continue;
 					}
 
-					if (this._accept(TokenType.Pipe) && this._accept(TokenType.CurlyClose)) {
-						// ..|} -> done
+					if (this._accept(TokenType.Pipe)) {
 						placeholder.appendChild(choice);
-						parent.appendChild(placeholder);
-						return true;
-					} else if (this._accept(TokenType.Forwardslash)) {
-						// ...|/<regex>/<format>/<options>} -> transform
-						if (this._parseTransform(placeholder)) {
+						if (this._accept(TokenType.CurlyClose)) {
+							// ..|} -> done
 							parent.appendChild(placeholder);
 							return true;
+						}
+						if (this._accept(TokenType.Forwardslash)) {
+							// ...|/<regex>/<format>/<options>} -> transform
+							if (this._parseTransform(placeholder)) {
+								parent.appendChild(placeholder);
+								return true;
+							}
 						}
 					}
 				}

--- a/src/vs/editor/contrib/snippet/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/snippetParser.ts
@@ -214,8 +214,11 @@ export class Text extends Marker {
 	}
 }
 
-export class Placeholder extends Marker {
+export abstract class TransformableMarker extends Marker {
+	public transform: Transform;
+}
 
+export class Placeholder extends TransformableMarker {
 	static compareByIndex(a: Placeholder, b: Placeholder): number {
 		if (a.index === b.index) {
 			return 0;
@@ -246,27 +249,27 @@ export class Placeholder extends Marker {
 			: undefined;
 	}
 
-	get transform(): Transform {
-		for (const child of this._children) {
-			if (child instanceof Transform) {
-				return child as Transform;
-			}
-		}
-		return undefined;
-	}
-
 	toTextmateString(): string {
-		if (this.children.length === 0) {
+		let transformString = '';
+		if (this.transform) {
+			transformString = this.transform.toTextmateString();
+		}
+		if (this.children.length === 0 && !this.transform) {
 			return `\$${this.index}`;
+		} else if (this.children.length === 0) {
+			return `\${${this.index}${transformString}}`;
 		} else if (this.choice) {
-			return `\${${this.index}|${this.choice.toTextmateString()}|}`;
+			return `\${${this.index}|${this.choice.toTextmateString()}|${transformString}}`;
 		} else {
-			return `\${${this.index}:${this.children.map(child => child.toTextmateString()).join('')}}`;
+			return `\${${this.index}:${this.children.map(child => child.toTextmateString()).join('')}${transformString}}`;
 		}
 	}
 
 	clone(): Placeholder {
 		let ret = new Placeholder(this.index);
+		if (this.transform) {
+			ret.transform = this.transform.clone();
+		}
 		ret._children = this.children.map(child => child.clone());
 		return ret;
 	}
@@ -393,7 +396,7 @@ export class FormatString extends Marker {
 	}
 }
 
-export class Variable extends Marker {
+export class Variable extends TransformableMarker {
 
 	constructor(public name: string) {
 		super();
@@ -401,9 +404,8 @@ export class Variable extends Marker {
 
 	resolve(resolver: VariableResolver): boolean {
 		let value = resolver.resolve(this);
-		let [firstChild] = this._children;
-		if (firstChild instanceof Transform && this._children.length === 1) {
-			value = firstChild.resolve(value || '');
+		if (this.transform) {
+			value = this.transform.resolve(value || '');
 		}
 		if (value !== undefined) {
 			this._children = [new Text(value)];
@@ -413,15 +415,22 @@ export class Variable extends Marker {
 	}
 
 	toTextmateString(): string {
+		let transformString = '';
+		if (this.transform) {
+			transformString = this.transform.toTextmateString();
+		}
 		if (this.children.length === 0) {
-			return `\${${this.name}}`;
+			return `\${${this.name}${transformString}}`;
 		} else {
-			return `\${${this.name}:${this.children.map(child => child.toTextmateString()).join('')}}`;
+			return `\${${this.name}:${this.children.map(child => child.toTextmateString()).join('')}${transformString}}`;
 		}
 	}
 
 	clone(): Variable {
 		const ret = new Variable(this.name);
+		if (this.transform) {
+			ret.transform = this.transform.clone();
+		}
 		ret._children = this.children.map(child => child.clone());
 		return ret;
 	}
@@ -592,6 +601,7 @@ export class SnippetParser {
 		for (const placeholder of incompletePlaceholders) {
 			if (placeholderDefaultValues.has(placeholder.index)) {
 				const clone = new Placeholder(placeholder.index);
+				clone.transform = placeholder.transform;
 				for (const child of placeholderDefaultValues.get(placeholder.index)) {
 					clone.appendChild(child.clone());
 				}
@@ -864,7 +874,7 @@ export class SnippetParser {
 		}
 	}
 
-	private _parseTransform(parent: Variable | Placeholder): boolean {
+	private _parseTransform(parent: TransformableMarker): boolean {
 		// ...<regex>/<format>/<options>}
 
 		let transform = new Transform();
@@ -929,7 +939,7 @@ export class SnippetParser {
 			return false;
 		}
 
-		parent.appendChild(transform);
+		parent.transform = transform;
 		return true;
 	}
 

--- a/src/vs/editor/contrib/snippet/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/snippetParser.ts
@@ -500,9 +500,6 @@ export class TextmateSnippet extends Marker {
 		let ret = 0;
 		walk([marker], marker => {
 			ret += marker.len();
-			if (marker instanceof Transform) {
-				return false;
-			}
 			return true;
 		});
 		return ret;

--- a/src/vs/editor/contrib/snippet/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/snippetSession.ts
@@ -87,6 +87,28 @@ export class OneSnippet {
 
 		this._initDecorations();
 
+		// Transform placeholder text if necessary
+		if (this._placeholderGroupsIdx >= 0) {
+			const firstPlaceholder = this._placeholderGroups[this._placeholderGroupsIdx][0];
+
+			// Check if the placeholder has a transformation
+			if (firstPlaceholder.transform) {
+				const id = this._placeholderDecorations.get(firstPlaceholder);
+				const range = this._editor.getModel().getDecorationRange(id);
+				const currentValue = this._editor.getModel().getValueInRange(range);
+				let operations: IIdentifiedSingleEditOperation[] = [];
+
+				// Apply the transformed text on every placeholder occurence
+				for (const placeholder of this._placeholderGroups[this._placeholderGroupsIdx]) {
+					const id = this._placeholderDecorations.get(placeholder);
+					const range = this._editor.getModel().getDecorationRange(id);
+
+					operations.push({ range: range, text: firstPlaceholder.transform.resolve(currentValue) });
+				}
+				this._editor.getModel().applyEdits(operations);
+			}
+		}
+
 		if (fwd === true && this._placeholderGroupsIdx < this._placeholderGroups.length - 1) {
 			this._placeholderGroupsIdx += 1;
 

--- a/src/vs/editor/contrib/snippet/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/snippetSession.ts
@@ -89,24 +89,19 @@ export class OneSnippet {
 
 		// Transform placeholder text if necessary
 		if (this._placeholderGroupsIdx >= 0) {
-			const firstPlaceholder = this._placeholderGroups[this._placeholderGroupsIdx][0];
+			let operations: IIdentifiedSingleEditOperation[] = [];
 
-			// Check if the placeholder has a transformation
-			if (firstPlaceholder.transform) {
-				const id = this._placeholderDecorations.get(firstPlaceholder);
-				const range = this._editor.getModel().getDecorationRange(id);
-				const currentValue = this._editor.getModel().getValueInRange(range);
-				let operations: IIdentifiedSingleEditOperation[] = [];
-
-				// Apply the transformed text on every placeholder occurence
-				for (const placeholder of this._placeholderGroups[this._placeholderGroupsIdx]) {
+			for (const placeholder of this._placeholderGroups[this._placeholderGroupsIdx]) {
+				// Check if the placeholder has a transformation
+				if (placeholder.transform) {
 					const id = this._placeholderDecorations.get(placeholder);
 					const range = this._editor.getModel().getDecorationRange(id);
+					const currentValue = this._editor.getModel().getValueInRange(range);
 
-					operations.push({ range: range, text: firstPlaceholder.transform.resolve(currentValue) });
+					operations.push({ range: range, text: placeholder.transform.resolve(currentValue) });
 				}
-				this._editor.getModel().applyEdits(operations);
 			}
+			this._editor.getModel().applyEdits(operations);
 		}
 
 		if (fwd === true && this._placeholderGroupsIdx < this._placeholderGroups.length - 1) {


### PR DESCRIPTION
This PR adds transformations for placeholders by extending the syntax in the same way transformations are use with variables. Transformations are executed, when the user changes to the next placeholder.

I don't know if there is a better/more efficient way, but for me it works.

Fixes #34683.
TODO:
- [x] Add tests
- [x] Update documentation

PS: My first contribution to vscode. Great editor. :)
Best Regards,
go2sh