### PR TITLE
Move early return at the top of function in intersectDiffWithRange

### DIFF
--- a/extensions/git/src/staging.ts
+++ b/extensions/git/src/staging.ts
@@ -85,6 +85,10 @@ export function getModifiedRange(textDocument: TextDocument, diff: LineChange): 
 }
 
 export function intersectDiffWithRange(textDocument: TextDocument, diff: LineChange, range: Range): LineChange | null {
+	if (diff.modifiedEndLineNumber === 0) {
+		return diff;
+	}
+
 	const modifiedRange = getModifiedRange(textDocument, diff);
 	const intersection = range.intersection(modifiedRange);
 
@@ -92,16 +96,12 @@ export function intersectDiffWithRange(textDocument: TextDocument, diff: LineCha
 		return null;
 	}
 
-	if (diff.modifiedEndLineNumber === 0) {
-		return diff;
-	} else {
-		return {
-			originalStartLineNumber: diff.originalStartLineNumber,
-			originalEndLineNumber: diff.originalEndLineNumber,
-			modifiedStartLineNumber: intersection.start.line + 1,
-			modifiedEndLineNumber: intersection.end.line + 1
-		};
-	}
+	return {
+		originalStartLineNumber: diff.originalStartLineNumber,
+		originalEndLineNumber: diff.originalEndLineNumber,
+		modifiedStartLineNumber: intersection.start.line + 1,
+		modifiedEndLineNumber: intersection.end.line + 1
+	};
 }
 
 export function invertLineChange(diff: LineChange): LineChange {


### PR DESCRIPTION
Fixes #50736

This is where the code was crashing (`src/vs/workbench/api/node/extHostDocumentData.ts`):
<img width="798" alt="screen shot 2018-09-11 at 21 39 29" src="https://user-images.githubusercontent.com/16692471/45386482-5adb0a00-b60b-11e8-8b94-1c872dee30d9.png">

I am not sure I fully understand the code, but we only seem to crash when this condition `diff.modifiedEndLineNumber === 0` is true, so given that `intersectDiffWithRange` just returns the `diff` when the same condition is true, I simply moved the early return at the top of the function to avoid the crash.