### PR TITLE
Add a message informing that no editors are open

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/media/explorerviewlet.css
+++ b/src/vs/workbench/parts/files/electron-browser/media/explorerviewlet.css
@@ -97,6 +97,10 @@
 	padding: 0 20px 0 20px;
 }
 
+.explorer-message {
+	padding: 0 20px 0 20px;
+}
+
 .explorer-viewlet .explorer-item.nonexistent-root {
 	opacity: 0.5;
 }


### PR DESCRIPTION
This will add a message stating "You have no open editors yet." when a user expands the Open Editors panel when no editors are present in the workbench. This is related to issue #59753 that suggested that the panel should not be toggleable if there are no editors open. However, @isidorn suggested instead that a default message similar to the Open Folder panel and Outline panel should be displayed.