### PR TITLE
Remove PPromise usage from NSFW IPC

### DIFF
--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -242,6 +242,10 @@ export interface IErrorWithActions {
 	actions?: IAction[];
 }
 
+export function isError(obj: any): obj is Error {
+	return obj instanceof Error;
+}
+
 export function isErrorWithActions(obj: any): obj is IErrorWithActions {
 	return obj instanceof Error && Array.isArray((obj as IErrorWithActions).actions);
 }

--- a/src/vs/base/common/errors.ts
+++ b/src/vs/base/common/errors.ts
@@ -242,10 +242,6 @@ export interface IErrorWithActions {
 	actions?: IAction[];
 }
 
-export function isError(obj: any): obj is Error {
-	return obj instanceof Error;
-}
-
 export function isErrorWithActions(obj: any): obj is IErrorWithActions {
 	return obj instanceof Error && Array.isArray((obj as IErrorWithActions).actions);
 }

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -423,6 +423,8 @@ export function forEach<I>(event: Event<I>, each: (i: I) => void): Event<I> {
 	return (listener, thisArgs = null, disposables?) => event(i => { each(i); listener.call(thisArgs, i); }, null, disposables);
 }
 
+export function filterEvent<T>(event: Event<T>, filter: (e: T) => boolean): Event<T>;
+export function filterEvent<T, R>(event: Event<T | R>, filter: (e: T | R) => e is R): Event<R>;
 export function filterEvent<T>(event: Event<T>, filter: (e: T) => boolean): Event<T> {
 	return (listener, thisArgs = null, disposables?) => event(e => filter(e) && listener.call(thisArgs, e), null, disposables);
 }

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -539,14 +539,18 @@ export function getNextTickChannel<T extends IChannel>(channel: T): T {
 			.then(() => channel.call(command, arg));
 	};
 
-	const listen = (event: string, arg: any) => {
+	const listen = (event: string, arg: any): Event<any> => {
 		if (didTick) {
 			return channel.listen(event, arg);
 		}
 
-		return TPromise.timeout(0)
+		const relay = new Relay();
+
+		TPromise.timeout(0)
 			.then(() => didTick = true)
-			.then(() => channel.listen(event, arg));
+			.then(() => relay.input = channel.listen(event, arg));
+
+		return relay.event;
 	};
 
 	return { call, listen } as T;

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -242,6 +242,7 @@ export class Client implements IChannelClient, IDisposable {
 	}
 
 	dispose() {
+		this._onDidProcessExit.dispose();
 		this.disposeDelayer.cancel();
 		this.disposeDelayer = null;
 		this.disposeClient();

--- a/src/vs/base/parts/ipc/node/ipc.cp.ts
+++ b/src/vs/base/parts/ipc/node/ipc.cp.ts
@@ -79,6 +79,9 @@ export class Client implements IChannelClient, IDisposable {
 	private _client: IPCClient;
 	private channels: { [name: string]: IChannel };
 
+	private _onDidProcessExit = new Emitter<{ code: number, signal: string }>();
+	readonly onDidProcessExit = this._onDidProcessExit.event;
+
 	constructor(private modulePath: string, private options: IIPCOptions) {
 		const timeout = options && options.timeout ? options.timeout : 60000;
 		this.disposeDelayer = new Delayer<void>(timeout);
@@ -221,6 +224,8 @@ export class Client implements IChannelClient, IDisposable {
 					this.disposeDelayer.cancel();
 					this.disposeClient();
 				}
+
+				this._onDidProcessExit.fire({ code, signal });
 			});
 		}
 

--- a/src/vs/workbench/services/files/node/watcher/nsfw/nsfwWatcherService.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/nsfwWatcherService.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as platform from 'vs/base/common/platform';
 import * as watcher from 'vs/workbench/services/files/node/watcher/common';
 import * as nsfw from 'vscode-nsfw';
-import { IWatcherService, IWatcherRequest, IWatcherOptions } from 'vs/workbench/services/files/node/watcher/nsfw/watcher';
+import { IWatcherService, IWatcherRequest, IWatcherOptions, IWatchError } from 'vs/workbench/services/files/node/watcher/nsfw/watcher';
 import { TPromise, TValueCallback } from 'vs/base/common/winjs.base';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { FileChangeType } from 'vs/platform/files/common/files';
@@ -39,10 +39,10 @@ export class NsfwWatcherService implements IWatcherService {
 	private _verboseLogging: boolean;
 	private enospcErrorLogged: boolean;
 
-	private _onWatchEvent = new Emitter<watcher.IRawFileChange[] | Error>();
+	private _onWatchEvent = new Emitter<watcher.IRawFileChange[] | IWatchError>();
 	readonly onWatchEvent = this._onWatchEvent.event;
 
-	watch(options: IWatcherOptions): Event<watcher.IRawFileChange[] | Error> {
+	watch(options: IWatcherOptions): Event<watcher.IRawFileChange[] | IWatchError> {
 		this._verboseLogging = options.verboseLogging;
 		return this.onWatchEvent;
 	}
@@ -66,7 +66,7 @@ export class NsfwWatcherService implements IWatcherService {
 			// See https://github.com/Microsoft/vscode/issues/7950
 			if (e === 'Inotify limit reached' && !this.enospcErrorLogged) {
 				this.enospcErrorLogged = true;
-				this._onWatchEvent.fire(new Error('Inotify limit reached (ENOSPC)'));
+				this._onWatchEvent.fire({ message: 'Inotify limit reached (ENOSPC)' });
 			}
 		});
 

--- a/src/vs/workbench/services/files/node/watcher/nsfw/nsfwWatcherService.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/nsfwWatcherService.ts
@@ -10,10 +10,11 @@ import * as platform from 'vs/base/common/platform';
 import * as watcher from 'vs/workbench/services/files/node/watcher/common';
 import * as nsfw from 'vscode-nsfw';
 import { IWatcherService, IWatcherRequest, IWatcherOptions } from 'vs/workbench/services/files/node/watcher/nsfw/watcher';
-import { TPromise, ProgressCallback, TValueCallback, ErrorCallback } from 'vs/base/common/winjs.base';
+import { TPromise, TValueCallback } from 'vs/base/common/winjs.base';
 import { ThrottledDelayer } from 'vs/base/common/async';
 import { FileChangeType } from 'vs/platform/files/common/files';
 import { normalizeNFC } from 'vs/base/common/normalization';
+import { Event, Emitter } from 'vs/base/common/event';
 
 const nsfwActionToRawChangeType: { [key: number]: number } = [];
 nsfwActionToRawChangeType[nsfw.actions.CREATED] = FileChangeType.ADDED;
@@ -35,20 +36,15 @@ export class NsfwWatcherService implements IWatcherService {
 	private static readonly FS_EVENT_DELAY = 50; // aggregate and only emit events when changes have stopped for this duration (in ms)
 
 	private _pathWatchers: { [watchPath: string]: IPathWatcher } = {};
-	private _watcherPromise: TPromise<void>;
-	private _progressCallback: ProgressCallback;
-	private _errorCallback: ErrorCallback;
 	private _verboseLogging: boolean;
 	private enospcErrorLogged: boolean;
 
-	public initialize(options: IWatcherOptions): TPromise<void> {
-		this._verboseLogging = true;
-		this._watcherPromise = new TPromise<void>((c, e, p) => {
-			this._errorCallback = e;
-			this._progressCallback = p;
+	private _onWatchEvent = new Emitter<watcher.IRawFileChange[] | Error>();
+	readonly onWatchEvent = this._onWatchEvent.event;
 
-		});
-		return this._watcherPromise;
+	watch(options: IWatcherOptions): Event<watcher.IRawFileChange[] | Error> {
+		this._verboseLogging = true;
+		return this.onWatchEvent;
 	}
 
 	private _watch(request: IWatcherRequest): void {
@@ -70,7 +66,7 @@ export class NsfwWatcherService implements IWatcherService {
 			// See https://github.com/Microsoft/vscode/issues/7950
 			if (e === 'Inotify limit reached' && !this.enospcErrorLogged) {
 				this.enospcErrorLogged = true;
-				this._errorCallback(new Error('Inotify limit reached (ENOSPC)'));
+				this._onWatchEvent.fire(new Error('Inotify limit reached (ENOSPC)'));
 			}
 		});
 
@@ -119,7 +115,7 @@ export class NsfwWatcherService implements IWatcherService {
 
 				// Broadcast to clients normalized
 				const res = watcher.normalize(events);
-				this._progressCallback(res);
+				this._onWatchEvent.fire(res);
 
 				// Logging
 				if (this._verboseLogging) {

--- a/src/vs/workbench/services/files/node/watcher/nsfw/nsfwWatcherService.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/nsfwWatcherService.ts
@@ -43,7 +43,7 @@ export class NsfwWatcherService implements IWatcherService {
 	readonly onWatchEvent = this._onWatchEvent.event;
 
 	watch(options: IWatcherOptions): Event<watcher.IRawFileChange[] | Error> {
-		this._verboseLogging = true;
+		this._verboseLogging = options.verboseLogging;
 		return this.onWatchEvent;
 	}
 

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcher.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcher.ts
@@ -6,6 +6,8 @@
 'use strict';
 
 import { TPromise } from 'vs/base/common/winjs.base';
+import { Event } from 'vs/base/common/event';
+import { IRawFileChange } from 'vs/workbench/services/files/node/watcher/common';
 
 export interface IWatcherRequest {
 	basePath: string;
@@ -17,6 +19,6 @@ export interface IWatcherOptions {
 }
 
 export interface IWatcherService {
-	initialize(options: IWatcherOptions): TPromise<void>;
+	watch(options: IWatcherOptions): Event<IRawFileChange[] | Error>;
 	setRoots(roots: IWatcherRequest[]): TPromise<void>;
 }

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcher.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcher.ts
@@ -18,7 +18,11 @@ export interface IWatcherOptions {
 	verboseLogging: boolean;
 }
 
+export interface IWatchError {
+	message: string;
+}
+
 export interface IWatcherService {
-	watch(options: IWatcherOptions): Event<IRawFileChange[] | Error>;
+	watch(options: IWatcherOptions): Event<IRawFileChange[] | IWatchError>;
 	setRoots(roots: IWatcherRequest[]): TPromise<void>;
 }

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherIpc.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherIpc.ts
@@ -9,24 +9,29 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IChannel } from 'vs/base/parts/ipc/common/ipc';
 import { IWatcherRequest, IWatcherService, IWatcherOptions } from './watcher';
 import { Event } from 'vs/base/common/event';
+import { IRawFileChange } from 'vs/workbench/services/files/node/watcher/common';
 
 export interface IWatcherChannel extends IChannel {
-	call(command: 'initialize', verboseLogging: boolean): TPromise<void>;
+	listen(event: 'watch', verboseLogging: boolean): Event<IRawFileChange[] | Error>;
+	listen<T>(event: string, arg?: any): Event<T>;
+
 	call(command: 'setRoots', request: IWatcherRequest[]): TPromise<void>;
-	call(command: string, arg: any): TPromise<any>;
+	call<T>(command: string, arg?: any): TPromise<T>;
 }
 
 export class WatcherChannel implements IWatcherChannel {
 
 	constructor(private service: IWatcherService) { }
 
-	listen<T>(event: string, arg?: any): Event<T> {
+	listen(event: string, arg?: any): Event<any> {
+		switch (event) {
+			case 'watch': return this.service.watch(arg);
+		}
 		throw new Error('No events');
 	}
 
 	call(command: string, arg: any): TPromise<any> {
 		switch (command) {
-			case 'initialize': return this.service.initialize(arg);
 			case 'setRoots': return this.service.setRoots(arg);
 		}
 		return undefined;
@@ -37,8 +42,8 @@ export class WatcherChannelClient implements IWatcherService {
 
 	constructor(private channel: IWatcherChannel) { }
 
-	initialize(options: IWatcherOptions): TPromise<void> {
-		return this.channel.call('initialize', options);
+	watch(options: IWatcherOptions): Event<IRawFileChange[] | Error> {
+		return this.channel.listen('watch', options);
 	}
 
 	setRoots(roots: IWatcherRequest[]): TPromise<void> {

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherIpc.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherIpc.ts
@@ -7,7 +7,7 @@
 
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IChannel } from 'vs/base/parts/ipc/common/ipc';
-import { IWatcherRequest, IWatcherService, IWatcherOptions } from './watcher';
+import { IWatcherRequest, IWatcherService, IWatcherOptions, IWatchError } from './watcher';
 import { Event } from 'vs/base/common/event';
 import { IRawFileChange } from 'vs/workbench/services/files/node/watcher/common';
 
@@ -42,7 +42,7 @@ export class WatcherChannelClient implements IWatcherService {
 
 	constructor(private channel: IWatcherChannel) { }
 
-	watch(options: IWatcherOptions): Event<IRawFileChange[] | Error> {
+	watch(options: IWatcherOptions): Event<IRawFileChange[] | IWatchError> {
 		return this.channel.listen('watch', options);
 	}
 

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
@@ -16,7 +16,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { filterEvent } from 'vs/base/common/event';
-import { isError } from 'vs/base/common/errors';
+import { IWatchError } from 'vs/workbench/services/files/node/watcher/nsfw/watcher';
 
 export class FileWatcher {
 	private static readonly MAX_RESTARTS = 5;
@@ -73,8 +73,8 @@ export class FileWatcher {
 		const options = { verboseLogging: this.verboseLogging };
 		const onWatchEvent = filterEvent(this.service.watch(options), () => !this.isDisposed);
 
-		const onError = filterEvent<any, Error>(onWatchEvent, isError);
-		onError(err => this.errorLogger(err.stack), null, this.toDispose);
+		const onError = filterEvent<any, IWatchError>(onWatchEvent, (e): e is IWatchError => typeof e.message === 'string');
+		onError(err => this.errorLogger(err.message), null, this.toDispose);
 
 		const onFileChanges = filterEvent<any, IRawFileChange[]>(onWatchEvent, (e): e is IRawFileChange[] => Array.isArray(e) && e.length > 0);
 		onFileChanges(e => this.onFileChanges(toFileChangesEvent(e)), null, this.toDispose);

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
@@ -5,7 +5,6 @@
 
 'use strict';
 
-import { TPromise } from 'vs/base/common/winjs.base';
 import { getNextTickChannel } from 'vs/base/parts/ipc/common/ipc';
 import { Client } from 'vs/base/parts/ipc/node/ipc.cp';
 import uri from 'vs/base/common/uri';
@@ -16,7 +15,8 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
-import { isPromiseCanceledError } from 'vs/base/common/errors';
+import { filterEvent } from 'vs/base/common/event';
+import { isError } from 'util';
 
 export class FileWatcher {
 	private static readonly MAX_RESTARTS = 5;
@@ -24,7 +24,7 @@ export class FileWatcher {
 	private service: WatcherChannelClient;
 	private isDisposed: boolean;
 	private restartCounter: number;
-	private toDispose: IDisposable[];
+	private toDispose: IDisposable[] = [];
 
 	constructor(
 		private contextService: IWorkspaceContextService,
@@ -35,17 +35,14 @@ export class FileWatcher {
 	) {
 		this.isDisposed = false;
 		this.restartCounter = 0;
-		this.toDispose = [];
 	}
 
 	public startWatching(): () => void {
-		const args = ['--type=watcherService'];
-
 		const client = new Client(
 			uri.parse(require.toUrl('bootstrap')).fsPath,
 			{
 				serverName: 'Watcher',
-				args,
+				args: ['--type=watcherService'],
 				env: {
 					AMD_ENTRYPOINT: 'vs/workbench/services/files/node/watcher/nsfw/watcherApp',
 					PIPE_LOGGING: 'true',
@@ -55,20 +52,7 @@ export class FileWatcher {
 		);
 		this.toDispose.push(client);
 
-		const options = {
-			verboseLogging: this.verboseLogging
-		};
-
-		// Initialize watcher
-		const channel = getNextTickChannel(client.getChannel<IWatcherChannel>('watcher'));
-		this.service = new WatcherChannelClient(channel);
-		this.service.initialize(options).then(null, err => {
-			if (!this.isDisposed && !isPromiseCanceledError(err)) {
-				return TPromise.wrapError(err); // the service lib uses the promise cancel error to indicate the process died, we do not want to bubble this up
-			}
-			return void 0;
-		}, (events: IRawFileChange[]) => this.onRawFileEvents(events)).done(() => {
-
+		client.onDidProcessExit(() => {
 			// our watcher app should never be completed because it keeps on watching. being in here indicates
 			// that the watcher process died and we want to restart it here. we only do it a max number of times
 			if (!this.isDisposed) {
@@ -80,11 +64,20 @@ export class FileWatcher {
 					this.errorLogger('[FileWatcher] failed to start after retrying for some time, giving up. Please report this as a bug report!');
 				}
 			}
-		}, error => {
-			if (!this.isDisposed) {
-				this.errorLogger(error);
-			}
-		});
+		}, null, this.toDispose);
+
+		// Initialize watcher
+		const channel = getNextTickChannel(client.getChannel<IWatcherChannel>('watcher'));
+		this.service = new WatcherChannelClient(channel);
+
+		const options = { verboseLogging: this.verboseLogging };
+		const onWatchEvent = filterEvent(this.service.watch(options), () => !this.isDisposed);
+
+		const onError = filterEvent<any, Error>(onWatchEvent, isError);
+		onError(err => this.errorLogger(err.stack), null, this.toDispose);
+
+		const onFileChanges = filterEvent<any, IRawFileChange[]>(onWatchEvent, (e): e is IRawFileChange[] => Array.isArray(e) && e.length > 0);
+		onFileChanges(e => this.onFileChanges(toFileChangesEvent(e)), null, this.toDispose);
 
 		// Start watching
 		this.updateFolders();
@@ -120,17 +113,6 @@ export class FileWatcher {
 				ignored
 			};
 		}));
-	}
-
-	private onRawFileEvents(events: IRawFileChange[]): void {
-		if (this.isDisposed) {
-			return;
-		}
-
-		// Emit through event emitter
-		if (events.length > 0) {
-			this.onFileChanges(toFileChangesEvent(events));
-		}
 	}
 
 	private dispose(): void {

--- a/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
+++ b/src/vs/workbench/services/files/node/watcher/nsfw/watcherService.ts
@@ -16,7 +16,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { filterEvent } from 'vs/base/common/event';
-import { isError } from 'util';
+import { isError } from 'vs/base/common/errors';
 
 export class FileWatcher {
 	private static readonly MAX_RESTARTS = 5;


### PR DESCRIPTION
Related to #53487

@bpasero This removes PPromise usage from the NSFWWatcherService. Give it a good test drive, especially wrt the process crashing and restarting everything again. Everything should work as before.

If good, I'll make exactly the same adoption for Chokidar, since both worlds seem identical.