### PR TITLE
Increase menu font size

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.css
+++ b/src/vs/base/browser/ui/menu/menu.css
@@ -53,6 +53,7 @@
 	padding: 0.8em 1em;
 	line-height: 1.1em;
 	background: none;
+	font-size: inherit;
 }
 
 .monaco-menu .monaco-action-bar.vertical .keybinding,

--- a/src/vs/workbench/browser/parts/menubar/media/menubarpart.css
+++ b/src/vs/workbench/browser/parts/menubar/media/menubarpart.css
@@ -6,7 +6,6 @@
 .monaco-workbench > .part.menubar {
 	display: flex;
 	position: absolute;
-	font-size: 12px;
 	box-sizing: border-box;
 	padding-left: 35px;
 	padding-right: 138px;

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -6,7 +6,6 @@
 .monaco-workbench > .part.titlebar {
 	box-sizing: border-box;
 	width: 100%;
-	font-size: 12px;
 	padding: 0 70px;
 	overflow: hidden;
 	flex-shrink: 0;


### PR DESCRIPTION
I can barely read the menus on my system, because it is 2px shorter than our default UI font size. Here is the difference for this PR (left is 13px, right is current 11px). IMO this makes a big difference and looks much better:

![screenshot from 2018-07-11 16-13-13](https://user-images.githubusercontent.com/22350/42577913-b1ebd386-8525-11e8-940a-a1fa214ddc00.png)
