### PR TITLE
Trimmed file search strings in the search menu

### DIFF
--- a/src/vs/workbench/parts/search/common/queryBuilder.ts
+++ b/src/vs/workbench/parts/search/common/queryBuilder.ts
@@ -80,7 +80,9 @@ export class QueryBuilder {
 			folderQueries,
 			usingSearchPaths: !!(searchPaths && searchPaths.length),
 			extraFileResources: options.extraFileResources,
-			filePattern: options.filePattern.trim(),
+			filePattern: options.filePattern
+				? options.filePattern.trim()
+				: options.filePattern,
 			excludePattern,
 			includePattern,
 			maxResults: options.maxResults,

--- a/src/vs/workbench/parts/search/common/queryBuilder.ts
+++ b/src/vs/workbench/parts/search/common/queryBuilder.ts
@@ -75,12 +75,12 @@ export class QueryBuilder {
 			this.resolveSmartCaseToCaseSensitive(contentPattern);
 		}
 
-		const query = <ISearchQuery>{
+		const query: ISearchQuery = {
 			type,
 			folderQueries,
 			usingSearchPaths: !!(searchPaths && searchPaths.length),
 			extraFileResources: options.extraFileResources,
-			filePattern: options.filePattern,
+			filePattern: options.filePattern.trim(),
 			excludePattern,
 			includePattern,
 			maxResults: options.maxResults,

--- a/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
+++ b/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
@@ -236,6 +236,21 @@ suite('QueryBuilder', () => {
 			});
 	});
 
+	test('file pattern trimming', () => {
+		const content = 'content';
+		assertEqualQueries(
+			queryBuilder.text(
+				PATTERN_INFO,
+				undefined,
+				{ filePattern: ` ${content} ` }
+			),
+			<ISearchQuery>{
+				contentPattern: PATTERN_INFO,
+				filePattern: content,
+				type: QueryType.Text
+			});
+	});
+
 	test('exclude ./ syntax', () => {
 		assertEqualQueries(
 			queryBuilder.text(


### PR DESCRIPTION
As suggested by roblourens, goes through `queryBuilder`'s `query` to trim the `filePattern`.

Fixes #54529.