### PR TITLE
Fixes #63095 - html encode hrefs in marked strings

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -122,6 +122,12 @@ export function renderMarkdown(markdown: IMarkdownString, options: RenderOptions
 			return text;
 
 		} else {
+			// HTML Encode href
+			href.replace(/&/g, '&amp;')
+				.replace(/</g, '&lt;')
+				.replace(/>/g, '&gt;')
+				.replace(/"/g, '&quot;')
+				.replace(/'/g, '&#39;');
 			return `<a href="#" data-href="${href}" title="${title || href}">${text}</a>`;
 		}
 	};


### PR DESCRIPTION
This fixes #63095 

/cc @jrieken 