### PR TITLE
Don't show existing filters in autocomplete

### DIFF
--- a/src/vs/workbench/parts/extensions/common/extensionQuery.ts
+++ b/src/vs/workbench/parts/extensions/common/extensionQuery.ts
@@ -21,15 +21,13 @@ export class Query {
 			'ext': ['']
 		};
 
-		let containsSub = (haystack: string) => (needle: string) => haystack.indexOf(needle) !== -1;
-		let queryContains = containsSub(query);
+		let queryContains = (substr: string) => query.indexOf(substr) > -1;
 		let hasSort = subcommands.sort.some(subcommand => queryContains(`@sort:${subcommand}`));
 		let hasCategory = subcommands.category.some(subcommand => queryContains(`@category:${subcommand}`));
 
 		return flatten(
 			commands.map(command => {
-				let commandContains = containsSub(command);
-				if (hasSort && commandContains('sort') || hasCategory && commandContains('category')) {
+				if (hasSort && command === 'sort' || hasCategory && command === 'category') {
 					return [];
 				}
 				if (subcommands[command]) {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -527,7 +527,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 		// dont show autosuggestions if the user has typed something, but hasn't used the trigger character
 		if (alreadyTypedCount > 0 && query[wordStart] !== '@') { return []; }
 
-		return Query.autocompletions().map(replacement => ({ fullText: replacement, overwrite: alreadyTypedCount }));
+		return Query.autocompletions(query).map(replacement => ({ fullText: replacement, overwrite: alreadyTypedCount }));
 	}
 
 	private count(): number {

--- a/src/vs/workbench/parts/extensions/test/common/extensionQuery.test.ts
+++ b/src/vs/workbench/parts/extensions/test/common/extensionQuery.test.ts
@@ -140,4 +140,12 @@ suite('Extension query', () => {
 		query2 = new Query('hello', 'installs', '');
 		assert(!query1.equals(query2));
 	});
+
+	test('autocomplete', () => {
+		Query.autocompletions('@sort:in').some(x => x === '@sort:installs ');
+		Query.autocompletions('@sort:installs').every(x => x !== '@sort:rating ');
+
+		Query.autocompletions('@category:blah').some(x => x === '@category:"extension packs" ');
+		Query.autocompletions('@category:"extension packs"').every(x => x !== '@category:formatters ');
+	});
 });


### PR DESCRIPTION
Fixes #55489 by filtering out all `@category:...` or `@search:...` suggestions when there exists a complete `@category:...` or `@search:...` (respectively) in the query already.