### PR TITLE
Open readonly files as readonly editors

### DIFF
--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -118,7 +118,8 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 
 				// Set Editor Model
 				const diffEditor = this.getControl();
-				diffEditor.setModel((<TextDiffEditorModel>resolvedModel).textDiffEditorModel);
+				const textDiffEditorModel = <TextDiffEditorModel>resolvedModel;
+				diffEditor.setModel((textDiffEditorModel).textDiffEditorModel);
 
 				// Apply Options from TextOptions
 				let optionsGotApplied = false;
@@ -141,6 +142,8 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 					this.nextDiffAction.updateEnablement();
 					this.previousDiffAction.updateEnablement();
 				}));
+
+				this.getControl().updateOptions({ readOnly: textDiffEditorModel.isReadonly() });
 
 				this.updateIgnoreTrimWhitespaceAction();
 			}, error => {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -118,8 +118,8 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 
 				// Set Editor Model
 				const diffEditor = this.getControl();
-				const textDiffEditorModel = <TextDiffEditorModel>resolvedModel;
-				diffEditor.setModel((textDiffEditorModel).textDiffEditorModel);
+				const resolvedDiffEditorModel = <TextDiffEditorModel>resolvedModel;
+				diffEditor.setModel(resolvedDiffEditorModel.textDiffEditorModel);
 
 				// Apply Options from TextOptions
 				let optionsGotApplied = false;
@@ -143,7 +143,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 					this.previousDiffAction.updateEnablement();
 				}));
 
-				this.getControl().updateOptions({ readOnly: textDiffEditorModel.isReadonly() });
+				this.getControl().updateOptions({ readOnly: resolvedDiffEditorModel.isReadonly() });
 
 				this.updateIgnoreTrimWhitespaceAction();
 			}, error => {

--- a/src/vs/workbench/common/editor/textDiffEditorModel.ts
+++ b/src/vs/workbench/common/editor/textDiffEditorModel.ts
@@ -66,6 +66,10 @@ export class TextDiffEditorModel extends DiffEditorModel {
 		return !!this._textDiffEditorModel;
 	}
 
+	public isReadonly(): boolean {
+		return this.modifiedModel.isReadonly();
+	}
+
 	public dispose(): void {
 
 		// Free the diff editor model but do not propagate the dispose() call to the two models

--- a/src/vs/workbench/common/editor/textEditorModel.ts
+++ b/src/vs/workbench/common/editor/textEditorModel.ts
@@ -137,6 +137,10 @@ export abstract class BaseTextEditorModel extends EditorModel implements ITextEd
 		return !!this.textEditorModelHandle;
 	}
 
+	public isReadonly(): boolean {
+		return false;
+	}
+
 	public dispose(): void {
 		if (this.modelDisposeListener) {
 			this.modelDisposeListener.dispose(); // dispose this first because it will trigger another dispose() otherwise

--- a/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
+++ b/src/vs/workbench/parts/files/browser/editors/textFileEditor.ts
@@ -146,6 +146,8 @@ export class TextFileEditor extends BaseTextEditor {
 				if (options && types.isFunction((<TextEditorOptions>options).apply)) {
 					(<TextEditorOptions>options).apply(textEditor, ScrollType.Immediate);
 				}
+
+				textEditor.updateOptions({ readOnly: textFileModel.isReadonly() });
 			}, error => {
 
 				// In case we tried to open a file inside the text editor and the response

--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -698,7 +698,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 			// be disposed if we are dirty, but if we are not dirty, save() and dispose() can still be triggered
 			// one after the other without waiting for the save() to complete. If we are disposed(), we risk
 			// saving contents to disk that are stale (see https://github.com/Microsoft/vscode/issues/50942).
-			// To fix this issue, we will not store the contents to disk when we got disposed. 
+			// To fix this issue, we will not store the contents to disk when we got disposed.
 			if (this.disposed) {
 				return void 0;
 			}
@@ -981,6 +981,10 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 
 	public isResolved(): boolean {
 		return !types.isUndefinedOrNull(this.lastResolvedDiskStat);
+	}
+
+	public isReadonly(): boolean {
+		return this.lastResolvedDiskStat.isReadonly;
 	}
 
 	/**

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -232,6 +232,8 @@ export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport
 
 	isResolved(): boolean;
 
+	isReadonly(): boolean;
+
 	isDisposed(): boolean;
 }
 


### PR DESCRIPTION
Refs: https://github.com/Microsoft/vscode/issues/51585

This makes all the readonly files open in the workbench as readonly editors.
Also takes into account the right hand side of the diff editor.