### PR TITLE
snippets: Add setInterval snippet

### DIFF
--- a/extensions/javascript/snippets/javascript.json
+++ b/extensions/javascript/snippets/javascript.json
@@ -140,6 +140,15 @@
 		],
 		"description": "Set Timeout Function"
 	},
+	"Set Interval Function": {
+		"prefix": "setinverval",
+		"body": [
+			"setInterval(() => {",
+			"\t$0",
+			"}, ${1:interval});"
+		],
+		"description": "Set Interval Function"
+	},
 	"Import external module.": {
 		"prefix": "import statement",
 		"body": [

--- a/extensions/javascript/snippets/javascript.json
+++ b/extensions/javascript/snippets/javascript.json
@@ -141,7 +141,7 @@
 		"description": "Set Timeout Function"
 	},
 	"Set Interval Function": {
-		"prefix": "setinverval",
+		"prefix": "setinterval",
 		"body": [
 			"setInterval(() => {",
 			"\t$0",


### PR DESCRIPTION
This PR adds the `setInterval` function snippet to JavaScript for parity with setTimeout.