### PR TITLE
Adding electron ARM and ARM64 tasks for cross-compiling

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -166,6 +166,8 @@ gulp.task('clean-electron', util.rimraf('.build/electron'));
 gulp.task('electron', ['clean-electron'], getElectron(process.arch));
 gulp.task('electron-ia32', ['clean-electron'], getElectron('ia32'));
 gulp.task('electron-x64', ['clean-electron'], getElectron('x64'));
+gulp.task('electron-arm', ['clean-electron'], getElectron('arm'));
+gulp.task('electron-arm64', ['clean-electron'], getElectron('arm64'));
 
 
 /**


### PR DESCRIPTION
This follows on from pull request #52119.

Adding these tasks will allow for explicitly downloading ARM and ARM64 versions of Electron when it is not the native architecture of the build machine (this is helpful for cross-compilation scenarios).