### PR TITLE
When resolving a merge conflict allow accepting the default message

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1514,6 +1514,24 @@ export class Repository {
 		}
 	}
 
+	cleanupCommitEditMessage(message: string): string {
+		//TODO: Support core.commentChar
+		return message.replace(/^\s*#.*$\n?/gm, '').trim();
+	}
+
+
+	async getMergeMessage(): Promise<string | undefined> {
+		const mergeMsgPath = path.join(this.repositoryRoot, '.git', 'MERGE_MSG');
+		try {
+			const raw = await readfile(mergeMsgPath, 'utf8');
+			return raw.trim();
+		}
+		catch {
+			return undefined;
+		}
+
+	}
+
 	async getCommitTemplate(): Promise<string> {
 		try {
 			const result = await this.run(['config', '--get', 'commit.template']);
@@ -1532,7 +1550,7 @@ export class Repository {
 			}
 
 			const raw = await readfile(templatePath, 'utf8');
-			return raw.replace(/^\s*#.*$\n?/gm, '').trim();
+			return raw.trim();
 
 		} catch (err) {
 			return '';

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1105,6 +1105,10 @@ export class Repository implements Disposable {
 		return await this.run(Operation.GetCommitTemplate, async () => this.repository.getCommitTemplate());
 	}
 
+	async cleanUpCommitEditMessage(editMessage: string): Promise<string> {
+		return this.repository.cleanupCommitEditMessage(editMessage);
+	}
+
 	async ignore(files: Uri[]): Promise<void> {
 		return await this.run(Operation.Ignore, async () => {
 			const ignoreFile = `${this.repository.root}${path.sep}.gitignore`;
@@ -1257,8 +1261,11 @@ export class Repository implements Disposable {
 		const config = workspace.getConfiguration('git');
 		const shouldIgnore = config.get<boolean>('ignoreLimitWarning') === true;
 		const useIcons = !config.get<boolean>('decorations.enabled', true);
-
 		this.isRepositoryHuge = didHitLimit;
+		const mergeMessage = await this.repository.getMergeMessage();
+		if (mergeMessage) {
+			this.inputBox.value = mergeMessage;
+		}
 
 		if (didHitLimit && !shouldIgnore && !this.didWarnAboutLimit) {
 			const knownHugeFolderPaths = await this.findKnownHugeFolderPathsToIgnore();


### PR DESCRIPTION
Fixes #6403

- Populates the inputBox with the default commit message when a merge conflict occurs.

- Comment lines ('#foo') are now shown in the input box, stripped away only when the actual commit happens.