### PR TITLE
Fix #63295:  Refer to Sudo in Linux Save Error Message

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/saveErrorHandler.ts
+++ b/src/vs/workbench/parts/files/electron-browser/saveErrorHandler.ts
@@ -31,6 +31,7 @@ import { ExecuteCommandAction } from 'vs/platform/actions/common/actions';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { once } from 'vs/base/common/event';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { isWindows } from 'vs/base/common/platform';
 
 export const CONFLICT_RESOLUTION_CONTEXT = 'saveConflictResolutionContext';
 export const CONFLICT_RESOLUTION_SCHEME = 'conflictResolution';
@@ -38,6 +39,9 @@ export const CONFLICT_RESOLUTION_SCHEME = 'conflictResolution';
 const LEARN_MORE_DIRTY_WRITE_IGNORE_KEY = 'learnMoreDirtyWriteError';
 
 const conflictEditorHelp = nls.localize('userGuide', "Use the actions in the editor tool bar to either undo your changes or overwrite the content on disk with your changes.");
+
+const adminUser = isWindows ? ('Admin') : ('Sudo');
+const adminUserLong = isWindows ? ('administrator') : ('superuser');
 
 // A handler for save error happening with conflict resolution actions
 export class SaveErrorHandler extends Disposable implements ISaveErrorHandler, IWorkbenchContribution {
@@ -158,12 +162,12 @@ export class SaveErrorHandler extends Disposable implements ISaveErrorHandler, I
 
 			if (isReadonly) {
 				if (triedToMakeWriteable) {
-					message = nls.localize('readonlySaveErrorAdmin', "Failed to save '{0}': File is write protected. Select 'Overwrite as Admin' to retry as administrator.", paths.basename(resource.fsPath));
+					message = nls.localize('readonlySaveErrorAdmin', "Failed to save '{0}': File is write protected. Select 'Overwrite as {1}' to retry as {2}.", paths.basename(resource.fsPath), adminUser, adminUserLong);
 				} else {
 					message = nls.localize('readonlySaveError', "Failed to save '{0}': File is write protected. Select 'Overwrite' to attempt to remove protection.", paths.basename(resource.fsPath));
 				}
 			} else if (isPermissionDenied) {
-				message = nls.localize('permissionDeniedSaveError', "Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.", paths.basename(resource.fsPath));
+				message = nls.localize('permissionDeniedSaveError', "Failed to save '{0}': Insufficient permissions. Select 'Retry as {1}' to retry as {2}.", paths.basename(resource.fsPath), adminUser, adminUserLong);
 			} else {
 				message = nls.localize('genericSaveError', "Failed to save '{0}': {1}", paths.basename(resource.fsPath), toErrorMessage(error, false));
 			}
@@ -272,7 +276,7 @@ class SaveElevatedAction extends Action {
 		private model: ITextFileEditorModel,
 		private triedToMakeWriteable: boolean
 	) {
-		super('workbench.files.action.saveElevated', triedToMakeWriteable ? nls.localize('overwriteElevated', "Overwrite as Admin...") : nls.localize('saveElevated', "Retry as Admin..."));
+		super('workbench.files.action.saveElevated', triedToMakeWriteable ? nls.localize('overwriteElevated', "Overwrite as {0}...", adminUser) : nls.localize('saveElevated', "Retry as {0}...", adminUser));
 	}
 
 	run(): Promise<any> {

--- a/src/vs/workbench/parts/files/electron-browser/saveErrorHandler.ts
+++ b/src/vs/workbench/parts/files/electron-browser/saveErrorHandler.ts
@@ -40,9 +40,6 @@ const LEARN_MORE_DIRTY_WRITE_IGNORE_KEY = 'learnMoreDirtyWriteError';
 
 const conflictEditorHelp = nls.localize('userGuide', "Use the actions in the editor tool bar to either undo your changes or overwrite the content on disk with your changes.");
 
-const adminUser = isWindows ? ('Admin') : ('Sudo');
-const adminUserLong = isWindows ? ('administrator') : ('superuser');
-
 // A handler for save error happening with conflict resolution actions
 export class SaveErrorHandler extends Disposable implements ISaveErrorHandler, IWorkbenchContribution {
 	private messages: ResourceMap<INotificationHandle>;
@@ -162,12 +159,12 @@ export class SaveErrorHandler extends Disposable implements ISaveErrorHandler, I
 
 			if (isReadonly) {
 				if (triedToMakeWriteable) {
-					message = nls.localize('readonlySaveErrorAdmin', "Failed to save '{0}': File is write protected. Select 'Overwrite as {1}' to retry as {2}.", paths.basename(resource.fsPath), adminUser, adminUserLong);
+					message = isWindows ? nls.localize('readonlySaveErrorAdmin', "Failed to save '{0}': File is write protected. Select 'Overwrite as Admin' to retry as administrator.", paths.basename(resource.fsPath)) : nls.localize('readonlySaveErrorSudo', "Failed to save '{0}': File is write protected. Select 'Overwrite as Sudo' to retry as superuser.", paths.basename(resource.fsPath));
 				} else {
 					message = nls.localize('readonlySaveError', "Failed to save '{0}': File is write protected. Select 'Overwrite' to attempt to remove protection.", paths.basename(resource.fsPath));
 				}
 			} else if (isPermissionDenied) {
-				message = nls.localize('permissionDeniedSaveError', "Failed to save '{0}': Insufficient permissions. Select 'Retry as {1}' to retry as {2}.", paths.basename(resource.fsPath), adminUser, adminUserLong);
+				message = isWindows ? nls.localize('permissionDeniedSaveError', "Failed to save '{0}': Insufficient permissions. Select 'Retry as Admin' to retry as administrator.", paths.basename(resource.fsPath)) : nls.localize('permissionDeniedSaveErrorSudo', "Failed to save '{0}': Insufficient permissions. Select 'Retry as Sudo' to retry as superuser.", paths.basename(resource.fsPath));
 			} else {
 				message = nls.localize('genericSaveError', "Failed to save '{0}': {1}", paths.basename(resource.fsPath), toErrorMessage(error, false));
 			}
@@ -276,7 +273,7 @@ class SaveElevatedAction extends Action {
 		private model: ITextFileEditorModel,
 		private triedToMakeWriteable: boolean
 	) {
-		super('workbench.files.action.saveElevated', triedToMakeWriteable ? nls.localize('overwriteElevated', "Overwrite as {0}...", adminUser) : nls.localize('saveElevated', "Retry as {0}...", adminUser));
+		super('workbench.files.action.saveElevated', triedToMakeWriteable ? isWindows ? nls.localize('overwriteElevated', "Overwrite as Admin...") : nls.localize('overwriteElevatedSudo', "Overwrite as Sudo...") : isWindows ? nls.localize('saveElevated', "Retry as Admin...") : nls.localize('saveElevatedSudo', "Retry as Sudo..."));
 	}
 
 	run(): Promise<any> {


### PR DESCRIPTION
This PR is meant to address #63295:

> When editing a file that can't be saved without elevation, a notification pops up, prompting to try and save as administrator. On Linux, perhaps this should say "Retry with sudo"

![image](https://user-images.githubusercontent.com/4128828/48680169-70116f00-eb4d-11e8-9058-581cc6d68b42.png)

I have changed the button to what @bpasero suggested in the issue ("Retry as Sudo"):

![image](https://user-images.githubusercontent.com/4128828/48680165-6425ad00-eb4d-11e8-9b03-2da717b1f3b8.png)

I look forward to any suggestions or comments, and I would be happy to change the code or error messages as necessary.  This is my first attempt at a contribution, so please let me know if I am missing anything.  Thanks!