### PR TITLE
Fix title rendering issues (ellipsis, clipping)

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/panelviewlet.css
+++ b/src/vs/workbench/browser/parts/views/media/panelviewlet.css
@@ -10,5 +10,4 @@
 	font-size: 11px;
 	-webkit-margin-before: 0;
 	-webkit-margin-after: 0;
-	display: flex;
 }

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -71,6 +71,10 @@ export class ExtensionsListView extends ViewletPanel {
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: options.title }, keybindingService, contextMenuService, configurationService);
 	}
 
+	protected renderHeader(container: HTMLElement): void {
+		this.renderHeaderTitle(container);
+	}
+
 	renderHeaderTitle(container: HTMLElement): void {
 		super.renderHeaderTitle(container, this.options.title);
 

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -27,6 +27,10 @@
 	height: calc(100% - 38px);
 }
 
+.extensions-viewlet > .extensions .list-actionbar-container {
+	margin-right: 10px;
+}
+
 .extensions-viewlet > .extensions .list-actionbar-container .monaco-action-bar .action-item > .octicon {
 	font-size: 12px;
 	line-height: 1;


### PR DESCRIPTION
Closes #54973 by fixing issues where titles in viewlet panels dont properly overflow with ellipsis, and recommendations text gets clipped by an actions panel which is not actually present