### PR TITLE
SelectBox: Implement logic for vertical flip of dropdown: Fixes: #53780

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
@@ -3,6 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* Use custom CSS vars to expose padding into parent select for padding calculation */
+.monaco-select-box-dropdown-padding {
+	--dropdown-padding-top: 1px;
+	--dropdown-padding-bottom: 1px;
+}
+
+.hc-black .monaco-select-box-dropdown-padding {
+	--dropdown-padding-top: 3px;
+	--dropdown-padding-bottom: 4px;
+}
+
 .monaco-select-box-dropdown-container {
 	display: none;
 }
@@ -18,8 +29,8 @@
 .monaco-select-box-dropdown-container > .select-box-dropdown-list-container {
 	flex: 0 0 auto;
 	align-self: flex-start;
-	padding-bottom: 1px;
-	padding-top: 1px;
+	padding-top: var(--dropdown-padding-top);
+	padding-bottom: var(--dropdown-padding-bottom);
 	padding-left: 1px;
 	padding-right: 1px;
 	width: 100%;
@@ -32,8 +43,8 @@
 }
 
 .hc-black .monaco-select-box-dropdown-container > .select-box-dropdown-list-container {
-	padding-bottom: 4px;
-	padding-top: 3px;
+	padding-top: var(--dropdown-padding-top);
+	padding-bottom: var(--dropdown-padding-bottom);
 }
 
 .monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row > .option-text {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -12,7 +12,7 @@ import { KeyCode, KeyCodeUtils } from 'vs/base/common/keyCodes';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import * as dom from 'vs/base/browser/dom';
 import * as arrays from 'vs/base/common/arrays';
-import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
+import { IContextViewProvider, AnchorPosition } from 'vs/base/browser/ui/contextview/contextview';
 import { List } from 'vs/base/browser/ui/list/listWidget';
 import { IVirtualDelegate, IRenderer } from 'vs/base/browser/ui/list/list';
 import { domEvent } from 'vs/base/browser/event';
@@ -79,6 +79,8 @@ class SelectListRenderer implements IRenderer<ISelectOptionItem, ISelectListTemp
 export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISelectOptionItem> {
 
 	private static readonly DEFAULT_DROPDOWN_MINIMUM_BOTTOM_MARGIN = 32;
+	private static readonly DEFAULT_DROPDOWN_MINIMUM_TOP_MARGIN = 42;
+	private static readonly DEFAULT_MINIMUM_VISIBLE_OPTIONS = 3;
 
 	private _isVisible: boolean;
 	private selectBoxOptions: ISelectBoxOptions;
@@ -97,6 +99,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 	private selectDropDownListContainer: HTMLElement;
 	private widthControlElement: HTMLElement;
 	private _currentSelection: number;
+	private _dropDownPosition: AnchorPosition;
 
 	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles, selectBoxOptions?: ISelectBoxOptions) {
 
@@ -111,7 +114,8 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		}
 
 		this.selectElement = document.createElement('select');
-		this.selectElement.className = 'monaco-select-box';
+		// Use custom CSS vars for padding calculation
+		this.selectElement.className = 'monaco-select-box monaco-select-box-dropdown-padding';
 
 		this._onDidSelect = new Emitter<ISelectData>();
 		this.styles = styles;
@@ -137,7 +141,8 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		// SetUp ContextView container to hold select Dropdown
 		this.contextViewProvider = contextViewProvider;
 		this.selectDropDownContainer = dom.$('.monaco-select-box-dropdown-container');
-
+		// Use custom CSS vars for padding calculation (shared with parent select)
+		dom.addClass(this.selectDropDownContainer, 'monaco-select-box-dropdown-padding');
 		// Setup list for drop-down select
 		this.createSelectList(this.selectDropDownContainer);
 
@@ -147,6 +152,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		this.widthControlElement = document.createElement('span');
 		this.widthControlElement.className = 'option-text-width-control';
 		dom.append(widthControlInnerDiv, this.widthControlElement);
+
+		// Always default to below position
+		this._dropDownPosition = AnchorPosition.BELOW;
 
 		// Inline stylesheet for themes
 		this.styleElement = dom.createStyleSheet(this.selectDropDownContainer);
@@ -363,7 +371,6 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		return option;
 	}
 
-	// Non-native select list handling
 	// ContextView dropdown methods
 
 	private showSelectDropDown() {
@@ -371,8 +378,12 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			return;
 		}
 
+		// Set drop-down position above/below from required height and margins
+		this.layoutSelectDropDown(true);
+
 		this._isVisible = true;
 		this.cloneElementFont(this.selectElement, this.selectDropDownContainer);
+
 		this.contextViewProvider.showContextView({
 			getAnchor: () => this.selectElement,
 			render: (container: HTMLElement) => this.renderSelectDropDown(container),
@@ -380,8 +391,11 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			onHide: () => {
 				dom.toggleClass(this.selectDropDownContainer, 'visible', false);
 				dom.toggleClass(this.selectElement, 'synthetic-focus', false);
-			}
+			},
+			anchorPosition: this._dropDownPosition
 		});
+
+		// Track initial selection the case user escape, blur
 		this._currentSelection = this.selected;
 	}
 
@@ -407,36 +421,62 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		};
 	}
 
-	private layoutSelectDropDown() {
+	private layoutSelectDropDown(preLayoutPosition?: boolean) {
 
 		// Layout ContextView drop down select list and container
-		// Have to manage our vertical overflow, sizing
-		// Need to be visible to measure
+		// Have to manage our vertical overflow, sizing, position below or above
+		// Position has to be determined and set prior to contextView instantiation
 
-		dom.toggleClass(this.selectDropDownContainer, 'visible', true);
-
-		const selectWidth = dom.getTotalWidth(this.selectElement);
-		const selectPosition = dom.getDomNodePagePosition(this.selectElement);
-
-		// Set container height to max from select bottom to margin (default/minBottomMargin)
-		let maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin);
-
-		if (maxSelectDropDownHeight < 0) {
-			maxSelectDropDownHeight = 0;
-		}
-
-		// SetUp list dimensions and layout - account for container padding
 		if (this.selectList) {
+
+			const selectPosition = dom.getDomNodePagePosition(this.selectElement);
+			const styles = getComputedStyle(this.selectElement);
+			const verticalPadding = parseFloat(styles.getPropertyValue('--dropdown-padding-top')) + parseFloat(styles.getPropertyValue('--dropdown-padding-bottom'));
+			let maxSelectDropDownHeight = 0;
+			maxSelectDropDownHeight = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin);
+
 			this.selectList.layout();
 			let listHeight = this.selectList.contentHeight;
-			const listContainerHeight = dom.getTotalHeight(this.selectDropDownListContainer);
-			const totalVerticalListPadding = listContainerHeight - listHeight;
 
-			// Always show complete list items - never more than Max available vertical height
-			if (listContainerHeight > maxSelectDropDownHeight) {
-				listHeight = ((Math.floor((maxSelectDropDownHeight - totalVerticalListPadding) / this.getHeight())) * this.getHeight());
+			// If we are only doing pre-layout check/adjust position only
+			// Calculate vertical space available, flip up if insufficient
+			// Use reflected padding on parent select, ContextView style properties not available before DOM attachment
+			if (preLayoutPosition) {
+
+				// Always show complete list items - never more than Max available vertical height
+				if (listHeight + verticalPadding > maxSelectDropDownHeight) {
+					const maxVisibleOptions = ((Math.floor((maxSelectDropDownHeight - verticalPadding) / this.getHeight())));
+
+					// Check if we can at least show min items otherwise flip above
+					if (maxVisibleOptions < SelectBoxList.DEFAULT_MINIMUM_VISIBLE_OPTIONS) {
+						this._dropDownPosition = AnchorPosition.ABOVE;
+					} else {
+						this._dropDownPosition = AnchorPosition.BELOW;
+					}
+				}
+				// Do full layout on showSelectDropDown only
+				return;
 			}
 
+			// Make visible to enable measurements
+			dom.toggleClass(this.selectDropDownContainer, 'visible', true);
+
+			// SetUp list dimensions and layout - account for container padding
+			// Use position to check above or below available space
+			if (this._dropDownPosition === AnchorPosition.BELOW) {
+				// Set container height to max from select bottom to margin (default/minBottomMargin)
+				if (listHeight + verticalPadding > maxSelectDropDownHeight) {
+					listHeight = ((Math.floor((maxSelectDropDownHeight - verticalPadding) / this.getHeight())) * this.getHeight());
+				}
+			} else {
+				// Set container height to max from select top to margin (default/minTopMargin)
+				maxSelectDropDownHeight = (selectPosition.top - SelectBoxList.DEFAULT_DROPDOWN_MINIMUM_TOP_MARGIN);
+				if (listHeight + verticalPadding > maxSelectDropDownHeight) {
+					listHeight = ((Math.floor((maxSelectDropDownHeight - SelectBoxList.DEFAULT_DROPDOWN_MINIMUM_TOP_MARGIN) / this.getHeight())) * this.getHeight());
+				}
+			}
+
+			// Set adjusted list height and relayout
 			this.selectList.layout(listHeight);
 			this.selectList.domFocus();
 
@@ -447,14 +487,26 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			}
 
 			// Set final container height after adjustments
-			this.selectDropDownContainer.style.height = (listHeight + totalVerticalListPadding) + 'px';
+			this.selectDropDownContainer.style.height = (listHeight + verticalPadding) + 'px';
 
 			// Determine optimal width - min(longest option), opt(parent select), max(ContextView controlled)
+			const selectWidth = dom.getTotalWidth(this.selectElement);
 			const selectMinWidth = this.setWidthControlElement(this.widthControlElement);
 			const selectOptimalWidth = Math.max(selectMinWidth, Math.round(selectWidth)).toString() + 'px';
 
-			this.selectDropDownContainer.style.minWidth = selectOptimalWidth;
+			console.debug('sW:sMinW:sOW: ' + selectWidth + ' ' + selectMinWidth + ' ' + selectOptimalWidth);
+			// this.selectDropDownContainer.style.minWidth = selectOptimalWidth;
+			this.selectDropDownContainer.style.width = selectOptimalWidth;
 
+			// this.selectDropDownContainer.style.height = '120px';
+			// this.selectDropDownContainer.style.width = '170px';
+			let styles2 = getComputedStyle(this.selectDropDownContainer);
+			console.debug('container ' + styles2.getPropertyValue('width'));
+			styles2 = getComputedStyle(this.selectDropDownListContainer);
+			console.debug('Lcontainer ' + styles2.getPropertyValue('width'));
+
+
+			// this.selectDropDownContainer.style.width = '155px'
 			// Maintain focus outline on parent select as well as list container - tabindex for focus
 			this.selectDropDownListContainer.setAttribute('tabindex', '0');
 			dom.toggleClass(this.selectElement, 'synthetic-focus', true);

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -494,19 +494,8 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			const selectMinWidth = this.setWidthControlElement(this.widthControlElement);
 			const selectOptimalWidth = Math.max(selectMinWidth, Math.round(selectWidth)).toString() + 'px';
 
-			console.debug('sW:sMinW:sOW: ' + selectWidth + ' ' + selectMinWidth + ' ' + selectOptimalWidth);
-			// this.selectDropDownContainer.style.minWidth = selectOptimalWidth;
 			this.selectDropDownContainer.style.width = selectOptimalWidth;
 
-			// this.selectDropDownContainer.style.height = '120px';
-			// this.selectDropDownContainer.style.width = '170px';
-			let styles2 = getComputedStyle(this.selectDropDownContainer);
-			console.debug('container ' + styles2.getPropertyValue('width'));
-			styles2 = getComputedStyle(this.selectDropDownListContainer);
-			console.debug('Lcontainer ' + styles2.getPropertyValue('width'));
-
-
-			// this.selectDropDownContainer.style.width = '155px'
 			// Maintain focus outline on parent select as well as list container - tabindex for focus
 			this.selectDropDownListContainer.setAttribute('tabindex', '0');
 			dom.toggleClass(this.selectElement, 'synthetic-focus', true);


### PR DESCRIPTION
@roblourens 
Congratulations !  The new settings configuration is now the biggest client of selectBox.
Hopefully it will do do justice ;-)

cc: @bpasero 

I had to be a lot more clever about the logic for flipping the drop-down.  Mainly there are tricky aspects
to the contextView in terms of determining dimensions before rendering.  I came up with something
I think is reasonably elegant exposing the padding to the parent select box which is always rendered while maintaining padding variables within the CSS.

Given these changes,  and a couple others I want to get in for July including the aria fixes ,  would you like me to add a test item?

Change Notes:

- If it is determined that the drop-down list will not fit below the parent select check:
    - If at least (3) select items will fit , maintain drop-down below
    - If there are more than three items, utilize scrollbar drop-down still below
    - Otherwise change contextIView position  to above

One can reproduce all of these scenarios using the settings preview which has many
select boxes with various numbers of items.  if one changes scroll position it is possible to see
the variety of scenarios.