### PR TITLE
Add link check for markdown files

### DIFF
--- a/build/azure-pipelines/linux/continuous-build-linux.yml
+++ b/build/azure-pipelines/linux/continuous-build-linux.yml
@@ -15,6 +15,8 @@ steps:
     versionSpec: "1.10.1"
 - script: |
     yarn
+    # Keep this version pinned:
+    sudo npm install -g markdown-link-check@3.7.2
   displayName: Install Dependencies
 - script: |
     yarn gulp electron-x64
@@ -37,6 +39,9 @@ steps:
 - script: |
     DISPLAY=:10 ./scripts/test.sh --tfs "Unit Tests"
   displayName: Run Unit Tests
+- script: |
+    find . -name \*.md -exec markdown-link-check {} \;
+  displayName: Test links
 - task: PublishTestResults@2
   displayName: Publish Tests Results
   inputs:

--- a/build/azure-pipelines/linux/continuous-build-linux.yml
+++ b/build/azure-pipelines/linux/continuous-build-linux.yml
@@ -19,7 +19,7 @@ steps:
     sudo npm install -g markdown-link-check@3.7.2
   displayName: Install Dependencies
 - script: |
-    yarn gulp electron-x64
+    sudo yarn gulp electron-x64
   displayName: Download Electron
 - script: |
     yarn gulp hygiene


### PR DESCRIPTION
Added a great check to the Linux build process that determines if any markdown files have dead links (errors such as 404 or just no response from the page).  I recently implemented this check into [PowerShell](https://github.com/PowerShell/PowerShell) and the community loves it.  If dead links are found it won't fail the entire status check.  