### PR TITLE
Option to not receive extension updates

### DIFF
--- a/src/vs/workbench/parts/extensions/common/extensions.ts
+++ b/src/vs/workbench/parts/extensions/common/extensions.ts
@@ -98,12 +98,12 @@ export const ConfigurationKey = 'extensions';
 export const AutoUpdateConfigurationKey = 'extensions.autoUpdate';
 export const ShowRecommendationsOnlyOnDemandKey = 'extensions.showRecommendationsOnlyOnDemand';
 export const CloseExtensionDetailsOnViewChangeKey = 'extensions.closeExtensionDetailsOnViewChange';
-export const RecievesUpdatesConfigurationKey = 'extensions.recieveUpdates';
+export const ReceivesUpdatesConfigurationKey = 'extensions.receiveUpdates';
 
 export interface IExtensionsConfiguration {
 	autoUpdate: boolean;
 	ignoreRecommendations: boolean;
 	showRecommendationsOnlyOnDemand: boolean;
 	closeExtensionDetailsOnViewChange: boolean;
-	recieveUpdates: boolean;
+	receiveUpdates: boolean;
 }

--- a/src/vs/workbench/parts/extensions/common/extensions.ts
+++ b/src/vs/workbench/parts/extensions/common/extensions.ts
@@ -98,10 +98,12 @@ export const ConfigurationKey = 'extensions';
 export const AutoUpdateConfigurationKey = 'extensions.autoUpdate';
 export const ShowRecommendationsOnlyOnDemandKey = 'extensions.showRecommendationsOnlyOnDemand';
 export const CloseExtensionDetailsOnViewChangeKey = 'extensions.closeExtensionDetailsOnViewChange';
+export const RecievesUpdatesConfigurationKey = 'extensions.recieveUpdates';
 
 export interface IExtensionsConfiguration {
 	autoUpdate: boolean;
 	ignoreRecommendations: boolean;
 	showRecommendationsOnlyOnDemand: boolean;
 	closeExtensionDetailsOnViewChange: boolean;
+	recieveUpdates: boolean;
 }

--- a/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
@@ -223,9 +223,9 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				description: localize('extensionsCloseExtensionDetailsOnViewChange', "If set to true, editors with extension details will be automatically closed upon navigating away from the Extensions View."),
 				default: false
 			},
-			'extensions.recieveUpdates': {
+			'extensions.receiveUpdates': {
 				type: 'boolean',
-				description: localize('extensionsRecieveUpdates', "Configure whether you receive updates for outdated extensions."),
+				description: localize('extensionsReceiveUpdates', "If set to true, updates for outdated installed extensions will be fetched. If set to false, extension auto-update feature is disabled regardless of the value for the extensions.autoUpdate setting"),
 				default: true
 			}
 		}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
@@ -222,6 +222,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				type: 'boolean',
 				description: localize('extensionsCloseExtensionDetailsOnViewChange', "If set to true, editors with extension details will be automatically closed upon navigating away from the Extensions View."),
 				default: false
+			},
+			'extensions.recieveUpdates': {
+				type: 'boolean',
+				description: localize('extensionsRecieveUpdates', "Configure whether you receive updates for outdated extensions."),
+				default: true
 			}
 		}
 	});

--- a/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
@@ -204,7 +204,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		properties: {
 			'extensions.autoUpdate': {
 				type: 'boolean',
-				description: localize('extensionsAutoUpdate', "Automatically update extensions"),
+				description: localize('extensionsAutoUpdate', "Automatically update extensions. If the setting 'extensions.receiveUpdates' is set to false, then extensions will not be updated, regardless of this setting."),
 				default: true,
 				scope: ConfigurationScope.APPLICATION
 			},
@@ -225,7 +225,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			},
 			'extensions.receiveUpdates': {
 				type: 'boolean',
-				description: localize('extensionsReceiveUpdates', "If set to true, updates for outdated installed extensions will be fetched. If set to false, extension auto-update feature is disabled regardless of the value for the extensions.autoUpdate setting"),
+				description: localize('extensionsReceiveUpdates', "Receive updates for outdated extensions, but not automatically update them. If set to false, extension auto-update feature is disabled regardless of the value for the 'extensions.autoUpdate' setting"),
 				default: true
 			}
 		}

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -26,7 +26,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IWindowService } from 'vs/platform/windows/common/windows';
 import Severity from 'vs/base/common/severity';
 import URI from 'vs/base/common/uri';
-import { IExtension, IExtensionDependencies, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey } from 'vs/workbench/parts/extensions/common/extensions';
+import { IExtension, IExtensionDependencies, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, RecievesUpdatesConfigurationKey } from 'vs/workbench/parts/extensions/common/extensions';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IURLService, IURLHandler } from 'vs/platform/url/common/url';
 import { ExtensionsInput } from 'vs/workbench/parts/extensions/common/extensionsInput';
@@ -415,6 +415,9 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService, 
 					this.checkForUpdates();
 				}
 			}
+			if (e.affectsConfiguration(RecievesUpdatesConfigurationKey)) {
+				this.eventuallySyncWithGallery(true);
+			}
 		}, this, this.disposables);
 
 		this.queryLocal().done(() => this.eventuallySyncWithGallery(true));
@@ -610,7 +613,14 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService, 
 		return this.configurationService.getValue(AutoUpdateConfigurationKey);
 	}
 
+	private isRecieveUpdatesEnabled(): boolean {
+		return this.configurationService.getValue(RecievesUpdatesConfigurationKey);
+	}
+
 	private eventuallySyncWithGallery(immediate = false): void {
+		if (!this.isRecieveUpdatesEnabled()) {
+			return;
+		}
 		const loop = () => this.syncWithGallery().then(() => this.eventuallySyncWithGallery());
 		const delay = immediate ? 0 : ExtensionsWorkbenchService.SyncPeriod;
 

--- a/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/parts/extensions/node/extensionsWorkbenchService.ts
@@ -26,7 +26,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IWindowService } from 'vs/platform/windows/common/windows';
 import Severity from 'vs/base/common/severity';
 import URI from 'vs/base/common/uri';
-import { IExtension, IExtensionDependencies, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, RecievesUpdatesConfigurationKey } from 'vs/workbench/parts/extensions/common/extensions';
+import { IExtension, IExtensionDependencies, ExtensionState, IExtensionsWorkbenchService, AutoUpdateConfigurationKey, ReceivesUpdatesConfigurationKey } from 'vs/workbench/parts/extensions/common/extensions';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IURLService, IURLHandler } from 'vs/platform/url/common/url';
 import { ExtensionsInput } from 'vs/workbench/parts/extensions/common/extensionsInput';
@@ -410,12 +410,12 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService, 
 		urlService.registerHandler(this);
 
 		this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(AutoUpdateConfigurationKey)) {
+			if (e.affectsConfiguration(AutoUpdateConfigurationKey) || e.affectsConfiguration(ReceivesUpdatesConfigurationKey)) {
 				if (this.isAutoUpdateEnabled()) {
 					this.checkForUpdates();
 				}
 			}
-			if (e.affectsConfiguration(RecievesUpdatesConfigurationKey)) {
+			if (e.affectsConfiguration(ReceivesUpdatesConfigurationKey)) {
 				this.eventuallySyncWithGallery(true);
 			}
 		}, this, this.disposables);
@@ -610,15 +610,15 @@ export class ExtensionsWorkbenchService implements IExtensionsWorkbenchService, 
 	}
 
 	private isAutoUpdateEnabled(): boolean {
-		return this.configurationService.getValue(AutoUpdateConfigurationKey);
+		return this.configurationService.getValue(AutoUpdateConfigurationKey) && this.isReceiveUpdatesEnabled();
 	}
 
-	private isRecieveUpdatesEnabled(): boolean {
-		return this.configurationService.getValue(RecievesUpdatesConfigurationKey);
+	private isReceiveUpdatesEnabled(): boolean {
+		return this.configurationService.getValue(ReceivesUpdatesConfigurationKey);
 	}
 
 	private eventuallySyncWithGallery(immediate = false): void {
-		if (!this.isRecieveUpdatesEnabled()) {
+		if (!this.isReceiveUpdatesEnabled()) {
 			return;
 		}
 		const loop = () => this.syncWithGallery().then(() => this.eventuallySyncWithGallery());

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import { assign } from 'vs/base/common/objects';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { generateUuid } from 'vs/base/common/uuid';
-import { IExtensionsWorkbenchService, ExtensionState } from 'vs/workbench/parts/extensions/common/extensions';
+import { IExtensionsWorkbenchService, ExtensionState, ReceivesUpdatesConfigurationKey } from 'vs/workbench/parts/extensions/common/extensions';
 import { ExtensionsWorkbenchService } from 'vs/workbench/parts/extensions/node/extensionsWorkbenchService';
 import {
 	IExtensionManagementService, IExtensionGalleryService, IExtensionEnablementService, IExtensionTipsService, ILocalExtension, LocalExtensionType, IGalleryExtension,
@@ -66,7 +66,14 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		instantiationService.stub(IURLService, URLService);
 
 		instantiationService.stub(IWorkspaceContextService, new TestContextService());
-		instantiationService.stub(IConfigurationService, { onDidUpdateConfiguration: () => { }, onDidChangeConfiguration: () => { }, getConfiguration: () => ({}) });
+		instantiationService.stub(IConfigurationService, {
+			onDidUpdateConfiguration: () => { },
+			onDidChangeConfiguration: () => { },
+			getConfiguration: () => ({}),
+			getValue: (a) => {
+				return a === ReceivesUpdatesConfigurationKey ? true : undefined;
+			}
+		});
 
 		instantiationService.stub(IExtensionManagementService, ExtensionManagementService);
 		instantiationService.stub(IExtensionManagementService, 'onInstallExtension', installEvent.event);


### PR DESCRIPTION
Related to #54354

With the addition of this setting, user can choose not to receive extension updates, thus enabling the last piece of the offline mode story.

@joaomoreno The corresponding setting for VS Code updates is the `update.channel`. What was the reason to have this setting take an enum of `default` and `none` instead of a boolean?