### PR TITLE
[themes] Add ability to reload themes without restarting the editor

### DIFF
--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -100,4 +100,5 @@ export interface IThemeExtensionPoint {
 	label?: string;
 	description?: string;
 	path: string;
+	_watch: boolean; // unsupported options to watch location
 }

--- a/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
@@ -43,6 +43,7 @@ export class ColorThemeData implements IColorTheme {
 	description?: string;
 	isLoaded: boolean;
 	location?: URI;
+	watch: boolean;
 	extensionData: ExtensionData;
 
 	get tokenColors(): ITokenColorizationRule[] {
@@ -185,7 +186,8 @@ export class ColorThemeData implements IColorTheme {
 			selector: this.id.split(' ').join('.'), // to not break old clients
 			themeTokenColors: this.themeTokenColors,
 			extensionData: this.extensionData,
-			colorMap: colorMapData
+			colorMap: colorMapData,
+			watch: this.watch
 		});
 	}
 
@@ -214,6 +216,7 @@ export class ColorThemeData implements IColorTheme {
 		themeData.settingsId = null;
 		themeData.isLoaded = false;
 		themeData.themeTokenColors = [{ settings: {} }];
+		themeData.watch = false;
 		return themeData;
 	}
 
@@ -224,6 +227,7 @@ export class ColorThemeData implements IColorTheme {
 		themeData.settingsId = settingsId;
 		themeData.isLoaded = true;
 		themeData.themeTokenColors = [{ settings: {} }];
+		themeData.watch = false;
 		return themeData;
 	}
 
@@ -240,7 +244,7 @@ export class ColorThemeData implements IColorTheme {
 						}
 						break;
 					case 'themeTokenColors':
-					case 'id': case 'label': case 'settingsId': case 'extensionData':
+					case 'id': case 'label': case 'settingsId': case 'extensionData': case 'watch':
 						theme[key] = data[key];
 						break;
 				}
@@ -260,6 +264,7 @@ export class ColorThemeData implements IColorTheme {
 		themeData.label = theme.label || Paths.basename(theme.path);
 		themeData.settingsId = theme.id || themeData.label;
 		themeData.description = theme.description;
+		themeData.watch = theme._watch === true;
 		themeData.location = colorThemeLocation;
 		themeData.extensionData = extensionData;
 		themeData.isLoaded = false;

--- a/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
@@ -135,15 +135,21 @@ export class ColorThemeData implements IColorTheme {
 	}
 
 	public ensureLoaded(fileService: IFileService): Promise<void> {
-		if (!this.isLoaded) {
-			if (this.location) {
-				return _loadColorTheme(fileService, this.location, this.themeTokenColors, this.colorMap).then(_ => {
-					this.isLoaded = true;
-					this.sanitizeTokenColors();
-				});
-			}
+		return !this.isLoaded ? this.load(fileService) : Promise.resolve(undefined);
+	}
+
+	public reload(fileService: IFileService): Promise<void> {
+		return this.load(fileService);
+	}
+
+	private load(fileService: IFileService): Promise<void> {
+		if (!this.location) {
+			return Promise.resolve(undefined);
 		}
-		return Promise.resolve(undefined);
+		return _loadColorTheme(fileService, this.location, this.themeTokenColors, this.colorMap).then(_ => {
+			this.isLoaded = true;
+			this.sanitizeTokenColors();
+		});
 	}
 
 	/**

--- a/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
@@ -29,20 +29,26 @@ export class FileIconThemeData implements IFileIconTheme {
 	private constructor() { }
 
 	public ensureLoaded(fileService: IFileService): Promise<string> {
-		if (!this.isLoaded) {
-			if (this.location) {
-				return _loadIconThemeDocument(fileService, this.location).then(iconThemeDocument => {
-					let result = _processIconThemeDocument(this.id, this.location!, iconThemeDocument);
-					this.styleSheetContent = result.content;
-					this.hasFileIcons = result.hasFileIcons;
-					this.hasFolderIcons = result.hasFolderIcons;
-					this.hidesExplorerArrows = result.hidesExplorerArrows;
-					this.isLoaded = true;
-					return this.styleSheetContent;
-				});
-			}
+		return !this.isLoaded ? this.load(fileService) : Promise.resolve(this.styleSheetContent);
+	}
+
+	public reload(fileService: IFileService): Promise<string> {
+		return this.load(fileService);
+	}
+
+	private load(fileService: IFileService): Promise<string> {
+		if (!this.location) {
+			return Promise.resolve(this.styleSheetContent);
 		}
-		return Promise.resolve(this.styleSheetContent);
+		return _loadIconThemeDocument(fileService, this.location).then(iconThemeDocument => {
+			const result = _processIconThemeDocument(this.id, this.location!, iconThemeDocument);
+			this.styleSheetContent = result.content;
+			this.hasFileIcons = result.hasFileIcons;
+			this.hasFolderIcons = result.hasFolderIcons;
+			this.hidesExplorerArrows = result.hidesExplorerArrows;
+			this.isLoaded = true;
+			return this.styleSheetContent;
+		});
 	}
 
 	static fromExtensionTheme(iconTheme: IThemeExtensionPoint, iconThemeLocation: URI, extensionData: ExtensionData): FileIconThemeData {

--- a/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
@@ -85,12 +85,12 @@ export class FileIconThemeData implements IFileIconTheme {
 		let themeData = new FileIconThemeData();
 		themeData.id = '';
 		themeData.label = '';
-		themeData.settingsId = null;
+		themeData.settingsId = undefined;
 		themeData.isLoaded = false;
 		themeData.hasFileIcons = false;
 		themeData.hasFolderIcons = false;
 		themeData.hidesExplorerArrows = false;
-		themeData.extensionData = null;
+		themeData.extensionData = undefined;
 		return themeData;
 	}
 

--- a/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/fileIconThemeData.ts
@@ -81,6 +81,19 @@ export class FileIconThemeData implements IFileIconTheme {
 		return themeData;
 	}
 
+	static createUnloadedTheme(id: string): FileIconThemeData {
+		let themeData = new FileIconThemeData();
+		themeData.id = '';
+		themeData.label = '';
+		themeData.settingsId = null;
+		themeData.isLoaded = false;
+		themeData.hasFileIcons = false;
+		themeData.hasFolderIcons = false;
+		themeData.hidesExplorerArrows = false;
+		themeData.extensionData = null;
+		return themeData;
+	}
+
 	static fromStorageData(input: string): FileIconThemeData | null {
 		try {
 			let data = JSON.parse(input);

--- a/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/electron-browser/workbenchThemeService.ts
@@ -356,8 +356,8 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 			if (this.watchedColorThemeLocation) {
 				this.fileService.unwatchFileChanges(this.watchedColorThemeLocation);
 			}
-			this.watchedColorThemeLocation = newTheme.location;
-			if (this.watchedColorThemeLocation) {
+			if (newTheme.location && (newTheme.watch || !!this.environmentService.extensionDevelopmentLocationURI)) {
+				this.watchedColorThemeLocation = newTheme.location;
 				this.fileService.watchFileChanges(this.watchedColorThemeLocation);
 			}
 		}


### PR DESCRIPTION
Resolves #45963

This PRs adds the ability to reload a theme (color or icon) without the need to restart the editor.

Replaces #60136