### PR TITLE
Adjust submenu arrows on windows custom menu

### DIFF
--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -96,8 +96,8 @@
 }
 
 .monaco-shell .monaco-menu .monaco-action-bar.vertical .submenu-indicator {
-	font-size: inherit;
-	padding: 0 1em;
+	font-size: 60%;
+	padding: 0 1.5em;
 }
 
 .monaco-shell .monaco-menu .action-item {

--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -97,7 +97,7 @@
 
 .monaco-shell .monaco-menu .monaco-action-bar.vertical .submenu-indicator {
 	font-size: 60%;
-	padding: 0 1.5em;
+	padding: 0 1.8em;
 }
 
 .monaco-shell .monaco-menu .action-item {


### PR DESCRIPTION
Fixes #54738

I adjusted the font-size and padding so they're a bit smaller.

**Before**
<img width="50%" src="https://user-images.githubusercontent.com/35271042/44481457-a72dbe00-a5fa-11e8-8102-90ac8b5ff56f.png">


**After**
<img width="50%" src="https://user-images.githubusercontent.com/35271042/44481397-85ccd200-a5fa-11e8-8fc0-6d2566f2834c.png">


It also matches closer to the native arrows:

<img width="50%" src="https://user-images.githubusercontent.com/35271042/44480995-8add5180-a5f9-11e8-9458-4f5f6f3b4e76.png">
