### PR TITLE
explorer: properly pass view state

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/explorerViewlet.ts
+++ b/src/vs/workbench/parts/files/electron-browser/explorerViewlet.ts
@@ -14,7 +14,7 @@ import { ActionRunner, FileViewletState } from 'vs/workbench/parts/files/electro
 import { ExplorerView, IExplorerViewOptions } from 'vs/workbench/parts/files/electron-browser/views/explorerView';
 import { EmptyView } from 'vs/workbench/parts/files/electron-browser/views/emptyView';
 import { OpenEditorsView } from 'vs/workbench/parts/files/electron-browser/views/openEditorsView';
-import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
@@ -217,7 +217,7 @@ export class ExplorerViewlet extends ViewContainerViewlet implements IExplorerVi
 			});
 
 			const explorerInstantiator = this.instantiationService.createChild(new ServiceCollection([IEditorService, delegatingEditorService]));
-			return explorerInstantiator.createInstance(ExplorerView, <IExplorerViewOptions>{ ...options, viewletState: this.fileViewletState });
+			return explorerInstantiator.createInstance(ExplorerView, <IExplorerViewOptions>{ ...options, viewletState: this.fileViewletState, viewState: this.getMemento(StorageScope.WORKSPACE) });
 		}
 		return super.createView(viewDescriptor, options);
 	}

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -46,6 +46,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 
 export interface IExplorerViewOptions extends IViewletViewOptions {
 	viewletState: FileViewletState;
+	viewState: object;
 }
 
 export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView {
@@ -99,7 +100,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 	) {
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: nls.localize('explorerSection', "Files Explorer Section") }, keybindingService, contextMenuService, configurationService);
 
-		this.viewState = options.viewletState;
+		this.viewState = options.viewState;
 		this.viewletState = options.viewletState;
 		this.autoReveal = true;
 


### PR DESCRIPTION
fixes #62706

This PR fixes the explorer that the proper workspace memento is passed to the view state object.