### PR TITLE
Increase max-width for find-widget in narrow view

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.css
+++ b/src/vs/editor/contrib/find/findWidget.css
@@ -247,7 +247,7 @@
 
 /* COLLAPSED (SMALLER THAN NARROW) */
 .monaco-editor .find-widget.collapsed-find-widget {
-	max-width: 111px !important;
+	max-width: 170px !important;
 }
 
 .monaco-editor .find-widget.collapsed-find-widget .button.previous,


### PR DESCRIPTION
Fixes #60037 

Created a PR because I wanted to make sure this didn't break in other scenarios. Not sure where the previous number came from but I increase the width so it fits:

![gif](https://user-images.githubusercontent.com/35271042/46619727-a9c77280-cad7-11e8-9038-8b7b9d87c85f.gif)

