### PR TITLE
Track which settings were contributed by extensions

### DIFF
--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -84,6 +84,7 @@ export interface IConfigurationNode {
 	allOf?: IConfigurationNode[];
 	overridable?: boolean;
 	scope?: ConfigurationScope;
+	contributedByExtension?: boolean;
 }
 
 export interface IDefaultConfigurationExtension {

--- a/src/vs/workbench/parts/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsLayout.ts
@@ -184,11 +184,6 @@ export const tocData: ITOCEntry = {
 					settings: ['telemetry.*']
 				}
 			]
-		},
-		{
-			id: 'extensions',
-			label: localize('extensions', "Extensions"),
-			settings: ['*']
 		}
 	]
 };

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -186,8 +186,31 @@ function inspectSetting(key: string, target: SettingsTarget, configurationServic
 	return { isConfigured, inspected, targetSelector };
 }
 
-export function resolveSettingsTree(tocData: ITOCEntry, settingsGroups: ISettingsGroup[]): ITOCEntry {
-	return _resolveSettingsTree(tocData, getFlatSettings(settingsGroups));
+export function resolveSettingsTree(tocData: ITOCEntry, coreSettingsGroups: ISettingsGroup[]): ITOCEntry {
+	return _resolveSettingsTree(tocData, getFlatSettings(coreSettingsGroups));
+}
+
+export function resolveExtensionsSettings(groups: ISettingsGroup[]): ITOCEntry {
+	const settingsGroupToEntry = (group: ISettingsGroup) => {
+		const flatSettings = arrays.flatten(
+			group.sections.map(section => section.settings));
+
+		return {
+			id: group.id,
+			label: group.title,
+			settings: flatSettings
+		};
+	};
+
+	const extGroups = groups
+		.sort((a, b) => a.title.localeCompare(b.title))
+		.map(g => settingsGroupToEntry(g));
+
+	return {
+		id: 'extensions',
+		label: localize('extensions', "Extensions"),
+		children: extGroups
+	};
 }
 
 function _resolveSettingsTree(tocData: ITOCEntry, allSettings: Set<ISetting>): ITOCEntry {

--- a/src/vs/workbench/services/configuration/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/services/configuration/common/configurationExtensionPoint.ts
@@ -106,7 +106,8 @@ configurationExtPoint.setHandler(extensions => {
 
 		validateProperties(configuration, extension);
 
-		configuration.id = extension.description.uuid || extension.description.id;
+		configuration.id = node.id || extension.description.uuid || extension.description.id;
+		configuration.contributedByExtension = true;
 		configuration.title = configuration.title || extension.description.displayName || extension.description.id;
 		configurations.push(configuration);
 	}

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -25,6 +25,7 @@ export interface ISettingsGroup {
 	title: string;
 	titleRange: IRange;
 	sections: ISettingsSection[];
+	contributedByExtension: boolean;
 }
 
 export interface ISettingsSection {

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -189,7 +189,8 @@ export class SettingsEditorModel extends AbstractSettingsModel implements ISetti
 					settings: filteredSettings
 				}],
 				title: modelGroup.title,
-				titleRange: modelGroup.titleRange
+				titleRange: modelGroup.titleRange,
+				contributedByExtension: !!modelGroup.contributedByExtension
 			};
 		}
 
@@ -503,7 +504,7 @@ export class DefaultSettings extends Disposable {
 			if (!settingsGroup) {
 				settingsGroup = result.filter(g => g.title === title)[0];
 				if (!settingsGroup) {
-					settingsGroup = { sections: [{ settings: [] }], id: config.id, title: title, titleRange: null, range: null };
+					settingsGroup = { sections: [{ settings: [] }], id: config.id, title: title, titleRange: null, range: null, contributedByExtension: !!config.contributedByExtension };
 					result.push(settingsGroup);
 				}
 			} else {
@@ -512,7 +513,7 @@ export class DefaultSettings extends Disposable {
 		}
 		if (config.properties) {
 			if (!settingsGroup) {
-				settingsGroup = { sections: [{ settings: [] }], id: config.id, title: config.id, titleRange: null, range: null };
+				settingsGroup = { sections: [{ settings: [] }], id: config.id, title: config.id, titleRange: null, range: null, contributedByExtension: !!config.contributedByExtension };
 				result.push(settingsGroup);
 			}
 			const configurationSettings: ISetting[] = [...settingsGroup.sections[settingsGroup.sections.length - 1].settings, ...this.parseSettings(config.properties)];


### PR DESCRIPTION
@sandy081 What do you think about this approach? It feels weird to have this prop on IConfigurationNode. The alternatives are

- Assume that `id` will always be the extension id. Search the list of extensions for a match. That's unsafe and awkward.
- Assume that any settings that aren't explicitly referenced in the settings layout must belong to extensions. Also awkward. 

Also, 'id' is not unique across groups, I don't know whether that's assumed anywhere.