### PR TITLE
Add Focus search list command. Fixes #53696 

### DIFF
--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -671,3 +671,11 @@ export const clearHistoryCommand: ICommandHandler = accessor => {
 	const searchHistoryService = accessor.get(ISearchHistoryService);
 	searchHistoryService.clearHistory();
 };
+
+export const focusSearchListCommand: ICommandHandler = accessor => {
+	const viewletService = accessor.get(IViewletService);
+	const panelService = accessor.get(IPanelService);
+	openSearchView(viewletService, panelService).then(searchView => {
+		searchView.moveFocusToResults();
+	});
+};

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -732,6 +732,10 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 		return promise;
 	}
 
+	public moveFocusToResults(): void {
+		this.tree.domFocus();
+	}
+
 	public focus(): void {
 		super.focus();
 

--- a/src/vs/workbench/parts/search/common/constants.ts
+++ b/src/vs/workbench/parts/search/common/constants.ts
@@ -16,6 +16,7 @@ export const CopyPathCommandId = 'search.action.copyPath';
 export const CopyMatchCommandId = 'search.action.copyMatch';
 export const CopyAllCommandId = 'search.action.copyAll';
 export const ClearSearchHistoryCommandId = 'search.action.clearHistory';
+export const FocusSearchListCommandID = 'search.action.focusSearchList';
 export const ReplaceActionId = 'search.action.replace';
 export const ReplaceAllInFileActionId = 'search.action.replaceAllInFile';
 export const ReplaceAllInFolderActionId = 'search.action.replaceAllInFolder';

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -52,7 +52,7 @@ import { getMultiSelectedResources } from 'vs/workbench/parts/files/browser/file
 import { Schemas } from 'vs/base/common/network';
 import { PanelRegistry, Extensions as PanelExtensions, PanelDescriptor } from 'vs/workbench/browser/panel';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
-import { openSearchView, getSearchView, ReplaceAllInFolderAction, ReplaceAllAction, CloseReplaceAction, FocusNextSearchResultAction, FocusPreviousSearchResultAction, ReplaceInFilesAction, FindInFilesAction, toggleCaseSensitiveCommand, toggleRegexCommand, CollapseDeepestExpandedLevelAction, toggleWholeWordCommand, RemoveAction, ReplaceAction, ClearSearchResultsAction, copyPathCommand, copyMatchCommand, copyAllCommand, clearHistoryCommand, FocusNextInputAction, FocusPreviousInputAction, RefreshAction } from 'vs/workbench/parts/search/browser/searchActions';
+import { openSearchView, getSearchView, ReplaceAllInFolderAction, ReplaceAllAction, CloseReplaceAction, FocusNextSearchResultAction, FocusPreviousSearchResultAction, ReplaceInFilesAction, FindInFilesAction, toggleCaseSensitiveCommand, toggleRegexCommand, CollapseDeepestExpandedLevelAction, toggleWholeWordCommand, RemoveAction, ReplaceAction, ClearSearchResultsAction, copyPathCommand, copyMatchCommand, copyAllCommand, clearHistoryCommand, FocusNextInputAction, FocusPreviousInputAction, RefreshAction, focusSearchListCommand } from 'vs/workbench/parts/search/browser/searchActions';
 import { VIEW_ID, ISearchConfigurationProperties } from 'vs/platform/search/common/search';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
@@ -330,6 +330,19 @@ MenuRegistry.appendMenuItem(MenuId.SearchContext, {
 	group: 'search_9',
 	order: 1
 });
+
+CommandsRegistry.registerCommand({
+	id: Constants.FocusSearchListCommandID,
+	handler: focusSearchListCommand
+});
+
+const focusSearchListCommandLabel = nls.localize('focusSearchListCommandLabel', "Focus List");
+const FocusSearchListCommand: ICommandAction = {
+	id: Constants.FocusSearchListCommandID,
+	title: focusSearchListCommandLabel,
+	category
+};
+MenuRegistry.addCommand(FocusSearchListCommand);
 
 const FIND_IN_FOLDER_ID = 'filesExplorer.findInFolder';
 CommandsRegistry.registerCommand({


### PR DESCRIPTION
Adds "Search: Focus List" command to focus the Search results from the editor view.
Addressed #53696 