### PR TITLE
Remove prompt to install packs for core languages 

### DIFF
--- a/src/vs/workbench/parts/localizations/electron-browser/localizations.contribution.ts
+++ b/src/vs/workbench/parts/localizations/electron-browser/localizations.contribution.ts
@@ -12,7 +12,7 @@ import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ConfigureLocaleAction } from 'vs/workbench/parts/localizations/electron-browser/localizationsActions';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
-import { ILocalizationsService, LanguageType } from 'vs/platform/localizations/common/localizations';
+import { ILocalizationsService } from 'vs/platform/localizations/common/localizations';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import * as platform from 'vs/base/common/platform';
 import { IExtensionManagementService, DidInstallExtensionEvent, LocalExtensionType, IExtensionGalleryService, IGalleryExtension, InstallOperation } from 'vs/platform/extensionManagement/common/extensionManagement';
@@ -98,24 +98,6 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 		}
 	}
 
-	private migrateToMarketplaceLanguagePack(language: string): void {
-		this.isLanguageInstalled(language)
-			.then(installed => {
-				if (!installed) {
-					this.getLanguagePackExtension(language)
-						.then(extension => {
-							if (extension) {
-								this.notificationService.prompt(Severity.Warning, localize('install language pack', "In the near future, VS Code will only support language packs in the form of Marketplace extensions. Please install the '{0}' extension in order to continue to use the currently configured language. ", extension.displayName || extension.displayName),
-									[
-										{ label: localize('install', "Install"), run: () => this.installExtension(extension) },
-										{ label: localize('more information', "More Information..."), run: () => window.open('https://go.microsoft.com/fwlink/?linkid=872941') }
-									]);
-							}
-						});
-				}
-			});
-	}
-
 	private checkAndInstall(): void {
 		const language = platform.language;
 		const locale = platform.locale;
@@ -124,11 +106,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 		if (!this.galleryService.isEnabled()) {
 			return;
 		}
-		if (language !== 'en' && language.indexOf('en-') !== -1) {
-			this.migrateToMarketplaceLanguagePack(language);
-			return;
-		}
-		if (locale === 'en' || locale.indexOf('en-') !== -1) {
+		if (language === 'en' || language.indexOf('en-') === 0) {
 			return;
 		}
 		if (language === locale || languagePackSuggestionIgnoreList.indexOf(language) > -1) {
@@ -233,19 +211,6 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 				});
 			});
 
-	}
-
-	private getLanguagePackExtension(language: string): TPromise<IGalleryExtension> {
-		return this.localizationService.getLanguageIds(LanguageType.Core)
-			.then(coreLanguages => {
-				if (coreLanguages.some(c => c.toLowerCase() === language)) {
-					const extensionIdPrefix = language === 'zh-cn' ? 'zh-hans' : language === 'zh-tw' ? 'zh-hant' : language;
-					const extensionId = `MS-CEINTL.vscode-language-pack-${extensionIdPrefix}`;
-					return this.galleryService.query({ names: [extensionId], pageSize: 1 })
-						.then(result => result.total === 1 ? result.firstPage[0] : null);
-				}
-				return null;
-			});
 	}
 
 	private isLanguageInstalled(language: string): TPromise<boolean> {


### PR DESCRIPTION
Now that we dont ship core language support out of the box, the prompt that we intend to do so in the future is not needed.
Related to #50588

cc @sandy081 