### PR TITLE
Extension Search should autosuggest dropdown on empty input (or at start of word)

### DIFF
--- a/src/vs/workbench/parts/extensions/common/extensionQuery.ts
+++ b/src/vs/workbench/parts/extensions/common/extensionQuery.ts
@@ -21,7 +21,11 @@ export class Query {
 			'ext': ['']
 		};
 
-		return flatten(commands.map(command => subcommands[command] ? subcommands[command].map(subcommand => `${command}:${subcommand}`) : [command]));
+		return flatten(
+			commands.map(command =>
+				subcommands[command]
+					? subcommands[command].map(subcommand => `@${command}:${subcommand}${subcommand === '' ? '' : ' '}`)
+					: [`@${command} `]));
 	}
 
 	static parse(value: string): Query {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -352,7 +352,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 
 		const onKeyDownMonaco = chain(this.searchBox.onKeyDown);
 		onKeyDownMonaco.filter(e => e.keyCode === KeyCode.Enter).on(e => e.preventDefault(), this, this.disposables);
-		onKeyDownMonaco.filter(e => e.keyCode === KeyCode.DownArrow).on(() => this.focusListView(), this, this.disposables);
+		onKeyDownMonaco.filter(e => e.keyCode === KeyCode.DownArrow && e.ctrlKey).on(() => this.focusListView(), this, this.disposables);
 
 		const searchChangeEvent = new Emitter<string>();
 		this.onSearchChange = searchChangeEvent.event;
@@ -514,10 +514,11 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 	}
 
 	private autoComplete(query: string, position: number): { fullText: string, overwrite: number }[] {
-		if (query.lastIndexOf('@', position - 1) !== query.lastIndexOf(' ', position - 1) + 1) { return []; }
-
-		let wordStart = query.lastIndexOf('@', position - 1) + 1;
+		let wordStart = query.lastIndexOf(' ', position - 1) + 1;
 		let alreadyTypedCount = position - wordStart - 1;
+
+		// dont show autosuggestions if the user has typed something, but hasn't used the trigger character
+		if (alreadyTypedCount > 0 && query[wordStart] !== '@') { return []; }
 
 		return Query.autocompletions().map(replacement => ({ fullText: replacement, overwrite: alreadyTypedCount }));
 	}


### PR DESCRIPTION
This enables `ctrl+space` in the extension view to suggest `@`-filters when the search box is empty or a the cursor is at the start of a new word