### PR TITLE
Settings Editor: Add aria labels for input elements Fixes: #54836

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -58,6 +58,9 @@ class SelectListRenderer implements IRenderer<ISelectOptionItem, ISelectListTemp
 		data.optionText.textContent = optionText;
 		data.root.setAttribute('aria-label', nls.localize('selectAriaOption', "{0}", optionText));
 
+		// Workaround for list labels
+		data.root.setAttribute('aria-selected', 'true');
+
 		// pseudo-select disabled option
 		if (optionDisabled) {
 			dom.addClass((<HTMLElement>data.root), 'option-disabled');

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -1196,13 +1196,32 @@ export class SettingsRenderer implements ITreeRenderer {
 		template.onChange = onChange;
 
 		template.checkbox.domNode.tabIndex = isSelected ? 0 : -1;
+
+		// Setup and add ARIA attributes
+		// Create id and label for control/input element - parent is wrapper div
+		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
+		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' checkbox ' + (dataElement.value ? 'checked ' : 'unchecked ') + template.isConfiguredElement.textContent;
+
+		// We use the parent control div for the aria-labelledby target
+		// Does not appear you can use the direct label on the element itself within a tree
+		template.checkbox.domNode.parentElement.setAttribute('id', id);
+		template.checkbox.domNode.parentElement.setAttribute('aria-label', label);
+
+		// Labels will not be read on descendent input elements of the parent treeitem
+		// unless defined as role=treeitem and indirect aria-labelledby approach
+		// TODO: Determine method to normally label input items with value read last
+		template.checkbox.domNode.setAttribute('id', id + 'item');
+		template.checkbox.domNode.setAttribute('role', 'treeitem');
+		template.checkbox.domNode.setAttribute('aria-labelledby', id + 'item ' + id);
+
 	}
 
 	private renderEnum(dataElement: SettingsTreeSettingElement, isSelected: boolean, template: ISettingEnumItemTemplate, onChange: (value: string) => void): void {
 		const displayOptions = getDisplayEnumOptions(dataElement.setting);
 		template.selectBox.setOptions(displayOptions);
 
-		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel;
+		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' combobox ' + template.isConfiguredElement.textContent;
+
 		template.selectBox.setAriaLabel(label);
 
 		const idx = dataElement.setting.enum.indexOf(dataElement.value);
@@ -1212,6 +1231,8 @@ export class SettingsRenderer implements ITreeRenderer {
 
 		if (template.controlElement.firstElementChild) {
 			template.controlElement.firstElementChild.setAttribute('tabindex', isSelected ? '0' : '-1');
+			// SelectBox needs to be treeitem to read correctly within tree
+			template.controlElement.firstElementChild.setAttribute('role', 'treeitem');
 		}
 	}
 
@@ -1220,7 +1241,26 @@ export class SettingsRenderer implements ITreeRenderer {
 		template.inputBox.value = dataElement.value;
 		template.onChange = value => onChange(value);
 		template.inputBox.inputElement.tabIndex = isSelected ? 0 : -1;
+
+		// Setup and add ARIA attributes
+		// Create id and label for control/input element - parent is wrapper div
+		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
+		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' ' + template.isConfiguredElement.textContent;
+
+		// We use the parent control div for the aria-labelledby target
+		// Does not appear you can use the direct label on the element itself within a tree
+		template.inputBox.inputElement.parentElement.setAttribute('id', id);
+		template.inputBox.inputElement.parentElement.setAttribute('aria-label', label);
+
+		// Labels will not be read on descendent input elements of the parent treeitem
+		// unless defined as role=treeitem and indirect aria-labelledby approach
+		// TODO: Determine method to normally label input items with value read last
+		template.inputBox.inputElement.setAttribute('id', id + 'item');
+		template.inputBox.inputElement.setAttribute('role', 'treeitem');
+		template.inputBox.inputElement.setAttribute('aria-labelledby', id + 'item ' + id);
+
 	}
+
 
 	private renderNumber(dataElement: SettingsTreeSettingElement, isSelected: boolean, template: ISettingTextItemTemplate, onChange: (value: number) => void): void {
 		template.onChange = null;
@@ -1229,6 +1269,24 @@ export class SettingsRenderer implements ITreeRenderer {
 		template.inputBox.inputElement.tabIndex = isSelected ? 0 : -1;
 
 		const parseFn = dataElement.valueType === 'integer' ? parseInt : parseFloat;
+
+		// Setup and add ARIA attributes
+		// Create id and label for control/input element - parent is wrapper div
+		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
+		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' number ' + template.isConfiguredElement.textContent;
+
+		// We use the parent control div for the aria-labelledby target
+		// Does not appear you can use the direct label on the element itself within a tree
+		template.inputBox.inputElement.parentElement.setAttribute('id', id);
+		template.inputBox.inputElement.parentElement.setAttribute('aria-label', label);
+
+		// Labels will not be read on descendent input elements of the parent treeitem
+		// unless defined as role=treeitem and indirect aria-labelledby approach
+		// TODO: Determine method to normally label input items with value read last
+		template.inputBox.inputElement.setAttribute('id', id + 'item');
+		template.inputBox.inputElement.setAttribute('role', 'treeitem');
+		template.inputBox.inputElement.setAttribute('aria-labelledby', id + 'item ' + id);
+
 	}
 
 	private renderExcludeSetting(dataElement: SettingsTreeSettingElement, isSelected: boolean, template: ISettingExcludeItemTemplate): void {


### PR DESCRIPTION
@roblourens 

This addresses labels for input elements as best as possible for elements within a tree.
My research suggests interactive elements within a tree are not formally supported
but at least NVDA does its best.

I believe will have to revisit this with more information, perhaps we need to use treegrid or
grid both of which explicitly support interactive elements.  These might need to be added as options
for list and tree widgets

I will also work at adding support for the links within descriptions but I will wait till after this milestone

No response yet on my question on this for NVDA
