### PR TITLE
Implement API for listening to executed commands

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -224,6 +224,8 @@ export class StandaloneCommandService implements ICommandService {
 
 	private readonly _onWillExecuteCommand = new Emitter<ICommandEvent>();
 	public readonly onWillExecuteCommand: Event<ICommandEvent> = this._onWillExecuteCommand.event;
+	private readonly _onDidExecuteCommand = new Emitter<ICommandEvent>();
+	public readonly onDidExecuteCommand: Event<ICommandEvent> = this._onDidExecuteCommand.event;
 
 	constructor(instantiationService: IInstantiationService) {
 		this._instantiationService = instantiationService;
@@ -247,6 +249,7 @@ export class StandaloneCommandService implements ICommandService {
 		try {
 			this._onWillExecuteCommand.fire({ commandId: id });
 			const result = this._instantiationService.invokeFunction.apply(this._instantiationService, [command.handler, ...args]) as T;
+			this._onDidExecuteCommand.fire({ commandId: id });
 			return Promise.resolve(result);
 		} catch (err) {
 			return Promise.reject(err);

--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -24,7 +24,7 @@ import { TextEdit, WorkspaceEdit, isResourceTextEdit } from 'vs/editor/common/mo
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { ITextEditorModel, ITextModelContentProvider, ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ITextResourceConfigurationService, ITextResourcePropertiesService } from 'vs/editor/common/services/resourceConfiguration';
-import { CommandsRegistry, ICommand, ICommandEvent, ICommandHandler, ICommandService } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommand, ICommandEvent, ICommandHandler, ICommandService, CommandExecutionSource } from 'vs/platform/commands/common/commands';
 import { IConfigurationChangeEvent, IConfigurationData, IConfigurationOverrides, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Configuration, ConfigurationModel, DefaultConfigurationModel } from 'vs/platform/configuration/common/configurationModels';
 import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -247,9 +247,9 @@ export class StandaloneCommandService implements ICommandService {
 		}
 
 		try {
-			this._onWillExecuteCommand.fire({ commandId: id });
+			this._onWillExecuteCommand.fire({ commandId: id, source: CommandExecutionSource.Editor });
 			const result = this._instantiationService.invokeFunction.apply(this._instantiationService, [command.handler, ...args]) as T;
-			this._onDidExecuteCommand.fire({ commandId: id });
+			this._onDidExecuteCommand.fire({ commandId: id, source: CommandExecutionSource.Editor });
 			return Promise.resolve(result);
 		} catch (err) {
 			return Promise.reject(err);

--- a/src/vs/editor/test/browser/editorTestServices.ts
+++ b/src/vs/editor/test/browser/editorTestServices.ts
@@ -31,6 +31,8 @@ export class TestCommandService implements ICommandService {
 
 	private readonly _onWillExecuteCommand = new Emitter<ICommandEvent>();
 	public readonly onWillExecuteCommand: Event<ICommandEvent> = this._onWillExecuteCommand.event;
+	private readonly _onDidExecuteCommand = new Emitter<ICommandEvent>();
+	public readonly onDidExecuteCommand: Event<ICommandEvent> = this._onDidExecuteCommand.event;
 
 	constructor(instantiationService: IInstantiationService) {
 		this._instantiationService = instantiationService;
@@ -45,6 +47,7 @@ export class TestCommandService implements ICommandService {
 		try {
 			this._onWillExecuteCommand.fire({ commandId: id });
 			const result = this._instantiationService.invokeFunction.apply(this._instantiationService, [command.handler, ...args]) as T;
+			this._onDidExecuteCommand.fire({ commandId: id });
 			return Promise.resolve(result);
 		} catch (err) {
 			return Promise.reject(err);

--- a/src/vs/editor/test/browser/editorTestServices.ts
+++ b/src/vs/editor/test/browser/editorTestServices.ts
@@ -8,7 +8,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { AbstractCodeEditorService } from 'vs/editor/browser/services/abstractCodeEditorService';
 import { IDecorationRenderOptions } from 'vs/editor/common/editorCommon';
 import { IModelDecorationOptions } from 'vs/editor/common/model';
-import { CommandsRegistry, ICommandEvent, ICommandService } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandEvent, ICommandService, CommandExecutionSource } from 'vs/platform/commands/common/commands';
 import { IResourceInput } from 'vs/platform/editor/common/editor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
@@ -45,9 +45,9 @@ export class TestCommandService implements ICommandService {
 		}
 
 		try {
-			this._onWillExecuteCommand.fire({ commandId: id });
+			this._onWillExecuteCommand.fire({ commandId: id, source: CommandExecutionSource.Editor });
 			const result = this._instantiationService.invokeFunction.apply(this._instantiationService, [command.handler, ...args]) as T;
-			this._onDidExecuteCommand.fire({ commandId: id });
+			this._onDidExecuteCommand.fire({ commandId: id, source: CommandExecutionSource.Editor });
 			return Promise.resolve(result);
 		} catch (err) {
 			return Promise.reject(err);

--- a/src/vs/editor/test/browser/services/openerService.test.ts
+++ b/src/vs/editor/test/browser/services/openerService.test.ts
@@ -17,6 +17,7 @@ suite('OpenerService', function () {
 	const commandService = new class implements ICommandService {
 		_serviceBrand: any;
 		onWillExecuteCommand = () => ({ dispose: () => { } });
+		onDidExecuteCommand = () => ({ dispose: () => { } });
 		executeCommand(id: string, ...args: any[]): Promise<any> {
 			lastCommand = { id, args };
 			return Promise.resolve(undefined);

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -11,8 +11,15 @@ import { LinkedList } from 'vs/base/common/linkedList';
 
 export const ICommandService = createDecorator<ICommandService>('commandService');
 
+export enum CommandExecutionSource {
+	CommandPalette,
+	Workbench,
+	Editor,
+}
+
 export interface ICommandEvent {
 	commandId: string;
+	source: CommandExecutionSource;
 }
 
 export interface ICommandService {
@@ -20,6 +27,13 @@ export interface ICommandService {
 	onWillExecuteCommand: Event<ICommandEvent>;
 	onDidExecuteCommand: Event<ICommandEvent>;
 	executeCommand<T = any>(commandId: string, ...args: any[]): Promise<T | undefined>;
+
+	/**
+	 * TODO: Find a cleaner way to proxy this.
+	 * CommandsHandler needs a way to emit that it
+	 * executed a command.
+	 */
+	_emitDidExecute?(event: ICommandEvent): void;
 }
 
 export interface ICommandsMap {

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -18,6 +18,7 @@ export interface ICommandEvent {
 export interface ICommandService {
 	_serviceBrand: any;
 	onWillExecuteCommand: Event<ICommandEvent>;
+	onDidExecuteCommand: Event<ICommandEvent>;
 	executeCommand<T = any>(commandId: string, ...args: any[]): Promise<T | undefined>;
 }
 
@@ -131,6 +132,7 @@ export const CommandsRegistry: ICommandRegistry = new class implements ICommandR
 export const NullCommandService: ICommandService = {
 	_serviceBrand: undefined,
 	onWillExecuteCommand: () => ({ dispose: () => { } }),
+	onDidExecuteCommand: () => ({ dispose: () => { } }),
 	executeCommand<T = any>() {
 		return Promise.resolve<T>(undefined);
 	}

--- a/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
+++ b/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
@@ -113,6 +113,7 @@ suite('AbstractKeybindingService', () => {
 			let commandService: ICommandService = {
 				_serviceBrand: undefined,
 				onWillExecuteCommand: () => ({ dispose: () => { } }),
+				onDidExecuteCommand: () => ({ dispose: () => { } }),
 				executeCommand: (commandId: string, ...args: any[]): Promise<any> => {
 					executeCommandCalls.push({
 						commandId: commandId,

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -552,6 +552,12 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region Kyle: onDidExecuteCommand
+	export namespace commands {
+		export const onDidExecuteCommand: Event<string>;
+	}
+	//#endregion
+
 	//#region André: debug
 
 	// deprecated

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -553,8 +553,19 @@ declare module 'vscode' {
 	//#endregion
 
 	//#region Kyle: onDidExecuteCommand
+	export enum CommandExecutionSource {
+		CommandPalette = 1,
+		Workbench = 2,
+		Editor = 3,
+	}
+
+	export interface CommandExecutedEvent {
+		readonly commandId: string;
+		readonly source: CommandExecutionSource;
+	}
+
 	export namespace commands {
-		export const onDidExecuteCommand: Event<string>;
+		export const onDidExecuteCommand: Event<CommandExecutedEvent>;
 	}
 	//#endregion
 

--- a/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
@@ -8,6 +8,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { ExtHostContext, MainThreadCommandsShape, ExtHostCommandsShape, MainContext, IExtHostContext } from '../node/extHost.protocol';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
 import { revive } from 'vs/base/common/marshalling';
+import { CommandExecutionSource } from 'vs/workbench/api/node/extHostTypeConverters';
 
 @extHostNamedCustomer(MainContext.MainThreadCommands)
 export class MainThreadCommands implements MainThreadCommandsShape {
@@ -24,8 +25,8 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostCommands);
 		this._generateCommandsDocumentationRegistration = CommandsRegistry.registerCommand('_generateCommandsDocumentation', () => this._generateCommandsDocumentation());
 
-		if (this._commandService) {
-			this._toDispose.push(this._commandService.onDidExecuteCommand((e) => this._proxy.$onDidExecuteCommand(e.commandId)));
+		if (this._commandService && this._commandService.onDidExecuteCommand) {
+			this._toDispose.push(this._commandService.onDidExecuteCommand((e) => this._proxy.$onDidExecuteCommand(e.commandId, CommandExecutionSource.to(e.source))));
 		}
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
@@ -8,6 +8,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { ExtHostContext, MainThreadCommandsShape, ExtHostCommandsShape, MainContext, IExtHostContext } from '../node/extHost.protocol';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
 import { revive } from 'vs/base/common/marshalling';
+import { CommandService } from 'vs/workbench/services/commands/common/commandService';
 
 @extHostNamedCustomer(MainContext.MainThreadCommands)
 export class MainThreadCommands implements MainThreadCommandsShape {
@@ -22,8 +23,11 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 		@ICommandService private readonly _commandService: ICommandService,
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostCommands);
-		this._toDispose.push(this._commandService.onDidExecuteCommand((e) => this._proxy.$onDidExecuteCommand(e.commandId)));
 		this._generateCommandsDocumentationRegistration = CommandsRegistry.registerCommand('_generateCommandsDocumentation', () => this._generateCommandsDocumentation());
+
+		if (_commandService instanceof CommandService) {
+			this._toDispose.push(this._commandService.onDidExecuteCommand((e) => this._proxy.$onDidExecuteCommand(e.commandId)));
+		}
 	}
 
 	dispose() {

--- a/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
@@ -25,7 +25,7 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostCommands);
 		this._generateCommandsDocumentationRegistration = CommandsRegistry.registerCommand('_generateCommandsDocumentation', () => this._generateCommandsDocumentation());
 
-		if (_commandService instanceof CommandService) {
+		if (this._commandService) {
 			this._toDispose.push(this._commandService.onDidExecuteCommand((e) => this._proxy.$onDidExecuteCommand(e.commandId)));
 		}
 	}

--- a/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadCommands.ts
@@ -8,7 +8,6 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { ExtHostContext, MainThreadCommandsShape, ExtHostCommandsShape, MainContext, IExtHostContext } from '../node/extHost.protocol';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
 import { revive } from 'vs/base/common/marshalling';
-import { CommandService } from 'vs/workbench/services/commands/common/commandService';
 
 @extHostNamedCustomer(MainContext.MainThreadCommands)
 export class MainThreadCommands implements MainThreadCommandsShape {

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -230,6 +230,9 @@ export function createApiFactory(
 					callback.apply(thisArg, [diff, ...args]);
 				});
 			}),
+			get onDidExecuteCommand(): Event<string> {
+				return extHostCommands.onDidExecuteCommand;
+			},
 			executeCommand<T>(id: string, ...args: any[]): Thenable<T> {
 				return extHostCommands.executeCommand<T>(checkCommand(id), ...args);
 			},

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -230,7 +230,7 @@ export function createApiFactory(
 					callback.apply(thisArg, [diff, ...args]);
 				});
 			}),
-			get onDidExecuteCommand(): Event<string> {
+			get onDidExecuteCommand(): Event<vscode.CommandExecutedEvent> {
 				return extHostCommands.onDidExecuteCommand;
 			},
 			executeCommand<T>(id: string, ...args: any[]): Thenable<T> {
@@ -748,6 +748,7 @@ export function createApiFactory(
 			Color: extHostTypes.Color,
 			ColorInformation: extHostTypes.ColorInformation,
 			ColorPresentation: extHostTypes.ColorPresentation,
+			CommandExecutionSource: extHostTypes.CommandExecutionSource,
 			CommentThreadCollapsibleState: extHostTypes.CommentThreadCollapsibleState,
 			CompletionItem: extHostTypes.CompletionItem,
 			CompletionItemKind: extHostTypes.CompletionItemKind,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -629,6 +629,7 @@ export interface MainThreadWindowShape extends IDisposable {
 export interface ExtHostCommandsShape {
 	$executeContributedCommand<T>(id: string, ...args: any[]): Promise<T>;
 	$getContributedCommandHandlerDescriptions(): Promise<{ [id: string]: string | ICommandHandlerDescription }>;
+	$onDidExecuteCommand(id: string): void;
 }
 
 export interface ExtHostConfigurationShape {

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -29,7 +29,7 @@ import { IPatternInfo, IRawFileMatch2, IRawQuery, IRawTextQuery, ISearchComplete
 import { StatusbarAlignment as MainThreadStatusBarAlignment } from 'vs/platform/statusbar/common/statusbar';
 import { ITelemetryInfo } from 'vs/platform/telemetry/common/telemetry';
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
-import { EndOfLine, IFileOperationOptions, TextEditorLineNumbersStyle } from 'vs/workbench/api/node/extHostTypes';
+import { EndOfLine, IFileOperationOptions, TextEditorLineNumbersStyle, CommandExecutionSource } from 'vs/workbench/api/node/extHostTypes';
 import { EditorViewColumn } from 'vs/workbench/api/shared/editor';
 import { TaskDTO, TaskExecutionDTO, TaskFilterDTO, TaskHandleDTO, TaskProcessEndedDTO, TaskProcessStartedDTO, TaskSystemInfoDTO, TaskSetDTO } from 'vs/workbench/api/shared/tasks';
 import { ITreeItem, IRevealOptions } from 'vs/workbench/common/views';
@@ -629,7 +629,7 @@ export interface MainThreadWindowShape extends IDisposable {
 export interface ExtHostCommandsShape {
 	$executeContributedCommand<T>(id: string, ...args: any[]): Promise<T>;
 	$getContributedCommandHandlerDescriptions(): Promise<{ [id: string]: string | ICommandHandlerDescription }>;
-	$onDidExecuteCommand(id: string): void;
+	$onDidExecuteCommand(id: string, source: CommandExecutionSource): void;
 }
 
 export interface ExtHostConfigurationShape {

--- a/src/vs/workbench/api/node/extHostCommands.ts
+++ b/src/vs/workbench/api/node/extHostCommands.ts
@@ -34,7 +34,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 	private readonly _converter: CommandsConverter;
 	private readonly _logService: ILogService;
 	private readonly _argumentProcessors: ArgumentProcessor[];
-	private readonly _onDidExecuteCommand: Emitter<string>;
+	private readonly _onDidExecuteCommand: Emitter<vscode.CommandExecutedEvent>;
 
 	constructor(
 		mainContext: IMainContext,
@@ -45,10 +45,10 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		this._logService = logService;
 		this._converter = new CommandsConverter(this, heapService);
 		this._argumentProcessors = [{ processArgument(a) { return revive(a, 0); } }];
-		this._onDidExecuteCommand = new Emitter<string>();
+		this._onDidExecuteCommand = new Emitter();
 	}
 
-	get onDidExecuteCommand(): Event<string> {
+	get onDidExecuteCommand(): Event<vscode.CommandExecutedEvent> {
 		return this._onDidExecuteCommand.event;
 	}
 
@@ -136,8 +136,8 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		}
 	}
 
-	$onDidExecuteCommand(id: string): void {
-		this._onDidExecuteCommand.fire(id);
+	$onDidExecuteCommand(id: string, source: extHostTypes.CommandExecutionSource): void {
+		this._onDidExecuteCommand.fire({ commandId: id, source });
 	}
 
 	$executeContributedCommand<T>(id: string, ...args: any[]): Promise<T> {

--- a/src/vs/workbench/api/node/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/node/extHostTypeConverters.ts
@@ -28,6 +28,7 @@ import * as marked from 'vs/base/common/marked/marked';
 import { parse } from 'vs/base/common/marshalling';
 import { cloneAndChange } from 'vs/base/common/objects';
 import { LogLevel as _MainLogLevel } from 'vs/platform/log/common/log';
+import { CommandExecutionSource as _MainCommandExecutionSource } from 'vs/platform/commands/common/commands';
 
 export interface PositionLike {
 	line: number;
@@ -1034,5 +1035,29 @@ export namespace LogLevel {
 		}
 
 		return types.LogLevel.Info;
+	}
+}
+
+export namespace CommandExecutionSource {
+	export function from(extSource: types.CommandExecutionSource): _MainCommandExecutionSource {
+		switch (extSource) {
+			case types.CommandExecutionSource.CommandPalette:
+				return _MainCommandExecutionSource.CommandPalette;
+			case types.CommandExecutionSource.Workbench:
+				return _MainCommandExecutionSource.Workbench;
+			case types.CommandExecutionSource.Editor:
+				return _MainCommandExecutionSource.Editor;
+		}
+	}
+
+	export function to(mainSource: _MainCommandExecutionSource): types.CommandExecutionSource {
+		switch (mainSource) {
+			case _MainCommandExecutionSource.CommandPalette:
+				return types.CommandExecutionSource.CommandPalette;
+			case _MainCommandExecutionSource.Editor:
+				return types.CommandExecutionSource.Editor;
+			case _MainCommandExecutionSource.Workbench:
+				return types.CommandExecutionSource.Workbench;
+		}
 	}
 }

--- a/src/vs/workbench/api/node/extHostTypes.ts
+++ b/src/vs/workbench/api/node/extHostTypes.ts
@@ -2025,6 +2025,12 @@ export class DebugAdapterImplementation implements vscode.DebugAdapterImplementa
 }
 */
 
+export enum CommandExecutionSource {
+	CommandPalette = 1,
+	Workbench = 2,
+	Editor = 3,
+}
+
 export enum LogLevel {
 	Trace = 1,
 	Debug = 2,

--- a/src/vs/workbench/services/commands/common/commandService.ts
+++ b/src/vs/workbench/services/commands/common/commandService.ts
@@ -18,6 +18,8 @@ export class CommandService extends Disposable implements ICommandService {
 
 	private readonly _onWillExecuteCommand: Emitter<ICommandEvent> = this._register(new Emitter<ICommandEvent>());
 	public readonly onWillExecuteCommand: Event<ICommandEvent> = this._onWillExecuteCommand.event;
+	private readonly _onDidExecuteCommand: Emitter<ICommandEvent> = this._register(new Emitter<ICommandEvent>());
+	public readonly onDidExecuteCommand: Event<ICommandEvent> = this._onDidExecuteCommand.event;
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -61,6 +63,7 @@ export class CommandService extends Disposable implements ICommandService {
 		try {
 			this._onWillExecuteCommand.fire({ commandId: id });
 			const result = this._instantiationService.invokeFunction.apply(this._instantiationService, [command.handler, ...args]);
+			this._onDidExecuteCommand.fire({ commandId: id });
 			return Promise.resolve(result);
 		} catch (err) {
 			return Promise.reject(err);

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -507,6 +507,7 @@ class MockCommandService implements ICommandService {
 	public callCount = 0;
 
 	onWillExecuteCommand = () => Disposable.None;
+	onDidExecuteCommand = () => Disposable.None;
 	public executeCommand(commandId: string, ...args: any[]): Promise<any> {
 		this.callCount++;
 

--- a/src/vs/workbench/test/electron-browser/api/extHostMessagerService.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostMessagerService.test.ts
@@ -24,6 +24,7 @@ const emptyDialogService = new class implements IDialogService {
 const emptyCommandService: ICommandService = {
 	_serviceBrand: undefined,
 	onWillExecuteCommand: () => ({ dispose: () => { } }),
+	onDidExecuteCommand: () => ({ dispose: () => { } }),
 	executeCommand: (commandId: string, ...args: any[]): Promise<any> => {
 		return Promise.resolve(undefined);
 	}

--- a/src/vs/workbench/test/electron-browser/api/extHostTypeConverter.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostTypeConverter.test.ts
@@ -5,11 +5,12 @@
 
 
 import * as assert from 'assert';
-import { MarkdownString, LogLevel } from 'vs/workbench/api/node/extHostTypeConverters';
+import { MarkdownString, LogLevel, CommandExecutionSource } from 'vs/workbench/api/node/extHostTypeConverters';
 import { isEmptyObject } from 'vs/base/common/types';
 import { size } from 'vs/base/common/collections';
 import * as types from 'vs/workbench/api/node/extHostTypes';
 import { LogLevel as _MainLogLevel } from 'vs/platform/log/common/log';
+import { CommandExecutionSource as _MainCommandExecutionSource } from 'vs/platform/commands/common/commands';
 
 suite('ExtHostTypeConverter', function () {
 
@@ -67,5 +68,15 @@ suite('ExtHostTypeConverter', function () {
 		assert.equal(LogLevel.to(_MainLogLevel.Error), types.LogLevel.Error);
 		assert.equal(LogLevel.to(_MainLogLevel.Info), types.LogLevel.Info);
 		assert.equal(LogLevel.to(_MainLogLevel.Off), types.LogLevel.Off);
+	});
+
+	test('CommandExecutionSource', () => {
+		assert.equal(CommandExecutionSource.from(types.CommandExecutionSource.CommandPalette), _MainCommandExecutionSource.CommandPalette);
+		assert.equal(CommandExecutionSource.from(types.CommandExecutionSource.Workbench), _MainCommandExecutionSource.Workbench);
+		assert.equal(CommandExecutionSource.from(types.CommandExecutionSource.Editor), _MainCommandExecutionSource.Editor);
+
+		assert.equal(CommandExecutionSource.to(_MainCommandExecutionSource.CommandPalette), types.CommandExecutionSource.CommandPalette);
+		assert.equal(CommandExecutionSource.to(_MainCommandExecutionSource.Workbench), types.CommandExecutionSource.Workbench);
+		assert.equal(CommandExecutionSource.to(_MainCommandExecutionSource.Editor), types.CommandExecutionSource.Editor);
 	});
 });


### PR DESCRIPTION
Implements `vscode.commands.onDidExecuteCommand`. This does not send args with commands, only the command id and source.

```ts
vscode.commands.onDidExecuteCommand((event: vscode.CommandExecutedEvent): void => {
    console.log('We executed the command', event.commandId, event.source);
});
```

https://github.com/Microsoft/vscode/issues/1431
https://github.com/Microsoft/vscode/issues/26729