### PR TITLE
use alt to focus the menu and and navigation

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -840,6 +840,7 @@ export const EventType = {
 	SUBMIT: 'submit',
 	RESET: 'reset',
 	FOCUS: 'focus',
+	FOCUS_IN: 'focusin',
 	FOCUS_OUT: 'focusout',
 	BLUR: 'blur',
 	INPUT: 'input',

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -840,6 +840,7 @@ export const EventType = {
 	SUBMIT: 'submit',
 	RESET: 'reset',
 	FOCUS: 'focus',
+	FOCUS_OUT: 'focusout',
 	BLUR: 'blur',
 	INPUT: 'input',
 	// Local Storage

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -321,7 +321,7 @@ class SubmenuActionItem extends MenuActionItem {
 	}
 
 	private createSubmenu() {
-		if (!this.parentData.submenu) {
+		if (!this.parentData.submenu && this.builder) {
 			this.submenuContainer = $(this.builder).div({ class: 'monaco-submenu menubar-menu-items-holder context-view' });
 
 			$(this.submenuContainer).style({

--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -15,6 +15,7 @@ import { Event } from 'vs/base/common/event';
 import { addClass, EventType, EventHelper, EventLike, removeTabIndexAndUpdateFocus } from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { $, Builder } from 'vs/base/browser/builder';
+import { RunOnceScheduler } from 'vs/base/common/async';
 
 export interface IMenuOptions {
 	context?: any;
@@ -241,6 +242,8 @@ class SubmenuActionItem extends MenuActionItem {
 	private mysubmenu: Menu;
 	private submenuContainer: Builder;
 	private mouseOver: boolean;
+	private showScheduler: RunOnceScheduler;
+	private hideScheduler: RunOnceScheduler;
 
 	constructor(
 		action: IAction,
@@ -249,6 +252,20 @@ class SubmenuActionItem extends MenuActionItem {
 		private submenuOptions?: IMenuOptions
 	) {
 		super(action, action, { label: true, isMenu: true });
+
+		this.showScheduler = new RunOnceScheduler(() => {
+			if (this.mouseOver) {
+				this.cleanupExistingSubmenu(false);
+				this.createSubmenu();
+			}
+		}, 250);
+
+		this.hideScheduler = new RunOnceScheduler(() => {
+			if (!this.mouseOver && this.parentData.submenu === this.mysubmenu) {
+				this.parentData.parent.focus();
+				this.cleanupExistingSubmenu(true);
+			}
+		}, 750);
 	}
 
 	public render(container: HTMLElement): void {
@@ -278,26 +295,14 @@ class SubmenuActionItem extends MenuActionItem {
 			if (!this.mouseOver) {
 				this.mouseOver = true;
 
-				setTimeout(() => {
-					if (this.mouseOver) {
-						this.cleanupExistingSubmenu(false);
-						this.createSubmenu();
-					}
-				}, 250);
-
+				this.showScheduler.schedule();
 			}
 		});
 
 		$(this.builder).on(EventType.MOUSE_LEAVE, (e) => {
 			this.mouseOver = false;
 
-			setTimeout(() => {
-				if (!this.mouseOver && this.parentData.submenu === this.mysubmenu) {
-					this.parentData.parent.focus();
-					this.cleanupExistingSubmenu(true);
-				}
-
-			}, 750);
+			this.hideScheduler.schedule();
 		});
 	}
 
@@ -321,7 +326,7 @@ class SubmenuActionItem extends MenuActionItem {
 	}
 
 	private createSubmenu() {
-		if (!this.parentData.submenu && this.builder) {
+		if (!this.parentData.submenu) {
 			this.submenuContainer = $(this.builder).div({ class: 'monaco-submenu menubar-menu-items-holder context-view' });
 
 			$(this.submenuContainer).style({
@@ -359,6 +364,9 @@ class SubmenuActionItem extends MenuActionItem {
 
 	public dispose() {
 		super.dispose();
+
+		this.hideScheduler.dispose();
+		this.showScheduler.dispose();
 
 		if (this.mysubmenu) {
 			this.mysubmenu.dispose();

--- a/src/vs/workbench/browser/parts/menubar/media/menubarpart.css
+++ b/src/vs/workbench/browser/parts/menubar/media/menubarpart.css
@@ -32,12 +32,15 @@
 	zoom: 1;
 }
 
+
 .monaco-workbench > .part.menubar > .menubar-menu-button.open,
+.monaco-workbench > .part.menubar > .menubar-menu-button:focus,
 .monaco-workbench > .part.menubar > .menubar-menu-button:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }
 
 .monaco-workbench > .part.menubar.light > .menubar-menu-button.open,
+.monaco-workbench > .part.menubar.light > .menubar-menu-button:focus,
 .monaco-workbench > .part.menubar.light > .menubar-menu-button:hover {
 	background-color: rgba(0, 0, 0, 0.1);
 }

--- a/src/vs/workbench/browser/parts/menubar/menubarPart.ts
+++ b/src/vs/workbench/browser/parts/menubar/menubarPart.ts
@@ -99,6 +99,7 @@ export class MenubarPart extends Part {
 
 	private menuUpdater: RunOnceScheduler;
 	private actionRunner: IActionRunner;
+	private focusToReturn: Builder;
 	private container: Builder;
 	private recentlyOpened: IRecentlyOpened;
 	private updatePending: boolean;
@@ -152,8 +153,10 @@ export class MenubarPart extends Part {
 
 		this.actionRunner = this._register(new ActionRunner());
 		this._register(this.actionRunner.onDidBeforeRun(() => {
-			if (this.focusedMenu && this.focusedMenu.holder) {
-				this.focusedMenu.holder.hide();
+			this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+			if (this.focusToReturn) {
+				this.focusToReturn.domFocus();
+				this.focusToReturn = null;
 			}
 		}));
 
@@ -699,6 +702,16 @@ export class MenubarPart extends Part {
 				}
 			});
 		}
+
+		this.container.on(EventType.FOCUS_IN, (e) => {
+			let event = e as FocusEvent;
+
+			if (event.relatedTarget) {
+				if (!this.container.getHTMLElement().contains(event.relatedTarget as HTMLElement)) {
+					this.focusToReturn = $(event.relatedTarget as HTMLElement);
+				}
+			}
+		});
 
 		this.container.on(EventType.FOCUS_OUT, (e) => {
 			let event = e as FocusEvent;

--- a/src/vs/workbench/browser/parts/menubar/menubarPart.ts
+++ b/src/vs/workbench/browser/parts/menubar/menubarPart.ts
@@ -43,6 +43,13 @@ interface CustomMenu {
 	actions?: IAction[];
 }
 
+enum MenubarState {
+	HIDDEN,
+	VISIBLE,
+	FOCUSED,
+	OPEN
+}
+
 export class MenubarPart extends Part {
 
 	private keys = [
@@ -84,8 +91,8 @@ export class MenubarPart extends Part {
 
 	private focusedMenu: {
 		index: number;
-		holder: Builder;
-		widget: Menu;
+		holder?: Builder;
+		widget?: Menu;
 	};
 
 	private customMenus: CustomMenu[];
@@ -95,8 +102,10 @@ export class MenubarPart extends Part {
 	private container: Builder;
 	private recentlyOpened: IRecentlyOpened;
 	private updatePending: boolean;
+	private focusingWithAlt: boolean;
 	private _modifierKeyStatus: IModifierKeyStatus;
-	private _isFocused: boolean;
+	private _focusState: MenubarState;
+
 	private _onVisibilityChange: Emitter<Dimension>;
 
 	private initialSizing: {
@@ -157,7 +166,7 @@ export class MenubarPart extends Part {
 			this.doSetupMenubar();
 		}
 
-		this.isFocused = false;
+		this._focusState = MenubarState.HIDDEN;
 
 		this.windowService.getRecentlyOpened().then((recentlyOpened) => {
 			this.recentlyOpened = recentlyOpened;
@@ -213,12 +222,12 @@ export class MenubarPart extends Part {
 		return this.configurationService.getValue<string>('window.titleBarStyle');
 	}
 
-	private get isFocused(): boolean {
-		return this._isFocused;
+	private get focusState(): MenubarState {
+		return this._focusState;
 	}
 
-	private set isFocused(value: boolean) {
-		if (this._isFocused && !value) {
+	private set focusState(value: MenubarState) {
+		if (this._focusState >= MenubarState.FOCUSED && value < MenubarState.FOCUSED) {
 			// Losing focus, update the menu if needed
 
 			if (this.updatePending) {
@@ -227,13 +236,80 @@ export class MenubarPart extends Part {
 			}
 		}
 
-		this._isFocused = value;
-
-		if (!this._isFocused && this.currentMenubarVisibility === 'toggle') {
-			if (this.container) {
-				this.hideMenubar();
-			}
+		if (value === this._focusState) {
+			return;
 		}
+
+		switch (value) {
+			case MenubarState.HIDDEN:
+				if (this.isVisible) {
+					this.hideMenubar();
+				}
+
+				if (this.isOpen) {
+					this.cleanupCustomMenu();
+				}
+
+				if (this.isFocused) {
+					this.focusedMenu = null;
+				}
+
+				break;
+			case MenubarState.VISIBLE:
+				if (!this.isVisible) {
+					this.showMenubar();
+				}
+
+				if (this.isOpen) {
+					this.cleanupCustomMenu();
+				}
+
+				if (this.isFocused) {
+					if (this.focusedMenu) {
+						this.customMenus[this.focusedMenu.index].buttonElement.domBlur();
+					}
+
+					this.focusedMenu = null;
+				}
+
+				break;
+			case MenubarState.FOCUSED:
+				if (!this.isVisible) {
+					this.showMenubar();
+				}
+
+				if (this.isOpen) {
+					this.cleanupCustomMenu();
+				}
+
+				if (this.focusedMenu) {
+					this.customMenus[this.focusedMenu.index].buttonElement.domFocus();
+				}
+				break;
+			case MenubarState.OPEN:
+				if (!this.isVisible) {
+					this.showMenubar();
+				}
+
+				if (this.focusedMenu) {
+					this.showCustomMenu(this.focusedMenu.index);
+				}
+				break;
+		}
+
+		this._focusState = value;
+	}
+
+	private get isVisible(): boolean {
+		return this.focusState >= MenubarState.VISIBLE;
+	}
+
+	private get isFocused(): boolean {
+		return this.focusState >= MenubarState.FOCUSED;
+	}
+
+	private get isOpen(): boolean {
+		return this.focusState >= MenubarState.OPEN;
 	}
 
 	private onDidChangeFullscreen(): void {
@@ -256,26 +332,42 @@ export class MenubarPart extends Part {
 		this.container.style('visibility', null);
 	}
 
-	private onModifierKeyToggled(modiferKeyStatus: IModifierKeyStatus): void {
+	private onModifierKeyToggled(modifierKeyStatus: IModifierKeyStatus): void {
+		const altKeyPressed = (!this._modifierKeyStatus || !this._modifierKeyStatus.altKey) && modifierKeyStatus.altKey;
+		const altKeyAlone = altKeyPressed && !modifierKeyStatus.ctrlKey && !modifierKeyStatus.shiftKey;
+		const allModifiersReleased = !modifierKeyStatus.altKey && !modifierKeyStatus.ctrlKey && !modifierKeyStatus.shiftKey;
+
 		if (this.currentMenubarVisibility === 'toggle') {
-			const altKeyPressed = (!this._modifierKeyStatus || !this._modifierKeyStatus.altKey) && modiferKeyStatus.altKey;
-			if (altKeyPressed && !modiferKeyStatus.ctrlKey && !modiferKeyStatus.shiftKey) {
-				this.showMenubar();
-			} else if (!this.isFocused) {
-				this.hideMenubar();
+			if (altKeyAlone) {
+				if (!this.isVisible) {
+					this.focusState = MenubarState.VISIBLE;
+				}
+			} else if (!allModifiersReleased && !this.isFocused) {
+				this.focusState = MenubarState.HIDDEN;
 			}
 		}
 
-		this._modifierKeyStatus = modiferKeyStatus;
+		if (allModifiersReleased && this.focusingWithAlt) {
+			if (!this.isFocused) {
+				this.focusedMenu = { index: 0 };
+				this.focusState = MenubarState.FOCUSED;
+			} else if (!this.isOpen) {
+				this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+			}
+		}
+
+		this._modifierKeyStatus = modifierKeyStatus;
 
 		if (this.currentEnableMenuBarMnemonics && this.customMenus) {
 			this.customMenus.forEach(customMenu => {
 				let child = customMenu.titleElement.child();
 				if (child) {
-					child.style('text-decoration', modiferKeyStatus.altKey ? 'underline' : null);
+					child.style('text-decoration', modifierKeyStatus.altKey ? 'underline' : null);
 				}
 			});
 		}
+
+		this.focusingWithAlt = altKeyAlone;
 	}
 
 	private onRecentlyOpenedChange(): void {
@@ -473,7 +565,7 @@ export class MenubarPart extends Part {
 
 			// Create the top level menu button element
 			if (firstTimeSetup) {
-				const buttonElement = $(this.container).div({ class: 'menubar-menu-button' }).attr('role', 'menu');
+				const buttonElement = $(this.container).div({ class: 'menubar-menu-button' }).attr({ 'role': 'menu', 'tabindex': 0 });
 				buttonElement.attr('aria-label', this.topLevelTitles[menuTitle].replace(/&&(.)/g, '$1'));
 
 				const titleElement = $(buttonElement).div({ class: 'menubar-menu-title', 'aria-hidden': true });
@@ -533,29 +625,55 @@ export class MenubarPart extends Part {
 			updateActions(menu, this.customMenus[menuIndex].actions);
 
 			if (firstTimeSetup) {
+				this.customMenus[menuIndex].buttonElement.on(EventType.KEY_UP, (e) => {
+					let event = new StandardKeyboardEvent(e as KeyboardEvent);
+					let eventHandled = true;
+
+					if ((event.equals(KeyCode.DownArrow) || event.equals(KeyCode.Enter)) && !this.isOpen) {
+						this.focusedMenu = { index: menuIndex };
+						this.focusState = MenubarState.OPEN;
+					} else {
+						eventHandled = false;
+					}
+
+					if (eventHandled) {
+						event.preventDefault();
+						event.stopPropagation();
+					}
+				});
+
 				this.customMenus[menuIndex].buttonElement.on(EventType.CLICK, () => {
 					if (this._modifierKeyStatus && (this._modifierKeyStatus.shiftKey || this._modifierKeyStatus.ctrlKey)) {
 						return; // supress keyboard shortcuts that shouldn't conflict
 					}
 
-					this.toggleCustomMenu(menuIndex);
-					this.isFocused = !this.isFocused;
+					if (this.isOpen) {
+						if (this.isCurrentMenu(menuIndex)) {
+							this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+						} else {
+							this.cleanupCustomMenu();
+							this.showCustomMenu(menuIndex);
+						}
+					} else {
+						this.focusedMenu = { index: menuIndex };
+						this.focusState = MenubarState.OPEN;
+					}
 				});
 
 				this.customMenus[menuIndex].buttonElement.on(EventType.MOUSE_ENTER, () => {
-					if (this.isFocused && !this.isCurrentMenu(menuIndex)) {
-						this.toggleCustomMenu(menuIndex);
+					if (this.isOpen && !this.isCurrentMenu(menuIndex)) {
+						this.customMenus[menuIndex].buttonElement.domFocus();
+						this.cleanupCustomMenu();
+						this.showCustomMenu(menuIndex);
+					} else if (this.isFocused && !this.isOpen) {
+						this.customMenus[menuIndex].buttonElement.domFocus();
 					}
 				});
 
 				this.customMenus[menuIndex].buttonElement.on(EventType.MOUSE_LEAVE, () => {
-					if (!this.isFocused) {
-						this.cleanupCustomMenu();
+					if (!this.isOpen && this.isFocused) {
+						this.customMenus[menuIndex].buttonElement.domBlur();
 					}
-				});
-
-				this.customMenus[menuIndex].buttonElement.on(EventType.BLUR, () => {
-					this.cleanupCustomMenu();
 				});
 			}
 		}
@@ -569,6 +687,8 @@ export class MenubarPart extends Part {
 					this.focusPrevious();
 				} else if (event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Tab)) {
 					this.focusNext();
+				} else if (event.equals(KeyCode.Escape) && this.isFocused && !this.isOpen) {
+					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
 				} else {
 					eventHandled = false;
 				}
@@ -579,9 +699,20 @@ export class MenubarPart extends Part {
 				}
 			});
 		}
+
+		this.container.on(EventType.FOCUS_OUT, (e) => {
+			let event = e as FocusEvent;
+
+			if (event.relatedTarget) {
+				if (!this.container.getHTMLElement().contains(event.relatedTarget as HTMLElement)) {
+					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+				}
+			}
+		});
 	}
 
 	private focusPrevious(): void {
+
 		if (!this.focusedMenu) {
 			return;
 		}
@@ -592,7 +723,13 @@ export class MenubarPart extends Part {
 			return;
 		}
 
-		this.toggleCustomMenu(newFocusedIndex);
+		if (this.isOpen) {
+			this.cleanupCustomMenu();
+			this.showCustomMenu(newFocusedIndex);
+		} else if (this.isFocused) {
+			this.focusedMenu.index = newFocusedIndex;
+			this.customMenus[newFocusedIndex].buttonElement.domFocus();
+		}
 	}
 
 	private focusNext(): void {
@@ -606,7 +743,13 @@ export class MenubarPart extends Part {
 			return;
 		}
 
-		this.toggleCustomMenu(newFocusedIndex);
+		if (this.isOpen) {
+			this.cleanupCustomMenu();
+			this.showCustomMenu(newFocusedIndex);
+		} else if (this.isFocused) {
+			this.focusedMenu.index = newFocusedIndex;
+			this.customMenus[newFocusedIndex].buttonElement.domFocus();
+		}
 	}
 
 	private getMenubarMenus(): IMenubarData {
@@ -665,31 +808,13 @@ export class MenubarPart extends Part {
 			if (this.focusedMenu.widget) {
 				this.focusedMenu.widget.dispose();
 			}
+
+			this.focusedMenu = { index: this.focusedMenu.index };
 		}
-
-		this.focusedMenu = null;
 	}
 
-	public focusCustomMenu(menuTitle: string): void {
-		this.toggleCustomMenu(0);
-	}
-
-	private toggleCustomMenu(menuIndex: number): void {
+	private showCustomMenu(menuIndex: number): void {
 		const customMenu = this.customMenus[menuIndex];
-
-		if (this.focusedMenu) {
-			let hiding: boolean = this.isCurrentMenu(menuIndex);
-
-			// Need to cleanup currently displayed menu
-			this.cleanupCustomMenu();
-
-			// Hiding this menu
-			if (hiding) {
-				return;
-			}
-		}
-
-		customMenu.buttonElement.domFocus();
 
 		let menuHolder = $(customMenu.buttonElement).div({ class: 'menubar-menu-items-holder' });
 
@@ -711,14 +836,12 @@ export class MenubarPart extends Part {
 		let menuWidget = this._register(new Menu(menuHolder.getHTMLElement(), customMenu.actions, menuOptions));
 
 		this._register(menuWidget.onDidCancel(() => {
-			this.cleanupCustomMenu();
-			this.isFocused = false;
+			this.focusState = MenubarState.FOCUSED;
 		}));
 
 		this._register(menuWidget.onDidBlur(() => {
 			setTimeout(() => {
 				this.cleanupCustomMenu();
-				this.isFocused = false;
 			}, 100);
 		}));
 

--- a/src/vs/workbench/browser/parts/menubar/menubarPart.ts
+++ b/src/vs/workbench/browser/parts/menubar/menubarPart.ts
@@ -154,10 +154,6 @@ export class MenubarPart extends Part {
 		this.actionRunner = this._register(new ActionRunner());
 		this._register(this.actionRunner.onDidBeforeRun(() => {
 			this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
-			if (this.focusToReturn) {
-				this.focusToReturn.domFocus();
-				this.focusToReturn = null;
-			}
 		}));
 
 		this._onVisibilityChange = this._register(new Emitter<Dimension>());
@@ -255,7 +251,13 @@ export class MenubarPart extends Part {
 
 				if (this.isFocused) {
 					this.focusedMenu = null;
+
+					if (this.focusToReturn) {
+						this.focusToReturn.domFocus();
+						this.focusToReturn = null;
+					}
 				}
+
 
 				break;
 			case MenubarState.VISIBLE:
@@ -273,6 +275,11 @@ export class MenubarPart extends Part {
 					}
 
 					this.focusedMenu = null;
+
+					if (this.focusToReturn) {
+						this.focusToReturn.domFocus();
+						this.focusToReturn = null;
+					}
 				}
 
 				break;
@@ -718,6 +725,7 @@ export class MenubarPart extends Part {
 
 			if (event.relatedTarget) {
 				if (!this.container.getHTMLElement().contains(event.relatedTarget as HTMLElement)) {
+					this.focusToReturn = null;
 					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
 				}
 			}


### PR DESCRIPTION
Please try this out with toggle setting enabled and without. Lots of code churn here because my previous focused behavior was poorly defined. I don't know how much better the new implementation but the idea is to work like a state machine with the following guidelines. If you plan to change `MenubarState`, update the focused menu and set the new state. If you are not modifying the state, you must handle the menu behavior yourself.