### PR TITLE
Built-in language features extensions should show languages as contributions

### DIFF
--- a/extensions/css-language-features/package.json
+++ b/extensions/css-language-features/package.json
@@ -26,6 +26,32 @@
     "Programming Languages"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "css",
+        "aliases": [
+          "CSS"
+        ],
+        "extensions": [
+          ".css"
+        ]
+      },
+      {
+        "id": "less",
+        "aliases": [
+          "Less"
+        ]
+      },
+      {
+        "id": "scss",
+        "aliases": [
+          "SCSS"
+        ],
+        "extensions": [
+          ".scss"
+        ]
+      }
+    ],
     "configuration": [
       {
         "order": 22,

--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -26,6 +26,28 @@
     "Programming Languages"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "html",
+        "extensions": [
+          ".html",
+          ".htm",
+          ".shtml",
+          ".xhtml",
+          ".mdoc",
+          ".jsp",
+          ".asp",
+          ".aspx",
+          ".jshtm",
+          ".volt",
+          ".ejs",
+          ".rhtml"
+        ],
+        "aliases": [
+          "HTML"
+        ]
+      }
+    ],
     "configuration": {
       "id": "html",
       "order": 20,

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -24,6 +24,34 @@
     "Programming Languages"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "json",
+        "aliases": [
+          "JSON"
+        ],
+        "extensions": [
+          ".json",
+          ".bowerrc",
+          ".jshintrc",
+          ".jscsrc",
+          ".eslintrc",
+          ".babelrc",
+          ".webmanifest",
+          ".js.map",
+          ".css.map"
+        ]
+      },
+      {
+        "id": "jsonc",
+        "aliases": [
+          "JSON with Comments"
+        ],
+        "extensions": [
+          ".jsonc"
+        ]
+      }
+    ],
     "configuration": {
       "id": "json",
       "order": 20,

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -26,6 +26,20 @@
 		"onWebviewPanel:markdown.preview"
 	],
 	"contributes": {
+		"languages": [
+			{
+				"id": "markdown",
+				"aliases": [
+					"Markdown"
+				],
+				"extensions": [
+					".md",
+					".mdown",
+					".markdown",
+					".markdn"
+				]
+			}
+		],
 		"commands": [
 			{
 				"command": "markdown.showPreview",

--- a/extensions/php-language-features/package.json
+++ b/extensions/php-language-features/package.json
@@ -16,6 +16,21 @@
 		"Programming Languages"
 	],
 	"contributes": {
+		"languages": [
+			{
+				"id": "php",
+				"extensions": [
+					".php",
+					".php4",
+					".php5",
+					".phtml",
+					".ctp"
+				],
+				"aliases": [
+					"php"
+				]
+			}
+		],
 		"configuration": {
 			"title": "%configuration.title%",
 			"type": "object",

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -44,6 +44,47 @@
   ],
   "main": "./out/extension",
   "contributes": {
+    "languages": [
+      {
+        "id": "typescript",
+        "aliases": [
+          "TypeScript"
+        ],
+        "extensions": [
+          ".ts"
+        ]
+      },
+      {
+        "id": "typescriptreact",
+        "aliases": [
+          "TypeScript React"
+        ],
+        "extensions": [
+          ".tsx"
+        ]
+      },
+      {
+        "id": "javascriptreact",
+        "aliases": [
+          "JavaScript React"
+        ],
+        "extensions": [
+          ".jsx"
+        ]
+      },
+      {
+        "id": "javascript",
+        "aliases": [
+          "JavaScript"
+        ],
+        "extensions": [
+          ".js",
+          ".es6",
+          ".mjs",
+          ".pac"
+        ]
+      }
+    ],
     "jsonValidation": [
       {
         "fileMatch": "package.json",

--- a/src/vs/workbench/services/mode/common/workbenchModeService.ts
+++ b/src/vs/workbench/services/mode/common/workbenchModeService.ts
@@ -31,7 +31,7 @@ export interface IRawLanguageExtensionPoint {
 }
 
 export const languagesExtPoint: IExtensionPoint<IRawLanguageExtensionPoint[]> = ExtensionsRegistry.registerExtensionPoint<IRawLanguageExtensionPoint[]>('languages', [], {
-	description: nls.localize('vscode.extension.contributes.languages', 'Contributes language declarations.'),
+	description: nls.localize('vscode.extension.contributes.languages', 'Contributes language features.'),
 	type: 'array',
 	items: {
 		type: 'object',

--- a/src/vs/workbench/services/textMate/electron-browser/TMGrammars.ts
+++ b/src/vs/workbench/services/textMate/electron-browser/TMGrammars.ts
@@ -26,7 +26,7 @@ export interface ITMSyntaxExtensionPoint {
 }
 
 export const grammarsExtPoint: IExtensionPoint<ITMSyntaxExtensionPoint[]> = ExtensionsRegistry.registerExtensionPoint<ITMSyntaxExtensionPoint[]>('grammars', [languagesExtPoint], {
-	description: nls.localize('vscode.extension.contributes.grammars', 'Contributes textmate tokenizers.'),
+	description: nls.localize('vscode.extension.contributes.grammars', 'Contributes textmate tokenizers for languages.'),
 	type: 'array',
 	defaultSnippets: [{ body: [{ language: '${1:id}', scopeName: 'source.${2:id}', path: './syntaxes/${3:id}.tmLanguage.' }] }],
 	items: {


### PR DESCRIPTION
Related to #54098

This PR fixes the issue of built-in extensions that provide rich language features not showing the language in the **Contributions** section in the extension editor.

