### PR TITLE
Fix #58183 - hide dirty-diff decorator when inside the diff-editor

### DIFF
--- a/src/vs/workbench/parts/scm/electron-browser/media/dirtydiffDecorator.css
+++ b/src/vs/workbench/parts/scm/electron-browser/media/dirtydiffDecorator.css
@@ -52,3 +52,7 @@
 	border-top-width: 0;
 	border-bottom-width: 0;
 }
+
+.monaco-editor.modified-in-monaco-diff-editor .margin-view-overlays > div > .dirty-diff-glyph {
+	display: none;
+}


### PR DESCRIPTION
This is the easiest solution I could think of, I couldn't figure out how to only show inside regular editor but not inside diff editor without changing alot of code.