### PR TITLE
feat: enable mojave dark mode support

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -169,6 +169,7 @@ const config = {
 		name: product.nameLong,
 		urlSchemes: [product.urlProtocol]
 	}],
+	darwinForceDarkModeSupport: true,
 	darwinCredits: darwinCreditsTemplate ? Buffer.from(darwinCreditsTemplate({ commit: commit, date: new Date().toISOString() })) : void 0,
 	linuxExecutableName: product.applicationName,
 	winIcon: 'resources/win32/code.ico',


### PR DESCRIPTION
Electron is not built on the 10.14 SDK so we need to set a special `Info.plist` key to tell macOS we support dark mode.

Closes #59421 
Closes #59283 
Closes #54838 (maybe, the line looks a little different but I think it's how mojave dark mode windows look)

Blocked by: https://github.com/joaomoreno/gulp-atom-electron/pull/51