### PR TITLE
SelectBox: Use offsetWidth to exclude margins. Fixes: #54292

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -489,8 +489,8 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			// Set final container height after adjustments
 			this.selectDropDownContainer.style.height = (listHeight + verticalPadding) + 'px';
 
-			// Determine optimal width - min(longest option), opt(parent select), max(ContextView controlled)
-			const selectWidth = dom.getTotalWidth(this.selectElement);
+			// Determine optimal width - min(longest option), opt(parent select, excluding margins), max(ContextView controlled)
+			const selectWidth = this.selectElement.offsetWidth;
 			const selectMinWidth = this.setWidthControlElement(this.widthControlElement);
 			const selectOptimalWidth = Math.max(selectMinWidth, Math.round(selectWidth)).toString() + 'px';
 


### PR DESCRIPTION
Fixes: #54292

Calculation for drop-down needs to use offsetWidth on the parent select to not include
margins.