### PR TITLE
webview - change context keys away from DOM focus/blur

### DIFF
--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -21,6 +21,7 @@ import { IEditorGroup } from 'vs/workbench/services/group/common/editorGroupsSer
 import { ICompositeControl } from 'vs/workbench/common/composite';
 import { ActionRunner, IAction } from 'vs/base/common/actions';
 
+export const ActiveEditorContext = new RawContextKey<string>('activeEditor', null);
 export const EditorsVisibleContext = new RawContextKey<boolean>('editorIsOpen', false);
 export const EditorGroupActiveEditorDirtyContext = new RawContextKey<boolean>('groupActiveEditorDirty', false);
 export const NoEditorsVisibleContext: ContextKeyExpr = EditorsVisibleContext.toNegated();

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -22,7 +22,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
 import { IResourceInput } from 'vs/platform/editor/common/editor';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
-import { IEditorInputFactoryRegistry, Extensions as EditorExtensions, TextCompareEditorVisibleContext, TEXT_DIFF_EDITOR_ID, EditorsVisibleContext, InEditorZenModeContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, IUntitledResourceInput, IResourceDiffInput, SplitEditorsVertically, TextCompareEditorActiveContext } from 'vs/workbench/common/editor';
+import { IEditorInputFactoryRegistry, Extensions as EditorExtensions, TextCompareEditorVisibleContext, TEXT_DIFF_EDITOR_ID, EditorsVisibleContext, InEditorZenModeContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, IUntitledResourceInput, IResourceDiffInput, SplitEditorsVertically, TextCompareEditorActiveContext, ActiveEditorContext } from 'vs/workbench/common/editor';
 import { HistoryService } from 'vs/workbench/services/history/electron-browser/history';
 import { ActivitybarPart } from 'vs/workbench/browser/parts/activitybar/activitybarPart';
 import { SidebarPart } from 'vs/workbench/browser/parts/sidebar/sidebarPart';
@@ -621,6 +621,7 @@ export class Workbench extends Disposable implements IPartService {
 		const sidebarVisibleContextRaw = new RawContextKey<boolean>('sidebarVisible', false);
 		this.sideBarVisibleContext = sidebarVisibleContextRaw.bindTo(this.contextKeyService);
 
+		const activeEditorContext = ActiveEditorContext.bindTo(this.contextKeyService);
 		const editorsVisibleContext = EditorsVisibleContext.bindTo(this.contextKeyService);
 		const textCompareEditorVisible = TextCompareEditorVisibleContext.bindTo(this.contextKeyService);
 		const textCompareEditorActive = TextCompareEditorActiveContext.bindTo(this.contextKeyService);
@@ -650,6 +651,12 @@ export class Workbench extends Disposable implements IPartService {
 				multipleEditorGroups.set(true);
 			} else {
 				multipleEditorGroups.reset();
+			}
+
+			if (activeControl) {
+				activeEditorContext.set(activeControl.getId());
+			} else {
+				activeEditorContext.reset();
 			}
 		};
 

--- a/src/vs/workbench/parts/html/electron-browser/html.contribution.ts
+++ b/src/vs/workbench/parts/html/electron-browser/html.contribution.ts
@@ -17,6 +17,7 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IEditorGroupsService, IEditorGroup } from 'vs/workbench/services/group/common/editorGroupsService';
 import { IExtensionsWorkbenchService } from 'vs/workbench/parts/extensions/common/extensions';
 import { IEditorRegistry, EditorDescriptor, Extensions as EditorExtensions } from 'vs/workbench/browser/editor';
+import { registerWebViewCommands } from 'vs/workbench/parts/webview/electron-browser/webview.contribution';
 
 function getActivePreviewsForResource(accessor: ServicesAccessor, resource: URI | string) {
 	const uri = resource instanceof URI ? resource : URI.parse(resource);
@@ -98,3 +99,5 @@ CommandsRegistry.registerCommand('_workbench.htmlPreview.postMessage', function 
 	}
 	return activePreviews.length > 0;
 });
+
+registerWebViewCommands(HtmlPreviewPart.ID);

--- a/src/vs/workbench/parts/html/electron-browser/htmlPreviewPart.ts
+++ b/src/vs/workbench/parts/html/electron-browser/htmlPreviewPart.ts
@@ -95,8 +95,6 @@ export class HtmlPreviewPart extends BaseWebviewEditor {
 
 			this._webview = this._instantiationService.createInstance(WebviewElement,
 				this._partService.getContainer(Parts.EDITOR_PART),
-				this.contextKey,
-				this.findInputFocusContextKey,
 				{
 					...webviewOptions,
 					useSameOriginForRoot: true

--- a/src/vs/workbench/parts/webview/electron-browser/baseWebviewEditor.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/baseWebviewEditor.ts
@@ -10,10 +10,6 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { WebviewElement } from './webviewElement';
 
-/**  A context key that is set when a webview editor has focus. */
-export const KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS = new RawContextKey<boolean>('webviewEditorFocus', false);
-/**  A context key that is set when the find widget find input in webview editor webview is focused. */
-export const KEYBINDING_CONTEXT_WEBVIEWEDITOR_FIND_WIDGET_INPUT_FOCUSED = new RawContextKey<boolean>('webviewEditorFindWidgetInputFocused', false);
 /**  A context key that is set when the find widget in a webview is visible. */
 export const KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE = new RawContextKey<boolean>('webviewFindWidgetVisible', false);
 
@@ -24,9 +20,7 @@ export const KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE = new RawContextKey<
 export abstract class BaseWebviewEditor extends BaseEditor {
 
 	protected _webview: WebviewElement | undefined;
-	protected contextKey: IContextKey<boolean>;
 	protected findWidgetVisible: IContextKey<boolean>;
-	protected findInputFocusContextKey: IContextKey<boolean>;
 
 	constructor(
 		id: string,
@@ -36,8 +30,6 @@ export abstract class BaseWebviewEditor extends BaseEditor {
 	) {
 		super(id, telemetryService, themeService);
 		if (contextKeyService) {
-			this.contextKey = KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS.bindTo(contextKeyService);
-			this.findInputFocusContextKey = KEYBINDING_CONTEXT_WEBVIEWEDITOR_FIND_WIDGET_INPUT_FOCUSED.bindTo(contextKeyService);
 			this.findWidgetVisible = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE.bindTo(contextKeyService);
 		}
 	}

--- a/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webview.contribution.ts
@@ -15,7 +15,7 @@ import { EditorDescriptor, Extensions as EditorExtensions, IEditorRegistry } fro
 import { Extensions as ActionExtensions, IWorkbenchActionRegistry } from 'vs/workbench/common/actions';
 import { Extensions as EditorInputExtensions, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
 import { WebviewEditorInputFactory } from 'vs/workbench/parts/webview/electron-browser/webviewEditorInputFactory';
-import { KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from './baseWebviewEditor';
+import { KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from './baseWebviewEditor';
 import { HideWebViewEditorFindCommand, OpenWebviewDeveloperToolsAction, ReloadWebviewAction, ShowWebViewEditorFindWidgetCommand, SelectAllWebviewEditorCommand } from './webviewCommands';
 import { WebviewEditor } from './webviewEditor';
 import { WebviewEditorInput } from './webviewEditorInput';
@@ -38,37 +38,43 @@ const webviewDeveloperCategory = localize('developer', "Developer");
 
 const actionRegistry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);
 
-const showNextFindWdigetCommand = new ShowWebViewEditorFindWidgetCommand({
-	id: ShowWebViewEditorFindWidgetCommand.ID,
-	precondition: KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS,
-	kbOpts: {
-		primary: KeyMod.CtrlCmd | KeyCode.KEY_F,
-		weight: KeybindingWeight.EditorContrib
-	}
-});
-showNextFindWdigetCommand.register();
+export function registerWebViewCommands(editorId: string): void {
+	const contextKeyExpr = ContextKeyExpr.equals('activeEditor', editorId);
 
-const hideCommand = new HideWebViewEditorFindCommand({
-	id: HideWebViewEditorFindCommand.ID,
-	precondition: ContextKeyExpr.and(
-		KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS,
-		KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE),
-	kbOpts: {
-		primary: KeyCode.Escape,
-		weight: KeybindingWeight.EditorContrib
-	}
-});
-hideCommand.register();
+	const showNextFindWidgetCommand = new ShowWebViewEditorFindWidgetCommand({
+		id: ShowWebViewEditorFindWidgetCommand.ID,
+		precondition: contextKeyExpr,
+		kbOpts: {
+			primary: KeyMod.CtrlCmd | KeyCode.KEY_F,
+			weight: KeybindingWeight.EditorContrib
+		}
+	});
+	showNextFindWidgetCommand.register();
 
-const selectAllCommand = new SelectAllWebviewEditorCommand({
-	id: SelectAllWebviewEditorCommand.ID,
-	precondition: KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS,
-	kbOpts: {
-		primary: KeyMod.CtrlCmd | KeyCode.KEY_A,
-		weight: KeybindingWeight.EditorContrib
-	}
-});
-selectAllCommand.register();
+	const hideCommand = new HideWebViewEditorFindCommand({
+		id: HideWebViewEditorFindCommand.ID,
+		precondition: ContextKeyExpr.and(
+			contextKeyExpr,
+			KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE),
+		kbOpts: {
+			primary: KeyCode.Escape,
+			weight: KeybindingWeight.EditorContrib
+		}
+	});
+	hideCommand.register();
+
+	const selectAllCommand = new SelectAllWebviewEditorCommand({
+		id: SelectAllWebviewEditorCommand.ID,
+		precondition: contextKeyExpr,
+		kbOpts: {
+			primary: KeyMod.CtrlCmd | KeyCode.KEY_A,
+			weight: KeybindingWeight.EditorContrib
+		}
+	});
+	selectAllCommand.register();
+}
+
+registerWebViewCommands(WebviewEditor.ID);
 
 actionRegistry.registerWorkbenchAction(
 	new SyncActionDescriptor(OpenWebviewDeveloperToolsAction, OpenWebviewDeveloperToolsAction.ID, OpenWebviewDeveloperToolsAction.LABEL),

--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
@@ -18,7 +18,7 @@ import { WebviewEditorInput } from 'vs/workbench/parts/webview/electron-browser/
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroup } from 'vs/workbench/services/group/common/editorGroupsService';
 import { IPartService, Parts } from 'vs/workbench/services/part/common/partService';
-import { BaseWebviewEditor, KEYBINDING_CONTEXT_WEBVIEWEDITOR_FIND_WIDGET_INPUT_FOCUSED, KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from './baseWebviewEditor';
+import { BaseWebviewEditor, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from './baseWebviewEditor';
 import { WebviewElement } from './webviewElement';
 import { IWindowService } from 'vs/platform/windows/common/windows';
 
@@ -224,15 +224,11 @@ export class WebviewEditor extends BaseWebviewEditor {
 
 		if (input.options.enableFindWidget) {
 			this._contextKeyService = this._register(this._contextKeyService.createScoped(this._webviewContent));
-			this.contextKey = KEYBINDING_CONTEXT_WEBVIEWEDITOR_FOCUS.bindTo(this._contextKeyService);
-			this.findInputFocusContextKey = KEYBINDING_CONTEXT_WEBVIEWEDITOR_FIND_WIDGET_INPUT_FOCUSED.bindTo(this._contextKeyService);
 			this.findWidgetVisible = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE.bindTo(this._contextKeyService);
 		}
 
 		this._webview = this._instantiationService.createInstance(WebviewElement,
 			this._partService.getContainer(Parts.EDITOR_PART),
-			this.contextKey,
-			this.findInputFocusContextKey,
 			{
 				enableWrappedPostMessage: true,
 				useSameOriginForRoot: false

--- a/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
@@ -7,7 +7,6 @@ import { addClass, addDisposableListener } from 'vs/base/browser/dom';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
-import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -37,8 +36,6 @@ export class WebviewElement extends Disposable {
 
 	constructor(
 		private readonly _styleElement: Element,
-		private readonly _contextKey: IContextKey<boolean>,
-		private readonly _findInputContextKey: IContextKey<boolean>,
 		private _options: WebviewOptions,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IThemeService private readonly _themeService: IThemeService,
@@ -168,16 +165,6 @@ export class WebviewElement extends Disposable {
 					return;
 			}
 		}));
-		this._register(addDisposableListener(this._webview, 'focus', () => {
-			if (this._contextKey) {
-				this._contextKey.set(true);
-			}
-		}));
-		this._register(addDisposableListener(this._webview, 'blur', () => {
-			if (this._contextKey) {
-				this._contextKey.reset();
-			}
-		}));
 		this._register(addDisposableListener(this._webview, 'devtools-opened', () => {
 			this._send('devtools-opened');
 		}));
@@ -193,19 +180,7 @@ export class WebviewElement extends Disposable {
 		parent.appendChild(this._webview);
 	}
 
-	public notifyFindWidgetFocusChanged(isFocused: boolean) {
-		this._contextKey.set(isFocused || document.activeElement === this._webview);
-	}
-
-	public notifyFindWidgetInputFocusChanged(isFocused: boolean) {
-		this._findInputContextKey.set(isFocused);
-	}
-
 	dispose(): void {
-		if (this._contextKey) {
-			this._contextKey.reset();
-		}
-
 		if (this._webview) {
 			this._webview.guestinstance = 'none';
 

--- a/src/vs/workbench/parts/webview/electron-browser/webviewFindWidget.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewFindWidget.ts
@@ -45,19 +45,11 @@ export class WebviewFindWidget extends SimpleFindWidget {
 		}
 	}
 
-	protected onFocusTrackerFocus() {
-		this._webview.notifyFindWidgetFocusChanged(true);
-	}
+	protected onFocusTrackerFocus() { }
 
-	protected onFocusTrackerBlur() {
-		this._webview.notifyFindWidgetFocusChanged(false);
-	}
+	protected onFocusTrackerBlur() { }
 
-	protected onFindInputFocusTrackerFocus() {
-		this._webview.notifyFindWidgetInputFocusChanged(true);
-	}
+	protected onFindInputFocusTrackerFocus() { }
 
-	protected onFindInputFocusTrackerBlur() {
-		this._webview.notifyFindWidgetInputFocusChanged(false);
-	}
+	protected onFindInputFocusTrackerBlur() { }
 }


### PR DESCRIPTION
This removes quite a bit of complicated code that relied on DOM focus/blur for certain commands in a `webview` editor in favour of a new context key `activeEditor` that will have the ID of the active editor as value. Instead of that behaviour, the commands now operate on the active editor. This has advantages:
* makes life easier for Electron 3.0.x where DOM focus in a `webview` is painful to get right
* enables `Cmd+F` to open the find widget in any editor that uses `webview` even if that `webview` does not have keyboard focus (matches our behaviour with text editors)

@mjbvz please take a look