### PR TITLE
SelectBox: ComboBox role workaround for native select Addresses: #60929

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -27,6 +27,13 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 		this.selectBoxOptions = selectBoxOptions || Object.create(null);
 
 		this.selectElement = document.createElement('select');
+
+		// Workaround for Electron 2.x
+		// Native select should not require explicit role attribute, however, Electron 2.x
+		// incorrectly exposes select as menuItem which interferes with labeling and results
+		// in the unlabeled not been read.  Electron 3 appears to fix.
+		this.selectElement.setAttribute('role', 'combobox');
+
 		this.selectElement.className = 'monaco-select-box';
 
 		if (typeof this.selectBoxOptions.ariaLabel === 'string') {


### PR DESCRIPTION
@chrmarti - thanks again for catching
@isidorn 
@Tyriar 
If anyone of you can review and merge, I am following new procedures not merging myself as non-MS team member.
Thanks!



- Assign explicit role=combobox to native select box (select)
- Electron 2.x incorrect assignment issue
- Voiceover also affected
- Equally addresses same issue with Debug Configurations label
- Does not affect SelectBox within new settings , already addressed there

See: #60929

![image](https://user-images.githubusercontent.com/25272315/47939923-4f93b480-debf-11e8-945a-2c938e635ba9.png)
