### PR TITLE
Fix #35361: fix native tabs on macOS 10.13

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -85,7 +85,7 @@ export class CodeApplication {
 		@ILogService private logService: ILogService,
 		@IEnvironmentService private environmentService: IEnvironmentService,
 		@ILifecycleService private lifecycleService: ILifecycleService,
-		@IConfigurationService configurationService: ConfigurationService,
+		@IConfigurationService private configurationService: ConfigurationService,
 		@IStateService private stateService: IStateService,
 		@IHistoryMainService private historyMainService: IHistoryMainService
 	) {
@@ -276,11 +276,11 @@ export class CodeApplication {
 
 		// Fix native tabs on macOS 10.13
 		// macOS enables a compatibility patch for any bundle ID beginning with
-		// "com.microsoft.", which breaks native tabs for VS Code.
+		// "com.microsoft.", which breaks native tabs for VS Code when using this
+		// identifier (from the official build).
 		// Explicitly opt out of the patch here before creating any windows.
-		// https://github.com/Microsoft/vscode/issues/35361#issuecomment-399794085
-
-		if (platform.isMacintosh) {
+		// See: https://github.com/Microsoft/vscode/issues/35361#issuecomment-399794085
+		if (platform.isMacintosh && this.configurationService.getValue<boolean>('window.nativeTabs') === true) {
 			systemPreferences.registerDefaults({ NSUseImprovedLayoutPass: true });
 		}
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { app, ipcMain as ipc } from 'electron';
+import { app, ipcMain as ipc, systemPreferences } from 'electron';
 import * as platform from 'vs/base/common/platform';
 import { WindowsManager } from 'vs/code/electron-main/windows';
 import { IWindowsService, OpenContext, ActiveWindowManager } from 'vs/platform/windows/common/windows';
@@ -272,6 +272,16 @@ export class CodeApplication {
 		// two icons in the taskbar for the same app.
 		if (platform.isWindows && product.win32AppUserModelId) {
 			app.setAppUserModelId(product.win32AppUserModelId);
+		}
+
+		// Fix native tabs on macOS 10.13
+		// macOS enables a compatibility patch for any bundle ID beginning with
+		// "com.microsoft.", which breaks native tabs for VS Code.
+		// Explicitly opt out of the patch here before creating any windows.
+		// https://github.com/Microsoft/vscode/issues/35361#issuecomment-399794085
+
+		if (platform.isMacintosh) {
+			systemPreferences.registerDefaults({ NSUseImprovedLayoutPass: true });
 		}
 
 		// Create Electron IPC Server


### PR DESCRIPTION
macOS 10.13 mistakenly enables a compatibility option on VS Code and VS Code Insiders because their bundle IDs begin with "com.microsoft.". This breaks native tabs.

Explicitly disable the compatibility patch using NSUserDefaults.

Note that Code-OSS is not affected by the bug, since its bundle ID is "com.visualstudio.code.oss". To test this behaviour, change darwinBundleIdentifier in product.json.

See #35361 for more information.

@bpasero