### PR TITLE
Enable strict null checking for workspaceStats test

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -656,6 +656,7 @@
 		"./vs/workbench/parts/snippets/test/electron-browser/snippetsRewrite.test.ts",
 		"./vs/workbench/parts/stats/node/stats.contribution.ts",
 		"./vs/workbench/parts/stats/node/workspaceStats.ts",
+		"./vs/workbench/parts/stats/test/workspaceStats.test.ts",
 		"./vs/workbench/parts/surveys/electron-browser/languageSurveys.contribution.ts",
 		"./vs/workbench/parts/surveys/electron-browser/nps.contribution.ts",
 		"./vs/workbench/parts/tasks/common/problemCollectors.ts",


### PR DESCRIPTION
#65233 

- [x] `"./vs/workbench/parts/stats/test/workspaceStats.test.ts"`