### PR TITLE
Search results badge update (continues #61532 efforts)

### DIFF
--- a/src/vs/workbench/parts/search/browser/media/searchview.css
+++ b/src/vs/workbench/parts/search/browser/media/searchview.css
@@ -328,12 +328,12 @@
 	margin-right: 12px;
 }
 
-.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .filematch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .foldermatch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row:hover .content .linematch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .filematch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .foldermatch .monaco-count-badge,
-.search-view > .results > .monaco-tree .monaco-tree-row.focused .content .linematch .monaco-count-badge {
+.search-view:not(.wide) > .results > .monaco-tree .monaco-tree-row:hover .content .filematch .monaco-count-badge,
+.search-view:not(.wide) > .results > .monaco-tree .monaco-tree-row:hover .content .foldermatch .monaco-count-badge,
+.search-view:not(.wide) > .results > .monaco-tree .monaco-tree-row:hover .content .linematch .monaco-count-badge,
+.search-view:not(.wide) > .results > .monaco-tree .monaco-tree-row.focused .content .filematch .monaco-count-badge,
+.search-view:not(.wide) > .results > .monaco-tree .monaco-tree-row.focused .content .foldermatch .monaco-count-badge,
+.search-view:not(.wide) > .results > .monaco-tree .monaco-tree-row.focused .content .linematch .monaco-count-badge {
 	display: none;
 }
 

--- a/src/vs/workbench/parts/search/browser/media/searchview.css
+++ b/src/vs/workbench/parts/search/browser/media/searchview.css
@@ -252,6 +252,24 @@
 	background: url("action-query-clear.svg") center center no-repeat;
 }
 
+.search-view.wide .monaco-tree .monaco-tree-row .foldermatch .actionBarContainer,
+.search-view.wide .monaco-tree .monaco-tree-row .filematch .actionBarContainer,
+.search-view .monaco-tree .monaco-tree-row .linematch .actionBarContainer {
+	flex: 1 0 auto;
+}
+
+.search-view:not(.wide) .monaco-tree .monaco-tree-row .foldermatch .actionBarContainer,
+.search-view:not(.wide) .monaco-tree .monaco-tree-row .filematch .actionBarContainer {
+	flex: 0 0 auto;
+}
+
+.search-view.actions-right .monaco-tree .monaco-tree-row .foldermatch .actionBarContainer,
+.search-view.actions-right .monaco-tree .monaco-tree-row .filematch .actionBarContainer,
+.search-view.actions-right .monaco-tree .monaco-tree-row .linematch .actionBarContainer,
+.search-view:not(.wide) .monaco-tree .monaco-tree-row .linematch .actionBarContainer {
+	text-align: right;
+}
+
 .search-view .monaco-tree .monaco-tree-row .monaco-action-bar {
 	line-height: 1em;
 	display: none;
@@ -265,14 +283,6 @@
 .search-view .monaco-tree .monaco-tree-row:hover:not(.highlighted) .monaco-action-bar,
 .search-view .monaco-tree .monaco-tree-row.focused .monaco-action-bar {
 	display: inline-block;
-}
-
-.search-view:not(.wide) .monaco-tree .monaco-tree-row .linematch .actionBarContainer {
-	flex: 1;
-}
-
-.search-view:not(.wide) .monaco-tree .monaco-tree-row .monaco-action-bar {
-	float: right;
 }
 
 .search-view .monaco-tree .monaco-tree-row .monaco-action-bar .action-label {

--- a/src/vs/workbench/parts/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/parts/search/browser/searchResultsView.ts
@@ -213,7 +213,8 @@ export class SearchRenderer extends Disposable implements IRenderer {
 		const label = this.instantiationService.createInstance(FileLabel, folderMatchElement, void 0);
 		const badge = new CountBadge(DOM.append(folderMatchElement, DOM.$('.badge')));
 		this._register(attachBadgeStyler(badge, this.themeService));
-		const actions = new ActionBar(folderMatchElement, { animated: false });
+		const actionBarContainer = DOM.append(folderMatchElement, DOM.$('.actionBarContainer'));
+		const actions = new ActionBar(actionBarContainer, { animated: false });
 		return { label, badge, actions };
 	}
 
@@ -222,7 +223,8 @@ export class SearchRenderer extends Disposable implements IRenderer {
 		const label = this.instantiationService.createInstance(FileLabel, fileMatchElement, void 0);
 		const badge = new CountBadge(DOM.append(fileMatchElement, DOM.$('.badge')));
 		this._register(attachBadgeStyler(badge, this.themeService));
-		const actions = new ActionBar(fileMatchElement, { animated: false });
+		const actionBarContainer = DOM.append(fileMatchElement, DOM.$('.actionBarContainer'));
+		const actions = new ActionBar(actionBarContainer, { animated: false });
 		return { el: fileMatchElement, label, badge, actions };
 	}
 
@@ -235,7 +237,7 @@ export class SearchRenderer extends Disposable implements IRenderer {
 		const replace = DOM.append(parent, DOM.$('span.replaceMatch'));
 		const after = DOM.append(parent, DOM.$('span'));
 		const lineNumber = DOM.append(container, DOM.$('span.matchLineNum'));
-		const actionBarContainer = DOM.append(container, DOM.$('span.actionBarContainer'));
+		const actionBarContainer = DOM.append(container, DOM.$('.actionBarContainer'));
 		const actions = new ActionBar(actionBarContainer, { animated: false });
 
 		return {

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -67,6 +67,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 
 	private static readonly WIDE_CLASS_NAME = 'wide';
 	private static readonly WIDE_VIEW_SIZE = 1000;
+	private static readonly ACTIONS_RIGHT_CLASS_NAME = 'actions-right';
 
 	private isDisposed: boolean;
 
@@ -787,8 +788,8 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 		}
 
 		const actionsPosition = this.configurationService.getValue<ISearchConfigurationProperties>('search').actionsPosition;
-		const useWideLayout = this.size.width >= SearchView.WIDE_VIEW_SIZE && actionsPosition === 'auto';
-		dom.toggleClass(this.getContainer(), SearchView.WIDE_CLASS_NAME, useWideLayout);
+		dom.toggleClass(this.getContainer(), SearchView.ACTIONS_RIGHT_CLASS_NAME, actionsPosition === 'right');
+		dom.toggleClass(this.getContainer(), SearchView.WIDE_CLASS_NAME, this.size.width >= SearchView.WIDE_VIEW_SIZE);
 
 		this.searchWidget.setWidth(this.size.width - 28 /* container margin */);
 


### PR DESCRIPTION
This PR make count badge always visible in wide search views as was proposed in https://github.com/Microsoft/vscode/pull/63965#issuecomment-443387693 .

Also a bit unifies layout for actions in different line types.

Behavior:
**Narrow (<1000px)**: No changes
- Content/filename & path take all available width.
- Count badge is always aligned to right. Visible while line is not hovered or focused.
- Actions are always aligned to right. Visible while line is hovered or focused.

**Wide (>=1000px)**: 
- Content/filename & path take all do not stretch.
- Count badge is always aligned to the end of content/filename & path. Always visible _(changed)_.
- Actions are aligned according to the `search.actionsPosition` value. Visible while line is hovered or focused.