### PR TITLE
Simplify and fix bugs in no results/result count message logic

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -769,12 +769,11 @@ export class SettingsEditor2 extends BaseEditor {
 	private onSearchInputChanged(): void {
 		const query = this.searchWidget.getValue().trim();
 		this.delayedFilterLogging.cancel();
-		this.triggerSearch(query.replace(/›/g, ' '))
-			.then(() => {
-				if (query && this.searchResultModel) {
-					this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
-				}
-			});
+		this.triggerSearch(query.replace(/›/g, ' ')).then(() => {
+			if (query && this.searchResultModel) {
+				this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
+			}
+		});
 	}
 
 	private parseSettingFromJSON(query: string): string {

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -956,7 +956,6 @@ export class SettingsEditor2 extends BaseEditor {
 
 	private renderResultCountMessages() {
 		let count = countSettingGroupChildrenWithPredicate(this.settingsTree.getInput() as SettingsTreeGroupElement, element => element.matchesAllTags(this.viewState.tagFilters));
-		console.log('triggered');
 		switch (count) {
 			case 0: this.countElement.innerText = localize('noResults', "No Settings Found"); break;
 			case 1: this.countElement.innerText = localize('oneResult', "1 Setting Found"); break;

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -36,7 +36,7 @@ import { PreferencesEditor } from 'vs/workbench/parts/preferences/browser/prefer
 import { SettingsTarget, SettingsTargetsWidget } from 'vs/workbench/parts/preferences/browser/preferencesWidgets';
 import { commonlyUsedData, tocData } from 'vs/workbench/parts/preferences/browser/settingsLayout';
 import { resolveExtensionsSettings, resolveSettingsTree, SettingsRenderer, SettingsTree } from 'vs/workbench/parts/preferences/browser/settingsTree';
-import { ISettingsEditorViewState, MODIFIED_SETTING_TAG, ONLINE_SERVICES_SETTING_TAG, SearchResultIdx, SearchResultModel, SettingsTreeGroupElement, SettingsTreeModel, SettingsTreeSettingElement } from 'vs/workbench/parts/preferences/browser/settingsTreeModels';
+import { ISettingsEditorViewState, MODIFIED_SETTING_TAG, ONLINE_SERVICES_SETTING_TAG, SearchResultIdx, SearchResultModel, SettingsTreeGroupElement, SettingsTreeModel, SettingsTreeSettingElement, countSettingGroupChildrenWithPredicate } from 'vs/workbench/parts/preferences/browser/settingsTreeModels';
 import { TOCRenderer, TOCTree, TOCTreeModel } from 'vs/workbench/parts/preferences/browser/tocTree';
 import { CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, IPreferencesSearchService, ISearchProvider } from 'vs/workbench/parts/preferences/common/preferences';
 import { IEditorGroup } from 'vs/workbench/services/group/common/editorGroupsService';
@@ -768,13 +768,14 @@ export class SettingsEditor2 extends BaseEditor {
 
 	private onSearchInputChanged(): void {
 		const query = this.searchWidget.getValue().trim();
-		if (query === '') { this.countElement.style.display = 'none'; this.noResultsMessage.style.display = 'none'; }
 		this.delayedFilterLogging.cancel();
-		this.triggerSearch(query.replace(/›/g, ' ')).then(() => {
-			if (query && this.searchResultModel) {
-				this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
-			}
-		});
+		this.triggerSearch(query.replace(/›/g, ' '))
+			.then(() => {
+				if (query && this.searchResultModel) {
+					this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
+				}
+			})
+			.then(() => this.renderResultCountMessages());
 	}
 
 	private parseSettingFromJSON(query: string): string {
@@ -944,12 +945,9 @@ export class SettingsEditor2 extends BaseEditor {
 				this.settingsTree.setInput(this.searchResultModel.root);
 			} else {
 				this.tocTreeModel.update();
-				expandAll(this.tocTree);
 				this.searchResultModel.setResult(type, result);
 			}
 
-			let count = this.searchResultModel.getUniqueResults().map(result => result ? result.filterMatches.length : 0).reduce((a, b) => a + b);
-			this.renderResultCountMessages(count);
 
 			this.tocTree.setSelection([]);
 			expandAll(this.tocTree);
@@ -958,7 +956,9 @@ export class SettingsEditor2 extends BaseEditor {
 		});
 	}
 
-	private renderResultCountMessages(count: number) {
+	private renderResultCountMessages() {
+		let count = countSettingGroupChildrenWithPredicate(this.settingsTree.getInput() as SettingsTreeGroupElement, element => element.matchesAllTags(this.viewState.tagFilters));
+
 		switch (count) {
 			case 0: this.countElement.innerText = localize('noResults', "No Settings Found"); break;
 			case 1: this.countElement.innerText = localize('oneResult', "1 Setting Found"); break;

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -774,8 +774,7 @@ export class SettingsEditor2 extends BaseEditor {
 				if (query && this.searchResultModel) {
 					this.delayedFilterLogging.trigger(() => this.reportFilteringUsed(query, this.searchResultModel.getUniqueResults()));
 				}
-			})
-			.then(() => this.renderResultCountMessages());
+			});
 	}
 
 	private parseSettingFromJSON(query: string): string {
@@ -822,9 +821,9 @@ export class SettingsEditor2 extends BaseEditor {
 			collapseAll(this.tocTree);
 
 			if (this.searchResultModel) {
-				return this.settingsTree.setInput(this.searchResultModel.root);
+				return this.settingsTree.setInput(this.searchResultModel.root).then(() => this.renderResultCountMessages());
 			} else {
-				return this.settingsTree.setInput(this.settingsTreeModel.root);
+				return this.settingsTree.setInput(this.settingsTreeModel.root).then(() => this.renderResultCountMessages());
 			}
 		}
 	}
@@ -908,7 +907,7 @@ export class SettingsEditor2 extends BaseEditor {
 								TPromise.wrap(null);
 						});
 					}
-				});
+				}).then(() => this.renderResultCountMessages());
 			} else {
 				return TPromise.wrap(null);
 			}
@@ -958,7 +957,7 @@ export class SettingsEditor2 extends BaseEditor {
 
 	private renderResultCountMessages() {
 		let count = countSettingGroupChildrenWithPredicate(this.settingsTree.getInput() as SettingsTreeGroupElement, element => element.matchesAllTags(this.viewState.tagFilters));
-
+		console.log('triggered');
 		switch (count) {
 			case 0: this.countElement.innerText = localize('noResults', "No Settings Found"); break;
 			case 1: this.countElement.innerText = localize('oneResult', "1 Setting Found"); break;

--- a/src/vs/workbench/parts/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTreeModels.ts
@@ -175,6 +175,22 @@ export class SettingsTreeSettingElement extends SettingsTreeElement {
 	}
 }
 
+export function countSettingGroupChildrenWithPredicate(tree: SettingsTreeGroupElement, predicate: (setting: SettingsTreeSettingElement) => boolean): number {
+	const recursiveCounter: (root: SettingsTreeGroupElement | SettingsTreeSettingElement | SettingsTreeNewExtensionsElement) => number =
+		root => {
+			if (root instanceof SettingsTreeGroupElement) {
+				return root.children.map(child => recursiveCounter(child)).reduce((a, b) => a + b, 0);
+			} else if (root instanceof SettingsTreeSettingElement) {
+				return +predicate(root);
+			} else if (root instanceof SettingsTreeNewExtensionsElement) {
+				return 0;
+			}
+
+			throw new Error('Argument to settingsTreeChildrenCount should only have group, setting, or extension elements');
+		};
+	return recursiveCounter(tree);
+}
+
 export class SettingsTreeModel {
 	protected _root: SettingsTreeGroupElement;
 	private _treeElementsById = new Map<string, SettingsTreeElement>();


### PR DESCRIPTION
This fixes #57090 by adding full support for filter tags in the count logic.