### PR TITLE
fix: items in split view are not draggable without separator-border

### DIFF
--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -162,11 +162,10 @@ export class SplitView extends Disposable {
 	}
 
 	style(styles: ISplitViewStyles): void {
+		dom.addClass(this.el, 'separator-border');
 		if (styles.separatorBorder.isTransparent()) {
-			dom.removeClass(this.el, 'separator-border');
 			this.el.style.removeProperty('--separator-border');
 		} else {
-			dom.addClass(this.el, 'separator-border');
 			this.el.style.setProperty('--separator-border', styles.separatorBorder.toString());
 		}
 	}


### PR DESCRIPTION
When you remove ```separator-border``` class from ```split-view```, the ```split-view-view``` is no longer accept items to drag.

It can be reproduced when ```editorGroup.border``` has alpha 00.
![2018-10-02_16-40-39](https://user-images.githubusercontent.com/3466287/46355889-f9ceb100-c661-11e8-9b8b-038c563efaca.gif)
