### PR TITLE
Update: Use babel icon for babel.config.js file in seti theme

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -1470,7 +1470,7 @@
 		"procfile": "_heroku",
 		"todo": "_todo",
 		"npm-debug.log": "_npm_ignored",
-		"babel.config.js": "_babel",
+		"babel.config.js": "_babel"
 	},
 	"languageIds": {
 		"bat": "_windows",
@@ -1819,7 +1819,7 @@
 			"cmakelists.txt": "_makefile_3_light",
 			"procfile": "_heroku_light",
 			"npm-debug.log": "_npm_ignored_light",
-			"babel.config.js": "_babel_light",
+			"babel.config.js": "_babel_light"
 		}
 	},
 	"version": "https://github.com/jesseweed/seti-ui/commit/7714a720646300bb8f6d1690752cd71f50991414"

--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -1469,7 +1469,8 @@
 		"cmakelists.txt": "_makefile_3",
 		"procfile": "_heroku",
 		"todo": "_todo",
-		"npm-debug.log": "_npm_ignored"
+		"npm-debug.log": "_npm_ignored",
+		"babel.config.js": "_babel",
 	},
 	"languageIds": {
 		"bat": "_windows",
@@ -1817,7 +1818,8 @@
 			"omakefile": "_makefile_2_light",
 			"cmakelists.txt": "_makefile_3_light",
 			"procfile": "_heroku_light",
-			"npm-debug.log": "_npm_ignored_light"
+			"npm-debug.log": "_npm_ignored_light",
+			"babel.config.js": "_babel_light",
 		}
 	},
 	"version": "https://github.com/jesseweed/seti-ui/commit/7714a720646300bb8f6d1690752cd71f50991414"


### PR DESCRIPTION
### What was done in this PR?
* Updated code to use babel icon for babel.config.js file

### What files does it affect?
* vs-seti-icon-theme.json

### Acceptance / Testing criteria:
1. Go to vscode, use seti theme and make a new file with name 'babel.config.js'
2. Now it will show babel icon.