### PR TITLE
Update highlighted text color on selected rows

### DIFF
--- a/src/vs/workbench/parts/outline/electron-browser/outlinePanel.css
+++ b/src/vs/workbench/parts/outline/electron-browser/outlinePanel.css
@@ -71,8 +71,13 @@
 	display: none;
 }
 
-.monaco-tree.focused .selected .outline-element-label, .monaco-tree.focused .selected .outline-element-decoration {
+.monaco-tree.focused .selected .outline-element-label, .monaco-tree.focused .selected .outline-element-decoration{
 	/* make sure selection color wins when a label is being selected */
+	color: inherit !important;
+}
+
+.monaco-tree.focused .selected .outline-element-label .monaco-highlighted-label .highlight{
+	/* allows text color to overwrite highlight text when selected  */
 	color: inherit !important;
 }
 

--- a/src/vs/workbench/parts/outline/electron-browser/outlinePanel.css
+++ b/src/vs/workbench/parts/outline/electron-browser/outlinePanel.css
@@ -76,8 +76,9 @@
 	color: inherit !important;
 }
 
-.monaco-tree.focused .selected .outline-element-label .monaco-highlighted-label .highlight{
-	/* allows text color to overwrite highlight text when selected  */
+.monaco-tree.focused .selected .outline-element-label .monaco-highlighted-label .highlight,
+.monaco-tree.focused .selected .monaco-icon-label .monaco-highlighted-label .highlight{
+	/* allows text color to use the default when selected  */
 	color: inherit !important;
 }
 


### PR DESCRIPTION
Fixes #55952. This only applies to the outline and breadcrumb views.

### Dark

| Outline | Breadcrumb |
|---|---|
|![image](https://user-images.githubusercontent.com/35271042/43849595-aa86e88a-9aea-11e8-8a9f-605e701a492d.png)|![image](https://user-images.githubusercontent.com/35271042/43849674-d72beda4-9aea-11e8-9989-e8db16ff5e32.png)|


### Light

| Outline | Breadcrumb |
|---|---|
|![image](https://user-images.githubusercontent.com/35271042/43849211-c3ff4ed4-9ae9-11e8-84ec-cb5587270b50.png)|![image](https://user-images.githubusercontent.com/35271042/43849454-52b1a2da-9aea-11e8-9688-3d166bad7e8e.png)|


cc @bpasero, quick open remains unchanged:

![image](https://user-images.githubusercontent.com/35271042/43849060-612d4888-9ae9-11e8-9175-c598a88cfbe9.png)
![image](https://user-images.githubusercontent.com/35271042/43849085-71922068-9ae9-11e8-9b90-04b90d8ee9d1.png)

