### PR TITLE
fix named multiline problem pattern parsing

### DIFF
--- a/src/vs/workbench/parts/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/parts/tasks/common/problemMatcher.ts
@@ -823,11 +823,6 @@ export class ProblemPatternParser extends Parser {
 	public parse(value: Config.NamedProblemPattern): NamedProblemPattern;
 	public parse(value: Config.NamedMultiLineCheckedProblemPattern): NamedMultiLineProblemPattern;
 	public parse(value: Config.ProblemPattern | Config.MultiLineProblemPattern | Config.NamedProblemPattern | Config.NamedMultiLineCheckedProblemPattern): any {
-		if ((Config.MultiLineProblemPattern.is(value) && !Config.MultiLineCheckedProblemPattern.is(value)) ||
-			(!Config.MultiLineProblemPattern.is(value) && !Config.CheckedProblemPattern.is(value))) {
-			this.error(localize('ProblemPatternParser.problemPattern.missingRegExp', 'The problem pattern is missing a regular expression.'));
-		}
-
 		if (Config.NamedMultiLineCheckedProblemPattern.is(value)) {
 			return this.createNamedMultiLineProblemPattern(value);
 		} else if (Config.MultiLineCheckedProblemPattern.is(value)) {
@@ -839,6 +834,7 @@ export class ProblemPatternParser extends Parser {
 		} else if (Config.CheckedProblemPattern.is(value)) {
 			return this.createSingleProblemPattern(value);
 		} else {
+			this.error(localize('ProblemPatternParser.problemPattern.missingRegExp', 'The problem pattern is missing a regular expression.'));
 			return null;
 		}
 	}

--- a/src/vs/workbench/parts/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/parts/tasks/common/problemMatcher.ts
@@ -625,16 +625,15 @@ export namespace Config {
 
 	export namespace MultiLineCheckedProblemPattern {
 		export function is(value: any): value is MultiLineCheckedProblemPattern {
-			let is = false;
-			if (value && Types.isArray(value)) {
-				is = true;
-				value.forEach(element => {
-					if (!Config.CheckedProblemPattern.is(element)) {
-						is = false;
-					}
-				});
+			if (!MultiLineProblemPattern.is(value)) {
+				return false;
 			}
-			return is;
+			for (const element of value) {
+				if (!Config.CheckedProblemPattern.is(element)) {
+					return false;
+				}
+			}
+			return true;
 		}
 	}
 


### PR DESCRIPTION
Before an error was being generated for valid named multiline problem patterns like this:
```json
"problemPatterns": [
    {
        "name": "rustc",
        "patterns": [
            {
                "regexp": "^(warning|warn|error)(?:\\[(.*?)\\])?: (.*)$",
                "severity": 1,
                "code": 2,
                "message": 3
            },
            {
                "regexp": "^[\\s->=]*(.*?):(\\d*):(\\d*)\\s*$",
                "file": 1,
                "line": 2,
                "column": 3
            }
        ]
    }
],
```
And when an error was generated the pattern was ignored.

This PR fixes that.