### PR TITLE
Add typings for Promise#finally

### DIFF
--- a/src/typings/lib.es2018.promise.d.ts
+++ b/src/typings/lib.es2018.promise.d.ts
@@ -1,0 +1,27 @@
+/*! *****************************************************************************
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License. You may obtain a copy of the
+License at http://www.apache.org/licenses/LICENSE-2.0
+
+THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
+See the Apache Version 2.0 License for specific language governing permissions
+and limitations under the License.
+***************************************************************************** */
+
+/**
+ * Represents the completion of an asynchronous operation
+ */
+interface Promise<T> {
+	/**
+	 * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+	 * resolved value cannot be modified from the callback.
+	 * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+	 * @returns A Promise for the completion of the callback.
+	 */
+	finally(onfinally?: (() => void) | undefined | null): Promise<T>;
+}

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -44,6 +44,9 @@ export function createCancelablePromise<T>(callback: (token: CancellationToken) 
 		catch<TResult = never>(reject?: ((reason: any) => TResult | Promise<TResult>) | undefined | null): Promise<T | TResult> {
 			return this.then(undefined, reject);
 		}
+		finally(onfinally?: (() => void) | undefined | null): Promise<T> {
+			return this.finally(onfinally);
+		}
 	};
 }
 

--- a/src/vs/workbench/api/node/extHostSearch.fileIndex.ts
+++ b/src/vs/workbench/api/node/extHostSearch.fileIndex.ts
@@ -576,6 +576,9 @@ export class FileIndexSearchManager {
 			catch(reject?) {
 				return this.then(undefined, reject);
 			}
+			finally(onFinally) {
+				return promise.finally(onFinally);
+			}
 		};
 	}
 }

--- a/src/vs/workbench/services/extensions/node/lazyPromise.ts
+++ b/src/vs/workbench/services/extensions/node/lazyPromise.ts
@@ -82,4 +82,8 @@ export class LazyPromise implements Promise<any> {
 	public catch(error: any): any {
 		return this._ensureActual().then(undefined, error);
 	}
+
+	public finally(callback): any {
+		return this._ensureActual().finally(callback);
+	}
 }

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -394,6 +394,9 @@ export class SearchService implements IRawSearchService {
 			catch(reject?) {
 				return this.then(undefined, reject);
 			}
+			finally(onFinally) {
+				return promise.finally(onFinally);
+			}
 		};
 	}
 }


### PR DESCRIPTION
This add `Promise.finally` types which Electron 3.0 supports. Holding back this since we aren't 100% sure yet that we stick to this version. @bpasero when do we have enough confidence?