### PR TITLE
#61410 Add keybinding to "Find in Folder" action

### DIFF
--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -371,7 +371,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: FIND_IN_FOLDER_ID,
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: ContextKeyExpr.and(ExplorerFolderContext, ResourceContextKey.Scheme.isEqualTo(Schemas.file)), // todo@remote
-	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_F,
+	primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KEY_F,
 	handler: searchInFolderCommand
 });
 

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -376,11 +376,6 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 CommandsRegistry.registerCommand({
-	id: FIND_IN_FOLDER_ID,
-	handler: searchInFolderCommand
-});
-
-CommandsRegistry.registerCommand({
 	id: ClearSearchResultsAction.ID,
 	handler: (accessor, args: any) => {
 		accessor.get(IInstantiationService).createInstance(ClearSearchResultsAction, ClearSearchResultsAction.ID, '').run();

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -20,7 +20,7 @@ import { getSelectionSearchString } from 'vs/editor/contrib/find/findController'
 import { ToggleCaseSensitiveKeybinding, ToggleRegexKeybinding, ToggleWholeWordKeybinding } from 'vs/editor/contrib/find/findModel';
 import * as nls from 'vs/nls';
 import { ICommandAction, MenuId, MenuRegistry, SyncActionDescriptor } from 'vs/platform/actions/common/actions';
-import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandHandler } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -340,34 +340,44 @@ const FocusSearchListCommand: ICommandAction = {
 };
 MenuRegistry.addCommand(FocusSearchListCommand);
 
+const searchInFolderCommand: ICommandHandler = (accessor, resource?: URI) => {
+	const listService = accessor.get(IListService);
+	const viewletService = accessor.get(IViewletService);
+	const panelService = accessor.get(IPanelService);
+	const fileService = accessor.get(IFileService);
+	const resources = getMultiSelectedResources(resource, listService, accessor.get(IEditorService));
+
+	return openSearchView(viewletService, panelService, true).then(searchView => {
+		if (resources && resources.length) {
+			return fileService.resolveFiles(resources.map(resource => ({ resource }))).then(results => {
+				const folders: URI[] = [];
+
+				results.forEach(result => {
+					if (result.success) {
+						folders.push(result.stat.isDirectory ? result.stat.resource : dirname(result.stat.resource));
+					}
+				});
+
+				searchView.searchInFolders(distinct(folders, folder => folder.toString()), (from, to) => relative(from, to));
+			});
+		}
+
+		return void 0;
+	});
+};
+
 const FIND_IN_FOLDER_ID = 'filesExplorer.findInFolder';
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: FIND_IN_FOLDER_ID,
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: ContextKeyExpr.and(ExplorerFolderContext, ResourceContextKey.Scheme.isEqualTo(Schemas.file)), // todo@remote
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_F,
+	handler: searchInFolderCommand
+});
+
 CommandsRegistry.registerCommand({
 	id: FIND_IN_FOLDER_ID,
-	handler: (accessor, resource?: URI) => {
-		const listService = accessor.get(IListService);
-		const viewletService = accessor.get(IViewletService);
-		const panelService = accessor.get(IPanelService);
-		const fileService = accessor.get(IFileService);
-		const resources = getMultiSelectedResources(resource, listService, accessor.get(IEditorService));
-
-		return openSearchView(viewletService, panelService, true).then(searchView => {
-			if (resources && resources.length) {
-				return fileService.resolveFiles(resources.map(resource => ({ resource }))).then(results => {
-					const folders: URI[] = [];
-
-					results.forEach(result => {
-						if (result.success) {
-							folders.push(result.stat.isDirectory ? result.stat.resource : dirname(result.stat.resource));
-						}
-					});
-
-					searchView.searchInFolders(distinct(folders, folder => folder.toString()), (from, to) => relative(from, to));
-				});
-			}
-
-			return void 0;
-		});
-	}
+	handler: searchInFolderCommand
 });
 
 CommandsRegistry.registerCommand({


### PR DESCRIPTION
Resolves https://github.com/Microsoft/vscode/issues/61410

Decided to go with proposed <kbd>cmd+alt+f</kbd> / <kbd>ctrl+alt+f</kbd>

I left the handler in `search.contibutions.ts` because of import linting rules on `workbench/parts/*/browser/*` files.  Happy to fix that if pointed how.