### PR TITLE
Settings: Fix aria labels using role=form.  Fixes: #54836

### DIFF
--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -211,10 +211,10 @@ export class ViewItem implements IViewItem {
 		// ARIA
 		// console.warn(this.context.tree.getHTMLElement().getAttribute('role'));
 		// console.warn(this.context.tree.getHTMLElement().getAttribute('aria-label'));
-
-		if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
-			this.element.setAttribute('role', 'treeitem');
-		}
+		console.warn('row render ' + this.context.tree.getHTMLElement().getAttribute('role'));
+		// if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
+		this.element.setAttribute('role', 'treeitem');
+		// }
 
 		const accessibility = this.context.accessibilityProvider;
 		const ariaLabel = accessibility.getAriaLabel(this.context.tree, this.model.getElement());
@@ -222,13 +222,14 @@ export class ViewItem implements IViewItem {
 			this.element.setAttribute('aria-label', ariaLabel);
 		}
 
+		console.warn('tree label ' + this.element.getAttribute('aria-label'));
 		// note we should probably do this by an option
-		if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
-			if (accessibility.getPosInSet && accessibility.getSetSize) {
-				this.element.setAttribute('aria-setsize', accessibility.getSetSize());
-				this.element.setAttribute('aria-posinset', accessibility.getPosInSet(this.context.tree, this.model.getElement()));
-			}
+		// if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
+		if (accessibility.getPosInSet && accessibility.getSetSize) {
+			this.element.setAttribute('aria-setsize', accessibility.getSetSize());
+			this.element.setAttribute('aria-posinset', accessibility.getPosInSet(this.context.tree, this.model.getElement()));
 		}
+		// }
 
 		if (this.model.hasTrait('focused')) {
 			const base64Id = strings.safeBtoa(this.model.id);
@@ -246,9 +247,9 @@ export class ViewItem implements IViewItem {
 		}
 
 		// note we should probably do this by an option
-		if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
-			this.element.setAttribute('aria-level', String(this.model.getDepth()));
-		}
+		// if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
+		this.element.setAttribute('aria-level', String(this.model.getDepth()));
+		// }
 
 		if (this.context.options.paddingOnRow) {
 			this.element.style.paddingLeft = this.context.options.twistiePixels + ((this.model.getDepth() - 1) * this.context.options.indentPixels) + 'px';

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -209,28 +209,16 @@ export class ViewItem implements IViewItem {
 		this.element.style.height = this.height + 'px';
 
 		// ARIA
-		// console.warn(this.context.tree.getHTMLElement().getAttribute('role'));
-		// console.warn(this.context.tree.getHTMLElement().getAttribute('aria-label'));
-		console.warn('row render ' + this.context.tree.getHTMLElement().getAttribute('role'));
-		// if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
 		this.element.setAttribute('role', 'treeitem');
-		// }
-
 		const accessibility = this.context.accessibilityProvider;
 		const ariaLabel = accessibility.getAriaLabel(this.context.tree, this.model.getElement());
 		if (ariaLabel) {
 			this.element.setAttribute('aria-label', ariaLabel);
 		}
-
-		console.warn('tree label ' + this.element.getAttribute('aria-label'));
-		// note we should probably do this by an option
-		// if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
 		if (accessibility.getPosInSet && accessibility.getSetSize) {
 			this.element.setAttribute('aria-setsize', accessibility.getSetSize());
 			this.element.setAttribute('aria-posinset', accessibility.getPosInSet(this.context.tree, this.model.getElement()));
 		}
-		// }
-
 		if (this.model.hasTrait('focused')) {
 			const base64Id = strings.safeBtoa(this.model.id);
 
@@ -245,11 +233,7 @@ export class ViewItem implements IViewItem {
 		} else {
 			this.element.removeAttribute('aria-expanded');
 		}
-
-		// note we should probably do this by an option
-		// if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
 		this.element.setAttribute('aria-level', String(this.model.getDepth()));
-		// }
 
 		if (this.context.options.paddingOnRow) {
 			this.element.style.paddingLeft = this.context.options.twistiePixels + ((this.model.getDepth() - 1) * this.context.options.indentPixels) + 'px';

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -209,16 +209,27 @@ export class ViewItem implements IViewItem {
 		this.element.style.height = this.height + 'px';
 
 		// ARIA
-		this.element.setAttribute('role', 'treeitem');
+		// console.warn(this.context.tree.getHTMLElement().getAttribute('role'));
+		// console.warn(this.context.tree.getHTMLElement().getAttribute('aria-label'));
+
+		if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
+			this.element.setAttribute('role', 'treeitem');
+		}
+
 		const accessibility = this.context.accessibilityProvider;
 		const ariaLabel = accessibility.getAriaLabel(this.context.tree, this.model.getElement());
 		if (ariaLabel) {
 			this.element.setAttribute('aria-label', ariaLabel);
 		}
-		if (accessibility.getPosInSet && accessibility.getSetSize) {
-			this.element.setAttribute('aria-setsize', accessibility.getSetSize());
-			this.element.setAttribute('aria-posinset', accessibility.getPosInSet(this.context.tree, this.model.getElement()));
+
+		// note we should probably do this by an option
+		if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
+			if (accessibility.getPosInSet && accessibility.getSetSize) {
+				this.element.setAttribute('aria-setsize', accessibility.getSetSize());
+				this.element.setAttribute('aria-posinset', accessibility.getPosInSet(this.context.tree, this.model.getElement()));
+			}
 		}
+
 		if (this.model.hasTrait('focused')) {
 			const base64Id = strings.safeBtoa(this.model.id);
 
@@ -233,7 +244,11 @@ export class ViewItem implements IViewItem {
 		} else {
 			this.element.removeAttribute('aria-expanded');
 		}
-		this.element.setAttribute('aria-level', String(this.model.getDepth()));
+
+		// note we should probably do this by an option
+		if (this.context.tree.getHTMLElement().getAttribute('role') !== 'form') {
+			this.element.setAttribute('aria-level', String(this.model.getDepth()));
+		}
 
 		if (this.context.options.paddingOnRow) {
 			this.element.style.paddingLeft = this.context.options.twistiePixels + ((this.model.getDepth() - 1) * this.context.options.indentPixels) + 'px';

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -467,6 +467,7 @@ export class SettingsEditor2 extends BaseEditor {
 			}));
 		this.settingsTree.getHTMLElement().attributes.removeNamedItem('tabindex');
 
+		// Have to redefine role of the tree widget to form for input elements
 		this.settingsTree.getHTMLElement().setAttribute('role', 'form');
 
 		this._register(this.settingsTree.onDidScroll(() => {

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -467,6 +467,8 @@ export class SettingsEditor2 extends BaseEditor {
 			}));
 		this.settingsTree.getHTMLElement().attributes.removeNamedItem('tabindex');
 
+		this.settingsTree.getHTMLElement().setAttribute('role', 'form');
+
 		this._register(this.settingsTree.onDidScroll(() => {
 			this.updateTreeScrollSync();
 		}));

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -468,6 +468,7 @@ export class SettingsEditor2 extends BaseEditor {
 		this.settingsTree.getHTMLElement().attributes.removeNamedItem('tabindex');
 
 		// Have to redefine role of the tree widget to form for input elements
+		// TODO:CDL make this an option for tree
 		this.settingsTree.getHTMLElement().setAttribute('role', 'form');
 
 		this._register(this.settingsTree.onDidScroll(() => {

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -907,8 +907,6 @@ export class SettingsRenderer implements ITreeRenderer {
 	}
 
 	private renderSettingElement(tree: ITree, element: SettingsTreeSettingElement, templateId: string, template: ISettingItemTemplate | ISettingBoolItemTemplate): void {
-		console.warn('render setting elements start');
-
 		template.context = element;
 		template.toolbar.context = element;
 
@@ -950,18 +948,11 @@ export class SettingsRenderer implements ITreeRenderer {
 			template.otherOverridesElement.textContent = '';
 		}
 
-		console.warn('attribute fix');
-
-		console.warn('\n' + template.containerElement.parentElement.outerHTML + '\n\n');
-		// CDL fix attributes
-		// template.containerElement.parentElement.removeAttribute('role');
-		// template.containerElement.parentElement.removeAttribute('aria-level');
+		// Remove tree attributes - sometimes overridden by tree - should be managed there
+		template.containerElement.parentElement.removeAttribute('role');
+		template.containerElement.parentElement.removeAttribute('aria-level');
 		template.containerElement.parentElement.removeAttribute('aria-posinset');
 		template.containerElement.parentElement.removeAttribute('aria-setsize');
-		// template.containerElement.parentElement.setAttribute('role','test');
-		console.warn('after fix');
-		console.warn('\n' + template.containerElement.parentElement.outerHTML + '\n\n');
-		console.warn('render setting elements finish');
 	}
 
 	private renderDescriptionMarkdown(text: string, disposeables: IDisposable[]): HTMLElement {
@@ -1025,8 +1016,6 @@ export class SettingsRenderer implements ITreeRenderer {
 		// unless defined as role=treeitem and indirect aria-labelledby approach
 		// TODO: Determine method to normally label input items with value read last
 		template.checkbox.domNode.setAttribute('id', id + '_Item');
-		// template.checkbox.domNode.setAttribute('role', 'treeitem');
-		// template.checkbox.domNode.setAttribute('aria-labelledby', id + '_Item ' + id);
 		template.checkbox.domNode.setAttribute('aria-labelledby', id);
 	}
 
@@ -1089,7 +1078,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		// Labels will not be read on descendent input elements of the parent treeitem
 		// unless defined as role=treeitem and indirect aria-labelledby approach
 		// TODO: Determine method to normally label input items with value read last
-		template.inputBox.inputElement.setAttribute('id', id + 'item');
+		template.inputBox.inputElement.setAttribute('id', id + '_Item');
 		template.inputBox.inputElement.setAttribute('role', 'textbox');
 		template.inputBox.inputElement.setAttribute('aria-labelledby', id);
 
@@ -1124,8 +1113,6 @@ export class SettingsRenderer implements ITreeRenderer {
 		// TODO: Determine method to normally label input items with value read last
 		template.inputBox.inputElement.setAttribute('id', id + '_Item');
 		template.inputBox.inputElement.setAttribute('role', 'textbox');
-		// template.inputBox.inputElement.setAttribute('aria-labelledby', id + '_Item ' + id);
-		// template.inputBox.inputElement.setAttribute('aria-labelledby', id + '_Item ');
 		template.inputBox.inputElement.setAttribute('aria-labelledby', id);
 
 		renderValidations(dataElement, template, true, label);

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -678,7 +678,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		// Also have to ignore embedded links - too buried to stop propagation
 		toDispose.push(DOM.addDisposableListener(descriptionElement, DOM.EventType.MOUSE_DOWN, (e) => {
 			const targetElement = <HTMLElement>e.toElement;
-			const targetId = descriptionElement.getAttribute('checkbox-label-target-id');
+			const targetId = descriptionElement.getAttribute('checkbox_label_target_id');
 
 			// Make sure we are not a link and the target ID matches
 			// Toggle target checkbox
@@ -932,10 +932,12 @@ export class SettingsRenderer implements ITreeRenderer {
 			template.descriptionElement.innerText = element.description;
 		}
 
+		const baseId = (element.displayCategory + '_' + element.displayLabel).replace(/ /g, '_').toLowerCase();
+		template.descriptionElement.id = baseId + '_setting_description';
+
 		if (templateId === SETTINGS_BOOL_TEMPLATE_ID) {
 			// Add checkbox target to description clickable and able to toggle checkbox
-			const checkbox_id = (element.displayCategory + '_' + element.displayLabel).replace(/ /g, '_') + '_Item';
-			template.descriptionElement.setAttribute('checkbox-label-target-id', checkbox_id);
+			template.descriptionElement.setAttribute('checkbox_label_target_id', baseId + '_setting_item');
 		}
 
 		if (element.overriddenScopeList.length) {
@@ -1003,20 +1005,20 @@ export class SettingsRenderer implements ITreeRenderer {
 
 		// Setup and add ARIA attributes
 		// Create id and label for control/input element - parent is wrapper div
-		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
+		const baseId = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_').toLowerCase();
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
-		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + (dataElement.value ? ' checked ' : ' unchecked ') + modifiedText;
+		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + ' ' + modifiedText;
 
 		// We use the parent control div for the aria-labelledby target
 		// Does not appear you can use the direct label on the element itself within a tree
-		template.checkbox.domNode.parentElement.setAttribute('id', id);
+		template.checkbox.domNode.parentElement.id = baseId + '_setting_label';
 		template.checkbox.domNode.parentElement.setAttribute('aria-label', label);
 
 		// Labels will not be read on descendent input elements of the parent treeitem
 		// unless defined as role=treeitem and indirect aria-labelledby approach
-		// TODO: Determine method to normally label input items with value read last
-		template.checkbox.domNode.setAttribute('id', id + '_Item');
-		template.checkbox.domNode.setAttribute('aria-labelledby', id);
+		template.checkbox.domNode.id = baseId + '_setting_item';
+		template.checkbox.domNode.setAttribute('aria-labelledby', baseId + '_setting_label');
+		template.checkbox.domNode.setAttribute('aria-describedby', baseId + '_setting_description');
 	}
 
 	private renderEnum(dataElement: SettingsTreeSettingElement, template: ISettingEnumItemTemplate, onChange: (value: string) => void): void {
@@ -1025,6 +1027,7 @@ export class SettingsRenderer implements ITreeRenderer {
 
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
 		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + ' ' + modifiedText;
+		const baseId = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_').toLowerCase();
 
 		template.selectBox.setAriaLabel(label);
 
@@ -1034,8 +1037,9 @@ export class SettingsRenderer implements ITreeRenderer {
 		template.onChange = idx => onChange(dataElement.setting.enum[idx]);
 
 		if (template.controlElement.firstElementChild) {
-			// SelectBox needs to be treeitem to read correctly within tree
+			// SelectBox needs to have treeitem changed to combobox to read correctly within tree
 			template.controlElement.firstElementChild.setAttribute('role', 'combobox');
+			template.controlElement.firstElementChild.setAttribute('aria-describedby', baseId + '_setting_description');
 		}
 
 		template.enumDescriptionElement.innerHTML = '';
@@ -1068,19 +1072,19 @@ export class SettingsRenderer implements ITreeRenderer {
 
 		// Setup and add ARIA attributes
 		// Create id and label for control/input element - parent is wrapper div
-		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
+		const baseId = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_').toLowerCase();
 
 		// We use the parent control div for the aria-labelledby target
 		// Does not appear you can use the direct label on the element itself within a tree
-		template.inputBox.inputElement.parentElement.setAttribute('id', id);
+		template.inputBox.inputElement.parentElement.id = baseId + '_setting_label';
 		template.inputBox.inputElement.parentElement.setAttribute('aria-label', label);
 
 		// Labels will not be read on descendent input elements of the parent treeitem
 		// unless defined as role=treeitem and indirect aria-labelledby approach
-		// TODO: Determine method to normally label input items with value read last
-		template.inputBox.inputElement.setAttribute('id', id + '_Item');
+		template.inputBox.inputElement.id = baseId + '_setting_item';
 		template.inputBox.inputElement.setAttribute('role', 'textbox');
-		template.inputBox.inputElement.setAttribute('aria-labelledby', id);
+		template.inputBox.inputElement.setAttribute('aria-labelledby', baseId + '_setting_label');
+		template.inputBox.inputElement.setAttribute('aria-describedby', baseId + '_setting_description');
 
 		renderValidations(dataElement, template, true, label);
 	}
@@ -1101,19 +1105,19 @@ export class SettingsRenderer implements ITreeRenderer {
 
 		// Setup and add ARIA attributes
 		// Create id and label for control/input element - parent is wrapper div
-		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
+		const baseId = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_').toLowerCase();
 
 		// We use the parent control div for the aria-labelledby target
 		// Does not appear you can use the direct label on the element itself within a tree
-		template.inputBox.inputElement.parentElement.setAttribute('id', id);
+		template.inputBox.inputElement.parentElement.id = baseId + '_setting_label';
 		template.inputBox.inputElement.parentElement.setAttribute('aria-label', label);
 
 		// Labels will not be read on descendent input elements of the parent treeitem
 		// unless defined as role=treeitem and indirect aria-labelledby approach
-		// TODO: Determine method to normally label input items with value read last
-		template.inputBox.inputElement.setAttribute('id', id + '_Item');
+		template.inputBox.inputElement.id = baseId + '_setting_item';
 		template.inputBox.inputElement.setAttribute('role', 'textbox');
-		template.inputBox.inputElement.setAttribute('aria-labelledby', id);
+		template.inputBox.inputElement.setAttribute('aria-labelledby', baseId + '_setting_label');
+		template.inputBox.inputElement.setAttribute('aria-describedby', baseId + '_setting_description');
 
 		renderValidations(dataElement, template, true, label);
 	}

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -678,11 +678,11 @@ export class SettingsRenderer implements ITreeRenderer {
 		// Also have to ignore embedded links - too buried to stop propagation
 		toDispose.push(DOM.addDisposableListener(descriptionElement, DOM.EventType.MOUSE_DOWN, (e) => {
 			const targetElement = <HTMLElement>e.toElement;
-			const targetId = descriptionElement.getAttribute('checkboxLabelTargetId');
+			const targetId = descriptionElement.getAttribute('checkbox-label-target-id');
 
 			// Make sure we are not a link and the target ID matches
 			// Toggle target checkbox
-			if (targetElement.tagName !== 'A' && targetId === template.checkbox.domNode.id) {
+			if (targetElement.tagName.toLowerCase() !== 'a' && targetId === template.checkbox.domNode.id) {
 				template.checkbox.checked = template.checkbox.checked ? false : true;
 			}
 			DOM.EventHelper.stop(e);
@@ -935,7 +935,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		if (templateId === SETTINGS_BOOL_TEMPLATE_ID) {
 			// Add checkbox target to description clickable and able to toggle checkbox
 			const checkbox_id = (element.displayCategory + '_' + element.displayLabel).replace(/ /g, '_') + '_Item';
-			template.descriptionElement.setAttribute('checkboxLabelTargetId', checkbox_id);
+			template.descriptionElement.setAttribute('checkbox-label-target-id', checkbox_id);
 		}
 
 		if (element.overriddenScopeList.length) {
@@ -999,7 +999,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		// Create id and label for control/input element - parent is wrapper div
 		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
-		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + (dataElement.value ? 'checked ' : 'unchecked ') + modifiedText;
+		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + (dataElement.value ? ' checked ' : ' unchecked ') + modifiedText;
 
 		// We use the parent control div for the aria-labelledby target
 		// Does not appear you can use the direct label on the element itself within a tree

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -907,6 +907,8 @@ export class SettingsRenderer implements ITreeRenderer {
 	}
 
 	private renderSettingElement(tree: ITree, element: SettingsTreeSettingElement, templateId: string, template: ISettingItemTemplate | ISettingBoolItemTemplate): void {
+		console.warn('render setting elements start');
+
 		template.context = element;
 		template.toolbar.context = element;
 
@@ -947,6 +949,19 @@ export class SettingsRenderer implements ITreeRenderer {
 		} else {
 			template.otherOverridesElement.textContent = '';
 		}
+
+		console.warn('attribute fix');
+
+		console.warn('\n' + template.containerElement.parentElement.outerHTML + '\n\n');
+		// CDL fix attributes
+		// template.containerElement.parentElement.removeAttribute('role');
+		// template.containerElement.parentElement.removeAttribute('aria-level');
+		template.containerElement.parentElement.removeAttribute('aria-posinset');
+		template.containerElement.parentElement.removeAttribute('aria-setsize');
+		// template.containerElement.parentElement.setAttribute('role','test');
+		console.warn('after fix');
+		console.warn('\n' + template.containerElement.parentElement.outerHTML + '\n\n');
+		console.warn('render setting elements finish');
 	}
 
 	private renderDescriptionMarkdown(text: string, disposeables: IDisposable[]): HTMLElement {

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -932,9 +932,11 @@ export class SettingsRenderer implements ITreeRenderer {
 			template.descriptionElement.innerText = element.description;
 		}
 
-		// Add checkbox target to description clickable and able to toggle checkbox
-		const checkbox_id = (element.displayCategory + '_' + element.displayLabel).replace(/ /g, '_') + '_Item';
-		template.descriptionElement.setAttribute('checkboxLabelTargetId', checkbox_id);
+		if (templateId === SETTINGS_BOOL_TEMPLATE_ID) {
+			// Add checkbox target to description clickable and able to toggle checkbox
+			const checkbox_id = (element.displayCategory + '_' + element.displayLabel).replace(/ /g, '_') + '_Item';
+			template.descriptionElement.setAttribute('checkboxLabelTargetId', checkbox_id);
+		}
 
 		if (element.overriddenScopeList.length) {
 			let otherOverridesLabel = element.isConfigured ?
@@ -997,7 +999,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		// Create id and label for control/input element - parent is wrapper div
 		const id = (dataElement.displayCategory + '_' + dataElement.displayLabel).replace(/ /g, '_');
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
-		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' checkbox ' + (dataElement.value ? 'checked ' : 'unchecked ') + modifiedText;
+		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + (dataElement.value ? 'checked ' : 'unchecked ') + modifiedText;
 
 		// We use the parent control div for the aria-labelledby target
 		// Does not appear you can use the direct label on the element itself within a tree
@@ -1008,9 +1010,9 @@ export class SettingsRenderer implements ITreeRenderer {
 		// unless defined as role=treeitem and indirect aria-labelledby approach
 		// TODO: Determine method to normally label input items with value read last
 		template.checkbox.domNode.setAttribute('id', id + '_Item');
-		template.checkbox.domNode.setAttribute('role', 'treeitem');
-		template.checkbox.domNode.setAttribute('aria-labelledby', id + '_Item ' + id);
-
+		// template.checkbox.domNode.setAttribute('role', 'treeitem');
+		// template.checkbox.domNode.setAttribute('aria-labelledby', id + '_Item ' + id);
+		template.checkbox.domNode.setAttribute('aria-labelledby', id);
 	}
 
 	private renderEnum(dataElement: SettingsTreeSettingElement, template: ISettingEnumItemTemplate, onChange: (value: string) => void): void {
@@ -1018,7 +1020,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		template.selectBox.setOptions(displayOptions);
 
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
-		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' combobox ' + modifiedText;
+		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + ' ' + modifiedText;
 
 		template.selectBox.setAriaLabel(label);
 
@@ -1029,7 +1031,7 @@ export class SettingsRenderer implements ITreeRenderer {
 
 		if (template.controlElement.firstElementChild) {
 			// SelectBox needs to be treeitem to read correctly within tree
-			template.controlElement.firstElementChild.setAttribute('role', 'treeitem');
+			template.controlElement.firstElementChild.setAttribute('role', 'combobox');
 		}
 
 		template.enumDescriptionElement.innerHTML = '';
@@ -1055,7 +1057,7 @@ export class SettingsRenderer implements ITreeRenderer {
 
 	private renderText(dataElement: SettingsTreeSettingElement, template: ISettingTextItemTemplate, onChange: (value: string) => void): void {
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
-		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' ' + modifiedText;
+		const label = dataElement.displayCategory + ' ' + dataElement.displayLabel + ' ' + modifiedText;
 		template.onChange = null;
 		template.inputBox.value = dataElement.value;
 		template.onChange = value => { renderValidations(dataElement, template, false, label); onChange(value); };
@@ -1073,8 +1075,8 @@ export class SettingsRenderer implements ITreeRenderer {
 		// unless defined as role=treeitem and indirect aria-labelledby approach
 		// TODO: Determine method to normally label input items with value read last
 		template.inputBox.inputElement.setAttribute('id', id + 'item');
-		template.inputBox.inputElement.setAttribute('role', 'treeitem');
-		template.inputBox.inputElement.setAttribute('aria-labelledby', id + 'item ' + id);
+		template.inputBox.inputElement.setAttribute('role', 'textbox');
+		template.inputBox.inputElement.setAttribute('aria-labelledby', id);
 
 		renderValidations(dataElement, template, true, label);
 	}
@@ -1082,7 +1084,7 @@ export class SettingsRenderer implements ITreeRenderer {
 
 	private renderNumber(dataElement: SettingsTreeSettingElement, template: ISettingTextItemTemplate, onChange: (value: number) => void): void {
 		const modifiedText = dataElement.isConfigured ? 'Modified' : '';
-		const label = ' ' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' number ' + modifiedText;
+		const label = '' + dataElement.displayCategory + ' ' + dataElement.displayLabel + ' number ' + modifiedText;
 		const numParseFn = (dataElement.valueType === 'integer' || dataElement.valueType === 'nullable-integer')
 			? parseInt : parseFloat;
 
@@ -1105,9 +1107,11 @@ export class SettingsRenderer implements ITreeRenderer {
 		// Labels will not be read on descendent input elements of the parent treeitem
 		// unless defined as role=treeitem and indirect aria-labelledby approach
 		// TODO: Determine method to normally label input items with value read last
-		template.inputBox.inputElement.setAttribute('id', id + 'item');
-		template.inputBox.inputElement.setAttribute('role', 'treeitem');
-		template.inputBox.inputElement.setAttribute('aria-labelledby', id + 'item ' + id);
+		template.inputBox.inputElement.setAttribute('id', id + '_Item');
+		template.inputBox.inputElement.setAttribute('role', 'textbox');
+		// template.inputBox.inputElement.setAttribute('aria-labelledby', id + '_Item ' + id);
+		// template.inputBox.inputElement.setAttribute('aria-labelledby', id + '_Item ');
+		template.inputBox.inputElement.setAttribute('aria-labelledby', id);
 
 		renderValidations(dataElement, template, true, label);
 	}


### PR DESCRIPTION
@roblourens 

this is still wip but, I wanted you to check it out and also think we will probably need to get some others in the discussion since I think we need to modify tree.

here's where I am:
- I think I have something that does not contradict what I understand for the roles, specifically form
- we need to make the tree use role = form to allow a nested interactive elements and their correct roles
- I actually had to identify the role on the input elements role=textbox for example
- the labeling, most specifically the reader output for selected text now works correctly
- I made the proof of concept changes to tree for experimentation 
- the changes to tree should be done by passing in an optional role 
- if tree is using role=form , I disable the attributes for level and position to not confuse the reader

We still have to deal with the fact that Links seem to have weird behaviors, but this is consistent with things like the welcome page where the reader says 'clickable' some random number of times.
https://github.com/nvaccess/nvda/issues/7430
Related: #52464

Should we open up the discussion about modifying tree?