### PR TITLE
Fix #62350

### DIFF
--- a/build/builtInExtensions.json
+++ b/build/builtInExtensions.json
@@ -31,7 +31,7 @@
 	},
 	{
 		"name": "ms-vscode.references-view",
-		"version": "0.0.7",
+		"version": "0.0.8",
 		"repo": "https://github.com/Microsoft/vscode-reference-view",
 		"metadata": {
 			"id": "36d19e17-7569-4841-a001-947eb18602b2",

--- a/build/builtInExtensions.json
+++ b/build/builtInExtensions.json
@@ -28,5 +28,20 @@
 			},
 			"publisherDisplayName": "Microsoft"
 		}
+	},
+	{
+		"name": "ms-vscode.references-view",
+		"version": "0.0.7",
+		"repo": "https://github.com/Microsoft/vscode-reference-view",
+		"metadata": {
+			"id": "36d19e17-7569-4841-a001-947eb18602b2",
+			"publisherId": {
+				"publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
+				"publisherName": "ms-vscode",
+				"displayName": "Microsoft",
+				"flags": "verified"
+			},
+			"publisherDisplayName": "Microsoft"
+		}
 	}
 ]

--- a/extensions/css-language-features/server/package.json
+++ b/extensions/css-language-features/server/package.json
@@ -9,10 +9,8 @@
   },
   "main": "./out/cssServerMain",
   "dependencies": {
-    "add": "^2.0.6",
     "vscode-css-languageservice": "^3.0.13-next.3",
-    "vscode-languageserver": "^5.1.0",
-    "yarn": "^1.12.1"
+    "vscode-languageserver": "^5.1.0"
   },
   "devDependencies": {
     "@types/mocha": "2.2.33",

--- a/extensions/css-language-features/server/package.json
+++ b/extensions/css-language-features/server/package.json
@@ -9,8 +9,10 @@
   },
   "main": "./out/cssServerMain",
   "dependencies": {
-    "vscode-css-languageservice": "^3.0.13-next.2",
-    "vscode-languageserver": "^5.1.0"
+    "add": "^2.0.6",
+    "vscode-css-languageservice": "^3.0.13-next.3",
+    "vscode-languageserver": "^5.1.0",
+    "yarn": "^1.12.1"
   },
   "devDependencies": {
     "@types/mocha": "2.2.33",

--- a/extensions/css-language-features/server/yarn.lock
+++ b/extensions/css-language-features/server/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.25.tgz#801fe4e39372cef18f268db880a5fbfcf71adc7e"
   integrity sha512-WXvAXaknB0c2cJ7N44e1kUrVu5K90mSfPPaT5XxfuSMxEWva86EYIwxUZM3jNZ2P1CIC9e2z4WJqpAF69PQxeA==
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
+
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
@@ -229,10 +234,10 @@ supports-color@5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
-vscode-css-languageservice@^3.0.13-next.2:
-  version "3.0.13-next.2"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-3.0.13-next.2.tgz#e5195629a39db6bdbf45273f65930196263a94e4"
-  integrity sha512-E/fZU/UqSsHh/UrWYcB6WjmJchhfiiHJEFMcmZjXUWoGJInS3W9+a/iFMp+691LpaX6NwxQUVqMMNvlqIs1m0w==
+vscode-css-languageservice@^3.0.13-next.3:
+  version "3.0.13-next.3"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-3.0.13-next.3.tgz#b9e6f253cace52fbb749d2fe194ae4b196f3543e"
+  integrity sha512-7+7JddZRt8zFRLbqygxJw+GHtbQ5o2YvgEFvi4ixvbUAX6KlY3Yw6CgUUbg9dmBla7h+GbtoDjwiLFV6Oy+SBQ==
   dependencies:
     vscode-languageserver-types "^3.13.0"
     vscode-nls "^4.0.0"
@@ -282,3 +287,8 @@ xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
+yarn@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.12.1.tgz#afa478c9234ee55e8f4cdcfb994acfa54b69c95b"
+  integrity sha512-vdVLrYWx73k4QR8ZpQQ3HJg/X8aAunjUHuPlADR/ogmZOhnqgAdETPz0e/Df+MW8Dno7F1dOxS5e3G6niobumw==

--- a/extensions/css-language-features/server/yarn.lock
+++ b/extensions/css-language-features/server/yarn.lock
@@ -12,11 +12,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.25.tgz#801fe4e39372cef18f268db880a5fbfcf71adc7e"
   integrity sha512-WXvAXaknB0c2cJ7N44e1kUrVu5K90mSfPPaT5XxfuSMxEWva86EYIwxUZM3jNZ2P1CIC9e2z4WJqpAF69PQxeA==
 
-add@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
-  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
-
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
@@ -287,8 +282,3 @@ xml@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
-
-yarn@^1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.12.1.tgz#afa478c9234ee55e8f4cdcfb994acfa54b69c95b"
-  integrity sha512-vdVLrYWx73k4QR8ZpQQ3HJg/X8aAunjUHuPlADR/ogmZOhnqgAdETPz0e/Df+MW8Dno7F1dOxS5e3G6niobumw==

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -15,7 +15,8 @@
   ],
   "main": "./client/out/jsonMain",
   "scripts": {
-    "compile": "gulp compile-extension:json-language-features-client && gulp compile-extension:json-language-features-server",
+    "compile": "gulp compile-extension:json-language-features-client compile-extension:json-language-features-server",
+    "watch": "gulp watch-extension:json-language-features-client watch-extension:json-language-features-server",
     "postinstall": "cd server && yarn install",
     "install-client-next": "yarn add vscode-languageclient@next"
   },

--- a/extensions/json-language-features/package.nls.json
+++ b/extensions/json-language-features/package.nls.json
@@ -10,5 +10,6 @@
 	"json.tracing.desc": "Traces the communication between VS Code and the JSON language server.",
 	"json.colorDecorators.enable.desc": "Enables or disables color decorators",
 	"json.colorDecorators.enable.deprecationMessage": "The setting `json.colorDecorators.enable` has been deprecated in favor of `editor.colorDecorators`.",
+	"json.schemaResolutionErrorMessage": "Unable to resolve schema.",
 	"json.clickToRetry": "Click to retry."
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.29.0",
-  "distro": "1cb32dbbee906f10b38315880e6f134d58b7944a",
+  "distro": "8d717142318180c500f0b8c8e1516c892195776f",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/product.json
+++ b/product.json
@@ -17,5 +17,8 @@
 	"win32ShellNameShort": "C&ode - OSS",
 	"darwinBundleIdentifier": "com.visualstudio.code.oss",
 	"reportIssueUrl": "https://github.com/Microsoft/vscode/issues/new",
-	"urlProtocol": "code-oss"
+	"urlProtocol": "code-oss",
+	"extensionAllowedProposedApi": [
+		"ms-vscode.references-view"
+	]
 }

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -239,6 +239,7 @@ export interface IWindowSettings {
 	nativeFullScreen: boolean;
 	enableMenuBarMnemonics: boolean;
 	closeWhenEmpty: boolean;
+	smoothScrollingWorkaround: boolean;
 	clickThroughInactive: boolean;
 }
 

--- a/src/vs/workbench/api/electron-browser/mainThreadDocumentContentProviders.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDocumentContentProviders.ts
@@ -3,19 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { onUnexpectedError } from 'vs/base/common/errors';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
+import { ITextModel, DefaultEndOfLine } from 'vs/editor/common/model';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
-import { EditOperation } from 'vs/editor/common/core/editOperation';
-import { Range } from 'vs/editor/common/core/range';
-import { ITextModel } from 'vs/editor/common/model';
-import { IEditorWorkerService } from 'vs/editor/common/services/editorWorkerService';
-import { IModelService } from 'vs/editor/common/services/modelService';
-import { IModeService } from 'vs/editor/common/services/modeService';
+import { MainThreadDocumentContentProvidersShape, ExtHostContext, ExtHostDocumentContentProvidersShape, MainContext, IExtHostContext } from '../node/extHost.protocol';
+import { createTextBuffer } from 'vs/editor/common/model/textModel';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { IModeService } from 'vs/editor/common/services/modeService';
+import { IModelService } from 'vs/editor/common/services/modelService';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
-import { ExtHostContext, ExtHostDocumentContentProvidersShape, IExtHostContext, MainContext, MainThreadDocumentContentProvidersShape } from '../node/extHost.protocol';
 
 @extHostNamedCustomer(MainContext.MainThreadDocumentContentProviders)
 export class MainThreadDocumentContentProviders implements MainThreadDocumentContentProvidersShape {
@@ -28,7 +25,6 @@ export class MainThreadDocumentContentProviders implements MainThreadDocumentCon
 		@ITextModelService private readonly _textModelResolverService: ITextModelService,
 		@IModeService private readonly _modeService: IModeService,
 		@IModelService private readonly _modelService: IModelService,
-		@IEditorWorkerService private readonly _editorWorkerService: IEditorWorkerService,
 		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostDocumentContentProviders);
@@ -69,11 +65,10 @@ export class MainThreadDocumentContentProviders implements MainThreadDocumentCon
 			return;
 		}
 
-		this._editorWorkerService.computeMoreMinimalEdits(model.uri, [{ text: value, range: model.getFullModelRange() }]).then(edits => {
-			if (edits.length > 0) {
-				// use the evil-edit as these models show in readonly-editor only
-				model.applyEdits(edits.map(edit => EditOperation.replace(Range.lift(edit.range), edit.text)));
-			}
-		}, onUnexpectedError);
+		const textBuffer = createTextBuffer(value, DefaultEndOfLine.CRLF);
+
+		if (!model.equalsTextBuffer(textBuffer)) {
+			model.setValueFromTextBuffer(textBuffer);
+		}
 	}
 }

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -30,14 +30,14 @@ import { Dimension, EventType, addDisposableListener, trackFocus } from 'vs/base
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { RawContextKey, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
-const SidebarFocusContextId = 'sidebarFocus';
-export const SidebarFocusContext = new RawContextKey<boolean>(SidebarFocusContextId, false);
+const SideBarFocusContextId = 'sideBarFocus';
+export const SidebarFocusContext = new RawContextKey<boolean>(SideBarFocusContextId, false);
 
 export class SidebarPart extends CompositePart<Viewlet> {
 
 	static readonly activeViewletSettingsKey = 'workbench.sidebar.activeviewletid';
 
-	private sidebarFocusContextKey: IContextKey<boolean>;
+	private sideBarFocusContextKey: IContextKey<boolean>;
 	private blockOpeningViewlet: boolean;
 
 	constructor(
@@ -71,7 +71,7 @@ export class SidebarPart extends CompositePart<Viewlet> {
 			{ hasTitle: true, borderWidth: () => (this.getColor(SIDE_BAR_BORDER) || this.getColor(contrastBorder)) ? 1 : 0 }
 		);
 
-		this.sidebarFocusContextKey = SidebarFocusContext.bindTo(contextKeyService);
+		this.sideBarFocusContextKey = SidebarFocusContext.bindTo(contextKeyService);
 	}
 
 	get onDidViewletOpen(): Event<IViewlet> {
@@ -88,10 +88,10 @@ export class SidebarPart extends CompositePart<Viewlet> {
 		const focusTracker = trackFocus(parent);
 
 		focusTracker.onDidFocus(() => {
-			this.sidebarFocusContextKey.set(true);
+			this.sideBarFocusContextKey.set(true);
 		});
 		focusTracker.onDidBlur(() => {
-			this.sidebarFocusContextKey.set(false);
+			this.sideBarFocusContextKey.set(false);
 		});
 	}
 

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -745,6 +745,7 @@ export class MenubarControl extends Disposable {
 							const submenuActions: SubmenuAction[] = [];
 							updateActions(submenu, submenuActions);
 							target.push(new SubmenuAction(action.label, submenuActions));
+							submenu.dispose();
 						} else {
 							action.label = this.calculateActionLabel(action);
 							target.push(action);
@@ -998,7 +999,8 @@ export class MenubarControl extends Disposable {
 
 				if (menuItem instanceof SubmenuItemAction) {
 					const submenu = { items: [] };
-					this.populateMenuItems(this.menuService.createMenu(menuItem.item.submenu, this.contextKeyService), submenu, keybindings);
+					const menuToDispose = this.menuService.createMenu(menuItem.item.submenu, this.contextKeyService);
+					this.populateMenuItems(menuToDispose, submenu, keybindings);
 
 					let menubarSubmenuItem: IMenubarMenuItemSubmenu = {
 						id: menuItem.id,
@@ -1007,6 +1009,7 @@ export class MenubarControl extends Disposable {
 					};
 
 					menuToPopulate.items.push(menubarSubmenuItem);
+					menuToDispose.dispose();
 				} else {
 					let menubarMenuItem: IMenubarMenuItemAction = {
 						id: menuItem.id,

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -15,7 +15,7 @@ import { ActionRunner, IActionRunner, IAction, Action } from 'vs/base/common/act
 import { Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import * as DOM from 'vs/base/browser/dom';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { isMacintosh } from 'vs/base/common/platform';
+import { isMacintosh, isLinux } from 'vs/base/common/platform';
 import { Menu, IMenuOptions, SubmenuAction, MENU_MNEMONIC_REGEX, cleanMnemonic, MENU_ESCAPED_MNEMONIC_REGEX } from 'vs/base/browser/ui/menu/menu';
 import { KeyCode, KeyCodeUtils } from 'vs/base/common/keyCodes';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
@@ -32,6 +32,9 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IUpdateService, StateType } from 'vs/platform/update/common/update';
 import { Gesture, EventType, GestureEvent } from 'vs/base/browser/touch';
 import { attachMenuStyler } from 'vs/platform/theme/common/styler';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 
 const $ = DOM.$;
 
@@ -124,7 +127,10 @@ export class MenubarControl extends Disposable {
 		@IKeybindingService private keybindingService: IKeybindingService,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@ILabelService private labelService: ILabelService,
-		@IUpdateService private updateService: IUpdateService
+		@IUpdateService private updateService: IUpdateService,
+		@IStorageService private storageService: IStorageService,
+		@INotificationService private notificationService: INotificationService,
+		@IPreferencesService private preferencesService: IPreferencesService
 	) {
 
 		super();
@@ -166,6 +172,8 @@ export class MenubarControl extends Disposable {
 		this.windowService.getRecentlyOpened().then((recentlyOpened) => {
 			this.recentlyOpened = recentlyOpened;
 		});
+
+		this.detectAndRecommendCustomTitlebar();
 
 		this.registerListeners();
 	}
@@ -348,6 +356,7 @@ export class MenubarControl extends Disposable {
 
 		if (event.affectsConfiguration('window.menuBarVisibility')) {
 			this.setUnfocusedState();
+			this.detectAndRecommendCustomTitlebar();
 		}
 	}
 
@@ -434,6 +443,41 @@ export class MenubarControl extends Disposable {
 			this.recentlyOpened = recentlyOpened;
 			this.setupMenubar();
 		});
+	}
+
+	private detectAndRecommendCustomTitlebar(): void {
+		if (!isLinux) {
+			return;
+		}
+
+		if (!this.storageService.getBoolean('menubar/electronFixRecommended', StorageScope.GLOBAL, false)) {
+			if (this.currentMenubarVisibility === 'hidden' || this.currentTitlebarStyleSetting === 'custom') {
+				// Issue will not arise for user, abort notification
+				return;
+			}
+
+			const message = nls.localize('menubar.electronFixRecommendation', "If you experience hard to read text in the menu bar, we recommend trying out the custom title bar.");
+			this.notificationService.prompt(Severity.Info, message, [
+				{
+					label: nls.localize('goToSetting', "Open Settings"),
+					run: () => {
+						return this.preferencesService.openGlobalSettings(undefined, { query: 'window.titleBarStyle' });
+					}
+				},
+				{
+					label: nls.localize('moreInfo', "More Info"),
+					run: () => {
+						window.open('https://go.microsoft.com/fwlink/?linkid=2038566');
+					}
+				},
+				{
+					label: nls.localize('neverShowAgain', "Don't Show Again"),
+					run: () => {
+						this.storageService.store('menubar/electronFixRecommended', true, StorageScope.GLOBAL);
+					}
+				}
+			]);
+		}
 	}
 
 	private registerListeners(): void {

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -830,6 +830,13 @@ configurationRegistry.registerConfiguration({
 			'description': nls.localize('window.nativeFullScreen', "Controls if native full-screen should be used on macOS. Disable this option to prevent macOS from creating a new space when going full-screen."),
 			'included': isMacintosh
 		},
+		'window.smoothScrollingWorkaround': {
+			'type': 'boolean',
+			'default': false,
+			'scope': ConfigurationScope.APPLICATION,
+			'markdownDescription': nls.localize('window.smoothScrollingWorkaround', "Enable this workaround if scrolling is no longer smooth after restoring a minimized VS Code window. This is a workaround for an issue (https://github.com/Microsoft/vscode/issues/13612) where scrolling starts to lag on devices with precision trackpads like the Surface devices from Microsoft. Enabling this workaround can result in a little bit of layout flickering after restoring the window from minimized state but is otherwise harmless. Note: in order for this workaround to function, make sure to also set `#window.titleBarStyle#` to `native`."),
+			'included': isWindows
+		},
 		'window.clickThroughInactive': {
 			'type': 'boolean',
 			'default': true,

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -682,7 +682,7 @@ configurationRegistry.registerConfiguration({
 		'workbench.enableLegacyStorage': {
 			'type': 'boolean',
 			'description': nls.localize('workbench.enableLegacyStorage', "Switches back to the previous storage implementation. Only change this setting if advised to do so."),
-			'default': false
+			'default': true
 		}
 	}
 });

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -681,7 +681,7 @@ configurationRegistry.registerConfiguration({
 		//TODO@Ben remove ('enableLegacyStorage') after a while
 		'workbench.enableLegacyStorage': {
 			'type': 'boolean',
-			'description': nls.localize('workbench.enableLegacyStorage', "Switches back to the previous storage implementation. Only change this setting if advised to do so."),
+			'markdownDescription': nls.localize('workbench.enableLegacyStorage', "Switches back to the previous storage implementation. Only change this setting if advised to do so. **Disabling legacy storage will drop your storage state.**"),
 			'default': true
 		}
 	}

--- a/src/vs/workbench/electron-browser/main.ts
+++ b/src/vs/workbench/electron-browser/main.ts
@@ -13,10 +13,10 @@ import * as comparer from 'vs/base/common/comparers';
 import * as platform from 'vs/base/common/platform';
 import { URI as uri } from 'vs/base/common/uri';
 import { IWorkspaceContextService, Workspace, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload, isSingleFolderWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
+import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { stat, exists, writeFile, readdir } from 'vs/base/node/pfs';
+import { stat, exists, writeFile } from 'vs/base/node/pfs';
 import { EnvironmentService } from 'vs/platform/environment/node/environmentService';
 import * as gracefulFs from 'graceful-fs';
 import { KeyboardMapperFactory } from 'vs/workbench/services/keybinding/electron-browser/keybindingService';
@@ -31,7 +31,7 @@ import { IUpdateService } from 'vs/platform/update/common/update';
 import { URLHandlerChannel, URLServiceChannelClient } from 'vs/platform/url/node/urlIpc';
 import { IURLService } from 'vs/platform/url/common/url';
 import { WorkspacesChannelClient } from 'vs/platform/workspaces/node/workspacesIpc';
-import { IWorkspacesService, ISingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspacesService, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { createSpdLogService } from 'vs/platform/log/node/spdlogService';
 import * as fs from 'fs';
 import { ConsoleLogService, MultiplexLogService, ILogService } from 'vs/platform/log/common/log';
@@ -46,9 +46,6 @@ import { Schemas } from 'vs/base/common/network';
 import { sanitizeFilePath, mkdirp } from 'vs/base/node/extfs';
 import { basename, join } from 'path';
 import { createHash } from 'crypto';
-import { parseStorage, StorageObject } from 'vs/platform/storage/common/storageLegacyMigration';
-import { StorageScope } from 'vs/platform/storage/common/storage';
-import { endsWith } from 'vs/base/common/strings';
 import { IdleValue } from 'vs/base/common/async';
 
 gracefulFs.gracefulify(fs); // enable gracefulFs
@@ -303,7 +300,9 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 			const storageService = new StorageService(workspaceStorageDBPath, true, logService, environmentService);
 
 			return storageService.init().then(() => {
-				if (exists) {
+				return storageService; // do not migrate this milestone
+
+				/* if (exists) {
 					return storageService; // return early if DB was already there
 				}
 
@@ -429,6 +428,7 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 
 					return storageService;
 				});
+				*/
 			});
 		});
 	});

--- a/src/vs/workbench/electron-browser/main.ts
+++ b/src/vs/workbench/electron-browser/main.ts
@@ -13,10 +13,10 @@ import * as comparer from 'vs/base/common/comparers';
 import * as platform from 'vs/base/common/platform';
 import { URI as uri } from 'vs/base/common/uri';
 import { IWorkspaceContextService, Workspace, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
+import { WorkspaceService, ISingleFolderWorkspaceInitializationPayload, IMultiFolderWorkspaceInitializationPayload, IEmptyWorkspaceInitializationPayload, IWorkspaceInitializationPayload, isSingleFolderWorkspaceInitializationPayload } from 'vs/workbench/services/configuration/node/configurationService';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { stat, exists, writeFile } from 'vs/base/node/pfs';
+import { stat, exists, writeFile, readdir } from 'vs/base/node/pfs';
 import { EnvironmentService } from 'vs/platform/environment/node/environmentService';
 import * as gracefulFs from 'graceful-fs';
 import { KeyboardMapperFactory } from 'vs/workbench/services/keybinding/electron-browser/keybindingService';
@@ -31,7 +31,7 @@ import { IUpdateService } from 'vs/platform/update/common/update';
 import { URLHandlerChannel, URLServiceChannelClient } from 'vs/platform/url/node/urlIpc';
 import { IURLService } from 'vs/platform/url/common/url';
 import { WorkspacesChannelClient } from 'vs/platform/workspaces/node/workspacesIpc';
-import { IWorkspacesService, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspacesService, ISingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { createSpdLogService } from 'vs/platform/log/node/spdlogService';
 import * as fs from 'fs';
 import { ConsoleLogService, MultiplexLogService, ILogService } from 'vs/platform/log/common/log';
@@ -46,6 +46,9 @@ import { Schemas } from 'vs/base/common/network';
 import { sanitizeFilePath, mkdirp } from 'vs/base/node/extfs';
 import { basename, join } from 'path';
 import { createHash } from 'crypto';
+import { parseStorage, StorageObject } from 'vs/platform/storage/common/storageLegacyMigration';
+import { StorageScope } from 'vs/platform/storage/common/storage';
+import { endsWith } from 'vs/base/common/strings';
 import { IdleValue } from 'vs/base/common/async';
 
 gracefulFs.gracefulify(fs); // enable gracefulFs
@@ -300,10 +303,8 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 			const storageService = new StorageService(workspaceStorageDBPath, true, logService, environmentService);
 
 			return storageService.init().then(() => {
-				return storageService; // do not migrate this milestone
-
-				/* if (exists) {
-					return storageService; // return early if DB was already there
+				if (exists || true) { // do not migrate this milestone
+					return storageService;
 				}
 
 				perf.mark('willMigrateWorkspaceStorageKeys');
@@ -428,7 +429,6 @@ function createStorageService(payload: IWorkspaceInitializationPayload, environm
 
 					return storageService;
 				});
-				*/
 			});
 		});
 	});

--- a/src/vs/workbench/parts/debug/electron-browser/repl.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/repl.ts
@@ -292,6 +292,12 @@ export class Repl extends Panel implements IPrivateReplService, IHistoryNavigati
 			accessibilityProvider: new ReplExpressionsAccessibilityProvider(),
 			controller
 		}, replTreeOptions);
+
+		// Make sure to select the session if debugging is already active
+		const focusedSession = this.debugService.getViewModel().focusedSession;
+		if (focusedSession) {
+			this.selectSession(focusedSession);
+		}
 	}
 
 	private createReplInput(container: HTMLElement): void {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -300,7 +300,7 @@ export class ExtensionsListView extends ViewletPanel {
 
 	private async queryGallery(query: Query, options: IQueryOptions): Promise<IPagedModel<IExtension>> {
 		const hasUserDefinedSortOrder = options.sortBy !== undefined;
-		if (!hasUserDefinedSortOrder) {
+		if (!hasUserDefinedSortOrder && !query.value.trim()) {
 			options.sortBy = SortBy.InstallCount;
 		}
 

--- a/src/vs/workbench/parts/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/parts/extensions/test/electron-browser/extensionsViews.test.ts
@@ -12,7 +12,7 @@ import { IExtensionsWorkbenchService } from 'vs/workbench/parts/extensions/commo
 import { ExtensionsWorkbenchService } from 'vs/workbench/parts/extensions/node/extensionsWorkbenchService';
 import {
 	IExtensionManagementService, IExtensionGalleryService, IExtensionEnablementService, IExtensionTipsService, ILocalExtension, LocalExtensionType, IGalleryExtension, IQueryOptions,
-	DidInstallExtensionEvent, DidUninstallExtensionEvent, InstallExtensionEvent, IExtensionIdentifier, IExtensionManagementServerService, IExtensionManagementServer, EnablementState, ExtensionRecommendationReason
+	DidInstallExtensionEvent, DidUninstallExtensionEvent, InstallExtensionEvent, IExtensionIdentifier, IExtensionManagementServerService, IExtensionManagementServer, EnablementState, ExtensionRecommendationReason, SortBy
 } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { getGalleryExtensionId, getGalleryExtensionIdFromLocal } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { ExtensionManagementService, getLocalExtensionIdFromManifest } from 'vs/platform/extensionManagement/node/extensionManagementService';
@@ -150,6 +150,33 @@ suite('ExtensionsListView Tests', () => {
 		assert.equal(ExtensionsListView.isInstalledExtensionsQuery('@enabled searchText'), true);
 		assert.equal(ExtensionsListView.isInstalledExtensionsQuery('@disabled searchText'), true);
 		assert.equal(ExtensionsListView.isInstalledExtensionsQuery('@outdated searchText'), true);
+	});
+
+	test('Test empty query equates to sort by install count', () => {
+		const target = <SinonStub>instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage());
+		return testableView.show('').then(() => {
+			assert.ok(target.calledOnce);
+			const options: IQueryOptions = target.args[0][0];
+			assert.equal(options.sortBy, SortBy.InstallCount);
+		});
+	});
+
+	test('Test non empty query without sort doesnt use sortBy', () => {
+		const target = <SinonStub>instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage());
+		return testableView.show('some extension').then(() => {
+			assert.ok(target.calledOnce);
+			const options: IQueryOptions = target.args[0][0];
+			assert.equal(options.sortBy, undefined);
+		});
+	});
+
+	test('Test query with sort uses sortBy', () => {
+		const target = <SinonStub>instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage());
+		return testableView.show('some extension @sort:rating').then(() => {
+			assert.ok(target.calledOnce);
+			const options: IQueryOptions = target.args[0][0];
+			assert.equal(options.sortBy, SortBy.WeightedRating);
+		});
 	});
 
 	test('Test installed query results', () => {

--- a/src/vs/workbench/parts/files/electron-browser/explorerViewlet.ts
+++ b/src/vs/workbench/parts/files/electron-browser/explorerViewlet.ts
@@ -217,7 +217,7 @@ export class ExplorerViewlet extends ViewContainerViewlet implements IExplorerVi
 			});
 
 			const explorerInstantiator = this.instantiationService.createChild(new ServiceCollection([IEditorService, delegatingEditorService]));
-			return explorerInstantiator.createInstance(ExplorerView, <IExplorerViewOptions>{ ...options, viewletState: this.fileViewletState });
+			return explorerInstantiator.createInstance(ExplorerView, <IExplorerViewOptions>{ ...options, fileViewletState: this.fileViewletState });
 		}
 		return super.createView(viewDescriptor, options);
 	}

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -45,7 +45,7 @@ import { IViewletPanelOptions } from 'vs/workbench/browser/parts/views/panelView
 import { ILabelService } from 'vs/platform/label/common/label';
 
 export interface IExplorerViewOptions extends IViewletViewOptions {
-	viewletState: FileViewletState;
+	fileViewletState: FileViewletState;
 }
 
 export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView {
@@ -61,7 +61,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 
 	private explorerViewer: WorkbenchTree;
 	private filter: FileFilter;
-	private viewletState: FileViewletState;
+	private fileViewletState: FileViewletState;
 
 	private explorerRefreshDelayer: ThrottledDelayer<void>;
 
@@ -100,7 +100,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 		super({ ...(options as IViewletPanelOptions), ariaHeaderLabel: nls.localize('explorerSection', "Files Explorer Section") }, keybindingService, contextMenuService, configurationService);
 
 		this.viewState = options.viewletState;
-		this.viewletState = options.viewletState;
+		this.fileViewletState = options.fileViewletState;
 		this.autoReveal = true;
 
 		this.explorerRefreshDelayer = new ThrottledDelayer<void>(ExplorerView.EXPLORER_FILE_CHANGES_REFRESH_DELAY);
@@ -406,7 +406,7 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 
 	private createViewer(container: HTMLElement): WorkbenchTree {
 		const dataSource = this.instantiationService.createInstance(FileDataSource);
-		const renderer = this.instantiationService.createInstance(FileRenderer, this.viewletState);
+		const renderer = this.instantiationService.createInstance(FileRenderer, this.fileViewletState);
 		const controller = this.instantiationService.createInstance(FileController);
 		this.disposables.push(controller);
 		const sorter = this.instantiationService.createInstance(FileSorter);

--- a/src/vs/workbench/parts/relauncher/electron-browser/relauncher.contribution.ts
+++ b/src/vs/workbench/parts/relauncher/electron-browser/relauncher.contribution.ts
@@ -15,7 +15,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { URI } from 'vs/base/common/uri';
 import { isEqual } from 'vs/base/common/resources';
-import { isLinux, isMacintosh } from 'vs/base/common/platform';
+import { isLinux, isMacintosh, isWindows } from 'vs/base/common/platform';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { equals } from 'vs/base/common/objects';
@@ -38,6 +38,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 	private enableCrashReporter: boolean;
 	private touchbarEnabled: boolean;
 	private treeHorizontalScrolling: boolean;
+	private windowsSmoothScrollingWorkaround: boolean;
 	private experimentalFileWatcher: boolean;
 	private fileWatcherExclude: object;
 	private legacyStorage: boolean;
@@ -141,6 +142,11 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 		// Legacy Workspace Storage
 		if (config.workbench && typeof config.workbench.enableLegacyStorage === 'boolean' && config.workbench.enableLegacyStorage !== this.legacyStorage) {
 			this.legacyStorage = config.workbench.enableLegacyStorage;
+			changed = true;
+		}
+		// Windows: smooth scrolling workaround
+		if (isWindows && config.window && typeof config.window.smoothScrollingWorkaround === 'boolean' && config.window.smoothScrollingWorkaround !== this.windowsSmoothScrollingWorkaround) {
+			this.windowsSmoothScrollingWorkaround = config.window.smoothScrollingWorkaround;
 			changed = true;
 		}
 

--- a/src/vs/workbench/parts/search/common/queryBuilder.ts
+++ b/src/vs/workbench/parts/search/common/queryBuilder.ts
@@ -312,7 +312,9 @@ export class QueryBuilder {
 			for (let excludePattern in rootConfig.excludePattern) {
 				const { pathPortion, globPortion } = splitSimpleGlob(excludePattern);
 				if (!pathPortion) { // **/foo
-					resolvedExcludes[globPortion] = rootConfig.excludePattern[excludePattern];
+					if (globPortion) {
+						resolvedExcludes[globPortion] = rootConfig.excludePattern[excludePattern];
+					}
 				} else if (strings.startsWith(pathPortion, searchPathRelativePath)) { // searchPathRelativePath/something/**/foo
 					// Strip `searchPathRelativePath/`
 					const resolvedPathPortion = pathPortion.substr(searchPathRelativePath.length + 1);
@@ -328,7 +330,7 @@ export class QueryBuilder {
 		return {
 			...rootConfig,
 			...{
-				includePattern: searchPath.pattern && patternListToIExpression([searchPath.pattern]),
+				includePattern: searchPath.pattern ? patternListToIExpression([searchPath.pattern]) : undefined,
 				excludePattern: Object.keys(resolvedExcludes).length ? resolvedExcludes : undefined
 			}
 		};
@@ -375,7 +377,7 @@ function splitGlobFromPath(searchPath: string): { pathPortion: string, globPorti
 function splitSimpleGlob(searchPath: string): { pathPortion: string, globPortion?: string } {
 	const globCharMatch = searchPath.match(/[\*\{\}\(\)\[\]\?]/);
 	if (globCharMatch) {
-		const globCharIdx = globCharMatch.index;
+		const globCharIdx = globCharMatch.index || 0;
 		return {
 			pathPortion: searchPath.substr(0, globCharIdx),
 			globPortion: searchPath.substr(globCharIdx)

--- a/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
+++ b/src/vs/workbench/parts/search/test/common/queryBuilder.test.ts
@@ -153,14 +153,11 @@ suite('QueryBuilder', () => {
 			<ITextQuery>{
 				contentPattern: PATTERN_INFO,
 				folderQueries: [{
-					folder: getUri(paths.join(ROOT_1, 'foo'))
-				}],
-				excludePattern: {
-					[paths.join(ROOT_1, 'foo/**/*.js')]: true,
-					[paths.join(ROOT_1, 'bar/**')]: {
-						'when': '$(basename).ts'
+					folder: getUri(paths.join(ROOT_1, 'foo')),
+					excludePattern: {
+						['**/*.js']: true
 					}
-				},
+				}],
 				type: QueryType.Text
 			});
 	});
@@ -212,7 +209,6 @@ suite('QueryBuilder', () => {
 				folderQueries: [
 					{ folder: getUri(paths.join(ROOT_2, 'src')) }
 				],
-				excludePattern: patternsToIExpression(paths.join(ROOT_1, 'foo/**/*.js'), paths.join(ROOT_2, 'bar')),
 				type: QueryType.Text
 			}
 		);

--- a/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
+++ b/src/vs/workbench/parts/tasks/node/taskConfiguration.ts
@@ -747,7 +747,7 @@ namespace CommandOptions {
 namespace CommandConfiguration {
 
 	export namespace PresentationOptions {
-		const properties: MetaData<Tasks.PresentationOptions, void>[] = [{ property: 'echo' }, { property: 'reveal' }, { property: 'focus' }, { property: 'panel' }, { property: 'showReuseMessage' }];
+		const properties: MetaData<Tasks.PresentationOptions, void>[] = [{ property: 'echo' }, { property: 'reveal' }, { property: 'focus' }, { property: 'panel' }, { property: 'showReuseMessage' }, { property: 'clear' }];
 
 		interface PresentationOptionsShape extends LegacyCommandProperties {
 			presentation?: PresentationOptions;

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -675,7 +675,7 @@ export class TerminalInstance implements ITerminalInstance {
 					});
 					return;
 				} else if (hasSpace) {
-					c('"' + path + '"');
+					c("& '" + path + "'");
 				} else {
 					c(path);
 				}

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -675,7 +675,12 @@ export class TerminalInstance implements ITerminalInstance {
 					});
 					return;
 				} else if (hasSpace) {
-					c("& '" + path + "'");
+					if(exe.indexOf('powershell') == -1){
+						c('"' + path + '"');
+					}
+					else{
+						c("& '" + path + "'");
+					}
 				} else {
 					c(path);
 				}

--- a/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
@@ -272,17 +272,12 @@ export class FileDialogService implements IFileDialogService {
 		if (defaultUri && defaultUri.scheme !== Schemas.file) {
 			return Promise.reject(new Error('Not supported - Open-dialogs can only be opened on `file`-uris.'));
 		}
-		const filters = [];
-		if (options.filters) {
-			for (let name in options.filters) {
-				filters.push({ name, extensions: options.filters[name] });
-			}
-		}
+
 		const newOptions: OpenDialogOptions = {
 			title: options.title,
 			defaultPath: defaultUri && defaultUri.fsPath,
 			buttonLabel: options.openLabel,
-			filters,
+			filters: options.filters,
 			properties: []
 		};
 		newOptions.properties.push('createDirectory');


### PR DESCRIPTION
Fix for the issue [#62350](https://github.com/Microsoft/vscode/issues/62350).
When we run a file with a path that has a space in it instead of running "c:\Users\matb\folder\sp ace.html" it will now execute & 'c:\Users\matb\folder\sp ace.html'. This way powershell will be able to execute the file as it is pretended.