### PR TITLE
Fix endLineNumber assignment in Problem Matcher

### DIFF
--- a/src/vs/workbench/parts/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/parts/tasks/common/problemMatcher.ts
@@ -289,7 +289,7 @@ abstract class AbstractLineMatcher implements ILineMatcher {
 					severity: this.getSeverity(data),
 					startLineNumber: location.startLineNumber,
 					startColumn: location.startCharacter,
-					endLineNumber: location.startLineNumber,
+					endLineNumber: location.endLineNumber,
 					endColumn: location.endCharacter,
 					message: data.message
 				};


### PR DESCRIPTION
This misassignement causes endLineNumber to be ignored when defining a problem matcher and therefore problems are only marked on one line.