### PR TITLE
Storage: do not migrate and use legacy storage

### DIFF
--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -682,7 +682,7 @@ configurationRegistry.registerConfiguration({
 		'workbench.enableLegacyStorage': {
 			'type': 'boolean',
 			'description': nls.localize('workbench.enableLegacyStorage', "Switches back to the previous storage implementation. Only change this setting if advised to do so."),
-			'default': false
+			'default': true
 		}
 	}
 });

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -681,7 +681,7 @@ configurationRegistry.registerConfiguration({
 		//TODO@Ben remove ('enableLegacyStorage') after a while
 		'workbench.enableLegacyStorage': {
 			'type': 'boolean',
-			'description': nls.localize('workbench.enableLegacyStorage', "Switches back to the previous storage implementation. Only change this setting if advised to do so."),
+			'markdownDescription': nls.localize('workbench.enableLegacyStorage', "Switches back to the previous storage implementation. Only change this setting if advised to do so. **Disabling legacy storage will drop your storage state.**"),
 			'default': true
 		}
 	}

--- a/src/vs/workbench/electron-browser/main.ts
+++ b/src/vs/workbench/electron-browser/main.ts
@@ -13,10 +13,10 @@ import * as comparer from 'vs/base/common/comparers';
 import * as platform from 'vs/base/common/platform';
 import { URI as uri } from 'vs/base/common/uri';
 import { IWorkspaceContextService, Workspace, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload, isSingleFolderWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
+import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { stat, exists, writeFile, readdir } from 'vs/base/node/pfs';
+import { stat, exists, writeFile } from 'vs/base/node/pfs';
 import { EnvironmentService } from 'vs/platform/environment/node/environmentService';
 import * as gracefulFs from 'graceful-fs';
 import { KeyboardMapperFactory } from 'vs/workbench/services/keybinding/electron-browser/keybindingService';
@@ -31,7 +31,7 @@ import { IUpdateService } from 'vs/platform/update/common/update';
 import { URLHandlerChannel, URLServiceChannelClient } from 'vs/platform/url/node/urlIpc';
 import { IURLService } from 'vs/platform/url/common/url';
 import { WorkspacesChannelClient } from 'vs/platform/workspaces/node/workspacesIpc';
-import { IWorkspacesService, ISingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspacesService, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { createSpdLogService } from 'vs/platform/log/node/spdlogService';
 import * as fs from 'fs';
 import { ConsoleLogService, MultiplexLogService, ILogService } from 'vs/platform/log/common/log';
@@ -46,9 +46,6 @@ import { Schemas } from 'vs/base/common/network';
 import { sanitizeFilePath, mkdirp } from 'vs/base/node/extfs';
 import { basename, join } from 'path';
 import { createHash } from 'crypto';
-import { parseStorage, StorageObject } from 'vs/platform/storage/common/storageLegacyMigration';
-import { StorageScope } from 'vs/platform/storage/common/storage';
-import { endsWith } from 'vs/base/common/strings';
 import { IdleValue } from 'vs/base/common/async';
 
 gracefulFs.gracefulify(fs); // enable gracefulFs
@@ -303,7 +300,9 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 			const storageService = new StorageService(workspaceStorageDBPath, true, logService, environmentService);
 
 			return storageService.init().then(() => {
-				if (exists) {
+				return storageService; // do not migrate this milestone
+
+				/* if (exists) {
 					return storageService; // return early if DB was already there
 				}
 
@@ -429,6 +428,7 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 
 					return storageService;
 				});
+				*/
 			});
 		});
 	});

--- a/src/vs/workbench/electron-browser/main.ts
+++ b/src/vs/workbench/electron-browser/main.ts
@@ -13,10 +13,10 @@ import * as comparer from 'vs/base/common/comparers';
 import * as platform from 'vs/base/common/platform';
 import { URI as uri } from 'vs/base/common/uri';
 import { IWorkspaceContextService, Workspace, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
+import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload, isSingleFolderWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { stat, exists, writeFile } from 'vs/base/node/pfs';
+import { stat, exists, writeFile, readdir } from 'vs/base/node/pfs';
 import { EnvironmentService } from 'vs/platform/environment/node/environmentService';
 import * as gracefulFs from 'graceful-fs';
 import { KeyboardMapperFactory } from 'vs/workbench/services/keybinding/electron-browser/keybindingService';
@@ -31,7 +31,7 @@ import { IUpdateService } from 'vs/platform/update/common/update';
 import { URLHandlerChannel, URLServiceChannelClient } from 'vs/platform/url/node/urlIpc';
 import { IURLService } from 'vs/platform/url/common/url';
 import { WorkspacesChannelClient } from 'vs/platform/workspaces/node/workspacesIpc';
-import { IWorkspacesService, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspacesService, ISingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { createSpdLogService } from 'vs/platform/log/node/spdlogService';
 import * as fs from 'fs';
 import { ConsoleLogService, MultiplexLogService, ILogService } from 'vs/platform/log/common/log';
@@ -46,6 +46,9 @@ import { Schemas } from 'vs/base/common/network';
 import { sanitizeFilePath, mkdirp } from 'vs/base/node/extfs';
 import { basename, join } from 'path';
 import { createHash } from 'crypto';
+import { parseStorage, StorageObject } from 'vs/platform/storage/common/storageLegacyMigration';
+import { StorageScope } from 'vs/platform/storage/common/storage';
+import { endsWith } from 'vs/base/common/strings';
 import { IdleValue } from 'vs/base/common/async';
 
 gracefulFs.gracefulify(fs); // enable gracefulFs
@@ -300,10 +303,8 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 			const storageService = new StorageService(workspaceStorageDBPath, true, logService, environmentService);
 
 			return storageService.init().then(() => {
-				return storageService; // do not migrate this milestone
-
-				/* if (exists) {
-					return storageService; // return early if DB was already there
+				if (exists || true) { // do not migrate this milestone
+					return storageService;
 				}
 
 				perf.mark('willMigrateWorkspaceStorageKeys');
@@ -428,7 +429,6 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 
 					return storageService;
 				});
-				*/
 			});
 		});
 	});


### PR DESCRIPTION
fixes #62733

This PR does the following:
* Changes the flag, so we use legacy chrome storage and not the new sql lite storage
* Comments out the storage migration code, so we would not do any migration this milestone

Assigning to @jrieken  for review and @egamma to potentially merge if we deicde to do that.