### PR TITLE
Run active file with spaces PowerShell Core Support

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -678,9 +678,19 @@ export class TerminalInstance implements ITerminalInstance {
 
 	public preparePathForTerminalAsync(path: string): Promise<string> {
 		return new Promise<string>(c => {
+			const exe = this.shellLaunchConfig.executable;
 			const hasSpace = path.indexOf(' ') !== -1;
+			const isPowerShell = exe.indexOf('pwsh') !== -1 ||
+				this.title.indexOf('pwsh') !== -1 ||
+				exe.toLocaleLowerCase().indexOf('powershell') !== -1 ||
+				this.title.toLocaleLowerCase().indexOf('powershell') !== -1;
+
+			if (hasSpace && isPowerShell) {
+				c(`& '${path.replace('\'', '\'\'')}'`);
+				return;
+			}
+
 			if (platform.isWindows) {
-				const exe = this.shellLaunchConfig.executable;
 				if (!exe) {
 					c(path);
 					return;
@@ -692,8 +702,6 @@ export class TerminalInstance implements ITerminalInstance {
 						c(this._escapeNonWindowsPath(stdout.trim()));
 					});
 					return;
-				} else if (hasSpace && (exe.indexOf('powershell') !== -1)) {
-					c('& \'' + path + '\'');
 				} else if (hasSpace) {
 					c('"' + path + '"');
 				} else {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -679,6 +679,15 @@ export class TerminalInstance implements ITerminalInstance {
 	public preparePathForTerminalAsync(path: string): Promise<string> {
 		return new Promise<string>(c => {
 			const exe = this.shellLaunchConfig.executable;
+			if (!exe) {
+				if (platform.isWindows) {
+					c(path);
+				} else {
+					c(this._escapeNonWindowsPath(path));
+				}
+				return;
+			}
+
 			const hasSpace = path.indexOf(' ') !== -1;
 			const isPowerShell = exe.indexOf('pwsh') !== -1 ||
 				this.title.indexOf('pwsh') !== -1 ||
@@ -691,10 +700,6 @@ export class TerminalInstance implements ITerminalInstance {
 			}
 
 			if (platform.isWindows) {
-				if (!exe) {
-					c(path);
-					return;
-				}
 				// 17063 is the build number where wsl path was introduced.
 				// Update Windows uriPath to be executed in WSL.
 				if (((exe.indexOf('wsl') !== -1) || ((exe.indexOf('bash.exe') !== -1) && (exe.indexOf('git') === -1))) && (TerminalInstance.getWindowsBuildNumber() >= 17063)) {

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -9,6 +9,7 @@ import * as platform from 'vs/base/common/platform';
 import * as dom from 'vs/base/browser/dom';
 import * as paths from 'vs/base/common/paths';
 import * as os from 'os';
+import * as path from 'path';
 import { Event, Emitter } from 'vs/base/common/event';
 import { debounce } from 'vs/base/common/decorators';
 import { WindowsShellHelper } from 'vs/workbench/parts/terminal/node/windowsShellHelper';
@@ -676,26 +677,24 @@ export class TerminalInstance implements ITerminalInstance {
 		}
 	}
 
-	public preparePathForTerminalAsync(path: string): Promise<string> {
+	public preparePathForTerminalAsync(originalPath: string): Promise<string> {
 		return new Promise<string>(c => {
 			const exe = this.shellLaunchConfig.executable;
 			if (!exe) {
-				if (platform.isWindows) {
-					c(path);
-				} else {
-					c(this._escapeNonWindowsPath(path));
-				}
+				c(originalPath);
 				return;
 			}
 
-			const hasSpace = path.indexOf(' ') !== -1;
-			const isPowerShell = exe.indexOf('pwsh') !== -1 ||
-				this.title.indexOf('pwsh') !== -1 ||
-				exe.toLocaleLowerCase().indexOf('powershell') !== -1 ||
-				this.title.toLocaleLowerCase().indexOf('powershell') !== -1;
+			const hasSpace = originalPath.indexOf(' ') !== -1;
+
+			const pathBasename = path.basename(exe, '.exe');
+			const isPowerShell = pathBasename === 'pwsh' ||
+				this.title === 'pwsh' ||
+				pathBasename === 'powershell' ||
+				this.title === 'powershell';
 
 			if (hasSpace && isPowerShell) {
-				c(`& '${path.replace('\'', '\'\'')}'`);
+				c(`& '${originalPath.replace('\'', '\'\'')}'`);
 				return;
 			}
 
@@ -703,18 +702,18 @@ export class TerminalInstance implements ITerminalInstance {
 				// 17063 is the build number where wsl path was introduced.
 				// Update Windows uriPath to be executed in WSL.
 				if (((exe.indexOf('wsl') !== -1) || ((exe.indexOf('bash.exe') !== -1) && (exe.indexOf('git') === -1))) && (TerminalInstance.getWindowsBuildNumber() >= 17063)) {
-					execFile('bash.exe', ['-c', 'echo $(wslpath ' + this._escapeNonWindowsPath(path) + ')'], {}, (error, stdout, stderr) => {
+					execFile('bash.exe', ['-c', 'echo $(wslpath ' + this._escapeNonWindowsPath(originalPath) + ')'], {}, (error, stdout, stderr) => {
 						c(this._escapeNonWindowsPath(stdout.trim()));
 					});
 					return;
 				} else if (hasSpace) {
-					c('"' + path + '"');
+					c('"' + originalPath + '"');
 				} else {
-					c(path);
+					c(originalPath);
 				}
 				return;
 			}
-			c(this._escapeNonWindowsPath(path));
+			c(this._escapeNonWindowsPath(originalPath));
 		});
 	}
 


### PR DESCRIPTION
This expands on https://github.com/Microsoft/vscode/pull/65331 to add support for:

* PowerShell Core (exe named `pwsh`) on all OS's
* Single quotes in paths for PowerShell (i.e `/Users/tyler/tyler's stuff/` -> `& '/Users/tyler/tyler''s stuff/'` to escape a `'` in a `'  '` string, you add an extra `'`)

Let me know if there is a possibility to add tests here - I'd love some guidance! 😊

cc @Tyriar 👍