### PR TITLE
Add sort option for breadcrumb symbol trees

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -157,7 +157,7 @@ const configurationValueWhitelist = [
 	'breadcrumbs.enabled',
 	'breadcrumbs.filePath',
 	'breadcrumbs.symbolPath',
-	'breadcrumbs.outlineSort',
+	'breadcrumbs.symbolSortOrder',
 	'breadcrumbs.useQuickPick',
 	'explorer.openEditors.visible',
 	'extensions.autoUpdate',

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -157,6 +157,7 @@ const configurationValueWhitelist = [
 	'breadcrumbs.enabled',
 	'breadcrumbs.filePath',
 	'breadcrumbs.symbolPath',
+	'breadcrumbs.outlineSort',
 	'breadcrumbs.useQuickPick',
 	'explorer.openEditors.visible',
 	'extensions.autoUpdate',

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -70,6 +70,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static UseQuickPick = BreadcrumbsConfig._stub<boolean>('breadcrumbs.useQuickPick');
 	static FilePath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.filePath');
 	static SymbolPath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.symbolPath');
+	static OutlineSort = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.outlineSort');
 	static FilterOnType = BreadcrumbsConfig._stub<boolean>('breadcrumbs.filterOnType');
 
 	static FileExcludes = BreadcrumbsConfig._stub<glob.IExpression>('files.exclude');
@@ -140,6 +141,17 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('symbolpath.on', "Show all symbols in the breadcrumbs view."),
 				localize('symbolpath.off', "Do not show symbols in the breadcrumbs view."),
 				localize('symbolpath.last', "Only show the current symbol in the breadcrumbs view."),
+			]
+		},
+		'breadcrumbs.outlineSort': {
+			description: localize('outlineSort', "Controls how symbols are sorted in the breadcrumbs outline view."),
+			type: 'string',
+			default: 'position',
+			enum: ['position', 'name', 'type'],
+			enumDescriptions: [
+				localize('outlineSort.position', "Show symbol outline in file position order."),
+				localize('outlineSort.name', "Show symbol outline in alphabetical order."),
+				localize('outlineSort.type', "Show symbol outline in symbol type order."),
 			]
 		},
 		// 'breadcrumbs.filterOnType': {

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -70,7 +70,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static UseQuickPick = BreadcrumbsConfig._stub<boolean>('breadcrumbs.useQuickPick');
 	static FilePath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.filePath');
 	static SymbolPath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.symbolPath');
-	static OutlineSort = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.outlineSort');
+	static SymbolSortOrder = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.symbolSortOrder');
 	static FilterOnType = BreadcrumbsConfig._stub<boolean>('breadcrumbs.filterOnType');
 
 	static FileExcludes = BreadcrumbsConfig._stub<glob.IExpression>('files.exclude');
@@ -143,15 +143,15 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('symbolpath.last', "Only show the current symbol in the breadcrumbs view."),
 			]
 		},
-		'breadcrumbs.outlineSort': {
-			description: localize('outlineSort', "Controls how symbols are sorted in the breadcrumbs outline view."),
+		'breadcrumbs.symbolSortOrder': {
+			description: localize('symbolSortOrder', "Controls how symbols are sorted in the breadcrumbs outline view."),
 			type: 'string',
 			default: 'position',
 			enum: ['position', 'name', 'type'],
 			enumDescriptions: [
-				localize('outlineSort.position', "Show symbol outline in file position order."),
-				localize('outlineSort.name', "Show symbol outline in alphabetical order."),
-				localize('outlineSort.type', "Show symbol outline in symbol type order."),
+				localize('symbolSortOrder.position', "Show symbol outline in file position order."),
+				localize('symbolSortOrder.name', "Show symbol outline in alphabetical order."),
+				localize('symbolSortOrder.type', "Show symbol outline in symbol type order."),
 			]
 		},
 		// 'breadcrumbs.filterOnType': {

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
@@ -52,7 +52,7 @@ export abstract class BreadcrumbsPicker {
 	protected readonly _treeContainer: HTMLDivElement;
 	protected readonly _tree: HighlightingWorkbenchTree;
 	protected readonly _focus: dom.IFocusTracker;
-	protected readonly _outlineSort: BreadcrumbsConfig<'position' | 'name' | 'type'>;
+	protected readonly _symbolSortOrder: BreadcrumbsConfig<'position' | 'name' | 'type'>;
 	private _layoutInfo: ILayoutInfo;
 
 	private readonly _onDidPickElement = new Emitter<{ target: any, payload: any }>();
@@ -89,7 +89,7 @@ export abstract class BreadcrumbsPicker {
 		this._treeContainer.style.boxShadow = `0px 5px 8px ${this._themeService.getTheme().getColor(widgetShadow)}`;
 		this._domNode.appendChild(this._treeContainer);
 
-		this._outlineSort = BreadcrumbsConfig.OutlineSort.bindTo(this._configurationService);
+		this._symbolSortOrder = BreadcrumbsConfig.SymbolSortOrder.bindTo(this._configurationService);
 
 		const filterConfig = BreadcrumbsConfig.FilterOnType.bindTo(this._configurationService);
 		this._disposables.push(filterConfig);
@@ -147,7 +147,7 @@ export abstract class BreadcrumbsPicker {
 		this._onDidPickElement.dispose();
 		this._tree.dispose();
 		this._focus.dispose();
-		this._outlineSort.dispose();
+		this._symbolSortOrder.dispose();
 	}
 
 	setInput(input: any, maxHeight: number, width: number, arrowSize: number, arrowOffset: number): void {
@@ -483,7 +483,7 @@ export class BreadcrumbsOutlinePicker extends BreadcrumbsPicker {
 	}
 
 	private _getOutlineItemComparator(): OutlineItemCompareType {
-		switch (this._outlineSort.getValue()) {
+		switch (this._symbolSortOrder.getValue()) {
 			case 'name':
 				return OutlineItemCompareType.ByName;
 			case 'type':

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
@@ -18,7 +18,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IDataSource, IFilter, IRenderer, ISorter, ITree } from 'vs/base/parts/tree/browser/tree';
 import 'vs/css!./media/breadcrumbscontrol';
 import { OutlineElement, OutlineModel, TreeElement } from 'vs/editor/contrib/documentSymbols/outlineModel';
-import { OutlineDataSource, OutlineItemComparator, OutlineRenderer } from 'vs/editor/contrib/documentSymbols/outlineTree';
+import { OutlineDataSource, OutlineItemComparator, OutlineRenderer, OutlineItemCompareType } from 'vs/editor/contrib/documentSymbols/outlineTree';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { FileKind, IFileService, IFileStat } from 'vs/platform/files/common/files';
@@ -52,6 +52,7 @@ export abstract class BreadcrumbsPicker {
 	protected readonly _treeContainer: HTMLDivElement;
 	protected readonly _tree: HighlightingWorkbenchTree;
 	protected readonly _focus: dom.IFocusTracker;
+	protected readonly _outlineSort: BreadcrumbsConfig<'position' | 'name' | 'type'>;
 	private _layoutInfo: ILayoutInfo;
 
 	private readonly _onDidPickElement = new Emitter<{ target: any, payload: any }>();
@@ -88,14 +89,16 @@ export abstract class BreadcrumbsPicker {
 		this._treeContainer.style.boxShadow = `0px 5px 8px ${this._themeService.getTheme().getColor(widgetShadow)}`;
 		this._domNode.appendChild(this._treeContainer);
 
+		this._outlineSort = BreadcrumbsConfig.OutlineSort.bindTo(this._configurationService);
+
 		const filterConfig = BreadcrumbsConfig.FilterOnType.bindTo(this._configurationService);
 		this._disposables.push(filterConfig);
 
-		const treeConifg = this._completeTreeConfiguration({ dataSource: undefined, renderer: undefined, highlighter: undefined });
+		const treeConfig = this._completeTreeConfiguration({ dataSource: undefined, renderer: undefined, highlighter: undefined });
 		this._tree = this._instantiationService.createInstance(
 			HighlightingWorkbenchTree,
 			this._treeContainer,
-			treeConifg,
+			treeConfig,
 			<IHighlightingTreeOptions>{ useShadows: false, filterOnType: filterConfig.getValue(), showTwistie: false, twistiePixels: 12 },
 			{ placeholder: localize('placeholder', "Find") }
 		);
@@ -144,6 +147,7 @@ export abstract class BreadcrumbsPicker {
 		this._onDidPickElement.dispose();
 		this._tree.dispose();
 		this._focus.dispose();
+		this._outlineSort.dispose();
 	}
 
 	setInput(input: any, maxHeight: number, width: number, arrowSize: number, arrowOffset: number): void {
@@ -464,7 +468,7 @@ export class BreadcrumbsOutlinePicker extends BreadcrumbsPicker {
 	protected _completeTreeConfiguration(config: IHighlightingTreeConfiguration): IHighlightingTreeConfiguration {
 		config.dataSource = this._instantiationService.createInstance(OutlineDataSource);
 		config.renderer = this._instantiationService.createInstance(OutlineRenderer);
-		config.sorter = new OutlineItemComparator();
+		config.sorter = new OutlineItemComparator(this._getOutlineItemComparator());
 		config.highlighter = new OutlineHighlighter();
 		return config;
 	}
@@ -475,6 +479,18 @@ export class BreadcrumbsOutlinePicker extends BreadcrumbsPicker {
 		}
 		if (element instanceof OutlineElement) {
 			return element;
+		}
+	}
+
+	private _getOutlineItemComparator(): OutlineItemCompareType {
+		switch (this._outlineSort.getValue()) {
+			case 'name':
+				return OutlineItemCompareType.ByName;
+			case 'type':
+				return OutlineItemCompareType.ByKind;
+			case 'position':
+			default:
+				return OutlineItemCompareType.ByPosition;
 		}
 	}
 }


### PR DESCRIPTION
'Position' shows symbols in file position order (default).
'Name' shows symbols in alphabetical order.
'Type' shows the symbols in symbol type order.

The configuration setting is not watched anywhere since the
breadcrumbs tree view is transient and would disappear in
changing the setting.

Implements #56695 
Effected by styling bug #61365 