### PR TITLE
Fixed warning when installing on debian 8

### DIFF
--- a/resources/linux/code-url-handler.desktop
+++ b/resources/linux/code-url-handler.desktop
@@ -9,5 +9,5 @@ NoDisplay=true
 StartupNotify=true
 StartupWMClass=@@NAME_SHORT@@
 Categories=Utility;TextEditor;Development;IDE;
-MimeType=x-scheme-handler/@@URLPROTOCOL@@
+MimeType=x-scheme-handler/@@URLPROTOCOL@@;
 Keywords=vscode;


### PR DESCRIPTION
Message in console:
>Setting up code-insiders (1.28.0-1537855491) ...
>/usr/share/applications/code-insiders-url-handler.desktop: warning: key "MimeType" is a list and does not have a semicolon as trailing character, fixing

Nothing fancy, just an annoying message in the console while updating code-insiders