### PR TITLE
fix issue #41558 - keybindings editor header no longer selects first item 

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -566,10 +566,7 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 		if (!element) {
 			return;
 		}
-		if (element.templateId === KEYBINDING_HEADER_TEMPLATE_ID) {
-			this.keybindingsList.focusNext();
-			return;
-		}
+
 		if (element.templateId === KEYBINDING_ENTRY_TEMPLATE_ID) {
 			this.keybindingFocusContextKey.set(true);
 		}


### PR DESCRIPTION
I removed the behavior the issue #41558  called into question. As @sandy081 mentioned it requires two clicks of down arrow now to get to the first result after search. Should I try to force the down arrow to select first result another way?

 Can also look at sorting based on column instead if that's definitely wanted.