### PR TITLE
Show warning when enabling proposed api for non-installed extensions

### DIFF
--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -551,6 +551,20 @@ export class ExtensionService extends Disposable implements IExtensionService {
 
 				const enableProposedApiFor: string | string[] = this._environmentService.args['enable-proposed-api'] || [];
 
+				const notFound = (id: string) => nls.localize('notFound', " Can not enable proposed API: Extension '{0}' not found.", id);
+				const useId = nls.localize('useId', "Make sure you use the full extension ID, including the publisher, eg: {0}", 'ms-vscode.csharp');
+
+				if (enableProposedApiFor.length) {
+					let allProposed = (enableProposedApiFor instanceof Array ? enableProposedApiFor : [enableProposedApiFor]).map(id => id.toLowerCase());
+					let allInstalled = allExtensions.map(description => description.id.toLowerCase());
+					allProposed.forEach(id => {
+						if (allInstalled.indexOf(id) === -1) {
+							console.warn(notFound);
+							this._notificationService.warn(`${notFound(id)}\n ${useId}`);
+						}
+					});
+				}
+
 				const enableProposedApiForAll = !this._environmentService.isBuilt ||
 					(!!this._environmentService.extensionDevelopmentPath && product.nameLong.indexOf('Insiders') >= 0) ||
 					(enableProposedApiFor.length === 0 && 'enable-proposed-api' in this._environmentService.args);

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -551,14 +551,13 @@ export class ExtensionService extends Disposable implements IExtensionService {
 
 				const enableProposedApiFor: string | string[] = this._environmentService.args['enable-proposed-api'] || [];
 
-				const notFound = (id: string) => nls.localize('notFound', "Extension `${id}` cannot use PROPOSED API as it cannot be found", id);
+				const notFound = (id: string) => nls.localize('notFound', "Extension \`{0}\` cannot use PROPOSED API as it cannot be found", id);
 
 				if (enableProposedApiFor.length) {
 					let allProposed = (enableProposedApiFor instanceof Array ? enableProposedApiFor : [enableProposedApiFor]);
-					let allInstalled = allExtensions.map(description => description.id);
 					allProposed.forEach(id => {
-						if (allInstalled.indexOf(id) === -1) {
-							console.error(notFound);
+						if (!allExtensions.some(description => description.id === id)) {
+							console.error(notFound(id));
 						}
 					});
 				}

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -551,16 +551,14 @@ export class ExtensionService extends Disposable implements IExtensionService {
 
 				const enableProposedApiFor: string | string[] = this._environmentService.args['enable-proposed-api'] || [];
 
-				const notFound = (id: string) => nls.localize('notFound', " Can not enable proposed API: Extension '{0}' not found.", id);
-				const useId = nls.localize('useId', "Make sure you use the full extension ID, including the publisher, eg: {0}", 'ms-vscode.csharp');
+				const notFound = (id: string) => nls.localize('notFound', "Extension `${id}` cannot use PROPOSED API as it cannot be found", id);
 
 				if (enableProposedApiFor.length) {
-					let allProposed = (enableProposedApiFor instanceof Array ? enableProposedApiFor : [enableProposedApiFor]).map(id => id.toLowerCase());
-					let allInstalled = allExtensions.map(description => description.id.toLowerCase());
+					let allProposed = (enableProposedApiFor instanceof Array ? enableProposedApiFor : [enableProposedApiFor]);
+					let allInstalled = allExtensions.map(description => description.id);
 					allProposed.forEach(id => {
 						if (allInstalled.indexOf(id) === -1) {
-							console.warn(notFound);
-							this._notificationService.warn(`${notFound(id)}\n ${useId}`);
+							console.error(notFound);
 						}
 					});
 				}


### PR DESCRIPTION
This closes #55516 by showing a notification and logging to console when attempting to enable proposed api for an extension which is not installed.