### PR TITLE
Fixes #64739

### DIFF
--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -46,7 +46,8 @@ export class DarwinUpdateService extends AbstractUpdateService {
 		this.logService.error('UpdateService error:', err);
 
 		// only show message when explicitly checking for updates
-		const message: string | undefined = !!context ? err : undefined;
+		const shouldShowMessage = this.state.type === StateType.CheckingForUpdates ? !!this.state.context : true;
+		const message: string | undefined = shouldShowMessage ? err : undefined;
 		this.setState(State.Idle(UpdateType.Archive, message));
 	}
 


### PR DESCRIPTION
This bug puts the darwin update service in a constant state of `Checking for updates...`. It happened because the symbol `context` is in our global scope due to the Mocha typings, so TypeScript failed to catch that use of `context` and it missing from the variable scope. @mjbvz Any way we can tweak that?

![image](https://user-images.githubusercontent.com/22350/49805977-cb9ed900-fd56-11e8-8201-e0ada7148058.png)
