### PR TITLE
debugService.onWillNewSession

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -35,8 +35,11 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostDebugService);
 		this._toDispose = [];
-		this._toDispose.push(debugService.onWillNewSession(session => {
+		this._toDispose.push(debugService.onDidNewSession(session => {
 			this._proxy.$acceptDebugSessionStarted(<DebugSessionUUID>session.getId(), session.configuration.type, session.getName(false));
+		}));
+		this._toDispose.push(debugService.onWillNewSession(session => {
+			// Need to start listening early to new session events because a custom event can come while a session is initialising
 			this._toDispose.push(session.onDidCustomEvent(event => {
 				if (event && event.sessionId) {
 					this._proxy.$acceptDebugSessionCustomEvent(event.sessionId, session.configuration.type, session.configuration.name, event);

--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -35,13 +35,11 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostDebugService);
 		this._toDispose = [];
-		this._toDispose.push(debugService.onDidNewSession(session => {
+		this._toDispose.push(debugService.onWillNewSession(session => {
 			this._proxy.$acceptDebugSessionStarted(<DebugSessionUUID>session.getId(), session.configuration.type, session.getName(false));
 			this._toDispose.push(session.onDidCustomEvent(event => {
 				if (event && event.sessionId) {
-					if (process) {
-						this._proxy.$acceptDebugSessionCustomEvent(event.sessionId, session.configuration.type, session.configuration.name, event);
-					}
+					this._proxy.$acceptDebugSessionCustomEvent(event.sessionId, session.configuration.type, session.configuration.name, event);
 				}
 			}));
 		}));

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -610,6 +610,11 @@ export interface IDebugService {
 	onDidNewSession: Event<ISession>;
 
 	/**
+	 * Allows to register on sessions about to be created (not yet fully initialised)
+	 */
+	onWillNewSession: Event<ISession>;
+
+	/**
 	 * Allows to register on end session events.
 	 */
 	onDidEndSession: Event<ISession>;

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -65,6 +65,7 @@ export class DebugService implements IDebugService {
 
 	private readonly _onDidChangeState: Emitter<State>;
 	private readonly _onDidNewSession: Emitter<ISession>;
+	private readonly _onWillNewSession: Emitter<ISession>;
 	private readonly _onDidEndSession: Emitter<ISession>;
 	private model: Model;
 	private viewModel: ViewModel;
@@ -105,6 +106,7 @@ export class DebugService implements IDebugService {
 		this.breakpointsToSendOnResourceSaved = new Set<string>();
 		this._onDidChangeState = new Emitter<State>();
 		this._onDidNewSession = new Emitter<ISession>();
+		this._onWillNewSession = new Emitter<ISession>();
 		this._onDidEndSession = new Emitter<ISession>();
 
 		this.configurationManager = this.instantiationService.createInstance(ConfigurationManager);
@@ -327,6 +329,10 @@ export class DebugService implements IDebugService {
 
 	get onDidNewSession(): Event<ISession> {
 		return this._onDidNewSession.event;
+	}
+
+	get onWillNewSession(): Event<ISession> {
+		return this._onWillNewSession.event;
 	}
 
 	get onDidEndSession(): Event<ISession> {
@@ -645,6 +651,7 @@ export class DebugService implements IDebugService {
 
 		const dbgr = this.configurationManager.getDebugger(resolved.type);
 		const session = this.instantiationService.createInstance(Session, sessionId, configuration, root, this.model);
+		this._onWillNewSession.fire(session);
 		this.allSessions.set(sessionId, session);
 		return session.initialize(dbgr).then(() => {
 			this.registerSessionListeners(session);

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -20,6 +20,10 @@ export class MockDebugService implements IDebugService {
 		return null;
 	}
 
+	public get onWillNewSession(): Event<ISession> {
+		return null;
+	}
+
 	public get onDidNewSession(): Event<ISession> {
 		return null;
 	}


### PR DESCRIPTION
Fixes #57641

This PR fixes the following issue:
if a session fires the custom event in the initalising phase it will be ignored.

This PR adds the onWillNewSession to the debugService which allows to register early to session new session events (even while the session is not yet initilised).
imho this turned out nice and clean