### PR TITLE
typo: Double word "in"

### DIFF
--- a/extensions/merge-conflict/src/documentMergeConflict.ts
+++ b/extensions/merge-conflict/src/documentMergeConflict.ts
@@ -34,8 +34,8 @@ export class DocumentMergeConflict implements interfaces.IDocumentMergeConflict 
 
 	public applyEdit(type: interfaces.CommitType, editor: vscode.TextEditor, edit: vscode.TextEditorEdit): void {
 
-		// Each conflict is a set of ranges as follows, note placements or newlines
-		// which may not in in spans
+		// Each conflict is a set of ranges as follows, note placements of newlines
+		// which may not be in spans
 		// [ Conflict Range             -- (Entire content below)
 		//   [ Current Header ]\n       -- >>>>> Header
 		//   [ Current Content ]        -- (content)


### PR DESCRIPTION
Also switched or -> of since I couldn't quite follow the current sentence