### PR TITLE
Fix a double dash in the previewer if an @param jsdoc tag has a hyphen after the param name

### DIFF
--- a/extensions/typescript-language-features/src/test/jsdocSnippet.test.ts
+++ b/extensions/typescript-language-features/src/test/jsdocSnippet.test.ts
@@ -6,7 +6,6 @@
 import * as assert from 'assert';
 import 'mocha';
 import { templateToSnippet } from '../features/jsDocCompletions';
-import { tagsMarkdownPreview } from '../utils/previewer';
 
 suite('typescript.jsDocSnippet', () => {
 	test('Should do nothing for single line input', async () => {
@@ -73,19 +72,6 @@ suite('typescript.jsDocSnippet', () => {
 				' * $0',
 				' * @param \\$arg ${1}',
 				' */'
-			].join('\n'));
-	});
-
-	test('Should ignore hyphens after a param tag', async () => {
-		assert.strictEqual(
-			tagsMarkdownPreview([{
-				name: 'param',
-				text: 'a - b'
-			}]),
-			[
-				'*@param* `a` — b',
-				'',
-				''
 			].join('\n'));
 	});
 });

--- a/extensions/typescript-language-features/src/test/jsdocSnippet.test.ts
+++ b/extensions/typescript-language-features/src/test/jsdocSnippet.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import { templateToSnippet } from '../features/jsDocCompletions';
+import { tagsMarkdownPreview } from '../utils/previewer';
 
 suite('typescript.jsDocSnippet', () => {
 	test('Should do nothing for single line input', async () => {
@@ -72,6 +73,19 @@ suite('typescript.jsDocSnippet', () => {
 				' * $0',
 				' * @param \\$arg ${1}',
 				' */'
+			].join('\n'));
+	});
+
+	test('Should ignore hyphens after a param tag', async () => {
+		assert.strictEqual(
+			tagsMarkdownPreview([{
+				name: 'param',
+				text: 'a - b'
+			}]),
+			[
+				'*@param* `a` — b',
+				'',
+				''
 			].join('\n'));
 	});
 });

--- a/extensions/typescript-language-features/src/test/previewer.test.ts
+++ b/extensions/typescript-language-features/src/test/previewer.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import 'mocha';
+import { tagsMarkdownPreview } from '../utils/previewer';
+
+suite('typescript.previewer', () => {
+	test('Should ignore hyphens after a param tag', async () => {
+		assert.strictEqual(
+			tagsMarkdownPreview([
+				{
+					name: 'param',
+					text: 'a - b'
+				}
+			]),
+			'*@param* `a` — b');
+	});
+});
+

--- a/extensions/typescript-language-features/src/utils/previewer.ts
+++ b/extensions/typescript-language-features/src/utils/previewer.ts
@@ -30,11 +30,12 @@ function getTagDocumentation(tag: Proto.JSDocTagInfo): string | undefined {
 			const body = (tag.text || '').split(/^([\w\.]+)\s*/);
 			if (body && body.length === 3) {
 				const param = body[1];
-				const doc = body[2];
+				let doc = body[2];
 				const label = `*@${tag.name}* \`${param}\``;
 				if (!doc) {
 					return label;
 				}
+				doc = doc.replace(/^\s*-/, "");
 				return label + (doc.match(/\r\n|\n/g) ? '  \n' + doc : ` — ${doc}`);
 			}
 	}

--- a/extensions/typescript-language-features/src/utils/previewer.ts
+++ b/extensions/typescript-language-features/src/utils/previewer.ts
@@ -27,15 +27,14 @@ function getTagBodyText(tag: Proto.JSDocTagInfo): string | undefined {
 function getTagDocumentation(tag: Proto.JSDocTagInfo): string | undefined {
 	switch (tag.name) {
 		case 'param':
-			const body = (tag.text || '').split(/^([\w\.]+)\s*/);
+			const body = (tag.text || '').split(/^([\w\.]+)\s*-?\s*/);
 			if (body && body.length === 3) {
 				const param = body[1];
-				let doc = body[2];
+				const doc = body[2];
 				const label = `*@${tag.name}* \`${param}\``;
 				if (!doc) {
 					return label;
 				}
-				doc = doc.replace(/^\s*-/, "");
 				return label + (doc.match(/\r\n|\n/g) ? '  \n' + doc : ` — ${doc}`);
 			}
 	}


### PR DESCRIPTION
[Here are some screenshots of the problem](https://imgur.com/a/OoxdKqx). The WIP tsdoc spec [allows a hyphen](https://github.com/Microsoft/tsdoc/issues/1) after the param name, and I believe jsdoc does as well. This would cause a double dash if the description was a single line (— -), and a bullet point if it were multiple lines because of markdown.

Resolves #53507.