### PR TITLE
Workbench grid dimension constraint propagation

### DIFF
--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -192,11 +192,10 @@ export class Grid<T extends IView> implements IDisposable {
 
 	get minimumWidth(): number { return this.gridview.minimumWidth; }
 	get minimumHeight(): number { return this.gridview.minimumHeight; }
-
 	get maximumWidth(): number { return this.gridview.maximumWidth; }
 	get maximumHeight(): number { return this.gridview.maximumHeight; }
 
-	public sashResetSizing: Sizing = Sizing.Distribute;
+	sashResetSizing: Sizing = Sizing.Distribute;
 
 	constructor(container: HTMLElement, view: T, options: IGridOptions = {}) {
 		this.gridview = new GridView(container, options);

--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -10,6 +10,7 @@ import { Orientation } from 'vs/base/browser/ui/sash/sash';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { tail2 as tail } from 'vs/base/common/arrays';
 import { orthogonal, IView, GridView, Sizing as GridViewSizing, Box, IGridViewStyles } from './gridview';
+import { Event } from 'vs/base/common/event';
 
 export { Orientation } from './gridview';
 
@@ -194,6 +195,7 @@ export class Grid<T extends IView> implements IDisposable {
 	get minimumHeight(): number { return this.gridview.minimumHeight; }
 	get maximumWidth(): number { return this.gridview.maximumWidth; }
 	get maximumHeight(): number { return this.gridview.maximumHeight; }
+	get onDidChange(): Event<{ width: number; height: number; }> { return this.gridview.onDidChange; }
 
 	sashResetSizing: Sizing = Sizing.Distribute;
 

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -442,6 +442,7 @@ export class GridView implements IDisposable {
 		this._root = root;
 		this.element.appendChild(root.element);
 		this.onDidSashResetRelay.input = root.onDidSashReset;
+		this._onDidChange.input = mapEvent(root.onDidChange, () => undefined); // TODO
 	}
 
 	get orientation(): Orientation {
@@ -466,6 +467,9 @@ export class GridView implements IDisposable {
 	get minimumHeight(): number { return this.root.minimumHeight; }
 	get maximumWidth(): number { return this.root.maximumHeight; }
 	get maximumHeight(): number { return this.root.maximumHeight; }
+
+	private _onDidChange = new Relay<{ width: number; height: number; }>();
+	readonly onDidChange = this._onDidChange.event;
 
 	constructor(container: HTMLElement, options: IGridViewOptions = {}) {
 		this.element = append(container, $('.monaco-grid-view'));

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -459,29 +459,13 @@ export class GridView implements IDisposable {
 		this.root.orthogonalLayout(orthogonalSize);
 	}
 
-	get width(): number {
-		return this.root.width;
-	}
+	get width(): number { return this.root.width; }
+	get height(): number { return this.root.height; }
 
-	get height(): number {
-		return this.root.height;
-	}
-
-	get minimumWidth(): number {
-		return this.root.minimumWidth;
-	}
-
-	get minimumHeight(): number {
-		return this.root.minimumHeight;
-	}
-
-	get maximumWidth(): number {
-		return this.root.maximumHeight;
-	}
-
-	get maximumHeight(): number {
-		return this.root.maximumHeight;
-	}
+	get minimumWidth(): number { return this.root.minimumWidth; }
+	get minimumHeight(): number { return this.root.minimumHeight; }
+	get maximumWidth(): number { return this.root.maximumHeight; }
+	get maximumHeight(): number { return this.root.maximumHeight; }
 
 	constructor(container: HTMLElement, options: IGridViewOptions = {}) {
 		this.element = append(container, $('.monaco-grid-view'));

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -363,7 +363,7 @@ class LeafNode implements ISplitView, IDisposable {
 	}
 
 	get onDidChange(): Event<number> {
-		return mapEvent(this.view.onDidChange, this.orientation === Orientation.HORIZONTAL ? ({ width }) => width : ({ height }) => height);
+		return mapEvent(this.view.onDidChange, this.orientation === Orientation.HORIZONTAL ? e => e && e.width : e => e && e.height);
 	}
 
 	set orthogonalStartSash(sash: Sash) {

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -104,11 +104,11 @@ class BranchNode implements ISplitView, IDisposable {
 	}
 
 	get minimumOrthogonalSize(): number {
-		return this.children.length === 0 ? 0 : this.children.reduce((r, c) => r + c.minimumSize, 0);
+		return this.splitview.minimumSize;
 	}
 
 	get maximumOrthogonalSize(): number {
-		return this.children.length === 0 ? Number.POSITIVE_INFINITY : this.children.reduce((r, c) => r + c.maximumSize, 0);
+		return this.splitview.maximumSize;
 	}
 
 	get minimumWidth(): number {

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -146,6 +146,14 @@ export class SplitView implements IDisposable {
 		return this.viewItems.length;
 	}
 
+	get minimumSize(): number {
+		return this.viewItems.reduce((r, item) => r + item.view.minimumSize, 0);
+	}
+
+	get maximumSize(): number {
+		return this.length === 0 ? Number.POSITIVE_INFINITY : this.viewItems.reduce((r, item) => r + item.view.maximumSize, 0);
+	}
+
 	private _orthogonalStartSash: Sash | undefined;
 	get orthogonalStartSash(): Sash | undefined { return this._orthogonalStartSash; }
 	set orthogonalStartSash(sash: Sash | undefined) {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -117,23 +117,23 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 	private registerListeners(): void {
 		this._register(this.themeService.onThemeChange(_ => this.layout()));
-		this._register(this.parts.editor.onDidPreferredSizeChange(() => this.onDidPreferredSizeChange()));
+		this._register(this.parts.editor.onDidChange(() => this.onDidEditorChange()));
 
 		this.registerSashListeners();
 	}
 
-	private onDidPreferredSizeChange(): void {
+	private onDidEditorChange(): void {
 		if (this.workbenchSize && (this.sidebarWidth || this.panelHeight)) {
 			if (this.editorGroupService.count > 1) {
-				const preferredEditorPartSize = this.parts.editor.preferredSize;
+				const minimumEditorPartSize = new Dimension(this.parts.editor.minimumWidth, this.parts.editor.minimumHeight);
 
-				const sidebarOverflow = this.workbenchSize.width - this.sidebarWidth < preferredEditorPartSize.width;
+				const sidebarOverflow = this.workbenchSize.width - this.sidebarWidth < minimumEditorPartSize.width;
 
 				let panelOverflow = false;
 				if (this.partService.getPanelPosition() === Position.RIGHT) {
-					panelOverflow = this.workbenchSize.width - this.panelWidth - this.sidebarWidth < preferredEditorPartSize.width;
+					panelOverflow = this.workbenchSize.width - this.panelWidth - this.sidebarWidth < minimumEditorPartSize.width;
 				} else {
-					panelOverflow = this.workbenchSize.height - this.panelHeight < preferredEditorPartSize.height;
+					panelOverflow = this.workbenchSize.height - this.panelHeight < minimumEditorPartSize.height;
 				}
 
 				// Trigger a layout if we detect that either sidebar or panel overflow
@@ -191,11 +191,11 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 			minSidebarWidth = 0;
 		}
 
-		return Math.max(this.partLayoutInfo.panel.minWidth, this.workbenchSize.width - this.parts.editor.preferredSize.width - minSidebarWidth - this.activitybarWidth);
+		return Math.max(this.partLayoutInfo.panel.minWidth, this.workbenchSize.width - this.parts.editor.minimumWidth - minSidebarWidth - this.activitybarWidth);
 	}
 
 	private computeMaxPanelHeight(): number {
-		return Math.max(this.partLayoutInfo.panel.minHeight, this.sidebarHeight /* simplification for: window.height - status.height - title-height */ - this.parts.editor.preferredSize.height);
+		return Math.max(this.partLayoutInfo.panel.minHeight, this.sidebarHeight /* simplification for: window.height - status.height - title-height */ - this.parts.editor.minimumHeight);
 	}
 
 	private get sidebarWidth(): number {
@@ -208,7 +208,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 	private set sidebarWidth(value: number) {
 		const panelMinWidth = this.partService.getPanelPosition() === Position.RIGHT && this.partService.isVisible(Parts.PANEL_PART) ? this.partLayoutInfo.panel.minWidth : 0;
-		const maxSidebarWidth = this.workbenchSize.width - this.activitybarWidth - this.parts.editor.preferredSize.width - panelMinWidth;
+		const maxSidebarWidth = this.workbenchSize.width - this.activitybarWidth - this.parts.editor.minimumWidth - panelMinWidth;
 
 		this._sidebarWidth = Math.max(this.partLayoutInfo.sidebar.minWidth, Math.min(maxSidebarWidth, value));
 	}
@@ -486,10 +486,10 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		editorSize.width = this.workbenchSize.width - sidebarSize.width - activityBarSize.width - (panelPosition === Position.RIGHT ? panelDimension.width : 0);
 		editorSize.height = sidebarSize.height - (panelPosition === Position.BOTTOM ? panelDimension.height : 0);
 
-		// Adjust for Editor Part preferred width
-		const preferredEditorPartSize = this.parts.editor.preferredSize;
-		if (editorSize.width < preferredEditorPartSize.width) {
-			const missingPreferredEditorWidth = preferredEditorPartSize.width - editorSize.width;
+		// Adjust for Editor Part minimum width
+		const minimumEditorPartSize = new Dimension(this.parts.editor.minimumWidth, this.parts.editor.minimumHeight);
+		if (editorSize.width < minimumEditorPartSize.width) {
+			const missingPreferredEditorWidth = minimumEditorPartSize.width - editorSize.width;
 			let outstandingMissingPreferredEditorWidth = missingPreferredEditorWidth;
 
 			// Take from Panel if Panel Position on the Right and Visible
@@ -512,9 +512,9 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 			}
 		}
 
-		// Adjust for Editor Part preferred height
-		if (editorSize.height < preferredEditorPartSize.height) {
-			const missingPreferredEditorHeight = preferredEditorPartSize.height - editorSize.height;
+		// Adjust for Editor Part minimum height
+		if (editorSize.height < minimumEditorPartSize.height) {
+			const missingPreferredEditorHeight = minimumEditorPartSize.height - editorSize.height;
 			let outstandingMissingPreferredEditorHeight = missingPreferredEditorHeight;
 
 			// Take from Panel if Panel Position on the Bottom and Visible
@@ -713,9 +713,8 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 			case Parts.SIDEBAR_PART:
 				this.sidebarWidth = this.sidebarWidth + sizeChangePxWidth; // Sidebar can not become smaller than MIN_PART_WIDTH
 
-				const preferredEditorPartSize = this.parts.editor.preferredSize;
-				if (this.workbenchSize.width - this.sidebarWidth < preferredEditorPartSize.width) {
-					this.sidebarWidth = this.workbenchSize.width - preferredEditorPartSize.width;
+				if (this.workbenchSize.width - this.sidebarWidth < this.parts.editor.minimumWidth) {
+					this.sidebarWidth = this.workbenchSize.width - this.parts.editor.minimumWidth;
 				}
 
 				doLayout = true;

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -117,7 +117,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 	private registerListeners(): void {
 		this._register(this.themeService.onThemeChange(_ => this.layout()));
-		this._register(this.parts.editor.onDidChange(() => this.onDidEditorChange()));
+		this._register(this.parts.editor.onDidSizeConstraintsChange(() => this.onDidEditorChange()));
 
 		this.registerSashListeners();
 	}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -117,12 +117,12 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 	private registerListeners(): void {
 		this._register(this.themeService.onThemeChange(_ => this.layout()));
-		this._register(this.parts.editor.onDidSizeConstraintsChange(() => this.onDidEditorChange()));
+		this._register(this.parts.editor.onDidSizeConstraintsChange(() => this.onDidEditorSizeConstraintsChange()));
 
 		this.registerSashListeners();
 	}
 
-	private onDidEditorChange(): void {
+	private onDidEditorSizeConstraintsChange(): void {
 		if (this.workbenchSize && (this.sidebarWidth || this.panelHeight)) {
 			if (this.editorGroupService.count > 1) {
 				const minimumEditorPartSize = new Dimension(this.parts.editor.minimumWidth, this.parts.editor.minimumHeight);

--- a/src/vs/workbench/browser/parts/editor/baseEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/baseEditor.ts
@@ -16,6 +16,7 @@ import { LRUCache } from 'vs/base/common/map';
 import URI from 'vs/base/common/uri';
 import { once } from 'vs/base/common/event';
 import { isEmptyObject } from 'vs/base/common/types';
+import { DEFAULT_EDITOR_MIN_DIMENSIONS, DEFAULT_EDITOR_MAX_DIMENSIONS } from 'vs/workbench/browser/parts/editor/editor';
 
 /**
  * The base class of editors in the workbench. Editors register themselves for specific editor inputs.
@@ -38,6 +39,11 @@ export abstract class BaseEditor extends Panel implements IEditor {
 
 	private _options: EditorOptions;
 	private _group: IEditorGroup;
+
+	readonly minimumWidth: number = DEFAULT_EDITOR_MIN_DIMENSIONS.width;
+	readonly maximumWidth: number = DEFAULT_EDITOR_MAX_DIMENSIONS.width;
+	readonly minimumHeight: number = DEFAULT_EDITOR_MIN_DIMENSIONS.height;
+	readonly maximumHeight: number = DEFAULT_EDITOR_MAX_DIMENSIONS.height;
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/browser/parts/editor/baseEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/baseEditor.ts
@@ -14,7 +14,7 @@ import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/group/
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { LRUCache } from 'vs/base/common/map';
 import URI from 'vs/base/common/uri';
-import { once } from 'vs/base/common/event';
+import { once, Event } from 'vs/base/common/event';
 import { isEmptyObject } from 'vs/base/common/types';
 import { DEFAULT_EDITOR_MIN_DIMENSIONS, DEFAULT_EDITOR_MAX_DIMENSIONS } from 'vs/workbench/browser/parts/editor/editor';
 
@@ -44,6 +44,7 @@ export abstract class BaseEditor extends Panel implements IEditor {
 	readonly maximumWidth: number = DEFAULT_EDITOR_MAX_DIMENSIONS.width;
 	readonly minimumHeight: number = DEFAULT_EDITOR_MIN_DIMENSIONS.height;
 	readonly maximumHeight: number = DEFAULT_EDITOR_MAX_DIMENSIONS.height;
+	readonly onDidChange: Event<{ width: number; height: number; }> = Event.None;
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/browser/parts/editor/baseEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/baseEditor.ts
@@ -33,18 +33,19 @@ import { DEFAULT_EDITOR_MIN_DIMENSIONS, DEFAULT_EDITOR_MAX_DIMENSIONS } from 'vs
  */
 export abstract class BaseEditor extends Panel implements IEditor {
 
+	readonly minimumWidth = DEFAULT_EDITOR_MIN_DIMENSIONS.width;
+	readonly maximumWidth = DEFAULT_EDITOR_MAX_DIMENSIONS.width;
+	readonly minimumHeight = DEFAULT_EDITOR_MIN_DIMENSIONS.height;
+	readonly maximumHeight = DEFAULT_EDITOR_MAX_DIMENSIONS.height;
+
+	readonly onDidSizeConstraintsChange: Event<{ width: number; height: number; }> = Event.None;
+
 	private static readonly EDITOR_MEMENTOS: Map<string, EditorMemento<any>> = new Map<string, EditorMemento<any>>();
 
 	protected _input: EditorInput;
 
 	private _options: EditorOptions;
 	private _group: IEditorGroup;
-
-	readonly minimumWidth: number = DEFAULT_EDITOR_MIN_DIMENSIONS.width;
-	readonly maximumWidth: number = DEFAULT_EDITOR_MAX_DIMENSIONS.width;
-	readonly minimumHeight: number = DEFAULT_EDITOR_MIN_DIMENSIONS.height;
-	readonly maximumHeight: number = DEFAULT_EDITOR_MAX_DIMENSIONS.height;
-	readonly onDidChange: Event<{ width: number; height: number; }> = Event.None;
 
 	constructor(
 		id: string,

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -21,8 +21,8 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 
 export const EDITOR_TITLE_HEIGHT = 35;
 
-export const EDITOR_MIN_DIMENSIONS = new Dimension(220, 70);
-export const EDITOR_MAX_DIMENSIONS = new Dimension(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
+export const DEFAULT_EDITOR_MIN_DIMENSIONS = new Dimension(220, 70);
+export const DEFAULT_EDITOR_MAX_DIMENSIONS = new Dimension(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
 
 export interface IEditorPartOptions extends IWorkbenchEditorPartConfiguration {
 	iconTheme?: string;

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -16,7 +16,7 @@ import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IProgressService, LongRunningOperation } from 'vs/platform/progress/common/progress';
 import { toWinJsPromise } from 'vs/base/common/async';
-import { IEditorGroupView } from 'vs/workbench/browser/parts/editor/editor';
+import { IEditorGroupView, DEFAULT_EDITOR_MIN_DIMENSIONS, DEFAULT_EDITOR_MAX_DIMENSIONS } from 'vs/workbench/browser/parts/editor/editor';
 import { Event, Emitter } from 'vs/base/common/event';
 
 export interface IOpenEditorResult {
@@ -34,10 +34,10 @@ export class EditorControl extends Disposable {
 	private dimension: Dimension;
 	private editorOperation: LongRunningOperation;
 
-	get minimumWidth(): number { return this._activeControl ? this._activeControl.minimumWidth : 0; }
-	get minimumHeight(): number { return this._activeControl ? this._activeControl.minimumHeight : 0; }
-	get maximumWidth(): number { return this._activeControl ? this._activeControl.maximumWidth : Number.POSITIVE_INFINITY; }
-	get maximumHeight(): number { return this._activeControl ? this._activeControl.maximumHeight : Number.POSITIVE_INFINITY; }
+	get minimumWidth(): number { return this._activeControl ? this._activeControl.minimumWidth : DEFAULT_EDITOR_MIN_DIMENSIONS.width; }
+	get minimumHeight(): number { return this._activeControl ? this._activeControl.minimumHeight : DEFAULT_EDITOR_MIN_DIMENSIONS.height; }
+	get maximumWidth(): number { return this._activeControl ? this._activeControl.maximumWidth : DEFAULT_EDITOR_MAX_DIMENSIONS.width; }
+	get maximumHeight(): number { return this._activeControl ? this._activeControl.maximumHeight : DEFAULT_EDITOR_MAX_DIMENSIONS.height; }
 
 	private _onDidChange = new Emitter<{ width: number; height: number; }>();
 	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidChange.event;

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { dispose, Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { dispose, Disposable, IDisposable, empty as EmptyDisposable } from 'vs/base/common/lifecycle';
 import { EditorInput, EditorOptions } from 'vs/workbench/common/editor';
 import { Dimension, show, hide, addClass } from 'vs/base/browser/dom';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -43,6 +43,7 @@ export class EditorControl extends Disposable {
 	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidChange.event;
 
 	private _activeControl: BaseEditor;
+	private activeControlDisposable: IDisposable = EmptyDisposable;
 	private controls: BaseEditor[] = [];
 
 	constructor(
@@ -58,7 +59,13 @@ export class EditorControl extends Disposable {
 	}
 
 	private setActiveControl(activeControl: BaseEditor) {
+		this.activeControlDisposable.dispose();
 		this._activeControl = activeControl;
+
+		if (activeControl) {
+			this.activeControlDisposable = activeControl.onDidChange(e => this._onDidChange.fire(e));
+		}
+
 		this._onDidChange.fire();
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -34,6 +34,14 @@ export class EditorControl extends Disposable {
 	private dimension: Dimension;
 	private editorOperation: LongRunningOperation;
 
+	get minimumWidth(): number { return this._activeControl ? this._activeControl.minimumWidth : 0; }
+	get minimumHeight(): number { return this._activeControl ? this._activeControl.minimumHeight : 0; }
+	get maximumWidth(): number { return this._activeControl ? this._activeControl.maximumWidth : Number.POSITIVE_INFINITY; }
+	get maximumHeight(): number { return this._activeControl ? this._activeControl.maximumHeight : Number.POSITIVE_INFINITY; }
+
+	private _onDidChange = new Emitter<{ width: number; height: number; }>();
+	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidChange.event;
+
 	private _activeControl: BaseEditor;
 	private controls: BaseEditor[] = [];
 
@@ -47,6 +55,11 @@ export class EditorControl extends Disposable {
 		super();
 
 		this.editorOperation = this._register(new LongRunningOperation(progressService));
+	}
+
+	private setActiveControl(activeControl: BaseEditor) {
+		this._activeControl = activeControl;
+		this._onDidChange.fire();
 	}
 
 	get activeControl(): BaseEditor {
@@ -77,7 +90,7 @@ export class EditorControl extends Disposable {
 		const control = this.doCreateEditorControl(descriptor);
 
 		// Remember editor as active
-		this._activeControl = control;
+		this.setActiveControl(control);
 
 		// Show editor
 		this.parent.appendChild(control.getContainer());
@@ -196,7 +209,7 @@ export class EditorControl extends Disposable {
 		this._activeControl.setVisible(false, this.groupView);
 
 		// Clear active control
-		this._activeControl = null;
+		this.setActiveControl(null);
 
 		// Clear focus listener
 		this.activeControlFocusListener = dispose(this.activeControlFocusListener);

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -244,6 +244,7 @@ export class EditorControl extends Disposable {
 
 	dispose(): void {
 		this.activeControlFocusListener = dispose(this.activeControlFocusListener);
+		this.activeControlDisposable = dispose(this.activeControlDisposable);
 
 		super.dispose();
 	}

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1336,7 +1336,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 	get maximumWidth(): number { return this.editorControl.maximumWidth; }
 	get maximumHeight(): number { return this.editorControl.maximumHeight; }
 
-	private _onDidChange = new Relay<{ width: number; height: number; }>();
+	private _onDidChange = this._register(new Relay<{ width: number; height: number; }>());
 	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidChange.event;
 
 	layout(width: number, height: number): void {

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -9,7 +9,7 @@ import 'vs/css!./media/editorgroupview';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorGroup, IEditorOpenOptions, EditorCloseEvent, ISerializedEditorGroup, isSerializedEditorGroup } from 'vs/workbench/common/editor/editorGroup';
 import { EditorInput, EditorOptions, GroupIdentifier, ConfirmResult, SideBySideEditorInput, CloseDirection, IEditorCloseEvent, EditorGroupActiveEditorDirtyContext } from 'vs/workbench/common/editor';
-import { Event, Emitter, once } from 'vs/base/common/event';
+import { Event, Emitter, once, Relay } from 'vs/base/common/event';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { addClass, addClasses, Dimension, trackFocus, toggleClass, removeClass, addDisposableListener, EventType, EventHelper, findParentWithClass, clearNode, isAncestor } from 'vs/base/browser/dom';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -34,7 +34,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { RunOnceWorker } from 'vs/base/common/async';
 import { EventType as TouchEventType, GestureEvent } from 'vs/base/browser/touch';
 import { TitleControl } from 'vs/workbench/browser/parts/editor/titleControl';
-import { IEditorGroupsAccessor, IEditorGroupView, IEditorPartOptionsChangeEvent, EDITOR_TITLE_HEIGHT, EDITOR_MIN_DIMENSIONS, EDITOR_MAX_DIMENSIONS, getActiveTextEditorOptions, IEditorOpeningEvent } from 'vs/workbench/browser/parts/editor/editor';
+import { IEditorGroupsAccessor, IEditorGroupView, IEditorPartOptionsChangeEvent, EDITOR_TITLE_HEIGHT, getActiveTextEditorOptions, IEditorOpeningEvent } from 'vs/workbench/browser/parts/editor/editor';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { join } from 'vs/base/common/paths';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
@@ -197,6 +197,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Editor control
 		this.editorControl = this._register(this.scopedInstantiationService.createInstance(EditorControl, this.editorContainer, this));
+		this._onDidChange.input = this.editorControl.onDidChange;
 
 		// Track Focus
 		this.doTrackFocus();
@@ -1330,12 +1331,13 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 	readonly element: HTMLElement = document.createElement('div');
 
-	readonly minimumWidth = EDITOR_MIN_DIMENSIONS.width;
-	readonly minimumHeight = EDITOR_MIN_DIMENSIONS.height;
-	readonly maximumWidth = EDITOR_MAX_DIMENSIONS.width;
-	readonly maximumHeight = EDITOR_MAX_DIMENSIONS.height;
+	get minimumWidth(): number { return this.editorControl.minimumWidth; }
+	get minimumHeight(): number { return this.editorControl.minimumHeight; }
+	get maximumWidth(): number { return this.editorControl.maximumWidth; }
+	get maximumHeight(): number { return this.editorControl.maximumHeight; }
 
-	get onDidChange() { return Event.None; } // only needed if minimum sizes ever change
+	private _onDidChange = new Relay<{ width: number; height: number; }>();
+	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidChange.event;
 
 	layout(width: number, height: number): void {
 		this.dimension = new Dimension(width, height);

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -197,7 +197,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Editor control
 		this.editorControl = this._register(this.scopedInstantiationService.createInstance(EditorControl, this.editorContainer, this));
-		this._onDidChange.input = this.editorControl.onDidChange;
+		this._onDidChange.input = this.editorControl.onDidSizeConstraintsChange;
 
 		// Track Focus
 		this.doTrackFocus();

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -74,7 +74,7 @@ export class SideBySideEditor extends BaseEditor {
 		this.detailsEditorContainer = DOM.$('.details-editor-container');
 		this.splitview.addView({
 			element: this.detailsEditorContainer,
-			layout: size => this.detailsEditor && this.detailsEditor.layout(new DOM.Dimension(size, this.dimension.height - 34 /* height of header container */)),
+			layout: size => this.detailsEditor && this.detailsEditor.layout(new DOM.Dimension(size, this.dimension.height)),
 			minimumSize: 220,
 			maximumSize: Number.POSITIVE_INFINITY,
 			onDidChange: Event.None
@@ -83,7 +83,7 @@ export class SideBySideEditor extends BaseEditor {
 		this.masterEditorContainer = DOM.$('.master-editor-container');
 		this.splitview.addView({
 			element: this.masterEditorContainer,
-			layout: size => this.masterEditor && this.masterEditor.layout(new DOM.Dimension(size, this.dimension.height - 34 /* height of header container */)),
+			layout: size => this.masterEditor && this.masterEditor.layout(new DOM.Dimension(size, this.dimension.height)),
 			minimumSize: 220,
 			maximumSize: Number.POSITIVE_INFINITY,
 			onDidChange: Event.None

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -55,7 +55,7 @@ export class SideBySideEditor extends BaseEditor {
 
 	private _onDidCreateEditors = new Emitter<{ width: number; height: number; }>();
 	private _onDidChange = new Relay<{ width: number; height: number; }>();
-	readonly onDidChange: Event<{ width: number; height: number; }> = anyEvent(this._onDidCreateEditors.event, this._onDidChange.event);
+	readonly onDidSizeConstraintsChange: Event<{ width: number; height: number; }> = anyEvent(this._onDidCreateEditors.event, this._onDidChange.event);
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -190,8 +190,8 @@ export class SideBySideEditor extends BaseEditor {
 		this.masterEditor = master;
 
 		this._onDidChange.input = anyEvent(
-			mapEvent(details.onDidChange, () => undefined),
-			mapEvent(master.onDidChange, () => undefined)
+			mapEvent(details.onDidSizeConstraintsChange, () => undefined),
+			mapEvent(master.onDidSizeConstraintsChange, () => undefined)
 		);
 
 		this._onDidCreateEditors.fire();

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -59,6 +59,26 @@ export interface IEditor {
 	group: IEditorGroup;
 
 	/**
+	 * The minimum width of this editor.
+	 */
+	readonly minimumWidth: number;
+
+	/**
+	 * The maximum width of this editor.
+	 */
+	readonly maximumWidth: number;
+
+	/**
+	 * The minimum height of this editor.
+	 */
+	readonly minimumHeight: number;
+
+	/**
+	 * The maximum height of this editor.
+	 */
+	readonly maximumHeight: number;
+
+	/**
 	 * Returns the unique identifier of this editor.
 	 */
 	getId(): string;

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -81,7 +81,7 @@ export interface IEditor {
 	/**
 	 * An event to notify whenever minimum/maximum width/height changes.
 	 */
-	readonly onDidChange: Event<{ width: number; height: number; }>;
+	readonly onDidSizeConstraintsChange: Event<{ width: number; height: number; }>;
 
 	/**
 	 * Returns the unique identifier of this editor.

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -79,6 +79,11 @@ export interface IEditor {
 	readonly maximumHeight: number;
 
 	/**
+	 * An event to notify whenever minimum/maximum width/height changes.
+	 */
+	readonly onDidChange: Event<{ width: number; height: number; }>;
+
+	/**
 	 * Returns the unique identifier of this editor.
 	 */
 	getId(): string;

--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -83,7 +83,7 @@ export class PreferencesEditor extends BaseEditor {
 	set maximumWidth(value: number) { /*noop*/ }
 
 	private _onDidCreateWidget = new Emitter<{ width: number; height: number; }>();
-	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidCreateWidget.event;
+	readonly onDidSizeConstraintsChange: Event<{ width: number; height: number; }> = this._onDidCreateWidget.event;
 
 	constructor(
 		@IPreferencesService private preferencesService: IPreferencesService,

--- a/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesEditor.ts
@@ -75,6 +75,16 @@ export class PreferencesEditor extends BaseEditor {
 
 	private lastFocusedWidget: SearchWidget | SideBySidePreferencesWidget = null;
 
+	get minimumWidth(): number { return this.sideBySidePreferencesWidget ? this.sideBySidePreferencesWidget.minimumWidth : 0; }
+	get maximumWidth(): number { return this.sideBySidePreferencesWidget ? this.sideBySidePreferencesWidget.maximumWidth : Number.POSITIVE_INFINITY; }
+
+	// these setters need to exist because this extends from BaseEditor
+	set minimumWidth(value: number) { /*noop*/ }
+	set maximumWidth(value: number) { /*noop*/ }
+
+	private _onDidCreateWidget = new Emitter<{ width: number; height: number; }>();
+	readonly onDidChange: Event<{ width: number; height: number; }> = this._onDidCreateWidget.event;
+
 	constructor(
 		@IPreferencesService private preferencesService: IPreferencesService,
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -122,6 +132,7 @@ export class PreferencesEditor extends BaseEditor {
 
 		const editorsContainer = DOM.append(parent, DOM.$('.preferences-editors-container'));
 		this.sideBySidePreferencesWidget = this._register(this.instantiationService.createInstance(SideBySidePreferencesWidget, editorsContainer));
+		this._onDidCreateWidget.fire();
 		this._register(this.sideBySidePreferencesWidget.onFocus(() => this.lastFocusedWidget = this.sideBySidePreferencesWidget));
 		this._register(this.sideBySidePreferencesWidget.onDidSettingsTargetChange(target => this.switchSettings(target)));
 
@@ -325,6 +336,11 @@ export class PreferencesEditor extends BaseEditor {
 			this.telemetryService.publicLog('defaultSettings.filter', data);
 			this._lastReportedFilter = filter;
 		}
+	}
+
+	dispose(): void {
+		this._onDidCreateWidget.dispose();
+		super.dispose();
 	}
 }
 
@@ -754,6 +770,9 @@ class SideBySidePreferencesWidget extends Widget {
 
 	private lastFocusedEditor: BaseEditor;
 	private splitview: SplitView;
+
+	get minimumWidth(): number { return this.splitview.minimumSize; }
+	get maximumWidth(): number { return this.splitview.maximumSize; }
 
 	constructor(
 		parentElement: HTMLElement,


### PR DESCRIPTION
Fixes #51964

- [x] Add dimension constraints to `BaseEditor`
- [x] Add dimension constraints to `EditorControl`
- [x] Add dimension constraints to `EditorGroupView`
- [x] Implement dimension constraints in `SideBySideEditor`
- [x] Implement dimension constraints in `PreferencesEditor`
- [x] Enable constraint propagation

@bpasero Give it a good smoke test, check side by side and preferences editor.