### PR TITLE
Remove workspaceContains from TS extension

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -42,10 +42,7 @@
     "onCommand:typescript.goToProjectConfig",
     "onCommand:typescript.openTsServerLog",
     "onCommand:workbench.action.tasks.runTask",
-    "workspaceContains:**/tsconfig.json",
-    "workspaceContains:**/jsconfig.json",
-    "workspaceContains:**/tsconfig.*.json",
-    "workspaceContains:**/jsconfig.*.json"
+    "onLanguage:jsonc"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
Possible workaround for #55649

workspaceContains unfortunately is expensive. We need to do https://github.com/Microsoft/vscode/issues/34711#issuecomment-370997462 to make them less expensive. It would be nice to avoid including them out of the box.

The downside is that the TS extension will be activated when not needed, such as when opening settings.json.  How bad is that?