### PR TITLE
Throttle code action auto trigger

### DIFF
--- a/src/vs/editor/contrib/codeAction/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionModel.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancelablePromise, createCancelablePromise } from 'vs/base/common/async';
-import { debounceEvent, Emitter, Event } from 'vs/base/common/event';
+import { CancelablePromise, createCancelablePromise, Delayer } from 'vs/base/common/async';
+import { Emitter, Event } from 'vs/base/common/event';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -24,6 +24,7 @@ export const SUPPORTED_CODE_ACTIONS = new RawContextKey<string>('supportedCodeAc
 export class CodeActionOracle {
 
 	private _disposables: IDisposable[] = [];
+	private readonly _autoTriggerDelayer: Delayer<void>;
 
 	constructor(
 		private _editor: ICodeEditor,
@@ -33,13 +34,16 @@ export class CodeActionOracle {
 		private readonly _progressService?: IProgressService,
 	) {
 		this._disposables.push(
-			debounceEvent(this._markerService.onMarkerChanged, (last, cur) => last ? last.concat(cur) : cur, delay / 2)(e => this._onMarkerChanges(e)),
-			debounceEvent(this._editor.onDidChangeCursorPosition, (last, cur) => cur, delay)(e => this._onCursorChange())
+			this._markerService.onMarkerChanged(e => this._onMarkerChanges(e)),
+			this._editor.onDidChangeCursorPosition(() => this._onCursorChange()),
 		);
+
+		this._autoTriggerDelayer = new Delayer<void>(delay);
 	}
 
 	dispose(): void {
 		this._disposables = dispose(this._disposables);
+		this._autoTriggerDelayer.cancel();
 	}
 
 	trigger(trigger: CodeActionTrigger) {
@@ -50,12 +54,16 @@ export class CodeActionOracle {
 	private _onMarkerChanges(resources: URI[]): void {
 		const { uri } = this._editor.getModel();
 		if (resources.some(resource => resource.toString() === uri.toString())) {
-			this.trigger({ type: 'auto' });
+			this._autoTriggerDelayer.trigger(() => {
+				this.trigger({ type: 'auto' });
+			});
 		}
 	}
 
 	private _onCursorChange(): void {
-		this.trigger({ type: 'auto' });
+		this._autoTriggerDelayer.trigger(() => {
+			this.trigger({ type: 'auto' });
+		});
 	}
 
 	private _getRangeOfMarker(selection: Selection): Range {

--- a/src/vs/editor/contrib/codeAction/test/codeActionModel.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/codeActionModel.test.ts
@@ -152,4 +152,32 @@ suite('CodeAction', () => {
 		// 	oracle.trigger('manual');
 		// });
 	});
+
+	test('Orcale -> should only auto trigger once for cursor and marker update right after each other', done => {
+		const reg = CodeActionProviderRegistry.register(languageIdentifier.language, testProvider);
+		disposables.push(reg);
+
+		let triggerCount = 0;
+		const oracle = new CodeActionOracle(editor, markerService, e => {
+			assert.equal(e.trigger.type, 'auto');
+			++triggerCount;
+
+			// give time for second trigger before completing test
+			setTimeout(() => {
+				oracle.dispose();
+				assert.strictEqual(triggerCount, 1);
+				done();
+			}, 50);
+		}, 5 /*delay*/);
+
+		markerService.changeOne('fake', uri, [{
+			startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 6,
+			message: 'error',
+			severity: 1,
+			code: '',
+			source: ''
+		}]);
+
+		editor.setSelection({ startLineNumber: 1, startColumn: 1, endLineNumber: 4, endColumn: 1 });
+	});
 });


### PR DESCRIPTION
Part of #57875

Switches to throttle code action auto triggers themselves rather than throttling the two events that cause auto triggers to happen.

With this change, if the orcle recieves a cursor update and a marker update at the same time, it will now only will auto trigger once instead of twice