### PR TITLE
Handle the edge case where there's a single quote but no space

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -801,7 +801,7 @@ export class TerminalInstance implements ITerminalInstance {
 				pathBasename === 'powershell' ||
 				this.title === 'powershell';
 
-			if (hasSpace && isPowerShell) {
+			if (isPowerShell && (hasSpace || originalPath.indexOf('\'') !== -1)) {
 				c(`& '${originalPath.replace('\'', '\'\'')}'`);
 				return;
 			}


### PR DESCRIPTION
Consider the path that does not have a space:

```
/Users/streamer/foo'.ps1
```

previously that `'` would not get escaped. 

Now it will 😊

cc @Tyriar 