### PR TITLE
Clean user input for git clone extension

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -405,6 +405,8 @@ export class CommandCenter {
 			return;
 		}
 
+		url = this.cleanCloneUrlInput(url);
+
 		const config = workspace.getConfiguration('git');
 		let defaultCloneDirectory = config.get<string>('defaultCloneDirectory') || os.homedir();
 		defaultCloneDirectory = defaultCloneDirectory.replace(/^~/, os.homedir());
@@ -492,6 +494,14 @@ export class CommandCenter {
 
 			throw err;
 		}
+	}
+
+	private cleanCloneUrlInput(url: string): string {
+		url = url.trim();
+		if (url.startsWith('git clone ')) {
+			return url.replace('git clone ', '');
+		}
+		return url;
 	}
 
 	@command('git.init')


### PR DESCRIPTION
Strip whitespace and "git clone " from start of string. This will allow
VSCode to intelligently handle copy and paste from command line
instructions being pasted into the clone input box.

---

I've created this PR because there have been a few times I have just copy-pasted a git clone command into the clone box, and the failure message is not very intuitive as to what went wrong.

This is my first PR, so please let me know if anything is missing here, or if the code is not up to standard or could be harmful. I have tried to keep the scope of the input clean as minimal as possible for this reason.