### PR TITLE
move rendering marker hover to hover widget

### DIFF
--- a/src/vs/base/browser/htmlContentRenderer.ts
+++ b/src/vs/base/browser/htmlContentRenderer.ts
@@ -6,7 +6,7 @@
 import * as DOM from 'vs/base/browser/dom';
 import { defaultGenerator } from 'vs/base/common/idGenerator';
 import { escape } from 'vs/base/common/strings';
-import { removeMarkdownEscapes, IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
+import { removeMarkdownEscapes, IMarkdownString } from 'vs/base/common/htmlContent';
 import * as marked from 'vs/base/common/marked/marked';
 import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -211,7 +211,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: RenderOptions
 	}
 
 	const markedOptions: marked.MarkedOptions = {
-		sanitize: markdown instanceof MarkdownString ? markdown.sanitize : true,
+		sanitize: true,
 		renderer
 	};
 

--- a/src/vs/base/common/htmlContent.ts
+++ b/src/vs/base/common/htmlContent.ts
@@ -16,7 +16,6 @@ export class MarkdownString implements IMarkdownString {
 
 	value: string;
 	isTrusted?: boolean;
-	sanitize: boolean = true;
 
 	constructor(value: string = '') {
 		this.value = value;

--- a/src/vs/editor/common/services/markerDecorationsServiceImpl.ts
+++ b/src/vs/editor/common/services/markerDecorationsServiceImpl.ts
@@ -57,6 +57,7 @@ export class MarkerDecorationsService extends Disposable implements IMarkerDecor
 		@IMarkerService private readonly _markerService: IMarkerService
 	) {
 		super();
+		modelService.getModels().forEach(model => this._onModelAdded(model));
 		this._register(modelService.onModelAdded(this._onModelAdded, this));
 		this._register(modelService.onModelRemoved(this._onModelRemoved, this));
 		this._register(this._markerService.onMarkerChanged(this._handleMarkerChange, this));

--- a/src/vs/editor/common/services/markerDecorationsServiceImpl.ts
+++ b/src/vs/editor/common/services/markerDecorationsServiceImpl.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IMarkerService, IMarker, MarkerSeverity, MarkerTag } from 'vs/platform/markers/common/markers';
+import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
+import { IModelDeltaDecoration, ITextModel, IModelDecorationOptions, TrackedRangeStickiness, OverviewRulerLane, IModelDecoration } from 'vs/editor/common/model';
+import { ClassName } from 'vs/editor/common/model/intervalTree';
+import { themeColorFromId, ThemeColor } from 'vs/platform/theme/common/themeService';
+import { overviewRulerWarning, overviewRulerInfo, overviewRulerError } from 'vs/editor/common/view/editorColorRegistry';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { Range } from 'vs/editor/common/core/range';
+import { keys } from 'vs/base/common/map';
+import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
+
+function MODEL_ID(resource: URI): string {
+	return resource.toString();
+}
+
+class MarkerDecorations extends Disposable {
+
+	private readonly _markersData: Map<string, IMarker> = new Map<string, IMarker>();
+
+	constructor(
+		readonly model: ITextModel
+	) {
+		super();
+		this._register(toDisposable(() => {
+			this.model.deltaDecorations(keys(this._markersData), []);
+			this._markersData.clear();
+		}));
+	}
+
+	public update(markers: IMarker[], newDecorations: IModelDeltaDecoration[]): void {
+		const ids = this.model.deltaDecorations(keys(this._markersData), newDecorations);
+		for (let index = 0; index < ids.length; index++) {
+			this._markersData.set(ids[index], markers[index]);
+		}
+	}
+
+	getMarker(decoration: IModelDecoration): IMarker | null {
+		return this._markersData.get(decoration.id);
+	}
+}
+
+export class MarkerDecorationsService extends Disposable implements IMarkerDecorationsService {
+
+	_serviceBrand: any;
+
+	private readonly _markerDecorations: Map<string, MarkerDecorations> = new Map<string, MarkerDecorations>();
+
+	constructor(
+		@IModelService modelService: IModelService,
+		@IMarkerService private readonly _markerService: IMarkerService
+	) {
+		super();
+		this._register(modelService.onModelAdded(this._onModelAdded, this));
+		this._register(modelService.onModelRemoved(this._onModelRemoved, this));
+		this._register(this._markerService.onMarkerChanged(this._handleMarkerChange, this));
+	}
+
+	getMarker(model: ITextModel, decoration: IModelDecoration): IMarker | null {
+		const markerDecorations = this._markerDecorations.get(MODEL_ID(model.uri));
+		return markerDecorations ? markerDecorations.getMarker(decoration) : null;
+	}
+
+	private _handleMarkerChange(changedResources: URI[]): void {
+		changedResources.forEach((resource) => {
+			const markerDecorations = this._markerDecorations.get(MODEL_ID(resource));
+			if (markerDecorations) {
+				this.updateDecorations(markerDecorations);
+			}
+		});
+	}
+
+	private _onModelAdded(model: ITextModel): void {
+		const markerDecorations = new MarkerDecorations(model);
+		this._markerDecorations.set(MODEL_ID(model.uri), markerDecorations);
+		this.updateDecorations(markerDecorations);
+	}
+
+	private _onModelRemoved(model: ITextModel): void {
+		const markerDecorations = this._markerDecorations.get(MODEL_ID(model.uri));
+		if (markerDecorations) {
+			markerDecorations.dispose();
+			this._markerDecorations.delete(MODEL_ID(model.uri));
+		}
+	}
+
+	private updateDecorations(markerDecorations: MarkerDecorations): void {
+		// Limit to the first 500 errors/warnings
+		const markers = this._markerService.read({ resource: markerDecorations.model.uri, take: 500 });
+		let newModelDecorations: IModelDeltaDecoration[] = markers.map((marker) => {
+			return {
+				range: this._createDecorationRange(markerDecorations.model, marker),
+				options: this._createDecorationOption(marker)
+			};
+		});
+		markerDecorations.update(markers, newModelDecorations);
+	}
+
+	private _createDecorationRange(model: ITextModel, rawMarker: IMarker): Range {
+
+		let ret = Range.lift(rawMarker);
+
+		if (rawMarker.severity === MarkerSeverity.Hint) {
+			if (!rawMarker.tags || rawMarker.tags.indexOf(MarkerTag.Unnecessary) === -1) {
+				// * never render hints on multiple lines
+				// * make enough space for three dots
+				ret = ret.setEndPosition(ret.startLineNumber, ret.startColumn + 2);
+			}
+		}
+
+		ret = model.validateRange(ret);
+
+		if (ret.isEmpty()) {
+			let word = model.getWordAtPosition(ret.getStartPosition());
+			if (word) {
+				ret = new Range(ret.startLineNumber, word.startColumn, ret.endLineNumber, word.endColumn);
+			} else {
+				let maxColumn = model.getLineLastNonWhitespaceColumn(ret.startLineNumber) ||
+					model.getLineMaxColumn(ret.startLineNumber);
+
+				if (maxColumn === 1) {
+					// empty line
+					// console.warn('marker on empty line:', marker);
+				} else if (ret.endColumn >= maxColumn) {
+					// behind eol
+					ret = new Range(ret.startLineNumber, maxColumn - 1, ret.endLineNumber, maxColumn);
+				} else {
+					// extend marker to width = 1
+					ret = new Range(ret.startLineNumber, ret.startColumn, ret.endLineNumber, ret.endColumn + 1);
+				}
+			}
+		} else if (rawMarker.endColumn === Number.MAX_VALUE && rawMarker.startColumn === 1 && ret.startLineNumber === ret.endLineNumber) {
+			let minColumn = model.getLineFirstNonWhitespaceColumn(rawMarker.startLineNumber);
+			if (minColumn < ret.endColumn) {
+				ret = new Range(ret.startLineNumber, minColumn, ret.endLineNumber, ret.endColumn);
+				rawMarker.startColumn = minColumn;
+			}
+		}
+		return ret;
+	}
+
+	private _createDecorationOption(marker: IMarker): IModelDecorationOptions {
+
+		let className: string;
+		let color: ThemeColor | undefined = undefined;
+		let zIndex: number;
+		let inlineClassName: string | undefined = undefined;
+
+		switch (marker.severity) {
+			case MarkerSeverity.Hint:
+				if (marker.tags && marker.tags.indexOf(MarkerTag.Unnecessary) >= 0) {
+					className = ClassName.EditorUnnecessaryDecoration;
+				} else {
+					className = ClassName.EditorHintDecoration;
+				}
+				zIndex = 0;
+				break;
+			case MarkerSeverity.Warning:
+				className = ClassName.EditorWarningDecoration;
+				color = themeColorFromId(overviewRulerWarning);
+				zIndex = 20;
+				break;
+			case MarkerSeverity.Info:
+				className = ClassName.EditorInfoDecoration;
+				color = themeColorFromId(overviewRulerInfo);
+				zIndex = 10;
+				break;
+			case MarkerSeverity.Error:
+			default:
+				className = ClassName.EditorErrorDecoration;
+				color = themeColorFromId(overviewRulerError);
+				zIndex = 30;
+				break;
+		}
+
+		if (marker.tags) {
+			if (marker.tags.indexOf(MarkerTag.Unnecessary) !== -1) {
+				inlineClassName = ClassName.EditorUnnecessaryInlineDecoration;
+			}
+		}
+
+		return {
+			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+			className,
+			showIfCollapsed: true,
+			overviewRuler: {
+				color,
+				position: OverviewRulerLane.Right
+			},
+			zIndex,
+			inlineClassName,
+		};
+	}
+}

--- a/src/vs/editor/common/services/markersDecorationService.ts
+++ b/src/vs/editor/common/services/markersDecorationService.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITextModel, IModelDecoration } from 'vs/editor/common/model';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { IMarker } from 'vs/platform/markers/common/markers';
+
+export const IMarkerDecorationsService = createDecorator<IMarkerDecorationsService>('markerDecorationsService');
+
+export interface IMarkerDecorationsService {
+	_serviceBrand: any;
+
+	getMarker(model: ITextModel, decoration: IModelDecoration): IMarker | null;
+}

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -3,20 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { Emitter, Event } from 'vs/base/common/event';
-import { MarkdownString } from 'vs/base/common/htmlContent';
-import { escape } from 'vs/base/common/strings';
 import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import * as network from 'vs/base/common/network';
-import { basename } from 'vs/base/common/paths';
 import * as platform from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 import { EDITOR_MODEL_DEFAULTS } from 'vs/editor/common/config/editorOptions';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { Range } from 'vs/editor/common/core/range';
-import { DefaultEndOfLine, EndOfLinePreference, EndOfLineSequence, IIdentifiedSingleEditOperation, IModelDecorationOptions, IModelDeltaDecoration, ITextBuffer, ITextBufferFactory, ITextModel, ITextModelCreationOptions, OverviewRulerLane, TrackedRangeStickiness } from 'vs/editor/common/model';
-import { ClassName } from 'vs/editor/common/model/intervalTree';
+import { DefaultEndOfLine, EndOfLinePreference, EndOfLineSequence, IIdentifiedSingleEditOperation, ITextBuffer, ITextBufferFactory, ITextModel, ITextModelCreationOptions } from 'vs/editor/common/model';
 import { TextModel, createTextBuffer } from 'vs/editor/common/model/textModel';
 import { IModelLanguageChangedEvent } from 'vs/editor/common/model/textModelEvents';
 import { LanguageIdentifier } from 'vs/editor/common/modes';
@@ -24,10 +19,8 @@ import { PLAINTEXT_LANGUAGE_IDENTIFIER } from 'vs/editor/common/modes/modesRegis
 import { ILanguageSelection } from 'vs/editor/common/services/modeService';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/resourceConfiguration';
-import { overviewRulerError, overviewRulerInfo, overviewRulerWarning } from 'vs/editor/common/view/editorColorRegistry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IMarker, IMarkerService, MarkerSeverity, MarkerTag } from 'vs/platform/markers/common/markers';
-import { ThemeColor, themeColorFromId } from 'vs/platform/theme/common/themeService';
+import { IMarkerService } from 'vs/platform/markers/common/markers';
 
 function MODEL_ID(resource: URI): string {
 	return resource.toString();
@@ -39,7 +32,6 @@ class ModelData implements IDisposable {
 	private _languageSelection: ILanguageSelection | null;
 	private _languageSelectionListener: IDisposable | null;
 
-	private _markerDecorations: string[];
 	private _modelEventListeners: IDisposable[];
 
 	constructor(
@@ -51,8 +43,6 @@ class ModelData implements IDisposable {
 
 		this._languageSelection = null;
 		this._languageSelectionListener = null;
-
-		this._markerDecorations = [];
 
 		this._modelEventListeners = [];
 		this._modelEventListeners.push(model.onWillDispose(() => onWillDispose(model)));
@@ -71,13 +61,8 @@ class ModelData implements IDisposable {
 	}
 
 	public dispose(): void {
-		this._markerDecorations = this.model.deltaDecorations(this._markerDecorations, []);
 		this._modelEventListeners = dispose(this._modelEventListeners);
 		this._disposeLanguageSelection();
-	}
-
-	public acceptMarkerDecorations(newDecorations: IModelDeltaDecoration[]): void {
-		this._markerDecorations = this.model.deltaDecorations(this._markerDecorations, newDecorations);
 	}
 
 	public setLanguage(languageSelection: ILanguageSelection): void {
@@ -85,155 +70,6 @@ class ModelData implements IDisposable {
 		this._languageSelection = languageSelection;
 		this._languageSelectionListener = this._languageSelection.onDidChange(() => this.model.setMode(languageSelection.languageIdentifier));
 		this.model.setMode(languageSelection.languageIdentifier);
-	}
-}
-
-class ModelMarkerHandler {
-
-	public static setMarkers(modelData: ModelData, markerService: IMarkerService): void {
-
-		// Limit to the first 500 errors/warnings
-		const markers = markerService.read({ resource: modelData.model.uri, take: 500 });
-
-		let newModelDecorations: IModelDeltaDecoration[] = markers.map((marker) => {
-			return {
-				range: ModelMarkerHandler._createDecorationRange(modelData.model, marker),
-				options: ModelMarkerHandler._createDecorationOption(marker)
-			};
-		});
-
-		modelData.acceptMarkerDecorations(newModelDecorations);
-	}
-
-	private static _createDecorationRange(model: ITextModel, rawMarker: IMarker): Range {
-
-		let ret = Range.lift(rawMarker);
-
-		if (rawMarker.severity === MarkerSeverity.Hint) {
-			if (!rawMarker.tags || rawMarker.tags.indexOf(MarkerTag.Unnecessary) === -1) {
-				// * never render hints on multiple lines
-				// * make enough space for three dots
-				ret = ret.setEndPosition(ret.startLineNumber, ret.startColumn + 2);
-			}
-		}
-
-		ret = model.validateRange(ret);
-
-		if (ret.isEmpty()) {
-			let word = model.getWordAtPosition(ret.getStartPosition());
-			if (word) {
-				ret = new Range(ret.startLineNumber, word.startColumn, ret.endLineNumber, word.endColumn);
-			} else {
-				let maxColumn = model.getLineLastNonWhitespaceColumn(ret.startLineNumber) ||
-					model.getLineMaxColumn(ret.startLineNumber);
-
-				if (maxColumn === 1) {
-					// empty line
-					// console.warn('marker on empty line:', marker);
-				} else if (ret.endColumn >= maxColumn) {
-					// behind eol
-					ret = new Range(ret.startLineNumber, maxColumn - 1, ret.endLineNumber, maxColumn);
-				} else {
-					// extend marker to width = 1
-					ret = new Range(ret.startLineNumber, ret.startColumn, ret.endLineNumber, ret.endColumn + 1);
-				}
-			}
-		} else if (rawMarker.endColumn === Number.MAX_VALUE && rawMarker.startColumn === 1 && ret.startLineNumber === ret.endLineNumber) {
-			let minColumn = model.getLineFirstNonWhitespaceColumn(rawMarker.startLineNumber);
-			if (minColumn < ret.endColumn) {
-				ret = new Range(ret.startLineNumber, minColumn, ret.endLineNumber, ret.endColumn);
-				rawMarker.startColumn = minColumn;
-			}
-		}
-		return ret;
-	}
-
-	private static _createDecorationOption(marker: IMarker): IModelDecorationOptions {
-
-		let className: string;
-		let color: ThemeColor | undefined = undefined;
-		let zIndex: number;
-		let inlineClassName: string | undefined = undefined;
-
-		switch (marker.severity) {
-			case MarkerSeverity.Hint:
-				if (marker.tags && marker.tags.indexOf(MarkerTag.Unnecessary) >= 0) {
-					className = ClassName.EditorUnnecessaryDecoration;
-				} else {
-					className = ClassName.EditorHintDecoration;
-				}
-				zIndex = 0;
-				break;
-			case MarkerSeverity.Warning:
-				className = ClassName.EditorWarningDecoration;
-				color = themeColorFromId(overviewRulerWarning);
-				zIndex = 20;
-				break;
-			case MarkerSeverity.Info:
-				className = ClassName.EditorInfoDecoration;
-				color = themeColorFromId(overviewRulerInfo);
-				zIndex = 10;
-				break;
-			case MarkerSeverity.Error:
-			default:
-				className = ClassName.EditorErrorDecoration;
-				color = themeColorFromId(overviewRulerError);
-				zIndex = 30;
-				break;
-		}
-
-		if (marker.tags) {
-			if (marker.tags.indexOf(MarkerTag.Unnecessary) !== -1) {
-				inlineClassName = ClassName.EditorUnnecessaryInlineDecoration;
-			}
-		}
-
-		let hoverMessage: MarkdownString | null = null;
-		let { message, source, relatedInformation, code } = marker;
-
-		if (typeof message === 'string') {
-
-			hoverMessage = new MarkdownString();
-			// Disable markdown renderer sanitize to allow html
-			// Hence, escape all input strings
-			hoverMessage.sanitize = false;
-
-			hoverMessage.appendMarkdown(`<div>`);
-			hoverMessage.appendMarkdown(`<span style='font-family: Monaco, Menlo, Consolas, "Droid Sans Mono", "Inconsolata", "Courier New", monospace, "Droid Sans Fallback"; white-space: pre-wrap;'>${escape(message.trim())}</span>`);
-			if (source) {
-				hoverMessage.appendMarkdown(`<span style='opacity: 0.6; padding-left:6px;'>${escape(source)}</span>`);
-				if (code) {
-					hoverMessage.appendMarkdown(`<span style='opacity: 0.6; padding-left:2px;'>(${escape(code)})</span>`);
-				}
-			} else if (code) {
-				hoverMessage.appendMarkdown(`<span style='opacity: 0.6; padding-left:6px;'>(${escape(code)})</span>`);
-			}
-			hoverMessage.appendMarkdown(`</div>`);
-
-			if (isNonEmptyArray(relatedInformation)) {
-				hoverMessage.appendMarkdown(`<ul>`);
-				for (const { message, resource, startLineNumber, startColumn } of relatedInformation) {
-					hoverMessage.appendMarkdown(`<li>`);
-					hoverMessage.appendMarkdown(`<a href='#' data-href='${resource.toString(false)}#${startLineNumber},${startColumn}'>${escape(basename(resource.path))}(${startLineNumber}, ${startColumn})</a>`);
-					hoverMessage.appendMarkdown(`<span>: ${escape(message)}</span>`);
-					hoverMessage.appendMarkdown(`</li>`);
-				}
-				hoverMessage.appendMarkdown(`</ul>`);
-			}
-		}
-
-		return {
-			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-			className,
-			hoverMessage,
-			showIfCollapsed: true,
-			overviewRuler: {
-				color,
-				position: OverviewRulerLane.Right
-			},
-			zIndex,
-			inlineClassName,
-		};
 	}
 }
 
@@ -283,7 +119,7 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 	constructor(
 		@IMarkerService markerService: IMarkerService | null,
 		@IConfigurationService configurationService: IConfigurationService,
-		@ITextResourcePropertiesService resourcePropertiesService: ITextResourcePropertiesService,
+		@ITextResourcePropertiesService resourcePropertiesService: ITextResourcePropertiesService
 	) {
 		super();
 		this._markerService = markerService;
@@ -291,11 +127,6 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 		this._resourcePropertiesService = resourcePropertiesService;
 		this._models = {};
 		this._modelCreationOptionsByLanguageAndResource = Object.create(null);
-
-		if (this._markerService) {
-			this._markerServiceSubscription = this._markerService.onMarkerChanged(this._handleMarkerChange, this);
-			this._handleMarkerChange(this._markerService.read().map(m => m.resource));
-		}
 
 		this._configurationServiceSubscription = this._configurationService.onDidChangeConfiguration(e => this._updateModelOptions());
 		this._updateModelOptions();
@@ -413,17 +244,6 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 		super.dispose();
 	}
 
-	private _handleMarkerChange(changedResources: URI[]): void {
-		changedResources.forEach((resource) => {
-			let modelId = MODEL_ID(resource);
-			let modelData = this._models[modelId];
-			if (!modelData) {
-				return;
-			}
-			ModelMarkerHandler.setMarkers(modelData, this._markerService!);
-		});
-	}
-
 	private _cleanUp(model: ITextModel): void {
 		// clean up markers for internal, transient models
 		if (model.uri.scheme === network.Schemas.inMemory
@@ -539,11 +359,6 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 			this.setMode(modelData.model, languageSelection);
 		} else {
 			modelData = this._createModelData(value, PLAINTEXT_LANGUAGE_IDENTIFIER, resource, isForSimpleWidget);
-		}
-
-		// handle markers (marker service => model)
-		if (this._markerService) {
-			ModelMarkerHandler.setMarkers(modelData, this._markerService);
 		}
 
 		this._onModelAdded.fire(modelData.model);

--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -24,6 +24,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { editorHoverBackground, editorHoverBorder, editorHoverHighlight, textCodeBlockBackground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 
 export class ModesHoverController implements IEditorContribution {
 
@@ -61,6 +62,7 @@ export class ModesHoverController implements IEditorContribution {
 	constructor(private readonly _editor: ICodeEditor,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IModeService private readonly _modeService: IModeService,
+		@IMarkerDecorationsService private readonly _markerDecorationsService: IMarkerDecorationsService,
 		@IThemeService private readonly _themeService: IThemeService
 	) {
 		this._toUnhook = [];
@@ -204,7 +206,7 @@ export class ModesHoverController implements IEditorContribution {
 
 	private _createHoverWidget() {
 		const renderer = new MarkdownRenderer(this._editor, this._modeService, this._openerService);
-		this._contentWidget = new ModesContentHoverWidget(this._editor, renderer, this._themeService);
+		this._contentWidget = new ModesContentHoverWidget(this._editor, renderer, this._markerDecorationsService, this._themeService);
 		this._glyphWidget = new ModesGlyphHoverWidget(this._editor, renderer);
 	}
 

--- a/src/vs/editor/contrib/smartSelect/test/smartSelect.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/smartSelect.test.ts
@@ -15,7 +15,6 @@ import { javascriptOnEnterRules } from 'vs/editor/test/common/modes/supports/jav
 import { ITextResourcePropertiesService } from 'vs/editor/common/services/resourceConfiguration';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { isLinux, isMacintosh } from 'vs/base/common/platform';
-import { MarkerService } from 'vs/platform/markers/common/markerService';
 import { BracketSelectionRangeProvider } from 'vs/editor/contrib/smartSelect/bracketSelections';
 import { provideSelectionRanges } from 'vs/editor/contrib/smartSelect/smartSelect';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -66,7 +65,7 @@ suite('SmartSelect', () => {
 
 	setup(() => {
 		const configurationService = new TestConfigurationService();
-		modelService = new ModelServiceImpl(new MarkerService(), configurationService, new TestTextResourcePropertiesService(configurationService));
+		modelService = new ModelServiceImpl(configurationService, new TestTextResourcePropertiesService(configurationService));
 		mode = new MockJSMode();
 	});
 

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -42,6 +42,8 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { MenuService } from 'vs/platform/actions/common/menuService';
+import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
+import { MarkerDecorationsService } from 'vs/editor/common/services/markerDecorationsServiceImpl';
 
 export interface IEditorOverrideServices {
 	[index: string]: any;
@@ -134,6 +136,8 @@ export module StaticServices {
 	export const modeService = define(IModeService, (o) => new ModeServiceImpl());
 
 	export const modelService = define(IModelService, (o) => new ModelServiceImpl(markerService.get(o), configurationService.get(o), resourcePropertiesService.get(o)));
+
+	export const markerDecorationsService = define(IMarkerDecorationsService, (o) => new MarkerDecorationsService(modelService.get(o), markerService.get(o)));
 
 	export const editorWorkerService = define(IEditorWorkerService, (o) => new EditorWorkerServiceImpl(modelService.get(o), resourceConfigurationService.get(o)));
 

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -135,7 +135,7 @@ export module StaticServices {
 
 	export const modeService = define(IModeService, (o) => new ModeServiceImpl());
 
-	export const modelService = define(IModelService, (o) => new ModelServiceImpl(markerService.get(o), configurationService.get(o), resourcePropertiesService.get(o)));
+	export const modelService = define(IModelService, (o) => new ModelServiceImpl(configurationService.get(o), resourcePropertiesService.get(o)));
 
 	export const markerDecorationsService = define(IMarkerDecorationsService, (o) => new MarkerDecorationsService(modelService.get(o), markerService.get(o)));
 

--- a/src/vs/editor/test/common/services/modelService.test.ts
+++ b/src/vs/editor/test/common/services/modelService.test.ts
@@ -27,7 +27,7 @@ suite('ModelService', () => {
 		configService.setUserConfiguration('files', { 'eol': '\n' });
 		configService.setUserConfiguration('files', { 'eol': '\r\n' }, URI.file(platform.isWindows ? 'c:\\myroot' : '/myroot'));
 
-		modelService = new ModelServiceImpl(null, configService, new TestTextResourcePropertiesService(configService));
+		modelService = new ModelServiceImpl(configService, new TestTextResourcePropertiesService(configService));
 	});
 
 	teardown(() => {

--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -104,6 +104,8 @@ import { TextResourcePropertiesService } from 'vs/workbench/services/textfile/el
 import { MultiExtensionManagementService } from 'vs/platform/extensionManagement/node/multiExtensionManagement';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { RemoteAuthorityResolverService } from 'vs/platform/remote/electron-browser/remoteAuthorityResolverService';
+import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
+import { MarkerDecorationsService } from 'vs/editor/common/services/markerDecorationsServiceImpl';
 
 /**
  * Services that we require for the Shell
@@ -488,6 +490,7 @@ export class WorkbenchShell extends Disposable {
 
 		serviceCollection.set(IMarkerService, new SyncDescriptor(MarkerService, undefined, true));
 
+
 		serviceCollection.set(IModeService, new SyncDescriptor(WorkbenchModeServiceImpl));
 
 		serviceCollection.set(ITextResourceConfigurationService, new SyncDescriptor(TextResourceConfigurationService));
@@ -495,6 +498,8 @@ export class WorkbenchShell extends Disposable {
 		serviceCollection.set(ITextResourcePropertiesService, new SyncDescriptor(TextResourcePropertiesService));
 
 		serviceCollection.set(IModelService, new SyncDescriptor(ModelServiceImpl, undefined, true));
+
+		serviceCollection.set(IMarkerDecorationsService, new SyncDescriptor(MarkerDecorationsService));
 
 		serviceCollection.set(IEditorWorkerService, new SyncDescriptor(EditorWorkerServiceImpl));
 

--- a/src/vs/workbench/test/electron-browser/api/mainThreadDocumentsAndEditors.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadDocumentsAndEditors.test.ts
@@ -42,7 +42,7 @@ suite('MainThreadDocumentsAndEditors', () => {
 		deltas.length = 0;
 		const configService = new TestConfigurationService();
 		configService.setUserConfiguration('editor', { 'detectIndentation': false });
-		modelService = new ModelServiceImpl(null, configService, new TestTextResourcePropertiesService(configService));
+		modelService = new ModelServiceImpl(configService, new TestTextResourcePropertiesService(configService));
 		codeEditorService = new TestCodeEditorService();
 		textFileService = new class extends mock<ITextFileService>() {
 			isDirty() { return false; }

--- a/src/vs/workbench/test/electron-browser/api/mainThreadEditors.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadEditors.test.ts
@@ -41,7 +41,7 @@ suite('MainThreadEditors', () => {
 
 	setup(() => {
 		const configService = new TestConfigurationService();
-		modelService = new ModelServiceImpl(null, configService, new TestTextResourcePropertiesService(configService));
+		modelService = new ModelServiceImpl(configService, new TestTextResourcePropertiesService(configService));
 		const codeEditorService = new TestCodeEditorService();
 
 		movedResources.clear();

--- a/src/vs/workbench/test/electron-browser/quickopen.perf.integrationTest.ts
+++ b/src/vs/workbench/test/electron-browser/quickopen.perf.integrationTest.ts
@@ -72,7 +72,7 @@ suite.skip('QuickOpen performance (integration)', () => {
 			[ITelemetryService, telemetryService],
 			[IConfigurationService, configurationService],
 			[ITextResourcePropertiesService, textResourcePropertiesService],
-			[IModelService, new ModelServiceImpl(null, configurationService, textResourcePropertiesService)],
+			[IModelService, new ModelServiceImpl(configurationService, textResourcePropertiesService)],
 			[IWorkspaceContextService, new TestContextService(testWorkspace(URI.file(testWorkspacePath)))],
 			[IEditorService, new TestEditorService()],
 			[IEditorGroupsService, new TestEditorGroupsService()],

--- a/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
+++ b/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
@@ -62,7 +62,7 @@ suite.skip('TextSearch performance (integration)', () => {
 			[ITelemetryService, telemetryService],
 			[IConfigurationService, configurationService],
 			[ITextResourcePropertiesService, textResourcePropertiesService],
-			[IModelService, new ModelServiceImpl(null, configurationService, textResourcePropertiesService)],
+			[IModelService, new ModelServiceImpl(configurationService, textResourcePropertiesService)],
 			[IWorkspaceContextService, new TestContextService(testWorkspace(URI.file(testWorkspacePath)))],
 			[IEditorService, new TestEditorService()],
 			[IEditorGroupsService, new TestEditorGroupsService()],


### PR DESCRIPTION
Fix #62370 

Moved rendering marker hover into hover widget which can display marker message and details nicely. And also applies right editor font to the message.