### PR TITLE
Handle UNC paths correctly in bootstrap.js

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -69,7 +69,15 @@ exports.uriFromPath = function (_path) {
 		pathName = '/' + pathName;
 	}
 
-	return encodeURI('file://' + pathName).replace(/#/g, '%23');
+	/** @type {string} */
+	let uri;
+	if (pathName.startsWith('//')) {
+		uri = encodeURI('file:' + pathName);
+	} else {
+		uri = encodeURI('file://' + pathName);
+	}
+
+	return uri.replace(/#/g, '%23');
 };
 //#endregion
 


### PR DESCRIPTION
`uriFromPath` now converts `\\computer\share\path` into `file://computer/share/path` instead of [incorrect](https://en.wikipedia.org/wiki/File_URI_scheme#Legacy_URLs)  `file:////computer/share/path`

Fixes #53857