### PR TITLE
Remove title attr from review-comment

### DIFF
--- a/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
@@ -64,7 +64,6 @@ export class CommentNode {
 
 		this._domNode.setAttribute('aria-label', `${comment.userName}, ${comment.body.value}`);
 		this._domNode.setAttribute('role', 'treeitem');
-		this._domNode.title = `${comment.userName}, ${comment.body.value}`;
 		this._clearTimeout = null;
 	}
 


### PR DESCRIPTION
aria-label covers screen readers, title just shows the tooltip.

Fixes Microsoft/vscode-pull-request-github#61