### PR TITLE
Show the "method" icon for constructors

### DIFF
--- a/src/vs/editor/contrib/documentSymbols/media/symbol-icons.css
+++ b/src/vs/editor/contrib/documentSymbols/media/symbol-icons.css
@@ -111,6 +111,15 @@
 	background-image: url('Class_16x_darkp.svg');
 }
 
+/* constructor */
+.monaco-workbench .symbol-icon.constructor {
+	background-image: url('Method_16x.svg');
+}
+.vs-dark .monaco-workbench .symbol-icon.constructor,
+.hc-black .monaco-workbench .symbol-icon.constructor {
+	background-image: url('Method_16x_darkp.svg');
+}
+
 /* file */
 .monaco-workbench .symbol-icon.file {
 	background-image: url('Document_16x.svg');


### PR DESCRIPTION
Related to #54712

This allows for constructors to use the "method" icon, where previously is was using the default "field" icon:

![image](https://user-images.githubusercontent.com/35271042/43209268-1206087a-8fe1-11e8-904d-3a1842c0f77b.png)
