### PR TITLE
Track experiment id

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -379,6 +379,7 @@ export class ExtensionsListView extends ViewletPanel {
 			for (let i = 0; i < this.searchExperiments.length; i++) {
 				if (text.toLowerCase() === this.searchExperiments[i].action.properties['searchText'] && Array.isArray(this.searchExperiments[i].action.properties['preferredResults'])) {
 					preferredResults = this.searchExperiments[i].action.properties['preferredResults'];
+					options.source += `-experiment-${this.searchExperiments[i].id}`;
 					break;
 				}
 			}


### PR DESCRIPTION
We now support experiments on extension search results.

This PR updates the query source in such cases so that we can track clicks/installs of the extensions that are part of the experiments