### PR TITLE
Remove capture of  "Default" in Clojure def regex

### DIFF
--- a/extensions/clojure/syntaxes/clojure.tmLanguage.json
+++ b/extensions/clojure/syntaxes/clojure.tmLanguage.json
@@ -126,7 +126,7 @@
 					"name": "storage.control.clojure"
 				},
 				{
-					"match": "(?<=(\\s|\\(|\\[|\\{))(declare-?|(in-)?ns|import|use|require|load|compile|(def[a-z\\-]*))(?=(\\s|\\)|\\]|\\}))",
+					"match": "(?<=(\\s|\\(|\\[|\\{))(declare-?|(in-)?ns|import|use|require|load|compile|(def(?!ault)[a-z\\-]*))(?=(\\s|\\)|\\]|\\}))",
 					"name": "keyword.control.clojure"
 				}
 			]


### PR DESCRIPTION
Before, the keyfn pattern match for Clojure would match all words starting with "def" (if surrounded by certain characters).
After, the match behaves the same, except it will not match words starting with "default" (including "defaults" "defaulting" etc.). "Default" and its derivatives are considered the only words staring with "def" that would be commonly used in code which are nearly always not definitions.