### PR TITLE
Git sync now publishes branch upon confirmation (#64183 issue fix)

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1764,7 +1764,17 @@ export class CommandCenter {
 	private async _sync(repository: Repository, rebase: boolean): Promise<void> {
 		const HEAD = repository.HEAD;
 
-		if (!HEAD || !HEAD.upstream) {
+		if (!HEAD) {
+			return;
+		} else if (!HEAD.upstream) {
+			const branchName = HEAD.name;
+			const message = localize('confirm publish branch', "The branch '{0}' has no upstream branch. Would you like to publish this branch?", branchName);
+			const yes = localize('ok', "OK");
+			const pick = await window.showWarningMessage(message, { modal: true }, yes);
+
+			if (pick === yes) {
+				await this.publish(repository);
+			}
 			return;
 		}
 


### PR DESCRIPTION
#64183 issue fix, based on how Push handles unpublished branches.