### PR TITLE
Update feature_request template for auto-label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+labels: feature-request
 ---
 
 <!-- Please search existing issues to avoid creating duplicates. -->


### PR DESCRIPTION
Github recently added a feature to auto-label issue templates. When user clicks feature request, label will be automatically assigned to feature-request.