### PR TITLE
Support tags on settings to filter in settings editor

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -911,7 +911,8 @@
         "git.autofetch": {
           "type": "boolean",
           "description": "%config.autofetch%",
-          "default": false
+          "default": false,
+          "tags": ["backgroundOnlineFeature"]
         },
         "git.confirmSync": {
           "type": "boolean",

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -73,7 +73,8 @@
           "type": "boolean",
           "default": false,
           "description": "%typescript.disableAutomaticTypeAcquisition%",
-          "scope": "window"
+          "scope": "window",
+          "tags": ["backgroundOnlineFeature"]
         },
         "typescript.npm": {
           "type": [

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -78,6 +78,7 @@ export interface IConfigurationPropertySchema extends IJSONSchema {
 	scope?: ConfigurationScope;
 	notMultiRootAdopted?: boolean;
 	included?: boolean;
+	tags?: string[];
 }
 
 export interface IConfigurationNode {

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -167,7 +167,8 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'telemetry.enableTelemetry': {
 			'type': 'boolean',
 			'description': localize('telemetry.enableTelemetry', "Enable usage data and errors to be sent to Microsoft."),
-			'default': true
+			'default': true,
+			'tags': ['backgroundOnlineFeature']
 		}
 	}
 });

--- a/src/vs/platform/update/node/update.config.contribution.ts
+++ b/src/vs/platform/update/node/update.config.contribution.ts
@@ -21,18 +21,21 @@ configurationRegistry.registerConfiguration({
 			'enum': ['none', 'default'],
 			'default': 'default',
 			'scope': ConfigurationScope.APPLICATION,
-			'description': nls.localize('updateChannel', "Configure whether you receive automatic updates from an update channel. Requires a restart after change.")
+			'description': nls.localize('updateChannel', "Configure whether you receive automatic updates from an update channel. Requires a restart after change."),
+			'tags': ['backgroundOnlineFeature']
 		},
 		'update.enableWindowsBackgroundUpdates': {
 			'type': 'boolean',
 			'default': true,
 			'scope': ConfigurationScope.APPLICATION,
-			'description': nls.localize('enableWindowsBackgroundUpdates', "Enables Windows background updates.")
+			'description': nls.localize('enableWindowsBackgroundUpdates', "Enables Windows background updates."),
+			'tags': ['backgroundOnlineFeature']
 		},
 		'update.showReleaseNotes': {
 			'type': 'boolean',
 			'default': true,
-			'description': nls.localize('showReleaseNotes', "Show Release Notes after an update.")
+			'description': nls.localize('showReleaseNotes', "Show Release Notes after an update."),
+			'tags': ['backgroundOnlineFeature']
 		}
 	}
 });

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -488,7 +488,8 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'description': nls.localize('enableNaturalLanguageSettingsSearch', "Controls whether to enable the natural language search mode for settings."),
 			'default': true,
-			'scope': ConfigurationScope.WINDOW
+			'scope': ConfigurationScope.WINDOW,
+			'tags': ['backgroundOnlineFeature']
 		},
 		'workbench.settings.settingsSearchTocBehavior': {
 			'type': 'string',

--- a/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensions.contribution.ts
@@ -206,7 +206,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 				type: 'boolean',
 				description: localize('extensionsAutoUpdate', "Automatically update extensions"),
 				default: true,
-				scope: ConfigurationScope.APPLICATION
+				scope: ConfigurationScope.APPLICATION,
+				tags: ['backgroundOnlineFeature']
 			},
 			'extensions.ignoreRecommendations': {
 				type: 'boolean',
@@ -216,7 +217,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			'extensions.showRecommendationsOnlyOnDemand': {
 				type: 'boolean',
 				description: localize('extensionsShowRecommendationsOnlyOnDemand', "When enabled, recommendations will not be fetched or shown unless specifically requested by the user."),
-				default: false
+				default: false,
+				tags: ['backgroundOnlineFeature']
 			},
 			'extensions.closeExtensionDetailsOnViewChange': {
 				type: 'boolean',

--- a/src/vs/workbench/services/configuration/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/services/configuration/common/configurationExtensionPoint.ts
@@ -46,6 +46,11 @@ const configurationEntrySchema: IJSONSchema = {
 									nls.localize('scope.resource.description', "Resource specific configuration, which can be configured in the User, Workspace or Folder settings.")
 								],
 								description: nls.localize('scope.description', "Scope in which the configuration is applicable. Available scopes are `window` and `resource`.")
+							},
+							tags: {
+								type: 'array',
+								default: [],
+								description: nls.localize('tags.description', "Tags that can be used to filter settings in the settings editor.")
 							}
 						}
 					}

--- a/src/vs/workbench/services/configuration/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/services/configuration/common/configurationExtensionPoint.ts
@@ -46,11 +46,6 @@ const configurationEntrySchema: IJSONSchema = {
 									nls.localize('scope.resource.description', "Resource specific configuration, which can be configured in the User, Workspace or Folder settings.")
 								],
 								description: nls.localize('scope.description', "Scope in which the configuration is applicable. Available scopes are `window` and `resource`.")
-							},
-							tags: {
-								type: 'array',
-								default: [],
-								description: nls.localize('tags.description', "Tags that can be used to filter settings in the settings editor.")
 							}
 						}
 					}

--- a/src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
+++ b/src/vs/workbench/services/crashReporter/electron-browser/crashReporterService.ts
@@ -37,7 +37,8 @@ configurationRegistry.registerConfiguration({
 		'telemetry.enableCrashReporter': {
 			'type': 'boolean',
 			'description': nls.localize('telemetry.enableCrashReporting', "Enable crash reports to be sent to Microsoft.\nThis option requires restart to take effect."),
-			'default': true
+			'default': true,
+			'tags': ['backgroundOnlineFeature']
 		}
 	}
 });


### PR DESCRIPTION
To support a separate viewing of settings that control background online features (as described in #54354), this PR adds tags to settings

cc @sandy081 