### PR TITLE
Place cursor at end of extensions search box on autofill

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -468,7 +468,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 		event.immediate = true;
 
 		this.searchBox.setValue(value);
-		this.searchBox.setSelection(new Range(1, value.length + 1, 1, value.length + 1));
+		this.searchBox.setPosition(new Position(1, value.length + 1));
 	}
 
 	private triggerSearch(immediate = false): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -468,6 +468,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 		event.immediate = true;
 
 		this.searchBox.setValue(value);
+		this.searchBox.setSelection(new Range(1, value.length + 1, 1, value.length + 1));
 	}
 
 	private triggerSearch(immediate = false): void {


### PR DESCRIPTION
This closes #55204 by putting cursor at the end of search text after using any of the show extensions commands