### PR TITLE
Add when context: isLastGroup / isFirstGroup / editorGroupIndex / isLeftGroup / isRightGroup / isTopGroup / isBottomGroup

### DIFF
--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -31,6 +31,9 @@ export const MultipleEditorGroupsContext = new RawContextKey<boolean>('multipleE
 export const SingleEditorGroupsContext = MultipleEditorGroupsContext.toNegated();
 export const InEditorZenModeContext = new RawContextKey<boolean>('inZenMode', false);
 export const SplitEditorsVertically = new RawContextKey<boolean>('splitEditorsVertically', false);
+export const EditorIsFirstGroupContext = new RawContextKey<boolean>('isFirstGroup', false);
+export const EditorIsLastGroupContext = new RawContextKey<boolean>('isLastGroup', false);
+export const EditorGroupIndexContext = new RawContextKey<number>('editorGroupIndex', 0);
 
 /**
  * Text diff editor id.

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -33,6 +33,10 @@ export const InEditorZenModeContext = new RawContextKey<boolean>('inZenMode', fa
 export const SplitEditorsVertically = new RawContextKey<boolean>('splitEditorsVertically', false);
 export const EditorIsFirstGroupContext = new RawContextKey<boolean>('isFirstGroup', false);
 export const EditorIsLastGroupContext = new RawContextKey<boolean>('isLastGroup', false);
+export const EditorIsLeftGroupContext = new RawContextKey<boolean>('isLeftGroup', false);
+export const EditorIsRightGroupContext = new RawContextKey<boolean>('isRightGroup', false);
+export const EditorIsBottomGroupContext = new RawContextKey<boolean>('isBottomGroup', false);
+export const EditorIsTopGroupContext = new RawContextKey<boolean>('isTopGroup', false);
 export const EditorGroupIndexContext = new RawContextKey<number>('editorGroupIndex', 0);
 
 /**

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -22,7 +22,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
 import { IResourceInput } from 'vs/platform/editor/common/editor';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
-import { IEditorInputFactoryRegistry, Extensions as EditorExtensions, TextCompareEditorVisibleContext, TEXT_DIFF_EDITOR_ID, EditorsVisibleContext, InEditorZenModeContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, IUntitledResourceInput, IResourceDiffInput, SplitEditorsVertically, TextCompareEditorActiveContext } from 'vs/workbench/common/editor';
+import { IEditorInputFactoryRegistry, Extensions as EditorExtensions, TextCompareEditorVisibleContext, TEXT_DIFF_EDITOR_ID, EditorsVisibleContext, InEditorZenModeContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, IUntitledResourceInput, IResourceDiffInput, SplitEditorsVertically, TextCompareEditorActiveContext, EditorIsFirstGroupContext, EditorIsLastGroupContext, EditorGroupIndexContext } from 'vs/workbench/common/editor';
 import { HistoryService } from 'vs/workbench/services/history/electron-browser/history';
 import { ActivitybarPart } from 'vs/workbench/browser/parts/activitybar/activitybarPart';
 import { SidebarPart } from 'vs/workbench/browser/parts/sidebar/sidebarPart';
@@ -626,10 +626,18 @@ export class Workbench extends Disposable implements IPartService {
 		const textCompareEditorActive = TextCompareEditorActiveContext.bindTo(this.contextKeyService);
 		const activeEditorGroupEmpty = ActiveEditorGroupEmptyContext.bindTo(this.contextKeyService);
 		const multipleEditorGroups = MultipleEditorGroupsContext.bindTo(this.contextKeyService);
+		const editorIsFirstGroupContext = EditorIsFirstGroupContext.bindTo(this.contextKeyService);
+		const editorIsLastGroupContext = EditorIsLastGroupContext.bindTo(this.contextKeyService);
+		const editorGroupIndexContext = EditorGroupIndexContext.bindTo(this.contextKeyService);
 
 		const updateEditorContextKeys = () => {
 			const activeControl = this.editorService.activeControl;
 			const visibleEditors = this.editorService.visibleControls;
+			const editorGroupIndex = visibleEditors.indexOf(activeControl);
+
+			editorGroupIndexContext.set(editorGroupIndex);
+			editorIsFirstGroupContext.set(editorGroupIndex === 0);
+			editorIsLastGroupContext.set(editorGroupIndex === visibleEditors.length - 1);
 
 			textCompareEditorActive.set(activeControl && activeControl.getId() === TEXT_DIFF_EDITOR_ID);
 			textCompareEditorVisible.set(visibleEditors.some(control => control.getId() === TEXT_DIFF_EDITOR_ID));


### PR DESCRIPTION
This PR addresses #22755 by adding several context keys to support the configuration of keyboard shortcuts based on which editor group is currently active.

![Editor Group Context Key Demo](https://cl.ly/1ba695e42ffb/Screen%252520Recording%2525202018-08-31%252520at%25252005.53%252520PM.gif)