### PR TITLE
Improve column selection by setting origin to clicked position

### DIFF
--- a/src/vs/editor/browser/view/viewController.ts
+++ b/src/vs/editor/browser/view/viewController.ts
@@ -193,7 +193,11 @@ export class ViewController {
 				}
 			} else {
 				if (data.inSelectionMode) {
-					this._moveToSelect(data.position);
+					if (data.altKey) {
+						this._columnSelect(data.position, data.mouseColumn);
+					} else {
+						this._moveToSelect(data.position);
+					}
 				} else {
 					this.moveTo(data.position);
 				}


### PR DESCRIPTION
In conjunction with setting `editor.multiCursorModifier` to `ctrlCmd`, this yields a much more natural `alt+click` experience. The goofier `shift+alt+click` that is the default uses the _prior_ cursor position as the start point of the column selection.

See #66444 - Resolve the column selection conversation 