### PR TITLE
Fixes tests error with faulty OS check when OS is Fedora

### DIFF
--- a/src/vs/workbench/parts/terminal/test/electron-browser/terminalConfigHelper.test.ts
+++ b/src/vs/workbench/parts/terminal/test/electron-browser/terminalConfigHelper.test.ts
@@ -32,7 +32,7 @@ suite('Workbench - TerminalConfigHelper', () => {
 		configHelper.panelContainer = fixture;
 		if (isFedora) {
 			assert.equal(configHelper.getFont().fontFamily, '\'DejaVu Sans Mono\', monospace', 'Fedora should have its font overridden when terminal.integrated.fontFamily not set');
-		} if (isUbuntu) {
+		} else if (isUbuntu) {
 			assert.equal(configHelper.getFont().fontFamily, '\'Ubuntu Mono\', monospace', 'Ubuntu should have its font overridden when terminal.integrated.fontFamily not set');
 		} else {
 			assert.equal(configHelper.getFont().fontFamily, 'foo', 'editor.fontFamily should be the fallback when terminal.integrated.fontFamily not set');


### PR DESCRIPTION
This is a minor fix which was preventing tests to run on Fedora.