### PR TITLE
Settings More actions label exp1 WIP Addresses: #57378

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -78,6 +78,8 @@ export class SettingsEditor2 extends BaseEditor {
 	private tocTreeContainer: HTMLElement;
 	private tocTree: WorkbenchTree;
 
+	private settingsAriaExtraLabelsContainer: HTMLElement;
+
 	private delayedFilterLogging: Delayer<void>;
 	private localSearchDelayer: Delayer<void>;
 	private remoteSearchThrottle: ThrottledDelayer<void>;
@@ -472,6 +474,10 @@ export class SettingsEditor2 extends BaseEditor {
 
 	private createSettingsTree(parent: HTMLElement): void {
 		this.settingsTreeContainer = DOM.append(parent, $('.settings-tree-container'));
+
+		// CDL extra labels div
+		this.settingsAriaExtraLabelsContainer = DOM.append(this.settingsTreeContainer, $('.settings-aria-extra-labels'));
+		this.settingsAriaExtraLabelsContainer.id = 'settings_aria_extra_labels';
 
 		this.settingsTreeRenderer = this.instantiationService.createInstance(SettingsRenderer, this.settingsTreeContainer);
 		this._register(this.settingsTreeRenderer.onDidChangeSetting(e => this.onDidChangeSetting(e.key, e.value)));

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -393,6 +393,21 @@ export class SettingsRenderer implements ITreeRenderer {
 			this.instantiationService.createInstance(CopySettingIdAction),
 			this.instantiationService.createInstance(CopySettingAsJSONAction),
 		];
+
+		const p = _measureContainer.parentElement;
+		// const extraLabelsContainer: HTMLElement = document.querySelector('.settings-aria-extra-labels');
+		// const e = document.getElementById('settings_aria_extra_labels');
+		const labelDiv = DOM.append(p, $('.settings-aria-extra-label'));
+		labelDiv.id = 'settings_aria_more_actions_shortcut_label';
+		const toggleMenuKeybinding = this.keybindingService.lookupKeybinding(SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU);
+		let settingsMoreActionsLabel = localize('settingsContextMenuAriaShortcut', "More Actions... ");
+		if (toggleMenuKeybinding) {
+			settingsMoreActionsLabel += ` (${toggleMenuKeybinding && toggleMenuKeybinding.getLabel()})`;
+			labelDiv.setAttribute('aria-label', settingsMoreActionsLabel);
+
+		}
+
+
 	}
 
 	showContextMenu(element: SettingsTreeSettingElement, settingDOMElement: HTMLElement): void {
@@ -823,10 +838,12 @@ export class SettingsRenderer implements ITreeRenderer {
 	private renderSettingEnumTemplate(tree: ITree, container: HTMLElement): ISettingEnumItemTemplate {
 		const common = this.renderCommonTemplate(tree, container, 'enum');
 
+		console.warn('start c ' + common.labelElement.getAttribute('aria-label1'));
 		const selectBox = new SelectBox([], undefined, this.contextViewService, undefined, {
 			hasDetails: true
 		});
 
+		console.warn('en c');
 		common.toDispose.push(selectBox);
 		common.toDispose.push(attachSelectBoxStyler(selectBox, this.themeService, {
 			selectBackground: settingsSelectBackground,
@@ -1223,7 +1240,7 @@ export class SettingsRenderer implements ITreeRenderer {
 		template.inputBox.inputElement.id = baseId + '_setting_item';
 		template.inputBox.inputElement.setAttribute('role', 'textbox');
 		template.inputBox.inputElement.setAttribute('aria-labelledby', baseId + '_setting_label');
-		template.inputBox.inputElement.setAttribute('aria-describedby', baseId + '_setting_description');
+		template.inputBox.inputElement.setAttribute('aria-describedby', baseId + '_setting_description settings_aria_more_actions_shortcut_label');
 
 		renderValidations(dataElement, template, true, label);
 	}


### PR DESCRIPTION
@roblourens 
want to see if this matches your thoughts for the reader output.

I'm not completely happy with the location of the new labels DIV I think it could be a child of the body
under the premise that we may have more need for-page global labels .

I also realize the partial duplication of code from your action bar title.  I'm not sure the title would ever get read because I don't think it ever gets focus yes?

Note: I only added the extra label to the number input box for example.  I also have to think of a more creative way to pass this to select box.  I think I need to change the constructor to accept extra labels
as well as a new set function.

I'm also thinking these types of 'keyboard indicator labels' may want to keep optional as in the user can disable them if there already familiar to reduce the chatter.  kind of echoes your comment on the extensions labels.