### PR TITLE
Don't include extension actions in tab order until focused

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsActions.ts
@@ -437,7 +437,7 @@ export class DropDownMenuActionItem extends ExtensionActionItem {
 		tabOnlyOnFocus: boolean,
 		@IContextMenuService private contextMenuService: IContextMenuService
 	) {
-		super(null, action, { icon: true, label: true, tabOnlyOnFocus: !!tabOnlyOnFocus });
+		super(null, action, { icon: true, label: true, tabOnlyOnFocus });
 		this.menuActionGroups = menuActionGroups;
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -11,16 +11,21 @@ import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { IPagedRenderer } from 'vs/base/browser/ui/list/listPaging';
-import { once } from 'vs/base/common/event';
+import { once, Emitter, Event } from 'vs/base/common/event';
 import { domEvent } from 'vs/base/browser/event';
 import { IExtension, IExtensionsWorkbenchService } from 'vs/workbench/parts/extensions/common/extensions';
-import { InstallAction, UpdateAction, ManageExtensionAction, ReloadAction, extensionButtonProminentBackground, extensionButtonProminentForeground, MaliciousStatusLabelAction, DisabledStatusLabelAction } from 'vs/workbench/parts/extensions/electron-browser/extensionsActions';
+import { InstallAction, UpdateAction, ManageExtensionAction, ReloadAction, extensionButtonProminentBackground, extensionButtonProminentForeground, MaliciousStatusLabelAction, DisabledStatusLabelAction, TabOnlyOnFocusActionItem } from 'vs/workbench/parts/extensions/electron-browser/extensionsActions';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { Label, RatingsWidget, InstallCountWidget } from 'vs/workbench/parts/extensions/browser/extensionsWidgets';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IExtensionTipsService, IExtensionManagementServerService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+
+export interface IExtensionWithFocus extends IExtension {
+	onDidFocusChange?: Event<boolean>;
+	onFocusChangeEventEmitter?: Emitter<boolean>;
+}
 
 export interface ITemplateData {
 	root: HTMLElement;
@@ -34,6 +39,7 @@ export interface ITemplateData {
 	extension: IExtension;
 	disposables: IDisposable[];
 	extensionDisposables: IDisposable[];
+	actionbar: ActionBar;
 }
 
 export class Delegate implements IListVirtualDelegate<IExtension> {
@@ -87,7 +93,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 				if (action.id === ManageExtensionAction.ID) {
 					return (<ManageExtensionAction>action).actionItem;
 				}
-				return null;
+				return new TabOnlyOnFocusActionItem(null, action, actionOptions);
 			}
 		});
 		actionbar.onDidRun(({ error }) => error && this.notificationService.error(error));
@@ -107,7 +113,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const disposables = [versionWidget, installCountWidget, ratingsWidget, maliciousStatusAction, disabledStatusAction, updateAction, installAction, reloadAction, manageAction, actionbar, bookmarkStyler];
 
 		return {
-			root, element, icon, name, installCount, ratings, author, description, disposables,
+			root, element, icon, name, installCount, ratings, author, description, disposables, actionbar,
 			extensionDisposables: [],
 			set extension(extension: IExtension) {
 				versionWidget.extension = extension;
@@ -137,7 +143,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		data.extension = null;
 	}
 
-	renderElement(extension: IExtension, index: number, data: ITemplateData): void {
+	renderElement(extension: IExtensionWithFocus, index: number, data: ITemplateData): void {
 		removeClass(data.element, 'loading');
 
 		data.extensionDisposables = dispose(data.extensionDisposables);
@@ -180,6 +186,14 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
 		if (extension.gallery && extension.gallery.properties && extension.gallery.properties.localizedLanguages && extension.gallery.properties.localizedLanguages.length) {
 			data.description.textContent = extension.gallery.properties.localizedLanguages.map(name => name[0].toLocaleUpperCase() + name.slice(1)).join(', ');
+		}
+
+		if (extension.onDidFocusChange) {
+			data.extensionDisposables.push(extension.onDidFocusChange(hasFocus => {
+				data.actionbar.items.forEach(item => {
+					(<TabOnlyOnFocusActionItem>item).setFocus(hasFocus);
+				});
+			}));
 		}
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsList.ts
@@ -14,7 +14,7 @@ import { IPagedRenderer } from 'vs/base/browser/ui/list/listPaging';
 import { once, Emitter, Event } from 'vs/base/common/event';
 import { domEvent } from 'vs/base/browser/event';
 import { IExtension, IExtensionsWorkbenchService } from 'vs/workbench/parts/extensions/common/extensions';
-import { InstallAction, UpdateAction, ManageExtensionAction, ReloadAction, extensionButtonProminentBackground, extensionButtonProminentForeground, MaliciousStatusLabelAction, DisabledStatusLabelAction, TabOnlyOnFocusActionItem } from 'vs/workbench/parts/extensions/electron-browser/extensionsActions';
+import { InstallAction, UpdateAction, ManageExtensionAction, ReloadAction, extensionButtonProminentBackground, extensionButtonProminentForeground, MaliciousStatusLabelAction, DisabledStatusLabelAction, ExtensionActionItem } from 'vs/workbench/parts/extensions/electron-browser/extensionsActions';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { Label, RatingsWidget, InstallCountWidget } from 'vs/workbench/parts/extensions/browser/extensionsWidgets';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -47,7 +47,7 @@ export class Delegate implements IListVirtualDelegate<IExtension> {
 	getTemplateId() { return 'extension'; }
 }
 
-const actionOptions = { icon: true, label: true };
+const actionOptions = { icon: true, label: true, tabOnlyOnFocus: true };
 
 export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 
@@ -93,7 +93,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 				if (action.id === ManageExtensionAction.ID) {
 					return (<ManageExtensionAction>action).actionItem;
 				}
-				return new TabOnlyOnFocusActionItem(null, action, actionOptions);
+				return new ExtensionActionItem(null, action, actionOptions);
 			}
 		});
 		actionbar.onDidRun(({ error }) => error && this.notificationService.error(error));
@@ -191,7 +191,7 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		if (extension.onDidFocusChange) {
 			data.extensionDisposables.push(extension.onDidFocusChange(hasFocus => {
 				data.actionbar.items.forEach(item => {
-					(<TabOnlyOnFocusActionItem>item).setFocus(hasFocus);
+					(<ExtensionActionItem>item).setFocus(hasFocus);
 				});
 			}));
 		}


### PR DESCRIPTION
This PR attempts to fix the bug #51496

In other lists (Search results, staged/unstaged files in gitview), only the focused list item's actions are shown. Therefore this problem doesnt exist there.

In Extensions viewlet, the actions on all list items are enabled and visible. This PR adds the below as per prior discussions: #59280

- Extend `ActionItem` class so as to not set tab index on the action item unless it receives focus
- Extend `IExtension` to include a event emitter and listener. The extensions list view would deal with this new class and fire the event on the extension list item that gets/loses focus
- Renderer for the extension list items will use the extended `ActionItem` in the action bar. It will listen to the focus change event on each extension list item, and update the action item appropriately