### PR TITLE
fixes #52531

### DIFF
--- a/src/vs/workbench/electron-browser/media/shell.css
+++ b/src/vs/workbench/electron-browser/media/shell.css
@@ -70,6 +70,10 @@
 	cursor: pointer;
 }
 
+.monaco-shell .context-view {
+	-webkit-app-region: no-drag;
+}
+
 .monaco-shell .monaco-menu .monaco-action-bar.vertical {
 	padding: .5em 0;
 }

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -1077,7 +1077,7 @@ export class Workbench extends Disposable implements IPartService {
 		part.id = id;
 		part.setAttribute('role', role);
 
-		this.workbench.appendChild(part);
+		this.workbench.insertBefore(part, this.workbench.lastChild);
 
 		return part;
 	}

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -1077,6 +1077,8 @@ export class Workbench extends Disposable implements IPartService {
 		part.id = id;
 		part.setAttribute('role', role);
 
+		// Insert all workbench parts at the beginning. Issue #52531
+		// This is primarily for the title bar to allow overriding -webkit-app-region
 		this.workbench.insertBefore(part, this.workbench.lastChild);
 
 		return part;


### PR DESCRIPTION
In order for the context menu to be clickable on top of the title bar, we must have webkit-app-region set to no-drag. In order for webkit-app-region to be effective, the dom node MUST be after the titlebar part to apply. This code would ensure that the workbench parts are always the first nodes in the workbench. It is a simple change but could have an unforeseen impact I am not aware of. If you have a better suggestion for reaching the same goal, let me know.

fixes #52531
