### PR TITLE
Fix #57910 - Add setting for auto fetch timeout

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1000,6 +1000,12 @@
             "usesOnlineServices"
           ]
         },
+        "git.autofetchPeriod": {
+          "type": "number",
+          "scope":"resource",
+          "description": "%config.autofetchPeriod%",
+          "default": 3
+        },
         "git.branchValidationRegex": {
           "type": "string",
           "description": "%config.branchValidationRegex%",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -67,6 +67,7 @@
 	"config.autoRepositoryDetection.openEditors": "Scan for parent folders of open files.",
 	"config.autorefresh": "Whether auto refreshing is enabled.",
 	"config.autofetch": "Whether auto fetching is enabled.",
+	"config.autofetchPeriod": "Time period, in minutes, between each auto fetch run",
 	"config.confirmSync": "Confirm before synchronizing git repositories.",
 	"config.countBadge": "Controls the git badge counter.",
 	"config.countBadge.all": "Count all changes.",

--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -19,15 +19,18 @@ function isRemoteOperation(operation: Operation): boolean {
 
 export class AutoFetcher {
 
-	private static readonly Period = 3 * 60 * 1000 /* three minutes */;
 	private static DidInformUser = 'autofetch.didInformUser';
 
-	private _onDidChange = new EventEmitter<boolean>();
+	private _onDidChange = new EventEmitter<boolean | number>();
 	private onDidChange = this._onDidChange.event;
 
 	private _enabled: boolean = false;
 	get enabled(): boolean { return this._enabled; }
 	set enabled(enabled: boolean) { this._enabled = enabled; this._onDidChange.fire(enabled); }
+
+	private _timeout: number = workspace.getConfiguration('git').get<number>('autofetchPeriod', 3) * 60 * 1000;
+	private get timeout(): number { return this._timeout; }
+	private set timeout(minutes: number) { this._timeout = minutes * 60 * 1000; this._onDidChange.fire(minutes); }
 
 	private disposables: Disposable[] = [];
 
@@ -72,19 +75,19 @@ export class AutoFetcher {
 
 	private onConfiguration(): void {
 		const gitConfig = workspace.getConfiguration('git');
+		const minutes = gitConfig.get<number>('autofetchPeriod', 3);
+		const autofetch = gitConfig.get<boolean>('autofetch');
 
-		if (gitConfig.get<boolean>('autofetch') === false) {
-			this.disable();
-		} else {
-			this.enable();
+		if (this.timeout !== minutes) {
+			this.timeout = minutes;
+		}
+
+		if (this.enabled !== autofetch) {
+			autofetch ? this.enable() : this.disable();
 		}
 	}
 
 	enable(): void {
-		if (this.enabled) {
-			return;
-		}
-
 		this.enabled = true;
 		this.run();
 	}
@@ -113,9 +116,9 @@ export class AutoFetcher {
 				return;
 			}
 
-			const timeout = new Promise(c => setTimeout(c, AutoFetcher.Period));
-			const whenDisabled = eventToPromise(filterEvent(this.onDidChange, enabled => !enabled));
-			await Promise.race([timeout, whenDisabled]);
+			const timeout = new Promise(c => setTimeout(c, this.timeout));
+			const onChanged = eventToPromise(filterEvent(this.onDidChange, () => true));
+			await Promise.race([timeout, onChanged]);
 		}
 	}
 


### PR DESCRIPTION
Finishes the race condition when either setting is changed, and then if it wasn’t disabled creates a new timeout using the new value (instead of waiting for it to go through the loop again to update).