### PR TITLE
Add electron workspace tagging

### DIFF
--- a/src/vs/workbench/parts/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/parts/stats/node/workspaceStats.ts
@@ -55,6 +55,7 @@ const ModulesToLookFor = [
 	'@angular/core',
 	'@ionic',
 	'vue',
+        'electron',
 	'tns-core-modules',
 	// Other interesting packages
 	'aws-sdk',
@@ -267,6 +268,7 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			"workspace.npm.react" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.@angular/core" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.vue" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+                        "workspace.npm.electron" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.aws-sdk" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.aws-amplify-sdk" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.azure" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },


### PR DESCRIPTION
This adds electron workspace tagging by looking for the `electron` npm package. Purpose us to gain insights into my many developers who build Electron apps from VS Code.