### PR TITLE
do not attempt edit operation for read-only editors

### DIFF
--- a/src/vs/editor/common/services/resolverService.ts
+++ b/src/vs/editor/common/services/resolverService.ts
@@ -42,4 +42,6 @@ export interface ITextEditorModel extends IEditorModel {
 	 * Provides access to the underlying `ITextModel`.
 	 */
 	textEditorModel: ITextModel;
+
+	isReadonly(): boolean;
 }

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -69,6 +69,10 @@ export class SimpleModel implements ITextEditorModel {
 		return this.model;
 	}
 
+	public isReadonly(): boolean {
+		return false;
+	}
+
 	public dispose(): void {
 		this._onDispose.fire();
 	}

--- a/src/vs/workbench/services/bulkEdit/electron-browser/bulkEditService.ts
+++ b/src/vs/workbench/services/bulkEdit/electron-browser/bulkEditService.ts
@@ -180,6 +180,9 @@ class BulkEditModel implements IDisposable {
 				if (!model || !model.textEditorModel) {
 					throw new Error(`Cannot load file ${key}`);
 				}
+				if (model.isReadonly) {
+					throw new Error(localize('editorIsReadonly', "Cannot edit a read-only editor."));
+				}
 
 				let task: ModelEditTask;
 				if (this._editor && this._editor.getModel().uri.toString() === model.textEditorModel.uri.toString()) {

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -254,8 +254,6 @@ export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport
 
 	isResolved(): boolean;
 
-	isReadonly(): boolean;
-
 	isDisposed(): boolean;
 }
 


### PR DESCRIPTION
fixes #53257


As suggessted in #53257 I have moved the `isReadonly()` property one level up.
If a user tries an edit operation I simply throw an error.

I did not test this out, first wanted to get feedback.
Thanks