### PR TITLE
remove z-index from menu code

### DIFF
--- a/src/vs/workbench/browser/parts/menubar/media/menubarpart.css
+++ b/src/vs/workbench/browser/parts/menubar/media/menubarpart.css
@@ -27,7 +27,6 @@
 	box-sizing: border-box;
 	padding: 0px 5px;
 	position: relative;
-	z-index: 10;
 	cursor: default;
 	-webkit-app-region: no-drag;
 	zoom: 1;


### PR DESCRIPTION
@sbatten it feels to me that the menu should never set any `z-index` because it is living in the context-view container that has a very high `z-index` already. Since `z-index` is not inheriting, if you set it to a low value, the bug https://github.com/Microsoft/vscode/issues/52539 shows up