### PR TITLE
Apply smooth caret setting immediately after setting change

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -89,6 +89,7 @@ export class ViewCursors extends ViewPart {
 		if (e.viewInfo) {
 			this._cursorBlinking = this._context.configuration.editor.viewInfo.cursorBlinking;
 			this._cursorStyle = this._context.configuration.editor.viewInfo.cursorStyle;
+			this._cursorSmoothCaretAnimation = this._context.configuration.editor.viewInfo.cursorSmoothCaretAnimation;
 		}
 
 		this._primaryCursor.onConfigurationChanged(e);


### PR DESCRIPTION
There was a small issue where after you toggle the setting, when you switch back to an editor tab the changes do not get applied immediately. This fixes that.

@alexandrudima