### PR TITLE
 Added strict null checks for findModel.test.ts

### DIFF
--- a/src/vs/editor/contrib/find/test/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/findModel.test.ts
@@ -1505,7 +1505,7 @@ suite('FindModel', () => {
 			]
 		);
 
-		editor.getModel().setValue('hello\nhi');
+		editor!.getModel()!.setValue('hello\nhi');
 		assertFindState(
 			editor,
 			[1, 1, 1, 1],
@@ -1536,7 +1536,7 @@ suite('FindModel', () => {
 
 		findModel.selectAllMatches();
 
-		assert.deepEqual(editor.getSelections().map(s => s.toString()), [
+		assert.deepEqual(editor!.getSelections()!.map(s => s.toString()), [
 			new Selection(6, 14, 6, 19),
 			new Selection(6, 27, 6, 32),
 			new Selection(7, 14, 7, 19),
@@ -1580,14 +1580,14 @@ suite('FindModel', () => {
 
 		findModel.selectAllMatches();
 
-		assert.deepEqual(editor.getSelections().map(s => s.toString()), [
+		assert.deepEqual(editor!.getSelections()!.map(s => s.toString()), [
 			new Selection(7, 14, 7, 19),
 			new Selection(6, 14, 6, 19),
 			new Selection(6, 27, 6, 32),
 			new Selection(8, 14, 8, 19)
 		].map(s => s.toString()));
 
-		assert.deepEqual(editor.getSelection().toString(), new Selection(7, 14, 7, 19).toString());
+		assert.deepEqual(editor!.getSelection()!.toString(), new Selection(7, 14, 7, 19).toString());
 
 		assertFindState(
 			editor,
@@ -1982,7 +1982,7 @@ suite('FindModel', () => {
 		for (let i = 0; i < 1100; i++) {
 			initialText += 'line' + i + '\n';
 		}
-		editor.getModel().setValue(initialText);
+		editor!.getModel()!.setValue(initialText);
 		let findState = new FindReplaceState();
 		findState.change({ searchString: '^', replaceString: 'a ', isRegex: true }, false);
 		let findModel = new FindModelBoundToEditorModel(editor, findState);
@@ -1994,7 +1994,7 @@ suite('FindModel', () => {
 			expectedText += 'a line' + i + '\n';
 		}
 		expectedText += 'a ';
-		assert.equal(editor.getModel().getValue(), expectedText);
+		assert.equal(editor!.getModel()!.getValue(), expectedText);
 
 		findModel.dispose();
 		findState.dispose();


### PR DESCRIPTION
#65233

In this PR:
- Fixed errors: "Object is possibly 'null'.", for tests in file "./vs/editor/contrib/find/test/findModel.test.ts"