### PR TITLE
Allow users to opt-out of features that send online requests in the background

### DIFF
--- a/extensions/npm/README.md
+++ b/extensions/npm/README.md
@@ -15,11 +15,15 @@ For more information about auto detection of Tasks, see the [documentation](http
 
 ### Script Explorer
 
-The Npm Script Explorer shows the npm scripts found in your workspace. The explorer view is enabled by the setting `npm.enableScriptExplorer`. A script can be opened, run, or debug from the explorer. 
+The Npm Script Explorer shows the npm scripts found in your workspace. The explorer view is enabled by the setting `npm.enableScriptExplorer`. A script can be opened, run, or debug from the explorer.
 
 ### Run Scripts from the Editor
 
 The extension provides code lense actions to run or debug a script from the editor.
+
+### Others
+
+The extension fetches data from https://registry.npmjs/org and https://registry.bower.io to provide auto-completion and information on hover features on npm dependencies.
 
 ## Settings
 

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -214,6 +214,13 @@
           "description": "%config.npm.scriptExplorerAction%",
           "scope": "window",
           "default": "open"
+        },
+        "npm.fetchOnlinePackageInfo": {
+          "type": "boolean",
+          "description": "%config.npm.fetchOnlinePackageInfo%",
+          "default": true,
+          "scope": "window",
+          "tags": ["usesOnlineServices"]
         }
       }
     },

--- a/extensions/npm/package.nls.json
+++ b/extensions/npm/package.nls.json
@@ -7,6 +7,7 @@
 	"config.npm.exclude": "Configure glob patterns for folders that should be excluded from automatic script detection.",
 	"config.npm.enableScriptExplorer": "Enable an explorer view for npm scripts.",
 	"config.npm.scriptExplorerAction": "The default click action used in the scripts explorer: 'open' or 'run', the default is 'open'.",
+	"config.npm.fetchOnlinePackageInfo": "Fetch data from https://registry.npmjs/org and https://registry.bower.io to provide auto-completion and information on hover features on npm dependencies.",
 	"npm.parseError": "Npm task detection: failed to parse the file {0}",
 	"taskdef.script": "The npm script to customize.",
 	"taskdef.path": "The path to the folder of the package.json file that provides the script. Can be omitted.",

--- a/extensions/npm/src/features/bowerJSONContribution.ts
+++ b/extensions/npm/src/features/bowerJSONContribution.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { MarkedString, CompletionItemKind, CompletionItem, DocumentSelector, SnippetString } from 'vscode';
-import { IJSONContribution, ISuggestionsCollector } from './jsonContributions';
+import { MarkedString, CompletionItemKind, CompletionItem, DocumentSelector, SnippetString, workspace } from 'vscode';
+import { IJSONContribution, ISuggestionsCollector, xhrDisabled } from './jsonContributions';
 import { XHRRequest } from 'request-light';
 import { Location } from 'jsonc-parser';
 import { textToMarkedString } from './markedTextUtil';
@@ -25,7 +25,19 @@ export class BowerJSONContribution implements IJSONContribution {
 		'hui', 'bootstrap-languages', 'async', 'gulp', 'jquery-pjax', 'coffeescript', 'hammer.js', 'ace', 'leaflet', 'jquery-mobile', 'sweetalert', 'typeahead.js', 'soup', 'typehead.js',
 		'sails', 'codeigniter2'];
 
-	public constructor(private xhr: XHRRequest) {
+	private xhr: XHRRequest;
+
+	public constructor(httprequestxhr: XHRRequest) {
+
+		const getxhr = () => {
+			return workspace.getConfiguration('npm').get('fetchOnlinePackageInfo') === false ? xhrDisabled : httprequestxhr;
+		};
+		this.xhr = getxhr();
+		workspace.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration('npm.fetchOnlinePackageInfo')) {
+				this.xhr = getxhr();
+			}
+		});
 	}
 
 	public getDocumentSelector(): DocumentSelector {

--- a/extensions/npm/src/features/jsonContributions.ts
+++ b/extensions/npm/src/features/jsonContributions.ts
@@ -164,3 +164,5 @@ export class JSONCompletionItemProvider implements CompletionItemProvider {
 		return nextToken === SyntaxKind.CloseBraceToken || nextToken === SyntaxKind.EOF;
 	}
 }
+
+export const xhrDisabled = () => Promise.reject({ responseText: 'Use of online resources is disabled.' });


### PR DESCRIPTION
As per https://github.com/Microsoft/vscode/issues/54354#issuecomment-407613058, we want to have settings that enable users to switch off any background features that make online requests.

This PR adds such a setting for the npm extension which fetches data from https://registry.npmjs/org and https://registry.bower.io to provide auto-completion and information on hover features on npm dependencies.