### PR TITLE
Update Quiet Light theme attribute colors

### DIFF
--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -97,7 +97,7 @@
 				"variable.language"
 			],
 			"settings": {
-				"foreground": "#AB6526"
+				"foreground": "#A15F26"
 			}
 		},
 		{
@@ -155,7 +155,7 @@
 				"constant"
 			],
 			"settings": {
-				"foreground": "#AB6526"
+				"foreground": "#A15F26"
 			}
 		},
 		{
@@ -183,7 +183,7 @@
 			"name": "Strings: Symbols",
 			"scope": "constant.other.symbol",
 			"settings": {
-				"foreground": "#AB6526"
+				"foreground": "#A15F26"
 			}
 		},
 		{
@@ -256,7 +256,7 @@
 				"punctuation.definition.entity"
 			],
 			"settings": {
-				"foreground": "#AB6526"
+				"foreground": "#A15F26"
 			}
 		},
 		{
@@ -282,7 +282,7 @@
 				"support.type.property-name"
 			],
 			"settings": {
-				"foreground": "#AB6526"
+				"foreground": "#A15F26"
 			}
 		},
 		{
@@ -427,7 +427,7 @@
 			"scope": "markup.inline.raw",
 			"settings": {
 				"fontStyle": "",
-				"foreground": "#AB6526"
+				"foreground": "#A15F26"
 			}
 		},
 		{

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -97,7 +97,7 @@
 				"variable.language"
 			],
 			"settings": {
-				"foreground": "#A15F26"
+				"foreground": "#9C5D27"
 			}
 		},
 		{
@@ -155,7 +155,7 @@
 				"constant"
 			],
 			"settings": {
-				"foreground": "#A15F26"
+				"foreground": "#9C5D27"
 			}
 		},
 		{
@@ -183,7 +183,7 @@
 			"name": "Strings: Symbols",
 			"scope": "constant.other.symbol",
 			"settings": {
-				"foreground": "#A15F26"
+				"foreground": "#9C5D27"
 			}
 		},
 		{
@@ -256,7 +256,7 @@
 				"punctuation.definition.entity"
 			],
 			"settings": {
-				"foreground": "#A15F26"
+				"foreground": "#9C5D27"
 			}
 		},
 		{
@@ -282,7 +282,7 @@
 				"support.type.property-name"
 			],
 			"settings": {
-				"foreground": "#A15F26"
+				"foreground": "#9C5D27"
 			}
 		},
 		{
@@ -427,7 +427,7 @@
 			"scope": "markup.inline.raw",
 			"settings": {
 				"fontStyle": "",
-				"foreground": "#A15F26"
+				"foreground": "#9C5D27"
 			}
 		},
 		{


### PR DESCRIPTION
Fixes #56791

Updated the attribute color from `#AB6526 ` to `#9C5D27 ` so that it passes the color contrast ratio for the editor background color and on selection:

![image](https://user-images.githubusercontent.com/35271042/45072447-d713a180-b08f-11e8-989a-c4edc4240e36.png)
