### PR TITLE
New config to turn off TypeScript autocomplete suggestions

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -529,6 +529,12 @@
           "type": "boolean",
           "default": true,
           "description": "%typescript.autoClosingTags%"
+				},
+			  "typescript.suggestions.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "%typescript.suggestions.enabled%",
+          "scope": "resource"
         }
       }
     },

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -65,5 +65,6 @@
 	"typescript.updateImportsOnFileMove.enabled.prompt": "Prompt on each rename.",
 	"typescript.updateImportsOnFileMove.enabled.always": "Always update paths automatically.",
 	"typescript.updateImportsOnFileMove.enabled.never": "Never rename paths and don't prompt.",
-	"typescript.autoClosingTags": "Enable/disable automatic closing of JSX tags. Requires using TypeScript 3.0 or newer in the workspace."
+	"typescript.autoClosingTags": "Enable/disable automatic closing of JSX tags. Requires using TypeScript 3.0 or newer in the workspace.",
+	"typescript.suggestions.enabled": "Enabled/disable autocomplete suggestions based on TypeScript"
 }

--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -610,12 +610,10 @@ function shouldExcludeCompletionEntry(
 	element: Proto.CompletionEntry,
 	completionConfiguration: CompletionConfiguration
 ) {
-	const isNameSuggestion = element.kind === PConst.Kind.warning;
-
 	return (
-		(!completionConfiguration.nameSuggestions && isNameSuggestion)
-		// if TypeScript suggestions turned off, remove everything that is not a name suggestion
-		|| (!completionConfiguration.typeScriptSuggestions && !isNameSuggestion)
+		// if TypeScript suggestions turned off, exclude every suggestion
+		!completionConfiguration.typeScriptSuggestions
+		|| (!completionConfiguration.nameSuggestions && element.kind === PConst.Kind.warning)
 		|| (!completionConfiguration.quickSuggestionsForPaths &&
 			(element.kind === PConst.Kind.directory || element.kind === PConst.Kind.script))
 		|| (!completionConfiguration.autoImportSuggestions && element.hasAction)

--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -240,6 +240,7 @@ interface CompletionConfiguration {
 	readonly nameSuggestions: boolean;
 	readonly quickSuggestionsForPaths: boolean;
 	readonly autoImportSuggestions: boolean;
+	readonly typeScriptSuggestions: boolean;
 }
 
 namespace CompletionConfiguration {
@@ -247,6 +248,7 @@ namespace CompletionConfiguration {
 	export const nameSuggestions = 'nameSuggestions';
 	export const quickSuggestionsForPaths = 'quickSuggestionsForPaths';
 	export const autoImportSuggestions = 'autoImportSuggestions.enabled';
+	export const typeScriptSuggestions = 'suggestions.enabled';
 
 	export function getConfigurationForResource(
 		resource: vscode.Uri
@@ -257,6 +259,7 @@ namespace CompletionConfiguration {
 			useCodeSnippetsOnMethodSuggest: typeScriptConfig.get<boolean>(CompletionConfiguration.useCodeSnippetsOnMethodSuggest, false),
 			quickSuggestionsForPaths: typeScriptConfig.get<boolean>(CompletionConfiguration.quickSuggestionsForPaths, true),
 			autoImportSuggestions: typeScriptConfig.get<boolean>(CompletionConfiguration.autoImportSuggestions, true),
+			typeScriptSuggestions: typeScriptConfig.get<boolean>(CompletionConfiguration.typeScriptSuggestions, true),
 			nameSuggestions: vscode.workspace.getConfiguration('javascript', resource).get(CompletionConfiguration.nameSuggestions, true)
 		};
 	}
@@ -607,8 +610,12 @@ function shouldExcludeCompletionEntry(
 	element: Proto.CompletionEntry,
 	completionConfiguration: CompletionConfiguration
 ) {
+	const isNameSuggestion = element.kind === PConst.Kind.warning
+
 	return (
-		(!completionConfiguration.nameSuggestions && element.kind === PConst.Kind.warning)
+		(!completionConfiguration.nameSuggestions && isNameSuggestion)
+		// if TypeScript suggestions turned off, remove everything that is not a name suggestion
+		|| (!completionConfiguration.typeScriptSuggestions && !isNameSuggestion)
 		|| (!completionConfiguration.quickSuggestionsForPaths &&
 			(element.kind === PConst.Kind.directory || element.kind === PConst.Kind.script))
 		|| (!completionConfiguration.autoImportSuggestions && element.hasAction)

--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -610,7 +610,7 @@ function shouldExcludeCompletionEntry(
 	element: Proto.CompletionEntry,
 	completionConfiguration: CompletionConfiguration
 ) {
-	const isNameSuggestion = element.kind === PConst.Kind.warning
+	const isNameSuggestion = element.kind === PConst.Kind.warning;
 
 	return (
 		(!completionConfiguration.nameSuggestions && isNameSuggestion)


### PR DESCRIPTION
A new `typescript.suggestions.enabled` config (boolean, default `true`)

Setting `false` removes all autocomplete suggestions provided by typescript via the built-in typescript-language-features extension.

The default is `true`, so that existing behaviour remains the same.

### Why?

The typescript autocomplete suggestions are a great feature, when you're working on a typescript project.

![image](https://user-images.githubusercontent.com/9915841/45124857-d8160300-b163-11e8-95ae-3a1bbaf24324.png)

But when you're working on a flow project using the [flow-for-vscode](https://github.com/flowtype/flow-for-vscode) plugin, it provides its own autocomplete suggestions via flow. So your autocomplete gets littered with duplicate suggestions coming from both typescript _and_ flow:

![image](https://user-images.githubusercontent.com/9915841/45124907-0f84af80-b164-11e8-830b-54d872ed15c5.png)

What this config does is turns off the typescript suggestions, so you get this instead:

![image](https://user-images.githubusercontent.com/9915841/45124826-bcaaf800-b163-11e8-847a-ef7efd1861ae.png)

I.e. no duplicates, only the`flow-for-vscode` suggestions. Problem solved.

### Prior Issues

There have been a few existing issues raised about this problem both on the `flow-for-vscode` project and here.

* [This one](https://github.com/flowtype/flow-for-vscode/issues/97)
* Which leads to [this one](https://github.com/Microsoft/vscode/issues/24974)
* Which leads to [this one](https://github.com/Microsoft/vscode/issues/17068), which claims to address the problem.

Quoting from the third issue there

> We have requests to support disabling all TS functionality. Instead of introducing a setting we should allow disabling built in extensions.

**So, what am I doing submitting a PR for a setting? Why doesn't #17068 solve the problem?**

Well, the thing is, as I commented [here](https://github.com/flowtype/flow-for-vscode/issues/97), I _don't_ want to disable _all_ of the javascript & typescript extension. I only want to disable the autocomplete suggestions coming from typescript.

Why? Because the extension also provides some other functionality I can't do without. 

* Cmd+click to imports and variable definitions
* Name based suggestions in js
* There may be others (I haven't spent enough time with the extension turned off to find them all!)

It's actually _worse_ to lose this functionality, than to just deal with the duplicates in autocomplete. So this is definitely not a solution to the problem.

I really believe vscode needs the ability to turn off typescript autocomplete, specifically. Flow support provided via the awesome [flow-for-vscode](https://github.com/flowtype/flow-for-vscode) combined with all of the rest vscode's great feature set makes it a really good editor for flow projects, but this autocomplete issue is one of the last remaining obvious and annoying things that just get in the way of productivity. *And it's so easy to fix!*

---

> Just a note, my PR here is just a reference implementation to highlight how simple this change could possibly be to land. I have tested it in real usage and with my own workflow it is working well, but I may have missed some corner cases / features I don't use. I'm more than happy to fix anything that's pointed out myself, or just to have this completely redone by someone who knows more in depth about how this could be done better if my implementation is too simple/naive. I just want this feature in mainline vscode! And I know a lot of other people do too.