### PR TITLE
only dismiss editor context menu when scrollTop has changed

### DIFF
--- a/src/vs/editor/contrib/contextmenu/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/contextmenu.ts
@@ -46,7 +46,7 @@ export class ContextMenuController implements IEditorContribution {
 
 		this._toDispose.push(this._editor.onContextMenu((e: IEditorMouseEvent) => this._onContextMenu(e)));
 		this._toDispose.push(this._editor.onDidScrollChange((e: IScrollEvent) => {
-			if (this._contextMenuIsBeingShownCount > 0) {
+			if (this._contextMenuIsBeingShownCount > 0 && e.scrollTopChanged) {
 				this._contextViewService.hideContextView();
 			}
 		}));


### PR DESCRIPTION
fixes #54594 

This change is to prevent the context menu from dismissing when the scrollTop has not changed (e.g. when CodeLenses are loaded). 

@rebornix and I think this should be a safe check as normal intentional scrolling should always move the scrollTop