### PR TITLE
extract common path prefix to shorten diff editor label

### DIFF
--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -487,8 +487,14 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 			const leftInput = this.createInput({ resource: resourceDiffInput.leftResource, forceFile: resourceDiffInput.forceFile });
 			const rightInput = this.createInput({ resource: resourceDiffInput.rightResource, forceFile: resourceDiffInput.forceFile });
 			const label = resourceDiffInput.label || localize('compareLabels', "{0} ↔ {1}", this.toDiffLabel(leftInput), this.toDiffLabel(rightInput));
+			const leftLabel = this.toDiffLabel(leftInput, this.workspaceContextService, this.environmentService);
+			const rightLabel = this.toDiffLabel(rightInput, this.workspaceContextService, this.environmentService);
+			const commonPrefix = [leftLabel, rightLabel].join('|').match(/^([^|]*)[^|]*(?:\|\1.*)*$/)[1];
+			const leftSlice = leftLabel.slice(commonPrefix.length);
+			const rightSlice = rightLabel.slice(commonPrefix.length);
+			const label = resourceDiffInput.label || localize('compareLabels', "{0} ↔ {1}", leftSlice, rightSlice);
 
-			return new DiffEditorInput(label, resourceDiffInput.description, leftInput, rightInput);
+			return new DiffEditorInput(label, commonPrefix, leftInput, rightInput);
 		}
 
 		// Untitled file support

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -17,7 +17,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { Schemas } from 'vs/base/common/network';
 import { Event, once, Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
-import { basename } from 'vs/base/common/paths';
+import { basename, sep } from 'vs/base/common/paths';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -486,15 +486,15 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		if (resourceDiffInput.leftResource && resourceDiffInput.rightResource) {
 			const leftInput = this.createInput({ resource: resourceDiffInput.leftResource, forceFile: resourceDiffInput.forceFile });
 			const rightInput = this.createInput({ resource: resourceDiffInput.rightResource, forceFile: resourceDiffInput.forceFile });
-			const label = resourceDiffInput.label || localize('compareLabels', "{0} ↔ {1}", this.toDiffLabel(leftInput), this.toDiffLabel(rightInput));
-			const leftLabel = this.toDiffLabel(leftInput, this.workspaceContextService, this.environmentService);
-			const rightLabel = this.toDiffLabel(rightInput, this.workspaceContextService, this.environmentService);
+			const leftLabel = this.toDiffLabel(leftInput);
+			const rightLabel = this.toDiffLabel(rightInput);
 			const commonPrefix = [leftLabel, rightLabel].join('|').match(/^([^|]*)[^|]*(?:\|\1.*)*$/)[1];
-			const leftSlice = leftLabel.slice(commonPrefix.length);
-			const rightSlice = rightLabel.slice(commonPrefix.length);
+			const commonPath = commonPrefix.slice(0, commonPrefix.lastIndexOf(sep) + 1);
+			const leftSlice = leftLabel.slice(commonPath.length);
+			const rightSlice = rightLabel.slice(commonPath.length);
 			const label = resourceDiffInput.label || localize('compareLabels', "{0} ↔ {1}", leftSlice, rightSlice);
 
-			return new DiffEditorInput(label, commonPrefix, leftInput, rightInput);
+			return new DiffEditorInput(label, commonPath, leftInput, rightInput);
 		}
 
 		// Untitled file support


### PR DESCRIPTION
When comparing two files with long paths, especially those colocated but with a long common path, it could be difficult to see where the paths start to vary, with this change, it becomes easier:

<table><tr><td><b>Before</b></td><td rowspan="2">
<img src='https://user-images.githubusercontent.com/610161/42390130-8a2d49f2-817d-11e8-8a85-6a06b37e0d1a.png' />
</td></tr><tr><td><b>After</b></td></tr></table>
