### PR TITLE
Add unknown argument checking

### DIFF
--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -90,8 +90,11 @@ const options: minimist.Opts = {
 		'debugBrkPluginHost': 'inspect-brk-extensions',
 		'debugSearch': 'inspect-search',
 		'debugBrkSearch': 'inspect-brk-search',
-	}
+	},
+	unknown: addUnknown
 };
+
+var unknownArgs = [];
 
 function validate(args: ParsedArgs): ParsedArgs {
 	if (args.goto) {
@@ -142,10 +145,23 @@ export function parseCLIProcessArgv(processArgv: string[]): ParsedArgs {
 }
 
 /**
+ * Use this to fail out when an unknown argument is passed
+ */
+function addUnknown(arg) {
+	console.log('Unknown argument: ', arg);
+	unknownArgs.push(arg);
+	return false;
+}
+
+/**
  * Use this to parse code arguments such as `--verbose --wait`
  */
 export function parseArgs(args: string[]): ParsedArgs {
-	return minimist(args, options) as ParsedArgs;
+	var parsedArgs = minimist(args, options) as ParsedArgs;
+	if (unknownArgs.length > 0) {
+		throw new Error('Unknown CLI options provided. Run with -h or --help to print usage.');
+	}
+	return parsedArgs;
 }
 
 const optionsHelp: { [name: string]: string; } = {

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -159,8 +159,12 @@ function addUnknown(arg) {
 export function parseArgs(args: string[]): ParsedArgs {
 	var parsedArgs = minimist(args, options) as ParsedArgs;
 	if (unknownArgs.length > 0) {
-		throw new Error('Unknown CLI options provided. Run with -h or --help to print usage.');
+		// The user has passed in unknown arguments, so display usage.
+		if (!parsedArgs.help) {
+			parsedArgs.help = true;
+		}
 	}
+	unknownArgs = [];
 	return parsedArgs;
 }
 


### PR DESCRIPTION
This commit adds a handler for when the command line tool is run with unknown arguments. It will print a message displaying the unknown arg and then exit the process.