### PR TITLE
add focus change listener once

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -211,7 +211,10 @@ export class NotificationsToasts extends Themable {
 
 		// Install Timers to Purge Notification
 		let purgeTimeoutHandle: any;
+		let listener: IDisposable;
+
 		const hideAfterTimeout = () => {
+
 			purgeTimeoutHandle = setTimeout(() => {
 
 				// If the notification is sticky or prompting and the window does not have
@@ -220,11 +223,14 @@ export class NotificationsToasts extends Themable {
 				// could immediately hide the notification because the timeout was triggered
 				// again.
 				if ((item.sticky || item.hasPrompt()) && !this.windowHasFocus) {
-					disposables.push(this.windowService.onDidChangeFocus(focus => {
-						if (focus) {
-							hideAfterTimeout();
-						}
-					}));
+					if (!listener) {
+						listener = this.windowService.onDidChangeFocus(focus => {
+							if (focus) {
+								hideAfterTimeout();
+							}
+						});
+						disposables.push(listener);
+					}
 				}
 
 				// Otherwise...


### PR DESCRIPTION
This PR is the minimal change I could come with to tackle #62970. It makes sure that only one focus change listener is added per (active) notification toast. That prevent the exponential listener growth/leak we have observed