### PR TITLE
Fix last merge conflict warnings when enable autoNavigateNextConflict

### DIFF
--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -158,6 +158,11 @@ export default class CommandHandler implements vscode.Disposable {
 		let navigationResult = await this.findConflictForNavigation(editor, direction);
 
 		if (!navigationResult) {
+			// Check for autoNavigateNextConflict, if it's enabled(which indicating no conflict remain), then do not show warning
+			const mergeConflictConfig = vscode.workspace.getConfiguration('merge-conflict');
+			if (mergeConflictConfig.get<boolean>('autoNavigateNextConflict.enabled')) {
+				return;
+			}
 			vscode.window.showWarningMessage(localize('noConflicts', 'No merge conflicts found in this file'));
 			return;
 		}


### PR DESCRIPTION
Fix #62385