### PR TITLE
Isidorn/debug start

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -183,8 +183,8 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 	public $startDebugging(_folderUri: uri | undefined, nameOrConfiguration: string | IConfig): Thenable<boolean> {
 		const folderUri = _folderUri ? uri.revive(_folderUri) : undefined;
 		const launch = this.debugService.getConfigurationManager().getLaunch(folderUri);
-		return this.debugService.startDebugging(launch, nameOrConfiguration).then(x => {
-			return true;
+		return this.debugService.startDebugging(launch, nameOrConfiguration).then(success => {
+			return success;
 		}, err => {
 			return TPromise.wrapError(new Error(err && err.message ? err.message : 'cannot start debugging'));
 		});

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -760,7 +760,7 @@ export interface IDebugService {
 	 * Also saves all files, manages if compounds are present in the configuration
 	 * and resolveds configurations via DebugConfigurationProviders.
 	 */
-	startDebugging(launch: ILaunch, configOrName?: IConfig | string, noDebug?: boolean): TPromise<void>;
+	startDebugging(launch: ILaunch, configOrName?: IConfig | string, noDebug?: boolean): TPromise<boolean>;
 
 	/**
 	 * Restarts a session or creates a new one if there is no active session.

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -759,6 +759,9 @@ export interface IDebugService {
 	 * Starts debugging. If the configOrName is not passed uses the selected configuration in the debug dropdown.
 	 * Also saves all files, manages if compounds are present in the configuration
 	 * and resolveds configurations via DebugConfigurationProviders.
+	 *
+	 * Returns true if the start debugging was successfull. For compound launches, all configurations have to start successfuly for it to return success.
+	 * On errors the startDebugging will throw an error, however some error and cancelations are handled and in that case will simply return false.
 	 */
 	startDebugging(launch: ILaunch, configOrName?: IConfig | string, noDebug?: boolean): TPromise<boolean>;
 

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -97,8 +97,8 @@ export class MockDebugService implements IDebugService {
 
 	public removeWatchExpressions(id?: string): void { }
 
-	public startDebugging(launch: ILaunch, configOrName?: IConfig | string, noDebug?: boolean): TPromise<any> {
-		return TPromise.as(null);
+	public startDebugging(launch: ILaunch, configOrName?: IConfig | string, noDebug?: boolean): TPromise<boolean> {
+		return TPromise.as(true);
 	}
 
 	public restartSession(): TPromise<any> {


### PR DESCRIPTION
fixes #54214
fixes #58822

This PR restructures the debugService.startDebugging such that:
* Compound configurations are no longer recursivly calling into `startDebugging`
* Initialization state is being enterted on the very start
* startDebugging now properly returns a boolean success. We can change this to an enum if in the future we need more fine grained result
* ExtHostDebugService adopts to this newest change
* some documentation update