### PR TITLE
Simplify not-in-use conditional operator

### DIFF
--- a/src/vs/platform/storage/node/storageService.ts
+++ b/src/vs/platform/storage/node/storageService.ts
@@ -77,7 +77,7 @@ export class StorageService extends Disposable implements IStorageService {
 			}
 		};
 
-		this.globalStorageWorkspacePath = workspaceStoragePath === StorageService.IN_MEMORY_PATH ? StorageService.IN_MEMORY_PATH : StorageService.IN_MEMORY_PATH;
+		this.globalStorageWorkspacePath = StorageService.IN_MEMORY_PATH;
 		this.globalStorage = new Storage({ path: this.globalStorageWorkspacePath, logging: this.loggingOptions });
 		this._register(this.globalStorage.onDidChangeStorage(key => this.handleDidChangeStorage(key, StorageScope.GLOBAL)));
 


### PR DESCRIPTION
A conditional operator for `this.globalStorageWorkspacePath` practically does nothing. I suppose it was meant to be used someway when first written in https://github.com/Microsoft/vscode/commit/d68c05c3d93c11d0995888b9d4e68207825819af . Could be a result of copy & paste error?