### PR TITLE
Menu: high contrast theme causes jumpy hover behaviour

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.css
+++ b/src/vs/base/browser/ui/menu/menu.css
@@ -141,6 +141,10 @@
 	box-shadow: none;
 }
 
+.hc-black .monaco-menu .monaco-action-bar.vertical .action-item {
+	border: 1px solid transparent; /* prevents jumpig behaviour on hover or focus */
+}
+
 .hc-black .monaco-menu .monaco-action-bar.vertical .action-item.focused {
 	background: none;
 	border: 1px dotted #f38518;


### PR DESCRIPTION
By showing a transparent border always (we do the same trick for list and tree).

fixes #53313