### PR TITLE
Support multiple configurations in extension editor

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -96,7 +96,7 @@ export interface IColor {
 
 export interface IExtensionContributions {
 	commands?: ICommand[];
-	configuration?: IConfiguration;
+	configuration?: IConfiguration | IConfiguration[];
 	debuggers?: IDebugger[];
 	grammars?: IGrammar[];
 	jsonValidation?: IJSONValidation[];

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -594,12 +594,13 @@ export class ExtensionEditor extends BaseEditor {
 	private renderSettings(container: HTMLElement, manifest: IExtensionManifest, onDetailsToggle: Function): boolean {
 		const contributes = manifest.contributes;
 		const configuration = contributes && contributes.configuration;
-		let properties = configuration && configuration.properties;
-		if (!properties && Array.isArray(configuration)) {
-			properties = {};
+		let properties = {};
+		if (Array.isArray(configuration)) {
 			configuration.forEach(config => {
 				properties = { ...properties, ...config.properties };
 			});
+		} else if (configuration) {
+			properties = configuration.properties;
 		}
 		const contrib = properties ? Object.keys(properties) : [];
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -594,7 +594,13 @@ export class ExtensionEditor extends BaseEditor {
 	private renderSettings(container: HTMLElement, manifest: IExtensionManifest, onDetailsToggle: Function): boolean {
 		const contributes = manifest.contributes;
 		const configuration = contributes && contributes.configuration;
-		const properties = configuration && configuration.properties;
+		let properties = configuration && configuration.properties;
+		if (Array.isArray(configuration)) {
+			properties = {};
+			configuration.forEach(config => {
+				properties = { ...properties, ...config.properties };
+			});
+		}
 		const contrib = properties ? Object.keys(properties) : [];
 
 		if (!contrib.length) {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -595,7 +595,7 @@ export class ExtensionEditor extends BaseEditor {
 		const contributes = manifest.contributes;
 		const configuration = contributes && contributes.configuration;
 		let properties = configuration && configuration.properties;
-		if (Array.isArray(configuration)) {
+		if (!properties && Array.isArray(configuration)) {
 			properties = {};
 			configuration.forEach(config => {
 				properties = { ...properties, ...config.properties };


### PR DESCRIPTION
Related to #54098

The CSS Language Features extensions fails to show any settings in the "Contributions" section of the extensions editor. This is because it contributes to multiple configuration targets and the editor cannot support this case