### PR TITLE
Fix block selection

### DIFF
--- a/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
@@ -115,4 +115,16 @@ suite('TokenSelectionSupport', () => {
 				// new Range(3, 19, 3, 20)
 			]);
 	});
+
+	test('non-empty block selection', () => {
+
+		assertGetRangesToPosition([
+			'0 + {',
+			'\t//',
+			'}'
+		], 3, 2, [
+				new Range(1, 1, 3, 2),
+				new Range(1, 5, 3, 2)
+			]);
+	});
 });


### PR DESCRIPTION
The problem is that smartSelect stucks on closing bracket if block isn't empty as shown below.
![block-selection-before](https://user-images.githubusercontent.com/511242/44331557-73c02780-a472-11e8-8c8b-fac8825f2b8f.gif)
This PR should fix the problem.
![block-selection-after](https://user-images.githubusercontent.com/511242/44331607-9a7e5e00-a472-11e8-9927-8fff0323226e.gif)