### PR TITLE
Completely hide tab close button when dirty state is highlighted in top border

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -244,29 +244,20 @@
 	padding-right: 5px; /* we need less room when sizing is shrink */
 }
 
-.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty {
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty:not(.dirty-border-top) {
 	background-repeat: no-repeat;
 	background-position-y: center;
 	background-position-x: calc(100% - 6px); /* to the right of the tab label */
 	padding-right: 28px; /* make room for dirty indication when we are running without close button */
 }
 
-.vs .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty {
+.vs .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty:not(.dirty-border-top) {
 	background-image: url('close-dirty.svg');
 }
 
-.vs-dark .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty,
+.vs-dark .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty:not(.dirty-border-top),
 .hc-black .monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty {
 	background-image: url('close-dirty-inverse.svg');
-}
-
-/* No Tab Close Button and "highlightModifiedTabs": true (should never show the dirty icon and never change tab width) */
-.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty.dirty-border-top {
-	background-image: none;
-	padding-right: 10px;
-}
-.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty.dirty-border-top.sizing-shrink {
-	padding-right: 5px;
 }
 
 /* Editor Actions */

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -260,6 +260,15 @@
 	background-image: url('close-dirty-inverse.svg');
 }
 
+/* No Tab Close Button and "highlightModifiedTabs": true (should never show the dirty icon and never change tab width) */
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty.dirty-border-top {
+	background-image: none;
+	padding-right: 10px;
+}
+.monaco-workbench > .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty.dirty-border-top.sizing-shrink {
+	padding-right: 5px;
+}
+
 /* Editor Actions */
 
 .monaco-workbench > .part.editor > .content .editor-group-container > .title .editor-actions {


### PR DESCRIPTION
Fixes #64684 

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/9638156/49729127-a5f5cf00-fc85-11e8-85e5-b792764f4033.gif) | ![after](https://user-images.githubusercontent.com/9638156/49729143-abebb000-fc85-11e8-9509-dfe861a91014.gif) |