### PR TITLE
Keep options shown in quick input & add to git's "Create new branch"

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -97,6 +97,7 @@ class CreateBranchItem implements QuickPickItem {
 
 	get label(): string { return localize('create branch', '$(plus) Create new branch'); }
 	get description(): string { return ''; }
+	get alwaysShow(): boolean { return true; }
 
 	async run(repository: Repository): Promise<void> {
 		await this.cc.branch(repository);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import * as assert from 'assert';
-import { window, commands } from 'vscode';
+import { window, commands, QuickPickItem } from 'vscode';
 import { closeAllEditors } from '../utils';
 
 interface QuickPickExpected {
@@ -130,6 +130,34 @@ suite('window namespace tests', function () {
 			setTimeout(() => {
 				quickPick.selectedItems = [quickPick.items[2]];
 			}, 0);
+		});
+
+		test('createQuickPick, always show', function (_done) {
+			let done = (err?: any) => {
+				done = () => {};
+				_done(err);
+			};
+
+			const quickPick = createQuickPick({
+				events: ['active', 'selection', 'accept', 'hide'],
+				activeItems: [['shleem']],
+				selectionItems: [['shleem']],
+				acceptedItems: {
+					active: [['shleem']],
+					selection: [['shleem']],
+					dispose: [true]
+				},
+			}, (err?: any) => done(err));
+			let items : QuickPickItem[] = ['plumbus', 'pleeb', 'shleem', 'gazorpazorp'].map(label => ({ label }));
+			items[2].alwaysShow = true;
+			quickPick.items = items;
+			quickPick.value = "obscure query to show only shleem";
+			quickPick.show();
+
+			(async () => {
+				await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+			})()
+				.catch(err => done(err));
 		});
 	});
 });

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1581,6 +1581,11 @@ declare module 'vscode' {
 		 * @see [QuickPickOptions.canPickMany](#QuickPickOptions.canPickMany)
 		 */
 		picked?: boolean;
+
+		/**
+		 * Optional flag indicating if this item should stay shown, regardless of search.
+		 */
+		alwaysShow?: boolean;
 	}
 
 	/**
@@ -8135,7 +8140,7 @@ declare module 'vscode' {
 		 * in arbitrary order and the initial debug configuration is piped through the chain.
 		 * Returning the value 'undefined' prevents the debug session from starting.
 		 * Returning the value 'null' prevents the debug session from starting and opens the underlying debug configuration instead.
-		 * 
+		 *
 		 * @param folder The workspace folder from which the configuration originates from or undefined for a folderless setup.
 		 * @param debugConfiguration The [debug configuration](#DebugConfiguration) to resolve.
 		 * @param token A cancellation token.

--- a/src/vs/workbench/api/node/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/node/extHostQuickOpen.ts
@@ -69,6 +69,7 @@ export class ExtHostQuickOpen implements ExtHostQuickOpenShape {
 					let description: string;
 					let detail: string;
 					let picked: boolean;
+					let alwaysShow: boolean;
 
 					if (typeof item === 'string') {
 						label = item;
@@ -77,12 +78,14 @@ export class ExtHostQuickOpen implements ExtHostQuickOpenShape {
 						description = item.description;
 						detail = item.detail;
 						picked = item.picked;
+						alwaysShow = item.alwaysShow;
 					}
 					pickItems.push({
 						label,
 						description,
 						handle,
 						detail,
+						alwaysShow,
 						picked
 					});
 				}
@@ -494,6 +497,7 @@ class ExtHostQuickPick<T extends QuickPickItem> extends ExtHostQuickInput implem
 				label: item.label,
 				description: item.description,
 				handle: i,
+				alwaysShow: item.alwaysShow,
 				detail: item.detail,
 				picked: item.picked
 			}))

--- a/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
@@ -38,6 +38,7 @@ interface IListElement {
 	saneLabel: string;
 	saneDescription?: string;
 	saneDetail?: string;
+	alwaysShow?: boolean;
 	checked: boolean;
 	separator: IQuickPickSeparator;
 	fireButtonTriggered: (event: IQuickPickItemButtonEvent<IQuickPickItem>) => void;
@@ -49,6 +50,7 @@ class ListElement implements IListElement {
 	saneLabel: string;
 	saneDescription?: string;
 	saneDetail?: string;
+	alwaysShow?: boolean;
 	shouldAlwaysShow = false;
 	hidden = false;
 	private _onChecked = new Emitter<boolean>();
@@ -363,6 +365,7 @@ export class QuickInputList {
 					saneLabel: item.label && item.label.replace(/\r?\n/g, ' '),
 					saneDescription: item.description && item.description.replace(/\r?\n/g, ' '),
 					saneDetail: item.detail && item.detail.replace(/\r?\n/g, ' '),
+					alwaysShow: item.alwaysShow,
 					checked: false,
 					separator: previous && previous.type === 'separator' ? previous : undefined,
 					fireButtonTriggered


### PR DESCRIPTION
![ezgif-4-6b247526e5](https://user-images.githubusercontent.com/6546430/45718723-b9bdf780-bba6-11e8-9e67-70b004f23b1e.gif)

## Main Changes

* `QuickPick` now supports an item field which will specify whether it should be kept shown regardless of user input
* Added integration test for this functionality
* Added the above functionality to the git extension's _"Create new branch"_ option, so that it stays open when not finding any branches (and thus closes #58730)

## Notes
* I am not a long-time contributor so I may have made redundant additions, would appreciate a pretty strict CR
* It appears that `ListElement` contains a `shouldAlwaysShow` field, but is not really used for anything
* Possible enhancement to this would be to keep the input after accepting git's _"Create new branch_" option, to prevent retyping it