### PR TITLE
Fixes #63095 - html encode hrefs in marked strings (for REAL this time)

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -123,7 +123,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: RenderOptions
 
 		} else {
 			// HTML Encode href
-			href.replace(/&/g, '&amp;')
+			href = href.replace(/&/g, '&amp;')
 				.replace(/</g, '&lt;')
 				.replace(/>/g, '&gt;')
 				.replace(/"/g, '&quot;')


### PR DESCRIPTION
Really fixes #63095. Fixes stupid mistake :disappointed: Teaches me to move the code around after I test it.

/cc @jrieken 