### PR TITLE
Adds webview select-all command

### DIFF
--- a/src/vs/workbench/parts/webview/electron-browser/baseWebviewEditor.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/baseWebviewEditor.ts
@@ -77,4 +77,10 @@ export abstract class BaseWebviewEditor extends BaseEditor {
 			this._webview.focus();
 		}
 	}
+
+	public selectAll(): void {
+		if (this._webview) {
+			this._webview.selectAll();
+		}
+	}
 }

--- a/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
@@ -16,7 +16,7 @@ import { Extensions as ActionExtensions, IWorkbenchActionRegistry } from 'vs/wor
 import { Extensions as EditorInputExtensions, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
 import { WebviewEditorInputFactory } from 'vs/workbench/parts/webview/electron-browser/webviewEditorInputFactory';
 import { KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from './baseWebviewEditor';
-import { HideWebViewEditorFindCommand, OpenWebviewDeveloperToolsAction, ReloadWebviewAction, ShowWebViewEditorFindWidgetCommand } from './webviewCommands';
+import { HideWebViewEditorFindCommand, OpenWebviewDeveloperToolsAction, ReloadWebviewAction, ShowWebViewEditorFindWidgetCommand, SelectAllWebviewEditorCommand } from './webviewCommands';
 import { WebviewEditor } from './webviewEditor';
 import { WebviewEditorInput } from './webviewEditorInput';
 import { IWebviewEditorService, WebviewEditorService } from './webviewEditorService';
@@ -58,6 +58,14 @@ const hideCommand = new HideWebViewEditorFindCommand({
 });
 KeybindingsRegistry.registerCommandAndKeybindingRule(hideCommand.toCommandAndKeybindingRule(KeybindingsRegistry.WEIGHT.editorContrib()));
 
+const selectAllCommand = new SelectAllWebviewEditorCommand({
+	id: SelectAllWebviewEditorCommand.ID,
+	precondition: KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS,
+	kbOpts: {
+		primary: KeyMod.CtrlCmd | KeyCode.KEY_A
+	}
+});
+KeybindingsRegistry.registerCommandAndKeybindingRule(selectAllCommand.toCommandAndKeybindingRule(KeybindingsRegistry.WEIGHT.editorContrib()));
 
 actionRegistry.registerWorkbenchAction(
 	new SyncActionDescriptor(OpenWebviewDeveloperToolsAction, OpenWebviewDeveloperToolsAction.ID, OpenWebviewDeveloperToolsAction.LABEL),

--- a/src/vs/workbench/parts/webview/electron-browser/webviewCommands.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewCommands.ts
@@ -33,6 +33,17 @@ export class HideWebViewEditorFindCommand extends Command {
 	}
 }
 
+export class SelectAllWebviewEditorCommand extends Command {
+	public static readonly ID = 'editor.action.webvieweditor.selectAll';
+
+	public runCommand(accessor: ServicesAccessor, args: any): void {
+		const webViewEditor = getActiveWebviewEditor(accessor);
+		if (webViewEditor) {
+			webViewEditor.selectAll();
+		}
+	}
+}
+
 export class OpenWebviewDeveloperToolsAction extends Action {
 	static readonly ID = 'workbench.action.webview.openDeveloperTools';
 	static readonly LABEL = nls.localize('openToolsLabel', "Open Webview Developer Tools");

--- a/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
@@ -443,6 +443,10 @@ export class WebviewElement extends Disposable {
 	public reload() {
 		this.contents = this._contents;
 	}
+
+	public selectAll() {
+		this._webview.selectAll();
+	}
 }
 
 


### PR DESCRIPTION
This change adds a select-all command for webviews, to fix #8794

//cc @mjbvz 