### PR TITLE
Add support for deleting comments

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1009,6 +1009,7 @@ export interface Comment {
 	readonly userName: string;
 	readonly gravatar: string;
 	readonly canEdit?: boolean;
+	readonly canDelete?: boolean;
 	readonly command?: Command;
 }
 
@@ -1041,6 +1042,7 @@ export interface DocumentCommentProvider {
 	createNewCommentThread(resource: URI, range: Range, text: string, token: CancellationToken): Promise<CommentThread>;
 	replyToCommentThread(resource: URI, range: Range, thread: CommentThread, text: string, token: CancellationToken): Promise<CommentThread>;
 	editComment(resource: URI, comment: Comment, text: string, token: CancellationToken): Promise<Comment>;
+	deleteComment(resource: URI, comment: Comment, token: CancellationToken): Promise<void>;
 	onDidChangeCommentThreads(): Event<CommentThreadChangedEvent>;
 }
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -685,6 +685,14 @@ declare module 'vscode' {
 		canEdit?: boolean;
 
 		/**
+		 * Whether the current user has permission to delete the comment.
+		 *
+		 * This will be treated as false if the comment is provided by a `WorkspaceCommentProvider`, or
+		 * if it is provided by a `DocumentCommentProvider` and  no `deleteComment` method is given.
+		 */
+		canDelete?: boolean;
+
+		/**
 		 * The command to be executed if the comment is selected in the Comments Panel
 		 */
 		command?: Command;
@@ -727,6 +735,11 @@ declare module 'vscode' {
 		 * Called when a user edits the comment body to the be new text text.
 		 */
 		editComment?(document: TextDocument, comment: Comment, text: string, token: CancellationToken): Promise<Comment>;
+
+		/**
+		 * Called when a user deletes the comment.
+		 */
+		deleteComment?(document: TextDocument, comment: Comment, token: CancellationToken): Promise<void>;
 
 		/**
 		 * Notify of updates to comment threads.

--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -80,6 +80,9 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 				},
 				editComment: async (uri, comment, text, token) => {
 					return this._proxy.$editComment(handle, uri, comment, text);
+				},
+				deleteComment: async (uri, comment, token) => {
+					return this._proxy.$deleteComment(handle, uri, comment);
 				}
 			}
 		);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -996,6 +996,7 @@ export interface ExtHostCommentsShape {
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Thenable<modes.CommentThread>;
 	$replyToCommentThread(handle: number, document: UriComponents, range: IRange, commentThread: modes.CommentThread, text: string): Thenable<modes.CommentThread>;
 	$editComment(handle: number, document: UriComponents, comment: modes.Comment, text: string): Thenable<modes.Comment>;
+	$deleteComment(handle: number, document: UriComponents, comment: modes.Comment): Thenable<void>;
 	$provideWorkspaceComments(handle: number): Thenable<modes.CommentThread[]>;
 }
 

--- a/src/vs/workbench/parts/comments/electron-browser/commentService.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentService.ts
@@ -5,6 +5,7 @@
 
 'use strict';
 
+import * as nls from 'vs/nls';
 import { CommentThread, DocumentCommentProvider, CommentThreadChangedEvent, CommentInfo, Comment } from 'vs/editor/common/modes';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -13,6 +14,7 @@ import { URI } from 'vs/base/common/uri';
 import { Range } from 'vs/editor/common/core/range';
 import { keys } from 'vs/base/common/map';
 import { CancellationToken } from 'vs/base/common/cancellation';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 export const ICommentService = createDecorator<ICommentService>('commentService');
 
@@ -42,6 +44,7 @@ export interface ICommentService {
 	createNewCommentThread(owner: number, resource: URI, range: Range, text: string): Promise<CommentThread>;
 	replyToCommentThread(owner: number, resource: URI, range: Range, thread: CommentThread, text: string): Promise<CommentThread>;
 	editComment(owner: number, resource: URI, comment: Comment, text: string): Promise<Comment>;
+	deleteComment(owner: number, resource: URI, comment: Comment): Promise<boolean>;
 	getComments(resource: URI): Promise<CommentInfo[]>;
 }
 
@@ -65,7 +68,7 @@ export class CommentService extends Disposable implements ICommentService {
 
 	private _commentProviders = new Map<number, DocumentCommentProvider>();
 
-	constructor() {
+	constructor(@INotificationService private notificationService: INotificationService) {
 		super();
 	}
 
@@ -123,6 +126,21 @@ export class CommentService extends Disposable implements ICommentService {
 		}
 
 		return null;
+	}
+
+	deleteComment(owner: number, resource: URI, comment: Comment): Promise<boolean> {
+		const commentProvider = this._commentProviders.get(owner);
+
+		if (commentProvider) {
+			try {
+				return commentProvider.deleteComment(resource, comment, CancellationToken.None).then(() => true);
+			} catch (e) {
+				this.notificationService.error(nls.localize('commentDeletionError', "Deleting the comment failed: {0}.", e.message));
+				return Promise.resolve(false);
+			}
+		}
+
+		return Promise.resolve(false);
 	}
 
 	getComments(resource: URI): Promise<CommentInfo[]> {

--- a/src/vs/workbench/parts/comments/electron-browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentsEditorContribution.ts
@@ -34,6 +34,7 @@ import { IModelDecorationOptions } from 'vs/editor/common/model';
 import { Color, RGBA } from 'vs/base/common/color';
 import { IMarginData } from 'vs/editor/browser/controller/mouseTarget';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 
 export const ctxReviewPanelVisible = new RawContextKey<boolean>('reviewPanelVisible', false);
 
@@ -184,7 +185,8 @@ export class ReviewController implements IEditorContribution {
 		@IModeService private modeService: IModeService,
 		@IModelService private modelService: IModelService,
 		@ICodeEditorService private codeEditorService: ICodeEditorService,
-		@IOpenerService private openerService: IOpenerService
+		@IOpenerService private openerService: IOpenerService,
+		@IDialogService private dialogService: IDialogService
 	) {
 		this.editor = editor;
 		this.globalToDispose = [];
@@ -356,7 +358,7 @@ export class ReviewController implements IEditorContribution {
 				}
 			});
 			added.forEach(thread => {
-				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.editor, e.owner, thread, {});
+				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.editor, e.owner, thread, {});
 				zoneWidget.display(thread.range.startLineNumber, this._commentingRangeDecorator.commentsOptions);
 				this._commentWidgets.push(zoneWidget);
 				this._commentInfos.filter(info => info.owner === e.owner)[0].threads.push(thread);
@@ -378,7 +380,7 @@ export class ReviewController implements IEditorContribution {
 		// add new comment
 		this._reviewPanelVisible.set(true);
 		const { replyCommand, ownerId } = newCommentInfo;
-		this._newCommentWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.editor, ownerId, {
+		this._newCommentWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.editor, ownerId, {
 			threadId: null,
 			resource: null,
 			comments: [],
@@ -505,7 +507,7 @@ export class ReviewController implements IEditorContribution {
 
 		this._commentInfos.forEach(info => {
 			info.threads.forEach(thread => {
-				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.editor, info.owner, thread, {});
+				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.editor, info.owner, thread, {});
 				zoneWidget.display(thread.range.startLineNumber, this._commentingRangeDecorator.commentsOptions);
 				this._commentWidgets.push(zoneWidget);
 			});

--- a/src/vs/workbench/parts/comments/electron-browser/media/review.css
+++ b/src/vs/workbench/parts/comments/electron-browser/media/review.css
@@ -44,7 +44,7 @@
 }
 
 .monaco-editor .review-widget .body .review-comment .comment-actions .action-item {
-	width: 30px;
+	width: 22px;
 }
 
 .monaco-editor .review-widget .body .review-comment .comment-title {


### PR DESCRIPTION
#58078

Adds support for deleting comments by exposing a `canDelete` flag on comments and `deleteComment` method on document comment providers.

![delete_comment](https://user-images.githubusercontent.com/3672607/45643757-a7da3880-ba70-11e8-9da9-61bee37c748e.gif)
