### PR TITLE
Added config option to sync+Rebase from statusbar

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -966,6 +966,11 @@
           "default": true,
           "description": "%config.showInlineOpenFileAction%"
         },
+        "git.statusBarSyncRebase": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.statusBarSyncRebase%"
+        },
         "git.inputValidation": {
           "type": "string",
           "enum": [

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -68,6 +68,7 @@
 	"config.decorations.enabled": "Controls if Git contributes colors and badges to the explorer and the open editors view.",
 	"config.promptToSaveFilesBeforeCommit": "Controls whether Git should check for unsaved files before committing.",
 	"config.showInlineOpenFileAction": "Controls whether to show an inline Open File action in the Git changes view.",
+	"config.statusBarSyncRebase": "Controls whether status bar sync icon will Sync with Rebase or not",
 	"config.inputValidation": "Controls when to show commit message input validation.",
 	"config.detectSubmodules": "Controls whether to automatically detect git submodules.",
 	"colors.added": "Color for added resources.",

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { Disposable, Command, EventEmitter, Event } from 'vscode';
+import { Disposable, Command, EventEmitter, Event, workspace } from 'vscode';
 import { Branch } from './git';
 import { Repository, Operation } from './repository';
 import { anyEvent, dispose } from './util';
@@ -91,6 +91,9 @@ class SyncStatusBar {
 			return undefined;
 		}
 
+		const config = workspace.getConfiguration('git');
+		let syncRebase = config.get<boolean>('statusBarSyncRebase');
+
 		const HEAD = this.state.HEAD;
 		let icon = '$(sync)';
 		let text = '';
@@ -102,7 +105,12 @@ class SyncStatusBar {
 				if (HEAD.ahead || HEAD.behind) {
 					text += this.repository.syncLabel;
 				}
-				command = 'git.sync';
+				if (syncRebase) {
+					command = 'git.syncRebase';
+
+				} else {
+					command = 'git.sync';
+				}
 				tooltip = localize('sync changes', "Synchronize Changes");
 			} else {
 				icon = '$(cloud-upload)';


### PR DESCRIPTION
Added a setting "git.statusBarSyncRebase" that allows you to override the statusbar sync option with syncRebase instead.

Resolves #50394.