### PR TITLE
Add display handling of files added by git add -N

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -327,6 +327,7 @@ export class CommandCenter {
 			case Status.MODIFIED:
 			case Status.UNTRACKED:
 			case Status.IGNORED:
+			case Status.INTENT_TO_ADD:
 				const repository = this.model.getRepository(resource.resourceUri);
 
 				if (!repository) {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -42,6 +42,7 @@ export const enum Status {
 	DELETED,
 	UNTRACKED,
 	IGNORED,
+	INTENT_TO_ADD,
 
 	ADDED_BY_US,
 	ADDED_BY_THEM,
@@ -117,6 +118,7 @@ export class Resource implements SourceControlResourceState {
 			case Status.INDEX_COPIED: return Resource.Icons[theme].Copied;
 			case Status.UNTRACKED: return Resource.Icons[theme].Untracked;
 			case Status.IGNORED: return Resource.Icons[theme].Ignored;
+			case Status.INTENT_TO_ADD: return Resource.Icons[theme].Added;
 			case Status.BOTH_DELETED: return Resource.Icons[theme].Conflict;
 			case Status.ADDED_BY_US: return Resource.Icons[theme].Conflict;
 			case Status.DELETED_BY_THEM: return Resource.Icons[theme].Conflict;
@@ -138,6 +140,7 @@ export class Resource implements SourceControlResourceState {
 			case Status.INDEX_COPIED: return localize('index copied', "Index Copied");
 			case Status.UNTRACKED: return localize('untracked', "Untracked");
 			case Status.IGNORED: return localize('ignored', "Ignored");
+			case Status.INTENT_TO_ADD: return localize('intent to add', "Intent to Add");
 			case Status.BOTH_DELETED: return localize('both deleted', "Both Deleted");
 			case Status.ADDED_BY_US: return localize('added by us', "Added By Us");
 			case Status.DELETED_BY_THEM: return localize('deleted by them', "Deleted By Them");
@@ -188,6 +191,7 @@ export class Resource implements SourceControlResourceState {
 			case Status.MODIFIED:
 				return 'M';
 			case Status.INDEX_ADDED:
+			case Status.INTENT_TO_ADD:
 				return 'A';
 			case Status.INDEX_DELETED:
 			case Status.DELETED:
@@ -221,6 +225,7 @@ export class Resource implements SourceControlResourceState {
 			case Status.DELETED:
 				return new ThemeColor('gitDecoration.deletedResourceForeground');
 			case Status.INDEX_ADDED:
+			case Status.INTENT_TO_ADD:
 				return new ThemeColor('gitDecoration.addedResourceForeground');
 			case Status.INDEX_RENAMED: // todo@joh - special color?
 			case Status.UNTRACKED:
@@ -1286,6 +1291,7 @@ export class Repository implements Disposable {
 			switch (raw.y) {
 				case 'M': workingTree.push(new Resource(ResourceGroupType.WorkingTree, uri, Status.MODIFIED, useIcons, renameUri)); break;
 				case 'D': workingTree.push(new Resource(ResourceGroupType.WorkingTree, uri, Status.DELETED, useIcons, renameUri)); break;
+				case 'A': workingTree.push(new Resource(ResourceGroupType.WorkingTree, uri, Status.INTENT_TO_ADD, useIcons, renameUri)); break;
 			}
 		});
 


### PR DESCRIPTION
Relates to #42665

Adds support for displaying files which were added by `git add -N`.

According to `man git-add`:
```
-N, --intent-to-add
           Record only the fact that the path will be added later. An entry for the path is placed in the
           index with no content. This is useful for, among other things, showing the unstaged content of
           such files with git diff and committing them with git commit -a.
```

As files in this state are only present in the working tree (and not the index or a part of any merge behavior), this change adds them to the `workingTree` section of the git UI (usually localized as "Changes").

Because there is no previous version of the file available, only a `right` entry in the editor is created when opened, just like files which have a status of `UNTRACKED`.

Before:
![before-intent-to-add](https://user-images.githubusercontent.com/6108845/45919914-fa8d6900-be51-11e8-988f-e85679b56d90.gif)

After:
![intent-to-add](https://user-images.githubusercontent.com/6108845/45919916-fcefc300-be51-11e8-931b-87a47826a813.gif)