### PR TITLE
Fix webview file icon for release notes

### DIFF
--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditorInput.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditorInput.ts
@@ -43,7 +43,7 @@ export class WebviewEditorInput extends EditorInput {
 			if (URI.isUri(value)) {
 				cssRules.push(`${webviewSelector} { content: ""; background-image: url(${value.toString()}); }`);
 			} else {
-				cssRules.push(`${webviewSelector} { content: ""; background-image: url(${value.light.toString()}); }`);
+				cssRules.push(`.vs ${webviewSelector} { content: ""; background-image: url(${value.light.toString()}); }`);
 				cssRules.push(`.vs-dark ${webviewSelector} { content: ""; background-image: url(${value.dark.toString()}); }`);
 			}
 		});


### PR DESCRIPTION
Fixes #60748

Added css hierarchy to webview file icons for the light theme so it doesn't show two file icons.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/35271042/46967667-17d6e100-d066-11e8-8d46-c0bd6223a764.png) |![image](https://user-images.githubusercontent.com/35271042/46967719-30df9200-d066-11e8-9b73-5df4b510f86d.png)|