### PR TITLE
Add CancellationToken methods

### DIFF
--- a/src/vs/base/common/cancellation.ts
+++ b/src/vs/base/common/cancellation.ts
@@ -9,6 +9,14 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { canceled, isPromiseCanceledError } from './errors';
 
+/**
+ * A cancellation token is passed to an asynchronous or long running
+ * operation to request cancellation, like cancelling a request
+ * for completion items because the user continued to type.
+ *
+ * To get an instance of a `CancellationToken` use a
+ * [CancellationTokenSource](#CancellationTokenSource).
+ */
 export interface CancellationToken {
 	/**
 	 * Checks whether this token has already been canceled.

--- a/src/vs/base/common/cancellation.ts
+++ b/src/vs/base/common/cancellation.ts
@@ -7,14 +7,24 @@
 
 import { Event, Emitter } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import { canceled, isPromiseCanceledError } from './errors';
 
 export interface CancellationToken {
+	/**
+	 * Checks whether this token has already been canceled.
+	 */
 	readonly isCancellationRequested: boolean;
+
 	/**
 	 * An event emitted when cancellation is requested
 	 * @event
 	 */
 	readonly onCancellationRequested: Event<any>;
+
+	/**
+	 * Throws if this token has already been canceled.
+	 */
+	throwIfCancellationRequested();
 }
 
 const shortcutEvent = Object.freeze(function (callback, context?): IDisposable {
@@ -24,15 +34,40 @@ const shortcutEvent = Object.freeze(function (callback, context?): IDisposable {
 
 export namespace CancellationToken {
 
+	/**
+	 * A token that will never be canceled.
+	 */
 	export const None: CancellationToken = Object.freeze({
 		isCancellationRequested: false,
-		onCancellationRequested: Event.None
+		onCancellationRequested: Event.None,
+		throwIfCancellationRequested() { },
 	});
 
+	/**
+	 * A token that is already canceled.
+	 */
 	export const Cancelled: CancellationToken = Object.freeze({
 		isCancellationRequested: true,
-		onCancellationRequested: shortcutEvent
+		onCancellationRequested: shortcutEvent,
+		throwIfCancellationRequested() {
+			throw canceledError();
+		},
 	});
+
+	/**
+	 * Returns an error that may be used to communicate cancellation.
+	 */
+	export function canceledError() {
+		return canceled();
+	}
+
+	/**
+	 * Tests an error to see whether it indicates cancellation.
+	 * @param error The error to test.
+	 */
+	export function isCanceledError(error: any): boolean {
+		return isPromiseCanceledError(error);
+	}
 }
 
 class MutableToken implements CancellationToken {
@@ -62,6 +97,12 @@ class MutableToken implements CancellationToken {
 			this._emitter = new Emitter<any>();
 		}
 		return this._emitter.event;
+	}
+
+	throwIfCancellationRequested() {
+		if (this._isCancelled) {
+			throw CancellationToken.canceledError();
+		}
 	}
 
 	public dispose(): void {

--- a/src/vs/base/test/common/cancellation.test.ts
+++ b/src/vs/base/test/common/cancellation.test.ts
@@ -96,4 +96,17 @@ suite('CancellationToken', function () {
 		source.cancel();
 		assert.equal(count, 0);
 	});
+
+	test('throwIfCancellationRequested throws only after cancellation', function () {
+		let source = new CancellationTokenSource();
+		source.token.throwIfCancellationRequested();
+		source.cancel();
+		assert.throws(() => source.token.throwIfCancellationRequested(), err => assert(CancellationToken.isCanceledError(err)));
+	});
+
+	test('cancellation error is recognizable', function () {
+		assert.notEqual(null, CancellationToken.canceledError());
+		assert(CancellationToken.isCanceledError(CancellationToken.canceledError()));
+		assert(!CancellationToken.isCanceledError(new Error('hi')));
+	});
 });

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1376,6 +1376,11 @@ declare module 'vscode' {
 		 * An [event](#Event) which fires upon cancellation.
 		 */
 		onCancellationRequested: Event<any>;
+
+		/**
+		 * Throws if this token has already been canceled.
+		 */
+		throwIfCancellationRequested();
 	}
 
 	/**


### PR DESCRIPTION
* throwIfCancellationRequested()
* canceledError() so folks can return errors without throwing first.
* isCanceledError(err) to test if an error represents a cancellation.

Also added API doc comments and tests for the new behavior.