### PR TITLE
Use es2017 as target for build scripts

### DIFF
--- a/build/gulpfile.mixin.js
+++ b/build/gulpfile.mixin.js
@@ -13,7 +13,6 @@ const es = require('event-stream');
 const util = require('./lib/util');
 const remote = require('gulp-remote-src');
 const zip = require('gulp-vinyl-zip');
-const assign = require('object-assign');
 
 const pkg = require('../package.json');
 
@@ -55,7 +54,7 @@ gulp.task('mixin', function () {
 			.pipe(util.rebase(2))
 			.pipe(productJsonFilter)
 			.pipe(buffer())
-			.pipe(json(o => assign({}, require('../product.json'), o)))
+			.pipe(json(o => Object.assign({}, require('../product.json'), o)))
 			.pipe(productJsonFilter.restore);
 
 		all = es.merge(mixin);

--- a/build/lib/bundle.js
+++ b/build/lib/bundle.js
@@ -4,19 +4,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-var fs = require("fs");
-var path = require("path");
-var vm = require("vm");
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
 /**
  * Bundle `entryPoints` given config `config`.
  */
 function bundle(entryPoints, config, callback) {
-    var entryPointsMap = {};
-    entryPoints.forEach(function (module) {
+    const entryPointsMap = {};
+    entryPoints.forEach((module) => {
         entryPointsMap[module.name] = module;
     });
-    var allMentionedModulesMap = {};
-    entryPoints.forEach(function (module) {
+    const allMentionedModulesMap = {};
+    entryPoints.forEach((module) => {
         allMentionedModulesMap[module.name] = true;
         (module.include || []).forEach(function (includedModule) {
             allMentionedModulesMap[includedModule] = true;
@@ -25,11 +25,11 @@ function bundle(entryPoints, config, callback) {
             allMentionedModulesMap[excludedModule] = true;
         });
     });
-    var code = require('fs').readFileSync(path.join(__dirname, '../../src/vs/loader.js'));
-    var r = vm.runInThisContext('(function(require, module, exports) { ' + code + '\n});');
-    var loaderModule = { exports: {} };
+    const code = require('fs').readFileSync(path.join(__dirname, '../../src/vs/loader.js'));
+    const r = vm.runInThisContext('(function(require, module, exports) { ' + code + '\n});');
+    const loaderModule = { exports: {} };
     r.call({}, require, loaderModule, loaderModule.exports);
-    var loader = loaderModule.exports;
+    const loader = loaderModule.exports;
     config.isBuild = true;
     config.paths = config.paths || {};
     if (!config.paths['vs/nls']) {
@@ -39,16 +39,16 @@ function bundle(entryPoints, config, callback) {
         config.paths['vs/css'] = 'out-build/vs/css.build';
     }
     loader.config(config);
-    loader(['require'], function (localRequire) {
-        var resolvePath = function (path) {
-            var r = localRequire.toUrl(path);
+    loader(['require'], (localRequire) => {
+        const resolvePath = (path) => {
+            const r = localRequire.toUrl(path);
             if (!/\.js/.test(r)) {
                 return r + '.js';
             }
             return r;
         };
-        for (var moduleId in entryPointsMap) {
-            var entryPoint = entryPointsMap[moduleId];
+        for (const moduleId in entryPointsMap) {
+            const entryPoint = entryPointsMap[moduleId];
             if (entryPoint.append) {
                 entryPoint.append = entryPoint.append.map(resolvePath);
             }
@@ -57,59 +57,59 @@ function bundle(entryPoints, config, callback) {
             }
         }
     });
-    loader(Object.keys(allMentionedModulesMap), function () {
-        var modules = loader.getBuildInfo();
-        var partialResult = emitEntryPoints(modules, entryPointsMap);
-        var cssInlinedResources = loader('vs/css').getInlinedResources();
+    loader(Object.keys(allMentionedModulesMap), () => {
+        const modules = loader.getBuildInfo();
+        const partialResult = emitEntryPoints(modules, entryPointsMap);
+        const cssInlinedResources = loader('vs/css').getInlinedResources();
         callback(null, {
             files: partialResult.files,
             cssInlinedResources: cssInlinedResources,
             bundleData: partialResult.bundleData
         });
-    }, function (err) { return callback(err, null); });
+    }, (err) => callback(err, null));
 }
 exports.bundle = bundle;
 function emitEntryPoints(modules, entryPoints) {
-    var modulesMap = {};
-    modules.forEach(function (m) {
+    const modulesMap = {};
+    modules.forEach((m) => {
         modulesMap[m.id] = m;
     });
-    var modulesGraph = {};
-    modules.forEach(function (m) {
+    const modulesGraph = {};
+    modules.forEach((m) => {
         modulesGraph[m.id] = m.dependencies;
     });
-    var sortedModules = topologicalSort(modulesGraph);
-    var result = [];
-    var usedPlugins = {};
-    var bundleData = {
+    const sortedModules = topologicalSort(modulesGraph);
+    let result = [];
+    const usedPlugins = {};
+    const bundleData = {
         graph: modulesGraph,
         bundles: {}
     };
-    Object.keys(entryPoints).forEach(function (moduleToBundle) {
-        var info = entryPoints[moduleToBundle];
-        var rootNodes = [moduleToBundle].concat(info.include || []);
-        var allDependencies = visit(rootNodes, modulesGraph);
-        var excludes = ['require', 'exports', 'module'].concat(info.exclude || []);
-        excludes.forEach(function (excludeRoot) {
-            var allExcludes = visit([excludeRoot], modulesGraph);
-            Object.keys(allExcludes).forEach(function (exclude) {
+    Object.keys(entryPoints).forEach((moduleToBundle) => {
+        const info = entryPoints[moduleToBundle];
+        const rootNodes = [moduleToBundle].concat(info.include || []);
+        const allDependencies = visit(rootNodes, modulesGraph);
+        const excludes = ['require', 'exports', 'module'].concat(info.exclude || []);
+        excludes.forEach((excludeRoot) => {
+            const allExcludes = visit([excludeRoot], modulesGraph);
+            Object.keys(allExcludes).forEach((exclude) => {
                 delete allDependencies[exclude];
             });
         });
-        var includedModules = sortedModules.filter(function (module) {
+        const includedModules = sortedModules.filter((module) => {
             return allDependencies[module];
         });
         bundleData.bundles[moduleToBundle] = includedModules;
-        var res = emitEntryPoint(modulesMap, modulesGraph, moduleToBundle, includedModules, info.prepend || [], info.append || [], info.dest);
+        const res = emitEntryPoint(modulesMap, modulesGraph, moduleToBundle, includedModules, info.prepend || [], info.append || [], info.dest);
         result = result.concat(res.files);
-        for (var pluginName in res.usedPlugins) {
+        for (const pluginName in res.usedPlugins) {
             usedPlugins[pluginName] = usedPlugins[pluginName] || res.usedPlugins[pluginName];
         }
     });
-    Object.keys(usedPlugins).forEach(function (pluginName) {
-        var plugin = usedPlugins[pluginName];
+    Object.keys(usedPlugins).forEach((pluginName) => {
+        const plugin = usedPlugins[pluginName];
         if (typeof plugin.finishBuild === 'function') {
-            var write = function (filename, contents) {
+            const write = (filename, contents) => {
                 result.push({
                     dest: filename,
                     sources: [{
@@ -128,16 +128,16 @@ function emitEntryPoints(modules, entryPoints) {
     };
 }
 function extractStrings(destFiles) {
-    var parseDefineCall = function (moduleMatch, depsMatch) {
-        var module = moduleMatch.replace(/^"|"$/g, '');
-        var deps = depsMatch.split(',');
-        deps = deps.map(function (dep) {
+    const parseDefineCall = (moduleMatch, depsMatch) => {
+        const module = moduleMatch.replace(/^"|"$/g, '');
+        let deps = depsMatch.split(',');
+        deps = deps.map((dep) => {
             dep = dep.trim();
             dep = dep.replace(/^"|"$/g, '');
             dep = dep.replace(/^'|'$/g, '');
-            var prefix = null;
-            var _path = null;
-            var pieces = dep.split('!');
+            let prefix = null;
+            let _path = null;
+            const pieces = dep.split('!');
             if (pieces.length > 1) {
                 prefix = pieces[0] + '!';
                 _path = pieces[1];
@@ -147,7 +147,7 @@ function extractStrings(destFiles) {
                 _path = pieces[0];
             }
             if (/^\.\//.test(_path) || /^\.\.\//.test(_path)) {
-                var res = path.join(path.dirname(module), _path).replace(/\\/g, '/');
+                const res = path.join(path.dirname(module), _path).replace(/\\/g, '/');
                 return prefix + res;
             }
             return prefix + _path;
@@ -157,7 +157,7 @@ function extractStrings(destFiles) {
             deps: deps
         };
     };
-    destFiles.forEach(function (destFile) {
+    destFiles.forEach((destFile) => {
         if (!/\.js$/.test(destFile.dest)) {
             return;
         }
@@ -165,44 +165,44 @@ function extractStrings(destFiles) {
             return;
         }
         // Do one pass to record the usage counts for each module id
-        var useCounts = {};
-        destFile.sources.forEach(function (source) {
-            var matches = source.contents.match(/define\(("[^"]+"),\s*\[(((, )?("|')[^"']+("|'))+)\]/);
+        const useCounts = {};
+        destFile.sources.forEach((source) => {
+            const matches = source.contents.match(/define\(("[^"]+"),\s*\[(((, )?("|')[^"']+("|'))+)\]/);
             if (!matches) {
                 return;
             }
-            var defineCall = parseDefineCall(matches[1], matches[2]);
+            const defineCall = parseDefineCall(matches[1], matches[2]);
             useCounts[defineCall.module] = (useCounts[defineCall.module] || 0) + 1;
-            defineCall.deps.forEach(function (dep) {
+            defineCall.deps.forEach((dep) => {
                 useCounts[dep] = (useCounts[dep] || 0) + 1;
             });
         });
-        var sortedByUseModules = Object.keys(useCounts);
-        sortedByUseModules.sort(function (a, b) {
+        const sortedByUseModules = Object.keys(useCounts);
+        sortedByUseModules.sort((a, b) => {
             return useCounts[b] - useCounts[a];
         });
-        var replacementMap = {};
-        sortedByUseModules.forEach(function (module, index) {
+        const replacementMap = {};
+        sortedByUseModules.forEach((module, index) => {
             replacementMap[module] = index;
         });
-        destFile.sources.forEach(function (source) {
-            source.contents = source.contents.replace(/define\(("[^"]+"),\s*\[(((, )?("|')[^"']+("|'))+)\]/, function (_, moduleMatch, depsMatch) {
-                var defineCall = parseDefineCall(moduleMatch, depsMatch);
-                return "define(__m[" + replacementMap[defineCall.module] + "/*" + defineCall.module + "*/], __M([" + defineCall.deps.map(function (dep) { return replacementMap[dep] + '/*' + dep + '*/'; }).join(',') + "])";
+        destFile.sources.forEach((source) => {
+            source.contents = source.contents.replace(/define\(("[^"]+"),\s*\[(((, )?("|')[^"']+("|'))+)\]/, (_, moduleMatch, depsMatch) => {
+                const defineCall = parseDefineCall(moduleMatch, depsMatch);
+                return `define(__m[${replacementMap[defineCall.module]}/*${defineCall.module}*/], __M([${defineCall.deps.map(dep => replacementMap[dep] + '/*' + dep + '*/').join(',')}])`;
             });
         });
         destFile.sources.unshift({
             path: null,
             contents: [
                 '(function() {',
-                "var __m = " + JSON.stringify(sortedByUseModules) + ";",
-                "var __M = function(deps) {",
-                "  var result = [];",
-                "  for (var i = 0, len = deps.length; i < len; i++) {",
-                "    result[i] = __m[deps[i]];",
-                "  }",
-                "  return result;",
-                "};"
+                `var __m = ${JSON.stringify(sortedByUseModules)};`,
+                `var __M = function(deps) {`,
+                `  var result = [];`,
+                `  for (var i = 0, len = deps.length; i < len; i++) {`,
+                `    result[i] = __m[deps[i]];`,
+                `  }`,
+                `  return result;`,
+                `};`
             ].join('\n')
         });
         destFile.sources.push({
@@ -214,7 +214,7 @@ function extractStrings(destFiles) {
 }
 function removeDuplicateTSBoilerplate(destFiles) {
     // Taken from typescript compiler => emitFiles
-    var BOILERPLATE = [
+    const BOILERPLATE = [
         { start: /^var __extends/, end: /^}\)\(\);$/ },
         { start: /^var __assign/, end: /^};$/ },
         { start: /^var __decorate/, end: /^};$/ },
@@ -223,14 +223,14 @@ function removeDuplicateTSBoilerplate(destFiles) {
         { start: /^var __awaiter/, end: /^};$/ },
         { start: /^var __generator/, end: /^};$/ },
     ];
-    destFiles.forEach(function (destFile) {
-        var SEEN_BOILERPLATE = [];
-        destFile.sources.forEach(function (source) {
-            var lines = source.contents.split(/\r\n|\n|\r/);
-            var newLines = [];
-            var IS_REMOVING_BOILERPLATE = false, END_BOILERPLATE;
-            for (var i = 0; i < lines.length; i++) {
-                var line = lines[i];
+    destFiles.forEach((destFile) => {
+        const SEEN_BOILERPLATE = [];
+        destFile.sources.forEach((source) => {
+            const lines = source.contents.split(/\r\n|\n|\r/);
+            const newLines = [];
+            let IS_REMOVING_BOILERPLATE = false, END_BOILERPLATE;
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
                 if (IS_REMOVING_BOILERPLATE) {
                     newLines.push('');
                     if (END_BOILERPLATE.test(line)) {
@@ -238,8 +238,8 @@ function removeDuplicateTSBoilerplate(destFiles) {
                     }
                 }
                 else {
-                    for (var j = 0; j < BOILERPLATE.length; j++) {
-                        var boilerplate = BOILERPLATE[j];
+                    for (let j = 0; j < BOILERPLATE.length; j++) {
+                        const boilerplate = BOILERPLATE[j];
                         if (boilerplate.start.test(line)) {
                             if (SEEN_BOILERPLATE[j]) {
                                 IS_REMOVING_BOILERPLATE = true;
@@ -267,30 +267,30 @@ function emitEntryPoint(modulesMap, deps, entryPoint, includedModules, prepend, 
     if (!dest) {
         dest = entryPoint + '.js';
     }
-    var mainResult = {
+    const mainResult = {
         sources: [],
         dest: dest
     }, results = [mainResult];
-    var usedPlugins = {};
-    var getLoaderPlugin = function (pluginName) {
+    const usedPlugins = {};
+    const getLoaderPlugin = (pluginName) => {
         if (!usedPlugins[pluginName]) {
             usedPlugins[pluginName] = modulesMap[pluginName].exports;
         }
         return usedPlugins[pluginName];
     };
-    includedModules.forEach(function (c) {
-        var bangIndex = c.indexOf('!');
+    includedModules.forEach((c) => {
+        const bangIndex = c.indexOf('!');
         if (bangIndex >= 0) {
-            var pluginName = c.substr(0, bangIndex);
-            var plugin = getLoaderPlugin(pluginName);
+            const pluginName = c.substr(0, bangIndex);
+            const plugin = getLoaderPlugin(pluginName);
             mainResult.sources.push(emitPlugin(entryPoint, plugin, pluginName, c.substr(bangIndex + 1)));
             return;
         }
-        var module = modulesMap[c];
+        const module = modulesMap[c];
         if (module.path === 'empty:') {
             return;
         }
-        var contents = readFileAndRemoveBOM(module.path);
+        const contents = readFileAndRemoveBOM(module.path);
         if (module.shim) {
             mainResult.sources.push(emitShimmedModule(c, deps[c], module.shim, module.path, contents));
         }
@@ -298,14 +298,14 @@ function emitEntryPoint(modulesMap, deps, entryPoint, includedModules, prepend, 
             mainResult.sources.push(emitNamedModule(c, module.defineLocation, module.path, contents));
         }
     });
-    Object.keys(usedPlugins).forEach(function (pluginName) {
-        var plugin = usedPlugins[pluginName];
+    Object.keys(usedPlugins).forEach((pluginName) => {
+        const plugin = usedPlugins[pluginName];
         if (typeof plugin.writeFile === 'function') {
-            var req = (function () {
+            const req = (() => {
                 throw new Error('no-no!');
             });
-            req.toUrl = function (something) { return something; };
-            var write = function (filename, contents) {
+            req.toUrl = something => something;
+            const write = (filename, contents) => {
                 results.push({
                     dest: filename,
                     sources: [{
@@ -317,15 +317,15 @@ function emitEntryPoint(modulesMap, deps, entryPoint, includedModules, prepend, 
             plugin.writeFile(pluginName, entryPoint, req, write, {});
         }
     });
-    var toIFile = function (path) {
-        var contents = readFileAndRemoveBOM(path);
+    const toIFile = (path) => {
+        const contents = readFileAndRemoveBOM(path);
         return {
             path: path,
             contents: contents
         };
     };
-    var toPrepend = (prepend || []).map(toIFile);
-    var toAppend = (append || []).map(toIFile);
+    const toPrepend = (prepend || []).map(toIFile);
+    const toAppend = (append || []).map(toIFile);
     mainResult.sources = toPrepend.concat(mainResult.sources).concat(toAppend);
     return {
         files: results,
@@ -333,8 +333,8 @@ function emitEntryPoint(modulesMap, deps, entryPoint, includedModules, prepend, 
     };
 }
 function readFileAndRemoveBOM(path) {
-    var BOM_CHAR_CODE = 65279;
-    var contents = fs.readFileSync(path, 'utf8');
+    const BOM_CHAR_CODE = 65279;
+    let contents = fs.readFileSync(path, 'utf8');
     // Remove BOM
     if (contents.charCodeAt(0) === BOM_CHAR_CODE) {
         contents = contents.substring(1);
@@ -342,15 +342,15 @@ function readFileAndRemoveBOM(path) {
     return contents;
 }
 function emitPlugin(entryPoint, plugin, pluginName, moduleName) {
-    var result = '';
+    let result = '';
     if (typeof plugin.write === 'function') {
-        var write = (function (what) {
+        const write = ((what) => {
             result += what;
         });
-        write.getEntryPoint = function () {
+        write.getEntryPoint = () => {
             return entryPoint;
         };
-        write.asModule = function (moduleId, code) {
+        write.asModule = (moduleId, code) => {
             code = code.replace(/^define\(/, 'define("' + moduleId + '",');
             result += code;
         };
@@ -363,18 +363,18 @@ function emitPlugin(entryPoint, plugin, pluginName, moduleName) {
 }
 function emitNamedModule(moduleId, defineCallPosition, path, contents) {
     // `defineCallPosition` is the position in code: |define()
-    var defineCallOffset = positionToOffset(contents, defineCallPosition.line, defineCallPosition.col);
+    const defineCallOffset = positionToOffset(contents, defineCallPosition.line, defineCallPosition.col);
     // `parensOffset` is the position in code: define|()
-    var parensOffset = contents.indexOf('(', defineCallOffset);
-    var insertStr = '"' + moduleId + '", ';
+    const parensOffset = contents.indexOf('(', defineCallOffset);
+    const insertStr = '"' + moduleId + '", ';
     return {
         path: path,
         contents: contents.substr(0, parensOffset + 1) + insertStr + contents.substr(parensOffset + 1)
     };
 }
 function emitShimmedModule(moduleId, myDeps, factory, path, contents) {
-    var strDeps = (myDeps.length > 0 ? '"' + myDeps.join('", "') + '"' : '');
-    var strDefine = 'define("' + moduleId + '", [' + strDeps + '], ' + factory + ');';
+    const strDeps = (myDeps.length > 0 ? '"' + myDeps.join('", "') + '"' : '');
+    const strDefine = 'define("' + moduleId + '", [' + strDeps + '], ' + factory + ');';
     return {
         path: path,
         contents: contents + '\n;\n' + strDefine
@@ -387,8 +387,8 @@ function positionToOffset(str, desiredLine, desiredCol) {
     if (desiredLine === 1) {
         return desiredCol - 1;
     }
-    var line = 1;
-    var lastNewLineOffset = -1;
+    let line = 1;
+    let lastNewLineOffset = -1;
     do {
         if (desiredLine === line) {
             return lastNewLineOffset + 1 + desiredCol - 1;
@@ -402,15 +402,15 @@ function positionToOffset(str, desiredLine, desiredCol) {
  * Return a set of reachable nodes in `graph` starting from `rootNodes`
  */
 function visit(rootNodes, graph) {
-    var result = {};
-    var queue = rootNodes;
-    rootNodes.forEach(function (node) {
+    const result = {};
+    const queue = rootNodes;
+    rootNodes.forEach((node) => {
         result[node] = true;
     });
     while (queue.length > 0) {
-        var el = queue.shift();
-        var myEdges = graph[el] || [];
-        myEdges.forEach(function (toNode) {
+        const el = queue.shift();
+        const myEdges = graph[el] || [];
+        myEdges.forEach((toNode) => {
             if (!result[toNode]) {
                 result[toNode] = true;
                 queue.push(toNode);
@@ -423,11 +423,11 @@ function visit(rootNodes, graph) {
  * Perform a topological sort on `graph`
  */
 function topologicalSort(graph) {
-    var allNodes = {}, outgoingEdgeCount = {}, inverseEdges = {};
-    Object.keys(graph).forEach(function (fromNode) {
+    const allNodes = {}, outgoingEdgeCount = {}, inverseEdges = {};
+    Object.keys(graph).forEach((fromNode) => {
         allNodes[fromNode] = true;
         outgoingEdgeCount[fromNode] = graph[fromNode].length;
-        graph[fromNode].forEach(function (toNode) {
+        graph[fromNode].forEach((toNode) => {
             allNodes[toNode] = true;
             outgoingEdgeCount[toNode] = outgoingEdgeCount[toNode] || 0;
             inverseEdges[toNode] = inverseEdges[toNode] || [];
@@ -435,8 +435,8 @@ function topologicalSort(graph) {
         });
     });
     // https://en.wikipedia.org/wiki/Topological_sorting
-    var S = [], L = [];
-    Object.keys(allNodes).forEach(function (node) {
+    const S = [], L = [];
+    Object.keys(allNodes).forEach((node) => {
         if (outgoingEdgeCount[node] === 0) {
             delete outgoingEdgeCount[node];
             S.push(node);
@@ -445,10 +445,10 @@ function topologicalSort(graph) {
     while (S.length > 0) {
         // Ensure the exact same order all the time with the same inputs
         S.sort();
-        var n = S.shift();
+        const n = S.shift();
         L.push(n);
-        var myInverseEdges = inverseEdges[n] || [];
-        myInverseEdges.forEach(function (m) {
+        const myInverseEdges = inverseEdges[n] || [];
+        myInverseEdges.forEach((m) => {
             outgoingEdgeCount[m]--;
             if (outgoingEdgeCount[m] === 0) {
                 delete outgoingEdgeCount[m];

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -18,7 +18,6 @@ import * as nls from './nls';
 import { createReporter } from './reporter';
 import * as util from './util';
 const watch = require('./watch');
-import assign = require('object-assign');
 
 const reporter = createReporter();
 
@@ -27,7 +26,7 @@ function getTypeScriptCompilerOptions(src: string) {
 	const tsconfig = require(`../../${src}/tsconfig.json`);
 	let options: { [key: string]: any };
 	if (tsconfig.extends) {
-		options = assign({}, require(path.join(rootDir, tsconfig.extends)).compilerOptions, tsconfig.compilerOptions);
+		options = Object.assign({}, require(path.join(rootDir, tsconfig.extends)).compilerOptions, tsconfig.compilerOptions);
 	} else {
 		options = tsconfig.compilerOptions;
 	}

--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -3,39 +3,28 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var es = require("event-stream");
-var fs = require("fs");
-var glob = require("glob");
-var gulp = require("gulp");
-var path = require("path");
-var File = require("vinyl");
-var vsce = require("vsce");
-var stats_1 = require("./stats");
-var util2 = require("./util");
-var remote = require("gulp-remote-src");
-var vzip = require('gulp-vinyl-zip');
-var filter = require("gulp-filter");
-var rename = require("gulp-rename");
-var util = require('gulp-util');
-var buffer = require('gulp-buffer');
-var json = require("gulp-json-editor");
-var webpack = require('webpack');
-var webpackGulp = require('webpack-stream');
-var root = path.resolve(path.join(__dirname, '..', '..'));
+const es = require("event-stream");
+const fs = require("fs");
+const glob = require("glob");
+const gulp = require("gulp");
+const path = require("path");
+const File = require("vinyl");
+const vsce = require("vsce");
+const stats_1 = require("./stats");
+const util2 = require("./util");
+const remote = require("gulp-remote-src");
+const vzip = require('gulp-vinyl-zip');
+const filter = require("gulp-filter");
+const rename = require("gulp-rename");
+const util = require('gulp-util');
+const buffer = require('gulp-buffer');
+const json = require("gulp-json-editor");
+const webpack = require('webpack');
+const webpackGulp = require('webpack-stream');
+const root = path.resolve(path.join(__dirname, '..', '..'));
 function fromLocal(extensionPath, sourceMappingURLBase) {
-    var webpackFilename = path.join(extensionPath, 'extension.webpack.config.js');
+    const webpackFilename = path.join(extensionPath, 'extension.webpack.config.js');
     if (fs.existsSync(webpackFilename)) {
         return fromLocalWebpack(extensionPath, sourceMappingURLBase);
     }
@@ -44,30 +33,30 @@ function fromLocal(extensionPath, sourceMappingURLBase) {
     }
 }
 function fromLocalWebpack(extensionPath, sourceMappingURLBase) {
-    var result = es.through();
-    var packagedDependencies = [];
-    var packageJsonConfig = require(path.join(extensionPath, 'package.json'));
-    var webpackRootConfig = require(path.join(extensionPath, 'extension.webpack.config.js'));
-    for (var key in webpackRootConfig.externals) {
+    const result = es.through();
+    const packagedDependencies = [];
+    const packageJsonConfig = require(path.join(extensionPath, 'package.json'));
+    const webpackRootConfig = require(path.join(extensionPath, 'extension.webpack.config.js'));
+    for (const key in webpackRootConfig.externals) {
         if (key in packageJsonConfig.dependencies) {
             packagedDependencies.push(key);
         }
     }
-    vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Yarn, packagedDependencies: packagedDependencies }).then(function (fileNames) {
-        var files = fileNames
-            .map(function (fileName) { return path.join(extensionPath, fileName); })
-            .map(function (filePath) { return new File({
+    vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Yarn, packagedDependencies }).then(fileNames => {
+        const files = fileNames
+            .map(fileName => path.join(extensionPath, fileName))
+            .map(filePath => new File({
             path: filePath,
             stat: fs.statSync(filePath),
             base: extensionPath,
             contents: fs.createReadStream(filePath)
-        }); });
-        var filesStream = es.readArray(files);
+        }));
+        const filesStream = es.readArray(files);
         // check for a webpack configuration files, then invoke webpack
         // and merge its output with the files stream. also rewrite the package.json
         // file to a new entry point
-        var webpackConfigLocations = glob.sync(path.join(extensionPath, '/**/extension.webpack.config.js'), { ignore: ['**/node_modules'] });
-        var packageJsonFilter = filter(function (f) {
+        const webpackConfigLocations = glob.sync(path.join(extensionPath, '/**/extension.webpack.config.js'), { ignore: ['**/node_modules'] });
+        const packageJsonFilter = filter(f => {
             if (path.basename(f.path) === 'package.json') {
                 // only modify package.json's next to the webpack file.
                 // to be safe, use existsSync instead of path comparison.
@@ -75,22 +64,22 @@ function fromLocalWebpack(extensionPath, sourceMappingURLBase) {
             }
             return false;
         }, { restore: true });
-        var patchFilesStream = filesStream
+        const patchFilesStream = filesStream
             .pipe(packageJsonFilter)
             .pipe(buffer())
-            .pipe(json(function (data) {
+            .pipe(json((data) => {
             // hardcoded entry point directory!
             data.main = data.main.replace('/out/', /dist/);
             return data;
         }))
             .pipe(packageJsonFilter.restore);
-        var webpackStreams = webpackConfigLocations.map(function (webpackConfigPath) {
-            var webpackDone = function (err, stats) {
-                util.log("Bundled extension: " + util.colors.yellow(path.join(path.basename(extensionPath), path.relative(extensionPath, webpackConfigPath))) + "...");
+        const webpackStreams = webpackConfigLocations.map(webpackConfigPath => {
+            const webpackDone = (err, stats) => {
+                util.log(`Bundled extension: ${util.colors.yellow(path.join(path.basename(extensionPath), path.relative(extensionPath, webpackConfigPath)))}...`);
                 if (err) {
                     result.emit('error', err);
                 }
-                var compilation = stats.compilation;
+                const { compilation } = stats;
                 if (compilation.errors.length > 0) {
                     result.emit('error', compilation.errors.join('\n'));
                 }
@@ -98,8 +87,8 @@ function fromLocalWebpack(extensionPath, sourceMappingURLBase) {
                     result.emit('error', compilation.warnings.join('\n'));
                 }
             };
-            var webpackConfig = __assign({}, require(webpackConfigPath), { mode: 'production' });
-            var relativeOutputPath = path.relative(extensionPath, webpackConfig.output.path);
+            const webpackConfig = Object.assign({}, require(webpackConfigPath), { mode: 'production' });
+            const relativeOutputPath = path.relative(extensionPath, webpackConfig.output.path);
             return webpackGulp(webpackConfig, webpack, webpackDone)
                 .pipe(es.through(function (data) {
                 data.stat = data.stat || {};
@@ -111,9 +100,9 @@ function fromLocalWebpack(extensionPath, sourceMappingURLBase) {
                 // * rewrite sourceMappingURL
                 // * save to disk so that upload-task picks this up
                 if (sourceMappingURLBase) {
-                    var contents = data.contents.toString('utf8');
+                    const contents = data.contents.toString('utf8');
                     data.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, function (_m, g1) {
-                        return "\n//# sourceMappingURL=" + sourceMappingURLBase + "/extensions/" + path.basename(extensionPath) + "/" + relativeOutputPath + "/" + g1;
+                        return `\n//# sourceMappingURL=${sourceMappingURLBase}/extensions/${path.basename(extensionPath)}/${relativeOutputPath}/${g1}`;
                     }), 'utf8');
                     if (/\.js\.map$/.test(data.path)) {
                         if (!fs.existsSync(path.dirname(data.path))) {
@@ -125,8 +114,14 @@ function fromLocalWebpack(extensionPath, sourceMappingURLBase) {
                 this.emit('data', data);
             }));
         });
-        es.merge.apply(es, webpackStreams.concat([patchFilesStream])).pipe(result);
-    }).catch(function (err) {
+        es.merge(...webpackStreams, patchFilesStream)
+            // .pipe(es.through(function (data) {
+            // 	// debug
+            // 	console.log('out', data.path, data.contents.length);
+            // 	this.emit('data', data);
+            // }))
+            .pipe(result);
+    }).catch(err => {
         console.error(extensionPath);
         console.error(packagedDependencies);
         result.emit('error', err);
@@ -134,56 +129,56 @@ function fromLocalWebpack(extensionPath, sourceMappingURLBase) {
     return result.pipe(stats_1.createStatsStream(path.basename(extensionPath)));
 }
 function fromLocalNormal(extensionPath) {
-    var result = es.through();
+    const result = es.through();
     vsce.listFiles({ cwd: extensionPath, packageManager: vsce.PackageManager.Yarn })
-        .then(function (fileNames) {
-        var files = fileNames
-            .map(function (fileName) { return path.join(extensionPath, fileName); })
-            .map(function (filePath) { return new File({
+        .then(fileNames => {
+        const files = fileNames
+            .map(fileName => path.join(extensionPath, fileName))
+            .map(filePath => new File({
             path: filePath,
             stat: fs.statSync(filePath),
             base: extensionPath,
             contents: fs.createReadStream(filePath)
-        }); });
+        }));
         es.readArray(files).pipe(result);
     })
-        .catch(function (err) { return result.emit('error', err); });
+        .catch(err => result.emit('error', err));
     return result.pipe(stats_1.createStatsStream(path.basename(extensionPath)));
 }
-var baseHeaders = {
+const baseHeaders = {
     'X-Market-Client-Id': 'VSCode Build',
     'User-Agent': 'VSCode Build',
     'X-Market-User-Id': '291C1CD0-051A-4123-9B4B-30D60EF52EE2',
 };
 function fromMarketplace(extensionName, version, metadata) {
-    var _a = extensionName.split('.'), publisher = _a[0], name = _a[1];
-    var url = "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/" + publisher + "/vsextensions/" + name + "/" + version + "/vspackage";
-    util.log('Downloading extension:', util.colors.yellow(extensionName + "@" + version), '...');
-    var options = {
+    const [publisher, name] = extensionName.split('.');
+    const url = `https://marketplace.visualstudio.com/_apis/public/gallery/publishers/${publisher}/vsextensions/${name}/${version}/vspackage`;
+    util.log('Downloading extension:', util.colors.yellow(`${extensionName}@${version}`), '...');
+    const options = {
         base: url,
         requestOptions: {
             gzip: true,
             headers: baseHeaders
         }
     };
-    var packageJsonFilter = filter('package.json', { restore: true });
+    const packageJsonFilter = filter('package.json', { restore: true });
     return remote('', options)
         .pipe(vzip.src())
         .pipe(filter('extension/**'))
-        .pipe(rename(function (p) { return p.dirname = p.dirname.replace(/^extension\/?/, ''); }))
+        .pipe(rename(p => p.dirname = p.dirname.replace(/^extension\/?/, '')))
         .pipe(packageJsonFilter)
         .pipe(buffer())
         .pipe(json({ __metadata: metadata }))
         .pipe(packageJsonFilter.restore);
 }
 exports.fromMarketplace = fromMarketplace;
-var excludedExtensions = [
+const excludedExtensions = [
     'vscode-api-tests',
     'vscode-colorize-tests',
     'ms-vscode.node-debug',
     'ms-vscode.node-debug2',
 ];
-var builtInExtensions = require('../builtInExtensions.json');
+const builtInExtensions = require('../builtInExtensions.json');
 /**
  * We're doing way too much stuff at once, with webpack et al. So much stuff
  * that while downloading extensions from the marketplace, node js doesn't get enough
@@ -191,13 +186,13 @@ var builtInExtensions = require('../builtInExtensions.json');
  * marketplace server cuts off the http request. So, we sequentialize the extensino tasks.
  */
 function sequence(streamProviders) {
-    var result = es.through();
+    const result = es.through();
     function pop() {
         if (streamProviders.length === 0) {
             result.emit('end');
         }
         else {
-            var fn = streamProviders.shift();
+            const fn = streamProviders.shift();
             fn()
                 .on('end', function () { setTimeout(pop, 0); })
                 .pipe(result, { end: false });
@@ -207,39 +202,27 @@ function sequence(streamProviders) {
     return result;
 }
 function packageExtensionsStream(optsIn) {
-    var opts = optsIn || {};
-    var localExtensionDescriptions = glob.sync('extensions/*/package.json')
-        .map(function (manifestPath) {
-        var extensionPath = path.dirname(path.join(root, manifestPath));
-        var extensionName = path.basename(extensionPath);
+    const opts = optsIn || {};
+    const localExtensionDescriptions = glob.sync('extensions/*/package.json')
+        .map(manifestPath => {
+        const extensionPath = path.dirname(path.join(root, manifestPath));
+        const extensionName = path.basename(extensionPath);
         return { name: extensionName, path: extensionPath };
     })
-        .filter(function (_a) {
-        var name = _a.name;
-        return excludedExtensions.indexOf(name) === -1;
-    })
-        .filter(function (_a) {
-        var name = _a.name;
-        return opts.desiredExtensions ? opts.desiredExtensions.indexOf(name) >= 0 : true;
-    })
-        .filter(function (_a) {
-        var name = _a.name;
-        return builtInExtensions.every(function (b) { return b.name !== name; });
-    });
-    var localExtensions = function () { return es.merge.apply(es, localExtensionDescriptions.map(function (extension) {
+        .filter(({ name }) => excludedExtensions.indexOf(name) === -1)
+        .filter(({ name }) => opts.desiredExtensions ? opts.desiredExtensions.indexOf(name) >= 0 : true)
+        .filter(({ name }) => builtInExtensions.every(b => b.name !== name));
+    const localExtensions = () => es.merge(...localExtensionDescriptions.map(extension => {
         return fromLocal(extension.path, opts.sourceMappingURLBase)
-            .pipe(rename(function (p) { return p.dirname = "extensions/" + extension.name + "/" + p.dirname; }));
-    })); };
-    var localExtensionDependencies = function () { return gulp.src('extensions/node_modules/**', { base: '.' }); };
-    var marketplaceExtensions = function () { return es.merge.apply(es, builtInExtensions
-        .filter(function (_a) {
-        var name = _a.name;
-        return opts.desiredExtensions ? opts.desiredExtensions.indexOf(name) >= 0 : true;
-    })
-        .map(function (extension) {
+            .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
+    }));
+    const localExtensionDependencies = () => gulp.src('extensions/node_modules/**', { base: '.' });
+    const marketplaceExtensions = () => es.merge(...builtInExtensions
+        .filter(({ name }) => opts.desiredExtensions ? opts.desiredExtensions.indexOf(name) >= 0 : true)
+        .map(extension => {
         return fromMarketplace(extension.name, extension.version, extension.metadata)
-            .pipe(rename(function (p) { return p.dirname = "extensions/" + extension.name + "/" + p.dirname; }));
-    })); };
+            .pipe(rename(p => p.dirname = `extensions/${extension.name}/${p.dirname}`));
+    }));
     return sequence([localExtensions, localExtensionDependencies, marketplaceExtensions])
         .pipe(util2.setExecutableBit(['**/*.sh']))
         .pipe(filter(['**', '!**/*.js.map']));

--- a/build/lib/git.js
+++ b/build/lib/git.js
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-var path = require("path");
-var fs = require("fs");
+const path = require("path");
+const fs = require("fs");
 /**
  * Returns the sha1 commit version of a repository or undefined in case of failure.
  */
 function getVersion(repo) {
-    var git = path.join(repo, '.git');
-    var headPath = path.join(git, 'HEAD');
-    var head;
+    const git = path.join(repo, '.git');
+    const headPath = path.join(git, 'HEAD');
+    let head;
     try {
         head = fs.readFileSync(headPath, 'utf8').trim();
     }
@@ -22,29 +22,29 @@ function getVersion(repo) {
     if (/^[0-9a-f]{40}$/i.test(head)) {
         return head;
     }
-    var refMatch = /^ref: (.*)$/.exec(head);
+    const refMatch = /^ref: (.*)$/.exec(head);
     if (!refMatch) {
         return void 0;
     }
-    var ref = refMatch[1];
-    var refPath = path.join(git, ref);
+    const ref = refMatch[1];
+    const refPath = path.join(git, ref);
     try {
         return fs.readFileSync(refPath, 'utf8').trim();
     }
     catch (e) {
         // noop
     }
-    var packedRefsPath = path.join(git, 'packed-refs');
-    var refsRaw;
+    const packedRefsPath = path.join(git, 'packed-refs');
+    let refsRaw;
     try {
         refsRaw = fs.readFileSync(packedRefsPath, 'utf8').trim();
     }
     catch (e) {
         return void 0;
     }
-    var refsRegex = /^([0-9a-f]{40})\s+(.+)$/gm;
-    var refsMatch;
-    var refs = {};
+    const refsRegex = /^([0-9a-f]{40})\s+(.+)$/gm;
+    let refsMatch;
+    let refs = {};
     while (refsMatch = refsRegex.exec(refsRaw)) {
         refs[refsMatch[2]] = refsMatch[1];
     }

--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -4,24 +4,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-var path = require("path");
-var fs = require("fs");
-var event_stream_1 = require("event-stream");
-var File = require("vinyl");
-var Is = require("is");
-var xml2js = require("xml2js");
-var glob = require("glob");
-var https = require("https");
-var gulp = require("gulp");
-var util = require("gulp-util");
-var iconv = require("iconv-lite");
-var NUMBER_OF_CONCURRENT_DOWNLOADS = 4;
-function log(message) {
-    var rest = [];
-    for (var _i = 1; _i < arguments.length; _i++) {
-        rest[_i - 1] = arguments[_i];
-    }
-    util.log.apply(util, [util.colors.green('[i18n]'), message].concat(rest));
+const path = require("path");
+const fs = require("fs");
+const event_stream_1 = require("event-stream");
+const File = require("vinyl");
+const Is = require("is");
+const xml2js = require("xml2js");
+const glob = require("glob");
+const https = require("https");
+const gulp = require("gulp");
+const util = require("gulp-util");
+const iconv = require("iconv-lite");
+const NUMBER_OF_CONCURRENT_DOWNLOADS = 4;
+function log(message, ...rest) {
+    util.log(util.colors.green('[i18n]'), message, ...rest);
 }
 exports.defaultLanguages = [
     { id: 'zh-tw', folderName: 'cht', transifexId: 'zh-hant' },
@@ -41,7 +37,7 @@ exports.extraLanguages = [
     { id: 'tr', folderName: 'trk' }
 ];
 // non built-in extensions also that are transifex and need to be part of the language packs
-var externalExtensionsWithTranslations = {
+const externalExtensionsWithTranslations = {
     'vscode-chrome-debug': 'msjsdiag.debugger-for-chrome',
     'vscode-node-debug': 'ms-vscode.node-debug',
     'vscode-node-debug2': 'ms-vscode.node-debug2'
@@ -49,8 +45,8 @@ var externalExtensionsWithTranslations = {
 var LocalizeInfo;
 (function (LocalizeInfo) {
     function is(value) {
-        var candidate = value;
-        return Is.defined(candidate) && Is.string(candidate.key) && (Is.undef(candidate.comment) || (Is.array(candidate.comment) && candidate.comment.every(function (element) { return Is.string(element); })));
+        let candidate = value;
+        return Is.defined(candidate) && Is.string(candidate.key) && (Is.undef(candidate.comment) || (Is.array(candidate.comment) && candidate.comment.every(element => Is.string(element))));
     }
     LocalizeInfo.is = is;
 })(LocalizeInfo || (LocalizeInfo = {}));
@@ -60,8 +56,8 @@ var BundledFormat;
         if (Is.undef(value)) {
             return false;
         }
-        var candidate = value;
-        var length = Object.keys(value).length;
+        let candidate = value;
+        let length = Object.keys(value).length;
         return length === 3 && Is.defined(candidate.keys) && Is.defined(candidate.messages) && Is.defined(candidate.bundles);
     }
     BundledFormat.is = is;
@@ -72,79 +68,71 @@ var PackageJsonFormat;
         if (Is.undef(value) || !Is.object(value)) {
             return false;
         }
-        return Object.keys(value).every(function (key) {
-            var element = value[key];
+        return Object.keys(value).every(key => {
+            let element = value[key];
             return Is.string(element) || (Is.object(element) && Is.defined(element.message) && Is.defined(element.comment));
         });
     }
     PackageJsonFormat.is = is;
 })(PackageJsonFormat || (PackageJsonFormat = {}));
-var Line = /** @class */ (function () {
-    function Line(indent) {
-        if (indent === void 0) { indent = 0; }
+class Line {
+    constructor(indent = 0) {
         this.buffer = [];
         if (indent > 0) {
             this.buffer.push(new Array(indent + 1).join(' '));
         }
     }
-    Line.prototype.append = function (value) {
+    append(value) {
         this.buffer.push(value);
         return this;
-    };
-    Line.prototype.toString = function () {
+    }
+    toString() {
         return this.buffer.join('');
-    };
-    return Line;
-}());
+    }
+}
 exports.Line = Line;
-var TextModel = /** @class */ (function () {
-    function TextModel(contents) {
+class TextModel {
+    constructor(contents) {
         this._lines = contents.split(/\r\n|\r|\n/);
     }
-    Object.defineProperty(TextModel.prototype, "lines", {
-        get: function () {
-            return this._lines;
-        },
-        enumerable: true,
-        configurable: true
-    });
-    return TextModel;
-}());
-var XLF = /** @class */ (function () {
-    function XLF(project) {
+    get lines() {
+        return this._lines;
+    }
+}
+class XLF {
+    constructor(project) {
         this.project = project;
         this.buffer = [];
         this.files = Object.create(null);
         this.numberOfMessages = 0;
     }
-    XLF.prototype.toString = function () {
+    toString() {
         this.appendHeader();
-        for (var file in this.files) {
-            this.appendNewLine("<file original=\"" + file + "\" source-language=\"en\" datatype=\"plaintext\"><body>", 2);
-            for (var _i = 0, _a = this.files[file]; _i < _a.length; _i++) {
-                var item = _a[_i];
+        for (let file in this.files) {
+            this.appendNewLine(`<file original="${file}" source-language="en" datatype="plaintext"><body>`, 2);
+            for (let item of this.files[file]) {
                 this.addStringItem(item);
             }
             this.appendNewLine('</body></file>', 2);
         }
         this.appendFooter();
         return this.buffer.join('\r\n');
-    };
-    XLF.prototype.addFile = function (original, keys, messages) {
+    }
+    addFile(original, keys, messages) {
         if (keys.length === 0) {
             console.log('No keys in ' + original);
             return;
         }
         if (keys.length !== messages.length) {
-            throw new Error("Unmatching keys(" + keys.length + ") and messages(" + messages.length + ").");
+            throw new Error(`Unmatching keys(${keys.length}) and messages(${messages.length}).`);
         }
         this.numberOfMessages += keys.length;
         this.files[original] = [];
-        var existingKeys = new Set();
-        for (var i = 0; i < keys.length; i++) {
-            var key = keys[i];
-            var realKey = void 0;
-            var comment = void 0;
+        let existingKeys = new Set();
+        for (let i = 0; i < keys.length; i++) {
+            let key = keys[i];
+            let realKey;
+            let comment;
             if (Is.string(key)) {
                 realKey = key;
                 comment = undefined;
@@ -152,144 +140,140 @@ var XLF = /** @class */ (function () {
             else if (LocalizeInfo.is(key)) {
                 realKey = key.key;
                 if (key.comment && key.comment.length > 0) {
-                    comment = key.comment.map(function (comment) { return encodeEntities(comment); }).join('\r\n');
+                    comment = key.comment.map(comment => encodeEntities(comment)).join('\r\n');
                 }
             }
             if (!realKey || existingKeys.has(realKey)) {
                 continue;
             }
             existingKeys.add(realKey);
-            var message = encodeEntities(messages[i]);
+            let message = encodeEntities(messages[i]);
             this.files[original].push({ id: realKey, message: message, comment: comment });
         }
-    };
-    XLF.prototype.addStringItem = function (item) {
+    }
+    addStringItem(item) {
         if (!item.id || !item.message) {
-            throw new Error("No item ID or value specified: " + JSON.stringify(item));
+            throw new Error(`No item ID or value specified: ${JSON.stringify(item)}`);
         }
-        this.appendNewLine("<trans-unit id=\"" + item.id + "\">", 4);
-        this.appendNewLine("<source xml:lang=\"en\">" + item.message + "</source>", 6);
+        this.appendNewLine(`<trans-unit id="${item.id}">`, 4);
+        this.appendNewLine(`<source xml:lang="en">${item.message}</source>`, 6);
         if (item.comment) {
-            this.appendNewLine("<note>" + item.comment + "</note>", 6);
+            this.appendNewLine(`<note>${item.comment}</note>`, 6);
         }
         this.appendNewLine('</trans-unit>', 4);
-    };
-    XLF.prototype.appendHeader = function () {
+    }
+    appendHeader() {
         this.appendNewLine('<?xml version="1.0" encoding="utf-8"?>', 0);
         this.appendNewLine('<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">', 0);
-    };
-    XLF.prototype.appendFooter = function () {
+    }
+    appendFooter() {
         this.appendNewLine('</xliff>', 0);
-    };
-    XLF.prototype.appendNewLine = function (content, indent) {
-        var line = new Line(indent);
+    }
+    appendNewLine(content, indent) {
+        let line = new Line(indent);
         line.append(content);
         this.buffer.push(line.toString());
-    };
-    XLF.parsePseudo = function (xlfString) {
-        return new Promise(function (resolve) {
-            var parser = new xml2js.Parser();
-            var files = [];
-            parser.parseString(xlfString, function (_err, result) {
-                var fileNodes = result['xliff']['file'];
-                fileNodes.forEach(function (file) {
-                    var originalFilePath = file.$.original;
-                    var messages = {};
-                    var transUnits = file.body[0]['trans-unit'];
-                    if (transUnits) {
-                        transUnits.forEach(function (unit) {
-                            var key = unit.$.id;
-                            var val = pseudify(unit.source[0]['_'].toString());
-                            if (key && val) {
-                                messages[key] = decodeEntities(val);
-                            }
-                        });
-                        files.push({ messages: messages, originalFilePath: originalFilePath, language: 'ps' });
-                    }
-                });
-                resolve(files);
-            });
-        });
-    };
-    XLF.parse = function (xlfString) {
-        return new Promise(function (resolve, reject) {
-            var parser = new xml2js.Parser();
-            var files = [];
-            parser.parseString(xlfString, function (err, result) {
-                if (err) {
-                    reject(new Error("XLF parsing error: Failed to parse XLIFF string. " + err));
+    }
+}
+XLF.parsePseudo = function (xlfString) {
+    return new Promise((resolve) => {
+        let parser = new xml2js.Parser();
+        let files = [];
+        parser.parseString(xlfString, function (_err, result) {
+            const fileNodes = result['xliff']['file'];
+            fileNodes.forEach(file => {
+                const originalFilePath = file.$.original;
+                const messages = {};
+                const transUnits = file.body[0]['trans-unit'];
+                if (transUnits) {
+                    transUnits.forEach((unit) => {
+                        const key = unit.$.id;
+                        const val = pseudify(unit.source[0]['_'].toString());
+                        if (key && val) {
+                            messages[key] = decodeEntities(val);
+                        }
+                    });
+                    files.push({ messages: messages, originalFilePath: originalFilePath, language: 'ps' });
                 }
-                var fileNodes = result['xliff']['file'];
-                if (!fileNodes) {
-                    reject(new Error("XLF parsing error: XLIFF file does not contain \"xliff\" or \"file\" node(s) required for parsing."));
-                }
-                fileNodes.forEach(function (file) {
-                    var originalFilePath = file.$.original;
-                    if (!originalFilePath) {
-                        reject(new Error("XLF parsing error: XLIFF file node does not contain original attribute to determine the original location of the resource file."));
-                    }
-                    var language = file.$['target-language'];
-                    if (!language) {
-                        reject(new Error("XLF parsing error: XLIFF file node does not contain target-language attribute to determine translated language."));
-                    }
-                    var messages = {};
-                    var transUnits = file.body[0]['trans-unit'];
-                    if (transUnits) {
-                        transUnits.forEach(function (unit) {
-                            var key = unit.$.id;
-                            if (!unit.target) {
-                                return; // No translation available
-                            }
-                            var val = unit.target.toString();
-                            if (key && val) {
-                                messages[key] = decodeEntities(val);
-                            }
-                            else {
-                                reject(new Error("XLF parsing error: XLIFF file does not contain full localization data. ID or target translation for one of the trans-unit nodes is not present."));
-                            }
-                        });
-                        files.push({ messages: messages, originalFilePath: originalFilePath, language: language.toLowerCase() });
-                    }
-                });
-                resolve(files);
             });
+            resolve(files);
         });
-    };
-    return XLF;
-}());
+    });
+};
+XLF.parse = function (xlfString) {
+    return new Promise((resolve, reject) => {
+        let parser = new xml2js.Parser();
+        let files = [];
+        parser.parseString(xlfString, function (err, result) {
+            if (err) {
+                reject(new Error(`XLF parsing error: Failed to parse XLIFF string. ${err}`));
+            }
+            const fileNodes = result['xliff']['file'];
+            if (!fileNodes) {
+                reject(new Error(`XLF parsing error: XLIFF file does not contain "xliff" or "file" node(s) required for parsing.`));
+            }
+            fileNodes.forEach((file) => {
+                const originalFilePath = file.$.original;
+                if (!originalFilePath) {
+                    reject(new Error(`XLF parsing error: XLIFF file node does not contain original attribute to determine the original location of the resource file.`));
+                }
+                let language = file.$['target-language'];
+                if (!language) {
+                    reject(new Error(`XLF parsing error: XLIFF file node does not contain target-language attribute to determine translated language.`));
+                }
+                const messages = {};
+                const transUnits = file.body[0]['trans-unit'];
+                if (transUnits) {
+                    transUnits.forEach((unit) => {
+                        const key = unit.$.id;
+                        if (!unit.target) {
+                            return; // No translation available
+                        }
+                        const val = unit.target.toString();
+                        if (key && val) {
+                            messages[key] = decodeEntities(val);
+                        }
+                        else {
+                            reject(new Error(`XLF parsing error: XLIFF file does not contain full localization data. ID or target translation for one of the trans-unit nodes is not present.`));
+                        }
+                    });
+                    files.push({ messages: messages, originalFilePath: originalFilePath, language: language.toLowerCase() });
+                }
+            });
+            resolve(files);
+        });
+    });
+};
 exports.XLF = XLF;
-var Limiter = /** @class */ (function () {
-    function Limiter(maxDegreeOfParalellism) {
+class Limiter {
+    constructor(maxDegreeOfParalellism) {
         this.maxDegreeOfParalellism = maxDegreeOfParalellism;
         this.outstandingPromises = [];
         this.runningPromises = 0;
     }
-    Limiter.prototype.queue = function (factory) {
-        var _this = this;
-        return new Promise(function (c, e) {
-            _this.outstandingPromises.push({ factory: factory, c: c, e: e });
-            _this.consume();
+    queue(factory) {
+        return new Promise((c, e) => {
+            this.outstandingPromises.push({ factory, c, e });
+            this.consume();
         });
-    };
-    Limiter.prototype.consume = function () {
-        var _this = this;
+    }
+    consume() {
         while (this.outstandingPromises.length && this.runningPromises < this.maxDegreeOfParalellism) {
-            var iLimitedTask = this.outstandingPromises.shift();
+            const iLimitedTask = this.outstandingPromises.shift();
             this.runningPromises++;
-            var promise = iLimitedTask.factory();
+            const promise = iLimitedTask.factory();
             promise.then(iLimitedTask.c).catch(iLimitedTask.e);
-            promise.then(function () { return _this.consumed(); }).catch(function () { return _this.consumed(); });
+            promise.then(() => this.consumed()).catch(() => this.consumed());
         }
-    };
-    Limiter.prototype.consumed = function () {
+    }
+    consumed() {
         this.runningPromises--;
         this.consume();
-    };
-    return Limiter;
-}());
+    }
+}
 exports.Limiter = Limiter;
 function sortLanguages(languages) {
-    return languages.sort(function (a, b) {
+    return languages.sort((a, b) => {
         return a.id < b.id ? -1 : (a.id > b.id ? 1 : 0);
     });
 }
@@ -300,8 +284,8 @@ function stripComments(content) {
     * Third matches block comments
     * Fourth matches line comments
     */
-    var regexp = /("(?:[^\\\"]*(?:\\.)?)*")|('(?:[^\\\']*(?:\\.)?)*')|(\/\*(?:\r?\n|.)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
-    var result = content.replace(regexp, function (match, _m1, _m2, m3, m4) {
+    const regexp = /("(?:[^\\\"]*(?:\\.)?)*")|('(?:[^\\\']*(?:\\.)?)*')|(\/\*(?:\r?\n|.)*?\*\/)|(\/{2,}.*?(?:(?:\r?\n)|$))/g;
+    let result = content.replace(regexp, (match, _m1, _m2, m3, m4) => {
         // Only one of m1, m2, m3, m4 matches
         if (m3) {
             // A block comment. Replace with nothing
@@ -309,9 +293,9 @@ function stripComments(content) {
         }
         else if (m4) {
             // A line comment. If it ends in \r?\n then keep it.
-            var length_1 = m4.length;
-            if (length_1 > 2 && m4[length_1 - 1] === '\n') {
-                return m4[length_1 - 2] === '\r' ? '\r\n' : '\n';
+            let length = m4.length;
+            if (length > 2 && m4[length - 1] === '\n') {
+                return m4[length - 2] === '\r' ? '\r\n' : '\n';
             }
             else {
                 return '';
@@ -325,9 +309,9 @@ function stripComments(content) {
     return result;
 }
 function escapeCharacters(value) {
-    var result = [];
-    for (var i = 0; i < value.length; i++) {
-        var ch = value.charAt(i);
+    const result = [];
+    for (let i = 0; i < value.length; i++) {
+        const ch = value.charAt(i);
         switch (ch) {
             case '\'':
                 result.push('\\\'');
@@ -360,22 +344,22 @@ function escapeCharacters(value) {
     return result.join('');
 }
 function processCoreBundleFormat(fileHeader, languages, json, emitter) {
-    var keysSection = json.keys;
-    var messageSection = json.messages;
-    var bundleSection = json.bundles;
-    var statistics = Object.create(null);
-    var defaultMessages = Object.create(null);
-    var modules = Object.keys(keysSection);
-    modules.forEach(function (module) {
-        var keys = keysSection[module];
-        var messages = messageSection[module];
+    let keysSection = json.keys;
+    let messageSection = json.messages;
+    let bundleSection = json.bundles;
+    let statistics = Object.create(null);
+    let defaultMessages = Object.create(null);
+    let modules = Object.keys(keysSection);
+    modules.forEach((module) => {
+        let keys = keysSection[module];
+        let messages = messageSection[module];
         if (!messages || keys.length !== messages.length) {
-            emitter.emit('error', "Message for module " + module + " corrupted. Mismatch in number of keys and messages.");
+            emitter.emit('error', `Message for module ${module} corrupted. Mismatch in number of keys and messages.`);
             return;
         }
-        var messageMap = Object.create(null);
+        let messageMap = Object.create(null);
         defaultMessages[module] = messageMap;
-        keys.map(function (key, i) {
+        keys.map((key, i) => {
             if (typeof key === 'string') {
                 messageMap[key] = messages[i];
             }
@@ -384,44 +368,44 @@ function processCoreBundleFormat(fileHeader, languages, json, emitter) {
             }
         });
     });
-    var languageDirectory = path.join(__dirname, '..', '..', 'i18n');
-    var sortedLanguages = sortLanguages(languages);
-    sortedLanguages.forEach(function (language) {
+    let languageDirectory = path.join(__dirname, '..', '..', 'i18n');
+    let sortedLanguages = sortLanguages(languages);
+    sortedLanguages.forEach((language) => {
         if (process.env['VSCODE_BUILD_VERBOSE']) {
-            log("Generating nls bundles for: " + language.id);
+            log(`Generating nls bundles for: ${language.id}`);
         }
         statistics[language.id] = 0;
-        var localizedModules = Object.create(null);
-        var languageFolderName = language.folderName || language.id;
-        var cwd = path.join(languageDirectory, languageFolderName, 'src');
-        modules.forEach(function (module) {
-            var order = keysSection[module];
-            var i18nFile = path.join(cwd, module) + '.i18n.json';
-            var messages = null;
+        let localizedModules = Object.create(null);
+        let languageFolderName = language.folderName || language.id;
+        let cwd = path.join(languageDirectory, languageFolderName, 'src');
+        modules.forEach((module) => {
+            let order = keysSection[module];
+            let i18nFile = path.join(cwd, module) + '.i18n.json';
+            let messages = null;
             if (fs.existsSync(i18nFile)) {
-                var content = stripComments(fs.readFileSync(i18nFile, 'utf8'));
+                let content = stripComments(fs.readFileSync(i18nFile, 'utf8'));
                 messages = JSON.parse(content);
             }
             else {
                 if (process.env['VSCODE_BUILD_VERBOSE']) {
-                    log("No localized messages found for module " + module + ". Using default messages.");
+                    log(`No localized messages found for module ${module}. Using default messages.`);
                 }
                 messages = defaultMessages[module];
                 statistics[language.id] = statistics[language.id] + Object.keys(messages).length;
             }
-            var localizedMessages = [];
-            order.forEach(function (keyInfo) {
-                var key = null;
+            let localizedMessages = [];
+            order.forEach((keyInfo) => {
+                let key = null;
                 if (typeof keyInfo === 'string') {
                     key = keyInfo;
                 }
                 else {
                     key = keyInfo.key;
                 }
-                var message = messages[key];
+                let message = messages[key];
                 if (!message) {
                     if (process.env['VSCODE_BUILD_VERBOSE']) {
-                        log("No localized message found for key " + key + " in module " + module + ". Using default message.");
+                        log(`No localized message found for key ${key} in module ${module}. Using default message.`);
                     }
                     message = defaultMessages[module][key];
                     statistics[language.id] = statistics[language.id] + 1;
@@ -430,21 +414,21 @@ function processCoreBundleFormat(fileHeader, languages, json, emitter) {
             });
             localizedModules[module] = localizedMessages;
         });
-        Object.keys(bundleSection).forEach(function (bundle) {
-            var modules = bundleSection[bundle];
-            var contents = [
+        Object.keys(bundleSection).forEach((bundle) => {
+            let modules = bundleSection[bundle];
+            let contents = [
                 fileHeader,
-                "define(\"" + bundle + ".nls." + language.id + "\", {"
+                `define("${bundle}.nls.${language.id}", {`
             ];
-            modules.forEach(function (module, index) {
-                contents.push("\t\"" + module + "\": [");
-                var messages = localizedModules[module];
+            modules.forEach((module, index) => {
+                contents.push(`\t"${module}": [`);
+                let messages = localizedModules[module];
                 if (!messages) {
-                    emitter.emit('error', "Didn't find messages for module " + module + ".");
+                    emitter.emit('error', `Didn't find messages for module ${module}.`);
                     return;
                 }
-                messages.forEach(function (message, index) {
-                    contents.push("\t\t\"" + escapeCharacters(message) + (index < messages.length ? '",' : '"'));
+                messages.forEach((message, index) => {
+                    contents.push(`\t\t"${escapeCharacters(message)}${index < messages.length ? '",' : '"'}`);
                 });
                 contents.push(index < modules.length - 1 ? '\t],' : '\t]');
             });
@@ -452,27 +436,27 @@ function processCoreBundleFormat(fileHeader, languages, json, emitter) {
             emitter.queue(new File({ path: bundle + '.nls.' + language.id + '.js', contents: Buffer.from(contents.join('\n'), 'utf-8') }));
         });
     });
-    Object.keys(statistics).forEach(function (key) {
-        var value = statistics[key];
-        log(key + " has " + value + " untranslated strings.");
+    Object.keys(statistics).forEach(key => {
+        let value = statistics[key];
+        log(`${key} has ${value} untranslated strings.`);
     });
-    sortedLanguages.forEach(function (language) {
-        var stats = statistics[language.id];
+    sortedLanguages.forEach(language => {
+        let stats = statistics[language.id];
         if (Is.undef(stats)) {
-            log("\tNo translations found for language " + language.id + ". Using default language instead.");
+            log(`\tNo translations found for language ${language.id}. Using default language instead.`);
         }
     });
 }
 function processNlsFiles(opts) {
     return event_stream_1.through(function (file) {
-        var fileName = path.basename(file.path);
+        let fileName = path.basename(file.path);
         if (fileName === 'nls.metadata.json') {
-            var json = null;
+            let json = null;
             if (file.isBuffer()) {
                 json = JSON.parse(file.contents.toString('utf8'));
             }
             else {
-                this.emit('error', "Failed to read component file: " + file.relative);
+                this.emit('error', `Failed to read component file: ${file.relative}`);
                 return;
             }
             if (BundledFormat.is(json)) {
@@ -483,9 +467,9 @@ function processNlsFiles(opts) {
     });
 }
 exports.processNlsFiles = processNlsFiles;
-var editorProject = 'vscode-editor', workbenchProject = 'vscode-workbench', extensionsProject = 'vscode-extensions', setupProject = 'vscode-setup';
+const editorProject = 'vscode-editor', workbenchProject = 'vscode-workbench', extensionsProject = 'vscode-extensions', setupProject = 'vscode-setup';
 function getResource(sourceFile) {
-    var resource;
+    let resource;
     if (/^vs\/platform/.test(sourceFile)) {
         return { name: 'vs/platform', project: editorProject };
     }
@@ -512,39 +496,39 @@ function getResource(sourceFile) {
     else if (/^vs\/workbench/.test(sourceFile)) {
         return { name: 'vs/workbench', project: workbenchProject };
     }
-    throw new Error("Could not identify the XLF bundle for " + sourceFile);
+    throw new Error(`Could not identify the XLF bundle for ${sourceFile}`);
 }
 exports.getResource = getResource;
 function createXlfFilesForCoreBundle() {
     return event_stream_1.through(function (file) {
-        var basename = path.basename(file.path);
+        const basename = path.basename(file.path);
         if (basename === 'nls.metadata.json') {
             if (file.isBuffer()) {
-                var xlfs = Object.create(null);
-                var json = JSON.parse(file.contents.toString('utf8'));
-                for (var coreModule in json.keys) {
-                    var projectResource = getResource(coreModule);
-                    var resource = projectResource.name;
-                    var project = projectResource.project;
-                    var keys = json.keys[coreModule];
-                    var messages = json.messages[coreModule];
+                const xlfs = Object.create(null);
+                const json = JSON.parse(file.contents.toString('utf8'));
+                for (let coreModule in json.keys) {
+                    const projectResource = getResource(coreModule);
+                    const resource = projectResource.name;
+                    const project = projectResource.project;
+                    const keys = json.keys[coreModule];
+                    const messages = json.messages[coreModule];
                     if (keys.length !== messages.length) {
-                        this.emit('error', "There is a mismatch between keys and messages in " + file.relative + " for module " + coreModule);
+                        this.emit('error', `There is a mismatch between keys and messages in ${file.relative} for module ${coreModule}`);
                         return;
                     }
                     else {
-                        var xlf = xlfs[resource];
+                        let xlf = xlfs[resource];
                         if (!xlf) {
                             xlf = new XLF(project);
                             xlfs[resource] = xlf;
                         }
-                        xlf.addFile("src/" + coreModule, keys, messages);
+                        xlf.addFile(`src/${coreModule}`, keys, messages);
                     }
                 }
-                for (var resource in xlfs) {
-                    var xlf = xlfs[resource];
-                    var filePath = xlf.project + "/" + resource.replace(/\//g, '_') + ".xlf";
-                    var xlfFile = new File({
+                for (let resource in xlfs) {
+                    const xlf = xlfs[resource];
+                    const filePath = `${xlf.project}/${resource.replace(/\//g, '_')}.xlf`;
+                    const xlfFile = new File({
                         path: filePath,
                         contents: Buffer.from(xlf.toString(), 'utf8')
                     });
@@ -552,48 +536,48 @@ function createXlfFilesForCoreBundle() {
                 }
             }
             else {
-                this.emit('error', new Error("File " + file.relative + " is not using a buffer content"));
+                this.emit('error', new Error(`File ${file.relative} is not using a buffer content`));
                 return;
             }
         }
         else {
-            this.emit('error', new Error("File " + file.relative + " is not a core meta data file."));
+            this.emit('error', new Error(`File ${file.relative} is not a core meta data file.`));
             return;
         }
     });
 }
 exports.createXlfFilesForCoreBundle = createXlfFilesForCoreBundle;
 function createXlfFilesForExtensions() {
-    var counter = 0;
-    var folderStreamEnded = false;
-    var folderStreamEndEmitted = false;
+    let counter = 0;
+    let folderStreamEnded = false;
+    let folderStreamEndEmitted = false;
     return event_stream_1.through(function (extensionFolder) {
-        var folderStream = this;
-        var stat = fs.statSync(extensionFolder.path);
+        const folderStream = this;
+        const stat = fs.statSync(extensionFolder.path);
         if (!stat.isDirectory()) {
             return;
         }
-        var extensionName = path.basename(extensionFolder.path);
+        let extensionName = path.basename(extensionFolder.path);
         if (extensionName === 'node_modules') {
             return;
         }
         counter++;
-        var _xlf;
+        let _xlf;
         function getXlf() {
             if (!_xlf) {
                 _xlf = new XLF(extensionsProject);
             }
             return _xlf;
         }
-        gulp.src(["./extensions/" + extensionName + "/package.nls.json", "./extensions/" + extensionName + "/**/nls.metadata.json"]).pipe(event_stream_1.through(function (file) {
+        gulp.src([`./extensions/${extensionName}/package.nls.json`, `./extensions/${extensionName}/**/nls.metadata.json`]).pipe(event_stream_1.through(function (file) {
             if (file.isBuffer()) {
-                var buffer = file.contents;
-                var basename = path.basename(file.path);
+                const buffer = file.contents;
+                const basename = path.basename(file.path);
                 if (basename === 'package.nls.json') {
-                    var json_1 = JSON.parse(buffer.toString('utf8'));
-                    var keys = Object.keys(json_1);
-                    var messages = keys.map(function (key) {
-                        var value = json_1[key];
+                    const json = JSON.parse(buffer.toString('utf8'));
+                    const keys = Object.keys(json);
+                    const messages = keys.map((key) => {
+                        const value = json[key];
                         if (Is.string(value)) {
                             return value;
                         }
@@ -601,27 +585,27 @@ function createXlfFilesForExtensions() {
                             return value.message;
                         }
                         else {
-                            return "Unknown message for key: " + key;
+                            return `Unknown message for key: ${key}`;
                         }
                     });
-                    getXlf().addFile("extensions/" + extensionName + "/package", keys, messages);
+                    getXlf().addFile(`extensions/${extensionName}/package`, keys, messages);
                 }
                 else if (basename === 'nls.metadata.json') {
-                    var json = JSON.parse(buffer.toString('utf8'));
-                    var relPath = path.relative("./extensions/" + extensionName, path.dirname(file.path));
-                    for (var file_1 in json) {
-                        var fileContent = json[file_1];
-                        getXlf().addFile("extensions/" + extensionName + "/" + relPath + "/" + file_1, fileContent.keys, fileContent.messages);
+                    const json = JSON.parse(buffer.toString('utf8'));
+                    const relPath = path.relative(`./extensions/${extensionName}`, path.dirname(file.path));
+                    for (let file in json) {
+                        const fileContent = json[file];
+                        getXlf().addFile(`extensions/${extensionName}/${relPath}/${file}`, fileContent.keys, fileContent.messages);
                     }
                 }
                 else {
-                    this.emit('error', new Error(file.path + " is not a valid extension nls file"));
+                    this.emit('error', new Error(`${file.path} is not a valid extension nls file`));
                     return;
                 }
             }
         }, function () {
             if (_xlf) {
-                var xlfFile = new File({
+                let xlfFile = new File({
                     path: path.join(extensionsProject, extensionName + '.xlf'),
                     contents: Buffer.from(_xlf.toString(), 'utf8')
                 });
@@ -645,7 +629,7 @@ function createXlfFilesForExtensions() {
 exports.createXlfFilesForExtensions = createXlfFilesForExtensions;
 function createXlfFilesForIsl() {
     return event_stream_1.through(function (file) {
-        var projectName, resourceFile;
+        let projectName, resourceFile;
         if (path.basename(file.path) === 'Default.isl') {
             projectName = setupProject;
             resourceFile = 'setup_default.xlf';
@@ -654,14 +638,14 @@ function createXlfFilesForIsl() {
             projectName = workbenchProject;
             resourceFile = 'setup_messages.xlf';
         }
-        var xlf = new XLF(projectName), keys = [], messages = [];
-        var model = new TextModel(file.contents.toString());
-        var inMessageSection = false;
-        model.lines.forEach(function (line) {
+        let xlf = new XLF(projectName), keys = [], messages = [];
+        let model = new TextModel(file.contents.toString());
+        let inMessageSection = false;
+        model.lines.forEach(line => {
             if (line.length === 0) {
                 return;
             }
-            var firstChar = line.charAt(0);
+            let firstChar = line.charAt(0);
             switch (firstChar) {
                 case ';':
                     // Comment line;
@@ -673,40 +657,40 @@ function createXlfFilesForIsl() {
             if (!inMessageSection) {
                 return;
             }
-            var sections = line.split('=');
+            let sections = line.split('=');
             if (sections.length !== 2) {
-                throw new Error("Badly formatted message found: " + line);
+                throw new Error(`Badly formatted message found: ${line}`);
             }
             else {
-                var key = sections[0];
-                var value = sections[1];
+                let key = sections[0];
+                let value = sections[1];
                 if (key.length > 0 && value.length > 0) {
                     keys.push(key);
                     messages.push(value);
                 }
             }
         });
-        var originalPath = file.path.substring(file.cwd.length + 1, file.path.split('.')[0].length).replace(/\\/g, '/');
+        const originalPath = file.path.substring(file.cwd.length + 1, file.path.split('.')[0].length).replace(/\\/g, '/');
         xlf.addFile(originalPath, keys, messages);
         // Emit only upon all ISL files combined into single XLF instance
-        var newFilePath = path.join(projectName, resourceFile);
-        var xlfFile = new File({ path: newFilePath, contents: Buffer.from(xlf.toString(), 'utf-8') });
+        const newFilePath = path.join(projectName, resourceFile);
+        const xlfFile = new File({ path: newFilePath, contents: Buffer.from(xlf.toString(), 'utf-8') });
         this.queue(xlfFile);
     });
 }
 exports.createXlfFilesForIsl = createXlfFilesForIsl;
 function pushXlfFiles(apiHostname, username, password) {
-    var tryGetPromises = [];
-    var updateCreatePromises = [];
+    let tryGetPromises = [];
+    let updateCreatePromises = [];
     return event_stream_1.through(function (file) {
-        var project = path.dirname(file.relative);
-        var fileName = path.basename(file.path);
-        var slug = fileName.substr(0, fileName.length - '.xlf'.length);
-        var credentials = username + ":" + password;
+        const project = path.dirname(file.relative);
+        const fileName = path.basename(file.path);
+        const slug = fileName.substr(0, fileName.length - '.xlf'.length);
+        const credentials = `${username}:${password}`;
         // Check if resource already exists, if not, then create it.
-        var promise = tryGetResource(project, slug, apiHostname, credentials);
+        let promise = tryGetResource(project, slug, apiHostname, credentials);
         tryGetPromises.push(promise);
-        promise.then(function (exists) {
+        promise.then(exists => {
             if (exists) {
                 promise = updateResource(project, slug, file, apiHostname, credentials);
             }
@@ -716,107 +700,100 @@ function pushXlfFiles(apiHostname, username, password) {
             updateCreatePromises.push(promise);
         });
     }, function () {
-        var _this = this;
         // End the pipe only after all the communication with Transifex API happened
-        Promise.all(tryGetPromises).then(function () {
-            Promise.all(updateCreatePromises).then(function () {
-                _this.queue(null);
-            }).catch(function (reason) { throw new Error(reason); });
-        }).catch(function (reason) { throw new Error(reason); });
+        Promise.all(tryGetPromises).then(() => {
+            Promise.all(updateCreatePromises).then(() => {
+                this.queue(null);
+            }).catch((reason) => { throw new Error(reason); });
+        }).catch((reason) => { throw new Error(reason); });
     });
 }
 exports.pushXlfFiles = pushXlfFiles;
 function getAllResources(project, apiHostname, username, password) {
-    return new Promise(function (resolve, reject) {
-        var credentials = username + ":" + password;
-        var options = {
+    return new Promise((resolve, reject) => {
+        const credentials = `${username}:${password}`;
+        const options = {
             hostname: apiHostname,
-            path: "/api/2/project/" + project + "/resources",
+            path: `/api/2/project/${project}/resources`,
             auth: credentials,
             method: 'GET'
         };
-        var request = https.request(options, function (res) {
-            var buffer = [];
-            res.on('data', function (chunk) { return buffer.push(chunk); });
-            res.on('end', function () {
+        const request = https.request(options, (res) => {
+            let buffer = [];
+            res.on('data', (chunk) => buffer.push(chunk));
+            res.on('end', () => {
                 if (res.statusCode === 200) {
-                    var json = JSON.parse(Buffer.concat(buffer).toString());
+                    let json = JSON.parse(Buffer.concat(buffer).toString());
                     if (Array.isArray(json)) {
-                        resolve(json.map(function (o) { return o.slug; }));
+                        resolve(json.map(o => o.slug));
                         return;
                     }
-                    reject("Unexpected data format. Response code: " + res.statusCode + ".");
+                    reject(`Unexpected data format. Response code: ${res.statusCode}.`);
                 }
                 else {
-                    reject("No resources in " + project + " returned no data. Response code: " + res.statusCode + ".");
+                    reject(`No resources in ${project} returned no data. Response code: ${res.statusCode}.`);
                 }
             });
         });
-        request.on('error', function (err) {
-            reject("Failed to query resources in " + project + " with the following error: " + err + ". " + options.path);
+        request.on('error', (err) => {
+            reject(`Failed to query resources in ${project} with the following error: ${err}. ${options.path}`);
         });
         request.end();
     });
 }
 function findObsoleteResources(apiHostname, username, password) {
-    var resourcesByProject = Object.create(null);
+    let resourcesByProject = Object.create(null);
     resourcesByProject[extensionsProject] = [].concat(externalExtensionsWithTranslations); // clone
     return event_stream_1.through(function (file) {
-        var project = path.dirname(file.relative);
-        var fileName = path.basename(file.path);
-        var slug = fileName.substr(0, fileName.length - '.xlf'.length);
-        var slugs = resourcesByProject[project];
+        const project = path.dirname(file.relative);
+        const fileName = path.basename(file.path);
+        const slug = fileName.substr(0, fileName.length - '.xlf'.length);
+        let slugs = resourcesByProject[project];
         if (!slugs) {
             resourcesByProject[project] = slugs = [];
         }
         slugs.push(slug);
         this.push(file);
     }, function () {
-        var _this = this;
-        var json = JSON.parse(fs.readFileSync('./build/lib/i18n.resources.json', 'utf8'));
-        var i18Resources = json.editor.concat(json.workbench).map(function (r) { return r.project + '/' + r.name.replace(/\//g, '_'); });
-        var extractedResources = [];
-        for (var _i = 0, _a = [workbenchProject, editorProject]; _i < _a.length; _i++) {
-            var project = _a[_i];
-            for (var _b = 0, _c = resourcesByProject[project]; _b < _c.length; _b++) {
-                var resource = _c[_b];
+        const json = JSON.parse(fs.readFileSync('./build/lib/i18n.resources.json', 'utf8'));
+        let i18Resources = [...json.editor, ...json.workbench].map((r) => r.project + '/' + r.name.replace(/\//g, '_'));
+        let extractedResources = [];
+        for (let project of [workbenchProject, editorProject]) {
+            for (let resource of resourcesByProject[project]) {
                 if (resource !== 'setup_messages') {
                     extractedResources.push(project + '/' + resource);
                 }
             }
         }
         if (i18Resources.length !== extractedResources.length) {
-            console.log("[i18n] Obsolete resources in file 'build/lib/i18n.resources.json': JSON.stringify(" + i18Resources.filter(function (p) { return extractedResources.indexOf(p) === -1; }) + ")");
-            console.log("[i18n] Missing resources in file 'build/lib/i18n.resources.json': JSON.stringify(" + extractedResources.filter(function (p) { return i18Resources.indexOf(p) === -1; }) + ")");
+            console.log(`[i18n] Obsolete resources in file 'build/lib/i18n.resources.json': JSON.stringify(${i18Resources.filter(p => extractedResources.indexOf(p) === -1)})`);
+            console.log(`[i18n] Missing resources in file 'build/lib/i18n.resources.json': JSON.stringify(${extractedResources.filter(p => i18Resources.indexOf(p) === -1)})`);
         }
-        var promises = [];
-        var _loop_1 = function (project) {
-            promises.push(getAllResources(project, apiHostname, username, password).then(function (resources) {
-                var expectedResources = resourcesByProject[project];
-                var unusedResources = resources.filter(function (resource) { return resource && expectedResources.indexOf(resource) === -1; });
+        let promises = [];
+        for (let project in resourcesByProject) {
+            promises.push(getAllResources(project, apiHostname, username, password).then(resources => {
+                let expectedResources = resourcesByProject[project];
+                let unusedResources = resources.filter(resource => resource && expectedResources.indexOf(resource) === -1);
                 if (unusedResources.length) {
-                    console.log("[transifex] Obsolete resources in project '" + project + "': " + unusedResources.join(', '));
+                    console.log(`[transifex] Obsolete resources in project '${project}': ${unusedResources.join(', ')}`);
                 }
             }));
-        };
-        for (var project in resourcesByProject) {
-            _loop_1(project);
         }
-        return Promise.all(promises).then(function (_) {
-            _this.push(null);
-        }).catch(function (reason) { throw new Error(reason); });
+        return Promise.all(promises).then(_ => {
+            this.push(null);
+        }).catch((reason) => { throw new Error(reason); });
     });
 }
 exports.findObsoleteResources = findObsoleteResources;
 function tryGetResource(project, slug, apiHostname, credentials) {
-    return new Promise(function (resolve, reject) {
-        var options = {
+    return new Promise((resolve, reject) => {
+        const options = {
             hostname: apiHostname,
-            path: "/api/2/project/" + project + "/resource/" + slug + "/?details",
+            path: `/api/2/project/${project}/resource/${slug}/?details`,
             auth: credentials,
             method: 'GET'
         };
-        var request = https.request(options, function (response) {
+        const request = https.request(options, (response) => {
             if (response.statusCode === 404) {
                 resolve(false);
             }
@@ -824,26 +801,26 @@ function tryGetResource(project, slug, apiHostname, credentials) {
                 resolve(true);
             }
             else {
-                reject("Failed to query resource " + project + "/" + slug + ". Response: " + response.statusCode + " " + response.statusMessage);
+                reject(`Failed to query resource ${project}/${slug}. Response: ${response.statusCode} ${response.statusMessage}`);
             }
         });
-        request.on('error', function (err) {
-            reject("Failed to get " + project + "/" + slug + " on Transifex: " + err);
+        request.on('error', (err) => {
+            reject(`Failed to get ${project}/${slug} on Transifex: ${err}`);
         });
         request.end();
     });
 }
 function createResource(project, slug, xlfFile, apiHostname, credentials) {
-    return new Promise(function (_resolve, reject) {
-        var data = JSON.stringify({
+    return new Promise((_resolve, reject) => {
+        const data = JSON.stringify({
             'content': xlfFile.contents.toString(),
             'name': slug,
             'slug': slug,
             'i18n_type': 'XLIFF'
         });
-        var options = {
+        const options = {
             hostname: apiHostname,
-            path: "/api/2/project/" + project + "/resources",
+            path: `/api/2/project/${project}/resources`,
             headers: {
                 'Content-Type': 'application/json',
                 'Content-Length': Buffer.byteLength(data)
@@ -851,16 +828,16 @@ function createResource(project, slug, xlfFile, apiHostname, credentials) {
             auth: credentials,
             method: 'POST'
         };
-        var request = https.request(options, function (res) {
+        let request = https.request(options, (res) => {
             if (res.statusCode === 201) {
-                log("Resource " + project + "/" + slug + " successfully created on Transifex.");
+                log(`Resource ${project}/${slug} successfully created on Transifex.`);
             }
             else {
-                reject("Something went wrong in the request creating " + slug + " in " + project + ". " + res.statusCode);
+                reject(`Something went wrong in the request creating ${slug} in ${project}. ${res.statusCode}`);
             }
         });
-        request.on('error', function (err) {
-            reject("Failed to create " + project + "/" + slug + " on Transifex: " + err);
+        request.on('error', (err) => {
+            reject(`Failed to create ${project}/${slug} on Transifex: ${err}`);
         });
         request.write(data);
         request.end();
@@ -871,11 +848,11 @@ function createResource(project, slug, xlfFile, apiHostname, credentials) {
  * https://dev.befoolish.co/tx-docs/public/projects/updating-content#what-happens-when-you-update-files
  */
 function updateResource(project, slug, xlfFile, apiHostname, credentials) {
-    return new Promise(function (resolve, reject) {
-        var data = JSON.stringify({ content: xlfFile.contents.toString() });
-        var options = {
+    return new Promise((resolve, reject) => {
+        const data = JSON.stringify({ content: xlfFile.contents.toString() });
+        const options = {
             hostname: apiHostname,
-            path: "/api/2/project/" + project + "/resource/" + slug + "/content",
+            path: `/api/2/project/${project}/resource/${slug}/content`,
             headers: {
                 'Content-Type': 'application/json',
                 'Content-Length': Buffer.byteLength(data)
@@ -883,48 +860,48 @@ function updateResource(project, slug, xlfFile, apiHostname, credentials) {
             auth: credentials,
             method: 'PUT'
         };
-        var request = https.request(options, function (res) {
+        let request = https.request(options, (res) => {
             if (res.statusCode === 200) {
                 res.setEncoding('utf8');
-                var responseBuffer_1 = '';
+                let responseBuffer = '';
                 res.on('data', function (chunk) {
-                    responseBuffer_1 += chunk;
+                    responseBuffer += chunk;
                 });
-                res.on('end', function () {
-                    var response = JSON.parse(responseBuffer_1);
-                    log("Resource " + project + "/" + slug + " successfully updated on Transifex. Strings added: " + response.strings_added + ", updated: " + response.strings_added + ", deleted: " + response.strings_added);
+                res.on('end', () => {
+                    const response = JSON.parse(responseBuffer);
+                    log(`Resource ${project}/${slug} successfully updated on Transifex. Strings added: ${response.strings_added}, updated: ${response.strings_added}, deleted: ${response.strings_added}`);
                     resolve();
                 });
             }
             else {
-                reject("Something went wrong in the request updating " + slug + " in " + project + ". " + res.statusCode);
+                reject(`Something went wrong in the request updating ${slug} in ${project}. ${res.statusCode}`);
             }
         });
-        request.on('error', function (err) {
-            reject("Failed to update " + project + "/" + slug + " on Transifex: " + err);
+        request.on('error', (err) => {
+            reject(`Failed to update ${project}/${slug} on Transifex: ${err}`);
         });
         request.write(data);
         request.end();
     });
 }
 // cache resources
-var _coreAndExtensionResources;
+let _coreAndExtensionResources;
 function pullCoreAndExtensionsXlfFiles(apiHostname, username, password, language, externalExtensions) {
     if (!_coreAndExtensionResources) {
         _coreAndExtensionResources = [];
         // editor and workbench
-        var json = JSON.parse(fs.readFileSync('./build/lib/i18n.resources.json', 'utf8'));
-        _coreAndExtensionResources.push.apply(_coreAndExtensionResources, json.editor);
-        _coreAndExtensionResources.push.apply(_coreAndExtensionResources, json.workbench);
+        const json = JSON.parse(fs.readFileSync('./build/lib/i18n.resources.json', 'utf8'));
+        _coreAndExtensionResources.push(...json.editor);
+        _coreAndExtensionResources.push(...json.workbench);
         // extensions
-        var extensionsToLocalize_1 = Object.create(null);
-        glob.sync('./extensions/**/*.nls.json').forEach(function (extension) { return extensionsToLocalize_1[extension.split('/')[2]] = true; });
-        glob.sync('./extensions/*/node_modules/vscode-nls').forEach(function (extension) { return extensionsToLocalize_1[extension.split('/')[2]] = true; });
-        Object.keys(extensionsToLocalize_1).forEach(function (extension) {
+        let extensionsToLocalize = Object.create(null);
+        glob.sync('./extensions/**/*.nls.json').forEach(extension => extensionsToLocalize[extension.split('/')[2]] = true);
+        glob.sync('./extensions/*/node_modules/vscode-nls').forEach(extension => extensionsToLocalize[extension.split('/')[2]] = true);
+        Object.keys(extensionsToLocalize).forEach(extension => {
             _coreAndExtensionResources.push({ name: extension, project: extensionsProject });
         });
         if (externalExtensions) {
-            for (var resourceName in externalExtensions) {
+            for (let resourceName in externalExtensions) {
                 _coreAndExtensionResources.push({ name: resourceName, project: extensionsProject });
             }
         }
@@ -933,7 +910,7 @@ function pullCoreAndExtensionsXlfFiles(apiHostname, username, password, language
 }
 exports.pullCoreAndExtensionsXlfFiles = pullCoreAndExtensionsXlfFiles;
 function pullSetupXlfFiles(apiHostname, username, password, language, includeDefault) {
-    var setupResources = [{ name: 'setup_messages', project: workbenchProject }];
+    let setupResources = [{ name: 'setup_messages', project: workbenchProject }];
     if (includeDefault) {
         setupResources.push({ name: 'setup_default', project: setupProject });
     }
@@ -941,9 +918,9 @@ function pullSetupXlfFiles(apiHostname, username, password, language, includeDef
 }
 exports.pullSetupXlfFiles = pullSetupXlfFiles;
 function pullXlfFiles(apiHostname, username, password, language, resources) {
-    var credentials = username + ":" + password;
-    var expectedTranslationsCount = resources.length;
-    var translationsRetrieved = 0, called = false;
+    const credentials = `${username}:${password}`;
+    let expectedTranslationsCount = resources.length;
+    let translationsRetrieved = 0, called = false;
     return event_stream_1.readable(function (_count, callback) {
         // Mark end of stream when all resources were retrieved
         if (translationsRetrieved === expectedTranslationsCount) {
@@ -951,77 +928,76 @@ function pullXlfFiles(apiHostname, username, password, language, resources) {
         }
         if (!called) {
             called = true;
-            var stream_1 = this;
+            const stream = this;
             resources.map(function (resource) {
-                retrieveResource(language, resource, apiHostname, credentials).then(function (file) {
+                retrieveResource(language, resource, apiHostname, credentials).then((file) => {
                     if (file) {
-                        stream_1.emit('data', file);
+                        stream.emit('data', file);
                     }
                     translationsRetrieved++;
-                }).catch(function (error) { throw new Error(error); });
+                }).catch(error => { throw new Error(error); });
             });
         }
         callback();
     });
 }
-var limiter = new Limiter(NUMBER_OF_CONCURRENT_DOWNLOADS);
+const limiter = new Limiter(NUMBER_OF_CONCURRENT_DOWNLOADS);
 function retrieveResource(language, resource, apiHostname, credentials) {
-    return limiter.queue(function () { return new Promise(function (resolve, reject) {
-        var slug = resource.name.replace(/\//g, '_');
-        var project = resource.project;
-        var transifexLanguageId = language.id === 'ps' ? 'en' : language.transifexId || language.id;
-        var options = {
+    return limiter.queue(() => new Promise((resolve, reject) => {
+        const slug = resource.name.replace(/\//g, '_');
+        const project = resource.project;
+        let transifexLanguageId = language.id === 'ps' ? 'en' : language.transifexId || language.id;
+        const options = {
             hostname: apiHostname,
-            path: "/api/2/project/" + project + "/resource/" + slug + "/translation/" + transifexLanguageId + "?file&mode=onlyreviewed",
+            path: `/api/2/project/${project}/resource/${slug}/translation/${transifexLanguageId}?file&mode=onlyreviewed`,
             auth: credentials,
             port: 443,
             method: 'GET'
         };
         console.log('[transifex] Fetching ' + options.path);
-        var request = https.request(options, function (res) {
-            var xlfBuffer = [];
-            res.on('data', function (chunk) { return xlfBuffer.push(chunk); });
-            res.on('end', function () {
+        let request = https.request(options, (res) => {
+            let xlfBuffer = [];
+            res.on('data', (chunk) => xlfBuffer.push(chunk));
+            res.on('end', () => {
                 if (res.statusCode === 200) {
-                    resolve(new File({ contents: Buffer.concat(xlfBuffer), path: project + "/" + slug + ".xlf" }));
+                    resolve(new File({ contents: Buffer.concat(xlfBuffer), path: `${project}/${slug}.xlf` }));
                 }
                 else if (res.statusCode === 404) {
-                    console.log("[transifex] " + slug + " in " + project + " returned no data.");
+                    console.log(`[transifex] ${slug} in ${project} returned no data.`);
                     resolve(null);
                 }
                 else {
-                    reject(slug + " in " + project + " returned no data. Response code: " + res.statusCode + ".");
+                    reject(`${slug} in ${project} returned no data. Response code: ${res.statusCode}.`);
                 }
             });
         });
-        request.on('error', function (err) {
-            reject("Failed to query resource " + slug + " with the following error: " + err + ". " + options.path);
+        request.on('error', (err) => {
+            reject(`Failed to query resource ${slug} with the following error: ${err}. ${options.path}`);
         });
         request.end();
-    }); });
+    }));
 }
 function prepareI18nFiles() {
-    var parsePromises = [];
+    let parsePromises = [];
     return event_stream_1.through(function (xlf) {
-        var stream = this;
-        var parsePromise = XLF.parse(xlf.contents.toString());
+        let stream = this;
+        let parsePromise = XLF.parse(xlf.contents.toString());
         parsePromises.push(parsePromise);
-        parsePromise.then(function (resolvedFiles) {
-            resolvedFiles.forEach(function (file) {
-                var translatedFile = createI18nFile(file.originalFilePath, file.messages);
+        parsePromise.then(resolvedFiles => {
+            resolvedFiles.forEach(file => {
+                let translatedFile = createI18nFile(file.originalFilePath, file.messages);
                 stream.queue(translatedFile);
             });
         });
     }, function () {
-        var _this = this;
         Promise.all(parsePromises)
-            .then(function () { _this.queue(null); })
-            .catch(function (reason) { throw new Error(reason); });
+            .then(() => { this.queue(null); })
+            .catch(reason => { throw new Error(reason); });
     });
 }
 exports.prepareI18nFiles = prepareI18nFiles;
 function createI18nFile(originalFilePath, messages) {
-    var result = Object.create(null);
+    let result = Object.create(null);
     result[''] = [
         '--------------------------------------------------------------------------------------------',
         'Copyright (c) Microsoft Corporation. All rights reserved.',
@@ -1029,11 +1005,10 @@ function createI18nFile(originalFilePath, messages) {
         '--------------------------------------------------------------------------------------------',
         'Do not edit this file. It is machine generated.'
     ];
-    for (var _i = 0, _a = Object.keys(messages); _i < _a.length; _i++) {
-        var key = _a[_i];
+    for (let key of Object.keys(messages)) {
         result[key] = messages[key];
     }
-    var content = JSON.stringify(result, null, '\t');
+    let content = JSON.stringify(result, null, '\t');
     if (process.platform === 'win32') {
         content = content.replace(/\n/g, '\r\n');
     }
@@ -1042,35 +1017,34 @@ function createI18nFile(originalFilePath, messages) {
         contents: Buffer.from(content, 'utf8')
     });
 }
-var i18nPackVersion = "1.0.0";
+const i18nPackVersion = "1.0.0";
 function pullI18nPackFiles(apiHostname, username, password, language, resultingTranslationPaths) {
     return pullCoreAndExtensionsXlfFiles(apiHostname, username, password, language, externalExtensionsWithTranslations)
         .pipe(prepareI18nPackFiles(externalExtensionsWithTranslations, resultingTranslationPaths, language.id === 'ps'));
 }
 exports.pullI18nPackFiles = pullI18nPackFiles;
-function prepareI18nPackFiles(externalExtensions, resultingTranslationPaths, pseudo) {
-    if (pseudo === void 0) { pseudo = false; }
-    var parsePromises = [];
-    var mainPack = { version: i18nPackVersion, contents: {} };
-    var extensionsPacks = {};
+function prepareI18nPackFiles(externalExtensions, resultingTranslationPaths, pseudo = false) {
+    let parsePromises = [];
+    let mainPack = { version: i18nPackVersion, contents: {} };
+    let extensionsPacks = {};
     return event_stream_1.through(function (xlf) {
-        var project = path.dirname(xlf.path);
-        var resource = path.basename(xlf.path, '.xlf');
-        var contents = xlf.contents.toString();
-        var parsePromise = pseudo ? XLF.parsePseudo(contents) : XLF.parse(contents);
+        let project = path.dirname(xlf.path);
+        let resource = path.basename(xlf.path, '.xlf');
+        let contents = xlf.contents.toString();
+        let parsePromise = pseudo ? XLF.parsePseudo(contents) : XLF.parse(contents);
         parsePromises.push(parsePromise);
-        parsePromise.then(function (resolvedFiles) {
-            resolvedFiles.forEach(function (file) {
-                var path = file.originalFilePath;
-                var firstSlash = path.indexOf('/');
+        parsePromise.then(resolvedFiles => {
+            resolvedFiles.forEach(file => {
+                const path = file.originalFilePath;
+                const firstSlash = path.indexOf('/');
                 if (project === extensionsProject) {
-                    var extPack = extensionsPacks[resource];
+                    let extPack = extensionsPacks[resource];
                     if (!extPack) {
                         extPack = extensionsPacks[resource] = { version: i18nPackVersion, contents: {} };
                     }
-                    var externalId = externalExtensions[resource];
+                    const externalId = externalExtensions[resource];
                     if (!externalId) { // internal extension: remove 'extensions/extensionId/' segnent
-                        var secondSlash = path.indexOf('/', firstSlash + 1);
+                        const secondSlash = path.indexOf('/', firstSlash + 1);
                         extPack.contents[path.substr(secondSlash + 1)] = file.messages;
                     }
                     else {
@@ -1083,90 +1057,88 @@ function prepareI18nPackFiles(externalExtensions, resultingTranslationPaths, pse
             });
         });
     }, function () {
-        var _this = this;
         Promise.all(parsePromises)
-            .then(function () {
-            var translatedMainFile = createI18nFile('./main', mainPack);
+            .then(() => {
+            const translatedMainFile = createI18nFile('./main', mainPack);
             resultingTranslationPaths.push({ id: 'vscode', resourceName: 'main.i18n.json' });
-            _this.queue(translatedMainFile);
-            for (var extension in extensionsPacks) {
-                var translatedExtFile = createI18nFile("./extensions/" + extension, extensionsPacks[extension]);
-                _this.queue(translatedExtFile);
-                var externalExtensionId = externalExtensions[extension];
+            this.queue(translatedMainFile);
+            for (let extension in extensionsPacks) {
+                const translatedExtFile = createI18nFile(`./extensions/${extension}`, extensionsPacks[extension]);
+                this.queue(translatedExtFile);
+                const externalExtensionId = externalExtensions[extension];
                 if (externalExtensionId) {
-                    resultingTranslationPaths.push({ id: externalExtensionId, resourceName: "extensions/" + extension + ".i18n.json" });
+                    resultingTranslationPaths.push({ id: externalExtensionId, resourceName: `extensions/${extension}.i18n.json` });
                 }
                 else {
-                    resultingTranslationPaths.push({ id: "vscode." + extension, resourceName: "extensions/" + extension + ".i18n.json" });
+                    resultingTranslationPaths.push({ id: `vscode.${extension}`, resourceName: `extensions/${extension}.i18n.json` });
                 }
             }
-            _this.queue(null);
+            this.queue(null);
         })
-            .catch(function (reason) { throw new Error(reason); });
+            .catch(reason => { throw new Error(reason); });
     });
 }
 exports.prepareI18nPackFiles = prepareI18nPackFiles;
 function prepareIslFiles(language, innoSetupConfig) {
-    var parsePromises = [];
+    let parsePromises = [];
     return event_stream_1.through(function (xlf) {
-        var stream = this;
-        var parsePromise = XLF.parse(xlf.contents.toString());
+        let stream = this;
+        let parsePromise = XLF.parse(xlf.contents.toString());
         parsePromises.push(parsePromise);
-        parsePromise.then(function (resolvedFiles) {
-            resolvedFiles.forEach(function (file) {
+        parsePromise.then(resolvedFiles => {
+            resolvedFiles.forEach(file => {
                 if (path.basename(file.originalFilePath) === 'Default' && !innoSetupConfig.defaultInfo) {
                     return;
                 }
-                var translatedFile = createIslFile(file.originalFilePath, file.messages, language, innoSetupConfig);
+                let translatedFile = createIslFile(file.originalFilePath, file.messages, language, innoSetupConfig);
                 stream.queue(translatedFile);
             });
         });
     }, function () {
-        var _this = this;
         Promise.all(parsePromises)
-            .then(function () { _this.queue(null); })
-            .catch(function (reason) { throw new Error(reason); });
+            .then(() => { this.queue(null); })
+            .catch(reason => { throw new Error(reason); });
     });
 }
 exports.prepareIslFiles = prepareIslFiles;
 function createIslFile(originalFilePath, messages, language, innoSetup) {
-    var content = [];
-    var originalContent;
+    let content = [];
+    let originalContent;
     if (path.basename(originalFilePath) === 'Default') {
         originalContent = new TextModel(fs.readFileSync(originalFilePath + '.isl', 'utf8'));
     }
     else {
         originalContent = new TextModel(fs.readFileSync(originalFilePath + '.en.isl', 'utf8'));
     }
-    originalContent.lines.forEach(function (line) {
+    originalContent.lines.forEach(line => {
         if (line.length > 0) {
-            var firstChar = line.charAt(0);
+            let firstChar = line.charAt(0);
             if (firstChar === '[' || firstChar === ';') {
                 if (line === '; *** Inno Setup version 5.5.3+ English messages ***') {
-                    content.push("; *** Inno Setup version 5.5.3+ " + innoSetup.defaultInfo.name + " messages ***");
+                    content.push(`; *** Inno Setup version 5.5.3+ ${innoSetup.defaultInfo.name} messages ***`);
                 }
                 else {
                     content.push(line);
                 }
             }
             else {
-                var sections = line.split('=');
-                var key = sections[0];
-                var translated = line;
+                let sections = line.split('=');
+                let key = sections[0];
+                let translated = line;
                 if (key) {
                     if (key === 'LanguageName') {
-                        translated = key + "=" + innoSetup.defaultInfo.name;
+                        translated = `${key}=${innoSetup.defaultInfo.name}`;
                     }
                     else if (key === 'LanguageID') {
-                        translated = key + "=" + innoSetup.defaultInfo.id;
+                        translated = `${key}=${innoSetup.defaultInfo.id}`;
                     }
                     else if (key === 'LanguageCodePage') {
-                        translated = key + "=" + innoSetup.codePage.substr(2);
+                        translated = `${key}=${innoSetup.codePage.substr(2)}`;
                     }
                     else {
-                        var translatedMessage = messages[key];
+                        let translatedMessage = messages[key];
                         if (translatedMessage) {
-                            translated = key + "=" + translatedMessage;
+                            translated = `${key}=${translatedMessage}`;
                         }
                     }
                 }
@@ -1174,17 +1146,17 @@ function createIslFile(originalFilePath, messages, language, innoSetup) {
             }
         }
     });
-    var basename = path.basename(originalFilePath);
-    var filePath = basename + "." + language.id + ".isl";
+    const basename = path.basename(originalFilePath);
+    const filePath = `${basename}.${language.id}.isl`;
     return new File({
         path: filePath,
         contents: iconv.encode(Buffer.from(content.join('\r\n'), 'utf8').toString(), innoSetup.codePage)
     });
 }
 function encodeEntities(value) {
-    var result = [];
-    for (var i = 0; i < value.length; i++) {
-        var ch = value[i];
+    let result = [];
+    for (let i = 0; i < value.length; i++) {
+        let ch = value[i];
         switch (ch) {
             case '<':
                 result.push('&lt;');

--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -348,7 +348,7 @@ export interface ITask<T> {
 
 interface ILimitedTaskFactory<T> {
 	factory: ITask<Promise<T>>;
-	c: (value?: T | Thenable<T>) => void;
+	c: (value?: T | Promise<T>) => void;
 	e: (error?: any) => void;
 }
 

--- a/build/lib/nls.js
+++ b/build/lib/nls.js
@@ -3,13 +3,12 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var ts = require("typescript");
-var lazy = require("lazy.js");
-var event_stream_1 = require("event-stream");
-var File = require("vinyl");
-var sm = require("source-map");
-var assign = require("object-assign");
-var path = require("path");
+const ts = require("typescript");
+const lazy = require("lazy.js");
+const event_stream_1 = require("event-stream");
+const File = require("vinyl");
+const sm = require("source-map");
+const path = require("path");
 var CollectStepResult;
 (function (CollectStepResult) {
     CollectStepResult[CollectStepResult["Yes"] = 0] = "Yes";
@@ -18,9 +17,9 @@ var CollectStepResult;
     CollectStepResult[CollectStepResult["NoAndRecurse"] = 3] = "NoAndRecurse";
 })(CollectStepResult || (CollectStepResult = {}));
 function collect(node, fn) {
-    var result = [];
+    const result = [];
     function loop(node) {
-        var stepResult = fn(node);
+        const stepResult = fn(node);
         if (stepResult === CollectStepResult.Yes || stepResult === CollectStepResult.YesAndRecurse) {
             result.push(node);
         }
@@ -32,43 +31,45 @@ function collect(node, fn) {
     return result;
 }
 function clone(object) {
-    var result = {};
-    for (var id in object) {
+    const result = {};
+    for (const id in object) {
         result[id] = object[id];
     }
     return result;
 }
 function template(lines) {
-    var indent = '', wrap = '';
+    let indent = '', wrap = '';
     if (lines.length > 1) {
         indent = '\t';
         wrap = '\n';
     }
-    return "/*---------------------------------------------------------\n * Copyright (C) Microsoft Corporation. All rights reserved.\n *--------------------------------------------------------*/\ndefine([], [" + (wrap + lines.map(function (l) { return indent + l; }).join(',\n') + wrap) + "]);";
+    return `/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+define([], [${wrap + lines.map(l => indent + l).join(',\n') + wrap}]);`;
 }
 /**
  * Returns a stream containing the patched JavaScript and source maps.
  */
 function nls() {
-    var input = event_stream_1.through();
-    var output = input.pipe(event_stream_1.through(function (f) {
-        var _this = this;
+    const input = event_stream_1.through();
+    const output = input.pipe(event_stream_1.through(function (f) {
         if (!f.sourceMap) {
-            return this.emit('error', new Error("File " + f.relative + " does not have sourcemaps."));
+            return this.emit('error', new Error(`File ${f.relative} does not have sourcemaps.`));
         }
-        var source = f.sourceMap.sources[0];
+        let source = f.sourceMap.sources[0];
         if (!source) {
-            return this.emit('error', new Error("File " + f.relative + " does not have a source in the source map."));
+            return this.emit('error', new Error(`File ${f.relative} does not have a source in the source map.`));
         }
-        var root = f.sourceMap.sourceRoot;
+        const root = f.sourceMap.sourceRoot;
         if (root) {
             source = path.join(root, source);
         }
-        var typescript = f.sourceMap.sourcesContent[0];
+        const typescript = f.sourceMap.sourcesContent[0];
         if (!typescript) {
-            return this.emit('error', new Error("File " + f.relative + " does not have the original content in the source map."));
+            return this.emit('error', new Error(`File ${f.relative} does not have the original content in the source map.`));
         }
-        nls.patchFiles(f, typescript).forEach(function (f) { return _this.emit('data', f); });
+        nls.patchFiles(f, typescript).forEach(f => this.emit('data', f));
     }));
     return event_stream_1.duplex(input, output);
 }
@@ -76,8 +77,7 @@ function isImportNode(node) {
     return node.kind === ts.SyntaxKind.ImportDeclaration || node.kind === ts.SyntaxKind.ImportEqualsDeclaration;
 }
 (function (nls_1) {
-    function fileFrom(file, contents, path) {
-        if (path === void 0) { path = file.path; }
+    function fileFrom(file, contents, path = file.path) {
         return new File({
             contents: Buffer.from(contents),
             base: file.base,
@@ -87,29 +87,27 @@ function isImportNode(node) {
     }
     nls_1.fileFrom = fileFrom;
     function mappedPositionFrom(source, lc) {
-        return { source: source, line: lc.line + 1, column: lc.character };
+        return { source, line: lc.line + 1, column: lc.character };
     }
     nls_1.mappedPositionFrom = mappedPositionFrom;
     function lcFrom(position) {
         return { line: position.line - 1, character: position.column };
     }
     nls_1.lcFrom = lcFrom;
-    var SingleFileServiceHost = /** @class */ (function () {
-        function SingleFileServiceHost(options, filename, contents) {
-            var _this = this;
+    class SingleFileServiceHost {
+        constructor(options, filename, contents) {
             this.options = options;
             this.filename = filename;
-            this.getCompilationSettings = function () { return _this.options; };
-            this.getScriptFileNames = function () { return [_this.filename]; };
-            this.getScriptVersion = function () { return '1'; };
-            this.getScriptSnapshot = function (name) { return name === _this.filename ? _this.file : _this.lib; };
-            this.getCurrentDirectory = function () { return ''; };
-            this.getDefaultLibFileName = function () { return 'lib.d.ts'; };
+            this.getCompilationSettings = () => this.options;
+            this.getScriptFileNames = () => [this.filename];
+            this.getScriptVersion = () => '1';
+            this.getScriptSnapshot = (name) => name === this.filename ? this.file : this.lib;
+            this.getCurrentDirectory = () => '';
+            this.getDefaultLibFileName = () => 'lib.d.ts';
             this.file = ts.ScriptSnapshot.fromString(contents);
             this.lib = ts.ScriptSnapshot.fromString('');
         }
-        return SingleFileServiceHost;
-    }());
+    }
     nls_1.SingleFileServiceHost = SingleFileServiceHost;
     function isCallExpressionWithinTextSpanCollectStep(textSpan, node) {
         if (!ts.textSpanContainsTextSpan({ start: node.pos, length: node.end - node.pos }, textSpan)) {
@@ -117,97 +115,96 @@ function isImportNode(node) {
         }
         return node.kind === ts.SyntaxKind.CallExpression ? CollectStepResult.YesAndRecurse : CollectStepResult.NoAndRecurse;
     }
-    function analyze(contents, options) {
-        if (options === void 0) { options = {}; }
-        var filename = 'file.ts';
-        var serviceHost = new SingleFileServiceHost(assign(clone(options), { noResolve: true }), filename, contents);
-        var service = ts.createLanguageService(serviceHost);
-        var sourceFile = ts.createSourceFile(filename, contents, ts.ScriptTarget.ES5, true);
+    function analyze(contents, options = {}) {
+        const filename = 'file.ts';
+        const serviceHost = new SingleFileServiceHost(Object.assign(clone(options), { noResolve: true }), filename, contents);
+        const service = ts.createLanguageService(serviceHost);
+        const sourceFile = ts.createSourceFile(filename, contents, ts.ScriptTarget.ES5, true);
         // all imports
-        var imports = lazy(collect(sourceFile, function (n) { return isImportNode(n) ? CollectStepResult.YesAndRecurse : CollectStepResult.NoAndRecurse; }));
+        const imports = lazy(collect(sourceFile, n => isImportNode(n) ? CollectStepResult.YesAndRecurse : CollectStepResult.NoAndRecurse));
         // import nls = require('vs/nls');
-        var importEqualsDeclarations = imports
-            .filter(function (n) { return n.kind === ts.SyntaxKind.ImportEqualsDeclaration; })
-            .map(function (n) { return n; })
-            .filter(function (d) { return d.moduleReference.kind === ts.SyntaxKind.ExternalModuleReference; })
-            .filter(function (d) { return d.moduleReference.expression.getText() === '\'vs/nls\''; });
+        const importEqualsDeclarations = imports
+            .filter(n => n.kind === ts.SyntaxKind.ImportEqualsDeclaration)
+            .map(n => n)
+            .filter(d => d.moduleReference.kind === ts.SyntaxKind.ExternalModuleReference)
+            .filter(d => d.moduleReference.expression.getText() === '\'vs/nls\'');
         // import ... from 'vs/nls';
-        var importDeclarations = imports
-            .filter(function (n) { return n.kind === ts.SyntaxKind.ImportDeclaration; })
-            .map(function (n) { return n; })
-            .filter(function (d) { return d.moduleSpecifier.kind === ts.SyntaxKind.StringLiteral; })
-            .filter(function (d) { return d.moduleSpecifier.getText() === '\'vs/nls\''; })
-            .filter(function (d) { return !!d.importClause && !!d.importClause.namedBindings; });
-        var nlsExpressions = importEqualsDeclarations
-            .map(function (d) { return d.moduleReference.expression; })
-            .concat(importDeclarations.map(function (d) { return d.moduleSpecifier; }))
-            .map(function (d) { return ({
+        const importDeclarations = imports
+            .filter(n => n.kind === ts.SyntaxKind.ImportDeclaration)
+            .map(n => n)
+            .filter(d => d.moduleSpecifier.kind === ts.SyntaxKind.StringLiteral)
+            .filter(d => d.moduleSpecifier.getText() === '\'vs/nls\'')
+            .filter(d => !!d.importClause && !!d.importClause.namedBindings);
+        const nlsExpressions = importEqualsDeclarations
+            .map(d => d.moduleReference.expression)
+            .concat(importDeclarations.map(d => d.moduleSpecifier))
+            .map(d => ({
             start: ts.getLineAndCharacterOfPosition(sourceFile, d.getStart()),
             end: ts.getLineAndCharacterOfPosition(sourceFile, d.getEnd())
-        }); });
+        }));
         // `nls.localize(...)` calls
-        var nlsLocalizeCallExpressions = importDeclarations
-            .filter(function (d) { return !!(d.importClause && d.importClause.namedBindings && d.importClause.namedBindings.kind === ts.SyntaxKind.NamespaceImport); })
-            .map(function (d) { return d.importClause.namedBindings.name; })
-            .concat(importEqualsDeclarations.map(function (d) { return d.name; }))
+        const nlsLocalizeCallExpressions = importDeclarations
+            .filter(d => !!(d.importClause && d.importClause.namedBindings && d.importClause.namedBindings.kind === ts.SyntaxKind.NamespaceImport))
+            .map(d => d.importClause.namedBindings.name)
+            .concat(importEqualsDeclarations.map(d => d.name))
             // find read-only references to `nls`
-            .map(function (n) { return service.getReferencesAtPosition(filename, n.pos + 1); })
+            .map(n => service.getReferencesAtPosition(filename, n.pos + 1))
             .flatten()
-            .filter(function (r) { return !r.isWriteAccess; })
+            .filter(r => !r.isWriteAccess)
             // find the deepest call expressions AST nodes that contain those references
-            .map(function (r) { return collect(sourceFile, function (n) { return isCallExpressionWithinTextSpanCollectStep(r.textSpan, n); }); })
-            .map(function (a) { return lazy(a).last(); })
-            .filter(function (n) { return !!n; })
-            .map(function (n) { return n; })
+            .map(r => collect(sourceFile, n => isCallExpressionWithinTextSpanCollectStep(r.textSpan, n)))
+            .map(a => lazy(a).last())
+            .filter(n => !!n)
+            .map(n => n)
             // only `localize` calls
-            .filter(function (n) { return n.expression.kind === ts.SyntaxKind.PropertyAccessExpression && n.expression.name.getText() === 'localize'; });
+            .filter(n => n.expression.kind === ts.SyntaxKind.PropertyAccessExpression && n.expression.name.getText() === 'localize');
         // `localize` named imports
-        var allLocalizeImportDeclarations = importDeclarations
-            .filter(function (d) { return !!(d.importClause && d.importClause.namedBindings && d.importClause.namedBindings.kind === ts.SyntaxKind.NamedImports); })
-            .map(function (d) { return [].concat(d.importClause.namedBindings.elements); })
+        const allLocalizeImportDeclarations = importDeclarations
+            .filter(d => !!(d.importClause && d.importClause.namedBindings && d.importClause.namedBindings.kind === ts.SyntaxKind.NamedImports))
+            .map(d => [].concat(d.importClause.namedBindings.elements))
             .flatten();
         // `localize` read-only references
-        var localizeReferences = allLocalizeImportDeclarations
-            .filter(function (d) { return d.name.getText() === 'localize'; })
-            .map(function (n) { return service.getReferencesAtPosition(filename, n.pos + 1); })
+        const localizeReferences = allLocalizeImportDeclarations
+            .filter(d => d.name.getText() === 'localize')
+            .map(n => service.getReferencesAtPosition(filename, n.pos + 1))
             .flatten()
-            .filter(function (r) { return !r.isWriteAccess; });
+            .filter(r => !r.isWriteAccess);
         // custom named `localize` read-only references
-        var namedLocalizeReferences = allLocalizeImportDeclarations
-            .filter(function (d) { return d.propertyName && d.propertyName.getText() === 'localize'; })
-            .map(function (n) { return service.getReferencesAtPosition(filename, n.name.pos + 1); })
+        const namedLocalizeReferences = allLocalizeImportDeclarations
+            .filter(d => d.propertyName && d.propertyName.getText() === 'localize')
+            .map(n => service.getReferencesAtPosition(filename, n.name.pos + 1))
             .flatten()
-            .filter(function (r) { return !r.isWriteAccess; });
+            .filter(r => !r.isWriteAccess);
         // find the deepest call expressions AST nodes that contain those references
-        var localizeCallExpressions = localizeReferences
+        const localizeCallExpressions = localizeReferences
             .concat(namedLocalizeReferences)
-            .map(function (r) { return collect(sourceFile, function (n) { return isCallExpressionWithinTextSpanCollectStep(r.textSpan, n); }); })
-            .map(function (a) { return lazy(a).last(); })
-            .filter(function (n) { return !!n; })
-            .map(function (n) { return n; });
+            .map(r => collect(sourceFile, n => isCallExpressionWithinTextSpanCollectStep(r.textSpan, n)))
+            .map(a => lazy(a).last())
+            .filter(n => !!n)
+            .map(n => n);
         // collect everything
-        var localizeCalls = nlsLocalizeCallExpressions
+        const localizeCalls = nlsLocalizeCallExpressions
             .concat(localizeCallExpressions)
-            .map(function (e) { return e.arguments; })
-            .filter(function (a) { return a.length > 1; })
-            .sort(function (a, b) { return a[0].getStart() - b[0].getStart(); })
-            .map(function (a) { return ({
+            .map(e => e.arguments)
+            .filter(a => a.length > 1)
+            .sort((a, b) => a[0].getStart() - b[0].getStart())
+            .map(a => ({
             keySpan: { start: ts.getLineAndCharacterOfPosition(sourceFile, a[0].getStart()), end: ts.getLineAndCharacterOfPosition(sourceFile, a[0].getEnd()) },
             key: a[0].getText(),
             valueSpan: { start: ts.getLineAndCharacterOfPosition(sourceFile, a[1].getStart()), end: ts.getLineAndCharacterOfPosition(sourceFile, a[1].getEnd()) },
             value: a[1].getText()
-        }); });
+        }));
         return {
             localizeCalls: localizeCalls.toArray(),
             nlsExpressions: nlsExpressions.toArray()
         };
     }
     nls_1.analyze = analyze;
-    var TextModel = /** @class */ (function () {
-        function TextModel(contents) {
-            var regex = /\r\n|\r|\n/g;
-            var index = 0;
-            var match;
+    class TextModel {
+        constructor(contents) {
+            const regex = /\r\n|\r|\n/g;
+            let index = 0;
+            let match;
             this.lines = [];
             this.lineEndings = [];
             while (match = regex.exec(contents)) {
@@ -220,85 +217,80 @@ function isImportNode(node) {
                 this.lineEndings.push('');
             }
         }
-        TextModel.prototype.get = function (index) {
+        get(index) {
             return this.lines[index];
-        };
-        TextModel.prototype.set = function (index, line) {
+        }
+        set(index, line) {
             this.lines[index] = line;
-        };
-        Object.defineProperty(TextModel.prototype, "lineCount", {
-            get: function () {
-                return this.lines.length;
-            },
-            enumerable: true,
-            configurable: true
-        });
+        }
+        get lineCount() {
+            return this.lines.length;
+        }
         /**
          * Applies patch(es) to the model.
          * Multiple patches must be ordered.
          * Does not support patches spanning multiple lines.
          */
-        TextModel.prototype.apply = function (patch) {
-            var startLineNumber = patch.span.start.line;
-            var endLineNumber = patch.span.end.line;
-            var startLine = this.lines[startLineNumber] || '';
-            var endLine = this.lines[endLineNumber] || '';
+        apply(patch) {
+            const startLineNumber = patch.span.start.line;
+            const endLineNumber = patch.span.end.line;
+            const startLine = this.lines[startLineNumber] || '';
+            const endLine = this.lines[endLineNumber] || '';
             this.lines[startLineNumber] = [
                 startLine.substring(0, patch.span.start.character),
                 patch.content,
                 endLine.substring(patch.span.end.character)
             ].join('');
-            for (var i = startLineNumber + 1; i <= endLineNumber; i++) {
+            for (let i = startLineNumber + 1; i <= endLineNumber; i++) {
                 this.lines[i] = '';
             }
-        };
-        TextModel.prototype.toString = function () {
+        }
+        toString() {
             return lazy(this.lines).zip(this.lineEndings)
                 .flatten().toArray().join('');
-        };
-        return TextModel;
-    }());
+        }
+    }
     nls_1.TextModel = TextModel;
     function patchJavascript(patches, contents, moduleId) {
-        var model = new nls.TextModel(contents);
+        const model = new nls.TextModel(contents);
         // patch the localize calls
-        lazy(patches).reverse().each(function (p) { return model.apply(p); });
+        lazy(patches).reverse().each(p => model.apply(p));
         // patch the 'vs/nls' imports
-        var firstLine = model.get(0);
-        var patchedFirstLine = firstLine.replace(/(['"])vs\/nls\1/g, "$1vs/nls!" + moduleId + "$1");
+        const firstLine = model.get(0);
+        const patchedFirstLine = firstLine.replace(/(['"])vs\/nls\1/g, `$1vs/nls!${moduleId}$1`);
         model.set(0, patchedFirstLine);
         return model.toString();
     }
     nls_1.patchJavascript = patchJavascript;
     function patchSourcemap(patches, rsm, smc) {
-        var smg = new sm.SourceMapGenerator({
+        const smg = new sm.SourceMapGenerator({
             file: rsm.file,
             sourceRoot: rsm.sourceRoot
         });
         patches = patches.reverse();
-        var currentLine = -1;
-        var currentLineDiff = 0;
-        var source = null;
-        smc.eachMapping(function (m) {
-            var patch = patches[patches.length - 1];
-            var original = { line: m.originalLine, column: m.originalColumn };
-            var generated = { line: m.generatedLine, column: m.generatedColumn };
+        let currentLine = -1;
+        let currentLineDiff = 0;
+        let source = null;
+        smc.eachMapping(m => {
+            const patch = patches[patches.length - 1];
+            const original = { line: m.originalLine, column: m.originalColumn };
+            const generated = { line: m.generatedLine, column: m.generatedColumn };
             if (currentLine !== generated.line) {
                 currentLineDiff = 0;
             }
             currentLine = generated.line;
             generated.column += currentLineDiff;
             if (patch && m.generatedLine - 1 === patch.span.end.line && m.generatedColumn === patch.span.end.character) {
-                var originalLength = patch.span.end.character - patch.span.start.character;
-                var modifiedLength = patch.content.length;
-                var lengthDiff = modifiedLength - originalLength;
+                const originalLength = patch.span.end.character - patch.span.start.character;
+                const modifiedLength = patch.content.length;
+                const lengthDiff = modifiedLength - originalLength;
                 currentLineDiff += lengthDiff;
                 generated.column += lengthDiff;
                 patches.pop();
             }
             source = rsm.sourceRoot ? path.relative(rsm.sourceRoot, m.source) : m.source;
             source = source.replace(/\\/g, '/');
-            smg.addMapping({ source: source, name: m.name, original: original, generated: generated });
+            smg.addMapping({ source, name: m.name, original, generated });
         }, null, sm.SourceMapConsumer.GENERATED_ORDER);
         if (source) {
             smg.setSourceContent(source, smc.sourceContentFor(source));
@@ -307,47 +299,47 @@ function isImportNode(node) {
     }
     nls_1.patchSourcemap = patchSourcemap;
     function patch(moduleId, typescript, javascript, sourcemap) {
-        var _a = analyze(typescript), localizeCalls = _a.localizeCalls, nlsExpressions = _a.nlsExpressions;
+        const { localizeCalls, nlsExpressions } = analyze(typescript);
         if (localizeCalls.length === 0) {
-            return { javascript: javascript, sourcemap: sourcemap };
+            return { javascript, sourcemap };
         }
-        var nlsKeys = template(localizeCalls.map(function (lc) { return lc.key; }));
-        var nls = template(localizeCalls.map(function (lc) { return lc.value; }));
-        var smc = new sm.SourceMapConsumer(sourcemap);
-        var positionFrom = mappedPositionFrom.bind(null, sourcemap.sources[0]);
-        var i = 0;
+        const nlsKeys = template(localizeCalls.map(lc => lc.key));
+        const nls = template(localizeCalls.map(lc => lc.value));
+        const smc = new sm.SourceMapConsumer(sourcemap);
+        const positionFrom = mappedPositionFrom.bind(null, sourcemap.sources[0]);
+        let i = 0;
         // build patches
-        var patches = lazy(localizeCalls)
-            .map(function (lc) { return ([
+        const patches = lazy(localizeCalls)
+            .map(lc => ([
             { range: lc.keySpan, content: '' + (i++) },
             { range: lc.valueSpan, content: 'null' }
-        ]); })
+        ]))
             .flatten()
-            .map(function (c) {
-            var start = lcFrom(smc.generatedPositionFor(positionFrom(c.range.start)));
-            var end = lcFrom(smc.generatedPositionFor(positionFrom(c.range.end)));
-            return { span: { start: start, end: end }, content: c.content };
+            .map(c => {
+            const start = lcFrom(smc.generatedPositionFor(positionFrom(c.range.start)));
+            const end = lcFrom(smc.generatedPositionFor(positionFrom(c.range.end)));
+            return { span: { start, end }, content: c.content };
         })
             .toArray();
         javascript = patchJavascript(patches, javascript, moduleId);
         // since imports are not within the sourcemap information,
         // we must do this MacGyver style
         if (nlsExpressions.length) {
-            javascript = javascript.replace(/^define\(.*$/m, function (line) {
-                return line.replace(/(['"])vs\/nls\1/g, "$1vs/nls!" + moduleId + "$1");
+            javascript = javascript.replace(/^define\(.*$/m, line => {
+                return line.replace(/(['"])vs\/nls\1/g, `$1vs/nls!${moduleId}$1`);
             });
         }
         sourcemap = patchSourcemap(patches, sourcemap, smc);
-        return { javascript: javascript, sourcemap: sourcemap, nlsKeys: nlsKeys, nls: nls };
+        return { javascript, sourcemap, nlsKeys, nls };
     }
     nls_1.patch = patch;
     function patchFiles(javascriptFile, typescript) {
         // hack?
-        var moduleId = javascriptFile.relative
+        const moduleId = javascriptFile.relative
             .replace(/\.js$/, '')
             .replace(/\\/g, '/');
-        var _a = patch(moduleId, typescript, javascriptFile.contents.toString(), javascriptFile.sourceMap), javascript = _a.javascript, sourcemap = _a.sourcemap, nlsKeys = _a.nlsKeys, nls = _a.nls;
-        var result = [fileFrom(javascriptFile, javascript)];
+        const { javascript, sourcemap, nlsKeys, nls } = patch(moduleId, typescript, javascriptFile.contents.toString(), javascriptFile.sourceMap);
+        const result = [fileFrom(javascriptFile, javascript)];
         result[0].sourceMap = sourcemap;
         if (nlsKeys) {
             result.push(fileFrom(javascriptFile, nlsKeys, javascriptFile.path.replace(/\.js$/, '.nls.keys.js')));

--- a/build/lib/nls.ts
+++ b/build/lib/nls.ts
@@ -8,7 +8,6 @@ import * as lazy from 'lazy.js';
 import { duplex, through } from 'event-stream';
 import * as File from 'vinyl';
 import * as sm from 'source-map';
-import assign = require('object-assign');
 import * as  path from 'path';
 
 declare class FileSourceMap extends File {
@@ -174,7 +173,7 @@ module nls {
 
 	export function analyze(contents: string, options: ts.CompilerOptions = {}): ILocalizeAnalysisResult {
 		const filename = 'file.ts';
-		const serviceHost = new SingleFileServiceHost(assign(clone(options), { noResolve: true }), filename, contents);
+		const serviceHost = new SingleFileServiceHost(Object.assign(clone(options), { noResolve: true }), filename, contents);
 		const service = ts.createLanguageService(serviceHost);
 		const sourceFile = ts.createSourceFile(filename, contents, ts.ScriptTarget.ES5, true);
 

--- a/build/lib/optimize.js
+++ b/build/lib/optimize.js
@@ -4,30 +4,30 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-var es = require("event-stream");
-var gulp = require("gulp");
-var concat = require("gulp-concat");
-var minifyCSS = require("gulp-cssnano");
-var filter = require("gulp-filter");
-var flatmap = require("gulp-flatmap");
-var sourcemaps = require("gulp-sourcemaps");
-var uglify = require("gulp-uglify");
-var composer = require("gulp-uglify/composer");
-var gulpUtil = require("gulp-util");
-var path = require("path");
-var pump = require("pump");
-var uglifyes = require("uglify-es");
-var VinylFile = require("vinyl");
-var bundle = require("./bundle");
-var i18n_1 = require("./i18n");
-var stats_1 = require("./stats");
-var util = require("./util");
-var REPO_ROOT_PATH = path.join(__dirname, '../..');
+const es = require("event-stream");
+const gulp = require("gulp");
+const concat = require("gulp-concat");
+const minifyCSS = require("gulp-cssnano");
+const filter = require("gulp-filter");
+const flatmap = require("gulp-flatmap");
+const sourcemaps = require("gulp-sourcemaps");
+const uglify = require("gulp-uglify");
+const composer = require("gulp-uglify/composer");
+const gulpUtil = require("gulp-util");
+const path = require("path");
+const pump = require("pump");
+const uglifyes = require("uglify-es");
+const VinylFile = require("vinyl");
+const bundle = require("./bundle");
+const i18n_1 = require("./i18n");
+const stats_1 = require("./stats");
+const util = require("./util");
+const REPO_ROOT_PATH = path.join(__dirname, '../..');
 function log(prefix, message) {
     gulpUtil.log(gulpUtil.colors.cyan('[' + prefix + ']'), message);
 }
 function loaderConfig(emptyPaths) {
-    var result = {
+    const result = {
         paths: {
             'vs': 'out-build/vs',
             'vscode': 'empty:'
@@ -38,20 +38,20 @@ function loaderConfig(emptyPaths) {
     return result;
 }
 exports.loaderConfig = loaderConfig;
-var IS_OUR_COPYRIGHT_REGEXP = /Copyright \(C\) Microsoft Corporation/i;
+const IS_OUR_COPYRIGHT_REGEXP = /Copyright \(C\) Microsoft Corporation/i;
 function loader(src, bundledFileHeader, bundleLoader) {
-    var sources = [
-        src + "/vs/loader.js"
+    let sources = [
+        `${src}/vs/loader.js`
     ];
     if (bundleLoader) {
         sources = sources.concat([
-            src + "/vs/css.js",
-            src + "/vs/nls.js"
+            `${src}/vs/css.js`,
+            `${src}/vs/nls.js`
         ]);
     }
-    var isFirst = true;
+    let isFirst = true;
     return (gulp
-        .src(sources, { base: "" + src })
+        .src(sources, { base: `${src}` })
         .pipe(es.through(function (data) {
         if (isFirst) {
             isFirst = false;
@@ -74,12 +74,12 @@ function loader(src, bundledFileHeader, bundleLoader) {
     })));
 }
 function toConcatStream(src, bundledFileHeader, sources, dest) {
-    var useSourcemaps = /\.js$/.test(dest) && !/\.nls\.js$/.test(dest);
+    const useSourcemaps = /\.js$/.test(dest) && !/\.nls\.js$/.test(dest);
     // If a bundle ends up including in any of the sources our copyright, then
     // insert a fake source at the beginning of each bundle with our copyright
-    var containsOurCopyright = false;
-    for (var i = 0, len = sources.length; i < len; i++) {
-        var fileContents = sources[i].contents;
+    let containsOurCopyright = false;
+    for (let i = 0, len = sources.length; i < len; i++) {
+        const fileContents = sources[i].contents;
         if (IS_OUR_COPYRIGHT_REGEXP.test(fileContents)) {
             containsOurCopyright = true;
             break;
@@ -91,9 +91,9 @@ function toConcatStream(src, bundledFileHeader, sources, dest) {
             contents: bundledFileHeader
         });
     }
-    var treatedSources = sources.map(function (source) {
-        var root = source.path ? REPO_ROOT_PATH.replace(/\\/g, '/') : '';
-        var base = source.path ? root + ("/" + src) : '';
+    const treatedSources = sources.map(function (source) {
+        const root = source.path ? REPO_ROOT_PATH.replace(/\\/g, '/') : '';
+        const base = source.path ? root + `/${src}` : '';
         return new VinylFile({
             path: source.path ? root + '/' + source.path.replace(/\\/g, '/') : 'fake',
             base: base,
@@ -111,33 +111,33 @@ function toBundleStream(src, bundledFileHeader, bundles) {
     }));
 }
 function optimizeTask(opts) {
-    var src = opts.src;
-    var entryPoints = opts.entryPoints;
-    var otherSources = opts.otherSources;
-    var resources = opts.resources;
-    var loaderConfig = opts.loaderConfig;
-    var bundledFileHeader = opts.header;
-    var bundleLoader = (typeof opts.bundleLoader === 'undefined' ? true : opts.bundleLoader);
-    var out = opts.out;
+    const src = opts.src;
+    const entryPoints = opts.entryPoints;
+    const otherSources = opts.otherSources;
+    const resources = opts.resources;
+    const loaderConfig = opts.loaderConfig;
+    const bundledFileHeader = opts.header;
+    const bundleLoader = (typeof opts.bundleLoader === 'undefined' ? true : opts.bundleLoader);
+    const out = opts.out;
     return function () {
-        var bundlesStream = es.through(); // this stream will contain the bundled files
-        var resourcesStream = es.through(); // this stream will contain the resources
-        var bundleInfoStream = es.through(); // this stream will contain bundleInfo.json
+        const bundlesStream = es.through(); // this stream will contain the bundled files
+        const resourcesStream = es.through(); // this stream will contain the resources
+        const bundleInfoStream = es.through(); // this stream will contain bundleInfo.json
         bundle.bundle(entryPoints, loaderConfig, function (err, result) {
             if (err || !result) {
                 return bundlesStream.emit('error', JSON.stringify(err));
             }
             toBundleStream(src, bundledFileHeader, result.files).pipe(bundlesStream);
             // Remove css inlined resources
-            var filteredResources = resources.slice();
+            const filteredResources = resources.slice();
             result.cssInlinedResources.forEach(function (resource) {
                 if (process.env['VSCODE_BUILD_VERBOSE']) {
                     log('optimizer', 'excluding inlined: ' + resource);
                 }
                 filteredResources.push('!' + resource);
             });
-            gulp.src(filteredResources, { base: "" + src }).pipe(resourcesStream);
-            var bundleInfoArray = [];
+            gulp.src(filteredResources, { base: `${src}` }).pipe(resourcesStream);
+            const bundleInfoArray = [];
             if (opts.bundleInfo) {
                 bundleInfoArray.push(new VinylFile({
                     path: 'bundleInfo.json',
@@ -147,9 +147,9 @@ function optimizeTask(opts) {
             }
             es.readArray(bundleInfoArray).pipe(bundleInfoStream);
         });
-        var otherSourcesStream = es.through();
-        var otherSourcesStreamArr = [];
-        gulp.src(otherSources, { base: "" + src })
+        const otherSourcesStream = es.through();
+        const otherSourcesStreamArr = [];
+        gulp.src(otherSources, { base: `${src}` })
             .pipe(es.through(function (data) {
             otherSourcesStreamArr.push(toConcatStream(src, bundledFileHeader, [data], data.relative));
         }, function () {
@@ -160,7 +160,7 @@ function optimizeTask(opts) {
                 es.merge(otherSourcesStreamArr).pipe(otherSourcesStream);
             }
         }));
-        var result = es.merge(loader(src, bundledFileHeader, bundleLoader), bundlesStream, otherSourcesStream, resourcesStream, bundleInfoStream);
+        const result = es.merge(loader(src, bundledFileHeader, bundleLoader), bundlesStream, otherSourcesStream, resourcesStream, bundleInfoStream);
         return result
             .pipe(sourcemaps.write('./', {
             sourceRoot: undefined,
@@ -180,14 +180,14 @@ exports.optimizeTask = optimizeTask;
  * to have a file "context" to include our copyright only once per file.
  */
 function uglifyWithCopyrights() {
-    var preserveComments = function (f) {
-        return function (_node, comment) {
-            var text = comment.value;
-            var type = comment.type;
+    const preserveComments = (f) => {
+        return (_node, comment) => {
+            const text = comment.value;
+            const type = comment.type;
             if (/@minifier_do_not_preserve/.test(text)) {
                 return false;
             }
-            var isOurCopyright = IS_OUR_COPYRIGHT_REGEXP.test(text);
+            const isOurCopyright = IS_OUR_COPYRIGHT_REGEXP.test(text);
             if (isOurCopyright) {
                 if (f.__hasOurCopyright) {
                     return false;
@@ -205,10 +205,10 @@ function uglifyWithCopyrights() {
             return false;
         };
     };
-    var minify = composer(uglifyes);
-    var input = es.through();
-    var output = input
-        .pipe(flatmap(function (stream, f) {
+    const minify = composer(uglifyes);
+    const input = es.through();
+    const output = input
+        .pipe(flatmap((stream, f) => {
         return stream.pipe(minify({
             output: {
                 comments: preserveComments(f),
@@ -219,18 +219,18 @@ function uglifyWithCopyrights() {
     return es.duplex(input, output);
 }
 function minifyTask(src, sourceMapBaseUrl) {
-    var sourceMappingURL = sourceMapBaseUrl ? (function (f) { return sourceMapBaseUrl + "/" + f.relative + ".map"; }) : undefined;
-    return function (cb) {
-        var jsFilter = filter('**/*.js', { restore: true });
-        var cssFilter = filter('**/*.css', { restore: true });
+    const sourceMappingURL = sourceMapBaseUrl ? ((f) => `${sourceMapBaseUrl}/${f.relative}.map`) : undefined;
+    return cb => {
+        const jsFilter = filter('**/*.js', { restore: true });
+        const cssFilter = filter('**/*.css', { restore: true });
         pump(gulp.src([src + '/**', '!' + src + '/**/*.map']), jsFilter, sourcemaps.init({ loadMaps: true }), uglifyWithCopyrights(), jsFilter.restore, cssFilter, minifyCSS({ reduceIdents: false }), cssFilter.restore, sourcemaps.write('./', {
-            sourceMappingURL: sourceMappingURL,
+            sourceMappingURL,
             sourceRoot: undefined,
             includeContent: true,
             addComment: true
-        }), gulp.dest(src + '-min'), function (err) {
+        }), gulp.dest(src + '-min'), (err) => {
             if (err instanceof uglify.GulpUglifyError) {
-                console.error("Uglify error in '" + (err.cause && err.cause.filename) + "'");
+                console.error(`Uglify error in '${err.cause && err.cause.filename}'`);
             }
             cb(err);
         });

--- a/build/lib/reporter.js
+++ b/build/lib/reporter.js
@@ -4,20 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-var es = require("event-stream");
-var _ = require("underscore");
-var util = require("gulp-util");
-var fs = require("fs");
-var path = require("path");
-var allErrors = [];
-var startTime = null;
-var count = 0;
+const es = require("event-stream");
+const _ = require("underscore");
+const util = require("gulp-util");
+const fs = require("fs");
+const path = require("path");
+const allErrors = [];
+let startTime = null;
+let count = 0;
 function onStart() {
     if (count++ > 0) {
         return;
     }
     startTime = new Date().getTime();
-    util.log("Starting " + util.colors.green('compilation') + "...");
+    util.log(`Starting ${util.colors.green('compilation')}...`);
 }
 function onEnd() {
     if (--count > 0) {
@@ -25,7 +25,7 @@ function onEnd() {
     }
     log();
 }
-var buildLogPath = path.join(path.dirname(path.dirname(__dirname)), '.build', 'log');
+const buildLogPath = path.join(path.dirname(path.dirname(__dirname)), '.build', 'log');
 try {
     fs.mkdirSync(path.dirname(buildLogPath));
 }
@@ -33,42 +33,39 @@ catch (err) {
     // ignore
 }
 function log() {
-    var errors = _.flatten(allErrors);
-    var seen = new Set();
-    errors.map(function (err) {
+    const errors = _.flatten(allErrors);
+    const seen = new Set();
+    errors.map(err => {
         if (!seen.has(err)) {
             seen.add(err);
-            util.log(util.colors.red('Error') + ": " + err);
+            util.log(`${util.colors.red('Error')}: ${err}`);
         }
     });
-    var regex = /^([^(]+)\((\d+),(\d+)\): (.*)$/;
-    var messages = errors
-        .map(function (err) { return regex.exec(err); })
-        .filter(function (match) { return !!match; })
-        .map(function (x) { return x; })
-        .map(function (_a) {
-        var path = _a[1], line = _a[2], column = _a[3], message = _a[4];
-        return ({ path: path, line: parseInt(line), column: parseInt(column), message: message });
-    });
+    const regex = /^([^(]+)\((\d+),(\d+)\): (.*)$/;
+    const messages = errors
+        .map(err => regex.exec(err))
+        .filter(match => !!match)
+        .map(x => x)
+        .map(([, path, line, column, message]) => ({ path, line: parseInt(line), column: parseInt(column), message }));
     try {
         fs.writeFileSync(buildLogPath, JSON.stringify(messages));
     }
     catch (err) {
         //noop
     }
-    util.log("Finished " + util.colors.green('compilation') + " with " + errors.length + " errors after " + util.colors.magenta((new Date().getTime() - startTime) + ' ms'));
+    util.log(`Finished ${util.colors.green('compilation')} with ${errors.length} errors after ${util.colors.magenta((new Date().getTime() - startTime) + ' ms')}`);
 }
 function createReporter() {
-    var errors = [];
+    const errors = [];
     allErrors.push(errors);
-    var ReportFunc = /** @class */ (function () {
-        function ReportFunc(err) {
+    class ReportFunc {
+        constructor(err) {
             errors.push(err);
         }
-        ReportFunc.hasErrors = function () {
+        static hasErrors() {
             return errors.length > 0;
-        };
-        ReportFunc.end = function (emitError) {
+        }
+        static end(emitError) {
             errors.length = 0;
             onStart();
             return es.through(undefined, function () {
@@ -78,7 +75,7 @@ function createReporter() {
                         log();
                     }
                     errors.__logged__ = true;
-                    var err = new Error("Found " + errors.length + " errors");
+                    const err = new Error(`Found ${errors.length} errors`);
                     err.__reporter__ = true;
                     this.emit('error', err);
                 }
@@ -86,9 +83,8 @@ function createReporter() {
                     this.emit('end');
                 }
             });
-        };
-        return ReportFunc;
-    }());
+        }
+    }
     return ReportFunc;
 }
 exports.createReporter = createReporter;

--- a/build/lib/snapshotLoader.js
+++ b/build/lib/snapshotLoader.js
@@ -5,25 +5,25 @@
 'use strict';
 var snaps;
 (function (snaps) {
-    var fs = require('fs');
-    var path = require('path');
-    var os = require('os');
-    var cp = require('child_process');
-    var mksnapshot = path.join(__dirname, "../../node_modules/.bin/" + (process.platform === 'win32' ? 'mksnapshot.cmd' : 'mksnapshot'));
-    var product = require('../../product.json');
-    var arch = (process.argv.join('').match(/--arch=(.*)/) || [])[1];
+    const fs = require('fs');
+    const path = require('path');
+    const os = require('os');
+    const cp = require('child_process');
+    const mksnapshot = path.join(__dirname, `../../node_modules/.bin/${process.platform === 'win32' ? 'mksnapshot.cmd' : 'mksnapshot'}`);
+    const product = require('../../product.json');
+    const arch = (process.argv.join('').match(/--arch=(.*)/) || [])[1];
     //
-    var loaderFilepath;
-    var startupBlobFilepath;
+    let loaderFilepath;
+    let startupBlobFilepath;
     switch (process.platform) {
         case 'darwin':
-            loaderFilepath = "VSCode-darwin/" + product.nameLong + ".app/Contents/Resources/app/out/vs/loader.js";
-            startupBlobFilepath = "VSCode-darwin/" + product.nameLong + ".app/Contents/Frameworks/Electron Framework.framework/Resources/snapshot_blob.bin";
+            loaderFilepath = `VSCode-darwin/${product.nameLong}.app/Contents/Resources/app/out/vs/loader.js`;
+            startupBlobFilepath = `VSCode-darwin/${product.nameLong}.app/Contents/Frameworks/Electron Framework.framework/Resources/snapshot_blob.bin`;
             break;
         case 'win32':
         case 'linux':
-            loaderFilepath = "VSCode-" + process.platform + "-" + arch + "/resources/app/out/vs/loader.js";
-            startupBlobFilepath = "VSCode-" + process.platform + "-" + arch + "/snapshot_blob.bin";
+            loaderFilepath = `VSCode-${process.platform}-${arch}/resources/app/out/vs/loader.js`;
+            startupBlobFilepath = `VSCode-${process.platform}-${arch}/snapshot_blob.bin`;
         default:
             throw new Error('Unknown platform');
     }
@@ -31,11 +31,24 @@ var snaps;
     startupBlobFilepath = path.join(__dirname, '../../../', startupBlobFilepath);
     snapshotLoader(loaderFilepath, startupBlobFilepath);
     function snapshotLoader(loaderFilepath, startupBlobFilepath) {
-        var inputFile = fs.readFileSync(loaderFilepath);
-        var wrappedInputFile = "\n\t\tvar Monaco_Loader_Init;\n\t\t(function() {\n\t\t\tvar doNotInitLoader = true;\n\t\t\t" + inputFile.toString() + ";\n\t\t\tMonaco_Loader_Init = function() {\n\t\t\t\tAMDLoader.init();\n\t\t\t\tCSSLoaderPlugin.init();\n\t\t\t\tNLSLoaderPlugin.init();\n\n\t\t\t\treturn { define, require };\n\t\t\t}\n\t\t})();\n\t\t";
-        var wrappedInputFilepath = path.join(os.tmpdir(), 'wrapped-loader.js');
+        const inputFile = fs.readFileSync(loaderFilepath);
+        const wrappedInputFile = `
+		var Monaco_Loader_Init;
+		(function() {
+			var doNotInitLoader = true;
+			${inputFile.toString()};
+			Monaco_Loader_Init = function() {
+				AMDLoader.init();
+				CSSLoaderPlugin.init();
+				NLSLoaderPlugin.init();
+
+				return { define, require };
+			}
+		})();
+		`;
+        const wrappedInputFilepath = path.join(os.tmpdir(), 'wrapped-loader.js');
         console.log(wrappedInputFilepath);
         fs.writeFileSync(wrappedInputFilepath, wrappedInputFile);
-        cp.execFileSync(mksnapshot, [wrappedInputFilepath, "--startup_blob", startupBlobFilepath]);
+        cp.execFileSync(mksnapshot, [wrappedInputFilepath, `--startup_blob`, startupBlobFilepath]);
     }
 })(snaps || (snaps = {}));

--- a/build/lib/standalone.js
+++ b/build/lib/standalone.js
@@ -4,13 +4,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-var ts = require("typescript");
-var fs = require("fs");
-var path = require("path");
-var tss = require("./treeshaking");
-var REPO_ROOT = path.join(__dirname, '../../');
-var SRC_DIR = path.join(REPO_ROOT, 'src');
-var dirCache = {};
+const ts = require("typescript");
+const fs = require("fs");
+const path = require("path");
+const tss = require("./treeshaking");
+const REPO_ROOT = path.join(__dirname, '../../');
+const SRC_DIR = path.join(REPO_ROOT, 'src');
+let dirCache = {};
 function writeFile(filePath, contents) {
     function ensureDirs(dirPath) {
         if (dirCache[dirPath]) {
@@ -27,39 +27,39 @@ function writeFile(filePath, contents) {
     fs.writeFileSync(filePath, contents);
 }
 function extractEditor(options) {
-    var tsConfig = JSON.parse(fs.readFileSync(path.join(options.sourcesRoot, 'tsconfig.json')).toString());
+    const tsConfig = JSON.parse(fs.readFileSync(path.join(options.sourcesRoot, 'tsconfig.json')).toString());
     tsConfig.compilerOptions.noUnusedLocals = false;
     tsConfig.compilerOptions.preserveConstEnums = false;
     tsConfig.compilerOptions.declaration = false;
     delete tsConfig.compilerOptions.types;
     tsConfig.exclude = [];
     options.compilerOptions = tsConfig.compilerOptions;
-    var result = tss.shake(options);
-    for (var fileName in result) {
+    let result = tss.shake(options);
+    for (let fileName in result) {
         if (result.hasOwnProperty(fileName)) {
             writeFile(path.join(options.destRoot, fileName), result[fileName]);
         }
     }
-    var copied = {};
-    var copyFile = function (fileName) {
+    let copied = {};
+    const copyFile = (fileName) => {
         if (copied[fileName]) {
             return;
         }
         copied[fileName] = true;
-        var srcPath = path.join(options.sourcesRoot, fileName);
-        var dstPath = path.join(options.destRoot, fileName);
+        const srcPath = path.join(options.sourcesRoot, fileName);
+        const dstPath = path.join(options.destRoot, fileName);
         writeFile(dstPath, fs.readFileSync(srcPath));
     };
-    var writeOutputFile = function (fileName, contents) {
+    const writeOutputFile = (fileName, contents) => {
         writeFile(path.join(options.destRoot, fileName), contents);
     };
-    for (var fileName in result) {
+    for (let fileName in result) {
         if (result.hasOwnProperty(fileName)) {
-            var fileContents = result[fileName];
-            var info = ts.preProcessFile(fileContents);
-            for (var i = info.importedFiles.length - 1; i >= 0; i--) {
-                var importedFileName = info.importedFiles[i].fileName;
-                var importedFilePath = void 0;
+            const fileContents = result[fileName];
+            const info = ts.preProcessFile(fileContents);
+            for (let i = info.importedFiles.length - 1; i >= 0; i--) {
+                const importedFileName = info.importedFiles[i].fileName;
+                let importedFilePath;
                 if (/^vs\/css!/.test(importedFileName)) {
                     importedFilePath = importedFileName.substr('vs/css!'.length) + '.css';
                 }
@@ -94,27 +94,27 @@ function extractEditor(options) {
 }
 exports.extractEditor = extractEditor;
 function createESMSourcesAndResources2(options) {
-    var SRC_FOLDER = path.join(REPO_ROOT, options.srcFolder);
-    var OUT_FOLDER = path.join(REPO_ROOT, options.outFolder);
-    var OUT_RESOURCES_FOLDER = path.join(REPO_ROOT, options.outResourcesFolder);
-    var getDestAbsoluteFilePath = function (file) {
-        var dest = options.renames[file.replace(/\\/g, '/')] || file;
+    const SRC_FOLDER = path.join(REPO_ROOT, options.srcFolder);
+    const OUT_FOLDER = path.join(REPO_ROOT, options.outFolder);
+    const OUT_RESOURCES_FOLDER = path.join(REPO_ROOT, options.outResourcesFolder);
+    const getDestAbsoluteFilePath = (file) => {
+        let dest = options.renames[file.replace(/\\/g, '/')] || file;
         if (dest === 'tsconfig.json') {
-            return path.join(OUT_FOLDER, "tsconfig.json");
+            return path.join(OUT_FOLDER, `tsconfig.json`);
         }
         if (/\.ts$/.test(dest)) {
             return path.join(OUT_FOLDER, dest);
         }
         return path.join(OUT_RESOURCES_FOLDER, dest);
     };
-    var allFiles = walkDirRecursive(SRC_FOLDER);
-    for (var i = 0; i < allFiles.length; i++) {
-        var file = allFiles[i];
+    const allFiles = walkDirRecursive(SRC_FOLDER);
+    for (let i = 0; i < allFiles.length; i++) {
+        const file = allFiles[i];
         if (options.ignores.indexOf(file.replace(/\\/g, '/')) >= 0) {
             continue;
         }
         if (file === 'tsconfig.json') {
-            var tsConfig = JSON.parse(fs.readFileSync(path.join(SRC_FOLDER, file)).toString());
+            const tsConfig = JSON.parse(fs.readFileSync(path.join(SRC_FOLDER, file)).toString());
             tsConfig.compilerOptions.module = 'es6';
             tsConfig.compilerOptions.outDir = path.join(path.relative(OUT_FOLDER, OUT_RESOURCES_FOLDER), 'vs');
             write(getDestAbsoluteFilePath(file), JSON.stringify(tsConfig, null, '\t'));
@@ -127,13 +127,13 @@ function createESMSourcesAndResources2(options) {
         }
         if (/\.ts$/.test(file)) {
             // Transform the .ts file
-            var fileContents = fs.readFileSync(path.join(SRC_FOLDER, file)).toString();
-            var info = ts.preProcessFile(fileContents);
-            for (var i_1 = info.importedFiles.length - 1; i_1 >= 0; i_1--) {
-                var importedFilename = info.importedFiles[i_1].fileName;
-                var pos = info.importedFiles[i_1].pos;
-                var end = info.importedFiles[i_1].end;
-                var importedFilepath = void 0;
+            let fileContents = fs.readFileSync(path.join(SRC_FOLDER, file)).toString();
+            const info = ts.preProcessFile(fileContents);
+            for (let i = info.importedFiles.length - 1; i >= 0; i--) {
+                const importedFilename = info.importedFiles[i].fileName;
+                const pos = info.importedFiles[i].pos;
+                const end = info.importedFiles[i].end;
+                let importedFilepath;
                 if (/^vs\/css!/.test(importedFilename)) {
                     importedFilepath = importedFilename.substr('vs/css!'.length) + '.css';
                 }
@@ -143,7 +143,7 @@ function createESMSourcesAndResources2(options) {
                 if (/(^\.\/)|(^\.\.\/)/.test(importedFilepath)) {
                     importedFilepath = path.join(path.dirname(file), importedFilepath);
                 }
-                var relativePath = void 0;
+                let relativePath;
                 if (importedFilepath === path.dirname(file)) {
                     relativePath = '../' + path.basename(path.dirname(file));
                 }
@@ -161,25 +161,25 @@ function createESMSourcesAndResources2(options) {
                     + fileContents.substring(end + 1));
             }
             fileContents = fileContents.replace(/import ([a-zA-z0-9]+) = require\(('[^']+')\);/g, function (_, m1, m2) {
-                return "import * as " + m1 + " from " + m2 + ";";
+                return `import * as ${m1} from ${m2};`;
             });
             write(getDestAbsoluteFilePath(file), fileContents);
             continue;
         }
-        console.log("UNKNOWN FILE: " + file);
+        console.log(`UNKNOWN FILE: ${file}`);
     }
     function walkDirRecursive(dir) {
         if (dir.charAt(dir.length - 1) !== '/' || dir.charAt(dir.length - 1) !== '\\') {
             dir += '/';
         }
-        var result = [];
+        let result = [];
         _walkDirRecursive(dir, result, dir.length);
         return result;
     }
     function _walkDirRecursive(dir, result, trimPos) {
-        var files = fs.readdirSync(dir);
-        for (var i = 0; i < files.length; i++) {
-            var file = path.join(dir, files[i]);
+        const files = fs.readdirSync(dir);
+        for (let i = 0; i < files.length; i++) {
+            const file = path.join(dir, files[i]);
             if (fs.statSync(file).isDirectory()) {
                 _walkDirRecursive(file, result, trimPos);
             }
@@ -194,10 +194,10 @@ function createESMSourcesAndResources2(options) {
         }
         writeFile(absoluteFilePath, contents);
         function toggleComments(fileContents) {
-            var lines = fileContents.split(/\r\n|\r|\n/);
-            var mode = 0;
-            for (var i = 0; i < lines.length; i++) {
-                var line = lines[i];
+            let lines = fileContents.split(/\r\n|\r|\n/);
+            let mode = 0;
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
                 if (mode === 0) {
                     if (/\/\/ ESM-comment-begin/.test(line)) {
                         mode = 1;
@@ -236,30 +236,30 @@ function transportCSS(module, enqueue, write) {
     if (!/\.css/.test(module)) {
         return false;
     }
-    var filename = path.join(SRC_DIR, module);
-    var fileContents = fs.readFileSync(filename).toString();
-    var inlineResources = 'base64'; // see https://github.com/Microsoft/monaco-editor/issues/148
-    var inlineResourcesLimit = 300000; //3000; // see https://github.com/Microsoft/monaco-editor/issues/336
-    var newContents = _rewriteOrInlineUrls(fileContents, inlineResources === 'base64', inlineResourcesLimit);
+    const filename = path.join(SRC_DIR, module);
+    const fileContents = fs.readFileSync(filename).toString();
+    const inlineResources = 'base64'; // see https://github.com/Microsoft/monaco-editor/issues/148
+    const inlineResourcesLimit = 300000; //3000; // see https://github.com/Microsoft/monaco-editor/issues/336
+    const newContents = _rewriteOrInlineUrls(fileContents, inlineResources === 'base64', inlineResourcesLimit);
     write(module, newContents);
     return true;
     function _rewriteOrInlineUrls(contents, forceBase64, inlineByteLimit) {
-        return _replaceURL(contents, function (url) {
-            var imagePath = path.join(path.dirname(module), url);
-            var fileContents = fs.readFileSync(path.join(SRC_DIR, imagePath));
+        return _replaceURL(contents, (url) => {
+            let imagePath = path.join(path.dirname(module), url);
+            let fileContents = fs.readFileSync(path.join(SRC_DIR, imagePath));
             if (fileContents.length < inlineByteLimit) {
-                var MIME = /\.svg$/.test(url) ? 'image/svg+xml' : 'image/png';
-                var DATA = ';base64,' + fileContents.toString('base64');
+                const MIME = /\.svg$/.test(url) ? 'image/svg+xml' : 'image/png';
+                let DATA = ';base64,' + fileContents.toString('base64');
                 if (!forceBase64 && /\.svg$/.test(url)) {
                     // .svg => url encode as explained at https://codepen.io/tigt/post/optimizing-svgs-in-data-uris
-                    var newText = fileContents.toString()
+                    let newText = fileContents.toString()
                         .replace(/"/g, '\'')
                         .replace(/</g, '%3C')
                         .replace(/>/g, '%3E')
                         .replace(/&/g, '%26')
                         .replace(/#/g, '%23')
                         .replace(/\s+/g, ' ');
-                    var encodedData = ',' + newText;
+                    let encodedData = ',' + newText;
                     if (encodedData.length < DATA.length) {
                         DATA = encodedData;
                     }
@@ -272,12 +272,8 @@ function transportCSS(module, enqueue, write) {
     }
     function _replaceURL(contents, replacer) {
         // Use ")" as the terminator as quotes are oftentimes not used at all
-        return contents.replace(/url\(\s*([^\)]+)\s*\)?/g, function (_) {
-            var matches = [];
-            for (var _i = 1; _i < arguments.length; _i++) {
-                matches[_i - 1] = arguments[_i];
-            }
-            var url = matches[0];
+        return contents.replace(/url\(\s*([^\)]+)\s*\)?/g, (_, ...matches) => {
+            let url = matches[0];
             // Eliminate starting quotes (the initial whitespace is not captured)
             if (url.charAt(0) === '"' || url.charAt(0) === '\'') {
                 url = url.substring(1);

--- a/build/lib/test/i18n.test.js
+++ b/build/lib/test/i18n.test.js
@@ -4,30 +4,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
-var assert = require("assert");
-var i18n = require("../i18n");
-suite('XLF Parser Tests', function () {
-    var sampleXlf = '<?xml version="1.0" encoding="utf-8"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"><file original="vs/base/common/keybinding" source-language="en" datatype="plaintext"><body><trans-unit id="key1"><source xml:lang="en">Key #1</source></trans-unit><trans-unit id="key2"><source xml:lang="en">Key #2 &amp;</source></trans-unit></body></file></xliff>';
-    var sampleTranslatedXlf = '<?xml version="1.0" encoding="utf-8"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"><file original="vs/base/common/keybinding" source-language="en" target-language="ru" datatype="plaintext"><body><trans-unit id="key1"><source xml:lang="en">Key #1</source><target>Кнопка #1</target></trans-unit><trans-unit id="key2"><source xml:lang="en">Key #2 &amp;</source><target>Кнопка #2 &amp;</target></trans-unit></body></file></xliff>';
-    var originalFilePath = 'vs/base/common/keybinding';
-    var keys = ['key1', 'key2'];
-    var messages = ['Key #1', 'Key #2 &'];
-    var translatedMessages = { key1: 'Кнопка #1', key2: 'Кнопка #2 &' };
-    test('Keys & messages to XLF conversion', function () {
-        var xlf = new i18n.XLF('vscode-workbench');
+const assert = require("assert");
+const i18n = require("../i18n");
+suite('XLF Parser Tests', () => {
+    const sampleXlf = '<?xml version="1.0" encoding="utf-8"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"><file original="vs/base/common/keybinding" source-language="en" datatype="plaintext"><body><trans-unit id="key1"><source xml:lang="en">Key #1</source></trans-unit><trans-unit id="key2"><source xml:lang="en">Key #2 &amp;</source></trans-unit></body></file></xliff>';
+    const sampleTranslatedXlf = '<?xml version="1.0" encoding="utf-8"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"><file original="vs/base/common/keybinding" source-language="en" target-language="ru" datatype="plaintext"><body><trans-unit id="key1"><source xml:lang="en">Key #1</source><target>Кнопка #1</target></trans-unit><trans-unit id="key2"><source xml:lang="en">Key #2 &amp;</source><target>Кнопка #2 &amp;</target></trans-unit></body></file></xliff>';
+    const originalFilePath = 'vs/base/common/keybinding';
+    const keys = ['key1', 'key2'];
+    const messages = ['Key #1', 'Key #2 &'];
+    const translatedMessages = { key1: 'Кнопка #1', key2: 'Кнопка #2 &' };
+    test('Keys & messages to XLF conversion', () => {
+        const xlf = new i18n.XLF('vscode-workbench');
         xlf.addFile(originalFilePath, keys, messages);
-        var xlfString = xlf.toString();
+        const xlfString = xlf.toString();
         assert.strictEqual(xlfString.replace(/\s{2,}/g, ''), sampleXlf);
     });
-    test('XLF to keys & messages conversion', function () {
+    test('XLF to keys & messages conversion', () => {
         i18n.XLF.parse(sampleTranslatedXlf).then(function (resolvedFiles) {
             assert.deepEqual(resolvedFiles[0].messages, translatedMessages);
             assert.strictEqual(resolvedFiles[0].originalFilePath, originalFilePath);
         });
     });
-    test('JSON file source path to Transifex resource match', function () {
-        var editorProject = 'vscode-editor', workbenchProject = 'vscode-workbench';
-        var platform = { name: 'vs/platform', project: editorProject }, editorContrib = { name: 'vs/editor/contrib', project: editorProject }, editor = { name: 'vs/editor', project: editorProject }, base = { name: 'vs/base', project: editorProject }, code = { name: 'vs/code', project: workbenchProject }, workbenchParts = { name: 'vs/workbench/parts/html', project: workbenchProject }, workbenchServices = { name: 'vs/workbench/services/files', project: workbenchProject }, workbench = { name: 'vs/workbench', project: workbenchProject };
+    test('JSON file source path to Transifex resource match', () => {
+        const editorProject = 'vscode-editor', workbenchProject = 'vscode-workbench';
+        const platform = { name: 'vs/platform', project: editorProject }, editorContrib = { name: 'vs/editor/contrib', project: editorProject }, editor = { name: 'vs/editor', project: editorProject }, base = { name: 'vs/base', project: editorProject }, code = { name: 'vs/code', project: workbenchProject }, workbenchParts = { name: 'vs/workbench/parts/html', project: workbenchProject }, workbenchServices = { name: 'vs/workbench/services/files', project: workbenchProject }, workbench = { name: 'vs/workbench', project: workbenchProject };
         assert.deepEqual(i18n.getResource('vs/platform/actions/browser/menusExtensionPoint'), platform);
         assert.deepEqual(i18n.getResource('vs/editor/contrib/clipboard/browser/clipboard'), editorContrib);
         assert.deepEqual(i18n.getResource('vs/editor/common/modes/modesRegistry'), editor);

--- a/build/lib/treeshaking.js
+++ b/build/lib/treeshaking.js
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-var fs = require("fs");
-var path = require("path");
-var ts = require("typescript");
-var TYPESCRIPT_LIB_FOLDER = path.dirname(require.resolve('typescript/lib/lib.d.ts'));
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const TYPESCRIPT_LIB_FOLDER = path.dirname(require.resolve('typescript/lib/lib.d.ts'));
 var ShakeLevel;
 (function (ShakeLevel) {
     ShakeLevel[ShakeLevel["Files"] = 0] = "Files";
@@ -15,37 +15,37 @@ var ShakeLevel;
     ShakeLevel[ShakeLevel["ClassMembers"] = 2] = "ClassMembers";
 })(ShakeLevel = exports.ShakeLevel || (exports.ShakeLevel = {}));
 function printDiagnostics(diagnostics) {
-    for (var i = 0; i < diagnostics.length; i++) {
-        var diag = diagnostics[i];
-        var result = '';
+    for (let i = 0; i < diagnostics.length; i++) {
+        const diag = diagnostics[i];
+        let result = '';
         if (diag.file) {
-            result += diag.file.fileName + ": ";
+            result += `${diag.file.fileName}: `;
         }
         if (diag.file && diag.start) {
-            var location_1 = diag.file.getLineAndCharacterOfPosition(diag.start);
-            result += "- " + (location_1.line + 1) + "," + location_1.character + " - ";
+            let location = diag.file.getLineAndCharacterOfPosition(diag.start);
+            result += `- ${location.line + 1},${location.character} - `;
         }
         result += JSON.stringify(diag.messageText);
         console.log(result);
     }
 }
 function shake(options) {
-    var languageService = createTypeScriptLanguageService(options);
-    var program = languageService.getProgram();
-    var globalDiagnostics = program.getGlobalDiagnostics();
+    const languageService = createTypeScriptLanguageService(options);
+    const program = languageService.getProgram();
+    const globalDiagnostics = program.getGlobalDiagnostics();
     if (globalDiagnostics.length > 0) {
         printDiagnostics(globalDiagnostics);
-        throw new Error("Compilation Errors encountered.");
+        throw new Error(`Compilation Errors encountered.`);
     }
-    var syntacticDiagnostics = program.getSyntacticDiagnostics();
+    const syntacticDiagnostics = program.getSyntacticDiagnostics();
     if (syntacticDiagnostics.length > 0) {
         printDiagnostics(syntacticDiagnostics);
-        throw new Error("Compilation Errors encountered.");
+        throw new Error(`Compilation Errors encountered.`);
     }
-    var semanticDiagnostics = program.getSemanticDiagnostics();
+    const semanticDiagnostics = program.getSemanticDiagnostics();
     if (semanticDiagnostics.length > 0) {
         printDiagnostics(semanticDiagnostics);
-        throw new Error("Compilation Errors encountered.");
+        throw new Error(`Compilation Errors encountered.`);
     }
     markNodes(languageService, options);
     return generateResult(languageService, options.shakeLevel);
@@ -54,98 +54,98 @@ exports.shake = shake;
 //#region Discovery, LanguageService & Setup
 function createTypeScriptLanguageService(options) {
     // Discover referenced files
-    var FILES = discoverAndReadFiles(options);
+    const FILES = discoverAndReadFiles(options);
     // Add fake usage files
-    options.inlineEntryPoints.forEach(function (inlineEntryPoint, index) {
-        FILES["inlineEntryPoint:" + index + ".ts"] = inlineEntryPoint;
+    options.inlineEntryPoints.forEach((inlineEntryPoint, index) => {
+        FILES[`inlineEntryPoint:${index}.ts`] = inlineEntryPoint;
     });
     // Add additional typings
-    options.typings.forEach(function (typing) {
-        var filePath = path.join(options.sourcesRoot, typing);
+    options.typings.forEach((typing) => {
+        const filePath = path.join(options.sourcesRoot, typing);
         FILES[typing] = fs.readFileSync(filePath).toString();
     });
     // Resolve libs
-    var RESOLVED_LIBS = {};
-    options.libs.forEach(function (filename) {
-        var filepath = path.join(TYPESCRIPT_LIB_FOLDER, filename);
-        RESOLVED_LIBS["defaultLib:" + filename] = fs.readFileSync(filepath).toString();
+    const RESOLVED_LIBS = {};
+    options.libs.forEach((filename) => {
+        const filepath = path.join(TYPESCRIPT_LIB_FOLDER, filename);
+        RESOLVED_LIBS[`defaultLib:${filename}`] = fs.readFileSync(filepath).toString();
     });
-    var host = new TypeScriptLanguageServiceHost(RESOLVED_LIBS, FILES, ts.convertCompilerOptionsFromJson(options.compilerOptions, "").options);
+    const host = new TypeScriptLanguageServiceHost(RESOLVED_LIBS, FILES, ts.convertCompilerOptionsFromJson(options.compilerOptions, ``).options);
     return ts.createLanguageService(host);
 }
 /**
  * Read imports and follow them until all files have been handled
  */
 function discoverAndReadFiles(options) {
-    var FILES = {};
-    var in_queue = Object.create(null);
-    var queue = [];
-    var enqueue = function (moduleId) {
+    const FILES = {};
+    const in_queue = Object.create(null);
+    const queue = [];
+    const enqueue = (moduleId) => {
         if (in_queue[moduleId]) {
             return;
         }
         in_queue[moduleId] = true;
         queue.push(moduleId);
     };
-    options.entryPoints.forEach(function (entryPoint) { return enqueue(entryPoint); });
+    options.entryPoints.forEach((entryPoint) => enqueue(entryPoint));
     while (queue.length > 0) {
-        var moduleId = queue.shift();
-        var dts_filename = path.join(options.sourcesRoot, moduleId + '.d.ts');
+        const moduleId = queue.shift();
+        const dts_filename = path.join(options.sourcesRoot, moduleId + '.d.ts');
         if (fs.existsSync(dts_filename)) {
-            var dts_filecontents = fs.readFileSync(dts_filename).toString();
-            FILES[moduleId + ".d.ts"] = dts_filecontents;
+            const dts_filecontents = fs.readFileSync(dts_filename).toString();
+            FILES[`${moduleId}.d.ts`] = dts_filecontents;
             continue;
         }
-        var ts_filename = void 0;
+        let ts_filename;
         if (options.redirects[moduleId]) {
             ts_filename = path.join(options.sourcesRoot, options.redirects[moduleId] + '.ts');
         }
         else {
             ts_filename = path.join(options.sourcesRoot, moduleId + '.ts');
         }
-        var ts_filecontents = fs.readFileSync(ts_filename).toString();
-        var info = ts.preProcessFile(ts_filecontents);
-        for (var i = info.importedFiles.length - 1; i >= 0; i--) {
-            var importedFileName = info.importedFiles[i].fileName;
+        const ts_filecontents = fs.readFileSync(ts_filename).toString();
+        const info = ts.preProcessFile(ts_filecontents);
+        for (let i = info.importedFiles.length - 1; i >= 0; i--) {
+            const importedFileName = info.importedFiles[i].fileName;
             if (options.importIgnorePattern.test(importedFileName)) {
                 // Ignore vs/css! imports
                 continue;
             }
-            var importedModuleId = importedFileName;
+            let importedModuleId = importedFileName;
             if (/(^\.\/)|(^\.\.\/)/.test(importedModuleId)) {
                 importedModuleId = path.join(path.dirname(moduleId), importedModuleId);
             }
             enqueue(importedModuleId);
         }
-        FILES[moduleId + ".ts"] = ts_filecontents;
+        FILES[`${moduleId}.ts`] = ts_filecontents;
     }
     return FILES;
 }
 /**
  * A TypeScript language service host
  */
-var TypeScriptLanguageServiceHost = /** @class */ (function () {
-    function TypeScriptLanguageServiceHost(libs, files, compilerOptions) {
+class TypeScriptLanguageServiceHost {
+    constructor(libs, files, compilerOptions) {
         this._libs = libs;
         this._files = files;
         this._compilerOptions = compilerOptions;
     }
     // --- language service host ---------------
-    TypeScriptLanguageServiceHost.prototype.getCompilationSettings = function () {
+    getCompilationSettings() {
         return this._compilerOptions;
-    };
-    TypeScriptLanguageServiceHost.prototype.getScriptFileNames = function () {
+    }
+    getScriptFileNames() {
         return ([]
             .concat(Object.keys(this._libs))
             .concat(Object.keys(this._files)));
-    };
-    TypeScriptLanguageServiceHost.prototype.getScriptVersion = function (_fileName) {
+    }
+    getScriptVersion(_fileName) {
         return '1';
-    };
-    TypeScriptLanguageServiceHost.prototype.getProjectVersion = function () {
+    }
+    getProjectVersion() {
         return '1';
-    };
-    TypeScriptLanguageServiceHost.prototype.getScriptSnapshot = function (fileName) {
+    }
+    getScriptSnapshot(fileName) {
         if (this._files.hasOwnProperty(fileName)) {
             return ts.ScriptSnapshot.fromString(this._files[fileName]);
         }
@@ -155,21 +155,20 @@ var TypeScriptLanguageServiceHost = /** @class */ (function () {
         else {
             return ts.ScriptSnapshot.fromString('');
         }
-    };
-    TypeScriptLanguageServiceHost.prototype.getScriptKind = function (_fileName) {
+    }
+    getScriptKind(_fileName) {
         return ts.ScriptKind.TS;
-    };
-    TypeScriptLanguageServiceHost.prototype.getCurrentDirectory = function () {
+    }
+    getCurrentDirectory() {
         return '';
-    };
-    TypeScriptLanguageServiceHost.prototype.getDefaultLibFileName = function (_options) {
+    }
+    getDefaultLibFileName(_options) {
         return 'defaultLib:lib.d.ts';
-    };
-    TypeScriptLanguageServiceHost.prototype.isDefaultLibFileName = function (fileName) {
+    }
+    isDefaultLibFileName(fileName) {
         return fileName === this.getDefaultLibFileName(this._compilerOptions);
-    };
-    return TypeScriptLanguageServiceHost;
-}());
+    }
+}
 //#endregion
 //#region Tree Shaking
 var NodeColor;
@@ -186,7 +185,7 @@ function setColor(node, color) {
 }
 function nodeOrParentIsBlack(node) {
     while (node) {
-        var color = getColor(node);
+        const color = getColor(node);
         if (color === 2 /* Black */) {
             return true;
         }
@@ -198,8 +197,7 @@ function nodeOrChildIsBlack(node) {
     if (getColor(node) === 2 /* Black */) {
         return true;
     }
-    for (var _i = 0, _a = node.getChildren(); _i < _a.length; _i++) {
-        var child = _a[_i];
+    for (const child of node.getChildren()) {
         if (nodeOrChildIsBlack(child)) {
             return true;
         }
@@ -207,22 +205,22 @@ function nodeOrChildIsBlack(node) {
     return false;
 }
 function markNodes(languageService, options) {
-    var program = languageService.getProgram();
+    const program = languageService.getProgram();
     if (!program) {
         throw new Error('Could not get program from language service');
     }
     if (options.shakeLevel === 0 /* Files */) {
         // Mark all source files Black
-        program.getSourceFiles().forEach(function (sourceFile) {
+        program.getSourceFiles().forEach((sourceFile) => {
             setColor(sourceFile, 2 /* Black */);
         });
         return;
     }
-    var black_queue = [];
-    var gray_queue = [];
-    var sourceFilesLoaded = {};
+    const black_queue = [];
+    const gray_queue = [];
+    const sourceFilesLoaded = {};
     function enqueueTopLevelModuleStatements(sourceFile) {
-        sourceFile.forEachChild(function (node) {
+        sourceFile.forEachChild((node) => {
             if (ts.isImportDeclaration(node)) {
                 if (!node.importClause && ts.isStringLiteral(node.moduleSpecifier)) {
                     setColor(node, 2 /* Black */);
@@ -259,7 +257,7 @@ function markNodes(languageService, options) {
         gray_queue.push(node);
     }
     function enqueue_black(node) {
-        var previousColor = getColor(node);
+        const previousColor = getColor(node);
         if (previousColor === 2 /* Black */) {
             return;
         }
@@ -277,12 +275,12 @@ function markNodes(languageService, options) {
         if (nodeOrParentIsBlack(node)) {
             return;
         }
-        var fileName = node.getSourceFile().fileName;
+        const fileName = node.getSourceFile().fileName;
         if (/^defaultLib:/.test(fileName) || /\.d\.ts$/.test(fileName)) {
             setColor(node, 2 /* Black */);
             return;
         }
-        var sourceFile = node.getSourceFile();
+        const sourceFile = node.getSourceFile();
         if (!sourceFilesLoaded[sourceFile.fileName]) {
             sourceFilesLoaded[sourceFile.fileName] = true;
             enqueueTopLevelModuleStatements(sourceFile);
@@ -293,15 +291,15 @@ function markNodes(languageService, options) {
         setColor(node, 2 /* Black */);
         black_queue.push(node);
         if (options.shakeLevel === 2 /* ClassMembers */ && (ts.isMethodDeclaration(node) || ts.isMethodSignature(node) || ts.isPropertySignature(node) || ts.isGetAccessor(node) || ts.isSetAccessor(node))) {
-            var references = languageService.getReferencesAtPosition(node.getSourceFile().fileName, node.name.pos + node.name.getLeadingTriviaWidth());
+            const references = languageService.getReferencesAtPosition(node.getSourceFile().fileName, node.name.pos + node.name.getLeadingTriviaWidth());
             if (references) {
-                for (var i = 0, len = references.length; i < len; i++) {
-                    var reference = references[i];
-                    var referenceSourceFile = program.getSourceFile(reference.fileName);
+                for (let i = 0, len = references.length; i < len; i++) {
+                    const reference = references[i];
+                    const referenceSourceFile = program.getSourceFile(reference.fileName);
                     if (!referenceSourceFile) {
                         continue;
                     }
-                    var referenceNode = getTokenAtPosition(referenceSourceFile, reference.textSpan.start, false, false);
+                    const referenceNode = getTokenAtPosition(referenceSourceFile, reference.textSpan.start, false, false);
                     if (ts.isMethodDeclaration(referenceNode.parent)
                         || ts.isPropertyDeclaration(referenceNode.parent)
                         || ts.isGetAccessor(referenceNode.parent)
@@ -313,9 +311,9 @@ function markNodes(languageService, options) {
         }
     }
     function enqueueFile(filename) {
-        var sourceFile = program.getSourceFile(filename);
+        const sourceFile = program.getSourceFile(filename);
         if (!sourceFile) {
-            console.warn("Cannot find source file " + filename);
+            console.warn(`Cannot find source file ${filename}`);
             return;
         }
         enqueue_black(sourceFile);
@@ -325,8 +323,8 @@ function markNodes(languageService, options) {
             // this import should be ignored
             return;
         }
-        var nodeSourceFile = node.getSourceFile();
-        var fullPath;
+        const nodeSourceFile = node.getSourceFile();
+        let fullPath;
         if (/(^\.\/)|(^\.\.\/)/.test(importText)) {
             fullPath = path.join(path.dirname(nodeSourceFile.fileName), importText) + '.ts';
         }
@@ -335,25 +333,25 @@ function markNodes(languageService, options) {
         }
         enqueueFile(fullPath);
     }
-    options.entryPoints.forEach(function (moduleId) { return enqueueFile(moduleId + '.ts'); });
+    options.entryPoints.forEach(moduleId => enqueueFile(moduleId + '.ts'));
     // Add fake usage files
-    options.inlineEntryPoints.forEach(function (_, index) { return enqueueFile("inlineEntryPoint:" + index + ".ts"); });
-    var step = 0;
-    var checker = program.getTypeChecker();
-    var _loop_1 = function () {
+    options.inlineEntryPoints.forEach((_, index) => enqueueFile(`inlineEntryPoint:${index}.ts`));
+    let step = 0;
+    const checker = program.getTypeChecker();
+    while (black_queue.length > 0 || gray_queue.length > 0) {
         ++step;
-        var node = void 0;
+        let node;
         if (step % 100 === 0) {
-            console.log(step + "/" + (step + black_queue.length + gray_queue.length) + " (" + black_queue.length + ", " + gray_queue.length + ")");
+            console.log(`${step}/${step + black_queue.length + gray_queue.length} (${black_queue.length}, ${gray_queue.length})`);
         }
         if (black_queue.length === 0) {
-            for (var i = 0; i < gray_queue.length; i++) {
-                var node_1 = gray_queue[i];
-                var nodeParent = node_1.parent;
+            for (let i = 0; i < gray_queue.length; i++) {
+                const node = gray_queue[i];
+                const nodeParent = node.parent;
                 if ((ts.isClassDeclaration(nodeParent) || ts.isInterfaceDeclaration(nodeParent)) && nodeOrChildIsBlack(nodeParent)) {
                     gray_queue.splice(i, 1);
-                    black_queue.push(node_1);
-                    setColor(node_1, 2 /* Black */);
+                    black_queue.push(node);
+                    setColor(node, 2 /* Black */);
                     i--;
                 }
             }
@@ -362,17 +360,18 @@ function markNodes(languageService, options) {
             node = black_queue.shift();
         }
         else {
-            return "break";
+            // only gray nodes remaining...
+            break;
         }
-        var nodeSourceFile = node.getSourceFile();
-        var loop = function (node) {
-            var _a = getRealNodeSymbol(checker, node), symbol = _a[0], symbolImportNode = _a[1];
+        const nodeSourceFile = node.getSourceFile();
+        const loop = (node) => {
+            const [symbol, symbolImportNode] = getRealNodeSymbol(checker, node);
             if (symbolImportNode) {
                 setColor(symbolImportNode, 2 /* Black */);
             }
             if (symbol && !nodeIsInItsOwnDeclaration(nodeSourceFile, node, symbol)) {
-                for (var i = 0, len = symbol.declarations.length; i < len; i++) {
-                    var declaration = symbol.declarations[i];
+                for (let i = 0, len = symbol.declarations.length; i < len; i++) {
+                    const declaration = symbol.declarations[i];
                     if (ts.isSourceFile(declaration)) {
                         // Do not enqueue full source files
                         // (they can be the declaration of a module import)
@@ -380,9 +379,9 @@ function markNodes(languageService, options) {
                     }
                     if (options.shakeLevel === 2 /* ClassMembers */ && (ts.isClassDeclaration(declaration) || ts.isInterfaceDeclaration(declaration))) {
                         enqueue_black(declaration.name);
-                        for (var j = 0; j < declaration.members.length; j++) {
-                            var member = declaration.members[j];
-                            var memberName = member.name ? member.name.getText() : null;
+                        for (let j = 0; j < declaration.members.length; j++) {
+                            const member = declaration.members[j];
+                            const memberName = member.name ? member.name.getText() : null;
                             if (ts.isConstructorDeclaration(member)
                                 || ts.isConstructSignatureDeclaration(member)
                                 || ts.isIndexSignatureDeclaration(member)
@@ -396,8 +395,7 @@ function markNodes(languageService, options) {
                         }
                         // queue the heritage clauses
                         if (declaration.heritageClauses) {
-                            for (var _i = 0, _b = declaration.heritageClauses; _i < _b.length; _i++) {
-                                var heritageClause = _b[_i];
+                            for (let heritageClause of declaration.heritageClauses) {
                                 enqueue_black(heritageClause);
                             }
                         }
@@ -410,17 +408,12 @@ function markNodes(languageService, options) {
             node.forEachChild(loop);
         };
         node.forEachChild(loop);
-    };
-    while (black_queue.length > 0 || gray_queue.length > 0) {
-        var state_1 = _loop_1();
-        if (state_1 === "break")
-            break;
     }
 }
 function nodeIsInItsOwnDeclaration(nodeSourceFile, node, symbol) {
-    for (var i = 0, len = symbol.declarations.length; i < len; i++) {
-        var declaration = symbol.declarations[i];
-        var declarationSourceFile = declaration.getSourceFile();
+    for (let i = 0, len = symbol.declarations.length; i < len; i++) {
+        const declaration = symbol.declarations[i];
+        const declarationSourceFile = declaration.getSourceFile();
         if (nodeSourceFile === declarationSourceFile) {
             if (declaration.pos <= node.pos && node.end <= declaration.end) {
                 return true;
@@ -430,28 +423,28 @@ function nodeIsInItsOwnDeclaration(nodeSourceFile, node, symbol) {
     return false;
 }
 function generateResult(languageService, shakeLevel) {
-    var program = languageService.getProgram();
+    const program = languageService.getProgram();
     if (!program) {
         throw new Error('Could not get program from language service');
     }
-    var result = {};
-    var writeFile = function (filePath, contents) {
+    let result = {};
+    const writeFile = (filePath, contents) => {
         result[filePath] = contents;
     };
-    program.getSourceFiles().forEach(function (sourceFile) {
-        var fileName = sourceFile.fileName;
+    program.getSourceFiles().forEach((sourceFile) => {
+        const fileName = sourceFile.fileName;
         if (/^defaultLib:/.test(fileName)) {
             return;
         }
-        var destination = fileName;
+        const destination = fileName;
         if (/\.d\.ts$/.test(fileName)) {
             if (nodeOrChildIsBlack(sourceFile)) {
                 writeFile(destination, sourceFile.text);
             }
             return;
         }
-        var text = sourceFile.text;
-        var result = '';
+        let text = sourceFile.text;
+        let result = '';
         function keep(node) {
             result += text.substring(node.pos, node.end);
         }
@@ -480,24 +473,24 @@ function generateResult(languageService, shakeLevel) {
                         }
                     }
                     else {
-                        var survivingImports = [];
-                        for (var i = 0; i < node.importClause.namedBindings.elements.length; i++) {
-                            var importNode = node.importClause.namedBindings.elements[i];
+                        let survivingImports = [];
+                        for (let i = 0; i < node.importClause.namedBindings.elements.length; i++) {
+                            const importNode = node.importClause.namedBindings.elements[i];
                             if (getColor(importNode) === 2 /* Black */) {
                                 survivingImports.push(importNode.getFullText(sourceFile));
                             }
                         }
-                        var leadingTriviaWidth = node.getLeadingTriviaWidth();
-                        var leadingTrivia = sourceFile.text.substr(node.pos, leadingTriviaWidth);
+                        const leadingTriviaWidth = node.getLeadingTriviaWidth();
+                        const leadingTrivia = sourceFile.text.substr(node.pos, leadingTriviaWidth);
                         if (survivingImports.length > 0) {
                             if (node.importClause && node.importClause.name && getColor(node.importClause) === 2 /* Black */) {
-                                return write(leadingTrivia + "import " + node.importClause.name.text + ", {" + survivingImports.join(',') + " } from" + node.moduleSpecifier.getFullText(sourceFile) + ";");
+                                return write(`${leadingTrivia}import ${node.importClause.name.text}, {${survivingImports.join(',')} } from${node.moduleSpecifier.getFullText(sourceFile)};`);
                             }
-                            return write(leadingTrivia + "import {" + survivingImports.join(',') + " } from" + node.moduleSpecifier.getFullText(sourceFile) + ";");
+                            return write(`${leadingTrivia}import {${survivingImports.join(',')} } from${node.moduleSpecifier.getFullText(sourceFile)};`);
                         }
                         else {
                             if (node.importClause && node.importClause.name && getColor(node.importClause) === 2 /* Black */) {
-                                return write(leadingTrivia + "import " + node.importClause.name.text + " from" + node.moduleSpecifier.getFullText(sourceFile) + ";");
+                                return write(`${leadingTrivia}import ${node.importClause.name.text} from${node.moduleSpecifier.getFullText(sourceFile)};`);
                             }
                         }
                     }
@@ -509,9 +502,9 @@ function generateResult(languageService, shakeLevel) {
                 }
             }
             if (shakeLevel === 2 /* ClassMembers */ && (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node)) && nodeOrChildIsBlack(node)) {
-                var toWrite = node.getFullText();
-                for (var i = node.members.length - 1; i >= 0; i--) {
-                    var member = node.members[i];
+                let toWrite = node.getFullText();
+                for (let i = node.members.length - 1; i >= 0; i--) {
+                    const member = node.members[i];
                     if (getColor(member) === 2 /* Black */ || !member.name) {
                         // keep method
                         continue;
@@ -520,8 +513,8 @@ function generateResult(languageService, shakeLevel) {
                         // TODO: keep all members ending with `Brand`...
                         continue;
                     }
-                    var pos = member.pos - node.pos;
-                    var end = member.end - node.pos;
+                    let pos = member.pos - node.pos;
+                    let end = member.end - node.pos;
                     toWrite = toWrite.substring(0, pos) + toWrite.substring(end);
                 }
                 return write(toWrite);
@@ -553,9 +546,9 @@ function generateResult(languageService, shakeLevel) {
  * Returns the node's symbol and the `import` node (if the symbol resolved from a different module)
  */
 function getRealNodeSymbol(checker, node) {
-    var getPropertySymbolsFromContextualType = ts.getPropertySymbolsFromContextualType;
-    var getContainingObjectLiteralElement = ts.getContainingObjectLiteralElement;
-    var getNameFromPropertyName = ts.getNameFromPropertyName;
+    const getPropertySymbolsFromContextualType = ts.getPropertySymbolsFromContextualType;
+    const getContainingObjectLiteralElement = ts.getContainingObjectLiteralElement;
+    const getNameFromPropertyName = ts.getNameFromPropertyName;
     // Go to the original declaration for cases:
     //
     //   (1) when the aliased symbol was declared in the location(parent).
@@ -583,15 +576,15 @@ function getRealNodeSymbol(checker, node) {
             return [null, null];
         }
     }
-    var parent = node.parent;
-    var symbol = checker.getSymbolAtLocation(node);
-    var importNode = null;
+    const { parent } = node;
+    let symbol = checker.getSymbolAtLocation(node);
+    let importNode = null;
     // If this is an alias, and the request came at the declaration location
     // get the aliased symbol instead. This allows for goto def on an import e.g.
     //   import {A, B} from "mod";
     // to jump to the implementation directly.
     if (symbol && symbol.flags & ts.SymbolFlags.Alias && shouldSkipAlias(node, symbol.declarations[0])) {
-        var aliased = checker.getAliasedSymbol(symbol);
+        const aliased = checker.getAliasedSymbol(symbol);
         if (aliased.declarations) {
             // We should mark the import as visited
             importNode = symbol.declarations[0];
@@ -620,17 +613,17 @@ function getRealNodeSymbol(checker, node) {
         //      bar<Test>(({pr/*goto*/op1})=>{});
         if (ts.isPropertyName(node) && ts.isBindingElement(parent) && ts.isObjectBindingPattern(parent.parent) &&
             (node === (parent.propertyName || parent.name))) {
-            var name_1 = getNameFromPropertyName(node);
-            var type = checker.getTypeAtLocation(parent.parent);
-            if (name_1 && type) {
+            const name = getNameFromPropertyName(node);
+            const type = checker.getTypeAtLocation(parent.parent);
+            if (name && type) {
                 if (type.isUnion()) {
-                    var prop = type.types[0].getProperty(name_1);
+                    const prop = type.types[0].getProperty(name);
                     if (prop) {
                         symbol = prop;
                     }
                 }
                 else {
-                    var prop = type.getProperty(name_1);
+                    const prop = type.getProperty(name);
                     if (prop) {
                         symbol = prop;
                     }
@@ -646,11 +639,11 @@ function getRealNodeSymbol(checker, node) {
         //      }
         //      function Foo(arg: Props) {}
         //      Foo( { pr/*1*/op1: 10, prop2: false })
-        var element = getContainingObjectLiteralElement(node);
+        const element = getContainingObjectLiteralElement(node);
         if (element) {
-            var contextualType = element && checker.getContextualType(element.parent);
+            const contextualType = element && checker.getContextualType(element.parent);
             if (contextualType) {
-                var propertySymbols = getPropertySymbolsFromContextualType(element, checker, contextualType, /*unionSymbolOk*/ false);
+                const propertySymbols = getPropertySymbolsFromContextualType(element, checker, contextualType, /*unionSymbolOk*/ false);
                 if (propertySymbols) {
                     symbol = propertySymbols[0];
                 }
@@ -664,17 +657,16 @@ function getRealNodeSymbol(checker, node) {
 }
 /** Get the token whose text contains the position */
 function getTokenAtPosition(sourceFile, position, allowPositionInLeadingTrivia, includeEndPosition) {
-    var current = sourceFile;
+    let current = sourceFile;
     outer: while (true) {
         // find the child that contains 'position'
-        for (var _i = 0, _a = current.getChildren(); _i < _a.length; _i++) {
-            var child = _a[_i];
-            var start = allowPositionInLeadingTrivia ? child.getFullStart() : child.getStart(sourceFile, /*includeJsDoc*/ true);
+        for (const child of current.getChildren()) {
+            const start = allowPositionInLeadingTrivia ? child.getFullStart() : child.getStart(sourceFile, /*includeJsDoc*/ true);
             if (start > position) {
                 // If this child begins after position, then all subsequent children will as well.
                 break;
             }
-            var end = child.getEnd();
+            const end = child.getEnd();
             if (position < end || (position === end && (child.kind === ts.SyntaxKind.EndOfFileToken || includeEndPosition))) {
                 current = child;
                 continue outer;

--- a/build/lib/tslint/duplicateImportsRule.js
+++ b/build/lib/tslint/duplicateImportsRule.js
@@ -3,51 +3,30 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    }
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-var path_1 = require("path");
-var Lint = require("tslint");
-var Rule = /** @class */ (function (_super) {
-    __extends(Rule, _super);
-    function Rule() {
-        return _super !== null && _super.apply(this, arguments) || this;
-    }
-    Rule.prototype.apply = function (sourceFile) {
+const path_1 = require("path");
+const Lint = require("tslint");
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
         return this.applyWithWalker(new ImportPatterns(sourceFile, this.getOptions()));
-    };
-    return Rule;
-}(Lint.Rules.AbstractRule));
-exports.Rule = Rule;
-var ImportPatterns = /** @class */ (function (_super) {
-    __extends(ImportPatterns, _super);
-    function ImportPatterns(file, opts) {
-        var _this = _super.call(this, file, opts) || this;
-        _this.imports = Object.create(null);
-        return _this;
     }
-    ImportPatterns.prototype.visitImportDeclaration = function (node) {
-        var path = node.moduleSpecifier.getText();
+}
+exports.Rule = Rule;
+class ImportPatterns extends Lint.RuleWalker {
+    constructor(file, opts) {
+        super(file, opts);
+        this.imports = Object.create(null);
+    }
+    visitImportDeclaration(node) {
+        let path = node.moduleSpecifier.getText();
         // remove quotes
         path = path.slice(1, -1);
         if (path[0] === '.') {
             path = path_1.join(path_1.dirname(node.getSourceFile().fileName), path);
         }
         if (this.imports[path]) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "Duplicate imports for '" + path + "'."));
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), `Duplicate imports for '${path}'.`));
         }
         this.imports[path] = true;
-    };
-    return ImportPatterns;
-}(Lint.RuleWalker));
+    }
+}

--- a/build/lib/tslint/importPatternsRule.js
+++ b/build/lib/tslint/importPatternsRule.js
@@ -3,82 +3,60 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    }
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-var ts = require("typescript");
-var Lint = require("tslint");
-var minimatch = require("minimatch");
-var path_1 = require("path");
-var Rule = /** @class */ (function (_super) {
-    __extends(Rule, _super);
-    function Rule() {
-        return _super !== null && _super.apply(this, arguments) || this;
-    }
-    Rule.prototype.apply = function (sourceFile) {
-        var configs = this.getOptions().ruleArguments;
-        for (var _i = 0, configs_1 = configs; _i < configs_1.length; _i++) {
-            var config = configs_1[_i];
+const ts = require("typescript");
+const Lint = require("tslint");
+const minimatch = require("minimatch");
+const path_1 = require("path");
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
+        const configs = this.getOptions().ruleArguments;
+        for (const config of configs) {
             if (minimatch(sourceFile.fileName, config.target)) {
                 return this.applyWithWalker(new ImportPatterns(sourceFile, this.getOptions(), config));
             }
         }
         return [];
-    };
-    return Rule;
-}(Lint.Rules.AbstractRule));
-exports.Rule = Rule;
-var ImportPatterns = /** @class */ (function (_super) {
-    __extends(ImportPatterns, _super);
-    function ImportPatterns(file, opts, _config) {
-        var _this = _super.call(this, file, opts) || this;
-        _this._config = _config;
-        return _this;
     }
-    ImportPatterns.prototype.visitImportEqualsDeclaration = function (node) {
+}
+exports.Rule = Rule;
+class ImportPatterns extends Lint.RuleWalker {
+    constructor(file, opts, _config) {
+        super(file, opts);
+        this._config = _config;
+    }
+    visitImportEqualsDeclaration(node) {
         if (node.moduleReference.kind === ts.SyntaxKind.ExternalModuleReference) {
             this._validateImport(node.moduleReference.expression.getText(), node);
         }
-    };
-    ImportPatterns.prototype.visitImportDeclaration = function (node) {
+    }
+    visitImportDeclaration(node) {
         this._validateImport(node.moduleSpecifier.getText(), node);
-    };
-    ImportPatterns.prototype.visitCallExpression = function (node) {
-        _super.prototype.visitCallExpression.call(this, node);
+    }
+    visitCallExpression(node) {
+        super.visitCallExpression(node);
         // import('foo') statements inside the code
         if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
-            var path = node.arguments[0];
+            const [path] = node.arguments;
             this._validateImport(path.getText(), node);
         }
-    };
-    ImportPatterns.prototype._validateImport = function (path, node) {
+    }
+    _validateImport(path, node) {
         // remove quotes
         path = path.slice(1, -1);
         // resolve relative paths
         if (path[0] === '.') {
             path = path_1.join(this.getSourceFile().fileName, path);
         }
-        var restrictions;
+        let restrictions;
         if (typeof this._config.restrictions === 'string') {
             restrictions = [this._config.restrictions];
         }
         else {
             restrictions = this._config.restrictions;
         }
-        var matched = false;
-        for (var _i = 0, restrictions_1 = restrictions; _i < restrictions_1.length; _i++) {
-            var pattern = restrictions_1[_i];
+        let matched = false;
+        for (const pattern of restrictions) {
             if (minimatch(path, pattern)) {
                 matched = true;
                 break;
@@ -86,8 +64,7 @@ var ImportPatterns = /** @class */ (function (_super) {
         }
         if (!matched) {
             // None of the restrictions matched
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "Imports violates '" + restrictions.join(' or ') + "' restrictions. See https://github.com/Microsoft/vscode/wiki/Code-Organization"));
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), `Imports violates '${restrictions.join(' or ')}' restrictions. See https://github.com/Microsoft/vscode/wiki/Code-Organization`));
         }
-    };
-    return ImportPatterns;
-}(Lint.RuleWalker));
+    }
+}

--- a/build/lib/tslint/layeringRule.js
+++ b/build/lib/tslint/layeringRule.js
@@ -3,39 +3,22 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    }
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-var ts = require("typescript");
-var Lint = require("tslint");
-var path_1 = require("path");
-var Rule = /** @class */ (function (_super) {
-    __extends(Rule, _super);
-    function Rule() {
-        return _super !== null && _super.apply(this, arguments) || this;
-    }
-    Rule.prototype.apply = function (sourceFile) {
-        var parts = path_1.dirname(sourceFile.fileName).split(/\\|\//);
-        var ruleArgs = this.getOptions().ruleArguments[0];
-        var config;
-        for (var i = parts.length - 1; i >= 0; i--) {
+const ts = require("typescript");
+const Lint = require("tslint");
+const path_1 = require("path");
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
+        const parts = path_1.dirname(sourceFile.fileName).split(/\\|\//);
+        const ruleArgs = this.getOptions().ruleArguments[0];
+        let config;
+        for (let i = parts.length - 1; i >= 0; i--) {
             if (ruleArgs[parts[i]]) {
                 config = {
                     allowed: new Set(ruleArgs[parts[i]]).add(parts[i]),
                     disallowed: new Set()
                 };
-                Object.keys(ruleArgs).forEach(function (key) {
+                Object.keys(ruleArgs).forEach(key => {
                     if (!config.allowed.has(key)) {
                         config.disallowed.add(key);
                     }
@@ -47,58 +30,54 @@ var Rule = /** @class */ (function (_super) {
             return [];
         }
         return this.applyWithWalker(new LayeringRule(sourceFile, config, this.getOptions()));
-    };
-    return Rule;
-}(Lint.Rules.AbstractRule));
-exports.Rule = Rule;
-var LayeringRule = /** @class */ (function (_super) {
-    __extends(LayeringRule, _super);
-    function LayeringRule(file, config, opts) {
-        var _this = _super.call(this, file, opts) || this;
-        _this._config = config;
-        return _this;
     }
-    LayeringRule.prototype.visitImportEqualsDeclaration = function (node) {
+}
+exports.Rule = Rule;
+class LayeringRule extends Lint.RuleWalker {
+    constructor(file, config, opts) {
+        super(file, opts);
+        this._config = config;
+    }
+    visitImportEqualsDeclaration(node) {
         if (node.moduleReference.kind === ts.SyntaxKind.ExternalModuleReference) {
             this._validateImport(node.moduleReference.expression.getText(), node);
         }
-    };
-    LayeringRule.prototype.visitImportDeclaration = function (node) {
+    }
+    visitImportDeclaration(node) {
         this._validateImport(node.moduleSpecifier.getText(), node);
-    };
-    LayeringRule.prototype.visitCallExpression = function (node) {
-        _super.prototype.visitCallExpression.call(this, node);
+    }
+    visitCallExpression(node) {
+        super.visitCallExpression(node);
         // import('foo') statements inside the code
         if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
-            var path = node.arguments[0];
+            const [path] = node.arguments;
             this._validateImport(path.getText(), node);
         }
-    };
-    LayeringRule.prototype._validateImport = function (path, node) {
+    }
+    _validateImport(path, node) {
         // remove quotes
         path = path.slice(1, -1);
         if (path[0] === '.') {
             path = path_1.join(path_1.dirname(node.getSourceFile().fileName), path);
         }
-        var parts = path_1.dirname(path).split(/\\|\//);
-        for (var i = parts.length - 1; i >= 0; i--) {
-            var part = parts[i];
+        const parts = path_1.dirname(path).split(/\\|\//);
+        for (let i = parts.length - 1; i >= 0; i--) {
+            const part = parts[i];
             if (this._config.allowed.has(part)) {
                 // GOOD - same layer
                 return;
             }
             if (this._config.disallowed.has(part)) {
                 // BAD - wrong layer
-                var message = "Bad layering. You are not allowed to access '" + part + "' from here, allowed layers are: [" + LayeringRule._print(this._config.allowed) + "]";
+                const message = `Bad layering. You are not allowed to access '${part}' from here, allowed layers are: [${LayeringRule._print(this._config.allowed)}]`;
                 this.addFailure(this.createFailure(node.getStart(), node.getWidth(), message));
                 return;
             }
         }
-    };
-    LayeringRule._print = function (set) {
-        var r = [];
-        set.forEach(function (e) { return r.push(e); });
+    }
+    static _print(set) {
+        const r = [];
+        set.forEach(e => r.push(e));
         return r.join(', ');
-    };
-    return LayeringRule;
-}(Lint.RuleWalker));
+    }
+}

--- a/build/lib/tslint/noStandaloneEditorRule.js
+++ b/build/lib/tslint/noStandaloneEditorRule.js
@@ -3,60 +3,41 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    }
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-var ts = require("typescript");
-var Lint = require("tslint");
-var path_1 = require("path");
-var Rule = /** @class */ (function (_super) {
-    __extends(Rule, _super);
-    function Rule() {
-        return _super !== null && _super.apply(this, arguments) || this;
-    }
-    Rule.prototype.apply = function (sourceFile) {
+const ts = require("typescript");
+const Lint = require("tslint");
+const path_1 = require("path");
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
         if (/vs(\/|\\)editor/.test(sourceFile.fileName)) {
             // the vs/editor folder is allowed to use the standalone editor
             return [];
         }
         return this.applyWithWalker(new NoStandaloneEditorRuleWalker(sourceFile, this.getOptions()));
-    };
-    return Rule;
-}(Lint.Rules.AbstractRule));
-exports.Rule = Rule;
-var NoStandaloneEditorRuleWalker = /** @class */ (function (_super) {
-    __extends(NoStandaloneEditorRuleWalker, _super);
-    function NoStandaloneEditorRuleWalker(file, opts) {
-        return _super.call(this, file, opts) || this;
     }
-    NoStandaloneEditorRuleWalker.prototype.visitImportEqualsDeclaration = function (node) {
+}
+exports.Rule = Rule;
+class NoStandaloneEditorRuleWalker extends Lint.RuleWalker {
+    constructor(file, opts) {
+        super(file, opts);
+    }
+    visitImportEqualsDeclaration(node) {
         if (node.moduleReference.kind === ts.SyntaxKind.ExternalModuleReference) {
             this._validateImport(node.moduleReference.expression.getText(), node);
         }
-    };
-    NoStandaloneEditorRuleWalker.prototype.visitImportDeclaration = function (node) {
+    }
+    visitImportDeclaration(node) {
         this._validateImport(node.moduleSpecifier.getText(), node);
-    };
-    NoStandaloneEditorRuleWalker.prototype.visitCallExpression = function (node) {
-        _super.prototype.visitCallExpression.call(this, node);
+    }
+    visitCallExpression(node) {
+        super.visitCallExpression(node);
         // import('foo') statements inside the code
         if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
-            var path = node.arguments[0];
+            const [path] = node.arguments;
             this._validateImport(path.getText(), node);
         }
-    };
-    NoStandaloneEditorRuleWalker.prototype._validateImport = function (path, node) {
+    }
+    _validateImport(path, node) {
         // remove quotes
         path = path.slice(1, -1);
         // resolve relative paths
@@ -68,8 +49,7 @@ var NoStandaloneEditorRuleWalker = /** @class */ (function (_super) {
             || /vs(\/|\\)editor(\/|\\)editor.api/.test(path)
             || /vs(\/|\\)editor(\/|\\)editor.main/.test(path)
             || /vs(\/|\\)editor(\/|\\)editor.worker/.test(path)) {
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "Not allowed to import standalone editor modules. See https://github.com/Microsoft/vscode/wiki/Code-Organization"));
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), `Not allowed to import standalone editor modules. See https://github.com/Microsoft/vscode/wiki/Code-Organization`));
         }
-    };
-    return NoStandaloneEditorRuleWalker;
-}(Lint.RuleWalker));
+    }
+}

--- a/build/lib/tslint/noUnexternalizedStringsRule.js
+++ b/build/lib/tslint/noUnexternalizedStringsRule.js
@@ -3,35 +3,17 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    }
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-var ts = require("typescript");
-var Lint = require("tslint");
+const ts = require("typescript");
+const Lint = require("tslint");
 /**
  * Implementation of the no-unexternalized-strings rule.
  */
-var Rule = /** @class */ (function (_super) {
-    __extends(Rule, _super);
-    function Rule() {
-        return _super !== null && _super.apply(this, arguments) || this;
-    }
-    Rule.prototype.apply = function (sourceFile) {
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
         return this.applyWithWalker(new NoUnexternalizedStringsRuleWalker(sourceFile, this.getOptions()));
-    };
-    return Rule;
-}(Lint.Rules.AbstractRule));
+    }
+}
 exports.Rule = Rule;
 function isStringLiteral(node) {
     return node && node.kind === ts.SyntaxKind.StringLiteral;
@@ -42,73 +24,70 @@ function isObjectLiteral(node) {
 function isPropertyAssignment(node) {
     return node && node.kind === ts.SyntaxKind.PropertyAssignment;
 }
-var NoUnexternalizedStringsRuleWalker = /** @class */ (function (_super) {
-    __extends(NoUnexternalizedStringsRuleWalker, _super);
-    function NoUnexternalizedStringsRuleWalker(file, opts) {
-        var _this = _super.call(this, file, opts) || this;
-        _this.signatures = Object.create(null);
-        _this.ignores = Object.create(null);
-        _this.messageIndex = undefined;
-        _this.keyIndex = undefined;
-        _this.usedKeys = Object.create(null);
-        var options = _this.getOptions();
-        var first = options && options.length > 0 ? options[0] : null;
+class NoUnexternalizedStringsRuleWalker extends Lint.RuleWalker {
+    constructor(file, opts) {
+        super(file, opts);
+        this.signatures = Object.create(null);
+        this.ignores = Object.create(null);
+        this.messageIndex = undefined;
+        this.keyIndex = undefined;
+        this.usedKeys = Object.create(null);
+        const options = this.getOptions();
+        const first = options && options.length > 0 ? options[0] : null;
         if (first) {
             if (Array.isArray(first.signatures)) {
-                first.signatures.forEach(function (signature) { return _this.signatures[signature] = true; });
+                first.signatures.forEach((signature) => this.signatures[signature] = true);
             }
             if (Array.isArray(first.ignores)) {
-                first.ignores.forEach(function (ignore) { return _this.ignores[ignore] = true; });
+                first.ignores.forEach((ignore) => this.ignores[ignore] = true);
             }
             if (typeof first.messageIndex !== 'undefined') {
-                _this.messageIndex = first.messageIndex;
+                this.messageIndex = first.messageIndex;
             }
             if (typeof first.keyIndex !== 'undefined') {
-                _this.keyIndex = first.keyIndex;
+                this.keyIndex = first.keyIndex;
             }
         }
-        return _this;
     }
-    NoUnexternalizedStringsRuleWalker.prototype.visitSourceFile = function (node) {
-        var _this = this;
-        _super.prototype.visitSourceFile.call(this, node);
-        Object.keys(this.usedKeys).forEach(function (key) {
-            var occurrences = _this.usedKeys[key];
+    visitSourceFile(node) {
+        super.visitSourceFile(node);
+        Object.keys(this.usedKeys).forEach(key => {
+            const occurrences = this.usedKeys[key];
             if (occurrences.length > 1) {
-                occurrences.forEach(function (occurrence) {
-                    _this.addFailure((_this.createFailure(occurrence.key.getStart(), occurrence.key.getWidth(), "Duplicate key " + occurrence.key.getText() + " with different message value.")));
+                occurrences.forEach(occurrence => {
+                    this.addFailure((this.createFailure(occurrence.key.getStart(), occurrence.key.getWidth(), `Duplicate key ${occurrence.key.getText()} with different message value.`)));
                 });
             }
         });
-    };
-    NoUnexternalizedStringsRuleWalker.prototype.visitStringLiteral = function (node) {
+    }
+    visitStringLiteral(node) {
         this.checkStringLiteral(node);
-        _super.prototype.visitStringLiteral.call(this, node);
-    };
-    NoUnexternalizedStringsRuleWalker.prototype.checkStringLiteral = function (node) {
-        var text = node.getText();
-        var doubleQuoted = text.length >= 2 && text[0] === NoUnexternalizedStringsRuleWalker.DOUBLE_QUOTE && text[text.length - 1] === NoUnexternalizedStringsRuleWalker.DOUBLE_QUOTE;
-        var info = this.findDescribingParent(node);
+        super.visitStringLiteral(node);
+    }
+    checkStringLiteral(node) {
+        const text = node.getText();
+        const doubleQuoted = text.length >= 2 && text[0] === NoUnexternalizedStringsRuleWalker.DOUBLE_QUOTE && text[text.length - 1] === NoUnexternalizedStringsRuleWalker.DOUBLE_QUOTE;
+        const info = this.findDescribingParent(node);
         // Ignore strings in import and export nodes.
         if (info && info.isImport && doubleQuoted) {
-            var fix = [
+            const fix = [
                 Lint.Replacement.replaceFromTo(node.getStart(), 1, '\''),
                 Lint.Replacement.replaceFromTo(node.getStart() + text.length - 1, 1, '\''),
             ];
             this.addFailureAtNode(node, NoUnexternalizedStringsRuleWalker.ImportFailureMessage, fix);
             return;
         }
-        var callInfo = info ? info.callInfo : null;
-        var functionName = callInfo ? callInfo.callExpression.expression.getText() : null;
+        const callInfo = info ? info.callInfo : null;
+        const functionName = callInfo ? callInfo.callExpression.expression.getText() : null;
         if (functionName && this.ignores[functionName]) {
             return;
         }
         if (doubleQuoted && (!callInfo || callInfo.argIndex === -1 || !this.signatures[functionName])) {
-            var s = node.getText();
-            var fix = [
-                Lint.Replacement.replaceFromTo(node.getStart(), node.getWidth(), "nls.localize('KEY-" + s.substring(1, s.length - 1) + "', " + s + ")"),
+            const s = node.getText();
+            const fix = [
+                Lint.Replacement.replaceFromTo(node.getStart(), node.getWidth(), `nls.localize('KEY-${s.substring(1, s.length - 1)}', ${s})`),
             ];
-            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), "Unexternalized string found: " + node.getText(), fix));
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), `Unexternalized string found: ${node.getText()}`, fix));
             return;
         }
         // We have a single quoted string outside a localize function name.
@@ -116,7 +95,7 @@ var NoUnexternalizedStringsRuleWalker = /** @class */ (function (_super) {
             return;
         }
         // We have a string that is a direct argument into the localize call.
-        var keyArg = callInfo && callInfo.argIndex === this.keyIndex
+        const keyArg = callInfo && callInfo.argIndex === this.keyIndex
             ? callInfo.callExpression.arguments[this.keyIndex]
             : null;
         if (keyArg) {
@@ -124,12 +103,12 @@ var NoUnexternalizedStringsRuleWalker = /** @class */ (function (_super) {
                 this.recordKey(keyArg, this.messageIndex && callInfo ? callInfo.callExpression.arguments[this.messageIndex] : undefined);
             }
             else if (isObjectLiteral(keyArg)) {
-                for (var i = 0; i < keyArg.properties.length; i++) {
-                    var property = keyArg.properties[i];
+                for (let i = 0; i < keyArg.properties.length; i++) {
+                    const property = keyArg.properties[i];
                     if (isPropertyAssignment(property)) {
-                        var name_1 = property.name.getText();
-                        if (name_1 === 'key') {
-                            var initializer = property.initializer;
+                        const name = property.name.getText();
+                        if (name === 'key') {
+                            const initializer = property.initializer;
                             if (isStringLiteral(initializer)) {
                                 this.recordKey(initializer, this.messageIndex && callInfo ? callInfo.callExpression.arguments[this.messageIndex] : undefined);
                             }
@@ -139,42 +118,42 @@ var NoUnexternalizedStringsRuleWalker = /** @class */ (function (_super) {
                 }
             }
         }
-        var messageArg = callInfo.callExpression.arguments[this.messageIndex];
+        const messageArg = callInfo.callExpression.arguments[this.messageIndex];
         if (messageArg && messageArg.kind !== ts.SyntaxKind.StringLiteral) {
-            this.addFailure(this.createFailure(messageArg.getStart(), messageArg.getWidth(), "Message argument to '" + callInfo.callExpression.expression.getText() + "' must be a string literal."));
+            this.addFailure(this.createFailure(messageArg.getStart(), messageArg.getWidth(), `Message argument to '${callInfo.callExpression.expression.getText()}' must be a string literal.`));
             return;
         }
-    };
-    NoUnexternalizedStringsRuleWalker.prototype.recordKey = function (keyNode, messageNode) {
-        var text = keyNode.getText();
+    }
+    recordKey(keyNode, messageNode) {
+        const text = keyNode.getText();
         // We have an empty key
         if (text.match(/(['"]) *\1/)) {
             if (messageNode) {
-                this.addFailureAtNode(keyNode, "Key is empty for message: " + messageNode.getText());
+                this.addFailureAtNode(keyNode, `Key is empty for message: ${messageNode.getText()}`);
             }
             else {
-                this.addFailureAtNode(keyNode, "Key is empty.");
+                this.addFailureAtNode(keyNode, `Key is empty.`);
             }
             return;
         }
-        var occurrences = this.usedKeys[text];
+        let occurrences = this.usedKeys[text];
         if (!occurrences) {
             occurrences = [];
             this.usedKeys[text] = occurrences;
         }
         if (messageNode) {
-            if (occurrences.some(function (pair) { return pair.message ? pair.message.getText() === messageNode.getText() : false; })) {
+            if (occurrences.some(pair => pair.message ? pair.message.getText() === messageNode.getText() : false)) {
                 return;
             }
         }
         occurrences.push({ key: keyNode, message: messageNode });
-    };
-    NoUnexternalizedStringsRuleWalker.prototype.findDescribingParent = function (node) {
-        var parent;
+    }
+    findDescribingParent(node) {
+        let parent;
         while ((parent = node.parent)) {
-            var kind = parent.kind;
+            const kind = parent.kind;
             if (kind === ts.SyntaxKind.CallExpression) {
-                var callExpression = parent;
+                const callExpression = parent;
                 return { callInfo: { callExpression: callExpression, argIndex: callExpression.arguments.indexOf(node) } };
             }
             else if (kind === ts.SyntaxKind.ImportEqualsDeclaration || kind === ts.SyntaxKind.ImportDeclaration || kind === ts.SyntaxKind.ExportDeclaration) {
@@ -189,8 +168,7 @@ var NoUnexternalizedStringsRuleWalker = /** @class */ (function (_super) {
             node = parent;
         }
         return null;
-    };
-    NoUnexternalizedStringsRuleWalker.ImportFailureMessage = 'Do not use double quotes for imports.';
-    NoUnexternalizedStringsRuleWalker.DOUBLE_QUOTE = '"';
-    return NoUnexternalizedStringsRuleWalker;
-}(Lint.RuleWalker));
+    }
+}
+NoUnexternalizedStringsRuleWalker.ImportFailureMessage = 'Do not use double quotes for imports.';
+NoUnexternalizedStringsRuleWalker.DOUBLE_QUOTE = '"';

--- a/build/lib/tslint/translationRemindRule.js
+++ b/build/lib/tslint/translationRemindRule.js
@@ -3,62 +3,43 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-var __extends = (this && this.__extends) || (function () {
-    var extendStatics = function (d, b) {
-        extendStatics = Object.setPrototypeOf ||
-            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
-        return extendStatics(d, b);
-    }
-    return function (d, b) {
-        extendStatics(d, b);
-        function __() { this.constructor = d; }
-        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-var Lint = require("tslint");
-var fs = require("fs");
-var Rule = /** @class */ (function (_super) {
-    __extends(Rule, _super);
-    function Rule() {
-        return _super !== null && _super.apply(this, arguments) || this;
-    }
-    Rule.prototype.apply = function (sourceFile) {
+const Lint = require("tslint");
+const fs = require("fs");
+class Rule extends Lint.Rules.AbstractRule {
+    apply(sourceFile) {
         return this.applyWithWalker(new TranslationRemindRuleWalker(sourceFile, this.getOptions()));
-    };
-    return Rule;
-}(Lint.Rules.AbstractRule));
-exports.Rule = Rule;
-var TranslationRemindRuleWalker = /** @class */ (function (_super) {
-    __extends(TranslationRemindRuleWalker, _super);
-    function TranslationRemindRuleWalker(file, opts) {
-        return _super.call(this, file, opts) || this;
     }
-    TranslationRemindRuleWalker.prototype.visitImportDeclaration = function (node) {
-        var declaration = node.moduleSpecifier.getText();
-        if (declaration !== "'" + TranslationRemindRuleWalker.NLS_MODULE + "'") {
+}
+exports.Rule = Rule;
+class TranslationRemindRuleWalker extends Lint.RuleWalker {
+    constructor(file, opts) {
+        super(file, opts);
+    }
+    visitImportDeclaration(node) {
+        const declaration = node.moduleSpecifier.getText();
+        if (declaration !== `'${TranslationRemindRuleWalker.NLS_MODULE}'`) {
             return;
         }
         this.visitImportLikeDeclaration(node);
-    };
-    TranslationRemindRuleWalker.prototype.visitImportEqualsDeclaration = function (node) {
-        var reference = node.moduleReference.getText();
-        if (reference !== "require('" + TranslationRemindRuleWalker.NLS_MODULE + "')") {
+    }
+    visitImportEqualsDeclaration(node) {
+        const reference = node.moduleReference.getText();
+        if (reference !== `require('${TranslationRemindRuleWalker.NLS_MODULE}')`) {
             return;
         }
         this.visitImportLikeDeclaration(node);
-    };
-    TranslationRemindRuleWalker.prototype.visitImportLikeDeclaration = function (node) {
-        var currentFile = node.getSourceFile().fileName;
-        var matchService = currentFile.match(/vs\/workbench\/services\/\w+/);
-        var matchPart = currentFile.match(/vs\/workbench\/parts\/\w+/);
+    }
+    visitImportLikeDeclaration(node) {
+        const currentFile = node.getSourceFile().fileName;
+        const matchService = currentFile.match(/vs\/workbench\/services\/\w+/);
+        const matchPart = currentFile.match(/vs\/workbench\/parts\/\w+/);
         if (!matchService && !matchPart) {
             return;
         }
-        var resource = matchService ? matchService[0] : matchPart[0];
-        var resourceDefined = false;
-        var json;
+        const resource = matchService ? matchService[0] : matchPart[0];
+        let resourceDefined = false;
+        let json;
         try {
             json = fs.readFileSync('./build/lib/i18n.resources.json', 'utf8');
         }
@@ -66,17 +47,16 @@ var TranslationRemindRuleWalker = /** @class */ (function (_super) {
             console.error('[translation-remind rule]: File with resources to pull from Transifex was not found. Aborting translation resource check for newly defined workbench part/service.');
             return;
         }
-        var workbenchResources = JSON.parse(json).workbench;
-        workbenchResources.forEach(function (existingResource) {
+        const workbenchResources = JSON.parse(json).workbench;
+        workbenchResources.forEach((existingResource) => {
             if (existingResource.name === resource) {
                 resourceDefined = true;
                 return;
             }
         });
         if (!resourceDefined) {
-            this.addFailureAtNode(node, "Please add '" + resource + "' to ./build/lib/i18n.resources.json file to use translations here.");
+            this.addFailureAtNode(node, `Please add '${resource}' to ./build/lib/i18n.resources.json file to use translations here.`);
         }
-    };
-    TranslationRemindRuleWalker.NLS_MODULE = 'vs/nls';
-    return TranslationRemindRuleWalker;
-}(Lint.RuleWalker));
+    }
+}
+TranslationRemindRuleWalker.NLS_MODULE = 'vs/nls';

--- a/build/lib/typings/object-assign.d.ts
+++ b/build/lib/typings/object-assign.d.ts
@@ -1,4 +1,0 @@
-declare module 'object-assign' {
-    function fn(target: any, ...sources: any[]): any;
-	export = fn;
-}

--- a/build/lib/util.js
+++ b/build/lib/util.js
@@ -4,29 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-var es = require("event-stream");
-var debounce = require("debounce");
-var _filter = require("gulp-filter");
-var rename = require("gulp-rename");
-var _ = require("underscore");
-var path = require("path");
-var fs = require("fs");
-var _rimraf = require("rimraf");
-var git = require("./git");
-var VinylFile = require("vinyl");
-var NoCancellationToken = { isCancellationRequested: function () { return false; } };
+const es = require("event-stream");
+const debounce = require("debounce");
+const _filter = require("gulp-filter");
+const rename = require("gulp-rename");
+const _ = require("underscore");
+const path = require("path");
+const fs = require("fs");
+const _rimraf = require("rimraf");
+const git = require("./git");
+const VinylFile = require("vinyl");
+const NoCancellationToken = { isCancellationRequested: () => false };
 function incremental(streamProvider, initial, supportsCancellation) {
-    var input = es.through();
-    var output = es.through();
-    var state = 'idle';
-    var buffer = Object.create(null);
-    var token = !supportsCancellation ? undefined : { isCancellationRequested: function () { return Object.keys(buffer).length > 0; } };
-    var run = function (input, isCancellable) {
+    const input = es.through();
+    const output = es.through();
+    let state = 'idle';
+    let buffer = Object.create(null);
+    const token = !supportsCancellation ? undefined : { isCancellationRequested: () => Object.keys(buffer).length > 0 };
+    const run = (input, isCancellable) => {
         state = 'running';
-        var stream = !supportsCancellation ? streamProvider() : streamProvider(isCancellable ? token : NoCancellationToken);
+        const stream = !supportsCancellation ? streamProvider() : streamProvider(isCancellable ? token : NoCancellationToken);
         input
             .pipe(stream)
-            .pipe(es.through(undefined, function () {
+            .pipe(es.through(undefined, () => {
             state = 'idle';
             eventuallyRun();
         }))
@@ -35,16 +35,16 @@ function incremental(streamProvider, initial, supportsCancellation) {
     if (initial) {
         run(initial, false);
     }
-    var eventuallyRun = debounce(function () {
-        var paths = Object.keys(buffer);
+    const eventuallyRun = debounce(() => {
+        const paths = Object.keys(buffer);
         if (paths.length === 0) {
             return;
         }
-        var data = paths.map(function (path) { return buffer[path]; });
+        const data = paths.map(path => buffer[path]);
         buffer = Object.create(null);
         run(es.readArray(data), true);
     }, 500);
-    input.on('data', function (f) {
+    input.on('data', (f) => {
         buffer[f.path] = f;
         if (state === 'idle') {
             eventuallyRun();
@@ -57,7 +57,7 @@ function fixWin32DirectoryPermissions() {
     if (!/win32/.test(process.platform)) {
         return es.through();
     }
-    return es.mapSync(function (f) {
+    return es.mapSync(f => {
         if (f.stat && f.stat.isDirectory && f.stat.isDirectory()) {
             f.stat.mode = 16877;
         }
@@ -66,16 +66,16 @@ function fixWin32DirectoryPermissions() {
 }
 exports.fixWin32DirectoryPermissions = fixWin32DirectoryPermissions;
 function setExecutableBit(pattern) {
-    var setBit = es.mapSync(function (f) {
+    const setBit = es.mapSync(f => {
         f.stat.mode = /* 100755 */ 33261;
         return f;
     });
     if (!pattern) {
         return setBit;
     }
-    var input = es.through();
-    var filter = _filter(pattern, { restore: true });
-    var output = input
+    const input = es.through();
+    const filter = _filter(pattern, { restore: true });
+    const output = input
         .pipe(filter)
         .pipe(setBit)
         .pipe(filter.restore);
@@ -83,7 +83,7 @@ function setExecutableBit(pattern) {
 }
 exports.setExecutableBit = setExecutableBit;
 function toFileUri(filePath) {
-    var match = filePath.match(/^([a-z])\:(.*)$/i);
+    const match = filePath.match(/^([a-z])\:(.*)$/i);
     if (match) {
         filePath = '/' + match[1].toUpperCase() + ':' + match[2];
     }
@@ -91,7 +91,7 @@ function toFileUri(filePath) {
 }
 exports.toFileUri = toFileUri;
 function skipDirectories() {
-    return es.mapSync(function (f) {
+    return es.mapSync(f => {
         if (!f.isDirectory()) {
             return f;
         }
@@ -99,15 +99,15 @@ function skipDirectories() {
 }
 exports.skipDirectories = skipDirectories;
 function cleanNodeModule(name, excludes, includes) {
-    var toGlob = function (path) { return '**/node_modules/' + name + (path ? '/' + path : ''); };
-    var negate = function (str) { return '!' + str; };
-    var allFilter = _filter(toGlob('**'), { restore: true });
-    var globs = [toGlob('**')].concat(excludes.map(_.compose(negate, toGlob)));
-    var input = es.through();
-    var nodeModuleInput = input.pipe(allFilter);
-    var output = nodeModuleInput.pipe(_filter(globs));
+    const toGlob = (path) => '**/node_modules/' + name + (path ? '/' + path : '');
+    const negate = (str) => '!' + str;
+    const allFilter = _filter(toGlob('**'), { restore: true });
+    const globs = [toGlob('**')].concat(excludes.map(_.compose(negate, toGlob)));
+    const input = es.through();
+    const nodeModuleInput = input.pipe(allFilter);
+    let output = nodeModuleInput.pipe(_filter(globs));
     if (includes) {
-        var includeGlobs = includes.map(toGlob);
+        const includeGlobs = includes.map(toGlob);
         output = es.merge(output, nodeModuleInput.pipe(_filter(includeGlobs)));
     }
     output = output.pipe(allFilter.restore);
@@ -115,9 +115,9 @@ function cleanNodeModule(name, excludes, includes) {
 }
 exports.cleanNodeModule = cleanNodeModule;
 function loadSourcemaps() {
-    var input = es.through();
-    var output = input
-        .pipe(es.map(function (f, cb) {
+    const input = es.through();
+    const output = input
+        .pipe(es.map((f, cb) => {
         if (f.sourceMap) {
             cb(undefined, f);
             return;
@@ -126,10 +126,10 @@ function loadSourcemaps() {
             cb(new Error('empty file'));
             return;
         }
-        var contents = f.contents.toString('utf8');
-        var reg = /\/\/# sourceMappingURL=(.*)$/g;
-        var lastMatch = null;
-        var match = null;
+        const contents = f.contents.toString('utf8');
+        const reg = /\/\/# sourceMappingURL=(.*)$/g;
+        let lastMatch = null;
+        let match = null;
         while (match = reg.exec(contents)) {
             lastMatch = match;
         }
@@ -145,7 +145,7 @@ function loadSourcemaps() {
             return;
         }
         f.contents = Buffer.from(contents.replace(/\/\/# sourceMappingURL=(.*)$/g, ''), 'utf8');
-        fs.readFile(path.join(path.dirname(f.path), lastMatch[1]), 'utf8', function (err, contents) {
+        fs.readFile(path.join(path.dirname(f.path), lastMatch[1]), 'utf8', (err, contents) => {
             if (err) {
                 return cb(err);
             }
@@ -157,10 +157,10 @@ function loadSourcemaps() {
 }
 exports.loadSourcemaps = loadSourcemaps;
 function stripSourceMappingURL() {
-    var input = es.through();
-    var output = input
-        .pipe(es.mapSync(function (f) {
-        var contents = f.contents.toString('utf8');
+    const input = es.through();
+    const output = input
+        .pipe(es.mapSync(f => {
+        const contents = f.contents.toString('utf8');
         f.contents = Buffer.from(contents.replace(/\n\/\/# sourceMappingURL=(.*)$/gm, ''), 'utf8');
         return f;
     }));
@@ -168,23 +168,23 @@ function stripSourceMappingURL() {
 }
 exports.stripSourceMappingURL = stripSourceMappingURL;
 function rimraf(dir) {
-    var retries = 0;
-    var retry = function (cb) {
-        _rimraf(dir, { maxBusyTries: 1 }, function (err) {
+    let retries = 0;
+    const retry = (cb) => {
+        _rimraf(dir, { maxBusyTries: 1 }, (err) => {
             if (!err) {
                 return cb();
             }
             if (err.code === 'ENOTEMPTY' && ++retries < 5) {
-                return setTimeout(function () { return retry(cb); }, 10);
+                return setTimeout(() => retry(cb), 10);
             }
             return cb(err);
         });
     };
-    return function (cb) { return retry(cb); };
+    return cb => retry(cb);
 }
 exports.rimraf = rimraf;
 function getVersion(root) {
-    var version = process.env['BUILD_SOURCEVERSION'];
+    let version = process.env['BUILD_SOURCEVERSION'];
     if (!version || !/^[0-9a-f]{40}$/i.test(version)) {
         version = git.getVersion(root);
     }
@@ -192,14 +192,14 @@ function getVersion(root) {
 }
 exports.getVersion = getVersion;
 function rebase(count) {
-    return rename(function (f) {
-        var parts = f.dirname ? f.dirname.split(/[\/\\]/) : [];
+    return rename(f => {
+        const parts = f.dirname ? f.dirname.split(/[\/\\]/) : [];
         f.dirname = parts.slice(count).join(path.sep);
     });
 }
 exports.rebase = rebase;
 function filter(fn) {
-    var result = es.through(function (data) {
+    const result = es.through(function (data) {
         if (fn(data)) {
             this.emit('data', data);
         }
@@ -212,8 +212,8 @@ function filter(fn) {
 }
 exports.filter = filter;
 function versionStringToNumber(versionStr) {
-    var semverRegex = /(\d+)\.(\d+)\.(\d+)/;
-    var match = versionStr.match(semverRegex);
+    const semverRegex = /(\d+)\.(\d+)\.(\d+)/;
+    const match = versionStr.match(semverRegex);
     if (!match) {
         throw new Error('Version string is not properly formatted: ' + versionStr);
     }

--- a/build/package.json
+++ b/build/package.json
@@ -5,8 +5,6 @@
     "@types/azure": "0.9.19",
     "@types/debounce": "^1.0.0",
     "@types/documentdb": "1.10.2",
-    "@types/es6-collections": "0.5.31",
-    "@types/es6-promise": "0.0.33",
     "@types/glob": "^7.1.1",
     "@types/gulp": "^4.0.5",
     "@types/gulp-concat": "^0.0.32",

--- a/build/tfs/darwin/enqueue.js
+++ b/build/tfs/darwin/enqueue.js
@@ -3,70 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 'use strict';
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var child_process_1 = require("child_process");
-var azure = require("azure-storage");
+const child_process_1 = require("child_process");
+const azure = require("azure-storage");
 function queueSigningRequest(quality, commit) {
-    var retryOperations = new azure.ExponentialRetryPolicyFilter();
-    var queueSvc = azure
+    const retryOperations = new azure.ExponentialRetryPolicyFilter();
+    const queueSvc = azure
         .createQueueService(process.env['AZURE_STORAGE_ACCOUNT_2'], process.env['AZURE_STORAGE_ACCESS_KEY_2'])
         .withFilter(retryOperations);
     queueSvc.messageEncoder = new azure.QueueMessageEncoder.TextBase64QueueMessageEncoder();
-    var message = quality + "/" + commit;
-    return new Promise(function (c, e) { return queueSvc.createMessage('sign-darwin', message, function (err) { return err ? e(err) : c(); }); });
+    const message = `${quality}/${commit}`;
+    return new Promise((c, e) => queueSvc.createMessage('sign-darwin', message, err => err ? e(err) : c()));
 }
-function main(quality) {
-    return __awaiter(this, void 0, void 0, function () {
-        var commit;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    commit = child_process_1.execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
-                    console.log("Queueing signing request for '" + quality + "/" + commit + "'...");
-                    return [4 /*yield*/, queueSigningRequest(quality, commit)];
-                case 1:
-                    _a.sent();
-                    return [2 /*return*/];
-            }
-        });
-    });
+async function main(quality) {
+    const commit = child_process_1.execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    console.log(`Queueing signing request for '${quality}/${commit}'...`);
+    await queueSigningRequest(quality, commit);
+    // console.log('Waiting on signed build...');
+    // await waitForSignedBuild(quality, commit);
+    // console.log('Found signed build!');
 }
-main(process.argv[2]).catch(function (err) {
+main(process.argv[2]).catch(err => {
     console.error(err);
     process.exit(1);
 });

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es2017",
 		"module": "commonjs",
 		"removeComments": false,
 		"preserveConstEnums": true,

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -42,16 +42,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/es6-collections@0.5.31":
-  version "0.5.31"
-  resolved "https://registry.yarnpkg.com/@types/es6-collections/-/es6-collections-0.5.31.tgz#faad21c930cd0ea7f71f51b9e5b555796c5ab23f"
-  integrity sha512-djEvbdTH5Uw7V0WqdMQLG4NK3+iu/FMZy/ylyhWEFnW5xOsXEWpivo/dhP+cR43Az+ipytza7dTSnpsWCxKYAw==
-
-"@types/es6-promise@0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/es6-promise/-/es6-promise-0.0.33.tgz#280a707e62b1b6bef1a86cc0861ec63cd06c7ff3"
-  integrity sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw==
-
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "mkdirp": "^0.5.0",
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.17.0",
-    "object-assign": "^4.0.1",
     "optimist": "0.3.5",
     "p-all": "^1.0.0",
     "pump": "^1.0.1",


### PR DESCRIPTION
Upgrades our build scripts to target ES2017 since they are run on modern versions of node

This allows us to remove shims for es6 features such as `Object.assign`, and also remove a few extra typings packages for es6 library features