### PR TITLE
Minor css tweaks to enable overflow ellipsis in more places

### DIFF
--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -36,6 +36,9 @@
 	font-weight: normal;
 	-webkit-margin-before: 0;
 	-webkit-margin-after: 0;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
 .monaco-workbench > .part > .title > .title-label a {

--- a/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/parts/extensions/electron-browser/media/extensionsViewlet.css
@@ -27,10 +27,6 @@
 	height: calc(100% - 38px);
 }
 
-.extensions-viewlet > .extensions .list-actionbar-container {
-	margin-right: 10px;
-}
-
 .extensions-viewlet > .extensions .list-actionbar-container .monaco-action-bar .action-item > .octicon {
 	font-size: 12px;
 	line-height: 1;
@@ -48,7 +44,7 @@
 }
 
 .extensions-viewlet > .extensions .panel-header {
-	padding-right: 12px;
+	padding-right: 28px;
 }
 
 .extensions-viewlet > .extensions .panel-header > .title {


### PR DESCRIPTION
This enables ellipsis again in viewlet titles and some viewlet panel titles. Regression from #53494, as HTML headings behave differently than spans when it comes to overflow.