### PR TITLE
SelectBox: Catch duplicate contextView disposal. Fixes: #54296

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -417,7 +417,15 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 
 		this.layoutSelectDropDown();
 		return {
-			dispose: () => container.removeChild(this.selectDropDownContainer) // remove to take out the CSS rules we add
+			dispose: () => {
+				// contextView will dispose itself if moving from one View to another
+				try {
+					container.removeChild(this.selectDropDownContainer); // remove to take out the CSS rules we add
+				}
+				catch (error) {
+					// Ignore, removed already by change of focus
+				}
+			}
 		};
 	}
 


### PR DESCRIPTION
#54296 

Catch and ignore exception on duplicate child removal when base contextView has already
disposed and removed child on focus change.