### PR TITLE
remove unnecessary filter conversion

### DIFF
--- a/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
@@ -272,17 +272,12 @@ export class FileDialogService implements IFileDialogService {
 		if (defaultUri && defaultUri.scheme !== Schemas.file) {
 			return Promise.reject(new Error('Not supported - Open-dialogs can only be opened on `file`-uris.'));
 		}
-		const filters = [];
-		if (options.filters) {
-			for (let name in options.filters) {
-				filters.push({ name, extensions: options.filters[name] });
-			}
-		}
+
 		const newOptions: OpenDialogOptions = {
 			title: options.title,
 			defaultPath: defaultUri && defaultUri.fsPath,
 			buttonLabel: options.openLabel,
-			filters,
+			filters: options.filters,
 			properties: []
 		};
 		newOptions.properties.push('createDirectory');


### PR DESCRIPTION
the removed code converts file filters from the extension API format, but the function receives them already converted.

fixes #62237 

will need to cherry pick to `release/1.29`