### PR TITLE
Avoid creating AppInsightsAppender when --disable-telemetry

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -106,13 +106,11 @@ function main(server: Server, initData: ISharedProcessInitData, configuration: I
 		telemetryLogService.info('===========================================================');
 
 		let appInsightsAppender: ITelemetryAppender | null = NullAppender;
-		if (product.aiConfig && product.aiConfig.asimovKey && isBuilt) {
-			appInsightsAppender = new AppInsightsAppender(eventPrefix, null, product.aiConfig.asimovKey, telemetryLogService);
-			disposables.push(appInsightsAppender); // Ensure the AI appender is disposed so that it flushes remaining data
-		}
-		server.registerChannel('telemetryAppender', new TelemetryAppenderChannel(appInsightsAppender));
-
 		if (!extensionDevelopmentLocationURI && !environmentService.args['disable-telemetry'] && product.enableTelemetry) {
+			if (product.aiConfig && product.aiConfig.asimovKey && isBuilt) {
+				appInsightsAppender = new AppInsightsAppender(eventPrefix, null, product.aiConfig.asimovKey, telemetryLogService);
+				disposables.push(appInsightsAppender); // Ensure the AI appender is disposed so that it flushes remaining data
+			}
 			const config: ITelemetryServiceConfig = {
 				appender: combinedAppender(appInsightsAppender, new LogAppender(logService)),
 				commonProperties: resolveCommonProperties(product.commit, pkg.version, configuration.machineId, installSourcePath),
@@ -123,6 +121,7 @@ function main(server: Server, initData: ISharedProcessInitData, configuration: I
 		} else {
 			services.set(ITelemetryService, NullTelemetryService);
 		}
+		server.registerChannel('telemetryAppender', new TelemetryAppenderChannel(appInsightsAppender));
 
 		services.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
 		services.set(IExtensionGalleryService, new SyncDescriptor(ExtensionGalleryService));


### PR DESCRIPTION
This PR skips creating the AppInsightsAppender (which is responsible for sending our telemetry events using ApplicationInsights SDK) when VS Code is started with --disable-telemetry flag.

This is partial fix to the issue #61646