### PR TITLE
node-pty@0.7.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "native-is-elevated": "^0.2.1",
     "native-keymap": "1.2.5",
     "native-watchdog": "1.0.0",
-    "node-pty": "0.7.7",
+    "node-pty": "0.7.8",
     "semver": "^5.5.0",
     "spdlog": "0.7.2",
     "sudo-prompt": "8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5148,9 +5148,9 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pty@0.7.7:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.7.tgz#919a9de7f0462ee72b260a6e4d5459d28fde2d25"
+node-pty@0.7.8:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.8.tgz#9ed2f01f84263acc96982876e734aa75490bf3d8"
   dependencies:
     nan "2.10.0"
 


### PR DESCRIPTION
Fixes #59334

---

This brings in the following release https://github.com/Microsoft/node-pty/releases/tag/0.7.8, it contains the fix for #59334, documentation and an update to an example project (not touched in vscode).