### PR TITLE
Improves support to Windows UNC files in a "yet-to-be-saved" state

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -121,7 +121,7 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 
 		let resource = untitledEditorInput.getResource();
 		if (untitledEditorInput.hasAssociatedFilePath) {
-			resource = URI.file(resource.fsPath); // untitled with associated file path use the file schema
+			resource = resource.with({ scheme: Schemas.file }); // untitled with associated file path use the file schema
 		}
 
 		const serialized: ISerializedUntitledEditorInput = {

--- a/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileCommands.ts
@@ -111,7 +111,7 @@ function save(resource: URI, isSaveAs: boolean, editorService: IEditorService, f
 			if (!isSaveAs && resource.scheme === Schemas.untitled && untitledEditorService.hasAssociatedFilePath(resource)) {
 				savePromise = textFileService.save(resource).then((result) => {
 					if (result) {
-						return URI.file(resource.fsPath);
+						return resource.with({ scheme: Schemas.file });
 					}
 
 					return null;

--- a/src/vs/workbench/services/textfile/common/textFileService.ts
+++ b/src/vs/workbench/services/textfile/common/textFileService.ts
@@ -439,16 +439,16 @@ export abstract class TextFileService implements ITextFileService {
 			for (let i = 0; i < untitledResources.length; i++) {
 				const untitled = untitledResources[i];
 				if (this.untitledEditorService.exists(untitled)) {
-					let targetPath: string;
+					let targetUri: URI;
 
 					// Untitled with associated file path don't need to prompt
 					if (this.untitledEditorService.hasAssociatedFilePath(untitled)) {
-						targetPath = untitled.fsPath;
+						targetUri = untitled.with({ scheme: Schemas.file });
 					}
 
 					// Otherwise ask user
 					else {
-						targetPath = await this.promptForPath(this.suggestFileName(untitled));
+						const targetPath = await this.promptForPath(this.suggestFileName(untitled));
 						if (!targetPath) {
 							return TPromise.as({
 								results: [...fileResources, ...untitledResources].map(r => {
@@ -458,9 +458,11 @@ export abstract class TextFileService implements ITextFileService {
 								})
 							});
 						}
+
+						targetUri = URI.file(targetPath);
 					}
 
-					targetsForUntitled.push(URI.file(targetPath));
+					targetsForUntitled.push(targetUri);
 				}
 			}
 

--- a/src/vs/workbench/services/textfile/test/textFileService.test.ts
+++ b/src/vs/workbench/services/textfile/test/textFileService.test.ts
@@ -5,10 +5,12 @@
 'use strict';
 
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import * as platform from 'vs/base/common/platform';
+import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { ILifecycleService, ShutdownEvent, ShutdownReason } from 'vs/platform/lifecycle/common/lifecycle';
-import { workbenchInstantiationService, TestLifecycleService, TestTextFileService, TestWindowsService, TestContextService } from 'vs/workbench/test/workbenchTestServices';
+import { workbenchInstantiationService, TestLifecycleService, TestTextFileService, TestWindowsService, TestContextService, TestFileService } from 'vs/workbench/test/workbenchTestServices';
 import { toResource } from 'vs/base/test/common/utils';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IWindowsService } from 'vs/platform/windows/common/windows';
@@ -17,9 +19,12 @@ import { ITextFileService } from 'vs/workbench/services/textfile/common/textfile
 import { ConfirmResult } from 'vs/workbench/common/editor';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorModel';
-import { HotExitConfiguration } from 'vs/platform/files/common/files';
+import { HotExitConfiguration, IFileService } from 'vs/platform/files/common/files';
 import { TextFileEditorModelManager } from 'vs/workbench/services/textfile/common/textFileEditorModelManager';
 import { IWorkspaceContextService, Workspace } from 'vs/platform/workspace/common/workspace';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
+import { Schemas } from 'vs/base/common/network';
 
 class ServiceAccessor {
 	constructor(
@@ -27,7 +32,9 @@ class ServiceAccessor {
 		@ITextFileService public textFileService: TestTextFileService,
 		@IUntitledEditorService public untitledEditorService: IUntitledEditorService,
 		@IWindowsService public windowsService: TestWindowsService,
-		@IWorkspaceContextService public contextService: TestContextService
+		@IWorkspaceContextService public contextService: TestContextService,
+		@IModelService public modelService: ModelServiceImpl,
+		@IFileService public fileService: TestFileService
 	) {
 	}
 }
@@ -190,6 +197,34 @@ suite('Files - TextFileService', () => {
 			return service.save(model.getResource()).then(res => {
 				assert.ok(res);
 				assert.ok(!service.isDirty(model.getResource()));
+			});
+		});
+	});
+
+	test('save - UNC path', function () {
+		const untitledUncUri = URI.from({ scheme: 'untitled', authority: 'server', path: '/share/path/file.txt' });
+		model = instantiationService.createInstance(TextFileEditorModel, untitledUncUri, 'utf8');
+		(<TextFileEditorModelManager>accessor.textFileService.models).add(model.getResource(), model);
+
+		const mockedFileUri = untitledUncUri.with({ scheme: Schemas.file });
+		const mockedEditorInput = instantiationService.createInstance(TextFileEditorModel, mockedFileUri, 'utf8');
+		const loadOrCreateStub = sinon.stub(accessor.textFileService.models, 'loadOrCreate', () => TPromise.wrap(mockedEditorInput));
+
+		sinon.stub(accessor.untitledEditorService, 'exists', () => true);
+		sinon.stub(accessor.untitledEditorService, 'hasAssociatedFilePath', () => true);
+		sinon.stub(accessor.modelService, 'updateModel', () => { });
+
+		return model.load().then(() => {
+			model.textEditorModel.setValue('foo');
+
+			return accessor.textFileService.saveAll(true).then(res => {
+				assert.ok(loadOrCreateStub.calledOnce);
+				assert.equal(res.results.length, 1);
+				assert.ok(res.results[0].success);
+
+				assert.equal(res.results[0].target.scheme, Schemas.file);
+				assert.equal(res.results[0].target.authority, untitledUncUri.authority);
+				assert.equal(res.results[0].target.path, untitledUncUri.path);
 			});
 		});
 	});


### PR DESCRIPTION
Fixes #49851

Improves support to Windows UNC files in a "yet-to-be-saved" state, which addresses the problem with creating `.gitignore` in a network folder from "Add to .gitignore" command.