### PR TITLE
add .vscodeignore syntax highlighting

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,0 +1,7 @@
+# VS Code
+
+**Notice:** This extension is bundled with Visual Studio Code. It can be disabled but not uninstalled.
+
+## Features
+
+This extension adds syntax highlighting to VS Code specific files like `.vscodeignore`.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vscode",
+  "displayName": "%displayName%",
+  "description": "%description%",
+  "version": "1.0.0",
+  "publisher": "vscode",
+  "engines": {
+    "vscode": "0.10.x"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "ignore",
+        "filenames": [
+          ".vscodeignore"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I have _no_ idea, if this is the correct way to do it 😄 I created a new extension called just `vscode` to handle VS Code specific features. I could imagine to have more VS Code specific functionality in the form of a built-in extension (e.g. also for things like `.vscode/*` files).

I guess current VS Code specific features are currently included somewhere in the `src/`? But I'm not sure if you want to maintain language-to-file-mappings there as well. I'm happy to move this change to a different place and to hear feedback! 😄 