### PR TITLE
Add setting to control when comments panel opens

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -74,7 +74,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 	private _documentProviders = new Map<number, IDisposable>();
 	private _workspaceProviders = new Map<number, IDisposable>();
 	private _handlers = new Map<number, string>();
-	private _openPanelListener: IDisposable;
+	private _openPanelListener: IDisposable | null;
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -115,11 +115,11 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 								this._commentService.setWorkspaceComments(providerId, commentThreads);
 							}
 
-							this._openPanelListener.dispose();
-							this._openPanelListener = null;
 						});
 					});
 
+					this._openPanelListener.dispose();
+					this._openPanelListener = null;
 				}
 			});
 		}

--- a/src/vs/workbench/parts/comments/electron-browser/comments.contribution.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/comments.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as nls from 'vs/nls';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -12,6 +13,11 @@ import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { COMMENTS_PANEL_ID, COMMENTS_PANEL_TITLE, CommentsPanel } from './commentsPanel';
 import 'vs/workbench/parts/comments/electron-browser/commentsEditorContribution';
 import { ICommentService, CommentService } from 'vs/workbench/parts/comments/electron-browser/commentService';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
+
+export interface ICommentsConfiguration {
+	openPanel: 'neverOpen' | 'openOnSessionStart' | 'openOnSessionStartWithComments';
+}
 
 export class CommentPanelVisibilityUpdater implements IWorkbenchContribution {
 
@@ -34,6 +40,21 @@ Registry.as<PanelRegistry>(PanelExtensions.Panels).registerPanel(new PanelDescri
 	'commentsPanel',
 	10
 ));
+
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'comments',
+	order: 20,
+	title: nls.localize('commentsConfigurationTitle', "Comments"),
+	type: 'object',
+	properties: {
+		'comments.openPanel': {
+			enum: ['neverOpen', 'openOnSessionStart', 'openOnSessionStartWithComments'],
+			default: 'openOnSessionStartWithComments',
+			description: nls.localize('openComments', "Controls when the comments panel should open.")
+		}
+	}
+});
 
 // Register view location updater
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(CommentPanelVisibilityUpdater, LifecyclePhase.Starting);

--- a/src/vs/workbench/parts/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsLayout.ts
@@ -154,6 +154,11 @@ export const tocData: ITOCEntry = {
 					id: 'features/problems',
 					label: localize('problems', "Problems"),
 					settings: ['problems.*']
+				},
+				{
+					id: 'features/comments',
+					label: localize('comments', "Comments"),
+					settings: ['comments.*']
 				}
 			]
 		},


### PR DESCRIPTION
Adds a setting to control the comment panel opening behavior, as described in https://github.com/Microsoft/vscode-pull-request-github/issues/70#issuecomment-446794124.

@roblourens this change also adds a "Comments" section to the TOC, since other panels had their own sections I thought it made sense to add one for comments as well. Let me know if you think there's a better place to put the setting