### PR TITLE
Relax condition on select all

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -1706,7 +1706,7 @@ registerCommand(new EditorOrNativeTextInputCommand({
 	editorHandler: CoreNavigationCommands.SelectAll,
 	inputHandler: 'selectAll',
 	id: 'editor.action.selectAll',
-	precondition: EditorContextKeys.focus,
+	precondition: EditorContextKeys.textInputFocus,
 	kbOpts: {
 		weight: CORE_WEIGHT,
 		kbExpr: null,


### PR DESCRIPTION
This enables `Ctrl+a` to select all in the Extensions Search, Logpoint Editor, and Repl Editor input areas. 