### PR TITLE
Don't pass logging path through environment block

### DIFF
--- a/src/vs/platform/environment/node/environmentService.ts
+++ b/src/vs/platform/environment/node/environmentService.ts
@@ -240,13 +240,15 @@ export class EnvironmentService implements IEnvironmentService {
 	get driverHandle(): string | undefined { return this._args['driver']; }
 	get driverVerbose(): boolean { return !!this._args['driver-verbose']; }
 
+	private static processLogFilePath: string | undefined;
+
 	constructor(private _args: ParsedArgs, private _execPath: string) {
-		if (!process.env['VSCODE_LOGS']) {
+		if (!EnvironmentService.processLogFilePath) {
 			const key = toLocalISOString(new Date()).replace(/-|:|\.\d+Z$/g, '');
-			process.env['VSCODE_LOGS'] = path.join(this.userDataPath, 'logs', key);
+			EnvironmentService.processLogFilePath = path.join(this.userDataPath, 'logs', key);
 		}
 
-		this.logsPath = process.env['VSCODE_LOGS']!;
+		this.logsPath = EnvironmentService.processLogFilePath;
 	}
 }
 


### PR DESCRIPTION
This address issue #64897.

What is happening is that any processes launched from VSCode (even other VSCode proceses in the case of debugging say an extension) end up trying to use the same logging path.

When a new instance of VSCode launches, the rotating logger then tries to open files (which are named by vscode parts such as "renderer", "cli", etc.) for exclusive access inside the same paths. This obviously fails because the previous instance still holds the files.

The fix for this is to have the environment service have a static variable that it assigns only once and sets that is its "logPath" property.