### PR TITLE
Fix a git extension compile error for TS 3.2

### DIFF
--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -33,7 +33,7 @@ export function combinedDisposable(disposables: IDisposable[]): IDisposable {
 export const EmptyDisposable = toDisposable(() => null);
 
 export function fireEvent<T>(event: Event<T>): Event<T> {
-	return (listener, thisArgs = null, disposables?) => event(_ => listener.call(thisArgs), null, disposables);
+	return (listener, thisArgs = null, disposables?) => event(e => listener.call(thisArgs, e), null, disposables);
 }
 
 export function mapEvent<I, O>(event: Event<I>, map: (i: I) => O): Event<O> {


### PR DESCRIPTION
With TS 3.2, `call` checks the expected number of arguments. This call was missing one and I think this is the correct fix but I don't know the code. @joaomoreno please check if this is correct or look into fixing this yourself (just install typescript@next locally to test it)