### PR TITLE
Finalize definition link

### DIFF
--- a/extensions/typescript-language-features/src/features/definitions.ts
+++ b/extensions/typescript-language-features/src/features/definitions.ts
@@ -17,12 +17,7 @@ export default class TypeScriptDefinitionProvider extends DefinitionProviderBase
 		super(client);
 	}
 
-	public async provideDefinition() {
-		// Implemented by provideDefinition2
-		return undefined;
-	}
-
-	public async provideDefinition2(
+	public async provideDefinition(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		token: vscode.CancellationToken | boolean

--- a/extensions/typescript-language-features/src/features/definitions.ts
+++ b/extensions/typescript-language-features/src/features/definitions.ts
@@ -44,10 +44,11 @@ export default class TypeScriptDefinitionProvider extends DefinitionProviderBase
 				const span = response.body.textSpan ? typeConverters.Range.fromTextSpan(response.body.textSpan) : undefined;
 				return locations
 					.map(location => {
-						const loc = typeConverters.Location.fromTextSpan(this.client.toResource(location.file), location);
-						return {
-							origin: span,
-							...loc,
+						const target = typeConverters.Location.fromTextSpan(this.client.toResource(location.file), location);
+						return <vscode.DefinitionLink>{
+							originSelectionRange: span,
+							targetRange: target.range,
+							targetUri: target.uri,
 						};
 					});
 			} catch {

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -565,7 +565,7 @@ export interface ImplementationProvider {
 	/**
 	 * Provide the implementation of the symbol at the given position and document.
 	 */
-	provideImplementation(model: model.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideImplementation(model: model.ITextModel, position: Position, token: CancellationToken): DefinitionLink | Thenable<DefinitionLink>;
 }
 
 /**
@@ -576,7 +576,7 @@ export interface TypeDefinitionProvider {
 	/**
 	 * Provide the type definition of the symbol at the given position and document.
 	 */
-	provideTypeDefinition(model: model.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+	provideTypeDefinition(model: model.ITextModel, position: Position, token: CancellationToken): DefinitionLink | Thenable<DefinitionLink>;
 }
 
 /**

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4933,7 +4933,7 @@ declare namespace monaco.languages {
 		/**
 		 * Provide the implementation of the symbol at the given position and document.
 		 */
-		provideImplementation(model: editor.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+		provideImplementation(model: editor.ITextModel, position: Position, token: CancellationToken): DefinitionLink | Thenable<DefinitionLink>;
 	}
 
 	/**
@@ -4944,7 +4944,7 @@ declare namespace monaco.languages {
 		/**
 		 * Provide the type definition of the symbol at the given position and document.
 		 */
-		provideTypeDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): Definition | Thenable<Definition>;
+		provideTypeDefinition(model: editor.ITextModel, position: Position, token: CancellationToken): DefinitionLink | Thenable<DefinitionLink>;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2157,11 +2157,46 @@ declare module 'vscode' {
 	}
 
 	/**
+	 * Information about where a symbol is defined.
+	 *
+	 * Provides additional metadata over normal [location](#Location) definitions, including the range of
+	 * the defining symbol
+	 */
+	export interface DefinitionLink {
+		/**
+		 * Span of the symbol being defined in the source file.
+		 *
+		 * Used as the underlined span for mouse definition hover. Defaults to the word range at
+		 * the definition position.
+		 */
+		originSelectionRange?: Range;
+
+		/**
+		 * The resource identifier of the definition.
+		 */
+		targetUri: Uri;
+
+		/**
+		 * The full range of the definition.
+		 *
+		 * For a class definition for example, this would be the entire body of the class definition.
+		 */
+		targetRange: Range;
+
+		/**
+		 * The span of the symbol definition.
+		 *
+		 * For a class definition, this would be the class name itself in the class definition.
+		 */
+		targetSelectionRange?: Range;
+	}
+
+	/**
 	 * The definition of a symbol represented as one or many [locations](#Location).
 	 * For most programming languages there is only one location at which a symbol is
 	 * defined.
 	 */
-	export type Definition = Location | Location[];
+	export type Definition = Location | Location[] | DefinitionLink[];
 
 	/**
 	 * The definition provider interface defines the contract between extensions and

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2196,7 +2196,7 @@ declare module 'vscode' {
 	 * For most programming languages there is only one location at which a symbol is
 	 * defined.
 	 */
-	export type Definition = Location | Location[] | DefinitionLink[];
+	export type Definition = Location | Location[];
 
 	/**
 	 * The definition provider interface defines the contract between extensions and
@@ -2214,7 +2214,7 @@ declare module 'vscode' {
 		 * @return A definition or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+		provideDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | DefinitionLink[]>;
 	}
 
 	/**
@@ -2232,7 +2232,7 @@ declare module 'vscode' {
 		 * @return A definition or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideImplementation(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+		provideImplementation(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | DefinitionLink[]>;
 	}
 
 	/**
@@ -2250,7 +2250,7 @@ declare module 'vscode' {
 		 * @return A definition or a thenable that resolves to such. The lack of a result can be
 		 * signaled by returning `undefined` or `null`.
 		 */
-		provideTypeDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition>;
+		provideTypeDefinition(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | DefinitionLink[]>;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1070,26 +1070,26 @@ declare module 'vscode' {
 		 * Used as the underlined span for mouse definition hover. Defaults to the word range at
 		 * the definition position.
 		 */
-		origin?: Range;
+		originSelectionRange?: Range;
 
 		/**
 		 * The resource identifier of the definition.
 		 */
-		uri: Uri;
+		targetUri: Uri;
 
 		/**
 		 * The full range of the definition.
 		 *
 		 * For a class definition for example, this would be the entire body of the class definition.
 		 */
-		range: Range;
+		targetRange: Range;
 
 		/**
 		 * The span of the symbol definition.
 		 *
 		 * For a class definition, this would be the class name itself in the class definition.
 		 */
-		selectionRange?: Range;
+		targetSelectionRange?: Range;
 	}
 
 	export interface DefinitionProvider {

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1054,47 +1054,4 @@ declare module 'vscode' {
 		export const onDidRenameFile: Event<FileRenameEvent>;
 	}
 	//#endregion
-
-	//#region Matt: Deinition range
-
-	/**
-	 * Information about where a symbol is defined.
-	 *
-	 * Provides additional metadata over normal [location](#Location) definitions, including the range of
-	 * the defining symbol
-	 */
-	export interface DefinitionLink {
-		/**
-		 * Span of the symbol being defined in the source file.
-		 *
-		 * Used as the underlined span for mouse definition hover. Defaults to the word range at
-		 * the definition position.
-		 */
-		originSelectionRange?: Range;
-
-		/**
-		 * The resource identifier of the definition.
-		 */
-		targetUri: Uri;
-
-		/**
-		 * The full range of the definition.
-		 *
-		 * For a class definition for example, this would be the entire body of the class definition.
-		 */
-		targetRange: Range;
-
-		/**
-		 * The span of the symbol definition.
-		 *
-		 * For a class definition, this would be the class name itself in the class definition.
-		 */
-		targetSelectionRange?: Range;
-	}
-
-	export interface DefinitionProvider {
-		provideDefinition2?(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Definition | DefinitionLink[]>;
-	}
-
-	//#endregion
 }

--- a/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadLanguageFeatures.ts
@@ -162,7 +162,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 	$registerImplementationSupport(handle: number, selector: ISerializedDocumentFilter[]): void {
 		this._registrations[handle] = modes.ImplementationProviderRegistry.register(typeConverters.LanguageSelector.from(selector), <modes.ImplementationProvider>{
 			provideImplementation: (model, position, token): Thenable<modes.Definition> => {
-				return wireCancellationToken(token, this._proxy.$provideImplementation(handle, model.uri, position)).then(MainThreadLanguageFeatures._reviveLocationDto);
+				return wireCancellationToken(token, this._proxy.$provideImplementation(handle, model.uri, position)).then(MainThreadLanguageFeatures._reviveDefinitionLinkDto);
 			}
 		});
 	}
@@ -170,7 +170,7 @@ export class MainThreadLanguageFeatures implements MainThreadLanguageFeaturesSha
 	$registerTypeDefinitionSupport(handle: number, selector: ISerializedDocumentFilter[]): void {
 		this._registrations[handle] = modes.TypeDefinitionProviderRegistry.register(typeConverters.LanguageSelector.from(selector), <modes.TypeDefinitionProvider>{
 			provideTypeDefinition: (model, position, token): Thenable<modes.Definition> => {
-				return wireCancellationToken(token, this._proxy.$provideTypeDefinition(handle, model.uri, position)).then(MainThreadLanguageFeatures._reviveLocationDto);
+				return wireCancellationToken(token, this._proxy.$provideTypeDefinition(handle, model.uri, position)).then(MainThreadLanguageFeatures._reviveDefinitionLinkDto);
 			}
 		});
 	}

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -812,8 +812,8 @@ export interface ExtHostLanguageFeaturesShape {
 	$provideCodeLenses(handle: number, resource: UriComponents): TPromise<modes.ICodeLensSymbol[]>;
 	$resolveCodeLens(handle: number, resource: UriComponents, symbol: modes.ICodeLensSymbol): TPromise<modes.ICodeLensSymbol>;
 	$provideDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<DefinitionLinkDto[]>;
-	$provideImplementation(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
-	$provideTypeDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<LocationDto | LocationDto[]>;
+	$provideImplementation(handle: number, resource: UriComponents, position: IPosition): TPromise<DefinitionLinkDto[]>;
+	$provideTypeDefinition(handle: number, resource: UriComponents, position: IPosition): TPromise<DefinitionLinkDto[]>;
 	$provideHover(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.Hover>;
 	$provideDocumentHighlights(handle: number, resource: UriComponents, position: IPosition): TPromise<modes.DocumentHighlight[]>;
 	$provideReferences(handle: number, resource: UriComponents, position: IPosition, context: modes.ReferenceContext): TPromise<LocationDto[]>;

--- a/src/vs/workbench/api/node/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/node/extHostLanguageFeatures.ts
@@ -166,14 +166,15 @@ class DefinitionAdapter {
 
 	private static convertDefinitionLink(value: vscode.Location | vscode.DefinitionLink): modes.DefinitionLink {
 		const definitionLink = <vscode.DefinitionLink>value;
+		const location = <vscode.Location>value;
 		return {
-			origin: definitionLink.origin
-				? typeConvert.Range.from(definitionLink.origin)
+			origin: definitionLink.originSelectionRange
+				? typeConvert.Range.from(definitionLink.originSelectionRange)
 				: undefined,
-			uri: value.uri,
-			range: typeConvert.Range.from(value.range),
-			selectionRange: definitionLink.selectionRange
-				? typeConvert.Range.from(definitionLink.selectionRange)
+			uri: definitionLink.targetUri ? definitionLink.targetUri : location.uri,
+			range: typeConvert.Range.from(definitionLink.targetRange ? definitionLink.targetRange : location.range),
+			selectionRange: definitionLink.targetSelectionRange
+				? typeConvert.Range.from(definitionLink.targetSelectionRange)
 				: undefined,
 		};
 	}

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -413,6 +413,23 @@ export const location = {
 	}
 };
 
+export namespace DefinitionLink {
+	export function from(value: vscode.Location | vscode.DefinitionLink): modes.DefinitionLink {
+		const definitionLink = <vscode.DefinitionLink>value;
+		const location = <vscode.Location>value;
+		return {
+			origin: definitionLink.originSelectionRange
+				? Range.from(definitionLink.originSelectionRange)
+				: undefined,
+			uri: definitionLink.targetUri ? definitionLink.targetUri : location.uri,
+			range: Range.from(definitionLink.targetRange ? definitionLink.targetRange : location.range),
+			selectionRange: definitionLink.targetSelectionRange
+				? Range.from(definitionLink.targetSelectionRange)
+				: undefined,
+		};
+	}
+}
+
 export namespace Hover {
 	export function from(hover: vscode.Hover): modes.Hover {
 		return <modes.Hover>{


### PR DESCRIPTION
- Gives fields more explicit names to definition link fields (target and origin)
- Moves api to `vscode.d.ts`
- Makes other definition providers (such as type definition provider and implementation provider) also return definition links