### PR TITLE
Fix #27393: Fix explorer inputbox alignment

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/media/explorerviewlet.css
+++ b/src/vs/workbench/parts/files/electron-browser/media/explorerviewlet.css
@@ -104,15 +104,18 @@
 .explorer-viewlet .explorer-item .monaco-inputbox {
 	width: 100%;
 	line-height: normal;
+	margin-left: -3px;
 }
 
 .monaco-workbench.linux .explorer-viewlet .explorer-item .monaco-inputbox,
 .monaco-workbench.mac .explorer-viewlet .explorer-item .monaco-inputbox {
 	height: 22px;
+	margin-left: -1px;
 }
 
 .explorer-viewlet .explorer-item .monaco-inputbox > .wrapper > .input {
 	padding: 1px 2px;
+	height: 19px;
 }
 
 .monaco-workbench.linux .explorer-viewlet .explorer-item .monaco-inputbox > .wrapper > .input,


### PR DESCRIPTION
- Fix for https://github.com/Microsoft/vscode/issues/27393, supersedes https://github.com/Microsoft/vscode/pull/60029
- Amends inputbox alignment for all supported platforms when in edit mode

###### TEST CASE
- Rename a file in Explorer
- Filename should not shift when switching between edit mode