### PR TITLE
Definition link API

### DIFF
--- a/extensions/typescript-language-features/src/features/definitionProviderBase.ts
+++ b/extensions/typescript-language-features/src/features/definitionProviderBase.ts
@@ -11,7 +11,7 @@ import * as typeConverters from '../utils/typeConverters';
 
 export default class TypeScriptDefinitionProviderBase {
 	constructor(
-		private readonly client: ITypeScriptServiceClient
+		protected readonly client: ITypeScriptServiceClient
 	) { }
 
 	protected async getSymbolLocations(

--- a/extensions/typescript-language-features/src/features/definitions.ts
+++ b/extensions/typescript-language-features/src/features/definitions.ts
@@ -4,11 +4,57 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import * as Proto from '../protocol';
 import { ITypeScriptServiceClient } from '../typescriptService';
+import API from '../utils/api';
+import * as typeConverters from '../utils/typeConverters';
 import DefinitionProviderBase from './definitionProviderBase';
 
-class TypeScriptDefinitionProvider extends DefinitionProviderBase implements vscode.DefinitionProvider {
-	public provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken | boolean): Promise<vscode.Definition | undefined> {
+export default class TypeScriptDefinitionProvider extends DefinitionProviderBase implements vscode.DefinitionProvider {
+	constructor(
+		client: ITypeScriptServiceClient
+	) {
+		super(client);
+	}
+
+	public async provideDefinition() {
+		// Implemented by provideDefinition2
+		return undefined;
+	}
+
+	public async provideDefinition2(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		token: vscode.CancellationToken | boolean
+	): Promise<vscode.DefinitionLink[] | vscode.Definition | undefined> {
+		if (this.client.apiVersion.gte(API.v270)) {
+			const filepath = this.client.toPath(document.uri);
+			if (!filepath) {
+				return undefined;
+			}
+
+			const args = typeConverters.Position.toFileLocationRequestArgs(filepath, position);
+			try {
+				const response = await this.client.execute('definitionAndBoundSpan', args, token);
+				const locations: Proto.FileSpan[] = (response && response.body && response.body.definitions) || [];
+				if (!locations) {
+					return undefined;
+				}
+
+				const span = response.body.textSpan ? typeConverters.Range.fromTextSpan(response.body.textSpan) : undefined;
+				return locations
+					.map(location => {
+						const loc = typeConverters.Location.fromTextSpan(this.client.toResource(location.file), location);
+						return {
+							origin: span,
+							...loc,
+						};
+					});
+			} catch {
+				return [];
+			}
+		}
+
 		return this.getSymbolLocations('definition', document, position, token);
 	}
 }

--- a/extensions/typescript-language-features/src/typescriptService.ts
+++ b/extensions/typescript-language-features/src/typescriptService.ts
@@ -59,6 +59,7 @@ export interface ITypeScriptServiceClient {
 	execute(command: 'completionEntryDetails', args: Proto.CompletionDetailsRequestArgs, token?: CancellationToken): Promise<Proto.CompletionDetailsResponse>;
 	execute(command: 'signatureHelp', args: Proto.SignatureHelpRequestArgs, token?: CancellationToken): Promise<Proto.SignatureHelpResponse>;
 	execute(command: 'definition', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DefinitionResponse>;
+	execute(command: 'definitionAndBoundSpan', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.DefinitionInfoAndBoundSpanReponse>;
 	execute(command: 'implementation', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ImplementationResponse>;
 	execute(command: 'typeDefinition', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.TypeDefinitionResponse>;
 	execute(command: 'references', args: Proto.FileLocationRequestArgs, token?: CancellationToken): Promise<Proto.ReferencesResponse>;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -538,6 +538,13 @@ export interface Location {
  */
 export type Definition = Location | Location[];
 
+export interface DefinitionLink {
+	origin?: IRange;
+	uri: URI;
+	range: IRange;
+	selectionRange?: IRange;
+}
+
 /**
  * The definition provider interface defines the contract between extensions and
  * the [go to definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
@@ -547,7 +554,7 @@ export interface DefinitionProvider {
 	/**
 	 * Provide the definition of the symbol at the given position and document.
 	 */
-	provideDefinition(model: model.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideDefinition(model: model.ITextModel, position: Position, token: CancellationToken): DefinitionLink | Thenable<DefinitionLink[]>;
 }
 
 /**

--- a/src/vs/editor/contrib/goToDefinition/goToDefinition.ts
+++ b/src/vs/editor/contrib/goToDefinition/goToDefinition.ts
@@ -10,7 +10,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { ITextModel } from 'vs/editor/common/model';
 import { registerDefaultLanguageCommand } from 'vs/editor/browser/editorExtensions';
 import LanguageFeatureRegistry from 'vs/editor/common/modes/languageFeatureRegistry';
-import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location } from 'vs/editor/common/modes';
+import { DefinitionProviderRegistry, ImplementationProviderRegistry, TypeDefinitionProviderRegistry, Location, DefinitionLink } from 'vs/editor/common/modes';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { asWinJsPromise } from 'vs/base/common/async';
 import { Position } from 'vs/editor/common/core/position';
@@ -21,11 +21,11 @@ function getDefinitions<T>(
 	position: Position,
 	registry: LanguageFeatureRegistry<T>,
 	provide: (provider: T, model: ITextModel, position: Position, token: CancellationToken) => Location | Location[] | Thenable<Location | Location[]>
-): TPromise<Location[]> {
+): TPromise<DefinitionLink[]> {
 	const provider = registry.ordered(model);
 
 	// get results
-	const promises = provider.map((provider, idx): TPromise<Location | Location[]> => {
+	const promises = provider.map((provider): TPromise<DefinitionLink | DefinitionLink[]> => {
 		return asWinJsPromise((token) => {
 			return provide(provider, model, position, token);
 		}).then(undefined, err => {
@@ -39,7 +39,7 @@ function getDefinitions<T>(
 }
 
 
-export function getDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<Location[]> {
+export function getDefinitionsAtPosition(model: ITextModel, position: Position): TPromise<DefinitionLink[]> {
 	return getDefinitions(model, position, DefinitionProviderRegistry, (provider, model, position, token) => {
 		return provider.provideDefinition(model, position, token);
 	});

--- a/src/vs/editor/contrib/goToDefinition/goToDefinitionMouse.ts
+++ b/src/vs/editor/contrib/goToDefinition/goToDefinitionMouse.ts
@@ -159,8 +159,7 @@ class GotoDefinitionWithMouseEditorContribution implements editorCommon.IEditorC
 
 					let wordRange: Range;
 					if (result.origin) {
-						const range = result.origin;
-						wordRange = new Range(range.startLineNumber, range.startColumn, range.endLineNumber, range.endColumn);
+						wordRange = Range.lift(result.origin);
 					} else {
 						wordRange = new Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn);
 					}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4805,6 +4805,13 @@ declare namespace monaco.languages {
 	 */
 	export type Definition = Location | Location[];
 
+	export interface DefinitionLink {
+		origin?: IRange;
+		uri: Uri;
+		range: IRange;
+		selectionRange?: IRange;
+	}
+
 	/**
 	 * The definition provider interface defines the contract between extensions and
 	 * the [go to definition](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
@@ -4814,7 +4821,7 @@ declare namespace monaco.languages {
 		/**
 		 * Provide the definition of the symbol at the given position and document.
 		 */
-		provideDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+		provideDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): DefinitionLink | Thenable<DefinitionLink[]>;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -730,10 +730,38 @@ declare module 'vscode' {
 
 	//#region Matt: Deinition range
 
+	/**
+	 * Information about where a symbol is defined.
+	 *
+	 * Provides additional metadata over normal [location](#Location) definitions, including the range of
+	 * the defining symbol
+	 */
 	export interface DefinitionLink {
+		/**
+		 * Span of the symbol being defined in the source file.
+		 *
+		 * Used as the underlined span for mouse definition hover. Defaults to the word range at
+		 * the definition position.
+		 */
 		origin?: Range;
+
+		/**
+		 * The resource identifier of the definition.
+		 */
 		uri: Uri;
+
+		/**
+		 * The full range of the definition.
+		 *
+		 * For a class definition for example, this would be the entire body of the class definition.
+		 */
 		range: Range;
+
+		/**
+		 * The span of the symbol definition.
+		 *
+		 * For a class definition, this would be the class name itself in the class definition.
+		 */
 		selectionRange?: Range;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -727,4 +727,19 @@ declare module 'vscode' {
 	}
 
 	//#endregion
+
+	//#region Matt: Deinition range
+
+	export interface DefinitionLink {
+		origin?: Range;
+		uri: Uri;
+		range: Range;
+		selectionRange?: Range;
+	}
+
+	export interface DefinitionProvider {
+		provideDefinition2?(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | DefinitionLink[]>;
+	}
+
+	//#endregion
 }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -752,6 +752,13 @@ export interface LocationDto {
 	range: IRange;
 }
 
+export interface DefinitionLinkDto {
+	origin: IRange;
+	uri: UriComponents;
+	range: IRange;
+	selectionRange?: IRange;
+}
+
 export interface WorkspaceSymbolDto extends IdObject {
 	name: string;
 	containerName?: string;
@@ -808,7 +815,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideDocumentSymbols(handle: number, resource: UriComponents): TPromise<modes.DocumentSymbol[]>;
 	$provideCodeLenses(handle: number, resource: UriComponents): TPromise<modes.ICodeLensSymbol[]>;
 	$resolveCodeLens(handle: number, resource: UriComponents, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol>;
-	$provideDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
+	$provideDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<DefinitionLinkDto[]>;
 	$provideImplementation(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
 	$provideTypeDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
 	$provideHover(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.Hover>;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -753,7 +753,7 @@ export interface LocationDto {
 }
 
 export interface DefinitionLinkDto {
-	origin: IRange;
+	origin?: IRange;
 	uri: UriComponents;
 	range: IRange;
 	selectionRange?: IRange;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -156,15 +156,15 @@ class DefinitionAdapter {
 
 		return asWinJsPromise(token => this._provider.provideDefinition2 ? this._provider.provideDefinition2(doc, pos, token) : this._provider.provideDefinition(doc, pos, token)).then((value): modes.DefinitionLink[] => {
 			if (Array.isArray(value)) {
-				return (value as (vscode.DefinitionLink | vscode.Location)[]).map(x => DefinitionAdapter.convertDefinitionLink(position, x));
+				return (value as (vscode.DefinitionLink | vscode.Location)[]).map(x => DefinitionAdapter.convertDefinitionLink(x));
 			} else if (value) {
-				return [DefinitionAdapter.convertDefinitionLink(position, value)];
+				return [DefinitionAdapter.convertDefinitionLink(value)];
 			}
 			return undefined;
 		});
 	}
 
-	private static convertDefinitionLink(position: IPosition, value: vscode.Location | vscode.DefinitionLink): modes.DefinitionLink {
+	private static convertDefinitionLink(value: vscode.Location | vscode.DefinitionLink): modes.DefinitionLink {
 		const definitionLink = <vscode.DefinitionLink>value;
 		return {
 			origin: definitionLink.origin


### PR DESCRIPTION
Add a new `DefinitionLink` type. This type allows definition providers to return additional metadata about a definition, such as the defining span.

Hook up this new provider for typescript

This PR replaces #48001

Fixes #10037