### PR TITLE
treeResourceNavigator: fire onSelection also for keyboard events

### DIFF
--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -610,12 +610,12 @@ export class TreeResourceNavigator2<T, TFilterData> extends Disposable {
 	}
 
 	private onSelection(e: ITreeEvent<T>): void {
-		if (!e.browserEvent || !(e.browserEvent instanceof MouseEvent)) {
+		if (!e.browserEvent) {
 			return;
 		}
 
 		const isDoubleClick = e.browserEvent.detail === 2;
-		const sideBySide = e.browserEvent.ctrlKey || e.browserEvent.metaKey || e.browserEvent.altKey;
+		const sideBySide = e.browserEvent instanceof MouseEvent && (e.browserEvent.ctrlKey || e.browserEvent.metaKey || e.browserEvent.altKey);
 		this.open(!isDoubleClick, isDoubleClick, sideBySide);
 	}
 


### PR DESCRIPTION
fixes #64834

The tree resource navigator was not firing onSelection events for keyboard because the markers panel was not caring about this and we simply picked up the navigator from that use case.

I have verified that this change does not break the markers panel and that it correctly fixes the issue in the call stack and in the loaded scripts