### PR TITLE
Fix #62207 ('null' tooltips on Quick Open view)

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -138,7 +138,7 @@ export class IconLabel extends Disposable {
 		this.domNode.title = options && options.title ? options.title : '';
 
 		if (this.labelNode instanceof HighlightedLabel) {
-			this.labelNode.set(label || '', options ? options.matches : void 0, options ? options.title : void 0, options && options.labelEscapeNewLines);
+			this.labelNode.set(label || '', options ? options.matches : void 0, options && options.title ? options.title : void 0, options && options.labelEscapeNewLines);
 		} else {
 			this.labelNode.textContent = label || '';
 		}


### PR DESCRIPTION
As specified in #62207, the commit 318250ae1230966df2c15e0af23688f4dfa646a6 broke tooltips on Quick Open view.

This is my first PR, so please keep me in touch if I made something wrong!