### PR TITLE
Support debugging process from the process explorer

### DIFF
--- a/src/vs/code/electron-browser/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterMain.ts
@@ -378,15 +378,19 @@ export class IssueReporter extends Disposable {
 
 		this.previewButton.onDidClick(() => this.createIssue());
 
+		function sendWorkbenchCommand(commandId: string) {
+			ipcRenderer.send('vscode:workbenchCommand', { id: commandId, from: 'issueReporter' });
+		}
+
 		this.addEventListener('disableExtensions', 'click', () => {
-			ipcRenderer.send('vscode:workbenchCommand', 'workbench.action.reloadWindowWithExtensionsDisabled');
+			sendWorkbenchCommand('workbench.action.reloadWindowWithExtensionsDisabled');
 		});
 
 		this.addEventListener('disableExtensions', 'keydown', (e: KeyboardEvent) => {
 			e.stopPropagation();
 			if (e.keyCode === 13 || e.keyCode === 32) {
-				ipcRenderer.send('vscode:workbenchCommand', 'workbench.extensions.action.disableAll');
-				ipcRenderer.send('vscode:workbenchCommand', 'workbench.action.reloadWindow');
+				sendWorkbenchCommand('workbench.extensions.action.disableAll');
+				sendWorkbenchCommand('workbench.action.reloadWindow');
 			}
 		});
 

--- a/src/vs/code/electron-browser/processExplorer/processExplorerMain.ts
+++ b/src/vs/code/electron-browser/processExplorer/processExplorerMain.ts
@@ -15,9 +15,13 @@ import * as browser from 'vs/base/browser/browser';
 import * as platform from 'vs/base/common/platform';
 import { IContextMenuItem } from 'vs/base/parts/contextmenu/common/contextmenu';
 import { popup } from 'vs/base/parts/contextmenu/electron-browser/contextmenu';
+import { DebugConfiguration } from 'vscode';
 
 let processList: any[];
 let mapPidToWindowTitle = new Map<number, string>();
+
+const DEBUG_FLAGS_PATTERN = /\s--(inspect|debug)(-brk|port)?=(\d+)?/;
+const DEBUG_PORT_PATTERN = /\s--(inspect|debug)-port=(\d+)/;
 
 function getProcessList(rootProcess: ProcessItem) {
 	const processes: any[] = [];
@@ -60,6 +64,40 @@ function getProcessItem(processes: any[], item: ProcessItem, indent: number): vo
 	if (Array.isArray(item.children)) {
 		item.children.forEach(child => getProcessItem(processes, child, indent + 1));
 	}
+}
+
+function isDebuggable(cmd: string): boolean {
+	const matches = DEBUG_FLAGS_PATTERN.exec(cmd);
+	return (matches && matches.length >= 2) || cmd.indexOf('node ') >= 0 || cmd.indexOf('node.exe') >= 0;
+}
+
+function attachTo(item: ProcessItem) {
+	const config: DebugConfiguration = {
+		type: 'node',
+		request: 'attach',
+		name: `process ${item.pid}`
+	};
+
+	let matches = DEBUG_FLAGS_PATTERN.exec(item.cmd);
+	if (matches && matches.length >= 2) {
+		// attach via port
+		if (matches.length === 4 && matches[3]) {
+			config.port = parseInt(matches[3]);
+		}
+		config.protocol = matches[1] === 'debug' ? 'legacy' : 'inspector';
+	} else {
+		// no port -> try to attach via pid (send SIGUSR1)
+		config.processId = String(item.pid);
+	}
+
+	// a debug-port=n or inspect-port=n overrides the port
+	matches = DEBUG_PORT_PATTERN.exec(item.cmd);
+	if (matches && matches.length === 3) {
+		// override port
+		config.port = parseInt(matches[2]);
+	}
+
+	ipcRenderer.send('vscode:workbenchCommand', { id: 'workbench.action.debug.start', from: 'processExplorer', args: [config] });
 }
 
 function getProcessIdWithHighestProperty(processList, propertyName: string) {
@@ -190,6 +228,20 @@ function showContextMenu(e) {
 				}
 			}
 		});
+
+		const item = processList.filter(process => process.pid === pid)[0];
+		if (item && isDebuggable(item.cmd)) {
+			items.push({
+				type: 'separator'
+			});
+
+			items.push({
+				label: localize('debug', "Debug"),
+				click() {
+					attachTo(item);
+				}
+			});
+		}
 	} else {
 		items.push({
 			label: localize('copyAll', "Copy All"),

--- a/src/vs/code/electron-browser/processExplorer/processExplorerMain.ts
+++ b/src/vs/code/electron-browser/processExplorer/processExplorerMain.ts
@@ -15,7 +15,6 @@ import * as browser from 'vs/base/browser/browser';
 import * as platform from 'vs/base/common/platform';
 import { IContextMenuItem } from 'vs/base/parts/contextmenu/common/contextmenu';
 import { popup } from 'vs/base/parts/contextmenu/electron-browser/contextmenu';
-import { DebugConfiguration } from 'vscode';
 
 let processList: any[];
 let mapPidToWindowTitle = new Map<number, string>();
@@ -72,7 +71,7 @@ function isDebuggable(cmd: string): boolean {
 }
 
 function attachTo(item: ProcessItem) {
-	const config: DebugConfiguration = {
+	const config: any = {
 		type: 'node',
 		request: 'attach',
 		name: `process ${item.pid}`

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -404,6 +404,7 @@ export interface IWindowConfiguration extends ParsedArgs {
 export interface IRunActionInWindowRequest {
 	id: string;
 	from: 'menu' | 'touchbar' | 'mouse';
+	args?: any[];
 }
 
 export class ActiveWindowManager implements IDisposable {

--- a/src/vs/workbench/common/actions.ts
+++ b/src/vs/workbench/common/actions.ts
@@ -110,7 +110,11 @@ Registry.add(Extensions.WorkbenchActions, new class implements IWorkbenchActionR
 
 				const from = args && args.from || 'keybinding';
 
-				return Promise.resolve(actionInstance.run(undefined, { from })).then(() => {
+				if (args) {
+					delete args.from;
+				}
+
+				return Promise.resolve(actionInstance.run(args, { from })).then(() => {
 					actionInstance.dispose();
 				}, err => {
 					actionInstance.dispose();

--- a/src/vs/workbench/common/actions.ts
+++ b/src/vs/workbench/common/actions.ts
@@ -110,11 +110,7 @@ Registry.add(Extensions.WorkbenchActions, new class implements IWorkbenchActionR
 
 				const from = args && args.from || 'keybinding';
 
-				if (args) {
-					delete args.from;
-				}
-
-				return Promise.resolve(actionInstance.run(args, { from })).then(() => {
+				return Promise.resolve(actionInstance.run(undefined, { from })).then(() => {
 					actionInstance.dispose();
 				}, err => {
 					actionInstance.dispose();

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -104,7 +104,7 @@ export class ElectronWindow extends Themable {
 
 		// Support runAction event
 		ipc.on('vscode:runAction', (event: any, request: IRunActionInWindowRequest) => {
-			const args: any[] = [];
+			const args: any[] = request.args || [];
 
 			// If we run an action from the touchbar, we fill in the currently active resource
 			// as payload because the touch bar items are context aware depending on the editor

--- a/src/vs/workbench/parts/debug/browser/debugActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActions.ts
@@ -10,7 +10,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IDebugService, State, IDebugSession, IThread, IEnablement, IBreakpoint, IStackFrame, REPL_ID }
+import { IDebugService, State, IDebugSession, IThread, IEnablement, IBreakpoint, IStackFrame, REPL_ID, IConfig }
 	from 'vs/workbench/parts/debug/common/debug';
 import { Variable, Expression, Thread, Breakpoint } from 'vs/workbench/parts/debug/common/debugModel';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
@@ -133,7 +133,11 @@ export class StartAction extends AbstractDebugAction {
 		this.toDispose.push(this.contextService.onDidChangeWorkbenchState(() => this.updateEnablement()));
 	}
 
-	public run(): Thenable<any> {
+	public run(config?: string | IConfig): Thenable<any> {
+		if (config) {
+			return this.debugService.startDebugging(undefined, config, this.isNoDebug());
+		}
+
 		const configurationManager = this.debugService.getConfigurationManager();
 		let launch = configurationManager.selectedConfiguration.launch;
 		if (!launch || launch.getConfigurationNames().length === 0) {

--- a/src/vs/workbench/parts/debug/browser/debugActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActions.ts
@@ -133,7 +133,9 @@ export class StartAction extends AbstractDebugAction {
 		this.toDispose.push(this.contextService.onDidChangeWorkbenchState(() => this.updateEnablement()));
 	}
 
-	public run(config?: string | IConfig): Thenable<any> {
+	// Note: When this action is executed from the process explorer, a config is passed. For all
+	// other cases it is run with no arguments.
+	public run(config?: IConfig): Thenable<any> {
 		if (config) {
 			return this.debugService.startDebugging(undefined, config, this.isNoDebug());
 		}

--- a/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debug.contribution.ts
@@ -10,7 +10,7 @@ import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { SyncActionDescriptor, MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { KeybindingWeight, IKeybindings } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { KeybindingWeight, IKeybindings, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { IWorkbenchActionRegistry, Extensions as WorkbenchActionRegistryExtensions } from 'vs/workbench/common/actions';
 import { ShowViewletAction, Extensions as ViewletExtensions, ViewletRegistry, ViewletDescriptor } from 'vs/workbench/browser/viewlet';
@@ -49,11 +49,13 @@ import { DebugViewlet } from 'vs/workbench/parts/debug/browser/debugViewlet';
 import { Repl, ClearReplAction } from 'vs/workbench/parts/debug/electron-browser/repl';
 import { DebugQuickOpenHandler } from 'vs/workbench/parts/debug/browser/debugQuickOpen';
 import { DebugStatus } from 'vs/workbench/parts/debug/browser/debugStatus';
-import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
+import { LifecyclePhase, ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { launchSchemaId } from 'vs/workbench/services/configuration/common/configuration';
 import { IEditorGroupsService } from 'vs/workbench/services/group/common/editorGroupsService';
 import { LoadedScriptsView } from 'vs/workbench/parts/debug/browser/loadedScriptsView';
 import { TOGGLE_LOG_POINT_ID, TOGGLE_CONDITIONAL_BREAKPOINT_ID, TOGGLE_BREAKPOINT_ID } from 'vs/workbench/parts/debug/browser/debugEditorActions';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 class OpenDebugViewletAction extends ShowViewletAction {
 	public static readonly ID = VIEWLET_ID;
@@ -129,8 +131,59 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).regi
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(StatusBarColorProvider, LifecyclePhase.Eventually);
 
 const debugCategory = nls.localize('debugCategory', "Debug");
-registry.registerWorkbenchAction(new SyncActionDescriptor(
-	StartAction, StartAction.ID, StartAction.LABEL, { primary: KeyCode.F5 }, CONTEXT_IN_DEBUG_MODE.toNegated()), 'Debug: Start Debugging', debugCategory);
+
+const startDebugDescriptor = new SyncActionDescriptor(StartAction, StartAction.ID, StartAction.LABEL, { primary: KeyCode.F5 }, CONTEXT_IN_DEBUG_MODE.toNegated());
+
+function startDebugHandler(accessor, args): Promise<void> {
+	const notificationService = accessor.get(INotificationService);
+	const instantiationService = accessor.get(IInstantiationService);
+	const lifecycleService = accessor.get(ILifecycleService);
+
+	return Promise.resolve(lifecycleService.when(LifecyclePhase.Ready).then(() => {
+		const actionInstance = instantiationService.createInstance(startDebugDescriptor.syncDescriptor);
+		try {
+			// don't run the action when not enabled
+			if (!actionInstance.enabled) {
+				actionInstance.dispose();
+
+				return void 0;
+			}
+
+			const from = args && args.from || 'keybinding';
+
+			if (args) {
+				delete args.from;
+			}
+
+			return Promise.resolve(actionInstance.run(args, { from })).then(() => {
+				actionInstance.dispose();
+			}, err => {
+				actionInstance.dispose();
+
+				return Promise.reject(err);
+			});
+		} catch (err) {
+			actionInstance.dispose();
+
+			return Promise.reject(err);
+		}
+	})).then(null, err => notificationService.error(err));
+}
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: StartAction.ID,
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: CONTEXT_IN_DEBUG_MODE.toNegated(),
+	primary: KeyCode.F5,
+	handler: startDebugHandler
+});
+
+MenuRegistry.addCommand({
+	id: StartAction.ID,
+	title: StartAction.LABEL,
+	category: debugCategory
+});
+
 registry.registerWorkbenchAction(new SyncActionDescriptor(StepOverAction, StepOverAction.ID, StepOverAction.LABEL, { primary: KeyCode.F10 }, CONTEXT_IN_DEBUG_MODE), 'Debug: Step Over', debugCategory);
 registry.registerWorkbenchAction(new SyncActionDescriptor(StepIntoAction, StepIntoAction.ID, StepIntoAction.LABEL, { primary: KeyCode.F11 }, CONTEXT_IN_DEBUG_MODE, KeybindingWeight.WorkbenchContrib + 1), 'Debug: Step Into', debugCategory);
 registry.registerWorkbenchAction(new SyncActionDescriptor(StepOutAction, StepOutAction.ID, StepOutAction.LABEL, { primary: KeyMod.Shift | KeyCode.F11 }, CONTEXT_IN_DEBUG_MODE), 'Debug: Step Out', debugCategory);


### PR DESCRIPTION
Adds a 'Debug' context menu item for processes that can be attached to in the process explorer. https://github.com/Microsoft/vscode/issues/63147

The issue service that communicates with the process explorer window lives in the main process, and the debug service is only in the renderer process. To start debugging, the issue service sends a `vscode:runAction` message to the renderer with the workbench debug start action id. To pass the debug config, I tweaked the `vscode:runAction` listener to pass through arguments to executeCommand. I also had to make a change to the workbench command handler to pass the argument, let me know if this looks reasonable.