### PR TITLE
Add quick open picker background+foreground theming

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenWidget.ts
@@ -44,8 +44,8 @@ export interface IQuickOpenOptions extends IQuickOpenStyles {
 }
 
 export interface IQuickOpenStyles extends IInputBoxStyles, ITreeStyles {
-	background?: Color;
-	foreground?: Color;
+	quickPickerBackground?: Color;
+	quickPickerForeground?: Color;
 	borderColor?: Color;
 	pickerGroupForeground?: Color;
 	pickerGroupBorder?: Color;
@@ -82,8 +82,8 @@ export const enum HideReason {
 }
 
 const defaultStyles = {
-	background: Color.fromHex('#1E1E1E'),
-	foreground: Color.fromHex('#CCCCCC'),
+	quickPickerBackground: Color.fromHex('#1E1E1E'),
+	quickPickerForeground: Color.fromHex('#CCCCCC'),
 	pickerGroupForeground: Color.fromHex('#0097FB'),
 	pickerGroupBorder: Color.fromHex('#3F3F46'),
 	widgetShadow: Color.fromHex('#000000'),
@@ -380,8 +380,8 @@ export class QuickOpenWidget extends Disposable implements IModelProvider {
 
 	protected applyStyles(): void {
 		if (this.element) {
-			const foreground = this.styles.foreground ? this.styles.foreground.toString() : null;
-			const background = this.styles.background ? this.styles.background.toString() : null;
+			const foreground = this.styles.quickPickerForeground ? this.styles.quickPickerForeground.toString() : null;
+			const background = this.styles.quickPickerBackground ? this.styles.quickPickerBackground.toString() : null;
 			const borderColor = this.styles.borderColor ? this.styles.borderColor.toString() : null;
 			const widgetShadow = this.styles.widgetShadow ? this.styles.widgetShadow.toString() : null;
 

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -208,9 +208,6 @@ export const listInvalidItemForeground = registerColor('list.invalidItemForegrou
 export const listErrorForeground = registerColor('list.errorForeground', { dark: '#F88070', light: '#B01011', hc: null }, nls.localize('listErrorForeground', 'Foreground color of list items containing errors.'));
 export const listWarningForeground = registerColor('list.warningForeground', { dark: '#4d9e4d', light: '#117711', hc: null }, nls.localize('listWarningForeground', 'Foreground color of list items containing warnings.'));
 
-export const pickerGroupForeground = registerColor('pickerGroup.foreground', { dark: '#3794FF', light: '#0066BF', hc: Color.white }, nls.localize('pickerGroupForeground', "Quick picker color for grouping labels."));
-export const pickerGroupBorder = registerColor('pickerGroup.border', { dark: '#3F3F46', light: '#CCCEDB', hc: Color.white }, nls.localize('pickerGroupBorder', "Quick picker color for grouping borders."));
-
 export const buttonForeground = registerColor('button.foreground', { dark: Color.white, light: Color.white, hc: Color.white }, nls.localize('buttonForeground', "Button foreground color."));
 export const buttonBackground = registerColor('button.background', { dark: '#0E639C', light: '#007ACC', hc: null }, nls.localize('buttonBackground', "Button background color."));
 export const buttonHoverBackground = registerColor('button.hoverBackground', { dark: lighten(buttonBackground, 0.2), light: darken(buttonBackground, 0.2), hc: null }, nls.localize('buttonHoverBackground', "Button background color when hovering."));
@@ -315,6 +312,15 @@ export const breadcrumbsBackground = registerColor('breadcrumb.background', { li
 export const breadcrumbsFocusForeground = registerColor('breadcrumb.focusForeground', { light: darken(foreground, .2), dark: lighten(foreground, .1), hc: lighten(foreground, .1) }, nls.localize('breadcrumbsFocusForeground', "Color of focused breadcrumb items."));
 export const breadcrumbsActiveSelectionForeground = registerColor('breadcrumb.activeSelectionForeground', { light: darken(foreground, .2), dark: lighten(foreground, .1), hc: lighten(foreground, .1) }, nls.localize('breadcrumbsSelectedForegound', "Color of selected breadcrumb items."));
 export const breadcrumbsPickerBackground = registerColor('breadcrumbPicker.background', { light: editorWidgetBackground, dark: editorWidgetBackground, hc: editorWidgetBackground }, nls.localize('breadcrumbsSelectedBackground', "Background color of breadcrumb item picker."));
+
+/**
+ * Quick picker
+ */
+export const quickPickerBackground = registerColor('quickPicker.background', { light: editorBackground, dark: editorBackground, hc: editorBackground }, nls.localize('quickPickerBackground', "Quick picker background color."));
+export const quickPickerForeground = registerColor('quickPicker.foreground', { light: editorForeground, dark: editorForeground, hc: editorForeground }, nls.localize('quickPickerForeground', "Quick picker foreground color."));
+
+export const pickerGroupForeground = registerColor('pickerGroup.foreground', { dark: '#3794FF', light: '#0066BF', hc: Color.white }, nls.localize('pickerGroupForeground', "Quick picker color for grouping labels."));
+export const pickerGroupBorder = registerColor('pickerGroup.border', { dark: '#3F3F46', light: '#CCCEDB', hc: Color.white }, nls.localize('pickerGroupBorder', "Quick picker color for grouping borders."));
 
 /**
  * Merge-conflict colors

--- a/src/vs/platform/theme/common/styler.ts
+++ b/src/vs/platform/theme/common/styler.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITheme, IThemeService } from 'vs/platform/theme/common/themeService';
-import { focusBorder, inputBackground, inputForeground, ColorIdentifier, selectForeground, selectBackground, selectListBackground, selectBorder, inputBorder, foreground, editorBackground, contrastBorder, inputActiveOptionBorder, listFocusBackground, listFocusForeground, listActiveSelectionBackground, listActiveSelectionForeground, listInactiveSelectionForeground, listInactiveSelectionBackground, listInactiveFocusBackground, listHoverBackground, listHoverForeground, listDropBackground, pickerGroupBorder, pickerGroupForeground, widgetShadow, inputValidationInfoBorder, inputValidationInfoBackground, inputValidationWarningBorder, inputValidationWarningBackground, inputValidationErrorBorder, inputValidationErrorBackground, activeContrastBorder, buttonForeground, buttonBackground, buttonHoverBackground, ColorFunction, badgeBackground, badgeForeground, progressBarBackground, breadcrumbsForeground, breadcrumbsFocusForeground, breadcrumbsActiveSelectionForeground, breadcrumbsBackground, editorWidgetBorder, inputValidationInfoForeground, inputValidationWarningForeground, inputValidationErrorForeground, menuForeground, menuBackground, menuSelectionForeground, menuSelectionBackground, menuSelectionBorder, menuBorder, menuSeparatorBackground } from 'vs/platform/theme/common/colorRegistry';
+import { focusBorder, inputBackground, inputForeground, ColorIdentifier, selectForeground, selectBackground, selectListBackground, selectBorder, inputBorder, foreground, contrastBorder, inputActiveOptionBorder, listFocusBackground, listFocusForeground, listActiveSelectionBackground, listActiveSelectionForeground, listInactiveSelectionForeground, listInactiveSelectionBackground, listInactiveFocusBackground, listHoverBackground, listHoverForeground, listDropBackground, quickPickerBackground, quickPickerForeground, pickerGroupBorder, pickerGroupForeground, widgetShadow, inputValidationInfoBorder, inputValidationInfoBackground, inputValidationWarningBorder, inputValidationWarningBackground, inputValidationErrorBorder, inputValidationErrorBackground, activeContrastBorder, buttonForeground, buttonBackground, buttonHoverBackground, ColorFunction, badgeBackground, badgeForeground, progressBarBackground, breadcrumbsForeground, breadcrumbsFocusForeground, breadcrumbsActiveSelectionForeground, breadcrumbsBackground, editorWidgetBorder, inputValidationInfoForeground, inputValidationWarningForeground, inputValidationErrorForeground, menuForeground, menuBackground, menuSelectionForeground, menuSelectionBackground, menuSelectionBorder, menuBorder, menuSeparatorBackground } from 'vs/platform/theme/common/colorRegistry';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Color } from 'vs/base/common/color';
 import { mixin } from 'vs/base/common/objects';
@@ -159,8 +159,8 @@ export function attachFindInputBoxStyler(widget: IThemable, themeService: ITheme
 }
 
 export interface IQuickOpenStyleOverrides extends IListStyleOverrides, IInputBoxStyleOverrides, IProgressBarStyleOverrides {
-	foreground?: ColorIdentifier;
-	background?: ColorIdentifier;
+	quickPickerForeground?: ColorIdentifier;
+	quickPickerBackground?: ColorIdentifier;
 	borderColor?: ColorIdentifier;
 	widgetShadow?: ColorIdentifier;
 	pickerGroupForeground?: ColorIdentifier;
@@ -169,8 +169,8 @@ export interface IQuickOpenStyleOverrides extends IListStyleOverrides, IInputBox
 
 export function attachQuickOpenStyler(widget: IThemable, themeService: IThemeService, style?: IQuickOpenStyleOverrides): IDisposable {
 	return attachStyler(themeService, {
-		foreground: (style && style.foreground) || foreground,
-		background: (style && style.background) || editorBackground,
+		quickPickerForeground: (style && style.quickPickerForeground) || quickPickerForeground,
+		quickPickerBackground: (style && style.quickPickerBackground) || quickPickerBackground,
 		borderColor: style && style.borderColor || contrastBorder,
 		widgetShadow: style && style.widgetShadow || widgetShadow,
 		progressBarBackground: style && style.progressBarBackground || progressBarBackground,

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -34,7 +34,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IContextKeyService, RawContextKey, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { SIDE_BAR_BACKGROUND, SIDE_BAR_FOREGROUND } from 'vs/workbench/common/theme';
 import { attachQuickOpenStyler } from 'vs/platform/theme/common/styler';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -187,7 +186,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 					treeCreator: (container, config, opts) => this.instantiationService.createInstance(WorkbenchTree, container, config, opts)
 				}
 			));
-			this._register(attachQuickOpenStyler(this.quickOpenWidget, this.themeService, { background: SIDE_BAR_BACKGROUND, foreground: SIDE_BAR_FOREGROUND }));
+			this._register(attachQuickOpenStyler(this.quickOpenWidget, this.themeService));
 
 			const quickOpenContainer = this.quickOpenWidget.create();
 			addClass(quickOpenContainer, 'show-file-icons');


### PR DESCRIPTION
PR adds the ability to theme the background and foreground of the Quick Picker/Quick Open element.

- Currently the picker background and foreground are set to the sidebar background and foreground. I couldn't find a way to carry that forward (my TypeScript skills are entry level), so I defaulted the values to the editor background and foreground.
- The issue I opened asked for background theming, but I thought people might want to theme the foreground and added that. Please let me know if that's not wanted!
- I named the property 'quickPicker' because of the current theme [reference section](https://code.visualstudio.com/docs/getstarted/theme-color-reference#_quick-picker). I wasn't sure about the name b/c the code refers to the 'quick open' element.

Closes #65153
