### PR TITLE
explicit this type on Disposable#dispose

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1432,7 +1432,7 @@ declare module 'vscode' {
 		/**
 		 * Dispose this object.
 		 */
-		dispose(): any;
+		dispose(this: Disposable): any;
 	}
 
 	/**


### PR DESCRIPTION
According to implementation:

https://github.com/Microsoft/vscode/blob/ae5b8fb1978bfb595ec4821af0d61d32d80a177c/src/vs/workbench/api/node/extHostTypes.ts#L36-L46

its `this` type needs to be explicit declared so that will be guard by wrong calling.