### PR TITLE
Improve UX for deprecated settings

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -145,7 +145,8 @@ export class SettingsTreeModel {
 		if (tocEntry.children) {
 			element.children = tocEntry.children.map(child => this.createSettingsTreeGroupElement(child, element));
 		} else if (tocEntry.settings) {
-			element.children = tocEntry.settings.map(s => this.createSettingsTreeSettingElement(<ISetting>s, element));
+			element.children = tocEntry.settings.map(s => this.createSettingsTreeSettingElement(<ISetting>s, element))
+				.filter(el => el.setting.deprecationMessage ? el.isConfigured : true);
 		}
 
 		this._treeElementsById.set(element.id, element);
@@ -1413,7 +1414,8 @@ export class SearchResultModel {
 
 	updateChildren(): void {
 		this.children = this.getFlatSettings()
-			.map(s => createSettingsTreeSettingElement(s, this, this._viewState.settingsTarget, this._configurationService));
+			.map(s => createSettingsTreeSettingElement(s, this, this._viewState.settingsTarget, this._configurationService))
+			.filter(el => el.setting.deprecationMessage ? el.isConfigured : true);
 
 		if (this.newExtensionSearchResults) {
 			const newExtElement = new SettingsTreeNewExtensionsElement();

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -44,6 +44,7 @@ export interface ISetting {
 	descriptionRanges: IRange[];
 	overrides?: ISetting[];
 	overrideOf?: ISetting;
+	deprecationMessage?: string;
 
 	// TODO@roblou maybe need new type and new EditorModel for GUI editor instead of ISetting which is used for text settings editor
 	type?: string | string[];

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -9,7 +9,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { JSONVisitor, visit } from 'vs/base/common/json';
 import { Disposable, IReference } from 'vs/base/common/lifecycle';
 import * as map from 'vs/base/common/map';
-import { assign } from 'vs/base/common/objects';
+import { assign, deepClone } from 'vs/base/common/objects';
 import URI from 'vs/base/common/uri';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
@@ -667,7 +667,13 @@ export class DefaultSettingsEditorModel extends AbstractSettingsModel implements
 		// Grab current result groups, only render non-empty groups
 		const resultGroups = map
 			.values(this._currentResultGroups)
+			.map(group => {
+				let groupCopy = deepClone(group);
+				groupCopy.result.filterMatches = group.result.filterMatches.filter(match => !match.setting.deprecationMessage);
+				return groupCopy;
+			})
 			.sort((a, b) => a.order - b.order);
+
 		const nonEmptyResultGroups = resultGroups.filter(group => group.result.filterMatches.length);
 
 		const startLine = tail(this.settingsGroups).range.endLineNumber + 2;

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -557,7 +557,6 @@ export class DefaultSettings extends Disposable {
 				if (prop.deprecationMessage) {
 					description.push(
 						'',
-						nls.localize('deprecatedSetting', "Warning: deprecated setting."),
 						prop.deprecationMessage,
 						nls.localize('deprecatedSetting.unstable', "This setting should not be used, and will be removed in a future release."));
 				}

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -551,7 +551,7 @@ export class DefaultSettings extends Disposable {
 		let result: ISetting[] = [];
 		for (let key in settingsObject) {
 			const prop = settingsObject[key];
-			if (!prop.deprecationMessage && this.matchesScope(prop)) {
+			if (this.matchesScope(prop)) {
 				const value = prop.default;
 				const description = (prop.description || '').split('\n');
 				const overrides = OVERRIDE_PROPERTY_PATTERN.test(key) ? this.parseOverrideSettings(prop.default) : [];
@@ -567,7 +567,8 @@ export class DefaultSettings extends Disposable {
 					type: prop.type,
 					enum: prop.enum,
 					enumDescriptions: prop.enumDescriptions,
-					tags: prop.tags
+					tags: prop.tags,
+					deprecationMessage: prop.deprecationMessage,
 				});
 			}
 		}

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -9,7 +9,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { JSONVisitor, visit } from 'vs/base/common/json';
 import { Disposable, IReference } from 'vs/base/common/lifecycle';
 import * as map from 'vs/base/common/map';
-import { assign, deepClone } from 'vs/base/common/objects';
+import { assign } from 'vs/base/common/objects';
 import URI from 'vs/base/common/uri';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
@@ -667,13 +667,7 @@ export class DefaultSettingsEditorModel extends AbstractSettingsModel implements
 		// Grab current result groups, only render non-empty groups
 		const resultGroups = map
 			.values(this._currentResultGroups)
-			.map(group => {
-				let groupCopy = deepClone(group);
-				groupCopy.result.filterMatches = group.result.filterMatches.filter(match => !match.setting.deprecationMessage);
-				return groupCopy;
-			})
 			.sort((a, b) => a.order - b.order);
-
 		const nonEmptyResultGroups = resultGroups.filter(group => group.result.filterMatches.length);
 
 		const startLine = tail(this.settingsGroups).range.endLineNumber + 2;

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -554,6 +554,13 @@ export class DefaultSettings extends Disposable {
 			if (this.matchesScope(prop)) {
 				const value = prop.default;
 				const description = (prop.description || '').split('\n');
+				if (prop.deprecationMessage) {
+					description.push(
+						'',
+						nls.localize('deprecatedSetting', "Warning: deprecated setting."),
+						prop.deprecationMessage,
+						nls.localize('deprecatedSetting.unstable', "This setting should not be used, and will be removed in a future release."));
+				}
 				const overrides = OVERRIDE_PROPERTY_PATTERN.test(key) ? this.parseOverrideSettings(prop.default) : [];
 				result.push({
 					key,


### PR DESCRIPTION
This PR enables modified deprecated settings to show in the new settings editor and adds additional warning text for deprecated settings in both the old editor and new. Deprecated settings now show up in old settings editor search. 

Full disclosure: this removes the existing behavior of deprecated settings not showing up at all in old editor, as the old and new share a model, and the old basically just renders the model as is. This meant that when I added deprecated settings to the model in order for the new editor to conditionally render them, the old editor would render them too. 

Edit: we previously had localized deprecation messages as well, so there isnt a positive spin like I previously said. Oh well. @roblourens if you have an idea for how to filter the old settings view, I'm all ears. It is just 5 at this point, so I personally think just having the deprecation message show up is fine.