### PR TITLE
missing word in string

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -522,7 +522,7 @@ const editorConfiguration: IConfigurationNode = {
 				'',
 			],
 			'default': EDITOR_DEFAULTS.autoClosingQuotes,
-			'description': nls.localize('autoClosingQuotes', "Controls whether the editor should automatically close quotes the user adds an opening quote.")
+			'description': nls.localize('autoClosingQuotes', "Controls whether the editor should automatically close quotes after the user adds an opening quote.")
 		},
 		'editor.autoWrapping': {
 			type: 'string',


### PR DESCRIPTION
during the localization phase a user has found there was a missing word in this sentence - proposing fix