### PR TITLE
Removed the redundant trailing source.ruby scope

### DIFF
--- a/extensions/ruby/syntaxes/ruby.tmLanguage.json
+++ b/extensions/ruby/syntaxes/ruby.tmLanguage.json
@@ -1206,9 +1206,6 @@
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.section.embedded.end.ruby"
-						},
-						"1": {
-							"name": "source.ruby"
 						}
 					},
 					"name": "meta.embedded.line.ruby",


### PR DESCRIPTION
There's a bug in the Ruby syntax json where the closing brace for interpolation gets an excess `source.ruby` scope. Fixed that.

Before:
![before](https://user-images.githubusercontent.com/2983624/43683773-81e3f1da-989b-11e8-9fa3-a5a3f4a29ab5.png)
After:
![after](https://user-images.githubusercontent.com/2983624/43683774-84e4eca4-989b-11e8-97bc-d11ae89bf7ce.png)
