### PR TITLE
set Linux's default "terminal.integrated.fontSize" to 13

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2396,7 +2396,7 @@ export const EDITOR_FONT_DEFAULTS = {
 	),
 	fontWeight: 'normal',
 	fontSize: (
-		platform.isMacintosh ? 12 : 14
+		platform.isMacintosh ? 12 : (platform.isLinux ? 13 : 14)
 	),
 	lineHeight: 0,
 	letterSpacing: 0,


### PR DESCRIPTION
As a bottom cut-off workaround (#35901).