### PR TITLE
Don't force update webview content when retainContextWhenHidden is set and contents have not changed

### DIFF
--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
@@ -190,7 +190,7 @@ export class WebviewEditor extends BaseWebviewEditor {
 			enableWrappedPostMessage: true,
 			useSameOriginForRoot: false,
 			localResourceRoots: input.options.localResourceRoots || this.getDefaultLocalResourceRoots()
-		});
+		}, input.options.retainContextWhenHidden);
 
 		if (this._webviewContent) {
 			this._webviewContent.style.visibility = 'visible';

--- a/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
@@ -242,7 +242,10 @@ export class WebviewElement extends Disposable {
 		});
 	}
 
-	public update(value: string, options: WebviewOptions) {
+	public update(value: string, options: WebviewOptions, retainContextWhenHidden: boolean) {
+		if (retainContextWhenHidden && value === this._contents && this._options && areWebviewInputOptionsEqual(options, this._options)) {
+			return;
+		}
 		this._contents = value;
 		this._options = options;
 		this._send('content', {


### PR DESCRIPTION
Port of fix for #59823 to release/1.28

**Problem**
Due to a logic change early in the iteration, the retainContextWhileHidden option stopped working. The root cause is that we would re-update the webview's html when it was shown again (even if the html was the same as when it was first set)

**Fix**
This is a scoped fix that should only apply to webview that have retainContextWhenHidden set. This should mitigate the impact of possible regressions from this change (as a small number of webviews use this option).

The fix itself is to not update the webview's html if it is the exact same as the html we saw previously.

**Testing**
Tested with a webview that uses retainContextWhenHidden and several that do not use this option.