### PR TITLE
Set diff editor border to match regular editor border. 

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -33,7 +33,7 @@ import { ColorId, MetadataConsts, FontStyle } from 'vs/editor/common/modes';
 import Event, { Emitter } from 'vs/base/common/event';
 import * as editorOptions from 'vs/editor/common/config/editorOptions';
 import { registerThemingParticipant, IThemeService, ITheme, getThemeTypeSelector } from 'vs/platform/theme/common/themeService';
-import { scrollbarShadow, diffInserted, diffRemoved, defaultInsertColor, defaultRemoveColor, diffInsertedOutline, diffRemovedOutline } from 'vs/platform/theme/common/colorRegistry';
+import { scrollbarShadow, diffInserted, diffRemoved, defaultInsertColor, defaultRemoveColor, diffInsertedOutline, diffRemovedOutline, diffBorder } from 'vs/platform/theme/common/colorRegistry';
 import { Color } from 'vs/base/common/color';
 import { OverviewRulerZone } from 'vs/editor/common/view/overviewZoneManager';
 import { IEditorWhitespace } from 'vs/editor/common/viewLayout/whitespaceComputer';
@@ -2029,5 +2029,10 @@ registerThemingParticipant((theme, collector) => {
 	let shadow = theme.getColor(scrollbarShadow);
 	if (shadow) {
 		collector.addRule(`.monaco-diff-editor.side-by-side .editor.modified { box-shadow: -6px 0 5px -5px ${shadow}; }`);
+	}
+
+	let border = theme.getColor(diffBorder);
+	if (border) {
+		collector.addRule(`.monaco-diff-editor.side-by-side .editor.modified { border-left: 1px solid ${border}; }`);
 	}
 });

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -280,7 +280,7 @@ export const diffRemoved = registerColor('diffEditor.removedTextBackground', { d
 export const diffInsertedOutline = registerColor('diffEditor.insertedTextBorder', { dark: null, light: null, hc: '#33ff2eff' }, nls.localize('diffEditorInsertedOutline', 'Outline color for the text that got inserted.'));
 export const diffRemovedOutline = registerColor('diffEditor.removedTextBorder', { dark: null, light: null, hc: '#FF008F' }, nls.localize('diffEditorRemovedOutline', 'Outline color for text that got removed.'));
 
-export const diffBorder = registerColor('diffEditor.diffEditorBorder', { dark: '#444444', light: '#E7E7E7', hc: contrastBorder }, nls.localize('diffEditorBorder', 'Border color of separation between original and modified diff editors.'));
+export const diffBorder = registerColor('diffEditor.diffEditorBorder', { dark: '#444444', light: '#E7E7E7', hc: contrastBorder }, nls.localize('diffEditorBorder', 'Border color between the original and modified diff editors.'));
 
 /**
  * Merge-conflict colors

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -280,6 +280,8 @@ export const diffRemoved = registerColor('diffEditor.removedTextBackground', { d
 export const diffInsertedOutline = registerColor('diffEditor.insertedTextBorder', { dark: null, light: null, hc: '#33ff2eff' }, nls.localize('diffEditorInsertedOutline', 'Outline color for the text that got inserted.'));
 export const diffRemovedOutline = registerColor('diffEditor.removedTextBorder', { dark: null, light: null, hc: '#FF008F' }, nls.localize('diffEditorRemovedOutline', 'Outline color for text that got removed.'));
 
+export const diffBorder = registerColor('diffEditor.diffEditorBorder', { dark: '#444444', light: '#E7E7E7', hc: contrastBorder }, nls.localize('diffEditorBorder', 'Border color of separation between original and modified diff editors.'));
+
 /**
  * Merge-conflict colors
  */


### PR DESCRIPTION
Set diff editor border to match regular editor border. 
Solves issue with no shadow showing no diff between editors.
Solves [#53523](https://github.com/Microsoft/vscode/issues/53523)