### PR TITLE
Polish tag search as per feedback

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -84,6 +84,8 @@ export class SettingsEditor2 extends BaseEditor {
 	private inSettingsEditorContextKey: IContextKey<boolean>;
 	private searchFocusContextKey: IContextKey<boolean>;
 
+	private tagRegex = /@tag:("([^"]*)"|[^"]\S*)(\s+|\b|$)/g;
+
 	/** Don't spam warnings */
 	private hasWarnedMissingSettings: boolean;
 
@@ -181,10 +183,10 @@ export class SettingsEditor2 extends BaseEditor {
 		this.searchWidget.clear();
 	}
 
-	filterByTag(tag: string): void {
+	search(text: string): void {
 		if (this.searchWidget) {
 			this.searchWidget.focus();
-			this.searchWidget.setValue(`@tag:${tag} `);
+			this.searchWidget.setValue(text);
 		}
 	}
 
@@ -233,7 +235,7 @@ export class SettingsEditor2 extends BaseEditor {
 
 		const actions = [
 			this.instantiationService.createInstance(FilterByTagAction,
-				localize('filterModifiedLabel', "Show modified settings only"),
+				localize('filterModifiedLabel', "Show modified settings"),
 				MODIFIED_SETTING_TAG,
 				this),
 			this.instantiationService.createInstance(
@@ -664,11 +666,14 @@ export class SettingsEditor2 extends BaseEditor {
 	private triggerSearch(query: string): TPromise<void> {
 		this.viewState.tagFilters = new Set<string>();
 		if (query) {
-			const tagMatches = query.match(/\s*@tag:(\S+)(.*)/); // For now, we support single tag at a time.
-			if (tagMatches) {
-				this.viewState.tagFilters.add(tagMatches[1]);
-				query = tagMatches[2];
-			}
+			query = query.replace(this.tagRegex, (_, quotedTag, tag) => {
+				this.viewState.tagFilters.add(tag || quotedTag);
+				return '';
+			});
+			query = query.replace(`@${MODIFIED_SETTING_TAG}`, () => {
+				this.viewState.tagFilters.add(MODIFIED_SETTING_TAG);
+				return '';
+			});
 		}
 		if (query) {
 			return this.searchInProgress = TPromise.join([
@@ -856,7 +861,7 @@ class FilterByTagAction extends Action {
 	}
 
 	run(): TPromise<void> {
-		this.settingsEditor.filterByTag(this.tag);
+		this.settingsEditor.search(this.tag === MODIFIED_SETTING_TAG ? `@${this.tag} ` : `@tag:${this.tag} `);
 		return TPromise.as(null);
 	}
 }

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -84,7 +84,7 @@ export class SettingsEditor2 extends BaseEditor {
 	private inSettingsEditorContextKey: IContextKey<boolean>;
 	private searchFocusContextKey: IContextKey<boolean>;
 
-	private tagRegex = /@tag:("([^"]*)"|[^"]\S*)(\s+|\b|$)/g;
+	private tagRegex = /(^|\s)@tag:("([^"]*)"|[^"]\S*)/g;
 
 	/** Don't spam warnings */
 	private hasWarnedMissingSettings: boolean;
@@ -666,7 +666,7 @@ export class SettingsEditor2 extends BaseEditor {
 	private triggerSearch(query: string): TPromise<void> {
 		this.viewState.tagFilters = new Set<string>();
 		if (query) {
-			query = query.replace(this.tagRegex, (_, quotedTag, tag) => {
+			query = query.replace(this.tagRegex, (_, __, quotedTag, tag) => {
 				this.viewState.tagFilters.add(tag || quotedTag);
 				return '';
 			});
@@ -675,6 +675,7 @@ export class SettingsEditor2 extends BaseEditor {
 				return '';
 			});
 		}
+		query = query.trim();
 		if (query) {
 			return this.searchInProgress = TPromise.join([
 				this.localSearchDelayer.trigger(() => this.localFilterPreferences(query)),

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -1181,11 +1181,9 @@ export class SettingsTreeFilter implements IFilter {
 
 		if (element instanceof SettingsTreeSettingElement && this.viewState.tagFilters && this.viewState.tagFilters.size) {
 			if (element.tags) {
-				let hasFilteredTag = false;
-				element.tags.forEach(tag => {
-					if (this.viewState.tagFilters.has(tag)) {
-						hasFilteredTag = true;
-					}
+				let hasFilteredTag = true;
+				this.viewState.tagFilters.forEach(tag => {
+					hasFilteredTag = hasFilteredTag && element.tags.has(tag);
 				});
 				return hasFilteredTag;
 			} else {


### PR DESCRIPTION
- Use `@modified` instead of `@tag:modified` to be inline with how we do search in the extensions view. 
- Update text for the modified action for consistency
- Support more than one @ filters