### PR TITLE
fix: git.promptToSaveFilesBeforeCommit should not warn on unstaged files

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1200,19 +1200,21 @@ export class CommandCenter {
 		const promptToSaveFilesBeforeCommit = config.get<boolean>('promptToSaveFilesBeforeCommit') === true;
 
 		if (promptToSaveFilesBeforeCommit) {
-			const unsavedTextDocuments = workspace.textDocuments
-				.filter(d => !d.isUntitled && d.isDirty && isDescendant(repository.root, d.uri.fsPath));
+			const stagedUnsavedTextDocuments = workspace.textDocuments
+				.filter(d => !d.isUntitled && d.isDirty && isDescendant(repository.root, d.uri.fsPath))
+				.filter(d => repository.indexGroup.resourceStates.some(s =>
+					s.resourceUri.path === d.uri.fsPath));
 
-			if (unsavedTextDocuments.length > 0) {
-				const message = unsavedTextDocuments.length === 1
-					? localize('unsaved files single', "The following file is unsaved: {0}.\n\nWould you like to save it before committing?", path.basename(unsavedTextDocuments[0].uri.fsPath))
-					: localize('unsaved files', "There are {0} unsaved files.\n\nWould you like to save them before committing?", unsavedTextDocuments.length);
+			if (stagedUnsavedTextDocuments.length > 0) {
+				const message = stagedUnsavedTextDocuments.length === 1
+					? localize('unsaved files single', "The following file is unsaved: {0}.\n\nWould you like to save it before committing?", path.basename(stagedUnsavedTextDocuments[0].uri.fsPath))
+					: localize('unsaved files', "There are {0} unsaved files.\n\nWould you like to save them before committing?", stagedUnsavedTextDocuments.length);
 				const saveAndCommit = localize('save and commit', "Save All & Commit");
 				const commit = localize('commit', "Commit Anyway");
 				const pick = await window.showWarningMessage(message, { modal: true }, saveAndCommit, commit);
 
 				if (pick === saveAndCommit) {
-					await Promise.all(unsavedTextDocuments.map(d => d.save()));
+					await Promise.all(stagedUnsavedTextDocuments.map(d => d.save()));
 					await repository.status();
 				} else if (pick !== commit) {
 					return false; // do not commit on cancel

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1207,8 +1207,8 @@ export class CommandCenter {
 
 			if (stagedUnsavedTextDocuments.length > 0) {
 				const message = stagedUnsavedTextDocuments.length === 1
-					? localize('unsaved files single', "The following file is unsaved: {0}.\n\nWould you like to save it before committing?", path.basename(stagedUnsavedTextDocuments[0].uri.fsPath))
-					: localize('unsaved files', "There are {0} unsaved files.\n\nWould you like to save them before committing?", stagedUnsavedTextDocuments.length);
+					? localize('unsaved files single', "The following staged file is unsaved: {0}.\n\nWould you like to save it before committing?", path.basename(stagedUnsavedTextDocuments[0].uri.fsPath))
+					: localize('unsaved files', "There are {0} unsaved staged files.\n\nWould you like to save them before committing?", stagedUnsavedTextDocuments.length);
 				const saveAndCommit = localize('save and commit', "Save All & Commit");
 				const commit = localize('commit', "Commit Anyway");
 				const pick = await window.showWarningMessage(message, { modal: true }, saveAndCommit, commit);


### PR DESCRIPTION
Fixes #66296. I've also changed the message strings to reflect this change. I'm not familiar with how localization is done on this project so I put that change in a separate commit.

The fix is implemented by computing unsaved documents as before and then comparing each one's path string with the paths of the objects in `repository.indexGroup.resourceStates`.