### PR TITLE
Fix #65287 - Disable warning in markdown preview doesn't immediately hide the warning

### DIFF
--- a/extensions/markdown-language-features/src/security.ts
+++ b/extensions/markdown-language-features/src/security.ts
@@ -149,6 +149,7 @@ export class PreviewSecuritySelector {
 
 		if (selection.type === 'toggle') {
 			this.cspArbiter.setShouldDisableSecurityWarning(!this.cspArbiter.shouldDisableSecurityWarnings());
+			this.webviewManager.refresh();
 			return;
 		} else {
 			await this.cspArbiter.setSecurityLevelForResource(resource, selection.type);


### PR DESCRIPTION
@mjbvz , This fixes #65287 
`this.webviewManager.refresh();` was not there when the selection was made and it was just returning after toggling the setting value.
So I added that line before return.
Please review this and let me know if its good :)