### PR TITLE
Fixing the icon displayed twice in GNOME Shell

### DIFF
--- a/resources/linux/code-url-handler.desktop
+++ b/resources/linux/code-url-handler.desktop
@@ -7,7 +7,6 @@ Icon=@@ICON@@
 Type=Application
 NoDisplay=true
 StartupNotify=true
-StartupWMClass=@@NAME_SHORT@@
 Categories=Utility;TextEditor;Development;IDE;
 MimeType=x-scheme-handler/@@URLPROTOCOL@@;
 Keywords=vscode;


### PR DESCRIPTION
Removing a line from the Linux URL Handler desktop application that conflicted with the main desktop application in GNOME Shell.

If you had VSCode pinned as favourite in GNOME Shell, when you opened the application this line was causing that GNOME Shell to recognize it as a different application, displaying the icon twice in the side panel. Removing this line solves the problem.

See this comment for a screenshot of the problem.
https://github.com/Microsoft/vscode/pull/56727#discussion_r229200658