### PR TITLE
Workaround duplicate rendered characters in Electron 2.0.x

### DIFF
--- a/src/vs/editor/browser/services/codeEditorServiceImpl.ts
+++ b/src/vs/editor/browser/services/codeEditorServiceImpl.ts
@@ -212,7 +212,7 @@ class DecorationTypeOptionsProvider implements IModelDecorationOptionsProvider {
 
 const _CSS_MAP: { [prop: string]: string; } = {
 	color: 'color:{0} !important;',
-	opacity: 'opacity:{0}; will-change: opacity;',
+	opacity: 'opacity:{0}; will-change: opacity;', // TODO@Ben: 'will-change: opacity' is a workaround for https://github.com/Microsoft/vscode/issues/52196
 	backgroundColor: 'background-color:{0};',
 
 	outline: 'outline:{0};',

--- a/src/vs/editor/browser/services/codeEditorServiceImpl.ts
+++ b/src/vs/editor/browser/services/codeEditorServiceImpl.ts
@@ -212,7 +212,7 @@ class DecorationTypeOptionsProvider implements IModelDecorationOptionsProvider {
 
 const _CSS_MAP: { [prop: string]: string; } = {
 	color: 'color:{0} !important;',
-	opacity: 'opacity:{0};',
+	opacity: 'opacity:{0}; will-change: opacity;',
 	backgroundColor: 'background-color:{0};',
 
 	outline: 'outline:{0};',

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1805,7 +1805,7 @@ registerThemingParticipant((theme, collector) => {
 
 	const unnecessaryForeground = theme.getColor(editorUnnecessaryCodeOpacity);
 	if (unnecessaryForeground) {
-		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { opacity: ${unnecessaryForeground.rgba.a}; will-change: opacity; }`);
+		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { opacity: ${unnecessaryForeground.rgba.a}; will-change: opacity; }`); // TODO@Ben: 'will-change: opacity' is a workaround for https://github.com/Microsoft/vscode/issues/52196
 	}
 
 	const unnecessaryBorder = theme.getColor(editorUnnecessaryCodeBorder);

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1805,7 +1805,7 @@ registerThemingParticipant((theme, collector) => {
 
 	const unnecessaryForeground = theme.getColor(editorUnnecessaryCodeOpacity);
 	if (unnecessaryForeground) {
-		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { opacity: ${unnecessaryForeground.rgba.a}; }`);
+		collector.addRule(`.${SHOW_UNUSED_ENABLED_CLASS} .monaco-editor .${ClassName.EditorUnnecessaryInlineDecoration} { opacity: ${unnecessaryForeground.rgba.a}; will-change: opacity; }`);
 	}
 
 	const unnecessaryBorder = theme.getColor(editorUnnecessaryCodeBorder);


### PR DESCRIPTION
This is a PR for `electron-2.0.x` branch (not master) with an attempt to workaround https://github.com/Microsoft/vscode/issues/52196.

We suspect the issue lies within Skia and thus hope is little to get this backported to Electron. As a workaround, putting those `span` elements with `opacity` on a separate drawing layer seems to fix this issue. This impacts:
* our unused variables style
* decorations from extensions that leverage `opacity`

