### PR TITLE
Autocomplete/validation `args` for keybindings.json

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -86,7 +86,28 @@ export namespace EditorScroll_ {
 					* 'value': Number of units to move. Default is '1'.
 					* 'revealCursor': If 'true' reveals the cursor if it is outside view port.
 				`,
-				constraint: isEditorScrollArgs
+				constraint: isEditorScrollArgs,
+				schema: {
+					'type': 'object',
+					'required': ['to'],
+					'properties': {
+						'to': {
+							'type': 'string',
+							'enum': ['up', 'down']
+						},
+						'by': {
+							'type': 'string',
+							'enum': ['line', 'wrappedLine', 'page', 'halfPage']
+						},
+						'value': {
+							'type': 'number',
+							'default': 1
+						},
+						'revealCursor': {
+							'type': 'boolean',
+						}
+					}
+				}
 			}
 		]
 	};
@@ -217,7 +238,20 @@ export namespace RevealLine_ {
 						'top', 'center', 'bottom'
 						\`\`\`
 				`,
-				constraint: isRevealLineArgs
+				constraint: isRevealLineArgs,
+				schema: {
+					'type': 'object',
+					'required': ['lineNumber'],
+					'properties': {
+						'lineNumber': {
+							'type': 'number',
+						},
+						'at': {
+							'type': 'string',
+							'enum': ['top', 'center', 'bottom']
+						}
+					}
+				}
 			}
 		]
 	};
@@ -1691,10 +1725,11 @@ class EditorHandlerCommand extends Command {
 
 	private readonly _handlerId: string;
 
-	constructor(id: string, handlerId: string) {
+	constructor(id: string, handlerId: string, description?: ICommandHandlerDescription) {
 		super({
 			id: id,
-			precondition: null
+			precondition: null,
+			description: description
 		});
 		this._handlerId = handlerId;
 	}
@@ -1767,12 +1802,26 @@ registerCommand(new EditorOrNativeTextInputCommand({
 }));
 registerCommand(new EditorHandlerCommand('default:' + Handler.Redo, Handler.Redo));
 
-function registerOverwritableCommand(handlerId: string): void {
+function registerOverwritableCommand(handlerId: string, description?: ICommandHandlerDescription): void {
 	registerCommand(new EditorHandlerCommand('default:' + handlerId, handlerId));
-	registerCommand(new EditorHandlerCommand(handlerId, handlerId));
+	registerCommand(new EditorHandlerCommand(handlerId, handlerId, description));
 }
 
-registerOverwritableCommand(Handler.Type);
+registerOverwritableCommand(Handler.Type, {
+	description: `Type`,
+	args: [{
+		name: 'args',
+		schema: {
+			'type': 'object',
+			'required': ['text'],
+			'properties': {
+				'text': {
+					'type': 'string'
+				}
+			},
+		}
+	}]
+});
 registerOverwritableCommand(Handler.ReplacePreviousChar);
 registerOverwritableCommand(Handler.CompositionStart);
 registerOverwritableCommand(Handler.CompositionEnd);

--- a/src/vs/editor/common/controller/cursorMoveCommands.ts
+++ b/src/vs/editor/common/controller/cursorMoveCommands.ts
@@ -616,7 +616,29 @@ export namespace CursorMove {
 					* 'value': Number of units to move. Default is '1'.
 					* 'select': If 'true' makes the selection. Default is 'false'.
 				`,
-				constraint: isCursorMoveArgs
+				constraint: isCursorMoveArgs,
+				schema: {
+					'type': 'object',
+					'required': ['to'],
+					'properties': {
+						'to': {
+							'type': 'string',
+							'enum': ['left', 'right', 'up', 'down', 'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter', 'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter', 'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside']
+						},
+						'by': {
+							'type': 'string',
+							'enum': ['line', 'wrappedLine', 'character', 'halfLine']
+						},
+						'value': {
+							'type': 'number',
+							'default': 1
+						},
+						'select': {
+							'type': 'boolean',
+							'default': false
+						}
+					}
+				}
 			}
 		]
 	};

--- a/src/vs/editor/contrib/codeAction/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionCommands.ts
@@ -253,7 +253,27 @@ export class CodeActionCommand extends EditorCommand {
 	constructor() {
 		super({
 			id: CodeActionCommand.Id,
-			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider)
+			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider),
+			description: {
+				description: `Trigger a code action`,
+				args: [{
+					name: 'args',
+					schema: {
+						'type': 'object',
+						'required': ['kind'],
+						'properties': {
+							'kind': {
+								'type': 'string'
+							},
+							'apply': {
+								'type': 'string',
+								'default': 'ifSingle',
+								'enum': ['first', 'ifSingle', 'never']
+							}
+						}
+					}
+				}]
+			}
 		});
 	}
 
@@ -297,6 +317,25 @@ export class RefactorAction extends EditorAction {
 				when: ContextKeyExpr.and(
 					EditorContextKeys.writable,
 					contextKeyForSupportedActions(CodeActionKind.Refactor)),
+			},
+			description: {
+				description: 'Refactor...',
+				args: [{
+					name: 'args',
+					schema: {
+						'type': 'object',
+						'properties': {
+							'kind': {
+								'type': 'string'
+							},
+							'apply': {
+								'type': 'string',
+								'default': 'never',
+								'enum': ['first', 'ifSingle', 'never']
+							}
+						}
+					}
+				}]
 			}
 		});
 	}
@@ -333,6 +372,25 @@ export class SourceAction extends EditorAction {
 				when: ContextKeyExpr.and(
 					EditorContextKeys.writable,
 					contextKeyForSupportedActions(CodeActionKind.Source)),
+			},
+			description: {
+				description: 'Source Action...',
+				args: [{
+					name: 'args',
+					schema: {
+						'type': 'object',
+						'properties': {
+							'kind': {
+								'type': 'string'
+							},
+							'apply': {
+								'type': 'string',
+								'default': 'never',
+								'enum': ['first', 'ifSingle', 'never']
+							}
+						}
+					}
+				}]
 			}
 		});
 	}

--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -519,7 +519,27 @@ class UnfoldAction extends FoldingAction<FoldingArguments> {
 						* 'direction': If 'up', unfold given number of levels up otherwise unfolds down.
 						* 'selectionLines': The start lines (0-based) of the editor selections to apply the unfold action to. If not set, the active selection(s) will be used.
 						`,
-						constraint: foldingArgumentsConstraint
+						constraint: foldingArgumentsConstraint,
+						schema: {
+							'type': 'object',
+							'properties': {
+								'levels': {
+									'type': 'number',
+									'default': 1
+								},
+								'direction': {
+									'type': 'string',
+									'enum': ['up', 'down'],
+									'default': 'down'
+								},
+								'selectionLines': {
+									'type': 'array',
+									'items': {
+										'type': 'number'
+									}
+								}
+							}
+						}
 					}
 				]
 			}
@@ -584,7 +604,27 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 							* 'direction': If 'up', folds given number of levels up otherwise folds down.
 							* 'selectionLines': The start lines (0-based) of the editor selections to apply the fold action to. If not set, the active selection(s) will be used.
 						`,
-						constraint: foldingArgumentsConstraint
+						constraint: foldingArgumentsConstraint,
+						schema: {
+							'type': 'object',
+							'properties': {
+								'levels': {
+									'type': 'number',
+									'default': 1
+								},
+								'direction': {
+									'type': 'string',
+									'enum': ['up', 'down'],
+									'default': 'down'
+								},
+								'selectionLines': {
+									'type': 'array',
+									'items': {
+										'type': 'number'
+									}
+								}
+							}
+						}
 					}
 				]
 			}

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -8,6 +8,7 @@ import { TypeConstraint, validateConstraints } from 'vs/base/common/types';
 import { ServicesAccessor, createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event, Emitter } from 'vs/base/common/event';
 import { LinkedList } from 'vs/base/common/linkedList';
+import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
 export const ICommandService = createDecorator<ICommandService>('commandService');
 
@@ -37,7 +38,7 @@ export interface ICommand {
 
 export interface ICommandHandlerDescription {
 	description: string;
-	args: { name: string; description?: string; constraint?: TypeConstraint; }[];
+	args: { name: string; description?: string; constraint?: TypeConstraint; schema?: IJSONSchema; }[];
 	returns?: string;
 }
 

--- a/src/vs/workbench/api/node/apiCommands.ts
+++ b/src/vs/workbench/api/node/apiCommands.ts
@@ -65,7 +65,24 @@ export class OpenFolderAPICommand {
 		return executor.executeCommand('_files.windowOpen', { urisToOpen: [{ uri }], forceNewWindow });
 	}
 }
-CommandsRegistry.registerCommand(OpenFolderAPICommand.ID, adjustHandler(OpenFolderAPICommand.execute));
+CommandsRegistry.registerCommand({
+	id: OpenFolderAPICommand.ID,
+	handler: adjustHandler(OpenFolderAPICommand.execute),
+	description: {
+		description: `Open a folder`,
+		args: [{
+			name: 'uri',
+			schema: {
+				'type': 'string'
+			}
+		}, {
+			name: 'forceNewWindow',
+			schema: {
+				'type': 'boolean'
+			}
+		}]
+	}
+});
 
 export class DiffAPICommand {
 	public static ID = 'vscode.diff';
@@ -126,7 +143,31 @@ export class SetEditorLayoutAPICommand {
 		return executor.executeCommand('layoutEditorGroups', layout);
 	}
 }
-CommandsRegistry.registerCommand(SetEditorLayoutAPICommand.ID, adjustHandler(SetEditorLayoutAPICommand.execute));
+CommandsRegistry.registerCommand({
+	id: SetEditorLayoutAPICommand.ID,
+	handler: adjustHandler(SetEditorLayoutAPICommand.execute),
+	description: {
+		description: 'Set Editor Layout',
+		args: [{
+			name: 'args',
+			schema: {
+				'type': 'object',
+				'required': ['groups'],
+				'properties': {
+					'orientation': {
+						'type': 'number',
+						'default': 0,
+						'enum': [0, 1]
+					},
+					'groups': {
+						'$ref': '#/definitions/editorGroupsSchema', // defined in keybindingService.ts ...
+						'default': [{}, {}],
+					}
+				}
+			}
+		}]
+	}
+});
 
 CommandsRegistry.registerCommand('_workbench.downloadResource', function (accessor: ServicesAccessor, resource: URI) {
 	const downloadService = accessor.get(IDownloadService);

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -90,7 +90,24 @@ function registerActiveEditorMoveCommand(): void {
 				{
 					name: nls.localize('editorCommand.activeEditorMove.arg.name', "Active editor move argument"),
 					description: nls.localize('editorCommand.activeEditorMove.arg.description', "Argument Properties:\n\t* 'to': String value providing where to move.\n\t* 'by': String value providing the unit for move (by tab or by group).\n\t* 'value': Number value providing how many positions or an absolute position to move."),
-					constraint: isActiveEditorMoveArg
+					constraint: isActiveEditorMoveArg,
+					schema: {
+						'type': 'object',
+						'required': ['to'],
+						'properties': {
+							'to': {
+								'type': 'string',
+								'enum': ['left', 'right']
+							},
+							'by': {
+								'type': 'string',
+								'enum': ['tab', 'group']
+							},
+							'value': {
+								'type': 'number'
+							}
+						},
+					}
 				}
 			]
 		}

--- a/src/vs/workbench/browser/parts/quickopen/quickopen.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickopen.ts
@@ -19,12 +19,24 @@ export const defaultQuickOpenContext = ContextKeyExpr.and(inQuickOpenContext, Co
 export const QUICKOPEN_ACTION_ID = 'workbench.action.quickOpen';
 export const QUICKOPEN_ACION_LABEL = nls.localize('quickOpen', "Go to File...");
 
-CommandsRegistry.registerCommand(QUICKOPEN_ACTION_ID, function (accessor: ServicesAccessor, prefix: string | null = null) {
-	const quickOpenService = accessor.get(IQuickOpenService);
+CommandsRegistry.registerCommand({
+	id: QUICKOPEN_ACTION_ID,
+	handler: function (accessor: ServicesAccessor, prefix: string | null = null) {
+		const quickOpenService = accessor.get(IQuickOpenService);
 
-	return quickOpenService.show(typeof prefix === 'string' ? prefix : undefined).then(() => {
-		return undefined;
-	});
+		return quickOpenService.show(typeof prefix === 'string' ? prefix : undefined).then(() => {
+			return undefined;
+		});
+	},
+	description: {
+		description: `Quick open`,
+		args: [{
+			name: 'prefix',
+			schema: {
+				'type': 'string'
+			}
+		}]
+	}
 });
 
 export const QUICKOPEN_FOCUS_SECONDARY_ACTION_ID = 'workbench.action.quickOpenPreviousEditor';

--- a/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/insertSnippet.ts
@@ -54,7 +54,28 @@ class InsertSnippetAction extends EditorAction {
 			id: 'editor.action.insertSnippet',
 			label: nls.localize('snippet.suggestions.label', "Insert Snippet"),
 			alias: 'Insert Snippet',
-			precondition: EditorContextKeys.writable
+			precondition: EditorContextKeys.writable,
+			description: {
+				description: `Insert Snippet`,
+				args: [{
+					name: 'args',
+					schema: {
+						'type': 'object',
+						'properties': {
+							'snippet': {
+								'type': 'string'
+							},
+							'langId': {
+								'type': 'string',
+
+							},
+							'name': {
+								'type': 'string'
+							}
+						},
+					}
+				}]
+			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
@@ -549,8 +549,20 @@ class TaskService extends Disposable implements ITaskService {
 	}
 
 	private registerCommands(): void {
-		CommandsRegistry.registerCommand('workbench.action.tasks.runTask', (accessor, arg) => {
-			this.runTaskCommand(arg);
+		CommandsRegistry.registerCommand({
+			id: 'workbench.action.tasks.runTask',
+			handler: (accessor, arg) => {
+				this.runTaskCommand(arg);
+			},
+			description: {
+				description: 'Run Task',
+				args: [{
+					name: 'args',
+					schema: {
+						'type': 'string',
+					}
+				}]
+			}
 		});
 
 		CommandsRegistry.registerCommand('workbench.action.tasks.reRunTask', (accessor, arg) => {

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminal.contribution.ts
@@ -514,7 +514,22 @@ actionRegistry.registerWorkbenchAction(new SyncActionDescriptor(FindPrevious, Fi
 
 const sendSequenceTerminalCommand = new SendSequenceTerminalCommand({
 	id: SendSequenceTerminalCommand.ID,
-	precondition: null
+	precondition: null,
+	description: {
+		description: `Send Custom Sequence To Terminal`,
+		args: [{
+			name: 'args',
+			schema: {
+				'type': 'object',
+				'required': ['text'],
+				'properties': {
+					'text': {
+						'type': 'string'
+					}
+				},
+			}
+		}]
+	}
 });
 sendSequenceTerminalCommand.register();
 

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -573,6 +573,24 @@ let schema: IJSONSchema = {
 	'id': schemaId,
 	'type': 'array',
 	'title': nls.localize('keybindings.json.title', "Keybindings configuration"),
+	'definitions': {
+		'editorGroups': {
+			'type': 'array',
+			'items': {
+				'type': 'object',
+				'properties': {
+					'groups': {
+						'$ref': '#/definitions/editorGroups',
+						'default': [{}, {}]
+					},
+					'size': {
+						'type': 'number',
+						'default': 0.5
+					}
+				}
+			}
+		}
+	},
 	'items': {
 		'required': ['key'],
 		'type': 'object',
@@ -593,7 +611,329 @@ let schema: IJSONSchema = {
 			'args': {
 				'description': nls.localize('keybindings.json.args', "Arguments to pass to the command to execute.")
 			}
-		}
+		},
+		'allOf': [{
+			'if': {
+				'properties': {
+					'command': { 'const': 'vscode.openFolder' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['path'],
+						'properties': {
+							'path': {
+								'type': 'string'
+							},
+						}
+					}
+				}
+			}
+		}, {
+			'if': {
+				'properties': {
+					'command': { 'const': 'vscode.setEditorLayout' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['groups'],
+						'properties': {
+							'orientation': {
+								'type': 'number',
+								'default': 0,
+								'enum': [0, 1]
+							},
+							'groups': {
+								'$ref': '#/definitions/editorGroups',
+								'default': [{}, {}]
+							}
+						}
+					}
+				}
+			}
+		}, {
+			'if': {
+				'properties': {
+					'command': { 'const': 'editor.action.codeAction' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['kind'],
+						'properties': {
+							'kind': {
+								'type': 'string'
+							},
+							'apply': {
+								'type': 'string',
+								'default': 'ifSingle',
+								'enum': ['first', 'ifSingle', 'never']
+							}
+						}
+					}
+				}
+			}
+		}, {
+			'if': {
+				'properties': {
+					'command': { 'enum': ['editor.action.refactor', 'editor.action.sourceAction'] },
+				}
+			},
+			'then': {
+				'properties': {
+					'args': {
+						'type': 'object',
+						'properties': {
+							'kind': {
+								'type': 'string'
+							},
+							'apply': {
+								'type': 'string',
+								'default': 'never',
+								'enum': ['first', 'ifSingle', 'never']
+							}
+						}
+					}
+				}
+			}
+		}, {
+			'if': {
+				'properties': {
+					'command': { 'const': 'workbench.action.tasks.runTask' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'string',
+					}
+				}
+			}
+		}, {
+			'if': {
+				'properties': {
+					'command': { 'enum': ['workbench.action.terminal.sendSequence', 'type'] },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['text'],
+						'properties': {
+							'text': {
+								'type': 'string'
+							}
+						},
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'const': 'editor.action.insertSnippet' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'properties': {
+							'snippet': {
+								'type': 'string'
+							},
+							'langId': {
+								'type': 'string',
+
+							},
+							'name': {
+								'type': 'string'
+							}
+						},
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'const': 'moveActiveEditor' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['to'],
+						'properties': {
+							'to': {
+								'type': 'string',
+								'enum': ['left', 'right']
+							},
+							'by': {
+								'type': 'string',
+								'enum': ['tab', 'group']
+							},
+							'value': {
+								'type': 'number'
+							}
+						},
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'const': 'editorScroll' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['to'],
+						'properties': {
+							'to': {
+								'type': 'string',
+								'enum': ['up', 'down']
+							},
+							'by': {
+								'type': 'string',
+								'enum': ['line', 'wrappedLine', 'page', 'halfPage']
+							},
+							'value': {
+								'type': 'number',
+								'default': 1
+							},
+							'revealCursor': {
+								'type': 'boolean',
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'const': 'revealLine' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['lineNumber'],
+						'properties': {
+							'lineNumber': {
+								'type': 'number',
+							},
+							'at': {
+								'type': 'string',
+								'enum': ['top', 'center', 'bottom']
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'const': 'cursorMove' },
+				}
+			},
+			'then': {
+				'required': ['args'],
+				'properties': {
+					'args': {
+						'type': 'object',
+						'required': ['to'],
+						'properties': {
+							'to': {
+								'type': 'string',
+								'enum': ['left', 'right', 'up', 'down', 'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter', 'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter', 'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside']
+							},
+							'by': {
+								'type': 'string',
+								'enum': ['line', 'wrappedLine', 'character', 'halfLine']
+							},
+							'value': {
+								'type': 'number',
+								'default': 1
+							},
+							'select': {
+								'type': 'boolean',
+								'default': false
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'enum': ['editor.fold', 'editor.unfold'] },
+				}
+			},
+			'then': {
+				'properties': {
+					'args': {
+						'type': 'object',
+						'properties': {
+							'levels': {
+								'type': 'number',
+								'default': 1
+							},
+							'direction': {
+								'type': 'string',
+								'enum': ['up', 'down'],
+								'default': 'down'
+							},
+							'selectionLines': {
+								'type': 'array',
+								'items': {
+									'type': 'number'
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			'if': {
+				'properties': {
+					'command': { 'const': 'workbench.action.quickOpen' }
+				}
+			},
+			'then': {
+				'properties': {
+					'args': {
+						'type': 'string'
+					}
+				}
+			}
+		}]
 	}
 };
 

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -15,7 +15,7 @@ import { Keybinding, ResolvedKeybinding } from 'vs/base/common/keyCodes';
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
 import { OS, OperatingSystem } from 'vs/base/common/platform';
 import { ConfigWatcher } from 'vs/base/node/config';
-import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ICommandService, CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Extensions as ConfigExtensions, IConfigurationNode, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -279,6 +279,8 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 		@IWindowService private readonly windowService: IWindowService
 	) {
 		super(contextKeyService, commandService, telemetryService, notificationService, statusBarService);
+
+		updateSchema();
 
 		let dispatchConfig = getDispatchConfig(configurationService);
 		configurationService.onDidChangeConfiguration((e) => {
@@ -574,13 +576,13 @@ let schema: IJSONSchema = {
 	'type': 'array',
 	'title': nls.localize('keybindings.json.title', "Keybindings configuration"),
 	'definitions': {
-		'editorGroups': {
+		'editorGroupsSchema': {
 			'type': 'array',
 			'items': {
 				'type': 'object',
 				'properties': {
 					'groups': {
-						'$ref': '#/definitions/editorGroups',
+						'$ref': '#/definitions/editorGroupsSchema',
 						'default': [{}, {}]
 					},
 					'size': {
@@ -612,333 +614,38 @@ let schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.args', "Arguments to pass to the command to execute.")
 			}
 		},
-		'allOf': [{
-			'if': {
-				'properties': {
-					'command': { 'const': 'vscode.openFolder' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['path'],
-						'properties': {
-							'path': {
-								'type': 'string'
-							},
-						}
-					}
-				}
-			}
-		}, {
-			'if': {
-				'properties': {
-					'command': { 'const': 'vscode.setEditorLayout' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['groups'],
-						'properties': {
-							'orientation': {
-								'type': 'number',
-								'default': 0,
-								'enum': [0, 1]
-							},
-							'groups': {
-								'$ref': '#/definitions/editorGroups',
-								'default': [{}, {}]
-							}
-						}
-					}
-				}
-			}
-		}, {
-			'if': {
-				'properties': {
-					'command': { 'const': 'editor.action.codeAction' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['kind'],
-						'properties': {
-							'kind': {
-								'type': 'string'
-							},
-							'apply': {
-								'type': 'string',
-								'default': 'ifSingle',
-								'enum': ['first', 'ifSingle', 'never']
-							}
-						}
-					}
-				}
-			}
-		}, {
-			'if': {
-				'properties': {
-					'command': { 'enum': ['editor.action.refactor', 'editor.action.sourceAction'] },
-				}
-			},
-			'then': {
-				'properties': {
-					'args': {
-						'type': 'object',
-						'properties': {
-							'kind': {
-								'type': 'string'
-							},
-							'apply': {
-								'type': 'string',
-								'default': 'never',
-								'enum': ['first', 'ifSingle', 'never']
-							}
-						}
-					}
-				}
-			}
-		}, {
-			'if': {
-				'properties': {
-					'command': { 'const': 'workbench.action.tasks.runTask' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'string',
-					}
-				}
-			}
-		}, {
-			'if': {
-				'properties': {
-					'command': { 'enum': ['workbench.action.terminal.sendSequence', 'type'] },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['text'],
-						'properties': {
-							'text': {
-								'type': 'string'
-							}
-						},
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'const': 'editor.action.insertSnippet' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'properties': {
-							'snippet': {
-								'type': 'string'
-							},
-							'langId': {
-								'type': 'string',
-
-							},
-							'name': {
-								'type': 'string'
-							}
-						},
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'const': 'moveActiveEditor' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['to'],
-						'properties': {
-							'to': {
-								'type': 'string',
-								'enum': ['left', 'right']
-							},
-							'by': {
-								'type': 'string',
-								'enum': ['tab', 'group']
-							},
-							'value': {
-								'type': 'number'
-							}
-						},
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'const': 'editorScroll' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['to'],
-						'properties': {
-							'to': {
-								'type': 'string',
-								'enum': ['up', 'down']
-							},
-							'by': {
-								'type': 'string',
-								'enum': ['line', 'wrappedLine', 'page', 'halfPage']
-							},
-							'value': {
-								'type': 'number',
-								'default': 1
-							},
-							'revealCursor': {
-								'type': 'boolean',
-							}
-						}
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'const': 'revealLine' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['lineNumber'],
-						'properties': {
-							'lineNumber': {
-								'type': 'number',
-							},
-							'at': {
-								'type': 'string',
-								'enum': ['top', 'center', 'bottom']
-							}
-						}
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'const': 'cursorMove' },
-				}
-			},
-			'then': {
-				'required': ['args'],
-				'properties': {
-					'args': {
-						'type': 'object',
-						'required': ['to'],
-						'properties': {
-							'to': {
-								'type': 'string',
-								'enum': ['left', 'right', 'up', 'down', 'wrappedLineStart', 'wrappedLineEnd', 'wrappedLineColumnCenter', 'wrappedLineFirstNonWhitespaceCharacter', 'wrappedLineLastNonWhitespaceCharacter', 'viewPortTop', 'viewPortCenter', 'viewPortBottom', 'viewPortIfOutside']
-							},
-							'by': {
-								'type': 'string',
-								'enum': ['line', 'wrappedLine', 'character', 'halfLine']
-							},
-							'value': {
-								'type': 'number',
-								'default': 1
-							},
-							'select': {
-								'type': 'boolean',
-								'default': false
-							}
-						}
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'enum': ['editor.fold', 'editor.unfold'] },
-				}
-			},
-			'then': {
-				'properties': {
-					'args': {
-						'type': 'object',
-						'properties': {
-							'levels': {
-								'type': 'number',
-								'default': 1
-							},
-							'direction': {
-								'type': 'string',
-								'enum': ['up', 'down'],
-								'default': 'down'
-							},
-							'selectionLines': {
-								'type': 'array',
-								'items': {
-									'type': 'number'
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		{
-			'if': {
-				'properties': {
-					'command': { 'const': 'workbench.action.quickOpen' }
-				}
-			},
-			'then': {
-				'properties': {
-					'args': {
-						'type': 'string'
-					}
-				}
-			}
-		}]
+		'allOf': []
 	}
 };
 
 let schemaRegistry = Registry.as<IJSONContributionRegistry>(Extensions.JSONContribution);
 schemaRegistry.registerSchema(schemaId, schema);
+
+function updateSchema() {
+	const allCommands = CommandsRegistry.getCommands();
+	for (let commandId in allCommands) {
+		const commandDescription = allCommands[commandId].description;
+		if (!commandDescription || !commandDescription.args || commandDescription.args.length !== 1 || !commandDescription.args[0].schema) {
+			continue;
+		}
+
+		const argsSchema = commandDescription.args[0].schema;
+		const addition = {
+			'if': {
+				'properties': {
+					'command': { 'const': commandId }
+				}
+			},
+			'then': {
+				'properties': {
+					'args': argsSchema
+				}
+			}
+		};
+
+		schema['items']['allOf'].push(addition);
+	}
+}
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigExtensions.Configuration);
 const keyboardConfiguration: IConfigurationNode = {


### PR DESCRIPTION
So ... some commands can take `args`.

* There is no documentation that would list **all** of them (even this page listing some, is not that great https://code.visualstudio.com/api/references/commands)
* There is no way to see or set `args` in keybindings GUI
* There is no validation/autocomplete in `keybindings.json`
* Searching in google for command and in vscode repo is not optimal

Progress:

- [x] `vscode.openFolder`
- [x] `vscode.setEditorLayout`
- [x] `workbench.action.tasks.runTask`
- [x] `workbench.action.terminal.sendSequence`
- [x] `workbench.action.quickOpen`
- [x] `editor.action.codeAction`
- [x] `editor.action.refactor`
- [x] `editor.action.sourceAction`
- [x] `editor.action.insertSnippet`
- [x] `editor.fold`
- [x] `editor.unfold`
- [x] `type`
- [x] `moveActiveEditor`
- [x] `editorScroll`
- [x] `revealLine`
- [x] `cursorMove`

![demo_autocomplete](https://user-images.githubusercontent.com/9638156/51089978-4f007f80-1786-11e9-8abf-1fa9c296d014.gif)

Before adding more commands I'd like to get some feedback.