### PR TITLE
Add telemetry for debug add breakpoints #55514

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -133,7 +133,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 						logMessage: l.logMessage
 					}
 				);
-				this.debugService.addBreakpoints(uri.revive(dto.uri), rawbps, 'mainThreadDebugService');
+				this.debugService.addBreakpoints(uri.revive(dto.uri), rawbps, 'extension');
 			} else if (dto.type === 'function') {
 				this.debugService.addFunctionBreakpoint(dto.functionName, dto.id);
 			}

--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -133,7 +133,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 						logMessage: l.logMessage
 					}
 				);
-				this.debugService.addBreakpoints(uri.revive(dto.uri), rawbps);
+				this.debugService.addBreakpoints(uri.revive(dto.uri), rawbps, 'mainThreadDebugService');
 			} else if (dto.type === 'function') {
 				this.debugService.addFunctionBreakpoint(dto.functionName, dto.id);
 			}

--- a/src/vs/workbench/parts/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/parts/debug/browser/debugCommands.ts
@@ -211,7 +211,7 @@ export function registerCommands(): void {
 				return Promise.resolve(null);
 			}
 			if (debugService.getConfigurationManager().canSetBreakpointsIn(widget.getModel())) {
-				return debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber, column: position.column > 1 ? position.column : undefined }]);
+				return debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber, column: position.column > 1 ? position.column : undefined }], 'debugCommands.inlineBreakpointCommand');
 			}
 		}
 

--- a/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
@@ -45,7 +45,7 @@ class ToggleBreakpointAction extends EditorAction {
 			return Promise.all(bps.map(bp => debugService.removeBreakpoints(bp.getId())));
 		}
 		if (debugService.getConfigurationManager().canSetBreakpointsIn(editor.getModel())) {
-			return debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber }], 'debugEditorActions.ToggleBreakpointAction');
+			return debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber }], 'debugEditorActions.toggleBreakpointAction');
 		}
 
 		return Promise.resolve(null);
@@ -130,7 +130,7 @@ class RunToCursorAction extends EditorAction {
 		const position = editor.getPosition();
 		const uri = editor.getModel().uri;
 		const bpExists = !!(debugService.getModel().getBreakpoints({ column: position.column, lineNumber: position.lineNumber, uri }).length);
-		return (bpExists ? Promise.resolve(null) : <Promise<any>>debugService.addBreakpoints(uri, [{ lineNumber: position.lineNumber, column: position.column }], 'debugEditorActions.RunToCursorAction')).then((breakpoints) => {
+		return (bpExists ? Promise.resolve(null) : <Promise<any>>debugService.addBreakpoints(uri, [{ lineNumber: position.lineNumber, column: position.column }], 'debugEditorActions.runToCursorAction')).then((breakpoints) => {
 			if (breakpoints && breakpoints.length) {
 				breakpointToRemove = breakpoints[0];
 			}

--- a/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugEditorActions.ts
@@ -45,7 +45,7 @@ class ToggleBreakpointAction extends EditorAction {
 			return Promise.all(bps.map(bp => debugService.removeBreakpoints(bp.getId())));
 		}
 		if (debugService.getConfigurationManager().canSetBreakpointsIn(editor.getModel())) {
-			return debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber }]);
+			return debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber }], 'debugEditorActions.ToggleBreakpointAction');
 		}
 
 		return Promise.resolve(null);
@@ -130,7 +130,7 @@ class RunToCursorAction extends EditorAction {
 		const position = editor.getPosition();
 		const uri = editor.getModel().uri;
 		const bpExists = !!(debugService.getModel().getBreakpoints({ column: position.column, lineNumber: position.lineNumber, uri }).length);
-		return (bpExists ? Promise.resolve(null) : <Promise<any>>debugService.addBreakpoints(uri, [{ lineNumber: position.lineNumber, column: position.column }])).then((breakpoints) => {
+		return (bpExists ? Promise.resolve(null) : <Promise<any>>debugService.addBreakpoints(uri, [{ lineNumber: position.lineNumber, column: position.column }], 'debugEditorActions.RunToCursorAction')).then((breakpoints) => {
 			if (breakpoints && breakpoints.length) {
 				breakpointToRemove = breakpoints[0];
 			}

--- a/src/vs/workbench/parts/debug/common/debug.ts
+++ b/src/vs/workbench/parts/debug/common/debug.ts
@@ -676,7 +676,7 @@ export interface IDebugService {
 	/**
 	 * Adds new breakpoints to the model for the file specified with the uri. Notifies debug adapter of breakpoint changes.
 	 */
-	addBreakpoints(uri: uri, rawBreakpoints: IBreakpointData[]): TPromise<IBreakpoint[]>;
+	addBreakpoints(uri: uri, rawBreakpoints: IBreakpointData[], context: string): TPromise<IBreakpoint[]>;
 
 	/**
 	 * Updates the breakpoints.

--- a/src/vs/workbench/parts/debug/electron-browser/breakpointWidget.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/breakpointWidget.ts
@@ -183,7 +183,7 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 					condition,
 					hitCondition,
 					logMessage
-				}]);
+				}], `breakpointWidget`);
 			}
 		}
 

--- a/src/vs/workbench/parts/debug/electron-browser/debugEditorContribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugEditorContribution.ts
@@ -148,7 +148,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 				nls.localize('addBreakpoint', "Add Breakpoint"),
 				null,
 				true,
-				() => this.debugService.addBreakpoints(uri, [{ lineNumber }])
+				() => this.debugService.addBreakpoints(uri, [{ lineNumber }], `debugEditorContextMenu`)
 			));
 			actions.push(new Action(
 				'addConditionalBreakpoint',
@@ -230,7 +230,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 						breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
 					}
 				} else if (canSetBreakpoints) {
-					this.debugService.addBreakpoints(uri, [{ lineNumber }]);
+					this.debugService.addBreakpoints(uri, [{ lineNumber }], `debugEditorGutter`);
 				}
 			}
 		}));

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -1069,23 +1069,18 @@ export class DebugService implements IDebugService {
 	private telemetryDebugAddBreakpoint(breakpoint: IBreakpoint, context: string): TPromise<any> {
 		/* __GDPR__
 			"debugAddBreakpoint" : {
-				"type" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-				"context": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+				"context": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+				"hasCondition": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+				"hasHitCondition": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+				"hasLogMessage": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 			}
 		*/
 
-		var breakpointType = 'Breakpoint';
-		if (breakpoint.condition) {
-			breakpointType = 'BreakpointConditional';
-		} else if (breakpoint.hitCondition) {
-			breakpointType = 'BreakpointHitCount';
-		} else if (breakpoint.logMessage) {
-			breakpointType = 'Logpoint';
-		}
-
 		return this.telemetryService.publicLog('debugAddBreakpoint', {
-			type: breakpointType,
-			context: context
+			context: context,
+			hasCondition: !!breakpoint.condition,
+			hasHitCondition: !!breakpoint.hitCondition,
+			hasLogMessage: !!breakpoint.logMessage
 		});
 	}
 }

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -1068,7 +1068,7 @@ export class DebugService implements IDebugService {
 
 	private telemetryDebugAddBreakpoint(breakpoint: IBreakpoint, context: string): TPromise<any> {
 		/* __GDPR__
-			"DebugAddBreakpoint" : {
+			"debugAddBreakpoint" : {
 				"type" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 				"context": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 			}


### PR DESCRIPTION
Adds telemetry for debug add breakpoints by extending `addBreakpoints` in `debugService` with new `context` parameter. 

Emits new `debugAddBreakpoint` telemetry event with `hasCondition`, `hasHitCondition`,  `hasLogMessage`, and `context` properties.

Fixes #55514

