### PR TITLE
Fixed checkForSnapUpdate in updateService.linux.ts to correctly identify snap version

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -82,7 +82,7 @@ export class LinuxUpdateService extends AbstractUpdateService {
 		// If the application was installed as a snap, updates happen in the
 		// background automatically, we just need to check to see if an update
 		// has already happened.
-		realpath(`/snap/${product.applicationName}/current`, (err, resolvedCurrentSnapPath) => {
+		realpath(`${path.dirname(process.env.SNAP!)}/current`, (err, resolvedCurrentSnapPath) => {
 			if (err) {
 				this.logService.error('update#checkForSnapUpdate(): Could not get realpath of application.');
 				return;


### PR DESCRIPTION
This issue stems from the following discussion where it appears that the snap build of vscode by snapcrafters was throwing warnings for being outdated.

https://github.com/snapcrafters/vscode/issues/29

Credit to @meddario as he was able to identify exactly the failing function.

The main issue in this case is that product.applicationName is looking for the name 'code', whilst the SNAP is mounted under the name 'vscode'.

Using https://github.com/snapcore/snapd/wiki/Environment-Variables

It seems that the environment variable SNAP is useful for identifying the mount point for the snap.

I have tested the backtick and functionality of the new code under a node shell. 

snap connect --run vscode

The code executed as expected.

