### PR TITLE
debug: onDidCustomEvent back to debugService

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -37,13 +37,14 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 		this._toDispose = [];
 		this._toDispose.push(debugService.onDidNewSession(session => {
 			this._proxy.$acceptDebugSessionStarted(<DebugSessionUUID>session.getId(), session.configuration.type, session.getName(false));
-			this._toDispose.push(session.onDidCustomEvent(event => {
-				if (event && event.sessionId) {
-					if (process) {
-						this._proxy.$acceptDebugSessionCustomEvent(event.sessionId, session.configuration.type, session.configuration.name, event);
-					}
+		}));
+		this._toDispose.push(debugService.onDidCustomEvent(event => {
+			if (event && event.sessionId) {
+				const session = this.debugService.getModel().getSessions().filter(p => p.getId() === event.sessionId).pop();
+				if (session) {
+					this._proxy.$acceptDebugSessionCustomEvent(event.sessionId, session.configuration.type, session.configuration.name, event);
 				}
-			}));
+			}
 		}));
 		this._toDispose.push(debugService.onDidEndSession(proc => this._proxy.$acceptDebugSessionTerminated(<DebugSessionUUID>proc.getId(), proc.configuration.type, proc.getName(false))));
 		this._toDispose.push(debugService.getViewModel().onDidFocusSession(proc => {

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -614,6 +614,8 @@ export interface IDebugService {
 	 */
 	onDidEndSession: Event<ISession>;
 
+	onDidCustomEvent: Event<DebugEvent>;
+
 	/**
 	 * Gets the current configuration manager.
 	 */

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -20,6 +20,10 @@ export class MockDebugService implements IDebugService {
 		return null;
 	}
 
+	public get onDidCustomEvent(): Event<DebugEvent> {
+		return null;
+	}
+
 	public get onDidNewSession(): Event<ISession> {
 		return null;
 	}


### PR DESCRIPTION
Fixes #57641 

This PR fixes the following issue:
if a session fires the custom event in the initalising phase it will be ignored.

This PR changes that the debugService is emitting `customEvent` like before and that the `mainThreadDebugService` listens on those. This way it is impossible for someone to miss the customEvent if they are registering on those once a new session is started (which happens after the initialise call).

Also debugService now first registers session listeners before doing the initialise which makes sense in all cases since the session can go down during the initialise call which would in theory leave the debug service in a bad state.