### PR TITLE
Fix exclude patterns for ./ searches

### DIFF
--- a/src/vs/workbench/parts/search/common/queryBuilder.ts
+++ b/src/vs/workbench/parts/search/common/queryBuilder.ts
@@ -312,7 +312,9 @@ export class QueryBuilder {
 			for (let excludePattern in rootConfig.excludePattern) {
 				const { pathPortion, globPortion } = splitSimpleGlob(excludePattern);
 				if (!pathPortion) { // **/foo
-					resolvedExcludes[globPortion] = rootConfig.excludePattern[excludePattern];
+					if (globPortion) {
+						resolvedExcludes[globPortion] = rootConfig.excludePattern[excludePattern];
+					}
 				} else if (strings.startsWith(pathPortion, searchPathRelativePath)) { // searchPathRelativePath/something/**/foo
 					// Strip `searchPathRelativePath/`
 					const resolvedPathPortion = pathPortion.substr(searchPathRelativePath.length + 1);
@@ -328,7 +330,7 @@ export class QueryBuilder {
 		return {
 			...rootConfig,
 			...{
-				includePattern: searchPath.pattern && patternListToIExpression([searchPath.pattern]),
+				includePattern: searchPath.pattern ? patternListToIExpression([searchPath.pattern]) : undefined,
 				excludePattern: Object.keys(resolvedExcludes).length ? resolvedExcludes : undefined
 			}
 		};
@@ -375,7 +377,7 @@ function splitGlobFromPath(searchPath: string): { pathPortion: string, globPorti
 function splitSimpleGlob(searchPath: string): { pathPortion: string, globPortion?: string } {
 	const globCharMatch = searchPath.match(/[\*\{\}\(\)\[\]\?]/);
 	if (globCharMatch) {
-		const globCharIdx = globCharMatch.index;
+		const globCharIdx = globCharMatch.index || 0;
 		return {
 			pathPortion: searchPath.substr(0, globCharIdx),
 			globPortion: searchPath.substr(globCharIdx)

--- a/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
+++ b/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
@@ -153,14 +153,11 @@ suite('QueryBuilder', () => {
 			<ITextQuery>{
 				contentPattern: PATTERN_INFO,
 				folderQueries: [{
-					folder: getUri(paths.join(ROOT_1, 'foo'))
-				}],
-				excludePattern: {
-					[paths.join(ROOT_1, 'foo/**/*.js')]: true,
-					[paths.join(ROOT_1, 'bar/**')]: {
-						'when': '$(basename).ts'
+					folder: getUri(paths.join(ROOT_1, 'foo')),
+					excludePattern: {
+						['**/*.js']: true
 					}
-				},
+				}],
 				type: QueryType.Text
 			});
 	});
@@ -212,7 +209,6 @@ suite('QueryBuilder', () => {
 				folderQueries: [
 					{ folder: getUri(paths.join(ROOT_2, 'src')) }
 				],
-				excludePattern: patternsToIExpression(paths.join(ROOT_1, 'foo/**/*.js'), paths.join(ROOT_2, 'bar')),
 				type: QueryType.Text
 			}
 		);


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/62409

This is not totally straightforward and I can explain it in person if that's better...

**The bug/impact**
The exclude settings are not applied correctly when searching with a `./` pattern. e.g. anytime you use `./` to search in a subfolder or a particular folder in a multiroot workspace, your search.exclude and files.exclude patterns will not be applied. This is a regression from 1.28. Only one person noticed this in the weeks that it was broken in Insiders, but I think it should be fixed for 1.29.

**Explanation**
When you search with a `./` pattern in the search view, we start the search from that folder, but have to apply exclude patterns in the context of the workspace folder. We used to start the search from the drive root, search all workspace folders at the same time, and apply these patterns as absolute paths. One problem with this is that the full spawned command sometimes gets too long and causes issues on Windows. Now, we search from the actual folder being searched and have to resolve exclude patterns for the subfolder being searched. Meaning, if you have an exclude pattern like `test/*.js` then search in `./test`, the exclude pattern must be applied as `*.js`. 

This has always been broken using the extension host based search and I missed this case when refactoring all of search to use the same EH based search. This PR removes the code that resolved exclude patterns to absolute paths, which isn't needed anymore, and resolves the patterns relative to the folder being searched. 

If you are thinking, "it would be simpler to search from the workspace folder and apply the `./` folder as a glob pattern", you are right, but ripgrep will still walk the whole cwd because it doesn't always use the glob patterns to optimize its file tree walking the way you might expect, without [carefully structuring](https://github.com/BurntSushi/ripgrep/issues/546) them.