### PR TITLE
Don't use 'window' in node/ files

### DIFF
--- a/src/vs/workbench/parts/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/parts/terminal/node/terminalProcess.ts
@@ -19,7 +19,7 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 	private _currentTitle: string = '';
 	private _processStartupComplete: Promise<void>;
 	private _isDisposed: boolean = false;
-	private _titleInterval: number = -1;
+	private _titleInterval: NodeJS.Timer | null = null;
 
 	private readonly _onProcessData = new Emitter<string>();
 	public get onProcessData(): Event<string> { return this._onProcessData.event; }
@@ -91,8 +91,10 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 
 	public dispose(): void {
 		this._isDisposed = true;
-		window.clearInterval(this._titleInterval);
-		this._titleInterval = -1;
+		if (this._titleInterval) {
+			clearInterval(this._titleInterval);
+		}
+		this._titleInterval = null;
 		this._onProcessData.dispose();
 		this._onProcessExit.dispose();
 		this._onProcessIdReady.dispose();
@@ -105,7 +107,7 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			this._sendProcessTitle();
 		}, 0);
 		// Setup polling
-		this._titleInterval = window.setInterval(() => {
+		this._titleInterval = setInterval(() => {
 			if (this._currentTitle !== this._ptyProcess.process) {
 				this._sendProcessTitle();
 			}


### PR DESCRIPTION
This came in with the conpty PR that was just merged a couple weeks ago.