### PR TITLE
include reference to the usefulness of the built-in reporting tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,13 @@ Do not add your issue as a comment to an existing issue unless it's for the iden
 
 The more information you can provide, the more likely someone will be successful at reproducing the issue and finding a fix.
 
+The built-in tool for reporting an issue, which you can access by using `Report Issue` in VS Code's Help menu, can help streamline this process by automatically providing the version of VS Code, all your installed extensions, and your system info. Additionally, the tool will search among existing issues to see if a similar issue already exists.
+
 Please include the following with each issue:
 
 * Version of VS Code
 
 * List of extensions that you have installed.
-  * **Tip:** You can easily add the list of extensions by creating the issue using `Report Issues` from VS Code's Help menu
 
 * Reproducible steps (1... 2... 3...) that cause the issue
 


### PR DESCRIPTION
Originally this was just going to be changing `Report Issues` to `Report Issue` (in VSCode, it's the singular not the plural) and I found myself appreciating the said tool and wondering why the contributing guidelines didn't mention how helpful it could be, so I wanted to remedy that