### PR TITLE
Fix autosuggest trigger chars not working in simpleWidgets

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1356,22 +1356,22 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		if (this.isSimpleWidget) {
 			commandDelegate = {
 				paste: (source: string, text: string, pasteOnNewLine: boolean, multicursorText: string[]) => {
-					this.cursor.trigger(source, editorCommon.Handler.Paste, { text, pasteOnNewLine, multicursorText });
+					this.trigger(source, editorCommon.Handler.Paste, { text, pasteOnNewLine, multicursorText });
 				},
 				type: (source: string, text: string) => {
-					this.cursor.trigger(source, editorCommon.Handler.Type, { text });
+					this.trigger(source, editorCommon.Handler.Type, { text });
 				},
 				replacePreviousChar: (source: string, text: string, replaceCharCnt: number) => {
-					this.cursor.trigger(source, editorCommon.Handler.ReplacePreviousChar, { text, replaceCharCnt });
+					this.trigger(source, editorCommon.Handler.ReplacePreviousChar, { text, replaceCharCnt });
 				},
 				compositionStart: (source: string) => {
-					this.cursor.trigger(source, editorCommon.Handler.CompositionStart, undefined);
+					this.trigger(source, editorCommon.Handler.CompositionStart, undefined);
 				},
 				compositionEnd: (source: string) => {
-					this.cursor.trigger(source, editorCommon.Handler.CompositionEnd, undefined);
+					this.trigger(source, editorCommon.Handler.CompositionEnd, undefined);
 				},
 				cut: (source: string) => {
-					this.cursor.trigger(source, editorCommon.Handler.Cut, undefined);
+					this.trigger(source, editorCommon.Handler.Cut, undefined);
 				}
 			};
 		} else {


### PR DESCRIPTION
Closes #54670, where the debug repl doesn't open autosuggest on typing period, by using `codeEditorWidget`'s `trigger` rather than `cursor`'s, as the latter does not properly fire `onWillType` or `onDidType` events.