### PR TITLE
Store translation paths relative to the extensions directory

### DIFF
--- a/src/vs/platform/localizations/node/localizations.ts
+++ b/src/vs/platform/localizations/node/localizations.ts
@@ -17,7 +17,7 @@ import product from 'vs/platform/node/product';
 import { distinct, equals } from 'vs/base/common/arrays';
 import { Event, Emitter } from 'vs/base/common/event';
 import { Schemas } from 'vs/base/common/network';
-import { posix } from 'path';
+import { posix, relative } from 'path';
 
 interface ILanguagePack {
 	hash: string;
@@ -103,7 +103,7 @@ class LanguagePacksCache extends Disposable {
 	private languagePacksFileLimiter: Limiter<void>;
 
 	constructor(
-		@IEnvironmentService environmentService: IEnvironmentService,
+		@IEnvironmentService private environmentService: IEnvironmentService,
 		@ILogService private logService: ILogService
 	) {
 		super();
@@ -152,7 +152,7 @@ class LanguagePacksCache extends Disposable {
 					languagePack.extensions.push({ extensionIdentifier, version: extension.manifest.version });
 				}
 				for (const translation of localizationContribution.translations) {
-					languagePack.translations[translation.id] = posix.join(extension.location.fsPath, translation.path);
+					languagePack.translations[translation.id] = posix.join(relative(this.environmentService.extensionsPath, extension.location.fsPath), translation.path);
 				}
 			}
 		}


### PR DESCRIPTION
Fix #54746

Store translation paths relative to the extensions directory