### PR TITLE
Sort opening editors in alphabetical order

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -35,6 +35,8 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	showIcons: true,
 	enablePreview: true,
 	openPositioning: 'right',
+	openPositioningSortOrder: 'asc',
+	openPositioningSortRule: 'name-local',
 	openSideBySideDirection: 'right',
 	closeEmptyGroups: true,
 	labelFormat: 'default',

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -982,6 +982,8 @@ export interface IWorkbenchEditorPartConfiguration {
 	enablePreviewFromQuickOpen?: boolean;
 	closeOnFileDelete?: boolean;
 	openPositioning?: 'left' | 'right' | 'first' | 'last';
+	openPositioningSortOrder?: 'asc' | 'desc';
+	openPositioningSortRule?: 'name-local' | 'name-absolute' | 'absolute';
 	openSideBySideDirection?: 'right' | 'down';
 	closeEmptyGroups?: boolean;
 	revealIfOpen?: boolean;

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -222,9 +222,21 @@ configurationRegistry.registerConfiguration({
 		},
 		'workbench.editor.openPositioning': {
 			'type': 'string',
-			'enum': ['left', 'right', 'first', 'last'],
+			'enum': ['left', 'right', 'first', 'last', 'sort'],
 			'default': 'right',
-			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'editorOpenPositioning' }, "Controls where editors open. Select 'left' or 'right' to open editors to the left or right of the currently active one. Select 'first' or 'last' to open editors independently from the currently active one.")
+			'description': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'editorOpenPositioning' }, "Controls where editors open. Select 'left' or 'right' to open editors to the left or right of the currently active one. Select 'first' or 'last' to open editors independently from the currently active one. Select 'sort' to open editors in alphabetical order.")
+		},
+		'workbench.editor.openPositioningSortOrder': {
+			'type': 'string',
+			'enum': ['asc', 'desc'],
+			'default': 'asc',
+			'description': nls.localize('openPositioningSortOrder', "Controls in which direction the open editors are sorted.")
+		},
+		'workbench.editor.openPositioningSortRule': {
+			'type': 'string',
+			'enum': ['name-local', 'name-absolute', 'absolute'],
+			'default': 'name-local',
+			'description': nls.localize('openPositioningSortRule', "Controls how the open editors are sorted.")
 		},
 		'workbench.editor.openSideBySideDirection': {
 			'type': 'string',


### PR DESCRIPTION
Hello,

The setting `workbench.editor.openPositioning` has a new possibility: `sort`.

It can be controlled by 2 new settings:
- `workbench.editor.openPositioningSortOrder`: `'asc' | 'desc'`
- `workbench.editor.openPositioningSortRule`: `'name-local' | 'name-absolute' | 'absolute'`

It can resolve the issue: #12453