### PR TITLE
Fixes #58313 - image uris with querystring not being detected properly

### DIFF
--- a/src/vs/workbench/browser/parts/editor/resourceViewer.ts
+++ b/src/vs/workbench/browser/parts/editor/resourceViewer.ts
@@ -581,7 +581,7 @@ class InlineImageView {
 function getMime(descriptor: IResourceDescriptor) {
 	let mime = descriptor.mime;
 	if (!mime && descriptor.resource.scheme !== Schemas.data) {
-		mime = mimes.getMediaMime(descriptor.resource.toString());
+		mime = mimes.getMediaMime(descriptor.resource.path);
 	}
 	return mime || mimes.MIME_BINARY;
 }


### PR DESCRIPTION
Fixes #58313 - uses the path to avoid issues with checking the extension