### PR TITLE
fixing strict null check errors (#61093)

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -381,6 +381,7 @@
 		"./vs/platform/integrity/common/integrity.ts",
 		"./vs/platform/integrity/node/integrityServiceImpl.ts",
 		"./vs/platform/issue/common/issue.ts",
+		"./vs/platform/issue/node/issueIpc.ts",
 		"./vs/platform/jsonschemas/common/jsonContributionRegistry.ts",
 		"./vs/platform/keybinding/common/abstractKeybindingService.ts",
 		"./vs/platform/keybinding/common/keybinding.ts",

--- a/src/vs/platform/issue/node/issueIpc.ts
+++ b/src/vs/platform/issue/node/issueIpc.ts
@@ -29,7 +29,7 @@ export class IssueChannel implements IIssueChannel {
 			case 'openProcessExplorer':
 				return this.service.openProcessExplorer(arg);
 		}
-		return undefined;
+		return TPromise.as(null);
 	}
 }
 


### PR DESCRIPTION
First attempt on #61093.

Also saw that `src/vs/platform/telemetry/common/telemetryService.ts` (which is included in strictNullChecks.json) is using a return value of `TPromise.as(undefined);` and wondered if that was preferred