### PR TITLE
Update package.json

### DIFF
--- a/extensions/html/package.json
+++ b/extensions/html/package.json
@@ -80,6 +80,13 @@
         "language": "html",
         "path": "./snippets/html.snippets.json"
       }
-    ]
+    ],
+    "configurationDefaults": {
+			"[html]": {
+				"editor.insertSpaces": true,
+				"editor.tabSize": 2,
+				"editor.autoIndent": false
+			}
+		}
   }
 }


### PR DESCRIPTION
It would be easier to correct the indentation in the html language, if the autoIndent boolean would be false, since there is an error in the autoIndentOnPaste for, at least, this language