### PR TITLE
Removed duplicate "the" from documentation.

### DIFF
--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -24,5 +24,5 @@
 	"markdown.preview.toggleLock.title": "Toggle Preview Locking",
 	"configuration.markdown.preview.openMarkdownLinks.description": "How should clicking on links to markdown files be handled in the preview.",
 	"configuration.markdown.preview.openMarkdownLinks.inEditor": "Try to open links in the editor",
-	"configuration.markdown.preview.openMarkdownLinks.inPreview": "Try to open links in the the markdown preview"
+	"configuration.markdown.preview.openMarkdownLinks.inPreview": "Try to open links in the markdown preview"
 }

--- a/src/typings/node.d.ts
+++ b/src/typings/node.d.ts
@@ -7155,11 +7155,11 @@ declare module "perf_hooks" {
          * A PerformanceMeasure is a subclass of PerformanceEntry whose performanceEntry.entryType is always 'measure',
          * and whose performanceEntry.duration measures the number of milliseconds elapsed since startMark and endMark.
          *
-         * The startMark argument may identify any existing PerformanceMark in the the Performance Timeline, or may identify
+         * The startMark argument may identify any existing PerformanceMark in the Performance Timeline, or may identify
          * any of the timestamp properties provided by the PerformanceNodeTiming class. If the named startMark does not exist,
          * then startMark is set to timeOrigin by default.
          *
-         * The endMark argument must identify any existing PerformanceMark in the the Performance Timeline or any of the timestamp
+         * The endMark argument must identify any existing PerformanceMark in the Performance Timeline or any of the timestamp
          * properties provided by the PerformanceNodeTiming class. If the named endMark does not exist, an error will be thrown.
          * @param name
          * @param startMark

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3790,7 +3790,7 @@ declare module 'vscode' {
 			/**
 			 * This property is deprecated and not fully supported anymore by
 			 * the editor (scope and lineStart are ignored).
-			 * Use the the autoClosingPairs property in the language configuration file instead.
+			 * Use the autoClosingPairs property in the language configuration file instead.
 			 * @deprecated
 			 */
 			docComment?: {
@@ -3804,7 +3804,7 @@ declare module 'vscode' {
 		/**
 		 * **Deprecated** Do not use.
 		 *
-		 * @deprecated * Use the the autoClosingPairs property in the language configuration file instead.
+		 * @deprecated * Use the autoClosingPairs property in the language configuration file instead.
 		 */
 		__characterPairSupport?: {
 			autoClosingPairs: {

--- a/src/vs/workbench/api/electron-browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDocumentsAndEditors.ts
@@ -271,7 +271,7 @@ class MainThreadDocumentAndEditorStateComputer {
 		}
 
 		// active editor: if none of the previous editors had focus we try
-		// to match output panels or the the active workbench editor with
+		// to match output panels or the active workbench editor with
 		// one of editor we have just computed
 		if (!activeEditor) {
 			let candidate: IEditor;

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -357,7 +357,7 @@ export class BreadcrumbsControl {
 				return combinedDisposable([selectListener, focusListener, picker]);
 			},
 			getAnchor: () => {
-				let maxInnerWidth = window.innerWidth - 8 /*a little less the the full widget*/;
+				let maxInnerWidth = window.innerWidth - 8 /*a little less the full widget*/;
 				let maxHeight = Math.min(window.innerHeight * .7, 300);
 
 				let pickerWidth = Math.min(maxInnerWidth, Math.max(240, maxInnerWidth / 4.17));


### PR DESCRIPTION
There were a few instances of the word "the" being duplicated in the documentation, so I removed them.