### PR TITLE
Remove extra margin and padding for auto suggestion description. 

### DIFF
--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -239,6 +239,11 @@
 	white-space: initial;
 }
 
+.monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .docs.markdown-docs p {
+	margin: 0;
+	padding: 0;
+}
+
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .docs .code {
 	white-space: pre-wrap;
 	word-wrap: break-word;


### PR DESCRIPTION
![same-margin-for-markdown-and-text-description](https://user-images.githubusercontent.com/635858/46572820-abffc480-c951-11e8-83b4-17fe2959ba83.gif)

This PR removed the extra spacing for markdown description layout in auto-suggestion. Refer to the issue  #59036 for more details.

cc @aeschli and @ramya-rao-a for feedback