### PR TITLE
Converted editor.test.ts and related to strictNullChecks

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -807,7 +807,11 @@
 		"./vs/workbench/test/common/editor/editorOptions.test.ts",
 		"./vs/workbench/test/common/notifications.test.ts",
 		"./vs/workbench/test/electron-browser/api/extHostTypes.test.ts",
-		"./vs/workbench/test/electron-browser/api/mock.ts"
+		"./vs/workbench/test/electron-browser/api/mock.ts",
+		"./vs/editor/contrib/find/test/findModel.test.ts",
+		"./vs/workbench/services/editor/test/browser/editorService.test.ts",
+		"./vs/workbench/services/textfile/test/textFileEditorModel.test.ts",
+		"./vs/workbench/test/common/editor/editor.test.ts"
 	],
 	"exclude": [
 		"./typings/require-monaco.d.ts"

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -770,42 +770,42 @@ export interface IActiveCodeEditor extends ICodeEditor {
 	/**
 	 * Returns the primary position of the cursor.
 	 */
-	getPosition(): Position;
+	getPosition(): Position | null;
 
 	/**
 	 * Returns the primary selection of the editor.
 	 */
-	getSelection(): Selection;
+	getSelection(): Selection | null;
 
 	/**
 	 * Returns all the selections of the editor.
 	 */
-	getSelections(): Selection[];
+	getSelections(): Selection[] | null;
 
 	/**
 	 * Saves current view state of the editor in a serializable object.
 	 */
-	saveViewState(): editorCommon.ICodeEditorViewState;
+	saveViewState(): editorCommon.ICodeEditorViewState | null;
 
 	/**
 	 * Type the getModel() of IEditor.
 	 */
-	getModel(): ITextModel;
+	getModel(): ITextModel | null;
 
 	/**
 	 * @internal
 	 */
-	_getCursors(): ICursors;
+	_getCursors(): ICursors | null;
 
 	/**
 	 * Get all the decorations on a line (filtering out decorations from other editors).
 	 */
-	getLineDecorations(lineNumber: number): IModelDecoration[];
+	getLineDecorations(lineNumber: number): IModelDecoration[] | null;
 
 	/**
 	 * Returns the editor's dom node
 	 */
-	getDomNode(): HTMLElement;
+	getDomNode(): HTMLElement | null;
 
 	/**
 	 * Get the visible position for `position`.
@@ -814,7 +814,7 @@ export interface IActiveCodeEditor extends ICodeEditor {
 	 * Explanation 2: the results of this method will not change if the container of the editor gets repositioned.
 	 * Warning: the results of this method are inaccurate for positions that are outside the current editor viewport.
 	 */
-	getScrolledVisiblePosition(position: IPosition): { top: number; left: number; height: number; };
+	getScrolledVisiblePosition(position: IPosition): { top: number; left: number; height: number; } | null;
 }
 
 /**

--- a/src/vs/editor/contrib/find/test/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/findModel.test.ts
@@ -1505,7 +1505,7 @@ suite('FindModel', () => {
 			]
 		);
 
-		editor.getModel().setValue('hello\nhi');
+		editor.getModel()!.setValue('hello\nhi');
 		assertFindState(
 			editor,
 			[1, 1, 1, 1],
@@ -1536,7 +1536,7 @@ suite('FindModel', () => {
 
 		findModel.selectAllMatches();
 
-		assert.deepEqual(editor.getSelections().map(s => s.toString()), [
+		assert.deepEqual(editor.getSelections()!.map(s => s.toString()), [
 			new Selection(6, 14, 6, 19),
 			new Selection(6, 27, 6, 32),
 			new Selection(7, 14, 7, 19),
@@ -1580,14 +1580,14 @@ suite('FindModel', () => {
 
 		findModel.selectAllMatches();
 
-		assert.deepEqual(editor.getSelections().map(s => s.toString()), [
+		assert.deepEqual(editor.getSelections()!.map(s => s.toString()), [
 			new Selection(7, 14, 7, 19),
 			new Selection(6, 14, 6, 19),
 			new Selection(6, 27, 6, 32),
 			new Selection(8, 14, 8, 19)
 		].map(s => s.toString()));
 
-		assert.deepEqual(editor.getSelection().toString(), new Selection(7, 14, 7, 19).toString());
+		assert.deepEqual(editor.getSelection()!.toString(), new Selection(7, 14, 7, 19).toString());
 
 		assertFindState(
 			editor,
@@ -1982,7 +1982,7 @@ suite('FindModel', () => {
 		for (let i = 0; i < 1100; i++) {
 			initialText += 'line' + i + '\n';
 		}
-		editor.getModel().setValue(initialText);
+		editor.getModel()!.setValue(initialText);
 		let findState = new FindReplaceState();
 		findState.change({ searchString: '^', replaceString: 'a ', isRegex: true }, false);
 		let findModel = new FindModelBoundToEditorModel(editor, findState);
@@ -1994,7 +1994,7 @@ suite('FindModel', () => {
 			expectedText += 'a line' + i + '\n';
 		}
 		expectedText += 'a ';
-		assert.equal(editor.getModel().getValue(), expectedText);
+		assert.equal(editor.getModel()!.getValue(), expectedText);
 
 		findModel.dispose();
 		findState.dispose();

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -91,7 +91,7 @@ export interface IEditor {
 	/**
 	 * Returns the underlying control of this editor.
 	 */
-	getControl(): IEditorControl;
+	getControl(): IEditorControl | null;
 
 	/**
 	 * Asks the underlying control to focus.
@@ -957,7 +957,7 @@ export interface IResourceOptions {
 	filter?: string | string[];
 }
 
-export function toResource(editor: IEditorInput, options?: IResourceOptions): URI | null {
+export function toResource(editor: IEditorInput | null, options?: IResourceOptions): URI | null {
 	if (!editor) {
 		return null;
 	}

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -53,7 +53,7 @@ export class TestEditorInput extends EditorInput implements IFileEditorInput {
 	resolve(): Promise<IEditorModel> { return !this.fails ? Promise.resolve(null) : Promise.reject(new Error('fails')); }
 	matches(other: TestEditorInput): boolean { return other && other.resource && this.resource.toString() === other.resource.toString() && other instanceof TestEditorInput; }
 	setEncoding(encoding: string) { }
-	getEncoding(): string { return null; }
+	getEncoding(): string { return null!; }
 	setPreferredEncoding(encoding: string) { }
 	getResource(): URI { return this.resource; }
 	setForceOpenAsBinary(): void { }
@@ -261,7 +261,7 @@ suite('Editor service', () => {
 		class MyEditor extends BaseEditor {
 
 			constructor(id: string) {
-				super(id, null, new TestThemeService(), new TestStorageService());
+				super(id, null!, new TestThemeService(), new TestStorageService());
 			}
 
 			getId(): string {

--- a/src/vs/workbench/services/textfile/test/textFileEditorModel.test.ts
+++ b/src/vs/workbench/services/textfile/test/textFileEditorModel.test.ts
@@ -40,7 +40,7 @@ suite('Files - TextFileEditorModel', () => {
 
 	teardown(() => {
 		(<TextFileEditorModelManager>accessor.textFileService.models).clear();
-		TextFileEditorModel.setSaveParticipant(null); // reset any set participant
+		TextFileEditorModel.setSaveParticipant(null!); // reset any set participant
 		accessor.fileService.setContent(content);
 	});
 
@@ -337,7 +337,7 @@ suite('Files - TextFileEditorModel', () => {
 		assert.ok(!sequentializer.pendingSave);
 
 		// pending removes itself after done
-		return sequentializer.setPending(1, Promise.resolve(null)).then(() => {
+		return sequentializer.setPending(1, Promise.resolve(null!)).then(() => {
 			assert.ok(!sequentializer.hasPendingSave());
 			assert.ok(!sequentializer.hasPendingSave(1));
 			assert.ok(!sequentializer.pendingSave);
@@ -361,11 +361,11 @@ suite('Files - TextFileEditorModel', () => {
 		const sequentializer = new SaveSequentializer();
 
 		let pendingDone = false;
-		sequentializer.setPending(1, timeout(1).then(() => { pendingDone = true; return null; }));
+		sequentializer.setPending(1, timeout(1).then(() => { pendingDone = true; return null!; }));
 
 		// next finishes instantly
 		let nextDone = false;
-		const res = sequentializer.setNext(() => Promise.resolve(null).then(() => { nextDone = true; return null; }));
+		const res = sequentializer.setNext(() => Promise.resolve(null).then(() => { nextDone = true; return null!; }));
 
 		return res.then(() => {
 			assert.ok(pendingDone);
@@ -377,11 +377,11 @@ suite('Files - TextFileEditorModel', () => {
 		const sequentializer = new SaveSequentializer();
 
 		let pendingDone = false;
-		sequentializer.setPending(1, timeout(1).then(() => { pendingDone = true; return null; }));
+		sequentializer.setPending(1, timeout(1).then(() => { pendingDone = true; return null!; }));
 
 		// next finishes after timeout
 		let nextDone = false;
-		const res = sequentializer.setNext(() => timeout(1).then(() => { nextDone = true; return null; }));
+		const res = sequentializer.setNext(() => timeout(1).then(() => { nextDone = true; return null!; }));
 
 		return res.then(() => {
 			assert.ok(pendingDone);
@@ -393,17 +393,17 @@ suite('Files - TextFileEditorModel', () => {
 		const sequentializer = new SaveSequentializer();
 
 		let pendingDone = false;
-		sequentializer.setPending(1, timeout(1).then(() => { pendingDone = true; return null; }));
+		sequentializer.setPending(1, timeout(1).then(() => { pendingDone = true; return null!; }));
 
 		// next finishes after timeout
 		let firstDone = false;
-		let firstRes = sequentializer.setNext(() => timeout(2).then(() => { firstDone = true; return null; }));
+		let firstRes = sequentializer.setNext(() => timeout(2).then(() => { firstDone = true; return null!; }));
 
 		let secondDone = false;
-		let secondRes = sequentializer.setNext(() => timeout(3).then(() => { secondDone = true; return null; }));
+		let secondRes = sequentializer.setNext(() => timeout(3).then(() => { secondDone = true; return null!; }));
 
 		let thirdDone = false;
-		let thirdRes = sequentializer.setNext(() => timeout(4).then(() => { thirdDone = true; return null; }));
+		let thirdRes = sequentializer.setNext(() => timeout(4).then(() => { thirdDone = true; return null!; }));
 
 		return Promise.all([firstRes, secondRes, thirdRes]).then(() => {
 			assert.ok(pendingDone);

--- a/src/vs/workbench/test/common/editor/editor.test.ts
+++ b/src/vs/workbench/test/common/editor/editor.test.ts
@@ -33,7 +33,7 @@ class FileEditorInput extends EditorInput {
 	}
 
 	resolve(): Promise<IEditorModel> {
-		return Promise.resolve(null);
+		return Promise.resolve(null!);
 	}
 }
 
@@ -59,18 +59,18 @@ suite('Workbench editor', () => {
 
 		const untitled = service.createOrGet();
 
-		assert.equal(toResource(untitled).toString(), untitled.getResource().toString());
-		assert.equal(toResource(untitled, { supportSideBySide: true }).toString(), untitled.getResource().toString());
-		assert.equal(toResource(untitled, { filter: Schemas.untitled }).toString(), untitled.getResource().toString());
-		assert.equal(toResource(untitled, { filter: [Schemas.file, Schemas.untitled] }).toString(), untitled.getResource().toString());
+		assert.equal(toResource(untitled)!.toString(), untitled.getResource().toString());
+		assert.equal(toResource(untitled, { supportSideBySide: true })!.toString(), untitled.getResource().toString());
+		assert.equal(toResource(untitled, { filter: Schemas.untitled })!.toString(), untitled.getResource().toString());
+		assert.equal(toResource(untitled, { filter: [Schemas.file, Schemas.untitled] })!.toString(), untitled.getResource().toString());
 		assert.ok(!toResource(untitled, { filter: Schemas.file }));
 
 		const file = new FileEditorInput(URI.file('/some/path.txt'));
 
-		assert.equal(toResource(file).toString(), file.getResource().toString());
-		assert.equal(toResource(file, { supportSideBySide: true }).toString(), file.getResource().toString());
-		assert.equal(toResource(file, { filter: Schemas.file }).toString(), file.getResource().toString());
-		assert.equal(toResource(file, { filter: [Schemas.file, Schemas.untitled] }).toString(), file.getResource().toString());
+		assert.equal(toResource(file)!.toString(), file.getResource().toString());
+		assert.equal(toResource(file, { supportSideBySide: true })!.toString(), file.getResource().toString());
+		assert.equal(toResource(file, { filter: Schemas.file })!.toString(), file.getResource().toString());
+		assert.equal(toResource(file, { filter: [Schemas.file, Schemas.untitled] })!.toString(), file.getResource().toString());
 		assert.ok(!toResource(file, { filter: Schemas.untitled }));
 
 		const diffEditorInput = new DiffEditorInput('name', 'description', untitled, file);
@@ -79,8 +79,8 @@ suite('Workbench editor', () => {
 		assert.ok(!toResource(diffEditorInput, { filter: Schemas.file }));
 		assert.ok(!toResource(diffEditorInput, { supportSideBySide: false }));
 
-		assert.equal(toResource(file, { supportSideBySide: true }).toString(), file.getResource().toString());
-		assert.equal(toResource(file, { supportSideBySide: true, filter: Schemas.file }).toString(), file.getResource().toString());
-		assert.equal(toResource(file, { supportSideBySide: true, filter: [Schemas.file, Schemas.untitled] }).toString(), file.getResource().toString());
+		assert.equal(toResource(file, { supportSideBySide: true })!.toString(), file.getResource().toString());
+		assert.equal(toResource(file, { supportSideBySide: true, filter: Schemas.file })!.toString(), file.getResource().toString());
+		assert.equal(toResource(file, { supportSideBySide: true, filter: [Schemas.file, Schemas.untitled] })!.toString(), file.getResource().toString());
 	});
 });


### PR DESCRIPTION
Continues #60565 for converting tests. A few files used TypeStat to add `!`s but the following interface changes were manually inferred from implementing classes:
* `IActiveCodeEditor`'s methods can all return `null`
* `IEditor` needs to report `getControl(): IEdotorControl | null` because `BaseEditor`'s `getControl` can return `null`

Edit: Same as #65672 build is failing on files I didn't touch for parts that don't interact with my changes 😕. Very confusing. Does anybody know why?