### PR TITLE
Suppress display of end-of-file newline as blank line

### DIFF
--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -23,7 +23,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 	private _lineHeight: number;
 	private _renderLineNumbers: RenderLineNumbersType;
 	private _renderCustomLineNumbers: ((lineNumber: number) => string) | null;
-	private _displayBlankLastLineNumber: boolean;
+	private _renderFinalNewline: boolean;
 	private _lineNumbersLeft: number;
 	private _lineNumbersWidth: number;
 	private _lastCursorModelPosition: Position;
@@ -45,7 +45,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 		this._lineHeight = config.lineHeight;
 		this._renderLineNumbers = config.viewInfo.renderLineNumbers;
 		this._renderCustomLineNumbers = config.viewInfo.renderCustomLineNumbers;
-		this._displayBlankLastLineNumber = config.viewInfo.displayBlankLastLineNumber;
+		this._renderFinalNewline = config.viewInfo.renderFinalNewline;
 		this._lineNumbersLeft = config.layoutInfo.lineNumbersLeft;
 		this._lineNumbersWidth = config.layoutInfo.lineNumbersWidth;
 	}
@@ -94,14 +94,12 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 
 	private _getLineRenderLineNumber(viewLineNumber: number): string {
 		const modelPosition = this._context.model.coordinatesConverter.convertViewPositionToModelPosition(new Position(viewLineNumber, 1));
-
 		if (modelPosition.column !== 1) {
 			return '';
 		}
-
 		let modelLineNumber = modelPosition.lineNumber;
 
-		if (!this._displayBlankLastLineNumber) {
+		if (!this._renderFinalNewline) {
 			const lineCount = this._context.model.getLineCount();
 			const lineContent = this._context.model.getLineContent(modelLineNumber);
 

--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -23,6 +23,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 	private _lineHeight: number;
 	private _renderLineNumbers: RenderLineNumbersType;
 	private _renderCustomLineNumbers: ((lineNumber: number) => string) | null;
+	private _displayBlankLastLineNumber: boolean;
 	private _lineNumbersLeft: number;
 	private _lineNumbersWidth: number;
 	private _lastCursorModelPosition: Position;
@@ -44,6 +45,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 		this._lineHeight = config.lineHeight;
 		this._renderLineNumbers = config.viewInfo.renderLineNumbers;
 		this._renderCustomLineNumbers = config.viewInfo.renderCustomLineNumbers;
+		this._displayBlankLastLineNumber = config.viewInfo.displayBlankLastLineNumber;
 		this._lineNumbersLeft = config.layoutInfo.lineNumbersLeft;
 		this._lineNumbersWidth = config.layoutInfo.lineNumbersWidth;
 	}
@@ -92,10 +94,21 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 
 	private _getLineRenderLineNumber(viewLineNumber: number): string {
 		const modelPosition = this._context.model.coordinatesConverter.convertViewPositionToModelPosition(new Position(viewLineNumber, 1));
+
 		if (modelPosition.column !== 1) {
 			return '';
 		}
+
 		let modelLineNumber = modelPosition.lineNumber;
+
+		if (!this._displayBlankLastLineNumber) {
+			const lineCount = this._context.model.getLineCount();
+			const lineContent = this._context.model.getLineContent(modelLineNumber);
+
+			if (modelLineNumber === lineCount && lineContent === '') {
+				return '';
+			}
+		}
 
 		if (this._renderCustomLineNumbers) {
 			return this._renderCustomLineNumbers(modelLineNumber);

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -264,10 +264,10 @@ const editorConfiguration: IConfigurationNode = {
 			'default': 'on',
 			'description': nls.localize('lineNumbers', "Controls the display of line numbers.")
 		},
-		'editor.displayBlankLastLineNumber': {
+		'editor.renderFinalNewline': {
 			'type': 'boolean',
-			'default': true,
-			'description': nls.localize('displayBlankLastLineNumber', "Controls whether last file line number is displayed when that line is blank.")
+			'default': EDITOR_DEFAULTS.viewInfo.renderFinalNewline,
+			'description': nls.localize('renderFinalNewline', "Render last line number when the file ends with a newline.")
 		},
 		'editor.rulers': {
 			'type': 'array',

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -264,6 +264,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': 'on',
 			'description': nls.localize('lineNumbers', "Controls the display of line numbers.")
 		},
+		'editor.displayBlankLastLineNumber': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('displayBlankLastLineNumber', "Controls whether last file line number is displayed when that line is blank.")
+		},
 		'editor.rulers': {
 			'type': 'array',
 			'items': {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -248,6 +248,11 @@ export interface IEditorOptions {
 	 * Defaults to true.
 	 */
 	lineNumbers?: 'on' | 'off' | 'relative' | 'interval' | ((lineNumber: number) => string);
+	/*
+	 * Controls whether last file line number is displayed when that line is blank.
+	 * Defaults to true.
+	*/
+	displayBlankLastLineNumber?: boolean;
 	/**
 	 * Should the corresponding line be selected when clicking on the line number?
 	 * Defaults to true.
@@ -951,6 +956,7 @@ export interface InternalEditorViewOptions {
 	readonly ariaLabel: string;
 	readonly renderLineNumbers: RenderLineNumbersType;
 	readonly renderCustomLineNumbers: ((lineNumber: number) => string) | null;
+	readonly displayBlankLastLineNumber: boolean;
 	readonly selectOnLineNumbers: boolean;
 	readonly glyphMargin: boolean;
 	readonly revealHorizontalRightPadding: number;
@@ -1258,6 +1264,7 @@ export class InternalEditorOptions {
 			&& a.ariaLabel === b.ariaLabel
 			&& a.renderLineNumbers === b.renderLineNumbers
 			&& a.renderCustomLineNumbers === b.renderCustomLineNumbers
+			&& a.displayBlankLastLineNumber === b.displayBlankLastLineNumber
 			&& a.selectOnLineNumbers === b.selectOnLineNumbers
 			&& a.glyphMargin === b.glyphMargin
 			&& a.revealHorizontalRightPadding === b.revealHorizontalRightPadding
@@ -1995,6 +2002,7 @@ export class EditorOptionsValidator {
 			ariaLabel: _string(opts.ariaLabel, defaults.ariaLabel),
 			renderLineNumbers: renderLineNumbers,
 			renderCustomLineNumbers: renderCustomLineNumbers,
+			displayBlankLastLineNumber: _boolean(opts.displayBlankLastLineNumber, defaults.displayBlankLastLineNumber),
 			selectOnLineNumbers: _boolean(opts.selectOnLineNumbers, defaults.selectOnLineNumbers),
 			glyphMargin: _boolean(opts.glyphMargin, defaults.glyphMargin),
 			revealHorizontalRightPadding: _clampedInt(opts.revealHorizontalRightPadding, defaults.revealHorizontalRightPadding, 0, 1000),
@@ -2115,6 +2123,7 @@ export class InternalEditorOptionsFactory {
 				ariaLabel: (accessibilityIsOff ? nls.localize('accessibilityOffAriaLabel', "The editor is not accessible at this time. Press Alt+F1 for options.") : opts.viewInfo.ariaLabel),
 				renderLineNumbers: opts.viewInfo.renderLineNumbers,
 				renderCustomLineNumbers: opts.viewInfo.renderCustomLineNumbers,
+				displayBlankLastLineNumber: opts.viewInfo.displayBlankLastLineNumber,
 				selectOnLineNumbers: opts.viewInfo.selectOnLineNumbers,
 				glyphMargin: opts.viewInfo.glyphMargin,
 				revealHorizontalRightPadding: opts.viewInfo.revealHorizontalRightPadding,
@@ -2577,6 +2586,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 		ariaLabel: nls.localize('editorViewAccessibleLabel', "Editor content"),
 		renderLineNumbers: RenderLineNumbersType.On,
 		renderCustomLineNumbers: null,
+		displayBlankLastLineNumber: true,
 		selectOnLineNumbers: true,
 		glyphMargin: true,
 		revealHorizontalRightPadding: 30,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -248,11 +248,11 @@ export interface IEditorOptions {
 	 * Defaults to true.
 	 */
 	lineNumbers?: 'on' | 'off' | 'relative' | 'interval' | ((lineNumber: number) => string);
-	/*
-	 * Controls whether last file line number is displayed when that line is blank.
-	 * Defaults to true.
+	/**
+	 * Render last line number when the file ends with a newline.
+	 * Defaults to true on Windows/Mac and to false on Linux.
 	*/
-	displayBlankLastLineNumber?: boolean;
+	renderFinalNewline?: boolean;
 	/**
 	 * Should the corresponding line be selected when clicking on the line number?
 	 * Defaults to true.
@@ -956,7 +956,7 @@ export interface InternalEditorViewOptions {
 	readonly ariaLabel: string;
 	readonly renderLineNumbers: RenderLineNumbersType;
 	readonly renderCustomLineNumbers: ((lineNumber: number) => string) | null;
-	readonly displayBlankLastLineNumber: boolean;
+	readonly renderFinalNewline: boolean;
 	readonly selectOnLineNumbers: boolean;
 	readonly glyphMargin: boolean;
 	readonly revealHorizontalRightPadding: number;
@@ -1264,7 +1264,7 @@ export class InternalEditorOptions {
 			&& a.ariaLabel === b.ariaLabel
 			&& a.renderLineNumbers === b.renderLineNumbers
 			&& a.renderCustomLineNumbers === b.renderCustomLineNumbers
-			&& a.displayBlankLastLineNumber === b.displayBlankLastLineNumber
+			&& a.renderFinalNewline === b.renderFinalNewline
 			&& a.selectOnLineNumbers === b.selectOnLineNumbers
 			&& a.glyphMargin === b.glyphMargin
 			&& a.revealHorizontalRightPadding === b.revealHorizontalRightPadding
@@ -2002,7 +2002,7 @@ export class EditorOptionsValidator {
 			ariaLabel: _string(opts.ariaLabel, defaults.ariaLabel),
 			renderLineNumbers: renderLineNumbers,
 			renderCustomLineNumbers: renderCustomLineNumbers,
-			displayBlankLastLineNumber: _boolean(opts.displayBlankLastLineNumber, defaults.displayBlankLastLineNumber),
+			renderFinalNewline: _boolean(opts.renderFinalNewline, defaults.renderFinalNewline),
 			selectOnLineNumbers: _boolean(opts.selectOnLineNumbers, defaults.selectOnLineNumbers),
 			glyphMargin: _boolean(opts.glyphMargin, defaults.glyphMargin),
 			revealHorizontalRightPadding: _clampedInt(opts.revealHorizontalRightPadding, defaults.revealHorizontalRightPadding, 0, 1000),
@@ -2123,7 +2123,7 @@ export class InternalEditorOptionsFactory {
 				ariaLabel: (accessibilityIsOff ? nls.localize('accessibilityOffAriaLabel', "The editor is not accessible at this time. Press Alt+F1 for options.") : opts.viewInfo.ariaLabel),
 				renderLineNumbers: opts.viewInfo.renderLineNumbers,
 				renderCustomLineNumbers: opts.viewInfo.renderCustomLineNumbers,
-				displayBlankLastLineNumber: opts.viewInfo.displayBlankLastLineNumber,
+				renderFinalNewline: opts.viewInfo.renderFinalNewline,
 				selectOnLineNumbers: opts.viewInfo.selectOnLineNumbers,
 				glyphMargin: opts.viewInfo.glyphMargin,
 				revealHorizontalRightPadding: opts.viewInfo.revealHorizontalRightPadding,
@@ -2586,7 +2586,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 		ariaLabel: nls.localize('editorViewAccessibleLabel', "Editor content"),
 		renderLineNumbers: RenderLineNumbersType.On,
 		renderCustomLineNumbers: null,
-		displayBlankLastLineNumber: true,
+		renderFinalNewline: (platform.isLinux ? false : true),
 		selectOnLineNumbers: true,
 		glyphMargin: true,
 		revealHorizontalRightPadding: 30,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2582,7 +2582,11 @@ declare namespace monaco.editor {
 		 * Defaults to true.
 		 */
 		lineNumbers?: 'on' | 'off' | 'relative' | 'interval' | ((lineNumber: number) => string);
-		displayBlankLastLineNumber?: boolean;
+		/**
+		 * Render last line number when the file ends with a newline.
+		 * Defaults to true on Windows/Mac and to false on Linux.
+		*/
+		renderFinalNewline?: boolean;
 		/**
 		 * Should the corresponding line be selected when clicking on the line number?
 		 * Defaults to true.
@@ -3220,7 +3224,7 @@ declare namespace monaco.editor {
 		readonly ariaLabel: string;
 		readonly renderLineNumbers: RenderLineNumbersType;
 		readonly renderCustomLineNumbers: ((lineNumber: number) => string) | null;
-		readonly displayBlankLastLineNumber: boolean;
+		readonly renderFinalNewline: boolean;
 		readonly selectOnLineNumbers: boolean;
 		readonly glyphMargin: boolean;
 		readonly revealHorizontalRightPadding: number;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2582,6 +2582,7 @@ declare namespace monaco.editor {
 		 * Defaults to true.
 		 */
 		lineNumbers?: 'on' | 'off' | 'relative' | 'interval' | ((lineNumber: number) => string);
+		displayBlankLastLineNumber?: boolean;
 		/**
 		 * Should the corresponding line be selected when clicking on the line number?
 		 * Defaults to true.
@@ -3219,6 +3220,7 @@ declare namespace monaco.editor {
 		readonly ariaLabel: string;
 		readonly renderLineNumbers: RenderLineNumbersType;
 		readonly renderCustomLineNumbers: ((lineNumber: number) => string) | null;
+		readonly displayBlankLastLineNumber: boolean;
 		readonly selectOnLineNumbers: boolean;
 		readonly glyphMargin: boolean;
 		readonly revealHorizontalRightPadding: number;


### PR DESCRIPTION
Fixes #1027.
We read the thread and the consensus seemed to be that there should be a setting that controls the display of the numbered blank line at the end of files. So that's what we did. We're not sure if we used the most correct naming, but after a couple of tests it does seem to work as intended. Here are some screenshots:

**Added setting**
![eof-nl-setting](https://i.imgur.com/UgTTJhb.png)

**No blank like**
![eof-no-nl](https://i.imgur.com/ftVQ9ai.png)

**Setting on**
![eof-nl-on](https://i.imgur.com/HYRwVAv.png)

**Setting off**
![eof-nl-off](https://i.imgur.com/ybzVce2.png)