### PR TITLE
Fix typo in comments

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,7 +81,7 @@ function onReady() {
 			nlsConfiguration = Promise.resolve(undefined);
 		}
 
-		// We first need to test a user defined locale. If it fails we try the app locale.
+		// First, we need to test a user defined locale. If it fails we try the app locale.
 		// If that fails we fall back to English.
 		nlsConfiguration.then((nlsConfig) => {
 

--- a/src/typings/node-pty.d.ts
+++ b/src/typings/node-pty.d.ts
@@ -11,7 +11,7 @@ declare module 'node-pty' {
 	 * escaped properly.
 	 * @param options The options of the terminal.
 	 * @see CommandLineToArgvW https://msdn.microsoft.com/en-us/library/windows/desktop/bb776391(v=vs.85).aspx
-	 * @see Parsing C++ Comamnd-Line Arguments https://msdn.microsoft.com/en-us/library/17w5ykft.aspx
+	 * @see Parsing C++ Command-Line Arguments https://msdn.microsoft.com/en-us/library/17w5ykft.aspx
 	 * @see GetCommandLine https://msdn.microsoft.com/en-us/library/windows/desktop/ms683156.aspx
 	 */
 	export function spawn(file: string, args: string[] | string, options: IPtyForkOptions): IPty;
@@ -58,7 +58,7 @@ declare module 'node-pty' {
 
 	  /**
 	   * Resizes the dimensions of the pty.
-	   * @param columns THe number of columns to use.
+	   * @param columns The number of columns to use.
 	   * @param rows The number of rows to use.
 	   */
 	  resize(columns: number, rows: number): void;

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -46,7 +46,7 @@ export interface IFileService {
 	onDidChangeFileSystemProviderRegistrations: Event<IFileSystemProviderRegistrationEvent>;
 
 	/**
-	 * Registeres a file system provider for a certain scheme.
+	 * Registers a file system provider for a certain scheme.
 	 */
 	registerProvider(scheme: string, provider: IFileSystemProvider): IDisposable;
 
@@ -80,7 +80,7 @@ export interface IFileService {
 	resolveFiles(toResolve: { resource: URI, options?: IResolveFileOptions }[]): TPromise<IResolveFileResult[]>;
 
 	/**
-	 *Finds out if a file identified by the resource exists.
+	 * Finds out if a file identified by the resource exists.
 	 */
 	existsFile(resource: URI): TPromise<boolean>;
 


### PR DESCRIPTION
**src/typings/node-pty.d.ts** 
- Line 14: Comamnd -> Command
- Line 61: THe -> The

**src/main.js**
- Line 84: We first need -> First, we need

**src/vs/platform/files/common/files.ts**:
- Line 49: Registeres -> Registers
- Line 83: *Finds out -> * Finds out
