### PR TITLE
SelectBox: Restore _sticky = false. Fixes: #64265

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -114,7 +114,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 	private selectionDetailsPane: HTMLElement;
 	private _skipLayout: boolean = false;
 
-	private _sticky: boolean = true; // for dev purposes only
+	private _sticky: boolean = false; // for dev purposes only
 
 	constructor(options: string[], selected: number, contextViewProvider: IContextViewProvider, styles: ISelectBoxStyles, selectBoxOptions?: ISelectBoxOptions) {
 


### PR DESCRIPTION
Fixes: #64265 - assuming unintentional

Reset _sticky flag to false - true prevents dropdown from closing on loss of focus- debugging flag

