### PR TITLE
Fix bug causing an aria alert to not be shown the third time

### DIFF
--- a/src/vs/base/browser/ui/aria/aria.ts
+++ b/src/vs/base/browser/ui/aria/aria.ts
@@ -53,14 +53,19 @@ export function status(msg: string): void {
 let repeatedTimes = 0;
 let prevText: string | undefined = undefined;
 function insertMessage(target: HTMLElement, msg: string): void {
-
 	if (!ariaContainer) {
 		// console.warn('ARIA support needs a container. Call setARIAContainer() first.');
 		return;
 	}
 
-	if (prevText === msg) { repeatedTimes++; }
-	prevText = msg;
+	if (prevText === msg) {
+		repeatedTimes++;
+	}
+	else {
+		prevText = msg;
+		repeatedTimes = 0;
+	}
+
 
 	switch (repeatedTimes) {
 		case 0: break;

--- a/src/vs/base/browser/ui/aria/aria.ts
+++ b/src/vs/base/browser/ui/aria/aria.ts
@@ -50,13 +50,22 @@ export function status(msg: string): void {
 	}
 }
 
+let repeatedTimes = 0;
+let prevText: string | undefined = undefined;
 function insertMessage(target: HTMLElement, msg: string): void {
+
 	if (!ariaContainer) {
 		// console.warn('ARIA support needs a container. Call setARIAContainer() first.');
 		return;
 	}
-	if (target.textContent === msg) {
-		msg = nls.localize('repeated', "{0} (occurred again)", msg);
+
+	if (prevText === msg) { repeatedTimes++; }
+	prevText = msg;
+
+	switch (repeatedTimes) {
+		case 0: break;
+		case 1: msg = nls.localize('repeated', "{0} (occurred again)", msg); break;
+		default: msg = nls.localize('repeatedNtimes', "{0} (occurred {1} times)", msg, repeatedTimes); break;
 	}
 
 	dom.clearNode(target);


### PR DESCRIPTION
 (and odd numbers thereafter)

Closes #27655. 

It seems the screen reader will not read the same alert text twice. We get around that by incrementing the number of times seen and using that as part of the text.

The previous implementation attempted to get around this by flip/flopping between `msg` and `msg (occurred again)` as the message text. However, this doesn't work because the `msg` would never get read after the first time. This is probably a bug in NVDA.