### PR TITLE
Correcting minLength and maxLength validation messages

### DIFF
--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -1082,12 +1082,12 @@ export function createValidator(prop: IConfigurationPropertySchema): ((value: an
 			{
 				enabled: prop.maxLength !== undefined,
 				isValid: (value => value.length <= prop.maxLength),
-				message: nls.localize('validations.maxLength', "Value must be fewer than {0} characters long.", prop.maxLength)
+				message: nls.localize('validations.maxLength', "Value must be {0} or fewer characters long.", prop.maxLength)
 			},
 			{
 				enabled: prop.minLength !== undefined,
 				isValid: (value => value.length >= prop.minLength),
-				message: nls.localize('validations.minLength', "Value must be more than {0} characters long.", prop.minLength)
+				message: nls.localize('validations.minLength', "Value must be {0} or more characters long.", prop.minLength)
 			},
 			{
 				enabled: patternRegex !== undefined,


### PR DESCRIPTION
If user violates `minLength` or `maxLength` configuration constraint, he receives slightly incorrect message. For example, for the following setting:

    "type": "string",
    "minLength": 4

message displayed if only 3 characters are entered would be:

    Value must be more than 4 characters long.

This is incorrect as comparison is than with larger-then-or-equal operator. Correct message should be:

    Value must be 4 or more characters long.

Same principle goes for `maxLength`.