### PR TITLE
check only dot at the end of a branch

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1307,7 +1307,7 @@ export class CommandCenter {
 				return name;
 			}
 
-			return name.replace(/^\.|\/\.|\.\.|~|\^|:|\/$|\.lock$|\.lock\/|\\|\*|\s|^\s*$|\.|\[|\]$/g, branchWhitespaceChar);
+			return name.replace(/^\.|\/\.|\.\.|~|\^|:|\/$|\.lock$|\.lock\/|\\|\*|\s|^\s*$|\.$|\[|\]$/g, branchWhitespaceChar);
 		};
 
 		const result = await window.showInputBox({


### PR DESCRIPTION
Fixes: #58816

Branches can contain "." (dot) but not at the end or beginning.

> They cannot end with a dot

https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html