### PR TITLE
put breadcrumbs on their own row

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -48,6 +48,11 @@
 	overflow: hidden;
 }
 
+.monaco-workbench > .part.editor > .content .editor-group-container > .title:not(.tabs) {
+	display: flex; /* when tabs are not shown, use flex layout */
+	flex-wrap: nowrap;
+}
+
 .monaco-workbench > .part.editor > .content .editor-group-container > .title.title-border-bottom::after {
 	content: '';
 	position: absolute;

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -44,15 +44,8 @@
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title {
 	position: relative;
-	display: flex;
-	flex-wrap: nowrap;
 	box-sizing:	border-box;
 	overflow: hidden;
-	justify-content: space-between;
-}
-
-.monaco-workbench > .part.editor > .content .editor-group-container > .title.tabs {
-	flex-wrap: wrap;
 }
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title.title-border-bottom::after {

--- a/src/vs/workbench/browser/parts/editor/media/notabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/notabstitlecontrol.css
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+/* Title Label */
+
 .monaco-workbench > .part.editor > .content .editor-group-container > .title > .label-container {
 	display: flex;
 	justify-content: flex-start;
@@ -10,8 +12,6 @@
 	overflow: hidden;
 	flex: auto;
 }
-
-/* Title Label */
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .title-label {
 	line-height: 35px;

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -5,11 +5,15 @@
 
 /* Title Container */
 
-.monaco-workbench > .part.editor > .content .editor-group-container > .title.tabs > .monaco-scrollable-element {
+.monaco-workbench > .part.editor > .content .editor-group-container > .title.tabs > .tabs-and-actions-container {
+	display: flex;
+}
+
+.monaco-workbench > .part.editor > .content .editor-group-container > .title.tabs > .tabs-and-actions-container > .monaco-scrollable-element {
 	flex: 1;
 }
 
-.monaco-workbench > .part.editor > .content .editor-group-container > .title.tabs > .monaco-scrollable-element .scrollbar {
+.monaco-workbench > .part.editor > .content .editor-group-container > .title.tabs > .tabs-and-actions-container > .monaco-scrollable-element .scrollbar {
 	z-index: 3; /* on top of tabs */
 	cursor: default;
 }

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -89,6 +89,11 @@ export class TabsTitleControl extends TitleControl {
 	protected create(parent: HTMLElement): void {
 		this.titleContainer = parent;
 
+		// Tabs and Actions Container (are on a single row with flex side-by-side)
+		const tabsAndActionsContainer = document.createElement('div');
+		addClass(tabsAndActionsContainer, 'tabs-and-actions-container');
+		this.titleContainer.appendChild(tabsAndActionsContainer);
+
 		// Tabs Container
 		this.tabsContainer = document.createElement('div');
 		this.tabsContainer.setAttribute('role', 'tablist');
@@ -100,12 +105,12 @@ export class TabsTitleControl extends TitleControl {
 
 		// Tabs Scrollbar
 		this.tabsScrollbar = this.createTabsScrollbar(this.tabsContainer);
-		this.titleContainer.appendChild(this.tabsScrollbar.getDomNode());
+		tabsAndActionsContainer.appendChild(this.tabsScrollbar.getDomNode());
 
 		// Editor Toolbar Container
 		this.editorToolbarContainer = document.createElement('div');
 		addClass(this.editorToolbarContainer, 'editor-actions');
-		this.titleContainer.appendChild(this.editorToolbarContainer);
+		tabsAndActionsContainer.appendChild(this.editorToolbarContainer);
 
 		// Editor Actions Toolbar
 		this.createEditorActionsToolBar(this.editorToolbarContainer);
@@ -113,7 +118,7 @@ export class TabsTitleControl extends TitleControl {
 		// Close Action
 		this.closeOneEditorAction = this._register(this.instantiationService.createInstance(CloseOneEditorAction, CloseOneEditorAction.ID, CloseOneEditorAction.LABEL));
 
-		// Breadcrumbs
+		// Breadcrumbs (are on a separate row below tabs and actions)
 		const breadcrumbsContainer = document.createElement('div');
 		addClass(breadcrumbsContainer, 'tabs-breadcrumbs');
 		this.titleContainer.appendChild(breadcrumbsContainer);
@@ -121,8 +126,6 @@ export class TabsTitleControl extends TitleControl {
 	}
 
 	private createTabsScrollbar(scrollable: HTMLElement): ScrollableElement {
-
-		// Custom Scrollbar
 		const tabsScrollbar = new ScrollableElement(scrollable, {
 			horizontal: ScrollbarVisibility.Auto,
 			vertical: ScrollbarVisibility.Hidden,


### PR DESCRIPTION
fixes https://github.com/Microsoft/vscode/issues/63764

@jrieken the reason for the layout and scrollbar issues seems to originate from the fact that the breadcrumbs - even though they are always on a second row below tabs - where put in the same parent as the tabs and editor actions. This change puts tabs and actions into their own container so that breadcrumbs can appear below without the crazy flex wrap that we currently have (e.g. it will now appear as 2 rows normally one div after the other). 

You can easily see why breadcrumbs currently flicker by changing their width to a small value, e.g. `200px`:

![image](https://user-images.githubusercontent.com/900690/49457923-15823f00-f7ec-11e8-9e28-aa4e710fe4ed.png)

We have set the size on the breadcrumb only after a delay, so it was briefly appearing in that corner (explains https://github.com/Microsoft/vscode/issues/63353).

Is there any reason for this `flex-wrap`?

My change removes some CSS properties that I think you added as part of the breadcrumb work because the `.editor-group-view > .title` no longer needs `display:flex`
