### PR TITLE
Enable strict null check for ./vs/base/test/common/keyCodes.test.ts

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -136,6 +136,7 @@
 		"./vs/base/test/common/json.test.ts",
 		"./vs/base/test/common/jsonEdit.test.ts",
 		"./vs/base/test/common/jsonFormatter.test.ts",
+		"./vs/base/test/common/keyCodes.test.ts",
 		"./vs/base/test/common/labels.test.ts",
 		"./vs/base/test/common/lifecycle.test.ts",
 		"./vs/base/test/common/linkedList.test.ts",

--- a/src/vs/base/test/common/keyCodes.test.ts
+++ b/src/vs/base/test/common/keyCodes.test.ts
@@ -9,13 +9,13 @@ import { OperatingSystem } from 'vs/base/common/platform';
 
 suite('keyCodes', () => {
 
-	function testBinaryEncoding(expected: Keybinding, k: number, OS: OperatingSystem): void {
+	function testBinaryEncoding(expected: Keybinding | null, k: number, OS: OperatingSystem): void {
 		assert.deepEqual(createKeybinding(k, OS), expected);
 	}
 
 	test('MAC binary encoding', () => {
 
-		function test(expected: Keybinding, k: number): void {
+		function test(expected: Keybinding | null, k: number): void {
 			testBinaryEncoding(expected, k, OperatingSystem.Macintosh);
 		}
 
@@ -57,7 +57,7 @@ suite('keyCodes', () => {
 
 		[OperatingSystem.Linux, OperatingSystem.Windows].forEach((OS) => {
 
-			function test(expected: Keybinding, k: number): void {
+			function test(expected: Keybinding | null, k: number): void {
 				testBinaryEncoding(expected, k, OS);
 			}
 


### PR DESCRIPTION
#65233

- [ ] `"./vs/base/test/common/keyCodes.test.ts"`