### PR TITLE
Add xterm mouseleave to dismiss widget

### DIFF
--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -575,6 +575,7 @@ export class TerminalInstance implements ITerminalInstance {
 
 			if (this._processManager) {
 				this._widgetManager = new TerminalWidgetManager(this._wrapperElement);
+				// HACK: This can be removed once this is fixed upstream xtermjs/xterm.js#1908
 				this._disposables.push(dom.addDisposableListener(this._xterm.element, 'mouseleave', () => {
 					this._widgetManager.closeMessage();
 				}));

--- a/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
+++ b/src/vs/workbench/parts/terminal/electron-browser/terminalInstance.ts
@@ -575,6 +575,9 @@ export class TerminalInstance implements ITerminalInstance {
 
 			if (this._processManager) {
 				this._widgetManager = new TerminalWidgetManager(this._wrapperElement);
+				this._disposables.push(dom.addDisposableListener(this._xterm.element, 'mouseleave', () => {
+					this._widgetManager.closeMessage();
+				}));
 				this._linkHandler.setWidgetManager(this._widgetManager);
 			}
 


### PR DESCRIPTION
Add a disposable listener to the 'mouseleave' event on the
terminalInstance xterm.element to dismiss any showing widget,
in case the user moves their mouse out of the xterm area directly,
without leaving the link that generated the widget/tooltip.

The real problem is xterm.js does not appear to be listening to the
'mouseleave' event of its own dom element, and so it does not fire
leaveCallback for registered CustomLinkHandler, WebLinkHandler, or
LocalLinkHandlers.  As a result, if the user has the terminal split near
the link that generated the widget/tooltip, the widget remains until the
mouse cursor re-enters the xterm area that generated it, for xterm to
dismiss itself.  See gif in #66421 for demonstration of the problem.

fixes #66421