### PR TITLE
Change 'overwrite' to 'override' in setting screens

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/parts/preferences/browser/preferencesRenderers.ts
@@ -95,7 +95,7 @@ export class UserSettingsRenderer extends Disposable implements IPreferencesRend
 	}
 
 	protected createHeader(): void {
-		this._register(new SettingsHeaderWidget(this.editor, '')).setMessage(nls.localize('emptyUserSettingsHeader', "Place your settings here to overwrite the Default Settings."));
+		this._register(new SettingsHeaderWidget(this.editor, '')).setMessage(nls.localize('emptyUserSettingsHeader', "Place your settings here to override the Default Settings."));
 	}
 
 	public render(): void {
@@ -191,7 +191,7 @@ export class WorkspaceSettingsRenderer extends UserSettingsRenderer implements I
 	}
 
 	protected createHeader(): void {
-		this._register(new SettingsHeaderWidget(this.editor, '')).setMessage(nls.localize('emptyWorkspaceSettingsHeader', "Place your settings here to overwrite the User Settings."));
+		this._register(new SettingsHeaderWidget(this.editor, '')).setMessage(nls.localize('emptyWorkspaceSettingsHeader', "Place your settings here to override the User Settings."));
 	}
 
 	public setAssociatedPreferencesModel(associatedPreferencesModel: IPreferencesEditorModel<ISetting>): void {
@@ -217,7 +217,7 @@ export class FolderSettingsRenderer extends UserSettingsRenderer implements IPre
 	}
 
 	protected createHeader(): void {
-		this._register(new SettingsHeaderWidget(this.editor, '')).setMessage(nls.localize('emptyFolderSettingsHeader', "Place your folder settings here to overwrite those from the Workspace Settings."));
+		this._register(new SettingsHeaderWidget(this.editor, '')).setMessage(nls.localize('emptyFolderSettingsHeader', "Place your folder settings here to override those from the Workspace Settings."));
 	}
 
 }

--- a/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingEditing.ts
@@ -246,6 +246,6 @@ export class KeybindingsEditingService extends Disposable implements IKeybinding
 	}
 
 	private getEmptyContent(EOL: string): string {
-		return '// ' + localize('emptyKeybindingsHeader', "Place your key bindings in this file to overwrite the defaults") + EOL + '[]';
+		return '// ' + localize('emptyKeybindingsHeader', "Place your key bindings in this file to override the defaults") + EOL + '[]';
 	}
 }

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -257,7 +257,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		*/
 		this.telemetryService.publicLog('openKeybindings', { textual });
 		if (textual) {
-			const emptyContents = '// ' + nls.localize('emptyKeybindingsHeader', "Place your key bindings in this file to overwrite the defaults") + '\n[\n]';
+			const emptyContents = '// ' + nls.localize('emptyKeybindingsHeader', "Place your key bindings in this file to override the defaults") + '\n[\n]';
 			const editableKeybindings = URI.file(this.environmentService.appKeybindingsPath);
 			const openDefaultKeybindings = !!this.configurationService.getValue('workbench.settings.openDefaultKeybindings');
 

--- a/src/vs/workbench/services/preferences/common/preferencesModels.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesModels.ts
@@ -1126,7 +1126,7 @@ function escapeInvisibleChars(enumValue: string): string {
 }
 
 export function defaultKeybindingsContents(keybindingService: IKeybindingService): string {
-	const defaultsHeader = '// ' + nls.localize('defaultKeybindingsHeader', "Overwrite key bindings by placing them into your key bindings file.");
+	const defaultsHeader = '// ' + nls.localize('defaultKeybindingsHeader', "Override key bindings by placing them into your key bindings file.");
 	return defaultsHeader + '\n' + keybindingService.getDefaultKeybindingsContent();
 }
 


### PR DESCRIPTION
On screens for workplace, folder, and other settings, there are prompts that inform the user of the hierarchy of the settings.
Overwrite implies that the setting will be changed rather than superseded.