### PR TITLE
Hide icons when using no-icons class

### DIFF
--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -162,6 +162,7 @@
 	display: none;
 }
 
+.monaco-editor .suggest-widget.no-icons .monaco-list .monaco-list-row .icon,
 .monaco-editor .suggest-widget.no-icons .monaco-list .monaco-list-row .monaco-icon-label.suggest-icon::before {
 	display: none;
 }

--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -162,7 +162,7 @@
 	display: none;
 }
 
-.monaco-editor .suggest-widget.no-icons .monaco-list .monaco-list-row .icon {
+.monaco-editor .suggest-widget.no-icons .monaco-list .monaco-list-row .monaco-icon-label.suggest-icon::before {
 	display: none;
 }
 


### PR DESCRIPTION
This PR fixes #61459

The bug is a regression due to https://github.com/Microsoft/vscode/commit/f13c8d1eab216fb84472a68c3ba8c3d9d76b1a30#diff-b1e324b56791c91ba94b301f2d739ea9

@jrieken Now that we use the icon-label to show the icons, what is the purpose of .icon now?


