### PR TITLE
Allow a terminal creation to ignore VSCode's process environment

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6848,9 +6848,8 @@ declare module 'vscode' {
 		 * Whether the terminal process environment should be exactly as provided in
 		 * `TerminalOptions.env`. When this is false (default), the environment will be based on the
 		 * window's environment and also apply configured platform settings like
-		 * `terminal.integrated.windows.env` on top.
-		 * When this is true, the complete environment must be provided  as nothing will be inherited from the process
-		 * or any configuration.
+		 * `terminal.integrated.windows.env` on top. When this is true, the complete environment
+		 * must be provided as nothing will be inherited from the process or any configuration.
 		 */
 		strictEnv?: boolean;
 	}

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6843,6 +6843,16 @@ declare module 'vscode' {
 		 * Object with environment variables that will be added to the VS Code process.
 		 */
 		env?: { [key: string]: string | null };
+
+		/**
+		 * Whether the terminal process environment should be exactly as provided in
+		 * `TerminalOptions.env`. When this is false (default), the environment will be based on the
+		 * window's environment and also apply configured platform settings like
+		 * `terminal.integrated.windows.env` on top.
+		 * When this is true, the complete environment must be provided  as nothing will be inherited from the process
+		 * or any configuration.
+		 */
+		strictEnv?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadTerminalService.ts
@@ -55,7 +55,7 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 		// when the extension host process goes down ?
 	}
 
-	public $createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, env?: { [key: string]: string }, waitOnExit?: boolean): Promise<{ id: number, name: string }> {
+	public $createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string, env?: { [key: string]: string }, waitOnExit?: boolean, strictEnv?: boolean): Promise<{ id: number, name: string }> {
 		const shellLaunchConfig: IShellLaunchConfig = {
 			name,
 			executable: shellPath,
@@ -63,7 +63,8 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 			cwd,
 			waitOnExit,
 			ignoreConfigurationCwd: true,
-			env
+			env,
+			strictEnv
 		};
 		const terminal = this.terminalService.createTerminal(shellLaunchConfig);
 		return Promise.resolve({

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -344,7 +344,7 @@ export interface MainThreadProgressShape extends IDisposable {
 }
 
 export interface MainThreadTerminalServiceShape extends IDisposable {
-	$createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string | URI, env?: { [key: string]: string }, waitOnExit?: boolean): Promise<{ id: number, name: string }>;
+	$createTerminal(name?: string, shellPath?: string, shellArgs?: string[], cwd?: string | URI, env?: { [key: string]: string }, waitOnExit?: boolean, strictEnv?: boolean): Promise<{ id: number, name: string }>;
 	$createTerminalRenderer(name: string): Promise<number>;
 	$dispose(terminalId: number): void;
 	$hide(terminalId: number): void;

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -104,9 +104,10 @@ export class ExtHostTerminal extends BaseExtHostTerminal implements vscode.Termi
 		shellArgs?: string[],
 		cwd?: string | URI,
 		env?: { [key: string]: string },
-		waitOnExit?: boolean
+		waitOnExit?: boolean,
+		strictEnv?: boolean
 	): void {
-		this._proxy.$createTerminal(this._name, shellPath, shellArgs, cwd, env, waitOnExit).then(terminal => {
+		this._proxy.$createTerminal(this._name, shellPath, shellArgs, cwd, env, waitOnExit, strictEnv).then(terminal => {
 			this._name = terminal.name;
 			this._runQueuedRequests(terminal.id);
 		});
@@ -269,7 +270,7 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 
 	public createTerminalFromOptions(options: vscode.TerminalOptions): vscode.Terminal {
 		const terminal = new ExtHostTerminal(this._proxy, options.name);
-		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.env /*, options.waitOnExit*/);
+		terminal.create(options.shellPath, options.shellArgs, options.cwd, options.env, /*options.waitOnExit*/ undefined, options.strictEnv);
 		this._terminals.push(terminal);
 		return terminal;
 	}

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -186,7 +186,8 @@ export interface IShellLaunchConfig {
 	 * Whether the terminal process environment should be exactly as provided in
 	 * `TerminalOptions.env`. When this is false (default), the environment will be based on the
 	 * window's environment and also apply configured platform settings like
-	 * `terminal.integrated.windows.env` on top.
+	 * `terminal.integrated.windows.env` on top. When this is true, the complete environment must be
+	 * provided as nothing will be inherited from the process or any configuration.
 	 */
 	strictEnv?: boolean;
 }

--- a/src/vs/workbench/parts/terminal/common/terminal.ts
+++ b/src/vs/workbench/parts/terminal/common/terminal.ts
@@ -181,6 +181,14 @@ export interface IShellLaunchConfig {
 	 * extensions full control over the terminal.
 	 */
 	isRendererOnly?: boolean;
+
+	/**
+	 * Whether the terminal process environment should be exactly as provided in
+	 * `TerminalOptions.env`. When this is false (default), the environment will be based on the
+	 * window's environment and also apply configured platform settings like
+	 * `terminal.integrated.windows.env` on top.
+	 */
+	strictEnv?: boolean;
 }
 
 export interface ITerminalService {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalProcessManager.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalProcessManager.ts
@@ -111,12 +111,12 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 			const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot(Schemas.file);
 			this.initialCwd = terminalEnvironment.getCwd(shellLaunchConfig, activeWorkspaceRootUri, this._configHelper.config.cwd);
 
-			// Compell type system as process.env should not have any undefined entries
+			// Compel type system as process.env should not have any undefined entries
 			let env: platform.IProcessEnvironment = {};
 
-			// When this is true, the caller must provide the complete environment as nothing will be inherited from the process
-			// or any configuration.
 			if (shellLaunchConfig.strictEnv) {
+				// Only base the terminal process environment on this environment and add the
+				// various mixins when strictEnv is false
 				env = { ...shellLaunchConfig.env } as any;
 			} else {
 				// Merge process env with the env from config and from shellLaunchConfig


### PR DESCRIPTION
#64731 - > Allow a terminal to be created with a specific environment by not inheriting VSCode's environment.
