### PR TITLE
Fix #55723 - Show appropriate error message when extension gallery service is not accessible

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -317,8 +317,7 @@ export class ExtensionsListView extends ViewletPanel {
 
 			if (text !== query.value) {
 				options = assign(options, { text: text.substr(0, 350), source: 'file-extension-tags' });
-				const pager = await this.extensionsWorkbenchService.queryGallery(options);
-				return new PagedModel(pager);
+				return this.extensionsWorkbenchService.queryGallery(options).then(pager => new PagedModel(pager));
 			}
 		}
 
@@ -328,8 +327,7 @@ export class ExtensionsListView extends ViewletPanel {
 			options.source = 'viewlet';
 		}
 
-		const pager = await this.extensionsWorkbenchService.queryGallery(options);
-		return new PagedModel(pager);
+		return this.extensionsWorkbenchService.queryGallery(options).then(pager => new PagedModel(pager));
 	}
 
 	private sortExtensions(extensions: IExtension[], options: IQueryOptions): IExtension[] {


### PR DESCRIPTION
This closes #55723 by replacing the await calls to normal promise call such that any errors are bubbled up. 
@ramya-rao-a also I was wondering if a unit test for the scenario should be added?  
