### PR TITLE
Workaround for webview focus visibility issue

### DIFF
--- a/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewElement.ts
@@ -288,6 +288,10 @@ export class WebviewElement extends Disposable {
 		}));
 		this._register(addDisposableListener(this._webview, 'dom-ready', () => {
 			this.layout();
+
+			// Workaround for https://github.com/electron/electron/issues/14474
+			this._webview.blur();
+			this._webview.focus();
 		}));
 		this._register(addDisposableListener(this._webview, 'crashed', () => {
 			console.error('embedded page crashed');


### PR DESCRIPTION
Addresses https://github.com/Microsoft/vscode/issues/65410

Bluring and refocusing the webview on `dom-ready` was a suggested workaround for the lack of focus indication in webviews with electron 3. From testing, this seems to work well