### PR TITLE
Search: Improvements to clear button behavior

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -520,13 +520,9 @@ export class HistoryInputBox extends InputBox implements IHistoryNavigationWidge
 
 	private readonly history: HistoryNavigator<string>;
 
-	private readonly _onInput = this._register(new Emitter<void>());
-	public readonly onInput: Event<void> = this._onInput.event;
-
 	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, options: IHistoryInputOptions) {
 		super(container, contextViewProvider, options);
 		this.history = new HistoryNavigator<string>(options.history, 100);
-		this.oninput(this.inputElement, (e) => this._onInput.fire());
 	}
 
 	public addToHistory(): void {

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -520,9 +520,13 @@ export class HistoryInputBox extends InputBox implements IHistoryNavigationWidge
 
 	private readonly history: HistoryNavigator<string>;
 
+	private readonly _onInput = this._register(new Emitter<void>());
+	public readonly onInput: Event<void> = this._onInput.event;
+
 	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, options: IHistoryInputOptions) {
 		super(container, contextViewProvider, options);
 		this.history = new HistoryNavigator<string>(options.history, 100);
+		this.oninput(this.inputElement, (e) => this._onInput.fire());
 	}
 
 	public addToHistory(): void {

--- a/src/vs/workbench/parts/search/browser/patternInputWidget.ts
+++ b/src/vs/workbench/parts/search/browser/patternInputWidget.ts
@@ -41,6 +41,9 @@ export class PatternInputWidget extends Widget {
 	private _onSubmit = this._register(new Emitter<boolean>());
 	public onSubmit: CommonEvent<boolean> = this._onSubmit.event;
 
+	private readonly _onInput = this._register(new Emitter<void>());
+	public readonly onInput: CommonEvent<void> = this._onInput.event;
+
 	private _onCancel = this._register(new Emitter<boolean>());
 	public onCancel: CommonEvent<boolean> = this._onCancel.event;
 
@@ -57,6 +60,8 @@ export class PatternInputWidget extends Widget {
 		this.inputBox = null;
 
 		this.render(options);
+
+		this.oninput(this.inputBox.inputElement, (e) => this._onInput.fire());
 
 		parent.appendChild(this.domNode);
 	}

--- a/src/vs/workbench/parts/search/browser/patternInputWidget.ts
+++ b/src/vs/workbench/parts/search/browser/patternInputWidget.ts
@@ -36,13 +36,10 @@ export class PatternInputWidget extends Widget {
 	private ariaLabel: string;
 
 	private domNode: HTMLElement;
-	protected inputBox: HistoryInputBox;
+	public inputBox: HistoryInputBox;
 
 	private _onSubmit = this._register(new Emitter<boolean>());
 	public onSubmit: CommonEvent<boolean> = this._onSubmit.event;
-
-	private readonly _onInput = this._register(new Emitter<void>());
-	public readonly onInput: CommonEvent<void> = this._onInput.event;
 
 	private _onCancel = this._register(new Emitter<boolean>());
 	public onCancel: CommonEvent<boolean> = this._onCancel.event;
@@ -60,8 +57,6 @@ export class PatternInputWidget extends Widget {
 		this.inputBox = null;
 
 		this.render(options);
-
-		this.oninput(this.inputBox.inputElement, (e) => this._onInput.fire());
 
 		parent.appendChild(this.domNode);
 	}

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -317,7 +317,7 @@ export class ClearSearchResultsAction extends Action {
 
 	update(): void {
 		const searchView = getSearchView(this.viewletService, this.panelService);
-		this.enabled = searchView && searchView.isSearchSubmitted();
+		this.enabled = searchView && !searchView.allSearchFieldsClear();//searchView.isSearchSubmitted();
 	}
 
 	public run(): Thenable<void> {

--- a/src/vs/workbench/parts/search/browser/searchActions.ts
+++ b/src/vs/workbench/parts/search/browser/searchActions.ts
@@ -317,7 +317,7 @@ export class ClearSearchResultsAction extends Action {
 
 	update(): void {
 		const searchView = getSearchView(this.viewletService, this.panelService);
-		this.enabled = searchView && !searchView.allSearchFieldsClear();//searchView.isSearchSubmitted();
+		this.enabled = searchView && (!searchView.allSearchFieldsClear() || searchView.hasSearchResults());
 	}
 
 	public run(): Thenable<void> {

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -161,6 +161,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 			(() => this.selectCurrentMatch()));
 
 		this.delayedRefresh = this._register(new Delayer<void>(250));
+
 	}
 
 	private onDidChangeWorkbenchState(): void {
@@ -271,6 +272,11 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 
 		this._register(this.viewModel.searchResult.onChange((event) => this.onSearchResultsChanged(event)));
 
+		this._register(this.searchWidget.searchInput.onInput(() => this.updateActions()));
+		this._register(this.searchWidget.replaceInput.onInput(() => this.updateActions()));
+		this._register(this.searchIncludePattern.onInput(() => this.updateActions()));
+		this._register(this.searchExcludePattern.onInput(() => this.updateActions()));
+
 		this._register(this.onDidFocus(() => this.viewletFocused.set(true)));
 		this._register(this.onDidBlur(() => this.viewletFocused.set(false)));
 	}
@@ -341,6 +347,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 		}));
 
 		this._register(this.searchWidget.onReplaceAll(() => this.replaceAll()));
+
 		this.trackInputBox(this.searchWidget.searchInputFocusTracker);
 		this.trackInputBox(this.searchWidget.replaceInputFocusTracker);
 	}
@@ -826,6 +833,13 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 		return this.searching;
 	}
 
+	public allSearchFieldsClear(): boolean {
+		return this.searchWidget.getReplaceValue() === '' &&
+			this.searchWidget.searchInput.getValue() === '' &&
+			this.searchIncludePattern.getValue() === '' &&
+			this.searchExcludePattern.getValue() === '';
+	}
+
 	public hasSearchResults(): boolean {
 		return !this.viewModel.searchResult.isEmpty();
 	}
@@ -837,7 +851,10 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 			this.showSearchWithoutFolderMessage();
 		}
 		this.searchWidget.clear();
+		this.searchIncludePattern.setValue('');
+		this.searchExcludePattern.setValue('');
 		this.viewModel.cancelSearch();
+		this.updateActions();
 	}
 
 	public cancelSearch(): boolean {

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -273,7 +273,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 		this._register(this.viewModel.searchResult.onChange((event) => this.onSearchResultsChanged(event)));
 
 		this._register(this.searchWidget.searchInput.onInput(() => this.updateActions()));
-		this._register(this.searchWidget.replaceInput.onInput(() => this.updateActions()));
+		this._register(this.searchWidget.replaceInput.onDidChange(() => this.updateActions()));
 		this._register(this.searchIncludePattern.onInput(() => this.updateActions()));
 		this._register(this.searchExcludePattern.onInput(() => this.updateActions()));
 

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -274,8 +274,8 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 
 		this._register(this.searchWidget.searchInput.onInput(() => this.updateActions()));
 		this._register(this.searchWidget.replaceInput.onDidChange(() => this.updateActions()));
-		this._register(this.searchIncludePattern.onInput(() => this.updateActions()));
-		this._register(this.searchExcludePattern.onInput(() => this.updateActions()));
+		this._register(this.searchIncludePattern.inputBox.onDidChange(() => this.updateActions()));
+		this._register(this.searchExcludePattern.inputBox.onDidChange(() => this.updateActions()));
 
 		this._register(this.onDidFocus(() => this.viewletFocused.set(true)));
 		this._register(this.onDidBlur(() => this.viewletFocused.set(false)));

--- a/src/vs/workbench/parts/search/browser/searchWidget.ts
+++ b/src/vs/workbench/parts/search/browser/searchWidget.ts
@@ -89,7 +89,7 @@ export class SearchWidget extends Widget {
 	private searchInputBoxFocused: IContextKey<boolean>;
 
 	private replaceContainer: HTMLElement;
-	private replaceInput: HistoryInputBox;
+	public replaceInput: HistoryInputBox;
 	private toggleReplaceButton: Button;
 	private replaceAllAction: ReplaceAllAction;
 	private replaceActive: IContextKey<boolean>;


### PR DESCRIPTION
Issue: https://github.com/Microsoft/vscode/issues/62952

Made a few improvements to the behavior of the search clear button based off the suggestions in the above issue.

The clear button now:
 - Enables after any input to any input box in the search form
 - Disables after input is cleared from all input boxes in the search form
 - Clears *all* input from the search form now including the include and exclude filters