### PR TITLE
Close param hints if you reach out of bounds of list instead of cycling

### DIFF
--- a/src/vs/editor/contrib/parameterHints/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/parameterHintsWidget.ts
@@ -451,8 +451,10 @@ export class ParameterHintsWidget implements IContentWidget, IDisposable {
 
 	next(): boolean {
 		const length = this.hints.signatures.length;
+		const last = (this.currentSignature % length) === (length - 1);
 
-		if (length < 2) {
+		// If there is only one signature, or we're on last signature of list
+		if (length < 2 || last) {
 			this.cancel();
 			return false;
 		}
@@ -464,8 +466,9 @@ export class ParameterHintsWidget implements IContentWidget, IDisposable {
 
 	previous(): boolean {
 		const length = this.hints.signatures.length;
+		const first = this.currentSignature === 0;
 
-		if (length < 2) {
+		if (length < 2 || first) {
 			this.cancel();
 			return false;
 		}

--- a/src/vs/editor/contrib/parameterHints/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/parameterHintsWidget.ts
@@ -459,7 +459,7 @@ export class ParameterHintsWidget implements IContentWidget, IDisposable {
 			return false;
 		}
 
-		this.currentSignature = (this.currentSignature + 1) % length;
+		this.currentSignature++;
 		this.render();
 		return true;
 	}
@@ -473,7 +473,7 @@ export class ParameterHintsWidget implements IContentWidget, IDisposable {
 			return false;
 		}
 
-		this.currentSignature = (this.currentSignature - 1 + length) % length;
+		this.currentSignature--;
 		this.render();
 		return true;
 	}


### PR DESCRIPTION
This is a solution to the issue of not being able to escape the param hints with only arrows:
[Here's the issue](https://github.com/Microsoft/vscode/issues/51191#issuecomment-402491386)