### PR TITLE
Fix broken Debug > Start Debugging global menu action

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugActions.ts
+++ b/src/vs/workbench/parts/debug/browser/debugActions.ts
@@ -136,7 +136,7 @@ export class StartAction extends AbstractDebugAction {
 	// Note: When this action is executed from the process explorer, a config is passed. For all
 	// other cases it is run with no arguments.
 	public run(config?: IConfig): Thenable<any> {
-		if (config) {
+		if (config && 'type' in config && 'request' in config) {
 			return this.debugService.startDebugging(undefined, config, this.isNoDebug());
 		}
 


### PR DESCRIPTION
The top level menu passes in `{}` and empty object, thus the check that @RMacfarlane and me introduced wrongly asumes it is the process explorer case. 
The fix correctly handles the main menu case.

For a complet fix of this please check issue https://github.com/Microsoft/vscode/issues/64858