### PR TITLE
Update Electron to 2.0.9

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "2.0.7"
+target "2.0.9"
 runtime "electron"

--- a/OSSREADME.json
+++ b/OSSREADME.json
@@ -51,7 +51,7 @@
 },
 {
 	"name": "electron",
-	"version": "2.0.7",
+	"version": "2.0.9",
 	"license": "MIT",
 	"repositoryURL": "https://github.com/electron/electron",
 	"isProd": true

--- a/test/smoke/package.json
+++ b/test/smoke/package.json
@@ -22,7 +22,7 @@
     "@types/webdriverio": "4.6.1",
     "concurrently": "^3.5.1",
     "cpx": "^1.5.0",
-    "electron": "^2.0.6",
+    "electron": "^2.0.9",
     "htmlparser2": "^3.9.2",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",

--- a/test/smoke/yarn.lock
+++ b/test/smoke/yarn.lock
@@ -493,9 +493,9 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.6.tgz#8e5c1bd2ebc08fa7a6ee906de3753c1ece9d7300"
+electron@2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.9.tgz#dfc863d653fa3a2dd4fea0c63303df9c0e33c602"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
As described in https://github.com/Microsoft/vscode/pull/57457

Fixes the glibc 2.28 problem, includes the other fixes that @bpasero  was waiting for