### PR TITLE
Fix typo in code comment

### DIFF
--- a/src/vs/workbench/parts/terminal/node/terminalCommandTracker.ts
+++ b/src/vs/workbench/parts/terminal/node/terminalCommandTracker.ts
@@ -8,7 +8,7 @@ import { ITerminalCommandTracker } from 'vs/workbench/parts/terminal/common/term
 import { IDisposable } from 'vs/base/common/lifecycle';
 
 /**
- * The minimize size of the prompt in which to assume the line is a command.
+ * The minimum size of the prompt in which to assume the line is a command.
  */
 const MINIMUM_PROMPT_LENGTH = 2;
 


### PR DESCRIPTION
Stumbled upon this typo while trying to understand/fix some behaviour of the selection feature in the terminal. Hope it's not too trivial for a PR ;)