### PR TITLE
Stop displaying 'and its contents' for empty directories

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/fileActions.ts
+++ b/src/vs/workbench/parts/files/electron-browser/fileActions.ts
@@ -720,6 +720,9 @@ class BaseDeleteFileAction extends BaseFileAction {
 		}
 
 		if (distinctElements[0].isDirectory) {
+			if (distinctElements[0].getChildrenCount() === 0) {
+				return nls.localize('confirmMoveTrashMessageEmptyFolder', "Are you sure you want to delete empty directory '{0}'?", distinctElements[0].name);
+			}
 			return nls.localize('confirmMoveTrashMessageFolder', "Are you sure you want to delete '{0}' and its contents?", distinctElements[0].name);
 		}
 


### PR DESCRIPTION
This changes the message when confirming deletion so that, if the single selected directory is empty, this is reflected. This confirms for the user that they have selected the correct directory if they are attempting to delete one

One potential disadvantage of this PR is that it adds another translation string.

I chose the translation key I did based on the below string, but the word directory was used in the above strings - there seems to be a mismatch 