### PR TITLE
add rust region comments (#55648)

### DIFF
--- a/extensions/rust/language-configuration.json
+++ b/extensions/rust/language-configuration.json
@@ -23,8 +23,8 @@
 	],
 	"folding": {
 		"markers": {
-			"start": "^\\s//region",
-			"end": "^\\s//endregion"
+			"start": "^\\s*// region",
+			"end": "^\\s*// endregion"
 		}
 	}
 }

--- a/extensions/rust/language-configuration.json
+++ b/extensions/rust/language-configuration.json
@@ -20,5 +20,11 @@
 		["(", ")"],
 		["\"", "\""],
 		["'", "'"]
-	]
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s//region",
+			"end": "^\\s//endregion"
+		}
+	}
 }


### PR DESCRIPTION
Allows adding regions to rust files.

Fixes #55648.

Attempts to conform to https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md#comments.

Note that I'm unsure if the `\\s*` is necessary - is indentation handled automatically?