### PR TITLE
Implement API for text editor focus

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -552,6 +552,32 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region Kyle: focused editor and terminal
+
+	export interface TextEditor {
+		readonly focused: boolean;
+	}
+
+	export namespace window {
+		export const onDidChangeTextEditorFocus: Event<TextEditorFocusChangeEvent>;
+	}
+
+	/**
+	 * Represents an event describing the change in a [text editor's options](#TextEditor.options).
+	 */
+	export interface TextEditorFocusChangeEvent {
+		/**
+		 * The [text editor](#TextEditor) for which the focus has changed.
+		 */
+		textEditor: TextEditor;
+		/**
+		 * Whether the [text editor](#TextEditor) is focused.
+		 */
+		focused: boolean;
+	}
+
+	//#endregion
+
 	//#region André: debug
 
 	// deprecated

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -409,6 +409,9 @@ export function createApiFactory(
 			onDidChangeTextEditorViewColumn(listener, thisArg?, disposables?) {
 				return extHostEditors.onDidChangeTextEditorViewColumn(listener, thisArg, disposables);
 			},
+			onDidChangeTextEditorFocus(listener) {
+				return extHostEditors.onDidChangeTextEditorFocus(listener);
+			},
 			onDidCloseTerminal(listener, thisArg?, disposables?) {
 				return extHostTerminalService.onDidCloseTerminal(listener, thisArg, disposables);
 			},

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -677,6 +677,7 @@ export interface IEditorPropertiesChangeData {
 	options: IResolvedTextEditorConfiguration | null;
 	selections: ISelectionChangeEvent | null;
 	visibleRanges: IRange[] | null;
+	focused: boolean | null;
 }
 export interface ISelectionChangeEvent {
 	selections: Selection[];

--- a/src/vs/workbench/api/node/extHostTextEditor.ts
+++ b/src/vs/workbench/api/node/extHostTextEditor.ts
@@ -319,6 +319,7 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 	private _visibleRanges: Range[];
 	private _viewColumn: vscode.ViewColumn;
 	private _disposed: boolean = false;
+	private _focused: boolean = false;
 	private _hasDecorationsForKey: { [key: string]: boolean; };
 
 	get id(): string { return this._id; }
@@ -349,6 +350,10 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 
 	@deprecated('TextEditor.hide') hide() {
 		this._proxy.$tryHideEditor(this._id);
+	}
+
+	get focused(): boolean {
+		return this._focused;
 	}
 
 	// ---- the document
@@ -485,6 +490,10 @@ export class ExtHostTextEditor implements vscode.TextEditor {
 	private _trySetSelection(): Promise<vscode.TextEditor> {
 		let selection = this._selections.map(TypeConverters.Selection.from);
 		return this._runOnProxy(() => this._proxy.$trySetSelections(this._id, selection));
+	}
+
+	_setFocused(focused: boolean): void {
+		this._focused = focused;
 	}
 
 	_acceptSelections(selections: Selection[]): void {

--- a/src/vs/workbench/api/node/extHostTextEditors.ts
+++ b/src/vs/workbench/api/node/extHostTextEditors.ts
@@ -17,6 +17,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 	private readonly _onDidChangeTextEditorOptions = new Emitter<vscode.TextEditorOptionsChangeEvent>();
 	private readonly _onDidChangeTextEditorVisibleRanges = new Emitter<vscode.TextEditorVisibleRangesChangeEvent>();
 	private readonly _onDidChangeTextEditorViewColumn = new Emitter<vscode.TextEditorViewColumnChangeEvent>();
+	private readonly _onDidChangeTextEditorFocus = new Emitter<vscode.TextEditorFocusChangeEvent>();
 	private readonly _onDidChangeActiveTextEditor = new Emitter<vscode.TextEditor | undefined>();
 	private readonly _onDidChangeVisibleTextEditors = new Emitter<vscode.TextEditor[]>();
 
@@ -24,6 +25,7 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 	readonly onDidChangeTextEditorOptions: Event<vscode.TextEditorOptionsChangeEvent> = this._onDidChangeTextEditorOptions.event;
 	readonly onDidChangeTextEditorVisibleRanges: Event<vscode.TextEditorVisibleRangesChangeEvent> = this._onDidChangeTextEditorVisibleRanges.event;
 	readonly onDidChangeTextEditorViewColumn: Event<vscode.TextEditorViewColumnChangeEvent> = this._onDidChangeTextEditorViewColumn.event;
+	readonly onDidChangeTextEditorFocus: Event<vscode.TextEditorFocusChangeEvent> = this._onDidChangeTextEditorFocus.event;
 	readonly onDidChangeActiveTextEditor: Event<vscode.TextEditor | undefined> = this._onDidChangeActiveTextEditor.event;
 	readonly onDidChangeVisibleTextEditors: Event<vscode.TextEditor[]> = this._onDidChangeVisibleTextEditors.event;
 
@@ -109,6 +111,9 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 			const visibleRanges = data.visibleRanges.map(TypeConverters.Range.to);
 			textEditor._acceptVisibleRanges(visibleRanges);
 		}
+		if (data.focused !== null) {
+			textEditor._setFocused(data.focused);
+		}
 
 		// (2) fire change events
 		if (data.options) {
@@ -131,6 +136,12 @@ export class ExtHostEditors implements ExtHostEditorsShape {
 			this._onDidChangeTextEditorVisibleRanges.fire({
 				textEditor,
 				visibleRanges
+			});
+		}
+		if (data.focused !== null) {
+			this._onDidChangeTextEditorFocus.fire({
+				textEditor,
+				focused: data.focused,
 			});
 		}
 	}


### PR DESCRIPTION
Implements `vscode.window.onDidChangeTextEditorFocus` and adds a `focused` property to the `TextEditor` interface. The purpose of this is to determine active focus for time-tracking. Detecting focus within the editor and (eventually) terminal will be helpful.

Seems there could be a bit of ambiguity comparing the functionality to the `onDidChangeActiveTextEditor` event (although they each serve a distinct but similar purpose). Not _exactly_ sure how to resolve this so ideas are welcome.

My thought was to implement `onDidChangeTerminalFocus` if this felt appropriate. 

https://github.com/Microsoft/vscode/issues/47615 is the only relevant issue I could find.