### PR TITLE
Handle Run Active when terminal executible is WSL

### DIFF
--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -501,6 +501,15 @@ export interface ITerminalInstance {
 	sendText(text: string, addNewLine: boolean): void;
 
 	/**
+	 * Takes a path and returns the properly escaped path to send to the terminal.
+	 * On Windows, this included trying to prepare the path for WSL if needed.
+	 *
+	 * @param path The path to be escaped and formatted.
+	 * @returns An escaped version of the path to be execuded in the terminal.
+	 */
+	preparePathForTerminalAsync(path: string): Promise<string>;
+
+	/**
 	 * Write text directly to the terminal, skipping the process if it exists.
 	 * @param text The text to write.
 	 */

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -657,21 +657,38 @@ export class RunActiveFileInTerminalAction extends Action {
 		}
 		let uriPath: string = uri.fsPath;
 		const hasSpace = uriPath.indexOf(' ') !== -1;
-		if (hasSpace && isWindows) {
-			uriPath = '"' + uriPath + '"';
-		} else if (!isWindows) {
-			if (uriPath.indexOf('\\') !== 0) {
-				uriPath = uriPath.replace(/\\/g, '\\\\');
+		if (isWindows) {
+			const exe = this.terminalService.getActiveInstance().shellLaunchConfig.executable;
+			const osVersion = (/(\d+)\.(\d+)\.(\d+)/g).exec(os.release());
+			let buildNumber: number = 0;
+			if (osVersion && osVersion.length === 4) {
+				buildNumber = parseInt(osVersion[3]);
 			}
-			const hasDoubleQuote = uriPath.indexOf('"') !== -1;
-			if (!hasSpace && hasDoubleQuote) {
-				uriPath = '\'' + uriPath + '\'';
+			// 17063 is the build number where wsl path was introduced.
+			// Update Windows uriPath to be executed in WSL.
+			if (((exe.indexOf('wsl') !== -1) || ((exe.indexOf('bash.exe') !== -1) && (exe.indexOf('git') === -1))) && (buildNumber >= 17063)) {
+				uriPath = 'runActive="$(wslpath ' + this._escapeNonWindowsPath(uriPath) + ')" && "${runActive}"';
 			} else if (hasSpace) {
-				uriPath = uriPath.replace(/ /g, '\\ ');
+				uriPath = '"' + uriPath + '"';
 			}
+		} else if (!isWindows) {
+			uriPath = this._escapeNonWindowsPath(uriPath);
 		}
 		instance.sendText(uriPath, true);
 		return this.terminalService.showPanel();
+	}
+
+	private _escapeNonWindowsPath(path: string): string {
+		let newPath = path;
+		if (newPath.indexOf('\\') !== 0) {
+			newPath = newPath.replace(/\\/g, '\\\\');
+		}
+		if (!newPath && (newPath.indexOf('"') !== -1)) {
+			newPath = '\'' + newPath + '\'';
+		} else if (newPath.indexOf(' ') !== -1) {
+			newPath = newPath.replace(/ /g, '\\ ');
+		}
+		return newPath;
 	}
 }
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -27,7 +27,6 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { PICK_WORKSPACE_FOLDER_COMMAND_ID } from 'vs/workbench/browser/actions/workspaceCommands';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { TERMINAL_COMMAND_ID } from 'vs/workbench/parts/terminal/common/terminalCommands';
-import { isWindows } from 'vs/base/common/platform';
 import { Command } from 'vs/editor/browser/editorExtensions';
 import { timeout } from 'vs/base/common/async';
 import { FindReplaceState } from 'vs/editor/contrib/find/findState';

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -221,14 +221,10 @@ export class TerminalService extends AbstractTerminalService implements ITermina
 		const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');
 		const system32Path = `${process.env['windir']}\\${is32ProcessOn64Windows ? 'Sysnative' : 'System32'}`;
 
-		const osVersion = (/(\d+)\.(\d+)\.(\d+)/g).exec(os.release());
 		let useWSLexe = false;
 
-		if (osVersion && osVersion.length === 4) {
-			const buildNumber = parseInt(osVersion[3]);
-			if (buildNumber >= 16299) {
-				useWSLexe = true;
-			}
+		if (TerminalInstance.getWindowsBuildNumber() >= 16299) {
+			useWSLexe = true;
 		}
 
 		const expectedLocations = {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalService.ts
@@ -6,7 +6,6 @@
 import * as nls from 'vs/nls';
 import * as pfs from 'vs/base/node/pfs';
 import * as platform from 'vs/base/common/platform';
-import * as os from 'os';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';


### PR DESCRIPTION
Note that this only works on Windows builds greater than 17063.
Fixes #36897 