### PR TITLE
only have the n second timeout for prelaunch tasks that do not send active

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -698,6 +698,9 @@ export class DebugService implements IDebugService {
 					// task is already running - nothing to do.
 					return TPromise.as(null);
 				}
+				once(TaskEventKind.Active, this.taskService.onDidStateChange)((taskEvent) => {
+					taskStarted = true;
+				});
 				const taskPromise = this.taskService.run(task);
 				if (task.isBackground) {
 					return new TPromise((c, e) => once(TaskEventKind.Inactive, this.taskService.onDidStateChange)(() => {


### PR DESCRIPTION
fixes #59835

This brings back the old behavior that the debug service listens to task active event and for tasks which send out an active event will not prompt after 10 seconds.
This bascially allows users to have prelaunch task which take a longer time