### PR TITLE
Added actions from #57321 to the 'No Settings Found'-message

### DIFF
--- a/src/vs/workbench/parts/preferences/electron-browser/media/settingsEditor2.css
+++ b/src/vs/workbench/parts/preferences/electron-browser/media/settingsEditor2.css
@@ -121,6 +121,10 @@
 	box-sizing: border-box;
 }
 
+.settings-editor > .settings-body > .no-results a.prominent {
+	text-decoration: underline;
+}
+
 .settings-editor.no-toc-search > .settings-body .settings-tree-container .monaco-tree-wrapper,
 .settings-editor.narrow > .settings-body .settings-tree-container .monaco-tree-wrapper {
 	margin-left: 0px;

--- a/src/vs/workbench/parts/preferences/electron-browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/electron-browser/settingsEditor2.ts
@@ -47,7 +47,6 @@ import { CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW
 import { IPreferencesService, ISearchResult, ISettingsEditorModel, ISettingsEditorOptions, SettingsEditorOptions, SettingValueType } from 'vs/workbench/services/preferences/common/preferences';
 import { SettingsEditor2Input } from 'vs/workbench/services/preferences/common/preferencesEditorInput';
 import { Settings2EditorModel } from 'vs/workbench/services/preferences/common/preferencesModels';
-import { Disposable } from 'vscode';
 
 const $ = DOM.$;
 
@@ -117,8 +116,6 @@ export class SettingsEditor2 extends BaseEditor {
 
 	/** Don't spam warnings */
 	private hasWarnedMissingSettings: boolean;
-
-	private disposables: Disposable[] = [];
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -466,7 +463,7 @@ export class SettingsEditor2 extends BaseEditor {
 
 		this.clearFilterLinkContainer.textContent = ' - ';
 		const clearFilterLink = DOM.append(this.clearFilterLinkContainer, $('a.pointer.prominent', { tabindex: 0 }, localize('clearSearchFilters', 'Clear Filters')));
-		this.disposables.push(DOM.addDisposableListener(clearFilterLink, DOM.EventType.CLICK, (e: MouseEvent) => {
+		this._register(DOM.addDisposableListener(clearFilterLink, DOM.EventType.CLICK, (e: MouseEvent) => {
 			DOM.EventHelper.stop(e, false);
 			this.clearSearchFilters();
 		}));
@@ -477,7 +474,7 @@ export class SettingsEditor2 extends BaseEditor {
 		clearSearchContainer.textContent = ' - ';
 
 		const clearSearch = DOM.append(clearSearchContainer, $('a.pointer.prominent', { tabindex: 0 }, localize('clearSearch', 'Clear Search')));
-		this.disposables.push(DOM.addDisposableListener(clearSearch, DOM.EventType.CLICK, (e: MouseEvent) => {
+		this._register(DOM.addDisposableListener(clearSearch, DOM.EventType.CLICK, (e: MouseEvent) => {
 			DOM.EventHelper.stop(e, false);
 			this.clearSearchResults();
 		}));
@@ -799,11 +796,6 @@ export class SettingsEditor2 extends BaseEditor {
 			}
 		*/
 		this.telemetryService.publicLog('settingsEditor.settingModified2', data2);
-	}
-
-	dispose() {
-		this.disposables.forEach(disposable => disposable.dispose());
-		super.dispose();
 	}
 
 	private render(token: CancellationToken): TPromise<any> {

--- a/src/vs/workbench/parts/preferences/electron-browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/electron-browser/settingsEditor2.ts
@@ -1002,11 +1002,6 @@ export class SettingsEditor2 extends BaseEditor {
 			const parsedQuery = parseQuery(query);
 			query = parsedQuery.query;
 			parsedQuery.tags.forEach(tag => this.viewState.tagFilters.add(tag));
-
-			// show or hide 'Clear Filters'-link
-			this.clearFilterLinkContainer.style.display = this.viewState.tagFilters.size > 0
-				? 'initial'
-				: 'none';
 		}
 
 		if (query && query !== '@') {
@@ -1207,6 +1202,9 @@ export class SettingsEditor2 extends BaseEditor {
 
 			this.countElement.style.display = 'block';
 			this.noResultsMessage.style.display = count === 0 ? 'block' : 'none';
+			this.clearFilterLinkContainer.style.display = this.viewState.tagFilters.size > 0
+				? 'initial'
+				: 'none';
 		}
 	}
 


### PR DESCRIPTION
This PR contains a first suggestion for adding the two actions for clearing all filters and clearing the search to the 'No Settings Found'-message on the settings-search as described in #57321.

The first one is only shown, if there are actually any filters active. The second one is always shown.
I am not sure how to deal with the translations here, since I was not able to find similar, already translated texts I added new ones. If this is not the correct way, please help me here.

As I am new to the codebase I am also not sure, whether the approach with the disposables array is the right one. Is there any documentation about the life cycle of the editor parts available?