### PR TITLE
Display '-patched' by version in about dialog and issue reporter when impure

### DIFF
--- a/src/vs/code/electron-browser/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterMain.ts
@@ -83,7 +83,7 @@ export class IssueReporter extends Disposable {
 		this.issueReporterModel = new IssueReporterModel({
 			issueType: configuration.data.issueType || IssueType.Bug,
 			versionInfo: {
-				vscodeVersion: `${pkg.name} ${pkg.version} (${product.commit || 'Commit unknown'}, ${product.date || 'Date unknown'})`,
+				vscodeVersion: `${pkg.name} ${pkg.version}${configuration.data.isPure ? '' : '-patched'} (${product.commit || 'Commit unknown'}, ${product.date || 'Date unknown'})`,
 				os: `${os.type()} ${os.arch()} ${os.release()}`
 			},
 			extensionsDisabled: !!this.environmentService.disableExtensions,

--- a/src/vs/platform/integrity/node/integrityServiceImpl.ts
+++ b/src/vs/platform/integrity/node/integrityServiceImpl.ts
@@ -15,6 +15,7 @@ import Severity from 'vs/base/common/severity';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { ILifecycleService, LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IWindowsService } from 'vs/platform/windows/common/windows';
 
 interface IStorageData {
 	dontShowPrompt: boolean;
@@ -64,7 +65,8 @@ export class IntegrityServiceImpl implements IIntegrityService {
 	constructor(
 		@INotificationService private notificationService: INotificationService,
 		@IStorageService storageService: IStorageService,
-		@ILifecycleService private lifecycleService: ILifecycleService
+		@ILifecycleService private lifecycleService: ILifecycleService,
+		@IWindowsService private windowsService: IWindowsService
 	) {
 		this._storage = new IntegrityStorage(storageService);
 
@@ -76,6 +78,8 @@ export class IntegrityServiceImpl implements IIntegrityService {
 				return;
 			}
 			this._prompt();
+
+			this.windowsService.updateIntegrity(r.isPure);
 		});
 	}
 

--- a/src/vs/platform/issue/common/issue.ts
+++ b/src/vs/platform/issue/common/issue.ts
@@ -48,6 +48,7 @@ export interface IssueReporterStyles extends WindowStyles {
 export interface IssueReporterData extends WindowData {
 	styles: IssueReporterStyles;
 	enabledExtensions: ILocalExtension[];
+	isPure: boolean;
 	issueType?: IssueType;
 }
 

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -175,6 +175,7 @@ export interface IWindowsService {
 	startCrashReporter(config: CrashReporterStartOptions): TPromise<void>;
 
 	openAboutDialog(): TPromise<void>;
+	updateIntegrity(isPure: boolean): TPromise<void>;
 }
 
 export const IWindowService = createDecorator<IWindowService>('windowService');

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -33,6 +33,7 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 	private disposables: IDisposable[] = [];
 
 	private _activeWindowId: number | undefined;
+	private _isPure: boolean = true;
 
 	readonly onWindowOpen: Event<number> = filterEvent(fromNodeEventEmitter(app, 'browser-window-created', (_, w: Electron.BrowserWindow) => w.id), id => !!this.windowsMainService.getWindowById(id));
 	readonly onWindowFocus: Event<number> = anyEvent(
@@ -508,7 +509,7 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		let version = app.getVersion();
 
 		if (product.target) {
-			version = `${version} (${product.target} setup)`;
+			version = `${version}${this._isPure ? '' : '-patched'} (${product.target} setup)`;
 		}
 
 		const detail = nls.localize('aboutDetail',
@@ -560,6 +561,11 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 
 		this.windowsMainService.open({ context: OpenContext.API, cli, urisToOpen });
 		return TPromise.wrap(true);
+	}
+
+	updateIntegrity(isPure: boolean): TPromise<void> {
+		this._isPure = isPure;
+		return TPromise.as(null);
 	}
 
 	dispose(): void {

--- a/src/vs/platform/windows/node/windowsIpc.ts
+++ b/src/vs/platform/windows/node/windowsIpc.ts
@@ -75,6 +75,7 @@ export interface IWindowsChannel extends IChannel {
 	call(command: 'openExternal', arg: string): TPromise<boolean>;
 	call(command: 'startCrashReporter', arg: CrashReporterStartOptions): TPromise<void>;
 	call(command: 'openAboutDialog'): TPromise<void>;
+	call(command: 'updateIntegrity', arg: boolean): TPromise<void>;
 }
 
 export class WindowsChannel implements IWindowsChannel {
@@ -180,6 +181,7 @@ export class WindowsChannel implements IWindowsChannel {
 			case 'openExternal': return this.service.openExternal(arg);
 			case 'startCrashReporter': return this.service.startCrashReporter(arg);
 			case 'openAboutDialog': return this.service.openAboutDialog();
+			case 'updateIntegrity': return this.service.updateIntegrity(arg);
 		}
 		return undefined;
 	}
@@ -405,5 +407,9 @@ export class WindowsChannelClient implements IWindowsService {
 
 	openAboutDialog(): TPromise<void> {
 		return this.channel.call('openAboutDialog');
+	}
+
+	updateIntegrity(isPure: boolean): TPromise<void> {
+		return this.channel.call('updateIntegrity', isPure);
 	}
 }

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -40,7 +40,6 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	_serviceBrand: any;
 
-	private static readonly NLS_UNSUPPORTED = nls.localize('patchedWindowTitle', "[Unsupported]");
 	private static readonly NLS_USER_IS_ADMIN = isWindows ? nls.localize('userIsAdmin', "[Administrator]") : nls.localize('userIsSudo', "[Superuser]");
 	private static readonly NLS_EXTENSION_HOST = nls.localize('devExtensionWindowTitlePrefix', "[Extension Development Host]");
 	private static readonly TITLE_DIRTY = '\u25cf ';
@@ -182,10 +181,6 @@ export class TitlebarPart extends Part implements ITitleService {
 
 		if (this.properties.isAdmin) {
 			title = `${title} ${TitlebarPart.NLS_USER_IS_ADMIN}`;
-		}
-
-		if (!this.properties.isPure) {
-			title = `${title} ${TitlebarPart.NLS_UNSUPPORTED}`;
 		}
 
 		// Extension Development Host gets a special title to identify itself

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -86,7 +86,7 @@ export class TitlebarPart extends Part implements ITitleService {
 	) {
 		super(id, { hasTitle: false }, themeService);
 
-		this.properties = { isPure: true, isAdmin: false };
+		this.properties = { isAdmin: false };
 		this.activeEditorListeners = [];
 
 		this.registerListeners();
@@ -193,11 +193,9 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	updateProperties(properties: ITitleProperties): void {
 		const isAdmin = typeof properties.isAdmin === 'boolean' ? properties.isAdmin : this.properties.isAdmin;
-		const isPure = typeof properties.isPure === 'boolean' ? properties.isPure : this.properties.isPure;
 
-		if (isAdmin !== this.properties.isAdmin || isPure !== this.properties.isPure) {
+		if (isAdmin !== this.properties.isAdmin) {
 			this.properties.isAdmin = isAdmin;
-			this.properties.isPure = isPure;
 
 			this.setTitle(this.getWindowTitle());
 		}

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -287,7 +287,10 @@ export class ElectronWindow extends Themable {
 		});
 
 		// Integrity warning
-		this.integrityService.isPure().then(res => this.titleService.updateProperties({ isPure: res.isPure }));
+		this.integrityService.isPure().then(res => {
+			this.titleService.updateProperties({ isPure: res.isPure });
+			this.windowsService.updateIntegrity(res.isPure);
+		});
 
 		// Root warning
 		this.lifecycleService.when(LifecyclePhase.Running).then(() => {

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -37,7 +37,6 @@ import { RunOnceScheduler } from 'vs/base/common/async';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { LifecyclePhase, ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
-import { IIntegrityService } from 'vs/platform/integrity/common/integrity';
 import { AccessibilitySupport, isRootUser, isWindows, isMacintosh } from 'vs/base/common/platform';
 import product from 'vs/platform/node/product';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -84,8 +83,7 @@ export class ElectronWindow extends Themable {
 		@IWorkspaceEditingService private workspaceEditingService: IWorkspaceEditingService,
 		@IFileService private fileService: IFileService,
 		@IMenuService private menuService: IMenuService,
-		@ILifecycleService private lifecycleService: ILifecycleService,
-		@IIntegrityService private integrityService: IIntegrityService
+		@ILifecycleService private lifecycleService: ILifecycleService
 	) {
 		super(themeService);
 
@@ -284,12 +282,6 @@ export class ElectronWindow extends Themable {
 		// Emit event when vscode has loaded
 		this.lifecycleService.when(LifecyclePhase.Running).then(() => {
 			ipc.send('vscode:workbenchLoaded', this.windowService.getCurrentWindowId());
-		});
-
-		// Integrity warning
-		this.integrityService.isPure().then(res => {
-			this.titleService.updateProperties({ isPure: res.isPure });
-			this.windowsService.updateIntegrity(res.isPure);
 		});
 
 		// Root warning

--- a/src/vs/workbench/services/title/common/titleService.ts
+++ b/src/vs/workbench/services/title/common/titleService.ts
@@ -9,7 +9,6 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 export const ITitleService = createDecorator<ITitleService>('titleService');
 
 export interface ITitleProperties {
-	isPure?: boolean;
 	isAdmin?: boolean;
 }
 

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -1348,6 +1348,10 @@ export class TestWindowsService implements IWindowsService {
 	openAboutDialog(): TPromise<void> {
 		return TPromise.as(void 0);
 	}
+
+	updateIntegrity(): TPromise<void> {
+		return TPromise.as(undefined);
+	}
 }
 
 export class TestTextResourceConfigurationService implements ITextResourceConfigurationService {


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/56929

When source code has been tampered with, adds '-patched' to the version information sent in the issue reporter and in the about dialog. Removes '[UNSUPPORTED]' from the titlebar.

Since the IntegrityService is not available when the WindowsService is constructed, I've added an `_isPure` flag to the WindowsService that gets updated after a window is created. 