### PR TITLE
Enable strict null checking for ./vs/platform/commands/test/commands.test.ts

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -373,6 +373,7 @@
 		"./vs/platform/clipboard/common/clipboardService.ts",
 		"./vs/platform/clipboard/electron-browser/clipboardService.ts",
 		"./vs/platform/commands/common/commands.ts",
+		"./vs/platform/commands/test/commands.test.ts",
 		"./vs/platform/configuration/common/configuration.ts",
 		"./vs/platform/configuration/common/configurationModels.ts",
 		"./vs/platform/configuration/common/configurationRegistry.ts",

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -43,7 +43,7 @@ export interface ICommandHandlerDescription {
 
 export interface ICommandRegistry {
 	onDidRegisterCommand: Event<string>;
-	registerCommand(id: string, command: ICommandHandler): IDisposable;
+	registerCommand(id: string, command?: ICommandHandler | null): IDisposable;
 	registerCommand(command: ICommand): IDisposable;
 	registerCommandAlias(oldId: string, newId: string): IDisposable;
 	getCommand(id: string): ICommand | undefined;

--- a/src/vs/platform/commands/test/commands.test.ts
+++ b/src/vs/platform/commands/test/commands.test.ts
@@ -14,7 +14,7 @@ suite('Command Tests', function () {
 	test('register/dispose', () => {
 		const command = function () { };
 		const reg = CommandsRegistry.registerCommand('foo', command);
-		assert.ok(CommandsRegistry.getCommand('foo').handler === command);
+		assert.ok(CommandsRegistry.getCommand('foo')!.handler === command);
 		reg.dispose();
 		assert.ok(CommandsRegistry.getCommand('foo') === undefined);
 	});
@@ -25,23 +25,23 @@ suite('Command Tests', function () {
 
 		// dispose overriding command
 		let reg1 = CommandsRegistry.registerCommand('foo', command1);
-		assert.ok(CommandsRegistry.getCommand('foo').handler === command1);
+		assert.ok(CommandsRegistry.getCommand('foo')!.handler === command1);
 
 		let reg2 = CommandsRegistry.registerCommand('foo', command2);
-		assert.ok(CommandsRegistry.getCommand('foo').handler === command2);
+		assert.ok(CommandsRegistry.getCommand('foo')!.handler === command2);
 		reg2.dispose();
 
-		assert.ok(CommandsRegistry.getCommand('foo').handler === command1);
+		assert.ok(CommandsRegistry.getCommand('foo')!.handler === command1);
 		reg1.dispose();
 		assert.ok(CommandsRegistry.getCommand('foo') === void 0);
 
 		// dispose override command first
 		reg1 = CommandsRegistry.registerCommand('foo', command1);
 		reg2 = CommandsRegistry.registerCommand('foo', command2);
-		assert.ok(CommandsRegistry.getCommand('foo').handler === command2);
+		assert.ok(CommandsRegistry.getCommand('foo')!.handler === command2);
 
 		reg1.dispose();
-		assert.ok(CommandsRegistry.getCommand('foo').handler === command2);
+		assert.ok(CommandsRegistry.getCommand('foo')!.handler === command2);
 
 		reg2.dispose();
 		assert.ok(CommandsRegistry.getCommand('foo') === void 0);
@@ -68,6 +68,7 @@ suite('Command Tests', function () {
 			}
 		});
 
+		// TODO: Can a handler's accessor (first param) be undefined?
 		CommandsRegistry.getCommands()['test'].handler.apply(undefined, [undefined, 'string']);
 		CommandsRegistry.getCommands()['test2'].handler.apply(undefined, [undefined, 'string']);
 		assert.throws(() => CommandsRegistry.getCommands()['test3'].handler.apply(undefined, [undefined, 'string']));


### PR DESCRIPTION
#65233 

I have a question here:
https://github.com/Microsoft/vscode/blob/9d33032690316e1a14844e9e926a315b0c207638/src/vs/platform/commands/test/commands.test.ts#L71-L75

This part of the test is failing because we're trying to pass `undefined` as the first argument of a "command handler". The first argument is the `accessor` (`ServicesAccessor`). Can it be `undefined`? If so, a bunch of other files are failing null-check because they try to access the `accessor`, which can be `undefined`.

If it cannot be `undefined`, we need to change the test to pass something else than `undefined`.