### PR TITLE
Fix context menu re-trigger race

### DIFF
--- a/src/vs/base/parts/contextmenu/electron-browser/contextmenu.ts
+++ b/src/vs/base/parts/contextmenu/electron-browser/contextmenu.ts
@@ -8,16 +8,21 @@
 import { ipcRenderer, Event } from 'electron';
 import { IContextMenuItem, ISerializableContextMenuItem, CONTEXT_MENU_CLOSE_CHANNEL, CONTEXT_MENU_CHANNEL, IPopupOptions, IContextMenuEvent } from 'vs/base/parts/contextmenu/common/contextmenu';
 
-let onClickChannelIds = 0;
+let contextMenuIdPool = 0;
 
 export function popup(items: IContextMenuItem[], options?: IPopupOptions): void {
 	const processedItems: IContextMenuItem[] = [];
 
-	const onClickChannel = `vscode:onContextMenu${onClickChannelIds++}`;
-	const onClickChannelHandler = (event: Event, itemId: number, context: IContextMenuEvent) => processedItems[itemId].click(context);
+	const contextMenuId = contextMenuIdPool++;
+	const onClickChannel = `vscode:onContextMenu${contextMenuId}`;
+	const onClickChannelHandler = (_event: Event, itemId: number, context: IContextMenuEvent) => processedItems[itemId].click(context);
 
 	ipcRenderer.once(onClickChannel, onClickChannelHandler);
-	ipcRenderer.once(CONTEXT_MENU_CLOSE_CHANNEL, () => {
+	ipcRenderer.once(CONTEXT_MENU_CLOSE_CHANNEL, (_event: Event, closedContextMenuId: number) => {
+		if (closedContextMenuId !== contextMenuId) {
+			return;
+		}
+
 		ipcRenderer.removeListener(onClickChannel, onClickChannelHandler);
 
 		if (options && options.onHide) {
@@ -25,7 +30,7 @@ export function popup(items: IContextMenuItem[], options?: IPopupOptions): void 
 		}
 	});
 
-	ipcRenderer.send(CONTEXT_MENU_CHANNEL, items.map(item => createItem(item, processedItems)), onClickChannel, options);
+	ipcRenderer.send(CONTEXT_MENU_CHANNEL, contextMenuId, items.map(item => createItem(item, processedItems)), onClickChannel, options);
 }
 
 function createItem(item: IContextMenuItem, processedItems: IContextMenuItem[]): ISerializableContextMenuItem {

--- a/src/vs/base/parts/contextmenu/electron-main/contextmenu.ts
+++ b/src/vs/base/parts/contextmenu/electron-main/contextmenu.ts
@@ -9,7 +9,7 @@ import { Menu, MenuItem, BrowserWindow, Event, ipcMain } from 'electron';
 import { ISerializableContextMenuItem, CONTEXT_MENU_CLOSE_CHANNEL, CONTEXT_MENU_CHANNEL, IPopupOptions } from 'vs/base/parts/contextmenu/common/contextmenu';
 
 export function registerContextMenuListener(): void {
-	ipcMain.on(CONTEXT_MENU_CHANNEL, (event: Event, items: ISerializableContextMenuItem[], onClickChannel: string, options?: IPopupOptions) => {
+	ipcMain.on(CONTEXT_MENU_CHANNEL, (event: Event, contextMenuId: number, items: ISerializableContextMenuItem[], onClickChannel: string, options?: IPopupOptions) => {
 		const menu = createMenu(event, onClickChannel, items);
 
 		menu.popup({
@@ -18,7 +18,7 @@ export function registerContextMenuListener(): void {
 			y: options ? options.y : void 0,
 			positioningItem: options ? options.positioningItem : void 0,
 			callback: () => {
-				event.sender.send(CONTEXT_MENU_CLOSE_CHANNEL);
+				event.sender.send(CONTEXT_MENU_CLOSE_CHANNEL, contextMenuId);
 			}
 		});
 	});


### PR DESCRIPTION
Fixes #58711

When a context menu is triggered from inside another context menu, we have a race condition related to ipc. This is caused by the `close` event for context menus being global. In the retrigger case, `close` ends up being fired after the second context menu is created. This ends up removing the click handler for the new context menu along with the click handler for the one that was just closed

The fix is adding a menu id to the close event so that we only remove the click handler for the closed menu