### PR TITLE
[CSS fix] Settings tab alignment

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/media/preferences.css
+++ b/src/vs/workbench/parts/preferences/browser/media/preferences.css
@@ -62,6 +62,7 @@
 	justify-content: flex-start;
 }
 
+.default-preferences-editor-container > .preferences-header-container > .default-preferences-header,
 .settings-tabs-widget > .monaco-action-bar .action-item {
 	padding: 3px 0px;
 }


### PR DESCRIPTION
Before 
![image](https://user-images.githubusercontent.com/18099464/46401950-0fa0ac80-c71c-11e8-878e-b583431557cc.png)



After fixing CSS
![image](https://user-images.githubusercontent.com/18099464/46401862-ce100180-c71b-11e8-8975-862d2ec25664.png)

Closes #59882
