### PR TITLE
Fix microsoft/vscode-pull-request-github#612. Allow fetching with limited depths

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -168,8 +168,8 @@ export class ApiRepository implements Repository {
 		return this._repository.removeRemote(name);
 	}
 
-	fetch(remote?: string | undefined, ref?: string | undefined): Promise<void> {
-		return this._repository.fetch(remote, ref);
+	fetch(remote?: string | undefined, ref?: string | undefined, depth?: number | undefined): Promise<void> {
+		return this._repository.fetch(remote, ref, depth);
 	}
 
 	pull(): Promise<void> {

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -153,7 +153,7 @@ export interface Repository {
 	addRemote(name: string, url: string): Promise<void>;
 	removeRemote(name: string): Promise<void>;
 
-	fetch(remote?: string, ref?: string): Promise<void>;
+	fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
 	pull(): Promise<void>;
 	push(remoteName?: string, branchName?: string, setUpstream?: boolean): Promise<void>;
 }

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1166,7 +1166,7 @@ export class Repository {
 		await this.run(args);
 	}
 
-	async fetch(options: { remote?: string, ref?: string, all?: boolean, prune?: boolean } = {}): Promise<void> {
+	async fetch(options: { remote?: string, ref?: string, all?: boolean, prune?: boolean, depth?: number } = {}): Promise<void> {
 		const args = ['fetch'];
 
 		if (options.remote) {
@@ -1183,6 +1183,9 @@ export class Repository {
 			args.push('--prune');
 		}
 
+		if (options.depth) {
+			args.push(`--depth=${options.depth}`);
+		}
 
 		try {
 			await this.run(args);
@@ -1198,7 +1201,7 @@ export class Repository {
 	}
 
 	async pull(rebase?: boolean, remote?: string, branch?: string): Promise<void> {
-		const args = ['pull', '--tags'];
+		const args = ['pull', '--tags', '--unshallow'];
 
 		if (rebase) {
 			args.push('-r');

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -908,8 +908,8 @@ export class Repository implements Disposable {
 		await this.run(Operation.Fetch, () => this.repository.fetch({ all: true }));
 	}
 
-	async fetch(remote?: string, ref?: string): Promise<void> {
-		await this.run(Operation.Fetch, () => this.repository.fetch({ remote, ref }));
+	async fetch(remote?: string, ref?: string, depth?: number): Promise<void> {
+		await this.run(Operation.Fetch, () => this.repository.fetch({ remote, ref, depth }));
 	}
 
 	@throttle


### PR DESCRIPTION
Add a new option for `fetch` api: `depth?: number | undefined` to allow us to fetch a branch with limited history and speed up branch switching.

However I'm not sure what I should do to allow `pull --unshallow`. It seems that we don't support any option for `pull` and we add `--tags` ourselves, so I follow the same logic by adding `--unshallow`. @joaomoreno probably has better ideas of whether I should just add a parameter for options.