### PR TITLE
Fix extension sort order when running experiments

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -299,7 +299,7 @@ export class ExtensionsListView extends ViewletPanel {
 	}
 
 	private async queryGallery(query: Query, options: IQueryOptions): Promise<IPagedModel<IExtension>> {
-		const hasUserDefinedSortOrder = typeof options.sortBy !== undefined;
+		const hasUserDefinedSortOrder = typeof options.sortBy !== 'undefined';
 		if (!hasUserDefinedSortOrder) {
 			options.sortBy = SortBy.InstallCount;
 		}

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -125,9 +125,6 @@ export class ExtensionsListView extends ViewletPanel {
 			case 'rating': options = assign(options, { sortBy: SortBy.WeightedRating }); break;
 			case 'name': options = assign(options, { sortBy: SortBy.Title }); break;
 		}
-		if (!query || !query.trim()) {
-			options.sortBy = SortBy.InstallCount;
-		}
 
 		const successCallback = model => {
 			this.setModel(model);
@@ -302,6 +299,11 @@ export class ExtensionsListView extends ViewletPanel {
 	}
 
 	private async queryGallery(query: Query, options: IQueryOptions): Promise<IPagedModel<IExtension>> {
+		const hasUserDefinedSortOrder = typeof options.sortBy !== undefined;
+		if (!hasUserDefinedSortOrder) {
+			options.sortBy = SortBy.InstallCount;
+		}
+
 		let value = query.value;
 
 		const idRegex = /@id:(([a-z0-9A-Z][a-z0-9\-A-Z]*)\.([a-z0-9A-Z][a-z0-9\-A-Z]*))/g;
@@ -358,11 +360,13 @@ export class ExtensionsListView extends ViewletPanel {
 		let preferredResults: string[] = [];
 		if (text) {
 			options = assign(options, { text: text.substr(0, 350), source: 'searchText' });
-			for (let i = 0; i < this.searchExperiments.length; i++) {
-				if (text.toLowerCase() === this.searchExperiments[i].action.properties['searchText'] && Array.isArray(this.searchExperiments[i].action.properties['preferredResults'])) {
-					preferredResults = this.searchExperiments[i].action.properties['preferredResults'];
-					options.source += `-experiment-${this.searchExperiments[i].id}`;
-					break;
+			if (!hasUserDefinedSortOrder) {
+				for (let i = 0; i < this.searchExperiments.length; i++) {
+					if (text.toLowerCase() === this.searchExperiments[i].action.properties['searchText'] && Array.isArray(this.searchExperiments[i].action.properties['preferredResults'])) {
+						preferredResults = this.searchExperiments[i].action.properties['preferredResults'];
+						options.source += `-experiment-${this.searchExperiments[i].id}`;
+						break;
+					}
 				}
 			}
 		} else {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -299,7 +299,7 @@ export class ExtensionsListView extends ViewletPanel {
 	}
 
 	private async queryGallery(query: Query, options: IQueryOptions): Promise<IPagedModel<IExtension>> {
-		const hasUserDefinedSortOrder = typeof options.sortBy !== 'undefined';
+		const hasUserDefinedSortOrder = options.sortBy !== undefined;
 		if (!hasUserDefinedSortOrder) {
 			options.sortBy = SortBy.InstallCount;
 		}

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsViews.test.ts
@@ -449,12 +449,6 @@ suite('ExtensionsListView Tests', () => {
 			otherRecommendationA,
 			workspaceRecommendationB
 		];
-		const preferredResults = [
-			workspaceRecommendationA,
-			workspaceRecommendationB,
-			fileBasedRecommendationA,
-			otherRecommendationA
-		];
 
 		const queryTarget = <SinonStub>instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage(...realResults));
 		const experimentTarget = <SinonStub>instantiationService.stubPromise(IExperimentService, 'getExperimentsByType', [{

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsViews.test.ts
@@ -441,6 +441,55 @@ suite('ExtensionsListView Tests', () => {
 		});
 	});
 
+	test('Skip preferred search experiment when user defines sort order', () => {
+		const searchText = 'search-me';
+		const realResults = [
+			fileBasedRecommendationA,
+			workspaceRecommendationA,
+			otherRecommendationA,
+			workspaceRecommendationB
+		];
+		const preferredResults = [
+			workspaceRecommendationA,
+			workspaceRecommendationB,
+			fileBasedRecommendationA,
+			otherRecommendationA
+		];
+
+		const queryTarget = <SinonStub>instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage(...realResults));
+		const experimentTarget = <SinonStub>instantiationService.stubPromise(IExperimentService, 'getExperimentsByType', [{
+			id: 'someId',
+			enabled: true,
+			state: ExperimentState.Run,
+			action: {
+				type: ExperimentActionType.ExtensionSearchResults,
+				properties: {
+					searchText: 'search-me',
+					preferredResults: [
+						workspaceRecommendationA.identifier.id,
+						'something-that-wasnt-in-first-page',
+						workspaceRecommendationB.identifier.id
+					]
+				}
+			}
+		}]);
+
+		testableView.dispose();
+		testableView = instantiationService.createInstance(ExtensionsListView, {});
+
+		return testableView.show('search-me @sort:installs').then(result => {
+			const options: IQueryOptions = queryTarget.args[0][0];
+
+			assert.ok(experimentTarget.calledOnce);
+			assert.ok(queryTarget.calledOnce);
+			assert.equal(options.text, searchText);
+			assert.equal(result.length, realResults.length);
+			for (let i = 0; i < realResults.length; i++) {
+				assert.equal(result.get(i).id, realResults[i].identifier.id);
+			}
+		});
+	});
+
 	function aLocalExtension(name: string = 'someext', manifest: any = {}, properties: any = {}, type: LocalExtensionType = LocalExtensionType.User): ILocalExtension {
 		const localExtension = <ILocalExtension>Object.create({ manifest: {} });
 		assign(localExtension, { type, manifest: {}, location: URI.file(`pub.${name}`) }, properties);


### PR DESCRIPTION
The experiment on extension search results sort order shouldnt be run when user has specified a sort order
Fixes #61671 