### PR TITLE
Removal of oppressive terminology

### DIFF
--- a/src/vs/workbench/parts/stats/test/workspaceStats.test.ts
+++ b/src/vs/workbench/parts/stats/test/workspaceStats.test.ts
@@ -15,7 +15,7 @@ function hash(value: string): string {
 
 suite('Telemetry - WorkspaceStats', () => {
 
-	const whitelist = [
+	const acceptance_list = [
 		'github.com',
 		'github2.com',
 		'github3.com',
@@ -27,37 +27,37 @@ suite('Telemetry - WorkspaceStats', () => {
 	];
 
 	test('HTTPS remotes', function () {
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://github.com/Microsoft/vscode.git'), whitelist), ['github.com']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://git.example.com/gitproject.git'), whitelist), ['example.com']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://username@github2.com/username/repository.git'), whitelist), ['github2.com']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://username:password@github3.com/username/repository.git'), whitelist), ['github3.com']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://username:password@example2.com:1234/username/repository.git'), whitelist), ['example2.com']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://example3.com:1234/username/repository.git'), whitelist), ['example3.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://github.com/Microsoft/vscode.git'), acceptance_list), ['github.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://git.example.com/gitproject.git'), acceptance_list), ['example.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://username@github2.com/username/repository.git'), acceptance_list), ['github2.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://username:password@github3.com/username/repository.git'), acceptance_list), ['github3.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://username:password@example2.com:1234/username/repository.git'), acceptance_list), ['example2.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('https://example3.com:1234/username/repository.git'), acceptance_list), ['example3.com']);
 	});
 
 	test('SSH remotes', function () {
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('ssh://user@git.server.org/project.git'), whitelist), ['server.org']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('ssh://user@git.server.org/project.git'), acceptance_list), ['server.org']);
 	});
 
 	test('SCP-like remotes', function () {
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('git@github.com:Microsoft/vscode.git'), whitelist), ['github.com']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('user@git.server.org:project.git'), whitelist), ['server.org']);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('git.server2.org:project.git'), whitelist), ['server2.org']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('git@github.com:Microsoft/vscode.git'), acceptance_list), ['github.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('user@git.server.org:project.git'), acceptance_list), ['server.org']);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('git.server2.org:project.git'), acceptance_list), ['server2.org']);
 	});
 
 	test('Local remotes', function () {
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('/opt/git/project.git'), whitelist), []);
-		assert.deepStrictEqual(getDomainsOfRemotes(remote('file:///opt/git/project.git'), whitelist), []);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('/opt/git/project.git'), acceptance_list), []);
+		assert.deepStrictEqual(getDomainsOfRemotes(remote('file:///opt/git/project.git'), acceptance_list), []);
 	});
 
 	test('Multiple remotes', function () {
 		const config = ['https://github.com/Microsoft/vscode.git', 'https://git.example.com/gitproject.git'].map(remote).join('');
-		assert.deepStrictEqual(getDomainsOfRemotes(config, whitelist).sort(), ['example.com', 'github.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(config, acceptance_list).sort(), ['example.com', 'github.com']);
 	});
 
-	test('Whitelisting', function () {
+	test('acceptance_listing', function () {
 		const config = ['https://github.com/Microsoft/vscode.git', 'https://git.foobar.com/gitproject.git'].map(remote).join('');
-		assert.deepStrictEqual(getDomainsOfRemotes(config, whitelist).sort(), ['aaaaaa.aaa', 'github.com']);
+		assert.deepStrictEqual(getDomainsOfRemotes(config, acceptance_list).sort(), ['aaaaaa.aaa', 'github.com']);
 	});
 
 	test('HTTPS remotes to be hashed', function () {


### PR DESCRIPTION
Changed some instances of `whitelist` to `acceptance_list`. 

After python's recent master/slave changes, I feel like it's appropriate not only for Godot to follow suite, but other large projects like Visual Studio Code as well.

Thanks!