### PR TITLE
Adds `editorUnnecessaryCode.foreground`.

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -46,7 +46,7 @@ import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { InternalEditorAction } from 'vs/editor/common/editorAction';
 import { ICommandDelegate } from 'vs/editor/browser/view/viewController';
 import { CoreEditorCommand } from 'vs/editor/browser/controller/coreCommands';
-import { editorErrorForeground, editorErrorBorder, editorWarningForeground, editorWarningBorder, editorInfoBorder, editorInfoForeground, editorHintForeground, editorHintBorder, editorUnnecessaryCodeOpacity, editorUnnecessaryCodeBorder } from 'vs/editor/common/view/editorColorRegistry';
+import { editorErrorForeground, editorErrorBorder, editorWarningForeground, editorWarningBorder, editorInfoBorder, editorInfoForeground, editorHintForeground, editorHintBorder, editorUnnecessaryCodeOpacity, editorUnnecessaryCodeBorder, editorUnnecessaryCodeForeground } from 'vs/editor/common/view/editorColorRegistry';
 import { Color } from 'vs/base/common/color';
 import { ClassName } from 'vs/editor/common/model/intervalTree';
 
@@ -1803,9 +1803,14 @@ registerThemingParticipant((theme, collector) => {
 		collector.addRule(`.monaco-editor .${ClassName.EditorHintDecoration} { background: url("data:image/svg+xml,${getDotDotDotSVGData(hintForeground)}") no-repeat bottom left; }`);
 	}
 
-	const unnecessaryForeground = theme.getColor(editorUnnecessaryCodeOpacity);
+	const unnecessaryForeground = theme.getColor(editorUnnecessaryCodeForeground);
 	if (unnecessaryForeground) {
-		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { opacity: ${unnecessaryForeground.rgba.a}; }`);
+		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { color: ${Color.Format.CSS.formatRGB(unnecessaryForeground)}; }`);
+	}
+
+	const unnecessaryOpacity = theme.getColor(editorUnnecessaryCodeOpacity);
+	if (unnecessaryOpacity) {
+		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { opacity: ${unnecessaryOpacity.rgba.a}; }`);
 	}
 
 	const unnecessaryBorder = theme.getColor(editorUnnecessaryCodeBorder);

--- a/src/vs/editor/common/view/editorColorRegistry.ts
+++ b/src/vs/editor/common/view/editorColorRegistry.ts
@@ -50,6 +50,7 @@ export const editorHintForeground = registerColor('editorHint.foreground', { dar
 export const editorHintBorder = registerColor('editorHint.border', { dark: null, light: null, hc: Color.fromHex('#eeeeee').transparent(0.8) }, nls.localize('hintBorder', 'Border color of hint squigglies in the editor.'));
 
 export const editorUnnecessaryCodeBorder = registerColor('editorUnnecessaryCode.border', { dark: null, light: null, hc: Color.fromHex('#fff').transparent(0.8) }, nls.localize('unnecessaryCodeBorder', 'Border of unnecessary code in the editor.'));
+export const editorUnnecessaryCodeForeground = registerColor('editorUnnecessaryCode.foreground', { dark: null, light: null, hc: null }, nls.localize('unnecessaryCodeForeground', 'Foreground color of unnecessary code in the editor overriding its syntax color.'));
 export const editorUnnecessaryCodeOpacity = registerColor('editorUnnecessaryCode.opacity', { dark: Color.fromHex('#000a'), light: Color.fromHex('#0007'), hc: null }, nls.localize('unnecessaryCodeOpacity', 'Opacity of unnecessary code in the editor.'));
 
 const rulerRangeDefault = new Color(new RGBA(0, 122, 204, 0.6));


### PR DESCRIPTION
This commit allows users to set a color for unused code which had been an
unconfigurable behavior (defaulting to a shade of gray) until #51104 / #52218 when
it was replaced with setting that allows for either decreasing the unused
token's opacity while preserving its color and/or setting the color of
a 2px dashed border that "underlines" the unused token.

The previous behavior avoided some contrast issues introduced by #51104 / #52218
when reducing the opacity of some syntax colors that were already at
or just over the low-contrast frontier into squintland, the unlegible
country, a place no programmer should be forced gaze.

Conversely, tokens that don't contrast enough with themselves won't scan
well when the programmer is looking for unused tokens.