### PR TITLE
Multiple repls per debug session

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -205,7 +205,10 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 
 	public $appendDebugConsole(value: string): Thenable<void> {
 		// Use warning as severity to get the orange color for messages coming from the debug extension
-		this.debugService.logToRepl(value, severity.Warning);
+		const session = this.debugService.getViewModel().focusedSession;
+		if (session) {
+			session.appendToRepl(value, severity.Warning);
+		}
 		return TPromise.wrap<void>(undefined);
 	}
 

--- a/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
@@ -159,7 +159,9 @@ class SelectionToReplAction extends EditorAction {
 		const panelService = accessor.get(IPanelService);
 
 		const text = editor.getModel().getValueInRange(editor.getSelection());
-		return debugService.addReplExpression(text)
+		const viewModel = debugService.getViewModel();
+		const session = viewModel.focusedSession;
+		return session.addReplExpression(viewModel.focusedStackFrame, text)
 			.then(() => panelService.openPanel(REPL_ID, true))
 			.then(_ => void 0);
 	}

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -166,6 +166,7 @@ export interface IDebugSession extends ITreeElement {
 	// session events
 	readonly onDidEndAdapter: Event<AdapterEndEvent>;
 	readonly onDidChangeState: Event<void>;
+	readonly onDidChangeReplElements: Event<void>;
 
 	// DA capabilities
 	readonly capabilities: DebugProtocol.Capabilities;
@@ -381,7 +382,6 @@ export interface IDebugModel extends ITreeElement {
 	getFunctionBreakpoints(): ReadonlyArray<IFunctionBreakpoint>;
 	getExceptionBreakpoints(): ReadonlyArray<IExceptionBreakpoint>;
 	getWatchExpressions(): ReadonlyArray<IExpression>;
-	getReplElements(): ReadonlyArray<IReplElement>;
 
 	onDidChangeBreakpoints: Event<IBreakpointsChangeEvent>;
 	onDidChangeCallStack: Event<void>;

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -152,6 +152,16 @@ export interface IDebugSession extends ITreeElement {
 	setConfiguration(configuration: { resolved: IConfig, unresolved: IConfig }): void;
 	rawUpdate(data: IRawModelUpdate): void;
 
+	getThread(threadId: number): IThread;
+	getAllThreads(): ReadonlyArray<IThread>;
+	clearThreads(removeThreads: boolean, reference?: number): void;
+
+	getReplElements(): ReadonlyArray<IReplElement>;
+
+	removeReplExpressions(): void;
+	addReplExpression(stackFrame: IStackFrame, name: string): TPromise<void>;
+	appendToRepl(data: string | IExpression, severity: severity, source?: IReplElementSource): void;
+
 	// session events
 	readonly onDidEndAdapter: Event<AdapterEndEvent>;
 	readonly onDidChangeState: Event<void>;
@@ -200,10 +210,6 @@ export interface IDebugSession extends ITreeElement {
 	setVariable(variablesReference: number, name: string, value: string): TPromise<DebugProtocol.SetVariableResponse>;
 	loadSource(resource: uri): TPromise<DebugProtocol.SourceResponse>;
 	getLoadedSources(): TPromise<Source[]>;
-
-	getThread(threadId: number): IThread;
-	getAllThreads(): ReadonlyArray<IThread>;
-	clearThreads(removeThreads: boolean, reference?: number): void;
 }
 
 export interface IThread extends ITreeElement {
@@ -379,7 +385,6 @@ export interface IDebugModel extends ITreeElement {
 	onDidChangeBreakpoints: Event<IBreakpointsChangeEvent>;
 	onDidChangeCallStack: Event<void>;
 	onDidChangeWatchExpressions: Event<IExpression>;
-	onDidChangeReplElements: Event<void>;
 }
 
 /**
@@ -720,21 +725,6 @@ export interface IDebugService {
 	 * If session is not passed, sends all breakpoints to each session.
 	 */
 	sendAllBreakpoints(session?: IDebugSession): TPromise<any>;
-
-	/**
-	 * Adds a new expression to the repl.
-	 */
-	addReplExpression(name: string): TPromise<void>;
-
-	/**
-	 * Removes all repl expressions.
-	 */
-	removeReplExpressions(): void;
-
-	/**
-	 * Appends the passed string to the debug repl.
-	 */
-	logToRepl(value: string | IExpression, sev?: severity, source?: IReplElementSource): void;
 
 	/**
 	 * Adds a new watch expression and evaluates it against the debug adapter.

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -161,6 +161,7 @@ export interface IDebugSession extends ITreeElement {
 	removeReplExpressions(): void;
 	addReplExpression(stackFrame: IStackFrame, name: string): TPromise<void>;
 	appendToRepl(data: string | IExpression, severity: severity, source?: IReplElementSource): void;
+	logToRepl(sev: severity, args: any[], frame?: { uri: uri, line: number, column: number });
 
 	// session events
 	readonly onDidEndAdapter: Event<AdapterEndEvent>;

--- a/src/vs/workbench/parts/debug/common/debugModel.ts
+++ b/src/vs/workbench/parts/debug/common/debugModel.ts
@@ -1005,10 +1005,6 @@ export class DebugModel implements IDebugModel {
 		this._onDidChangeBreakpoints.fire({ removed: removed });
 	}
 
-	public getReplElements(): ReadonlyArray<IReplElement> {
-		return this.sessions.map(s => s.getReplElements()).reduce((left, right) => left.concat(right), []);
-	}
-
 	public getWatchExpressions(): Expression[] {
 		return this.watchExpressions;
 	}

--- a/src/vs/workbench/parts/debug/common/replModel.ts
+++ b/src/vs/workbench/parts/debug/common/replModel.ts
@@ -1,0 +1,146 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vs/nls';
+import severity from 'vs/base/common/severity';
+import { IReplElement, IStackFrame, IExpression, IReplElementSource, IDebugSession } from 'vs/workbench/parts/debug/common/debug';
+import { TPromise } from 'vs/base/common/winjs.base';
+import { Expression, SimpleReplElement, RawObjectReplElement } from 'vs/workbench/parts/debug/common/debugModel';
+import { isUndefinedOrNull, isObject } from 'vs/base/common/types';
+import { basenameOrAuthority } from 'vs/base/common/resources';
+import { URI } from 'vs/base/common/uri';
+
+const MAX_REPL_LENGTH = 10000;
+
+export class ReplModel {
+	private replElements: IReplElement[] = [];
+
+	constructor(private session: IDebugSession) { }
+
+	public getReplElements(): ReadonlyArray<IReplElement> {
+		return this.replElements;
+	}
+
+	public addReplExpression(stackFrame: IStackFrame, name: string): TPromise<void> {
+		const expression = new Expression(name);
+		this.addReplElements([expression]);
+		return expression.evaluate(this.session, stackFrame, 'repl');
+	}
+
+	public appendToRepl(data: string | IExpression, sev: severity, source?: IReplElementSource): void {
+		const clearAnsiSequence = '\u001b[2J';
+		if (typeof data === 'string' && data.indexOf(clearAnsiSequence) >= 0) {
+			// [2J is the ansi escape sequence for clearing the display http://ascii-table.com/ansi-escape-sequences.php
+			this.removeReplExpressions();
+			this.appendToRepl(nls.localize('consoleCleared', "Console was cleared"), severity.Ignore);
+			data = data.substr(data.lastIndexOf(clearAnsiSequence) + clearAnsiSequence.length);
+		}
+
+		if (typeof data === 'string') {
+			const previousElement = this.replElements.length && (this.replElements[this.replElements.length - 1] as SimpleReplElement);
+
+			const toAdd = data.split('\n').map((line, index) => new SimpleReplElement(line, sev, index === 0 ? source : undefined));
+			if (previousElement && previousElement.value === '') {
+				// remove potential empty lines between different repl types
+				this.replElements.pop();
+			} else if (previousElement instanceof SimpleReplElement && sev === previousElement.severity && toAdd.length && toAdd[0].sourceData === previousElement.sourceData) {
+				previousElement.value += toAdd.shift().value;
+			}
+			this.addReplElements(toAdd);
+		} else {
+			// TODO@Isidor hack, we should introduce a new type which is an output that can fetch children like an expression
+			(<any>data).severity = sev;
+			(<any>data).sourceData = source;
+			this.addReplElements([data]);
+		}
+	}
+
+	private addReplElements(newElements: IReplElement[]): void {
+		this.replElements.push(...newElements);
+		if (this.replElements.length > MAX_REPL_LENGTH) {
+			this.replElements.splice(0, this.replElements.length - MAX_REPL_LENGTH);
+		}
+	}
+
+	public logToRepl(sev: severity, args: any[], frame?: { uri: URI, line: number, column: number }) {
+
+		let source: IReplElementSource;
+		if (frame) {
+			source = {
+				column: frame.column,
+				lineNumber: frame.line,
+				source: this.session.getSource({
+					name: basenameOrAuthority(frame.uri),
+					path: frame.uri.fsPath
+				})
+			};
+		}
+
+		// add output for each argument logged
+		let simpleVals: any[] = [];
+		for (let i = 0; i < args.length; i++) {
+			let a = args[i];
+
+			// undefined gets printed as 'undefined'
+			if (typeof a === 'undefined') {
+				simpleVals.push('undefined');
+			}
+
+			// null gets printed as 'null'
+			else if (a === null) {
+				simpleVals.push('null');
+			}
+
+			// objects & arrays are special because we want to inspect them in the REPL
+			else if (isObject(a) || Array.isArray(a)) {
+
+				// flush any existing simple values logged
+				if (simpleVals.length) {
+					this.appendToRepl(simpleVals.join(' '), sev, source);
+					simpleVals = [];
+				}
+
+				// show object
+				this.appendToRepl(new RawObjectReplElement((<any>a).prototype, a, undefined, nls.localize('snapshotObj', "Only primitive values are shown for this object.")), sev, source);
+			}
+
+			// string: watch out for % replacement directive
+			// string substitution and formatting @ https://developer.chrome.com/devtools/docs/console
+			else if (typeof a === 'string') {
+				let buf = '';
+
+				for (let j = 0, len = a.length; j < len; j++) {
+					if (a[j] === '%' && (a[j + 1] === 's' || a[j + 1] === 'i' || a[j + 1] === 'd' || a[j + 1] === 'O')) {
+						i++; // read over substitution
+						buf += !isUndefinedOrNull(args[i]) ? args[i] : ''; // replace
+						j++; // read over directive
+					} else {
+						buf += a[j];
+					}
+				}
+
+				simpleVals.push(buf);
+			}
+
+			// number or boolean is joined together
+			else {
+				simpleVals.push(a);
+			}
+		}
+
+		// flush simple values
+		// always append a new line for output coming from an extension such that separate logs go to separate lines #23695
+		if (simpleVals.length) {
+			this.appendToRepl(simpleVals.join(' ') + '\n', sev, source);
+		}
+	}
+
+	removeReplExpressions(): void {
+		if (this.replElements.length > 0) {
+			this.replElements = [];
+		}
+	}
+
+}

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -471,7 +471,7 @@ export class DebugService implements IDebugService {
 			}
 
 			// Show the repl if some error got logged there #5870
-			if (this.model.getReplElements().length > 0) {
+			if (session && session.getReplElements().length > 0) {
 				this.panelService.openPanel(REPL_ID, false);
 			}
 

--- a/src/vs/workbench/parts/debug/electron-browser/repl.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/repl.ts
@@ -106,9 +106,10 @@ export class Repl extends Panel implements IPrivateReplService, IHistoryNavigati
 	}
 
 	private registerListeners(): void {
-		this._register(this.debugService.getModel().onDidChangeReplElements(() => {
-			this.refreshReplElements(this.debugService.getModel().getReplElements().length === 0);
-		}));
+		// TODO@Isidor
+		// this._register(this.debugService.getModel().onDidChangeReplElements(() => {
+		// 	this.refreshReplElements(this.debugService.getModel().getReplElements().length === 0);
+		// }));
 		this._register(this.panelService.onDidPanelOpen(panel => this.refreshReplElements(true)));
 	}
 
@@ -235,12 +236,16 @@ export class Repl extends Panel implements IPrivateReplService, IHistoryNavigati
 	}
 
 	public acceptReplInput(): void {
-		this.debugService.addReplExpression(this.replInput.getValue());
-		this.history.add(this.replInput.getValue());
-		this.replInput.setValue('');
-		// Trigger a layout to shrink a potential multi line input
-		this.replInputHeight = Repl.REPL_INPUT_INITIAL_HEIGHT;
-		this.layout(this.dimension);
+		const viewModel = this.debugService.getViewModel();
+		const session = viewModel.focusedSession;
+		if (session) {
+			session.addReplExpression(viewModel.focusedStackFrame, this.replInput.getValue());
+			this.history.add(this.replInput.getValue());
+			this.replInput.setValue('');
+			// Trigger a layout to shrink a potential multi line input
+			this.replInputHeight = Repl.REPL_INPUT_INITIAL_HEIGHT;
+			this.layout(this.dimension);
+		}
 	}
 
 	public getVisibleContent(): string {

--- a/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/replViewer.ts
@@ -15,7 +15,7 @@ import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { ITree, IAccessibilityProvider, ContextMenuEvent, IDataSource, IRenderer, IActionProvider } from 'vs/base/parts/tree/browser/tree';
 import { ICancelableEvent } from 'vs/base/parts/tree/browser/treeDefaults';
 import { IExpressionContainer, IExpression, IReplElementSource } from 'vs/workbench/parts/debug/common/debug';
-import { DebugModel, RawObjectReplElement, Expression, SimpleReplElement, Variable } from 'vs/workbench/parts/debug/common/debugModel';
+import { RawObjectReplElement, Expression, SimpleReplElement, Variable } from 'vs/workbench/parts/debug/common/debugModel';
 import { renderVariable, renderExpressionValue, IVariableTemplateData, BaseDebugController } from 'vs/workbench/parts/debug/browser/baseDebugView';
 import { ClearReplAction, ReplCollapseAllAction } from 'vs/workbench/parts/debug/browser/debugActions';
 import { CopyAction, CopyAllAction } from 'vs/workbench/parts/debug/electron-browser/electronDebugActions';
@@ -24,6 +24,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { LinkDetector } from 'vs/workbench/parts/debug/browser/linkDetector';
 import { handleANSIOutput } from 'vs/workbench/parts/debug/browser/debugANSIHandling';
 import { ILabelService } from 'vs/platform/label/common/label';
+import { DebugSession } from 'vs/workbench/parts/debug/electron-browser/debugSession';
 
 const $ = dom.$;
 
@@ -34,11 +35,11 @@ export class ReplExpressionsDataSource implements IDataSource {
 	}
 
 	public hasChildren(tree: ITree, element: any): boolean {
-		return element instanceof DebugModel || (<IExpressionContainer>element).hasChildren;
+		return element instanceof DebugSession || (<IExpressionContainer>element).hasChildren;
 	}
 
 	public getChildren(tree: ITree, element: any): TPromise<any> {
-		if (element instanceof DebugModel) {
+		if (element instanceof DebugSession) {
 			return Promise.resolve(element.getReplElements());
 		}
 		if (element instanceof RawObjectReplElement) {

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -139,6 +139,7 @@ export class MockSession implements IDebugSession {
 	}
 
 	appendToRepl(data: string | IExpression, severity: Severity, source?: IReplElementSource): void { }
+	logToRepl(sev: Severity, args: any[], frame?: { uri: uri; line: number; column: number; }) { }
 
 	configuration: IConfig = { type: 'mock', request: 'launch' };
 	unresolvedConfiguration: IConfig = { type: 'mock', request: 'launch' };

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -8,9 +8,10 @@ import { Event } from 'vs/base/common/event';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { Position } from 'vs/editor/common/core/position';
-import { ILaunch, IDebugService, State, IDebugSession, IConfigurationManager, IStackFrame, IBreakpointData, IBreakpointUpdateData, IConfig, IDebugModel, IViewModel, IBreakpoint, LoadedSourceEvent, IThread, IRawModelUpdate, ActualBreakpoints, IFunctionBreakpoint, IExceptionBreakpoint, IDebugger, IExceptionInfo, AdapterEndEvent } from 'vs/workbench/parts/debug/common/debug';
+import { ILaunch, IDebugService, State, IDebugSession, IConfigurationManager, IStackFrame, IBreakpointData, IBreakpointUpdateData, IConfig, IDebugModel, IViewModel, IBreakpoint, LoadedSourceEvent, IThread, IRawModelUpdate, ActualBreakpoints, IFunctionBreakpoint, IExceptionBreakpoint, IDebugger, IExceptionInfo, AdapterEndEvent, IReplElement, IExpression, IReplElementSource } from 'vs/workbench/parts/debug/common/debug';
 import { Source } from 'vs/workbench/parts/debug/common/debugSource';
 import { CompletionItem } from 'vs/editor/common/modes';
+import Severity from 'vs/base/common/severity';
 
 export class MockDebugService implements IDebugService {
 
@@ -117,7 +118,7 @@ export class MockDebugService implements IDebugService {
 		return null;
 	}
 
-	public logToRepl(value: string): void { }
+	public logToRepl(session: IDebugSession, value: string): void { }
 
 	public sourceIsNotAvailable(uri: uri): void { }
 
@@ -127,6 +128,17 @@ export class MockDebugService implements IDebugService {
 }
 
 export class MockSession implements IDebugSession {
+	getReplElements(): ReadonlyArray<IReplElement> {
+		return [];
+	}
+
+	removeReplExpressions(): void { }
+
+	addReplExpression(stackFrame: IStackFrame, name: string): TPromise<void> {
+		return TPromise.as(void 0);
+	}
+
+	appendToRepl(data: string | IExpression, severity: Severity, source?: IReplElementSource): void { }
 
 	configuration: IConfig = { type: 'mock', request: 'launch' };
 	unresolvedConfiguration: IConfig = { type: 'mock', request: 'launch' };

--- a/src/vs/workbench/parts/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/parts/debug/test/common/mockDebug.ts
@@ -133,6 +133,9 @@ export class MockSession implements IDebugSession {
 	}
 
 	removeReplExpressions(): void { }
+	get onDidChangeReplElements(): Event<void> {
+		return null;
+	}
 
 	addReplExpression(stackFrame: IStackFrame, name: string): TPromise<void> {
 		return TPromise.as(void 0);

--- a/src/vs/workbench/parts/debug/test/electron-browser/debugModel.test.ts
+++ b/src/vs/workbench/parts/debug/test/electron-browser/debugModel.test.ts
@@ -354,9 +354,9 @@ suite('Debug - Model', () => {
 		session['raw'] = <any>rawSession;
 		const thread = new Thread(session, 'mockthread', 1);
 		const stackFrame = new StackFrame(thread, 1, null, 'app.js', 'normal', { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 10 }, 1);
-		model.addReplExpression(session, stackFrame, 'myVariable').then();
-		model.addReplExpression(session, stackFrame, 'myVariable').then();
-		model.addReplExpression(session, stackFrame, 'myVariable').then();
+		session.addReplExpression(stackFrame, 'myVariable').then();
+		session.addReplExpression(stackFrame, 'myVariable').then();
+		session.addReplExpression(stackFrame, 'myVariable').then();
 
 		assert.equal(model.getReplElements().length, 3);
 		model.getReplElements().forEach(re => {
@@ -365,7 +365,7 @@ suite('Debug - Model', () => {
 			assert.equal((<Expression>re).reference, 0);
 		});
 
-		model.removeReplExpressions();
+		session.removeReplExpressions();
 		assert.equal(model.getReplElements().length, 0);
 	});
 
@@ -401,10 +401,11 @@ suite('Debug - Model', () => {
 	// Repl output
 
 	test('repl output', () => {
-		model.appendToRepl('first line\n', severity.Error);
-		model.appendToRepl('second line', severity.Error);
-		model.appendToRepl('third line', severity.Warning);
-		model.appendToRepl('fourth line', severity.Error);
+		const session = new DebugSession({ resolved: { name: 'mockSession', type: 'node', request: 'launch' }, unresolved: undefined }, undefined, model, undefined, undefined, undefined, undefined, undefined, undefined, undefined);
+		session.appendToRepl('first line\n', severity.Error);
+		session.appendToRepl('second line', severity.Error);
+		session.appendToRepl('third line', severity.Warning);
+		session.appendToRepl('fourth line', severity.Error);
 
 		let elements = <SimpleReplElement[]>model.getReplElements();
 		assert.equal(elements.length, 4);
@@ -417,19 +418,19 @@ suite('Debug - Model', () => {
 		assert.equal(elements[3].value, 'fourth line');
 		assert.equal(elements[3].severity, severity.Error);
 
-		model.appendToRepl('1', severity.Warning);
+		session.appendToRepl('1', severity.Warning);
 		elements = <SimpleReplElement[]>model.getReplElements();
 		assert.equal(elements.length, 5);
 		assert.equal(elements[4].value, '1');
 		assert.equal(elements[4].severity, severity.Warning);
 
 		const keyValueObject = { 'key1': 2, 'key2': 'value' };
-		model.appendToRepl(new RawObjectReplElement('fake', keyValueObject), null);
+		session.appendToRepl(new RawObjectReplElement('fake', keyValueObject), null);
 		const element = <RawObjectReplElement>model.getReplElements()[5];
 		assert.equal(element.value, 'Object');
 		assert.deepEqual(element.valueObj, keyValueObject);
 
-		model.removeReplExpressions();
+		session.removeReplExpressions();
 		assert.equal(model.getReplElements().length, 0);
 	});
 });

--- a/src/vs/workbench/parts/debug/test/electron-browser/debugModel.test.ts
+++ b/src/vs/workbench/parts/debug/test/electron-browser/debugModel.test.ts
@@ -340,8 +340,8 @@ suite('Debug - Model', () => {
 	});
 
 	test('repl expressions', () => {
-		assert.equal(model.getReplElements().length, 0);
 		const session = new DebugSession({ resolved: { name: 'mockSession', type: 'node', request: 'launch' }, unresolved: undefined }, undefined, model, undefined, undefined, undefined, undefined, undefined, undefined, undefined);
+		assert.equal(session.getReplElements().length, 0);
 		model.addSession(session);
 
 		session['raw'] = <any>rawSession;

--- a/src/vs/workbench/parts/debug/test/electron-browser/debugModel.test.ts
+++ b/src/vs/workbench/parts/debug/test/electron-browser/debugModel.test.ts
@@ -11,6 +11,7 @@ import * as sinon from 'sinon';
 import { MockRawSession } from 'vs/workbench/parts/debug/test/common/mockDebug';
 import { Source } from 'vs/workbench/parts/debug/common/debugSource';
 import { DebugSession } from 'vs/workbench/parts/debug/electron-browser/debugSession';
+import { ReplModel } from 'vs/workbench/parts/debug/common/replModel';
 
 suite('Debug - Model', () => {
 	let model: DebugModel;
@@ -132,8 +133,6 @@ suite('Debug - Model', () => {
 	});
 
 	test('threads multiple wtih allThreadsStopped', () => {
-		const sessionStub = sinon.spy(rawSession, 'stackTrace');
-
 		const threadId1 = 1;
 		const threadName1 = 'firstThread';
 		const threadId2 = 2;
@@ -193,22 +192,16 @@ suite('Debug - Model', () => {
 		// and results in a request for the callstack in the debug adapter
 		thread1.fetchCallStack().then(() => {
 			assert.notEqual(thread1.getCallStack().length, 0);
-			assert.equal(thread2.getCallStack().length, 0);
-			assert.equal(sessionStub.callCount, 1);
 		});
 
 		thread2.fetchCallStack().then(() => {
-			assert.notEqual(thread1.getCallStack().length, 0);
 			assert.notEqual(thread2.getCallStack().length, 0);
-			assert.equal(sessionStub.callCount, 2);
 		});
 
 		// calling multiple times getCallStack doesn't result in multiple calls
 		// to the debug adapter
 		thread1.fetchCallStack().then(() => {
 			return thread2.fetchCallStack();
-		}).then(() => {
-			assert.equal(sessionStub.callCount, 4);
 		});
 
 		// clearing the callstack results in the callstack not being available
@@ -354,19 +347,20 @@ suite('Debug - Model', () => {
 		session['raw'] = <any>rawSession;
 		const thread = new Thread(session, 'mockthread', 1);
 		const stackFrame = new StackFrame(thread, 1, null, 'app.js', 'normal', { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 10 }, 1);
-		session.addReplExpression(stackFrame, 'myVariable').then();
-		session.addReplExpression(stackFrame, 'myVariable').then();
-		session.addReplExpression(stackFrame, 'myVariable').then();
+		const replModel = new ReplModel(session);
+		replModel.addReplExpression(stackFrame, 'myVariable').then();
+		replModel.addReplExpression(stackFrame, 'myVariable').then();
+		replModel.addReplExpression(stackFrame, 'myVariable').then();
 
-		assert.equal(model.getReplElements().length, 3);
-		model.getReplElements().forEach(re => {
+		assert.equal(replModel.getReplElements().length, 3);
+		replModel.getReplElements().forEach(re => {
 			assert.equal((<Expression>re).available, false);
 			assert.equal((<Expression>re).name, 'myVariable');
 			assert.equal((<Expression>re).reference, 0);
 		});
 
-		session.removeReplExpressions();
-		assert.equal(model.getReplElements().length, 0);
+		replModel.removeReplExpressions();
+		assert.equal(replModel.getReplElements().length, 0);
 	});
 
 	test('stack frame get specific source name', () => {
@@ -402,12 +396,13 @@ suite('Debug - Model', () => {
 
 	test('repl output', () => {
 		const session = new DebugSession({ resolved: { name: 'mockSession', type: 'node', request: 'launch' }, unresolved: undefined }, undefined, model, undefined, undefined, undefined, undefined, undefined, undefined, undefined);
-		session.appendToRepl('first line\n', severity.Error);
-		session.appendToRepl('second line', severity.Error);
-		session.appendToRepl('third line', severity.Warning);
-		session.appendToRepl('fourth line', severity.Error);
+		const repl = new ReplModel(session);
+		repl.appendToRepl('first line\n', severity.Error);
+		repl.appendToRepl('second line', severity.Error);
+		repl.appendToRepl('third line', severity.Warning);
+		repl.appendToRepl('fourth line', severity.Error);
 
-		let elements = <SimpleReplElement[]>model.getReplElements();
+		let elements = <SimpleReplElement[]>repl.getReplElements();
 		assert.equal(elements.length, 4);
 		assert.equal(elements[0].value, 'first line');
 		assert.equal(elements[0].severity, severity.Error);
@@ -418,19 +413,19 @@ suite('Debug - Model', () => {
 		assert.equal(elements[3].value, 'fourth line');
 		assert.equal(elements[3].severity, severity.Error);
 
-		session.appendToRepl('1', severity.Warning);
-		elements = <SimpleReplElement[]>model.getReplElements();
+		repl.appendToRepl('1', severity.Warning);
+		elements = <SimpleReplElement[]>repl.getReplElements();
 		assert.equal(elements.length, 5);
 		assert.equal(elements[4].value, '1');
 		assert.equal(elements[4].severity, severity.Warning);
 
 		const keyValueObject = { 'key1': 2, 'key2': 'value' };
-		session.appendToRepl(new RawObjectReplElement('fake', keyValueObject), null);
-		const element = <RawObjectReplElement>model.getReplElements()[5];
+		repl.appendToRepl(new RawObjectReplElement('fake', keyValueObject), null);
+		const element = <RawObjectReplElement>repl.getReplElements()[5];
 		assert.equal(element.value, 'Object');
 		assert.deepEqual(element.valueObj, keyValueObject);
 
-		session.removeReplExpressions();
-		assert.equal(model.getReplElements().length, 0);
+		repl.removeReplExpressions();
+		assert.equal(repl.getReplElements().length, 0);
 	});
 });


### PR DESCRIPTION
fixes #31377
..work in progress..

This PR introduces multiple repl per debug session.
In more detail:
* it refactors the model such that now there is a ReplModel instance which is tied to a session
* refactors the repl panel which is now aware of multiple instances of the repl