### PR TITLE
Add self, static and parent to variable.language.php

### DIFF
--- a/extensions/php/syntaxes/php.tmLanguage.json
+++ b/extensions/php/syntaxes/php.tmLanguage.json
@@ -2456,7 +2456,12 @@
 							"patterns": [
 								{
 									"match": "\\b(self|static|parent)\\b",
-									"name": "storage.type.php"
+									"name": "storage.type.php",
+									"captures": {
+										"1": {
+											"name": "variable.language.php"
+										}
+									}
 								},
 								{
 									"include": "#class-name"


### PR DESCRIPTION
`self`, `static` and `parent` for PHP in most of the other editors like Sublime and Atom are in `variable.language`, which makes it easy to sync theme color theme for `$this` and `static`.