### PR TITLE
Access active source control provider

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -256,6 +256,19 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region scm
+	export namespace scm {
+		/**
+		 * The currently active [source control](#SourceControl).
+		 */
+		export let activeSourceControl: SourceControl | undefined;
+		/**
+		 * An [event](#Event) which fires when the active [source control](#SourceControl) has changed.
+		 */
+		export const onDidChangeActiveSourceControl: Event<SourceControl>;
+	}
+	//#endregion
+
 	//#region Comments
 	/**
 	 * Comments provider related APIs are still in early stages, they may be changed significantly during our API experiments.

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -566,6 +566,12 @@ export function createApiFactory(
 			get inputBox() {
 				return extHostSCM.getLastInputBox(extension);
 			},
+			get activeSourceControl() {
+				return extHostSCM.activeSourceControl;
+			},
+			get onDidChangeActiveSourceControl() {
+				return extHostSCM.onDidChangeActiveSourceControl;
+			},
 			createSourceControl(id: string, label: string, rootUri?: vscode.Uri) {
 				return extHostSCM.createSourceControl(extension, id, label, rootUri);
 			}

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -782,6 +782,7 @@ export interface ExtHostTerminalServiceShape {
 export interface ExtHostSCMShape {
 	$provideOriginalResource(sourceControlHandle: number, uri: UriComponents): TPromise<UriComponents>;
 	$onInputBoxValueChange(sourceControlHandle: number, value: string): TPromise<void>;
+	$acceptActiveSourceControlChange(sourceControlHandle: number): TPromise<void>;
 	$executeResourceCommand(sourceControlHandle: number, groupHandle: number, handle: number): TPromise<void>;
 	$validateInput(sourceControlHandle: number, value: string, cursorPosition: number): TPromise<[string, number] | undefined>;
 }


### PR DESCRIPTION
In our Pull Request multi root workspace scenario, we'd like to know which source control provider is active and show corresponding pull requests. We expect the experience to be similar to the git status bar items, which will update when the active source control provider changes.

We used to have this API but removed in https://github.com/Microsoft/vscode/commit/a8b294585535b6327a92e32c3b7f9c580f7300b3#diff-158dcbfd31a2238ddd6a89b8a4a23316 . Here I listen to the `repository.onFocus` event (learnt from `scmActivity`), we can probably move this to SCM service.

@joaomoreno feel free to write your own implementation if you think it's a valid request and my code needs a lot of change.
