### PR TITLE
Adopt AbstractTreeRenderer to get re-render behavior

### DIFF
--- a/src/vs/workbench/parts/outline/electron-browser/outlinePanel.ts
+++ b/src/vs/workbench/parts/outline/electron-browser/outlinePanel.ts
@@ -14,7 +14,7 @@ import { Action, IAction, RadioGroup } from 'vs/base/common/actions';
 import { firstIndex } from 'vs/base/common/arrays';
 import { createCancelablePromise, TimeoutTimer } from 'vs/base/common/async';
 import { isPromiseCanceledError, onUnexpectedError } from 'vs/base/common/errors';
-import { Emitter } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
 import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { dispose, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
@@ -356,8 +356,9 @@ export class OutlinePanel extends ViewletPanel {
 			}
 		};
 
-		this._treeGroupRenderer = this._instantiationService.createInstance(NOutlineGroupRenderer);
-		this._treeElementRenderer = this._instantiationService.createInstance(NOutlineElementRenderer);
+		// TODO@joh: pass along to the renderers an event which should trigger a re-render of elements
+		this._treeGroupRenderer = this._instantiationService.createInstance(NOutlineGroupRenderer, Event.None);
+		this._treeElementRenderer = this._instantiationService.createInstance(NOutlineElementRenderer, Event.None);
 		this._treeFilter = this._instantiationService.createInstance(NOutlineFilter);
 
 		this._tree = <any>this._instantiationService.createInstance(WorkbenchObjectTree,
@@ -373,7 +374,7 @@ export class OutlinePanel extends ViewletPanel {
 		this._treeElementRenderer.renderProblemColors = this._configurationService.getValue(OutlineConfigKeys.problemsColors);
 		this._treeElementRenderer.renderProblemBadges = this._configurationService.getValue(OutlineConfigKeys.problemsBadges);
 
-		this._disposables.push(this._tree, this._input);
+		this._disposables.push(this._tree, this._input, this._treeGroupRenderer, this._treeElementRenderer);
 		this._disposables.push(this._outlineViewState.onDidChange(this._onDidChangeUserState, this));
 
 		// feature: toggle icons


### PR DESCRIPTION
This adopts the `AbstractTreeRenderer` from `master` into the two Outline renderers. This base class remembers which elements have been rendered and re-renders them whenever a provided event fires. The event is of type `T | T[] | undefined` meaning:

- `T` only that element will be re-rendered
- `T[]` only those elements will be re-rendered
- `undefined` every rendered element will be re-rendered

The name `AbstractTreeRenderer` (and `AbstractListRenderer`) are pretty bad, but I'm lacking ideas for improving it. I'd like the name to convey the fact that they remember rendered elements and trigger re-renderings based on a given event. Any suggestions?

@jrieken I left a `TODO@joh` marker for where you can plug in the event which should trigger element re-rendering.