### PR TITLE
expose waitOnExit in vscode.TerminalOptions for extensions

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6634,6 +6634,11 @@ declare module 'vscode' {
 		 * Object with environment variables that will be added to the VS Code process.
 		 */
 		env?: { [key: string]: string | null };
+
+		/**
+		 * Wait for a keypress before closing the terminal after executable exits.
+		 */
+		waitOnExit?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -254,7 +254,7 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 
 	public createTerminalFromOptions(options: vscode.TerminalOptions): vscode.Terminal {
 		const terminal = new ExtHostTerminal(this._proxy, options.name);
-		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.env /*, options.waitOnExit*/);
+		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.env, options.waitOnExit);
 		this._terminals.push(terminal);
 		return terminal;
 	}


### PR DESCRIPTION
This PR exposes to extensions the the existing `waitOnExit` attribute on terminals.