### PR TITLE
Allow empty git commit

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -191,6 +191,11 @@
         "category": "Git"
       },
       {
+        "command": "git.commitEmpty",
+        "title": "%command.commitEmpty%",
+        "category": "Git"
+      },
+      {
         "command": "git.commitStagedSigned",
         "title": "%command.commitStagedSigned%",
         "category": "Git"
@@ -418,6 +423,10 @@
           "when": "config.git.enabled && gitOpenRepositoryCount != 0"
         },
         {
+          "command": "git.commitEmpty",
+          "when": "config.git.allowcommitEmptys && gitOpenRepositoryCount != 0"
+        },
+        {
           "command": "git.commitStaged",
           "when": "config.git.enabled && gitOpenRepositoryCount != 0"
         },
@@ -596,6 +605,11 @@
         },
         {
           "command": "git.commitStaged",
+          "group": "3_commit",
+          "when": "scmProvider == git"
+        },
+        {
+          "command": "git.commitEmpty",
           "group": "3_commit",
           "when": "scmProvider == git"
         },
@@ -989,6 +1003,12 @@
           "type": "boolean",
           "scope": "resource",
           "description": "%config.enableCommitSigning%",
+          "default": false
+        },
+        "git.allowEmptyCommits": {
+          "type": "boolean",
+          "scope": "resource",
+          "description": "%config.allowEmptyCommits%",
           "default": false
         },
         "git.decorations.enabled": {

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -22,6 +22,7 @@
 	"command.cleanAll": "Discard All Changes",
 	"command.commit": "Commit",
 	"command.commitStaged": "Commit Staged",
+	"command.commitEmpty": "Commit Empty",
 	"command.commitStagedSigned": "Commit Staged (Signed Off)",
 	"command.commitStagedAmend": "Commit Staged (Amend)",
 	"command.commitAll": "Commit All",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1071,10 +1071,13 @@ export class CommandCenter {
 		}
 
 		if (
+			(
 			// no changes
 			(noStagedChanges && noUnstagedChanges)
 			// or no staged changes and not `all`
 			|| (!opts.all && noStagedChanges)
+		)
+			&& !opts.empty
 		) {
 			window.showInformationMessage(localize('no changes', "There are no changes to commit."));
 			return false;
@@ -1117,6 +1120,11 @@ export class CommandCenter {
 		if (message && didCommit) {
 			repository.inputBox.value = await repository.getCommitTemplate();
 		}
+	}
+
+	@command('git.commitEmpty', { repository: true})
+	async commit(repository: Repository): Promise<void> {
+		await this.commitWithAnyInput(repository, { empty: true });
 	}
 
 	@command('git.commit', { repository: true })

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -940,6 +940,9 @@ export class Repository {
 		if (opts.signCommit) {
 			args.push('-S');
 		}
+		if (opts.empty) {
+			args.push('--allow-empty');
+		}
 
 		try {
 			await this.run(args, { input: message || '' });

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -386,6 +386,7 @@ export interface CommitOptions {
 	amend?: boolean;
 	signoff?: boolean;
 	signCommit?: boolean;
+	empty?: boolean;
 }
 
 export interface GitResourceGroup extends SourceControlResourceGroup {


### PR DESCRIPTION
With some of our salt config we sometimes need to push an empty commit (with the commit message being the name of the service we need to redeploy). 

It's also good if you need to trigger any other sort of commit hooks where the commit message is used for some purpose. 

I tried as much as possible to just slimly insert this feature alongside the rest of the git stuff.