### PR TITLE
Fix #62083: Maximize panel causes left panel to shrink

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -432,7 +432,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 		//Restore old sidebar when maximize panel is toggled
 		if (options && options.toggleMaximizedPanel && (panelPosition === Position.RIGHT) && (sidebarPosition === Position.LEFT) && !isSidebarHidden) {
-			if(this.panelMaximized){
+			if (this.panelMaximized) {
 				//Store user's sidebar width
 				this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL);
 			} else {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -430,23 +430,19 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		this.sidebarHeight = this.workbenchSize.height - this.statusbarHeight - this.titlebarHeight;
 		let sidebarSize = new Dimension(this.sidebarWidth, this.sidebarHeight);
 
-		//Start of working area
+		//Restore old sidebar when pannel is toggled
 		if (options && options.toggleMaximizedPanel && (panelPosition === Position.RIGHT) && (sidebarPosition === Position.LEFT) && !isSidebarHidden) {
-			let sidebarWidth: number;
-			sidebarWidth = this.sidebarWidth;
-
-			//2 paths, maximising, minimizing
 			if(this.panelMaximized){
 				//Store user's sidebar width
 				this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL);
-				sidebarWidth = this.partLayoutInfo.sidebar.minWidth;
+				sidebarSize.width = this.partLayoutInfo.sidebar.minWidth;
 			} else {
 				//Retrieve user's sidebar width
 				this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH);
-				sidebarWidth = Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized);
+				sidebarSize.width = Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized);
 			}
-			sidebarSize.width = sidebarWidth;
 		}
+
 		// Activity Bar
 		let activityBarSize = new Dimension(this.activitybarWidth, sidebarSize.height);
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -435,23 +435,18 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 			let sidebarWidth: number;
 			sidebarWidth = this.sidebarWidth;
 
-			//if Pannel is not maximised, store sidebar
-			if(!this.panelMaximized) {
-				this.sidebarSizeBeforeMaximized = sidebarWidth;
+			//2 paths, maximising, minimizing
+			if(this.panelMaximized){
+				//Store user's sidebar width
+				this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL);
+				sidebarWidth = this.partLayoutInfo.sidebar.minWidth;
+			} else {
+				//Retrieve user's sidebar width
+				this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH);
+				sidebarWidth = Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized);
 			}
-
-			//if Pannel is not maximised, store sidebar
-			this.panelMaximized ?
-			this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH)
-			:
-			this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL);
-
-
-			//Toogle sidebar Size with Pannel
-			sidebarWidth = this.panelMaximized ? Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized) : this.partLayoutInfo.sidebar.minWidth;
 			sidebarSize.width = sidebarWidth;
 		}
-
 		// Activity Bar
 		let activityBarSize = new Dimension(this.activitybarWidth, sidebarSize.height);
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -420,7 +420,6 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		const menubarVisibility = this.partService.getMenubarVisibility();
 
 		// Sidebar
-		//Todo: Get some of the sidebar memory in here
 		if (this.sidebarWidth === -1) {
 			this.sidebarWidth = this.workbenchSize.width / 5;
 		}
@@ -432,17 +431,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		let sidebarSize = new Dimension(this.sidebarWidth, this.sidebarHeight);
 
 		//Start of working area
-
-		//if we are minimizing pannel
-			//set sidebar to old size
-		//else
-			//remember size
-			//set sidebar to min
-
-
-
-		// TODO: Toogle sidebar Size with Pannel
-		if (options && options.toggleMaximizedPanel && (panelPosition === Position.RIGHT) && !isSidebarHidden) {
+		if (options && options.toggleMaximizedPanel && (panelPosition === Position.RIGHT) && (sidebarPosition === Position.LEFT) && !isSidebarHidden) {
 			let sidebarWidth: number;
 			sidebarWidth = this.sidebarWidth;
 
@@ -460,10 +449,8 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 			//Toogle sidebar Size with Pannel
 			sidebarWidth = this.panelMaximized ? Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized) : this.partLayoutInfo.sidebar.minWidth;
-
 			sidebarSize.width = sidebarWidth;
 		}
-		// TODO: End of working area
 
 		// Activity Bar
 		let activityBarSize = new Dimension(this.activitybarWidth, sidebarSize.height);

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -442,16 +442,21 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 
 		// TODO: Toogle sidebar Size with Pannel
-		if (options && options.toggleMaximizedPanel) {
+		if (options && options.toggleMaximizedPanel && (panelPosition === Position.RIGHT) && !isSidebarHidden) {
 			let sidebarWidth: number;
 			sidebarWidth = this.sidebarWidth;
 
 			//if Pannel is not maximised, store sidebar
-			this.panelMaximized ? this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL) :
-			this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH);
+			if(!this.panelMaximized) {
+				this.sidebarSizeBeforeMaximized = sidebarWidth;
+			}
 
 			//if Pannel is not maximised, store sidebar
-			this.sidebarSizeBeforeMaximized = this.panelMaximized ? sidebarWidth : this.sidebarSizeBeforeMaximized;
+			this.panelMaximized ?
+			this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH)
+			:
+			this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL);
+
 
 			//Toogle sidebar Size with Pannel
 			sidebarWidth = this.panelMaximized ? Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized) : this.partLayoutInfo.sidebar.minWidth;

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -430,7 +430,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		this.sidebarHeight = this.workbenchSize.height - this.statusbarHeight - this.titlebarHeight;
 		let sidebarSize = new Dimension(this.sidebarWidth, this.sidebarHeight);
 
-		//Restore old sidebar when pannel is toggled
+		//Restore old sidebar when maximize panel is toggled
 		if (options && options.toggleMaximizedPanel && (panelPosition === Position.RIGHT) && (sidebarPosition === Position.LEFT) && !isSidebarHidden) {
 			if(this.panelMaximized){
 				//Store user's sidebar width
@@ -605,7 +605,6 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		const activitybarContainer = this.parts.activitybar.getContainer();
 		size(activitybarContainer, null, activityBarSize.height);
 		if (sidebarPosition === Position.LEFT) {
-			//todo find what position does
 			this.parts.activitybar.getContainer().style.right = '';
 			position(activitybarContainer, this.titlebarHeight, null, 0, 0);
 		} else {
@@ -623,7 +622,6 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		size(sidebarContainer, sidebarSize.width, sidebarSize.height);
 		const editorAndPanelWidth = editorSize.width + (panelPosition === Position.RIGHT ? panelWidth : 0);
 		if (sidebarPosition === Position.LEFT) {
-			//set size to what it was before maximize
 			position(sidebarContainer, this.titlebarHeight, editorAndPanelWidth, this.statusbarHeight, activityBarSize.width);
 		} else {
 			position(sidebarContainer, this.titlebarHeight, activityBarSize.width, this.statusbarHeight, editorAndPanelWidth);

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -52,6 +52,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 	private static readonly sashXTwoWidthSettingsKey = 'workbench.panel.width';
 	private static readonly sashYHeightSettingsKey = 'workbench.panel.height';
 	private static readonly panelSizeBeforeMaximizedKey = 'workbench.panel.sizeBeforeMaximized';
+	private static readonly sidebarSizeBeforeMaximizedKey = 'workbench.sidebar.sizeBeforeMaximized';
 
 	private workbenchSize: Dimension;
 
@@ -64,6 +65,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 	private titlebarHeight: number;
 	private statusbarHeight: number;
 	private panelSizeBeforeMaximized: number;
+	private sidebarSizeBeforeMaximized: number;
 	private panelMaximized: boolean;
 	private _panelHeight: number;
 	private _panelWidth: number;
@@ -418,6 +420,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		const menubarVisibility = this.partService.getMenubarVisibility();
 
 		// Sidebar
+		//Todo: Get some of the sidebar memory in here
 		if (this.sidebarWidth === -1) {
 			this.sidebarWidth = this.workbenchSize.width / 5;
 		}
@@ -427,6 +430,35 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 
 		this.sidebarHeight = this.workbenchSize.height - this.statusbarHeight - this.titlebarHeight;
 		let sidebarSize = new Dimension(this.sidebarWidth, this.sidebarHeight);
+
+		//Start of working area
+
+		//if we are minimizing pannel
+			//set sidebar to old size
+		//else
+			//remember size
+			//set sidebar to min
+
+
+
+		// TODO: Toogle sidebar Size with Pannel
+		if (options && options.toggleMaximizedPanel) {
+			let sidebarWidth: number;
+			sidebarWidth = this.sidebarWidth;
+
+			//if Pannel is not maximised, store sidebar
+			this.panelMaximized ? this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL) :
+			this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH);
+
+			//if Pannel is not maximised, store sidebar
+			this.sidebarSizeBeforeMaximized = this.panelMaximized ? sidebarWidth : this.sidebarSizeBeforeMaximized;
+
+			//Toogle sidebar Size with Pannel
+			sidebarWidth = this.panelMaximized ? Math.max(this.partLayoutInfo.sidebar.minWidth, this.sidebarSizeBeforeMaximized) : this.partLayoutInfo.sidebar.minWidth;
+
+			sidebarSize.width = sidebarWidth;
+		}
+		// TODO: End of working area
 
 		// Activity Bar
 		let activityBarSize = new Dimension(this.activitybarWidth, sidebarSize.height);
@@ -590,6 +622,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		const activitybarContainer = this.parts.activitybar.getContainer();
 		size(activitybarContainer, null, activityBarSize.height);
 		if (sidebarPosition === Position.LEFT) {
+			//todo find what position does
 			this.parts.activitybar.getContainer().style.right = '';
 			position(activitybarContainer, this.titlebarHeight, null, 0, 0);
 		} else {
@@ -607,6 +640,7 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 		size(sidebarContainer, sidebarSize.width, sidebarSize.height);
 		const editorAndPanelWidth = editorSize.width + (panelPosition === Position.RIGHT ? panelWidth : 0);
 		if (sidebarPosition === Position.LEFT) {
+			//set size to what it was before maximize
 			position(sidebarContainer, this.titlebarHeight, editorAndPanelWidth, this.statusbarHeight, activityBarSize.width);
 		} else {
 			position(sidebarContainer, this.titlebarHeight, activityBarSize.width, this.statusbarHeight, editorAndPanelWidth);

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -435,7 +435,6 @@ export class WorkbenchLayout extends Disposable implements IVerticalSashLayoutPr
 			if(this.panelMaximized){
 				//Store user's sidebar width
 				this.storageService.store(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, this.sidebarWidth, StorageScope.GLOBAL);
-				sidebarSize.width = this.partLayoutInfo.sidebar.minWidth;
 			} else {
 				//Retrieve user's sidebar width
 				this.sidebarSizeBeforeMaximized = this.storageService.getInteger(WorkbenchLayout.sidebarSizeBeforeMaximizedKey, StorageScope.GLOBAL, DEFAULT_SIDEBAR_PART_WIDTH);


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/62083: 

> Toggling "Maximize Panel Size" when the panel is positioned to the right causes the left panel (e.g. Explorer) to shrink. This means that every time I toggle the panel expansion on and then off, I need to resize the left view (by double clicking on the divider between the explorer view and the editor view to auto-adjust).

I added a stored variable that records the width of the Sidebar, when the Panel is minimized the old Sidebar width is retrieved and used. 

Please let me know what kind of improvements I should make.