### PR TITLE
Allow a task to execute an extension command.

### DIFF
--- a/build/builtInExtensions.json
+++ b/build/builtInExtensions.json
@@ -43,5 +43,20 @@
 			},
 			"publisherDisplayName": "Microsoft"
 		}
+	},
+	{
+		"name": "ms-vscode.cpptools",
+		"version": "0.20.1",
+		"repo": "https://github.com/Microsoft/vscode-cpptools",
+		"metadata": {
+			"id": "36d19e17-7569-4841-a001-947eb18602b2",
+			"publisherId": {
+				"publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
+				"publisherName": "ms-vscode",
+				"displayName": "Microsoft",
+				"flags": "verified"
+			},
+			"publisherDisplayName": "Microsoft"
+		}
 	}
 ]

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4950,6 +4950,16 @@ declare module 'vscode' {
 		 * Arguments for executing the command.
 		 */
 		args?: any[];
+
+		/**
+		 * Called to show the output of the running command.
+		 */
+		showOutput?(): any;
+
+		/**
+		 * Called to terminate the output of a running command.
+		 */
+		terminate?(): any;
 	}
 
 	export class ExtensionCommandExecution {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4945,6 +4945,26 @@ declare module 'vscode' {
 		options?: ShellExecutionOptions;
 	}
 
+	export class ExtensionCommandExecution {
+		/**
+		 * Creates an extension command execution to be invoked through a task.
+		 * @param command The command identifier to invoke.
+		 * @param args Arguments for executing the command.
+		 */
+		constructor(command: string, ...args: any[]);
+
+		/**
+		 * The command identifier to execute.
+		 * Command must be registered through [registerCommand](#commands.registerCommand).
+		 */
+		command: string;
+
+		/**
+		 * Arguments for executing the command.
+		 */
+		args?: any;
+	}
+
 	/**
 	 * The scope of a task.
 	 */
@@ -4978,7 +4998,7 @@ declare module 'vscode' {
 		 *  or '$eslint'. Problem matchers can be contributed by an extension using
 		 *  the `problemMatchers` extension point.
 		 */
-		constructor(taskDefinition: TaskDefinition, name: string, source: string, execution?: ProcessExecution | ShellExecution, problemMatchers?: string | string[]);
+		constructor(taskDefinition: TaskDefinition, name: string, source: string, execution?: ProcessExecution | ShellExecution | ExtensionCommandExecution, problemMatchers?: string | string[]);
 
 		/**
 		 * Creates a new task.
@@ -4992,7 +5012,7 @@ declare module 'vscode' {
 		 *  or '$eslint'. Problem matchers can be contributed by an extension using
 		 *  the `problemMatchers` extension point.
 		 */
-		constructor(taskDefinition: TaskDefinition, target: WorkspaceFolder | TaskScope.Global | TaskScope.Workspace, name: string, source: string, execution?: ProcessExecution | ShellExecution, problemMatchers?: string | string[]);
+		constructor(taskDefinition: TaskDefinition, target: WorkspaceFolder | TaskScope.Global | TaskScope.Workspace, name: string, source: string, execution?: ProcessExecution | ShellExecution | ExtensionCommandExecution, problemMatchers?: string | string[]);
 
 		/**
 		 * The task's definition.
@@ -5012,7 +5032,7 @@ declare module 'vscode' {
 		/**
 		 * The task's execution engine
 		 */
-		execution: ProcessExecution | ShellExecution;
+		execution: ProcessExecution | ShellExecution | ExtensionCommandExecution;
 
 		/**
 		 * Whether the task is a background task or not.
@@ -5840,7 +5860,6 @@ declare module 'vscode' {
 		 * the command handler function doesn't return anything.
 		 */
 		export function executeCommand<T>(command: string, ...rest: any[]): Thenable<T | undefined>;
-		export function executeCommand<T>(command: 'vscode.previewHtml', error: { '⚠️ The vscode.previewHtml command is deprecated and will be removed. Please switch to using the Webview Api': never }, ...rest: any[]): Thenable<T | undefined>;
 
 		/**
 		 * Retrieve the list of all available commands. Commands starting an underscore are

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4945,13 +4945,20 @@ declare module 'vscode' {
 		options?: ShellExecutionOptions;
 	}
 
+	export interface ExtensionCommandExecutionOptions {
+		/**
+		 * Arguments for executing the command.
+		 */
+		args?: any[];
+	}
+
 	export class ExtensionCommandExecution {
 		/**
 		 * Creates an extension command execution to be invoked through a task.
 		 * @param command The command identifier to invoke.
-		 * @param args Arguments for executing the command.
+		 * @param options Options for executing the command.
 		 */
-		constructor(command: string, ...args: any[]);
+		constructor(command: string, options?: ExtensionCommandExecutionOptions);
 
 		/**
 		 * The command identifier to execute.
@@ -4960,9 +4967,9 @@ declare module 'vscode' {
 		command: string;
 
 		/**
-		 * Arguments for executing the command.
+		 * Options used to execute the extension command.
 		 */
-		args?: any;
+		options?: ExtensionCommandExecutionOptions;
 	}
 
 	/**

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4954,7 +4954,7 @@ declare module 'vscode' {
 		/**
 		 * Called to show the output of the running command.
 		 */
-		showOutput?(): any;
+		reveal?(): any;
 
 		/**
 		 * Called to terminate the output of a running command.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6702,6 +6702,12 @@ declare module 'vscode' {
 		cwd?: string;
 
 		/**
+		 * When set to true, the process environment from VSCode is ignored and the
+		 * terminal process only contains what is in the "env" member.
+		 */
+		noInheritEnv?: boolean;
+
+		/**
 		 * Object with environment variables that will be added to the VS Code process.
 		 */
 		env?: { [key: string]: string | null };

--- a/src/vs/workbench/api/electron-browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTask.ts
@@ -456,6 +456,17 @@ export class MainThreadTask implements MainThreadTaskShape {
 		this._providers.clear();
 	}
 
+	public $provideTaskId(task: Task): Thenable<string> {
+		return new Promise((resolve, reject) => {
+			let taskTransfer = task._source as any as ExtensionTaskSourceTransfer;
+			let taskIdentifier = TaskDefinition.createTaskIdentifier(taskTransfer.__definition, console);
+			if (taskIdentifier !== void 0) {
+				resolve(`${task._id}.${taskIdentifier._key}`);
+			}
+			reject(new Error('Unable to create task identifier'));
+		});
+	}
+
 	public $registerTaskProvider(handle: number): Thenable<void> {
 		let provider: ITaskProvider = {
 			provideTasks: (validTypes: IStringDictionary<boolean>) => {

--- a/src/vs/workbench/api/electron-browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTask.ts
@@ -210,7 +210,9 @@ namespace ExtensionCommandExecutionDTO {
 		if (value.options !== void 0 && value.options !== null &&
 			value.options.extensionCommand !== void 0 && value.options.extensionCommand !== null) {
 			result.options = {
-				args: value.options.extensionCommand.args
+				args: value.options.extensionCommand.args,
+				showOutput: value.options.extensionCommand.showOutput,
+				terminate: value.options.extensionCommand.terminate,
 			};
 		}
 
@@ -231,7 +233,9 @@ namespace ExtensionCommandExecutionDTO {
 		if (value.options !== void 0 && value.options !== null) {
 			result.options = {
 				extensionCommand: {
-					args: value.options.args
+					args: value.options.args,
+					showOutput: value.options.showOutput,
+					terminate: value.options.terminate
 				}
 			};
 		}
@@ -438,6 +442,10 @@ export class MainThreadTask implements MainThreadTaskShape {
 			} else if (event.kind === TaskEventKind.End) {
 				this._proxy.$OnDidEndTask(TaskExecutionDTO.from(Task.getTaskExecution(task)));
 			}
+		});
+
+		this._taskService.onRequestTerminateExtensionCommandTask((task) => {
+			this._proxy.$terminateExtensionCommandTask(TaskExecutionDTO.from(Task.getTaskExecution(task)));
 		});
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTask.ts
@@ -203,24 +203,40 @@ namespace ExtensionCommandExecutionDTO {
 			return undefined;
 		}
 
-		return {
+		let result: ExtensionCommandExecutionDTO = {
 			command: value.name,
-			args: value.args
 		};
+
+		if (value.options !== void 0 && value.options !== null &&
+			value.options.extensionCommand !== void 0 && value.options.extensionCommand !== null) {
+			result.options = {
+				args: value.options.extensionCommand.args
+			};
+		}
+
+		return result;
 	}
 
 	export function to(value: ExtensionCommandExecutionDTO): CommandConfiguration {
 		if (value === void 0 || value === null) {
 			return undefined;
 		}
-		return {
+
+		let result: CommandConfiguration = {
 			runtime: RuntimeType.ExtensionCommand,
 			name: value.command,
-			options: {
-				extensionCommandArguments: value.args
-			},
-			presentation: undefined,
+			presentation: undefined
 		};
+
+		if (value.options !== void 0 && value.options !== null) {
+			result.options = {
+				extensionCommand: {
+					args: value.options.args
+				}
+			};
+		}
+
+		return result;
 	}
 }
 

--- a/src/vs/workbench/api/electron-browser/mainThreadTask.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTask.ts
@@ -211,7 +211,7 @@ namespace ExtensionCommandExecutionDTO {
 			value.options.extensionCommand !== void 0 && value.options.extensionCommand !== null) {
 			result.options = {
 				args: value.options.extensionCommand.args,
-				showOutput: value.options.extensionCommand.showOutput,
+				showOutput: value.options.extensionCommand.reveal,
 				terminate: value.options.extensionCommand.terminate,
 			};
 		}
@@ -234,7 +234,7 @@ namespace ExtensionCommandExecutionDTO {
 			result.options = {
 				extensionCommand: {
 					args: value.options.args,
-					showOutput: value.options.showOutput,
+					reveal: value.options.showOutput,
 					terminate: value.options.terminate
 				}
 			};
@@ -444,8 +444,16 @@ export class MainThreadTask implements MainThreadTaskShape {
 			}
 		});
 
+		// Handles requests from the task service to terminate an extension command task.
+		// It merely routes the request to the extension host thread.
 		this._taskService.onRequestTerminateExtensionCommandTask((task) => {
 			this._proxy.$terminateExtensionCommandTask(TaskExecutionDTO.from(Task.getTaskExecution(task)));
+		});
+
+		// Handles requests from the task service to terminate an reveal a command task's output.
+		// It merely routes the request to the extension host thread.
+		this._taskService.onRequestRevealExtensionCommandTask((task) => {
+			this._proxy.$revealExtensionCommandTask(TaskExecutionDTO.from(Task.getTaskExecution(task)));
 		});
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -53,7 +53,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 		// when the extension host process goes down ?
 	}
 
-	public $createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, env?: { [key: string]: string }, waitOnExit?: boolean): Thenable<number> {
+	public $createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, noInheritEnv?: boolean, env?: { [key: string]: string }, waitOnExit?: boolean): Thenable<number> {
 		const shellLaunchConfig: IShellLaunchConfig = {
 			name,
 			executable: shellPath,
@@ -61,6 +61,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			cwd,
 			waitOnExit,
 			ignoreConfigurationCwd: true,
+			noInheritEnv: noInheritEnv,
 			env
 		};
 		return Promise.resolve(this.terminalService.createTerminal(shellLaunchConfig).id);

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -758,6 +758,7 @@ export function createApiFactory(
 			DocumentSymbol: extHostTypes.DocumentSymbol,
 			EndOfLine: extHostTypes.EndOfLine,
 			EventEmitter: Emitter,
+			ExtensionCommandExecution: extHostTypes.ExtensionCommandExecution,
 			FileChangeType: extHostTypes.FileChangeType,
 			FileSystemError: extHostTypes.FileSystemError,
 			FileType: files.FileType,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -331,7 +331,7 @@ export interface MainThreadProgressShape extends IDisposable {
 }
 
 export interface MainThreadTerminalServiceShape extends IDisposable {
-	$createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, env?: { [key: string]: string }, waitOnExit?: boolean): Thenable<number>;
+	$createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, noInheritEnv?: boolean, env?: { [key: string]: string }, waitOnExit?: boolean): Thenable<number>;
 	$createTerminalRenderer(name: string): Thenable<number>;
 	$dispose(terminalId: number): void;
 	$hide(terminalId: number): void;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -911,6 +911,7 @@ export interface ExtHostSCMShape {
 }
 
 export interface ExtHostTaskShape {
+	$terminateExtensionCommandTask(execution: TaskExecutionDTO): Thenable<void>;
 	$provideTasks(handle: number, validTypes: { [key: string]: boolean; }): Thenable<TaskSet>;
 	$onDidStartTask(execution: TaskExecutionDTO): void;
 	$onDidStartTaskProcess(value: TaskProcessStartedDTO): void;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -35,7 +35,7 @@ import { TaskDTO, TaskExecutionDTO, TaskFilterDTO, TaskHandleDTO, TaskProcessEnd
 import { ITreeItem, IRevealOptions } from 'vs/workbench/common/views';
 import { IAdapterDescriptor, IConfig, ITerminalSettings } from 'vs/workbench/parts/debug/common/debug';
 import { ITextQueryBuilderOptions } from 'vs/workbench/parts/search/common/queryBuilder';
-import { TaskSet } from 'vs/workbench/parts/tasks/common/tasks';
+import { TaskSet, Task } from 'vs/workbench/parts/tasks/common/tasks';
 import { ITerminalDimensions } from 'vs/workbench/parts/terminal/common/terminal';
 import { IExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 import { IRPCProtocol, ProxyIdentifier, createExtHostContextProxyIdentifier as createExtId, createMainContextProxyIdentifier as createMainId } from 'vs/workbench/services/extensions/node/proxyIdentifier';
@@ -521,6 +521,7 @@ export interface MainThreadTaskShape extends IDisposable {
 	$executeTask(task: TaskHandleDTO | TaskDTO): Thenable<TaskExecutionDTO>;
 	$terminateTask(id: string): Thenable<void>;
 	$registerTaskSystem(scheme: string, info: TaskSystemInfoDTO): void;
+	$provideTaskId(task: Task): Thenable<string>;
 }
 
 export interface MainThreadExtensionServiceShape extends IDisposable {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -913,6 +913,7 @@ export interface ExtHostSCMShape {
 
 export interface ExtHostTaskShape {
 	$terminateExtensionCommandTask(execution: TaskExecutionDTO): Thenable<void>;
+	$revealExtensionCommandTask(execution: TaskExecutionDTO): Thenable<void>;
 	$provideTasks(handle: number, validTypes: { [key: string]: boolean; }): Thenable<TaskSet>;
 	$onDidStartTask(execution: TaskExecutionDTO): void;
 	$onDidStartTaskProcess(value: TaskProcessStartedDTO): void;

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -420,7 +420,9 @@ namespace Tasks {
 			name: value.command,
 			presentation: undefined,
 			options: {
-				extensionCommandArguments: value.args
+				extensionCommand: {
+					args: value.options && value.options.args
+				}
 			}
 		};
 	}
@@ -556,10 +558,17 @@ namespace ExtensionCallbackExecutionDTO {
 			return undefined;
 		}
 
-		return {
+		let result: ExtensionCommandExecutionDTO = {
 			command: value.command,
-			args: value.args
 		};
+
+		if (value.options !== void 0 && value.options !== null) {
+			result.options = {
+				args: value.options.args
+			};
+		}
+
+		return result;
 	}
 
 	export function to(value: ExtensionCommandExecutionDTO): types.ExtensionCommandExecution {
@@ -567,7 +576,11 @@ namespace ExtensionCallbackExecutionDTO {
 			return undefined;
 		}
 
-		return new types.ExtensionCommandExecution(value.command, value.args);
+		if (value.options !== void 0 && value.options !== null) {
+			return new types.ExtensionCommandExecution(value.command, { args: value.options.args });
+		}
+
+		return new types.ExtensionCommandExecution(value.command);
 	}
 }
 

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -415,16 +415,21 @@ namespace Tasks {
 			return undefined;
 		}
 
-		return {
+		let result: tasks.CommandConfiguration = {
 			runtime: tasks.RuntimeType.ExtensionCommand,
 			name: value.command,
-			presentation: undefined,
-			options: {
-				extensionCommand: {
-					args: value.options && value.options.args
-				}
-			}
+			presentation: undefined
 		};
+
+		if (value.options !== void 0 && value.options !== null) {
+			result.options = {
+				extensionCommand: {
+					args: value.options.args
+				}
+			};
+		}
+
+		return result;
 	}
 
 	function getProcessCommand(value: vscode.ProcessExecution): tasks.CommandConfiguration {

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -103,10 +103,11 @@ export class ExtHostTerminal extends BaseExtHostTerminal implements vscode.Termi
 		shellPath?: string,
 		shellArgs?: string[],
 		cwd?: string,
+		noInheritEnv?: boolean,
 		env?: { [key: string]: string },
 		waitOnExit?: boolean
 	): void {
-		this._proxy.$createTerminal(this._name, shellPath, shellArgs, cwd, env, waitOnExit).then((id) => {
+		this._proxy.$createTerminal(this._name, shellPath, shellArgs, cwd, noInheritEnv, env, waitOnExit).then((id) => {
 			this._runQueuedRequests(id);
 		});
 	}
@@ -261,7 +262,7 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 
 	public createTerminalFromOptions(options: vscode.TerminalOptions): vscode.Terminal {
 		const terminal = new ExtHostTerminal(this._proxy, options.name);
-		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.env /*, options.waitOnExit*/);
+		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.noInheritEnv, options.env /*, options.waitOnExit*/);
 		this._terminals.push(terminal);
 		return terminal;
 	}

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1495,19 +1495,19 @@ export class ProcessExecution implements vscode.ProcessExecution {
 
 export class ExtensionCommandExecution implements vscode.ExtensionCommandExecution {
 	private readonly _command: string;
-	private _args?: any;
+	private _options?: vscode.ExtensionCommandExecutionOptions;
 
-	public constructor(command: string, ...args: any[]) {
+	public constructor(command: string, options?: vscode.ExtensionCommandExecutionOptions) {
 		this._command = command;
-		this._args = args;
+		this._options = options;
 	}
 
-	public get args(): any {
-		return this._args;
+	public get options(): vscode.ExtensionCommandExecutionOptions {
+		return this._options;
 	}
 
-	public set args(value: any) {
-		this._args = value;
+	public set options(value: vscode.ExtensionCommandExecutionOptions) {
+		this._options = value;
 	}
 
 	public get command(): string {
@@ -1518,10 +1518,10 @@ export class ExtensionCommandExecution implements vscode.ExtensionCommandExecuti
 		const hash = crypto.createHash('md5');
 		hash.update('extensionCommand');
 		hash.update(this.command);
-		if (this._args !== void 0) {
+		if (this._options !== void 0) {
 			// Use best effort attempt to has the arguments.
 			try {
-				const jsonValue: string = JSON.stringify(this._args);
+				const jsonValue: string = JSON.stringify(this._options);
 				hash.update(jsonValue);
 			} catch (e) {
 			}

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -1518,10 +1518,10 @@ export class ExtensionCommandExecution implements vscode.ExtensionCommandExecuti
 		const hash = crypto.createHash('md5');
 		hash.update('extensionCommand');
 		hash.update(this.command);
-		if (this._options !== void 0) {
+		if (this._options !== void 0 && this._options.args !== void 0) {
 			// Use best effort attempt to has the arguments.
 			try {
-				const jsonValue: string = JSON.stringify(this._options);
+				const jsonValue: string = JSON.stringify(this._options.args);
 				hash.update(jsonValue);
 			} catch (e) {
 			}

--- a/src/vs/workbench/api/shared/tasks.ts
+++ b/src/vs/workbench/api/shared/tasks.ts
@@ -60,9 +60,13 @@ export interface ShellExecutionDTO {
 	options?: ShellExecutionOptionsDTO;
 }
 
+export interface ExtensionCommandExecutionOptionsDTO {
+	args: any[];
+}
+
 export interface ExtensionCommandExecutionDTO {
 	command: string;
-	args: any;
+	options?: ExtensionCommandExecutionOptionsDTO;
 }
 
 export interface TaskSourceDTO {

--- a/src/vs/workbench/api/shared/tasks.ts
+++ b/src/vs/workbench/api/shared/tasks.ts
@@ -60,6 +60,11 @@ export interface ShellExecutionDTO {
 	options?: ShellExecutionOptionsDTO;
 }
 
+export interface ExtensionCommandExecutionDTO {
+	command: string;
+	args: any;
+}
+
 export interface TaskSourceDTO {
 	label: string;
 	extensionId?: string;
@@ -74,7 +79,7 @@ export interface TaskHandleDTO {
 export interface TaskDTO {
 	_id: string;
 	name: string;
-	execution: ProcessExecutionDTO | ShellExecutionDTO;
+	execution: ProcessExecutionDTO | ShellExecutionDTO | ExtensionCommandExecutionDTO;
 	definition: TaskDefinitionDTO;
 	isBackground: boolean;
 	source: TaskSourceDTO;

--- a/src/vs/workbench/api/shared/tasks.ts
+++ b/src/vs/workbench/api/shared/tasks.ts
@@ -62,6 +62,8 @@ export interface ShellExecutionDTO {
 
 export interface ExtensionCommandExecutionOptionsDTO {
 	args: any[];
+	showOutput?(): any;
+	terminate?(): any;
 }
 
 export interface ExtensionCommandExecutionDTO {

--- a/src/vs/workbench/parts/tasks/common/taskService.ts
+++ b/src/vs/workbench/parts/tasks/common/taskService.ts
@@ -42,6 +42,7 @@ export interface ITaskService {
 	_serviceBrand: any;
 	onDidStateChange: Event<TaskEvent>;
 	onRequestTerminateExtensionCommandTask: Event<Task>;
+	onRequestRevealExtensionCommandTask: Event<Task>;
 	supportsMultipleTaskExecutions: boolean;
 
 	configureAction(): Action;

--- a/src/vs/workbench/parts/tasks/common/taskService.ts
+++ b/src/vs/workbench/parts/tasks/common/taskService.ts
@@ -41,6 +41,7 @@ export interface TaskFilter {
 export interface ITaskService {
 	_serviceBrand: any;
 	onDidStateChange: Event<TaskEvent>;
+	onRequestTerminateExtensionCommandTask: Event<Task>;
 	supportsMultipleTaskExecutions: boolean;
 
 	configureAction(): Action;

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -89,11 +89,18 @@ export interface ShellConfiguration {
 	quoting?: ShellQuotingOptions;
 }
 
+export interface ExtensionCommandConfiguration {
+	/**
+	 * Arguments for executing the command.
+	 */
+	args?: any[];
+}
+
 export interface CommandOptions {
 	/**
 	 * Configuration information when the task is a extension command.
 	 */
-	extensionCommandArguments?: any;
+	extensionCommand?: ExtensionCommandConfiguration;
 
 	/**
 	 * The shell to use if the task is a shell command.

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -94,6 +94,16 @@ export interface ExtensionCommandConfiguration {
 	 * Arguments for executing the command.
 	 */
 	args?: any[];
+
+	/**
+	 * Called to show the output of the running command.
+	 */
+	showOutput?(): any;
+
+	/**
+	 * Called to terminate the output of a running command.
+	 */
+	terminate?(): any;
 }
 
 export interface CommandOptions {

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -90,6 +90,10 @@ export interface ShellConfiguration {
 }
 
 export interface CommandOptions {
+	/**
+	 * Configuration information when the task is a extension command.
+	 */
+	extensionCommandArguments?: any;
 
 	/**
 	 * The shell to use if the task is a shell command.
@@ -214,12 +218,15 @@ export interface PresentationOptions {
 
 export enum RuntimeType {
 	Shell = 1,
-	Process = 2
+	Process = 2,
+	ExtensionCommand = 3
 }
 
 export namespace RuntimeType {
 	export function fromString(value: string): RuntimeType {
 		switch (value.toLowerCase()) {
+			case 'extensionCommand':
+				return RuntimeType.ExtensionCommand;
 			case 'shell':
 				return RuntimeType.Shell;
 			case 'process':

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -96,9 +96,9 @@ export interface ExtensionCommandConfiguration {
 	args?: any[];
 
 	/**
-	 * Called to show the output of the running command.
+	 * Called to reveal the output of the running command.
 	 */
-	showOutput?(): any;
+	reveal?(): any;
 
 	/**
 	 * Called to terminate the output of a running command.

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -479,7 +479,19 @@ export namespace CustomTask {
 	export function getDefinition(task: CustomTask): KeyedTaskIdentifier {
 		let type: string;
 		if (task.command !== void 0) {
-			type = task.command.runtime === RuntimeType.Shell ? 'shell' : 'process';
+			switch (task.command.runtime) {
+				case RuntimeType.Shell:
+					type = 'shell';
+					break;
+
+				case RuntimeType.Process:
+					type = 'process';
+					break;
+
+				case RuntimeType.ExtensionCommand:
+					type = 'extensionCommand';
+					break;
+			}
 		} else {
 			type = '$composite';
 		}

--- a/src/vs/workbench/parts/tasks/common/tasks.ts
+++ b/src/vs/workbench/parts/tasks/common/tasks.ts
@@ -491,6 +491,10 @@ export namespace CustomTask {
 				case RuntimeType.ExtensionCommand:
 					type = 'extensionCommand';
 					break;
+
+				default:
+					type = 'process';
+					break;
 			}
 		} else {
 			type = '$composite';

--- a/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/jsonSchema_v2.ts
@@ -171,9 +171,9 @@ const group: IJSONSchema = {
 
 const taskType: IJSONSchema = {
 	type: 'string',
-	enum: ['shell', 'process'],
+	enum: ['shell', 'process', 'extensionCommand'],
 	default: 'shell',
-	description: nls.localize('JsonSchema.tasks.type', 'Defines whether the task is run as a process or as a command inside a shell.')
+	description: nls.localize('JsonSchema.tasks.type', 'Defines whether the task is run as a process, command inside a shell, or as an extension command.')
 };
 
 const command: IJSONSchema = {

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -2356,8 +2356,7 @@ class TaskService extends Disposable implements ITaskService {
 					}
 				}
 				if (defaultTask) {
-					// TODO: Why were we wiping out this array?
-					// tasks = [];
+					tasks = [];
 					defaultEntry = {
 						label: nls.localize('TaskService.defaultBuildTaskExists', '{0} is already marked as the default build task', Task.getQualifiedLabel(defaultTask)),
 						task: defaultTask
@@ -2375,10 +2374,8 @@ class TaskService extends Disposable implements ITaskService {
 								this.openConfig(selectedTask);
 							}
 
-							for (let modifyTask of tasks) {
-								if (!InMemoryTask.is(modifyTask)) {
-									this.customize(modifyTask, { group: { kind: 'build', isDefault: modifyTask === selectedTask } }, true);
-								}
+							if (!InMemoryTask.is(selectedTask)) {
+								this.customize(selectedTask, { group: { kind: 'build', isDefault: true } }, true);
 							}
 						});
 				});

--- a/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/terminalTaskSystem.ts
@@ -235,7 +235,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 		return new TPromise<TaskTerminateResponse>((resolve, reject) => {
 			// For extension command tasks, there is no associated terminal.
 			if (ContributedTask.is(task) && task.command.runtime === RuntimeType.ExtensionCommand) {
-				resolve({ success: true, task: task });
+				resolve({ success: false, task: task });
 			} else {
 				let terminal = activeTerminal.terminal;
 				const onExit = terminal.onExit(() => {

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -1460,7 +1460,7 @@ namespace TaskParser {
 	function isCustomTask(value: CustomTask | ConfiguringTask): value is CustomTask {
 		let type = value.type;
 		let customize = (value as any).customize;
-		return customize === void 0 && (type === void 0 || type === null || type === Tasks.CUSTOMIZED_TASK_TYPE || type === 'shell' || type === 'process');
+		return customize === void 0 && (type === void 0 || type === null || type === Tasks.CUSTOMIZED_TASK_TYPE || type === 'shell' || type === 'process' || type === 'extensionCommand');
 	}
 
 	export function from(this: void, externals: (CustomTask | ConfiguringTask)[], globals: Globals, context: ParseContext): TaskParseResult {

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -880,7 +880,7 @@ namespace CommandConfiguration {
 
 		result.name = ShellString.from(config.command);
 		if (Types.isString(config.type)) {
-			if (config.type === 'shell' || config.type === 'process') {
+			if (config.type === 'shell' || config.type === 'process' || config.type === 'extensionCommand') {
 				result.runtime = Tasks.RuntimeType.fromString(config.type);
 			}
 		}
@@ -1323,7 +1323,7 @@ namespace CustomTask {
 		if (type === void 0 || type === null) {
 			type = Tasks.CUSTOMIZED_TASK_TYPE;
 		}
-		if (type !== Tasks.CUSTOMIZED_TASK_TYPE && type !== 'shell' && type !== 'process') {
+		if (type !== Tasks.CUSTOMIZED_TASK_TYPE && type !== 'shell' && type !== 'process' && type !== 'extensionCommand') {
 			context.problemReporter.error(nls.localize('ConfigurationParser.notCustom', 'Error: tasks is not declared as a custom task. The configuration will be ignored.\n{0}\n', JSON.stringify(external, null, 4)));
 			return undefined;
 		}

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -148,6 +148,12 @@ export interface IShellLaunchConfig {
 	cwd?: string;
 
 	/**
+	 * When set to true, the process environment from VSCode is ignored and the
+	 * terminal process only contains what is in the "env" member.
+	 */
+	noInheritEnv?: boolean;
+
+	/**
 	 * A custom environment for the terminal, if this is not set the environment will be inherited
 	 * from the VS Code process.
 	 */


### PR DESCRIPTION
#63153 

Creates a mechanism for allowing an extension to define a task that actually executes an extension command.

This pull request is just to gather some initial feedback.

The implementation is not yet done.

What needs to be considered:
1) Cancellation support when an extension command is running as a task
2) Allow a task to be defined in JSON (update the JSON schema)
3) Reconcile a task-definition's properties with "options" that can be specified by a task provider.
4) And more that I may be missing..

