### PR TITLE
Fix #48853 - Collapse newlines on files containing only newlines

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -174,8 +174,7 @@ export class TrimFinalNewLinesParticipant implements ISaveParticipantParticipant
 		let currentLineNumber = model.getLineCount();
 		let currentLine = model.getLineContent(currentLineNumber);
 		let currentLineIsEmptyOrWhitespace = strings.lastNonWhitespaceIndex(currentLine) === -1;
-		while (currentLineIsEmptyOrWhitespace) {
-			currentLineNumber--;
+		while (currentLineIsEmptyOrWhitespace && --currentLineNumber > 1) {
 			currentLine = model.getLineContent(currentLineNumber);
 			currentLineIsEmptyOrWhitespace = strings.lastNonWhitespaceIndex(currentLine) === -1;
 		}

--- a/src/vs/workbench/test/electron-browser/api/mainThreadSaveParticipant.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadSaveParticipant.test.ts
@@ -109,6 +109,12 @@ suite('MainThreadSaveParticipant', function () {
 			model.textEditorModel.setValue(lineContent);
 			participant.participate(model, { reason: SaveReason.EXPLICIT });
 			assert.equal(snapshotToString(model.createSnapshot()), `${textContent}${eol}${textContent}${eol}`);
+
+			// Collapse new lines into one when file has only newlines bug#48853
+			lineContent = `${eol}${eol}${eol}`;
+			model.textEditorModel.setValue(lineContent);
+			participant.participate(model, { reason: SaveReason.EXPLICIT });
+			assert.equal(snapshotToString(model.createSnapshot()), `${eol}`);
 		});
 	});
 


### PR DESCRIPTION
When `files.trimFinalNewlines` is enabled, new lines are collapsed into one if new lines are present in the file. Fixes #48853.