### PR TITLE
Use string type for `command` property

### DIFF
--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -578,6 +578,7 @@ let schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.key', "Key or key sequence (separated by space)"),
 			},
 			'command': {
+				'type': 'string',
 				'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
 			},
 			'when': {


### PR DESCRIPTION
Fixes #62602