### PR TITLE
Fix issues with keybindings list header behavior (#41558)

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
@@ -99,23 +99,30 @@
 	border-collapse: separate;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header {
+	height: 30px;
+	line-height: 30px;
+}
+
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row {
 	cursor: default;
 	display: flex;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row.odd:not(.focused):not(.selected):not(:hover),
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list:not(:focus) .monaco-list-row.focused.odd:not(.selected):not(:hover),
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list:not(.focused) .monaco-list-row.focused.odd:not(.selected):not(:hover) {
 	background-color: rgba(130, 130, 130, 0.04);
 }
 
-.keybindings-editor > .keybindings-body .keybindings-list-container .monaco-list-row > .header {
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .header {
 	text-align: left;
 	font-weight: bold;
 }
 
-.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .header,
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .header,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .column {
 	align-items: center;
 	display: flex;
@@ -123,11 +130,13 @@
 	margin-right: 6px;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .actions,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .actions {
 	width: 24px;
 	padding-right: 2px;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .command,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .command {
 	flex: 0.75;
 }
@@ -143,6 +152,7 @@
 	margin-top: 2px;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .keybinding,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .keybinding {
 	flex: 0.5;
 }
@@ -151,10 +161,12 @@
 	padding-left: 10px;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .source,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .source {
 	flex: 0 0 100px;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-container .keybindings-list-header > .when,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .when {
 	flex: 1;
 }

--- a/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
@@ -19,7 +19,6 @@ import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKe
 import { KeybindingResolver } from 'vs/platform/keybinding/common/keybindingResolver';
 
 export const KEYBINDING_ENTRY_TEMPLATE_ID = 'keybinding.entry.template';
-export const KEYBINDING_HEADER_TEMPLATE_ID = 'keybinding.header.template';
 
 const SOURCE_DEFAULT = localize('default', "Default");
 const SOURCE_USER = localize('user', "User");


### PR DESCRIPTION
Resolves #41558

Fixes all the issues displayed in https://github.com/Microsoft/vscode/issues/41558#issuecomment-357817507 by moving the list header out from the list as suggested in https://github.com/Microsoft/vscode/pull/41789#issuecomment-359000189. This also makes the list header stay in place when scrolling the list, which makes it easier to make sense of the columns.