### PR TITLE
Electron 2.0.8

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "2.0.7"
+target "2.0.8"
 runtime "electron"

--- a/OSSREADME.json
+++ b/OSSREADME.json
@@ -51,7 +51,7 @@
 },
 {
 	"name": "electron",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"license": "MIT",
 	"repositoryURL": "https://github.com/electron/electron",
 	"isProd": true


### PR DESCRIPTION
This fixes a crash on Linux systems running Glibc 2.28 (see electron/electron#13972, #55934 etc.). All the tests pass, and no more crashes on Arch Linux, even with the offending glibc patch un-reverted.