### PR TITLE
Default 'Quick Switch Window' selection to be next window

### DIFF
--- a/src/vs/workbench/electron-browser/actions.ts
+++ b/src/vs/workbench/electron-browser/actions.ts
@@ -614,9 +614,11 @@ export abstract class BaseSwitchWindow extends Action {
 				action: (!this.isQuickNavigate() && currentWindowId !== win.id) ? this.closeWindowAction : void 0
 			} as IFilePickOpenEntry));
 
+			const autoFocusIndex = (picks.indexOf(picks.filter(pick => pick.payload === currentWindowId)[0]) + 1) % picks.length;
+
 			this.quickOpenService.pick(picks, {
 				contextKey: 'inWindowsPicker',
-				autoFocus: { autoFocusFirstEntry: true },
+				autoFocus: { autoFocusIndex },
 				placeHolder,
 				quickNavigateConfiguration: this.isQuickNavigate() ? { keybindings: this.keybindingService.lookupKeybindings(this.id) } : void 0
 			});


### PR DESCRIPTION
In response to #55166. Defaults the window switcher to the next window, instead of the first window in the list.