### PR TITLE
Prefer const enum over const object in intervalTree.ts

### DIFF
--- a/src/vs/editor/common/model/intervalTree.ts
+++ b/src/vs/editor/common/model/intervalTree.ts
@@ -12,14 +12,14 @@ import { IModelDecoration, TrackedRangeStickiness as ActualTrackedRangeStickines
 // The red-black tree is based on the "Introduction to Algorithms" by Cormen, Leiserson and Rivest.
 //
 
-export const ClassName = {
-	EditorHintDecoration: 'squiggly-hint',
-	EditorInfoDecoration: 'squiggly-info',
-	EditorWarningDecoration: 'squiggly-warning',
-	EditorErrorDecoration: 'squiggly-error',
-	EditorUnnecessaryDecoration: 'squiggly-unnecessary',
-	EditorUnnecessaryInlineDecoration: 'squiggly-inline-unnecessary'
-};
+export const enum ClassName {
+	EditorHintDecoration = 'squiggly-hint',
+	EditorInfoDecoration = 'squiggly-info',
+	EditorWarningDecoration = 'squiggly-warning',
+	EditorErrorDecoration = 'squiggly-error',
+	EditorUnnecessaryDecoration = 'squiggly-unnecessary',
+	EditorUnnecessaryInlineDecoration = 'squiggly-inline-unnecessary'
+}
 
 /**
  * Describes the behavior of decorations when typing/editing near their edges.


### PR DESCRIPTION
I believe these are functionally equivalent provided no external library imports intervalTree.ts and depends on `ClassName`, the generated JS is much smaller though as the values get inlined:

```ts
export const a1 = {
	b: 'c'
};

console.log('1', a1.b);

const enum a2 {
	b = 'c'
};

console.log('2', a2.b);
```

Compiles to:

```js
define(["require", "exports"], function (require, exports) {
    "use strict";
    Object.defineProperty(exports, "__esModule", { value: true });
    exports.a1 = {
        b: 'c'
    };
    console.log('1', exports.a1.b);
    ;
    console.log('2', "c" /* b */);
});

```