### PR TITLE
debug: restart shuold also resolve configuration by providers when changed

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -579,7 +579,13 @@ export class DebugService implements IDebugService {
 								}
 							}
 
-							(needsToSubstitute ? this.substituteVariables(launch, unresolved) : TPromise.as(session.configuration)).then(resolved => {
+							let configPromise = TPromise.as(session.configuration);
+							if (needsToSubstitute) {
+								configPromise = this.configurationManager.resolveConfigurationByProviders(launch.workspace && launch.workspace.uri, unresolved.type, unresolved)
+									.then(resolved => this.substituteVariables(launch, resolved));
+							}
+
+							configPromise.then(resolved => {
 								session.setConfiguration({ resolved, unresolved });
 								session.configuration.__restart = restartData;
 


### PR DESCRIPTION
fixes #59795

This fixes the issue introduced by a debug restart refactoring that the configurations are no longer resolved by debug proivders on restart.
Previously on restart we were calling the monster `startDebugging` which would do everything and now we are trying to do just what is needed on the restart. However on a refactoring I forgot to resolve configuration by providers.