### PR TITLE
Fix issues wrapping links/emails using Emmet command

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -643,14 +643,30 @@ function expandAbbr(input: ExpandAbbreviationInput): string {
 				}
 
 				// If wrapping with a block element, insert newline in the text to wrap.
-				if (wrappingNode && inlineElements.indexOf(wrappingNode.name) === -1 && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true)) {
-					wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
+				if (wrappingNode && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true)) {
+					if (inlineElements.indexOf(wrappingNode.name) === -1) {
+						wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
+					}
+
+					// Fixes #54711
+					if (wrappingNode.name === 'a') {
+						let hrefAtt = wrappingNode.attributes.filter((a) => a.name === 'href')[0];
+						if (hrefAtt) {
+							hrefAtt.value = input.textToWrap[0]; // This is safe because we've already checked that length is 1.
+						} else {
+							wrappingNode.attributes.push({
+								name: 'href',
+								options: {},
+								value: input.textToWrap[0] // This is safe because we've already checked that length is 1.
+							});
+						}
+					}
 				}
 			}
 			expandedText = helper.expandAbbreviation(parsedAbbr, expandOptions);
 			// All $anyword would have been escaped by the emmet helper.
 			// Remove the escaping backslash from $TM_SELECTED_TEXT so that VS Code Snippet controller can treat it as a variable
-			expandedText = expandedText.replace('\\$TM_SELECTED_TEXT', '$TM_SELECTED_TEXT');
+			expandedText = expandedText.replace(/\\\$TM_SELECTED_TEXT/g, '$TM_SELECTED_TEXT');
 		} else {
 			expandedText = helper.expandAbbreviation(input.abbreviation, expandOptions);
 		}

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -193,6 +193,10 @@ function doWrapping(individualLines: boolean, args: any) {
 					let textToWrap: string[];
 					if (individualLines) {
 						textToWrap = rangesAndContent.textToWrapInPreview;
+					} else if (abbreviation === 'a') {
+						// Fix for https://github.com/Microsoft/vscode/issues/54711
+						// tl;dr - Can't use the $TM_SELECTED_TEXT variable or the href attribute won't get resolved properly
+						textToWrap = rangesAndContent.textToWrapInPreview;
 					} else {
 						textToWrap = rangeToReplace.isSingleLine ? ['$TM_SELECTED_TEXT'] : ['\n\t$TM_SELECTED_TEXT\n'];
 					}

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -639,9 +639,9 @@ function expandAbbr(input: ExpandAbbreviationInput, isPreviewing: boolean = fals
 				}
 
 				// If wrapping with a block element, insert newline in the text to wrap.
-				if (wrappingNode && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true)) {
+				if (wrappingNode) {
 					wrappingNode.value = isPreviewing ? wrappingNode.value : selectedTextPlaceholder;
-					if (inlineElements.indexOf(wrappingNode.name) === -1) {
+					if (inlineElements.indexOf(wrappingNode.name) === -1 && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true)) {
 						wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
 					}
 

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -193,10 +193,6 @@ function doWrapping(individualLines: boolean, args: any) {
 					let textToWrap: string[];
 					if (individualLines) {
 						textToWrap = rangesAndContent.textToWrapInPreview;
-					} else if (abbreviation === 'a') {
-						// Fix for https://github.com/Microsoft/vscode/issues/54711
-						// tl;dr - Can't use the $TM_SELECTED_TEXT variable or the href attribute won't get resolved properly
-						textToWrap = rangesAndContent.textToWrapInPreview;
 					} else {
 						textToWrap = rangeToReplace.isSingleLine ? ['$TM_SELECTED_TEXT'] : ['\n\t$TM_SELECTED_TEXT\n'];
 					}

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -647,7 +647,6 @@ function expandAbbr(input: ExpandAbbreviationInput, isPreviewing: boolean = fals
 
 					// Fixes #54711
 					if (wrappingNode.name === 'a' && !isPreviewing) {
-						wrappingNode.value = selectedTextPlaceholder;
 						let hrefAtt = wrappingNode.attributes.filter((a: any) => a.name === 'href')[0];
 						if (hrefAtt && hrefAtt.value) {
 							// Replace a *valid* with $TM_SELECTED_TEXT so that multi-cursor mode works correctly.

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -649,8 +649,15 @@ function expandAbbr(input: ExpandAbbreviationInput, isPreviewing: boolean = fals
 					if (wrappingNode.name === 'a' && !isPreviewing) {
 						let hrefAtt = wrappingNode.attributes.filter((a: any) => a.name === 'href')[0];
 						if (hrefAtt && hrefAtt.value) {
-							// Replace a *valid* with $TM_SELECTED_TEXT so that multi-cursor mode works correctly.
-							hrefAtt.value = selectedTextPlaceholder;
+							// $TM_SELECTED_TEXT doesn't maintain the prefix correctly, so we need to strip it out here and add it in manually.
+							var prefix = '';
+							var index = hrefAtt.value.indexOf(input.textToWrap);
+							if (index > 0) {
+								prefix = hrefAtt.value.substring(0, index);
+							}
+
+							// Replace a *valid* href with $TM_SELECTED_TEXT so that multi-cursor mode works correctly.
+							hrefAtt.value = prefix + selectedTextPlaceholder;
 						}
 					}
 				}

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -345,13 +345,13 @@ suite('Tests for Wrap with Abbreviations', () => {
 			www.google.com.au
 		`;
 		const expectedContents = `
-			<a href="www.google.com">www.google.com</a>
-			<a href="www.google.com.au">www.google.com.au</a>
+			<a href="http://www.google.com">www.google.com</a>
+			<a href="http://www.google.com.au">www.google.com.au</a>
 		`;
 
 		return withRandomFileEditor(contents, 'html', (editor, _) => {
-			editor.selections = [new Selection(1, 0, 1, 17), new Selection(2, 0, 2, 20)];
-			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'a' });
+			editor.selections = [new Selection(1, 0, 2, 20)];
+			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'a*' });
 			if (!promise) {
 				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');
 				return Promise.resolve();

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -321,7 +321,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 			www.google.com
 		`;
 		const expectedContents = `
-			<a href="www.google.com">www.google.com</a>
+			<a href="http://www.google.com">www.google.com</a>
 		`;
 
 		return withRandomFileEditor(contents, 'html', (editor, _) => {

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -319,13 +319,15 @@ suite('Tests for Wrap with Abbreviations', () => {
 	test('Wrap maintains href', () => {
 		const contents = `
 			www.google.com
+			https://github.com
 		`;
 		const expectedContents = `
 			<a href="http://www.google.com">www.google.com</a>
+			<a href="https://github.com">https://github.com</a>
 		`;
 
 		return withRandomFileEditor(contents, 'html', (editor, _) => {
-			editor.selections = [new Selection(1, 1, 1, 1)];
+			editor.selections = [new Selection(1, 1, 1, 1), new Selection(2, 1, 2, 1)];
 			const promise = wrapWithAbbreviation({ abbreviation: 'a' });
 			if (!promise) {
 				assert.equal(1, 2, 'Wrap with Abbreviation returned undefined.');
@@ -334,6 +336,32 @@ suite('Tests for Wrap with Abbreviations', () => {
 
 			return promise.then(() => {
 				assert.equal(editor.document.getText(), expectedContents);
+				return Promise.resolve();
+			});
+		});
+	});
+
+	test('Wrap multiline with abbreviation "a" maintains multicursor', () => {
+		const contents = `
+			www.google.com
+			www.google.com
+		`;
+		const expectedContents = `
+			<a href="http://www.google.com">www.google.com</a>
+			<a href="http://www.google.com">www.google.com</a>
+		`;
+
+		return withRandomFileEditor(contents, 'html', (editor, _) => {
+			editor.selections = [new Selection(1, 1, 1, 1), new Selection(2, 1, 2, 1)];
+			const promise = wrapWithAbbreviation({ abbreviation: 'a' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap with Abbreviation returned undefined.');
+				return Promise.resolve();
+			}
+
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), expectedContents);
+				assert.equal(editor.selections.length, 2);
 				return Promise.resolve();
 			});
 		});

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -315,6 +315,54 @@ suite('Tests for Wrap with Abbreviations', () => {
 
 		return testWrapIndividualLinesWithAbbreviation([new Selection(2,2,3,33)], '.hello$*', wrapIndividualLinesJsxExpected, htmlContentsForWrapTests, 'jsx');
 	});
+
+	test('Wrap maintains href', () => {
+		const contents = `
+			www.google.com
+		`;
+		const expectedContents = `
+			<a href="www.google.com">www.google.com</a>
+		`;
+
+		return withRandomFileEditor(contents, 'html', (editor, _) => {
+			editor.selections = [new Selection(1, 1, 1, 1)];
+			const promise = wrapWithAbbreviation({ abbreviation: 'a' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap with Abbreviation returned undefined.');
+				return Promise.resolve();
+			}
+
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), expectedContents);
+				return Promise.resolve();
+			});
+		});
+	});
+
+	test('Wrap Individual Lines maintains href', () => {
+		const contents = `
+			www.google.com
+			www.google.com.au
+		`;
+		const expectedContents = `
+			<a href="www.google.com">www.google.com</a>
+			<a href="www.google.com.au">www.google.com.au</a>
+		`;
+
+		return withRandomFileEditor(contents, 'html', (editor, _) => {
+			editor.selections = [new Selection(1, 0, 1, 17), new Selection(2, 0, 2, 20)];
+			const promise = wrapIndividualLinesWithAbbreviation({ abbreviation: 'a' });
+			if (!promise) {
+				assert.equal(1, 2, 'Wrap Individual Lines with Abbreviation returned undefined.');
+				return Promise.resolve();
+			}
+
+			return promise.then(() => {
+				assert.equal(editor.document.getText(), expectedContents);
+				return Promise.resolve();
+			});
+		});
+	});
 });
 
 


### PR DESCRIPTION
Use the exact text to wrap, instead of a variable, for <a> tags so that any urls or emails get appropiately resolved and inserted into the href attribute. 

Fixes #54711

I'm not very confident with this fix, but it does do the job nicely. Basically, the preview uses the `expandAbbr` function while the final result that's inserted into the editor uses the `expandAbbreviationInRange` function, which are both quite different. The key difference though is that the preview call chain uses the _actual_ text to wrap, while the editor call chain uses the `$TM_SELECTED_TEXT` variable, which doesn't get parsed by the Emmet helper and as such, doesn't recognize that there's a valid url or email that needs to be added to the href attribute.

Happy to take suggestions on better/alternative approaches.