### PR TITLE
Fixed #50149 - Added Command to make column cursor using selection

### DIFF
--- a/src/vs/editor/contrib/multicursor/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/multicursor.ts
@@ -216,6 +216,31 @@ class InsertCursorAtTopOfLineSelected extends EditorAction {
 	}
 }
 
+class ConvertSelectionToCursors extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.convertSelectionToCursors',
+			label: nls.localize('mutlicursor.convertSelectionToCursors', "Convert Selection To Cursors"),
+			alias: 'Convert Selection To Cursors',
+			precondition: null
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		const selection = editor.getSelection();
+
+		let newSelections = [];
+		for (let i = selection.startLineNumber; i <= selection.endLineNumber; i++) {
+			newSelections.push(new Selection(i, selection.startColumn, i, selection.startColumn));
+		}
+
+		if (newSelections.length > 0) {
+			editor.setSelections(newSelections);
+		}
+	}
+}
+
 export class MultiCursorSessionResult {
 	constructor(
 		public readonly selections: Selection[],
@@ -996,3 +1021,4 @@ registerEditorAction(SelectHighlightsAction);
 registerEditorAction(CompatChangeAll);
 registerEditorAction(InsertCursorAtEndOfLineSelected);
 registerEditorAction(InsertCursorAtTopOfLineSelected);
+registerEditorAction(ConvertSelectionToCursors);


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/50149.

It adds a command to convert a selection to cursors.

Command in Action:
![convertselectiontocursor](https://user-images.githubusercontent.com/16523071/49416166-11501600-f747-11e8-99f2-0f901d7c276b.gif)

Thanks for considering this request.