### PR TITLE
Add entries to scm/git context menu for force pushing

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -653,9 +653,19 @@
           "when": "scmProvider == git"
         },
         {
+          "command": "git.pushForce",
+          "group": "1_sync",
+          "when": "scmProvider == git && config.git.allowForcePush"
+        },
+        {
           "command": "git.pushTo",
           "group": "1_sync",
           "when": "scmProvider == git"
+        },
+        {
+          "command": "git.pushToForce",
+          "group": "1_sync",
+          "when": "scmProvider == git && config.git.allowForcePush"
         },
         {
           "command": "git.publish",


### PR DESCRIPTION
This PR adds entries for the feature introduced with #53286 to the scm/git context menu. This uses the same logic to display as other push related entries on the same menu plus the force push setting toggle, which is disabled by default.

This makes it more simple to use for some users who prefer menus instead of the command palette, while being still hidden by default and displaying a warning before use, thus preventing users unaware of the possible drawbacks from accidentally using it.