### PR TITLE
eslintrc: Mark as root config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+	"root": true,
 	"env": {
 		"node": true,
 		"es6": true


### PR DESCRIPTION
This stops ESLint from looking in parent folders for more .eslintrc config files. [More information here.](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy)