### PR TITLE
complex command typos and add dash between argument and descriptions

### DIFF
--- a/src/vs/editor/common/controller/cursorMoveCommands.ts
+++ b/src/vs/editor/common/controller/cursorMoveCommands.ts
@@ -607,7 +607,7 @@ export namespace CursorMove {
 						\`\`\`
 						'left', 'right', 'up', 'down'
 						'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter'
-						'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter',
+						'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter'
 						'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside'
 						\`\`\`
 					* 'by': Unit to move. Default is computed based on 'to' value.

--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -495,7 +495,7 @@ class UnfoldAction extends FoldingAction<FoldingArguments> {
 						name: 'Unfold editor argument',
 						description: `Property-value pairs that can be passed through this argument:
 						* 'levels': Number of levels to unfold. If not set, defaults to 1.
-						* 'direction': If 'up', unfold given number of levels up otherwise unfolds down
+						* 'direction': If 'up', unfold given number of levels up otherwise unfolds down.
 						* 'selectionLines': The start lines (0-based) of the editor selections to apply the unfold action to. If not set, the active selection(s) will be used.
 						`,
 						constraint: foldingArgumentsConstraint
@@ -557,8 +557,8 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 					{
 						name: 'Fold editor argument',
 						description: `Property-value pairs that can be passed through this argument:
-							* 'levels': Number of levels to fold. Defaults to 1
-							* 'direction': If 'up', folds given number of levels up otherwise folds down
+							* 'levels': Number of levels to fold. Defaults to 1.
+							* 'direction': If 'up', folds given number of levels up otherwise folds down.
 							* 'selectionLines': The start lines (0-based) of the editor selections to apply the fold action to. If not set, the active selection(s) will be used.
 						`,
 						constraint: foldingArgumentsConstraint

--- a/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
@@ -94,11 +94,11 @@ function _generateMarkdown(description: string | ICommandHandlerDescription): st
 		parts.push('\n\n');
 		if (description.args) {
 			for (let arg of description.args) {
-				parts.push(`* _${arg.name}_ ${arg.description || ''}\n`);
+				parts.push(`* _${arg.name}_ - ${arg.description || ''}\n`);
 			}
 		}
 		if (description.returns) {
-			parts.push(`* _(returns)_ ${description.returns}`);
+			parts.push(`* _(returns)_ - ${description.returns}`);
 		}
 		parts.push('\n\n');
 		return parts.join('');

--- a/src/vs/workbench/api/node/extHostApiCommands.ts
+++ b/src/vs/workbench/api/node/extHostApiCommands.ts
@@ -253,7 +253,7 @@ export class ExtHostApiCommands {
 		});
 
 		this._register(SetEditorLayoutAPICommand.ID, adjustHandler(SetEditorLayoutAPICommand.execute), {
-			description: 'Sets the editor layout. The layout is described as object with an initial (optional) orientation (0 = horizontal, 1 = vertical) and an array of editor groups within. Each editor group can have a size and another array of editor groups that will be layed out orthogonal to the orientation. If editor group sizes are provided, their sum must be 1 to be applied per row or column. Example for a 2x2 grid: `{ orientation: 0, groups: [{ groups: [{}, {}], size: 0.5 }, { groups: [{}, {}], size: 0.5 }] }`',
+			description: 'Sets the editor layout. The layout is described as object with an initial (optional) orientation (0 = horizontal, 1 = vertical) and an array of editor groups within. Each editor group can have a size and another array of editor groups that will be laid out orthogonal to the orientation. If editor group sizes are provided, their sum must be 1 to be applied per row or column. Example for a 2x2 grid: `{ orientation: 0, groups: [{ groups: [{}, {}], size: 0.5 }, { groups: [{}, {}], size: 0.5 }] }`',
 			args: [
 				{ name: 'layout', description: 'The editor layout to set.', constraint: (value: EditorGroupLayout) => typeof value === 'object' && Array.isArray(value.groups) }
 			]


### PR DESCRIPTION
Adding a dash to separate italics arguments from desciptions.

Before:

![image](https://user-images.githubusercontent.com/12818376/42716938-d3d4fdcc-86b2-11e8-8b75-b0173068d30b.png)

Now:

![image](https://user-images.githubusercontent.com/12818376/42716912-b7c5c436-86b2-11e8-9765-6fcbaca2351d.png)
