### PR TITLE
Enable strict null checking for AsyncDataTree test

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -109,6 +109,7 @@
 		"./vs/base/test/browser/ui/list/rangeMap.test.ts",
 		"./vs/base/test/browser/ui/scrollbar/scrollableElement.test.ts",
 		"./vs/base/test/browser/ui/scrollbar/scrollbarState.test.ts",
+		"./vs/base/test/browser/ui/tree/asyncDataTree.test.ts",
 		"./vs/base/test/browser/ui/tree/indexTreeModel.test.ts",
 		"./vs/base/test/browser/ui/tree/objectTree.test.ts",
 		"./vs/base/test/browser/ui/tree/objectTreeModel.test.ts",

--- a/src/vs/base/test/browser/ui/tree/asyncDataTree.test.ts
+++ b/src/vs/base/test/browser/ui/tree/asyncDataTree.test.ts
@@ -53,7 +53,7 @@ suite('AsyncDataTree', function () {
 
 		const dataSource = new class implements IAsyncDataSource<Element, Element> {
 			hasChildren(element: Element): boolean {
-				return element.children && element.children.length > 0;
+				return !element.children && element.children!.length > 0;
 			}
 			getChildren(element: Element): Promise<Element[]> {
 				return Promise.resolve(element.children || []);
@@ -91,14 +91,14 @@ suite('AsyncDataTree', function () {
 			{ id: 'ac' }
 		];
 
-		await tree.refresh(null);
+		await tree.refresh(null!);
 		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
 
 		await tree.expand(_('a'));
 		assert.equal(container.querySelectorAll('.monaco-list-row').length, 4);
 
 		_('a').children = [];
-		await tree.refresh(null);
+		await tree.refresh(null!);
 		assert.equal(container.querySelectorAll('.monaco-list-row').length, 1);
 	});
 });


### PR DESCRIPTION
#65233 

- [x] `"./vs/base/test/browser/ui/tree/asyncDataTree.test.ts"`