### PR TITLE
Open Editors: revisit order of groups to be based on visual order

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -419,12 +419,15 @@ export class EditorPart extends Part implements EditorGroupsServiceImpl, IEditor
 		// Mark preferred size as changed
 		this.resetPreferredSize();
 
-		// Events for groupd that got added
+		// Events for groups that got added
 		this.getGroups(GroupsOrder.GRID_APPEARANCE).forEach(groupView => {
 			if (currentGroupViews.indexOf(groupView) === -1) {
 				this._onDidAddGroup.fire(groupView);
 			}
 		});
+
+		// Update labels
+		this.updateGroupLabels();
 
 		// Restore focus as needed
 		if (gridHasFocus) {
@@ -474,6 +477,9 @@ export class EditorPart extends Part implements EditorGroupsServiceImpl, IEditor
 
 		// Event
 		this._onDidAddGroup.fire(newGroupView);
+
+		// Update labels
+		this.updateGroupLabels();
 
 		return newGroupView;
 	}
@@ -631,12 +637,8 @@ export class EditorPart extends Part implements EditorGroupsServiceImpl, IEditor
 			this._activeGroup.focus();
 		}
 
-		// Update labels: since our labels are created using the index of the
-		// group, removing a group might produce gaps. So we iterate over all
-		// groups and reassign the label based on the index.
-		this.getGroups(GroupsOrder.CREATION_TIME).forEach((group, index) => {
-			group.setLabel(this.getGroupLabel(index + 1));
-		});
+		// Update labels
+		this.updateGroupLabels();
 
 		// Update container
 		this.updateContainer();
@@ -646,10 +648,6 @@ export class EditorPart extends Part implements EditorGroupsServiceImpl, IEditor
 
 		// Event
 		this._onDidRemoveGroup.fire(groupView);
-	}
-
-	private getGroupLabel(index: number): string {
-		return localize('groupLabel', "Group {0}", index);
 	}
 
 	moveGroup(group: IEditorGroupView | GroupIdentifier, location: IEditorGroupView | GroupIdentifier, direction: GroupDirection): IEditorGroupView {
@@ -885,6 +883,21 @@ export class EditorPart extends Part implements EditorGroupsServiceImpl, IEditor
 
 	private updateContainer(): void {
 		toggleClass(this.container, 'empty', this.isEmpty());
+	}
+
+	private updateGroupLabels(): void {
+
+		// Since our labels are created using the index of the
+		// group, adding/removing a group might produce gaps.
+		// So we iterate over all groups and reassign the label
+		// based on the index.
+		this.getGroups(GroupsOrder.GRID_APPEARANCE).forEach((group, index) => {
+			group.setLabel(this.getGroupLabel(index + 1));
+		});
+	}
+
+	private getGroupLabel(index: number): string {
+		return localize('groupLabel', "Group {0}", index);
 	}
 
 	private isEmpty(): boolean {

--- a/src/vs/workbench/browser/parts/editor/editorPicker.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPicker.ts
@@ -117,7 +117,7 @@ export abstract class BaseEditorPicker extends QuickOpenHandler {
 
 		// Sorting
 		if (query.value) {
-			const groups = this.editorGroupService.getGroups(GroupsOrder.CREATION_TIME);
+			const groups = this.editorGroupService.getGroups(GroupsOrder.GRID_APPEARANCE);
 			entries.sort((e1, e2) => {
 				if (e1.group !== e2.group) {
 					return groups.indexOf(e1.group) - groups.indexOf(e2.group); // older groups first
@@ -206,7 +206,7 @@ export class AllEditorsPicker extends BaseEditorPicker {
 	protected getEditorEntries(): EditorPickerEntry[] {
 		const entries: EditorPickerEntry[] = [];
 
-		this.editorGroupService.getGroups(GroupsOrder.CREATION_TIME).forEach(group => {
+		this.editorGroupService.getGroups(GroupsOrder.GRID_APPEARANCE).forEach(group => {
 			group.editors.forEach(editor => {
 				entries.push(this.instantiationService.createInstance(EditorPickerEntry, editor, group));
 			});

--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -10,7 +10,7 @@ import { IAction, ActionRunner } from 'vs/base/common/actions';
 import * as dom from 'vs/base/browser/dom';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IEditorGroupsService, IEditorGroup, GroupChangeKind } from 'vs/workbench/services/group/common/editorGroupsService';
+import { IEditorGroupsService, IEditorGroup, GroupChangeKind, GroupsOrder } from 'vs/workbench/services/group/common/editorGroupsService';
 import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IEditorInput } from 'vs/workbench/common/editor';
@@ -326,7 +326,7 @@ export class OpenEditorsView extends ViewletPanel {
 
 	private get elements(): (IEditorGroup | OpenEditor)[] {
 		const result: (IEditorGroup | OpenEditor)[] = [];
-		this.editorGroupService.groups.forEach(g => {
+		this.editorGroupService.getGroups(GroupsOrder.GRID_APPEARANCE).forEach(g => {
 			if (this.showGroups) {
 				result.push(g);
 			}
@@ -342,7 +342,7 @@ export class OpenEditorsView extends ViewletPanel {
 			return index;
 		}
 
-		for (let g of this.editorGroupService.groups) {
+		for (let g of this.editorGroupService.getGroups(GroupsOrder.GRID_APPEARANCE)) {
 			if (g.id === group.id) {
 				return index + (!!editor ? 1 : 0);
 			} else {


### PR DESCRIPTION
#56084

@isidorn I started on this and it seems to be working OK. I am not sure if the "Open Editors" view needs another listener for when a group is added because this has impact now on the order:
* start with 1 group
* add another group
* open a group in the middle of the two

=> previously the group in the middle would just be "Group 3" and show up at the end of the "open editors" list and now I would expect it to show in the center with "Group 2".