### PR TITLE
Update Markdown link snippets to use https

### DIFF
--- a/extensions/markdown-basics/snippets/markdown.json
+++ b/extensions/markdown-basics/snippets/markdown.json
@@ -60,12 +60,12 @@
 	},
 	"Insert link": {
 		"prefix": "link",
-		"body": "[${1:text}](http://${2:link})$0",
+		"body": "[${1:text}](https://${2:link})$0",
 		"description": "Insert link"
 	},
 	"Insert image": {
 		"prefix": "image",
-		"body": "![${1:alt}](http://${2:link})$0",
+		"body": "![${1:alt}](https://${2:link})$0",
 		"description": "Insert image"
 	}
 }


### PR DESCRIPTION
As suggested in #56386 I switched the http to https for links and image links.