### PR TITLE
Remove css vendor prefixed rules for transition and transform

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -28,10 +28,6 @@
 .monaco-action-bar .action-item {
 	cursor: pointer;
 	display: inline-block;
-	-ms-transition: -ms-transform 50ms ease;
-	-webkit-transition: -webkit-transform 50ms ease;
-	-moz-transition: -moz-transform 50ms ease;
-	-o-transition: -o-transform 50ms ease;
 	transition: transform 50ms ease;
 	position: relative;  /* DO NOT REMOVE - this is the key to preventing the ghosting icon bug in Chrome 42 */
 }
@@ -41,11 +37,7 @@
 }
 
 .monaco-action-bar.animated .action-item.active {
-	-ms-transform: scale(1.272019649, 1.272019649); /* 1.272019649 = √φ */
-	-webkit-transform: scale(1.272019649, 1.272019649);
-	-moz-transform: scale(1.272019649, 1.272019649);
-	-o-transform: scale(1.272019649, 1.272019649);
-	transform: scale(1.272019649, 1.272019649);
+	transform: scale(1.272019649, 1.272019649); /* 1.272019649 = √φ */
 }
 
 .monaco-action-bar .action-item .icon {
@@ -87,10 +79,6 @@
 }
 
 .monaco-action-bar.animated.vertical .action-item.active {
-	-ms-transform: translate(5px, 0);
-	-webkit-transform: translate(5px, 0);
-	-moz-transform: translate(5px, 0);
-	-o-transform: translate(5px, 0);
 	transform: translate(5px, 0);
 }
 

--- a/src/vs/base/browser/ui/menu/menu.css
+++ b/src/vs/base/browser/ui/menu/menu.css
@@ -14,20 +14,12 @@
 
 .monaco-menu .monaco-action-bar.vertical .action-item {
 	padding: 0;
-	-ms-transform: none;
-	-webkit-transform: none;
-	-moz-transform: none;
-	-o-transform: none;
 	transform: none;
 	display: -ms-flexbox;
 	display: flex;
 }
 
 .monaco-menu .monaco-action-bar.vertical .action-item.active {
-	-ms-transform: none;
-	-webkit-transform: none;
-	-moz-transform: none;
-	-o-transform: none;
 	transform: none;
 }
 

--- a/src/vs/base/browser/ui/progressbar/progressbar.css
+++ b/src/vs/base/browser/ui/progressbar/progressbar.css
@@ -24,10 +24,6 @@
 .monaco-progress-container.discrete .progress-bit {
 	left: 0;
 	transition: width 100ms linear;
-	-webkit-transition: width 100ms linear;
-	-o-transition: width 100ms linear;
-	-moz-transition: width 100ms linear;
-	-ms-transition: width 100ms linear;
 }
 
 .monaco-progress-container.discrete.done .progress-bit {

--- a/src/vs/base/browser/ui/scrollbar/media/scrollbars.css
+++ b/src/vs/base/browser/ui/scrollbar/media/scrollbars.css
@@ -44,10 +44,6 @@
 	/* Background rule added for IE9 - to allow clicks on dom node */
 	background:rgba(0,0,0,0);
 
-	-webkit-transition: opacity 100ms linear;
-	-o-transition: opacity 100ms linear;
-	-moz-transition: opacity 100ms linear;
-	-ms-transition: opacity 100ms linear;
 	transition: opacity 100ms linear;
 }
 .monaco-scrollable-element > .invisible {
@@ -55,10 +51,6 @@
 	pointer-events: none;
 }
 .monaco-scrollable-element > .invisible.fade {
-	-webkit-transition: opacity 800ms linear;
-	-o-transition: opacity 800ms linear;
-	-moz-transition: opacity 800ms linear;
-	-ms-transition: opacity 800ms linear;
 	transition: opacity 800ms linear;
 }
 

--- a/src/vs/base/browser/ui/splitview/panelview.css
+++ b/src/vs/base/browser/ui/splitview/panelview.css
@@ -90,21 +90,13 @@
 
 .monaco-panel-view.animated .split-view-view {
 	transition-duration: 0.15s;
-	-webkit-transition-duration: 0.15s;
-	-moz-transition-duration: 0.15s;
 	transition-timing-function: ease-out;
-	-webkit-transition-timing-function: ease-out;
-	-moz-transition-timing-function: ease-out;
 }
 
 .monaco-panel-view.animated.vertical .split-view-view {
 	transition-property: height;
-	-webkit-transition-property: height;
-	-moz-transition-property: height;
 }
 
 .monaco-panel-view.animated.horizontal .split-view-view {
 	transition-property: width;
-	-webkit-transition-property: width;
-	-moz-transition-property: width;
 }

--- a/src/vs/editor/contrib/find/findWidget.css
+++ b/src/vs/editor/contrib/find/findWidget.css
@@ -36,13 +36,7 @@
 	height: 34px; /* find input height */
 	overflow: hidden;
 	line-height: 19px;
-
-	-webkit-transition: top 200ms linear;
-	-o-transition: top 200ms linear;
-	-moz-transition: top 200ms linear;
-	-ms-transition: top 200ms linear;
 	transition: top 200ms linear;
-
 	padding: 0 4px;
 }
 /* Find widget when replace is toggled on */

--- a/src/vs/editor/contrib/find/simpleFindWidget.css
+++ b/src/vs/editor/contrib/find/simpleFindWidget.css
@@ -22,11 +22,6 @@
 	padding: 4px;
 	align-items: center;
 	pointer-events: all;
-
-	-webkit-transition: top 200ms linear;
-	-o-transition: top 200ms linear;
-	-moz-transition: top 200ms linear;
-	-ms-transition: top 200ms linear;
 	transition: top 200ms linear;
 }
 

--- a/src/vs/editor/contrib/parameterHints/parameterHints.css
+++ b/src/vs/editor/contrib/parameterHints/parameterHints.css
@@ -22,9 +22,6 @@
 }
 
 .monaco-editor .parameter-hints-widget.visible {
-	-webkit-transition: left .05s ease-in-out;
-	-moz-transition: left .05s ease-in-out;
-	-o-transition: left .05s ease-in-out;
 	transition: left .05s ease-in-out;
 }
 

--- a/src/vs/workbench/parts/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/parts/debug/browser/media/debugViewlet.css
@@ -72,7 +72,6 @@
 	background-position: center center;
 	flex-shrink: 0;
 	transition: transform 50ms ease;
-	-webkit-transition: -webkit-transform 50ms ease;
 }
 
 .vs-dark .monaco-workbench > .part > .title > .title-actions .start-debug-action-item .icon,
@@ -93,7 +92,6 @@
 }
 
 .monaco-workbench > .part > .title > .title-actions .start-debug-action-item .icon.active {
-	-webkit-transform: scale(1.272019649, 1.272019649);
 	transform: scale(1.272019649, 1.272019649);
 }
 


### PR DESCRIPTION
The css3 `transform` and `transition` rules are now widely supported by all modern browsers. I do not believe we need to ship vendor prefixed rules for these anymore