### PR TITLE
Improve the macOptionClickForcesSelection message in terminal.contributions.ts

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -121,7 +121,7 @@ configurationRegistry.registerConfiguration({
 			'default': false
 		},
 		'terminal.integrated.macOptionClickForcesSelection': {
-			'description': nls.localize('terminal.integrated.macOptionClickForcesSelection', "Whether to force selection when when using option+click on macOS, this will force a regular (line) selection and disallow the use of column selection mode. This enables copying and pasting using the regular terminal selection when in tmux mouse mode for example."),
+			'description': nls.localize('terminal.integrated.macOptionClickForcesSelection', "Whether to force selection when using Option+click on macOS. This will force a regular (line) selection and disallow the use of column selection mode. This enables copying and pasting using the regular terminal selection, for example, when mouse mode is enabled in tmux."),
 			'type': 'boolean',
 			'default': false
 		},


### PR DESCRIPTION
Added by @Tyriar with dcb35c91468f9bbbff8f487b7261e99f2c6736c6
Removed an extra when, and rephrased the single sentence to multiple ones.