### PR TITLE
Add setting to allow to disable Replace Preview

### DIFF
--- a/src/vs/platform/search/common/search.ts
+++ b/src/vs/platform/search/common/search.ts
@@ -282,6 +282,7 @@ export interface ISearchConfigurationProperties {
 	smartCase: boolean;
 	globalFindClipboard: boolean;
 	location: 'sidebar' | 'panel';
+	useReplacePreview: boolean;
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -18,7 +18,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { ICommandHandler } from 'vs/platform/commands/common/commands';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { ISearchHistoryService, VIEW_ID } from 'vs/platform/search/common/search';
+import { ISearchHistoryService, VIEW_ID, ISearchConfiguration } from 'vs/platform/search/common/search';
 import { SearchView } from 'vs/workbench/parts/search/browser/searchView';
 import * as Constants from 'vs/workbench/parts/search/common/constants';
 import { IReplaceService } from 'vs/workbench/parts/search/common/replace';
@@ -28,6 +28,7 @@ import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { normalize } from 'vs/base/common/paths';
 import { IEditorGroupsService } from 'vs/workbench/services/group/common/editorGroupsService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export function isSearchViewFocused(viewletService: IViewletService, panelService: IPanelService): boolean {
 	let searchView = getSearchView(viewletService, panelService);
@@ -561,7 +562,8 @@ export class ReplaceAction extends AbstractSearchAndReplaceAction {
 	constructor(private viewer: ITree, private element: Match, private viewlet: SearchView,
 		@IReplaceService private replaceService: IReplaceService,
 		@IKeybindingService keyBindingService: IKeybindingService,
-		@IEditorService private editorService: IEditorService) {
+		@IEditorService private editorService: IEditorService,
+		@IConfigurationService private configurationService: IConfigurationService) {
 		super(Constants.ReplaceActionId, appendKeyBindingLabel(ReplaceAction.LABEL, keyBindingService.lookupKeybinding(Constants.ReplaceActionId), keyBindingService), 'action-replace');
 	}
 
@@ -575,7 +577,9 @@ export class ReplaceAction extends AbstractSearchAndReplaceAction {
 			}
 			let elementToShowReplacePreview = this.getElementToShowReplacePreview(elementToFocus);
 			this.viewer.domFocus();
-			if (!elementToShowReplacePreview || this.hasToOpenFile()) {
+
+			const useReplacePreview = this.configurationService.getValue<ISearchConfiguration>().search.useReplacePreview;
+			if (!useReplacePreview || !elementToShowReplacePreview || this.hasToOpenFile()) {
 				this.viewlet.open(this.element, true);
 			} else {
 				this.replaceService.openReplacePreview(elementToShowReplacePreview, true);

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -1402,7 +1402,8 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 			return TPromise.as(true);
 		}
 
-		return (this.viewModel.isReplaceActive() && !!this.viewModel.replaceString) ?
+		const useReplacePreview = this.configurationService.getValue<ISearchConfiguration>().search.useReplacePreview;
+		return (useReplacePreview && this.viewModel.isReplaceActive() && !!this.viewModel.replaceString) ?
 			this.replaceService.openReplacePreview(lineMatch, preserveFocus, sideBySide, pinned) :
 			this.open(lineMatch, preserveFocus, sideBySide, pinned);
 	}

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -647,7 +647,7 @@ configurationRegistry.registerConfiguration({
 		'search.useReplacePreview': {
 			type: 'boolean',
 			default: true,
-			description: nls.localize('search.useReplacePreview', "Controls whether to open Replace Preview when replacing a match."),
+			description: nls.localize('search.useReplacePreview', "Controls whether to open Replace Preview when selecting or replacing a match."),
 		}
 	}
 });

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -643,6 +643,11 @@ configurationRegistry.registerConfiguration({
 			],
 			default: 'auto',
 			description: nls.localize('search.collapseAllResults', "Controls whether the search results will be collapsed or expanded."),
+		},
+		'search.useReplacePreview': {
+			type: 'boolean',
+			default: true,
+			description: nls.localize('search.useReplacePreview', "Controls whether to open Replace Preview when replacing a match."),
 		}
 	}
 });


### PR DESCRIPTION
Introduces a new settings option "search.useReplacePreview" which
allows you to disable "Replace Preview" during a Search/Replace.

Closes #60027