### PR TITLE
Prevent 'Report Issue' and 'Process Explorer' windows to be opened in fullscreen mode

### DIFF
--- a/src/vs/platform/issue/electron-main/issueService.ts
+++ b/src/vs/platform/issue/electron-main/issueService.ts
@@ -118,6 +118,7 @@ export class IssueService implements IIssueService {
 					const position = this.getWindowPosition(this._issueParentWindow, 700, 800);
 
 					this._issueWindow = new BrowserWindow({
+						fullscreen: false,
 						width: position.width,
 						height: position.height,
 						minWidth: 300,
@@ -163,6 +164,7 @@ export class IssueService implements IIssueService {
 					this._processExplorerWindow = new BrowserWindow({
 						skipTaskbar: true,
 						resizable: true,
+						fullscreen: false,
 						width: position.width,
 						height: position.height,
 						minWidth: 300,


### PR DESCRIPTION
It fixes #64306 preventing issueWindow and processExplorerWindow to be opened in fullscreen mode.

I believe it (the fact that issueWindow and processExplorerWindow should be opened always in non-fullscreen mode) applies for every case and every platform.

