### PR TITLE
Try to checkout a new local branch when checking out a remote branch

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -23,14 +23,13 @@ const localize = nls.loadMessageBundle();
 class CheckoutItem implements QuickPickItem {
 
 	protected get shortCommit(): string { return (this.ref.commit || '').substr(0, 8); }
-	protected get treeish(): string | undefined { return this.ref.name; }
 	get label(): string { return this.ref.name || this.shortCommit; }
 	get description(): string { return this.shortCommit; }
 
 	constructor(protected ref: Ref) { }
 
 	async run(repository: Repository): Promise<void> {
-		const ref = this.treeish;
+		const ref = this.ref.name;
 
 		if (!ref) {
 			return;
@@ -53,13 +52,12 @@ class CheckoutRemoteHeadItem extends CheckoutItem {
 		return localize('remote branch at', "Remote branch at {0}", this.shortCommit);
 	}
 
-	protected get treeish(): string | undefined {
+	async run(repository: Repository): Promise<void> {
 		if (!this.ref.name) {
 			return;
 		}
 
-		const match = /^[^/]+\/(.*)$/.exec(this.ref.name);
-		return match ? match[1] : this.ref.name;
+		await repository.checkoutTracking(this.ref.name);
 	}
 }
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -899,8 +899,12 @@ export class Repository {
 		await this.run(['update-index', '--cacheinfo', mode, hash, path]);
 	}
 
-	async checkout(treeish: string, paths: string[]): Promise<void> {
+	async checkout(treeish: string, paths: string[], opts: { track?: boolean } = Object.create(null)): Promise<void> {
 		const args = ['checkout', '-q'];
+
+		if (opts.track) {
+			args.push('--track');
+		}
 
 		if (treeish) {
 			args.push(treeish);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -283,6 +283,7 @@ export enum Operation {
 	Clean = 'Clean',
 	Branch = 'Branch',
 	Checkout = 'Checkout',
+	CheckoutTracking = 'CheckoutTracking',
 	Reset = 'Reset',
 	Fetch = 'Fetch',
 	Pull = 'Pull',
@@ -767,6 +768,10 @@ export class Repository implements Disposable {
 
 	async checkout(treeish: string): Promise<void> {
 		await this.run(Operation.Checkout, () => this.repository.checkout(treeish, []));
+	}
+
+	async checkoutTracking(treeish: string): Promise<void> {
+		await this.run(Operation.CheckoutTracking, () => this.repository.checkout(treeish, [], { track: true }));
 	}
 
 	async getCommit(ref: string): Promise<Commit> {


### PR DESCRIPTION
This handles the case when no local branch exists. You will get an error if a local branch with the same name already exists. Better behavior for this case can be implemented later.

Fixes #54601