### PR TITLE
Add border for dirty tabs

### DIFF
--- a/extensions/theme-abyss/themes/abyss-color-theme.json
+++ b/extensions/theme-abyss/themes/abyss-color-theme.json
@@ -372,6 +372,7 @@
 		"tab.border": "#2b2b4a",
 		// "tab.activeBackground": "",
 		"tab.inactiveBackground": "#10192c",
+		"tab.modifiedBorder": "#0072bf",
 		// "tab.activeForeground": "",
 		// "tab.inactiveForeground": "",
 

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -22,6 +22,7 @@
 		"editorGroupHeader.tabsBackground": "#131510",
 		"editorLineNumber.activeForeground": "#adadad",
 		"tab.inactiveBackground": "#131510",
+		"tab.modifiedBorder": "#cd9731",
 		"titleBar.activeBackground": "#423523",
 		"statusBar.background": "#423523",
 		"statusBar.debuggingBackground": "#423523",

--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -23,6 +23,7 @@
 		"editorGroupHeader.tabsBackground": "#282828",
 		"tab.inactiveBackground": "#404040",
 		"tab.border": "#303030",
+		"tab.modifiedBorder": "#6796e6",
 		"tab.inactiveForeground": "#d8d8d8",
 		"peekView.border": "#3655b5",
 		"panelTitle.activeForeground": "#ffffff",

--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -35,6 +35,7 @@
 		"editorGroup.dropBackground": "#41433980",
 		"tab.inactiveBackground": "#34352f",
 		"tab.border": "#1e1f1c",
+		"tab.modifiedBorder": "#007acc",
 		"tab.inactiveForeground": "#ccccc7", // needs to be bright so it's readable when another editor group is focused
 		"widget.shadow": "#000000",
 		"progressBar.background": "#75715E",

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -497,6 +497,7 @@
 		"editor.lineHighlightBackground": "#E4F6D4",
 		"editorLineNumber.activeForeground": "#9769dc",
 		"editor.selectionBackground": "#C9D0D9",
+		"tab.modifiedBorder": "#f1897f",
 		"panel.background": "#F5F5F5",
 		"sideBar.background": "#F2F2F2",
 		"sideBarSectionHeader.background": "#ede8ef",

--- a/extensions/theme-red/themes/Red-color-theme.json
+++ b/extensions/theme-red/themes/Red-color-theme.json
@@ -5,6 +5,7 @@
 		"activityBar.background": "#580000",
 		"tab.inactiveBackground": "#300a0a",
 		"tab.activeBackground": "#490000",
+		"tab.modifiedBorder": "#db7e58",
 		"sideBar.background": "#330000",
 		"statusBar.background": "#700000",
 		"statusBar.noFolderBackground": "#700000",

--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -422,6 +422,7 @@
 		"tab.inactiveForeground": "#93A1A1",
 		"tab.inactiveBackground": "#004052",
 		"tab.border": "#003847",
+		"tab.modifiedBorder": "#268bd2",
 
 		// Workbench: Activity Bar
 		"activityBar.background": "#003847",

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -417,6 +417,7 @@
 		"tab.activeBackground": "#FDF6E3",
 		"tab.inactiveForeground": "#586E75",
 		"tab.inactiveBackground": "#D3CBB7",
+		"tab.modifiedBorder": "#cb4b16",
 		// "tab.activeBackground": "",
 		// "tab.activeForeground": "",
 		// "tab.inactiveForeground": "",

--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-theme.json
@@ -26,6 +26,7 @@
 		"editorGroup.dropBackground": "#25375daa",
 		"peekViewResult.background": "#001c40",
 		"tab.inactiveBackground": "#001c40",
+		"tab.modifiedBorder": "#FFEEAD",
 		"debugToolBar.background": "#001c40",
 		"titleBar.activeBackground": "#001126",
 		"statusBar.background": "#001126",

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -183,6 +183,7 @@ const configurationValueWhitelist = [
 	'workbench.editor.enablePreview',
 	'workbench.editor.enablePreviewFromQuickOpen',
 	'workbench.editor.showTabs',
+	'workbench.editor.highlightModifiedTabs',
 	'workbench.editor.swipeToNavigate',
 	'workbench.sideBar.location',
 	'workbench.startupEditor',

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -30,7 +30,7 @@ export interface IEditorPartOptions extends IWorkbenchEditorPartConfiguration {
 
 export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	showTabs: true,
-	dirtyTabBorder: false,
+	highlightModifiedTabs: false,
 	tabCloseButton: 'right',
 	tabSizing: 'fit',
 	showIcons: true,

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -30,6 +30,7 @@ export interface IEditorPartOptions extends IWorkbenchEditorPartConfiguration {
 
 export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	showTabs: true,
+	dirtyTabBorder: false,
 	tabCloseButton: 'right',
 	tabSizing: 'fit',
 	showIcons: true,

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -97,6 +97,7 @@
 	display: block;
 	position: absolute;
 	top: 0;
+	margin-top: -2px;
 	left: 0;
 	z-index: 6; /* over possible title border */
 	pointer-events: none;

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -39,7 +39,6 @@
 	height: 35px;
 	box-sizing: border-box;
 	padding-left: 10px;
-	border-top: 2px solid transparent;
 }
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.has-icon-theme.close-button-right,
@@ -97,13 +96,24 @@
 	display: block;
 	position: absolute;
 	top: 0;
-	margin-top: -2px;
 	left: 0;
 	z-index: 6; /* over possible title border */
 	pointer-events: none;
 	background-color: var(--tab-border-top-color);
 	width: 100%;
 	height: 1px;
+}
+
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border-top > .tab-border-top-container {
+	display: block;
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: 6; /* over possible title border */
+	pointer-events: none;
+	background-color: var(--tab-border-top-color);
+	width: 100%;
+	height: 2px;
 }
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-bottom > .tab-border-bottom-container {

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -92,40 +92,33 @@
 	display: none; /* hidden by default until a color is provided (see below) */
 }
 
-.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-top > .tab-border-top-container {
-	display: block;
-	position: absolute;
-	top: 0;
-	left: 0;
-	z-index: 6; /* over possible title border */
-	pointer-events: none;
-	background-color: var(--tab-border-top-color);
-	width: 100%;
-	height: 1px;
-}
-
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-top > .tab-border-top-container,
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-bottom > .tab-border-bottom-container,
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border-top > .tab-border-top-container {
 	display: block;
 	position: absolute;
-	top: 0;
 	left: 0;
 	z-index: 6; /* over possible title border */
 	pointer-events: none;
-	background-color: var(--tab-border-top-color);
 	width: 100%;
-	height: 2px;
+}
+
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-top > .tab-border-top-container {
+	top: 0;
+	height: 1px;
+	background-color: var(--tab-border-top-color);
 }
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.tab-border-bottom > .tab-border-bottom-container {
-	display: block;
-	position: absolute;
 	bottom: 0;
-	left: 0;
-	z-index: 6; /* over possible title border */
-	pointer-events: none;
-	background-color: var(--tab-border-bottom-color);
-	width: 100%;
 	height: 1px;
+	background-color: var(--tab-border-bottom-color);
+}
+
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border-top > .tab-border-top-container {
+	top: 0;
+	height: 2px;
+	background-color: var(--tab-dirty-border-top-color);
 }
 
 /* Tab Label */

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -39,6 +39,7 @@
 	height: 35px;
 	box-sizing: border-box;
 	padding-left: 10px;
+	border-top: 2px solid transparent;
 }
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.has-icon-theme.close-button-right,

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -27,7 +27,7 @@ import { ScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElemen
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { getOrSet } from 'vs/base/common/map';
 import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_DIRTY_ACTIVE_FOCUSED_BORDER, TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER, TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER, TAB_DIRTY_INACTIVE_FOCUSED_BORDER } from 'vs/workbench/common/theme';
+import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_FOCUSED_BORDER } from 'vs/workbench/common/theme';
 import { activeContrastBorder, contrastBorder, editorBackground, breadcrumbsBackground } from 'vs/platform/theme/common/colorRegistry';
 import { ResourcesDropHandler, fillResourceDataTransfers, DraggedEditorIdentifier, DraggedEditorGroupIdentifier, DragAndDropObserver } from 'vs/workbench/browser/dnd';
 import { Color } from 'vs/base/common/color';
@@ -1150,35 +1150,35 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
 	// Dirty tab borders
 	if (theme.type !== 'hc') {
-		const tabDirtyActiveFocusedBorder = theme.getColor(TAB_DIRTY_ACTIVE_FOCUSED_BORDER);
-		if (tabDirtyActiveFocusedBorder) {
+		const tabModifiedActiveFocusedBorder = theme.getColor(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER);
+		if (tabModifiedActiveFocusedBorder) {
 			collector.addRule(`
 				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active.dirty-border  {
-					box-shadow: ${tabDirtyActiveFocusedBorder} 0 2px inset !important;
+					box-shadow: ${tabModifiedActiveFocusedBorder} 0 2px inset !important;
 				}
 			`);
 		}
-		const tabDirtyActiveUnfocusedBorder = theme.getColor(TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER);
-		if (tabDirtyActiveUnfocusedBorder) {
+		const tabModifiedActiveUnfocusedBorder = theme.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
+		if (tabModifiedActiveUnfocusedBorder) {
 			collector.addRule(`
 				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.dirty-border  {
-					box-shadow: ${tabDirtyActiveUnfocusedBorder} 0 2px inset !important;
+					box-shadow: ${tabModifiedActiveUnfocusedBorder} 0 2px inset !important;
 				}
 			`);
 		}
-		const tabDirtyInactiveFocusedBorder = theme.getColor(TAB_DIRTY_INACTIVE_FOCUSED_BORDER);
-		if (tabDirtyInactiveFocusedBorder) {
+		const tabModifiedInactiveFocusedBorder = theme.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
+		if (tabModifiedInactiveFocusedBorder) {
 			collector.addRule(`
 				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty-border  {
-					box-shadow: ${tabDirtyInactiveFocusedBorder} 0 2px inset !important;
+					box-shadow: ${tabModifiedInactiveFocusedBorder} 0 2px inset !important;
 				}
 			`);
 		}
-		const tabDirtyInactiveUnfocusedBorder = theme.getColor(TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER);
-		if (tabDirtyInactiveUnfocusedBorder) {
+		const tabModifiedInactiveUnfocusedBorder = theme.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
+		if (tabModifiedInactiveUnfocusedBorder) {
 			collector.addRule(`
 				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border  {
-					box-shadow: ${tabDirtyInactiveUnfocusedBorder} 0 2px inset !important;
+					box-shadow: ${tabModifiedInactiveUnfocusedBorder} 0 2px inset !important;
 				}
 			`);
 		}

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -27,7 +27,7 @@ import { ScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElemen
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { getOrSet } from 'vs/base/common/map';
 import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_MODIFIED_BORDER, TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_FOCUSED_BORDER } from 'vs/workbench/common/theme';
+import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_ACTIVE_MODIFIED_BORDER, TAB_INACTIVE_MODIFIED_BORDER, TAB_UNFOCUSED_ACTIVE_MODIFIED_BORDER, TAB_UNFOCUSED_INACTIVE_MODIFIED_BORDER } from 'vs/workbench/common/theme';
 import { activeContrastBorder, contrastBorder, editorBackground, breadcrumbsBackground } from 'vs/platform/theme/common/colorRegistry';
 import { ResourcesDropHandler, fillResourceDataTransfers, DraggedEditorIdentifier, DraggedEditorGroupIdentifier, DragAndDropObserver } from 'vs/workbench/browser/dnd';
 import { Color } from 'vs/base/common/color';
@@ -917,22 +917,22 @@ export class TabsTitleControl extends TitleControl {
 				const isTabActive = this.group.isActive(editor);
 
 				if (isGroupActive && isTabActive) {
-					const tabModifiedBorder = this.getColor(TAB_MODIFIED_BORDER);
+					const tabModifiedBorder = this.getColor(TAB_ACTIVE_MODIFIED_BORDER);
 					if (tabModifiedBorder) {
 						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedBorder.toString());
 					}
 				} else if (isGroupActive && !isTabActive) {
-					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
+					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_INACTIVE_MODIFIED_BORDER);
 					if (tabModifiedInactiveFocusedBorder) {
 						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedInactiveFocusedBorder.toString());
 					}
 				} else if (!isGroupActive && isTabActive) {
-					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
+					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_UNFOCUSED_ACTIVE_MODIFIED_BORDER);
 					if (tabModifiedActiveUnfocusedBorder) {
 						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedActiveUnfocusedBorder.toString());
 					}
 				} else {
-					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
+					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_UNFOCUSED_INACTIVE_MODIFIED_BORDER);
 					if (tabModifiedInactiveUnfocusedBorder) {
 						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedInactiveUnfocusedBorder.toString());
 					}

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -877,7 +877,7 @@ export class TabsTitleControl extends TitleControl {
 				tabContainer.style.setProperty('--tab-border-bottom-color', activeTabBorderColorBottom.toString());
 			} else {
 				removeClass(tabContainer, 'tab-border-bottom');
-				// tabContainer.style.removeProperty('--tab-border-bottom-color');
+				tabContainer.style.removeProperty('--tab-border-bottom-color');
 			}
 
 			const activeTabBorderColorTop = this.getColor(isGroupActive ? TAB_ACTIVE_BORDER_TOP : TAB_UNFOCUSED_ACTIVE_BORDER_TOP);
@@ -886,7 +886,7 @@ export class TabsTitleControl extends TitleControl {
 				tabContainer.style.setProperty('--tab-border-top-color', activeTabBorderColorTop.toString());
 			} else {
 				removeClass(tabContainer, 'tab-border-top');
-				// tabContainer.style.removeProperty('--tab-border-top-color');
+				tabContainer.style.removeProperty('--tab-border-top-color');
 			}
 
 			// Label

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -27,7 +27,7 @@ import { ScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElemen
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { getOrSet } from 'vs/base/common/map';
 import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP } from 'vs/workbench/common/theme';
+import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_DIRTY_BORDER_TOP } from 'vs/workbench/common/theme';
 import { activeContrastBorder, contrastBorder, editorBackground, breadcrumbsBackground } from 'vs/platform/theme/common/colorRegistry';
 import { ResourcesDropHandler, fillResourceDataTransfers, DraggedEditorIdentifier, DraggedEditorGroupIdentifier, DragAndDropObserver } from 'vs/workbench/browser/dnd';
 import { Color } from 'vs/base/common/color';
@@ -1140,8 +1140,19 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
-	// Fade out styles via linear gradient (when tabs are set to shrink)
 	if (theme.type !== 'hc') {
+		// Dirty tab border
+		const dirtyTabBorderTop = theme.getColor(TAB_DIRTY_BORDER_TOP);
+		const activeTabBorderTop = theme.getColor(TAB_ACTIVE_BORDER_TOP);
+		if (dirtyTabBorderTop && !activeTabBorderTop) {// conflicts with active top border
+			collector.addRule(`
+				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty  {
+					box-shadow: ${dirtyTabBorderTop} 0 3px inset !important;
+				}
+			`);
+		}
+
+		// Fade out styles via linear gradient (when tabs are set to shrink)
 		const workbenchBackground = WORKBENCH_BACKGROUND(theme);
 		const editorBackgroundColor = theme.getColor(editorBackground);
 		const editorGroupHeaderTabsBackground = theme.getColor(EDITOR_GROUP_HEADER_TABS_BACKGROUND);

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -342,7 +342,9 @@ export class TabsTitleControl extends TitleControl {
 		// Activity has an impact on each tab
 		this.forEachTab((editor, index, tabContainer, tabLabelWidget, tabLabel) => {
 			this.redrawEditorActive(isGroupActive, editor, tabContainer, tabLabelWidget);
-			this.redrawEditorDirty(editor, tabContainer);
+			if (this.accessor.partOptions.highlightModifiedTabs) {
+				this.redrawEditorDirty(editor, tabContainer);
+			}
 		});
 
 		// Activity has an impact on the toolbar, so we need to update and layout
@@ -908,41 +910,43 @@ export class TabsTitleControl extends TitleControl {
 	}
 
 	private redrawEditorDirty(editor: IEditorInput, tabContainer: HTMLElement): void {
+
+		// Tab: dirty
 		if (editor.isDirty()) {
 			addClass(tabContainer, 'dirty');
 
-			if (this.accessor.partOptions.highlightModifiedTabs && !this.getColor(TAB_ACTIVE_BORDER_TOP)) {
-				addClass(tabContainer, 'dirty-border-top');
+			// Highlight modified tabs with a border if configured
+			if (this.accessor.partOptions.highlightModifiedTabs) {
 				const isGroupActive = this.accessor.activeGroup === this.group;
 				const isTabActive = this.group.isActive(editor);
 
+				let modifiedBorderColor: string;
 				if (isGroupActive && isTabActive) {
-					const tabModifiedBorder = this.getColor(TAB_ACTIVE_MODIFIED_BORDER);
-					if (tabModifiedBorder) {
-						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedBorder.toString());
-					}
+					modifiedBorderColor = this.getColor(TAB_ACTIVE_MODIFIED_BORDER);
 				} else if (isGroupActive && !isTabActive) {
-					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_INACTIVE_MODIFIED_BORDER);
-					if (tabModifiedInactiveFocusedBorder) {
-						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedInactiveFocusedBorder.toString());
-					}
+					modifiedBorderColor = this.getColor(TAB_INACTIVE_MODIFIED_BORDER);
 				} else if (!isGroupActive && isTabActive) {
-					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_UNFOCUSED_ACTIVE_MODIFIED_BORDER);
-					if (tabModifiedActiveUnfocusedBorder) {
-						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedActiveUnfocusedBorder.toString());
-					}
+					modifiedBorderColor = this.getColor(TAB_UNFOCUSED_ACTIVE_MODIFIED_BORDER);
 				} else {
-					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_UNFOCUSED_INACTIVE_MODIFIED_BORDER);
-					if (tabModifiedInactiveUnfocusedBorder) {
-						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedInactiveUnfocusedBorder.toString());
-					}
+					modifiedBorderColor = this.getColor(TAB_UNFOCUSED_INACTIVE_MODIFIED_BORDER);
+				}
+
+				if (modifiedBorderColor) {
+					addClass(tabContainer, 'dirty-border-top');
+					tabContainer.style.setProperty('--tab-dirty-border-top-color', modifiedBorderColor);
 				}
 			} else {
 				removeClass(tabContainer, 'dirty-border-top');
+				tabContainer.style.removeProperty('--tab-dirty-border-top-color');
 			}
-		} else {
+		}
+
+		// Tab: not dirty
+		else {
 			removeClass(tabContainer, 'dirty');
+
 			removeClass(tabContainer, 'dirty-border-top');
+			tabContainer.style.removeProperty('--tab-dirty-border-top-color');
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -27,7 +27,7 @@ import { ScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElemen
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { getOrSet } from 'vs/base/common/map';
 import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_FOCUSED_BORDER } from 'vs/workbench/common/theme';
+import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_MODIFIED_BORDER, TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER, TAB_MODIFIED_INACTIVE_FOCUSED_BORDER } from 'vs/workbench/common/theme';
 import { activeContrastBorder, contrastBorder, editorBackground, breadcrumbsBackground } from 'vs/platform/theme/common/colorRegistry';
 import { ResourcesDropHandler, fillResourceDataTransfers, DraggedEditorIdentifier, DraggedEditorGroupIdentifier, DragAndDropObserver } from 'vs/workbench/browser/dnd';
 import { Color } from 'vs/base/common/color';
@@ -1150,7 +1150,7 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 
 	// Dirty tab borders
 	if (theme.type !== 'hc') {
-		const tabModifiedActiveFocusedBorder = theme.getColor(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER);
+		const tabModifiedActiveFocusedBorder = theme.getColor(TAB_MODIFIED_BORDER);
 		if (tabModifiedActiveFocusedBorder) {
 			collector.addRule(`
 				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active.dirty-border  {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -27,7 +27,7 @@ import { ScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElemen
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { getOrSet } from 'vs/base/common/map';
 import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
-import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_DIRTY_BORDER_TOP } from 'vs/workbench/common/theme';
+import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER, TAB_HOVER_BACKGROUND, TAB_HOVER_BORDER, TAB_UNFOCUSED_HOVER_BACKGROUND, TAB_UNFOCUSED_HOVER_BORDER, EDITOR_GROUP_HEADER_TABS_BACKGROUND, WORKBENCH_BACKGROUND, TAB_ACTIVE_BORDER_TOP, TAB_UNFOCUSED_ACTIVE_BORDER_TOP, TAB_DIRTY_ACTIVE_FOCUSED_BORDER, TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER, TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER, TAB_DIRTY_INACTIVE_FOCUSED_BORDER } from 'vs/workbench/common/theme';
 import { activeContrastBorder, contrastBorder, editorBackground, breadcrumbsBackground } from 'vs/platform/theme/common/colorRegistry';
 import { ResourcesDropHandler, fillResourceDataTransfers, DraggedEditorIdentifier, DraggedEditorGroupIdentifier, DragAndDropObserver } from 'vs/workbench/browser/dnd';
 import { Color } from 'vs/base/common/color';
@@ -908,8 +908,15 @@ export class TabsTitleControl extends TitleControl {
 	private redrawEditorDirty(editor: IEditorInput, tabContainer: HTMLElement): void {
 		if (editor.isDirty()) {
 			addClass(tabContainer, 'dirty');
+
+			if (this.accessor.partOptions.dirtyTabBorder && !this.getColor(TAB_ACTIVE_BORDER_TOP)) {
+				addClass(tabContainer, 'dirty-border');
+			} else {
+				removeClass(tabContainer, 'dirty-border');
+			}
 		} else {
 			removeClass(tabContainer, 'dirty');
+			removeClass(tabContainer, 'dirty-border');
 		}
 	}
 
@@ -1140,19 +1147,44 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 		`);
 	}
 
+	// Dirty tab borders
 	if (theme.type !== 'hc') {
-		// Dirty tab border
-		const dirtyTabBorderTop = theme.getColor(TAB_DIRTY_BORDER_TOP);
-		const activeTabBorderTop = theme.getColor(TAB_ACTIVE_BORDER_TOP);
-		if (dirtyTabBorderTop && !activeTabBorderTop) {// conflicts with active top border
+		const tabDirtyActiveFocusedBorder = theme.getColor(TAB_DIRTY_ACTIVE_FOCUSED_BORDER);
+		if (tabDirtyActiveFocusedBorder) {
 			collector.addRule(`
-				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty  {
-					box-shadow: ${dirtyTabBorderTop} 0 3px inset !important;
+				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active.dirty-border  {
+					box-shadow: ${tabDirtyActiveFocusedBorder} 0 2px inset !important;
 				}
 			`);
 		}
+		const tabDirtyActiveUnfocusedBorder = theme.getColor(TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER);
+		if (tabDirtyActiveUnfocusedBorder) {
+			collector.addRule(`
+				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.dirty-border  {
+					box-shadow: ${tabDirtyActiveUnfocusedBorder} 0 2px inset !important;
+				}
+			`);
+		}
+		const tabDirtyInactiveFocusedBorder = theme.getColor(TAB_DIRTY_INACTIVE_FOCUSED_BORDER);
+		if (tabDirtyInactiveFocusedBorder) {
+			collector.addRule(`
+				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty-border  {
+					box-shadow: ${tabDirtyInactiveFocusedBorder} 0 2px inset !important;
+				}
+			`);
+		}
+		const tabDirtyInactiveUnfocusedBorder = theme.getColor(TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER);
+		if (tabDirtyInactiveUnfocusedBorder) {
+			collector.addRule(`
+				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border  {
+					box-shadow: ${tabDirtyInactiveUnfocusedBorder} 0 2px inset !important;
+				}
+			`);
+		}
+	}
 
-		// Fade out styles via linear gradient (when tabs are set to shrink)
+	// Fade out styles via linear gradient (when tabs are set to shrink)
+	if (theme.type !== 'hc') {
 		const workbenchBackground = WORKBENCH_BACKGROUND(theme);
 		const editorBackgroundColor = theme.getColor(editorBackground);
 		const editorGroupHeaderTabsBackground = theme.getColor(EDITOR_GROUP_HEADER_TABS_BACKGROUND);

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -380,7 +380,8 @@ export class TabsTitleControl extends TitleControl {
 			oldOptions.tabCloseButton !== newOptions.tabCloseButton ||
 			oldOptions.tabSizing !== newOptions.tabSizing ||
 			oldOptions.showIcons !== newOptions.showIcons ||
-			oldOptions.iconTheme !== newOptions.iconTheme
+			oldOptions.iconTheme !== newOptions.iconTheme ||
+			oldOptions.dirtyTabBorder !== newOptions.dirtyTabBorder
 		) {
 			this.redraw();
 		}

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -918,30 +918,30 @@ export class TabsTitleControl extends TitleControl {
 				if (isFocusedEditorGroup && isActiveEditorTab) {
 					const tabModifiedBorder = this.getColor(TAB_MODIFIED_BORDER);
 					if (tabModifiedBorder) {
-						tabContainer.style.borderTopColor = tabModifiedBorder;
+						tabContainer.style.borderTop = `2px solid ${tabModifiedBorder}`;
 					}
 				} else if (isFocusedEditorGroup && !isActiveEditorTab) {
 					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
 					if (tabModifiedInactiveFocusedBorder) {
-						tabContainer.style.borderTopColor = tabModifiedInactiveFocusedBorder;
+						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveFocusedBorder}`;
 					}
 				} else if (!isFocusedEditorGroup && isActiveEditorTab) {
 					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
 					if (tabModifiedActiveUnfocusedBorder) {
-						tabContainer.style.borderTopColor = tabModifiedActiveUnfocusedBorder;
+						tabContainer.style.borderTop = `2px solid ${tabModifiedActiveUnfocusedBorder}`;
 					}
 				} else {
 					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
 					if (tabModifiedInactiveUnfocusedBorder) {
-						tabContainer.style.borderTopColor = tabModifiedInactiveUnfocusedBorder;
+						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveUnfocusedBorder}`;
 					}
 				}
 			} else {
-				tabContainer.style.borderTopColor = 'transparent';
+				tabContainer.style.borderTop = null;
 			}
 		} else {
 			removeClass(tabContainer, 'dirty');
-			tabContainer.style.borderTopColor = 'transparent';
+			tabContainer.style.borderTop = null;
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -877,7 +877,7 @@ export class TabsTitleControl extends TitleControl {
 				tabContainer.style.setProperty('--tab-border-bottom-color', activeTabBorderColorBottom.toString());
 			} else {
 				removeClass(tabContainer, 'tab-border-bottom');
-				tabContainer.style.removeProperty('--tab-border-bottom-color');
+				// tabContainer.style.removeProperty('--tab-border-bottom-color');
 			}
 
 			const activeTabBorderColorTop = this.getColor(isGroupActive ? TAB_ACTIVE_BORDER_TOP : TAB_UNFOCUSED_ACTIVE_BORDER_TOP);
@@ -886,7 +886,7 @@ export class TabsTitleControl extends TitleControl {
 				tabContainer.style.setProperty('--tab-border-top-color', activeTabBorderColorTop.toString());
 			} else {
 				removeClass(tabContainer, 'tab-border-top');
-				tabContainer.style.removeProperty('--tab-border-top-color');
+				// tabContainer.style.removeProperty('--tab-border-top-color');
 			}
 
 			// Label
@@ -912,36 +912,37 @@ export class TabsTitleControl extends TitleControl {
 			addClass(tabContainer, 'dirty');
 
 			if (this.accessor.partOptions.highlightModifiedTabs && !this.getColor(TAB_ACTIVE_BORDER_TOP)) {
-				const isFocusedEditorGroup = this.accessor.activeGroup === this.group;
-				const isActiveEditorTab = this.group.isActive(editor);
+				addClass(tabContainer, 'dirty-border-top');
+				const isGroupActive = this.accessor.activeGroup === this.group;
+				const isTabActive = this.group.isActive(editor);
 
-				if (isFocusedEditorGroup && isActiveEditorTab) {
+				if (isGroupActive && isTabActive) {
 					const tabModifiedBorder = this.getColor(TAB_MODIFIED_BORDER);
 					if (tabModifiedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedBorder}`;
+						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedBorder.toString());
 					}
-				} else if (isFocusedEditorGroup && !isActiveEditorTab) {
+				} else if (isGroupActive && !isTabActive) {
 					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
 					if (tabModifiedInactiveFocusedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveFocusedBorder}`;
+						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedInactiveFocusedBorder.toString());
 					}
-				} else if (!isFocusedEditorGroup && isActiveEditorTab) {
+				} else if (!isGroupActive && isTabActive) {
 					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
 					if (tabModifiedActiveUnfocusedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedActiveUnfocusedBorder}`;
+						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedActiveUnfocusedBorder.toString());
 					}
 				} else {
 					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
 					if (tabModifiedInactiveUnfocusedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveUnfocusedBorder}`;
+						tabContainer.style.setProperty('--tab-border-top-color', tabModifiedInactiveUnfocusedBorder.toString());
 					}
 				}
 			} else {
-				tabContainer.style.borderTop = null;
+				removeClass(tabContainer, 'dirty-border-top');
 			}
 		} else {
 			removeClass(tabContainer, 'dirty');
-			tabContainer.style.borderTop = null;
+			removeClass(tabContainer, 'dirty-border-top');
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -918,30 +918,30 @@ export class TabsTitleControl extends TitleControl {
 				if (isFocusedEditorGroup && isActiveEditorTab) {
 					const tabModifiedBorder = this.getColor(TAB_MODIFIED_BORDER);
 					if (tabModifiedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedBorder}`;
+						tabContainer.style.borderTopColor = tabModifiedBorder;
 					}
 				} else if (isFocusedEditorGroup && !isActiveEditorTab) {
 					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
 					if (tabModifiedInactiveFocusedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveFocusedBorder}`;
+						tabContainer.style.borderTopColor = tabModifiedInactiveFocusedBorder;
 					}
 				} else if (!isFocusedEditorGroup && isActiveEditorTab) {
 					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
 					if (tabModifiedActiveUnfocusedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedActiveUnfocusedBorder}`;
+						tabContainer.style.borderTopColor = tabModifiedActiveUnfocusedBorder;
 					}
 				} else {
 					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
 					if (tabModifiedInactiveUnfocusedBorder) {
-						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveUnfocusedBorder}`;
+						tabContainer.style.borderTopColor = tabModifiedInactiveUnfocusedBorder;
 					}
 				}
 			} else {
-				tabContainer.style.borderTop = null;
+				tabContainer.style.borderTopColor = 'transparent';
 			}
 		} else {
 			removeClass(tabContainer, 'dirty');
-			tabContainer.style.borderTop = null;
+			tabContainer.style.borderTopColor = 'transparent';
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -342,6 +342,7 @@ export class TabsTitleControl extends TitleControl {
 		// Activity has an impact on each tab
 		this.forEachTab((editor, index, tabContainer, tabLabelWidget, tabLabel) => {
 			this.redrawEditorActive(isGroupActive, editor, tabContainer, tabLabelWidget);
+			this.redrawEditorDirty(editor, tabContainer);
 		});
 
 		// Activity has an impact on the toolbar, so we need to update and layout
@@ -895,7 +896,7 @@ export class TabsTitleControl extends TitleControl {
 		// Tab is inactive
 		else {
 
-			// Containr
+			// Container
 			removeClass(tabContainer, 'active');
 			tabContainer.setAttribute('aria-selected', 'false');
 			tabContainer.style.backgroundColor = this.getColor(TAB_INACTIVE_BACKGROUND);
@@ -911,13 +912,36 @@ export class TabsTitleControl extends TitleControl {
 			addClass(tabContainer, 'dirty');
 
 			if (this.accessor.partOptions.highlightModifiedTabs && !this.getColor(TAB_ACTIVE_BORDER_TOP)) {
-				addClass(tabContainer, 'dirty-border');
+				const isFocusedEditorGroup = this.accessor.activeGroup === this.group;
+				const isActiveEditorTab = this.group.isActive(editor);
+
+				if (isFocusedEditorGroup && isActiveEditorTab) {
+					const tabModifiedBorder = this.getColor(TAB_MODIFIED_BORDER);
+					if (tabModifiedBorder) {
+						tabContainer.style.borderTop = `2px solid ${tabModifiedBorder}`;
+					}
+				} else if (isFocusedEditorGroup && !isActiveEditorTab) {
+					const tabModifiedInactiveFocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
+					if (tabModifiedInactiveFocusedBorder) {
+						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveFocusedBorder}`;
+					}
+				} else if (!isFocusedEditorGroup && isActiveEditorTab) {
+					const tabModifiedActiveUnfocusedBorder = this.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
+					if (tabModifiedActiveUnfocusedBorder) {
+						tabContainer.style.borderTop = `2px solid ${tabModifiedActiveUnfocusedBorder}`;
+					}
+				} else {
+					const tabModifiedInactiveUnfocusedBorder = this.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
+					if (tabModifiedInactiveUnfocusedBorder) {
+						tabContainer.style.borderTop = `2px solid ${tabModifiedInactiveUnfocusedBorder}`;
+					}
+				}
 			} else {
-				removeClass(tabContainer, 'dirty-border');
+				tabContainer.style.borderTop = null;
 			}
 		} else {
 			removeClass(tabContainer, 'dirty');
-			removeClass(tabContainer, 'dirty-border');
+			tabContainer.style.borderTop = null;
 		}
 	}
 
@@ -1146,42 +1170,6 @@ registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
 				box-shadow: ${tabUnfocusedHoverBorder} 0 -1px inset !important;
 			}
 		`);
-	}
-
-	// Dirty tab borders
-	if (theme.type !== 'hc') {
-		const tabModifiedActiveFocusedBorder = theme.getColor(TAB_MODIFIED_BORDER);
-		if (tabModifiedActiveFocusedBorder) {
-			collector.addRule(`
-				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active.dirty-border  {
-					box-shadow: ${tabModifiedActiveFocusedBorder} 0 2px inset !important;
-				}
-			`);
-		}
-		const tabModifiedActiveUnfocusedBorder = theme.getColor(TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER);
-		if (tabModifiedActiveUnfocusedBorder) {
-			collector.addRule(`
-				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active.dirty-border  {
-					box-shadow: ${tabModifiedActiveUnfocusedBorder} 0 2px inset !important;
-				}
-			`);
-		}
-		const tabModifiedInactiveFocusedBorder = theme.getColor(TAB_MODIFIED_INACTIVE_FOCUSED_BORDER);
-		if (tabModifiedInactiveFocusedBorder) {
-			collector.addRule(`
-				.monaco-workbench > .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.dirty-border  {
-					box-shadow: ${tabModifiedInactiveFocusedBorder} 0 2px inset !important;
-				}
-			`);
-		}
-		const tabModifiedInactiveUnfocusedBorder = theme.getColor(TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER);
-		if (tabModifiedInactiveUnfocusedBorder) {
-			collector.addRule(`
-				.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.dirty-border  {
-					box-shadow: ${tabModifiedInactiveUnfocusedBorder} 0 2px inset !important;
-				}
-			`);
-		}
 	}
 
 	// Fade out styles via linear gradient (when tabs are set to shrink)

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -381,7 +381,7 @@ export class TabsTitleControl extends TitleControl {
 			oldOptions.tabSizing !== newOptions.tabSizing ||
 			oldOptions.showIcons !== newOptions.showIcons ||
 			oldOptions.iconTheme !== newOptions.iconTheme ||
-			oldOptions.dirtyTabBorder !== newOptions.dirtyTabBorder
+			oldOptions.highlightModifiedTabs !== newOptions.highlightModifiedTabs
 		) {
 			this.redraw();
 		}
@@ -910,7 +910,7 @@ export class TabsTitleControl extends TitleControl {
 		if (editor.isDirty()) {
 			addClass(tabContainer, 'dirty');
 
-			if (this.accessor.partOptions.dirtyTabBorder && !this.getColor(TAB_ACTIVE_BORDER_TOP)) {
+			if (this.accessor.partOptions.highlightModifiedTabs && !this.getColor(TAB_ACTIVE_BORDER_TOP)) {
 				addClass(tabContainer, 'dirty-border');
 			} else {
 				removeClass(tabContainer, 'dirty-border');

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -938,7 +938,7 @@ export interface IWorkbenchEditorConfiguration {
 
 export interface IWorkbenchEditorPartConfiguration {
 	showTabs?: boolean;
-	dirtyTabBorder?: boolean;
+	highlightModifiedTabs?: boolean;
 	tabCloseButton?: 'left' | 'right' | 'off';
 	tabSizing?: 'fit' | 'shrink';
 	showIcons?: boolean;

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -938,6 +938,7 @@ export interface IWorkbenchEditorConfiguration {
 
 export interface IWorkbenchEditorPartConfiguration {
 	showTabs?: boolean;
+	dirtyTabBorder?: boolean;
 	tabCloseButton?: 'left' | 'right' | 'off';
 	tabSizing?: 'fit' | 'shrink';
 	showIcons?: boolean;

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -79,7 +79,7 @@ export const TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedA
 }, nls.localize('tabModifiedActiveUnfocusedBorder', "Border on the top of modified (dirty) active tab in unfocused editor group."));
 
 export const TAB_MODIFIED_INACTIVE_FOCUSED_BORDER = registerColor('tab.modifiedInactiveFocusedBorder', {
-	dark: transparent(TAB_MODIFIED_BORDER, 0.85),
+	dark: transparent(TAB_MODIFIED_BORDER, 0.75),
 	light: transparent(TAB_MODIFIED_BORDER, 0.7),
 	hc: null
 }, nls.localize('tabModifiedInactiveFocusedBorder', "Border on the top of modified (dirty) inactive tab in focused editor group."));

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -60,47 +60,47 @@ export const TAB_ACTIVE_BORDER = registerColor('tab.activeBorder', {
 	hc: null
 }, nls.localize('tabActiveBorder', "Border on the bottom of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
-export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
-	dark: null,
-	light: null,
-	hc: null
-}, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
-
-export const TAB_MODIFIED_BORDER = registerColor('tab.modifiedBorder', {
-	dark: '#39C',
-	light: '#3AE',
-	hc: null
-}, nls.localize('tabModifiedBorder', "Border on the top of modified (dirty) active tab in focused editor group."));
-
-export const TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedActiveUnfocusedBorder', {
-	dark: transparent(TAB_MODIFIED_BORDER, 0.8),
-	light: transparent(TAB_MODIFIED_BORDER, 0.9),
-	hc: null
-}, nls.localize('tabModifiedActiveUnfocusedBorder', "Border on the top of modified (dirty) active tab in unfocused editor group."));
-
-export const TAB_MODIFIED_INACTIVE_FOCUSED_BORDER = registerColor('tab.modifiedInactiveFocusedBorder', {
-	dark: transparent(TAB_MODIFIED_BORDER, 0.75),
-	light: transparent(TAB_MODIFIED_BORDER, 0.7),
-	hc: null
-}, nls.localize('tabModifiedInactiveFocusedBorder', "Border on the top of modified (dirty) inactive tab in focused editor group."));
-
-export const TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedInactiveUnfocusedBorder', {
-	dark: transparent(TAB_MODIFIED_BORDER, 0.65),
-	light: transparent(TAB_MODIFIED_BORDER, 0.6),
-	hc: null
-}, nls.localize('tabModifiedInactiveUnfocusedBorder', "Border on the top of modified (dirty) inactive tab in unfocused editor group."));
-
 export const TAB_UNFOCUSED_ACTIVE_BORDER = registerColor('tab.unfocusedActiveBorder', {
 	dark: transparent(TAB_ACTIVE_BORDER, 0.5),
 	light: transparent(TAB_ACTIVE_BORDER, 0.7),
 	hc: null
 }, nls.localize('tabActiveUnfocusedBorder', "Border on the bottom of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
+export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
+	dark: null,
+	light: null,
+	hc: null
+}, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
+
 export const TAB_UNFOCUSED_ACTIVE_BORDER_TOP = registerColor('tab.unfocusedActiveBorderTop', {
 	dark: transparent(TAB_ACTIVE_BORDER_TOP, 0.5),
 	light: transparent(TAB_ACTIVE_BORDER_TOP, 0.7),
 	hc: null
 }, nls.localize('tabActiveUnfocusedBorderTop', "Border to the top of an active tab in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
+
+export const TAB_ACTIVE_MODIFIED_BORDER = registerColor('tab.activeModifiedBorder', {
+	dark: '#3399CC',
+	light: '#33AAEE',
+	hc: null
+}, nls.localize('tabActiveModifiedBorder', "Border on the top of modified (dirty) active tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
+
+export const TAB_INACTIVE_MODIFIED_BORDER = registerColor('tab.inactiveModifiedBorder', {
+	dark: transparent(TAB_ACTIVE_MODIFIED_BORDER, 0.5),
+	light: transparent(TAB_ACTIVE_MODIFIED_BORDER, 0.5),
+	hc: Color.white
+}, nls.localize('tabInactiveModifiedBorder', "Border on the top of modified (dirty) inactive tabs in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
+
+export const TAB_UNFOCUSED_ACTIVE_MODIFIED_BORDER = registerColor('tab.unfocusedActiveModifiedBorder', {
+	dark: transparent(TAB_ACTIVE_MODIFIED_BORDER, 0.5),
+	light: transparent(TAB_ACTIVE_MODIFIED_BORDER, 0.7),
+	hc: Color.white
+}, nls.localize('unfocusedActiveModifiedBorder', "Border on the top of modified (dirty) active tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
+
+export const TAB_UNFOCUSED_INACTIVE_MODIFIED_BORDER = registerColor('tab.unfocusedInactiveModifiedBorder', {
+	dark: transparent(TAB_INACTIVE_MODIFIED_BORDER, 0.5),
+	light: transparent(TAB_INACTIVE_MODIFIED_BORDER, 0.5),
+	hc: Color.white
+}, nls.localize('unfocusedINactiveModifiedBorder', "Border on the top of modified (dirty) inactive tabs in an unfocused group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
 export const TAB_HOVER_BORDER = registerColor('tab.hoverBorder', {
 	dark: null,

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -66,29 +66,29 @@ export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
 	hc: null
 }, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
-export const TAB_DIRTY_ACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyActiveFocusedBorder', {
+export const TAB_MODIFIED_ACTIVE_FOCUSED_BORDER = registerColor('tab.modifiedActiveFocusedBorder', {
 	dark: '#39C',
 	light: '#3AE',
 	hc: null
-}, nls.localize('tabDirtyActiveFocusedBorder', "Border on the top of dirty active tab in active editor group."));
+}, nls.localize('tabModifiedActiveFocusedBorder', "Border on the top of modified (dirty) active tab in focused editor group."));
 
-export const TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.dirtyActiveUnfocusedBorder', {
-	dark: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.8),
-	light: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.9),
+export const TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedActiveUnfocusedBorder', {
+	dark: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.8),
+	light: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.9),
 	hc: null
-}, nls.localize('tabDirtyActiveUnfocusedBorder', "Border on the top of dirty active tab in inactive editor group."));
+}, nls.localize('tabModifiedActiveUnfocusedBorder', "Border on the top of modified (dirty) active tab in unfocused editor group."));
 
-export const TAB_DIRTY_INACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyInactiveFocusedBorder', {
-	dark: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.85),
-	light: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.7),
+export const TAB_MODIFIED_INACTIVE_FOCUSED_BORDER = registerColor('tab.modifiedInactiveFocusedBorder', {
+	dark: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.85),
+	light: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.7),
 	hc: null
-}, nls.localize('tabDirtyInactiveFocusedBorder', "Border on the top of dirty inactive tab in active editor group."));
+}, nls.localize('tabModifiedInactiveFocusedBorder', "Border on the top of modified (dirty) inactive tab in focused editor group."));
 
-export const TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER = registerColor('tab.dirtyInactiveUnfocusedBorder', {
-	dark: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.65),
-	light: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.6),
+export const TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedInactiveUnfocusedBorder', {
+	dark: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.65),
+	light: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.6),
 	hc: null
-}, nls.localize('tabDirtyInactiveUnfocusedBorder', "Border on the top of dirty inactive tab in inactive editor group."));
+}, nls.localize('tabModifiedInactiveUnfocusedBorder', "Border on the top of modified (dirty) inactive tab in unfocused editor group."));
 
 export const TAB_UNFOCUSED_ACTIVE_BORDER = registerColor('tab.unfocusedActiveBorder', {
 	dark: transparent(TAB_ACTIVE_BORDER, 0.5),

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -66,11 +66,29 @@ export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
 	hc: null
 }, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
-export const TAB_DIRTY_BORDER_TOP = registerColor('tab.dirtyBorderTop', {
+export const TAB_DIRTY_ACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyActiveFocusedBorder', {
 	dark: null,
 	light: null,
 	hc: null
-}, nls.localize('tabDirtyBorderTop', "Border on the top of dirty file tabs in editor area."));
+}, nls.localize('tabDirtyActiveFocusedBorder', "Border on the top of dirty active tab in active editor group."));
+
+export const TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.dirtyActiveUnfocusedBorder', {
+	dark: null,
+	light: null,
+	hc: null
+}, nls.localize('tabDirtyActiveUnfocusedBorder', "Border on the top of dirty active tab in inactive editor group."));
+
+export const TAB_DIRTY_INACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyInactiveFocusedBorder', {
+	dark: null,
+	light: null,
+	hc: null
+}, nls.localize('tabDirtyInactiveFocusedBorder', "Border on the top of dirty inactive tab in active editor group."));
+
+export const TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER = registerColor('tab.dirtyInactiveUnfocusedBorder', {
+	dark: null,
+	light: null,
+	hc: null
+}, nls.localize('tabDirtyInactiveUnfocusedBorder', "Border on the top of dirty inactive tab in inactive editor group."));
 
 export const TAB_UNFOCUSED_ACTIVE_BORDER = registerColor('tab.unfocusedActiveBorder', {
 	dark: transparent(TAB_ACTIVE_BORDER, 0.5),

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -66,27 +66,27 @@ export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
 	hc: null
 }, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
-export const TAB_MODIFIED_ACTIVE_FOCUSED_BORDER = registerColor('tab.modifiedActiveFocusedBorder', {
+export const TAB_MODIFIED_BORDER = registerColor('tab.modifiedBorder', {
 	dark: '#39C',
 	light: '#3AE',
 	hc: null
-}, nls.localize('tabModifiedActiveFocusedBorder', "Border on the top of modified (dirty) active tab in focused editor group."));
+}, nls.localize('tabModifiedBorder', "Border on the top of modified (dirty) active tab in focused editor group."));
 
 export const TAB_MODIFIED_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedActiveUnfocusedBorder', {
-	dark: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.8),
-	light: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.9),
+	dark: transparent(TAB_MODIFIED_BORDER, 0.8),
+	light: transparent(TAB_MODIFIED_BORDER, 0.9),
 	hc: null
 }, nls.localize('tabModifiedActiveUnfocusedBorder', "Border on the top of modified (dirty) active tab in unfocused editor group."));
 
 export const TAB_MODIFIED_INACTIVE_FOCUSED_BORDER = registerColor('tab.modifiedInactiveFocusedBorder', {
-	dark: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.85),
-	light: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.7),
+	dark: transparent(TAB_MODIFIED_BORDER, 0.85),
+	light: transparent(TAB_MODIFIED_BORDER, 0.7),
 	hc: null
 }, nls.localize('tabModifiedInactiveFocusedBorder', "Border on the top of modified (dirty) inactive tab in focused editor group."));
 
 export const TAB_MODIFIED_INACTIVE_UNFOCUSED_BORDER = registerColor('tab.modifiedInactiveUnfocusedBorder', {
-	dark: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.65),
-	light: transparent(TAB_MODIFIED_ACTIVE_FOCUSED_BORDER, 0.6),
+	dark: transparent(TAB_MODIFIED_BORDER, 0.65),
+	light: transparent(TAB_MODIFIED_BORDER, 0.6),
 	hc: null
 }, nls.localize('tabModifiedInactiveUnfocusedBorder', "Border on the top of modified (dirty) inactive tab in unfocused editor group."));
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -66,6 +66,12 @@ export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
 	hc: null
 }, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
+export const TAB_DIRTY_BORDER_TOP = registerColor('tab.dirtyBorderTop', {
+	dark: null,
+	light: null,
+	hc: null
+}, nls.localize('tabDirtyBorderTop', "Border on the top of dirty file tabs in editor area."));
+
 export const TAB_UNFOCUSED_ACTIVE_BORDER = registerColor('tab.unfocusedActiveBorder', {
 	dark: transparent(TAB_ACTIVE_BORDER, 0.5),
 	light: transparent(TAB_ACTIVE_BORDER, 0.7),

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -67,8 +67,8 @@ export const TAB_ACTIVE_BORDER_TOP = registerColor('tab.activeBorderTop', {
 }, nls.localize('tabActiveBorderTop', "Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups."));
 
 export const TAB_DIRTY_ACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyActiveFocusedBorder', {
-	dark: null,
-	light: null,
+	dark: '#39C',
+	light: '#3AE',
 	hc: null
 }, nls.localize('tabDirtyActiveFocusedBorder', "Border on the top of dirty active tab in active editor group."));
 

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -73,20 +73,20 @@ export const TAB_DIRTY_ACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyActiveFoc
 }, nls.localize('tabDirtyActiveFocusedBorder', "Border on the top of dirty active tab in active editor group."));
 
 export const TAB_DIRTY_ACTIVE_UNFOCUSED_BORDER = registerColor('tab.dirtyActiveUnfocusedBorder', {
-	dark: null,
-	light: null,
+	dark: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.8),
+	light: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.9),
 	hc: null
 }, nls.localize('tabDirtyActiveUnfocusedBorder', "Border on the top of dirty active tab in inactive editor group."));
 
 export const TAB_DIRTY_INACTIVE_FOCUSED_BORDER = registerColor('tab.dirtyInactiveFocusedBorder', {
-	dark: null,
-	light: null,
+	dark: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.85),
+	light: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.7),
 	hc: null
 }, nls.localize('tabDirtyInactiveFocusedBorder', "Border on the top of dirty inactive tab in active editor group."));
 
 export const TAB_DIRTY_INACTIVE_UNFOCUSED_BORDER = registerColor('tab.dirtyInactiveUnfocusedBorder', {
-	dark: null,
-	light: null,
+	dark: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.65),
+	light: transparent(TAB_DIRTY_ACTIVE_FOCUSED_BORDER, 0.6),
 	hc: null
 }, nls.localize('tabDirtyInactiveUnfocusedBorder', "Border on the top of dirty inactive tab in inactive editor group."));
 

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -480,9 +480,9 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('showEditorTabs', "Controls whether opened editors should show in tabs or not."),
 			'default': true
 		},
-		'workbench.editor.dirtyTabBorder': {
+		'workbench.editor.highlightModifiedTabs': {
 			'type': 'boolean',
-			'description': nls.localize('showEditorDirtyTabBorder', "Controls whether top border is drawn on dirty file tabs or not."),
+			'description': nls.localize('highlightModifiedTabs', "Controls whether top border is drawn on modified (dirty) file tabs or not."),
 			'default': false
 		},
 		'workbench.editor.labelFormat': {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -480,6 +480,11 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('showEditorTabs', "Controls whether opened editors should show in tabs or not."),
 			'default': true
 		},
+		'workbench.editor.dirtyTabBorder': {
+			'type': 'boolean',
+			'description': nls.localize('showEditorDirtyTabBorder', "Controls whether top border is drawn on dirty file tabs or not."),
+			'default': false
+		},
 		'workbench.editor.labelFormat': {
 			'type': 'string',
 			'enum': ['default', 'short', 'medium', 'long'],

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -482,7 +482,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'workbench.editor.highlightModifiedTabs': {
 			'type': 'boolean',
-			'description': nls.localize('highlightModifiedTabs', "Controls whether top border is drawn on modified (dirty) file tabs or not."),
+			'description': nls.localize('highlightModifiedTabs', "Controls whether a top border is drawn on modified (dirty) editor tabs or not."),
 			'default': false
 		},
 		'workbench.editor.labelFormat': {


### PR DESCRIPTION
Fixes #26284 

Adds a themable top border for tabs. 
Disabled in `hc` themes. 
Disabled if `tab.activeBorderTop` is set.

`2px` border does't look very good using light themes(especially fullscreen).