### PR TITLE
Fix bug causing workspace recommendations to go away upon ignoring a recommendation

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -801,8 +801,8 @@ export class WorkspaceRecommendedExtensionsView extends ExtensionsListView {
 	}
 
 	async show(query: string): Promise<IPagedModel<IExtension>> {
-		let shouldShowWorkspaceRecommended = query && (query.trim() === '@recommended' || query.trim() === '@recommended:workspace');
-		let model = await (shouldShowWorkspaceRecommended ? super.show(this.recommendedExtensionsQuery) : this.showEmptyModel());
+		let shouldShowEmptyView = query && query.trim() !== '@recommended' && query.trim() !== '@recommended:workspace';
+		let model = await (shouldShowEmptyView ? this.showEmptyModel() : super.show(this.recommendedExtensionsQuery));
 		this.setExpanded(model.length > 0);
 		return model;
 	}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -801,7 +801,7 @@ export class WorkspaceRecommendedExtensionsView extends ExtensionsListView {
 	}
 
 	async show(query: string): Promise<IPagedModel<IExtension>> {
-		let model = await ((query && query.trim() !== '@recommended') ? this.showEmptyModel() : super.show(this.recommendedExtensionsQuery));
+		let model = await (/@recommended/.test(query) ? super.show(this.recommendedExtensionsQuery) : this.showEmptyModel());
 		this.setExpanded(model.length > 0);
 		return model;
 	}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -801,7 +801,8 @@ export class WorkspaceRecommendedExtensionsView extends ExtensionsListView {
 	}
 
 	async show(query: string): Promise<IPagedModel<IExtension>> {
-		let model = await (/@recommended/.test(query) ? super.show(this.recommendedExtensionsQuery) : this.showEmptyModel());
+		let shouldShowWorkspaceRecommended = query && (query.trim() === '@recommended' || query.trim() === '@recommended:workspace');
+		let model = await (shouldShowWorkspaceRecommended ? super.show(this.recommendedExtensionsQuery) : this.showEmptyModel());
 		this.setExpanded(model.length > 0);
 		return model;
 	}


### PR DESCRIPTION
Fixes #55596, where all workspace recommendations (the pane in the `@recommended` search view) would vanish after ignoring any recommendation. 

I think this should be in July becuase it is pretty jarring and unexpected, and it happens any time you're in the `@recommended` search view and ignore any recommenedation