### PR TITLE
Fixed #59395 - Emmet Syntax Profiles tag_nl produces no extra space

### DIFF
--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -614,7 +614,7 @@ function expandAbbr(input: ExpandAbbreviationInput): string {
 				}
 
 				// If wrapping with a block element, insert newline in the text to wrap.
-				if (wrappingNode && inlineElements.indexOf(wrappingNode.name) === -1 && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true )) {
+				if (wrappingNode && inlineElements.indexOf(wrappingNode.name) === -1 && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true)) {
 					wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
 				}
 			}

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -614,7 +614,7 @@ function expandAbbr(input: ExpandAbbreviationInput): string {
 				}
 
 				// If wrapping with a block element, insert newline in the text to wrap.
-				if (wrappingNode && inlineElements.indexOf(wrappingNode.name) === -1) {
+				if (wrappingNode && inlineElements.indexOf(wrappingNode.name) === -1 && (expandOptions['profile'].hasOwnProperty('format') ? expandOptions['profile'].format : true )) {
 					wrappingNode.value = '\n\t' + wrappingNode.value + '\n';
 				}
 			}

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -5,7 +5,7 @@
 
 import 'mocha';
 import * as assert from 'assert';
-import { Selection } from 'vscode';
+import { Selection, workspace, ConfigurationTarget } from 'vscode';
 import { withRandomFileEditor, closeAllEditors } from './testUtils';
 import { wrapWithAbbreviation, wrapIndividualLinesWithAbbreviation } from '../abbreviationActions';
 
@@ -56,6 +56,13 @@ const wrapMultiLineAbbrExpected = `
 	</ul>
 `;
 
+const wrapInlineElementExpectedFormatFalse = `
+	<ul class="nav main">
+		<h1><li class="item1">img</li></h1>
+		<h1><li class="item2">$hithere</li></h1>
+	</ul>
+`;
+
 suite('Tests for Wrap with Abbreviations', () => {
 	teardown(closeAllEditors);
 
@@ -63,6 +70,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 	const multiCursorsWithSelection = [new Selection(2, 2, 2, 28), new Selection(3, 2, 3, 33)];
 	const multiCursorsWithFullLineSelection = [new Selection(2, 0, 2, 28), new Selection(3, 0, 4, 0)];
 
+	const oldValueForSyntaxProfiles = workspace.getConfiguration('emmet').inspect('syntaxProfile');
 
 	test('Wrap with block element using multi cursor', () => {
 		return testWrapWithAbbreviation(multiCursors, 'div', wrapBlockElementExpected);
@@ -337,6 +345,14 @@ suite('Tests for Wrap with Abbreviations', () => {
 			return promise.then(() => {
 				assert.equal(editor.document.getText(), wrapIndividualLinesExpected);
 				return Promise.resolve();
+			});
+		});
+	});
+
+	test('Wrap individual lines with abbreviation and format set to false)', () => {
+		return workspace.getConfiguration('emmet').update('syntaxProfiles',{ 'html' : { 'format': false } } , ConfigurationTarget.Global).then(() => {
+			return testWrapWithAbbreviation(multiCursors,'h1',wrapInlineElementExpectedFormatFalse).then(() => {
+				return workspace.getConfiguration('emmet').update('syntaxProfiles',oldValueForSyntaxProfiles ? oldValueForSyntaxProfiles.globalValue : undefined, ConfigurationTarget.Global);
 			});
 		});
 	});

--- a/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
+++ b/extensions/emmet/src/test/wrapWithAbbreviation.test.ts
@@ -349,7 +349,7 @@ suite('Tests for Wrap with Abbreviations', () => {
 		});
 	});
 
-	test('Wrap individual lines with abbreviation and format set to false)', () => {
+	test('Wrap individual lines with abbreviation and format set to false', () => {
 		return workspace.getConfiguration('emmet').update('syntaxProfiles',{ 'html' : { 'format': false } } , ConfigurationTarget.Global).then(() => {
 			return testWrapWithAbbreviation(multiCursors,'h1',wrapInlineElementExpectedFormatFalse).then(() => {
 				return workspace.getConfiguration('emmet').update('syntaxProfiles',oldValueForSyntaxProfiles ? oldValueForSyntaxProfiles.globalValue : undefined, ConfigurationTarget.Global);


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/59395.

With:
```
"emmet.syntaxProfiles": {
        "html": {
            "tag_nl": false            
        }
    },
```

It no longer allows extra space.

Before:
![vscode-59395-before](https://user-images.githubusercontent.com/16523071/46586211-18a9ba80-ca49-11e8-915a-1d302e2258a5.gif)


After:
![vscode-59395](https://user-images.githubusercontent.com/16523071/46586284-5eb34e00-ca4a-11e8-81a0-e76c7e3e1c8f.gif)

Thanks for considering this request.