### PR TITLE
Disable fuzzy matching for extensions autosuggest

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -693,6 +693,7 @@ function mixinHTMLInputStyleOptions(config: IEditorOptions, ariaLabel?: string):
 	config.ariaLabel = ariaLabel || '';
 	config.cursorWidth = 1;
 	config.snippetSuggestions = 'none';
+	config.suggest = { filterGraceful: false };
 	config.fontFamily = ' -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "HelveticaNeue-Light", "Ubuntu", "Droid Sans", sans-serif';
 	return config;
 }


### PR DESCRIPTION
Closes #55422 by disabling fuzzy matching in extensions search box. Previously the filter would account for some accidental transpositions when showing results, which led to unexpected behaviour.