### PR TITLE
PHP built-in extension: fix on indentationRules

### DIFF
--- a/extensions/php/language-configuration.json
+++ b/extensions/php/language-configuration.json
@@ -25,8 +25,8 @@
 		["`", "`"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "({(?!.+}).*|\\(|\\[|((else(\\s)?)?if|else|for(each)?|while|switch).*:)\\s*(/[/*].*)?$",
-		"decreaseIndentPattern": "^(.*\\*\\/)?\\s*((\\})|(\\)+[;,])|(\\][;,])|\\b(else:)|\\b((end(if|for(each)?|while|switch));))"
+		"increaseIndentPattern": "({(?!.+}).*|\\(|\\[|((else(\\s)?)?if|else|for(each)?|while|switch).*:)\\s*(.*\\?>)?(/[/*].*)?$",
+		"decreaseIndentPattern": "^(.*\\*\\/)?\\s*(<\\?(php)?\\s*)?((\\})|(\\)+[;,])|(\\][;,])|\\b(else:)|\\b((end(if|for(each)?|while|switch))\\s*;))"
 	},
 	"folding": {
 		"markers": {


### PR DESCRIPTION
Now it consider lines starting with `<?php`, `<?` or ending with `?>`

It fixes #44137