### PR TITLE
Fix Markdown Preview incorrectly encodes a link

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -181,7 +181,8 @@ export class MarkdownEngine {
 			try {
 				const externalSchemeUri = getUriForLinkWithKnownExternalScheme(link);
 				if (externalSchemeUri) {
-					return normalizeLink(externalSchemeUri.toString());
+					// set true to skip encoding
+					return normalizeLink(externalSchemeUri.toString(true));
 				}
 
 


### PR DESCRIPTION
For known external scheme, the customized normalizeLink method use vscode.Uri to parse and create
the string representation of the link before caling the original normalizeLink method.
The toString method of vscode.Uri encodes the result by default, and this is unecessary since encoding
is handled by the original normalizeLink method.

Calls toString method with skipEncoding option.

Resolves: #60525