### PR TITLE
added .hintrc and moved .babelrc to jsonc grammar

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -24,7 +24,6 @@
           ".jshintrc",
           ".jscsrc",
           ".eslintrc",
-          ".babelrc",
           ".webmanifest",
           ".js.map",
           ".css.map"
@@ -45,6 +44,8 @@
           "JSON with Comments"
         ],
         "extensions": [
+          ".hintrc",
+          ".babelrc",
           ".jsonc"
         ],
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
Hi there!

I noticed `.hintrc` from https://webhint.io/ isn't automatically recognized as JSON(C). Is this the correct way to add support for it?

I also moved `.babelrc`, because it can include comments.