### PR TITLE
SmartSelect fixes and tests

### DIFF
--- a/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
@@ -115,4 +115,8 @@ suite('TokenSelectionSupport', () => {
 				// new Range(3, 19, 3, 20)
 			]);
 	});
+
+	test('empty file', () => {
+		assertGetRangesToPosition([''], 1, 1, []);
+	});
 });

--- a/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
@@ -144,4 +144,15 @@ suite('TokenSelectionSupport', () => {
 				new Range(5, 13, 5, 16),
 			]);
 	});
+
+	test('non-empty block selection', () => {
+		assertGetRangesToPosition([
+			'0 + {',
+			'\t//',
+			'}'
+		], 3, 2, [
+				new Range(1, 1, 3, 2),
+				new Range(1, 5, 3, 2)
+			]);
+	});
 });

--- a/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/tokenSelectionSupport.test.ts
@@ -119,4 +119,29 @@ suite('TokenSelectionSupport', () => {
 	test('empty file', () => {
 		assertGetRangesToPosition([''], 1, 1, []);
 	});
+
+	test('adjacent blocks', () => {
+
+		assertGetRangesToPosition([
+			'function a(bar, foo) {',
+			'\t// begin',
+			'\tif (bar) {',
+			'\t\treturn bar',
+			'\t} else if (foo) {',
+			'\t\treturn foo',
+			'\t} else {',
+			'\t\treturn null',
+			'\t}',
+			'\t// end',
+			'}'
+		], 5, 15, [
+				new Range(1, 1, 11, 2),
+				new Range(1, 22, 11, 2),
+				new Range(2, 1, 10, 8),
+				new Range(3, 1, 9, 3),
+				new Range(5, 3, 7, 3),
+				new Range(5, 12, 5, 17),
+				new Range(5, 13, 5, 16),
+			]);
+	});
 });


### PR DESCRIPTION
There are couple of changes and fixes which should improve Smart Select:

1. `tokenTree.ts` refactoring. `Node.parent` is removed (it's useless and there was an issue with it anyway) and `NodeList` and `Block` behave like immutable now. `_doGetRangesToPosition` changed respectively and collects ranges top-to-bottom instead of bottom-to-top.

2. Fix from https://github.com/Microsoft/vscode/pull/56807 PR.

3. Improvement of selection of adjacent blocks (I didn't make better name for it). It's when the ending of one block is on on the same line with the beginning of the another block.
Before:
![adjacent-before](https://user-images.githubusercontent.com/511242/44469402-12de4e00-a630-11e8-8f3e-5983ec625ed4.gif)
After:
![adjacent-after](https://user-images.githubusercontent.com/511242/44469430-238ec400-a630-11e8-8f6c-9c492b437417.gif)

4. Tests!
