### PR TITLE
Scrolling zoom is reversed if image viewer doesn't have focus

### DIFF
--- a/src/vs/workbench/browser/parts/editor/resourceViewer.ts
+++ b/src/vs/workbench/browser/parts/editor/resourceViewer.ts
@@ -438,7 +438,7 @@ class InlineImageView {
 			updateScale(scale);
 		}
 
-		disposables.push(DOM.addDisposableListener(container, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+		disposables.push(DOM.addDisposableListener(window, DOM.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 			if (!image) {
 				return;
 			}
@@ -451,7 +451,7 @@ class InlineImageView {
 			}
 		}));
 
-		disposables.push(DOM.addDisposableListener(container, DOM.EventType.KEY_UP, (e: KeyboardEvent) => {
+		disposables.push(DOM.addDisposableListener(window, DOM.EventType.KEY_UP, (e: KeyboardEvent) => {
 			if (!image) {
 				return;
 			}


### PR DESCRIPTION
Steps to reproduce:

1. Open two split tabs with images next to each other.
2. Try to zoom with Ctrl+Scroll on each of the images
3. Notice that the image which doesn't have focus has reversed zoom in / zoom out

Issue is that when Ctrl is pressed and image viewer doesn't have focus, then "keydown" event is never received and "ctrlPressed" variable is never set to true.
However when "wheel" event is received, code checks for e.ctrlKey to detect pinching. Then pinching is incorrectly detected and on the line 522 the zoom direction is reversed.

In this solution I'm registering listeners globally so Ctrl event is received even when the image viewer doesn't have focus.

fixes partially #55470 - now scrolling will be consistent.