### PR TITLE
fix check to determine if an operation was specified

### DIFF
--- a/build/tfs/linux/repoapi_client.sh
+++ b/build/tfs/linux/repoapi_client.sh
@@ -358,7 +358,7 @@ echo "Performing $operation $operand"
 ParseConfigFile "$configFile"
 
 # Exit if no operation was specified
-if [ -z "operation" ]; then
+if [ -z "$operation" ]; then
     Usage
 fi
 


### PR DESCRIPTION
The use of a literal string in the test appeared to be a typo.