### PR TITLE
Remove confusing Start from wordPartLeft commands ID : #53497

### DIFF
--- a/src/vs/editor/contrib/wordPartOperations/wordPartOperations.ts
+++ b/src/vs/editor/contrib/wordPartOperations/wordPartOperations.ts
@@ -79,7 +79,7 @@ export class CursorWordPartLeft extends WordPartLeftCommand {
 		super({
 			inSelectionMode: false,
 			wordNavigationType: WordNavigationType.WordStart,
-			id: 'cursorWordPartStartLeft',
+			id: 'cursorWordPartLeft',
 			precondition: null,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -95,7 +95,7 @@ export class CursorWordPartLeftSelect extends WordPartLeftCommand {
 		super({
 			inSelectionMode: true,
 			wordNavigationType: WordNavigationType.WordStart,
-			id: 'cursorWordPartStartLeftSelect',
+			id: 'cursorWordPartLeftSelect',
 			precondition: null,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,


### PR DESCRIPTION
ping @alexandrudima

(_I did not test this change yet, but looking at what I needed to change it seems to be enough - I'll test later today_)

Fixes #53497