### PR TITLE
Add new cases to lose focus

### DIFF
--- a/src/vs/workbench/browser/parts/menubar/menubarPart.ts
+++ b/src/vs/workbench/browser/parts/menubar/menubarPart.ts
@@ -151,7 +151,7 @@ export class MenubarPart extends Part {
 
 		this.actionRunner = this._register(new ActionRunner());
 		this._register(this.actionRunner.onDidBeforeRun(() => {
-			this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+			this.setUnfocusedState();
 		}));
 
 		this._onVisibilityChange = this._register(new Emitter<Dimension>());
@@ -330,13 +330,7 @@ export class MenubarPart extends Part {
 				this.container.removeClass('inactive');
 			} else {
 				this.container.addClass('inactive');
-				if (!hasFocus) {
-					if (this.isVisible && this.currentMenubarVisibility === 'toggle') {
-						this.focusState = MenubarState.HIDDEN;
-					} else if (this.isFocused) {
-						this.focusState = MenubarState.VISIBLE;
-					}
-				}
+				this.setUnfocusedState();
 			}
 		}
 	}
@@ -345,6 +339,10 @@ export class MenubarPart extends Part {
 		if (this.keys.some(key => event.affectsConfiguration(key))) {
 			this.setupMenubar();
 		}
+	}
+
+	private setUnfocusedState(): void {
+		this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
 	}
 
 	private hideMenubar(): void {
@@ -377,7 +375,7 @@ export class MenubarPart extends Part {
 				this.focusedMenu = { index: 0 };
 				this.focusState = MenubarState.FOCUSED;
 			} else if (!this.isOpen) {
-				this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+				this.setUnfocusedState();
 			}
 		}
 
@@ -678,7 +676,7 @@ export class MenubarPart extends Part {
 
 					if (this.isOpen) {
 						if (this.isCurrentMenu(menuIndex)) {
-							this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+							this.setUnfocusedState();
 						} else {
 							this.cleanupCustomMenu();
 							this.showCustomMenu(menuIndex);
@@ -716,7 +714,7 @@ export class MenubarPart extends Part {
 				} else if (event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Tab)) {
 					this.focusNext();
 				} else if (event.equals(KeyCode.Escape) && this.isFocused && !this.isOpen) {
-					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+					this.setUnfocusedState();
 				} else {
 					eventHandled = false;
 				}
@@ -728,9 +726,9 @@ export class MenubarPart extends Part {
 			});
 
 			this._register($(window).on(EventType.CLICK, () => {
-				// This click is outide the menubar so it counts as a focus out
+				// This click is outside the menubar so it counts as a focus out
 				if (this.isFocused) {
-					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+					this.setUnfocusedState();
 				}
 			}));
 		}
@@ -751,7 +749,7 @@ export class MenubarPart extends Part {
 			if (event.relatedTarget) {
 				if (!this.container.getHTMLElement().contains(event.relatedTarget as HTMLElement)) {
 					this.focusToReturn = null;
-					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+					this.setUnfocusedState();
 				}
 			}
 		});

--- a/src/vs/workbench/browser/parts/menubar/menubarPart.ts
+++ b/src/vs/workbench/browser/parts/menubar/menubarPart.ts
@@ -330,6 +330,13 @@ export class MenubarPart extends Part {
 				this.container.removeClass('inactive');
 			} else {
 				this.container.addClass('inactive');
+				if (!hasFocus) {
+					if (this.isVisible && this.currentMenubarVisibility === 'toggle') {
+						this.focusState = MenubarState.HIDDEN;
+					} else if (this.isFocused) {
+						this.focusState = MenubarState.VISIBLE;
+					}
+				}
 			}
 		}
 	}
@@ -664,7 +671,7 @@ export class MenubarPart extends Part {
 					}
 				});
 
-				this.customMenus[menuIndex].buttonElement.on(EventType.CLICK, () => {
+				this.customMenus[menuIndex].buttonElement.on(EventType.CLICK, (e) => {
 					if (this._modifierKeyStatus && (this._modifierKeyStatus.shiftKey || this._modifierKeyStatus.ctrlKey)) {
 						return; // supress keyboard shortcuts that shouldn't conflict
 					}
@@ -680,6 +687,9 @@ export class MenubarPart extends Part {
 						this.focusedMenu = { index: menuIndex };
 						this.focusState = MenubarState.OPEN;
 					}
+
+					e.preventDefault();
+					e.stopPropagation();
 				});
 
 				this.customMenus[menuIndex].buttonElement.on(EventType.MOUSE_ENTER, () => {
@@ -716,6 +726,13 @@ export class MenubarPart extends Part {
 					event.stopPropagation();
 				}
 			});
+
+			this._register($(window).on(EventType.CLICK, () => {
+				// This click is outide the menubar so it counts as a focus out
+				if (this.isFocused) {
+					this.focusState = this.currentMenubarVisibility === 'toggle' ? MenubarState.HIDDEN : MenubarState.VISIBLE;
+				}
+			}));
 		}
 
 		this.container.on(EventType.FOCUS_IN, (e) => {


### PR DESCRIPTION
ref #54092

1) Losing window focus should stop focusing menubar
2) Clicking a dom element (even a non-focusable one) that isn't the menubar should stop focusing menubar.
