### PR TITLE
Git discard changes fails for large changesets with "ENAMETOOLONG" Fix for #65693

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -844,21 +844,70 @@ export class Repository implements Disposable {
 				}
 			});
 
-			const promises: Promise<void>[] = [];
+			const maxCommandLineLength: number = 30000;
 
 			if (toClean.length > 0) {
-				promises.push(this.repository.clean(toClean));
+				let sliceStart: number = 0;
+				let sliceEnd: number = 1;
+				let accumulatedStringLength = 0;
+
+				while (sliceEnd < toClean.length) {
+					if ((accumulatedStringLength + (toClean[sliceEnd - 1].length + 1)) > maxCommandLineLength) {
+						await this.repository.clean(toClean.slice(sliceStart, sliceEnd));
+						sliceStart = sliceEnd;
+						sliceEnd++;
+						accumulatedStringLength = 0;
+					}
+					else {
+						accumulatedStringLength += toClean[sliceEnd - 1].length + 1;
+						sliceEnd++;
+					}
+				}
+
+				await this.repository.clean(toClean.slice(sliceStart, sliceEnd));
 			}
 
 			if (toCheckout.length > 0) {
-				promises.push(this.repository.checkout('', toCheckout));
+				let sliceStart: number = 0;
+				let sliceEnd: number = 1;
+				let accumulatedStringLength = 0;
+
+				while (sliceEnd < toCheckout.length) {
+					if ((accumulatedStringLength + (toCheckout[sliceEnd - 1].length + 1)) > maxCommandLineLength) {
+						await this.repository.checkout('', toCheckout.slice(sliceStart, sliceEnd));
+						sliceStart = sliceEnd;
+						sliceEnd++;
+						accumulatedStringLength = 0;
+					}
+					else {
+						accumulatedStringLength += toCheckout[sliceEnd - 1].length + 1;
+						sliceEnd++;
+					}
+				}
+
+				await this.repository.checkout('', toCheckout.slice(sliceStart, sliceEnd));
 			}
 
 			if (submodulesToUpdate.length > 0) {
-				promises.push(this.repository.updateSubmodules(submodulesToUpdate));
-			}
+				let sliceStart: number = 0;
+				let sliceEnd: number = 1;
+				let accumulatedStringLength = 0;
 
-			await Promise.all(promises);
+				while (sliceEnd < submodulesToUpdate.length) {
+					if ((accumulatedStringLength + (submodulesToUpdate[sliceEnd - 1].length + 1)) > maxCommandLineLength) {
+						await this.repository.updateSubmodules(submodulesToUpdate.slice(sliceStart, sliceEnd));
+						sliceStart = sliceEnd;
+						sliceEnd++;
+						accumulatedStringLength = 0;
+					}
+					else {
+						accumulatedStringLength += submodulesToUpdate[sliceEnd - 1].length + 1;
+						sliceEnd++;
+					}
+				}
+
+				await this.repository.updateSubmodules(submodulesToUpdate.slice(sliceStart, sliceEnd));
+			}
 		});
 	}
 


### PR DESCRIPTION
Chunk clean, checkout and update submodule commands within repository.ts to ensure the length of the files passed to the repository are less than 30k characters to avoid ENAMETOOLONG failures on Windows when working with very large changesets.

This was reported in #65693 and #23943.

The problem is there is a limitation to the maximum size of the command line arguments passed to ChildProcess spawn, and the code was calling git commands with all full file paths listed which may exceed the maximum allowable length for arguments.  This would cause a git failure, and the discard would not happen.

This change chunks the clean, checkout and submodule update commands to length of the joined file paths being passed to git is less than 30k characters.