### PR TITLE
Fix typos in workbench.editor.labelFormat

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -488,10 +488,10 @@ configurationRegistry.registerConfiguration({
 			'type': 'string',
 			'enum': ['default', 'short', 'medium', 'long'],
 			'enumDescriptions': [
-				nls.localize('workbench.editor.labelFormat.default', "Show the name of the file. When tabs are enabled and two files have the same name in one group the distinguinshing sections of each file's path are added. When tabs are disabled, the path relative to the workspace folder is shown if the editor is active."),
-				nls.localize('workbench.editor.labelFormat.short', "Show the name of the file followed by it's directory name."),
-				nls.localize('workbench.editor.labelFormat.medium', "Show the name of the file followed by it's path relative to the workspace folder."),
-				nls.localize('workbench.editor.labelFormat.long', "Show the name of the file followed by it's absolute path.")
+				nls.localize('workbench.editor.labelFormat.default', "Show the name of the file. When tabs are enabled and two files have the same name in one group the distinguishing sections of each file's path are added. When tabs are disabled, the path relative to the workspace folder is shown if the editor is active."),
+				nls.localize('workbench.editor.labelFormat.short', "Show the name of the file followed by its directory name."),
+				nls.localize('workbench.editor.labelFormat.medium', "Show the name of the file followed by its path relative to the workspace folder."),
+				nls.localize('workbench.editor.labelFormat.long', "Show the name of the file followed by its absolute path.")
 			],
 			'default': 'default',
 			'description': nls.localize({


### PR DESCRIPTION
Just removing a couple of characters that shouldn't be here. Note that the _distinguinshing_ error was reported in #35286 and supposed to be fixed by a03ede1 but actually was not. So, this fixes #35286, I guess?