### PR TITLE
Allow users to enable/disable automatic tasks

### DIFF
--- a/src/vs/workbench/parts/tasks/electron-browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/runAutomaticTasks.ts
@@ -12,9 +12,6 @@ import { RunOnOptions, Task, TaskRunSource } from 'vs/workbench/parts/tasks/comm
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { Action } from 'vs/base/common/actions';
-import { Registry } from 'vs/platform/registry/common/platform';
-import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
-import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 
 const ARE_AUTOMATIC_TASKS_ALLOWED_IN_WORKSPACE = 'tasks.run.allowAutomatic';
 
@@ -130,7 +127,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 export class AllowAutomaticTaskRunning extends Action {
 
 	public static readonly ID = 'workbench.action.tasks.allowAutomaticRunning';
-	public static readonly LABEL = nls.localize('workbench.action.tasks.allowAutomaticRunning', "Allow Automatic Tasks in this Folder");
+	public static readonly LABEL = nls.localize('workbench.action.tasks.allowAutomaticRunning', "Allow Automatic Tasks in Folder");
 
 	constructor(
 		id: string, label: string,
@@ -148,7 +145,7 @@ export class AllowAutomaticTaskRunning extends Action {
 export class DisallowAutomaticTaskRunning extends Action {
 
 	public static readonly ID = 'workbench.action.tasks.disallowAutomaticRunning';
-	public static readonly LABEL = nls.localize('workbench.action.tasks.disallowAutomaticRunning', "Disallow Automatic Tasks in this Folder");
+	public static readonly LABEL = nls.localize('workbench.action.tasks.disallowAutomaticRunning', "Disallow Automatic Tasks in Folder");
 
 	constructor(
 		id: string, label: string,
@@ -162,9 +159,3 @@ export class DisallowAutomaticTaskRunning extends Action {
 		return Promise.resolve(void 0);
 	}
 }
-
-const category = nls.localize('tasksCategory', "Tasks");
-const actionRegistry = Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions);
-
-actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(AllowAutomaticTaskRunning, AllowAutomaticTaskRunning.ID, AllowAutomaticTaskRunning.LABEL), 'Tasks: Allow Automatic Tasks in Folder', category);
-actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DisallowAutomaticTaskRunning, DisallowAutomaticTaskRunning.ID, DisallowAutomaticTaskRunning.LABEL), 'Tasks: Disallow Automatic Tasks in Folder', category);

--- a/src/vs/workbench/parts/tasks/electron-browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/runAutomaticTasks.ts
@@ -166,5 +166,5 @@ export class DisallowAutomaticTaskRunning extends Action {
 const category = nls.localize('tasksCategory', "Tasks");
 const actionRegistry = Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions);
 
-actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(AllowAutomaticTaskRunning, AllowAutomaticTaskRunning.ID, AllowAutomaticTaskRunning.LABEL), 'Tasks: Allow Automatic Tasks in this Folder', category);
-actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DisallowAutomaticTaskRunning, DisallowAutomaticTaskRunning.ID, DisallowAutomaticTaskRunning.LABEL), 'Tasks: Disallow Automatic Tasks in this Folder', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(AllowAutomaticTaskRunning, AllowAutomaticTaskRunning.ID, AllowAutomaticTaskRunning.LABEL), 'Tasks: Allow Automatic Tasks in Folder', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DisallowAutomaticTaskRunning, DisallowAutomaticTaskRunning.ID, DisallowAutomaticTaskRunning.LABEL), 'Tasks: Disallow Automatic Tasks in Folder', category);

--- a/src/vs/workbench/parts/tasks/electron-browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/runAutomaticTasks.ts
@@ -11,6 +11,10 @@ import { forEach } from 'vs/base/common/collections';
 import { RunOnOptions, Task, TaskRunSource } from 'vs/workbench/parts/tasks/common/tasks';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { Action } from 'vs/base/common/actions';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
+import { SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 
 const ARE_AUTOMATIC_TASKS_ALLOWED_IN_WORKSPACE = 'tasks.run.allowAutomatic';
 
@@ -122,3 +126,45 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 	}
 
 }
+
+export class AllowAutomaticTaskRunning extends Action {
+
+	public static readonly ID = 'workbench.action.tasks.allowAutomaticRunning';
+	public static readonly LABEL = nls.localize('workbench.action.tasks.allowAutomaticRunning', "Allow Automatic Tasks in this Folder");
+
+	constructor(
+		id: string, label: string,
+		@IStorageService private storageService: IStorageService
+	) {
+		super(id, label);
+	}
+
+	public run(event?: any): Promise<any> {
+		this.storageService.store(ARE_AUTOMATIC_TASKS_ALLOWED_IN_WORKSPACE, true, StorageScope.WORKSPACE);
+		return Promise.resolve(void 0);
+	}
+}
+
+export class DisallowAutomaticTaskRunning extends Action {
+
+	public static readonly ID = 'workbench.action.tasks.disallowAutomaticRunning';
+	public static readonly LABEL = nls.localize('workbench.action.tasks.disallowAutomaticRunning', "Disallow Automatic Tasks in this Folder");
+
+	constructor(
+		id: string, label: string,
+		@IStorageService private storageService: IStorageService
+	) {
+		super(id, label);
+	}
+
+	public run(event?: any): Promise<any> {
+		this.storageService.store(ARE_AUTOMATIC_TASKS_ALLOWED_IN_WORKSPACE, false, StorageScope.WORKSPACE);
+		return Promise.resolve(void 0);
+	}
+}
+
+const category = nls.localize('tasksCategory', "Tasks");
+const actionRegistry = Registry.as<IWorkbenchActionRegistry>(Extensions.WorkbenchActions);
+
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(AllowAutomaticTaskRunning, AllowAutomaticTaskRunning.ID, AllowAutomaticTaskRunning.LABEL), 'Tasks: Allow Automatic Tasks in this Folder', category);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DisallowAutomaticTaskRunning, DisallowAutomaticTaskRunning.ID, DisallowAutomaticTaskRunning.LABEL), 'Tasks: Disallow Automatic Tasks in this Folder', category);

--- a/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/parts/tasks/electron-browser/task.contribution.ts
@@ -30,7 +30,7 @@ import { OcticonLabel } from 'vs/base/browser/ui/octiconLabel/octiconLabel';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ILifecycleService, LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
-import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
+import { MenuRegistry, MenuId, SyncActionDescriptor } from 'vs/platform/actions/common/actions';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IMarkerService, MarkerStatistics } from 'vs/platform/markers/common/markers';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -94,12 +94,18 @@ import { IQuickInputService, IQuickPickItem, QuickPickInput } from 'vs/platform/
 import { TaskDefinitionRegistry } from 'vs/workbench/parts/tasks/common/taskDefinitionRegistry';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
-import { RunAutomaticTasks } from 'vs/workbench/parts/tasks/electron-browser/runAutomaticTasks';
+import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
+import { RunAutomaticTasks, AllowAutomaticTaskRunning, DisallowAutomaticTaskRunning } from 'vs/workbench/parts/tasks/electron-browser/runAutomaticTasks';
 
 let tasksCategory = nls.localize('tasksCategory', "Tasks");
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchRegistry.registerWorkbenchContribution(RunAutomaticTasks, LifecyclePhase.Eventually);
+
+const actionRegistry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(AllowAutomaticTaskRunning, AllowAutomaticTaskRunning.ID, AllowAutomaticTaskRunning.LABEL), 'Tasks: Allow Automatic Tasks in Folder', tasksCategory);
+actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(DisallowAutomaticTaskRunning, DisallowAutomaticTaskRunning.ID, DisallowAutomaticTaskRunning.LABEL), 'Tasks: Disallow Automatic Tasks in Folder', tasksCategory);
+
 
 namespace ConfigureTaskAction {
 	export const ID = 'workbench.action.tasks.configureTaskRunner';


### PR DESCRIPTION
Implements #64613.

This is a simple implementation that adds two commands. One for enabling. One for disabling.  It mimics what we currently have for terminal shell configurations.

This should be revised in future iterations.
