### PR TITLE
Transform languageId of zh-cn,zh-tw to zh-hans,zh-hant when pull tran…

### DIFF
--- a/build/npm/update-localization-extension.js
+++ b/build/npm/update-localization-extension.js
@@ -43,7 +43,12 @@ function update(idOrPath) {
 		let apiToken = process.env.TRANSIFEX_API_TOKEN;
 		let languageId = localization.transifexId || localization.languageId;
 		let translationDataFolder = path.join(locExtFolder, 'translations');
-
+		if (languageId === "zh-cn") {
+			languageId = "zh-hans";
+		}
+		if (languageId === "zh-tw") {
+			languageId = "zh-hant";
+		}
 		if (fs.existsSync(translationDataFolder) && fs.existsSync(path.join(translationDataFolder, 'main.i18n.json'))) {
 			console.log('Clearing  \'' + translationDataFolder + '\'...');
 			rimraf.sync(translationDataFolder);


### PR DESCRIPTION
…slation from Transifex.
When translation project was setup in Transifex, new languageId standard was adapted (zh-hans, zh-hant). While in vscode, keeping using legacy languageId (zh-cn, zh-tw).
In order for the automation work, need to transform languageId read from package.json to what Transifex understands.
The change has been tested with zh-cn, zh-tw (worked) and other languages (no impact.)