### PR TITLE
Support configuring TypeScript plugins

### DIFF
--- a/extensions/typescript-language-features/src/commands.ts
+++ b/extensions/typescript-language-features/src/commands.ts
@@ -105,6 +105,18 @@ export class JavaScriptGoToProjectConfigCommand implements Command {
 	}
 }
 
+export class ConfigurePluginCommand implements Command {
+	public readonly id = '_typescript.configurePlugin';
+
+	public constructor(
+		private readonly lazyClientHost: Lazy<TypeScriptServiceClientHost>,
+	) { }
+
+	public execute(pluginName: string, configuration: any) {
+		this.lazyClientHost.value.serviceClient.configurePlugin(pluginName, configuration, true /* reconfigureOnRestart */);
+	}
+}
+
 async function goToProjectConfig(
 	clientHost: TypeScriptServiceClientHost,
 	isTypeScriptProject: boolean,

--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -108,6 +108,7 @@ function registerCommands(
 	commandManager.register(new commands.RestartTsServerCommand(lazyClientHost));
 	commandManager.register(new commands.TypeScriptGoToProjectConfigCommand(lazyClientHost));
 	commandManager.register(new commands.JavaScriptGoToProjectConfigCommand(lazyClientHost));
+	commandManager.register(new commands.ConfigurePluginCommand(lazyClientHost));
 }
 
 function isSupportedDocument(

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -71,6 +71,8 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 	public readonly bufferSyncSupport: BufferSyncSupport;
 	public readonly diagnosticsManager: DiagnosticsManager;
 
+	private pluginConfigurations: Map<string, any>;
+
 	constructor(
 		private readonly workspaceState: vscode.Memento,
 		private readonly onDidChangeTypeScriptVersion: (version: TypeScriptVersion) => void,
@@ -132,6 +134,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		this.telemetryReporter = this._register(new TelemetryReporter(() => this._tsserverVersion || this._apiVersion.versionString));
 
 		this.typescriptServerSpawner = new TypeScriptServerSpawner(this.versionProvider, this.logDirectoryProvider, this.pluginPathsProvider, this.logger, this.telemetryReporter, this.tracer);
+		this.pluginConfigurations = new Map<string, any>();
 	}
 
 	public get configuration() {
@@ -406,6 +409,11 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		if (resendModels) {
 			this._onResendModelsRequested.fire();
 		}
+
+		// Reconfigure any plugins
+		this.pluginConfigurations.forEach((config, pluginName) => {
+			this.configurePlugin(pluginName, config);
+		});
 	}
 
 	private setCompilerOptionsForInferredProjects(configuration: TypeScriptServiceConfiguration): void {
@@ -718,8 +726,16 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		this._apiVersion = API.defaultVersion;
 		this._tsserverVersion = undefined;
 	}
-}
 
+	public configurePlugin(pluginName: string, configuration: any, reconfigureOnRestart?: boolean): any {
+		this.executeWithoutWaitingForResponse('configurePlugin', { pluginName, configuration });
+
+		if (reconfigureOnRestart) {
+			// Remember the updated configuration so we can send the command again if TSServer restarts for any reason
+			this.pluginConfigurations.set(pluginName, configuration);
+		}
+	}
+}
 
 function getDignosticsKind(event: Proto.Event) {
 	switch (event.event) {


### PR DESCRIPTION
Depends on https://github.com/Microsoft/TypeScript/pull/28106

- Register a new command, '_typescript.configurePlugin', that may be invoked from other VSCode extensions that contribute TypeScript plugins to send additional configuration data.
- The configuration is passed along using the `configurePlugins` tsserver command (see https://github.com/Microsoft/TypeScript/pull/28106)
- If tsserver restarts for any reason, the most recent configurations set by this command, if any, will be reset via another `configurePlugins` call.