### PR TITLE
Bring back sticky

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/suggestModel.ts
@@ -85,7 +85,7 @@ export const enum State {
 
 export class SuggestModel implements IDisposable {
 
-	private readonly sticky = true; // for development purposes
+	private readonly sticky = false; // for development purposes only
 
 	private _editor: ICodeEditor;
 	private _toDispose: IDisposable[] = [];

--- a/src/vs/editor/contrib/suggest/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/suggestModel.ts
@@ -85,6 +85,8 @@ export const enum State {
 
 export class SuggestModel implements IDisposable {
 
+	private readonly sticky = true; // for development purposes
+
 	private _editor: ICodeEditor;
 	private _toDispose: IDisposable[] = [];
 	private _quickSuggestDelay: number;
@@ -124,7 +126,9 @@ export class SuggestModel implements IDisposable {
 			this.cancel();
 		}));
 		this._toDispose.push(this._editor.onDidBlurEditorText(() => {
-			this.cancel();
+			if (!this.sticky) {
+				this.cancel();
+			}
 		}));
 		this._toDispose.push(this._editor.onDidChangeConfiguration(() => {
 			this._updateTriggerCharacters();

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -35,7 +35,6 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { TimeoutTimer, CancelablePromise, createCancelablePromise } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 
-const sticky = false; // for development purposes
 const expandSuggestionDocsByDefault = false;
 const maxSuggestionsToShow = 12;
 
@@ -456,7 +455,6 @@ export class SuggestWidget implements IContentWidget, IVirtualDelegate<ICompleti
 				listInactiveFocusOutline: activeContrastBorder
 			}),
 			themeService.onThemeChange(t => this.onThemeChange(t)),
-			editor.onDidBlurEditorText(() => this.onEditorBlur()),
 			editor.onDidLayoutChange(() => this.onEditorLayoutChange()),
 			this.list.onSelectionChange(e => this.onListSelection(e)),
 			this.list.onFocusChange(e => this.onListFocus(e)),
@@ -479,18 +477,6 @@ export class SuggestWidget implements IContentWidget, IVirtualDelegate<ICompleti
 		}
 
 		this.editor.layoutContentWidget(this);
-	}
-
-	private onEditorBlur(): void {
-		if (sticky) {
-			return;
-		}
-
-		this.editorBlurTimeout.cancelAndSet(() => {
-			if (!this.editor.hasTextFocus()) {
-				this.setState(State.Hidden);
-			}
-		}, 150);
 	}
 
 	private onEditorLayoutChange(): void {


### PR DESCRIPTION
https://github.com/Microsoft/vscode/commit/c0917d8e6f0f1b5ea06ef231b24ff2ffa1416589 cancels the suggest model on editor blur which in turn [hides the suggest widget](https://github.com/Microsoft/vscode/blob/52ed999139d8c10d3e8ee003d8a6336a9c1d1fa7/src/vs/editor/contrib/suggest/suggestController.ts#L110-L114)

But, the suggest widget already had code in place to hide the widget on editor blur which was skipped if `sticky` was set to `true` for development purposes.

This PR moves the sticky to suggestModel and cleans up the now redundant code to hide the widget.