### PR TITLE
Fix yarn prerequisites when installing with yarn that has major version >1

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -18,7 +18,7 @@ const parsedYarnVersion = /^(\d+)\.(\d+)\./.exec(yarnVersion);
 const majorYarnVersion = parseInt(parsedYarnVersion[1]);
 const minorYarnVersion = parseInt(parsedYarnVersion[2]);
 
-if (majorYarnVersion < 1 || minorYarnVersion < 10) {
+if (majorYarnVersion < 1 || (majorYarnVersion == 1 && minorYarnVersion < 10)) {
 	console.error('\033[1;31m*** Please use yarn >=1.10.1.\033[0;0m');
 	err = true;
 }


### PR DESCRIPTION
Fix the preinstall script when checking the yarn major and minor version.

The previous preinstall script would break if installing using yarn version 2.0.0 for example