### PR TITLE
Improve Dependencies and Contributions UI in the Extension editor

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionEditor.css
@@ -248,6 +248,7 @@
 
 .extension-editor > .body > .content table th {
 	text-align: left;
+	word-break: keep-all;
 }
 
 .extension-editor > .body > .content table code:not(:empty) {
@@ -314,6 +315,7 @@
 .extension-editor .subcontent .monaco-tree-row .dependency > .icon {
 	height: 40px;
 	width: 40px;
+	object-fit: contain;
 }
 
 .extension-editor .subcontent .monaco-tree-row .dependency > .details > .header > .name {


### PR DESCRIPTION
Hi. 
This PR makes a couple of minor changes to extension editor.

- [x] maintain image's aspect ratio
- [x] no wrapping of table title by character

|before|after|
|---|---|
|![1](https://user-images.githubusercontent.com/8474118/41506792-851dc87e-725f-11e8-9e52-3d9cb102708d.png)|![2](https://user-images.githubusercontent.com/8474118/41506795-8ab61d86-725f-11e8-90a5-16d241bdfdf2.png)|
![3](https://user-images.githubusercontent.com/8474118/41506943-ae59a75a-7262-11e8-94d6-fc3b0b0a38ca.png)|![4](https://user-images.githubusercontent.com/8474118/41506944-b0075f34-7262-11e8-82a0-178b6d151426.png)|


