### PR TITLE
Add simple expandable instanceLimit option in tasks. Fixes #32264

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5022,7 +5022,7 @@ declare module 'vscode' {
 		/**
 		 * Defines if the application can have only 1 active instance at a time
 		 */
-		singleInstanceOnly?: boolean;
+		instanceLimit?: boolean;
 
 		/**
 		 * A human-readable string describing the source of this

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5020,6 +5020,11 @@ declare module 'vscode' {
 		isBackground: boolean;
 
 		/**
+		 * Defines if the application can have only 1 active instance at a time
+		 */
+		singleInstanceOnly?: boolean;
+
+		/**
 		 * A human-readable string describing the source of this
 		 * shell task, e.g. 'gulp' or 'npm'.
 		 */

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -399,6 +399,7 @@ namespace Tasks {
 			group: task.group ? (task.group as types.TaskGroup).id : undefined,
 			command: command,
 			isBackground: !!task.isBackground,
+			singleInstanceOnly: !!task.singleInstanceOnly,
 			problemMatchers: task.problemMatchers.slice(),
 			hasDefinedMatchers: (task as types.Task).hasDefinedMatchers
 		};

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -399,7 +399,7 @@ namespace Tasks {
 			group: task.group ? (task.group as types.TaskGroup).id : undefined,
 			command: command,
 			isBackground: !!task.isBackground,
-			singleInstanceOnly: !!task.singleInstanceOnly,
+			instanceLimit: !!task.instanceLimit,
 			problemMatchers: task.problemMatchers.slice(),
 			hasDefinedMatchers: (task as types.Task).hasDefinedMatchers
 		};

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1600,7 +1600,7 @@ export class Task implements vscode.Task {
 	private _problemMatchers: string[];
 	private _hasDefinedMatchers: boolean;
 	private _isBackground: boolean;
-	private _singleInstanceOnly: boolean;
+	private _instanceLimit: boolean;
 	private _source: string;
 	private _group: TaskGroup;
 	private _presentationOptions: vscode.TaskPresentationOptions;
@@ -1639,7 +1639,7 @@ export class Task implements vscode.Task {
 			this._hasDefinedMatchers = false;
 		}
 		this._isBackground = false;
-		this._singleInstanceOnly = false;
+		this._instanceLimit = false;
 	}
 
 	get _id(): string {
@@ -1738,8 +1738,8 @@ export class Task implements vscode.Task {
 		return this._isBackground;
 	}
 
-	get singleInstanceOnly(): boolean {
-		return this._singleInstanceOnly;
+	get instanceLimit(): boolean {
+		return this._instanceLimit;
 	}
 
 	set isBackground(value: boolean) {
@@ -1750,11 +1750,11 @@ export class Task implements vscode.Task {
 		this._isBackground = value;
 	}
 
-	set singleInstanceOnly(value: boolean) {
+	set instanceLimit(value: boolean) {
 		if (value !== true && value !== false) {
 			value = false;
 		}
-		this._singleInstanceOnly = value;
+		this._instanceLimit = value;
 	}
 
 	get source(): string {

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1600,6 +1600,7 @@ export class Task implements vscode.Task {
 	private _problemMatchers: string[];
 	private _hasDefinedMatchers: boolean;
 	private _isBackground: boolean;
+	private _singleInstanceOnly: boolean;
 	private _source: string;
 	private _group: TaskGroup;
 	private _presentationOptions: vscode.TaskPresentationOptions;
@@ -1638,6 +1639,7 @@ export class Task implements vscode.Task {
 			this._hasDefinedMatchers = false;
 		}
 		this._isBackground = false;
+		this._singleInstanceOnly = false;
 	}
 
 	get _id(): string {
@@ -1736,12 +1738,23 @@ export class Task implements vscode.Task {
 		return this._isBackground;
 	}
 
+	get singleInstanceOnly(): boolean {
+		return this._singleInstanceOnly;
+	}
+
 	set isBackground(value: boolean) {
 		if (value !== true && value !== false) {
 			value = false;
 		}
 		this.clear();
 		this._isBackground = value;
+	}
+
+	set singleInstanceOnly(value: boolean) {
+		if (value !== true && value !== false) {
+			value = false;
+		}
+		this._singleInstanceOnly = value;
 	}
 
 	get source(): string {

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -406,7 +406,7 @@ export interface ConfigurationProperties {
 	/**
 	 * Defines if the application can have only 1 active instance at a time
 	 */
-	singleInstanceOnly?: boolean;
+	instanceLimit?: boolean;
 
 	/**
 	 * Whether the task should prompt on close for confirmation if running.

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -404,6 +404,11 @@ export interface ConfigurationProperties {
 	isBackground?: boolean;
 
 	/**
+	 * Defines if the application can have only 1 active instance at a time
+	 */
+	singleInstanceOnly?: boolean;
+
+	/**
 	 * Whether the task should prompt on close for confirmation if running.
 	 */
 	promptOnClose?: boolean;

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchemaCommon.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchemaCommon.ts
@@ -151,6 +151,11 @@ const schema: IJSONSchema = {
 					description: nls.localize('JsonSchema.tasks.background', 'Whether the executed task is kept alive and is running in the background.'),
 					default: true
 				},
+				singleInstanceOnly: {
+					type: 'boolean',
+					description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+					default: false
+				},
 				promptOnClose: {
 					type: 'boolean',
 					description: nls.localize('JsonSchema.tasks.promptOnClose', 'Whether the user is prompted when VS Code closes with a running task.'),
@@ -204,6 +209,11 @@ const schema: IJSONSchema = {
 					type: 'boolean',
 					description: nls.localize('JsonSchema.background', 'Whether the executed task is kept alive and is running in the background.'),
 					default: true
+				},
+				singleInstanceOnly: {
+					type: 'boolean',
+					description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+					default: false
 				},
 				promptOnClose: {
 					type: 'boolean',

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchemaCommon.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchemaCommon.ts
@@ -151,9 +151,9 @@ const schema: IJSONSchema = {
 					description: nls.localize('JsonSchema.tasks.background', 'Whether the executed task is kept alive and is running in the background.'),
 					default: true
 				},
-				singleInstanceOnly: {
+				instanceLimit: {
 					type: 'boolean',
-					description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+					description: nls.localize('JsonSchema.tasks.instanceLimit', 'Whether the executed task can have only 1 active instance at a time.'),
 					default: false
 				},
 				promptOnClose: {
@@ -210,9 +210,9 @@ const schema: IJSONSchema = {
 					description: nls.localize('JsonSchema.background', 'Whether the executed task is kept alive and is running in the background.'),
 					default: true
 				},
-				singleInstanceOnly: {
+				instanceLimit: {
 					type: 'boolean',
-					description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+					description: nls.localize('JsonSchema.tasks.instanceLimit', 'Whether the executed task can have only 1 active instance at a time.'),
 					default: false
 				},
 				promptOnClose: {

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
@@ -303,6 +303,11 @@ let taskConfiguration: IJSONSchema = {
 			description: nls.localize('JsonSchema.tasks.background', 'Whether the executed task is kept alive and is running in the background.'),
 			default: true
 		},
+		singleInstanceOnly: {
+			type: 'boolean',
+			description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+			default: false
+		},
 		promptOnClose: {
 			type: 'boolean',
 			description: nls.localize('JsonSchema.tasks.promptOnClose', 'Whether the user is prompted when VS Code closes with a running task.'),

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
@@ -303,9 +303,9 @@ let taskConfiguration: IJSONSchema = {
 			description: nls.localize('JsonSchema.tasks.background', 'Whether the executed task is kept alive and is running in the background.'),
 			default: true
 		},
-		singleInstanceOnly: {
+		instanceLimit: {
 			type: 'boolean',
-			description: nls.localize('JsonSchema.tasks.singleInstanceOnly', 'Whether the executed task can have only 1 active instance at a time.'),
+			description: nls.localize('JsonSchema.tasks.instanceLimit', 'Whether the executed task can have only 1 active instance at a time.'),
 			default: false
 		},
 		promptOnClose: {

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1225,6 +1225,10 @@ class TaskService extends Disposable implements ITaskService {
 					let active = executeResult.active;
 					if (active.same) {
 						let message;
+						if (task.singleInstanceOnly) {
+							this.restart(task);
+							message = nls.localize('TaskSystem.singleInstanceOnly', 'Restarting \'{0}\'.', Task.getQualifiedLabel(task));
+						} else
 						if (active.background) {
 							message = nls.localize('TaskSystem.activeSame.background', 'The task \'{0}\' is already active and in background mode.', Task.getQualifiedLabel(task));
 						} else {

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1228,8 +1228,7 @@ class TaskService extends Disposable implements ITaskService {
 						if (task.singleInstanceOnly) {
 							this.restart(task);
 							message = nls.localize('TaskSystem.singleInstanceOnly', 'Restarting \'{0}\'.', Task.getQualifiedLabel(task));
-						} else
-						if (active.background) {
+						} else if (active.background) {
 							message = nls.localize('TaskSystem.activeSame.background', 'The task \'{0}\' is already active and in background mode.', Task.getQualifiedLabel(task));
 						} else {
 							message = nls.localize('TaskSystem.activeSame.noBackground', 'The task \'{0}\' is already active.', Task.getQualifiedLabel(task));

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -1225,9 +1225,9 @@ class TaskService extends Disposable implements ITaskService {
 					let active = executeResult.active;
 					if (active.same) {
 						let message;
-						if (task.singleInstanceOnly) {
+						if (task.instanceLimit) {
 							this.restart(task);
-							message = nls.localize('TaskSystem.singleInstanceOnly', 'Restarting \'{0}\'.', Task.getQualifiedLabel(task));
+							message = nls.localize('TaskSystem.instanceLimit', 'Restarting \'{0}\'.', Task.getQualifiedLabel(task));
 						} else if (active.background) {
 							message = nls.localize('TaskSystem.activeSame.background', 'The task \'{0}\' is already active and in background mode.', Task.getQualifiedLabel(task));
 						} else {

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -1852,7 +1852,7 @@ class ConfigurationParser {
 		if ((!result.custom || result.custom.length === 0) && (globals.command && globals.command.name)) {
 			let matchers: ProblemMatcher[] = ProblemMatcherConverter.from(fileConfig.problemMatcher, context);
 			let isBackground = fileConfig.isBackground ? !!fileConfig.isBackground : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
-			let instanceLimit = fileConfig.instanceLimit ? !!fileConfig.instanceLimit : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
+			let instanceLimit = fileConfig.instanceLimit ? true : undefined;
 			let name = Tasks.CommandString.value(globals.command.name);
 			let task: Tasks.CustomTask = {
 				_id: context.uuidMap.getUUID(name),

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -284,6 +284,11 @@ export interface ConfigurationProperties {
 	isBackground?: boolean;
 
 	/**
+	 * Defines if the application can have only 1 active instance at a time.
+	 */
+	singleInstanceOnly?: boolean;
+
+	/**
 	 * Whether the task should prompt on close for confirmation if running.
 	 */
 	promptOnClose?: boolean;
@@ -425,6 +430,11 @@ export interface BaseTaskRunnerConfiguration {
 	 * Specifies whether a global command is a background task.
 	 */
 	isBackground?: boolean;
+
+	/**
+	 * Defines if the application can have only 1 active instance at a time.
+	 */
+	singleInstanceOnly?: boolean;
 
 	/**
 	 * Whether the task should prompt on close for confirmation if running.
@@ -1153,7 +1163,7 @@ namespace ConfigurationProperties {
 	const properties: MetaData<Tasks.ConfigurationProperties, any>[] = [
 
 		{ property: 'name' }, { property: 'identifier' }, { property: 'group' }, { property: 'isBackground' },
-		{ property: 'promptOnClose' }, { property: 'dependsOn' },
+		{ property: 'promptOnClose' }, { property: 'dependsOn' }, { property: 'singleInstanceOnly' },
 		{ property: 'presentation', type: CommandConfiguration.PresentationOptions }, { property: 'problemMatchers' }
 	];
 
@@ -1173,6 +1183,9 @@ namespace ConfigurationProperties {
 		}
 		if (external.isBackground !== void 0) {
 			result.isBackground = !!external.isBackground;
+		}
+		if (external.singleInstanceOnly !== void 0) {
+			result.singleInstanceOnly = !!external.singleInstanceOnly;
 		}
 		if (external.promptOnClose !== void 0) {
 			result.promptOnClose = !!external.promptOnClose;
@@ -1400,6 +1413,9 @@ namespace CustomTask {
 		if (task.isBackground === void 0) {
 			task.isBackground = false;
 		}
+		if (task.singleInstanceOnly === void 0) {
+			task.singleInstanceOnly = false;
+		}
 		if (task.problemMatchers === void 0) {
 			task.problemMatchers = EMPTY_ARRAY;
 		}
@@ -1424,6 +1440,7 @@ namespace CustomTask {
 		assignProperty(resultConfigProps, configuredProps, 'group');
 		assignProperty(resultConfigProps, configuredProps, 'groupType');
 		assignProperty(resultConfigProps, configuredProps, 'isBackground');
+		assignProperty(resultConfigProps, configuredProps, 'singleInstanceOnly');
 		assignProperty(resultConfigProps, configuredProps, 'dependsOn');
 		assignProperty(resultConfigProps, configuredProps, 'problemMatchers');
 		assignProperty(resultConfigProps, configuredProps, 'promptOnClose');
@@ -1435,6 +1452,7 @@ namespace CustomTask {
 		fillProperty(resultConfigProps, contributedConfigProps, 'group');
 		fillProperty(resultConfigProps, contributedConfigProps, 'groupType');
 		fillProperty(resultConfigProps, contributedConfigProps, 'isBackground');
+		fillProperty(resultConfigProps, contributedConfigProps, 'singleInstanceOnly');
 		fillProperty(resultConfigProps, contributedConfigProps, 'dependsOn');
 		fillProperty(resultConfigProps, contributedConfigProps, 'problemMatchers');
 		fillProperty(resultConfigProps, contributedConfigProps, 'promptOnClose');
@@ -1834,6 +1852,7 @@ class ConfigurationParser {
 		if ((!result.custom || result.custom.length === 0) && (globals.command && globals.command.name)) {
 			let matchers: ProblemMatcher[] = ProblemMatcherConverter.from(fileConfig.problemMatcher, context);
 			let isBackground = fileConfig.isBackground ? !!fileConfig.isBackground : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
+			let singleInstanceOnly = fileConfig.singleInstanceOnly ? !!fileConfig.singleInstanceOnly : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
 			let name = Tasks.CommandString.value(globals.command.name);
 			let task: Tasks.CustomTask = {
 				_id: context.uuidMap.getUUID(name),
@@ -1850,6 +1869,7 @@ class ConfigurationParser {
 					suppressTaskName: true
 				},
 				isBackground: isBackground,
+				singleInstanceOnly: singleInstanceOnly,
 				problemMatchers: matchers,
 				hasDefinedMatchers: false,
 			};

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -286,7 +286,7 @@ export interface ConfigurationProperties {
 	/**
 	 * Defines if the application can have only 1 active instance at a time.
 	 */
-	singleInstanceOnly?: boolean;
+	instanceLimit?: boolean;
 
 	/**
 	 * Whether the task should prompt on close for confirmation if running.
@@ -434,7 +434,7 @@ export interface BaseTaskRunnerConfiguration {
 	/**
 	 * Defines if the application can have only 1 active instance at a time.
 	 */
-	singleInstanceOnly?: boolean;
+	instanceLimit?: boolean;
 
 	/**
 	 * Whether the task should prompt on close for confirmation if running.
@@ -1163,7 +1163,7 @@ namespace ConfigurationProperties {
 	const properties: MetaData<Tasks.ConfigurationProperties, any>[] = [
 
 		{ property: 'name' }, { property: 'identifier' }, { property: 'group' }, { property: 'isBackground' },
-		{ property: 'promptOnClose' }, { property: 'dependsOn' }, { property: 'singleInstanceOnly' },
+		{ property: 'promptOnClose' }, { property: 'dependsOn' }, { property: 'instanceLimit' },
 		{ property: 'presentation', type: CommandConfiguration.PresentationOptions }, { property: 'problemMatchers' }
 	];
 
@@ -1184,8 +1184,8 @@ namespace ConfigurationProperties {
 		if (external.isBackground !== void 0) {
 			result.isBackground = !!external.isBackground;
 		}
-		if (external.singleInstanceOnly !== void 0) {
-			result.singleInstanceOnly = !!external.singleInstanceOnly;
+		if (external.instanceLimit !== void 0) {
+			result.instanceLimit = !!external.instanceLimit;
 		}
 		if (external.promptOnClose !== void 0) {
 			result.promptOnClose = !!external.promptOnClose;
@@ -1413,8 +1413,8 @@ namespace CustomTask {
 		if (task.isBackground === void 0) {
 			task.isBackground = false;
 		}
-		if (task.singleInstanceOnly === void 0) {
-			task.singleInstanceOnly = false;
+		if (task.instanceLimit === void 0) {
+			task.instanceLimit = false;
 		}
 		if (task.problemMatchers === void 0) {
 			task.problemMatchers = EMPTY_ARRAY;
@@ -1440,7 +1440,7 @@ namespace CustomTask {
 		assignProperty(resultConfigProps, configuredProps, 'group');
 		assignProperty(resultConfigProps, configuredProps, 'groupType');
 		assignProperty(resultConfigProps, configuredProps, 'isBackground');
-		assignProperty(resultConfigProps, configuredProps, 'singleInstanceOnly');
+		assignProperty(resultConfigProps, configuredProps, 'instanceLimit');
 		assignProperty(resultConfigProps, configuredProps, 'dependsOn');
 		assignProperty(resultConfigProps, configuredProps, 'problemMatchers');
 		assignProperty(resultConfigProps, configuredProps, 'promptOnClose');
@@ -1452,7 +1452,7 @@ namespace CustomTask {
 		fillProperty(resultConfigProps, contributedConfigProps, 'group');
 		fillProperty(resultConfigProps, contributedConfigProps, 'groupType');
 		fillProperty(resultConfigProps, contributedConfigProps, 'isBackground');
-		fillProperty(resultConfigProps, contributedConfigProps, 'singleInstanceOnly');
+		fillProperty(resultConfigProps, contributedConfigProps, 'instanceLimit');
 		fillProperty(resultConfigProps, contributedConfigProps, 'dependsOn');
 		fillProperty(resultConfigProps, contributedConfigProps, 'problemMatchers');
 		fillProperty(resultConfigProps, contributedConfigProps, 'promptOnClose');
@@ -1852,7 +1852,7 @@ class ConfigurationParser {
 		if ((!result.custom || result.custom.length === 0) && (globals.command && globals.command.name)) {
 			let matchers: ProblemMatcher[] = ProblemMatcherConverter.from(fileConfig.problemMatcher, context);
 			let isBackground = fileConfig.isBackground ? !!fileConfig.isBackground : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
-			let singleInstanceOnly = fileConfig.singleInstanceOnly ? !!fileConfig.singleInstanceOnly : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
+			let instanceLimit = fileConfig.instanceLimit ? !!fileConfig.instanceLimit : fileConfig.isWatching ? !!fileConfig.isWatching : undefined;
 			let name = Tasks.CommandString.value(globals.command.name);
 			let task: Tasks.CustomTask = {
 				_id: context.uuidMap.getUUID(name),
@@ -1869,7 +1869,7 @@ class ConfigurationParser {
 					suppressTaskName: true
 				},
 				isBackground: isBackground,
-				singleInstanceOnly: singleInstanceOnly,
+				instanceLimit: instanceLimit,
 				problemMatchers: matchers,
 				hasDefinedMatchers: false,
 			};

--- a/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts
+++ b/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts
@@ -190,6 +190,7 @@ class CustomTaskBuilder {
 			name: name,
 			command: this.commandBuilder.result,
 			isBackground: false,
+			singleInstanceOnly: false,
 			promptOnClose: true,
 			problemMatchers: [],
 			hasDefinedMatchers: false
@@ -214,6 +215,11 @@ class CustomTaskBuilder {
 
 	public isBackground(value: boolean): CustomTaskBuilder {
 		this.result.isBackground = value;
+		return this;
+	}
+
+	public singleInstanceOnly(value: boolean): CustomTaskBuilder {
+		this.result.singleInstanceOnly = value;
 		return this;
 	}
 

--- a/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts
+++ b/src/vs/workbench/parts/tasks/test/electron-browser/configuration.test.ts
@@ -190,7 +190,7 @@ class CustomTaskBuilder {
 			name: name,
 			command: this.commandBuilder.result,
 			isBackground: false,
-			singleInstanceOnly: false,
+			instanceLimit: false,
 			promptOnClose: true,
 			problemMatchers: [],
 			hasDefinedMatchers: false
@@ -218,8 +218,8 @@ class CustomTaskBuilder {
 		return this;
 	}
 
-	public singleInstanceOnly(value: boolean): CustomTaskBuilder {
-		this.result.singleInstanceOnly = value;
+	public instanceLimit(value: boolean): CustomTaskBuilder {
+		this.result.instanceLimit = value;
 		return this;
 	}
 


### PR DESCRIPTION
Since #32384 seems dead with certain desired changes unfinished, this is just a trivial rewrite of that PR with a more open ended task option named `instanceLimit` instead of `singleInstanceOnly`. I also cleaned up some implementation details that I thought were a little weird.

For now, I've kept the simple `boolean` option and simply setting `instanceLimit: true` should restart any running task if I understand the code correctly. I also think this is the sane default behavior.

Unfortunately I have not been able to test this yet as setting up the full vscode build environment has been problematic for me.

I hope someone can test this, confirm it works, and accepts this so that the other dependent issues (#30726 #40027) and [more controls](https://github.com/Microsoft/vscode/pull/32384#issuecomment-424114086) can be worked on. This trivial implementation would I think still be useful for many.