### PR TITLE
Fix #60067 - Toolbar ActionItems can't be triggered by keyboard events

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -472,6 +472,8 @@ export class ActionBar extends Disposable implements IActionRunner {
 				this.focusNext();
 			} else if (event.equals(KeyCode.Escape)) {
 				this.cancel();
+			} else if (event.equals(KeyCode.Space) || event.equals(KeyCode.Enter)) {
+				this.doTrigger(event);
 			} else if (this.isTriggerKeyEvent(event)) {
 				// Staying out of the else branch even if not triggered
 				if (this.options.triggerKeys && this.options.triggerKeys.keyDown) {


### PR DESCRIPTION
Potential fix for #60067 

- Added in keyboard triggers for space and enter, much like requested in other accessibility issues.