### PR TITLE
Adding missed dependency libxss1

### DIFF
--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -1,7 +1,7 @@
 Package: @@NAME@@
 Version: @@VERSION@@
 Section: devel
-Depends: libnotify4, libnss3 (>= 2:3.26), gnupg, apt, libxkbfile1, libgconf-2-4, libsecret-1-0, libgtk-3-0 (>= 3.10.0)
+Depends: libnotify4, libnss3 (>= 2:3.26), gnupg, apt, libxkbfile1, libgconf-2-4, libsecret-1-0, libgtk-3-0 (>= 3.10.0), libxss1
 Priority: optional
 Architecture: @@ARCHITECTURE@@
 Maintainer: Microsoft Corporation <vscode-linux@microsoft.com>


### PR DESCRIPTION
In releasing for Chromebook I'm working on a minimal installation, so the base distribution has less packages pre-installed.

libxss1 is both a compile-time and run-time dependency, which would appear to have been missed (on my system it causes run-time errors if it's not present, due to the absence of libXss.so.1). I would expect this to cause the same issue on other minimal Debian installations.