### PR TITLE
Added link directly to main wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please see also our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Many of the core components and extensions to Code live in their own repositories on GitHub. For example, the [node debug adapter](https://github.com/microsoft/vscode-node-debug) and the [mono debug adapter](https://github.com/microsoft/vscode-mono-debug).
 
-For a complete list, please see the [Related Projects](https://github.com/Microsoft/vscode/wiki/Related-Projects) page on our wiki.
+For a complete list, please see the [Related Projects](https://github.com/Microsoft/vscode/wiki/Related-Projects) page on our [wiki](https://github.com/Microsoft/vscode/wiki).
 
 ## License
 


### PR DESCRIPTION
Added a link directly to the main wiki page from the README and not only to the Related Projects sub-section of the wiki.