### PR TITLE
Fix #64993

### DIFF
--- a/extensions/html-language-features/client/src/htmlMain.ts
+++ b/extensions/html-language-features/client/src/htmlMain.ts
@@ -52,11 +52,19 @@ export function activate(context: ExtensionContext) {
 	let tagPaths: string[] = workspace.getConfiguration('html').get('experimental.custom.tags', []);
 	let attributePaths: string[] = workspace.getConfiguration('html').get('experimental.custom.attributes', []);
 
-	if (tagPaths) {
-		const workspaceRoot = workspace.workspaceFolders![0].uri.fsPath;
-		tagPaths = tagPaths.map(d => {
-			return path.resolve(workspaceRoot, d);
-		});
+	if (tagPaths && tagPaths.length > 0) {
+		if (!workspace.workspaceFolders) {
+			tagPaths = [];
+		} else {
+			try {
+				const workspaceRoot = workspace.workspaceFolders[0].uri.fsPath;
+				tagPaths = tagPaths.map(d => {
+					return path.resolve(workspaceRoot, d);
+				});
+			} catch (err) {
+				tagPaths = [];
+			}
+		}
 	}
 
 	// Options to control the language client


### PR DESCRIPTION
Explanation:

`workspace.workspaceFolders` can be null, so if someone opens empty folder and start editing HTML file, HTML Language Server might crash.

Fix:

The current fix catches empty workspace folder case and set `tagPaths` to empty, so no additional tags are loaded.

Limitation:

Ideally, when you open two folders in a workspace and each has different `html.experimental.tags/attributes` settings, VS Code should read different settings from each workspace and offer IntelliSense based on their config. This case is not handled yet due to complexity.