### PR TITLE
Fix bug causing settings name to sometimes be improperly copied.

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -747,7 +747,7 @@ export class SettingsEditor2 extends BaseEditor {
 	private onSearchInputChanged(): void {
 		const query = this.searchWidget.getValue().trim();
 		this.delayedFilterLogging.cancel();
-		this.triggerSearch(query.replace(/ › /g, ' ')).then(() => {
+		this.triggerSearch(query.replace(/›/g, ' ')).then(() => {
 			if (query && this.searchResultModel) {
 				this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
 			}

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -747,7 +747,7 @@ export class SettingsEditor2 extends BaseEditor {
 	private onSearchInputChanged(): void {
 		const query = this.searchWidget.getValue().trim();
 		this.delayedFilterLogging.cancel();
-		this.triggerSearch(query).then(() => {
+		this.triggerSearch(query.replace(/ › /g, ' ')).then(() => {
 			if (query && this.searchResultModel) {
 				this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
 			}

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -1468,7 +1468,7 @@ class CopySettingNameAction extends Action {
 
 	run(context: SettingsTreeSettingElement): TPromise<void> {
 		if (context) {
-			const name = `${context.displayCategory}: ${context.displayLabel}`;
+			const name = `${context.displayCategory || context.parent.label}: ${context.displayLabel}`;
 			this.clipboardService.writeText(name);
 		}
 

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -1468,7 +1468,7 @@ class CopySettingNameAction extends Action {
 
 	run(context: SettingsTreeSettingElement): TPromise<void> {
 		if (context) {
-			const name = `${context.displayCategory || context.parent.label}: ${context.displayLabel}`;
+			const name = `${context.displayCategory}: ${context.displayLabel}`;
 			this.clipboardService.writeText(name);
 		}
 


### PR DESCRIPTION
Closes #56860

We should also maybe filter out the little arrow symbols on copy, as if you paste that into the search it doesn't find the relevant setting. 

Alternatively we could filter those out on search.