### PR TITLE
[StandaloneEditor] Initialize static field 'SCHEME'

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -493,7 +493,7 @@ export class SimpleWorkspaceContextService implements IWorkspaceContextService {
 
 	public _serviceBrand: any;
 
-	private static SCHEME: 'inmemory';
+	private static SCHEME = 'inmemory';
 
 	private readonly _onDidChangeWorkspaceName: Emitter<void> = new Emitter<void>();
 	public readonly onDidChangeWorkspaceName: Event<void> = this._onDidChangeWorkspaceName.event;


### PR DESCRIPTION
If you try to run the monaco-editor from source you get the error that the scheme of a Uri must not be empty. This is because the static field `SCHEME` is never initialized in `simpleServices`.