### PR TITLE
Fix 60243

### DIFF
--- a/src/vs/platform/windows/node/windowsIpc.ts
+++ b/src/vs/platform/windows/node/windowsIpc.ts
@@ -141,7 +141,7 @@ export class WindowsChannel implements IWindowsChannel {
 			case 'removeFromRecentlyOpened': {
 				let paths: (IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | URI | string)[] = arg;
 				if (Array.isArray(paths)) {
-					paths = paths.map(path => URI.isUri(path) ? URI.revive(path) : path);
+					paths = paths.map(path => isWorkspaceIdentifier(path) ? path : URI.revive(path));
 				}
 				return this.service.removeFromRecentlyOpened(paths);
 			}

--- a/src/vs/platform/windows/node/windowsIpc.ts
+++ b/src/vs/platform/windows/node/windowsIpc.ts
@@ -141,7 +141,7 @@ export class WindowsChannel implements IWindowsChannel {
 			case 'removeFromRecentlyOpened': {
 				let paths: (IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | URI | string)[] = arg;
 				if (Array.isArray(paths)) {
-					paths = paths.map(path => isWorkspaceIdentifier(path) ? path : URI.revive(path));
+					paths = paths.map(path => isWorkspaceIdentifier(path) || typeof path === 'string' ? path : URI.revive(path));
 				}
 				return this.service.removeFromRecentlyOpened(paths);
 			}


### PR DESCRIPTION
#60243

The problem with the previous fix is that _URI.toJSON() skips empty string properties and URI.isUri() then doesn't recognize it. The fix is to revert to the code from two changes back which also covers #58131.