### PR TITLE
Gulp (et al) Task autodetection and execution within WSL

### DIFF
--- a/extensions/grunt/package.json
+++ b/extensions/grunt/package.json
@@ -40,6 +40,12 @@
           ],
           "default": "on",
           "description": "%config.grunt.autoDetect%"
+        },
+        "grunt.useWSL": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "%config.grunt.useWSL%"
         }
       }
     },

--- a/extensions/grunt/package.nls.json
+++ b/extensions/grunt/package.nls.json
@@ -2,6 +2,7 @@
 	"description": "Extension to add Grunt capabilities to VSCode.",
 	"displayName": "Grunt support for VSCode",
 	"config.grunt.autoDetect": "Controls whether auto detection of Grunt tasks is on or off. Default is on.",
+	"config.grunt.useWSL": "Instructs the extension to attempt to run Grunt tasks using the Windows Subsystem for Linux. Default is false.",
 	"grunt.taskDefinition.type.description": "The Grunt task to customize.",
 	"grunt.taskDefinition.file.description": "The Grunt file that provides the task. Can be omitted."
 }

--- a/extensions/gulp/package.json
+++ b/extensions/gulp/package.json
@@ -40,6 +40,12 @@
           ],
           "default": "on",
           "description": "%config.gulp.autoDetect%"
+        },
+        "gulp.useWSL": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "%config.gulp.useWSL%"
         }
       }
     },

--- a/extensions/gulp/package.nls.json
+++ b/extensions/gulp/package.nls.json
@@ -2,6 +2,7 @@
 	"description": "Extension to add Gulp capabilities to VSCode.",
 	"displayName": "Gulp support for VSCode",
 	"config.gulp.autoDetect": "Controls whether auto detection of Gulp tasks is on or off. Default is on.",
+	"config.gulp.useWSL": "Instructs the extension to attempt to run Gulp tasks using the Windows Subsystem for Linux. Default is false.",
 	"gulp.taskDefinition.type.description": "The Gulp task to customize.",
 	"gulp.taskDefinition.file.description": "The Gulp file that provides the task. Can be omitted."
 }

--- a/extensions/jake/package.json
+++ b/extensions/jake/package.json
@@ -40,6 +40,12 @@
           ],
           "default": "on",
           "description": "%config.jake.autoDetect%"
+        },
+        "jake.useWSL": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "%config.jake.useWSL%"
         }
       }
     },

--- a/extensions/jake/package.nls.json
+++ b/extensions/jake/package.nls.json
@@ -3,5 +3,6 @@
 	"displayName": "Jake support for VSCode",
 	"jake.taskDefinition.type.description": "The Jake task to customize.",
 	"jake.taskDefinition.file.description": "The Jake file that provides the task. Can be omitted.",
-	"config.jake.autoDetect": "Controls whether auto detection of Jake tasks is on or off. Default is on."
+	"config.jake.autoDetect": "Controls whether auto detection of Jake tasks is on or off. Default is on.",
+	"config.jake.useWSL": "Instructs the extension to attempt to run Jake tasks using the Windows Subsystem for Linux. Default is false."
 }

--- a/extensions/jake/src/main.ts
+++ b/extensions/jake/src/main.ts
@@ -81,6 +81,10 @@ class FolderDetector {
 		return vscode.workspace.getConfiguration('jake', this._workspaceFolder.uri).get<AutoDetect>('autoDetect') === 'on';
 	}
 
+	public useWSL(): boolean {
+		return vscode.workspace.getConfiguration('jake', this._workspaceFolder.uri).get<boolean>('useWSL') === true;
+	}
+
 	public start(): void {
 		let pattern = path.join(this._workspaceFolder.uri.fsPath, '{Jakefile,Jakefile.js}');
 		this.fileWatcher = vscode.workspace.createFileSystemWatcher(pattern);
@@ -111,9 +115,17 @@ class FolderDetector {
 		}
 
 		let jakeCommand: string;
-		let platform = process.platform;
+		let platform: NodeJS.Platform | 'wsl' = process.platform;
+
+		if (platform === 'win32' && this.useWSL()) {
+			platform = 'wsl';
+		}
+
 		if (platform === 'win32' && await exists(path.join(rootPath!, 'node_modules', '.bin', 'jake.cmd'))) {
 			jakeCommand = path.join('.', 'node_modules', '.bin', 'jake.cmd');
+		} else if (platform === 'wsl' && await exists(path.join(rootPath!, 'node_modules', '.bin', 'jake'))) {
+			// Using WSL, so we're on windows, need to build path with proper separators.
+			jakeCommand = path.posix.join('.', 'node_modules', '.bin', 'jake');
 		} else if ((platform === 'linux' || platform === 'darwin') && await exists(path.join(rootPath!, 'node_modules', '.bin', 'jake'))) {
 			jakeCommand = path.join('.', 'node_modules', '.bin', 'jake');
 		} else {
@@ -122,6 +134,9 @@ class FolderDetector {
 
 		let commandLine = `${jakeCommand} --tasks`;
 		try {
+			if (platform === 'wsl') {
+				commandLine = `wsl.exe -e ${commandLine}`;
+			}
 			let { stdout, stderr } = await exec(commandLine, { cwd: rootPath });
 			if (stderr) {
 				getOutputChannel().appendLine(stderr);
@@ -244,7 +259,7 @@ class TaskDetector {
 
 	private updateProvider(): void {
 		if (!this.taskProvider && this.detectors.size > 0) {
-			this.taskProvider = vscode.workspace.registerTaskProvider('gulp', {
+			this.taskProvider = vscode.workspace.registerTaskProvider('jake', {
 				provideTasks: () => {
 					return this.getTasks();
 				},

--- a/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts
@@ -580,6 +580,10 @@ export class TerminalTaskSystem implements ITaskSystem {
 					if (!shellSpecified) {
 						toAdd.push('-c');
 					}
+				} else if (basename === 'wsl.exe') {
+					if (!shellSpecified) {
+						toAdd.push('-e');
+					}
 				} else {
 					if (!shellSpecified) {
 						toAdd.push('/d', '/c');


### PR DESCRIPTION
I've been trying to switch all of my environments over to WSL full time, but vscode had been giving me trouble when trying to detect and run javascript tasks when I only have the command-line tools installed in WSL. I no longer have node installed on windows (aside from the install required to run code-oss), so there was no way to get vscode to detect or run tasks in my repos. 

This PR adds three new config options (all default to false): 
* `"gulp.useWSL": boolean`
* `"grunt.useWSL": boolean`
* `"jake.useWSL": boolean`

Each option allows the respective extension to attempt to use wsl during task detection, otherwise the extensions behave as normal.

Furthermore, I also added support for `wsl.exe` in `terminalTaskSystem.ts`. This allows tasks to use wsl when the user config option "terminal.integrated.shell.windows" points at `wsl.exe`. 

This is my first non-trivial PR to vscode, so comments are welcome! I doubt you'll be happy about extending the platform type: `let platform: NodeJS.Platform | 'wsl' = process.platform;` but I think that makes the code more clear. 

Thanks for the awesome editor!