### PR TITLE
debug repl: Make sure to select the session if debugging is already actuve

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/repl.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/repl.ts
@@ -292,6 +292,12 @@ export class Repl extends Panel implements IPrivateReplService, IHistoryNavigati
 			accessibilityProvider: new ReplExpressionsAccessibilityProvider(),
 			controller
 		}, replTreeOptions);
+
+		// Make sure to select the session if debugging is already active
+		const focusedSession = this.debugService.getViewModel().focusedSession;
+		if (focusedSession) {
+			this.selectSession(focusedSession);
+		}
 	}
 
 	private createReplInput(container: HTMLElement): void {


### PR DESCRIPTION
fixes #62473

The issue is that it can happen that the debug repl gets created while debugging has already started. 
In that case the debug repl will never select a session, since no new session focused events will arrive.

The fix is very simple and straight forwerd. Once the repl is created check if there is an active debug session, if there is, select it and render it.

I have verified this fixes the issue #62473