### PR TITLE
Fix #57222 - improve no user.email/user.name config error message

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1714,6 +1714,12 @@ export class CommandCenter {
 						type = 'warning';
 						options.modal = false;
 						break;
+					case GitErrorCodes.NoUserNameConfigured:
+					case GitErrorCodes.NoUserEmailConfigured:
+						message = localize('missing user info', "Make sure that user.email and user.name are configured correctly.\n\n{0}\n{1}",
+							"git config --global user.email \"you@example.com\"",
+							"git config --global user.name \"Your Name\"");
+						break;
 					default:
 						const hint = (err.stderr || err.message || String(err))
 							.replace(/^error: /mi, '')

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1716,7 +1716,9 @@ export class CommandCenter {
 						break;
 					case GitErrorCodes.NoUserNameConfigured:
 					case GitErrorCodes.NoUserEmailConfigured:
-						message = localize('missing user info', "Make sure that user.email and user.name are configured correctly.\n\n{0}\n{1}",
+						message = localize('missing user info', "Make sure that user.email and user.name are configured correctly.\n\n{0}\n{1}\n\n{2}\n{3}",
+							"current user.name: " + err.userName || "",
+							"current user.email: " + err.userEmail || "",
 							"git config --global user.email \"you@example.com\"",
 							"git config --global user.name \"Your Name\"");
 						break;

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1717,8 +1717,8 @@ export class CommandCenter {
 					case GitErrorCodes.NoUserNameConfigured:
 					case GitErrorCodes.NoUserEmailConfigured:
 						message = localize('missing user info', "Make sure that user.email and user.name are configured correctly.\n\n{0}\n{1}\n\n{2}\n{3}",
-							"current user.name: " + err.userName || "",
 							"current user.email: " + err.userEmail || "",
+							"current user.name: " + err.userName || "",
 							"git config --global user.email \"you@example.com\"",
 							"git config --global user.name \"Your Name\"");
 						break;

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -978,19 +978,25 @@ export class Repository {
 			throw commitErr;
 		}
 
-		try {
-			await this.run(['config', '--get-all', 'user.name']);
-		} catch (err) {
-			err.gitErrorCode = GitErrorCodes.NoUserNameConfigured;
-			throw err;
-		}
+		let userName, userEmail;
 
 		try {
-			await this.run(['config', '--get-all', 'user.email']);
-		} catch (err) {
-			err.gitErrorCode = GitErrorCodes.NoUserEmailConfigured;
-			throw err;
+			const nameResult = await this.run(['config', '--get-all', 'user.name']);
+			userName = nameResult.stdout.split('\n').filter(l => !!l).pop();
+		} catch (err) { }
+
+		try {
+			const emailResult = await this.run(['config', '--get-all', 'user.email']);
+			userEmail = emailResult.stdout.split('\n').filter(l => !!l).pop();
+		} catch (err) { }
+
+		if (userName && userEmail) {
+			throw commitErr;
 		}
+
+		commitErr.gitErrorCode = !userName ? GitErrorCodes.NoUserNameConfigured : GitErrorCodes.NoUserEmailConfigured;
+		commitErr.userName = userName;
+		commitErr.userEmail = userEmail;
 
 		throw commitErr;
 	}


### PR DESCRIPTION
The new message looks like this:

![image](https://user-images.githubusercontent.com/22118580/45210218-a1410980-b297-11e8-9362-c522ee02f0d6.png)

Tell me if anything can be improved. Thanks!