### PR TITLE
Use HTML headings for viewlet titles.

### DIFF
--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -30,9 +30,12 @@
 	padding-left: 12px;
 }
 
-.monaco-workbench > .part > .title > .title-label span {
+.monaco-workbench > .part > .title > .title-label h2 {
 	font-size: 11px;
 	cursor: default;
+	font-weight: normal;
+	-webkit-margin-before: 0;
+	-webkit-margin-after: 0;
 }
 
 .monaco-workbench > .part > .title > .title-label a {

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -434,7 +434,7 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		$(parent).div({
 			'class': 'title-label'
 		}, div => {
-			titleLabel = div.span();
+			titleLabel = div.element('h2');
 		});
 
 		const $this = this;

--- a/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
@@ -21,7 +21,7 @@
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab .monaco-icon-label::before,
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .title-label a,
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a,
-.monaco-workbench > .part.editor > .content .editor-group-container > .title .title-label span,
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .title-label h2,
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label span {
 	cursor: pointer;
 }

--- a/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
+++ b/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
@@ -12,7 +12,7 @@
 	visibility: hidden !important;
 }
 
-.monaco-workbench > .sidebar > .title > .title-label span {
+.monaco-workbench > .sidebar > .title > .title-label h2 {
 	text-transform: uppercase;
 }
 

--- a/src/vs/workbench/browser/parts/views/media/panelviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/panelviewlet.css
@@ -3,8 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-panel-view .panel > .panel-header > .title {
+.monaco-panel-view .panel > .panel-header > h3.title {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	font-size: 11px;
+	-webkit-margin-before: 0;
+	-webkit-margin-after: 0;
 }

--- a/src/vs/workbench/browser/parts/views/media/panelviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/panelviewlet.css
@@ -10,4 +10,5 @@
 	font-size: 11px;
 	-webkit-margin-before: 0;
 	-webkit-margin-after: 0;
+	display: flex;
 }

--- a/src/vs/workbench/browser/parts/views/media/panelviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/panelviewlet.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-panel-view .panel > .panel-header > h3.title {
+.monaco-panel-view .panel > .panel-header h3.title {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;

--- a/src/vs/workbench/browser/parts/views/panelViewlet.ts
+++ b/src/vs/workbench/browser/parts/views/panelViewlet.ts
@@ -100,7 +100,7 @@ export abstract class ViewletPanel extends Panel implements IView {
 	protected renderHeader(container: HTMLElement): void {
 		this.headerContainer = container;
 
-		this.renderHeaderTitle(container, [], [this.title]);
+		this.renderHeaderTitle(container, this.title);
 
 		const actions = append(container, $('.actions'));
 		this.toolbar = new ToolBar(actions, this.contextMenuService, {
@@ -119,8 +119,8 @@ export abstract class ViewletPanel extends Panel implements IView {
 		this.updateActionsVisibility();
 	}
 
-	protected renderHeaderTitle(container: HTMLElement, classList: string[], children: (string | Node)[]): void {
-		append(container, $('h3.' + ['title', ...classList].join('.'), null, ...children));
+	protected renderHeaderTitle(container: HTMLElement, title: string): void {
+		append(container, $('h3.title', null, title));
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/views/panelViewlet.ts
+++ b/src/vs/workbench/browser/parts/views/panelViewlet.ts
@@ -120,7 +120,7 @@ export abstract class ViewletPanel extends Panel implements IView {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		append(container, $('.title', null, this.title));
+		append(container, $('h3.title', null, this.title));
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/views/panelViewlet.ts
+++ b/src/vs/workbench/browser/parts/views/panelViewlet.ts
@@ -100,7 +100,7 @@ export abstract class ViewletPanel extends Panel implements IView {
 	protected renderHeader(container: HTMLElement): void {
 		this.headerContainer = container;
 
-		this.renderHeaderTitle(container);
+		this.renderHeaderTitle(container, [], [this.title]);
 
 		const actions = append(container, $('.actions'));
 		this.toolbar = new ToolBar(actions, this.contextMenuService, {
@@ -119,8 +119,8 @@ export abstract class ViewletPanel extends Panel implements IView {
 		this.updateActionsVisibility();
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): void {
-		append(container, $('h3.title', null, this.title));
+	protected renderHeaderTitle(container: HTMLElement, classList: string[], children: (string | Node)[]): HTMLElement {
+		return append(container, $('h3.' + ['title', ...classList].join('.'), null, ...children));
 	}
 
 	focus(): void {

--- a/src/vs/workbench/browser/parts/views/panelViewlet.ts
+++ b/src/vs/workbench/browser/parts/views/panelViewlet.ts
@@ -119,8 +119,8 @@ export abstract class ViewletPanel extends Panel implements IView {
 		this.updateActionsVisibility();
 	}
 
-	protected renderHeaderTitle(container: HTMLElement, classList: string[], children: (string | Node)[]): HTMLElement {
-		return append(container, $('h3.' + ['title', ...classList].join('.'), null, ...children));
+	protected renderHeaderTitle(container: HTMLElement, classList: string[], children: (string | Node)[]): void {
+		append(container, $('h3.' + ['title', ...classList].join('.'), null, ...children));
 	}
 
 	focus(): void {

--- a/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
@@ -87,13 +87,14 @@ export class CallStackView extends TreeViewsViewletPanel {
 		}, 50);
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): void {
-		const title = dom.append(container, $('h3.title.debug-call-stack-title'));
-		const name = dom.append(title, $('span'));
+	protected renderHeaderTitle(container: HTMLElement): HTMLElement {
+		const name = $('span');
 		name.textContent = this.options.title;
-		this.pauseMessage = dom.append(title, $('span.pause-message'));
+		this.pauseMessage = $('span.pause-message');
 		this.pauseMessage.hidden = true;
 		this.pauseMessageLabel = dom.append(this.pauseMessage, $('span.label'));
+
+		return super.renderHeaderTitle(container, ['debug-call-stack-title'], [name, this.pauseMessage]);
 	}
 
 	public renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
@@ -88,7 +88,7 @@ export class CallStackView extends TreeViewsViewletPanel {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		const title = dom.append(container, $('.title.debug-call-stack-title'));
+		const title = dom.append(container, $('h3.title.debug-call-stack-title'));
 		const name = dom.append(title, $('span'));
 		name.textContent = this.options.title;
 		this.pauseMessage = dom.append(title, $('span.pause-message'));

--- a/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
@@ -88,13 +88,12 @@ export class CallStackView extends TreeViewsViewletPanel {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		const name = $('span');
-		name.textContent = this.options.title;
-		this.pauseMessage = $('span.pause-message');
+		let titleContainer = dom.append(container, $('.debug-call-stack-title'));
+		super.renderHeaderTitle(titleContainer, this.options.title);
+
+		this.pauseMessage = dom.append(titleContainer, $('span.pause-message'));
 		this.pauseMessage.hidden = true;
 		this.pauseMessageLabel = dom.append(this.pauseMessage, $('span.label'));
-
-		super.renderHeaderTitle(container, ['debug-call-stack-title'], [name, this.pauseMessage]);
 	}
 
 	public renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/callStackView.ts
@@ -87,14 +87,14 @@ export class CallStackView extends TreeViewsViewletPanel {
 		}, 50);
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): HTMLElement {
+	protected renderHeaderTitle(container: HTMLElement): void {
 		const name = $('span');
 		name.textContent = this.options.title;
 		this.pauseMessage = $('span.pause-message');
 		this.pauseMessage.hidden = true;
 		this.pauseMessageLabel = dom.append(this.pauseMessage, $('span.label'));
 
-		return super.renderHeaderTitle(container, ['debug-call-stack-title'], [name, this.pauseMessage]);
+		super.renderHeaderTitle(container, ['debug-call-stack-title'], [name, this.pauseMessage]);
 	}
 
 	public renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -72,7 +72,7 @@ export class ExtensionsListView extends ViewletPanel {
 	}
 
 	renderHeader(container: HTMLElement): void {
-		const titleDiv = append(container, $('div.title'));
+		const titleDiv = append(container, $('h3.title'));
 		append(titleDiv, $('span')).textContent = this.options.title;
 
 		this.badgeContainer = append(container, $('.count-badge-wrapper'));

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -72,13 +72,11 @@ export class ExtensionsListView extends ViewletPanel {
 	}
 
 	renderHeaderTitle(container: HTMLElement): void {
-		let title = $('span');
-		title.textContent = this.options.title;
+		super.renderHeaderTitle(container, this.options.title);
 
-		this.badgeContainer = $('.count-badge-wrapper');
+		this.badgeContainer = append(container, $('.count-badge-wrapper'));
 		this.badge = new CountBadge(this.badgeContainer);
 		this.disposables.push(attachBadgeStyler(this.badge, this.themeService));
-		super.renderHeaderTitle(container, [], [title, this.badgeContainer]);
 	}
 
 	renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -71,14 +71,14 @@ export class ExtensionsListView extends ViewletPanel {
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: options.title }, keybindingService, contextMenuService, configurationService);
 	}
 
-	renderHeaderTitle(container: HTMLElement): HTMLElement {
+	renderHeaderTitle(container: HTMLElement): void {
 		let title = $('span');
 		title.textContent = this.options.title;
 
 		this.badgeContainer = $('.count-badge-wrapper');
 		this.badge = new CountBadge(this.badgeContainer);
 		this.disposables.push(attachBadgeStyler(this.badge, this.themeService));
-		return super.renderHeaderTitle(container, [], [title, this.badgeContainer]);
+		super.renderHeaderTitle(container, [], [title, this.badgeContainer]);
 	}
 
 	renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -71,13 +71,14 @@ export class ExtensionsListView extends ViewletPanel {
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: options.title }, keybindingService, contextMenuService, configurationService);
 	}
 
-	renderHeader(container: HTMLElement): void {
-		const titleDiv = append(container, $('h3.title'));
-		append(titleDiv, $('span')).textContent = this.options.title;
+	renderHeaderTitle(container: HTMLElement): HTMLElement {
+		let title = $('span');
+		title.textContent = this.options.title;
 
-		this.badgeContainer = append(container, $('.count-badge-wrapper'));
+		this.badgeContainer = $('.count-badge-wrapper');
 		this.badge = new CountBadge(this.badgeContainer);
 		this.disposables.push(attachBadgeStyler(this.badge, this.themeService));
+		return super.renderHeaderTitle(container, [], [title, this.badgeContainer]);
 	}
 
 	renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensions.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensions.css
@@ -7,3 +7,8 @@
 	-webkit-mask: url('extensions-dark.svg') no-repeat 50% 50%;
 	-webkit-mask-size: 21px;
 }
+
+.extensions .split-view-view .panel-header .count-badge-wrapper {
+	position: absolute;
+	right: 12px;
+}

--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -175,7 +175,7 @@ export class OpenEditorsView extends ViewletPanel {
 		}));
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): HTMLElement {
+	protected renderHeaderTitle(container: HTMLElement): void {
 
 		const title = $('span', null, this.title);
 		const count = $('.count');
@@ -195,7 +195,7 @@ export class OpenEditorsView extends ViewletPanel {
 		})));
 
 		this.updateDirtyIndicator();
-		return super.renderHeaderTitle(container, [], [title, count]);
+		super.renderHeaderTitle(container, [], [title, count]);
 	}
 
 	public renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -176,7 +176,7 @@ export class OpenEditorsView extends ViewletPanel {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		const title = dom.append(container, $('.title'));
+		const title = dom.append(container, $('h3.title'));
 		dom.append(title, $('span', null, this.title));
 
 		const count = dom.append(container, $('.count'));

--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -175,11 +175,10 @@ export class OpenEditorsView extends ViewletPanel {
 		}));
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): void {
-		const title = dom.append(container, $('h3.title'));
-		dom.append(title, $('span', null, this.title));
+	protected renderHeaderTitle(container: HTMLElement): HTMLElement {
 
-		const count = dom.append(container, $('.count'));
+		const title = $('span', null, this.title);
+		const count = $('.count');
 		this.dirtyCountElement = dom.append(count, $('.monaco-count-badge'));
 
 		this.disposables.push((attachStylerCallback(this.themeService, { badgeBackground, badgeForeground, contrastBorder }, colors => {
@@ -196,6 +195,7 @@ export class OpenEditorsView extends ViewletPanel {
 		})));
 
 		this.updateDirtyIndicator();
+		return super.renderHeaderTitle(container, [], [title, count]);
 	}
 
 	public renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -176,9 +176,9 @@ export class OpenEditorsView extends ViewletPanel {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
+		super.renderHeaderTitle(container, this.title);
 
-		const title = $('span', null, this.title);
-		const count = $('.count');
+		const count = dom.append(container, $('.count'));
 		this.dirtyCountElement = dom.append(count, $('.monaco-count-badge'));
 
 		this.disposables.push((attachStylerCallback(this.themeService, { badgeBackground, badgeForeground, contrastBorder }, colors => {
@@ -195,7 +195,6 @@ export class OpenEditorsView extends ViewletPanel {
 		})));
 
 		this.updateDirtyIndicator();
-		super.renderHeaderTitle(container, [], [title, count]);
 	}
 
 	public renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/parts/scm/electron-browser/media/scmViewlet.css
+++ b/src/vs/workbench/parts/scm/electron-browser/media/scmViewlet.css
@@ -51,7 +51,7 @@
 	display: none;
 }
 
-.scm-viewlet .scm-provider > .name > .type {
+.scm-viewlet .scm-provider > .type {
 	opacity: 0.7;
 	margin-left: 0.5em;
 	font-size: 0.9em;

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -764,7 +764,7 @@ export class RepositoryPanel extends ViewletPanel {
 		this.menus.onDidChangeTitle(this.updateActions, this, this.disposables);
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): HTMLElement {
+	protected renderHeaderTitle(container: HTMLElement): void {
 		const name = $('.name');
 		const title = append(name, $('span.title'));
 		const type = append(name, $('span.type'));
@@ -780,7 +780,7 @@ export class RepositoryPanel extends ViewletPanel {
 		const onContextMenu = mapEvent(stop(domEvent(container, 'contextmenu')), e => new StandardMouseEvent(e));
 		onContextMenu(this.onContextMenu, this, this.disposables);
 
-		return super.renderHeaderTitle(container, ['scm-provider'], [name]);
+		super.renderHeaderTitle(container, ['scm-provider'], [name]);
 	}
 
 	private onContextMenu(event: StandardMouseEvent): void {

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -764,9 +764,8 @@ export class RepositoryPanel extends ViewletPanel {
 		this.menus.onDidChangeTitle(this.updateActions, this, this.disposables);
 	}
 
-	protected renderHeaderTitle(container: HTMLElement): void {
-		const header = append(container, $('h3.title.scm-provider'));
-		const name = append(header, $('.name'));
+	protected renderHeaderTitle(container: HTMLElement): HTMLElement {
+		const name = $('.name');
 		const title = append(name, $('span.title'));
 		const type = append(name, $('span.type'));
 
@@ -780,6 +779,8 @@ export class RepositoryPanel extends ViewletPanel {
 
 		const onContextMenu = mapEvent(stop(domEvent(container, 'contextmenu')), e => new StandardMouseEvent(e));
 		onContextMenu(this.onContextMenu, this, this.disposables);
+
+		return super.renderHeaderTitle(container, ['scm-provider'], [name]);
 	}
 
 	private onContextMenu(event: StandardMouseEvent): void {

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -765,22 +765,22 @@ export class RepositoryPanel extends ViewletPanel {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		const name = $('.name');
-		const title = append(name, $('span.title'));
-		const type = append(name, $('span.type'));
+		let title: string;
+		let type: string;
 
 		if (this.repository.provider.rootUri) {
-			title.textContent = basename(this.repository.provider.rootUri.fsPath);
-			type.textContent = this.repository.provider.label;
+			title = basename(this.repository.provider.rootUri.fsPath);
+			type = this.repository.provider.label;
 		} else {
-			title.textContent = this.repository.provider.label;
-			type.textContent = '';
+			title = this.repository.provider.label;
+			type = '';
 		}
 
+		super.renderHeaderTitle(container, title);
+		addClass(container, 'scm-provider');
+		append(container, $('span.type', null, type));
 		const onContextMenu = mapEvent(stop(domEvent(container, 'contextmenu')), e => new StandardMouseEvent(e));
 		onContextMenu(this.onContextMenu, this, this.disposables);
-
-		super.renderHeaderTitle(container, ['scm-provider'], [name]);
 	}
 
 	private onContextMenu(event: StandardMouseEvent): void {

--- a/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/scmViewlet.ts
@@ -765,7 +765,7 @@ export class RepositoryPanel extends ViewletPanel {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		const header = append(container, $('.title.scm-provider'));
+		const header = append(container, $('h3.title.scm-provider'));
 		const name = append(header, $('.name'));
 		const title = append(name, $('span.title'));
 		const type = append(name, $('span.type'));

--- a/test/smoke/src/areas/workbench/viewlet.ts
+++ b/test/smoke/src/areas/workbench/viewlet.ts
@@ -12,6 +12,6 @@ export abstract class Viewlet {
 	constructor(protected code: Code) { }
 
 	async waitForTitle(fn: (title: string) => boolean): Promise<void> {
-		await this.code.waitForTextContent('.monaco-workbench-container .part.sidebar > .title > .title-label > span', undefined, fn);
+		await this.code.waitForTextContent('.monaco-workbench-container .part.sidebar > .title > .title-label > h2', undefined, fn);
 	}
 }


### PR DESCRIPTION
Closes #51760

We should also probably set the individual pane titles to have `h3`s. Right now they're just `div`'s with text inside, which means they do not get read as headings, even though they function as headings. 