### PR TITLE
Add multiline description support in user snippets

### DIFF
--- a/src/vs/workbench/parts/snippets/electron-browser/snippets.contribution.ts
+++ b/src/vs/workbench/parts/snippets/electron-browser/snippets.contribution.ts
@@ -51,7 +51,7 @@ const languageScopeSchema: IJSONSchema = {
 			},
 			description: {
 				description: nls.localize('snippetSchema.json.description', 'The snippet description.'),
-				type: 'string'
+				type: ['string', 'array']
 			}
 		},
 		additionalProperties: false

--- a/src/vs/workbench/parts/snippets/electron-browser/snippetsFile.ts
+++ b/src/vs/workbench/parts/snippets/electron-browser/snippetsFile.ts
@@ -232,6 +232,10 @@ export class SnippetFile {
 			body = body.join('\n');
 		}
 
+		if (Array.isArray(description)) {
+			description = description.join('\n');
+		}
+
 		if ((typeof prefix !== 'string' && !Array.isArray(prefix)) || typeof body !== 'string') {
 			return;
 		}


### PR DESCRIPTION
Closes #66036 

### Present scenario

> Inorder to show a lot of description, it is required must write a huge string which includes many escape characters the one given below.

```json
"toctree": {
	"prefix": ".. toctree::",
	"body": [
		".. toctree::",
		"$0"
	],
	"description": "A toctree item, have these options:\n\t:maxdepth: para\n\t:caption: para
\n\t:numbered:\n\t:titlesonly:\n\t:glob:\n\t:reversed:\n\t:hidden:\n\t:includehidden:",
	"scope": "text.restructuredtext"
},
```

### Proposed solution

```json
"toctree": {
	"prefix": ".. toctree::",
	"body": [
		".. toctree::",
		"$0"
	],
	"description": [
		"A toctree item, have these options:",
		":maxdepth: para",
		":caption: para",
		":numbered:",
		":titlesonly:",
		":glob:",
		":reversed:",
		":hidden:",
		":includehidden:"
	],
	"scope": "text.restructuredtext"
},
```