### PR TITLE
Move collapseDeepestExpandedLevel action implementation out of tree

### DIFF
--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -110,13 +110,6 @@ export interface ITree {
 	collapseAll(elements?: any[], recursive?: boolean): WinJS.Promise;
 
 	/**
-	 * Collapses several elements.
-	 * Collapses all elements at the greatest tree depth that has expanded elements.
-	 * The returned promise returns a boolean for whether the elements were collapsed or not.
-	 */
-	collapseDeepestExpandedLevel(): WinJS.Promise;
-
-	/**
 	 * Toggles an element's expansion state.
 	 */
 	toggleExpansion(element: any, recursive?: boolean): WinJS.Promise;

--- a/src/vs/base/parts/tree/browser/treeImpl.ts
+++ b/src/vs/base/parts/tree/browser/treeImpl.ts
@@ -184,10 +184,6 @@ export class Tree implements _.ITree {
 		return this.model.collapseAll(elements, recursive);
 	}
 
-	public collapseDeepestExpandedLevel(): WinJS.Promise {
-		return this.model.collapseDeepestExpandedLevel();
-	}
-
 	public toggleExpansion(element: any, recursive: boolean = false): WinJS.Promise {
 		return this.model.toggleExpansion(element, recursive);
 	}

--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -559,17 +559,6 @@ export class Item {
 		return result;
 	}
 
-	public getChildren(): Item[] {
-		var child = this.firstChild;
-		var results = [];
-		while (child) {
-			results.push(child);
-			child = child.next;
-		}
-
-		return results;
-	}
-
 	private isAncestorOf(item: Item): boolean {
 		while (item) {
 			if (item.id === this.id) {
@@ -1038,27 +1027,6 @@ export class TreeModel {
 			promises.push(this.collapse(elements[i], recursive));
 		}
 		return WinJS.Promise.join(promises);
-	}
-
-	public collapseDeepestExpandedLevel(): WinJS.Promise {
-		var levelToCollapse = this.findDeepestExpandedLevel(this.input, 0);
-
-		var items = [this.input];
-		for (var i = 0; i < levelToCollapse; i++) {
-			items = arrays.flatten(items.map(node => node.getChildren()));
-		}
-
-		var promises = items.map(child => this.collapse(child, false));
-		return WinJS.Promise.join(promises);
-	}
-
-	private findDeepestExpandedLevel(item: Item, currentLevel: number): number {
-		var expandedChildren = item.getChildren().filter(child => child.isExpanded());
-		if (!expandedChildren.length) {
-			return currentLevel;
-		}
-
-		return Math.max(...expandedChildren.map(child => this.findDeepestExpandedLevel(child, currentLevel + 1)));
 	}
 
 	public toggleExpansion(element: any, recursive: boolean = false): WinJS.Promise {

--- a/src/vs/base/parts/tree/test/browser/treeModel.test.ts
+++ b/src/vs/base/parts/tree/test/browser/treeModel.test.ts
@@ -613,23 +613,6 @@ suite('TreeModel - Expansion', () => {
 		});
 	});
 
-	test('collapseDeepestExpandedLevel', () => {
-		return model.setInput(SAMPLE.DEEP2).then(() => {
-			return model.expand(SAMPLE.DEEP2.children[0]).then(() => {
-				return model.expand(SAMPLE.DEEP2.children[0].children[0]).then(() => {
-
-					assert(model.isExpanded(SAMPLE.DEEP2.children[0]));
-					assert(model.isExpanded(SAMPLE.DEEP2.children[0].children[0]));
-
-					return model.collapseDeepestExpandedLevel().then(() => {
-						assert(model.isExpanded(SAMPLE.DEEP2.children[0]));
-						assert(!model.isExpanded(SAMPLE.DEEP2.children[0].children[0]));
-					});
-				});
-			});
-		});
-	});
-
 	test('auto expand single child folders', () => {
 		return model.setInput(SAMPLE.DEEP).then(() => {
 			return model.expand(SAMPLE.DEEP.children[0]).then(() => {

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -233,7 +233,34 @@ export class CollapseDeepestExpandedLevelAction extends Action {
 				return TPromise.as(null); // Global action disabled if user is in edit mode from another action
 			}
 
-			viewer.collapseDeepestExpandedLevel();
+			/**
+			 * The hierarchy is FolderMatch, FileMatch, Match. If the top level is FileMatches, then there is only
+			 * one level to collapse so collapse everything. If FolderMatch, check if there are visible grandchildren,
+			 * i.e. if Matches are returned by the navigator, and if so, collapse to them, otherwise collapse all levels.
+			 */
+			const navigator = viewer.getNavigator();
+			let node = navigator.first();
+			let collapseFileMatchLevel = false;
+			if (node instanceof FolderMatch) {
+				while (node = navigator.next()) {
+					if (node instanceof Match) {
+						collapseFileMatchLevel = true;
+						break;
+					}
+				}
+			}
+
+			if (collapseFileMatchLevel) {
+				node = navigator.first();
+				do {
+					if (node instanceof FileMatch) {
+						viewer.collapse(node);
+					}
+				} while (node = navigator.next());
+			} else {
+				viewer.collapseAll();
+			}
+
 			viewer.clearSelection();
 			viewer.clearFocus();
 			viewer.domFocus();


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/45397, removes the `collapseDeepestExpandedLevel` method from Tree and instead implements it in search actions

I'm not a huge fan of this change (I liked having it generic and on the tree 😄) since the new implementation relies on assumptions about the hierarchy of search result data, but I suppose this hierarchy is unlikely to change.

Let me know what you think.