### PR TITLE
Allow globalState to be synchronized across multiple windows

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadStorage.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadStorage.ts
@@ -3,47 +3,74 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TPromise } from 'vs/base/common/winjs.base';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
-import { MainThreadStorageShape, MainContext, IExtHostContext } from '../node/extHost.protocol';
+import { MainThreadStorageShape, MainContext, IExtHostContext, ExtHostStorageShape, ExtHostContext } from '../node/extHost.protocol';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
+import { IDisposable } from 'vs/base/common/lifecycle';
 
 @extHostNamedCustomer(MainContext.MainThreadStorage)
 export class MainThreadStorage implements MainThreadStorageShape {
 
 	private _storageService: IStorageService;
+	private _proxy: ExtHostStorageShape;
+	private _storageListener: IDisposable;
+	private _sharedStorageKeysToWatch: Map<string, boolean> = new Map<string, boolean>();
 
 	constructor(
 		extHostContext: IExtHostContext,
 		@IStorageService storageService: IStorageService
 	) {
 		this._storageService = storageService;
+		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostStorage);
+
+		this._storageListener = this._storageService.onDidChangeStorage(e => {
+			let shared = e.scope === StorageScope.GLOBAL;
+			if (shared && this._sharedStorageKeysToWatch.has(e.key)) {
+				let value = this._getValue(shared, e.key);
+				if (value instanceof Error) {
+					return; // ignore parsing errors that can happen
+				}
+				this._proxy.$acceptValue(shared, e.key, value);
+			}
+		});
 	}
 
 	dispose(): void {
+		this._storageListener.dispose();
 	}
 
 	$getValue<T>(shared: boolean, key: string): Thenable<T> {
+		if (shared) {
+			this._sharedStorageKeysToWatch.set(key, true);
+		}
+		let value = this._getValue<T>(shared, key);
+		if (value instanceof Error) {
+			return Promise.reject(value);
+		}
+		return Promise.resolve(value);
+	}
+
+	private _getValue<T>(shared: boolean, key: string): T | Error {
 		let jsonValue = this._storageService.get(key, shared ? StorageScope.GLOBAL : StorageScope.WORKSPACE);
 		if (!jsonValue) {
-			return TPromise.as(undefined);
+			return undefined;
 		}
 		let value: T;
 		try {
 			value = JSON.parse(jsonValue);
-			return TPromise.as(value);
+			return value;
 		} catch (err) {
-			return TPromise.wrapError<T>(err);
+			return err;
 		}
 	}
 
-	$setValue(shared: boolean, key: string, value: any): Thenable<void> {
-		let jsonValue: any;
+	$setValue(shared: boolean, key: string, value: object): Thenable<void> {
+		let jsonValue: string;
 		try {
 			jsonValue = JSON.stringify(value);
 			this._storageService.store(key, jsonValue, shared ? StorageScope.GLOBAL : StorageScope.WORKSPACE);
 		} catch (err) {
-			return TPromise.wrapError(err);
+			return Promise.reject(err);
 		}
 		return undefined;
 	}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -62,6 +62,7 @@ import { ExtHostSearch } from './extHostSearch';
 import { ExtHostUrls } from './extHostUrls';
 import { localize } from 'vs/nls';
 import { ExtHostClipboard } from 'vs/workbench/api/node/extHostClipboard';
+import { ExtHostStorage } from 'vs/workbench/api/node/extHostStorage';
 
 export interface IExtensionApiFactory {
 	(extension: IExtensionDescription): typeof vscode;
@@ -94,7 +95,8 @@ export function createApiFactory(
 	extHostWorkspace: ExtHostWorkspace,
 	extHostConfiguration: ExtHostConfiguration,
 	extensionService: ExtHostExtensionService,
-	extHostLogService: ExtHostLogService
+	extHostLogService: ExtHostLogService,
+	extHostStorage: ExtHostStorage
 ): IExtensionApiFactory {
 
 	let schemeTransformer: ISchemeTransformer | null = null;
@@ -129,6 +131,7 @@ export function createApiFactory(
 	const extHostProgress = rpcProtocol.set(ExtHostContext.ExtHostProgress, new ExtHostProgress(rpcProtocol.getProxy(MainContext.MainThreadProgress)));
 	const exthostCommentProviders = rpcProtocol.set(ExtHostContext.ExtHostComments, new ExtHostComments(rpcProtocol, extHostCommands.converter, extHostDocuments));
 	const extHostOutputService = rpcProtocol.set(ExtHostContext.ExtHostOutputService, new ExtHostOutputService(initData.logsLocation, rpcProtocol));
+	rpcProtocol.set(ExtHostContext.ExtHostStorage, extHostStorage);
 
 	// Check that no named customers are missing
 	const expected: ProxyIdentifier<any>[] = Object.keys(ExtHostContext).map((key) => (<any>ExtHostContext)[key]);

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -430,7 +430,7 @@ export interface MainThreadStatusBarShape extends IDisposable {
 
 export interface MainThreadStorageShape extends IDisposable {
 	$getValue<T>(shared: boolean, key: string): Thenable<T>;
-	$setValue(shared: boolean, key: string, value: any): Thenable<void>;
+	$setValue(shared: boolean, key: string, value: object): Thenable<void>;
 }
 
 export interface MainThreadTelemetryShape extends IDisposable {
@@ -1016,6 +1016,10 @@ export interface ExtHostCommentsShape {
 	$provideWorkspaceComments(handle: number): Thenable<modes.CommentThread[]>;
 }
 
+export interface ExtHostStorageShape {
+	$acceptValue(shared: boolean, key: string, value: object): void;
+}
+
 // --- proxy identifiers
 
 export const MainContext = {
@@ -1081,6 +1085,7 @@ export const ExtHostContext = {
 	ExtHostWebviews: createExtId<ExtHostWebviewsShape>('ExtHostWebviews'),
 	ExtHostProgress: createMainId<ExtHostProgressShape>('ExtHostProgress'),
 	ExtHostComments: createMainId<ExtHostCommentsShape>('ExtHostComments'),
+	ExtHostStorage: createMainId<ExtHostStorageShape>('ExtHostStorage'),
 	ExtHostUrls: createExtId<ExtHostUrlsShape>('ExtHostUrls'),
 	ExtHostOutputService: createMainId<ExtHostOutputServiceShape>('ExtHostOutputService'),
 };

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -40,6 +40,12 @@ class ExtensionMemento implements IExtensionMemento {
 			this._value = value;
 			return this;
 		});
+
+		this._storage.onDidChangeStorage(e => {
+			if (e.shared === this._shared && e.key === this._id) {
+				this._value = e.value;
+			}
+		});
 	}
 
 	get whenReady(): Thenable<ExtensionMemento> {
@@ -150,7 +156,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		this._activator = null;
 
 		// initialize API first (i.e. do not release barrier until the API is initialized)
-		const apiFactory = createApiFactory(initData, extHostContext, extHostWorkspace, extHostConfiguration, this, this._extHostLogService);
+		const apiFactory = createApiFactory(initData, extHostContext, extHostWorkspace, extHostConfiguration, this, this._extHostLogService, this._storage);
 
 		initializeExtensionApi(this, apiFactory).then(() => {
 

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { dispose } from 'vs/base/common/lifecycle';
+import { dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { join } from 'path';
 import { mkdirp, dirExists, realpath, writeFile } from 'vs/base/node/pfs';
 import Severity from 'vs/base/common/severity';
@@ -30,6 +30,7 @@ class ExtensionMemento implements IExtensionMemento {
 
 	private readonly _init: Thenable<ExtensionMemento>;
 	private _value: { [n: string]: any; };
+	private readonly _storageListener: IDisposable;
 
 	constructor(id: string, global: boolean, storage: ExtHostStorage) {
 		this._id = id;
@@ -41,7 +42,7 @@ class ExtensionMemento implements IExtensionMemento {
 			return this;
 		});
 
-		this._storage.onDidChangeStorage(e => {
+		this._storageListener = this._storage.onDidChangeStorage(e => {
 			if (e.shared === this._shared && e.key === this._id) {
 				this._value = e.value;
 			}
@@ -65,6 +66,10 @@ class ExtensionMemento implements IExtensionMemento {
 		return this._storage
 			.setValue(this._shared, this._id, this._value)
 			.then(() => true);
+	}
+
+	dispose(): void {
+		this._storageListener.dispose();
 	}
 }
 

--- a/src/vs/workbench/api/node/extHostStorage.ts
+++ b/src/vs/workbench/api/node/extHostStorage.ts
@@ -3,11 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MainContext, MainThreadStorageShape, IMainContext } from './extHost.protocol';
+import { MainContext, MainThreadStorageShape, IMainContext, ExtHostStorageShape } from './extHost.protocol';
+import { Emitter } from 'vs/base/common/event';
 
-export class ExtHostStorage {
+export interface IStorageChangeEvent {
+	shared: boolean;
+	key: string;
+	value: object;
+}
+
+export class ExtHostStorage implements ExtHostStorageShape {
 
 	private _proxy: MainThreadStorageShape;
+
+	private _onDidChangeStorage = new Emitter<IStorageChangeEvent>();
+	readonly onDidChangeStorage = this._onDidChangeStorage.event;
 
 	constructor(mainContext: IMainContext) {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadStorage);
@@ -17,7 +27,11 @@ export class ExtHostStorage {
 		return this._proxy.$getValue<T>(shared, key).then(value => value || defaultValue);
 	}
 
-	setValue(shared: boolean, key: string, value: any): Thenable<void> {
+	setValue(shared: boolean, key: string, value: object): Thenable<void> {
 		return this._proxy.$setValue(shared, key, value);
+	}
+
+	$acceptValue(shared: boolean, key: string, value: object): void {
+		this._onDidChangeStorage.fire({ shared, key, value });
 	}
 }


### PR DESCRIPTION
fixes #55834

@jrieken this makes the storage on the extension host side aware of changes to the shared (=global) state. To reduce spam on the extension host pipe, I am only sending over data that was previously asked for (`_sharedStorageKeysToWatch`).

Since this is (as far as I know) not an issue with non-shared storage data, the event is only triggered for shared data.