### PR TITLE
Markdown: Fix captures for link-ref-shortcut

### DIFF
--- a/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
+++ b/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json
@@ -2469,7 +2469,7 @@
 						"2": {
 							"name": "string.other.link.title.markdown"
 						},
-						"4": {
+						"3": {
 							"name": "punctuation.definition.string.end.markdown"
 						}
 					},


### PR DESCRIPTION
Markdown text between square brackets has mismatching bracket colours with some themes.
For example, the phrase `[text]` with the Quiet Light theme appears as:
![image](https://user-images.githubusercontent.com/9019681/46836846-22049100-cd81-11e8-9605-a3ec8049cba8.png)

The problem is likely because `link-ref-shortcut`, defined in markdown.tmLanguage, is looking for a fourth capture when there are only three.
This PR should fix this.