### PR TITLE
Return whether git.checkout succeeded

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1347,9 +1347,9 @@ export class CommandCenter {
 	}
 
 	@command('git.checkout', { repository: true })
-	async checkout(repository: Repository, treeish: string): Promise<void> {
+	async checkout(repository: Repository, treeish: string): Promise<boolean> {
 		if (typeof treeish === 'string') {
-			return await repository.checkout(treeish);
+			return await repository.checkout(treeish).then(_ => true);
 		}
 
 		const config = workspace.getConfiguration('git');
@@ -1373,10 +1373,10 @@ export class CommandCenter {
 		const choice = await window.showQuickPick(picks, { placeHolder });
 
 		if (!choice) {
-			throw new Error('Cancelled');
+			return false;
 		}
 
-		await choice.run(repository);
+		return choice.run(repository).then(_ => true);
 	}
 
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1948,10 +1948,6 @@ export class CommandCenter {
 			this.telemetryReporter.sendTelemetryEvent('git.command', { command: id });
 
 			return result.catch(async err => {
-				if (err.message === 'Cancelled') {
-					return;
-				}
-
 				const options: MessageOptions = {
 					modal: true
 				};


### PR DESCRIPTION
This would help fix https://github.com/Microsoft/vscode-pull-request-github/issues/346 - in an extension I want to be able to distinguish whether the checkout command ran to completion, or if the user quit while the quick picker was open