### PR TITLE
Fix #64077 - Allow to sort branches alphabetically

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1233,6 +1233,15 @@
           "type": "boolean",
           "default": true,
           "description": "%config.openDiffOnClick%"
+        },
+        "git.sortOrderForBranchList": {
+          "type": "string",
+          "enum": [
+            "committerdate",
+            "alphabetically"
+          ],
+          "default": "committerdate",
+          "description": "%config.sortOrderForBranchList%"
         }
       }
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -111,6 +111,7 @@
 	"config.useForcePushWithLease": "Controls whether force pushing uses the safer force-with-lease variant.",
 	"config.confirmForcePush": "Controls whether to ask for confirmation before force-pushing.",
 	"config.openDiffOnClick": "Controls whether the diff editor should be opened when clicking a change. Otherwise the regular editor will be opened.",
+	"config.sortOrderForBranchList": "Controls the sort order for listing branches",
 	"colors.added": "Color for added resources.",
 	"colors.modified": "Color for modified resources.",
 	"colors.deleted": "Color for deleted resources.",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1380,8 +1380,13 @@ export class Repository {
 		}
 	}
 
-	async getRefs(): Promise<Ref[]> {
-		const result = await this.run(['for-each-ref', '--format', '%(refname) %(objectname)', '--sort', '-committerdate']);
+	async getRefs(sortBranchListByCommitterDate?: Boolean): Promise<Ref[]> {
+		const args = ['for-each-ref', '--format', '%(refname) %(objectname)'];
+		if (sortBranchListByCommitterDate) {
+			args.push('--sort');
+			args.push('-committerdate');
+		}
+		const result = await this.run(args);
 
 		const fn = (line: string): Ref | null => {
 			let match: RegExpExecArray | null;

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1170,6 +1170,8 @@ export class Repository implements Disposable {
 			const result = await this.retryRun(operation, runOperation);
 
 			if (!isReadOnly(operation)) {
+				const onConfigListener = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.sortOrderForBranchList'));
+				onConfigListener(this.updateModelState, this, this.disposables);
 				await this.updateModelState();
 			}
 
@@ -1217,6 +1219,7 @@ export class Repository implements Disposable {
 		const config = workspace.getConfiguration('git');
 		const shouldIgnore = config.get<boolean>('ignoreLimitWarning') === true;
 		const useIcons = !config.get<boolean>('decorations.enabled', true);
+		const sortBranchListByCommitterDate = config.get<string>('sortOrderForBranchList') === 'committerdate';
 
 		this.isRepositoryHuge = didHitLimit;
 
@@ -1248,7 +1251,7 @@ export class Repository implements Disposable {
 			// noop
 		}
 
-		const [refs, remotes, submodules, rebaseCommit] = await Promise.all([this.repository.getRefs(), this.repository.getRemotes(), this.repository.getSubmodules(), this.getRebaseCommit()]);
+		const [refs, remotes, submodules, rebaseCommit] = await Promise.all([this.repository.getRefs(sortBranchListByCommitterDate), this.repository.getRemotes(), this.repository.getSubmodules(), this.getRebaseCommit()]);
 
 		this._HEAD = HEAD;
 		this._refs = refs;


### PR DESCRIPTION
@joaomoreno , Added a setting called "**sortOrderForBranchList**" to fix #64077 ( I can change the name if you suggest something from your end).

FYI : git sorts it default by refname if we don't specify any sort order ( https://git-scm.com/docs/git-for-each-ref#git-for-each-ref---sortltkeygt )

Please check this and review the changes :)

PS : Tested the working of this and it works fine :)