### PR TITLE
zh-hans and zh-hant are invalid locales

### DIFF
--- a/src/vs/workbench/parts/localizations/electron-browser/localizations.contribution.ts
+++ b/src/vs/workbench/parts/localizations/electron-browser/localizations.contribution.ts
@@ -141,19 +141,15 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 					return;
 				}
 
-				const extensionIdPostfix = this.getPossibleChineseMapping(locale);
-				const ceintlExtensionSearch = this.galleryService.query({ names: [`MS-CEINTL.vscode-language-pack-${extensionIdPostfix}`], pageSize: 1 });
-				const tagSearch = this.galleryService.query({ text: `tag:lp-${locale}`, pageSize: 1 });
-
-				TPromise.join([ceintlExtensionSearch, tagSearch]).then(([ceintlResult, tagResult]) => {
-					if (ceintlResult.total === 0 && tagResult.total === 0) {
+				this.galleryService.query({ text: `tag:lp-${locale}`, pageSize: 1 }).then(tagResult => {
+					if (tagResult.total === 0) {
 						return;
 					}
 
-					const extensionToInstall = ceintlResult.total === 1 ? ceintlResult.firstPage[0] : tagResult.total === 1 ? tagResult.firstPage[0] : null;
-					const extensionToFetchTranslationsFrom = extensionToInstall || (tagResult.total > 0 ? tagResult.firstPage[0] : null);
+					const extensionToInstall = tagResult.total === 1 ? tagResult.firstPage[0] : tagResult.firstPage.filter(e => e.publisher === 'MS-CEINTL' && e.name.indexOf('vscode-language-pack') === 0)[0];
+					const extensionToFetchTranslationsFrom = extensionToInstall || tagResult.firstPage[0];
 
-					if (!extensionToFetchTranslationsFrom || !extensionToFetchTranslationsFrom.assets.manifest) {
+					if (!extensionToFetchTranslationsFrom.assets.manifest) {
 						return;
 					}
 
@@ -234,11 +230,6 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 				});
 			});
 
-	}
-
-	private getPossibleChineseMapping(locale: string): string {
-		locale = locale.toLowerCase();
-		return locale === 'zh-cn' ? 'zh-hans' : locale === 'zh-tw' ? 'zh-hant' : locale;
 	}
 
 	private getLanguagePackExtension(language: string): TPromise<IGalleryExtension> {

--- a/src/vs/workbench/parts/localizations/electron-browser/localizations.contribution.ts
+++ b/src/vs/workbench/parts/localizations/electron-browser/localizations.contribution.ts
@@ -141,7 +141,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 					return;
 				}
 
-				this.galleryService.query({ text: `tag:lp-${locale}`, pageSize: 1 }).then(tagResult => {
+				this.galleryService.query({ text: `tag:lp-${locale}` }).then(tagResult => {
 					if (tagResult.total === 0) {
 						return;
 					}


### PR DESCRIPTION
Previous design was to recommend language packs from Microsoft. If none are found, we then made a tag based search in the marketplace. If the result had a single extension, we recommend that else prompt user to execute the same search and then choose.

Since the language packs for `zh-cn` and `zh-tw` are actually named `zh-hans` and `zh-hant`, step 1 returned a language pack from Microsoft when user changed locale to `zh-hans` or `zh-hant` which caused the issue detailed in #53139

This PR removes step 1 from above and does the below
- Perform tag based search in marketplace. If result has single extension, recommend that
- If result has multiple extensions and one of them is from Microsoft, recommend that
- Else prompt user to execute the same search and then choose.

cc @dbaeumer @sandy081 