### PR TITLE
Removed snapUpdate.sh and replaced with inline command

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -203,13 +203,10 @@ function prepareSnapPackage(arch) {
 			.pipe(replace('@@VERSION@@', commit.substr(0, 8)))
 			.pipe(rename('snap/snapcraft.yaml'));
 
-		const snapUpdate = gulp.src('resources/linux/snap/snapUpdate.sh', { base: '.' })
-			.pipe(rename(`usr/share/${product.applicationName}/snapUpdate.sh`));
-
 		const electronLaunch = gulp.src('resources/linux/snap/electron-launch', { base: '.' })
 			.pipe(rename('electron-launch'));
 
-		const all = es.merge(desktop, icon, code, snapcraft, electronLaunch, snapUpdate);
+		const all = es.merge(desktop, icon, code, snapcraft, electronLaunch);
 
 		return all.pipe(vfs.dest(destination));
 	};

--- a/resources/linux/snap/snapUpdate.sh
+++ b/resources/linux/snap/snapUpdate.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-sleep 2
-$SNAP_NAME

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -125,9 +125,11 @@ export class LinuxUpdateService extends AbstractUpdateService {
 		}
 
 		// Allow 3 seconds for VS Code to close
-		spawn('bash', ['-c', path.join(snap, `usr/share/${product.applicationName}/snapUpdate.sh`)], {
+		spawn('sleep 3 && $SNAP_NAME', {
+			shell: true,
 			detached: true,
-			stdio: ['ignore', 'ignore', 'ignore']
+			stdio: 'ignore',
 		});
+
 	}
 }

--- a/src/vs/platform/update/electron-main/updateService.snap.ts
+++ b/src/vs/platform/update/electron-main/updateService.snap.ts
@@ -6,7 +6,6 @@
 import { Event, Emitter } from 'vs/base/common/event';
 import { timeout } from 'vs/base/common/async';
 import { ILifecycleService } from 'vs/platform/lifecycle/electron-main/lifecycleMain';
-import product from 'vs/platform/node/product';
 import { IUpdateService, State, StateType, AvailableForDownload, UpdateType } from 'vs/platform/update/common/update';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -14,7 +13,6 @@ import * as path from 'path';
 import { realpath, watch } from 'fs';
 import { spawn } from 'child_process';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { stat } from 'vs/base/node/pfs';
 
 abstract class AbstractUpdateService2 implements IUpdateService {
 
@@ -137,8 +135,6 @@ export class SnapUpdateService extends AbstractUpdateService2 {
 
 	_serviceBrand: any;
 
-	private snapUpdatePath: string;
-
 	constructor(
 		private snap: string,
 		private snapRevision: string,
@@ -148,8 +144,6 @@ export class SnapUpdateService extends AbstractUpdateService2 {
 		@ITelemetryService private telemetryService: ITelemetryService
 	) {
 		super(lifecycleService, environmentService, logService);
-
-		this.snapUpdatePath = path.join(this.snap, `usr/share/${product.applicationName}/snapUpdate.sh`);
 
 		const watcher = watch(path.dirname(this.snap));
 		const onChange = Event.fromNodeEventEmitter(watcher, 'change', (_, fileName: string) => fileName);
@@ -196,19 +190,14 @@ export class SnapUpdateService extends AbstractUpdateService2 {
 		this.logService.trace('update#quitAndInstall(): running raw#quitAndInstall()');
 
 		// Allow 3 seconds for VS Code to close
-		spawn('bash', ['-c', this.snapUpdatePath], {
+		spawn('sleep 3 && $SNAP_NAME', {
+			shell: true,
 			detached: true,
-			stdio: ['ignore', 'ignore', 'ignore']
+			stdio: 'ignore',
 		});
 	}
 
 	private async isUpdateAvailable(): Promise<boolean> {
-		try {
-			await stat(this.snapUpdatePath);
-		} catch (err) {
-			return false;
-		}
-
 		const resolvedCurrentSnapPath = await new Promise<string>((c, e) => realpath(`${path.dirname(this.snap)}/current`, (err, r) => err ? e(err) : c(r)));
 		const currentRevision = path.basename(resolvedCurrentSnapPath);
 		return this.snapRevision !== currentRevision;


### PR DESCRIPTION
This patch removes the need for snapUpdate.sh. This has the following benefits:
+Simplifies the build process by avoiding setting and moving the file.
+Avoids creating a new shell that simply spawns another shell environment.
+Simplifies the update mechanism by removing the need to track the existence of snapUpdate.sh.
+Keeps the logic for snapUpdate.sh close to updateService.snap.ts


I have tested the code changes to spawn within a Node environment in vscode console and it correctly spawns another instance of vscode.

If this patch isn't wanted, there are still some changes that may be suggested. For example, currently updateService.linux.ts is calling snapUpdate.sh but the default Linux builds aren't being built with the script. Similarly, the comment for executing snapUpdate.sh isn't correct.

Running the command 'grep -nr --exclude-dir=".git" 'snapUpdate.sh' .' produces no results so I assume I have removed all references.