### PR TITLE
Fix #58731 & add test & preserve input for "create new branch"

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import * as assert from 'assert';
-import { window, commands } from 'vscode';
+import { window, commands, QuickPickItem } from 'vscode';
 import { closeAllEditors } from '../utils';
 
 interface QuickPickExpected {
@@ -98,6 +98,31 @@ suite('window namespace tests', function () {
 				await commands.executeCommand('workbench.action.quickPickManyToggle');
 				await commands.executeCommand('workbench.action.quickOpenSelectNext');
 				await commands.executeCommand('workbench.action.quickPickManyToggle');
+				await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
+			})()
+				.catch(err => done(err));
+		});
+
+		test('createQuickPick, always show', function (_done) {
+			let done = (err?: any) => {
+				done = () => { };
+				_done(err);
+			};
+			const quickPick = createQuickPick({
+				events: ['active', 'selection', 'accept', 'hide'],
+				activeItems: [['shleem']],
+				selectionItems: [['shleem']],
+				acceptedItems: {
+					active: [['shleem']],
+					selection: [['shleem']]
+				},
+			}, (err?: any) => done(err));
+			let items: QuickPickItem[] = ['plumbus', 'pleeb', 'shleem', 'gazorpazorp'].map(label => ({ label }));
+			items[2].shouldAlwaysShow = true;
+			quickPick.items = items;
+			quickPick.value = "obscure query to show only shleem";
+			quickPick.show();
+			(async () => {
 				await commands.executeCommand('workbench.action.acceptSelectedQuickOpenItem');
 			})()
 				.catch(err => done(err));

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -17,6 +17,7 @@ export interface IQuickPickItem {
 	label: string;
 	description?: string;
 	detail?: string;
+	shouldAlwaysShow?: boolean;
 	iconClasses?: string[];
 	buttons?: IQuickInputButton[];
 	picked?: boolean;

--- a/src/vs/workbench/api/node/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/node/extHostQuickOpen.ts
@@ -499,6 +499,7 @@ class ExtHostQuickPick<T extends QuickPickItem> extends ExtHostQuickInput implem
 				label: item.label,
 				description: item.description,
 				handle: i,
+				shouldAlwaysShow: item.shouldAlwaysShow,
 				detail: item.detail,
 				picked: item.picked
 			}))

--- a/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
@@ -38,6 +38,7 @@ interface IListElement {
 	saneLabel: string;
 	saneDescription?: string;
 	saneDetail?: string;
+	shouldAlwaysShow?: boolean;
 	checked: boolean;
 	separator: IQuickPickSeparator;
 	fireButtonTriggered: (event: IQuickPickItemButtonEvent<IQuickPickItem>) => void;
@@ -49,7 +50,7 @@ class ListElement implements IListElement {
 	saneLabel: string;
 	saneDescription?: string;
 	saneDetail?: string;
-	shouldAlwaysShow = false;
+	shouldAlwaysShow?: boolean;
 	hidden = false;
 	private _onChecked = new Emitter<boolean>();
 	onChecked = this._onChecked.event;
@@ -369,6 +370,7 @@ export class QuickInputList {
 					saneLabel: item.label && item.label.replace(/\r?\n/g, ' '),
 					saneDescription: item.description && item.description.replace(/\r?\n/g, ' '),
 					saneDetail: item.detail && item.detail.replace(/\r?\n/g, ' '),
+					shouldAlwaysShow: item.shouldAlwaysShow,
 					checked: false,
 					separator: previous && previous.type === 'separator' ? previous : undefined,
 					fireButtonTriggered


### PR DESCRIPTION
After #58731, when explicitly setting items on a `QuickPick` (i.e. via the `createQuickPick()` API as opposed to `showQuickPick()` with the items as arguments), the `shouldAlwaysShow` field was not propagated.

This PR resolves this issue and adds a test.