### PR TITLE
Improve JSON scheme warning UX

### DIFF
--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "./client/out/jsonMain",
   "scripts": {
-    "compile": "gulp compile-extension:json-language-features-client && gulp compile-extension:json-language-features-server",
+    "compile": "gulp compile-extension:json-language-features-client compile-extension:json-language-features-server",
+    "watch": "gulp watch-extension:json-language-features-client watch-extension:json-language-features-server",
     "postinstall": "cd server && yarn install",
     "install-client-next": "yarn add vscode-languageclient@next"
   },

--- a/extensions/json-language-features/package.nls.json
+++ b/extensions/json-language-features/package.nls.json
@@ -10,5 +10,6 @@
 	"json.tracing.desc": "Traces the communication between VS Code and the JSON language server.",
 	"json.colorDecorators.enable.desc": "Enables or disables color decorators",
 	"json.colorDecorators.enable.deprecationMessage": "The setting `json.colorDecorators.enable` has been deprecated in favor of `editor.colorDecorators`.",
+	"json.schemaResolutionErrorMessage": "Unable to resolve schema.",
 	"json.clickToRetry": "Click to retry."
 }


### PR DESCRIPTION
Reason: The old implementation causes inconsistencies in the UI that might confuse the user. For example, when an endpoint became valid, the warning sign still shows. Also the error message was ambiguous and confusing.

---

Please check the following behaviors:

Have the json setting below, and create a file `foo.json`.

```json
{
  "json.schemas": [
    {
      "fileMatch": [
        "foo.json"
      ],
      "url": "http://json.schemastore.org/ansible-stable-2.5"
    }
  ]
}
```

Try:

- Switch between multiple editors (`foo.json` editor, other editors, the settings editor for all the 3 cases below:
  - Modify `http://json.schemastore.org/ansible-stable-2.5` to be an invalid URL, for example, change `json` to `js`
  - Modify `http://json.schemastore.org/ansible-stable-2.5` to a valid URL that doesn't contain schema. For example, `http://json.schemastore.org/404`
  - Turn off your wifi so the JSON schema is unresolvable. Then turn it on, click the statusbar item to retry resolving schema.

Verify:

- #62146 and #62149 
- Icons do not flash
- When switching between editors, the warning icon only displays the target file that cannot resolve JSON schema