### PR TITLE
Gentle shutdown of application in smoke test

### DIFF
--- a/src/vs/platform/driver/electron-main/driver.ts
+++ b/src/vs/platform/driver/electron-main/driver.ts
@@ -71,6 +71,10 @@ export class Driver implements IDriver, IWindowDriverRegistry {
 		this.windowsService.reload(window);
 	}
 
+	async exitApplication(): Promise<void> {
+		return this.windowsService.quit();
+	}
+
 	async dispatchKeybinding(windowId: number, keybinding: string): Promise<void> {
 		await this.whenUnfrozen(windowId);
 

--- a/src/vs/platform/driver/node/driver.ts
+++ b/src/vs/platform/driver/node/driver.ts
@@ -30,6 +30,7 @@ export interface IDriver {
 	getWindowIds(): Promise<number[]>;
 	capturePage(windowId: number): Promise<string>;
 	reloadWindow(windowId: number): Promise<void>;
+	exitApplication(): Promise<void>;
 	dispatchKeybinding(windowId: number, keybinding: string): Promise<void>;
 	click(windowId: number, selector: string, xoffset?: number | undefined, yoffset?: number | undefined): Promise<void>;
 	doubleClick(windowId: number, selector: string): Promise<void>;
@@ -56,6 +57,7 @@ export class DriverChannel implements IServerChannel {
 			case 'getWindowIds': return this.driver.getWindowIds();
 			case 'capturePage': return this.driver.capturePage(arg);
 			case 'reloadWindow': return this.driver.reloadWindow(arg);
+			case 'exitApplication': return this.driver.exitApplication();
 			case 'dispatchKeybinding': return this.driver.dispatchKeybinding(arg[0], arg[1]);
 			case 'click': return this.driver.click(arg[0], arg[1], arg[2], arg[3]);
 			case 'doubleClick': return this.driver.doubleClick(arg[0], arg[1]);
@@ -88,6 +90,10 @@ export class DriverChannelClient implements IDriver {
 
 	reloadWindow(windowId: number): Promise<void> {
 		return this.channel.call('reloadWindow', windowId);
+	}
+
+	exitApplication(): Promise<void> {
+		return this.channel.call('exitApplication');
 	}
 
 	dispatchKeybinding(windowId: number, keybinding: string): Promise<void> {

--- a/test/smoke/src/application.ts
+++ b/test/smoke/src/application.ts
@@ -89,6 +89,7 @@ export class Application {
 
 	async stop(): Promise<any> {
 		if (this._code) {
+			await this._code.exit();
 			this._code.dispose();
 			this._code = undefined;
 		}

--- a/test/smoke/src/vscode/code.ts
+++ b/test/smoke/src/vscode/code.ts
@@ -64,7 +64,7 @@ async function connect(child: cp.ChildProcess, outPath: string, handlePath: stri
 	while (true) {
 		try {
 			const { client, driver } = await connectDriver(outPath, handlePath);
-			return new Code(child, client, driver, logger);
+			return new Code(client, driver, logger);
 		} catch (err) {
 			if (++errCount > 50) {
 				child.kill();
@@ -188,7 +188,6 @@ export class Code {
 	private driver: IDriver;
 
 	constructor(
-		private process: cp.ChildProcess,
 		private client: IDisposable,
 		driver: IDriver,
 		readonly logger: Logger
@@ -228,6 +227,10 @@ export class Code {
 	async reload(): Promise<void> {
 		const windowId = await this.getActiveWindowId();
 		await this.driver.reloadWindow(windowId);
+	}
+
+	async exit(): Promise<void> {
+		await this.driver.exitApplication();
 	}
 
 	async waitForTextContent(selector: string, textContent?: string, accept?: (result: string) => boolean): Promise<string> {
@@ -302,7 +305,6 @@ export class Code {
 
 	dispose(): void {
 		this.client.dispose();
-		this.process.kill();
 	}
 }
 


### PR DESCRIPTION
On the end of a smoke test we kill the child process. On Windows this causes subprocesses to go haywire and live on. This was the safest cross-platform solution I could think of.