### PR TITLE
Settings: detailed description bug exp1 WIP

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.css
@@ -62,8 +62,48 @@
 	box-sizing:			border-box;
 }
 
+.select-box-details-pane-mirror-float-anchor {
+	position: relative;
+	display: block;
+	padding: 0px;
+	margin: 0px;
+}
+
+
+.select-box-details-pane-mirror-float-container {
+	display: flex;
+	flex-direction: column;
+	text-align: left;
+	overflow: hidden;
+	position: absolute;
+	padding: 0px;
+	margin: 0px;
+}
+
 .monaco-select-box-dropdown-container > .select-box-details-pane {
 	padding: 5px;
+}
+
+.select-box-details-pane-mirror-container {
+	flex:  0 0 auto;
+	align-self: flex-start;
+
+	-webkit-box-sizing:	border-box;
+	-o-box-sizing:		border-box;
+	-moz-box-sizing:	border-box;
+	-ms-box-sizing:		border-box;
+	box-sizing:			border-box;
+	margin: 0;
+	overflow: hidden;
+}
+
+.select-box-details-pane > .select-box-description-markdown * {
+	margin: 0;
+}
+
+.select-box-details-pane-mirror-container > .select-box-description-markdown > * {
+	padding: 5px;
+	background: #222222;
 }
 
 .hc-black .monaco-select-box-dropdown-container > .select-box-dropdown-list-container {

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -107,6 +107,10 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 	private detailsProvider: (index: number) => { details: string, isMarkdown: boolean };
 	private selectionDetailsPane: HTMLElement;
 
+	private detailsPaneMirrorFloatAnchor: HTMLElement;
+	private detailsPaneMirrorFloatContainer: HTMLElement;
+	private detailsPaneMirrorContainer: HTMLElement;
+	private detailsPaneMirrorMarkdown: HTMLElement;
 
 	private _sticky: boolean = false; // for dev purposes only
 
@@ -138,6 +142,18 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		this.constructSelectDropDown(contextViewProvider);
 
 		this.setOptions(options, selected);
+
+		this.detailsPaneMirrorFloatAnchor = document.createElement('div'); // relative anchor
+
+		this.detailsPaneMirrorFloatContainer = document.createElement('div'); // absolute flex
+		this.detailsPaneMirrorContainer = document.createElement('div'); // absolute flex
+		this.detailsPaneMirrorMarkdown = document.createElement('div'); // absolute flex
+		this.detailsPaneMirrorFloatAnchor.appendChild(this.detailsPaneMirrorFloatContainer);
+		this.detailsPaneMirrorFloatContainer.appendChild(this.detailsPaneMirrorContainer);
+		this.detailsPaneMirrorContainer.appendChild(this.detailsPaneMirrorMarkdown);
+		// this.tempDescriptionContainerElement.style.display = 'none';
+		// this.detailsPaneMirrorFloatAnchor.style.position = 'relative';
+		// this.detailsPaneMirrorFloatContainer.style.position = 'absolute';
 	}
 
 	// IDelegate - List renderer
@@ -313,6 +329,10 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		container.appendChild(this.selectElement);
 		this.setOptions(this.options, this.selected);
 		this.applyStyles();
+		dom.addClass(this.detailsPaneMirrorFloatAnchor, 'select-box-details-pane-mirror-float-anchor');
+		this.selectElement.parentElement.appendChild(this.detailsPaneMirrorFloatAnchor);
+		dom.addClass(this.detailsPaneMirrorFloatContainer, 'select-box-details-pane-mirror-float-container');
+		dom.addClass(this.detailsPaneMirrorContainer, 'select-box-details-pane-mirror-container');
 	}
 
 	public style(styles: ISelectBoxStyles): void {
@@ -443,6 +463,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		}
 
 		this._isVisible = false;
+		this.detailsPaneMirrorContainer.style.display = 'none';
 
 		if (focusSelect) {
 			this.selectElement.focus();
@@ -468,6 +489,45 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		};
 	}
 
+
+	private layoutMirrorDescriptions(): number {
+
+		let detailsPaneMirrorFloatContainer = this.detailsPaneMirrorFloatContainer;
+		let detailsPaneMirrorContainer = this.detailsPaneMirrorContainer;
+
+		// test for non MD
+		// let description  = {details: 'test description 1' , isMarkdown: false};
+
+		let description = this.detailsProvider ? this.detailsProvider(this.selected) : { details: '', isMarkdown: false };
+
+		if (description.details) {
+			if (description.isMarkdown) {
+				this.detailsPaneMirrorContainer.removeChild(this.detailsPaneMirrorMarkdown);
+				this.detailsPaneMirrorMarkdown = detailsPaneMirrorContainer.appendChild(this.renderDescriptionMarkdown(description.details));
+			} else {
+				this.detailsPaneMirrorContainer.innerText = description.details;
+				this.detailsPaneMirrorContainer.style.padding = '5px';
+			}
+			this.detailsPaneMirrorContainer.style.display = 'block';
+		} else {
+			detailsPaneMirrorContainer.style.display = 'none';
+		}
+
+		this.cloneElementFont(this.selectElement, detailsPaneMirrorContainer);
+
+		// Float container is absolutely positioned and used for measurement
+		// VisibleForDebug
+		detailsPaneMirrorFloatContainer.style.opacity = '0';
+
+		detailsPaneMirrorFloatContainer.style.top = '-100px';
+		detailsPaneMirrorFloatContainer.style.left = '-0px';
+
+		detailsPaneMirrorContainer.style.width = this.selectElement.offsetWidth.toString() + 'px';
+
+		let h = dom.getDomNodePagePosition(this.detailsPaneMirrorMarkdown);
+		return h.height;
+	}
+
 	private layoutSelectDropDown(preLayoutPosition?: boolean): boolean {
 
 		// Layout ContextView drop down select list and container
@@ -478,9 +538,12 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 
 			const selectPosition = dom.getDomNodePagePosition(this.selectElement);
 			const styles = getComputedStyle(this.selectElement);
+			// Layout mirror description pane for measurements
+			const detailsPaneHeight = this.layoutMirrorDescriptions();
+
 			const verticalPadding = parseFloat(styles.getPropertyValue('--dropdown-padding-top')) + parseFloat(styles.getPropertyValue('--dropdown-padding-bottom'));
-			const maxSelectDropDownHeightBelow = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin);
-			const maxSelectDropDownHeightAbove = (selectPosition.top - SelectBoxList.DEFAULT_DROPDOWN_MINIMUM_TOP_MARGIN);
+			const maxSelectDropDownHeightBelow = (window.innerHeight - selectPosition.top - selectPosition.height - this.selectBoxOptions.minBottomMargin - detailsPaneHeight);
+			const maxSelectDropDownHeightAbove = (selectPosition.top - SelectBoxList.DEFAULT_DROPDOWN_MINIMUM_TOP_MARGIN - detailsPaneHeight);
 
 			// Get initial list height and determine space above and below
 			this.selectList.layout();
@@ -489,12 +552,15 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			const maxVisibleOptionsBelow = ((Math.floor((maxSelectDropDownHeightBelow - verticalPadding) / this.getHeight())));
 			const maxVisibleOptionsAbove = ((Math.floor((maxSelectDropDownHeightAbove - verticalPadding) / this.getHeight())));
 
+
+
 			// If we are only doing pre-layout check/adjust position only
 			// Calculate vertical space available, flip up if insufficient
 			// Use reflected padding on parent select, ContextView style
 			// properties not available before DOM attachment
 
 			if (preLayoutPosition) {
+
 				// Check if select moved out of viewport , do not open
 				// If at least one option cannot be shown, don't open the drop-down or hide/remove if open
 
@@ -549,7 +615,6 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 			} else {
 				// Set container height to max from select top to margin (default/minTopMargin)
 				if (minRequiredDropDownHeight > maxSelectDropDownHeightAbove) {
-					// listHeight = ((Math.floor((maxSelectDropDownHeightBelow - verticalPadding) / this.getHeight())) * this.getHeight());
 					listHeight = (maxVisibleOptionsAbove * this.getHeight() + verticalPadding);
 				}
 			}
@@ -571,9 +636,14 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 
 			this.selectDropDownContainer.style.width = selectOptimalWidth;
 
+			// Set final container height after adjustments
+			this.selectDropDownContainer.style.height = (listHeight + verticalPadding + detailsPaneHeight) + 'px';
+
 			// Maintain focus outline on parent select as well as list container - tabindex for focus
 			this.selectDropDownListContainer.setAttribute('tabindex', '0');
 			dom.toggleClass(this.selectElement, 'synthetic-focus', true);
+			dom.toggleClass(this.selectDropDownContainer, 'synthetic-focus', true);
+
 			return true;
 		} else {
 			return false;
@@ -732,13 +802,21 @@ export class SelectBoxList implements ISelectBoxDelegate, IVirtualDelegate<ISele
 		this.selectionDetailsPane.innerText = '';
 		const selectedIndex = e.indexes[0];
 		let description = this.detailsProvider ? this.detailsProvider(selectedIndex) : { details: '', isMarkdown: false };
+
 		if (description.details) {
 			if (description.isMarkdown) {
 				this.selectionDetailsPane.appendChild(this.renderDescriptionMarkdown(description.details));
+				this.detailsPaneMirrorMarkdown.innerHTML = this.selectionDetailsPane.firstElementChild.innerHTML;
 			} else {
 				this.selectionDetailsPane.innerText = description.details;
+				this.detailsPaneMirrorContainer.innerText = description.details;
 			}
+			this.cloneElementFont(this.selectElement, this.detailsPaneMirrorMarkdown);
 			this.selectionDetailsPane.style.display = 'block';
+
+			// PROBLEM: This adjust container but anchor point does not
+			this.selectDropDownContainer.style.height = (this.selectList.contentHeight + 5 + this.selectionDetailsPane.offsetHeight) + 'px';
+			// this.detailsPaneMirrorFloatContainer.style.opacity = '0';
 		} else {
 			this.selectionDetailsPane.style.display = 'none';
 		}


### PR DESCRIPTION
anchor problem when flipped above

When DD is above user moving selection would cause list to move up and down with different description sizes. (because variable element is on bottom between list and select anchor)
I don't think that's going to work well.  Description above will also look odd, but not have jumping.

I think we have to maintain below, and scroll the select if necessary
I am not aware of anything similar existing to compare this to.

your thoughts?  BTW the easiest way to see some of these things is to focus on the first select
and zoom then open the select when forced to flip above.  you can see some of the oddities.

I will continue to work on this tomorrow but I think I need your opinions

Update:  After more experimentation I propose the following:
- within selectbox , on open determine space , if insufficient below, fire move event
- within settings2 add fire move event handler, use tree.reveal(element, 0)
- do not open if cannot fit one entry

Basically we are working around limitations of contextV which does not to re-layout when above
and I have not found a clever way of forcing layout, perhaps there is a way.