### PR TITLE
Tree and list onMiddleMouseClick

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -346,6 +346,7 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 
 	@memoize get onMouseClick(): Event<IListMouseEvent<T>> { return filterEvent(mapEvent(domEvent(this.domNode, 'click'), e => this.toMouseEvent(e)), e => e.index >= 0); }
 	@memoize get onMouseDblClick(): Event<IListMouseEvent<T>> { return filterEvent(mapEvent(domEvent(this.domNode, 'dblclick'), e => this.toMouseEvent(e)), e => e.index >= 0); }
+	@memoize get onMouseMiddleClick(): Event<IListMouseEvent<T>> { return filterEvent(mapEvent(domEvent(this.domNode, 'auxclick'), e => this.toMouseEvent(e)), e => e.index >= 0); }
 	@memoize get onMouseUp(): Event<IListMouseEvent<T>> { return filterEvent(mapEvent(domEvent(this.domNode, 'mouseup'), e => this.toMouseEvent(e)), e => e.index >= 0); }
 	@memoize get onMouseDown(): Event<IListMouseEvent<T>> { return filterEvent(mapEvent(domEvent(this.domNode, 'mousedown'), e => this.toMouseEvent(e)), e => e.index >= 0); }
 	@memoize get onMouseOver(): Event<IListMouseEvent<T>> { return filterEvent(mapEvent(domEvent(this.domNode, 'mouseover'), e => this.toMouseEvent(e)), e => e.index >= 0); }

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -875,6 +875,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 
 	get onMouseClick(): Event<IListMouseEvent<T>> { return this.view.onMouseClick; }
 	get onMouseDblClick(): Event<IListMouseEvent<T>> { return this.view.onMouseDblClick; }
+	get onMouseMiddleClick(): Event<IListMouseEvent<T>> { return this.view.onMouseMiddleClick; }
 	get onMouseUp(): Event<IListMouseEvent<T>> { return this.view.onMouseUp; }
 	get onMouseDown(): Event<IListMouseEvent<T>> { return this.view.onMouseDown; }
 	get onMouseOver(): Event<IListMouseEvent<T>> { return this.view.onMouseOver; }

--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -556,6 +556,11 @@ export interface IController {
 	onKeyUp(tree: ITree, event: Keyboard.IKeyboardEvent): boolean;
 
 	/**
+	 * Called when a mouse middle button is pressed down on an element.
+	 */
+	onMouseMiddleClick?(tree: ITree, element: any, event: Mouse.IMouseEvent): boolean;
+
+	/**
 	 * Called when a mouse button is pressed down on an element.
 	 */
 	onMouseDown?(tree: ITree, element: any, event: Mouse.IMouseEvent): boolean;

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -551,6 +551,7 @@ export class TreeView extends HeightMap {
 		this.viewListeners.push(DOM.addDisposableListener(this.domNode, 'keyup', (e) => this.onKeyUp(e)));
 		this.viewListeners.push(DOM.addDisposableListener(this.domNode, 'mousedown', (e) => this.onMouseDown(e)));
 		this.viewListeners.push(DOM.addDisposableListener(this.domNode, 'mouseup', (e) => this.onMouseUp(e)));
+		this.viewListeners.push(DOM.addDisposableListener(this.wrapper, 'auxclick', (e) => this.onMouseMiddleClick(e)));
 		this.viewListeners.push(DOM.addDisposableListener(this.wrapper, 'click', (e) => this.onClick(e)));
 		this.viewListeners.push(DOM.addDisposableListener(this.domNode, 'contextmenu', (e) => this.onContextMenu(e)));
 		this.viewListeners.push(DOM.addDisposableListener(this.wrapper, Touch.EventType.Tap, (e) => this.onTap(e)));
@@ -1210,6 +1211,20 @@ export class TreeView extends HeightMap {
 		this.lastClickTimeStamp = Date.now();
 
 		this.context.controller.onClick(this.context.tree, item.model.getElement(), event);
+	}
+
+	private onMouseMiddleClick(e: MouseEvent): void {
+		if (!this.context.controller.onMouseMiddleClick) {
+			return;
+		}
+
+		var event = new Mouse.StandardMouseEvent(e);
+		var item = this.getItemAround(event.target);
+
+		if (!item) {
+			return;
+		}
+		this.context.controller.onMouseMiddleClick(this.context.tree, item.model.getElement(), event);
 	}
 
 	private onMouseDown(e: MouseEvent): void {

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -500,8 +500,20 @@ export class FileController extends WorkbenchTreeController implements IDisposab
 					sideBySide = tree.useAltAsMultipleSelectionModifier ? (event.ctrlKey || event.metaKey) : event.altKey;
 				}
 
-				this.openEditor(stat, { preserveFocus, sideBySide, pinned: isDoubleClick || (event && event.middleButton) });
+				this.openEditor(stat, { preserveFocus, sideBySide, pinned: isDoubleClick });
 			}
+		}
+
+		return true;
+	}
+
+	public onMouseMiddleClick(tree: WorkbenchTree, element: ExplorerItem | Model, event: IMouseEvent): boolean {
+		let sideBySide = false;
+		if (event) {
+			sideBySide = tree.useAltAsMultipleSelectionModifier ? (event.ctrlKey || event.metaKey) : event.altKey;
+		}
+		if (element instanceof ExplorerItem && !element.isDirectory) {
+			this.openEditor(element, { preserveFocus: true, sideBySide, pinned: true });
 		}
 
 		return true;

--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -252,28 +252,27 @@ export class OpenEditorsView extends ViewletPanel {
 		});
 
 		// Open when selecting via keyboard
+		this.disposables.push(this.list.onMouseMiddleClick(e => {
+			if (e && e.element instanceof OpenEditor) {
+				e.element.group.closeEditor(e.element.editor);
+			}
+		}));
 		this.disposables.push(this.list.onOpen(e => {
 			const browserEvent = e.browserEvent;
 
 			let openToSide = false;
 			let isSingleClick = false;
 			let isDoubleClick = false;
-			let isMiddleClick = false;
 			if (browserEvent instanceof MouseEvent) {
 				isSingleClick = browserEvent.detail === 1;
 				isDoubleClick = browserEvent.detail === 2;
-				isMiddleClick = browserEvent.button === 1 /* middle button */;
 				openToSide = this.list.useAltAsMultipleSelectionModifier ? (browserEvent.ctrlKey || browserEvent.metaKey) : browserEvent.altKey;
 			}
 
 			const focused = this.list.getFocusedElements();
 			const element = focused.length ? focused[0] : undefined;
 			if (element instanceof OpenEditor) {
-				if (isMiddleClick) {
-					element.group.closeEditor(element.editor);
-				} else {
-					this.openEditor(element, { preserveFocus: isSingleClick, pinned: isDoubleClick, sideBySide: openToSide });
-				}
+				this.openEditor(element, { preserveFocus: isSingleClick, pinned: isDoubleClick, sideBySide: openToSide });
 			} else {
 				this.editorGroupService.activateGroup(element);
 			}


### PR DESCRIPTION
fixes #58442

This PR exposes onMouseMiddleClick events on the tree and list.
It also adopts this in the explroer and open editors view such that the behavior there is no longer broken.


Please note that there is still one wrong usage in quick open [here](https://github.com/Microsoft/vscode/blob/d6bce8751996470c0d7c05d1f1c084d4313f94e2/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts#L443)
However I was not sure how was that even working before so for now I made no changes there.

fyi @joaomoreno 