### PR TITLE
Menu extends ActionBar 

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -356,7 +356,6 @@ export interface IActionBarOptions {
 	actionRunner?: IActionRunner;
 	ariaLabel?: string;
 	animated?: boolean;
-	isMenu?: boolean;
 }
 
 let defaultOptions: IActionBarOptions = {

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -377,12 +377,12 @@ export class ActionBar implements IActionRunner {
 
 	// Items
 	public items: IActionItem[];
-	private focusedItem: number;
+	protected focusedItem: number;
 	private focusTracker: DOM.IFocusTracker;
 
 	// Elements
 	public domNode: HTMLElement;
-	private actionsList: HTMLElement;
+	protected actionsList: HTMLElement;
 
 	private toDispose: lifecycle.IDisposable[];
 
@@ -490,46 +490,10 @@ export class ActionBar implements IActionRunner {
 
 		this.actionsList = document.createElement('ul');
 		this.actionsList.className = 'actions-container';
-		if (this.options.isMenu) {
-			this.actionsList.setAttribute('role', 'menu');
-		} else {
-			this.actionsList.setAttribute('role', 'toolbar');
-		}
+		this.actionsList.setAttribute('role', 'toolbar');
+
 		if (this.options.ariaLabel) {
 			this.actionsList.setAttribute('aria-label', this.options.ariaLabel);
-		}
-
-		if (this.options.isMenu) {
-			this.domNode.tabIndex = 0;
-
-			$(this.domNode).on(DOM.EventType.MOUSE_OUT, (e) => {
-				let relatedTarget = (e as MouseEvent).relatedTarget as HTMLElement;
-				if (!DOM.isAncestor(relatedTarget, this.domNode)) {
-					this.focusedItem = undefined;
-					this.updateFocus();
-					e.stopPropagation();
-				}
-			});
-
-			$(this.actionsList).on(DOM.EventType.MOUSE_OVER, (e) => {
-				let target = e.target as HTMLElement;
-				if (!target || !DOM.isAncestor(target, this.actionsList) || target === this.actionsList) {
-					return;
-				}
-
-				while (target.parentElement !== this.actionsList) {
-					target = target.parentElement;
-				}
-
-				if (DOM.hasClass(target, 'action-item')) {
-					const lastFocusedItem = this.focusedItem;
-					this.setFocusedItem(target);
-
-					if (lastFocusedItem !== this.focusedItem) {
-						this.updateFocus();
-					}
-				}
-			});
 		}
 
 		this.domNode.appendChild(this.actionsList);
@@ -558,16 +522,6 @@ export class ActionBar implements IActionRunner {
 			this.actionsList.setAttribute('aria-label', label);
 		} else {
 			this.actionsList.removeAttribute('aria-label');
-		}
-	}
-
-	private setFocusedItem(element: HTMLElement): void {
-		for (let i = 0; i < this.actionsList.children.length; i++) {
-			let elem = this.actionsList.children[i];
-			if (element === elem) {
-				this.focusedItem = i;
-				break;
-			}
 		}
 	}
 
@@ -739,7 +693,7 @@ export class ActionBar implements IActionRunner {
 		this.updateFocus(true);
 	}
 
-	private updateFocus(fromRight?: boolean): void {
+	protected updateFocus(fromRight?: boolean): void {
 		if (typeof this.focusedItem === 'undefined') {
 			this.domNode.focus();
 		}


### PR DESCRIPTION
ref #55258

This is what the extension model would look like. I think it demonstrates that the Menu is very closely related to the ActionBar and gives us more freedom to tweak Menu behavior without impacting ActionBar which is ubiquitous. 

@joaomoreno had suggested forking ActionBar which I considered (have not ruled out), but wanted to hear everyone's opinion after seeing the amount of code that easily remains in ActionBar.

fyi, I am also working on the new mnemonics model which would require the menu to know about its actions list which cannot be done with the current menu/actionbar structure in a clean/reliable way without additional interfaces being added once again to ActionBar. 