### PR TITLE
fix promise polyfill, chaining promises works

### DIFF
--- a/src/vs/base/common/winjs.polyfill.promise.ts
+++ b/src/vs/base/common/winjs.polyfill.promise.ts
@@ -71,19 +71,47 @@ export class PolyfillPromise<T = any> implements Promise<T> {
 
 	then(onFulfilled?: any, onRejected?: any): PolyfillPromise {
 		let sync = true;
+		// To support chaining, we need to return the value of the
+		// onFulfilled and onRejected callback.
+		// WinJSPromise supports a flat-map style #then, ie. the callbacks
+		// passed to WinJSPromise#then can return a Promise.
 		let promise = new PolyfillPromise(this._winjsPromise.then(
 			onFulfilled && function (value) {
 				if (!sync) {
-					onFulfilled(value);
+					return onFulfilled(value);
 				} else {
-					platform.setImmediate(() => onFulfilled(value));
+					return new WinJSPromise((resolve, reject) => {
+						platform.setImmediate(() => {
+							let result;
+							try {
+								result = onFulfilled(value);
+							}
+							catch (err2) {
+								reject(err2);
+								return;
+							}
+							resolve(result);
+						});
+					});
 				}
 			},
 			onRejected && function (err) {
 				if (!sync) {
-					onRejected(err);
+					return onRejected(err);
 				} else {
-					platform.setImmediate(() => onRejected(err));
+					return new WinJSPromise((resolve, reject) => {
+						platform.setImmediate(() => {
+							let result;
+							try {
+								result = onRejected(err);
+							}
+							catch (err2) {
+								reject(err2);
+								return;
+							}
+							resolve(result);
+						});
+					});
 				}
 			}
 		));


### PR DESCRIPTION
Possible solution for #57722 

The callbacks in WinJSPromise.then (like native Promises) can return another promise instead of the next value. This can be used to allow chaining promises while stil having them work asynchronously.