### PR TITLE
Experimenting with Recent Menu

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -18,6 +18,7 @@ import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableEle
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { Event, Emitter } from 'vs/base/common/event';
 import { AnchorAlignment } from 'vs/base/browser/ui/contextview/contextview';
+import { assign } from 'vs/base/common/objects';
 
 export const MENU_MNEMONIC_REGEX: RegExp = /\(&{1,2}(.)\)|&{1,2}(.)/;
 export const MENU_ESCAPED_MNEMONIC_REGEX: RegExp = /(?:&amp;){1,2}(.)/;
@@ -280,7 +281,12 @@ export class Menu extends ActionBar {
 				}
 			}
 
-			const menuActionItem = new MenuActionItem(options.context, action, menuItemOptions);
+			const context = { args: action.label };
+			if (options.context) {
+				assign(context, options.context);
+			}
+
+			const menuActionItem = new MenuActionItem(context, action, menuItemOptions);
 
 			if (options.enableMnemonics) {
 				const mnemonic = menuActionItem.getMnemonic();

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -28,6 +28,7 @@ export interface ICommandAction extends IBaseCommandAction {
 	iconLocation?: { dark: URI; light?: URI; };
 	precondition?: ContextKeyExpr;
 	toggled?: ContextKeyExpr;
+	args?: any[];
 }
 
 export interface ISerializableCommandAction extends IBaseCommandAction {
@@ -256,6 +257,10 @@ export class MenuItemAction extends ExecuteCommandAction {
 
 	run(...args: any[]): Promise<any> {
 		let runArgs: any[] = [];
+
+		if (this.item.args) {
+			runArgs = [...runArgs, ...this.item.args];
+		}
 
 		if (this._options.arg) {
 			runArgs = [...runArgs, this._options.arg];


### PR DESCRIPTION
@bpasero @isidorn 
Experimenting with ways to remove custom logic for the recent menu in the menu bar. I don't know where this code would live, but the idea is that a listener manages the Recent Submenu data model when the recent menu is updated. This would mean commands would have to be registered to handle the different URIs. Not sure if this can be parameterized to have a single command that can be re-used. This would both remove custom logic from the menu bar but I *think* we could reuse it in the native case as well. Not sure due to fallback case on macOS.

P.S. don't try this code with the native menu
/cc @jrieken is this menu model abuse?