### PR TITLE
(doc) Corrected Stack Overflow tag name

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,9 @@
 ---
 name: Question
-about: The issue tracker is not for questions. Please ask questions on https://stackoverflow.com/questions/tagged/vscode.
+about: The issue tracker is not for questions. Please ask questions on https://stackoverflow.com/questions/tagged/visual-studio-code.
 
 ---
 
 🚨 The issue tracker is not for questions 🚨
 
-If you have a question, please ask it on https://stackoverflow.com/questions/tagged/vscode.
+If you have a question, please ask it on https://stackoverflow.com/questions/tagged/visual-studio-code.


### PR DESCRIPTION
- This confused me, as I was trying to tag a new question with `vscode` but this doesn't exist