### PR TITLE
Add a setting to control cwd behavior on terminal split

### DIFF
--- a/src/vs/workbench/parts/terminal/browser/terminalTab.ts
+++ b/src/vs/workbench/parts/terminal/browser/terminalTab.ts
@@ -366,7 +366,6 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 		if (newTerminalSize < TERMINAL_MIN_USEFUL_SIZE) {
 			return undefined;
 		}
-
 		const instance = this._terminalService.createInstance(
 			terminalFocusContextKey,
 			configHelper,

--- a/src/vs/workbench/parts/terminal/browser/terminalTab.ts
+++ b/src/vs/workbench/parts/terminal/browser/terminalTab.ts
@@ -9,6 +9,8 @@ import { Event, Emitter, anyEvent } from 'vs/base/common/event';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import { SplitView, Orientation, IView, Sizing } from 'vs/base/browser/ui/splitview/splitview';
 import { IPartService, Position } from 'vs/workbench/services/part/common/partService';
+import { isWindows } from 'vs/base/common/platform';
+import { execSync } from 'child_process';
 
 const SPLIT_PANE_MIN_SIZE = 120;
 const TERMINAL_MIN_USEFUL_SIZE = 250;
@@ -374,6 +376,15 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 			}
 			case 'SourceInitialCwd': {
 				shellLaunchConfig.cwd = this.activeInstance.getInitialCwd();
+			}
+			case 'Cwd': {
+				if (!isWindows) {
+					let pid = this.activeInstance.processId;
+					let output = execSync('lsof -p ' + pid + ' | grep cwd').toString();
+					shellLaunchConfig.cwd = output.substring(output.indexOf('/'), output.length - 1);
+				} else {
+					shellLaunchConfig.cwd = this.activeInstance.getInitialCwd();
+				}
 			}
 		}
 

--- a/src/vs/workbench/parts/terminal/browser/terminalTab.ts
+++ b/src/vs/workbench/parts/terminal/browser/terminalTab.ts
@@ -366,6 +366,17 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 		if (newTerminalSize < TERMINAL_MIN_USEFUL_SIZE) {
 			return undefined;
 		}
+
+		switch (configHelper.config.splitCwdSource) {
+			case 'ShellDefault': {
+				// allow default behavior
+				break;
+			}
+			case 'SourceInitialCwd': {
+				shellLaunchConfig.cwd = this.activeInstance.getInitialCwd();
+			}
+		}
+
 		const instance = this._terminalService.createInstance(
 			terminalFocusContextKey,
 			configHelper,

--- a/src/vs/workbench/parts/terminal/browser/terminalTab.ts
+++ b/src/vs/workbench/parts/terminal/browser/terminalTab.ts
@@ -9,8 +9,6 @@ import { Event, Emitter, anyEvent } from 'vs/base/common/event';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import { SplitView, Orientation, IView, Sizing } from 'vs/base/browser/ui/splitview/splitview';
 import { IPartService, Position } from 'vs/workbench/services/part/common/partService';
-import { isWindows } from 'vs/base/common/platform';
-import { execSync } from 'child_process';
 
 const SPLIT_PANE_MIN_SIZE = 120;
 const TERMINAL_MIN_USEFUL_SIZE = 250;
@@ -367,25 +365,6 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 		const newTerminalSize = ((this._panelPosition === Position.BOTTOM ? this._container.clientWidth : this._container.clientHeight) / (this._terminalInstances.length + 1));
 		if (newTerminalSize < TERMINAL_MIN_USEFUL_SIZE) {
 			return undefined;
-		}
-
-		switch (configHelper.config.splitCwdSource) {
-			case 'ShellDefault': {
-				// allow default behavior
-				break;
-			}
-			case 'SourceInitialCwd': {
-				shellLaunchConfig.cwd = this.activeInstance.getInitialCwd();
-			}
-			case 'Cwd': {
-				if (!isWindows) {
-					let pid = this.activeInstance.processId;
-					let output = execSync('lsof -p ' + pid + ' | grep cwd').toString();
-					shellLaunchConfig.cwd = output.substring(output.indexOf('/'), output.length - 1);
-				} else {
-					shellLaunchConfig.cwd = this.activeInstance.getInitialCwd();
-				}
-			}
 		}
 
 		const instance = this._terminalService.createInstance(

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -100,6 +100,7 @@ export interface ITerminalConfiguration {
 	};
 	showExitAlert: boolean;
 	experimentalBufferImpl: 'JsArray' | 'TypedArray';
+	splitCwdSource: 'ShellDefault' | 'SourceInitialCwd';
 }
 
 export interface ITerminalConfigHelper {
@@ -585,6 +586,8 @@ export interface ITerminalInstance {
 	addDisposable(disposable: IDisposable): void;
 
 	toggleEscapeSequenceLogging(): void;
+
+	getInitialCwd(): string;
 }
 
 export interface ITerminalCommandTracker {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -100,7 +100,7 @@ export interface ITerminalConfiguration {
 	};
 	showExitAlert: boolean;
 	experimentalBufferImpl: 'JsArray' | 'TypedArray';
-	splitCwdSource: 'ShellDefault' | 'SourceInitialCwd';
+	splitCwdSource: 'ShellDefault' | 'SourceInitialCwd' | 'Cwd';
 }
 
 export interface ITerminalConfigHelper {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -100,7 +100,7 @@ export interface ITerminalConfiguration {
 	};
 	showExitAlert: boolean;
 	experimentalBufferImpl: 'JsArray' | 'TypedArray';
-	splitCwdSource: 'workspaceRoot' | 'sourceInitialCwd' | 'sourceCwd';
+	splitCwd: 'workspaceRoot' | 'sourceInitialCwd' | 'sourceCwd';
 }
 
 export interface ITerminalConfigHelper {
@@ -592,7 +592,7 @@ export interface ITerminalInstance {
 
 	toggleEscapeSequenceLogging(): void;
 
-	getCwd(configHelper: ITerminalConfigHelper): Promise<string>;
+	getCwd(): Promise<string>;
 }
 
 export interface ITerminalCommandTracker {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -403,6 +403,11 @@ export interface ITerminalInstance {
 	readonly commandTracker: ITerminalCommandTracker;
 
 	/**
+	 * The cwd that the terminal instance was initialized with.
+	 */
+	readonly initialCwd: string;
+
+	/**
 	 * Dispose the terminal instance, removing it from the panel/service and freeing up resources.
 	 *
 	 * @param isShuttingDown Whether VS Code is shutting down, if so kill any terminal processes
@@ -586,8 +591,6 @@ export interface ITerminalInstance {
 	addDisposable(disposable: IDisposable): void;
 
 	toggleEscapeSequenceLogging(): void;
-
-	getInitialCwd(): string;
 }
 
 export interface ITerminalCommandTracker {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -100,7 +100,7 @@ export interface ITerminalConfiguration {
 	};
 	showExitAlert: boolean;
 	experimentalBufferImpl: 'JsArray' | 'TypedArray';
-	splitCwdSource: 'ShellDefault' | 'SourceInitialCwd' | 'Cwd';
+	splitCwdSource: 'workspaceRoot' | 'sourceInitialCwd' | 'sourceCwd';
 }
 
 export interface ITerminalConfigHelper {

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -591,6 +591,8 @@ export interface ITerminalInstance {
 	addDisposable(disposable: IDisposable): void;
 
 	toggleEscapeSequenceLogging(): void;
+
+	getCwd(configHelper: ITerminalConfigHelper): Promise<string>;
 }
 
 export interface ITerminalCommandTracker {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -383,7 +383,7 @@ configurationRegistry.registerConfiguration({
 		'terminal.integrated.splitCwdSource': {
 			description: nls.localize('terminal.integrated.splitCwdSource', "Controls the source of the starting cwd for terminals created by splitting."),
 			type: 'string',
-			enum: ['ShellDefault', 'SourceInitialCwd'],
+			enum: ['ShellDefault', 'SourceInitialCwd', 'Cwd'],
 			default: 'ShellDefault'
 		},
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -380,6 +380,12 @@ configurationRegistry.registerConfiguration({
 			enum: ['JsArray', 'TypedArray'],
 			default: 'JsArray'
 		},
+		'terminal.integrated.splitCwdSource': {
+			description: nls.localize('terminal.integrated.splitCwdSource', "Controls the source of the starting cwd for terminals created by splitting."),
+			type: 'string',
+			enum: ['ShellDefault', 'SourceInitialCwd'],
+			default: 'ShellDefault'
+		},
 	}
 });
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -384,6 +384,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('terminal.integrated.splitCwdSource', "Controls the source of the starting cwd for terminals created by splitting."),
 			type: 'string',
 			enum: ['ShellDefault', 'SourceInitialCwd', 'Cwd'],
+			enumDescriptions: [
+				nls.localize('splitCwdSource.ShellDefault', "A new split terminal will use the workspace root as the cwd."),
+				nls.localize('splitCwdSource.SourceInitialCwd', "A new split terminal will use the cwd that the parent terminal started with."),
+				nls.localize('splitCwdSource.Cwd', "on macOS and Linux, a new split terminal will use the cwd of the parent terminal. On Windows, this behaves the same as SourceInitialCwd."),
+			],
 			default: 'ShellDefault'
 		},
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -383,7 +383,7 @@ configurationRegistry.registerConfiguration({
 		'terminal.integrated.splitCwdSource': {
 			description: nls.localize('terminal.integrated.splitCwdSource', "Controls the source of the starting cwd for terminals created by splitting."),
 			type: 'string',
-			enum: ['workspaceRoot', 'sourceInitialCwd', 'cwd'],
+			enum: ['workspaceRoot', 'sourceInitialCwd', 'sourceCwd'],
 			enumDescriptions: [
 				nls.localize('terminal.integrated.splitCwdSource.workspaceRoot', "A new split terminal will use the workspace root as the cwd."),
 				nls.localize('terminal.integrated.splitCwdSource.sourceInitialCwd', "A new split terminal will use the cwd that the parent terminal started with."),

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -380,14 +380,14 @@ configurationRegistry.registerConfiguration({
 			enum: ['JsArray', 'TypedArray'],
 			default: 'JsArray'
 		},
-		'terminal.integrated.splitCwdSource': {
-			description: nls.localize('terminal.integrated.splitCwdSource', "Controls the source of the starting cwd for terminals created by splitting."),
+		'terminal.integrated.splitCwd': {
+			description: nls.localize('terminal.integrated.splitCwd', "Controls the source of the starting cwd for terminals created by splitting."),
 			type: 'string',
 			enum: ['workspaceRoot', 'sourceInitialCwd', 'sourceCwd'],
 			enumDescriptions: [
-				nls.localize('terminal.integrated.splitCwdSource.workspaceRoot', "A new split terminal will use the workspace root as the cwd."),
-				nls.localize('terminal.integrated.splitCwdSource.sourceInitialCwd', "A new split terminal will use the cwd that the parent terminal started with."),
-				nls.localize('terminal.integrated.splitCwdSource.sourceCwd', "On macOS and Linux, a new split terminal will use the cwd of the parent terminal. On Windows, this behaves the same as sourceInitialCwd."),
+				nls.localize('terminal.integrated.splitCwd.workspaceRoot', "A new split terminal will use the workspace root as the cwd."),
+				nls.localize('terminal.integrated.splitCwd.sourceInitialCwd', "A new split terminal will use the cwd that the parent terminal started with."),
+				nls.localize('terminal.integrated.splitCwd.sourceCwd', "On macOS and Linux, a new split terminal will use the cwd of the parent terminal. On Windows, this behaves the same as sourceInitialCwd."),
 			],
 			default: 'workspaceRoot'
 		},

--- a/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminal.contribution.ts
@@ -383,13 +383,13 @@ configurationRegistry.registerConfiguration({
 		'terminal.integrated.splitCwdSource': {
 			description: nls.localize('terminal.integrated.splitCwdSource', "Controls the source of the starting cwd for terminals created by splitting."),
 			type: 'string',
-			enum: ['ShellDefault', 'SourceInitialCwd', 'Cwd'],
+			enum: ['workspaceRoot', 'sourceInitialCwd', 'cwd'],
 			enumDescriptions: [
-				nls.localize('splitCwdSource.ShellDefault', "A new split terminal will use the workspace root as the cwd."),
-				nls.localize('splitCwdSource.SourceInitialCwd', "A new split terminal will use the cwd that the parent terminal started with."),
-				nls.localize('splitCwdSource.Cwd', "on macOS and Linux, a new split terminal will use the cwd of the parent terminal. On Windows, this behaves the same as SourceInitialCwd."),
+				nls.localize('terminal.integrated.splitCwdSource.workspaceRoot', "A new split terminal will use the workspace root as the cwd."),
+				nls.localize('terminal.integrated.splitCwdSource.sourceInitialCwd', "A new split terminal will use the cwd that the parent terminal started with."),
+				nls.localize('terminal.integrated.splitCwdSource.sourceCwd', "On macOS and Linux, a new split terminal will use the cwd of the parent terminal. On Windows, this behaves the same as sourceInitialCwd."),
 			],
-			default: 'ShellDefault'
+			default: 'workspaceRoot'
 		},
 	}
 });

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import { Action, IAction } from 'vs/base/common/actions';
 import { EndOfLinePreference } from 'vs/editor/common/model';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
-import { ITerminalService, TERMINAL_PANEL_ID, ITerminalInstance, Direction, IShellLaunchConfig } from 'vs/workbench/parts/terminal/common/terminal';
+import { ITerminalService, TERMINAL_PANEL_ID, ITerminalInstance, Direction, IShellLaunchConfig, ITerminalConfigHelper } from 'vs/workbench/parts/terminal/common/terminal';
 import { SelectActionItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { TogglePanelAction } from 'vs/workbench/browser/panel';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
@@ -31,6 +31,25 @@ import { timeout } from 'vs/base/common/async';
 import { FindReplaceState } from 'vs/editor/contrib/find/findState';
 
 export const TERMINAL_PICKER_PREFIX = 'term ';
+
+function getCwdForSplit(configHelper: ITerminalConfigHelper, instance: ITerminalInstance): Promise<string> {
+	switch (configHelper.config.splitCwd) {
+		case 'workspaceRoot': {
+			// allow default behavior
+			return new Promise<string>(resolve => {
+				resolve('');
+			});
+		}
+		case 'sourceInitialCwd': {
+			return new Promise<string>(resolve => {
+				resolve(instance.initialCwd);
+			});
+		}
+		case 'sourceCwd': {
+			return instance.getCwd();
+		}
+	}
+}
 
 export class ToggleTerminalAction extends TogglePanelAction {
 
@@ -262,8 +281,8 @@ export class CreateNewTerminalAction extends Action {
 		if (event instanceof MouseEvent && (event.altKey || event.ctrlKey)) {
 			const activeInstance = this.terminalService.getActiveInstance();
 			if (activeInstance) {
-				return activeInstance.getCwd(this.terminalService.configHelper).then(cwd => {
-					this.terminalService.splitInstance(activeInstance, { cwd: cwd });
+				return getCwdForSplit(this.terminalService.configHelper, activeInstance).then(cwd => {
+					this.terminalService.splitInstance(activeInstance, { cwd });
 					return Promise.resolve(null);
 				});
 			}
@@ -341,7 +360,7 @@ export class SplitTerminalAction extends Action {
 
 		const folders = this.workspaceContextService.getWorkspace().folders;
 
-		let pathPromise: PromiseLike<any> = Promise.resolve({});
+		let pathPromise: Promise<IShellLaunchConfig> = Promise.resolve({});
 		if (folders.length > 1) {
 			// Only choose a path when there's more than 1 folder
 			const options: IPickOptions<IQuickPickItem> = {
@@ -360,8 +379,8 @@ export class SplitTerminalAction extends Action {
 			if (!path) {
 				return Promise.resolve(void 0);
 			}
-			return instance.getCwd(this._terminalService.configHelper).then(cwd => {
-				(path as IShellLaunchConfig).cwd = cwd;
+			return getCwdForSplit(this._terminalService.configHelper, instance).then(cwd => {
+				path.cwd = cwd;
 				this._terminalService.splitInstance(instance, path);
 				return this._terminalService.showPanel(true);
 			});
@@ -385,8 +404,8 @@ export class SplitInActiveWorkspaceTerminalAction extends Action {
 		if (!instance) {
 			return Promise.resolve(void 0);
 		}
-		return instance.getCwd(this._terminalService.configHelper).then(cwd => {
-			this._terminalService.splitInstance(instance, { cwd: cwd });
+		return getCwdForSplit(this._terminalService.configHelper, instance).then(cwd => {
+			this._terminalService.splitInstance(instance, { cwd });
 			return this._terminalService.showPanel(true);
 		});
 	}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalActions.ts
@@ -44,19 +44,22 @@ function getCwd(configHelper: ITerminalConfigHelper, activeInstance: ITerminalIn
 		}
 		case 'sourceInitialCwd': {
 			return new Promise<string>(resolve => {
-				resolve(activeInstance.getInitialCwd());
+				resolve(activeInstance.initialCwd);
 			});
 		}
 		case 'sourceCwd': {
 			if (!isWindows) {
 				let pid = activeInstance.processId;
 				return new Promise<string>(resolve => {
-					let output = exec('lsof -p ' + pid + ' | grep cwd').toString();
-					resolve(output.substring(output.indexOf('/'), output.length - 1));
+					exec('lsof -p ' + pid + ' | grep cwd', (error, stdout, stderr) => {
+						if (stdout !== '') {
+							resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
+						}
+					});
 				});
 			} else {
 				return new Promise<string>(resolve => {
-					resolve(activeInstance.getInitialCwd());
+					resolve(activeInstance.initialCwd);
 				});
 			}
 		}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -1145,6 +1145,10 @@ export class TerminalInstance implements ITerminalInstance {
 		this._xterm._core.debug = !this._xterm._core.debug;
 		this._xterm.setOption('debug', this._xterm._core.debug);
 	}
+
+	public getInitialCwd(): string {
+		return this._processManager.initialCwd;
+	}
 }
 
 registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -1146,7 +1146,7 @@ export class TerminalInstance implements ITerminalInstance {
 		this._xterm.setOption('debug', this._xterm._core.debug);
 	}
 
-	public getInitialCwd(): string {
+	public get initialCwd(): string {
 		return this._processManager.initialCwd;
 	}
 }

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -15,7 +15,7 @@ import { Terminal as XTermTerminal, ISearchOptions } from 'vscode-xterm';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
-import { ITerminalInstance, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, TERMINAL_PANEL_ID, IShellLaunchConfig, ITerminalProcessManager, ProcessState, NEVER_MEASURE_RENDER_TIME_STORAGE_KEY, ITerminalDimensions, ITerminalConfigHelper } from 'vs/workbench/parts/terminal/common/terminal';
+import { ITerminalInstance, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, TERMINAL_PANEL_ID, IShellLaunchConfig, ITerminalProcessManager, ProcessState, NEVER_MEASURE_RENDER_TIME_STORAGE_KEY, ITerminalDimensions } from 'vs/workbench/parts/terminal/common/terminal';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { TabFocus } from 'vs/editor/common/config/commonEditorConfig';
@@ -1150,35 +1150,20 @@ export class TerminalInstance implements ITerminalInstance {
 		return this._processManager.initialCwd;
 	}
 
-	public getCwd(configHelper: ITerminalConfigHelper): Promise<string> {
-		switch (configHelper.config.splitCwdSource) {
-			case 'workspaceRoot': {
-				// allow default behavior
-				return new Promise<string>(resolve => {
-					resolve('');
+	public getCwd(): Promise<string> {
+		if (!platform.isWindows) {
+			let pid = this.processId;
+			return new Promise<string>(resolve => {
+				exec('lsof -p ' + pid + ' | grep cwd', (error, stdout, stderr) => {
+					if (stdout !== '') {
+						resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
+					}
 				});
-			}
-			case 'sourceInitialCwd': {
-				return new Promise<string>(resolve => {
-					resolve(this.initialCwd);
-				});
-			}
-			case 'sourceCwd': {
-				if (!platform.isWindows) {
-					let pid = this.processId;
-					return new Promise<string>(resolve => {
-						exec('lsof -p ' + pid + ' | grep cwd', (error, stdout, stderr) => {
-							if (stdout !== '') {
-								resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
-							}
-						});
-					});
-				} else {
-					return new Promise<string>(resolve => {
-						resolve(this.initialCwd);
-					});
-				}
-			}
+			});
+		} else {
+			return new Promise<string>(resolve => {
+				resolve(this.initialCwd);
+			});
 		}
 	}
 }


### PR DESCRIPTION
Adds a new setting: `terminal.integrated.splitCwdSource`
With these options: `ShellDefault`, `SourceInitialCwd`, `Cwd`
`ShellDefault` is the existing behavior. The new split terminal's cwd will be the workspace root.
`SourceInitialCwd` uses the 'parent' terminals initial cwd for the new terminal.
`Cwd` on macOS and Linux this gets the cwd of the 'parent' terminal and uses that as the cwd for the new split terminal.
Default setting is to keep the existing behavior with `ShellDefault`

Fixes #48447 


