### PR TITLE
Add tabstops only to actions in focused list items

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -233,6 +233,7 @@ export interface IActionItemOptions extends IBaseActionItemOptions {
 	icon?: boolean;
 	label?: boolean;
 	keybinding?: string;
+	disableTabstops?: boolean;
 }
 
 export class ActionItem extends BaseActionItem {
@@ -330,7 +331,9 @@ export class ActionItem extends BaseActionItem {
 			this.label.removeAttribute('aria-disabled');
 			DOM.removeClass(this.element, 'disabled');
 			DOM.removeClass(this.label, 'disabled');
-			this.label.tabIndex = 0;
+			if (!this.options.disableTabstops) {
+				this.label.tabIndex = 0;
+			}
 		} else {
 			this.label.setAttribute('aria-disabled', 'true');
 			DOM.addClass(this.element, 'disabled');

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -398,10 +398,10 @@ export class DropDownMenuActionItem extends ActionItem {
 	get menuActionGroups(): IAction[][] { return this._menuActionGroups; }
 	set menuActionGroups(menuActionGroups: IAction[][]) { this._menuActionGroups = menuActionGroups; }
 
-	constructor(action: IAction, menuActionGroups: IAction[][],
+	constructor(action: IAction, menuActionGroups: IAction[][], disableTabstops: boolean,
 		@IContextMenuService private contextMenuService: IContextMenuService
 	) {
-		super(null, action, { icon: true, label: true });
+		super(null, action, { icon: true, label: true, disableTabstops });
 		this.menuActionGroups = menuActionGroups;
 	}
 
@@ -447,13 +447,14 @@ export class ManageExtensionAction extends Action {
 	set extension(extension: IExtension) { this._extension = extension; this.update(); }
 
 	constructor(
+		private disableTabstops: boolean = false,
 		@IExtensionsWorkbenchService private extensionsWorkbenchService: IExtensionsWorkbenchService,
 		@IInstantiationService private instantiationService: IInstantiationService
 	) {
 		super(ManageExtensionAction.ID);
 
 		this.tooltip = localize('manage', "Manage");
-		this._actionItem = this.instantiationService.createInstance(DropDownMenuActionItem, this, this.createMenuActionGroups());
+		this._actionItem = this.instantiationService.createInstance(DropDownMenuActionItem, this, this.createMenuActionGroups(), this.disableTabstops);
 		this.disposables.push(this._actionItem);
 
 		this.disposables.push(this.extensionsWorkbenchService.onChange(extension => {
@@ -615,7 +616,7 @@ export class EnableAction extends Action {
 			instantiationService.createInstance(EnableGloballyAction, EnableGloballyAction.LABEL),
 			instantiationService.createInstance(EnableForWorkspaceAction, EnableForWorkspaceAction.LABEL)
 		];
-		this._actionItem = this.instantiationService.createInstance(DropDownMenuActionItem, this, [this._enableActions]);
+		this._actionItem = this.instantiationService.createInstance(DropDownMenuActionItem, this, [this._enableActions], false);
 		this.disposables.push(this._actionItem);
 
 		this.disposables.push(this.extensionsWorkbenchService.onChange(extension => {
@@ -761,7 +762,7 @@ export class DisableAction extends Action {
 			instantiationService.createInstance(DisableGloballyAction, DisableGloballyAction.LABEL),
 			instantiationService.createInstance(DisableForWorkspaceAction, DisableForWorkspaceAction.LABEL)
 		];
-		this._actionItem = this.instantiationService.createInstance(DropDownMenuActionItem, this, [this._disableActions]);
+		this._actionItem = this.instantiationService.createInstance(DropDownMenuActionItem, this, [this._disableActions], false);
 		this.disposables.push(this._actionItem);
 
 		this.disposables.push(this.extensionsWorkbenchService.onChange(extension => {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -43,7 +43,7 @@ export class Delegate implements IVirtualDelegate<IExtension> {
 	getTemplateId() { return 'extension'; }
 }
 
-const actionOptions = { icon: true, label: true };
+const actionOptions = { icon: true, label: true, disableTabstops: true };
 
 export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
@@ -103,7 +103,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const installAction = this.instantiationService.createInstance(InstallAction);
 		const updateAction = this.instantiationService.createInstance(UpdateAction);
 		const reloadAction = this.instantiationService.createInstance(ReloadAction, false);
-		const manageAction = this.instantiationService.createInstance(ManageExtensionAction);
+		const manageAction = this.instantiationService.createInstance(ManageExtensionAction, true);
 
 		actionbar.push([updateAction, reloadAction, installAction, disabledStatusAction, maliciousStatusAction, manageAction], actionOptions);
 		const disposables = [versionWidget, installCountWidget, ratingsWidget, maliciousStatusAction, disabledStatusAction, updateAction, installAction, reloadAction, manageAction, actionbar, bookmarkStyler];


### PR DESCRIPTION
This PR attempts to fix the bug #51496

In other lists (Search results, staged/unstaged files in gitview), only the focused list item's actions are shown. Therefore this problem doesnt exist there.

In Extensions viewlet, the actions on all list items are enabled and visible. This PR ensures that these actions do not get the tab index until the corresponding list item gets focus.

This is done by resorting to work with the dom elements directly, because there is no way for the list item renderer to be notified of the focus event