### PR TITLE
Reduce language pack checks

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -140,6 +140,7 @@ export interface IGalleryExtensionProperties {
 	dependencies?: string[];
 	extensionPack?: string[];
 	engine?: string;
+	localizedLanguages?: string[];
 }
 
 export interface IGalleryExtensionAsset {

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -278,7 +278,7 @@ function getEngine(version: IRawGalleryExtensionVersion): string {
 function getLocalizedLanguages(version: IRawGalleryExtensionVersion): string[] {
 	const values = version.properties ? version.properties.filter(p => p.key === PropertyType.LocalizedLanguages) : [];
 	const value = (values.length > 0 && values[0].value) || '';
-	return value.split(',');
+	return value ? value.split(',') : [];
 }
 
 function getIsPreview(flags: string): boolean {

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -116,7 +116,8 @@ const AssetType = {
 const PropertyType = {
 	Dependency: 'Microsoft.VisualStudio.Code.ExtensionDependencies',
 	ExtensionPack: 'Microsoft.VisualStudio.Code.ExtensionPack',
-	Engine: 'Microsoft.VisualStudio.Code.Engine'
+	Engine: 'Microsoft.VisualStudio.Code.Engine',
+	LocalizedLanguages: 'Microsoft.VisualStudio.Code.LocalizedLanguages'
 };
 
 interface ICriterium {
@@ -274,6 +275,12 @@ function getEngine(version: IRawGalleryExtensionVersion): string {
 	return (values.length > 0 && values[0].value) || '';
 }
 
+function getLocalizedLanguages(version: IRawGalleryExtensionVersion): string[] {
+	const values = version.properties ? version.properties.filter(p => p.key === PropertyType.LocalizedLanguages) : [];
+	const value = (values.length > 0 && values[0].value) || '';
+	return value.split(',');
+}
+
 function getIsPreview(flags: string): boolean {
 	return flags.indexOf('preview') !== -1;
 }
@@ -310,7 +317,8 @@ function toExtension(galleryExtension: IRawGalleryExtension, version: IRawGaller
 		properties: {
 			dependencies: getExtensions(version, PropertyType.Dependency),
 			extensionPack: getExtensions(version, PropertyType.ExtensionPack),
-			engine: getEngine(version)
+			engine: getEngine(version),
+			localizedLanguages: getLocalizedLanguages(version)
 		},
 		/* __GDPR__FRAGMENT__
 			"GalleryExtensionTelemetryData2" : {
@@ -594,6 +602,7 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 						if (rawVersion) {
 							extension.properties.dependencies = getExtensions(rawVersion, PropertyType.Dependency);
 							extension.properties.engine = getEngine(rawVersion);
+							extension.properties.localizedLanguages = getLocalizedLanguages(rawVersion);
 							extension.assets.download = getVersionAsset(rawVersion, AssetType.VSIX);
 							extension.version = rawVersion.version;
 							return extension;

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -49,6 +49,7 @@ const actionOptions = { icon: true, label: true };
 export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
 	constructor(
+		private languagePacks: string[],
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@INotificationService private notificationService: INotificationService,
 		@IExtensionsWorkbenchService private extensionsWorkbenchService: IExtensionsWorkbenchService,
@@ -181,13 +182,15 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		data.ratings.style.display = '';
 		data.extension = extension;
 
-		const manifestPromise = createCancelablePromise(token => extension.getManifest(token).then(manifest => {
-			if (manifest) {
-				const name = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.length > 0 && manifest.contributes.localizations[0].localizedLanguageName;
-				if (name) { data.description.textContent = name[0].toLocaleUpperCase() + name.slice(1); }
-			}
-		}));
-		data.disposables.push(toDisposable(() => manifestPromise.cancel()));
+		if (this.languagePacks.indexOf(extension.id) > -1) {
+			const manifestPromise = createCancelablePromise(token => extension.getManifest(token).then(manifest => {
+				if (manifest) {
+					const name = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.length > 0 && manifest.contributes.localizations[0].localizedLanguageName;
+					if (name) { data.description.textContent = name[0].toLocaleUpperCase() + name.slice(1); }
+				}
+			}));
+			data.disposables.push(toDisposable(() => manifestPromise.cancel()));
+		}
 	}
 
 	disposeElement(): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -7,7 +7,7 @@
 
 import { localize } from 'vs/nls';
 import { append, $, addClass, removeClass, toggleClass } from 'vs/base/browser/dom';
-import { IDisposable, dispose, toDisposable } from 'vs/base/common/lifecycle';
+import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { Action } from 'vs/base/common/actions';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -23,7 +23,6 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { IExtensionTipsService, IExtensionManagementServerService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
-import { createCancelablePromise } from 'vs/base/common/async';
 
 export interface ITemplateData {
 	root: HTMLElement;
@@ -49,7 +48,6 @@ const actionOptions = { icon: true, label: true };
 export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
 	constructor(
-		private languagePacks: string[],
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@INotificationService private notificationService: INotificationService,
 		@IExtensionsWorkbenchService private extensionsWorkbenchService: IExtensionsWorkbenchService,
@@ -184,14 +182,6 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
 		if (extension.gallery && extension.gallery.properties && extension.gallery.properties.localizedLanguages && extension.gallery.properties.localizedLanguages.length) {
 			data.description.textContent = extension.gallery.properties.localizedLanguages.filter(name => name.trim()).map(name => name[0].toLocaleUpperCase() + name.slice(1)).join(', ');
-		} else if (this.languagePacks.indexOf(extension.id) > -1) {
-			const manifestPromise = createCancelablePromise(token => extension.getManifest(token).then(manifest => {
-				if (manifest) {
-					const name = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.length > 0 && manifest.contributes.localizations[0].localizedLanguageName;
-					if (name) { data.description.textContent = name[0].toLocaleUpperCase() + name.slice(1); }
-				}
-			}));
-			data.disposables.push(toDisposable(() => manifestPromise.cancel()));
 		}
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -181,7 +181,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		data.extension = extension;
 
 		if (extension.gallery && extension.gallery.properties && extension.gallery.properties.localizedLanguages && extension.gallery.properties.localizedLanguages.length) {
-			data.description.textContent = extension.gallery.properties.localizedLanguages.filter(name => name.trim()).map(name => name[0].toLocaleUpperCase() + name.slice(1)).join(', ');
+			data.description.textContent = extension.gallery.properties.localizedLanguages.map(name => name[0].toLocaleUpperCase() + name.slice(1)).join(', ');
 		}
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -182,7 +182,9 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		data.ratings.style.display = '';
 		data.extension = extension;
 
-		if (this.languagePacks.indexOf(extension.id) > -1) {
+		if (extension.gallery && extension.gallery.properties && extension.gallery.properties.localizedLanguages && extension.gallery.properties.localizedLanguages.length) {
+			data.description.textContent = extension.gallery.properties.localizedLanguages.filter(name => name.trim()).map(name => name[0].toLocaleUpperCase() + name.slice(1)).join(', ');
+		} else if (this.languagePacks.indexOf(extension.id) > -1) {
 			const manifestPromise = createCancelablePromise(token => extension.getManifest(token).then(manifest => {
 				if (manifest) {
 					const name = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.length > 0 && manifest.contributes.localizations[0].localizedLanguageName;

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -8,7 +8,7 @@
 
 import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
-import { dispose } from 'vs/base/common/lifecycle';
+import { dispose, toDisposable } from 'vs/base/common/lifecycle';
 import { assign } from 'vs/base/common/objects';
 import { chain } from 'vs/base/common/event';
 import { isPromiseCanceledError, create as createError } from 'vs/base/common/errors';
@@ -40,6 +40,7 @@ import { ViewletPanel, IViewletPanelOptions } from 'vs/workbench/browser/parts/v
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { distinct } from 'vs/base/common/arrays';
 import { IExperimentService } from 'vs/workbench/parts/experiments/node/experimentService';
+import { createCancelablePromise } from 'vs/base/common/async';
 
 export class ExtensionsListView extends ViewletPanel {
 
@@ -48,6 +49,7 @@ export class ExtensionsListView extends ViewletPanel {
 	private badge: CountBadge;
 	protected badgeContainer: HTMLElement;
 	private list: WorkbenchPagedList<IExtension>;
+	private languagePacks: string[] = [];
 
 	constructor(
 		private options: IViewletViewOptions,
@@ -67,6 +69,19 @@ export class ExtensionsListView extends ViewletPanel {
 		@IExperimentService private experimentService: IExperimentService
 	) {
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: options.title }, keybindingService, contextMenuService, configurationService);
+		const languagePackPromise = createCancelablePromise(token => {
+			return this.extensionsWorkbenchService.queryGallery({ text: 'category:"language packs"' }).then(pager => {
+				this.languagePacks.push(...pager.firstPage.map(e => e.id));
+				const allPromises = [];
+				for (let i = 1; i < pager.total; i++) {
+					allPromises.push(pager.getPage(i, token).then(result => {
+						this.languagePacks.push(...result.map(e => e.id));
+					}));
+				}
+				return TPromise.join(allPromises);
+			});
+		});
+		this.disposables.push(toDisposable(() => languagePackPromise.cancel()));
 	}
 
 	protected renderHeader(container: HTMLElement): void {
@@ -85,7 +100,7 @@ export class ExtensionsListView extends ViewletPanel {
 		this.extensionsList = append(container, $('.extensions-list'));
 		this.messageBox = append(container, $('.message'));
 		const delegate = new Delegate();
-		const renderer = this.instantiationService.createInstance(Renderer);
+		const renderer = this.instantiationService.createInstance(Renderer, this.languagePacks);
 		this.list = this.instantiationService.createInstance(WorkbenchPagedList, this.extensionsList, delegate, [renderer], {
 			ariaLabel: localize('extensions', "Extensions"),
 			multipleSelectionSupport: false

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -69,6 +69,8 @@ export class ExtensionsListView extends ViewletPanel {
 		@IExperimentService private experimentService: IExperimentService
 	) {
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: options.title }, keybindingService, contextMenuService, configurationService);
+
+		// TODO: Remove this once all the language packs we own are published using the latest vsce
 		const languagePackPromise = createCancelablePromise(token => {
 			return this.extensionsWorkbenchService.queryGallery({ text: 'category:"language packs"' }).then(pager => {
 				this.languagePacks.push(...pager.firstPage.map(e => e.id));


### PR DESCRIPTION
This PR is to reduce the number of marketplace calls being made to check if given extension is a language pack so that the extension description can be updated to be the localized language

Fixes #58074

@sandy081 

The current solution will still make a call for each ExtensionListView being created. 
A better solution would be to fetch the language pack just once per VS Code window/session in which case the `ExtensionWorkbenchService` would be the most appropriate home.

Thoughts?
