### PR TITLE
Fix 63749 - Markdown, U+2028, and "Go to Symbol in File..."

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -109,13 +109,14 @@ export class MarkdownEngine {
 	}
 
 	public async parse(document: vscode.Uri, source: string): Promise<Token[]> {
+		const UNICODE_NEWLINE_REGEX = /\u2028|\u2029/g;
 		const { text, offset } = this.stripFrontmatter(source);
 		this.currentDocument = document;
 		this._slugCount = new Map<string, number>();
 
 		const engine = await this.getEngine(document);
 
-		return engine.parse(text, {}).map(token => {
+		return engine.parse(text.replace(UNICODE_NEWLINE_REGEX, ''), {}).map(token => {
 			if (token.map) {
 				token.map[0] += offset;
 				token.map[1] += offset;

--- a/extensions/markdown-language-features/src/tableOfContentsProvider.ts
+++ b/extensions/markdown-language-features/src/tableOfContentsProvider.ts
@@ -49,7 +49,8 @@ export class TableOfContentsProvider {
 
 	private async buildToc(document: SkinnyTextDocument): Promise<TocEntry[]> {
 		const toc: TocEntry[] = [];
-		const tokens = await this.engine.parse(document.uri, document.getText());
+		const UNICODE_NEWLINE_REGEX = /\u2028|\u2029/g;
+		const tokens = await this.engine.parse(document.uri, document.getText().replace(UNICODE_NEWLINE_REGEX, ''));
 
 		const slugCount = new Map<string, number>();
 

--- a/extensions/markdown-language-features/src/tableOfContentsProvider.ts
+++ b/extensions/markdown-language-features/src/tableOfContentsProvider.ts
@@ -49,8 +49,7 @@ export class TableOfContentsProvider {
 
 	private async buildToc(document: SkinnyTextDocument): Promise<TocEntry[]> {
 		const toc: TocEntry[] = [];
-		const UNICODE_NEWLINE_REGEX = /\u2028|\u2029/g;
-		const tokens = await this.engine.parse(document.uri, document.getText().replace(UNICODE_NEWLINE_REGEX, ''));
+		const tokens = await this.engine.parse(document.uri, document.getText());
 
 		const slugCount = new Map<string, number>();
 

--- a/extensions/markdown-language-features/src/test/documentSymbolProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentSymbolProvider.test.ts
@@ -83,7 +83,7 @@ suite('markdown.DocumentSymbolProvider', () => {
 		assert.strictEqual(symbols[0].children[1].name, '## h3');
 	});
 
-	test.skip('Should handle line separator in file. Issue #63749', async () => {
+	test('Should handle line separator in file. Issue #63749', async () => {
 		const symbols = await getSymbolsForFile(`# A
 - foo 
 


### PR DESCRIPTION
@mjbvz , Added UNICODE_NEWLINE_REGEX to replace those characters, fixes #63749 .
Please review this and let me know if any changes are needed :)
Thanks.

PS: Unit tested for many cases with those  `U+2028` chars and it works all fine :) 