### PR TITLE
Fix #64379 - SimpleFindWidget position was changed (in hidden state)

### DIFF
--- a/src/vs/editor/contrib/find/simpleFindWidget.css
+++ b/src/vs/editor/contrib/find/simpleFindWidget.css
@@ -18,7 +18,7 @@
 .monaco-workbench .simple-find-part {
 	z-index: 10;
 	position: relative;
-	top: -40px;
+	top: -45px;
 	display: flex;
 	padding: 4px;
 	align-items: center;


### PR DESCRIPTION
SimpleFindWidget position was changed (in hidden state) for shadow hiding