### PR TITLE
Expose SourceControl on repositories in the git extension API

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -7,8 +7,8 @@
 
 import { Model } from '../model';
 import { Repository as BaseRepository, Resource } from '../repository';
-import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, Ref, Submodule, Commit, Change } from './git';
-import { Event, SourceControlInputBox, Uri } from 'vscode';
+import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, Ref, Submodule, Commit, Change, SourceControl } from './git';
+import { Event, SourceControlInputBox, Uri, SourceControl as CompleteSourceControl } from 'vscode';
 import { mapEvent } from '../util';
 
 class ApiInputBox implements InputBox {
@@ -39,11 +39,22 @@ export class ApiRepositoryState implements RepositoryState {
 	constructor(private _repository: BaseRepository) { }
 }
 
+export class ApiSourceControl implements SourceControl {
+	get id(): string { return this._sourceControl.id; }
+	get rootUri(): Uri | undefined { return this._sourceControl.rootUri; }
+	get selected(): boolean { return this._sourceControl.selected; }
+
+	readonly onDidChangeSelection = this._sourceControl.onDidChangeSelection;
+
+	constructor(private _sourceControl: CompleteSourceControl) { }
+}
+
 export class ApiRepository implements Repository {
 
 	readonly rootUri: Uri = Uri.file(this._repository.root);
 	readonly inputBox: InputBox = new ApiInputBox(this._repository.inputBox);
 	readonly state: RepositoryState = new ApiRepositoryState(this._repository);
+	readonly sourceControl: SourceControl = new ApiSourceControl(this._repository.sourceControl);
 
 	constructor(private _repository: BaseRepository) { }
 

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -13,6 +13,13 @@ export interface InputBox {
 	value: string;
 }
 
+export interface SourceControl {
+	readonly id: string;
+	readonly rootUri: Uri | undefined;
+	readonly selected: boolean;
+	readonly onDidChangeSelection: Event<boolean>;
+}
+
 export const enum RefType {
 	Head,
 	RemoteHead,
@@ -79,6 +86,7 @@ export interface Repository {
 	readonly rootUri: Uri;
 	readonly inputBox: InputBox;
 	readonly state: RepositoryState;
+	readonly sourceControl: SourceControl;
 
 	getConfigs(): Promise<{ key: string; value: string; }[]>;
 	getConfig(key: string): Promise<string>;


### PR DESCRIPTION
Exposes a `sourceControl` property to each repo that has selection info on it