### PR TITLE
Option to control actions alignment in search results

### DIFF
--- a/src/vs/platform/search/common/search.ts
+++ b/src/vs/platform/search/common/search.ts
@@ -333,6 +333,7 @@ export interface ISearchConfigurationProperties {
 	useReplacePreview: boolean;
 	showLineNumbers: boolean;
 	usePCRE2: boolean;
+	actionsPosition: 'auto' | 'right';
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {

--- a/src/vs/workbench/parts/search/browser/media/searchview.css
+++ b/src/vs/workbench/parts/search/browser/media/searchview.css
@@ -290,7 +290,7 @@
 .search-view > .results > .monaco-tree .monaco-tree-row.focused .content .filematch .monaco-count-badge,
 .search-view > .results > .monaco-tree .monaco-tree-row.focused .content .foldermatch .monaco-count-badge,
 .search-view > .results > .monaco-tree .monaco-tree-row.focused .content .linematch .monaco-count-badge {
-	display: none;
+	margin-right: 0;
 }
 
 .search-view .focused .monaco-tree-row.selected:not(.highlighted) > .content.actions .action-remove,

--- a/src/vs/workbench/parts/search/browser/media/searchview.css
+++ b/src/vs/workbench/parts/search/browser/media/searchview.css
@@ -179,18 +179,6 @@
 	padding: 0;
 }
 
-.search-view:not(.wide) .foldermatch .monaco-icon-label,
-.search-view:not(.wide) .filematch .monaco-icon-label {
-	flex: 1;
-}
-
-.search-view:not(.wide) .monaco-tree .monaco-tree-row:hover:not(.highlighted) .foldermatch .monaco-icon-label,
-.search-view:not(.wide) .monaco-tree .monaco-tree-row.focused .foldermatch .monaco-icon-label,
-.search-view:not(.wide) .monaco-tree .monaco-tree-row:hover:not(.highlighted) .filematch .monaco-icon-label,
-.search-view:not(.wide) .monaco-tree .monaco-tree-row.focused .filematch .monaco-icon-label {
-	flex: 1;
-}
-
 .search-view .foldermatch .directory,
 .search-view .filematch .directory {
 	opacity: 0.7;
@@ -198,8 +186,8 @@
 	margin-left: 0.8em;
 }
 
-.search-view.wide .foldermatch .badge,
-.search-view.wide .filematch .badge {
+.search-view .foldermatch .badge,
+.search-view .filematch .badge {
 	margin-left: 10px;
 }
 
@@ -246,15 +234,11 @@
 
 .search-view .monaco-tree .monaco-tree-row:hover:not(.highlighted) .monaco-action-bar,
 .search-view .monaco-tree .monaco-tree-row.focused .monaco-action-bar {
-	display: inline-block;
-}
-
-.search-view:not(.wide) .monaco-tree .monaco-tree-row .linematch .actionBarContainer {
-	flex: 1;
+	display: block;
 }
 
 .search-view:not(.wide) .monaco-tree .monaco-tree-row .monaco-action-bar {
-	float: right;
+	flex: 1 0 auto;
 }
 
 .search-view .monaco-tree .monaco-tree-row .monaco-action-bar .action-label {

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -235,8 +235,7 @@ export class SearchRenderer extends Disposable implements IRenderer {
 		const replace = DOM.append(parent, DOM.$('span.replaceMatch'));
 		const after = DOM.append(parent, DOM.$('span'));
 		const lineNumber = DOM.append(container, DOM.$('span.matchLineNum'));
-		const actionBarContainer = DOM.append(container, DOM.$('span.actionBarContainer'));
-		const actions = new ActionBar(actionBarContainer, { animated: false });
+		const actions = new ActionBar(container, { animated: false });
 
 		return {
 			parent,

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -32,7 +32,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { TreeResourceNavigator, WorkbenchTree } from 'vs/platform/list/browser/listService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IProgressService } from 'vs/platform/progress/common/progress';
-import { IPatternInfo, ISearchComplete, ISearchConfiguration, ISearchHistoryService, ISearchHistoryValues, ISearchProgressItem, ITextQuery, VIEW_ID, SearchErrorCode } from 'vs/platform/search/common/search';
+import { IPatternInfo, ISearchComplete, ISearchConfiguration, ISearchHistoryService, ISearchHistoryValues, ISearchProgressItem, ITextQuery, VIEW_ID, SearchErrorCode, ISearchConfigurationProperties } from 'vs/platform/search/common/search';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { diffInserted, diffInsertedOutline, diffRemoved, diffRemovedOutline, editorFindMatchHighlight, editorFindMatchHighlightBorder, listActiveSelectionForeground } from 'vs/platform/theme/common/colorRegistry';
@@ -785,11 +785,9 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 			return;
 		}
 
-		if (this.size.width >= SearchView.WIDE_VIEW_SIZE) {
-			dom.addClass(this.getContainer(), SearchView.WIDE_CLASS_NAME);
-		} else {
-			dom.removeClass(this.getContainer(), SearchView.WIDE_CLASS_NAME);
-		}
+		const actionsPosition = this.configurationService.getValue<ISearchConfigurationProperties>('search').actionsPosition;
+		const useWideLayout = this.size.width >= SearchView.WIDE_VIEW_SIZE && actionsPosition === 'auto';
+		dom.toggleClass(this.getContainer(), SearchView.WIDE_CLASS_NAME, useWideLayout);
 
 		this.searchWidget.setWidth(this.size.width - 28 /* container margin */);
 

--- a/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
+++ b/src/vs/workbench/parts/search/electron-browser/search.contribution.ts
@@ -674,6 +674,12 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			description: nls.localize('search.usePCRE2', "Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookbehind and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.")
+		},
+		'search.actionsPosition': {
+			type: 'string',
+			enum: ['auto', 'right'],
+			default: 'auto',
+			description: nls.localize('search.actionsPosition', "Controls whether to show actions at the end of match or always aligned to the right in wide panels.")
 		}
 	}
 });


### PR DESCRIPTION
Fixes #61532 

This PR adds new `search.actionsPosition` option that can force search result action (replace, replace all, dismiss) to be always displayed at the right edge of the panel.

Other change - count badge for files and folders matches are displayed at the end of match and visible on hover. Only negative aspect of later change is shift of badge in really narrow search block when actions become visible on hover. Since count badge doesn't have click handlers its shift shouldn't be so bad (in comparison with any actionable element).

@roblourens looks like I've removed changes introduces in [your commit](https://github.com/Microsoft/vscode/commit/f3f7d97129cabb8279a03860f3110875b45f337b). Could you please describe what issues this commit fixed or give me a link to the issue. I will check that this PR doesn't regress there.

Also I haven't found test related to search results badge/actions layout etc. Are there tests that I should update in this PR?