### PR TITLE
fix menubar focus trap

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -183,6 +183,7 @@
 	-webkit-app-region: no-drag;
 	zoom: 1;
 	white-space: nowrap;
+	outline: 0;
 }
 
 .monaco-workbench .menubar .menubar-menu-items-holder {

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -696,7 +696,7 @@ export class MenubarControl extends Disposable {
 			// Create the top level menu button element
 			if (firstTimeSetup) {
 
-				const buttonElement = $('div.menubar-menu-button', { 'role': 'menuitem', 'tabindex': 0, 'aria-label': cleanMenuLabel, 'aria-haspopup': true });
+				const buttonElement = $('div.menubar-menu-button', { 'role': 'menuitem', 'tabindex': -1, 'aria-label': cleanMenuLabel, 'aria-haspopup': true });
 				const titleElement = $('div.menubar-menu-title', { 'role': 'none', 'aria-hidden': true });
 
 				buttonElement.appendChild(titleElement);
@@ -840,9 +840,9 @@ export class MenubarControl extends Disposable {
 				let eventHandled = true;
 				const key = !!e.key ? KeyCodeUtils.fromString(e.key) : KeyCode.Unknown;
 
-				if (event.equals(KeyCode.LeftArrow) || (event.shiftKey && event.keyCode === KeyCode.Tab)) {
+				if (event.equals(KeyCode.LeftArrow)) {
 					this.focusPrevious();
-				} else if (event.equals(KeyCode.RightArrow) || event.equals(KeyCode.Tab)) {
+				} else if (event.equals(KeyCode.RightArrow)) {
 					this.focusNext();
 				} else if (event.equals(KeyCode.Escape) && this.isFocused && !this.isOpen) {
 					this.setUnfocusedState();

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -279,7 +279,6 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	createContentArea(parent: HTMLElement): HTMLElement {
 		this.titleContainer = parent;
-		this.titleContainer.tabIndex = -1;
 
 		// Draggable region that we can manipulate for #52522
 		this.dragRegion = append(this.titleContainer, $('div.titlebar-drag-region'));

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -279,6 +279,7 @@ export class TitlebarPart extends Part implements ITitleService {
 
 	createContentArea(parent: HTMLElement): HTMLElement {
 		this.titleContainer = parent;
+		this.titleContainer.tabIndex = -1;
 
 		// Draggable region that we can manipulate for #52522
 		this.dragRegion = append(this.titleContainer, $('div.titlebar-drag-region'));


### PR DESCRIPTION
Menubars shouldn't be part of the tab order and don't usually respond to tab when inside
fixes #62423 