### PR TITLE
Enable strict null checking for files test

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -405,6 +405,7 @@
 		"./vs/platform/extensions/node/extensionValidator.ts",
 		"./vs/platform/files/common/files.ts",
 		"./vs/platform/files/node/files.ts",
+		"./vs/platform/files/test/files.test.ts",
 		"./vs/platform/history/common/history.ts",
 		"./vs/platform/history/electron-main/historyMainService.ts",
 		"./vs/platform/instantiation/common/descriptors.ts",

--- a/src/vs/platform/files/test/files.test.ts
+++ b/src/vs/platform/files/test/files.test.ts
@@ -45,7 +45,7 @@ suite('Files', () => {
 		assert.strictEqual(true, r1.gotDeleted());
 	});
 
-	function testIsEqual(testMethod: (pA: string, pB: string, ignoreCase: boolean) => boolean): void {
+	function testIsEqual(testMethod: (pA: string | null | undefined, pB: string, ignoreCase: boolean) => boolean): void {
 
 		// corner cases
 		assert(testMethod('', '', true));


### PR DESCRIPTION
Fix strict null checking for `"./vs/platform/files/test/files.test.ts"`.

This is my first pull request and first contribution to VSCode. Any feedback is welcomed and appreciated.