### PR TITLE
changed code.iss to not create a folder in start menu

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -73,7 +73,7 @@ Source: "tools\*"; DestDir: "{app}\tools"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
-Name: "{commondesktop}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: desktopicon; AppUserModelID: "{#AppUserId}"
+Name: "{commonprograms}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: desktopicon; AppUserModelID: "{#AppUserId}"
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: quicklaunchicon; AppUserModelID: "{#AppUserId}"
 
 [Run]


### PR DESCRIPTION
Hi.

This PR changes the inno setup configuration so that installing VSCode will only create a Start menu icon instead of a folder containing the icon, like discussed in #51562.