### PR TITLE
Support disabling automatic updates (#12817)

### DIFF
--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -74,7 +74,10 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		this.setState(State.Idle(this.getUpdateType()));
 
 		// Start checking for updates after 30 seconds
-		this.scheduleCheckForUpdates(30 * 1000).then(null, err => this.logService.error(err));
+		const autoCheckForUpdates = this.configurationService.getValue<boolean>('update.autoCheckForUpdates');
+		if (autoCheckForUpdates) {
+			this.scheduleCheckForUpdates(30 * 1000).then(null, err => this.logService.error(err));
+		}
 	}
 
 	private getProductQuality(): string {

--- a/src/vs/platform/update/node/update.config.contribution.ts
+++ b/src/vs/platform/update/node/update.config.contribution.ts
@@ -19,7 +19,14 @@ configurationRegistry.registerConfiguration({
 			'enum': ['none', 'default'],
 			'default': 'default',
 			'scope': ConfigurationScope.APPLICATION,
-			'description': nls.localize('updateChannel', "Configure whether you receive automatic updates from an update channel. Requires a restart after change. The updates are fetched from a Microsoft online service."),
+			'description': nls.localize('updateChannel', "Defines the channel from which updates are fetched. Requires a restart after change. The updates are fetched from a Microsoft online service."),
+			'tags': ['usesOnlineServices']
+		},
+		'update.autoCheckForUpdates': {
+			'type': 'boolean',
+			'default': true,
+			'scope': ConfigurationScope.APPLICATION,
+			'description': nls.localize('autoCheckForUpdates', "Controls whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."),
 			'tags': ['usesOnlineServices']
 		},
 		'update.enableWindowsBackgroundUpdates': {


### PR DESCRIPTION
Previously, the only way to turn off automatic updates was setting
'updateChannel' to 'none', which also disabled manual updates.

Resolves #12817.