### PR TITLE
Use detailed text for reload button in extension editor

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -369,7 +369,7 @@ export class ExtensionEditor extends BaseEditor {
 		const updateAction = this.instantiationService.createInstance(UpdateAction);
 		const enableAction = this.instantiationService.createInstance(EnableAction);
 		const disableAction = this.instantiationService.createInstance(DisableAction);
-		const reloadAction = this.instantiationService.createInstance(ReloadAction);
+		const reloadAction = this.instantiationService.createInstance(ReloadAction, false);
 
 		installAction.extension = extension;
 		maliciousStatusAction.extension = extension;

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -369,7 +369,7 @@ export class ExtensionEditor extends BaseEditor {
 		const updateAction = this.instantiationService.createInstance(UpdateAction);
 		const enableAction = this.instantiationService.createInstance(EnableAction);
 		const disableAction = this.instantiationService.createInstance(DisableAction);
-		const reloadAction = this.instantiationService.createInstance(ReloadAction, false);
+		const reloadAction = this.instantiationService.createInstance(ReloadAction, true);
 
 		installAction.extension = extension;
 		maliciousStatusAction.extension = extension;

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -960,7 +960,7 @@ export class ReloadAction extends Action {
 	private throttler: Throttler;
 
 	constructor(
-		private useShortLabel: boolean,
+		private useLongLabel: boolean,
 		@IExtensionsWorkbenchService private extensionsWorkbenchService: IExtensionsWorkbenchService,
 		@IWindowService private windowService: IWindowService,
 		@IExtensionService private extensionService: IExtensionService,
@@ -1044,10 +1044,10 @@ export class ReloadAction extends Action {
 	}
 
 	private setTooltip(text: string) {
-		if (this.useShortLabel) {
-			this.tooltip = text;
-		} else {
+		if (this.useLongLabel) {
 			this.label = text;
+		} else {
+			this.tooltip = text;
 		}
 	}
 	run(): TPromise<any> {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -1008,14 +1008,14 @@ export class ReloadAction extends Action {
 				if (isDifferentVersionRunning && !isDisabled) {
 					// Requires reload to run the updated extension
 					this.enabled = true;
-					this.setTooltip(localize('postUpdateTooltip', "Reload to update"));
+					this.setTooltip(localize('postUpdateTooltip', "Reload to Update"));
 					this.reloadMessage = localize('postUpdateMessage', "Reload this window to activate the updated extension '{0}'?", this.extension.displayName);
 					return;
 				}
 				if (isDisabled) {
 					// Requires reload to disable the extension
 					this.enabled = true;
-					this.setTooltip(localize('postDisableTooltip', "Reload to deactivate"));
+					this.setTooltip(localize('postDisableTooltip', "Reload to Deactivate"));
 					this.reloadMessage = localize('postDisableMessage', "Reload this window to deactivate the extension '{0}'?", this.extension.displayName);
 					return;
 				}
@@ -1026,7 +1026,7 @@ export class ReloadAction extends Action {
 				if (extensionServer && extensionServer.authority === localServer.authority && !isDisabled) {
 					// Requires reload to enable the extension
 					this.enabled = true;
-					this.setTooltip(localize('postEnableTooltip', "Reload to activate"));
+					this.setTooltip(localize('postEnableTooltip', "Reload to Activate"));
 					this.reloadMessage = localize('postEnableMessage', "Reload this window to activate the extension '{0}'?", this.extension.displayName);
 					return;
 				}
@@ -1037,7 +1037,7 @@ export class ReloadAction extends Action {
 		if (isUninstalled && runningExtension) {
 			// Requires reload to deactivate the extension
 			this.enabled = true;
-			this.setTooltip(localize('postUninstallTooltip', "Reload to deactivate"));
+			this.setTooltip(localize('postUninstallTooltip', "Reload to Deactivate"));
 			this.reloadMessage = localize('postUninstallMessage', "Reload this window to deactivate the uninstalled extension '{0}'?", this.extension.displayName);
 			return;
 		}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -960,6 +960,7 @@ export class ReloadAction extends Action {
 	private throttler: Throttler;
 
 	constructor(
+		private useShortLabel: boolean,
 		@IExtensionsWorkbenchService private extensionsWorkbenchService: IExtensionsWorkbenchService,
 		@IWindowService private windowService: IWindowService,
 		@IExtensionService private extensionService: IExtensionService,
@@ -1007,14 +1008,14 @@ export class ReloadAction extends Action {
 				if (isDifferentVersionRunning && !isDisabled) {
 					// Requires reload to run the updated extension
 					this.enabled = true;
-					this.tooltip = localize('postUpdateTooltip', "Reload to update");
+					this.setTooltip(localize('postUpdateTooltip', "Reload to update"));
 					this.reloadMessage = localize('postUpdateMessage', "Reload this window to activate the updated extension '{0}'?", this.extension.displayName);
 					return;
 				}
 				if (isDisabled) {
 					// Requires reload to disable the extension
 					this.enabled = true;
-					this.tooltip = localize('postDisableTooltip', "Reload to deactivate");
+					this.setTooltip(localize('postDisableTooltip', "Reload to deactivate"));
 					this.reloadMessage = localize('postDisableMessage', "Reload this window to deactivate the extension '{0}'?", this.extension.displayName);
 					return;
 				}
@@ -1025,7 +1026,7 @@ export class ReloadAction extends Action {
 				if (extensionServer && extensionServer.authority === localServer.authority && !isDisabled) {
 					// Requires reload to enable the extension
 					this.enabled = true;
-					this.tooltip = localize('postEnableTooltip', "Reload to activate");
+					this.setTooltip(localize('postEnableTooltip', "Reload to activate"));
 					this.reloadMessage = localize('postEnableMessage', "Reload this window to activate the extension '{0}'?", this.extension.displayName);
 					return;
 				}
@@ -1036,12 +1037,19 @@ export class ReloadAction extends Action {
 		if (isUninstalled && runningExtension) {
 			// Requires reload to deactivate the extension
 			this.enabled = true;
-			this.tooltip = localize('postUninstallTooltip', "Reload to deactivate");
+			this.setTooltip(localize('postUninstallTooltip', "Reload to deactivate"));
 			this.reloadMessage = localize('postUninstallMessage', "Reload this window to deactivate the uninstalled extension '{0}'?", this.extension.displayName);
 			return;
 		}
 	}
 
+	private setTooltip(text: string) {
+		if (this.useShortLabel) {
+			this.tooltip = text;
+		} else {
+			this.label = text;
+		}
+	}
 	run(): TPromise<any> {
 		return this.windowService.reloadWindow();
 	}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -102,7 +102,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const disabledStatusAction = this.instantiationService.createInstance(DisabledStatusLabelAction);
 		const installAction = this.instantiationService.createInstance(InstallAction);
 		const updateAction = this.instantiationService.createInstance(UpdateAction);
-		const reloadAction = this.instantiationService.createInstance(ReloadAction, true);
+		const reloadAction = this.instantiationService.createInstance(ReloadAction, false);
 		const manageAction = this.instantiationService.createInstance(ManageExtensionAction);
 
 		actionbar.push([updateAction, reloadAction, installAction, disabledStatusAction, maliciousStatusAction, manageAction], actionOptions);

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -102,7 +102,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const disabledStatusAction = this.instantiationService.createInstance(DisabledStatusLabelAction);
 		const installAction = this.instantiationService.createInstance(InstallAction);
 		const updateAction = this.instantiationService.createInstance(UpdateAction);
-		const reloadAction = this.instantiationService.createInstance(ReloadAction);
+		const reloadAction = this.instantiationService.createInstance(ReloadAction, true);
 		const manageAction = this.instantiationService.createInstance(ManageExtensionAction);
 
 		actionbar.push([updateAction, reloadAction, installAction, disabledStatusAction, maliciousStatusAction, manageAction], actionOptions);


### PR DESCRIPTION
This PR is to update the text on the Reload button in the extension editor to include hint on the reload is needed. This resolves the discussion in #56028