### PR TITLE
Fixed isUpdateAvailable in updateService.snap.ts to correctly identify snap version

### DIFF
--- a/resources/linux/snap/snapUpdate.sh
+++ b/resources/linux/snap/snapUpdate.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 sleep 2
-@@NAME@@
+$SNAP_NAME

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -164,7 +164,7 @@ export class SnapUpdateService extends AbstractUpdateService2 {
 
 		this.isUpdateAvailable().then(result => {
 			if (result) {
-				this.setState(State.Ready({ version: 'something', productVersion: 'someting' }));
+				this.setState(State.Ready({ version: 'something', productVersion: 'something' }));
 			} else {
 				/* __GDPR__
 					"update:notAvailable" : {
@@ -191,12 +191,8 @@ export class SnapUpdateService extends AbstractUpdateService2 {
 	protected doQuitAndInstall(): void {
 		this.logService.trace('update#quitAndInstall(): running raw#quitAndInstall()');
 
-		if (typeof process.env.SNAP === 'undefined') {
-			return;
-		}
-
 		// Allow 3 seconds for VS Code to close
-		spawn('bash', ['-c', path.join(process.env.SNAP, `usr/share/${product.applicationName}/snapUpdate.sh`)], {
+		spawn('bash', ['-c', path.join(process.env.SNAP!, `usr/share/${product.applicationName}/snapUpdate.sh`)], {
 			detached: true,
 			stdio: ['ignore', 'ignore', 'ignore']
 		});
@@ -204,7 +200,7 @@ export class SnapUpdateService extends AbstractUpdateService2 {
 
 	private isUpdateAvailable(): Thenable<boolean> {
 		return new Promise((c, e) => {
-			realpath(`/snap/${product.applicationName}/current`, (err, resolvedCurrentSnapPath) => {
+			realpath(`${path.dirname(process.env.SNAP!)}/current`, (err, resolvedCurrentSnapPath) => {
 				if (err) { return e(err); }
 
 				const currentRevision = path.basename(resolvedCurrentSnapPath);


### PR DESCRIPTION
Hello again,

I seem to have missed this line of code from https://github.com/Microsoft/vscode/pull/63716.

This change should occur for the exact same reason as the above PR.

In this case, the snap and product.applicationName is expecting the snap to be mounted at 
/snap/code/current. It is instead mounted at /snap/vscode/current.

The non-null assertion operator should be safe as the environment variable is checked at construction. I Although a similar check also appears to occur in doQuitAndInstall. I have removed that check and used the non-null assertion operator.If this isn't correct, I am happy to change it.


Running "grep -nr '`/snap/${product.applicationName}/current`' . " does not produce anymore results.

I am sorry for missing this in the initial PR.
