### PR TITLE
Improve file explorer indentation levels

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -430,7 +430,8 @@ export class ExplorerView extends TreeViewsViewletPanel implements IExplorerView
 			accessibilityProvider
 		}, {
 				autoExpandSingleChildren: true,
-				ariaLabel: nls.localize('treeAriaLabel', "Files Explorer")
+				ariaLabel: nls.localize('treeAriaLabel', "Files Explorer"),
+				indentPixels: 20
 			});
 
 		// Bind context keys


### PR DESCRIPTION
When looking at directories and files in the file explorer panel, the default indentation level is 12px. For many users, this default is not big enough and causes the nesting levels of the directories and files to be hard to figure out.

This patch simply increases the default file explorer indentation from 12px to 20px, yielding a much easier-on-the-eyes view of the files. Perhaps this value could go into a user setting and become configurable. Making this change directly in the code is much better than hacks such as slapping additional nasty css to the end of the `vs/workbench/workbench.main.css` file (which causes VS Code to complain that the installation has become corrupt).

On the image below, the left is the default and the right is what this change produces (ie - a visually more helpful level of indentation):

<img width="989" alt="indent levels" src="https://user-images.githubusercontent.com/142875/51236432-6169ed00-192f-11e9-8f8a-916583ba4901.png">
