### PR TITLE
tree: if horizontal scrolling is enabled leave space for it

### DIFF
--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -845,7 +845,8 @@ export class TreeView extends HeightMap {
 	}
 
 	public set viewHeight(height: number) {
-		this.scrollableElement.setScrollDimensions({ height });
+		const heightWithHorizontalScrollIntoAccount = this.horizontalScrolling ? height - 20 : height;
+		this.scrollableElement.setScrollDimensions({ height: heightWithHorizontalScrollIntoAccount });
 	}
 
 	private set scrollHeight(scrollHeight: number) {

--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -845,12 +845,12 @@ export class TreeView extends HeightMap {
 	}
 
 	public set viewHeight(height: number) {
-		const heightWithHorizontalScrollIntoAccount = this.horizontalScrolling ? height - 20 : height;
-		this.scrollableElement.setScrollDimensions({ height: heightWithHorizontalScrollIntoAccount });
+		this.scrollableElement.setScrollDimensions({ height });
 	}
 
 	private set scrollHeight(scrollHeight: number) {
-		this.scrollableElement.setScrollDimensions({ scrollHeight });
+		const horizontalScrollHeight = this.horizontalScrolling ? 10 : 0;
+		this.scrollableElement.setScrollDimensions({ scrollHeight: scrollHeight + horizontalScrollHeight });
 	}
 
 	public get viewWidth(): number {
@@ -872,8 +872,9 @@ export class TreeView extends HeightMap {
 	}
 
 	public set scrollTop(scrollTop: number) {
+		const horizontalScrollHeight = this.horizontalScrolling ? 10 : 0;
 		this.scrollableElement.setScrollDimensions({
-			scrollHeight: this.getContentHeight()
+			scrollHeight: this.getContentHeight() + horizontalScrollHeight
 		});
 		this.scrollableElement.setScrollPosition({
 			scrollTop: scrollTop

--- a/src/vs/workbench/parts/debug/electron-browser/debugHover.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugHover.ts
@@ -261,7 +261,7 @@ export class DebugHoverWidget implements IContentWidget {
 		if (visibleElementsCount === 0) {
 			this.doShow(this.showAtPosition, this.tree.getInput(), false, true);
 		} else {
-			const height = Math.min(visibleElementsCount, MAX_ELEMENTS_SHOWN) * 18;
+			const height = Math.min(visibleElementsCount, MAX_ELEMENTS_SHOWN) * 18 + 10; // add 10 px for the horizontal scroll bar
 
 			if (this.treeContainer.clientHeight !== height) {
 				this.treeContainer.style.height = `${height}px`;


### PR DESCRIPTION
fixes https://github.com/Microsoft/vscode/issues/59452

The issue with this approach is that we would always leave vertical space even if there is enough horizontal space and the scroll is not shown.
Also it is not so precise. Sometimes the element would overflow it and it looks a bit broken to me.

This solution works great for my debug hover though.
@joaomoreno let me know what you think

![scroll](https://user-images.githubusercontent.com/1926584/48494902-16e4cb00-e82f-11e8-8153-cb147c26a18e.gif)
