### PR TITLE
Add WebviewPanel.iconPath

### DIFF
--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const telemetryReporter = loadDefaultTelemetryReporter();
 	context.subscriptions.push(telemetryReporter);
 
-	const contributions = getMarkdownExtensionContributions();
+	const contributions = getMarkdownExtensionContributions(context);
 
 	const cspArbiter = new ExtensionContentSecurityPolicyArbiter(context.globalState, context.workspaceState);
 	const engine = new MarkdownEngine(contributions, githubSlugifier);

--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -271,6 +271,14 @@ export class MarkdownPreview {
 		this.editor.title = MarkdownPreview.getPreviewTitle(this._resource, this._locked);
 	}
 
+	private get iconPath() {
+		const root = path.join(this._contributions.extensionPath, 'media');
+		return {
+			light: vscode.Uri.file(path.join(root, 'Preview.svg')),
+			dark: vscode.Uri.file(path.join(root, 'Preview_inverse.svg'))
+		};
+	}
+
 	private isPreviewOf(resource: vscode.Uri): boolean {
 		return this._resource.fsPath === resource.fsPath;
 	}
@@ -327,6 +335,7 @@ export class MarkdownPreview {
 		const content = await this._contentProvider.provideTextDocumentContent(document, this._previewConfigurations, this.line, this.state);
 		if (this._resource === resource) {
 			this.editor.title = MarkdownPreview.getPreviewTitle(this._resource, this._locked);
+			this.editor.iconPath = this.iconPath;
 			this.editor.webview.options = MarkdownPreview.getWebviewOptions(resource, this._contributions);
 			this.editor.webview.html = content;
 		}

--- a/extensions/markdown-language-features/src/markdownExtensions.ts
+++ b/extensions/markdown-language-features/src/markdownExtensions.ts
@@ -26,6 +26,7 @@ const resolveExtensionResources = (extension: vscode.Extension<any>, resourcePat
 };
 
 export interface MarkdownContributions {
+	readonly extensionPath: string;
 	readonly previewScripts: vscode.Uri[];
 	readonly previewStyles: vscode.Uri[];
 	readonly markdownItPlugins: Thenable<(md: any) => any>[];
@@ -39,6 +40,10 @@ class MarkdownExtensionContributions implements MarkdownContributions {
 	private readonly _plugins: Thenable<(md: any) => any>[] = [];
 
 	private _loaded = false;
+
+	public constructor(
+		public readonly extensionPath: string,
+	) { }
 
 	public get previewScripts(): vscode.Uri[] {
 		this.ensureLoaded();
@@ -111,6 +116,6 @@ class MarkdownExtensionContributions implements MarkdownContributions {
 	}
 }
 
-export function getMarkdownExtensionContributions(): MarkdownContributions {
-	return new MarkdownExtensionContributions();
+export function getMarkdownExtensionContributions(context: vscode.ExtensionContext): MarkdownContributions {
+	return new MarkdownExtensionContributions(context.extensionPath);
 }

--- a/extensions/markdown-language-features/src/test/engine.ts
+++ b/extensions/markdown-language-features/src/test/engine.ts
@@ -9,6 +9,7 @@ import { MarkdownContributions } from '../markdownExtensions';
 import { githubSlugifier } from '../slugify';
 
 const emptyContributions = new class implements MarkdownContributions {
+	readonly extensionPath = '';
 	readonly previewScripts: vscode.Uri[] = [];
 	readonly previewStyles: vscode.Uri[] = [];
 	readonly previewResourceRoots: vscode.Uri[] = [];

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5501,6 +5501,11 @@ declare module 'vscode' {
 		title: string;
 
 		/**
+		 * Icon for the panel show in UI.
+		 */
+		iconPath?: Uri | { light: Uri; dark: Uri };
+
+		/**
 		 * Webview belonging to the panel.
 		 */
 		readonly webview: Webview;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5501,7 +5501,7 @@ declare module 'vscode' {
 		title: string;
 
 		/**
-		 * Icon for the panel show in UI.
+		 * Icon for the panel shown in UI.
 		 */
 		iconPath?: Uri | { light: Uri; dark: Uri };
 

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -96,6 +96,26 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 		webview.setName(value);
 	}
 
+	public $setIconPath(handle: WebviewPanelHandle, value: UriComponents | { light: UriComponents, dark: UriComponents } | undefined): void {
+		const webview = this.getWebview(handle);
+		if (!value) {
+			webview.setIconPath(undefined);
+			return;
+		}
+
+		const themeIcon = value as { light: UriComponents, dark: UriComponents };
+		if (themeIcon.light && themeIcon.dark) {
+			webview.setIconPath({
+				light: URI.revive(themeIcon.light),
+				dark: URI.revive(themeIcon.dark)
+			});
+			return;
+		}
+
+		webview.setIconPath(URI.revive(value));
+
+	}
+
 	public $setHtml(handle: WebviewPanelHandle, value: string): void {
 		const webview = this.getWebview(handle);
 		webview.html = value;

--- a/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWebview.ts
@@ -130,7 +130,7 @@ export class MainThreadWebviews implements MainThreadWebviewsShape, WebviewReviv
 		webview.setName(value);
 	}
 
-	public $setIconPath(handle: WebviewPanelHandle, value: UriComponents | { light: UriComponents, dark: UriComponents } | undefined): void {
+	public $setIconPath(handle: WebviewPanelHandle, value: { light: UriComponents, dark: UriComponents } | undefined): void {
 		const webview = this.getWebview(handle);
 		MainThreadWebviews.updateStyleElement(webview, reviveWebviewIcon(value));
 	}
@@ -345,20 +345,14 @@ function reviveWebviewOptions(options: WebviewInputOptions): WebviewInputOptions
 }
 
 function reviveWebviewIcon(
-	value: UriComponents | { light: UriComponents, dark: UriComponents } | undefined
+	value: { light: UriComponents, dark: UriComponents } | undefined
 ): { light: URI, dark: URI } | undefined {
 	if (!value) {
 		return undefined;
 	}
 
-	const themeIcon = value as { light: UriComponents, dark: UriComponents };
-	if (themeIcon.light && themeIcon.dark) {
-		return {
-			light: URI.revive(themeIcon.light),
-			dark: URI.revive(themeIcon.dark)
-		};
-	}
-
-	const icon = URI.revive(value);
-	return { light: icon, dark: icon };
+	return {
+		light: URI.revive(value.light),
+		dark: URI.revive(value.dark)
+	};
 }

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -430,6 +430,7 @@ export interface MainThreadWebviewsShape extends IDisposable {
 	$disposeWebview(handle: WebviewPanelHandle): void;
 	$reveal(handle: WebviewPanelHandle, viewColumn: EditorViewColumn | null, preserveFocus: boolean): void;
 	$setTitle(handle: WebviewPanelHandle, value: string): void;
+	$setIconPath(handle: WebviewPanelHandle, value: UriComponents | { light: UriComponents, dark: UriComponents } | undefined): void;
 	$setHtml(handle: WebviewPanelHandle, value: string): void;
 	$setOptions(handle: WebviewPanelHandle, options: vscode.WebviewOptions): void;
 	$postMessage(handle: WebviewPanelHandle, value: any): Thenable<boolean>;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -430,7 +430,7 @@ export interface MainThreadWebviewsShape extends IDisposable {
 	$disposeWebview(handle: WebviewPanelHandle): void;
 	$reveal(handle: WebviewPanelHandle, viewColumn: EditorViewColumn | null, preserveFocus: boolean): void;
 	$setTitle(handle: WebviewPanelHandle, value: string): void;
-	$setIconPath(handle: WebviewPanelHandle, value: UriComponents | { light: UriComponents, dark: UriComponents } | undefined): void;
+	$setIconPath(handle: WebviewPanelHandle, value: { light: UriComponents, dark: UriComponents } | undefined): void;
 	$setHtml(handle: WebviewPanelHandle, value: string): void;
 	$setOptions(handle: WebviewPanelHandle, options: vscode.WebviewOptions): void;
 	$postMessage(handle: WebviewPanelHandle, value: any): Thenable<boolean>;

--- a/src/vs/workbench/api/node/extHostWebview.ts
+++ b/src/vs/workbench/api/node/extHostWebview.ts
@@ -3,14 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MainContext, MainThreadWebviewsShape, IMainContext, ExtHostWebviewsShape, WebviewPanelHandle, WebviewPanelViewState } from './extHost.protocol';
-import * as vscode from 'vscode';
-import { Event, Emitter } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
+import URI from 'vs/base/common/uri';
+import { TPromise } from 'vs/base/common/winjs.base';
 import * as typeConverters from 'vs/workbench/api/node/extHostTypeConverters';
 import { EditorViewColumn } from 'vs/workbench/api/shared/editor';
-import { TPromise } from 'vs/base/common/winjs.base';
+import * as vscode from 'vscode';
+import { ExtHostWebviewsShape, IMainContext, MainContext, MainThreadWebviewsShape, WebviewPanelHandle, WebviewPanelViewState } from './extHost.protocol';
 import { Disposable } from './extHostTypes';
-import URI from 'vs/base/common/uri';
+
+
+type IconPath = URI | { light: URI, dark: URI };
 
 export class ExtHostWebview implements vscode.Webview {
 	private readonly _handle: WebviewPanelHandle;
@@ -78,6 +81,7 @@ export class ExtHostWebviewPanel implements vscode.WebviewPanel {
 	private readonly _proxy: MainThreadWebviewsShape;
 	private readonly _viewType: string;
 	private _title: string;
+	private _iconPath: IconPath;
 
 	private readonly _options: vscode.WebviewPanelOptions;
 	private readonly _webview: ExtHostWebview;
@@ -147,6 +151,19 @@ export class ExtHostWebviewPanel implements vscode.WebviewPanel {
 		if (this._title !== value) {
 			this._title = value;
 			this._proxy.$setTitle(this._handle, value);
+		}
+	}
+
+	get iconPath(): IconPath | undefined {
+		this.assertNotDisposed();
+		return this._iconPath;
+	}
+
+	set iconPath(value: IconPath | undefined) {
+		this.assertNotDisposed();
+		if (this._iconPath !== value) {
+			this._iconPath = value;
+			this._proxy.$setIconPath(this._handle, value);
 		}
 	}
 

--- a/src/vs/workbench/api/node/extHostWebview.ts
+++ b/src/vs/workbench/api/node/extHostWebview.ts
@@ -163,7 +163,8 @@ export class ExtHostWebviewPanel implements vscode.WebviewPanel {
 		this.assertNotDisposed();
 		if (this._iconPath !== value) {
 			this._iconPath = value;
-			this._proxy.$setIconPath(this._handle, value);
+
+			this._proxy.$setIconPath(this._handle, URI.isUri(value) ? { light: value, dark: value } : value);
 		}
 	}
 

--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
@@ -26,34 +26,6 @@ export class WebviewEditor extends BaseWebviewEditor {
 
 	public static readonly ID = 'WebviewEditor';
 
-	private static _styleElement?: HTMLStyleElement;
-
-	private static _icons = new Map<number, URI | { light: URI, dark: URI }>();
-
-	private static updateStyleElement(id: number, iconPath: URI | { light: URI, dark: URI } | undefined) {
-		if (!this._styleElement) {
-			this._styleElement = DOM.createStyleSheet();
-			this._styleElement.className = 'webview-icons';
-		}
-
-		if (!iconPath) {
-			this._icons.delete(id);
-		} else {
-			this._icons.set(id, iconPath);
-		}
-
-		const cssRules: string[] = [];
-		this._icons.forEach((value, key) => {
-			if (URI.isUri(value)) {
-				cssRules.push(`.show-file-icons .webview-${key}-name-file-icon::before { content: ""; background-image: url(${value.toString()}); }`);
-			} else {
-				cssRules.push(`.show-file-icons .webview-${key}-name-file-icon::before { content: ""; background-image: url(${value.light.toString()}); }`);
-				cssRules.push(`.vs-dark .show-file-icons .webview-${key}-name-file-icon::before { content: ""; background-image: url(${value.dark.toString()}); }`);
-			}
-		});
-		this._styleElement.innerHTML = cssRules.join('\n');
-	}
-
 	private _editorFrame: HTMLElement;
 	private _content: HTMLElement;
 	private _webviewContent: HTMLElement | undefined;
@@ -61,8 +33,6 @@ export class WebviewEditor extends BaseWebviewEditor {
 	private _webviewFocusTracker?: DOM.IFocusTracker;
 	private _webviewFocusListenerDisposable?: IDisposable;
 	private _onFocusWindowHandler?: IDisposable;
-	private _iconChangedHandler?: IDisposable;
-
 
 	private readonly _onDidFocusWebview = new Emitter<void>();
 
@@ -145,10 +115,6 @@ export class WebviewEditor extends BaseWebviewEditor {
 			this._onFocusWindowHandler.dispose();
 		}
 
-		if (this._iconChangedHandler) {
-			this._iconChangedHandler.dispose();
-		}
-
 		super.dispose();
 	}
 
@@ -225,14 +191,6 @@ export class WebviewEditor extends BaseWebviewEditor {
 			localResourceRoots: input.options.localResourceRoots || this.getDefaultLocalResourceRoots()
 		};
 		input.html = input.html;
-
-		const updateIcon = () => WebviewEditor.updateStyleElement(input.getId(), input.getIconPath());
-		if (this._onFocusWindowHandler) {
-			this._onFocusWindowHandler.dispose();
-		}
-
-		this._onFocusWindowHandler = input.onDidChangeIcon(updateIcon);
-		updateIcon();
 
 		if (this._webviewContent) {
 			this._webviewContent.style.visibility = 'visible';

--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditorInput.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditorInput.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Emitter } from 'vs/base/common/event';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
 import URI from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -12,7 +13,6 @@ import { IPartService, Parts } from 'vs/workbench/services/part/common/partServi
 import * as vscode from 'vscode';
 import { WebviewEvents, WebviewInputOptions, WebviewReviver } from './webviewEditorService';
 import { WebviewElement } from './webviewElement';
-import { Emitter } from 'vs/base/common/event';
 
 export class WebviewEditorInput extends EditorInput {
 	private static handlePool = 0;
@@ -20,7 +20,6 @@ export class WebviewEditorInput extends EditorInput {
 	public static readonly typeId = 'workbench.editors.webviewInput';
 
 	private _name: string;
-	private _iconPath?: URI | { light: URI, dark: URI };
 	private _options: WebviewInputOptions;
 	private _html: string = '';
 	private _currentWebviewHtml: string = '';
@@ -108,15 +107,6 @@ export class WebviewEditorInput extends EditorInput {
 	public setName(value: string): void {
 		this._name = value;
 		this._onDidChangeLabel.fire();
-	}
-
-	public setIconPath(value: URI | { light: URI, dark: URI } | undefined): void {
-		this._iconPath = value;
-		this._onDidChangeIcon.fire();
-	}
-
-	public getIconPath(): URI | { light: URI, dark: URI } | undefined {
-		return this._iconPath;
 	}
 
 	public matches(other: IEditorInput): boolean {


### PR DESCRIPTION
Allows webviews to provide icons used in UI. Adds a new `WebviewPanel.iconPath` property for this. Extensions can provide a single icon, or icons for the light and dark themes

Replaces the static contribution approach from #49657

Fixes #48864