### PR TITLE
Use CancellationToken for search

### DIFF
--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -697,9 +697,9 @@ export interface ExtHostFileSystemShape {
 }
 
 export interface ExtHostSearchShape {
-	$provideFileSearchResults(handle: number, session: number, query: IRawSearchQuery): TPromise<ISearchCompleteStats>;
-	$clearCache(cacheKey: string): TPromise<void>;
-	$provideTextSearchResults(handle: number, session: number, pattern: IPatternInfo, query: IRawSearchQuery): TPromise<ISearchCompleteStats>;
+	$provideFileSearchResults(handle: number, session: number, query: IRawSearchQuery, token: CancellationToken): Thenable<ISearchCompleteStats>;
+	$clearCache(cacheKey: string): Thenable<void>;
+	$provideTextSearchResults(handle: number, session: number, pattern: IPatternInfo, query: IRawSearchQuery, token: CancellationToken): Thenable<ISearchCompleteStats>;
 }
 
 export interface ExtHostExtensionServiceShape {

--- a/src/vs/workbench/test/electron-browser/api/extHostSearch.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostSearch.test.ts
@@ -17,6 +17,7 @@ import { ExtHostSearch } from 'vs/workbench/api/node/extHostSearch';
 import { Range } from 'vs/workbench/api/node/extHostTypes';
 import { TestRPCProtocol } from 'vs/workbench/test/electron-browser/api/testRPCProtocol';
 import * as vscode from 'vscode';
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
 
 let rpcProtocol: TestRPCProtocol;
 let extHostSearch: ExtHostSearch;
@@ -74,10 +75,11 @@ suite('ExtHostSearch', () => {
 	async function runFileSearch(query: IRawSearchQuery, cancel = false): Promise<{ results: URI[]; stats: ISearchCompleteStats }> {
 		let stats: ISearchCompleteStats;
 		try {
-			const p = extHostSearch.$provideFileSearchResults(mockMainThreadSearch.lastHandle, 0, query);
+			const cancellation = new CancellationTokenSource();
+			const p = extHostSearch.$provideFileSearchResults(mockMainThreadSearch.lastHandle, 0, query, cancellation.token);
 			if (cancel) {
 				await new TPromise(resolve => process.nextTick(resolve));
-				p.cancel();
+				cancellation.cancel();
 			}
 
 			stats = await p;
@@ -98,10 +100,11 @@ suite('ExtHostSearch', () => {
 	async function runTextSearch(pattern: IPatternInfo, query: IRawSearchQuery, cancel = false): Promise<{ results: IFileMatch[], stats: ISearchCompleteStats }> {
 		let stats: ISearchCompleteStats;
 		try {
-			const p = extHostSearch.$provideTextSearchResults(mockMainThreadSearch.lastHandle, 0, pattern, query);
+			const cancellation = new CancellationTokenSource();
+			const p = extHostSearch.$provideTextSearchResults(mockMainThreadSearch.lastHandle, 0, pattern, query, cancellation.token);
 			if (cancel) {
 				await new TPromise(resolve => process.nextTick(resolve));
-				p.cancel();
+				cancellation.cancel();
 			}
 
 			stats = await p;


### PR DESCRIPTION
This PR supports #56137 by removing winjs-promise-cancel-callbacks and by using the cancellation token approach.