### PR TITLE
label: handle lazy formaters

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -63,7 +63,7 @@ import { serve as serveDriver } from 'vs/platform/driver/electron-main/driver';
 import { IMenubarService } from 'vs/platform/menubar/common/menubar';
 import { MenubarService } from 'vs/platform/menubar/electron-main/menubarService';
 import { MenubarChannel } from 'vs/platform/menubar/node/menubarIpc';
-import { ILabelService } from 'vs/platform/label/common/label';
+import { ILabelService, RegisterFormatterEvent } from 'vs/platform/label/common/label';
 import { CodeMenu } from 'vs/code/electron-main/menus';
 import { hasArgs } from 'vs/platform/environment/node/argv';
 import { RunOnceScheduler } from 'vs/base/common/async';
@@ -232,8 +232,8 @@ export class CodeApplication {
 			}
 		});
 
-		ipc.on('vscode:labelRegisterFormater', (event: any, { scheme, formater }) => {
-			this.labelService.registerFormatter(scheme, formater);
+		ipc.on('vscode:labelRegisterFormater', (event: any, data: RegisterFormatterEvent) => {
+			this.labelService.registerFormatter(data.scheme, data.formatter);
 		});
 
 		ipc.on('vscode:toggleDevTools', (event: Event) => {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -232,7 +232,7 @@ export class CodeApplication {
 			}
 		});
 
-		ipc.on('vscode:labelRegisterFormater', (event: any, data: RegisterFormatterEvent) => {
+		ipc.on('vscode:labelRegisterFormatter', (event: any, data: RegisterFormatterEvent) => {
 			this.labelService.registerFormatter(data.scheme, data.formatter);
 		});
 

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -45,7 +45,7 @@ import { WorkspaceEdit, isResourceTextEdit, TextEdit } from 'vs/editor/common/mo
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { localize } from 'vs/nls';
-import { ILabelService, LabelRules } from 'vs/platform/label/common/label';
+import { ILabelService, LabelRules, RegisterFormatterEvent } from 'vs/platform/label/common/label';
 
 export class SimpleModel implements ITextEditorModel {
 
@@ -599,8 +599,8 @@ export class SimpleBulkEditService implements IBulkEditService {
 export class SimpleUriLabelService implements ILabelService {
 	_serviceBrand: any;
 
-	private readonly _onDidRegisterFormatter: Emitter<{ scheme: string, formatter: LabelRules }> = new Emitter<{ scheme: string, formatter: LabelRules }>();
-	public readonly onDidRegisterFormatter: Event<{ scheme: string, formatter: LabelRules }> = this._onDidRegisterFormatter.event;
+	private readonly _onDidRegisterFormatter: Emitter<RegisterFormatterEvent> = new Emitter<RegisterFormatterEvent>();
+	public readonly onDidRegisterFormatter: Event<RegisterFormatterEvent> = this._onDidRegisterFormatter.event;
 
 	public getUriLabel(resource: URI, relative?: boolean): string {
 		if (resource.scheme === 'file') {

--- a/src/vs/platform/history/electron-main/historyMainService.ts
+++ b/src/vs/platform/history/electron-main/historyMainService.ts
@@ -60,6 +60,7 @@ export class HistoryMainService implements IHistoryMainService {
 
 	private registerListeners(): void {
 		this.workspacesMainService.onWorkspaceSaved(e => this.onWorkspaceSaved(e));
+		this.labelService.onDidRegisterFormatter(() => this._onRecentlyOpenedChange.fire());
 	}
 
 	private onWorkspaceSaved(e: IWorkspaceSavedEvent): void {

--- a/src/vs/platform/label/common/label.ts
+++ b/src/vs/platform/label/common/label.ts
@@ -19,12 +19,17 @@ import { isParent } from 'vs/platform/files/common/files';
 import { basename, dirname, join } from 'vs/base/common/paths';
 import { Schemas } from 'vs/base/common/network';
 
+export interface RegisterFormatterEvent {
+	scheme: string;
+	formatter: LabelRules;
+}
+
 export interface ILabelService {
 	_serviceBrand: any;
 	getUriLabel(resource: URI, relative?: boolean, forceNoTildify?: boolean): string;
 	getWorkspaceLabel(workspace: (IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | IWorkspace), options?: { verbose: boolean }): string;
 	registerFormatter(schema: string, formatter: LabelRules): IDisposable;
-	onDidRegisterFormatter: Event<{ scheme: string, formatter: LabelRules }>;
+	onDidRegisterFormatter: Event<RegisterFormatterEvent>;
 }
 
 export interface LabelRules {
@@ -51,14 +56,14 @@ export class LabelService implements ILabelService {
 	_serviceBrand: any;
 
 	private readonly formatters = new Map<string, LabelRules>();
-	private readonly _onDidRegisterFormatter = new Emitter<{ scheme: string, formatter: LabelRules }>();
+	private readonly _onDidRegisterFormatter = new Emitter<RegisterFormatterEvent>();
 
 	constructor(
 		@IEnvironmentService private environmentService: IEnvironmentService,
 		@IWorkspaceContextService private contextService: IWorkspaceContextService
 	) { }
 
-	get onDidRegisterFormatter(): Event<{ scheme: string, formatter: LabelRules }> {
+	get onDidRegisterFormatter(): Event<RegisterFormatterEvent> {
 		return this._onDidRegisterFormatter.event;
 	}
 

--- a/src/vs/platform/label/electron-browser/label.contribution.ts
+++ b/src/vs/platform/label/electron-browser/label.contribution.ts
@@ -17,7 +17,7 @@ class LabelRegistrationContribution implements IWorkbenchContribution {
 
 	constructor(@ILabelService labelService: ILabelService) {
 		labelService.onDidRegisterFormatter(data => {
-			ipc.send('vscode:labelRegisterFormater', data);
+			ipc.send('vscode:labelRegisterFormatter', data);
 		});
 	}
 }

--- a/src/vs/workbench/browser/labels.ts
+++ b/src/vs/workbench/browser/labels.ts
@@ -139,6 +139,10 @@ export class ResourceLabel extends IconLabel {
 			return true; // same resource but different kind (file, folder)
 		}
 
+		if (newResource && this.computedPathLabel !== this.labelService.getUriLabel(newResource)) {
+			return true;
+		}
+
 		if (newResource && oldResource) {
 			return newResource.toString() !== oldResource.toString();
 		}

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -102,6 +102,7 @@ export class TitlebarPart extends Part implements ITitleService {
 		this._register(this.contextService.onDidChangeWorkspaceFolders(() => this.setTitle(this.getWindowTitle())));
 		this._register(this.contextService.onDidChangeWorkbenchState(() => this.setTitle(this.getWindowTitle())));
 		this._register(this.contextService.onDidChangeWorkspaceName(() => this.setTitle(this.getWindowTitle())));
+		this._register(this.labelService.onDidRegisterFormatter(() => this.setTitle(this.getWindowTitle())));
 	}
 
 	private onBlur(): void {

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -145,6 +145,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		};
 
 		this.disposables.push(this.contextService.onDidChangeWorkspaceName(setHeader));
+		this.disposables.push(this.labelService.onDidRegisterFormatter(setHeader));
 		setHeader();
 	}
 
@@ -200,6 +201,10 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		this.disposables.push(this.contextService.onDidChangeWorkspaceFolders(e => this.refreshFromEvent(e.added)));
 		this.disposables.push(this.contextService.onDidChangeWorkbenchState(e => this.refreshFromEvent()));
 		this.disposables.push(this.fileService.onDidChangeFileSystemProviderRegistrations(() => this.refreshFromEvent()));
+		this.disposables.push(this.labelService.onDidRegisterFormatter(() => {
+			this._onDidChangeTitleArea.fire();
+			this.refreshFromEvent();
+		}));
 	}
 
 	layoutBody(size: number): void {


### PR DESCRIPTION
This PR handles the case when the label formatter comes lazily.
Basically the explorer, open recent and titlebar will update once the new label formatter is registered (which can happen some time after the startup).

I have tested this in my local setup where I just register the file formatter with a 5 second timeout and it works fine.

I tried to cover the most visible ux places for this. Note that it can still happen in some places that we show an outdated label.
Next steps: the proper solution would be to do this inside the ResourceLabel class since that is being shared across the workbench, but that would require a larger refactoring which I plan to do when I am back from vacation. Currently clients pass to the ResourceLabel what to render and have too much control. I would like to give more power to the ResourceLabel class so that only there I would listen to the formatter changes and re-render when needed.

fyi @egamma @alexandrudima 