### PR TITLE
Fixed emmet validation when open angle bracket is followed by space

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -440,7 +440,6 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 	const endAngle = '>';
 	const escape = '\\';
 	const question = '?';
-	const space = ' ';
 	const currentHtmlNode = <HtmlNode>currentNode;
 	let start = new vscode.Position(0, 0);
 
@@ -501,7 +500,7 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 		}
 		// Fix for https://github.com/Microsoft/vscode/issues/55411
 		// A space is not a valid character right after < in a tag name.
-		if (char === space && textToBackTrack[i] === startAngle) {
+		if (/\s/.test(char) && textToBackTrack[i] === startAngle) {
 			i--;
 			continue;
 		}

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -440,6 +440,7 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 	const endAngle = '>';
 	const escape = '\\';
 	const question = '?';
+	const space = ' ';
 	const currentHtmlNode = <HtmlNode>currentNode;
 	let start = new vscode.Position(0, 0);
 
@@ -495,6 +496,12 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 			continue;
 		}
 		if (char === question && textToBackTrack[i] === startAngle) {
+			i--;
+			continue;
+		}
+		// Fix for https://github.com/Microsoft/vscode/issues/55411
+		// A space is not a valid character right after < in a tag name.
+		if (char === space && textToBackTrack[i] === startAngle) {
 			i--;
 			continue;
 		}

--- a/extensions/emmet/src/test/abbreviationAction.test.ts
+++ b/extensions/emmet/src/test/abbreviationAction.test.ts
@@ -466,6 +466,16 @@ suite('Tests for jsx, xml and xsl', () => {
 		});
 	});
 
+	test('Expand abbreviation with condition containing less than sign for jsx', () => {
+		return withRandomFileEditor('if (foo < 10) { span.bar', 'javascriptreact', (editor, doc) => {
+			editor.selection = new Selection(0, 27, 0, 27);
+			return expandEmmetAbbreviation({ language: 'javascriptreact' }).then(() => {
+				assert.equal(editor.document.getText(), 'if (foo < 10) { <span className="bar"></span>');
+				return Promise.resolve();
+			});
+		});
+	});
+
 	test('No expanding text inside open tag in completion list (jsx)', () => {
 		return testNoCompletion('jsx', htmlContents, new Selection(2, 4, 2, 4));
 	});


### PR DESCRIPTION
Fix for issue [#55411](https://github.com/Microsoft/vscode/issues/55411).

Much like the check for PHP's `<?`, it checks for an open angle bracket followed by a space, which is not valid as an HTML Tag, based on the [W3C recommendation](https://www.w3.org/TR/html5/syntax.html#start-tags).

This will fix issues where, for example, emmet won't trigger in JSX when the if statement contains a `<`, eg: `if (age < 10) ...`.

This will **not** work if the there is no space after the angle bracket, as in `if (age <10)`, as numbers are valid within tag names.  But this problem should be taken care of by linting.