### PR TITLE
Avoid accessing style in treeview if we don't need to

### DIFF
--- a/src/vs/base/parts/tree/browser/treeView.ts
+++ b/src/vs/base/parts/tree/browser/treeView.ts
@@ -260,8 +260,11 @@ export class ViewItem implements IViewItem {
 		}
 
 		if (!skipUserRender && this.element) {
-			const style = window.getComputedStyle(this.element);
-			const paddingLeft = parseFloat(style.paddingLeft);
+			let paddingLeft: number | undefined;
+			if (this.context.horizontalScrolling) {
+				const style = window.getComputedStyle(this.element);
+				paddingLeft = parseFloat(style.paddingLeft);
+			}
 
 			if (this.context.horizontalScrolling) {
 				this.element.style.width = 'fit-content';


### PR DESCRIPTION
Fixes #64576

We compute the style of an element to in order to access its left padding value. However this value is only used when `horizontalScrolling` is enabled.

With this change, we only compute the style when `horizontalScrolling` is true and the value will be used later in the function