### PR TITLE
Update extensions/html/snippets/html.snippets.json

### DIFF
--- a/extensions/html/snippets/html.snippets.json
+++ b/extensions/html/snippets/html.snippets.json
@@ -4,17 +4,11 @@
 		"body": [
 			"<!DOCTYPE html>",
 			"<html>",
-			"<head>",
-			"\t<meta charset=\"utf-8\" />",
-			"\t<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">",
-			"\t<title>${1:Page Title}</title>",
-			"\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
-			"\t<link rel=\"stylesheet\" type=\"text/css\" media=\"screen\" href=\"${2:main.css}\" />",
-			"\t<script src=\"${3:main.js}\"></script>",
-			"</head>",
-			"<body>",
-			"\t$0",
-			"</body>",
+			"\t<head>",
+			"\t</head>",
+			"\t<body>",
+			"\t\t$0",
+			"\t</body>",
 			"</html>"
 		],
 		"description": "Simple HTML5 starting point"


### PR DESCRIPTION
We should not assume that users want extra DOM elements when the description says "simple". Also, the head and body elements are technically child nodes of the html element and should therefore be indented to represent this.