### PR TITLE
Update appinsights dependency 

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1341,7 +1341,7 @@
     "file-type": "^7.2.0",
     "iconv-lite": "0.4.19",
     "jschardet": "^1.6.0",
-    "vscode-extension-telemetry": "0.0.22",
+    "vscode-extension-telemetry": "0.1.0",
     "vscode-nls": "^4.0.0",
     "which": "^1.3.0"
   },

--- a/extensions/git/yarn.lock
+++ b/extensions/git/yarn.lock
@@ -30,9 +30,9 @@
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/@types/which/-/which-1.0.28.tgz#016e387629b8817bed653fe32eab5d11279c8df6"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
@@ -257,11 +257,11 @@ supports-color@3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-vscode-extension-telemetry@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz#ec7d6d85afb5b198aab09e80cba9e16b6d588e56"
+vscode-extension-telemetry@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz#3cdcb61d03829966bd04b5f11471a1e40d6abaad"
   dependencies:
-    applicationinsights "1.0.5"
+    applicationinsights "1.0.6"
 
 vscode-nls@^4.0.0:
   version "4.0.0"

--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -175,7 +175,7 @@
     }
   },
   "dependencies": {
-    "vscode-extension-telemetry": "0.0.22",
+    "vscode-extension-telemetry": "0.1.0",
     "vscode-languageclient": "^5.1.0",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/html-language-features/yarn.lock
+++ b/extensions/html-language-features/yarn.lock
@@ -6,9 +6,9 @@
   version "8.10.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.25.tgz#801fe4e39372cef18f268db880a5fbfcf71adc7e"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
@@ -28,11 +28,11 @@ semver@^5.3.0, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
-vscode-extension-telemetry@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz#ec7d6d85afb5b198aab09e80cba9e16b6d588e56"
+vscode-extension-telemetry@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz#3cdcb61d03829966bd04b5f11471a1e40d6abaad"
   dependencies:
-    applicationinsights "1.0.5"
+    applicationinsights "1.0.6"
 
 vscode-jsonrpc@^4.0.0:
   version "4.0.0"

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -100,7 +100,7 @@
     }
   },
   "dependencies": {
-    "vscode-extension-telemetry": "0.0.22",
+    "vscode-extension-telemetry": "0.1.0",
     "vscode-languageclient": "^5.1.0",
     "vscode-nls": "^4.0.0"
   },

--- a/extensions/json-language-features/yarn.lock
+++ b/extensions/json-language-features/yarn.lock
@@ -6,9 +6,9 @@
   version "8.10.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.25.tgz#801fe4e39372cef18f268db880a5fbfcf71adc7e"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
@@ -32,11 +32,11 @@ semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
-vscode-extension-telemetry@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz#ec7d6d85afb5b198aab09e80cba9e16b6d588e56"
+vscode-extension-telemetry@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz#3cdcb61d03829966bd04b5f11471a1e40d6abaad"
   dependencies:
-    applicationinsights "1.0.5"
+    applicationinsights "1.0.6"
 
 vscode-jsonrpc@^4.0.0:
   version "4.0.0"

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -309,7 +309,7 @@
 		"highlight.js": "9.12.0",
 		"markdown-it": "^8.4.1",
 		"markdown-it-named-headers": "0.0.4",
-		"vscode-extension-telemetry": "0.0.22",
+		"vscode-extension-telemetry": "0.1.0",
 		"vscode-nls": "^4.0.0"
 	},
 	"devDependencies": {

--- a/extensions/markdown-language-features/yarn.lock
+++ b/extensions/markdown-language-features/yarn.lock
@@ -133,9 +133,9 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
@@ -5456,11 +5456,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vscode-extension-telemetry@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz#ec7d6d85afb5b198aab09e80cba9e16b6d588e56"
+vscode-extension-telemetry@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz#3cdcb61d03829966bd04b5f11471a1e40d6abaad"
   dependencies:
-    applicationinsights "1.0.5"
+    applicationinsights "1.0.6"
 
 vscode-nls@^4.0.0:
   version "4.0.0"

--- a/extensions/search-rg/package.json
+++ b/extensions/search-rg/package.json
@@ -13,7 +13,7 @@
   },
   "categories": [],
   "dependencies": {
-    "vscode-extension-telemetry": "0.0.22",
+    "vscode-extension-telemetry": "0.1.0",
     "vscode-nls": "^4.0.0",
     "vscode-ripgrep": "1.1.0"
   },

--- a/extensions/search-rg/yarn.lock
+++ b/extensions/search-rg/yarn.lock
@@ -49,9 +49,9 @@ ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
@@ -1539,11 +1539,11 @@ vinyl@^2.0.1, vinyl@^2.0.2:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-extension-telemetry@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz#ec7d6d85afb5b198aab09e80cba9e16b6d588e56"
+vscode-extension-telemetry@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz#3cdcb61d03829966bd04b5f11471a1e40d6abaad"
   dependencies:
-    applicationinsights "1.0.5"
+    applicationinsights "1.0.6"
 
 vscode-nls@^4.0.0:
   version "4.0.0"

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "jsonc-parser": "^2.0.1",
     "semver": "5.5.1",
-    "vscode-extension-telemetry": "0.0.22",
+    "vscode-extension-telemetry": "0.1.0",
     "vscode-nls": "^4.0.0"
   },
   "devDependencies": {

--- a/extensions/typescript-language-features/yarn.lock
+++ b/extensions/typescript-language-features/yarn.lock
@@ -49,9 +49,9 @@ ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"
@@ -1546,11 +1546,11 @@ vinyl@^2.0.1, vinyl@^2.0.2:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode-extension-telemetry@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz#ec7d6d85afb5b198aab09e80cba9e16b6d588e56"
+vscode-extension-telemetry@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz#3cdcb61d03829966bd04b5f11471a1e40d6abaad"
   dependencies:
-    applicationinsights "1.0.5"
+    applicationinsights "1.0.6"
 
 vscode-nls@^4.0.0:
   version "4.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "download-builtin-extensions": "node build/lib/builtInExtensions.js"
   },
   "dependencies": {
-    "applicationinsights": "1.0.5",
+    "applicationinsights": "1.0.6",
     "fast-plist": "0.1.2",
     "gc-signals": "^0.0.1",
     "getmac": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,9 +375,9 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-applicationinsights@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.5.tgz#a60d1ffdf7aa1ac77c637c0ef7fcf2a9671cc869"
+applicationinsights@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.6.tgz#bc201810de91cea910dab34e8ad35ecde488edeb"
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"


### PR DESCRIPTION
#60585 details issues of multiple powershell sessions being spawned by application insights which fixed the issue on their end today.

This PR is to update the versions of applicationinsights and vscode-extension-telemetry to fix #60585 