### PR TITLE
Update styles for better actions alignment support in search (related to #61532)

### DIFF
--- a/src/vs/workbench/parts/search/browser/media/searchview.css
+++ b/src/vs/workbench/parts/search/browser/media/searchview.css
@@ -197,16 +197,9 @@
 	padding: 0;
 }
 
-.search-view:not(.wide) .foldermatch .monaco-icon-label,
-.search-view:not(.wide) .filematch .monaco-icon-label {
-	flex: 1;
-}
-
-.search-view:not(.wide) .monaco-tree .monaco-tree-row:hover:not(.highlighted) .foldermatch .monaco-icon-label,
-.search-view:not(.wide) .monaco-tree .monaco-tree-row.focused .foldermatch .monaco-icon-label,
-.search-view:not(.wide) .monaco-tree .monaco-tree-row:hover:not(.highlighted) .filematch .monaco-icon-label,
-.search-view:not(.wide) .monaco-tree .monaco-tree-row.focused .filematch .monaco-icon-label {
-	flex: 1;
+.search-view .foldermatch .monaco-icon-label,
+.search-view .filematch .monaco-icon-label {
+	flex: 0 1 auto;
 }
 
 .search-view .foldermatch .directory,
@@ -216,9 +209,9 @@
 	margin-left: 0.8em;
 }
 
-.search-view.wide .foldermatch .badge,
-.search-view.wide .filematch .badge {
-	margin-left: 10px;
+.search-view .foldermatch .badge,
+.search-view .filematch .badge {
+	margin-left: 0.4em;
 }
 
 .search-view .linematch {
@@ -267,12 +260,13 @@
 	display: inline-block;
 }
 
-.search-view:not(.wide) .monaco-tree .monaco-tree-row .linematch .actionBarContainer {
-	flex: 1;
+.search-view .monaco-tree .monaco-tree-row .actionBarContainer {
+	flex: 1 0 auto;
+	text-align: left;
 }
 
-.search-view:not(.wide) .monaco-tree .monaco-tree-row .monaco-action-bar {
-	float: right;
+.search-view:not(.wide) .monaco-tree .monaco-tree-row .actionBarContainer {
+	text-align: right;
 }
 
 .search-view .monaco-tree .monaco-tree-row .monaco-action-bar .action-label {
@@ -315,16 +309,12 @@
 }
 
 .search-view .monaco-count-badge {
-	margin-right: 12px;
+	margin-right: 0.8em;
 }
 
-.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .filematch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .foldermatch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .linematch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .filematch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .foldermatch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .linematch .monaco-count-badge {
-	display: none;
+.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .monaco-count-badge,
+.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .monaco-count-badge {
+	margin-right: 0;
 }
 
 .search-view .focused .monaco-tree-row.selected:not(.highlighted) > .content.actions .action-remove,

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -213,7 +213,8 @@ export class SearchRenderer extends Disposable implements IRenderer {
 		const label = this.instantiationService.createInstance(FileLabel, folderMatchElement, void 0);
 		const badge = new CountBadge(DOM.append(folderMatchElement, DOM.$('.badge')));
 		this._register(attachBadgeStyler(badge, this.themeService));
-		const actions = new ActionBar(folderMatchElement, { animated: false });
+		const actionBarContainer = DOM.append(folderMatchElement, DOM.$('span.actionBarContainer'));
+		const actions = new ActionBar(actionBarContainer, { animated: false });
 		return { label, badge, actions };
 	}
 
@@ -222,7 +223,8 @@ export class SearchRenderer extends Disposable implements IRenderer {
 		const label = this.instantiationService.createInstance(FileLabel, fileMatchElement, void 0);
 		const badge = new CountBadge(DOM.append(fileMatchElement, DOM.$('.badge')));
 		this._register(attachBadgeStyler(badge, this.themeService));
-		const actions = new ActionBar(fileMatchElement, { animated: false });
+		const actionBarContainer = DOM.append(fileMatchElement, DOM.$('span.actionBarContainer'));
+		const actions = new ActionBar(actionBarContainer, { animated: false });
 		return { el: fileMatchElement, label, badge, actions };
 	}
 


### PR DESCRIPTION
This in second iteration of #63457 for #61532.
New property logic that controls class responsible for aligment was restored in https://github.com/Microsoft/vscode/commit/1c62ed721e6091dd5e99f0f3c3f04c8691ed6a8e.

This PR updates styles and layout for results rows and actions bar to achieve next goals:
 - Count badge is always aligned to the left (at the end of content) - this is static info that is related to content (file name or folder name) and it makes sense to treat it in the same way as line numbers in match strings.
- Count badge is always visible - it doesn't make sense to hide count badge if actions are on the right side or search is wide enough to display both badge and actions. It will be shifted if search panel is narrow (same behavior as with line numbers)
- Unified layout and styles for match lines and file/folder lines - added wrapper that allows easy achieve left and right action alignment and avoid #63834.
- Margins for badge now are same as for actions, to achieve similar alignment
(Should I also update margins for line numbers, because now scroll bar can overlap line numbers, but not actions/count badge? Or I can create separate issue for it.)

<details>
<summary>Gif (34 MB)</summary>
<div>

[Link to gif](https://1drv.ms/u/s!AtVT9rmPUvLGqJgSwOLWb7ufxfpLKg) (expires in 60 days)

(GitHub doesn't allow to upload it and doesn't play animation when it is embedded)

</div>
</details>
