### PR TITLE
grid: container as a readonly property

### DIFF
--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -198,8 +198,12 @@ export class Grid<T extends IView> implements IDisposable {
 
 	public sashResetSizing: Sizing = Sizing.Distribute;
 
-	constructor(container: HTMLElement, view: T, options: IGridOptions = {}) {
-		this.gridview = new GridView(container, options);
+	get container(): HTMLElement {
+		return this.gridview.container;
+	}
+
+	constructor(view: T, options: IGridOptions = {}) {
+		this.gridview = new GridView(options);
 		this.disposables.push(this.gridview);
 
 		this.gridview.onDidSashReset(this.doResetViewSize, this, this.disposables);
@@ -439,7 +443,7 @@ export class SerializableGrid<T extends ISerializableView> extends Grid<T> {
 		return SerializableGrid.getFirstLeaf(node.children[0]);
 	}
 
-	static deserialize<T extends ISerializableView>(container: HTMLElement, json: ISerializedGrid, deserializer: IViewDeserializer<T>, options: IGridOptions = {}): SerializableGrid<T> {
+	static deserialize<T extends ISerializableView>(json: ISerializedGrid, deserializer: IViewDeserializer<T>, options: IGridOptions = {}): SerializableGrid<T> {
 		if (typeof json.orientation !== 'number') {
 			throw new Error('Invalid JSON: \'orientation\' property must be a number.');
 		} else if (typeof json.width !== 'number') {
@@ -460,7 +464,7 @@ export class SerializableGrid<T extends ISerializableView> extends Grid<T> {
 			throw new Error('Invalid serialized state, first leaf not found');
 		}
 
-		const result = new SerializableGrid<T>(container, firstLeaf.view, options);
+		const result = new SerializableGrid<T>(firstLeaf.view, options);
 		result.orientation = orientation;
 		result.restoreViews(firstLeaf.view, orientation, root);
 		result.initialLayoutContext = { width, height, root };

--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -199,7 +199,7 @@ export class Grid<T extends IView> implements IDisposable {
 	public sashResetSizing: Sizing = Sizing.Distribute;
 
 	get container(): HTMLElement {
-		return this.gridview.container;
+		return this.gridview.element;
 	}
 
 	constructor(view: T, options: IGridOptions = {}) {

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -483,8 +483,11 @@ export class GridView implements IDisposable {
 		return this.root.maximumHeight;
 	}
 
-	constructor(container: HTMLElement, options: IGridViewOptions = {}) {
-		this.element = append(container, $('.monaco-grid-view'));
+	readonly container: HTMLElement;
+
+	constructor(options: IGridViewOptions = {}) {
+		this.container = $('.');
+		this.element = append(this.container, $('.monaco-grid-view'));
 		this.styles = options.styles || defaultStyles;
 		this.root = new BranchNode(Orientation.VERTICAL, this.styles);
 	}

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -10,7 +10,7 @@ import { Event, anyEvent, Emitter, mapEvent, Relay } from 'vs/base/common/event'
 import { Orientation, Sash } from 'vs/base/browser/ui/sash/sash';
 import { SplitView, IView as ISplitView, Sizing, ISplitViewStyles } from 'vs/base/browser/ui/splitview/splitview';
 import { empty as EmptyDisposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
-import { $, append } from 'vs/base/browser/dom';
+import { $ } from 'vs/base/browser/dom';
 import { tail2 as tail } from 'vs/base/common/arrays';
 import { Color } from 'vs/base/common/color';
 
@@ -418,7 +418,7 @@ function flipNode<T extends Node>(node: T, size: number, orthogonalSize: number)
 
 export class GridView implements IDisposable {
 
-	private element: HTMLElement;
+	readonly element: HTMLElement;
 	private styles: IGridViewStyles;
 
 	private _root: BranchNode;
@@ -483,11 +483,8 @@ export class GridView implements IDisposable {
 		return this.root.maximumHeight;
 	}
 
-	readonly container: HTMLElement;
-
 	constructor(options: IGridViewOptions = {}) {
-		this.container = $('.');
-		this.element = append(this.container, $('.monaco-grid-view'));
+		this.element = $('.monaco-grid-view');
 		this.styles = options.styles || defaultStyles;
 		this.root = new BranchNode(Orientation.VERTICAL, this.styles);
 	}
@@ -760,7 +757,5 @@ export class GridView implements IDisposable {
 		if (this.element && this.element.parentElement) {
 			this.element.parentElement.removeChild(this.element);
 		}
-
-		this.element = null;
 	}
 }

--- a/src/vs/base/test/browser/ui/grid/grid.test.ts
+++ b/src/vs/base/test/browser/ui/grid/grid.test.ts
@@ -4,20 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Direction, Grid, getRelativeLocation, Orientation, SerializableGrid, ISerializableView, IViewDeserializer, GridNode, Sizing, isGridBranchNode, sanitizeGridNodeDescriptor, GridNodeDescriptor, createSerializedGrid } from 'vs/base/browser/ui/grid/grid';
+import { Direction, getRelativeLocation, Orientation, SerializableGrid, ISerializableView, IViewDeserializer, GridNode, Sizing, isGridBranchNode, sanitizeGridNodeDescriptor, GridNodeDescriptor, createSerializedGrid, Grid } from 'vs/base/browser/ui/grid/grid';
 import { TestView, nodesToArrays } from './util';
 import { deepClone } from 'vs/base/common/objects';
 
-function setupGrid(view: TestView): Grid<TestView> {
-	const grid = new Grid(view);
-	grid.container.style.position = 'absolute';
-	grid.container.style.width = `${800}px`;
-	grid.container.style.height = `${600}px`;
-
-	return grid;
-}
-
 suite('Grid', function () {
+	let container: HTMLElement;
+
+	setup(function () {
+		container = document.createElement('div');
+		container.style.position = 'absolute';
+		container.style.width = `${800}px`;
+		container.style.height = `${600}px`;
+	});
+
+	teardown(function () {
+		container = null;
+	});
 
 	test('getRelativeLocation', function () {
 		assert.deepEqual(getRelativeLocation(Orientation.VERTICAL, [0], Direction.Up), [0]);
@@ -53,7 +56,8 @@ suite('Grid', function () {
 
 	test('empty', function () {
 		const view1 = new TestView(100, Number.MAX_VALUE, 100, Number.MAX_VALUE);
-		const gridview = setupGrid(view1);
+		const gridview = new Grid(view1);
+		container.appendChild(gridview.container);
 		gridview.layout(800, 600);
 
 		assert.deepEqual(view1.size, [800, 600]);
@@ -61,7 +65,8 @@ suite('Grid', function () {
 
 	test('two views vertically', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -73,7 +78,9 @@ suite('Grid', function () {
 
 	test('two views horizontally', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
+
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -85,7 +92,9 @@ suite('Grid', function () {
 
 	test('simple layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
+
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -118,7 +127,8 @@ suite('Grid', function () {
 
 	test('another simple layout with automatic size distribution', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
@@ -161,7 +171,9 @@ suite('Grid', function () {
 
 	test('another simple layout with split size distribution', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
+
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -203,7 +215,8 @@ suite('Grid', function () {
 
 	test('3/2 layout with split', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
@@ -237,7 +250,8 @@ suite('Grid', function () {
 
 	test('sizing should be correct after branch demotion #50564', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -262,7 +276,8 @@ suite('Grid', function () {
 
 	test('sizing should be correct after branch demotion #50675', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -287,7 +302,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on single view layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -304,7 +320,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on simple layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -347,7 +364,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on a complex layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -387,7 +405,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on another simple layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -408,7 +427,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should only return immediate neighbors', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupGrid(view1);
+		const grid = new Grid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -465,19 +485,25 @@ function nodesToNames(node: GridNode<TestSerializableView>): any {
 	}
 }
 
-function setupSerializedGrid(view: TestSerializableView): SerializableGrid<TestSerializableView> {
-	const grid = new SerializableGrid(view);
-	grid.container.style.position = 'absolute';
-	grid.container.style.width = `${800}px`;
-	grid.container.style.height = `${600}px`;
-
-	return grid;
-}
-
 suite('SerializableGrid', function () {
+
+	let container: HTMLElement;
+
+	setup(function () {
+		container = document.createElement('div');
+		container.style.position = 'absolute';
+		container.style.width = `${800}px`;
+		container.style.height = `${600}px`;
+	});
+
+	teardown(function () {
+		container = null;
+	});
+
 	test('serialize empty', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 		grid.layout(800, 600);
 
 		assert.deepEqual(grid.serialize(), {
@@ -502,7 +528,8 @@ suite('SerializableGrid', function () {
 
 	test('serialize simple layout', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -555,7 +582,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize empty', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 		grid.layout(800, 600);
 
 		const json = grid.serialize();
@@ -570,7 +598,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize simple layout', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -617,7 +646,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize simple layout with scaling', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -655,7 +685,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize 4 view layout (ben issue #2)', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -688,7 +719,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize 2 view layout (ben issue #3)', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 
@@ -712,7 +744,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize simple view layout #50609', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = setupSerializedGrid(view1);
+		const grid = new SerializableGrid(view1);
+		container.appendChild(grid.container);
 
 		grid.layout(800, 600);
 

--- a/src/vs/base/test/browser/ui/grid/grid.test.ts
+++ b/src/vs/base/test/browser/ui/grid/grid.test.ts
@@ -8,19 +8,16 @@ import { Direction, Grid, getRelativeLocation, Orientation, SerializableGrid, IS
 import { TestView, nodesToArrays } from './util';
 import { deepClone } from 'vs/base/common/objects';
 
+function setupGrid(view: TestView): Grid<TestView> {
+	const grid = new Grid(view);
+	grid.container.style.position = 'absolute';
+	grid.container.style.width = `${800}px`;
+	grid.container.style.height = `${600}px`;
+
+	return grid;
+}
+
 suite('Grid', function () {
-	let container: HTMLElement;
-
-	setup(function () {
-		container = document.createElement('div');
-		container.style.position = 'absolute';
-		container.style.width = `${800}px`;
-		container.style.height = `${600}px`;
-	});
-
-	teardown(function () {
-		container = null;
-	});
 
 	test('getRelativeLocation', function () {
 		assert.deepEqual(getRelativeLocation(Orientation.VERTICAL, [0], Direction.Up), [0]);
@@ -56,7 +53,7 @@ suite('Grid', function () {
 
 	test('empty', function () {
 		const view1 = new TestView(100, Number.MAX_VALUE, 100, Number.MAX_VALUE);
-		const gridview = new Grid(container, view1);
+		const gridview = setupGrid(view1);
 		gridview.layout(800, 600);
 
 		assert.deepEqual(view1.size, [800, 600]);
@@ -64,7 +61,7 @@ suite('Grid', function () {
 
 	test('two views vertically', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -76,7 +73,7 @@ suite('Grid', function () {
 
 	test('two views horizontally', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -88,7 +85,7 @@ suite('Grid', function () {
 
 	test('simple layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -121,7 +118,8 @@ suite('Grid', function () {
 
 	test('another simple layout with automatic size distribution', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -163,7 +161,7 @@ suite('Grid', function () {
 
 	test('another simple layout with split size distribution', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -205,7 +203,8 @@ suite('Grid', function () {
 
 	test('3/2 layout with split', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 		assert.deepEqual(view1.size, [800, 600]);
 
@@ -238,7 +237,8 @@ suite('Grid', function () {
 
 	test('sizing should be correct after branch demotion #50564', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -262,7 +262,8 @@ suite('Grid', function () {
 
 	test('sizing should be correct after branch demotion #50675', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -286,7 +287,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on single view layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		assert.deepEqual(grid.getNeighborViews(view1, Direction.Up), []);
@@ -302,7 +304,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on simple layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -344,7 +347,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on a complex layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -383,7 +387,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should work on another simple layout', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -403,7 +408,8 @@ suite('Grid', function () {
 
 	test('getNeighborViews should only return immediate neighbors', function () {
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new Grid(container, view1);
+		const grid = setupGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -459,23 +465,19 @@ function nodesToNames(node: GridNode<TestSerializableView>): any {
 	}
 }
 
+function setupSerializedGrid(view: TestSerializableView): SerializableGrid<TestSerializableView> {
+	const grid = new SerializableGrid(view);
+	grid.container.style.position = 'absolute';
+	grid.container.style.width = `${800}px`;
+	grid.container.style.height = `${600}px`;
+
+	return grid;
+}
+
 suite('SerializableGrid', function () {
-	let container: HTMLElement;
-
-	setup(function () {
-		container = document.createElement('div');
-		container.style.position = 'absolute';
-		container.style.width = `${800}px`;
-		container.style.height = `${600}px`;
-	});
-
-	teardown(function () {
-		container = null;
-	});
-
 	test('serialize empty', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
 		grid.layout(800, 600);
 
 		assert.deepEqual(grid.serialize(), {
@@ -500,7 +502,7 @@ suite('SerializableGrid', function () {
 
 	test('serialize simple layout', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -553,14 +555,14 @@ suite('SerializableGrid', function () {
 
 	test('deserialize empty', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
 		grid.layout(800, 600);
 
 		const json = grid.serialize();
 		grid.dispose();
 
 		const deserializer = new TestViewDeserializer();
-		const grid2 = SerializableGrid.deserialize(container, json, deserializer);
+		const grid2 = SerializableGrid.deserialize(json, deserializer);
 		grid2.layout(800, 600);
 
 		assert.deepEqual(nodesToNames(grid2.getViews()), ['view1']);
@@ -568,7 +570,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize simple layout', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -587,7 +590,7 @@ suite('SerializableGrid', function () {
 		grid.dispose();
 
 		const deserializer = new TestViewDeserializer();
-		const grid2 = SerializableGrid.deserialize(container, json, deserializer);
+		const grid2 = SerializableGrid.deserialize(json, deserializer);
 
 		const view1Copy = deserializer.getView('view1');
 		const view2Copy = deserializer.getView('view2');
@@ -614,7 +617,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize simple layout with scaling', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -633,7 +637,7 @@ suite('SerializableGrid', function () {
 		grid.dispose();
 
 		const deserializer = new TestViewDeserializer();
-		const grid2 = SerializableGrid.deserialize(container, json, deserializer);
+		const grid2 = SerializableGrid.deserialize(json, deserializer);
 
 		const view1Copy = deserializer.getView('view1');
 		const view2Copy = deserializer.getView('view2');
@@ -651,7 +655,7 @@ suite('SerializableGrid', function () {
 
 	test('deserialize 4 view layout (ben issue #2)', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -667,7 +671,7 @@ suite('SerializableGrid', function () {
 		grid.dispose();
 
 		const deserializer = new TestViewDeserializer();
-		const grid2 = SerializableGrid.deserialize(container, json, deserializer);
+		const grid2 = SerializableGrid.deserialize(json, deserializer);
 
 		const view1Copy = deserializer.getView('view1');
 		const view2Copy = deserializer.getView('view2');
@@ -684,7 +688,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize 2 view layout (ben issue #3)', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -694,7 +699,7 @@ suite('SerializableGrid', function () {
 		grid.dispose();
 
 		const deserializer = new TestViewDeserializer();
-		const grid2 = SerializableGrid.deserialize(container, json, deserializer);
+		const grid2 = SerializableGrid.deserialize(json, deserializer);
 
 		const view1Copy = deserializer.getView('view1');
 		const view2Copy = deserializer.getView('view2');
@@ -707,7 +712,8 @@ suite('SerializableGrid', function () {
 
 	test('deserialize simple view layout #50609', function () {
 		const view1 = new TestSerializableView('view1', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		const grid = new SerializableGrid(container, view1);
+		const grid = setupSerializedGrid(view1);
+
 		grid.layout(800, 600);
 
 		const view2 = new TestSerializableView('view2', 50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
@@ -722,7 +728,7 @@ suite('SerializableGrid', function () {
 		grid.dispose();
 
 		const deserializer = new TestViewDeserializer();
-		const grid2 = SerializableGrid.deserialize(container, json, deserializer);
+		const grid2 = SerializableGrid.deserialize(json, deserializer);
 
 		const view2Copy = deserializer.getView('view2');
 		const view3Copy = deserializer.getView('view3');

--- a/src/vs/base/test/browser/ui/grid/gridview.test.ts
+++ b/src/vs/base/test/browser/ui/grid/gridview.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { $ } from 'vs/base/browser/dom';
 import { GridView, IView, Sizing } from 'vs/base/browser/ui/grid/gridview';
 import { nodesToArrays, TestView } from './util';
 
@@ -12,9 +13,12 @@ suite('Gridview', function () {
 
 	setup(function () {
 		gridview = new GridView();
-		gridview.container.style.position = 'absolute';
-		gridview.container.style.width = `${200}px`;
-		gridview.container.style.height = `${200}px`;
+		const container = $('.container');
+
+		container.style.position = 'absolute';
+		container.style.width = `${200}px`;
+		container.style.height = `${200}px`;
+		container.appendChild(gridview.element);
 	});
 
 	teardown(function () {

--- a/src/vs/base/test/browser/ui/grid/gridview.test.ts
+++ b/src/vs/base/test/browser/ui/grid/gridview.test.ts
@@ -8,27 +8,25 @@ import { GridView, IView, Sizing } from 'vs/base/browser/ui/grid/gridview';
 import { nodesToArrays, TestView } from './util';
 
 suite('Gridview', function () {
-	let container: HTMLElement;
+	let gridview: GridView;
 
 	setup(function () {
-		container = document.createElement('div');
-		container.style.position = 'absolute';
-		container.style.width = `${200}px`;
-		container.style.height = `${200}px`;
+		gridview = new GridView();
+		gridview.container.style.position = 'absolute';
+		gridview.container.style.width = `${200}px`;
+		gridview.container.style.height = `${200}px`;
 	});
 
 	teardown(function () {
-		container = null;
+		gridview = null;
 	});
 
 	test('empty gridview is empty', function () {
-		const gridview = new GridView(container);
 		assert.deepEqual(nodesToArrays(gridview.getViews()), []);
 		gridview.dispose();
 	});
 
 	test('gridview addView', function () {
-		const gridview = new GridView(container);
 
 		const view = new TestView(20, 20, 20, 20);
 		assert.throws(() => gridview.addView(view, 200, []), 'empty location');
@@ -51,7 +49,6 @@ suite('Gridview', function () {
 	});
 
 	test('gridview addView nested', function () {
-		const gridview = new GridView(container);
 
 		const views = [
 			new TestView(20, 20, 20, 20),
@@ -71,7 +68,6 @@ suite('Gridview', function () {
 	});
 
 	test('gridview addView deep nested', function () {
-		const gridview = new GridView(container);
 
 		const view1 = new TestView(20, 20, 20, 20);
 		gridview.addView(view1 as IView, 200, [0]);
@@ -109,84 +105,82 @@ suite('Gridview', function () {
 	});
 
 	test('simple layout', function () {
-		const grid = new GridView(container);
-		grid.layout(800, 600);
+		gridview.layout(800, 600);
 
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view1, 200, [0]);
+		gridview.addView(view1, 200, [0]);
 		assert.deepEqual(view1.size, [800, 600]);
-		assert.deepEqual(grid.getViewSize([0]), { width: 800, height: 600 });
+		assert.deepEqual(gridview.getViewSize([0]), { width: 800, height: 600 });
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view2, 200, [0]);
+		gridview.addView(view2, 200, [0]);
 		assert.deepEqual(view1.size, [800, 400]);
-		assert.deepEqual(grid.getViewSize([1]), { width: 800, height: 400 });
+		assert.deepEqual(gridview.getViewSize([1]), { width: 800, height: 400 });
 		assert.deepEqual(view2.size, [800, 200]);
-		assert.deepEqual(grid.getViewSize([0]), { width: 800, height: 200 });
+		assert.deepEqual(gridview.getViewSize([0]), { width: 800, height: 200 });
 
 		const view3 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view3, 200, [1, 1]);
+		gridview.addView(view3, 200, [1, 1]);
 		assert.deepEqual(view1.size, [600, 400]);
-		assert.deepEqual(grid.getViewSize([1, 0]), { width: 600, height: 400 });
+		assert.deepEqual(gridview.getViewSize([1, 0]), { width: 600, height: 400 });
 		assert.deepEqual(view2.size, [800, 200]);
-		assert.deepEqual(grid.getViewSize([0]), { width: 800, height: 200 });
+		assert.deepEqual(gridview.getViewSize([0]), { width: 800, height: 200 });
 		assert.deepEqual(view3.size, [200, 400]);
-		assert.deepEqual(grid.getViewSize([1, 1]), { width: 200, height: 400 });
+		assert.deepEqual(gridview.getViewSize([1, 1]), { width: 200, height: 400 });
 
 		const view4 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view4, 200, [0, 0]);
+		gridview.addView(view4, 200, [0, 0]);
 		assert.deepEqual(view1.size, [600, 400]);
-		assert.deepEqual(grid.getViewSize([1, 0]), { width: 600, height: 400 });
+		assert.deepEqual(gridview.getViewSize([1, 0]), { width: 600, height: 400 });
 		assert.deepEqual(view2.size, [600, 200]);
-		assert.deepEqual(grid.getViewSize([0, 1]), { width: 600, height: 200 });
+		assert.deepEqual(gridview.getViewSize([0, 1]), { width: 600, height: 200 });
 		assert.deepEqual(view3.size, [200, 400]);
-		assert.deepEqual(grid.getViewSize([1, 1]), { width: 200, height: 400 });
+		assert.deepEqual(gridview.getViewSize([1, 1]), { width: 200, height: 400 });
 		assert.deepEqual(view4.size, [200, 200]);
-		assert.deepEqual(grid.getViewSize([0, 0]), { width: 200, height: 200 });
+		assert.deepEqual(gridview.getViewSize([0, 0]), { width: 200, height: 200 });
 
 		const view5 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view5, 100, [1, 0, 1]);
+		gridview.addView(view5, 100, [1, 0, 1]);
 		assert.deepEqual(view1.size, [600, 300]);
-		assert.deepEqual(grid.getViewSize([1, 0, 0]), { width: 600, height: 300 });
+		assert.deepEqual(gridview.getViewSize([1, 0, 0]), { width: 600, height: 300 });
 		assert.deepEqual(view2.size, [600, 200]);
-		assert.deepEqual(grid.getViewSize([0, 1]), { width: 600, height: 200 });
+		assert.deepEqual(gridview.getViewSize([0, 1]), { width: 600, height: 200 });
 		assert.deepEqual(view3.size, [200, 400]);
-		assert.deepEqual(grid.getViewSize([1, 1]), { width: 200, height: 400 });
+		assert.deepEqual(gridview.getViewSize([1, 1]), { width: 200, height: 400 });
 		assert.deepEqual(view4.size, [200, 200]);
-		assert.deepEqual(grid.getViewSize([0, 0]), { width: 200, height: 200 });
+		assert.deepEqual(gridview.getViewSize([0, 0]), { width: 200, height: 200 });
 		assert.deepEqual(view5.size, [600, 100]);
-		assert.deepEqual(grid.getViewSize([1, 0, 1]), { width: 600, height: 100 });
+		assert.deepEqual(gridview.getViewSize([1, 0, 1]), { width: 600, height: 100 });
 	});
 
 	test('simple layout with automatic size distribution', function () {
-		const grid = new GridView(container);
-		grid.layout(800, 600);
+		gridview.layout(800, 600);
 
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view1, Sizing.Distribute, [0]);
+		gridview.addView(view1, Sizing.Distribute, [0]);
 		assert.deepEqual(view1.size, [800, 600]);
-		assert.deepEqual(grid.getViewSize([0]), { width: 800, height: 600 });
+		assert.deepEqual(gridview.getViewSize([0]), { width: 800, height: 600 });
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view2, Sizing.Distribute, [0]);
+		gridview.addView(view2, Sizing.Distribute, [0]);
 		assert.deepEqual(view1.size, [800, 300]);
 		assert.deepEqual(view2.size, [800, 300]);
 
 		const view3 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view3, Sizing.Distribute, [1, 1]);
+		gridview.addView(view3, Sizing.Distribute, [1, 1]);
 		assert.deepEqual(view1.size, [400, 300]);
 		assert.deepEqual(view2.size, [800, 300]);
 		assert.deepEqual(view3.size, [400, 300]);
 
 		const view4 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view4, Sizing.Distribute, [0, 0]);
+		gridview.addView(view4, Sizing.Distribute, [0, 0]);
 		assert.deepEqual(view1.size, [400, 300]);
 		assert.deepEqual(view2.size, [400, 300]);
 		assert.deepEqual(view3.size, [400, 300]);
 		assert.deepEqual(view4.size, [400, 300]);
 
 		const view5 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view5, Sizing.Distribute, [1, 0, 1]);
+		gridview.addView(view5, Sizing.Distribute, [1, 0, 1]);
 		assert.deepEqual(view1.size, [400, 150]);
 		assert.deepEqual(view2.size, [400, 300]);
 		assert.deepEqual(view3.size, [400, 300]);
@@ -195,18 +189,17 @@ suite('Gridview', function () {
 	});
 
 	test('addviews before layout call 1', function () {
-		const grid = new GridView(container);
 
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view1, 200, [0]);
+		gridview.addView(view1, 200, [0]);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view2, 200, [0]);
+		gridview.addView(view2, 200, [0]);
 
 		const view3 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view3, 200, [1, 1]);
+		gridview.addView(view3, 200, [1, 1]);
 
-		grid.layout(800, 600);
+		gridview.layout(800, 600);
 
 		assert.deepEqual(view1.size, [400, 300]);
 		assert.deepEqual(view2.size, [800, 300]);
@@ -214,18 +207,17 @@ suite('Gridview', function () {
 	});
 
 	test('addviews before layout call 2', function () {
-		const grid = new GridView(container);
 
 		const view1 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view1, 200, [0]);
+		gridview.addView(view1, 200, [0]);
 
 		const view2 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view2, 200, [0]);
+		gridview.addView(view2, 200, [0]);
 
 		const view3 = new TestView(50, Number.MAX_VALUE, 50, Number.MAX_VALUE);
-		grid.addView(view3, 200, [0, 0]);
+		gridview.addView(view3, 200, [0, 0]);
 
-		grid.layout(800, 600);
+		gridview.layout(800, 600);
 
 		assert.deepEqual(view1.size, [800, 300]);
 		assert.deepEqual(view2.size, [400, 300]);


### PR DESCRIPTION
To make ti easier to move the grid to another parent.
imho simplified some code, no need to pass around container as much as before.
Tests pass, smoke tests pass, I tried it out and looks decent

fyi @bpasero 