### PR TITLE
Enum descriptions in new settings editor via SelectBox widget

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -22,6 +22,7 @@ export interface RenderOptions {
 	className?: string;
 	inline?: boolean;
 	actionHandler?: IContentActionHandler;
+	eventToIntercept?: 'mousedown' | 'mouseup' | 'click' | 'dblclick';
 	codeBlockRenderer?: (modeId: string, value: string) => Thenable<string>;
 	codeBlockRenderCallback?: () => void;
 }
@@ -143,7 +144,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: RenderOptions
 	}
 
 	if (options.actionHandler) {
-		options.actionHandler.disposeables.push(DOM.addStandardDisposableListener(element, 'click', event => {
+		options.actionHandler.disposeables.push(DOM.addStandardDisposableListener(element, options.eventToIntercept || 'click', event => {
 			let target = event.target;
 			if (target.tagName !== 'A') {
 				target = target.parentElement;

--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -22,7 +22,6 @@ export interface RenderOptions {
 	className?: string;
 	inline?: boolean;
 	actionHandler?: IContentActionHandler;
-	eventToIntercept?: 'mousedown' | 'mouseup' | 'click' | 'dblclick';
 	codeBlockRenderer?: (modeId: string, value: string) => Thenable<string>;
 	codeBlockRenderCallback?: () => void;
 }
@@ -144,7 +143,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: RenderOptions
 	}
 
 	if (options.actionHandler) {
-		options.actionHandler.disposeables.push(DOM.addStandardDisposableListener(element, options.eventToIntercept || 'click', event => {
+		options.actionHandler.disposeables.push(DOM.addStandardDisposableListener(element, 'click', event => {
 			let target = event.target;
 			if (target.tagName !== 'A') {
 				target = target.parentElement;

--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -14,6 +14,7 @@ import { IListStyles } from 'vs/base/browser/ui/list/listWidget';
 import { SelectBoxNative } from 'vs/base/browser/ui/selectBox/selectBoxNative';
 import { SelectBoxList } from 'vs/base/browser/ui/selectBox/selectBoxCustom';
 import { isMacintosh } from 'vs/base/common/platform';
+import { IContentActionHandler } from 'vs/base/browser/htmlContentRenderer';
 
 // Public SelectBox interface - Calls routed to appropriate select implementation class
 
@@ -24,7 +25,7 @@ export interface ISelectBoxDelegate {
 	setOptions(options: string[], selected?: number, disabled?: number): void;
 	select(index: number): void;
 	setAriaLabel(label: string);
-	setDetailsProvider(provider: (index: number) => string);
+	setDetailsProvider(provider: (index: number) => { details: string, isMarkdown: boolean });
 	focus(): void;
 	blur(): void;
 	dispose(): void;
@@ -39,6 +40,7 @@ export interface ISelectBoxOptions {
 	ariaLabel?: string;
 	minBottomMargin?: number;
 	hasDetails?: boolean;
+	markdownActionHandler?: IContentActionHandler;
 }
 
 export interface ISelectBoxStyles extends IListStyles {
@@ -98,7 +100,7 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 		this.selectBoxDelegate.setAriaLabel(label);
 	}
 
-	public setDetailsProvider(provider: (index: number) => string): void {
+	public setDetailsProvider(provider: (index: number) => { details: string, isMarkdown: boolean }): void {
 		this.selectBoxDelegate.setDetailsProvider(provider);
 	}
 

--- a/src/vs/base/browser/ui/selectBox/selectBox.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBox.ts
@@ -24,6 +24,7 @@ export interface ISelectBoxDelegate {
 	setOptions(options: string[], selected?: number, disabled?: number): void;
 	select(index: number): void;
 	setAriaLabel(label: string);
+	setDetailsProvider(provider: (index: number) => string);
 	focus(): void;
 	blur(): void;
 	dispose(): void;
@@ -37,6 +38,7 @@ export interface ISelectBoxDelegate {
 export interface ISelectBoxOptions {
 	ariaLabel?: string;
 	minBottomMargin?: number;
+	hasDetails?: boolean;
 }
 
 export interface ISelectBoxStyles extends IListStyles {
@@ -44,6 +46,7 @@ export interface ISelectBoxStyles extends IListStyles {
 	selectListBackground?: Color;
 	selectForeground?: Color;
 	selectBorder?: Color;
+	selectListBorder?: Color;
 	focusBorder?: Color;
 }
 
@@ -68,7 +71,7 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 		mixin(this.styles, defaultStyles, false);
 
 		// Instantiate select implementation based on platform
-		if (isMacintosh) {
+		if (isMacintosh && !(selectBoxOptions && selectBoxOptions.hasDetails)) {
 			this.selectBoxDelegate = new SelectBoxNative(options, selected, styles, selectBoxOptions);
 		} else {
 			this.selectBoxDelegate = new SelectBoxList(options, selected, contextViewProvider, styles, selectBoxOptions);
@@ -93,6 +96,10 @@ export class SelectBox extends Widget implements ISelectBoxDelegate {
 
 	public setAriaLabel(label: string): void {
 		this.selectBoxDelegate.setAriaLabel(label);
+	}
+
+	public setDetailsProvider(provider: (index: number) => string): void {
+		this.selectBoxDelegate.setDetailsProvider(provider);
 	}
 
 	public focus(): void {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
@@ -16,6 +16,11 @@
 
 .monaco-select-box-dropdown-container {
 	display: none;
+	-webkit-box-sizing:	border-box;
+	-o-box-sizing:		border-box;
+	-moz-box-sizing:	border-box;
+	-ms-box-sizing:		border-box;
+	box-sizing:			border-box;
 }
 
 .monaco-select-box-dropdown-container.visible {
@@ -40,6 +45,10 @@
 	-moz-box-sizing:	border-box;
 	-ms-box-sizing:		border-box;
 	box-sizing:			border-box;
+}
+
+.monaco-select-box-dropdown-container > .select-box-details-pane {
+	padding: 5px;
 }
 
 .hc-black .monaco-select-box-dropdown-container > .select-box-dropdown-list-container {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
@@ -23,6 +23,21 @@
 	box-sizing:			border-box;
 }
 
+.monaco-select-box-dropdown-container > .select-box-details-pane > .select-box-description-markdown * {
+	margin: 0;
+}
+
+.monaco-select-box-dropdown-container > .select-box-details-pane > .select-box-description-markdown a:focus {
+	outline: 1px solid -webkit-focus-ring-color;
+	outline-offset: -1px;
+}
+
+.monaco-select-box-dropdown-container > .select-box-details-pane > .select-box-description-markdown code {
+	line-height: 15px; /** For some reason, this is needed, otherwise <code> will take up 20px height */
+	font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
+}
+
+
 .monaco-select-box-dropdown-container.visible {
 	display: flex;
 	flex-direction: column;

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -14,7 +14,7 @@ import * as dom from 'vs/base/browser/dom';
 import * as arrays from 'vs/base/common/arrays';
 import { IContextViewProvider, AnchorPosition } from 'vs/base/browser/ui/contextview/contextview';
 import { List } from 'vs/base/browser/ui/list/listWidget';
-import { IVirtualDelegate, IRenderer } from 'vs/base/browser/ui/list/list';
+import { IVirtualDelegate, IRenderer, IListEvent } from 'vs/base/browser/ui/list/list';
 import { domEvent } from 'vs/base/browser/event';
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { ISelectBoxDelegate, ISelectBoxOptions, ISelectBoxStyles, ISelectData } from 'vs/base/browser/ui/selectBox/selectBox';
@@ -103,6 +103,10 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 	private widthControlElement: HTMLElement;
 	private _currentSelection: number;
 	private _dropDownPosition: AnchorPosition;
+	private detailsProvider: (index: number) => string;
+	private selectionDetailsPane: HTMLElement;
+
+	private _sticky: boolean = false; // for dev purposes only
 
 	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles, selectBoxOptions?: ISelectBoxOptions) {
 
@@ -153,6 +157,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		dom.addClass(this.selectDropDownContainer, 'monaco-select-box-dropdown-padding');
 		// Setup list for drop-down select
 		this.createSelectList(this.selectDropDownContainer);
+		this.selectionDetailsPane = dom.append(this.selectDropDownContainer, $('.select-box-details-pane'));
 
 		// Create span flex box item/div we can measure and control
 		let widthControlOuterDiv = dom.append(this.selectDropDownContainer, $('.select-box-dropdown-container-width-control'));
@@ -285,6 +290,10 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		this.selectList.getHTMLElement().setAttribute('aria-label', this.selectBoxOptions.ariaLabel);
 	}
 
+	public setDetailsProvider(provider: (index: number) => string): void {
+		this.detailsProvider = provider;
+	}
+
 	public focus(): void {
 		if (this.selectElement) {
 			this.selectElement.focus();
@@ -318,6 +327,15 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 
 		if (this.styles.listFocusForeground) {
 			content.push(`.monaco-select-box-dropdown-container > .select-box-dropdown-list-container .monaco-list .monaco-list-row.focused:not(:hover) { color: ${this.styles.listFocusForeground} !important; }`);
+		}
+
+		if (!this.styles.selectBorder.equals(this.styles.selectBackground)) {
+			content.push(`.monaco-select-box-dropdown-container { border: 1px solid ${this.styles.selectBorder} } `);
+			content.push(`.monaco-select-box-dropdown-container > .select-box-details-pane { border-top: 1px solid ${this.styles.selectBorder} } `);
+		}
+		else if (this.styles.selectListBorder) {
+			content.push(`.monaco-select-box-dropdown-container { border: 1px solid ${this.styles.selectListBorder} } `);
+			content.push(`.monaco-select-box-dropdown-container > .select-box-details-pane { border-top: 1px solid ${this.styles.selectListBorder} } `);
 		}
 
 		// Hover foreground - ignore for disabled options
@@ -370,6 +388,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 
 			let listBackground = this.styles.selectListBackground ? this.styles.selectListBackground.toString() : background;
 			this.selectDropDownListContainer.style.backgroundColor = listBackground;
+			this.selectionDetailsPane.style.backgroundColor = listBackground;
 			const optionsBorder = this.styles.focusBorder ? this.styles.focusBorder.toString() : null;
 			this.selectDropDownContainer.style.outlineColor = optionsBorder;
 			this.selectDropDownContainer.style.outlineOffset = '-1px';
@@ -543,9 +562,6 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 				this.selectList.reveal(this.selectList.getFocus()[0] || 0);
 			}
 
-			// Set final container height after adjustments
-			this.selectDropDownContainer.style.height = (listHeight + verticalPadding) + 'px';
-
 			// Determine optimal width - min(longest option), opt(parent select, excluding margins), max(ContextView controlled)
 			const selectWidth = this.selectElement.offsetWidth;
 			const selectMinWidth = this.setWidthControlElement(this.widthControlElement);
@@ -556,7 +572,6 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			// Maintain focus outline on parent select as well as list container - tabindex for focus
 			this.selectDropDownListContainer.setAttribute('tabindex', '0');
 			dom.toggleClass(this.selectElement, 'synthetic-focus', true);
-			dom.toggleClass(this.selectDropDownContainer, 'synthetic-focus', true);
 			return true;
 		} else {
 			return false;
@@ -626,7 +641,11 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			.filter(() => this.selectList.length > 0)
 			.on(e => this.onMouseUp(e), this, this.toDispose);
 
-		this.toDispose.push(this.selectList.onDidBlur(e => this.onListBlur()));
+		this.toDispose.push(
+			this.selectList.onDidBlur(e => this.onListBlur()),
+			this.selectList.onMouseOver(e => this.selectList.setFocus([e.index])),
+			this.selectList.onFocusChange(e => this.onListFocus(e))
+		);
 
 		this.selectList.getHTMLElement().setAttribute('aria-expanded', 'true');
 	}
@@ -672,13 +691,20 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 
 	// List Exit - passive - implicit no selection change, hide drop-down
 	private onListBlur(): void {
-
+		if (this._sticky) { return; }
 		if (this.selected !== this._currentSelection) {
 			// Reset selected to current if no change
 			this.select(this._currentSelection);
 		}
 
 		this.hideSelectDropDown(false);
+	}
+
+	// List Focus Change - passive - update details pane with newly focused element's data
+	private onListFocus(e: IListEvent<ISelectOptionItem>) {
+		const selectedIndex = e.indexes[0];
+		this.selectionDetailsPane.innerText = this.detailsProvider ? this.detailsProvider(selectedIndex) || '' : '';
+		this.selectionDetailsPane.style.display = this.selectionDetailsPane.innerText ? 'block' : 'none';
 	}
 
 	// List keyboard controller

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -718,8 +718,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		};
 
 		const renderedMarkdown = renderMarkdown({ value: text }, {
-			actionHandler: this.selectBoxOptions.markdownActionHandler,
-			eventToIntercept: 'mousedown' // intercept `mousedown` because the widget disappears before a `click` can happen
+			actionHandler: this.selectBoxOptions.markdownActionHandler
 		});
 
 		renderedMarkdown.classList.add('select-box-description-markdown');

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -113,7 +113,7 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 		this.selectElement.setAttribute('aria-label', label);
 	}
 
-	public setDetailsProvider(provider: (index: number) => string): void {
+	public setDetailsProvider(provider: any): void {
 		console.error('details are not available for native select boxes');
 	}
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -113,6 +113,10 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 		this.selectElement.setAttribute('aria-label', label);
 	}
 
+	public setDetailsProvider(provider: (index: number) => string): void {
+		console.error('details are not available for native select boxes');
+	}
+
 	public focus(): void {
 		if (this.selectElement) {
 			this.selectElement.focus();

--- a/src/vs/platform/theme/common/styler.ts
+++ b/src/vs/platform/theme/common/styler.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import { ITheme, IThemeService } from 'vs/platform/theme/common/themeService';
-import { focusBorder, inputBackground, inputForeground, ColorIdentifier, selectForeground, selectBackground, selectListBackground, selectBorder, inputBorder, foreground, editorBackground, contrastBorder, inputActiveOptionBorder, listFocusBackground, listFocusForeground, listActiveSelectionBackground, listActiveSelectionForeground, listInactiveSelectionForeground, listInactiveSelectionBackground, listInactiveFocusBackground, listHoverBackground, listHoverForeground, listDropBackground, pickerGroupBorder, pickerGroupForeground, widgetShadow, inputValidationInfoBorder, inputValidationInfoBackground, inputValidationWarningBorder, inputValidationWarningBackground, inputValidationErrorBorder, inputValidationErrorBackground, activeContrastBorder, buttonForeground, buttonBackground, buttonHoverBackground, ColorFunction, badgeBackground, badgeForeground, progressBarBackground, breadcrumbsForeground, breadcrumbsFocusForeground, breadcrumbsActiveSelectionForeground, breadcrumbsBackground } from 'vs/platform/theme/common/colorRegistry';
+import { focusBorder, inputBackground, inputForeground, ColorIdentifier, selectForeground, selectBackground, selectListBackground, selectBorder, inputBorder, foreground, editorBackground, contrastBorder, inputActiveOptionBorder, listFocusBackground, listFocusForeground, listActiveSelectionBackground, listActiveSelectionForeground, listInactiveSelectionForeground, listInactiveSelectionBackground, listInactiveFocusBackground, listHoverBackground, listHoverForeground, listDropBackground, pickerGroupBorder, pickerGroupForeground, widgetShadow, inputValidationInfoBorder, inputValidationInfoBackground, inputValidationWarningBorder, inputValidationWarningBackground, inputValidationErrorBorder, inputValidationErrorBackground, activeContrastBorder, buttonForeground, buttonBackground, buttonHoverBackground, ColorFunction, badgeBackground, badgeForeground, progressBarBackground, breadcrumbsForeground, breadcrumbsFocusForeground, breadcrumbsActiveSelectionForeground, breadcrumbsBackground, editorWidgetBorder } from 'vs/platform/theme/common/colorRegistry';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Color } from 'vs/base/common/color';
 import { mixin } from 'vs/base/common/objects';
@@ -129,7 +129,8 @@ export function attachSelectBoxStyler(widget: IThemable, themeService: IThemeSer
 		listFocusOutline: (style && style.listFocusOutline) || activeContrastBorder,
 		listHoverBackground: (style && style.listHoverBackground) || listHoverBackground,
 		listHoverForeground: (style && style.listHoverForeground) || listHoverForeground,
-		listHoverOutline: (style && style.listFocusOutline) || activeContrastBorder
+		listHoverOutline: (style && style.listFocusOutline) || activeContrastBorder,
+		selectListBorder: (style && style.selectListBorder) || editorWidgetBorder
 	} as ISelectBoxStyleOverrides, widget);
 }
 

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -494,6 +494,7 @@ export class SettingsEditor2 extends BaseEditor {
 	}
 
 	private updateTreeScrollSync(): void {
+		this.settingsTreeRenderer.cancelSuggesters();
 		if (this.searchResultModel) {
 			return;
 		}

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -41,7 +41,7 @@ import { attachButtonStyler, attachInputBoxStyler, attachSelectBoxStyler, attach
 import { ICssStyleCollector, ITheme, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { ITOCEntry } from 'vs/workbench/parts/preferences/browser/settingsLayout';
 import { ISettingsEditorViewState, isExcludeSetting, SettingsTreeElement, SettingsTreeGroupElement, SettingsTreeNewExtensionsElement, SettingsTreeSettingElement, settingKeyToDisplayFormat } from 'vs/workbench/parts/preferences/browser/settingsTreeModels';
-import { ExcludeSettingWidget, IExcludeDataItem, settingsHeaderForeground, settingsNumberInputBackground, settingsNumberInputBorder, settingsNumberInputForeground, settingsSelectBackground, settingsSelectBorder, settingsSelectForeground, settingsTextInputBackground, settingsTextInputBorder, settingsTextInputForeground } from 'vs/workbench/parts/preferences/browser/settingsWidgets';
+import { ExcludeSettingWidget, IExcludeDataItem, settingsHeaderForeground, settingsNumberInputBackground, settingsNumberInputBorder, settingsNumberInputForeground, settingsSelectBackground, settingsSelectBorder, settingsSelectListBorder, settingsSelectForeground, settingsTextInputBackground, settingsTextInputBorder, settingsTextInputForeground } from 'vs/workbench/parts/preferences/browser/settingsWidgets';
 import { ISetting, ISettingsGroup } from 'vs/workbench/services/preferences/common/preferences';
 
 const $ = DOM.$;
@@ -706,15 +706,20 @@ export class SettingsRenderer implements ITreeRenderer {
 		return template;
 	}
 
+	public cancelSuggesters() {
+		this.contextViewService.hideContextView();
+	}
+
 	private renderSettingEnumTemplate(tree: ITree, container: HTMLElement): ISettingEnumItemTemplate {
 		const common = this.renderCommonTemplate(tree, container, 'enum');
 
-		const selectBox = new SelectBox([], undefined, this.contextViewService);
+		const selectBox = new SelectBox([], undefined, this.contextViewService, undefined, { hasDetails: true });
 		common.toDispose.push(selectBox);
 		common.toDispose.push(attachSelectBoxStyler(selectBox, this.themeService, {
 			selectBackground: settingsSelectBackground,
 			selectForeground: settingsSelectForeground,
-			selectBorder: settingsSelectBorder
+			selectBorder: settingsSelectBorder,
+			selectListBorder: settingsSelectListBorder
 		}));
 		selectBox.render(common.controlElement);
 		const selectElement = common.controlElement.querySelector('select');
@@ -997,6 +1002,7 @@ export class SettingsRenderer implements ITreeRenderer {
 	private renderEnum(dataElement: SettingsTreeSettingElement, template: ISettingEnumItemTemplate, onChange: (value: string) => void): void {
 		const displayOptions = getDisplayEnumOptions(dataElement.setting);
 		template.selectBox.setOptions(displayOptions);
+		template.selectBox.setDetailsProvider(index => dataElement.setting.enumDescriptions && dataElement.setting.enumDescriptions[index]);
 
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
 		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' combobox ' + modifiedText;
@@ -1014,24 +1020,6 @@ export class SettingsRenderer implements ITreeRenderer {
 		}
 
 		template.enumDescriptionElement.innerHTML = '';
-		// if (dataElement.setting.enumDescriptions && dataElement.setting.enum && dataElement.setting.enum.length < SettingsRenderer.MAX_ENUM_DESCRIPTIONS) {
-		// 	if (isSelected) {
-		// 		let enumDescriptionText = '\n' + dataElement.setting.enumDescriptions
-		// 			.map((desc, i) => {
-		// 				const displayEnum = escapeInvisibleChars(dataElement.setting.enum[i]);
-		// 				return desc ?
-		// 					` - \`${displayEnum}\`: ${desc}` :
-		// 					` - \`${dataElement.setting.enum[i]}\``;
-		// 			})
-		// 			.filter(desc => !!desc)
-		// 			.join('\n');
-
-		// 		const renderedMarkdown = this.renderDescriptionMarkdown(fixSettingLinks(enumDescriptionText), template.toDispose);
-		// 		template.enumDescriptionElement.appendChild(renderedMarkdown);
-		// 	}
-
-		// 	return { overflows: true };
-		// }
 	}
 
 	private renderText(dataElement: SettingsTreeSettingElement, template: ISettingTextItemTemplate, onChange: (value: string) => void): void {

--- a/src/vs/workbench/parts/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsWidgets.ts
@@ -64,6 +64,8 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	if (link) {
 		collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item .setting-item-description-markdown a { color: ${link}; }`);
 		collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item .setting-item-description-markdown a > code { color: ${link}; }`);
+		collector.addRule(`.monaco-select-box-dropdown-container > .select-box-details-pane > .select-box-description-markdown a { color: ${link}; }`);
+		collector.addRule(`.monaco-select-box-dropdown-container > .select-box-details-pane > .select-box-description-markdown a > code { color: ${link}; }`);
 	}
 
 	const headerForegroundColor = theme.getColor(settingsHeaderForeground);
@@ -110,6 +112,8 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const codeTextForegroundColor = theme.getColor(textPreformatForeground);
 	if (codeTextForegroundColor) {
 		collector.addRule(`.settings-editor > .settings-body > .settings-tree-container .setting-item .setting-item-description-markdown code { color: ${codeTextForegroundColor} }`);
+		collector.addRule(`.monaco-select-box-dropdown-container > .select-box-details-pane > .select-box-description-markdown code { color: ${codeTextForegroundColor} }`);
+
 	}
 
 	const modifiedItemIndicatorColor = theme.getColor(modifiedItemIndicator);

--- a/src/vs/workbench/parts/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsWidgets.ts
@@ -16,7 +16,7 @@ import { Disposable, dispose, IDisposable } from 'vs/base/common/lifecycle';
 import 'vs/css!./media/settingsWidgets';
 import { localize } from 'vs/nls';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
-import { foreground, inputBackground, inputBorder, inputForeground, listActiveSelectionBackground, listActiveSelectionForeground, listHoverBackground, listHoverForeground, listInactiveSelectionBackground, listInactiveSelectionForeground, registerColor, selectBackground, selectBorder, selectForeground, textLinkForeground, textPreformatForeground } from 'vs/platform/theme/common/colorRegistry';
+import { foreground, inputBackground, inputBorder, inputForeground, listActiveSelectionBackground, listActiveSelectionForeground, listHoverBackground, listHoverForeground, listInactiveSelectionBackground, listInactiveSelectionForeground, registerColor, selectBackground, selectBorder, selectForeground, textLinkForeground, textPreformatForeground, editorWidgetBorder } from 'vs/platform/theme/common/colorRegistry';
 import { attachButtonStyler, attachInputBoxStyler } from 'vs/platform/theme/common/styler';
 import { ICssStyleCollector, ITheme, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 
@@ -32,6 +32,7 @@ export const modifiedItemIndicator = registerColor('settings.modifiedItemIndicat
 export const settingsSelectBackground = registerColor('settings.dropdownBackground', { dark: selectBackground, light: selectBackground, hc: selectBackground }, localize('settingsDropdownBackground', "(For settings editor preview) Settings editor dropdown background."));
 export const settingsSelectForeground = registerColor('settings.dropdownForeground', { dark: selectForeground, light: selectForeground, hc: selectForeground }, localize('settingsDropdownForeground', "(For settings editor preview) Settings editor dropdown foreground."));
 export const settingsSelectBorder = registerColor('settings.dropdownBorder', { dark: selectBorder, light: selectBorder, hc: selectBorder }, localize('settingsDropdownBorder', "(For settings editor preview) Settings editor dropdown border."));
+export const settingsSelectListBorder = registerColor('settings.dropdownListBorder', { dark: editorWidgetBorder, light: editorWidgetBorder, hc: editorWidgetBorder }, localize('settingsDropdownListBorder', "(For settings editor preview) Settings editor dropdown list border. This surrounds the options and separates the options from the description."));
 
 // Bool control colors
 export const settingsCheckboxBackground = registerColor('settings.checkboxBackground', { dark: selectBackground, light: selectBackground, hc: selectBackground }, localize('settingsCheckboxBackground', "(For settings editor preview) Settings editor checkbox background."));


### PR DESCRIPTION
Closes #55796

Alternative implementation to #56511.

Main concern with this approach is the styling needed to separate the details from the list items. In this implementation I've added an additional color token that specifies the border colors for the dropdown and separating line, which defaults to the `editorWidgetBorder` color, and only applies if the existing `settingsDropdownBorder` is the same as the list background color. Its a confusing process that is required because of the lightness of the dropdown, and still doesnt give great results, as the `editorWidgetBorder` is typically used against darker backgrounds, and in as such appears washed out in some dark themes. 

Dark+:
![image](https://user-images.githubusercontent.com/8586769/44495988-220cce00-a627-11e8-93f2-0a8c5f322ab2.png)

Dracula:
![image](https://user-images.githubusercontent.com/8586769/44496128-e1fa1b00-a627-11e8-9a2d-d6c472cee037.png)


Monokai:
![image](https://user-images.githubusercontent.com/8586769/44496149-f9d19f00-a627-11e8-873e-238d6b3b83ec.png)

Solarized Dark:
![image](https://user-images.githubusercontent.com/8586769/44496162-11a92300-a628-11e8-8c36-ded8d2cb7892.png)

Light themes are better because these tend to define a dropdown border color which acts as a good fallback:

Solarized Light:
![image](https://user-images.githubusercontent.com/8586769/44496185-3c937700-a628-11e8-8ec0-d2654bd4d37a.png)



