### PR TITLE
Fixes stuck hover widget when triggered manually, with "editor.hover": false

### DIFF
--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -13,7 +13,8 @@ import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { Range } from 'vs/editor/common/core/range';
-import * as editorCommon from 'vs/editor/common/editorCommon';
+import { IEditorContribution, IScrollEvent } from 'vs/editor/common/editorCommon';
+import { IConfigurationChangedEvent } from 'vs/editor/common/config/editorOptions';
 import { registerEditorAction, registerEditorContribution, ServicesAccessor, EditorAction } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { ModesContentHoverWidget } from './modesContentHover';
@@ -26,12 +27,12 @@ import { MarkdownRenderer } from 'vs/editor/contrib/markdown/markdownRenderer';
 import { IEmptyContentData } from 'vs/editor/browser/controller/mouseTarget';
 import { HoverStartMode } from 'vs/editor/contrib/hover/hoverOperation';
 
-export class ModesHoverController implements editorCommon.IEditorContribution {
+export class ModesHoverController implements IEditorContribution {
 
 	private static readonly ID = 'editor.contrib.hover';
 
-	private _editor: ICodeEditor;
 	private _toUnhook: IDisposable[];
+	private _didChangeConfigurationHandler: IDisposable;
 
 	private _contentWidget: ModesContentHoverWidget;
 	private _glyphWidget: ModesGlyphHoverWidget;
@@ -52,40 +53,65 @@ export class ModesHoverController implements editorCommon.IEditorContribution {
 
 	private _isMouseDown: boolean;
 	private _hoverClicked: boolean;
+	private _isHoverEnabled: boolean;
 
 	static get(editor: ICodeEditor): ModesHoverController {
 		return editor.getContribution<ModesHoverController>(ModesHoverController.ID);
 	}
 
-	constructor(editor: ICodeEditor,
+	constructor(private readonly _editor: ICodeEditor,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IModeService private readonly _modeService: IModeService,
 		@IThemeService private readonly _themeService: IThemeService
 	) {
-		this._editor = editor;
-
 		this._toUnhook = [];
-		this._isMouseDown = false;
 
-		if (editor.getConfiguration().contribInfo.hover) {
+		this._isMouseDown = false;
+		this._hoverClicked = false;
+
+		this._hookEvents();
+
+		this._didChangeConfigurationHandler = this._editor.onDidChangeConfiguration((e: IConfigurationChangedEvent) => {
+			if (e.contribInfo) {
+				this._hideWidgets();
+				this._unhookEvents();
+				this._hookEvents();
+			}
+		});
+	}
+
+	private _hookEvents(): void {
+		const hideWidgetsEventHandler = () => this._hideWidgets();
+
+		this._isHoverEnabled = this._editor.getConfiguration().contribInfo.hover.enabled;
+		if (this._isHoverEnabled) {
 			this._toUnhook.push(this._editor.onMouseDown((e: IEditorMouseEvent) => this._onEditorMouseDown(e)));
 			this._toUnhook.push(this._editor.onMouseUp((e: IEditorMouseEvent) => this._onEditorMouseUp(e)));
 			this._toUnhook.push(this._editor.onMouseMove((e: IEditorMouseEvent) => this._onEditorMouseMove(e)));
-			this._toUnhook.push(this._editor.onMouseLeave((e: IEditorMouseEvent) => this._hideWidgets()));
 			this._toUnhook.push(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
-			this._toUnhook.push(this._editor.onDidChangeModel(() => this._hideWidgets()));
 			this._toUnhook.push(this._editor.onDidChangeModelDecorations(() => this._onModelDecorationsChanged()));
-			this._toUnhook.push(this._editor.onDidScrollChange((e) => {
-				if (e.scrollTopChanged || e.scrollLeftChanged) {
-					this._hideWidgets();
-				}
-			}));
+		} else {
+			this._toUnhook.push(this._editor.onMouseMove(hideWidgetsEventHandler));
 		}
+
+		this._toUnhook.push(this._editor.onMouseLeave(hideWidgetsEventHandler));
+		this._toUnhook.push(this._editor.onDidChangeModel(hideWidgetsEventHandler));
+		this._toUnhook.push(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
+	}
+
+	private _unhookEvents(): void {
+		this._toUnhook = dispose(this._toUnhook);
 	}
 
 	private _onModelDecorationsChanged(): void {
 		this.contentWidget.onModelDecorationsChanged();
 		this.glyphWidget.onModelDecorationsChanged();
+	}
+
+	private _onEditorScrollChanged(e: IScrollEvent): void {
+		if (e.scrollTopChanged || e.scrollLeftChanged) {
+			this._hideWidgets();
+		}
 	}
 
 	private _onEditorMouseDown(mouseEvent: IEditorMouseEvent): void {
@@ -142,12 +168,18 @@ export class ModesHoverController implements editorCommon.IEditorContribution {
 			}
 		}
 
-		if (this._editor.getConfiguration().contribInfo.hover && targetType === MouseTargetType.CONTENT_TEXT) {
+		if (targetType === MouseTargetType.CONTENT_TEXT) {
 			this.glyphWidget.hide();
-			this.contentWidget.startShowingAt(mouseEvent.target.range, HoverStartMode.Delayed, false);
+
+			if (this._isHoverEnabled) {
+				this.contentWidget.startShowingAt(mouseEvent.target.range, HoverStartMode.Delayed, false);
+			}
 		} else if (targetType === MouseTargetType.GUTTER_GLYPH_MARGIN) {
 			this.contentWidget.hide();
-			this.glyphWidget.startShowingAt(mouseEvent.target.position.lineNumber);
+
+			if (this._isHoverEnabled) {
+				this.glyphWidget.startShowingAt(mouseEvent.target.position.lineNumber);
+			}
 		} else {
 			this._hideWidgets();
 		}
@@ -184,7 +216,9 @@ export class ModesHoverController implements editorCommon.IEditorContribution {
 	}
 
 	public dispose(): void {
-		this._toUnhook = dispose(this._toUnhook);
+		this._unhookEvents();
+		this._didChangeConfigurationHandler.dispose();
+
 		if (this._glyphWidget) {
 			this._glyphWidget.dispose();
 			this._glyphWidget = null;


### PR DESCRIPTION
If the editor's preference `editor.hover` is set to `false` and the hover widget is triggered with `CMD + K`, `CMD + I`, it gets stuck in the page and does not go away with interactions such as mouse movement, mouse leave, editor scroll or editor model changes. This PR fixes this behaviour by hiding the tooltip when the above interactions happen.

Also, this PR adds support to react to changes on the preference `editor.hover` without having to reload the editor, effectively allowing the plugin suggested by @rebornix to work for the use case of #25715.