### PR TITLE
Revert "list: right click should  not select/focus"

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -454,10 +454,6 @@ class MouseController<T> implements IDisposable {
 	}
 
 	private onMouseDown(e: IListMouseEvent<T> | IListTouchEvent<T>): void {
-		if (e.browserEvent instanceof MouseEvent && e.browserEvent.button === 2) {
-			return;
-		}
-
 		if (this.options.focusOnMouseDown === false) {
 			e.browserEvent.preventDefault();
 			e.browserEvent.stopPropagation();


### PR DESCRIPTION
This fixes the Open Editors context menus.