### PR TITLE
Fix #57910 - Make autofetch period customizable

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -991,6 +991,11 @@
             "usesOnlineServices"
           ]
         },
+        "git.autoFetchPeriod": {
+          "type": "number",
+          "default": 180,
+          "description": "%config.autoFetchPeriod%"
+        },
         "git.branchValidationRegex": {
           "type": "string",
           "description": "%config.branchValidationRegex%",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -104,6 +104,7 @@
 	"config.useForcePushWithLease": "Controls whether force pushing uses the safer force-with-lease variant.",
 	"config.confirmForcePush": "Controls whether to ask for confirmation before force-pushing.",
 	"colors.added": "Color for added resources.",
+	"config.autoFetchPeriod": "Controls the auto fetch period in seconds(if enabled).",
 	"colors.modified": "Color for modified resources.",
 	"colors.deleted": "Color for deleted resources.",
 	"colors.untracked": "Color for untracked resources.",

--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -19,11 +19,14 @@ function isRemoteOperation(operation: Operation): boolean {
 
 export class AutoFetcher {
 
-	private static readonly Period = 3 * 60 * 1000 /* three minutes */;
 	private static DidInformUser = 'autofetch.didInformUser';
 
 	private _onDidChange = new EventEmitter<boolean>();
 	private onDidChange = this._onDidChange.event;
+
+	private _autoFetchPeriod = workspace.getConfiguration('git').get<number>('autoFetchPeriod') as number;
+	get autoFetchPeriod(): number { return this._autoFetchPeriod; }
+	set autoFetchPeriod(autoFetchPeriod: number) { this._autoFetchPeriod = autoFetchPeriod; }
 
 	private _enabled: boolean = false;
 	get enabled(): boolean { return this._enabled; }
@@ -72,10 +75,15 @@ export class AutoFetcher {
 
 	private onConfiguration(): void {
 		const gitConfig = workspace.getConfiguration('git');
+		const Period = gitConfig.get<number>('autoFetchPeriod') as number;
 
 		if (gitConfig.get<boolean>('autofetch') === false) {
 			this.disable();
 		} else {
+			if (Period !== this.autoFetchPeriod) {
+				this.disable();
+				this.autoFetchPeriod = Period;
+			}
 			this.enable();
 		}
 	}
@@ -113,7 +121,12 @@ export class AutoFetcher {
 				return;
 			}
 
-			const timeout = new Promise(c => setTimeout(c, AutoFetcher.Period));
+			if (Math.max(0, this.autoFetchPeriod) === 0) {
+				const gitConfig = workspace.getConfiguration('git');
+				this.autoFetchPeriod = gitConfig.inspect('autoFetchPeriod')!.defaultValue as number;
+			}
+
+			const timeout = new Promise(c => setTimeout(c, this.autoFetchPeriod * 1000));
 			const whenDisabled = eventToPromise(filterEvent(this.onDidChange, enabled => !enabled));
 			await Promise.race([timeout, whenDisabled]);
 		}


### PR DESCRIPTION
@joaomoreno , Changed the code as per review comments to fix #57910 .

workspace.onDidChangeConfiguration event already existed and calls this.onConfiguration() when a configuration changes, so wrote the logic into the existing this.onConfiguration() function to handle the change in auto fetch period.
Please let me know if this is okay.
Thanks :)
