### PR TITLE
menus: use proper command id for centered layout

### DIFF
--- a/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
+++ b/src/vs/workbench/browser/actions/toggleCenteredLayout.ts
@@ -46,7 +46,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	group: '2_layouts',
 	command: {
-		id: 'workbench.action.editorLayoutCentered',
+		id: 'workbench.action.toggleCenteredLayout',
 		title: nls.localize({ key: 'miCenteredEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Centered")
 	},
 	order: 2


### PR DESCRIPTION
fixes #62984

We always had the wrong id in the appendMenuItem, just before we were using an old way of adding menu entries, thus this was not hit.
This fix simply fixes the command id name.