### PR TITLE
add powershell cli script

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -375,7 +375,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		if (platform === 'win32') {
 			result = es.merge(result, gulp.src('resources/win32/bin/code.js', { base: 'resources/win32', allowEmpty: true }));
 
-			result = es.merge(result, gulp.src('resources/win32/bin/code.cmd', { base: 'resources/win32' })
+			result = es.merge(result, gulp.src(['resources/win32/bin/code.cmd', 'resources/win32/bin/code.ps1'], { base: 'resources/win32' })
 				.pipe(replace('@@NAME@@', product.nameShort))
 				.pipe(rename(function (f) { f.basename = product.applicationName; })));
 

--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -75,6 +75,7 @@ Name: "addcontextmenufiles"; Description: "{cm:AddContextMenuFiles,{#NameShort}}
 Name: "addcontextmenufolders"; Description: "{cm:AddContextMenuFolders,{#NameShort}}"; GroupDescription: "{cm:Other}"; Flags: unchecked
 Name: "associatewithfiles"; Description: "{cm:AssociateWithFiles,{#NameShort}}"; GroupDescription: "{cm:Other}"; Flags: unchecked
 Name: "addtopath"; Description: "{cm:AddToPath}"; GroupDescription: "{cm:Other}"
+Name: "addpowershellalias"; Description: "{cm:AddPowerShellAlias}"; GroupDescription: "{cm:Other}"
 Name: "runcode"; Description: "{cm:RunAfter,{#NameShort}}"; GroupDescription: "{cm:Other}"; Check: WizardSilent
 
 [Files]
@@ -90,6 +91,14 @@ Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#NameLong}"; File
 [Run]
 Filename: "{app}\{#ExeBasename}.exe"; Description: "{cm:LaunchProgram,{#NameLong}}"; Tasks: runcode; Flags: nowait postinstall; Check: ShouldRunAfterUpdate
 Filename: "{app}\{#ExeBasename}.exe"; Description: "{cm:LaunchProgram,{#NameLong}}"; Flags: nowait postinstall; Check: WizardNotSilent
+#if "user" == InstallTarget
+#define PowerShellProfilePropName "CurrentUserAllHosts"
+#else
+#define PowerShellProfilePropName "AllUsersAllHosts"
+#endif
+#define ExeBasenameNoSpaces StringChange(ExeBasename, ' ', '')
+
+Filename: powershell.exe; Parameters: "if (!(Test-Path alias:code)) {{ New-Item -ItemType Directory -Force -Path (Split-Path $PROFILE.{#PowerShellProfilePropName}) | Out-Null; '','Set-Alias -Name code -Value ''{app}\bin\{#ExeBasenameNoSpaces}.ps1'' -Description ''{#NameLong}''' | Add-Content -Force -LiteralPath $profile.{#PowerShellProfilePropName} }"; Description: Updating PowerShell profile; Tasks: addpowershellalias; Flags: runascurrentuser
 
 [Registry]
 #if "user" == InstallTarget

--- a/build/win32/i18n/messages.en.isl
+++ b/build/win32/i18n/messages.en.isl
@@ -3,6 +3,7 @@ AddContextMenuFiles=Add "Open with %1" action to Windows Explorer file context m
 AddContextMenuFolders=Add "Open with %1" action to Windows Explorer directory context menu
 AssociateWithFiles=Register %1 as an editor for supported file types
 AddToPath=Add to PATH (requires shell restart)
+AddPowerShellAlias=Add alias to PowerShell profile
 RunAfter=Run %1 after installation
 Other=Other:
 SourceFile=%1 Source File

--- a/resources/win32/bin/code.ps1
+++ b/resources/win32/bin/code.ps1
@@ -1,0 +1,3 @@
+$env:VSCODE_DEV = ''
+$env:ELECTRON_RUN_AS_NODE = '1'
+& "$PSScriptRoot\..\@@NAME@@.exe" "$PSScriptRoot\..\resources\app\out\cli.js" @args | Write-Output


### PR DESCRIPTION
A PowerShell script for launching code is a good way to deal with this.  It can deal with launching from an unmapped network share. There are still a couple of challenges to deal with.

1. The script needs to cope with quoted arguments.  For example, a user might want to run `code "c:\folder with spaces in the name"`.
2. The script should show cli output produced by code and it should wait until that output is complete before returning control to the caller.  For example, a user might want to run `code --list-extensions`.

One way to build the script is to use Start-Process with the ArgumentList parameter.  This does not work well with quoted arguments.  Another way is to use the call operator (&).  This works well with quoted arguments, but does not wait for code.exe to complete before returning control to the OS.  This results in weird behavior when running a command like `code --list-extensions` which writes to stdout and exits.  We can deal with this by piping output from the call operator to `Write-Output` or `Write-Host`.  I don't know if this will correctly deal with data written to stderr.

Fixes #53764

Here's a gif of what happens when the cli script for launch code does not wait for code to exit before returning.

![code-bad-cli-handling](https://user-images.githubusercontent.com/1843336/45718198-3c749180-bb6a-11e8-9b53-beb8c62c9c3f.gif)
