### PR TITLE
fixed documentation typo: 'guardeed' -> 'guaranteed'

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -336,7 +336,7 @@ export class URI implements UriComponents {
 	// ---- printing/externalize ---------------------------
 
 	/**
-	 * Creates a string presentation for this URI. It's guardeed that calling
+	 * Creates a string presentation for this URI. It's guaranteed that calling
 	 * `URI.parse` with the result of this function creates an URI which is equal
 	 * to this URI.
 	 *

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -182,7 +182,7 @@ declare namespace monaco {
 			fragment?: string;
 		}): Uri;
 		/**
-		 * Creates a string presentation for this Uri. It's guardeed that calling
+		 * Creates a string presentation for this Uri. It's guaranteed that calling
 		 * `Uri.parse` with the result of this function creates an Uri which is equal
 		 * to this Uri.
 		 *


### PR DESCRIPTION
The word 'guardeed' appeared twice in code comments, judging from the context I believe this word was meant to be 'guaranteed', I've made the change.

I'm not sure there is an issue for this but it is very trivial so I just went ahead with the fix.