### PR TITLE
add _workbench.enterWorkspace

### DIFF
--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -120,6 +120,7 @@ export interface IWindowsService {
 	openDevTools(windowId: number, options?: IDevToolsOptions): TPromise<void>;
 	toggleDevTools(windowId: number): TPromise<void>;
 	closeWorkspace(windowId: number): TPromise<void>;
+	enterWorkspace(windowId: number, path: string): TPromise<IEnterWorkspaceResult>;
 	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult>;
 	saveAndEnterWorkspace(windowId: number, path: string): TPromise<IEnterWorkspaceResult>;
 	toggleFullScreen(windowId: number): TPromise<void>;
@@ -200,6 +201,7 @@ export interface IWindowService {
 	toggleDevTools(): TPromise<void>;
 	closeWorkspace(): TPromise<void>;
 	updateTouchBar(items: ISerializableCommandAction[][]): TPromise<void>;
+	enterWorkspace(path: string): TPromise<IEnterWorkspaceResult>;
 	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult>;
 	saveAndEnterWorkspace(path: string): TPromise<IEnterWorkspaceResult>;
 	toggleFullScreen(): TPromise<void>;

--- a/src/vs/platform/windows/common/windowsIpc.ts
+++ b/src/vs/platform/windows/common/windowsIpc.ts
@@ -34,6 +34,7 @@ export interface IWindowsChannel extends IChannel {
 	call(command: 'reloadWindow', arg: [number, ParsedArgs]): TPromise<void>;
 	call(command: 'toggleDevTools', arg: number): TPromise<void>;
 	call(command: 'closeWorkspace', arg: number): TPromise<void>;
+	call(command: 'enterWorkspace', arg: [number, string]): TPromise<IEnterWorkspaceResult>;
 	call(command: 'createAndEnterWorkspace', arg: [number, IWorkspaceFolderCreationData[], string]): TPromise<IEnterWorkspaceResult>;
 	call(command: 'saveAndEnterWorkspace', arg: [number, string]): TPromise<IEnterWorkspaceResult>;
 	call(command: 'toggleFullScreen', arg: number): TPromise<void>;
@@ -120,6 +121,7 @@ export class WindowsChannel implements IWindowsChannel {
 			case 'openDevTools': return this.service.openDevTools(arg[0], arg[1]);
 			case 'toggleDevTools': return this.service.toggleDevTools(arg);
 			case 'closeWorkspace': return this.service.closeWorkspace(arg);
+			case 'enterWorkspace': return this.service.enterWorkspace(arg[0], arg[1]);
 			case 'createAndEnterWorkspace': {
 				const rawFolders: IWorkspaceFolderCreationData[] = arg[1];
 				let folders: IWorkspaceFolderCreationData[];
@@ -232,6 +234,10 @@ export class WindowsChannelClient implements IWindowsService {
 
 	closeWorkspace(windowId: number): TPromise<void> {
 		return this.channel.call('closeWorkspace', windowId);
+	}
+
+	enterWorkspace(windowId: number, path: string): TPromise<IEnterWorkspaceResult> {
+		return this.channel.call('enterWorkspace', [windowId, path]);
 	}
 
 	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult> {

--- a/src/vs/platform/windows/electron-browser/windowService.ts
+++ b/src/vs/platform/windows/electron-browser/windowService.ts
@@ -81,6 +81,10 @@ export class WindowService implements IWindowService {
 		return this.windowsService.closeWorkspace(this.windowId);
 	}
 
+	enterWorkspace(path: string): TPromise<IEnterWorkspaceResult> {
+		return this.windowsService.enterWorkspace(this.windowId, path);
+	}
+
 	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult> {
 		return this.windowsService.createAndEnterWorkspace(this.windowId, folders, path);
 	}

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -92,6 +92,7 @@ export interface IWindowsMainService {
 	// methods
 	ready(initialUserEnv: IProcessEnvironment): void;
 	reload(win: ICodeWindow, cli?: ParsedArgs): void;
+	enterWorkspace(win: ICodeWindow, path: string): TPromise<IEnterWorkspaceResult>;
 	createAndEnterWorkspace(win: ICodeWindow, folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult>;
 	saveAndEnterWorkspace(win: ICodeWindow, path: string): TPromise<IEnterWorkspaceResult>;
 	closeWorkspace(win: ICodeWindow): void;

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -171,6 +171,17 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		return TPromise.as(null);
 	}
 
+	enterWorkspace(windowId: number, path: string): TPromise<IEnterWorkspaceResult> {
+		this.logService.trace('windowsService#enterWorkspace', windowId);
+		const codeWindow = this.windowsMainService.getWindowById(windowId);
+
+		if (codeWindow) {
+			return this.windowsMainService.enterWorkspace(codeWindow, path);
+		}
+
+		return TPromise.as(null);
+	}
+
 	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult> {
 		this.logService.trace('windowsService#createAndEnterWorkspace', windowId);
 		const codeWindow = this.windowsMainService.getWindowById(windowId);

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -92,6 +92,8 @@ export interface IWorkspacesMainService extends IWorkspacesService {
 
 	createWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier;
 
+	resolveWorkspace(path: string): TPromise<IResolvedWorkspace>;
+
 	resolveWorkspaceSync(path: string): IResolvedWorkspace;
 
 	isUntitledWorkspace(workspace: IWorkspaceIdentifier): boolean;

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -58,6 +58,14 @@ export class WorkspacesMainService implements IWorkspacesMainService {
 		return this._onUntitledWorkspaceDeleted.event;
 	}
 
+	resolveWorkspace(path: string): TPromise<IResolvedWorkspace> {
+		if (!this.isWorkspacePath(path)) {
+			return TPromise.as(null); // does not look like a valid workspace config file
+		}
+
+		return readFile(path, 'utf8').then(contents => this.doResolveWorkspace(path, contents));
+	}
+
 	resolveWorkspaceSync(path: string): IResolvedWorkspace {
 		if (!this.isWorkspacePath(path)) {
 			return null; // does not look like a valid workspace config file

--- a/src/vs/workbench/api/electron-browser/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWorkspace.ts
@@ -10,7 +10,7 @@ import URI, { UriComponents } from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IFileMatch, IFolderQuery, IPatternInfo, IQueryOptions, ISearchConfiguration, ISearchQuery, ISearchService, QueryType } from 'vs/platform/search/common/search';
 import { IStatusbarService } from 'vs/platform/statusbar/common/statusbar';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
@@ -19,6 +19,7 @@ import { QueryBuilder } from 'vs/workbench/parts/search/common/queryBuilder';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IWorkspaceEditingService } from 'vs/workbench/services/workspace/common/workspaceEditing';
 import { ExtHostContext, ExtHostWorkspaceShape, IExtHostContext, MainContext, MainThreadWorkspaceShape } from '../node/extHost.protocol';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 @extHostNamedCustomer(MainContext.MainThreadWorkspace)
 export class MainThreadWorkspace implements MainThreadWorkspaceShape {
@@ -210,3 +211,9 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 		});
 	}
 }
+
+CommandsRegistry.registerCommand('_workbench.enterWorkspace', function (accessor: ServicesAccessor, workspace: URI) {
+	const workspaceEditingService = accessor.get(IWorkspaceEditingService);
+
+	return workspaceEditingService.enterWorkspace(workspace.fsPath);
+});

--- a/src/vs/workbench/services/workspace/common/workspaceEditing.ts
+++ b/src/vs/workbench/services/workspace/common/workspaceEditing.ts
@@ -34,6 +34,11 @@ export interface IWorkspaceEditingService {
 	updateFolders(index: number, deleteCount?: number, foldersToAdd?: IWorkspaceFolderCreationData[], donotNotifyError?: boolean): TPromise<void>;
 
 	/**
+	 * enters the workspace with the provided path.
+	 */
+	enterWorkspace(path: string): TPromise<void>;
+
+	/**
 	 * creates a new workspace with the provided folders and opens it. if path is provided
 	 * the workspace will be saved into that location.
 	 */

--- a/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
@@ -144,6 +144,10 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		return false;
 	}
 
+	enterWorkspace(path: string): TPromise<void> {
+		return this.doEnterWorkspace(() => this.windowService.enterWorkspace(path));
+	}
+
 	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<void> {
 		return this.doEnterWorkspace(() => this.windowService.createAndEnterWorkspace(folders, path));
 	}

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -1009,6 +1009,10 @@ export class TestWindowService implements IWindowService {
 		return TPromise.as(void 0);
 	}
 
+	enterWorkspace(path: string): TPromise<IEnterWorkspaceResult> {
+		return TPromise.as(void 0);
+	}
+
 	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): TPromise<IEnterWorkspaceResult> {
 		return TPromise.as(void 0);
 	}
@@ -1159,6 +1163,10 @@ export class TestWindowsService implements IWindowsService {
 	}
 
 	closeWorkspace(windowId: number): TPromise<void> {
+		return TPromise.as(void 0);
+	}
+
+	enterWorkspace(windowId: number, path: string): TPromise<IEnterWorkspaceResult> {
 		return TPromise.as(void 0);
 	}
 


### PR DESCRIPTION
Related to https://github.com/Microsoft/vscode/issues/35109 (but not a full fix for it). Fixes https://github.com/Microsoft/vscode/issues/54335

This enables LiveShare to enter a workspace without window reload:

```
vscode.commands.executeCommand('_workbench.enterWorkspace', vscode.Uri.file('<path to workspace file'));
```

This is not a general mechanism for switching without window reload, it only works best if the target workspace was never opened before, because:
* untitled files in the target workspace will not be merged with the current windows untitled files (they will end up as new untitled files in an empty window)
* the UI state is overwritten from the current workspace into the target workspace
* no UI state from the target workspace is restored

As a result of calling this command, the extension host will still restart.

/cc @egamma 