### PR TITLE
Clear Editor Selection When Find Widget Is Closed

### DIFF
--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -9,6 +9,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import * as strings from 'vs/base/common/strings';
 import * as editorCommon from 'vs/editor/common/editorCommon';
+import { Selection } from 'vs/editor/common/core/selection';
 import { registerEditorContribution, registerEditorAction, ServicesAccessor, EditorAction, EditorCommand, registerEditorCommand } from 'vs/editor/browser/editorExtensions';
 import { FIND_IDS, FindModelBoundToEditorModel, ToggleCaseSensitiveKeybinding, ToggleRegexKeybinding, ToggleWholeWordKeybinding, ToggleSearchScopeKeybinding, CONTEXT_FIND_WIDGET_VISIBLE, CONTEXT_FIND_INPUT_FOCUSED } from 'vs/editor/contrib/find/findModel';
 import { FindReplaceState, FindReplaceStateChangedEvent, INewFindReplaceState } from 'vs/editor/contrib/find/findState';
@@ -185,11 +186,25 @@ export class CommonFindController extends Disposable implements editorCommon.IEd
 		return this._state;
 	}
 
+	private clearSelection(): void {
+		const currentSelection: Selection = this._editor.getSelection();
+		const newSelection: Selection = (
+			new Selection(
+				currentSelection.startLineNumber,
+				currentSelection.startColumn,
+				currentSelection.startLineNumber,
+				currentSelection.startColumn
+			)
+		);
+		this._editor.setSelection(newSelection);
+	}
+
 	public closeFindWidget(): void {
 		this._state.change({
 			isRevealed: false,
 			searchScope: null
 		}, false);
+		this.clearSelection();
 		this._editor.focus();
 	}
 

--- a/src/vs/editor/contrib/find/test/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/findController.test.ts
@@ -175,8 +175,8 @@ suite('FindController', () => {
 			findController.closeFindWidget();
 			findController.hasFocus = false;
 
-			// The cursor is now at end of the first line, with ABC on that line highlighted.
-			assert.deepEqual(fromRange(editor.getSelection()), [1, 1, 1, 4]);
+			// The cursor is now at the beginning of ABC
+			assert.deepEqual(fromRange(editor.getSelection()), [1, 1, 1, 1]);
 
 			// I hit delete to remove it and change the text to XYZ.
 			editor.pushUndoStop();
@@ -569,6 +569,30 @@ suite('FindController query options persistence', () => {
 			});
 
 			assert.deepEqual(findController.getState().searchScope, new Selection(1, 2, 1, 3));
+		});
+	});
+
+	test('Clear Editor Selection When Find Widget Is Closed', () => {
+		withTestCodeEditor([
+			'ABC',
+			'AB',
+			'XYZ',
+			'ABC'
+		], { serviceCollection: serviceCollection }, (editor, cursor) => {
+			// The cursor is at the very top, of the file, at the first line
+			const findController = editor.registerAndInstantiateContribution<TestFindController>(TestFindController);
+			const findState = findController.getState();
+			const startFindAction = new StartFindAction();
+			// I hit Ctrl+F to show the Find dialog
+			startFindAction.run(null, editor);
+			// I type "AB"
+			findState.change({ searchString: 'AB' }, true);
+			// The second "AB" is highlighted as wholeWord is true.
+			assert.deepEqual(fromRange(editor.getSelection()), [2, 1, 2, 3]);
+			// Close the find widget
+			findController.closeFindWidget();
+			// Test to make sure that the selection is now at the beginning of the word which was found
+			assert.deepEqual(fromRange(editor.getSelection()), [2, 1, 2, 1]);
 		});
 	});
 });


### PR DESCRIPTION
(I Submited a PR for this. Resubmiting now with tests)

This causes the editor selection to be cleared, when the Find
widget is closed.  The cursor will be placed at the beginning of
where the selection was before it was cleared.

The purpose of this change is to mitigate the inconvenient assumption
that all searches will result in a need to type over the searched text,
which seems to rarely be the case.  Currently, if a person wishes to exit
the Find widget after performing a search, they will need to type the
escape keystroke once to close the Find widget.  Then, they will
need to type the escape keystroke again to clear the highlighted
selection from the search.