### PR TITLE
Settings: Fix shortcutkey label enabling translation. Fixes #59147

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -169,7 +169,7 @@ export class SettingsEditor2 extends BaseEditor {
 	}
 
 	private get currentSettingsContextMenuKeyBindingLabel() {
-		return this.keybindingService.lookupKeybinding(SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU).getLabel();
+		return this.keybindingService.lookupKeybinding(SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU).getAriaLabel();
 	}
 
 	createEditor(parent: HTMLElement): void {
@@ -274,8 +274,7 @@ export class SettingsEditor2 extends BaseEditor {
 		if (labelElement) {
 			const settingsContextMenuShortcut = this.currentSettingsContextMenuKeyBindingLabel;
 			if (settingsContextMenuShortcut) {
-				const settingsMoreActionsLabel = localize('settingsContextMenuAriaShortcut', "For more actions, Press ");
-				labelElement.setAttribute('aria-label', settingsMoreActionsLabel + settingsContextMenuShortcut);
+				labelElement.setAttribute('aria-label', localize('settingsContextMenuAriaShortcut', "For more actions, Press {0}.", settingsContextMenuShortcut));
 			}
 		}
 


### PR DESCRIPTION
- use getAriaLabel for shortcut key binding
- you single parameterized string for localized label

FYI
@roblourens 
@qcz 
