### PR TITLE
Quote args for bash, fixes #61056

### DIFF
--- a/src/vs/workbench/parts/debug/node/terminals.ts
+++ b/src/vs/workbench/parts/debug/node/terminals.ts
@@ -388,8 +388,8 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 		case ShellType.bash:
 
 			quote = (s: string) => {
-				s = s.replace(/\"/g, '\\"');
-				return (s.indexOf(' ') >= 0 || s.indexOf('\\') >= 0) ? `"${s}"` : s;
+				s = s.replace(/'/g, '\'\\\'\'');
+				return `'${s}'`;
 			};
 
 			if (args.cwd) {
@@ -400,9 +400,9 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 				for (let key in args.env) {
 					const value = args.env[key];
 					if (value === null) {
-						command += ` -u "${key}"`;
+						command += ` -u ${quote(key)}`;
 					} else {
-						command += ` "${key}=${value}"`;
+						command += ` ${quote(`${key}=${value}`)}`;
 					}
 				}
 				command += ' ';


### PR DESCRIPTION
The TerminalLauncher does not properly escape arguments for the Bash
shell. This change wraps all arguments in single-quotes, and escapes the
single quote. This means that bash special characters in arguments will not be
evaluated.