### PR TITLE
Add the numpad divide key for toggle comment

### DIFF
--- a/src/vs/editor/contrib/comment/comment.ts
+++ b/src/vs/editor/contrib/comment/comment.ts
@@ -55,6 +55,7 @@ class ToggleCommentLineAction extends CommentLineAction {
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
 				primary: KeyMod.CtrlCmd | KeyCode.US_SLASH,
+				secondary: [KeyMod.CtrlCmd | KeyCode.NUMPAD_DIVIDE],
 				weight: KeybindingWeight.EditorContrib
 			},
 			menubarOpts: {


### PR DESCRIPTION
Add the ctrl + numpad divide key to the list of keyboard shortcuts for the toggle comment feature