### PR TITLE
Strict null checks for windowsKeyboardMapper.test.ts

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -809,7 +809,8 @@
 		"./vs/workbench/services/title/common/titleService.ts",
 		"./vs/workbench/services/workspace/common/workspaceEditing.ts",
 		"./vs/workbench/test/common/editor/editorOptions.test.ts",
-		"./vs/workbench/test/electron-browser/api/mock.ts"
+		"./vs/workbench/test/electron-browser/api/mock.ts",
+		"./vs/workbench/services/keybinding/test/windowsKeyboardMapper.test.ts"
 	],
 	"exclude": [
 		"./typings/require-monaco.d.ts"

--- a/src/vs/workbench/services/keybinding/test/windowsKeyboardMapper.test.ts
+++ b/src/vs/workbench/services/keybinding/test/windowsKeyboardMapper.test.ts
@@ -17,7 +17,8 @@ async function createKeyboardMapper(isUSStandard: boolean, file: string): Promis
 }
 
 function _assertResolveKeybinding(mapper: WindowsKeyboardMapper, k: number, expected: IResolvedKeybinding[]): void {
-	assertResolveKeybinding(mapper, createKeybinding(k, OperatingSystem.Windows), expected);
+	const keyBinding = createKeybinding(k, OperatingSystem.Windows);
+	assertResolveKeybinding(mapper, keyBinding!, expected);
 }
 
 suite('keyboardMapper - WINDOWS de_ch', () => {
@@ -73,7 +74,7 @@ suite('keyboardMapper - WINDOWS de_ch', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.KEY_Z,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+Z',
@@ -112,7 +113,7 @@ suite('keyboardMapper - WINDOWS de_ch', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.US_CLOSE_SQUARE_BRACKET,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+^',
@@ -255,7 +256,7 @@ suite('keyboardMapper - WINDOWS de_ch', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.Home,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+Home',
@@ -295,7 +296,7 @@ suite('keyboardMapper - WINDOWS de_ch', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.Ctrl,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+',
@@ -359,7 +360,7 @@ suite('keyboardMapper - WINDOWS en_us', () => {
 		assertResolveUserBinding(
 			mapper,
 			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			null,
+			null!,
 			[{
 				label: 'Ctrl+,',
 				ariaLabel: 'Control+,',
@@ -381,7 +382,7 @@ suite('keyboardMapper - WINDOWS en_us', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.Ctrl,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+',
@@ -417,7 +418,7 @@ suite('keyboardMapper - WINDOWS por_ptb', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.ABNT_C1,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+/',
@@ -440,7 +441,7 @@ suite('keyboardMapper - WINDOWS por_ptb', () => {
 				altKey: false,
 				metaKey: false,
 				keyCode: KeyCode.ABNT_C2,
-				code: null
+				code: null!
 			},
 			{
 				label: 'Ctrl+.',


### PR DESCRIPTION
As part of #65233.