### PR TITLE
Fix format on save to only happen on explicit saves

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadSaveParticipant.ts
@@ -223,7 +223,7 @@ class FormatOnSaveParticipant implements ISaveParticipantParticipant {
 	participate(editorModel: ITextFileEditorModel, env: { reason: SaveReason }): Promise<void> {
 
 		const model = editorModel.textEditorModel;
-		if (env.reason === SaveReason.AUTO
+		if (env.reason !== SaveReason.EXPLICIT
 			|| !this._configurationService.getValue('editor.formatOnSave', { overrideIdentifier: model.getLanguageIdentifier().language, resource: editorModel.getResource() })) {
 			return undefined;
 		}


### PR DESCRIPTION
Fixes #62526

I believe formatting only on manual saves is the intended behavior of these settings, but it is not clear. If this is not the intended behavior then in my opinion it should be changed to work this way.