### PR TITLE
[WIP] Add support for editing comments

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1013,6 +1013,7 @@ export interface Comment {
 	readonly body: IMarkdownString;
 	readonly userName: string;
 	readonly gravatar: string;
+	readonly canEdit: boolean;
 	readonly command?: Command;
 }
 
@@ -1044,6 +1045,7 @@ export interface DocumentCommentProvider {
 	provideDocumentComments(resource: URI, token: CancellationToken): Promise<CommentInfo>;
 	createNewCommentThread(resource: URI, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
 	replyToCommentThread(resource: URI, range: Range, thread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
+	editComment(resource: URI, comment: Comment, text: string, token: CancellationToken): Promise<Comment>;
 	onDidChangeCommentThreads(): Event<CommentThreadChangedEvent>;
 }
 
@@ -1052,8 +1054,6 @@ export interface DocumentCommentProvider {
  */
 export interface WorkspaceCommentProvider {
 	provideWorkspaceComments(token: CancellationToken): Promise<CommentThread[]>;
-	createNewCommentThread(resource: URI, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
-	replyToCommentThread(resource: URI, range: Range, thread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
 	onDidChangeCommentThreads(): Event<CommentThreadChangedEvent>;
 }
 

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1013,7 +1013,7 @@ export interface Comment {
 	readonly body: IMarkdownString;
 	readonly userName: string;
 	readonly gravatar: string;
-	readonly canEdit: boolean;
+	readonly canEdit?: boolean;
 	readonly command?: Command;
 }
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -594,10 +594,35 @@ declare module 'vscode' {
 	}
 
 	interface Comment {
+		/**
+		 * The id of the comment
+		 */
 		commentId: string;
+
+		/**
+		 * The text of the comment
+		 */
 		body: MarkdownString;
+
+		/**
+		 * The display name of the user who created the comment
+		 */
 		userName: string;
+
+		/**
+		 * The avatar src of the user who created the comment
+		 */
 		gravatar: string;
+
+		/**
+		 * Whether the current user has permission to edit the comment. This will be treated as false if no `editComment` method
+		 * is provided on the DocumentCommentProvider.
+		 */
+		canEdit?: boolean;
+
+		/**
+		 * The command to be executed if the comment is selected in the Comments Panel
+		 */
 		command?: Command;
 	}
 
@@ -619,14 +644,42 @@ declare module 'vscode' {
 	}
 
 	interface DocumentCommentProvider {
+		/**
+		 * Provide the commenting ranges and comment threads for the given document. The comments are displayed within the editor.
+		 */
 		provideDocumentComments(document: TextDocument, token: CancellationToken): Promise<CommentInfo>;
+
+		/**
+		 * Called when a user adds a new comment thread in the document at the specified range, with body text.
+		 */
 		createNewCommentThread(document: TextDocument, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
+
+		/**
+		 * Called when a user replies to a new comment thread in the document at the specified range, with body text.
+		 */
 		replyToCommentThread(document: TextDocument, range: Range, commentThread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
+
+		/**
+		 * Called when a user edits the comment body to the be new text text.
+		 */
+		editComment?(document: TextDocument, comment: Comment, text: string, token: CancellationToken): Promise<Comment>;
+
+		/**
+		 * Notify of updates to comment threads.
+		 */
 		onDidChangeCommentThreads: Event<CommentThreadChangedEvent>;
 	}
 
 	interface WorkspaceCommentProvider {
+		/**
+		 * Provide all comments for the workspace. Comments are shown within the comments panel. Selecting a comment
+		 * from the panel runs the comment's command.
+		 */
 		provideWorkspaceComments(token: CancellationToken): Promise<CommentThread[]>;
+
+		/**
+		 * Notify of updates to comment threads.
+		 */
 		onDidChangeCommentThreads: Event<CommentThreadChangedEvent>;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -615,8 +615,10 @@ declare module 'vscode' {
 		gravatar: string;
 
 		/**
-		 * Whether the current user has permission to edit the comment. This will be treated as false if no `editComment` method
-		 * is provided on the DocumentCommentProvider.
+		 * Whether the current user has permission to edit the comment.
+		 *
+		 * This will be treated as false if the comment is provided by a `WorkspaceCommentProvider`, or
+		 * if it is provided by a `DocumentCommentProvider` and  no `editComment` method is given.
 		 */
 		canEdit?: boolean;
 

--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -77,6 +77,9 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 				},
 				replyToCommentThread: async (uri, range, thread, text, token) => {
 					return this._proxy.$replyToCommentThread(handle, uri, range, thread, text);
+				},
+				editComment: async (uri, comment, text, token) => {
+					return this._proxy.$editComment(handle, uri, comment, text);
 				}
 			}
 		);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -989,6 +989,7 @@ export interface ExtHostCommentsShape {
 	$provideDocumentComments(handle: number, document: UriComponents): Thenable<modes.CommentInfo>;
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Thenable<modes.CommentThread>;
 	$replyToCommentThread(handle: number, document: UriComponents, range: IRange, commentThread: modes.CommentThread, text: string): Thenable<modes.CommentThread>;
+	$editComment(handle: number, document: UriComponents, comment: modes.Comment, text: string): Thenable<modes.Comment>;
 	$provideWorkspaceComments(handle: number): Thenable<modes.CommentThread[]>;
 }
 

--- a/src/vs/workbench/api/node/extHostComments.ts
+++ b/src/vs/workbench/api/node/extHostComments.ts
@@ -73,10 +73,10 @@ export class ExtHostComments implements ExtHostCommentsShape {
 			return TPromise.as(null);
 		}
 
+		const provider = this._documentProviders.get(handle);
 		return asThenable(() => {
-			let provider = this._documentProviders.get(handle);
 			return provider.createNewCommentThread(data.document, ran, text, CancellationToken.None);
-		}).then(commentThread => commentThread ? convertToCommentThread(commentThread, this._commandsConverter) : null);
+		}).then(commentThread => commentThread ? convertToCommentThread(provider, commentThread, this._commandsConverter) : null);
 	}
 
 	$replyToCommentThread(handle: number, uri: UriComponents, range: IRange, thread: modes.CommentThread, text: string): Thenable<modes.CommentThread> {
@@ -87,10 +87,10 @@ export class ExtHostComments implements ExtHostCommentsShape {
 			return TPromise.as(null);
 		}
 
+		const provider = this._documentProviders.get(handle);
 		return asThenable(() => {
-			let provider = this._documentProviders.get(handle);
 			return provider.replyToCommentThread(data.document, ran, convertFromCommentThread(thread), text, CancellationToken.None);
-		}).then(commentThread => commentThread ? convertToCommentThread(commentThread, this._commandsConverter) : null);
+		}).then(commentThread => commentThread ? convertToCommentThread(provider, commentThread, this._commandsConverter) : null);
 	}
 
 	$editComment(handle: number, uri: UriComponents, comment: modes.Comment, text: string): Thenable<modes.Comment> {
@@ -103,7 +103,7 @@ export class ExtHostComments implements ExtHostCommentsShape {
 		const provider = this._documentProviders.get(handle);
 		return asThenable(() => {
 			return provider.editComment(data.document, convertFromComment(comment), text, CancellationToken.None);
-		}).then(comment => convertToComment(comment, this._commandsConverter));
+		}).then(comment => convertToComment(provider, comment, this._commandsConverter));
 	}
 
 	$provideDocumentComments(handle: number, uri: UriComponents): Thenable<modes.CommentInfo> {
@@ -112,11 +112,10 @@ export class ExtHostComments implements ExtHostCommentsShape {
 			return TPromise.as(null);
 		}
 
+		const provider = this._documentProviders.get(handle);
 		return asThenable(() => {
-			let provider = this._documentProviders.get(handle);
 			return provider.provideDocumentComments(data.document, CancellationToken.None);
-		})
-			.then(commentInfo => commentInfo ? convertCommentInfo(handle, commentInfo, this._commandsConverter) : null);
+		}).then(commentInfo => commentInfo ? convertCommentInfo(handle, provider, commentInfo, this._commandsConverter) : null);
 	}
 
 	$provideWorkspaceComments(handle: number): Thenable<modes.CommentThread[]> {
@@ -128,7 +127,7 @@ export class ExtHostComments implements ExtHostCommentsShape {
 		return asThenable(() => {
 			return provider.provideWorkspaceComments(CancellationToken.None);
 		}).then(comments =>
-			comments.map(x => convertToCommentThread(x, this._commandsConverter)
+			comments.map(comment => convertToCommentThread(provider, comment, this._commandsConverter)
 			));
 	}
 
@@ -137,28 +136,28 @@ export class ExtHostComments implements ExtHostCommentsShape {
 
 			this._proxy.$onDidCommentThreadsChange(handle, {
 				owner: handle,
-				changed: event.changed.map(x => convertToCommentThread(x, this._commandsConverter)),
-				added: event.added.map(x => convertToCommentThread(x, this._commandsConverter)),
-				removed: event.removed.map(x => convertToCommentThread(x, this._commandsConverter))
+				changed: event.changed.map(thread => convertToCommentThread(provider, thread, this._commandsConverter)),
+				added: event.added.map(thread => convertToCommentThread(provider, thread, this._commandsConverter)),
+				removed: event.removed.map(thread => convertToCommentThread(provider, thread, this._commandsConverter))
 			});
 		});
 	}
 }
 
-function convertCommentInfo(owner: number, vscodeCommentInfo: vscode.CommentInfo, commandsConverter: CommandsConverter): modes.CommentInfo {
+function convertCommentInfo(owner: number, provider: vscode.DocumentCommentProvider, vscodeCommentInfo: vscode.CommentInfo, commandsConverter: CommandsConverter): modes.CommentInfo {
 	return {
 		owner: owner,
-		threads: vscodeCommentInfo.threads.map(x => convertToCommentThread(x, commandsConverter)),
+		threads: vscodeCommentInfo.threads.map(x => convertToCommentThread(provider, x, commandsConverter)),
 		commentingRanges: vscodeCommentInfo.commentingRanges ? vscodeCommentInfo.commentingRanges.map(range => extHostTypeConverter.Range.from(range)) : []
 	};
 }
 
-function convertToCommentThread(vscodeCommentThread: vscode.CommentThread, commandsConverter: CommandsConverter): modes.CommentThread {
+function convertToCommentThread(provider: vscode.DocumentCommentProvider | vscode.WorkspaceCommentProvider, vscodeCommentThread: vscode.CommentThread, commandsConverter: CommandsConverter): modes.CommentThread {
 	return {
 		threadId: vscodeCommentThread.threadId,
 		resource: vscodeCommentThread.resource.toString(),
 		range: extHostTypeConverter.Range.from(vscodeCommentThread.range),
-		comments: vscodeCommentThread.comments.map(comment => convertToComment(comment, commandsConverter)),
+		comments: vscodeCommentThread.comments.map(comment => convertToComment(provider, comment, commandsConverter)),
 		collapsibleState: vscodeCommentThread.collapsibleState
 	};
 }
@@ -183,13 +182,14 @@ function convertFromComment(comment: modes.Comment): vscode.Comment {
 	};
 }
 
-function convertToComment(vscodeComment: vscode.Comment, commandsConverter: CommandsConverter): modes.Comment {
+function convertToComment(provider: vscode.DocumentCommentProvider | vscode.WorkspaceCommentProvider, vscodeComment: vscode.Comment, commandsConverter: CommandsConverter): modes.Comment {
+	const canEdit = !!(provider as vscode.DocumentCommentProvider).editComment && vscodeComment.canEdit;
 	return {
 		commentId: vscodeComment.commentId,
 		body: extHostTypeConverter.MarkdownString.from(vscodeComment.body),
 		userName: vscodeComment.userName,
 		gravatar: vscodeComment.gravatar,
-		canEdit: vscodeComment.canEdit,
+		canEdit: canEdit,
 		command: vscodeComment.command ? commandsConverter.toInternal(vscodeComment.command) : null
 	};
 }

--- a/src/vs/workbench/api/node/extHostComments.ts
+++ b/src/vs/workbench/api/node/extHostComments.ts
@@ -93,6 +93,19 @@ export class ExtHostComments implements ExtHostCommentsShape {
 		}).then(commentThread => commentThread ? convertToCommentThread(commentThread, this._commandsConverter) : null);
 	}
 
+	$editComment(handle: number, uri: UriComponents, comment: modes.Comment, text: string): Thenable<modes.Comment> {
+		const data = this._documents.getDocumentData(URI.revive(uri));
+
+		if (!data || !data.document) {
+			throw new Error('Unable to retrieve document from URI');
+		}
+
+		const provider = this._documentProviders.get(handle);
+		return asThenable(() => {
+			return provider.editComment(data.document, convertFromComment(comment), text, CancellationToken.None);
+		}).then(comment => convertToComment(comment, this._commandsConverter));
+	}
+
 	$provideDocumentComments(handle: number, uri: UriComponents): Thenable<modes.CommentInfo> {
 		const data = this._documents.getDocumentData(URI.revive(uri));
 		if (!data || !data.document) {
@@ -165,7 +178,8 @@ function convertFromComment(comment: modes.Comment): vscode.Comment {
 		commentId: comment.commentId,
 		body: extHostTypeConverter.MarkdownString.to(comment.body),
 		userName: comment.userName,
-		gravatar: comment.gravatar
+		gravatar: comment.gravatar,
+		canEdit: comment.canEdit
 	};
 }
 
@@ -175,6 +189,7 @@ function convertToComment(vscodeComment: vscode.Comment, commandsConverter: Comm
 		body: extHostTypeConverter.MarkdownString.from(vscodeComment.body),
 		userName: vscodeComment.userName,
 		gravatar: vscodeComment.gravatar,
+		canEdit: vscodeComment.canEdit,
 		command: vscodeComment.command ? commandsConverter.toInternal(vscodeComment.command) : null
 	};
 }

--- a/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
@@ -25,6 +25,7 @@ import { ICommentService } from 'vs/workbench/parts/comments/electron-browser/co
 import { SimpleCommentEditor } from 'vs/workbench/parts/comments/electron-browser/simpleCommentEditor';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { isMacintosh } from 'vs/base/common/platform';
+import { Selection } from 'vs/editor/common/core/selection';
 
 const UPDATE_COMMENT_LABEL = nls.localize('label.updateComment', "Update comment");
 const UPDATE_IN_PROGRESS_LABEL = nls.localize('label.updatingComment', "Updating comment...");
@@ -108,6 +109,9 @@ export class CommentNode extends Disposable {
 		this._commentEditor.setValue(this.comment.body.value);
 		this._commentEditor.layout({ width: container.clientWidth - 14, height: 90 });
 		this._commentEditor.focus();
+		const lastLine = this._commentEditorModel.getLineCount();
+		const lastColumn = this._commentEditorModel.getLineContent(lastLine).length + 1;
+		this._commentEditor.setSelection(new Selection(lastLine, lastColumn, lastLine, lastColumn));
 
 		this._toDispose.push(this._commentEditor.onKeyDown((e: IKeyboardEvent) => {
 			const isCmdOrCtrl = isMacintosh ? e.metaKey : e.ctrlKey;
@@ -123,10 +127,12 @@ export class CommentNode extends Disposable {
 	private removeCommentEditor() {
 		this._editAction.enabled = true;
 		this._body.classList.remove('hidden');
-		this._commentEditContainer.remove();
 
 		this._commentEditorModel.dispose();
 		this._commentEditor.dispose();
+		this._commentEditor = null;
+
+		this._commentEditContainer.remove();
 	}
 
 	private editComment(): void {

--- a/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
@@ -202,7 +202,7 @@ export class CommentNode extends Disposable {
 		}));
 
 		this._toDispose.push(dom.addDisposableListener(this._domNode, 'mouseleave', (e: MouseEvent) => {
-			if (document.activeElement !== e.target) {
+			if (!this._domNode.contains(document.activeElement)) {
 				actionsContainer.classList.add('hidden');
 			}
 		}));

--- a/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
@@ -104,12 +104,6 @@ export class CommentNode extends Disposable {
 		this._commentEditor.layout({ width: container.clientWidth - 14, height: 90 });
 		this._commentEditor.focus();
 
-		this._toDispose.push(this._commentEditor.onDidBlurEditorWidget(e => {
-			if (!this._domNode.contains(document.activeElement) && this._commentEditor.getValue() === this.comment.body.value) {
-				this.removeCommentEditor();
-			}
-		}));
-
 		this._toDispose.push(this._commentEditor);
 		this._toDispose.push(this._commentEditorModel);
 	}
@@ -192,8 +186,12 @@ export class CommentNode extends Disposable {
 		}));
 
 		this._toDispose.push(dom.addDisposableListener(this._domNode, 'focusout', (e: FocusEvent) => {
-			if (!(<HTMLElement>e.target).contains((<HTMLElement>e.relatedTarget))) {
+			if (!this._domNode.contains((<HTMLElement>e.relatedTarget))) {
 				actionsContainer.classList.add('hidden');
+
+				if (this._commentEditor && this._commentEditor.getValue() === this.comment.body.value) {
+					this.removeCommentEditor();
+				}
 			}
 		}));
 	}

--- a/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
@@ -20,6 +20,8 @@ import { SimpleCommentEditor } from 'vs/workbench/parts/comments/electron-browse
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { IModeService } from 'vs/editor/common/services/modeService';
+import { inputValidationErrorBorder } from 'vs/platform/theme/common/colorRegistry';
+import { ITextModel } from 'vs/editor/common/model';
 
 const UPDATE_COMMENT_LABEL = nls.localize('label.updateComment', "Update comment");
 const UPDATE_IN_PROGRESS_LABEL = nls.localize('label.updatingComment', "Updating comment...");
@@ -29,7 +31,11 @@ export class CommentNode extends Disposable {
 	private _body: HTMLElement;
 	private _md: HTMLElement;
 	private _clearTimeout: any;
+
 	private _editAction: Action;
+	private _commentEditContainer: HTMLElement;
+	private _commentEditor: SimpleCommentEditor;
+	private _commentEditorModel: ITextModel;
 
 	public get domNode(): HTMLElement {
 		return this._domNode;
@@ -55,19 +61,7 @@ export class CommentNode extends Disposable {
 		img.src = comment.gravatar;
 		const commentDetailsContainer = dom.append(this._domNode, dom.$('.review-comment-contents'));
 
-		const header = dom.append(commentDetailsContainer, dom.$('div.comment-title'));
-		const author = dom.append(header, dom.$('strong.author'));
-		author.innerText = comment.userName;
-
-		if (comment.canEdit) {
-			const actionsContainer = dom.append(header, dom.$('.comment-actions'));
-			const actionbarWidget = new ActionBar(actionsContainer, {});
-			this._toDispose.push(actionbarWidget);
-
-			this._editAction = this.createEditAction(commentDetailsContainer);
-
-			actionbarWidget.push(this._editAction, { label: false, icon: true });
-		}
+		this.createHeader(commentDetailsContainer);
 
 		this._body = dom.append(commentDetailsContainer, dom.$('div.comment-body'));
 		this._md = this.markdownRenderer.render(comment.body).element;
@@ -78,75 +72,130 @@ export class CommentNode extends Disposable {
 		this._clearTimeout = null;
 	}
 
+	private createHeader(commentDetailsContainer: HTMLElement): void {
+		const header = dom.append(commentDetailsContainer, dom.$('div.comment-title'));
+		const author = dom.append(header, dom.$('strong.author'));
+		author.innerText = this.comment.userName;
+
+		const actions: Action[] = [];
+		if (this.comment.canEdit) {
+			this._editAction = this.createEditAction(commentDetailsContainer);
+			actions.push(this._editAction);
+		}
+
+		if (actions.length) {
+			const actionsContainer = dom.append(header, dom.$('.comment-actions.hidden'));
+			const actionBar = new ActionBar(actionsContainer, {});
+			this._toDispose.push(actionBar);
+			this.registerActionBarListeners(actionsContainer);
+
+			actions.forEach(action => actionBar.push(action, { label: false, icon: true }));
+		}
+	}
+
+	private createCommentEditor(): void {
+		const container = dom.append(this._commentEditContainer, dom.$('.edit-textarea'));
+		this._commentEditor = this.instantiationService.createInstance(SimpleCommentEditor, container, SimpleCommentEditor.getEditorOptions());
+		const resource = URI.parse(`comment:commentinput-${this.comment.commentId}-${Date.now()}.md`);
+		this._commentEditorModel = this.modelService.createModel('', this.modeService.getOrCreateModeByFilenameOrFirstLine(resource.path), resource, true);
+
+		this._commentEditor.setModel(this._commentEditorModel);
+		this._commentEditor.setValue(this.comment.body.value);
+		this._commentEditor.layout({ width: container.clientWidth - 14, height: 90 });
+		this._commentEditor.focus();
+
+		this._toDispose.push(this._commentEditor.onDidBlurEditorWidget(e => {
+			if (!this._domNode.contains(document.activeElement) && this._commentEditor.getValue() === this.comment.body.value) {
+				this.removeCommentEditor();
+			}
+		}));
+
+		this._toDispose.push(this._commentEditor);
+		this._toDispose.push(this._commentEditorModel);
+	}
+
+	private removeCommentEditor() {
+		this._editAction.enabled = true;
+		this._body.classList.remove('hidden');
+		this._commentEditContainer.remove();
+
+		this._commentEditorModel.dispose();
+		this._commentEditor.dispose();
+	}
+
 	private createEditAction(commentDetailsContainer: HTMLElement): Action {
 		return new Action('comment.edit', nls.localize('label.edit', "Edit"), 'octicon octicon-pencil', true, () => {
 			this._body.classList.add('hidden');
-			const editingContainer = dom.append(commentDetailsContainer, dom.$('.edit-container'));
-			const editingBoxContainer = dom.append(editingContainer, dom.$('.edit-textarea'));
-			const editBox = this.instantiationService.createInstance(SimpleCommentEditor, editingBoxContainer, SimpleCommentEditor.getEditorOptions());
-			this._toDispose.push(editBox);
-			const resource = URI.parse(`comment:commentinput-kjalfksjdf.md`);
-			const model = this.modelService.createModel('', this.modeService.getOrCreateModeByFilenameOrFirstLine(resource.path), resource, true);
-			this._toDispose.push(model);
-			editBox.setModel(model);
-			editBox.setValue(this.comment.body.value);
-			editBox.layout();
-			editBox.focus();
+			this._commentEditContainer = dom.append(commentDetailsContainer, dom.$('.edit-container'));
+			this.createCommentEditor();
 
-			const formActions = dom.append(editingContainer, dom.$('.form-actions'));
-			const updateCommentButton = new Button(formActions);
-			updateCommentButton.label = UPDATE_COMMENT_LABEL;
-			attachButtonStyler(updateCommentButton, this.themeService);
-
-			updateCommentButton.onDidClick(_ => {
-				updateCommentButton.enabled = false;
-				updateCommentButton.label = UPDATE_IN_PROGRESS_LABEL;
-
-				try {
-					this.commentService.editComment(this.owner, this.resource, this.comment, editBox.getValue()).then(editedComment => {
-						updateCommentButton.enabled = true;
-						updateCommentButton.label = UPDATE_COMMENT_LABEL;
-
-						this._editAction.enabled = true;
-						this._body.classList.remove('hidden');
-						editingContainer.remove();
-
-						model.dispose();
-						editBox.dispose();
-
-						this.update(editedComment);
-					});
-				} catch (e) {
-					// TODO Display error message
-					updateCommentButton.enabled = true;
-					updateCommentButton.label = UPDATE_COMMENT_LABEL;
-				}
-			});
-
-			this._toDispose.push(editBox.onDidChangeModelContent(_ => {
-				if (editBox.getValue()) {
-					updateCommentButton.enabled = true;
-				} else {
-					updateCommentButton.enabled = false;
-				}
-			}));
+			const error = dom.append(this._commentEditContainer, dom.$('.validation-error.hidden'));
+			const formActions = dom.append(this._commentEditContainer, dom.$('.form-actions'));
 
 			const cancelEditButton = new Button(formActions);
 			cancelEditButton.label = nls.localize('label.cancel', "Cancel");
 			attachButtonStyler(cancelEditButton, this.themeService);
 
-			cancelEditButton.onDidClick(_ => {
-				this._editAction.enabled = true;
-				this._body.classList.remove('hidden');
-				editingContainer.remove();
+			this._toDispose.push(cancelEditButton.onDidClick(_ => {
+				this.removeCommentEditor();
+			}));
 
-				model.dispose();
-				editBox.dispose();
-			});
+			const updateCommentButton = new Button(formActions);
+			updateCommentButton.label = UPDATE_COMMENT_LABEL;
+			attachButtonStyler(updateCommentButton, this.themeService);
+
+			this._toDispose.push(updateCommentButton.onDidClick(_ => {
+				updateCommentButton.enabled = false;
+				updateCommentButton.label = UPDATE_IN_PROGRESS_LABEL;
+
+				try {
+					this.commentService.editComment(this.owner, this.resource, this.comment, this._commentEditor.getValue()).then(editedComment => {
+						updateCommentButton.enabled = true;
+						updateCommentButton.label = UPDATE_COMMENT_LABEL;
+						this._commentEditor.getDomNode().style.outline = '';
+						this.removeCommentEditor();
+						this.update(editedComment);
+					});
+				} catch (e) {
+					updateCommentButton.enabled = true;
+					updateCommentButton.label = UPDATE_COMMENT_LABEL;
+
+					this._commentEditor.getDomNode().style.outline = `1px solid ${this.themeService.getTheme().getColor(inputValidationErrorBorder)}`;
+					error.textContent = nls.localize('commentCreationError', "Updating the comment failed: {0}.", e.message);
+					error.classList.remove('hidden');
+					this._commentEditor.focus();
+				}
+			}));
+
+			this._toDispose.push(this._commentEditor.onDidChangeModelContent(_ => {
+				updateCommentButton.enabled = !!this._commentEditor.getValue();
+			}));
 
 			this._editAction.enabled = false;
 			return null;
 		});
+	}
+
+	private registerActionBarListeners(actionsContainer: HTMLElement): void {
+		this._toDispose.push(dom.addDisposableListener(this._domNode, 'mouseenter', () => {
+			actionsContainer.classList.remove('hidden');
+		}));
+
+		this._toDispose.push(dom.addDisposableListener(this._domNode, 'focus', () => {
+			actionsContainer.classList.remove('hidden');
+		}));
+
+		this._toDispose.push(dom.addDisposableListener(this._domNode, 'mouseleave', (e: MouseEvent) => {
+			if (document.activeElement !== e.target) {
+				actionsContainer.classList.add('hidden');
+			}
+		}));
+
+		this._toDispose.push(dom.addDisposableListener(this._domNode, 'focusout', (e: FocusEvent) => {
+			if (!(<HTMLElement>e.target).contains((<HTMLElement>e.relatedTarget))) {
+				actionsContainer.classList.add('hidden');
+			}
+		}));
 	}
 
 	update(newComment: modes.Comment) {

--- a/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentNode.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as nls from 'vs/nls';
+import * as dom from 'vs/base/browser/dom';
+import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
+import { Button } from 'vs/base/browser/ui/button/button';
+import { Action } from 'vs/base/common/actions';
+import { Disposable } from 'vs/base/common/lifecycle';
+import * as modes from 'vs/editor/common/modes';
+import { attachButtonStyler } from 'vs/platform/theme/common/styler';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { URI } from 'vs/base/common/uri';
+import { ICommentService } from 'vs/workbench/parts/comments/electron-browser/commentService';
+import { MarkdownRenderer } from 'vs/editor/contrib/markdown/markdownRenderer';
+import { SimpleCommentEditor } from 'vs/workbench/parts/comments/electron-browser/simpleCommentEditor';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { IModeService } from 'vs/editor/common/services/modeService';
+
+const UPDATE_COMMENT_LABEL = nls.localize('label.updateComment', "Update comment");
+const UPDATE_IN_PROGRESS_LABEL = nls.localize('label.updatingComment', "Updating comment...");
+
+export class CommentNode extends Disposable {
+	private _domNode: HTMLElement;
+	private _body: HTMLElement;
+	private _md: HTMLElement;
+	private _clearTimeout: any;
+	private _editAction: Action;
+
+	public get domNode(): HTMLElement {
+		return this._domNode;
+	}
+
+	constructor(
+		public comment: modes.Comment,
+		private owner: number,
+		private resource: URI,
+		private markdownRenderer: MarkdownRenderer,
+		private themeService: IThemeService,
+		private instantiationService: IInstantiationService,
+		private commentService: ICommentService,
+		private modelService: IModelService,
+		private modeService: IModeService
+	) {
+		super();
+
+		this._domNode = dom.$('div.review-comment');
+		this._domNode.tabIndex = 0;
+		const avatar = dom.append(this._domNode, dom.$('div.avatar-container'));
+		const img = <HTMLImageElement>dom.append(avatar, dom.$('img.avatar'));
+		img.src = comment.gravatar;
+		const commentDetailsContainer = dom.append(this._domNode, dom.$('.review-comment-contents'));
+
+		const header = dom.append(commentDetailsContainer, dom.$('div.comment-title'));
+		const author = dom.append(header, dom.$('strong.author'));
+		author.innerText = comment.userName;
+
+		if (comment.canEdit) {
+			const actionsContainer = dom.append(header, dom.$('.comment-actions'));
+			const actionbarWidget = new ActionBar(actionsContainer, {});
+			this._toDispose.push(actionbarWidget);
+
+			this._editAction = this.createEditAction(commentDetailsContainer);
+
+			actionbarWidget.push(this._editAction, { label: false, icon: true });
+		}
+
+		this._body = dom.append(commentDetailsContainer, dom.$('div.comment-body'));
+		this._md = this.markdownRenderer.render(comment.body).element;
+		this._body.appendChild(this._md);
+
+		this._domNode.setAttribute('aria-label', `${comment.userName}, ${comment.body.value}`);
+		this._domNode.setAttribute('role', 'treeitem');
+		this._clearTimeout = null;
+	}
+
+	private createEditAction(commentDetailsContainer: HTMLElement): Action {
+		return new Action('comment.edit', nls.localize('label.edit', "Edit"), 'octicon octicon-pencil', true, () => {
+			this._body.classList.add('hidden');
+			const editingContainer = dom.append(commentDetailsContainer, dom.$('.edit-container'));
+			const editingBoxContainer = dom.append(editingContainer, dom.$('.edit-textarea'));
+			const editBox = this.instantiationService.createInstance(SimpleCommentEditor, editingBoxContainer, SimpleCommentEditor.getEditorOptions());
+			this._toDispose.push(editBox);
+			const resource = URI.parse(`comment:commentinput-kjalfksjdf.md`);
+			const model = this.modelService.createModel('', this.modeService.getOrCreateModeByFilenameOrFirstLine(resource.path), resource, true);
+			this._toDispose.push(model);
+			editBox.setModel(model);
+			editBox.setValue(this.comment.body.value);
+			editBox.layout();
+			editBox.focus();
+
+			const formActions = dom.append(editingContainer, dom.$('.form-actions'));
+			const updateCommentButton = new Button(formActions);
+			updateCommentButton.label = UPDATE_COMMENT_LABEL;
+			attachButtonStyler(updateCommentButton, this.themeService);
+
+			updateCommentButton.onDidClick(_ => {
+				updateCommentButton.enabled = false;
+				updateCommentButton.label = UPDATE_IN_PROGRESS_LABEL;
+
+				try {
+					this.commentService.editComment(this.owner, this.resource, this.comment, editBox.getValue()).then(editedComment => {
+						updateCommentButton.enabled = true;
+						updateCommentButton.label = UPDATE_COMMENT_LABEL;
+
+						this._editAction.enabled = true;
+						this._body.classList.remove('hidden');
+						editingContainer.remove();
+
+						model.dispose();
+						editBox.dispose();
+
+						this.update(editedComment);
+					});
+				} catch (e) {
+					// TODO Display error message
+					updateCommentButton.enabled = true;
+					updateCommentButton.label = UPDATE_COMMENT_LABEL;
+				}
+			});
+
+			this._toDispose.push(editBox.onDidChangeModelContent(_ => {
+				if (editBox.getValue()) {
+					updateCommentButton.enabled = true;
+				} else {
+					updateCommentButton.enabled = false;
+				}
+			}));
+
+			const cancelEditButton = new Button(formActions);
+			cancelEditButton.label = nls.localize('label.cancel', "Cancel");
+			attachButtonStyler(cancelEditButton, this.themeService);
+
+			cancelEditButton.onDidClick(_ => {
+				this._editAction.enabled = true;
+				this._body.classList.remove('hidden');
+				editingContainer.remove();
+
+				model.dispose();
+				editBox.dispose();
+			});
+
+			this._editAction.enabled = false;
+			return null;
+		});
+	}
+
+	update(newComment: modes.Comment) {
+		if (newComment.body !== this.comment.body) {
+			this._body.removeChild(this._md);
+			this._md = this.markdownRenderer.render(newComment.body).element;
+			this._body.appendChild(this._md);
+		}
+
+		this.comment = newComment;
+	}
+
+	focus() {
+		this.domNode.focus();
+		if (!this._clearTimeout) {
+			dom.addClass(this.domNode, 'focus');
+			this._clearTimeout = setTimeout(() => {
+				dom.removeClass(this.domNode, 'focus');
+			}, 3000);
+		}
+	}
+
+	dispose() {
+		this._toDispose.forEach(disposeable => disposeable.dispose());
+	}
+}

--- a/src/vs/workbench/parts/comments/electron-browser/commentService.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentService.ts
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { CommentThread, DocumentCommentProvider, CommentThreadChangedEvent, CommentInfo } from 'vs/editor/common/modes';
+import { CommentThread, DocumentCommentProvider, CommentThreadChangedEvent, CommentInfo, Comment } from 'vs/editor/common/modes';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event, Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -41,6 +41,7 @@ export interface ICommentService {
 	updateComments(event: CommentThreadChangedEvent): void;
 	createNewCommentThread(owner: number, resource: URI, range: Range, text: string): Promise<CommentThread>;
 	replyToCommentThread(owner: number, resource: URI, range: Range, thread: CommentThread, text: string): Promise<CommentThread>;
+	editComment(owner: number, resource: URI, comment: Comment, text: string): Promise<Comment>;
 	getComments(resource: URI): Promise<CommentInfo[]>;
 }
 
@@ -109,6 +110,16 @@ export class CommentService extends Disposable implements ICommentService {
 
 		if (commentProvider) {
 			return commentProvider.replyToCommentThread(resource, range, thread, text, CancellationToken.None);
+		}
+
+		return null;
+	}
+
+	editComment(owner: number, resource: URI, comment: Comment, text: string): Promise<Comment> {
+		const commentProvider = this._commentProviders.get(owner);
+
+		if (commentProvider) {
+			return commentProvider.editComment(resource, comment, text, CancellationToken.None);
 		}
 
 		return null;

--- a/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
@@ -592,12 +592,12 @@ export class ReviewZoneWidget extends ZoneWidget {
 
 		const errorBorder = theme.getColor(inputValidationErrorBorder);
 		if (errorBorder) {
-			content.push(`.monaco-editor .review-widget .body .comment-form .validation-error { border: 1px solid ${errorBorder}; }`);
+			content.push(`.monaco-editor .review-widget .validation-error { border: 1px solid ${errorBorder}; }`);
 		}
 
 		const errorBackground = theme.getColor(inputValidationErrorBackground);
 		if (errorBackground) {
-			content.push(`.monaco-editor .review-widget .body .comment-form .validation-error { background: ${errorBackground}; }`);
+			content.push(`.monaco-editor .review-widget .validation-error { background: ${errorBackground}; }`);
 		}
 
 		const errorForeground = theme.getColor(inputValidationErrorForeground);

--- a/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
@@ -37,64 +37,11 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { MarkdownRenderer } from 'vs/editor/contrib/markdown/markdownRenderer';
 import { IMarginData } from 'vs/editor/browser/controller/mouseTarget';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
+import { CommentNode } from 'vs/workbench/parts/comments/electron-browser/commentNode';
 
 export const COMMENTEDITOR_DECORATION_KEY = 'commenteditordecoration';
 const COLLAPSE_ACTION_CLASS = 'expand-review-action octicon octicon-x';
 const COMMENT_SCHEME = 'comment';
-
-export class CommentNode {
-	private _domNode: HTMLElement;
-	private _body: HTMLElement;
-	private _md: HTMLElement;
-	private _clearTimeout: any;
-
-	public get domNode(): HTMLElement {
-		return this._domNode;
-	}
-
-	constructor(
-		public comment: modes.Comment,
-		private markdownRenderer: MarkdownRenderer,
-	) {
-		this._domNode = dom.$('div.review-comment');
-		this._domNode.tabIndex = 0;
-		let avatar = dom.append(this._domNode, dom.$('div.avatar-container'));
-		let img = <HTMLImageElement>dom.append(avatar, dom.$('img.avatar'));
-		img.src = comment.gravatar;
-		let commentDetailsContainer = dom.append(this._domNode, dom.$('.review-comment-contents'));
-
-		let header = dom.append(commentDetailsContainer, dom.$('div'));
-		let author = dom.append(header, dom.$('strong.author'));
-		author.innerText = comment.userName;
-		this._body = dom.append(commentDetailsContainer, dom.$('div.comment-body'));
-		this._md = this.markdownRenderer.render(comment.body).element;
-		this._body.appendChild(this._md);
-
-		this._domNode.setAttribute('aria-label', `${comment.userName}, ${comment.body.value}`);
-		this._domNode.setAttribute('role', 'treeitem');
-		this._clearTimeout = null;
-	}
-
-	update(newComment: modes.Comment) {
-		if (newComment.body !== this.comment.body) {
-			this._body.removeChild(this._md);
-			this._md = this.markdownRenderer.render(newComment.body).element;
-			this._body.appendChild(this._md);
-		}
-
-		this.comment = newComment;
-	}
-
-	focus() {
-		this.domNode.focus();
-		if (!this._clearTimeout) {
-			dom.addClass(this.domNode, 'focus');
-			this._clearTimeout = setTimeout(() => {
-				dom.removeClass(this.domNode, 'focus');
-			}, 3000);
-		}
-	}
-}
 
 let INMEM_MODEL_ID = 0;
 
@@ -219,9 +166,9 @@ export class ReviewZoneWidget extends ZoneWidget {
 				this.dispose();
 				return null;
 			}
+
 			this._isCollapsed = true;
 			this.hide();
-
 			return null;
 		});
 
@@ -265,7 +212,19 @@ export class ReviewZoneWidget extends ZoneWidget {
 				lastCommentElement = oldCommentNode[0].domNode;
 				newCommentNodeList.unshift(oldCommentNode[0]);
 			} else {
-				let newElement = new CommentNode(currentComment, this._markdownRenderer);
+				let newElement = new CommentNode(
+					currentComment,
+					this.owner,
+					this.editor.getModel().uri,
+					this._markdownRenderer,
+					this.themeService,
+					this.instantiationService,
+					this.commentService,
+					this.modelService,
+					this.modeService);
+				// Does this makes sense to put here?
+				this._disposables.push(newElement);
+
 				newCommentNodeList.unshift(newElement);
 				if (lastCommentElement) {
 					this._commentsElement.insertBefore(newElement.domNode, lastCommentElement);
@@ -302,7 +261,16 @@ export class ReviewZoneWidget extends ZoneWidget {
 
 		this._commentElements = [];
 		for (let i = 0; i < this._commentThread.comments.length; i++) {
-			let newCommentNode = new CommentNode(this._commentThread.comments[i], this._markdownRenderer);
+			let newCommentNode = new CommentNode(this._commentThread.comments[i],
+				this.owner,
+				this.editor.getModel().uri,
+				this._markdownRenderer,
+				this.themeService,
+				this.instantiationService,
+				this.commentService,
+				this.modelService,
+				this.modeService);
+			this._disposables.push(newCommentNode);
 			this._commentElements.push(newCommentNode);
 			this._commentsElement.appendChild(newCommentNode.domNode);
 		}
@@ -592,18 +560,18 @@ export class ReviewZoneWidget extends ZoneWidget {
 		const content: string[] = [];
 		const linkColor = theme.getColor(textLinkForeground);
 		if (linkColor) {
-			content.push(`.monaco-editor .review-widget .body .review-comment a { color: ${linkColor} }`);
+			content.push(`.monaco-editor .review-widget .body .comment-body a { color: ${linkColor} }`);
 		}
 
 		const linkActiveColor = theme.getColor(textLinkActiveForeground);
 		if (linkActiveColor) {
-			content.push(`.monaco-editor .review-widget .body .review-comment a:hover, a:active { color: ${linkActiveColor} }`);
+			content.push(`.monaco-editor .review-widget .body .comment-body a:hover, a:active { color: ${linkActiveColor} }`);
 		}
 
 		const focusColor = theme.getColor(focusBorder);
 		if (focusColor) {
-			content.push(`.monaco-editor .review-widget .body .review-comment a:focus { outline: 1px solid ${focusColor}; }`);
-			content.push(`.monaco-editor .review-widget .body .comment-form .monaco-editor.focused { outline: 1px solid ${focusColor}; }`);
+			content.push(`.monaco-editor .review-widget .body .comment-body a:focus { outline: 1px solid ${focusColor}; }`);
+			content.push(`.monaco-editor .review-widget .body .monaco-editor.focused { outline: 1px solid ${focusColor}; }`);
 		}
 
 		const blockQuoteBackground = theme.getColor(textBlockQuoteBackground);
@@ -619,7 +587,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 		const hcBorder = theme.getColor(contrastBorder);
 		if (hcBorder) {
 			content.push(`.monaco-editor .review-widget .body .comment-form .review-thread-reply-button { outline-color: ${hcBorder}; }`);
-			content.push(`.monaco-editor .review-widget .body .comment-form .monaco-editor { outline: 1px solid ${hcBorder}; }`);
+			content.push(`.monaco-editor .review-widget .body .monaco-editor { outline: 1px solid ${hcBorder}; }`);
 		}
 
 		const errorBorder = theme.getColor(inputValidationErrorBorder);

--- a/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
@@ -222,7 +222,6 @@ export class ReviewZoneWidget extends ZoneWidget {
 					this.commentService,
 					this.modelService,
 					this.modeService);
-				// Does this makes sense to put here?
 				this._disposables.push(newElement);
 
 				newCommentNodeList.unshift(newElement);

--- a/src/vs/workbench/parts/comments/electron-browser/media/review.css
+++ b/src/vs/workbench/parts/comments/electron-browser/media/review.css
@@ -35,7 +35,28 @@
 	display: flex;
 }
 
-.monaco-editor .review-widget .body .review-comment blockquote {
+.monaco-editor .review-widget .body .review-comment .comment-actions {
+	margin-left: auto;
+}
+
+.monaco-editor .review-widget .body .review-comment .comment-actions .action-item {
+	width: 30px;
+}
+
+.monaco-editor .review-widget .body .review-comment .comment-title {
+	display: flex;
+	width: 100%;
+}
+
+.monaco-editor .review-widget .body .review-comment .comment-title .action-label.octicon {
+	line-height: 18px;
+}
+
+.monaco-editor .review-widget .body .comment-body.hidden {
+	display: none;
+}
+
+.monaco-editor .review-widget .body .comment-body blockquote {
 	margin: 0 7px 0 5px;
 	padding: 0 16px 0 10px;
 	border-left-width: 5px;
@@ -60,6 +81,7 @@
 .monaco-editor .review-widget .body .review-comment .review-comment-contents {
 	margin-left: 20px;
 	user-select: text;
+	width: 100%;
 }
 
 .monaco-editor .review-widget .body pre {
@@ -68,7 +90,7 @@
 	white-space: pre;
 }
 
-.monaco-editor.vs-dark .review-widget .body .review-comment .review-comment-contents h4 {
+.monaco-editor.vs-dark .review-widget .body .comment-body h4 {
 	margin: 0;
 }
 
@@ -85,39 +107,39 @@
 	color: #e0e0e0;
 }
 
-.monaco-editor .review-widget .body p,
-.monaco-editor .review-widget .body ul {
+.monaco-editor .review-widget .body .comment-body p,
+.monaco-editor .review-widget .body .comment-body ul {
 	margin: 8px 0;
 }
 
-.monaco-editor .review-widget .body p:first-child,
-.monaco-editor .review-widget .body ul:first-child {
+.monaco-editor .review-widget .body .comment-body p:first-child,
+.monaco-editor .review-widget .body .comment-body ul:first-child {
 	margin-top: 0;
 }
 
-.monaco-editor .review-widget .body p:last-child,
-.monaco-editor .review-widget .body ul:last-child {
+.monaco-editor .review-widget .body .comment-body p:last-child,
+.monaco-editor .review-widget .body.comment-body  ul:last-child {
 	margin-bottom: 0;
 }
 
-.monaco-editor .review-widget .body ul {
+.monaco-editor .review-widget .body .comment-body ul {
 	padding-left: 20px;
 }
 
-.monaco-editor .review-widget .body li>p {
+.monaco-editor .review-widget .body .comment-body li>p {
 	margin-bottom: 0;
 }
 
-.monaco-editor .review-widget .body li>ul {
+.monaco-editor .review-widget .body .comment-body li>ul {
 	margin-top: 0;
 }
 
-.monaco-editor .review-widget .body code {
+.monaco-editor .review-widget .body .comment-body code {
 	border-radius: 3px;
 	padding: 0 0.4em;
 }
 
-.monaco-editor .review-widget .body span {
+.monaco-editor .review-widget .body .comment-body span {
 	white-space: pre;
 }
 
@@ -184,8 +206,8 @@
 	outline-width: 1px;
 }
 
-.monaco-editor .review-widget .body .comment-form .monaco-editor {
-	display: none;
+.monaco-editor .review-widget .body .comment-form .monaco-editor,
+.monaco-editor .review-widget .body .edit-container .monaco-editor {
 	width: 100%;
 	min-height: 90px;
 	max-height: 500px;
@@ -194,15 +216,32 @@
 	padding: 6px 0 6px 12px;
 }
 
+.monaco-editor .review-widget .body .comment-form .monaco-editor,
 .monaco-editor .review-widget .body .comment-form .form-actions {
-	overflow: auto;
-	padding: 10px 0;
 	display: none;
 }
 
-.monaco-editor .review-widget .body .comment-form .monaco-text-button {
+.monaco-editor .review-widget .body .comment-form .form-actions,
+.monaco-editor .review-widget .body .edit-container .form-actions {
+	overflow: auto;
+	padding: 10px 0;
+}
+
+
+.monaco-editor .review-widget .body .edit-container {
+	margin-right: 28px;
+}
+
+.monaco-editor .review-widget .body .edit-textarea {
+	height: 90px;
+	margin-bottom: 10px;
+}
+
+.monaco-editor .review-widget .body .comment-form .monaco-text-button,
+.monaco-editor .review-widget .body .edit-container .monaco-text-button {
 	width: auto;
 	padding: 4px 10px;
+	margin-left: 5px;
 	float: right;
 }
 

--- a/src/vs/workbench/parts/comments/electron-browser/media/review.css
+++ b/src/vs/workbench/parts/comments/electron-browser/media/review.css
@@ -98,6 +98,7 @@
 .monaco-editor.vs-dark .review-widget .body .review-comment .review-comment-contents .author {
 	color: #fff;
 	font-weight: 600;
+	line-height: 19px;
 }
 
 .monaco-editor.vs-dark .review-widget .body .review-comment .review-comment-contents .comment-body {

--- a/src/vs/workbench/parts/comments/electron-browser/media/review.css
+++ b/src/vs/workbench/parts/comments/electron-browser/media/review.css
@@ -30,6 +30,10 @@
 	position: absolute;
 }
 
+.monaco-editor .review-widget .hidden {
+	display: none !important;
+}
+
 .monaco-editor .review-widget .body .review-comment {
 	padding: 8px 16px 8px 20px;
 	display: flex;
@@ -50,10 +54,6 @@
 
 .monaco-editor .review-widget .body .review-comment .comment-title .action-label.octicon {
 	line-height: 18px;
-}
-
-.monaco-editor .review-widget .body .comment-body.hidden {
-	display: none;
 }
 
 .monaco-editor .review-widget .body .comment-body blockquote {
@@ -79,9 +79,10 @@
 }
 
 .monaco-editor .review-widget .body .review-comment .review-comment-contents {
-	margin-left: 20px;
+	padding-left: 20px;
 	user-select: text;
 	width: 100%;
+	overflow: hidden;
 }
 
 .monaco-editor .review-widget .body pre {
@@ -152,7 +153,7 @@
 	padding: 8px 0;
 }
 
-.monaco-editor .review-widget .body .comment-form .validation-error {
+.monaco-editor .review-widget .validation-error {
 	display: inline-block;
 	overflow: hidden;
 	text-align: left;
@@ -169,10 +170,6 @@
 	margin-top: -1px;
 	margin-left: -1px;
 	word-wrap: break-word;
-}
-
-.monaco-editor .review-widget .body .comment-form .validation-error.hidden {
-	display: none;
 }
 
 .monaco-editor .review-widget .body .comment-form.expand .review-thread-reply-button {
@@ -213,6 +210,7 @@
 	max-height: 500px;
 	border-radius: 3px;
 	border: 0px;
+	box-sizing: content-box;
 	padding: 6px 0 6px 12px;
 }
 
@@ -227,14 +225,14 @@
 	padding: 10px 0;
 }
 
-
-.monaco-editor .review-widget .body .edit-container {
-	margin-right: 28px;
+.monaco-editor .review-widget .body .edit-container .form-actions {
+	display: flex;
+	justify-content: flex-end;
 }
 
 .monaco-editor .review-widget .body .edit-textarea {
 	height: 90px;
-	margin-bottom: 10px;
+	margin: 5px 0 10px 0;
 }
 
 .monaco-editor .review-widget .body .comment-form .monaco-text-button,
@@ -242,6 +240,9 @@
 	width: auto;
 	padding: 4px 10px;
 	margin-left: 5px;
+}
+
+.monaco-editor .review-widget .body .comment-form .monaco-text-button {
 	float: right;
 }
 


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/58078

![edit_comment](https://user-images.githubusercontent.com/3672607/45496605-b18b3580-b72a-11e8-8e3e-d621b57e595e.gif)

Adds an 'editComment' method to the `DocumentCommentProvider` and a `canEdit` to comments. Still needs a bit of UI cleanup, edit icon is pulled right on edit, need to display errors properly, considering showing edit icon only on hover