### PR TITLE
Enable strict null check for ./vs/base/test/common/history.test.ts

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -133,6 +133,7 @@
 		"./vs/base/test/common/filters.perf.test.ts",
 		"./vs/base/test/common/filters.test.ts",
 		"./vs/base/test/common/hash.test.ts",
+		"./vs/base/test/common/history.test.ts",
 		"./vs/base/test/common/json.test.ts",
 		"./vs/base/test/common/jsonEdit.test.ts",
 		"./vs/base/test/common/jsonFormatter.test.ts",

--- a/src/vs/base/test/common/history.test.ts
+++ b/src/vs/base/test/common/history.test.ts
@@ -113,8 +113,8 @@ suite('History Navigator', () => {
 		assert.equal(testObject.current(), undefined);
 	});
 
-	function toArray(historyNavigator: HistoryNavigator<string>): string[] {
-		let result: string[] = [];
+	function toArray(historyNavigator: HistoryNavigator<string>): Array<string | null> {
+		let result: Array<string | null> = [];
 		historyNavigator.first();
 		if (historyNavigator.current()) {
 			do {


### PR DESCRIPTION
#65233

- [ ] `"./vs/base/test/common/history.test.ts"`

Not sure how to fix this. `yarn strict-null-check`
https://github.com/Microsoft/vscode/blob/f903e6d226f953e158deb397de871fd34dce1979/src/vs/base/test/common/history.test.ts#L116-L126

```javascript
result.push(historyNavigator.current());
```

`result` is defined as a type `string[]`
`historyNavigator.current()` is defined as type `<T> | null`, in this case `string | null`.

I'm thinking of changing the types for `HistoryNavigator.<method>` back to just return `T` and not `T | null`

Thoughts ?