### PR TITLE
Re-enable link detection (fixes #34026)

### DIFF
--- a/src/vs/workbench/parts/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/parts/debug/browser/debugANSIHandling.ts
@@ -120,15 +120,7 @@ export function appendStylizedStringToContainer(root: HTMLElement, stringContent
 		return;
 	}
 
-	const content = linkDetector.handleLinks(stringContent);
-	let container: HTMLElement;
-
-	if (typeof content === 'string') {
-		container = document.createElement('span');
-		container.textContent = content;
-	} else {
-		container = content;
-	}
+	const container = linkDetector.handleLinks(stringContent);
 
 	container.className = cssClasses.join(' ');
 	root.appendChild(container);

--- a/src/vs/workbench/parts/debug/browser/exceptionWidget.ts
+++ b/src/vs/workbench/parts/debug/browser/exceptionWidget.ts
@@ -80,22 +80,8 @@ export class ExceptionWidget extends ZoneWidget {
 		if (this.exceptionInfo.details && this.exceptionInfo.details.stackTrace) {
 			let stackTrace = $('.stack-trace');
 			const linkDetector = this.instantiationService.createInstance(LinkDetector);
-
-			const stackTraceContainer = document.createElement('span');
-
-			// Detect links one line at a time so we don't go over the detector's character limit
-			const lines = this.exceptionInfo.details.stackTrace.split('\n');
-			lines.forEach((line, index) => {
-				let linkedLine = linkDetector.handleLinks(line + '\n');
-				if (typeof linkedLine === 'string') {
-					const span = document.createElement('span');
-					span.textContent = linkedLine;
-					linkedLine = span;
-				}
-				stackTraceContainer.appendChild(linkedLine);
-			});
-
-			stackTrace.appendChild(stackTraceContainer);
+			const linkedStackTrace = linkDetector.handleLinks(this.exceptionInfo.details.stackTrace);
+			stackTrace.appendChild(linkedStackTrace);
 			dom.append(container, stackTrace);
 		}
 	}

--- a/src/vs/workbench/parts/debug/browser/exceptionWidget.ts
+++ b/src/vs/workbench/parts/debug/browser/exceptionWidget.ts
@@ -80,8 +80,22 @@ export class ExceptionWidget extends ZoneWidget {
 		if (this.exceptionInfo.details && this.exceptionInfo.details.stackTrace) {
 			let stackTrace = $('.stack-trace');
 			const linkDetector = this.instantiationService.createInstance(LinkDetector);
-			const linkedStackTrace = linkDetector.handleLinks(this.exceptionInfo.details.stackTrace);
-			typeof linkedStackTrace === 'string' ? stackTrace.textContent = linkedStackTrace : stackTrace.appendChild(linkedStackTrace);
+
+			const stackTraceContainer = document.createElement('span');
+
+			// Detect links one line at a time so we don't go over the detector's character limit
+			const lines = this.exceptionInfo.details.stackTrace.split('\n');
+			lines.forEach((line, index) => {
+				let linkedLine = linkDetector.handleLinks(line + '\n');
+				if (typeof linkedLine === 'string') {
+					const span = document.createElement('span');
+					span.textContent = linkedLine;
+					linkedLine = span;
+				}
+				stackTraceContainer.appendChild(linkedLine);
+			});
+
+			stackTrace.appendChild(stackTraceContainer);
 			dom.append(container, stackTrace);
 		}
 	}

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -19,7 +19,8 @@ export class LinkDetector {
 		// group 3: line number, matched by (:(\d+))
 		// group 4: column number, matched by ((?::(\d+))?)
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g
+		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g,
+		/module/ig,
 	];
 
 	constructor(
@@ -78,7 +79,7 @@ export class LinkDetector {
 						continue;
 					}
 
-					let textBeforeLink = line.substring(lastMatchIndex, match.index);
+					const textBeforeLink = line.substring(lastMatchIndex, match.index);
 					if (textBeforeLink) {
 						// textBeforeLink may have matches for other patterns, so we run handleLinks on it before adding it.
 						lineContainer.appendChild(this.handleLinks(textBeforeLink));
@@ -98,12 +99,17 @@ export class LinkDetector {
 
 					// Append last string part if no more link matches
 					if (!match) {
-						let textAfterLink = line.substr(currentMatch.index + currentMatch[0].length);
+						const textAfterLink = line.substr(currentMatch.index + currentMatch[0].length);
 						if (textAfterLink) {
 							// textAfterLink may have matches for other patterns, so we run handleLinks on it before adding it.
 							lineContainer.appendChild(this.handleLinks(textAfterLink));
 						}
 					}
+				}
+
+				// If we found a match, don't check any more patterns
+				if (lineContainer.hasChildNodes()) {
+					break;
 				}
 			}
 

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -78,7 +78,7 @@ export class LinkDetector {
 						continue;
 					}
 
-					let textBeforeLink = line.substring(lastMatchIndex, match.index);
+					const textBeforeLink = line.substring(lastMatchIndex, match.index);
 					if (textBeforeLink) {
 						// textBeforeLink may have matches for other patterns, so we run handleLinks on it before adding it.
 						lineContainer.appendChild(this.handleLinks(textBeforeLink));
@@ -98,12 +98,17 @@ export class LinkDetector {
 
 					// Append last string part if no more link matches
 					if (!match) {
-						let textAfterLink = line.substr(currentMatch.index + currentMatch[0].length);
+						const textAfterLink = line.substr(currentMatch.index + currentMatch[0].length);
 						if (textAfterLink) {
 							// textAfterLink may have matches for other patterns, so we run handleLinks on it before adding it.
 							lineContainer.appendChild(this.handleLinks(textAfterLink));
 						}
 					}
+				}
+
+				// If we found any matches for this pattern, don't check any more patterns
+				if (lineContainer.hasChildNodes()) {
+					break;
 				}
 			}
 

--- a/src/vs/workbench/parts/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/parts/debug/browser/linkDetector.ts
@@ -19,8 +19,7 @@ export class LinkDetector {
 		// group 3: line number, matched by (:(\d+))
 		// group 4: column number, matched by ((?::(\d+))?)
 		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
-		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g,
-		/module/ig,
+		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g
 	];
 
 	constructor(
@@ -79,7 +78,7 @@ export class LinkDetector {
 						continue;
 					}
 
-					const textBeforeLink = line.substring(lastMatchIndex, match.index);
+					let textBeforeLink = line.substring(lastMatchIndex, match.index);
 					if (textBeforeLink) {
 						// textBeforeLink may have matches for other patterns, so we run handleLinks on it before adding it.
 						lineContainer.appendChild(this.handleLinks(textBeforeLink));
@@ -99,17 +98,12 @@ export class LinkDetector {
 
 					// Append last string part if no more link matches
 					if (!match) {
-						const textAfterLink = line.substr(currentMatch.index + currentMatch[0].length);
+						let textAfterLink = line.substr(currentMatch.index + currentMatch[0].length);
 						if (textAfterLink) {
 							// textAfterLink may have matches for other patterns, so we run handleLinks on it before adding it.
 							lineContainer.appendChild(this.handleLinks(textAfterLink));
 						}
 					}
-				}
-
-				// If we found a match, don't check any more patterns
-				if (lineContainer.hasChildNodes()) {
-					break;
 				}
 			}
 

--- a/src/vs/workbench/parts/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/parts/debug/test/browser/linkDetector.test.ts
@@ -75,9 +75,9 @@ suite('Debug - Link Detector', () => {
 	});
 
 	test('singleLineLinkAndText', function () {
-		var input = isWindows ? 'The link: C:/foo/bar.js:12:34' : 'The link: /Users/foo/bar.js:12:34';
-		var expectedOutput = /^<span><span>The link: <\/span><a title=".*">.*\/foo\/bar.js:12:34<\/a><\/span>$/;
-		var output = linkDetector.handleLinks(input);
+		const input = isWindows ? 'The link: C:/foo/bar.js:12:34' : 'The link: /Users/foo/bar.js:12:34';
+		const expectedOutput = /^<span><span>The link: <\/span><a title=".*">.*\/foo\/bar.js:12:34<\/a><\/span>$/;
+		const output = linkDetector.handleLinks(input);
 
 		assert.equal(2, output.children.length);
 		assert.equal('SPAN', output.tagName);

--- a/src/vs/workbench/parts/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/parts/debug/test/browser/linkDetector.test.ts
@@ -104,7 +104,7 @@ suite('Debug - Link Detector', () => {
 		assertElementIsLink(output.children[1]);
 		assertElementIsLink(output.children[3]);
 		assert.equal(isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34', output.children[1].textContent);
-		assert.equal(isWindows ? 'C:/boo/far.js:56:78' : '/Users/boo/far.js:56:78', output.children[3].textContent);
+		assert.equal(isWindows ? 'D:/boo/far.js:56:78' : '/Users/boo/far.js:56:78', output.children[3].textContent);
 	});
 
 	test('multilineNoLinks', () => {

--- a/src/vs/workbench/parts/debug/test/browser/linkDetector.test.ts
+++ b/src/vs/workbench/parts/debug/test/browser/linkDetector.test.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { workbenchInstantiationService } from 'vs/workbench/test/workbenchTestServices';
+import { LinkDetector } from 'vs/workbench/parts/debug/browser/linkDetector';
+import { isWindows } from 'vs/base/common/platform';
+
+suite('Debug - Link Detector', () => {
+
+	let linkDetector: LinkDetector;
+
+	/**
+	 * Instantiate a {@link LinkDetector} for use by the functions being tested.
+	 */
+	setup(() => {
+		const instantiationService: TestInstantiationService = <TestInstantiationService>workbenchInstantiationService();
+		linkDetector = instantiationService.createInstance(LinkDetector);
+	});
+
+	/**
+	 * Assert that a given Element is an anchor element with an onClick event.
+	 *
+	 * @param element The Element to verify.
+	 */
+	function assertElementIsLink(element: Element) {
+		assert(element instanceof HTMLAnchorElement);
+		assert.notEqual(null, (element as HTMLAnchorElement).onclick);
+	}
+
+	test('noLinks', () => {
+		const input = 'I am a string';
+		const expectedOutput = '<span>I am a string</span>';
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(0, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal(expectedOutput, output.outerHTML);
+	});
+
+	test('trailingNewline', () => {
+		const input = 'I am a string\n';
+		const expectedOutput = '<span>I am a string\n</span>';
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(0, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal(expectedOutput, output.outerHTML);
+	});
+
+	test('singleLineLink', () => {
+		const input = isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34';
+		const expectedOutput = /^<span><a title=".*">.*\/foo\/bar.js:12:34<\/a><\/span>$/;
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(1, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal('A', output.firstElementChild.tagName);
+		assert(expectedOutput.test(output.outerHTML));
+		assertElementIsLink(output.firstElementChild);
+		assert.equal(isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34', output.firstElementChild.textContent);
+	});
+
+	test('relativeLink', () => {
+		const input = '\./foo/bar.js';
+		const expectedOutput = '<span>\./foo/bar.js</span>';
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(0, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal(expectedOutput, output.outerHTML);
+	});
+
+	test('singleLineLinkAndText', function () {
+		var input = isWindows ? 'The link: C:/foo/bar.js:12:34' : 'The link: /Users/foo/bar.js:12:34';
+		var expectedOutput = /^<span><span>The link: <\/span><a title=".*">.*\/foo\/bar.js:12:34<\/a><\/span>$/;
+		var output = linkDetector.handleLinks(input);
+
+		assert.equal(2, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal('SPAN', output.children[0].tagName);
+		assert.equal('A', output.children[1].tagName);
+		assert(expectedOutput.test(output.outerHTML));
+		assertElementIsLink(output.children[1]);
+		assert.equal(isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34', output.children[1].textContent);
+	});
+
+	test('singleLineMultipleLinks', () => {
+		const input = isWindows ? 'Here is a link C:/foo/bar.js:12:34 and here is another D:/boo/far.js:56:78' :
+			'Here is a link /Users/foo/bar.js:12:34 and here is another /Users/boo/far.js:56:78';
+		const expectedOutput = /^<span><span>Here is a link <\/span><a title=".*">.*\/foo\/bar.js:12:34<\/a><span> and here is another <\/span><a title=".*">.*\/boo\/far.js:56:78<\/a><\/span>$/;
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(4, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal('SPAN', output.children[0].tagName);
+		assert.equal('A', output.children[1].tagName);
+		assert.equal('SPAN', output.children[2].tagName);
+		assert.equal('A', output.children[3].tagName);
+		assert(expectedOutput.test(output.outerHTML));
+		assertElementIsLink(output.children[1]);
+		assertElementIsLink(output.children[3]);
+		assert.equal(isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34', output.children[1].textContent);
+		assert.equal(isWindows ? 'C:/boo/far.js:56:78' : '/Users/boo/far.js:56:78', output.children[3].textContent);
+	});
+
+	test('multilineNoLinks', () => {
+		const input = 'Line one\nLine two\nLine three';
+		const expectedOutput = /^<span><span>Line one\n<\/span><span>Line two\n<\/span><span>Line three<\/span><\/span>$/;
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(3, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal('SPAN', output.children[0].tagName);
+		assert.equal('SPAN', output.children[1].tagName);
+		assert.equal('SPAN', output.children[2].tagName);
+		assert(expectedOutput.test(output.outerHTML));
+	});
+
+	test('multilineTrailingNewline', () => {
+		const input = 'I am a string\nAnd I am another\n';
+		const expectedOutput = '<span><span>I am a string\n<\/span><span>And I am another\n<\/span><\/span>';
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(2, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal('SPAN', output.children[0].tagName);
+		assert.equal('SPAN', output.children[1].tagName);
+		assert.equal(expectedOutput, output.outerHTML);
+	});
+
+	test('multilineWithLinks', () => {
+		const input = isWindows ? 'I have a link for you\nHere it is: C:/foo/bar.js:12:34\nCool, huh?' :
+			'I have a link for you\nHere it is: /Users/foo/bar.js:12:34\nCool, huh?';
+		const expectedOutput = /^<span><span>I have a link for you\n<\/span><span><span>Here it is: <\/span><a title=".*">.*\/foo\/bar.js:12:34<\/a><span>\n<\/span><\/span><span>Cool, huh\?<\/span><\/span>$/;
+		const output = linkDetector.handleLinks(input);
+
+		assert.equal(3, output.children.length);
+		assert.equal('SPAN', output.tagName);
+		assert.equal('SPAN', output.children[0].tagName);
+		assert.equal('SPAN', output.children[1].tagName);
+		assert.equal('SPAN', output.children[2].tagName);
+		assert.equal('SPAN', output.children[1].children[0].tagName);
+		assert.equal('A', output.children[1].children[1].tagName);
+		assert.equal('SPAN', output.children[1].children[2].tagName);
+		assert(expectedOutput.test(output.outerHTML));
+		assertElementIsLink(output.children[1].children[1]);
+		assert.equal(isWindows ? 'C:/foo/bar.js:12:34' : '/Users/foo/bar.js:12:34', output.children[1].children[1].textContent);
+	});
+});


### PR DESCRIPTION
This change brings back a handy feature: clickable file links for stack traces in the Debug Console and Exception Widget.