### PR TITLE
Add URL handler support for Linux desktops

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -35,6 +35,13 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@ICON@@', product.applicationName))
 			.pipe(rename('usr/share/applications/' + product.applicationName + '.desktop'));
 
+		const desktopUrlHandler = gulp.src('resources/linux/code-url-handler.desktop', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(replace('@@ICON@@', product.applicationName))
+			.pipe(rename('usr/share/applications/' + product.applicationName + '-url-handler.desktop'));
+
 		const appdata = gulp.src('resources/linux/code.appdata.xml', { base: '.' })
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
 			.pipe(replace('@@NAME@@', product.applicationName))
@@ -78,7 +85,7 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(rename('DEBIAN/postinst'));
 
-		const all = es.merge(control, postinst, postrm, prerm, desktop, appdata, icon, code);
+		const all = es.merge(control, postinst, postrm, prerm, desktop, desktopUrlHandler, appdata, icon, code);
 
 		return all.pipe(vfs.dest(destination));
 	};
@@ -113,6 +120,13 @@ function prepareRpmPackage(arch) {
 			.pipe(replace('@@ICON@@', product.applicationName))
 			.pipe(rename('BUILD/usr/share/applications/' + product.applicationName + '.desktop'));
 
+		const desktopUrlHandler = gulp.src('resources/linux/code-url-handler.desktop', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME_SHORT@@', product.nameShort))
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(replace('@@ICON@@', product.applicationName))
+			.pipe(rename('BUILD/usr/share/applications/' + product.applicationName + '-url-handler.desktop'));
+
 		const appdata = gulp.src('resources/linux/code.appdata.xml', { base: '.' })
 			.pipe(replace('@@NAME_LONG@@', product.nameLong))
 			.pipe(replace('@@NAME@@', product.applicationName))
@@ -142,7 +156,7 @@ function prepareRpmPackage(arch) {
 		const specIcon = gulp.src('resources/linux/rpm/code.xpm', { base: '.' })
 			.pipe(rename('SOURCES/' + product.applicationName + '.xpm'));
 
-		const all = es.merge(code, desktop, appdata, icon, spec, specIcon);
+		const all = es.merge(code, desktop, desktopUrlHandler, appdata, icon, spec, specIcon);
 
 		return all.pipe(vfs.dest(getRpmBuildPath(rpmArch)));
 	};

--- a/resources/linux/code-url-handler.desktop
+++ b/resources/linux/code-url-handler.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=@@NAME_LONG@@ - URL Handler
+Comment=Code Editing. Redefined.
+GenericName=Text Editor
+Exec=/usr/share/@@NAME@@/@@NAME@@ --open-url %U
+Icon=@@ICON@@
+Type=Application
+NoDisplay=true
+StartupNotify=true
+StartupWMClass=@@NAME_SHORT@@
+Categories=Utility;TextEditor;Development;IDE;
+MimeType=x-scheme-handler/vscode
+Keywords=vscode;

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -15,6 +15,7 @@ update-alternatives --install /usr/bin/editor editor /usr/bin/@@NAME@@ 0
 # Install the desktop entry
 if hash desktop-file-install 2>/dev/null; then
 	desktop-file-install /usr/share/applications/@@NAME@@.desktop
+	desktop-file-install /usr/share/applications/@@NAME@@-url-handler.desktop
 fi
 
 if [ "@@NAME@@" != "code-oss" ]; then

--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -20,6 +20,7 @@ mkdir -p %{buildroot}/usr/share/applications
 mkdir -p %{buildroot}/usr/share/pixmaps
 cp -r usr/share/@@NAME@@/* %{buildroot}/usr/share/@@NAME@@
 cp -r usr/share/applications/@@NAME@@.desktop %{buildroot}/usr/share/applications
+cp -r usr/share/applications/@@NAME@@-url-handler.desktop %{buildroot}/usr/share/applications
 cp -r usr/share/pixmaps/@@NAME@@.png %{buildroot}/usr/share/pixmaps
 
 %post
@@ -51,4 +52,5 @@ fi
 
 /usr/share/@@NAME@@/
 /usr/share/applications/@@NAME@@.desktop
+/usr/share/applications/@@NAME@@-url-handler.desktop
 /usr/share/pixmaps/@@NAME@@.png


### PR DESCRIPTION
This works by adding a `NoDisplay` desktop file that registers for the MIME type `x-scheme-handler/vscode` to the deb and rpm package.

I added a `URL Handler` suffix to the name in that desktop file so it's discernible in menu editors from the main desktop file. It will appear like that in the UI in some places though.

![image](https://user-images.githubusercontent.com/24731903/44294671-a9fb7c80-a2a3-11e8-8c38-a4b37c6a9c7a.png)

See: [Desktop Entry Specification - Recognized desktop entry keys](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s06.html), [shared-mime-info-spec - URI scheme handlers](https://specifications.freedesktop.org/shared-mime-info-spec/shared-mime-info-spec-latest.html#idm140625828587776)

Fixes #48528

P.S. I wonder if `desktop-file-install` is really needed... I think the database is updated automatically when installing a desktop file from a deb.