### PR TITLE
Fixes #27107 - User terminal's cwd for links

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -944,7 +944,7 @@ export class TerminalInstance implements ITerminalInstance {
 		this._onLineData.fire(lineData);
 	}
 
-	private _onKey(key: string, ev: KeyboardEvent) {
+	private _onKey(key: string, ev: KeyboardEvent): void {
 		const event = new StandardKeyboardEvent(ev);
 
 		if (event.equals(KeyCode.Enter)) {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -10,6 +10,7 @@ import * as dom from 'vs/base/browser/dom';
 import * as paths from 'vs/base/common/paths';
 import * as os from 'os';
 import { Event, Emitter } from 'vs/base/common/event';
+import { debounce } from 'vs/base/common/decorators';
 import { WindowsShellHelper } from 'vs/workbench/parts/terminal/node/windowsShellHelper';
 import { Terminal as XTermTerminal, ISearchOptions } from 'vscode-xterm';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
@@ -17,6 +18,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { ITerminalInstance, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, TERMINAL_PANEL_ID, IShellLaunchConfig, ITerminalProcessManager, ProcessState, NEVER_MEASURE_RENDER_TIME_STORAGE_KEY, ITerminalDimensions } from 'vs/workbench/parts/terminal/common/terminal';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { KeyCode } from 'vs/base/common/keyCodes';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { TabFocus } from 'vs/editor/common/config/commonEditorConfig';
 import { TerminalConfigHelper } from 'vs/workbench/parts/terminal/electron-browser/terminalConfigHelper';
@@ -310,13 +312,15 @@ export class TerminalInstance implements ITerminalInstance {
 		}
 		this._xterm.winptyCompatInit();
 		this._xterm.on('linefeed', () => this._onLineFeed());
+		this._xterm.on('key', (key, ev) => this._onKey(key, ev));
+
 		if (this._processManager) {
 			this._processManager.onProcessData(data => this._onProcessData(data));
 			this._xterm.on('data', data => this._processManager.write(data));
 			// TODO: How does the cwd work on detached processes?
 			this._linkHandler = this._instantiationService.createInstance(TerminalLinkHandler, this._xterm, platform.platform);
 			this.processReady.then(() => {
-				this._linkHandler.initialCwd = this._processManager.initialCwd;
+				this._linkHandler.processCwd = this._processManager.initialCwd;
 			});
 		}
 		this._xterm.on('focus', () => this._onFocus.fire(this));
@@ -938,6 +942,24 @@ export class TerminalInstance implements ITerminalInstance {
 			lineData = buffer.translateBufferLineToString(lineIndex, false) + lineData;
 		}
 		this._onLineData.fire(lineData);
+	}
+
+	private _onKey(key: string, ev: KeyboardEvent) {
+		const event = new StandardKeyboardEvent(ev);
+
+		if (event.equals(KeyCode.Enter)) {
+			this._updateProcessCwd();
+		}
+	}
+
+	@debounce(2000)
+	private async _updateProcessCwd(): Promise<string> {
+		// reset cwd if it has changed, so file based url paths can be resolved
+		const cwd = await this.getCwd();
+		if (cwd) {
+			this._linkHandler.processCwd = cwd;
+		}
+		return cwd;
 	}
 
 	public updateConfig(): void {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
@@ -60,7 +60,7 @@ export class TerminalLinkHandler {
 	private _hoverDisposables: IDisposable[] = [];
 	private _mouseMoveDisposable: IDisposable;
 	private _widgetManager: TerminalWidgetManager;
-	private _initialCwd: string;
+	private _processCwd: string;
 	private _localLinkPattern: RegExp;
 
 	constructor(
@@ -82,8 +82,8 @@ export class TerminalLinkHandler {
 		this._widgetManager = widgetManager;
 	}
 
-	public set initialCwd(initialCwd: string) {
-		this._initialCwd = initialCwd;
+	public set processCwd(processCwd: string) {
+		this._processCwd = processCwd;
 	}
 
 	public registerCustomLinkHandler(regex: RegExp, handler: (uri: string) => void, matchIndex?: number, validationCallback?: XtermLinkMatcherValidationCallback): number {
@@ -227,20 +227,20 @@ export class TerminalLinkHandler {
 
 			// Resolve relative paths (.\a, ..\a, ~\a, a\b)
 			if (!link.match('^' + winDrivePrefix)) {
-				if (!this._initialCwd) {
+				if (!this._processCwd) {
 					// Abort if no workspace is open
 					return null;
 				}
-				link = path.join(this._initialCwd, link);
+				link = path.join(this._processCwd, link);
 			}
 		}
 		// Resolve workspace path . | .. | <relative_path> -> <path>/. | <path>/.. | <path>/<relative_path>
 		else if (link.charAt(0) !== '/' && link.charAt(0) !== '~') {
-			if (!this._initialCwd) {
+			if (!this._processCwd) {
 				// Abort if no workspace is open
 				return null;
 			}
-			link = path.join(this._initialCwd, link);
+			link = path.join(this._processCwd, link);
 		}
 		return link;
 	}
@@ -256,7 +256,7 @@ export class TerminalLinkHandler {
 			return Promise.resolve(void 0);
 		}
 
-		// Open an editor if the path exists
+		// Ensure the file exists on disk, so an editor can be opened after clicking it
 		return pfs.fileExists(linkUrl).then(isFile => {
 			if (!isFile) {
 				return null;

--- a/src/vs/workbench/parts/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/parts/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -170,7 +170,7 @@ suite('Workbench - TerminalLinkHandler', () => {
 	suite('preprocessPath', () => {
 		test('Windows', () => {
 			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Windows, null, null, null, null);
-			linkHandler.initialCwd = 'C:\\base';
+			linkHandler.processCwd = 'C:\\base';
 
 			let stub = sinon.stub(path, 'join', function (arg1: string, arg2: string) {
 				return arg1 + '\\' + arg2;
@@ -183,7 +183,7 @@ suite('Workbench - TerminalLinkHandler', () => {
 		});
 		test('Windows - spaces', () => {
 			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Windows, null, null, null, null);
-			linkHandler.initialCwd = 'C:\\base dir';
+			linkHandler.processCwd = 'C:\\base dir';
 
 			let stub = sinon.stub(path, 'join', function (arg1: string, arg2: string) {
 				return arg1 + '\\' + arg2;
@@ -197,7 +197,7 @@ suite('Workbench - TerminalLinkHandler', () => {
 
 		test('Linux', () => {
 			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, null, null, null, null);
-			linkHandler.initialCwd = '/base';
+			linkHandler.processCwd = '/base';
 
 			let stub = sinon.stub(path, 'join', function (arg1: string, arg2: string) {
 				return arg1 + '/' + arg2;


### PR DESCRIPTION
Implementation Details:

 * renaming initialCwd -> processCwd
 * debounce _updateProcessCwd with a 2 second 
* only call _updateProcessCwd when user presses enter on xterm
