### PR TITLE
SelectBox: Add setAriaLabel() Fixes: #54412

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -23,6 +23,7 @@ export interface ISelectBoxDelegate {
 	readonly onDidSelect: Event<ISelectData>;
 	setOptions(options: string[], selected?: number, disabled?: number): void;
 	select(index: number): void;
+	setAriaLabel(label: string);
 	focus(): void;
 	blur(): void;
 	dispose(): void;
@@ -88,6 +89,10 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 
 	public select(index: number): void {
 		this.selectBoxDelegate.select(index);
+	}
+
+	public setAriaLabel(label: string): void {
+		this.selectBoxDelegate.setAriaLabel(label);
 	}
 
 	public focus(): void {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -276,6 +276,12 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		this.selectElement.title = this.options[this.selected];
 	}
 
+	public setAriaLabel(label: string): void {
+		this.selectBoxOptions.ariaLabel = label;
+		this.selectElement.setAttribute('aria-label', this.selectBoxOptions.ariaLabel);
+		this.selectList.getHTMLElement().setAttribute('aria-label', this.selectBoxOptions.ariaLabel);
+	}
+
 	public focus(): void {
 		if (this.selectElement) {
 			this.selectElement.focus();

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -108,6 +108,11 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 		this.selectElement.title = this.options[this.selected];
 	}
 
+	public setAriaLabel(label: string): void {
+		this.selectBoxOptions.ariaLabel = label;
+		this.selectElement.setAttribute('aria-label', label);
+	}
+
 	public focus(): void {
 		if (this.selectElement) {
 			this.selectElement.focus();


### PR DESCRIPTION
Add setAriaLabel() to enable clients to set label after constructor.  

Fixes: #54412

