### PR TITLE
Customising activity bar icon colors

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -193,13 +193,13 @@ export class PlaceHolderToggleCompositePinnedAction extends ToggleCompositePinne
 
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
-	const activeBackgroundColor = theme.getColor(ACTIVITY_BAR_FOREGROUND);
-	if (activeBackgroundColor) {
+	const activeForegroundColor = theme.getColor(ACTIVITY_BAR_FOREGROUND);
+	if (activeForegroundColor) {
 		collector.addRule(`
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.active .action-label,
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:focus .action-label,
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:hover .action-label {
-				background-color: ${activeBackgroundColor} !important;
+				background-color: ${activeForegroundColor} !important;
 			}
 		`);
 	}

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -24,7 +24,7 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ActivityAction, ActivityActionItem, ICompositeBarColors, ToggleCompositePinnedAction, ICompositeBar } from 'vs/workbench/browser/parts/compositeBarActions';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { URI } from 'vs/base/common/uri';
-import { ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND, ACTIVITY_BAR_FOREGROUND } from 'vs/workbench/common/theme';
+import { ACTIVITY_BAR_FOREGROUND } from 'vs/workbench/common/theme';
 
 export class ViewletActivityAction extends ActivityAction {
 
@@ -193,7 +193,7 @@ export class PlaceHolderToggleCompositePinnedAction extends ToggleCompositePinne
 
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
-	const activeBackgroundColor = theme.defines(ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND);
+	const activeBackgroundColor = theme.getColor(ACTIVITY_BAR_FOREGROUND);
 	if (activeBackgroundColor) {
 		collector.addRule(`
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.active .action-label,

--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -24,6 +24,7 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ActivityAction, ActivityActionItem, ICompositeBarColors, ToggleCompositePinnedAction, ICompositeBar } from 'vs/workbench/browser/parts/compositeBarActions';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { URI } from 'vs/base/common/uri';
+import { ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND, ACTIVITY_BAR_FOREGROUND } from 'vs/workbench/common/theme';
 
 export class ViewletActivityAction extends ActivityAction {
 
@@ -110,7 +111,7 @@ export class GlobalActivityActionItem extends ActivityActionItem {
 
 	constructor(
 		action: GlobalActivityAction,
-		colors: ICompositeBarColors,
+		colors: (theme: ITheme) => ICompositeBarColors,
 		@IThemeService themeService: IThemeService,
 		@IContextMenuService protected contextMenuService: IContextMenuService
 	) {
@@ -172,12 +173,10 @@ export class PlaceHolderViewletActivityAction extends ViewletActivityAction {
 
 		const iconClass = `.monaco-workbench > .activitybar .monaco-action-bar .action-label.${this.class}`; // Generate Placeholder CSS to show the icon in the activity bar
 		DOM.createCSSRule(iconClass, `-webkit-mask: url('${iconUrl || ''}') no-repeat 50% 50%`);
-		this.enabled = false;
 	}
 
 	setActivity(activity: IActivity): void {
 		this.activity = activity;
-		this.enabled = true;
 	}
 }
 
@@ -185,17 +184,25 @@ export class PlaceHolderToggleCompositePinnedAction extends ToggleCompositePinne
 
 	constructor(id: string, compositeBar: ICompositeBar) {
 		super({ id, name: id, cssClass: void 0 }, compositeBar);
-
-		this.enabled = false;
 	}
 
 	setActivity(activity: IActivity): void {
 		this.label = activity.name;
-		this.enabled = true;
 	}
 }
 
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
+
+	const activeBackgroundColor = theme.defines(ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND);
+	if (activeBackgroundColor) {
+		collector.addRule(`
+			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.active .action-label,
+			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:focus .action-label,
+			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:hover .action-label {
+				background-color: ${activeBackgroundColor} !important;
+			}
+		`);
+	}
 
 	// Styling with Outline color (e.g. high contrast theme)
 	const outline = theme.getColor(activeContrastBorder);
@@ -208,7 +215,6 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 				left: 9px;
 				height: 32px;
 				width: 32px;
-				opacity: 0.6;
 			}
 
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.active:before,
@@ -220,12 +226,6 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:hover:before {
 				outline: 1px dashed;
-			}
-
-			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.active:before,
-			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.checked:before,
-			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:hover:before {
-				opacity: 1;
 			}
 
 			.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:focus:before {
@@ -247,21 +247,10 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		const focusBorderColor = theme.getColor(focusBorder);
 		if (focusBorderColor) {
 			collector.addRule(`
-				.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.active .action-label,
-				.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item.checked .action-label,
-				.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:focus .action-label,
-				.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:hover .action-label {
-					opacity: 1;
-				}
-
-				.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item .action-label {
-					opacity: 0.6;
-				}
-
-				.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:focus:before {
-					border-left-color: ${focusBorderColor};
-				}
-			`);
+					.monaco-workbench > .activitybar > .content .monaco-action-bar .action-item:focus:before {
+						border-left-color: ${focusBorderColor};
+					}
+				`);
 		}
 	}
 });

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -20,7 +20,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ToggleActivityBarVisibilityAction } from 'vs/workbench/browser/actions/toggleActivityBarVisibility';
 import { IThemeService, registerThemingParticipant, ITheme } from 'vs/platform/theme/common/themeService';
-import { ACTIVITY_BAR_BACKGROUND, ACTIVITY_BAR_BORDER, ACTIVITY_BAR_FOREGROUND, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND, ACTIVITY_BAR_ITEM_INACTIVE_FOREGROUND, ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND } from 'vs/workbench/common/theme';
+import { ACTIVITY_BAR_BACKGROUND, ACTIVITY_BAR_BORDER, ACTIVITY_BAR_FOREGROUND, ACTIVITY_BAR_BADGE_BACKGROUND, ACTIVITY_BAR_BADGE_FOREGROUND, ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND, ACTIVITY_BAR_INACTIVE_FOREGROUND } from 'vs/workbench/common/theme';
 import { contrastBorder } from 'vs/platform/theme/common/colorRegistry';
 import { CompositeBar } from 'vs/workbench/browser/parts/compositeBar';
 import { isMacintosh } from 'vs/base/common/platform';
@@ -202,8 +202,8 @@ export class ActivitybarPart extends Part {
 
 	private getActivitybarItemColors(theme: ITheme): ICompositeBarColors {
 		return <ICompositeBarColors>{
-			backgroundColor: theme.defines(ACTIVITY_BAR_ITEM_INACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_ITEM_INACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND).transparent(0.6),
-			activeBackgroundColor: theme.defines(ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND),
+			backgroundColor: theme.defines(ACTIVITY_BAR_INACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_INACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND).transparent(0.6),
+			activeBackgroundColor: theme.getColor(ACTIVITY_BAR_FOREGROUND),
 			badgeBackground: theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND),
 			badgeForeground: theme.getColor(ACTIVITY_BAR_BADGE_FOREGROUND),
 			dragAndDropBackground: theme.getColor(ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND)

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -203,7 +203,7 @@ export class ActivitybarPart extends Part {
 	private getActivitybarItemColors(theme: ITheme): ICompositeBarColors {
 		return <ICompositeBarColors>{
 			activeForegroundColor: theme.getColor(ACTIVITY_BAR_FOREGROUND),
-			inactiveForegroundColor: theme.defines(ACTIVITY_BAR_INACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_INACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND).transparent(0.6),
+			inactiveForegroundColor: theme.getColor(ACTIVITY_BAR_INACTIVE_FOREGROUND),
 			badgeBackground: theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND),
 			badgeForeground: theme.getColor(ACTIVITY_BAR_BADGE_FOREGROUND),
 			dragAndDropBackground: theme.getColor(ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND),

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -202,11 +202,12 @@ export class ActivitybarPart extends Part {
 
 	private getActivitybarItemColors(theme: ITheme): ICompositeBarColors {
 		return <ICompositeBarColors>{
-			backgroundColor: theme.defines(ACTIVITY_BAR_INACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_INACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND).transparent(0.6),
-			activeBackgroundColor: theme.getColor(ACTIVITY_BAR_FOREGROUND),
+			activeForegroundColor: theme.getColor(ACTIVITY_BAR_FOREGROUND),
+			inactiveForegroundColor: theme.defines(ACTIVITY_BAR_INACTIVE_FOREGROUND) ? theme.getColor(ACTIVITY_BAR_INACTIVE_FOREGROUND) : theme.getColor(ACTIVITY_BAR_FOREGROUND).transparent(0.6),
 			badgeBackground: theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND),
 			badgeForeground: theme.getColor(ACTIVITY_BAR_BADGE_FOREGROUND),
-			dragAndDropBackground: theme.getColor(ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND)
+			dragAndDropBackground: theme.getColor(ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND),
+			backgroundColor: null, activeBorderBottomColor: null,
 		};
 	}
 

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -207,7 +207,7 @@ export class ActivitybarPart extends Part {
 			badgeBackground: theme.getColor(ACTIVITY_BAR_BADGE_BACKGROUND),
 			badgeForeground: theme.getColor(ACTIVITY_BAR_BADGE_FOREGROUND),
 			dragAndDropBackground: theme.getColor(ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND),
-			backgroundColor: null, activeBorderBottomColor: null,
+			activeBorderBottomColor: null,
 		};
 	}
 

--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -22,12 +22,13 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { Widget } from 'vs/base/browser/ui/widget';
 import { isUndefinedOrNull } from 'vs/base/common/types';
 import { LocalSelectionTransfer } from 'vs/workbench/browser/dnd';
+import { ITheme } from 'vs/platform/theme/common/themeService';
 
 export interface ICompositeBarOptions {
 	icon: boolean;
 	storageId: string;
 	orientation: ActionsOrientation;
-	colors: ICompositeBarColors;
+	colors: (theme: ITheme) => ICompositeBarColors;
 	compositeSize: number;
 	overflowActionSize: number;
 	getActivityAction: (compositeId: string) => ActivityAction;

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -113,7 +113,6 @@ export class ActivityAction extends Action {
 }
 
 export interface ICompositeBarColors {
-	backgroundColor: Color;
 	activeBorderBottomColor: Color;
 	activeForegroundColor: Color;
 	inactiveForegroundColor: Color;
@@ -157,16 +156,16 @@ export class ActivityActionItem extends BaseActionItem {
 		const theme = this.themeService.getTheme();
 		const colors = this.options.colors(theme);
 
-		if (this.options.icon) {
-			const foreground = this._action.checked ? colors.activeForegroundColor : colors.inactiveForegroundColor;
-			this.label.style.backgroundColor = foreground ? foreground.toString() : null;
-		} else if (this.label) {
-			const background = colors.backgroundColor;
-			const foreground = this._action.checked ? colors.activeForegroundColor : colors.inactiveForegroundColor;
-			const borderBottomColor = this._action.checked ? colors.activeBorderBottomColor : null;
-			this.label.style.backgroundColor = background ? background.toString() : null;
-			this.label.style.color = foreground ? foreground.toString() : null;
-			this.label.style.borderBottomColor = borderBottomColor ? borderBottomColor.toString() : null;
+		if (this.label) {
+			if (this.options.icon) {
+				const foreground = this._action.checked ? colors.activeForegroundColor : colors.inactiveForegroundColor;
+				this.label.style.backgroundColor = foreground ? foreground.toString() : null;
+			} else {
+				const foreground = this._action.checked ? colors.activeForegroundColor : colors.inactiveForegroundColor;
+				const borderBottomColor = this._action.checked ? colors.activeBorderBottomColor : null;
+				this.label.style.color = foreground ? foreground.toString() : null;
+				this.label.style.borderBottomColor = borderBottomColor ? borderBottomColor.toString() : null;
+			}
 		}
 
 		// Badge

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -114,7 +114,9 @@ export class ActivityAction extends Action {
 
 export interface ICompositeBarColors {
 	backgroundColor: Color;
-	activeBackgroundColor: Color;
+	activeBorderBottomColor: Color;
+	activeForegroundColor: Color;
+	inactiveForegroundColor: Color;
 	badgeBackground: Color;
 	badgeForeground: Color;
 	dragAndDropBackground: Color;
@@ -154,10 +156,17 @@ export class ActivityActionItem extends BaseActionItem {
 	protected updateStyles(): void {
 		const theme = this.themeService.getTheme();
 		const colors = this.options.colors(theme);
-		// Label
-		if (this.label && this.options.icon) {
-			const background = this._action.checked ? colors.activeBackgroundColor : colors.backgroundColor;
+
+		if (this.options.icon) {
+			const foreground = this._action.checked ? colors.activeForegroundColor : colors.inactiveForegroundColor;
+			this.label.style.backgroundColor = foreground ? foreground.toString() : null;
+		} else if (this.label) {
+			const background = colors.backgroundColor;
+			const foreground = this._action.checked ? colors.activeForegroundColor : colors.inactiveForegroundColor;
+			const borderBottomColor = this._action.checked ? colors.activeBorderBottomColor : null;
 			this.label.style.backgroundColor = background ? background.toString() : null;
+			this.label.style.color = foreground ? foreground.toString() : null;
+			this.label.style.borderBottomColor = borderBottomColor ? borderBottomColor.toString() : null;
 		}
 
 		// Badge

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -96,7 +96,9 @@ export class PanelPart extends CompositePart<Panel> implements IPanelService {
 			overflowActionSize: 44,
 			colors: theme => ({
 				backgroundColor: theme.getColor(PANEL_BACKGROUND),
-				activeBackgroundColor: theme.getColor(PANEL_BACKGROUND),
+				activeBorderBottomColor: theme.getColor(PANEL_ACTIVE_TITLE_BORDER),
+				activeForegroundColor: theme.getColor(PANEL_ACTIVE_TITLE_FOREGROUND),
+				inactiveForegroundColor: theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND),
 				badgeBackground: theme.getColor(badgeBackground),
 				badgeForeground: theme.getColor(badgeForeground),
 				dragAndDropBackground: theme.getColor(PANEL_DRAG_AND_DROP_BACKGROUND)
@@ -321,20 +323,9 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	const titleActiveBorder = theme.getColor(PANEL_ACTIVE_TITLE_BORDER);
 	if (titleActive || titleActiveBorder) {
 		collector.addRule(`
-			.monaco-workbench > .part.panel > .title > .panel-switcher-container > .monaco-action-bar .action-item:hover .action-label,
-			.monaco-workbench > .part.panel > .title > .panel-switcher-container > .monaco-action-bar .action-item.checked .action-label {
-				color: ${titleActive};
-				border-bottom-color: ${titleActiveBorder};
-			}
-		`);
-	}
-
-	// Title Inactive
-	const titleInactive = theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND);
-	if (titleInactive) {
-		collector.addRule(`
-			.monaco-workbench > .part.panel > .title > .panel-switcher-container > .monaco-action-bar .action-item .action-label {
-				color: ${titleInactive};
+			.monaco-workbench > .part.panel > .title > .panel-switcher-container > .monaco-action-bar .action-item:hover .action-label {
+				color: ${titleActive} !important;
+				border-bottom-color: ${titleActiveBorder} !important;
 			}
 		`);
 	}
@@ -344,7 +335,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 	if (focusBorderColor) {
 		collector.addRule(`
 			.monaco-workbench > .part.panel > .title > .panel-switcher-container > .monaco-action-bar .action-item:focus .action-label {
-				color: ${titleActive};
+				color: ${titleActive} !important;
 				border-bottom-color: ${focusBorderColor} !important;
 				border-bottom: 1px solid;
 			}

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -95,7 +95,6 @@ export class PanelPart extends CompositePart<Panel> implements IPanelService {
 			compositeSize: 0,
 			overflowActionSize: 44,
 			colors: theme => ({
-				backgroundColor: theme.getColor(PANEL_BACKGROUND),
 				activeBorderBottomColor: theme.getColor(PANEL_ACTIVE_TITLE_BORDER),
 				activeForegroundColor: theme.getColor(PANEL_ACTIVE_TITLE_FOREGROUND),
 				inactiveForegroundColor: theme.getColor(PANEL_INACTIVE_TITLE_FOREGROUND),

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -94,12 +94,13 @@ export class PanelPart extends CompositePart<Panel> implements IPanelService {
 			hidePart: () => this.partService.setPanelHidden(true),
 			compositeSize: 0,
 			overflowActionSize: 44,
-			colors: {
-				backgroundColor: PANEL_BACKGROUND,
-				badgeBackground,
-				badgeForeground,
-				dragAndDropBackground: PANEL_DRAG_AND_DROP_BACKGROUND
-			}
+			colors: theme => ({
+				backgroundColor: theme.getColor(PANEL_BACKGROUND),
+				activeBackgroundColor: theme.getColor(PANEL_BACKGROUND),
+				badgeBackground: theme.getColor(badgeBackground),
+				badgeForeground: theme.getColor(badgeForeground),
+				dragAndDropBackground: theme.getColor(PANEL_DRAG_AND_DROP_BACKGROUND)
+			})
 		}));
 
 		for (const panel of this.getPanels()) {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -296,12 +296,23 @@ export const ACTIVITY_BAR_BORDER = registerColor('activityBar.border', {
 	hc: contrastBorder
 }, nls.localize('activityBarBorder', "Activity bar border color separating to the side bar. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
-
 export const ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND = registerColor('activityBar.dropBackground', {
 	dark: Color.white.transparent(0.12),
 	light: Color.white.transparent(0.12),
 	hc: Color.white.transparent(0.12),
 }, nls.localize('activityBarDragAndDropBackground', "Drag and drop feedback color for the activity bar items. The color should have transparency so that the activity bar entries can still shine through. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_ITEM_INACTIVE_FOREGROUND = registerColor('activityBarItem.inactiveForeground', {
+	dark: Color.white.transparent(0.6),
+	light: Color.white.transparent(0.6),
+	hc: Color.white
+}, nls.localize('activityBarInActiveForeground', "Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND = registerColor('activityBarItem.activeForeground', {
+	dark: Color.white,
+	light: Color.white,
+	hc: Color.white
+}, nls.localize('activityBarActiveForeground', "Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_BADGE_BACKGROUND = registerColor('activityBarBadge.background', {
 	dark: '#007ACC',

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -291,8 +291,8 @@ export const ACTIVITY_BAR_FOREGROUND = registerColor('activityBar.foreground', {
 }, nls.localize('activityBarForeground', "Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_INACTIVE_FOREGROUND = registerColor('activityBar.inactiveForeground', {
-	dark: Color.white.transparent(0.6),
-	light: Color.white.transparent(0.6),
+	dark: transparent(ACTIVITY_BAR_FOREGROUND, 0.6),
+	light: transparent(ACTIVITY_BAR_FOREGROUND, 0.6),
 	hc: Color.white
 }, nls.localize('activityBarInActiveForeground', "Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -288,7 +288,13 @@ export const ACTIVITY_BAR_FOREGROUND = registerColor('activityBar.foreground', {
 	dark: Color.white,
 	light: Color.white,
 	hc: Color.white
-}, nls.localize('activityBarForeground', "Activity bar foreground color (e.g. used for the icons). The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+}, nls.localize('activityBarForeground', "Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+export const ACTIVITY_BAR_INACTIVE_FOREGROUND = registerColor('activityBar.inactiveForeground', {
+	dark: Color.white.transparent(0.6),
+	light: Color.white.transparent(0.6),
+	hc: Color.white
+}, nls.localize('activityBarInActiveForeground', "Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_BORDER = registerColor('activityBar.border', {
 	dark: null,
@@ -301,18 +307,6 @@ export const ACTIVITY_BAR_DRAG_AND_DROP_BACKGROUND = registerColor('activityBar.
 	light: Color.white.transparent(0.12),
 	hc: Color.white.transparent(0.12),
 }, nls.localize('activityBarDragAndDropBackground', "Drag and drop feedback color for the activity bar items. The color should have transparency so that the activity bar entries can still shine through. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
-
-export const ACTIVITY_BAR_ITEM_INACTIVE_FOREGROUND = registerColor('activityBarItem.inactiveForeground', {
-	dark: Color.white.transparent(0.6),
-	light: Color.white.transparent(0.6),
-	hc: Color.white
-}, nls.localize('activityBarInActiveForeground', "Activity bar item foreground color when it is inactive. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
-
-export const ACTIVITY_BAR_ITEM_ACTIVE_FOREGROUND = registerColor('activityBarItem.activeForeground', {
-	dark: Color.white,
-	light: Color.white,
-	hc: Color.white
-}, nls.localize('activityBarActiveForeground', "Activity bar item foreground color when it is active. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
 export const ACTIVITY_BAR_BADGE_BACKGROUND = registerColor('activityBarBadge.background', {
 	dark: '#007ACC',

--- a/src/vs/workbench/parts/output/electron-browser/outputServices.ts
+++ b/src/vs/workbench/parts/output/electron-browser/outputServices.ts
@@ -507,7 +507,7 @@ export class OutputService extends Disposable implements IOutputService, ITextMo
 		if (panel && panel.getId() === OUTPUT_PANEL_ID) {
 			this._outputPanel = <OutputPanel>this.panelService.getActivePanel();
 			if (this.activeChannel) {
-				return this.doShowChannel(this.activeChannel, true);
+				return this.doShowChannel(this.activeChannel, false);
 			}
 		}
 		return TPromise.as(null);


### PR DESCRIPTION
Added following identifiers to customise activity bar icon colours

- `activityBarItem.inactiveForeground` - Activity bar item foreground color when it is inactive
- `activityBarItem.activeForeground` - Activity bar item foreground color when it is active

Fixes #51796