### PR TITLE
Create new search input model for each instance of a settings editor

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -123,7 +123,6 @@ export class SettingsEditor2 extends BaseEditor {
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			this.onConfigUpdate(e.affectedKeys);
 		}));
-		SettingsEditor2.NUM_INSTANCES++;
 	}
 
 	private get currentSettingsModel() {
@@ -214,7 +213,7 @@ export class SettingsEditor2 extends BaseEditor {
 			provideResults: (query: string) => {
 				return ['@modified', '@tag:usesOnlineServices'].filter(tag => query.indexOf(tag) === -1).map(tag => tag + ' ');
 			}
-		}, searchBoxLabel, 'settingseditor:searchinput' + SettingsEditor2.NUM_INSTANCES, {
+		}, searchBoxLabel, 'settingseditor:searchinput' + SettingsEditor2.NUM_INSTANCES++, {
 				placeholderText: searchBoxLabel,
 				focusContextKey: this.searchFocusContextKey,
 				// TODO: Aria-live

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -49,6 +49,7 @@ const $ = DOM.$;
 export class SettingsEditor2 extends BaseEditor {
 
 	public static readonly ID: string = 'workbench.editor.settings2';
+	private static NUM_INSTANCES: number = 0;
 
 	private defaultSettingsEditorModel: DefaultSettingsEditorModel;
 
@@ -122,6 +123,7 @@ export class SettingsEditor2 extends BaseEditor {
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			this.onConfigUpdate(e.affectedKeys);
 		}));
+		SettingsEditor2.NUM_INSTANCES++;
 	}
 
 	private get currentSettingsModel() {
@@ -212,7 +214,7 @@ export class SettingsEditor2 extends BaseEditor {
 			provideResults: (query: string) => {
 				return ['@modified', '@tag:usesOnlineServices'].filter(tag => query.indexOf(tag) === -1).map(tag => tag + ' ');
 			}
-		}, searchBoxLabel, 'settingseditor:searchinput', {
+		}, searchBoxLabel, 'settingseditor:searchinput' + SettingsEditor2.NUM_INSTANCES, {
 				placeholderText: searchBoxLabel,
 				focusContextKey: this.searchFocusContextKey,
 				// TODO: Aria-live


### PR DESCRIPTION
This closes #56432 by keeping track of how many editors have been made and making a new text model for each one's search text. @roblourens what do you think of the `NUM_INSTANCES` static?