### PR TITLE
List: Support dynamic height elements

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -8,6 +8,7 @@ import { GestureEvent } from 'vs/base/browser/touch';
 export interface IListVirtualDelegate<T> {
 	getHeight(element: T): number;
 	getTemplateId(element: T): string;
+	hasDynamicHeight?(element: T): boolean;
 }
 
 export interface IListRenderer<T, TTemplateData> {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -68,6 +68,10 @@ export class ComposedTreeDelegate<T, N extends { element: T }> implements IListV
 	getTemplateId(element: N): string {
 		return this.delegate.getTemplateId(element.element);
 	}
+
+	hasDynamicHeight(element: N): boolean {
+		return !!this.delegate.hasDynamicHeight && this.delegate.hasDynamicHeight(element.element);
+	}
 }
 
 interface ITreeListTemplateData<T> {

--- a/test/tree/public/index.html
+++ b/test/tree/public/index.html
@@ -45,13 +45,16 @@
 			function createIndexTree() {
 				const delegate = {
 					getHeight() { return 22; },
-					getTemplateId() { return 'template'; }
+					getTemplateId() { return 'template'; },
+					hasDynamicHeight() { return true; }
 				};
 
 				const renderer = {
 					templateId: 'template',
 					renderTemplate(container) { return container; },
-					renderElement(element, index, container) { container.textContent = element.element; },
+					renderElement(element, index, container) {
+						container.innerHTML = `${element.element}<br />${element.element}<br />${element.element}`;
+					},
 					disposeElement() { },
 					disposeTemplate() { }
 				};
@@ -79,7 +82,7 @@
 					}
 				};
 
-				const tree = new IndexTree(container, delegate, [renderer], { filter: treeFilter });
+				const tree = new IndexTree(container, delegate, [renderer], { filter: treeFilter, setRowLineHeight: false });
 
 				return { tree, treeFilter };
 			}

--- a/test/tree/public/index.html
+++ b/test/tree/public/index.html
@@ -82,7 +82,7 @@
 					}
 				};
 
-				const tree = new IndexTree(container, delegate, [renderer], { filter: treeFilter, setRowLineHeight: false });
+				const tree = new IndexTree(container, delegate, [renderer], { filter: treeFilter, setRowLineHeight: false, supportDynamicHeights: true });
 
 				return { tree, treeFilter };
 			}

--- a/test/tree/server.js
+++ b/test/tree/server.js
@@ -17,7 +17,7 @@ async function getTree(fsPath, level) {
 	const element = path.basename(fsPath);
 	const stat = await fs.stat(fsPath);
 
-	if (!stat.isDirectory() || element === '.git' || element === '.build' || level >= 5) {
+	if (!stat.isDirectory() || element === '.git' || element === '.build' || level >= 2) {
 		return { element };
 	}
 


### PR DESCRIPTION
Dynamic height elements:

- [x] Have a provisional height, provided by the virtual delegate
- [x] Get an accurate height value when they actually get rendered
- [x] Can get their height value invalidated when the list's width changes

This comes at a performance cost.

This will be useful for the settings editor @roblourens  as well as the debug console @isidorn .