### PR TITLE
Support C# in markdown preview code block syntax highlighting.

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -46,6 +46,9 @@ export class MarkdownEngine {
 					if (lang && lang.toLocaleLowerCase() === 'json5') {
 						lang = 'json';
 					}
+					if (lang && lang.toLocaleLowerCase() === 'c#') {
+						lang = 'cs';
+					}
 					if (lang && hljs.getLanguage(lang)) {
 						try {
 							return `<div>${hljs.highlight(lang, str, true).value}</div>`;


### PR DESCRIPTION
Fixes #61240 

Seems the problem coming from [highlight.js](https://github.com/highlightjs/highlight.js) package. Adding this snippit solved the problem.
```js
if (lang && lang.toLocaleLowerCase() === 'c#') {
    lang = 'cs';
}
```