### PR TITLE
Don't skip children with script source attached

### DIFF
--- a/src/vs/workbench/parts/debug/browser/loadedScriptsView.ts
+++ b/src/vs/workbench/parts/debug/browser/loadedScriptsView.ts
@@ -127,7 +127,7 @@ class BaseTreeItem {
 	// skips intermediate single-child nodes
 	getChildren(): TPromise<BaseTreeItem[]> {
 		const child = this.oneChild();
-		if (child) {
+		if (child && !child.hasSource()) {
 			return child.getChildren();
 		}
 		const array = Object.keys(this._children).map(key => this._children[key]);
@@ -185,6 +185,10 @@ class BaseTreeItem {
 			}
 		}
 		return undefined;
+	}
+
+	private hasSource(): boolean {
+		return this._source !== undefined;
 	}
 }
 


### PR DESCRIPTION
In the case where there's a directory which contains only one loaded
file, that file will be skipped over and no children will be returned.