### PR TITLE
Printing to PDF

### DIFF
--- a/src/vs/workbench/parts/webview/electron-browser/webview-pre.js
+++ b/src/vs/workbench/parts/webview/electron-browser/webview-pre.js
@@ -437,4 +437,13 @@
 		// signal ready
 		ipcRenderer.sendToHost('webview-ready', process.pid);
 	});
+
+	window.matchMedia("print").addListener(function (mql) {
+		if (mql.matches) {
+			var obj = document.getElementsByTagName("iframe")[0];
+			obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+		}
+	});
+
+	//TODO: Reset to normal when no longer printing
 }());

--- a/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
@@ -16,7 +16,7 @@ import { Extensions as ActionExtensions, IWorkbenchActionRegistry } from 'vs/wor
 import { Extensions as EditorInputExtensions, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
 import { WebviewEditorInputFactory } from 'vs/workbench/parts/webview/electron-browser/webviewEditorInputFactory';
 import { KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from './baseWebviewEditor';
-import { HideWebViewEditorFindCommand, OpenWebviewDeveloperToolsAction, ReloadWebviewAction, ShowWebViewEditorFindWidgetCommand, SelectAllWebviewEditorCommand } from './webviewCommands';
+import { HideWebViewEditorFindCommand, OpenWebviewDeveloperToolsAction, ReloadWebviewAction, ShowWebViewEditorFindWidgetCommand, SelectAllWebviewEditorCommand, PrintToPDFAction } from './webviewCommands';
 import { WebviewEditor } from './webviewEditor';
 import { WebviewEditorInput } from './webviewEditorInput';
 import { IWebviewEditorService, WebviewEditorService } from './webviewEditorService';
@@ -78,4 +78,9 @@ actionRegistry.registerWorkbenchAction(
 actionRegistry.registerWorkbenchAction(
 	new SyncActionDescriptor(ReloadWebviewAction, ReloadWebviewAction.ID, ReloadWebviewAction.LABEL),
 	'Reload Webview',
+	webviewDeveloperCategory);
+
+actionRegistry.registerWorkbenchAction(
+	new SyncActionDescriptor(PrintToPDFAction, PrintToPDFAction.ID, PrintToPDFAction.LABEL),
+	'Print to PDF',
 	webviewDeveloperCategory);

--- a/src/vs/workbench/parts/webview/electron-browser/webview.html
+++ b/src/vs/workbench/parts/webview/electron-browser/webview.html
@@ -2,6 +2,14 @@
 <html lang="en" style="width: 100%; height: 100%">
 <head>
 	<title>Virtual Document</title>
+	<script>
+		window.matchMedia("print").addListener(function (mql) {
+				if (mql.matches) {
+					var obj = document.getElementsByTagName("iframe")[0];
+					obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+				}
+			});
+	</script>
 </head>
 <body style="margin: 0; overflow: hidden; width: 100%; height: 100%">
 </body>

--- a/src/vs/workbench/parts/webview/electron-browser/webviewCommands.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewCommands.ts
@@ -10,6 +10,7 @@ import * as nls from 'vs/nls';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { BaseWebviewEditor } from './baseWebviewEditor';
+import { writeFile } from 'fs';
 
 export class ShowWebViewEditorFindWidgetCommand extends Command {
 	public static readonly ID = 'editor.action.webvieweditor.showFind';
@@ -65,6 +66,45 @@ export class OpenWebviewDeveloperToolsAction extends Action {
 			}
 		}
 		return null;
+	}
+}
+
+export class PrintToPDFAction extends Action {
+	static readonly ID = 'workbench.action.webview.printToPDF';
+	static readonly LABEL = nls.localize('print2PDF', "Print To PDF");
+
+	public constructor(
+		id: string,
+		label: string
+	) {
+		super(id, label);
+	}
+
+	public run(): TPromise<any> {
+		const elements = document.querySelectorAll('webview.ready');
+		const out = this;
+		for (let i = 0; i < elements.length; i++) {
+			try {
+				const wv = (elements.item(i) as Electron.WebviewTag)
+				wv.printToPDF({
+					marginsType: 0,
+					printBackground: true
+				}, (er, dt) => {
+					//TODO: Need to ask user where to store file. At least make it OS-Unspecific
+					writeFile(out.getUserHome() + '\\document.pdf', dt, (err) => {
+						if (err) throw err;
+						console.log('The file has been saved!');
+					});
+				});
+			} catch (e) {
+				console.error(e);
+			}
+		}
+		return null;
+	}
+
+	public getUserHome() {
+		return process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
 	}
 }
 


### PR DESCRIPTION
Started from #39698

This pull request adds the feature to print any webview element to pdf by using the built in features of [webview](https://electronjs.org/docs/api/webview-tag#webviewprinttopdfoptions-callback)

This feature needs to integrated, as [extensions](https://marketplace.visualstudio.com/items?itemName=yzane.markdown-pdf) do not print [markdown extensions](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid).

Currently this is integrated as an action in the command palette, however could be moved to a button in the webview or maybe markdown-preview.

**Current problems:**
Inside webview an iFrame is placed (maybe for security reasons). Because of this, the html to pdf writer cannot break content, which causes content to get cut off:

![image](https://user-images.githubusercontent.com/5946409/44311700-75470c80-a3ec-11e8-9a2a-9c3966400dc7.png)

The `window.matchMedia` is necessary, as otherwise only one page is printed.

Thoughts and ideas welcome!