### PR TITLE
FIX: Switching over HTTPS repository when updating Debian packages

### DIFF
--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -67,6 +67,6 @@ NdCFTW7wY0Fb1fWJ+/KTsC4=
 	if [ "$WRITE_SOURCE" -eq "1" ]; then
 		echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.
-deb [arch=amd64] http://packages.microsoft.com/repos/vscode stable main" > $CODE_SOURCE_PART
+deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main" > $CODE_SOURCE_PART
 	fi
 fi


### PR DESCRIPTION
I just noticed today my Ubuntu-based distribution, LinuxMint,
asked me to update VS Code using https rather than https.

Microsoft Skype, on the other hand, uses HTTPS for downloading
its package updates, so I believe it should also be following
Skype's approach.

Here I am just pasting a curl result at the VSCode repository
in https, showing it works normally.

$ curl -I https://packages.microsoft.com/repos/vscode/
HTTP/1.1 200 OK
Server: nginx/1.10.3 (Ubuntu)
Date: Wed, 05 Sep 2018 19:24:14 GMT
Content-Type: text/html
Connection: keep-alive
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Content-Type-Options: nosniff