### PR TITLE
Fix bug causing borderes in monaco inputs when a trasparent bacground is used

### DIFF
--- a/src/vs/workbench/parts/codeEditor/browser/media/suggestEnabledInput.css
+++ b/src/vs/workbench/parts/codeEditor/browser/media/suggestEnabledInput.css
@@ -11,7 +11,7 @@
 .suggest-input-container .monaco-editor,
 .suggest-input-container .mtk1 {
 	/* allow the embedded monaco to be styled from the outer context */
-	background-color: inherit;
+	background-color: transparent;
 	color: inherit;
 }
 


### PR DESCRIPTION
Closes #56489 by ensuring the transparency of a background color doesn't stack on multiple layers