### PR TITLE
Avoid warning from URI.parse when url is file path

### DIFF
--- a/src/vs/workbench/parts/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/parts/stats/node/workspaceStats.ts
@@ -71,6 +71,8 @@ function extractDomain(url: string): string {
 		let match = url.match(SshProtocolMatcher);
 		if (match) {
 			return stripLowLevelDomains(match[2]);
+		} else {
+			return null;
 		}
 	}
 	try {


### PR DESCRIPTION
For git remote addresses that are paths and not uri, we were relying on the absence of `authority` in the output of `URI.parse` to determine that there is no remote to extract from the remote url in the git config.

With https://github.com/Microsoft/vscode/commit/ce15d8c355a2591bd6c2a850fca4df14cf0b05ab, we now print out a warning to the console, when `URI.parse` is given an invalid uri.

This PR is to avoid calling `URI.parse` when the remote address is not a url in the first place so as to fix #58516 
cc @kieferrm 