### PR TITLE
add more markdown extensions

### DIFF
--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -17,9 +17,13 @@
 				],
 				"extensions": [
 					".md",
+          ".mkd",
+          ".mdwn",
 					".mdown",
 					".markdown",
 					".markdn",
+          ".mdtxt",
+          ".mdtext",
 					".workbook"
 				],
 				"configuration": "./language-configuration.json"


### PR DESCRIPTION
Hi,

I'm using `.mkd` for all my markdown files because `.md` is historically for [Modula-2](https://en.wikipedia.org/wiki/Modula-2). I prefer `.mkd` over other alternative extensions because it is shorter and clearer.
So each time I install vscode on a new machine I'm adding

```json
    "files.associations": {
        "*.mkd": "markdown"
    },
```

to `settings.json`.

I think this extension (as some other) should be added and recognized by default: https://superuser.com/questions/249436/file-extension-for-markdown-files

I'm also asking myself if it is relevant to keep `.workbook` as it is not standard but used only by one app: Xamarin.

I don't know if it is the right file to push that change.