### PR TITLE
Add url attribute to diagnostics and markers, rendering as links in various views (#11847)

### DIFF
--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -164,28 +164,30 @@ class ModelMarkerHandler {
 		}
 
 		let hoverMessage: MarkdownString | null = null;
-		let { message, source, relatedInformation, code } = marker;
+		let { message, source, relatedInformation, url, code } = marker;
 
 		if (typeof message === 'string') {
 			message = message.trim();
 
 			if (source) {
+				let codeSuffix = url ? `[${code}](${url})` : code;
+
 				if (/\n/g.test(message)) {
 					if (code) {
-						message = nls.localize('diagAndSourceAndCodeMultiline', "[{0}]\n{1} [{2}]", source, message, code);
+						message = nls.localize('diagAndSourceAndCodeMultiline', "[{0}]\n{1} [{2}]", source, message, codeSuffix);
 					} else {
 						message = nls.localize('diagAndSourceMultiline', "[{0}]\n{1}", source, message);
 					}
 				} else {
 					if (code) {
-						message = nls.localize('diagAndSourceAndCode', "[{0}] {1} [{2}]", source, message, code);
+						message = nls.localize('diagAndSourceAndCode', "[{0}] {1} [{2}]", source, message, codeSuffix);
 					} else {
 						message = nls.localize('diagAndSource', "[{0}] {1}", source, message);
 					}
 				}
 			}
 
-			hoverMessage = new MarkdownString().appendCodeblock('_', message);
+			hoverMessage = new MarkdownString().appendMarkdown(message);
 
 			if (!isFalsyOrEmpty(relatedInformation)) {
 				hoverMessage.appendMarkdown('\n');

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1121,6 +1121,7 @@ declare namespace monaco.editor {
 		resource: Uri;
 		severity: MarkerSeverity;
 		code?: string;
+		url?: string;
 		message: string;
 		source?: string;
 		startLineNumber: number;
@@ -1136,6 +1137,7 @@ declare namespace monaco.editor {
 	 */
 	export interface IMarkerData {
 		code?: string;
+		url?: string;
 		severity: MarkerSeverity;
 		message: string;
 		source?: string;

--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -179,7 +179,7 @@ export class MarkerService implements IMarkerService {
 
 	private static _toMarker(owner: string, resource: URI, data: IMarkerData): IMarker | undefined {
 		let {
-			code, severity,
+			code, url, severity,
 			message, source,
 			startLineNumber, startColumn, endLineNumber, endColumn,
 			relatedInformation,
@@ -192,6 +192,7 @@ export class MarkerService implements IMarkerService {
 
 		// santize data
 		code = code || null;
+		url = url || null;
 		startLineNumber = startLineNumber > 0 ? startLineNumber : 1;
 		startColumn = startColumn > 0 ? startColumn : 1;
 		endLineNumber = endLineNumber >= startLineNumber ? endLineNumber : startLineNumber;
@@ -201,6 +202,7 @@ export class MarkerService implements IMarkerService {
 			resource,
 			owner,
 			code,
+			url,
 			severity,
 			message,
 			source,

--- a/src/vs/platform/markers/common/markers.ts
+++ b/src/vs/platform/markers/common/markers.ts
@@ -78,6 +78,7 @@ export namespace MarkerSeverity {
  */
 export interface IMarkerData {
 	code?: string;
+	url?: string;
 	severity: MarkerSeverity;
 	message: string;
 	source?: string;
@@ -99,6 +100,7 @@ export interface IMarker {
 	resource: URI;
 	severity: MarkerSeverity;
 	code?: string;
+	url?: string;
 	message: string;
 	source?: string;
 	startLineNumber: number;
@@ -127,6 +129,11 @@ export namespace IMarkerData {
 		}
 		if (markerData.code) {
 			result.push(markerData.code.replace('¦', '\¦'));
+		} else {
+			result.push(emptyString);
+		}
+		if (markerData.url) {
+			result.push(markerData.url.replace('¦', '\¦'));
 		} else {
 			result.push(emptyString);
 		}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4097,6 +4097,11 @@ declare module 'vscode' {
 		code?: string | number;
 
 		/**
+		 * A HTTP URL to a resource explaining the diagnostic.
+		 */
+		url?: string;
+
+		/**
 		 * An array of related diagnostic information, e.g. when symbol-names within
 		 * a scope collide all definitions can be marked via this property.
 		 */

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -108,6 +108,7 @@ export namespace Diagnostic {
 			message: value.message,
 			source: value.source,
 			code: isString(value.code) || isNumber(value.code) ? String(value.code) : void 0,
+			url: isString(value.url) ? value.url : void 0,
 			severity: DiagnosticSeverity.from(value.severity),
 			relatedInformation: value.relatedInformation && value.relatedInformation.map(DiagnosticRelatedInformation.from),
 			tags: Array.isArray(value.tags) ? value.tags.map(DiagnosticTag.from) : undefined,

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -791,6 +791,7 @@ export class Diagnostic {
 	message: string;
 	source: string;
 	code: string | number;
+	url?: string;
 	severity: DiagnosticSeverity;
 	relatedInformation: DiagnosticRelatedInformation[];
 	tags?: DiagnosticTag[];
@@ -808,6 +809,7 @@ export class Diagnostic {
 			range: this.range,
 			source: this.source,
 			code: this.code,
+			url: this.url,
 		};
 	}
 
@@ -821,6 +823,7 @@ export class Diagnostic {
 		return a.message === b.message
 			&& a.severity === b.severity
 			&& a.code === b.code
+			&& a.url === b.url
 			&& a.severity === b.severity
 			&& a.source === b.source
 			&& a.range.isEqual(b.range)

--- a/src/vs/workbench/parts/markers/electron-browser/markersTreeViewer.ts
+++ b/src/vs/workbench/parts/markers/electron-browser/markersTreeViewer.ts
@@ -223,7 +223,7 @@ export class MarkerRenderer implements ITreeRenderer<Marker, MarkerFilterData, I
 		data.icon = dom.append(container, dom.$('.icon'));
 		data.source = new HighlightedLabel(dom.append(container, dom.$('')));
 		data.description = new HighlightedLabel(dom.append(container, dom.$('.marker-description')));
-		data.code = new HighlightedLabel(dom.append(container, dom.$('')));
+		data.code = new HighlightedLabel(dom.append(container, dom.$('a')));
 		data.lnCol = dom.append(container, dom.$('span.marker-line'));
 		return data;
 	}
@@ -248,6 +248,11 @@ export class MarkerRenderer implements ITreeRenderer<Marker, MarkerFilterData, I
 
 		dom.toggleClass(templateData.code.element, 'marker-code', !!marker.code);
 		templateData.code.set(marker.code || '', codeMatches);
+
+		if (marker.url) {
+			templateData.code.element.parentElement.setAttribute('href', marker.url);
+			templateData.code.element.parentElement.setAttribute('target', '_blank');
+		}
 
 		templateData.lnCol.textContent = Messages.MARKERS_PANEL_AT_LINE_COL_NUMBER(marker.startLineNumber, marker.startColumn);
 	}

--- a/src/vs/workbench/parts/markers/test/electron-browser/markersModel.test.ts
+++ b/src/vs/workbench/parts/markers/test/electron-browser/markersModel.test.ts
@@ -105,6 +105,7 @@ suite('MarkersModel Test', () => {
 	test('toString()', () => {
 		let marker = aMarker('a/res1');
 		marker.code = '1234';
+		marker.url = 'https://www.example.com/';
 		assert.equal(JSON.stringify({ ...marker, resource: marker.resource.path }, null, '\t'), new Marker(marker).toString());
 
 		marker = aMarker('a/res2', MarkerSeverity.Warning);


### PR DESCRIPTION
Fixes #11847. This adds a `url` field to the [Diagnostic](https://code.visualstudio.com/docs/extensionAPI/vscode-api#Diagnostic) API, as well as to Marker. This field is optional, and will be rendered as a link on the existing `code` rendering (#60749, #49215).

Here is what this looks like in the three UIs I've implemented it so far:

<img width="686" alt="diagnostic-link-11847" src="https://user-images.githubusercontent.com/877585/47269014-bb415d80-d560-11e8-9cb0-b34691d2a609.png">

The visual appearance could be better in all three cases; but I will need guidance to understand how best to improve this.

This specific example uses the URL provided by my PR to vscode-eslint: https://github.com/Microsoft/vscode-eslint/pull/562. All of this is inspired by the prior art of Atom and its linter-eslint. See https://github.com/Microsoft/vscode/issues/11847#issuecomment-429770826 for more details.

Note: for this to work, https://github.com/Microsoft/vscode-languageserver-node/pull/432 is also needed.

---

To test this, here is what is needed:

- Dev environment of https://github.com/Microsoft/vscode
- Dev environment of https://github.com/Microsoft/vscode-eslint
- Dev environment of https://github.com/Microsoft/vscode-extension-vscode
- Dev environment of https://github.com/Microsoft/vscode-languageserver-node
- `npm link` all of these between one another.
- Manually copy the dev `vscode.d.ts` from `vscode` to `vscode-extension-vscode` (I think)
- Start the dev version of VS Code as specified in `vscode`, then with this dev editor open `vscode-eslint` and use its "Launch Extension" launch configuration.