### PR TITLE
Makefile grammar updating: tests are updated about the handling @, - and +

### DIFF
--- a/extensions/make/test/colorize-fixtures/makefile
+++ b/extensions/make/test/colorize-fixtures/makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: hello
+all: echo hello
 
 .PHONY: hello
 hello: main.o factorial.o \
@@ -25,8 +25,8 @@ hello.o: hello.cpp \
 clean:
 	rm *o hello
 
-.PHONY: all
-all:
+.PHONY: var
+var:
 	# "$$" in a shell means to escape makefile's variable substitution.
 	some_shell_var=$$(sed -nre 's/some regex with (group)/\1/p')
 
@@ -34,6 +34,10 @@ all:
 echo:
 	echo "#" and '#' in quotes are not comments \
 		and '\' will be continued
+	@echo Shell is not printed out, just a message.
+	@-+-+echo Error will be ignored here; invalidcommand
+	# And we can see variables are highlited as supposed to be:
+	@echo '$(CC) $(shell echo "123") -o $@'
 
 define defined
   $(info Checking existance of $(1) $(flavor $(1)))

--- a/extensions/make/test/colorize-results/makefile.json
+++ b/extensions/make/test/colorize-results/makefile.json
@@ -55,7 +55,7 @@
 		}
 	},
 	{
-		"c": " hello",
+		"c": " echo hello",
 		"t": "source.makefile meta.scope.target.makefile meta.scope.prerequisites.makefile",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
@@ -715,7 +715,7 @@
 		}
 	},
 	{
-		"c": " all",
+		"c": " var",
 		"t": "source.makefile meta.scope.target.makefile meta.scope.prerequisites.makefile",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
@@ -726,7 +726,7 @@
 		}
 	},
 	{
-		"c": "all",
+		"c": "var",
 		"t": "source.makefile meta.scope.target.makefile entity.name.function.target.makefile",
 		"r": {
 			"dark_plus": "entity.name.function: #DCDCAA",
@@ -892,6 +892,259 @@
 	},
 	{
 		"c": "\t\tand '\\' will be continued",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "\t",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "@",
+		"t": "source.makefile meta.scope.recipe.makefile keyword.control.@.makefile",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": "echo Shell is not printed out, just a message.",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "\t",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "@-+-+",
+		"t": "source.makefile meta.scope.recipe.makefile keyword.control.@-+-+.makefile",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": "echo Error will be ignored here; invalidcommand",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "\t",
+		"t": "source.makefile punctuation.whitespace.comment.leading.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.makefile comment.line.number-sign.makefile punctuation.definition.comment.makefile",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " And we can see variables are highlited as supposed to be:",
+		"t": "source.makefile comment.line.number-sign.makefile",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "\t",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "@",
+		"t": "source.makefile meta.scope.recipe.makefile keyword.control.@.makefile",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": "echo '",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "$(",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile punctuation.definition.variable.makefile",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "CC",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile variable.other.makefile",
+		"r": {
+			"dark_plus": "variable: #9CDCFE",
+			"light_plus": "variable: #001080",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": ")",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile punctuation.definition.variable.makefile",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "$(",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile punctuation.definition.variable.makefile",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "shell",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile meta.scope.function-call.makefile support.function.shell.makefile",
+		"r": {
+			"dark_plus": "support.function: #DCDCAA",
+			"light_plus": "support.function: #795E26",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "support.function: #DCDCAA"
+		}
+	},
+	{
+		"c": " echo \"123\"",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile meta.scope.function-call.makefile",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ")",
+		"t": "source.makefile meta.scope.recipe.makefile string.interpolated.makefile punctuation.definition.variable.makefile",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": " -o ",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "$@",
+		"t": "source.makefile meta.scope.recipe.makefile variable.language.makefile",
+		"r": {
+			"dark_plus": "variable.language: #569CD6",
+			"light_plus": "variable.language: #0000FF",
+			"dark_vs": "variable.language: #569CD6",
+			"light_vs": "variable.language: #0000FF",
+			"hc_black": "variable: #9CDCFE"
+		}
+	},
+	{
+		"c": "'",
 		"t": "source.makefile meta.scope.recipe.makefile",
 		"r": {
 			"dark_plus": "default: #D4D4D4",


### PR DESCRIPTION
1. @, - and + in the beginning of recipes are colored.
2. Shell in recipes is not colored by shellscript extension anymore:
improper colorizing of Makefile variables, low suitability.

About the pull request: the diff is mostly about the disabling a shellscript colorizing inside the Makefile, so there are joined lines like a _"c": "(sed -nre 's/some regex with (group)/\\1/p')"_. You can see _echo "#" and '#'..._ without shellscript colorization, but it's expected: you can see the last line on the screenshot looks better with proper highlight of Makefile variables, which is desirable behavior.

Tests will work after updating the grammar from the upstream.

Shellscript coloring makes more harm than advantage: Makefile treats $(variable) with absolute high priority under processing, and shellscript extension is not able to handle those rules, confusing the developer. Also there are problems to consistently colorize $(shell ..) and !=.

**Before:**
![before](https://user-images.githubusercontent.com/5967447/50387979-00753d80-0712-11e9-93a0-17b4770c2608.jpg)
**After:**
![after](https://user-images.githubusercontent.com/5967447/50387980-02d79780-0712-11e9-8194-62e90cfce696.jpg)
