### PR TITLE
adding ability to set checked state for menu item at registration

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -27,6 +27,7 @@ export interface IBaseCommandAction {
 export interface ICommandAction extends IBaseCommandAction {
 	iconLocation?: { dark: URI; light?: URI; };
 	precondition?: ContextKeyExpr;
+	effectToggled?: ContextKeyExpr;
 }
 
 export interface ISerializableCommandAction extends IBaseCommandAction {
@@ -220,7 +221,6 @@ export class ExecuteCommandAction extends Action {
 }
 
 export class SubmenuItemAction extends Action {
-	// private _options: IMenuActionOptions;
 
 	readonly item: ISubmenuItem;
 	constructor(item: ISubmenuItem) {
@@ -246,6 +246,10 @@ export class MenuItemAction extends ExecuteCommandAction {
 		typeof item.title === 'string' ? super(item.id, item.title, commandService) : super(item.id, item.title.value, commandService);
 		this._cssClass = undefined;
 		this._enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
+		if (item.effectToggled && contextKeyService.contextMatchesRules(item.effectToggled)) {
+			this._checked = true;
+		}
+
 		this._options = options || {};
 
 		this.item = item;

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -27,7 +27,7 @@ export interface IBaseCommandAction {
 export interface ICommandAction extends IBaseCommandAction {
 	iconLocation?: { dark: URI; light?: URI; };
 	precondition?: ContextKeyExpr;
-	effectToggled?: ContextKeyExpr;
+	toggled?: ContextKeyExpr;
 }
 
 export interface ISerializableCommandAction extends IBaseCommandAction {
@@ -246,9 +246,7 @@ export class MenuItemAction extends ExecuteCommandAction {
 		typeof item.title === 'string' ? super(item.id, item.title, commandService) : super(item.id, item.title.value, commandService);
 		this._cssClass = undefined;
 		this._enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
-		if (item.effectToggled && contextKeyService.contextMatchesRules(item.effectToggled)) {
-			this._checked = true;
-		}
+		this._checked = item.toggled && contextKeyService.contextMatchesRules(item.toggled);
 
 		this._options = options || {};
 

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -459,7 +459,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	command: {
 		id: 'breadcrumbs.toggle',
 		title: localize('miToggleBreadcrumbs', "Toggle &&Breadcrumbs"),
-		effectToggled: ContextKeyExpr.equals('config.breadcrumbs.enabled', true)
+		toggled: ContextKeyExpr.equals('config.breadcrumbs.enabled', true)
 	}
 });
 CommandsRegistry.registerCommand('breadcrumbs.toggle', accessor => {

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -458,7 +458,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	order: 99,
 	command: {
 		id: 'breadcrumbs.toggle',
-		title: localize('miToggleBreadcrumbs', "Toggle &&Breadcrumbs")
+		title: localize('miToggleBreadcrumbs', "Toggle &&Breadcrumbs"),
+		effectToggled: ContextKeyExpr.equals('config.breadcrumbs.enabled', true)
 	}
 });
 CommandsRegistry.registerCommand('breadcrumbs.toggle', accessor => {

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -179,10 +179,6 @@ export class MenubarControl extends Disposable {
 		return enableMenuBarMnemonics;
 	}
 
-	private get currentAutoSaveSetting(): string {
-		return this.configurationService.getValue<string>('files.autoSave');
-	}
-
 	private get currentSidebarPosition(): string {
 		return this.configurationService.getValue<string>('workbench.sideBar.location');
 	}
@@ -485,17 +481,6 @@ export class MenubarControl extends Disposable {
 		this.mnemonics.set(KeyCodeUtils.fromString(mnemonic), menuIndex);
 	}
 
-	private setCheckedStatus(action: IAction | IMenubarMenuItemAction) {
-		switch (action.id) {
-			case 'workbench.action.toggleAutoSave':
-				action.checked = this.currentAutoSaveSetting !== 'off';
-				break;
-
-			default:
-				break;
-		}
-	}
-
 	private calculateActionLabel(action: IAction | IMenubarMenuItemAction): string {
 		let label = action.label;
 		switch (action.id) {
@@ -717,7 +702,6 @@ export class MenubarControl extends Disposable {
 							target.push(new SubmenuAction(action.label, submenuActions));
 						} else {
 							action.label = this.calculateActionLabel(action);
-							this.setCheckedStatus(action);
 							target.push(action);
 						}
 					}
@@ -987,9 +971,7 @@ export class MenubarControl extends Disposable {
 						keybinding: this.getMenubarKeybinding(menuItem.id)
 					};
 
-					this.setCheckedStatus(menubarMenuItem);
 					menubarMenuItem.label = this.calculateActionLabel(menubarMenuItem);
-
 					menuToPopulate.items.push(menubarMenuItem);
 				}
 			});

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleMinimap.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleMinimap.ts
@@ -37,7 +37,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	command: {
 		id: ToggleMinimapAction.ID,
 		title: nls.localize({ key: 'miToggleMinimap', comment: ['&& denotes a mnemonic'] }, "Toggle &&Minimap"),
-		effectToggled: ContextKeyExpr.equals('config.editor.minimap.enabled', true)
+		toggled: ContextKeyExpr.equals('config.editor.minimap.enabled', true)
 	},
 	order: 2
 });

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleMinimap.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleMinimap.ts
@@ -9,6 +9,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { Action } from 'vs/base/common/actions';
 import { SyncActionDescriptor, MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
 export class ToggleMinimapAction extends Action {
 	public static readonly ID = 'editor.action.toggleMinimap';
@@ -35,7 +36,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	group: '5_editor',
 	command: {
 		id: ToggleMinimapAction.ID,
-		title: nls.localize({ key: 'miToggleMinimap', comment: ['&& denotes a mnemonic'] }, "Toggle &&Minimap")
+		title: nls.localize({ key: 'miToggleMinimap', comment: ['&& denotes a mnemonic'] }, "Toggle &&Minimap"),
+		effectToggled: ContextKeyExpr.equals('config.editor.minimap.enabled', true)
 	},
 	order: 2
 });

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderControlCharacter.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderControlCharacter.ts
@@ -38,7 +38,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	command: {
 		id: ToggleRenderControlCharacterAction.ID,
 		title: nls.localize({ key: 'miToggleRenderControlCharacters', comment: ['&& denotes a mnemonic'] }, "Toggle &&Control Characters"),
-		effectToggled: ContextKeyExpr.equals('config.editor.renderControlCharacters', true)
+		toggled: ContextKeyExpr.equals('config.editor.renderControlCharacters', true)
 	},
 	order: 4
 });

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderControlCharacter.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderControlCharacter.ts
@@ -9,6 +9,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { Action } from 'vs/base/common/actions';
 import { SyncActionDescriptor, MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
 export class ToggleRenderControlCharacterAction extends Action {
 
@@ -36,7 +37,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	group: '5_editor',
 	command: {
 		id: ToggleRenderControlCharacterAction.ID,
-		title: nls.localize({ key: 'miToggleRenderControlCharacters', comment: ['&& denotes a mnemonic'] }, "Toggle &&Control Characters")
+		title: nls.localize({ key: 'miToggleRenderControlCharacters', comment: ['&& denotes a mnemonic'] }, "Toggle &&Control Characters"),
+		effectToggled: ContextKeyExpr.equals('config.editor.renderControlCharacters', true)
 	},
 	order: 4
 });

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderWhitespace.ts
@@ -9,6 +9,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { Action } from 'vs/base/common/actions';
 import { SyncActionDescriptor, MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
 export class ToggleRenderWhitespaceAction extends Action {
 
@@ -44,7 +45,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	group: '5_editor',
 	command: {
 		id: ToggleRenderWhitespaceAction.ID,
-		title: nls.localize({ key: 'miToggleRenderWhitespace', comment: ['&& denotes a mnemonic'] }, "Toggle &&Render Whitespace")
+		title: nls.localize({ key: 'miToggleRenderWhitespace', comment: ['&& denotes a mnemonic'] }, "Toggle &&Render Whitespace"),
+		effectToggled: ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none')
 	},
 	order: 3
 });

--- a/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/parts/codeEditor/electron-browser/toggleRenderWhitespace.ts
@@ -46,7 +46,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
 	command: {
 		id: ToggleRenderWhitespaceAction.ID,
 		title: nls.localize({ key: 'miToggleRenderWhitespace', comment: ['&& denotes a mnemonic'] }, "Toggle &&Render Whitespace"),
-		effectToggled: ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none')
+		toggled: ContextKeyExpr.notEquals('config.editor.renderWhitespace', 'none')
 	},
 	order: 3
 });

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -555,7 +555,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 	group: '5_autosave',
 	command: {
 		id: ToggleAutoSaveAction.ID,
-		title: nls.localize({ key: 'miAutoSave', comment: ['&& denotes a mnemonic'] }, "A&&uto Save")
+		title: nls.localize({ key: 'miAutoSave', comment: ['&& denotes a mnemonic'] }, "A&&uto Save"),
+		effectToggled: ContextKeyExpr.notEquals('config.files.autoSave', 'off')
 	},
 	order: 1
 });

--- a/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.contribution.ts
@@ -556,7 +556,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarFileMenu, {
 	command: {
 		id: ToggleAutoSaveAction.ID,
 		title: nls.localize({ key: 'miAutoSave', comment: ['&& denotes a mnemonic'] }, "A&&uto Save"),
-		effectToggled: ContextKeyExpr.notEquals('config.files.autoSave', 'off')
+		toggled: ContextKeyExpr.notEquals('config.files.autoSave', 'off')
 	},
 	order: 1
 });


### PR DESCRIPTION
resolves #58422
resolves #56885
resolves #14986

word wrap has a transient state which is what is controlled by the action (not the setting), so I haven't done that one yet.

Can also look into #46807 as well.