### PR TITLE
Improve word part move and delete for capitalized snake case

### DIFF
--- a/src/vs/editor/contrib/wordPartOperations/test/wordPartOperations.test.ts
+++ b/src/vs/editor/contrib/wordPartOperations/test/wordPartOperations.test.ts
@@ -39,7 +39,7 @@ suite('WordPartOperations', () => {
 	test('move word part left basic', () => {
 		withTestCodeEditor([
 			'start line',
-			'thisIsACamelCaseVar  this_is_a_snake_case_var',
+			'thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse',
 			'end line'
 		], {}, (editor, _) => {
 			editor.setPosition(new Position(3, 8));
@@ -47,6 +47,16 @@ suite('WordPartOperations', () => {
 				[3, 5],
 				[3, 4],
 				[3, 1],
+				[2, 81],
+				[2, 78],
+				[2, 73],
+				[2, 70],
+				[2, 66],
+				[2, 65],
+				[2, 59],
+				[2, 54],
+				[2, 51],
+				[2, 47],
 				[2, 46],
 				[2, 42],
 				[2, 37],
@@ -82,7 +92,7 @@ suite('WordPartOperations', () => {
 	test('move word part right basic', () => {
 		withTestCodeEditor([
 			'start line',
-			'thisIsACamelCaseVar  this_is_a_snake_case_var',
+			'thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse',
 			'end line'
 		], {}, (editor, _) => {
 			editor.setPosition(new Position(1, 1));
@@ -105,6 +115,16 @@ suite('WordPartOperations', () => {
 				[2, 38],
 				[2, 43],
 				[2, 46],
+				[2, 47],
+				[2, 52],
+				[2, 55],
+				[2, 60],
+				[2, 65],
+				[2, 66],
+				[2, 71],
+				[2, 73],
+				[2, 78],
+				[2, 81],
 				[3, 1],
 				[3, 4],
 				[3, 5],
@@ -117,93 +137,112 @@ suite('WordPartOperations', () => {
 				const pos = editor.getPosition();
 				actualStops.push([pos.lineNumber, pos.column]);
 			}
-
 			assert.deepEqual(actualStops, expectedStops);
 		});
 	});
 
 	test('delete word part left basic', () => {
 		withTestCodeEditor([
-			'   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var'
+			'   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse'
 		], {}, (editor, _) => {
 			const model = editor.getModel();
-			editor.setPosition(new Position(1, 84));
+			editor.setPosition(new Position(1, 1000));
 
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case', '001');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake', '002');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a', '003');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is', '004');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this', '005');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  ', '006');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar', '007');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCase', '008');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamel', '009');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsA', '010');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIs', '011');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  this', '012');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  ', '013');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */', '014');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 ', '015');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3', '015bis');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-', '016');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5', '017');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +', '018');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 ', '019');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3', '019bis');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= ', '020');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+=', '021');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a', '022');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text ', '023');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text', '024');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some ', '025');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some', '026');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just ', '027');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just', '028');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* ', '029');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /*', '030');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   ', '031');
-			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '', '032');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixed', '001');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_IS', '002');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this', '003');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE ', '004');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE', '005');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS', '006');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS', '007');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS', '008');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var ', '009');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '010');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case', '011');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake', '012');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a', '013');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is', '014');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this', '015');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  ', '016');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar', '017');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamelCase', '018');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsACamel', '019');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIsA', '020');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  thisIs', '021');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  this', '022');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */  ', '023');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 */', '024');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3 ', '025');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-3', '025bis');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5-', '026');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +5', '027');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 +', '028');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3 ', '029');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= 3', '029bis');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+= ', '030');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a+=', '031');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text a', '032');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text ', '033');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some text', '034');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some ', '035');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just some', '036');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just ', '037');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* Just', '038');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /* ', '039');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   /*', '040');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '   ', '041');
+			deleteWordPartLeft(editor); assert.equal(model.getLineContent(1), '', '042');
 		});
 	});
 
 	test('delete word part right basic', () => {
 		withTestCodeEditor([
-			'   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var'
+			'   /* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse'
 		], {}, (editor, _) => {
 			const model = editor.getModel();
 			editor.setPosition(new Position(1, 1));
 
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '/* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '001');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '002');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '003');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '004');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '005');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '006');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '007');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '008');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '009');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '010');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '011');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '012');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '013');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '014');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '3 */  thisIsACamelCaseVar  this_is_a_snake_case_var', '015');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' */  thisIsACamelCaseVar  this_is_a_snake_case_var', '016');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '  thisIsACamelCaseVar  this_is_a_snake_case_var', '017');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'thisIsACamelCaseVar  this_is_a_snake_case_var', '018');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'IsACamelCaseVar  this_is_a_snake_case_var', '019');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'ACamelCaseVar  this_is_a_snake_case_var', '020');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'CamelCaseVar  this_is_a_snake_case_var', '021');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'CaseVar  this_is_a_snake_case_var', '022');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'Var  this_is_a_snake_case_var', '023');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '  this_is_a_snake_case_var', '024');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'this_is_a_snake_case_var', '025');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'is_a_snake_case_var', '026');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'a_snake_case_var', '027');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'snake_case_var', '028');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'case_var', '029');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'var', '030');
-			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '', '031');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '/* Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '001');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '002');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'Just some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '003');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '004');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'some text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '005');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '006');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'text a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '007');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '008');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'a+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '009');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '+= 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '010');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' 3 +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '011');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' +5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '012');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '5-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '013');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '-3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '014');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '3 */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '015');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' */  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '016');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '  thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '017');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'thisIsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '018');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'IsACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '019');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'ACamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '020');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'CamelCaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '021');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'CaseVar  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '022');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'Var  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '023');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '  this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '024');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'this_is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '025');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'is_a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '026');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'a_snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '027');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'snake_case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '028');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'case_var THIS_IS_CAPS_SNAKE this_ISMixedUse', '029');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'var THIS_IS_CAPS_SNAKE this_ISMixedUse', '030');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' THIS_IS_CAPS_SNAKE this_ISMixedUse', '031');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'THIS_IS_CAPS_SNAKE this_ISMixedUse', '032');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'IS_CAPS_SNAKE this_ISMixedUse', '033');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'CAPS_SNAKE this_ISMixedUse', '034');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'SNAKE this_ISMixedUse', '035');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), ' this_ISMixedUse', '036');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'this_ISMixedUse', '037');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'ISMixedUse', '038');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'MixedUse', '039');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), 'Use', '040');
+			deleteWordPartRight(editor); assert.equal(model.getLineContent(1), '', '041');
 		});
 	});
 });


### PR DESCRIPTION
In ruby (and perhaps other languages) the convention for constants is
ALL_CAPS_SNAKE_CASE. This change allows stepping through word parts for
this case. It also handles mixed case where an all caps part is likely
an acronym with a capitalized word following. eg: `DSLModel`.