### PR TITLE
Fix for #53710 adopt TS support for checking JSON files

### DIFF
--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -15,7 +15,6 @@ const cp = require('child_process');
 
 var root = path.dirname(__dirname);
 var sha1 = util.getVersion(root);
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 var semver = require('./monaco/package.json').version;
 var headerVersion = semver + '(' + sha1 + ')';
 
@@ -230,7 +229,7 @@ gulp.task('editor-distro', ['clean-editor-distro', 'compile-editor-esm', 'minify
 });
 
 gulp.task('analyze-editor-distro', function () {
-	// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
+	// @ts-ignore 
 	var bundleInfo = require('../out-editor/bundleInfo.json');
 	var graph = bundleInfo.graph;
 	var bundles = bundleInfo.bundles;

--- a/build/gulpfile.mixin.js
+++ b/build/gulpfile.mixin.js
@@ -15,7 +15,6 @@ const remote = require('gulp-remote-src');
 const zip = require('gulp-vinyl-zip');
 const assign = require('object-assign');
 
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const pkg = require('../package.json');
 
 gulp.task('mixin', function () {
@@ -56,7 +55,6 @@ gulp.task('mixin', function () {
 			.pipe(util.rebase(2))
 			.pipe(productJsonFilter)
 			.pipe(buffer())
-			// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 			.pipe(json(o => assign({}, require('../product.json'), o)))
 			.pipe(productJsonFilter.restore);
 

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -25,9 +25,7 @@ const buildfile = require('../src/buildfile');
 const common = require('./lib/optimize');
 const root = path.dirname(__dirname);
 const commit = util.getVersion(root);
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const packageJson = require('../package.json');
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const product = require('../product.json');
 const crypto = require('crypto');
 const i18n = require('./lib/i18n');
@@ -40,12 +38,12 @@ const productionDependencies = deps.getProductionDependencies(path.dirname(__dir
 // @ts-ignore
 const baseModules = Object.keys(process.binding('natives')).filter(n => !/^_|\//.test(n));
 const nodeModules = ['electron', 'original-fs']
+	// @ts-ignore JSON checking: dependencies property is optional
 	.concat(Object.keys(product.dependencies || {}))
 	.concat(_.uniq(productionDependencies.map(d => d.name)))
 	.concat(baseModules);
 
 // Build
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const builtInExtensions = require('./builtInExtensions.json');
 
 const excludedExtensions = [
@@ -120,6 +118,8 @@ gulp.task('clean-minified-vscode', util.rimraf('out-vscode-min'));
 gulp.task('minify-vscode', ['clean-minified-vscode', 'optimize-index-js'], common.minifyTask('out-vscode', baseUrl));
 
 // Package
+
+// @ts-ignore JSON checking: darwinCredits is optional
 const darwinCreditsTemplate = product.darwinCredits && _.template(fs.readFileSync(path.join(root, product.darwinCredits), 'utf8'));
 
 const config = {
@@ -148,6 +148,8 @@ const config = {
 	linuxExecutableName: product.applicationName,
 	winIcon: 'resources/win32/code.ico',
 	token: process.env['VSCODE_MIXIN_PASSWORD'] || process.env['GITHUB_TOKEN'] || void 0,
+
+	// @ts-ignore JSON checking: electronRepository is optional
 	repo: product.electronRepository || void 0
 };
 
@@ -255,6 +257,7 @@ function packageTask(platform, arch, opts) {
 			.pipe(filter(['**', '!**/*.js.map']));
 
 		let version = packageJson.version;
+		// @ts-ignore JSON checking: quality is optional
 		const quality = product.quality;
 
 		if (quality && quality !== 'stable') {
@@ -286,6 +289,7 @@ function packageTask(platform, arch, opts) {
 
 		const depsSrc = [
 			..._.flatten(productionDependencies.map(d => path.relative(root, d.path)).map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`])),
+			// @ts-ignore JSON checking: dependencies is optional
 			..._.flatten(Object.keys(product.dependencies || {}).map(d => [`node_modules/${d}/**`, `!node_modules/${d}/**/{test,tests}/**`]))
 		];
 

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -12,11 +12,8 @@ const shell = require('gulp-shell');
 const es = require('event-stream');
 const vfs = require('vinyl-fs');
 const util = require('./lib/util');
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const packageJson = require('../package.json');
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const product = require('../product.json');
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const rpmDependencies = require('../resources/linux/rpm/dependencies.json');
 
 const linuxPackageRevision = Math.floor(new Date().getTime() / 1000);
@@ -75,7 +72,9 @@ function prepareDebPackage(arch) {
 		const postinst = gulp.src('resources/linux/debian/postinst.template', { base: '.' })
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@ARCHITECTURE@@', debArch))
+			// @ts-ignore JSON checking: quality is optional
 			.pipe(replace('@@QUALITY@@', product.quality || '@@QUALITY@@'))
+			// @ts-ignore JSON checking: updateUrl is optional
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(rename('DEBIAN/postinst'));
 
@@ -133,7 +132,9 @@ function prepareRpmPackage(arch) {
 			.pipe(replace('@@RELEASE@@', linuxPackageRevision))
 			.pipe(replace('@@ARCHITECTURE@@', rpmArch))
 			.pipe(replace('@@LICENSE@@', product.licenseName))
+			// @ts-ignore JSON checking: quality is optional
 			.pipe(replace('@@QUALITY@@', product.quality || '@@QUALITY@@'))
+			// @ts-ignore JSON checking: updateUrl is optional
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(replace('@@DEPENDENCIES@@', rpmDependencies[rpmArch].join(', ')))
 			.pipe(rename('SPECS/' + product.applicationName + '.spec'));

--- a/build/gulpfile.vscode.win32.js
+++ b/build/gulpfile.vscode.win32.js
@@ -12,9 +12,7 @@ const assert = require('assert');
 const cp = require('child_process');
 const _7z = require('7zip')['7z'];
 const util = require('./lib/util');
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const pkg = require('../package.json');
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const product = require('../product.json');
 const vfs = require('vinyl-fs');
 const mkdirp = require('mkdirp');

--- a/build/lib/builtInExtensions.js
+++ b/build/lib/builtInExtensions.js
@@ -17,7 +17,6 @@ const ext = require('./extensions');
 const util = require('gulp-util');
 
 const root = path.dirname(path.dirname(__dirname));
-// @ts-ignore Microsoft/TypeScript#21262 complains about a require of a JSON file
 const builtInExtensions = require('../builtInExtensions.json');
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 

--- a/build/lib/optimize.ts
+++ b/build/lib/optimize.ts
@@ -22,6 +22,7 @@ import * as gulpUtil from 'gulp-util';
 import * as flatmap from 'gulp-flatmap';
 import * as pump from 'pump';
 import * as sm from 'source-map';
+import { Language } from './i18n';
 
 const REPO_ROOT_PATH = path.join(__dirname, '../..');
 
@@ -159,6 +160,10 @@ export interface IOptimizeTaskOpts {
 	 * (out folder name)
 	 */
 	out: string;
+	/**
+	 * (out folder name)
+	 */
+	languages?: Language[];
 }
 
 export function optimizeTask(opts: IOptimizeTaskOpts): () => NodeJS.ReadWriteStream {

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -6,6 +6,7 @@
 		"removeComments": false,
 		"preserveConstEnums": true,
 		"sourceMap": false,
+		"resolveJsonModule": true,
 		"experimentalDecorators": true,
 		// enable JavaScript type checking for the language service
 		// use the tsconfig.build.json for compiling wich disable JavaScript


### PR DESCRIPTION
The PR enables JSON checking for the build folder.
It removes several @TS-Ignores and adds some news for JSON properties that we treat as optional.

