### PR TITLE
Fix #62785 empty lines in debug console copyAll

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/electronDebugActions.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/electronDebugActions.ts
@@ -77,7 +77,7 @@ export class CopyAllAction extends Action {
 			if (text) {
 				text += lineDelimiter;
 			}
-			text += (<IReplElement>navigator.current()).toString();
+			text += (<IReplElement>navigator.current()).toString().trimRight();
 		}
 
 		clipboard.writeText(removeAnsiEscapeCodes(text));


### PR DESCRIPTION
## Example outputs

Fixes #62785 - Copy All action in debug terminal inserts extra lines in between output

### Prior to change

<p>

```

C:\Program Files\nodejs\node.exe --inspect-brk=32511 binSearch.js 
Debugger listening on ws://127.0.0.1:32511/6309b5be-dae5-424f-9065-ba2b8af0a4d0

Debugger attached.

c:\Users\matth\Desktop\binSearch.js:5

const binarySearch = (tar, nums) => {

                     ^



RangeError: Maximum call stack size exceeded

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:5:22)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

Waiting for the debugger to disconnect...

RangeError: Maximum call stack size exceeded
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:5:22)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

```

</p>

### After change 

<p>

```

C:\Program Files\nodejs\node.exe --inspect-brk=3546 binSearch.js
Debugger listening on ws://127.0.0.1:3546/f4a816f9-e0bb-43f9-be24-7e36e30ee971
Debugger attached.
c:\Users\matth\Desktop\binSearch.js:5
const binarySearch = (tar, nums) => {
                     ^

RangeError: Maximum call stack size exceeded
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:5:22)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
Waiting for the debugger to disconnect...
RangeError: Maximum call stack size exceeded
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:5:22)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)
    at binarySearch (c:\Users\matth\Desktop\binSearch.js:21:12)

```

</p>

Tested with master branch on both Windows 10 and ArchLinux.