### PR TITLE
Use <user-file-path> instead of aaaaaaaaaa

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -141,11 +141,11 @@ export class TelemetryService implements ITelemetryService {
 				}
 				// Anoynimize user file paths that do not need to be retained or cleaned up.
 				if (!nodeModulesRegex.test(result[0]) && cleanUpIndexes.every(([x, y]) => result.index < x || result.index >= y)) {
-					updatedStack += stack.substring(lastIndex, result.index) + '<user-file-path>';
+					updatedStack += stack.substring(lastIndex, result.index) + '<REDACTED: user-file-path>';
 					lastIndex = fileRegex.lastIndex;
 				}
 			}
-			if (lastIndex < stack.length - 1) {
+			if (lastIndex < stack.length) {
 				updatedStack += stack.substr(lastIndex);
 			}
 		}

--- a/src/vs/platform/telemetry/common/telemetryService.ts
+++ b/src/vs/platform/telemetry/common/telemetryService.ts
@@ -131,6 +131,8 @@ export class TelemetryService implements ITelemetryService {
 
 			const nodeModulesRegex = /^[\\\/]?(node_modules|node_modules\.asar)[\\\/]/;
 			const fileRegex = /(file:\/\/)?([a-zA-Z]:(\\\\|\\|\/)|(\\\\|\\|\/))?([\w-\._]+(\\\\|\\|\/))+[\w-\._]*/g;
+			let lastIndex = 0;
+			updatedStack = '';
 
 			while (true) {
 				const result = fileRegex.exec(stack);
@@ -139,8 +141,12 @@ export class TelemetryService implements ITelemetryService {
 				}
 				// Anoynimize user file paths that do not need to be retained or cleaned up.
 				if (!nodeModulesRegex.test(result[0]) && cleanUpIndexes.every(([x, y]) => result.index < x || result.index >= y)) {
-					updatedStack = updatedStack.slice(0, result.index) + result[0].replace(/./g, 'a') + updatedStack.slice(fileRegex.lastIndex);
+					updatedStack += stack.substring(lastIndex, result.index) + '<user-file-path>';
+					lastIndex = fileRegex.lastIndex;
 				}
+			}
+			if (lastIndex < stack.length - 1) {
+				updatedStack += stack.substr(lastIndex);
 			}
 		}
 

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -48,7 +48,7 @@ class ErrorTestingSettings {
 	public noSuchFileMessage: string;
 	public stack: string[];
 	public randomUserFile: string = 'a/path/that/doe_snt/con-tain/code/names.js';
-	public anonymizedRandomUserFile: string = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+	public anonymizedRandomUserFile: string = '<user-file-path>';
 	public nodeModulePathToRetain: string = 'node_modules/path/that/shouldbe/retained/names.js:14:15854';
 	public nodeModuleAsarPathToRetain: string = 'node_modules.asar/path/that/shouldbe/retained/names.js:14:12354';
 

--- a/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/telemetryService.test.ts
@@ -48,7 +48,7 @@ class ErrorTestingSettings {
 	public noSuchFileMessage: string;
 	public stack: string[];
 	public randomUserFile: string = 'a/path/that/doe_snt/con-tain/code/names.js';
-	public anonymizedRandomUserFile: string = '<user-file-path>';
+	public anonymizedRandomUserFile: string = '<REDACTED: user-file-path>';
 	public nodeModulePathToRetain: string = 'node_modules/path/that/shouldbe/retained/names.js:14:15854';
 	public nodeModuleAsarPathToRetain: string = 'node_modules.asar/path/that/shouldbe/retained/names.js:14:12354';
 


### PR DESCRIPTION
Call stacks in our error telemetry contains a lot of `aaaaaaaaaaaaaaaa` in place of file paths.
This PR replaces that with `<user-file-path>`