### PR TITLE
Fix #62350

### DIFF
--- a/build/tfs/darwin/product-build-darwin.yml
+++ b/build/tfs/darwin/product-build-darwin.yml
@@ -11,32 +11,58 @@ steps:
     set -e
     echo "machine monacotools.visualstudio.com password $(VSO_PAT)" > ~/.netrc
     yarn
-    npm run gulp -- hygiene
-    npm run monaco-compile-check
-    VSCODE_MIXIN_PASSWORD="$(VSCODE_MIXIN_PASSWORD)" npm run gulp -- mixin
+    yarn gulp -- hygiene
+    yarn monaco-compile-check
+    VSCODE_MIXIN_PASSWORD="$(VSCODE_MIXIN_PASSWORD)" yarn gulp -- mixin
     node build/tfs/common/installDistro.js
     node build/lib/builtInExtensions.js
+  displayName: Prepare build
 
 - script: |
     set -e
     VSCODE_MIXIN_PASSWORD="$(VSCODE_MIXIN_PASSWORD)" \
     AZURE_STORAGE_ACCESS_KEY="$(AZURE_STORAGE_ACCESS_KEY)" \
-    npm run gulp -- vscode-darwin-min upload-vscode-sourcemaps
-  name: build
+    yarn gulp -- vscode-darwin-min upload-vscode-sourcemaps
+  displayName: Build
 
 - script: |
     set -e
     ./scripts/test.sh --build --tfs "Unit Tests"
-    APP_NAME="`ls $(agent.builddirectory)/VSCode-darwin | head -n 1`"
+    # APP_NAME="`ls $(agent.builddirectory)/VSCode-darwin | head -n 1`"
     # yarn smoketest -- --build "$(agent.builddirectory)/VSCode-darwin/$APP_NAME"
-  name: test
+  displayName: Run unit tests
 
 - script: |
     set -e
-    # archive the unsigned build
-    pushd ../VSCode-darwin && zip -r -X -y ../VSCode-darwin-unsigned.zip * && popd
+    pushd ../VSCode-darwin && zip -r -X -y ../VSCode-darwin.zip * && popd
+  displayName: Archive build
 
-    # publish the unsigned build
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  inputs:
+    ConnectedServiceName: 'ESRP CodeSign'
+    FolderPath: '$(agent.builddirectory)'
+    Pattern: 'VSCode-darwin.zip'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [
+        {
+          "keyCode": "CP-401337-Apple",
+          "operationSetCode": "MacAppDeveloperSign",
+          "parameters": [ ],
+          "toolName": "sign",
+          "toolVersion": "1.0"
+        }
+      ]
+    SessionTimeout: 120
+  displayName: Codesign
+
+- script: |
+    set -e
+
+    # remove pkg from archive
+    zip -d ../VSCode-darwin.zip "*.pkg"
+
+    # publish the build
     PACKAGEJSON=`ls ../VSCode-darwin/*.app/Contents/Resources/app/package.json`
     VERSION=`node -p "require(\"$PACKAGEJSON\").version"`
     AZURE_DOCUMENTDB_MASTERKEY="$(AZURE_DOCUMENTDB_MASTERKEY)" \
@@ -45,19 +71,16 @@ steps:
     node build/tfs/common/publish.js \
       "$(VSCODE_QUALITY)" \
       darwin \
-      archive-unsigned \
-      "VSCode-darwin-$(VSCODE_QUALITY)-unsigned.zip" \
+      archive \
+      "VSCode-darwin-$(VSCODE_QUALITY).zip" \
       $VERSION \
-      false \
-      ../VSCode-darwin-unsigned.zip
+      true \
+      ../VSCode-darwin.zip
 
     # publish hockeyapp symbols
     node build/tfs/common/symbols.js "$(VSCODE_MIXIN_PASSWORD)" "$(VSCODE_HOCKEYAPP_TOKEN)" "$(VSCODE_ARCH)" "$(VSCODE_HOCKEYAPP_ID_MACOS)"
 
-    # enqueue the unsigned build
-    AZURE_DOCUMENTDB_MASTERKEY="$(AZURE_DOCUMENTDB_MASTERKEY)" \
-    AZURE_STORAGE_ACCESS_KEY_2="$(AZURE_STORAGE_ACCESS_KEY_2)" \
-    node build/tfs/darwin/enqueue.js "$(VSCODE_QUALITY)"
-
+    # upload configuration
     AZURE_STORAGE_ACCESS_KEY="$(AZURE_STORAGE_ACCESS_KEY)" \
-    npm run gulp -- upload-vscode-configuration
+    yarn gulp -- upload-vscode-configuration
+  displayName: Publish

--- a/extensions/html-language-features/server/src/modes/javascriptMode.ts
+++ b/extensions/html-language-features/server/src/modes/javascriptMode.ts
@@ -18,9 +18,12 @@ import * as ts from 'typescript';
 import { join } from 'path';
 
 const FILE_NAME = 'vscode://javascript/1';  // the same 'file' is used for all contents
-const JQUERY_D_TS = join(__dirname, '../../lib/jquery.d.ts');
-
 const JS_WORD_REGEX = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g;
+
+let jquery_d_ts = join(__dirname, '../lib/jquery.d.ts'); // when packaged
+if (!ts.sys.fileExists(jquery_d_ts)) {
+	jquery_d_ts = join(__dirname, '../../lib/jquery.d.ts'); // from source
+}
 
 export function getJavaScriptMode(documentRegions: LanguageModelCache<HTMLDocumentRegions>, workspace: Workspace): LanguageMode {
 	let jsDocuments = getLanguageModelCache<TextDocument>(10, 60, document => documentRegions.get(document).getEmbeddedDocument('javascript'));
@@ -36,7 +39,7 @@ export function getJavaScriptMode(documentRegions: LanguageModelCache<HTMLDocume
 	}
 	const host: ts.LanguageServiceHost = {
 		getCompilationSettings: () => compilerOptions,
-		getScriptFileNames: () => [FILE_NAME, JQUERY_D_TS],
+		getScriptFileNames: () => [FILE_NAME, jquery_d_ts],
 		getScriptKind: () => ts.ScriptKind.JS,
 		getScriptVersion: (fileName: string) => {
 			if (fileName === FILE_NAME) {

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "3.0.1"
+    "typescript": "3.0.3"
   },
   "scripts": {
     "postinstall": "node ./postinstall"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-typescript@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+typescript@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "distro": "c140338a23ed045af10f275b62c2bb794ac81ce2",
   "author": {
     "name": "Microsoft Corporation"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "distro": "c140338a23ed045af10f275b62c2bb794ac81ce2",
   "author": {
     "name": "Microsoft Corporation"

--- a/src/vs/platform/history/electron-main/historyMainService.ts
+++ b/src/vs/platform/history/electron-main/historyMainService.ts
@@ -119,7 +119,7 @@ export class HistoryMainService implements IHistoryMainService {
 		const mru = this.getRecentlyOpened();
 		let update = false;
 
-		pathsToRemove.forEach((pathToRemove => {
+		pathsToRemove.forEach(pathToRemove => {
 
 			// Remove workspace
 			let index = arrays.firstIndex(mru.workspaces, workspace => {
@@ -131,7 +131,7 @@ export class HistoryMainService implements IHistoryMainService {
 				}
 				if (typeof pathToRemove === 'string') {
 					if (isSingleFolderWorkspaceIdentifier(workspace)) {
-						return workspace.scheme === Schemas.file && areResourcesEqual(URI.file(pathToRemove), workspace);
+						return workspace.scheme === Schemas.file && isEqual(pathToRemove, workspace.fsPath, !isLinux /* ignorecase */);
 					}
 					if (isWorkspaceIdentifier(workspace)) {
 						return isEqual(pathToRemove, workspace.configPath, !isLinux /* ignorecase */);
@@ -145,15 +145,20 @@ export class HistoryMainService implements IHistoryMainService {
 			}
 
 			// Remove file
-			const pathToRemoveURI = pathToRemove instanceof URI ? pathToRemove : typeof pathToRemove === 'string' ? URI.file(pathToRemove) : null;
-			if (pathToRemoveURI) {
-				index = arrays.firstIndex(mru.files, file => areResourcesEqual(file, pathToRemoveURI));
-			}
+			index = arrays.firstIndex(mru.files, file => {
+				if (pathToRemove instanceof URI) {
+					return areResourcesEqual(file, pathToRemove);
+				} else if (typeof pathToRemove === 'string') {
+					return isEqual(file.fsPath, pathToRemove, !isLinux /* ignorecase */);
+				}
+				return false;
+			});
+
 			if (index >= 0) {
 				mru.files.splice(index, 1);
 				update = true;
 			}
-		}));
+		});
 
 		if (update) {
 			this.saveRecentlyOpened(mru);

--- a/src/vs/workbench/browser/parts/views/customView.ts
+++ b/src/vs/workbench/browser/parts/views/customView.ts
@@ -510,7 +510,7 @@ class TreeRenderer implements IRenderer {
 			templateData.resourceLabel.setLabel({ name: label }, { title, hideIcon: true, extraClasses: ['custom-view-tree-node-item-resourceLabel'] });
 		}
 
-		templateData.icon.style.backgroundImage = iconUrl ? `url('${iconUrl}')` : '';
+		templateData.icon.style.backgroundImage = iconUrl ? `url('${iconUrl.toString(true)}')` : '';
 		DOM.toggleClass(templateData.icon, 'custom-view-tree-node-item-icon', !!iconUrl);
 		templateData.actionBar.context = (<TreeViewItemHandleArg>{ $treeViewId: this.treeViewId, $treeItemHandle: node.handle });
 		templateData.actionBar.push(this.menus.getResourceActions(node), { icon: true, label: false });

--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -641,6 +641,10 @@ export class DebugService implements IDebugService {
 		).then(() => {
 			this.initializing = false;
 			this.onStateChange();
+		}, err => {
+			this.initializing = false;
+			this.onStateChange();
+			return TPromise.wrapError(err);
 		});
 	}
 

--- a/src/vs/workbench/parts/output/electron-browser/outputServices.ts
+++ b/src/vs/workbench/parts/output/electron-browser/outputServices.ts
@@ -5,6 +5,7 @@
 
 import * as nls from 'vs/nls';
 import * as paths from 'vs/base/common/paths';
+import * as strings from 'vs/base/common/strings';
 import * as extfs from 'vs/base/node/extfs';
 import * as fs from 'fs';
 import { TPromise } from 'vs/base/common/winjs.base';
@@ -16,7 +17,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { EditorOptions } from 'vs/workbench/common/editor';
-import { IOutputChannelIdentifier, IOutputChannel, IOutputService, Extensions, OUTPUT_PANEL_ID, IOutputChannelRegistry, OUTPUT_SCHEME, OUTPUT_MIME, LOG_SCHEME, LOG_MIME, CONTEXT_ACTIVE_LOG_OUTPUT } from 'vs/workbench/parts/output/common/output';
+import { IOutputChannelIdentifier, IOutputChannel, IOutputService, Extensions, OUTPUT_PANEL_ID, IOutputChannelRegistry, OUTPUT_SCHEME, OUTPUT_MIME, MAX_OUTPUT_LENGTH, LOG_SCHEME, LOG_MIME, CONTEXT_ACTIVE_LOG_OUTPUT } from 'vs/workbench/parts/output/common/output';
 import { OutputPanel } from 'vs/workbench/parts/output/browser/outputPanel';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -36,6 +37,7 @@ import { RotatingLogger } from 'spdlog';
 import { toLocalISOString } from 'vs/base/common/date';
 import { IWindowService } from 'vs/platform/windows/common/windows';
 import { ILogService } from 'vs/platform/log/common/log';
+import { binarySearch } from 'vs/base/common/arrays';
 import { Schemas } from 'vs/base/common/network';
 import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -582,7 +584,13 @@ export class OutputService extends Disposable implements IOutputService, ITextMo
 		if (channelData && channelData.file) {
 			return this.instantiationService.createInstance(FileOutputChannel, channelData, uri);
 		}
-		return this.instantiationService.createInstance(OutputChannelBackedByFile, { id, label: channelData ? channelData.label : '' }, this.outputDir, uri);
+		try {
+			return this.instantiationService.createInstance(OutputChannelBackedByFile, { id, label: channelData ? channelData.label : '' }, this.outputDir, uri);
+		} catch (e) {
+			// Do not crash if spdlog rotating logger cannot be loaded (workaround for https://github.com/Microsoft/vscode/issues/47883)
+			this.logService.error(e);
+			return this.instantiationService.createInstance(BufferredOutputChannel, { id, label: channelData ? channelData.label : '' });
+		}
 	}
 
 	private doShowChannel(channel: IOutputChannel, preserveFocus: boolean): Thenable<void> {
@@ -651,5 +659,145 @@ export class LogContentProvider {
 			this.channels.set(id, channel);
 		}
 		return channel;
+	}
+}
+// Remove this channel when https://github.com/Microsoft/vscode/issues/47883 is fixed
+class BufferredOutputChannel extends Disposable implements OutputChannel {
+
+	readonly id: string;
+	readonly label: string;
+	readonly file: URI = null;
+	scrollLock: boolean = false;
+
+	protected _onDidAppendedContent: Emitter<void> = new Emitter<void>();
+	readonly onDidAppendedContent: Event<void> = this._onDidAppendedContent.event;
+
+	private readonly _onDispose: Emitter<void> = new Emitter<void>();
+	readonly onDispose: Event<void> = this._onDispose.event;
+
+	private modelUpdater: RunOnceScheduler;
+	private model: ITextModel;
+	private readonly bufferredContent: BufferedContent;
+	private lastReadId: number = void 0;
+
+	constructor(
+		protected readonly outputChannelIdentifier: IOutputChannelIdentifier,
+		@IModelService private modelService: IModelService,
+		@IModeService private modeService: IModeService
+	) {
+		super();
+
+		this.id = outputChannelIdentifier.id;
+		this.label = outputChannelIdentifier.label;
+
+		this.modelUpdater = new RunOnceScheduler(() => this.updateModel(), 300);
+		this._register(toDisposable(() => this.modelUpdater.cancel()));
+
+		this.bufferredContent = new BufferedContent();
+		this._register(toDisposable(() => this.bufferredContent.clear()));
+	}
+
+	append(output: string) {
+		this.bufferredContent.append(output);
+		if (!this.modelUpdater.isScheduled()) {
+			this.modelUpdater.schedule();
+		}
+	}
+
+	clear(): void {
+		if (this.modelUpdater.isScheduled()) {
+			this.modelUpdater.cancel();
+		}
+		if (this.model) {
+			this.model.setValue('');
+		}
+		this.bufferredContent.clear();
+		this.lastReadId = void 0;
+	}
+
+	loadModel(): TPromise<ITextModel> {
+		const { value, id } = this.bufferredContent.getDelta(this.lastReadId);
+		if (this.model) {
+			this.model.setValue(value);
+		} else {
+			this.model = this.createModel(value);
+		}
+		this.lastReadId = id;
+		return TPromise.as(this.model);
+	}
+
+	private createModel(content: string): ITextModel {
+		const model = this.modelService.createModel(content, this.modeService.getOrCreateMode(OUTPUT_MIME), URI.from({ scheme: OUTPUT_SCHEME, path: this.id }));
+		const disposables: IDisposable[] = [];
+		disposables.push(model.onWillDispose(() => {
+			this.model = null;
+			dispose(disposables);
+		}));
+		return model;
+	}
+
+	private updateModel(): void {
+		if (this.model) {
+			const { value, id } = this.bufferredContent.getDelta(this.lastReadId);
+			this.lastReadId = id;
+			const lastLine = this.model.getLineCount();
+			const lastLineMaxColumn = this.model.getLineMaxColumn(lastLine);
+			this.model.applyEdits([EditOperation.insert(new Position(lastLine, lastLineMaxColumn), value)]);
+			this._onDidAppendedContent.fire();
+		}
+	}
+
+	dispose(): void {
+		this._onDispose.fire();
+		super.dispose();
+	}
+}
+
+class BufferedContent {
+
+	private data: string[] = [];
+	private dataIds: number[] = [];
+	private idPool = 0;
+	private length = 0;
+
+	public append(content: string): void {
+		this.data.push(content);
+		this.dataIds.push(++this.idPool);
+		this.length += content.length;
+		this.trim();
+	}
+
+	public clear(): void {
+		this.data.length = 0;
+		this.dataIds.length = 0;
+		this.length = 0;
+	}
+
+	private trim(): void {
+		if (this.length < MAX_OUTPUT_LENGTH * 1.2) {
+			return;
+		}
+
+		while (this.length > MAX_OUTPUT_LENGTH) {
+			this.dataIds.shift();
+			const removed = this.data.shift();
+			this.length -= removed.length;
+		}
+	}
+
+	public getDelta(previousId?: number): { value: string, id: number } {
+		let idx = -1;
+		if (previousId !== void 0) {
+			idx = binarySearch(this.dataIds, previousId, (a, b) => a - b);
+		}
+
+		const id = this.idPool;
+		if (idx >= 0) {
+			const value = strings.removeAnsiEscapeCodes(this.data.slice(idx + 1).join(''));
+			return { value, id };
+		} else {
+			const value = strings.removeAnsiEscapeCodes(this.data.join(''));
+			return { value, id };
+		}
 	}
 }

--- a/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsEditor2.ts
@@ -1020,7 +1020,7 @@ export class SettingsEditor2 extends BaseEditor {
 								TPromise.wrap(null);
 						});
 					}
-				}).then(() => this.renderResultCountMessages());
+				});
 			} else {
 				return TPromise.wrap(null);
 			}
@@ -1064,7 +1064,11 @@ export class SettingsEditor2 extends BaseEditor {
 			this.tocTree.setFocus(null);
 			expandAll(this.tocTree);
 
-			return this.renderTree().then(() => result);
+			return this.renderTree().then(() => {
+				this.renderResultCountMessages();
+
+				return result;
+			});
 		});
 	}
 

--- a/src/vs/workbench/parts/search/browser/searchView.ts
+++ b/src/vs/workbench/parts/search/browser/searchView.ts
@@ -1078,6 +1078,13 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 		const excludePattern = this.inputPatternExcludes.getValue();
 		const includePattern = this.inputPatternIncludes.getValue();
 
+		// Need the full match line to correctly calculate replace text, if this is a search/replace with regex group references ($1, $2, ...).
+		// 10000 chars is enough to avoid sending huge amounts of text around, if you do a replace with a longer match, it may or may not resolve the group refs correctly.
+		// https://github.com/Microsoft/vscode/issues/58374
+		const totalChars = content.isRegExp ? 10000 :
+			this.isWide ? 250 :
+				75;
+
 		const options: IQueryOptions = {
 			extraFileResources: getOutOfWorkspaceEditorResources(this.editorService, this.contextService),
 			maxResults: SearchView.MAX_TEXT_RESULTS,
@@ -1088,7 +1095,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 			previewOptions: {
 				leadingChars: 20,
 				maxLines: 1,
-				totalChars: this.isWide ? 250 : 75
+				totalChars
 			}
 		};
 		const folderResources = this.contextService.getWorkspace().folders;

--- a/src/vs/workbench/parts/search/common/searchModel.ts
+++ b/src/vs/workbench/parts/search/common/searchModel.ts
@@ -27,6 +27,8 @@ import { IReplaceService } from 'vs/workbench/parts/search/common/replace';
 
 export class Match {
 
+	private static readonly MAX_PREVIEW_CHARS = 250;
+
 	private _id: string;
 	private _range: Range;
 	private _previewText: string;
@@ -66,9 +68,14 @@ export class Match {
 	}
 
 	public preview(): { before: string; inside: string; after: string; } {
-		const before = this._previewText.substring(0, this._rangeInPreviewText.startColumn - 1),
+		let before = this._previewText.substring(0, this._rangeInPreviewText.startColumn - 1),
 			inside = this.getMatchString(),
 			after = this._previewText.substring(this._rangeInPreviewText.endColumn - 1);
+
+		let charsRemaining = Match.MAX_PREVIEW_CHARS - before.length;
+		inside = inside.substr(0, charsRemaining);
+		charsRemaining -= inside.length;
+		after = after.substr(0, charsRemaining);
 
 		return {
 			before,

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -305,7 +305,10 @@ export class TerminalInstance implements ITerminalInstance {
 			this._processManager.onProcessData(data => this._onProcessData(data));
 			this._xterm.on('data', data => this._processManager.write(data));
 			// TODO: How does the cwd work on detached processes?
-			this._linkHandler = this._instantiationService.createInstance(TerminalLinkHandler, this._xterm, platform.platform, this._processManager.initialCwd);
+			this._linkHandler = this._instantiationService.createInstance(TerminalLinkHandler, this._xterm, platform.platform);
+			this.processReady.then(() => {
+				this._linkHandler.initialCwd = this._processManager.initialCwd;
+			});
 		}
 		this._xterm.on('focus', () => this._onFocus.fire(this));
 

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -634,6 +634,15 @@ export class TerminalInstance implements ITerminalInstance {
 	}
 
 	public sendText(text: string, addNewLine: boolean): void {
+		if(platform.isWindows){
+			if(text.indexOf(' ') >= 0){
+				var first = "& '";
+				var last = "'";
+				var path1 = first.concat(text);
+				text = path1.concat(last);
+			}
+		}
+
 		// Normalize line endings to 'enter' press.
 		text = text.replace(TerminalInstance.EOL_REGEX, '\r');
 		if (addNewLine && text.substr(text.length - 1) !== '\r') {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalLinkHandler.ts
@@ -61,13 +61,13 @@ export class TerminalLinkHandler {
 	private _hoverDisposables: IDisposable[] = [];
 	private _mouseMoveDisposable: IDisposable;
 	private _widgetManager: TerminalWidgetManager;
+	private _initialCwd: string;
 
 	private _localLinkPattern: RegExp;
 
 	constructor(
 		private _xterm: any,
 		private _platform: platform.Platform,
-		private _initialCwd: string,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IEditorService private readonly _editorService: IEditorService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -82,6 +82,10 @@ export class TerminalLinkHandler {
 
 	public setWidgetManager(widgetManager: TerminalWidgetManager): void {
 		this._widgetManager = widgetManager;
+	}
+
+	public set initialCwd(initialCwd: string) {
+		this._initialCwd = initialCwd;
 	}
 
 	public registerCustomLinkHandler(regex: RegExp, handler: (uri: string) => void, matchIndex?: number, validationCallback?: XtermLinkMatcherValidationCallback): number {
@@ -147,10 +151,6 @@ export class TerminalLinkHandler {
 
 	private _handleLocalLink(link: string): TPromise<any> {
 		return this._resolvePath(link).then(resolvedLink => {
-			if (!resolvedLink) {
-				return void 0;
-			}
-
 			const normalizedPath = path.normalize(path.resolve(resolvedLink));
 			const normalizedUrl = this.extractLinkUrl(normalizedPath);
 			const resource = Uri.file(normalizedUrl);

--- a/src/vs/workbench/parts/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/parts/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -33,7 +33,7 @@ interface LinkFormatInfo {
 suite('Workbench - TerminalLinkHandler', () => {
 	suite('localLinkRegex', () => {
 		test('Windows', () => {
-			const terminalLinkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Windows, null, null, null, null, null);
+			const terminalLinkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Windows, null, null, null, null);
 			function testLink(link: string, linkUrl: string, lineNo?: string, columnNo?: string) {
 				assert.equal(terminalLinkHandler.extractLinkUrl(link), linkUrl);
 				assert.equal(terminalLinkHandler.extractLinkUrl(`:${link}:`), linkUrl);
@@ -103,7 +103,7 @@ suite('Workbench - TerminalLinkHandler', () => {
 		});
 
 		test('Linux', () => {
-			const terminalLinkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, null, null, null, null, null);
+			const terminalLinkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, null, null, null, null);
 			function testLink(link: string, linkUrl: string, lineNo?: string, columnNo?: string) {
 				assert.equal(terminalLinkHandler.extractLinkUrl(link), linkUrl);
 				assert.equal(terminalLinkHandler.extractLinkUrl(`:${link}:`), linkUrl);
@@ -167,7 +167,8 @@ suite('Workbench - TerminalLinkHandler', () => {
 
 	suite('preprocessPath', () => {
 		test('Windows', () => {
-			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Windows, 'C:\\base', null, null, null, null);
+			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Windows, null, null, null, null);
+			linkHandler.initialCwd = 'C:\\base';
 
 			let stub = sinon.stub(path, 'join', function (arg1: string, arg2: string) {
 				return arg1 + '\\' + arg2;
@@ -180,7 +181,8 @@ suite('Workbench - TerminalLinkHandler', () => {
 		});
 
 		test('Linux', () => {
-			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, '/base', null, null, null, null);
+			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, null, null, null, null);
+			linkHandler.initialCwd = '/base';
 
 			let stub = sinon.stub(path, 'join', function (arg1: string, arg2: string) {
 				return arg1 + '/' + arg2;
@@ -193,7 +195,7 @@ suite('Workbench - TerminalLinkHandler', () => {
 		});
 
 		test('No Workspace', () => {
-			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, null, null, null, null, null);
+			const linkHandler = new TestTerminalLinkHandler(new TestXterm(), Platform.Linux, null, null, null, null);
 
 			assert.equal(linkHandler.preprocessPath('./src/file1'), null);
 			assert.equal(linkHandler.preprocessPath('src/file2'), null);

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -28,7 +28,6 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { FileEditorInput } from 'vs/workbench/parts/files/common/editors/fileEditorInput';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
-import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { EditorServiceImpl } from 'vs/workbench/browser/parts/editor/editor';
 
 export class TestEditorControl extends BaseEditor {
@@ -303,100 +302,6 @@ suite('Editor service', () => {
 					return rightGroup.closeEditor(input).then(() => {
 						assert.equal(input.isDisposed(), true);
 					});
-				});
-			});
-		});
-	});
-
-	test('close editor does not dispose when editor opened in other group (diff input)', function () {
-		const partInstantiator = workbenchInstantiationService();
-
-		const part = partInstantiator.createInstance(EditorPart, 'id', false);
-		part.create(document.createElement('div'));
-		part.layout(new Dimension(400, 300));
-
-		const testInstantiationService = partInstantiator.createChild(new ServiceCollection([IEditorGroupsService, part]));
-
-		const service: IEditorService = testInstantiationService.createInstance(EditorService);
-
-		const input = testInstantiationService.createInstance(TestEditorInput, URI.parse('my://resource'));
-		const otherInput = testInstantiationService.createInstance(TestEditorInput, URI.parse('my://resource2'));
-		const diffInput = new DiffEditorInput('name', 'description', input, otherInput);
-
-		const rootGroup = part.activeGroup;
-		const rightGroup = part.addGroup(rootGroup, GroupDirection.RIGHT);
-
-		// Open input
-		return service.openEditor(diffInput, { pinned: true }).then(editor => {
-			return service.openEditor(diffInput, { pinned: true }, rightGroup).then(editor => {
-
-				// Close input
-				return rootGroup.closeEditor(diffInput).then(() => {
-					assert.equal(diffInput.isDisposed(), false);
-					assert.equal(input.isDisposed(), false);
-					assert.equal(otherInput.isDisposed(), false);
-
-					return rightGroup.closeEditor(diffInput).then(() => {
-						assert.equal(diffInput.isDisposed(), true);
-						assert.equal(input.isDisposed(), true);
-						assert.equal(otherInput.isDisposed(), true);
-					});
-				});
-			});
-		});
-	});
-
-	test('close editor disposes properly (diff input)', function () {
-		const partInstantiator = workbenchInstantiationService();
-
-		const part = partInstantiator.createInstance(EditorPart, 'id', false);
-		part.create(document.createElement('div'));
-		part.layout(new Dimension(400, 300));
-
-		const testInstantiationService = partInstantiator.createChild(new ServiceCollection([IEditorGroupsService, part]));
-
-		const service: IEditorService = testInstantiationService.createInstance(EditorService);
-
-		const input = testInstantiationService.createInstance(TestEditorInput, URI.parse('my://resource'));
-		const otherInput = testInstantiationService.createInstance(TestEditorInput, URI.parse('my://resource2'));
-		const diffInput = new DiffEditorInput('name', 'description', input, otherInput);
-
-		// Open input
-		return service.openEditor(diffInput, { pinned: true }).then(editor => {
-
-			// Close input
-			return editor.group.closeEditor(diffInput).then(() => {
-				assert.equal(diffInput.isDisposed(), true);
-				assert.equal(otherInput.isDisposed(), true);
-				assert.equal(input.isDisposed(), true);
-			});
-		});
-	});
-
-	test('close editor disposes properly (diff input, left side still opened)', function () {
-		const partInstantiator = workbenchInstantiationService();
-
-		const part = partInstantiator.createInstance(EditorPart, 'id', false);
-		part.create(document.createElement('div'));
-		part.layout(new Dimension(400, 300));
-
-		const testInstantiationService = partInstantiator.createChild(new ServiceCollection([IEditorGroupsService, part]));
-
-		const service: IEditorService = testInstantiationService.createInstance(EditorService);
-
-		const input = testInstantiationService.createInstance(TestEditorInput, URI.parse('my://resource'));
-		const otherInput = testInstantiationService.createInstance(TestEditorInput, URI.parse('my://resource2'));
-		const diffInput = new DiffEditorInput('name', 'description', input, otherInput);
-
-		// Open input
-		return service.openEditor(diffInput, { pinned: true }).then(editor => {
-			return service.openEditor(input, { pinned: true }).then(editor => {
-
-				// Close input
-				return editor.group.closeEditor(diffInput).then(() => {
-					assert.equal(diffInput.isDisposed(), true);
-					assert.equal(otherInput.isDisposed(), true);
-					assert.equal(input.isDisposed(), false);
 				});
 			});
 		});

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -556,10 +556,10 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 		if (!keyInfo) {
 			return false;
 		}
-		if (keyInfo.value) {
-			return true;
+		if (!keyInfo.value || /\s/.test(keyInfo.value)) {
+			return false;
 		}
-		return false;
+		return true;
 	}
 }
 


### PR DESCRIPTION
Fix for the issue [#62350](https://github.com/Microsoft/vscode/issues/62350). 
When we run a file with a path that has a space in it instead of running **"c:\Users\matb\folder\sp ace.html"** it will now execute **& 'c:\Users\matb\folder\sp ace.html'**. This way powershell will be able to execute the file as it is pretended.