### PR TITLE
debug: do not treat TaskEventActive as if the task started

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -879,9 +879,6 @@ export class DebugService implements IDebugService {
 					// task is already running - nothing to do.
 					return TPromise.as(null);
 				}
-				once(TaskEventKind.Active, this.taskService.onDidStateChange)((taskEvent) => {
-					taskStarted = true;
-				});
 				const taskPromise = this.taskService.run(task);
 				if (task.isBackground) {
 					return new TPromise((c, e) => once(TaskEventKind.Inactive, this.taskService.onDidStateChange)(() => c(null)));


### PR DESCRIPTION
fixes #57346

No point in treating the task active event as if the task started since the promise will never complete.