### PR TITLE
Settings: Utilize selectBox.setAriaLabel Related: #53821

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -908,6 +908,9 @@ export class SettingsRenderer implements IRenderer {
 		const displayOptions = dataElement.setting.enum.map(escapeInvisibleChars);
 		template.selectBox.setOptions(displayOptions);
 
+		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel;
+		template.selectBox.setAriaLabel(label);
+
 		const idx = dataElement.setting.enum.indexOf(dataElement.value);
 		template.onChange = null;
 		template.selectBox.select(idx);


### PR DESCRIPTION
@roblourens 
I patched in the new setAriaLabel method using the combination of category and description.

You have a lot of potential reader labels.  This label sets both the parent select(unexpanded state)
as well as the label on the list(expanded state).  I noticed no label is read when the select gets focus,
the list label is read when the drop down this expanded.  I am assuming one of the parent labels
from the settings tree is overridng the select. That is probably how you want it.

If you want to hand in anything else , glad to take assignments.