### PR TITLE
Show "Go to Implementation" in the Context Menu

### DIFF
--- a/src/vs/editor/contrib/goToDefinition/goToDefinitionCommands.ts
+++ b/src/vs/editor/contrib/goToDefinition/goToDefinitionCommands.ts
@@ -277,6 +277,10 @@ export class GoToImplementationAction extends ImplementationAction {
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.F12
+			},
+			menuOpts: {
+				group: 'navigation',
+				order: 1.3
 			}
 		});
 	}


### PR DESCRIPTION
When initally implemented in #18346, Go to Implementation was listed on the menu, after which it was replaced there with #19699 in favor of Go to Type Definition.

Since the LSP [stabilised in 3.6](https://github.com/Microsoft/language-server-protocol/commit/e4e92487b2d164aa7cb6e36216267a0c99e7167a) the Go to Implementation alongside Go to Type Definition, I believe we should bring it back to the menu to help discover the feature.

It's only populated in the menu only when there's an implementation provider for current document selector, so overpopulating the menu shouldn't be a problem.

I know that Rust folks should be happy with this addition (being able to navigate via trait implementations is very helpful, in fact we're just switching from using our own custom 'find impls' command/menu item to LSP 3.6 in https://github.com/rust-lang-nursery/rls/pull/936), but I believe the same can be said for other devs (e.g. [Java](https://github.com/redhat-developer/vscode-java/issues/446)).