### PR TITLE
Support odd indentation sizes (fixes #17639)

### DIFF
--- a/src/vs/editor/common/model/indentationGuesser.ts
+++ b/src/vs/editor/common/model/indentationGuesser.ts
@@ -112,8 +112,8 @@ export function guessIndentation(source: ITextBuffer, defaultTabSize: number, de
 	let previousLineText = '';						// content of latest line that contained non-whitespace chars
 	let previousLineIndentation = 0;				// index at which latest line contained the first non-whitespace char
 
-	const ALLOWED_TAB_SIZE_GUESSES = [2, 4, 6, 8];	// limit guesses for `tabSize` to 2, 4, 6 or 8.
-	const MAX_ALLOWED_TAB_SIZE_GUESS = 8;			// max(2,4,6,8) = 8
+	const ALLOWED_TAB_SIZE_GUESSES = [2, 4, 6, 8, 3, 5, 7];	// prefer even guesses for `tabSize`, limit to [2, 8].
+	const MAX_ALLOWED_TAB_SIZE_GUESS = 8;			// max(ALLOWED_TAB_SIZE_GUESSES) = 8
 
 	let spacesDiffCount = [0, 0, 0, 0, 0, 0, 0, 0, 0];		// `tabSize` scores
 	let tmp = new SpacesDiffResult();

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -315,7 +315,7 @@ suite('Editor Model - TextModel', () => {
 			'            ',
 			'              ',
 		], 'whitespace lines don\'t count');
-		assertGuess(true, 4, [
+		assertGuess(true, 3, [
 			'x',
 			'   x',
 			'   x',
@@ -328,8 +328,8 @@ suite('Editor Model - TextModel', () => {
 			'   x',
 			'   x',
 			'    x',
-		], 'odd number is not allowed: 6x3, 3x4');
-		assertGuess(true, 4, [
+		], '6x3, 3x4');
+		assertGuess(true, 5, [
 			'x',
 			'     x',
 			'     x',
@@ -342,8 +342,12 @@ suite('Editor Model - TextModel', () => {
 			'     x',
 			'     x',
 			'    x',
-		], 'odd number is not allowed: 6x5, 3x4');
-		assertGuess(true, 4, [
+		], '6x5, 3x4');
+		assertGuess(true, 7, [
+			'x',
+			'       x',
+			'       x',
+			'     x',
 			'x',
 			'       x',
 			'       x',
@@ -352,11 +356,7 @@ suite('Editor Model - TextModel', () => {
 			'       x',
 			'       x',
 			'    x',
-			'x',
-			'       x',
-			'       x',
-			'    x',
-		], 'odd number is not allowed: 6x7, 3x4');
+		], '6x7, 1x5, 2x4');
 		assertGuess(true, 2, [
 			'x',
 			'  x',
@@ -508,7 +508,7 @@ suite('Editor Model - TextModel', () => {
 			'        x',
 			'        x',
 		], '6x4, 2x5, 4x8');
-		assertGuess(true, undefined, [
+		assertGuess(true, 3, [
 			'x',
 			' x',
 			' x',


### PR DESCRIPTION
Adds support for 3, 5 and 7 space indentation. Given equal support, still prefers even numbered indentation.