### PR TITLE
Improve i18n of new task identifier related strings

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -1043,10 +1043,10 @@ export class DebugService implements debug.IDebugService {
 		// run a task before starting a debug session
 		return this.taskService.getTask(root, taskId).then(task => {
 			if (!task) {
-				if (typeof taskId === 'string')
-					return TPromise.wrapError(errors.create(nls.localize('DebugTaskNotFoundWithTaskId', "Could not find the task '{0}'.", taskId)));
-				
-				return TPromise.wrapError(errors.create(nls.localize('DebugTaskNotFound', "Could not find the specified task.")));
+				const errorMessage = typeof taskId === 'string'
+					? nls.localize('DebugTaskNotFoundWithTaskId', "Could not find the task '{0}'.", taskId)
+					: nls.localize('DebugTaskNotFound', "Could not find the specified task.");
+				return TPromise.wrapError(errors.create(errorMessage));
 			}
 
 			function once(kind: TaskEventKind, event: Event<TaskEvent>): Event<TaskEvent> {

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -1042,9 +1042,11 @@ export class DebugService implements debug.IDebugService {
 		}
 		// run a task before starting a debug session
 		return this.taskService.getTask(root, taskId).then(task => {
-			const taskDisplayName = typeof taskId === 'string' ? `'${taskId}'` : nls.localize('specified', "specified");
 			if (!task) {
-				return TPromise.wrapError(errors.create(nls.localize('DebugTaskNotFound', "Could not find the task {0}.", taskDisplayName)));
+				if (typeof taskId === 'string')
+					return TPromise.wrapError(errors.create(nls.localize('DebugTaskNotFoundWithTaskId', "Could not find the task '{0}'.", taskId)));
+				
+				return TPromise.wrapError(errors.create(nls.localize('DebugTaskNotFound', "Could not find the specified task.")));
 			}
 
 			function once(kind: TaskEventKind, event: Event<TaskEvent>): Event<TaskEvent> {
@@ -1088,7 +1090,10 @@ export class DebugService implements debug.IDebugService {
 
 				setTimeout(() => {
 					if (!taskStarted) {
-						e({ severity: severity.Error, message: nls.localize('taskNotTracked', "The task {0} cannot be tracked.", taskDisplayName) });
+						const errorMessage = typeof taskId === 'string'
+							  ? nls.localize('taskNotTrackedWithTaskId', "The specified task cannot be tracked.")
+							  : nls.localize('taskNotTracked', "The task '{0}' cannot be tracked.", taskDisplayName)
+						e({ severity: severity.Error, message:  });
 					}
 				}, 10000);
 			});


### PR DESCRIPTION
The new task identifier related strings introduced by @isidorn in cc5c10303b2e87875582c99ee249eba0884ccd78 can have a task Id substituted or not, in this case 'specified' string will be used. In this current form it cannot be correctly translated to Hungarian (and possibly to other languages). I split the two possibilities (one with task ID and the other without task Id) to two distinct error messages in both cases.