### PR TITLE
Experiments shld provide local text for commands too

### DIFF
--- a/src/vs/workbench/parts/experiments/electron-browser/experimentalPrompt.ts
+++ b/src/vs/workbench/parts/experiments/electron-browser/experimentalPrompt.ts
@@ -51,7 +51,7 @@ export class ExperimentalPrompts extends Disposable implements IWorkbenchContrib
 		};
 
 		const actionProperties = (<IExperimentActionPromptProperties>experiment.action.properties);
-		const promptText = ExperimentalPrompts.getPromptText(actionProperties, language);
+		const promptText = ExperimentalPrompts.getLocalizedText(actionProperties.promptText, language);
 		if (!actionProperties || !promptText) {
 			return;
 		}
@@ -60,10 +60,11 @@ export class ExperimentalPrompts extends Disposable implements IWorkbenchContrib
 		}
 
 		const choices: IPromptChoice[] = actionProperties.commands.map((command: IExperimentActionPromptCommand) => {
+			const commandText = ExperimentalPrompts.getLocalizedText(command.text, language);
 			return {
-				label: command.text,
+				label: commandText,
 				run: () => {
-					logTelemetry(command.text);
+					logTelemetry(commandText);
 					if (command.externalLink) {
 						window.open(command.externalLink);
 					} else if (command.curatedExtensionsKey && Array.isArray(command.curatedExtensionsList)) {
@@ -94,15 +95,15 @@ export class ExperimentalPrompts extends Disposable implements IWorkbenchContrib
 		this._disposables = dispose(this._disposables);
 	}
 
-	static getPromptText(actionProperties: IExperimentActionPromptProperties, displayLanguage: string): string {
-		if (typeof actionProperties.promptText === 'string') {
-			return actionProperties.promptText;
+	static getLocalizedText(text: string | { [key: string]: string }, displayLanguage: string): string {
+		if (typeof text === 'string') {
+			return text;
 		}
-		const msgInEnglish = actionProperties.promptText['en'] || actionProperties.promptText['en-us'];
+		const msgInEnglish = text['en'] || text['en-us'];
 		displayLanguage = displayLanguage.toLowerCase();
-		if (!actionProperties.promptText[displayLanguage] && displayLanguage.indexOf('-') === 2) {
+		if (!text[displayLanguage] && displayLanguage.indexOf('-') === 2) {
 			displayLanguage = displayLanguage.substr(0, 2);
 		}
-		return actionProperties.promptText[displayLanguage] || msgInEnglish;
+		return text[displayLanguage] || msgInEnglish;
 	}
 }

--- a/src/vs/workbench/parts/experiments/node/experimentService.ts
+++ b/src/vs/workbench/parts/experiments/node/experimentService.ts
@@ -83,7 +83,7 @@ export interface IExperimentActionPromptProperties {
 }
 
 export interface IExperimentActionPromptCommand {
-	text: string;
+	text: string | { [key: string]: string };
 	externalLink?: string;
 	curatedExtensionsKey?: string;
 	curatedExtensionsList?: string[];

--- a/src/vs/workbench/parts/experiments/test/electron-browser/experimentalPrompts.test.ts
+++ b/src/vs/workbench/parts/experiments/test/electron-browser/experimentalPrompts.test.ts
@@ -185,13 +185,13 @@ suite('Experimental Prompts', () => {
 			commands: []
 		};
 
-		assert.equal(ExperimentalPrompts.getPromptText(simpleTextCase, 'any-language'), simpleTextCase.promptText);
-		assert.equal(ExperimentalPrompts.getPromptText(multipleLocaleCase, 'en'), multipleLocaleCase.promptText['en']);
-		assert.equal(ExperimentalPrompts.getPromptText(multipleLocaleCase, 'de'), multipleLocaleCase.promptText['de']);
-		assert.equal(ExperimentalPrompts.getPromptText(multipleLocaleCase, 'en-au'), multipleLocaleCase.promptText['en-au']);
-		assert.equal(ExperimentalPrompts.getPromptText(multipleLocaleCase, 'en-gb'), multipleLocaleCase.promptText['en']);
-		assert.equal(ExperimentalPrompts.getPromptText(multipleLocaleCase, 'fr'), multipleLocaleCase.promptText['en']);
-		assert.equal(ExperimentalPrompts.getPromptText(englishUSTextCase, 'fr'), englishUSTextCase.promptText['en-us']);
-		assert.equal(!!ExperimentalPrompts.getPromptText(noEnglishTextCase, 'fr'), false);
+		assert.equal(ExperimentalPrompts.getLocalizedText(simpleTextCase.promptText, 'any-language'), simpleTextCase.promptText);
+		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en'), multipleLocaleCase.promptText['en']);
+		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'de'), multipleLocaleCase.promptText['de']);
+		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en-au'), multipleLocaleCase.promptText['en-au']);
+		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'en-gb'), multipleLocaleCase.promptText['en']);
+		assert.equal(ExperimentalPrompts.getLocalizedText(multipleLocaleCase.promptText, 'fr'), multipleLocaleCase.promptText['en']);
+		assert.equal(ExperimentalPrompts.getLocalizedText(englishUSTextCase.promptText, 'fr'), englishUSTextCase.promptText['en-us']);
+		assert.equal(!!ExperimentalPrompts.getLocalizedText(noEnglishTextCase.promptText, 'fr'), false);
 	});
 });


### PR DESCRIPTION
https://github.com/Microsoft/vscode/commit/53ec5ac5b8826642653fd1f1ad62489ec563aec0#diff-90725d5e77bad319c8378b0eb8f0c17e allowed localized text for the prompts

This PR does the same for the text in the commands that show as buttons in the notifications