### PR TITLE
Open release notes in product from changelog in built in extensions

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -494,7 +494,7 @@ export class ExtensionEditor extends BaseEditor {
 
 				this.activeWebview.onDidClickLink(link => {
 					// Whitelist supported schemes for links
-					if (link && ['http', 'https', 'mailto'].indexOf(link.scheme) >= 0) {
+					if (link && ['http', 'https', 'mailto', 'command'].indexOf(link.scheme) >= 0) {
 						this.openerService.open(link);
 					}
 				}, null, this.contentDisposables);

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -49,6 +49,7 @@ import { assign } from 'vs/base/common/objects';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { ExtensionsTree, IExtensionData } from 'vs/workbench/parts/extensions/browser/extensionsViewer';
+import { ShowCurrentReleaseNotesAction } from 'vs/workbench/parts/update/electron-browser/update';
 
 /**  A context key that is set when an extension editor webview has focus. */
 export const KEYBINDING_CONTEXT_EXTENSIONEDITOR_WEBVIEW_FOCUS = new RawContextKey<boolean>('extensionEditorWebviewFocus', undefined);
@@ -493,8 +494,11 @@ export class ExtensionEditor extends BaseEditor {
 				this.activeWebview.contents = body;
 
 				this.activeWebview.onDidClickLink(link => {
+					if (!link) {
+						return;
+					}
 					// Whitelist supported schemes for links
-					if (link && ['http', 'https', 'mailto', 'command'].indexOf(link.scheme) >= 0) {
+					if (['http', 'https', 'mailto'].indexOf(link.scheme) >= 0 || (link.scheme === 'command' && link.path === ShowCurrentReleaseNotesAction.ID)) {
 						this.openerService.open(link);
 					}
 				}, null, this.contentDisposables);

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -276,7 +276,7 @@ ${this.description}
 
 		if (!changelogUrl) {
 			if (this.type === LocalExtensionType.System) {
-				return TPromise.as(nls.localize('checkReleaseNotes', 'Please check the [VS Code Release Notes](https://code.visualstudio.com/updates) for changes to the built-in extensions.'));
+				return TPromise.as(nls.localize('checkReleaseNotes', 'Please check the [VS Code Release Notes](command:update.showCurrentReleaseNotes) for changes to the built-in extensions.'));
 			}
 
 			return TPromise.wrapError<string>(new Error('not available'));

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -276,7 +276,7 @@ ${this.description}
 
 		if (!changelogUrl) {
 			if (this.type === LocalExtensionType.System) {
-				return TPromise.as(nls.localize('checkReleaseNotes', 'Please check the [VS Code Release Notes](command:update.showCurrentReleaseNotes) for changes to the built-in extensions.'));
+				return TPromise.as('Please check the [VS Code Release Notes](command:update.showCurrentReleaseNotes) for changes to the built-in extensions.');
 			}
 
 			return TPromise.wrapError<string>(new Error('not available'));


### PR DESCRIPTION
Related to #54098

@mjbvz @sandy081, 
Do you foresee any issue in including `command` in the whitelist of supported schemas for links in the markdown webviews in the extension editor?
