### PR TITLE
Make Emmet: "update image size" consistant with "follow link"

### DIFF
--- a/extensions/emmet/src/locateFile.ts
+++ b/extensions/emmet/src/locateFile.ts
@@ -10,7 +10,9 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
-const reAbsolute = /^\/+/;
+const reAbsolutePosix = /^\/+/;
+const reAbsoluteWin32 = /^\\+/;
+const reAbsolute = path.sep === '/' ? reAbsolutePosix : reAbsoluteWin32;
 
 /**
  * Locates given `filePath` on user’s file system and returns absolute path to it.


### PR DESCRIPTION
Fixes #50325.

I question whether this should actually be the reverse: follow link should respect starting a file name with "/" as being an index off of the filesystem root, not the project directory.