### PR TITLE
Fixes #64747

### DIFF
--- a/src/vs/base/browser/ui/tree/media/tree.css
+++ b/src/vs/base/browser/ui/tree/media/tree.css
@@ -23,6 +23,7 @@
 
 .monaco-tl-contents {
 	flex: 1;
+	overflow: hidden;
 }
 
 .monaco-tl-twistie.collapsible {


### PR DESCRIPTION
We're missing an overflow behavior for the new tree's row contents.