### PR TITLE
Allow buttons to show outline on keyboard focus

### DIFF
--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -11,6 +11,7 @@
 	padding: 4px;
 	text-align: center;
 	cursor: pointer;
+	outline-offset: 2px !important;
 }
 
 .monaco-text-button:hover {

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -110,6 +110,7 @@
 
 .monaco-workbench .notifications-list-container .notification-list-item.expanded > .notification-list-item-details-row {
 	display: flex;
+	overflow: visible;
 }
 
 /** Notification: Source */
@@ -125,7 +126,6 @@
 
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container {
 	display: flex;
-	overflow: hidden;
 }
 
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container .monaco-button {
@@ -133,7 +133,7 @@
 	padding: 5px 10px;
 	margin-left: 10px;
 	font-size: 12px;
-	overflow: hidden;
+	overflow: visible;
 	text-overflow: ellipsis;
 }
 

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -104,7 +104,7 @@
 .monaco-workbench .notifications-list-container .notification-list-item > .notification-list-item-details-row {
 	display: none;
 	align-items: center;
-	padding: 0 5px;
+	padding: 0 0 0 5px;
 	overflow: hidden; /* details row should never overflow */
 }
 
@@ -131,7 +131,7 @@
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container .monaco-button {
 	max-width: fit-content;
 	padding: 5px 10px;
-	margin: 4px 4px 4px 6px;
+	margin: 4px 5px 4px 6px;
 	font-size: 12px;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -110,7 +110,6 @@
 
 .monaco-workbench .notifications-list-container .notification-list-item.expanded > .notification-list-item-details-row {
 	display: flex;
-	overflow: visible;
 }
 
 /** Notification: Source */
@@ -126,14 +125,15 @@
 
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container {
 	display: flex;
+	overflow: hidden;
 }
 
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container .monaco-button {
 	max-width: fit-content;
 	padding: 5px 10px;
-	margin-left: 10px;
+	margin: 4px 4px 4px 6px;
 	font-size: 12px;
-	overflow: visible;
+	overflow: hidden;
 	text-overflow: ellipsis;
 }
 

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -104,7 +104,7 @@
 .monaco-workbench .notifications-list-container .notification-list-item > .notification-list-item-details-row {
 	display: none;
 	align-items: center;
-	padding: 0 0 0 5px;
+	padding-left: 5px;
 	overflow: hidden; /* details row should never overflow */
 }
 
@@ -131,7 +131,7 @@
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container .monaco-button {
 	max-width: fit-content;
 	padding: 5px 10px;
-	margin: 4px 5px 4px 6px;
+	margin: 4px 5px; /* allows button focus outline to be visible */
 	font-size: 12px;
 	overflow: hidden;
 	text-overflow: ellipsis;


### PR DESCRIPTION
Fixes #52676

This only appears on keyboard focus and doesn't show for active clicks. I also tweaked the overflow properties for the outside containers in order to get the outline focus to be shown, tested this on all platforms (macOS/Win/Linux) and didn't see this break anything.

![gif](https://user-images.githubusercontent.com/35271042/46313786-9a977080-c57d-11e8-852a-7cc19b670934.gif)

![image](https://user-images.githubusercontent.com/35271042/46312357-b3058c00-c579-11e8-8012-7a6df1cf5298.png)