### PR TITLE
SelectBox: Prevent layout/hide on no room/offscreen Fixes: #55750

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -173,6 +173,11 @@ export class ContextView {
 	}
 
 	private doLayout(): void {
+		// Check that we still have a delegate - this.delegate.layout may have hidden
+		if (!this.isVisible()) {
+			return;
+		}
+
 		// Get anchor
 		let anchor = this.delegate.getAnchor();
 


### PR DESCRIPTION
@joaomoreno 

- Prevent select box from opening if at least one option cannot be shown above or below
- Hide if doing relay out and there is no room above or below
- Prevent select box from opening if it has overflowed in the status bar or top margin
- Hide on same condition above if relayout

- Fix contextview to check that delegate still exists in doLayout in case client hides