### PR TITLE
Fix to make the EH debugging to work when live share proxy the debug adapter

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugActionsWidget.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActionsWidget.ts
@@ -270,7 +270,8 @@ export class DebugActionsWidget extends Themable implements IWorkbenchContributi
 
 		const state = debugService.state;
 		const session = debugService.getViewModel().focusedSession;
-		const attached = session && session.configuration.request === 'attach' && session.configuration.type && !strings.equalsIgnoreCase(session.configuration.type, 'extensionHost');
+		const debugType = session.configuration.type === 'vslsShare' ? (<any>session.configuration).adapterProxy.configuration.type : session.configuration.type;
+		const attached = session && session.configuration.request === 'attach' && session.configuration.type && !strings.equalsIgnoreCase(debugType, 'extensionHost');
 
 		return allActions.filter(a => {
 			if (a.id === ContinueAction.ID) {

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -399,7 +399,7 @@ export class DebugService implements IDebugService {
 	}
 
 	private isExtensionHostDebugging(config: IConfig) {
-		return equalsIgnoreCase(config.type, 'extensionhost');
+		return equalsIgnoreCase(config.type === 'vslsShare' ? (<any>config).adapterProxy.configuration.type : config.type, 'extensionhost');
 	}
 
 	private attachExtensionHost(session: DebugSession, port: number): TPromise<void> {


### PR DESCRIPTION
A recent change on vscode stop 'injecting' the '__sessionI' property for all resolved configurations except the EH debugging type. vscode will always see the type as 'vslsShare' insted of 'extensionHost' type.
The changes will identify such cases and inspect the debug configuration looking for the proper debug type.