### PR TITLE
Fix search CRLF files with non-regex multiline search

### DIFF
--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -383,6 +383,7 @@ function getRgArgs(query: vscode.TextSearchQuery, options: vscode.TextSearchOpti
 	} else if (query.isRegExp) {
 		let fixedRegexpQuery = fixRegexEndingPattern(query.pattern);
 		fixedRegexpQuery = fixRegexNewline(fixedRegexpQuery);
+		fixedRegexpQuery = fixNewline(fixedRegexpQuery);
 		fixedRegexpQuery = fixRegexCRMatchingNonWordClass(fixedRegexpQuery, !!query.isMultiline);
 		fixedRegexpQuery = fixRegexCRMatchingWhitespaceClass(fixedRegexpQuery, !!query.isMultiline);
 		args.push('--regexp', fixedRegexpQuery);
@@ -479,4 +480,8 @@ export function fixRegexCRMatchingNonWordClass(pattern: string, isMultiline: boo
 	return isMultiline ?
 		pattern.replace(/([^\\]|^)((?:\\\\)*)\\W/g, '$1$2(\\r?\\n|[^\\w\\r])') :
 		pattern.replace(/([^\\]|^)((?:\\\\)*)\\W/g, '$1$2[^\\w\\r]');
+}
+
+export function fixNewline(pattern: string): string {
+	return pattern.replace(/\n/g, '\\r?\\n');
 }

--- a/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngine.test.ts
+++ b/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngine.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import { joinPath } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { Range } from 'vs/workbench/services/search/node/ripgrepSearchUtils';
-import { fixRegexCRMatchingNonWordClass, fixRegexCRMatchingWhitespaceClass, fixRegexEndingPattern, fixRegexNewline, IRgMatch, IRgMessage, RipgrepParser, unicodeEscapesToPCRE2 } from 'vs/workbench/services/search/node/ripgrepTextSearchEngine';
+import { fixRegexCRMatchingNonWordClass, fixRegexCRMatchingWhitespaceClass, fixRegexEndingPattern, fixRegexNewline, IRgMatch, IRgMessage, RipgrepParser, unicodeEscapesToPCRE2, fixNewline } from 'vs/workbench/services/search/node/ripgrepTextSearchEngine';
 import { TextSearchResult } from 'vscode';
 
 suite('RipgrepTextSearchEngine', () => {
@@ -108,6 +108,27 @@ suite('RipgrepTextSearchEngine', () => {
 			['foo\\n+abc', 'foo\r\nabc', true],
 			['foo\\n+abc', 'foo\n\n\nabc', true],
 		].forEach(testFixRegexNewline);
+	});
+
+	test('fixNewline', () => {
+		function testFixNewline([inputReg, testStr, shouldMatch = true]): void {
+			const fixed = fixNewline(inputReg);
+			const reg = new RegExp(fixed);
+			assert.equal(reg.test(testStr), shouldMatch, `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`);
+		}
+
+		[
+			['foo', 'foo'],
+
+			['foo\n', 'foo\r\n'],
+			['foo\n', 'foo\n'],
+			['foo\nabc', 'foo\r\nabc'],
+			['foo\nabc', 'foo\nabc'],
+			['foo\r\n', 'foo\r\n'],
+
+			['foo\nbarc', 'foobar', false],
+			['foobar', 'foo\nbar', false],
+		].forEach(testFixNewline);
 	});
 
 	suite('RipgrepParser', () => {


### PR DESCRIPTION
Fixes #65120

Normalizing newline literals in the query to `\r?\n` to match either CRLF or LF line endings.