### PR TITLE
Php inside css style tags

### DIFF
--- a/extensions/php/syntaxes/html.tmLanguage.json
+++ b/extensions/php/syntaxes/html.tmLanguage.json
@@ -109,7 +109,7 @@
 				}
 			]
 		},
-		"text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php))": {
+		"text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))": {
 			"patterns": [
 				{
 					"include": "#php-tag"


### PR DESCRIPTION
Allow to recognize syntax when embedding php in css style tags within php files, similar to html and js script tags, e.g.:

```
<style type="text/css">
<?php if ( empty( $comments ) ) { ?>
	.comments {
		display: block;
	}
<?php } ?>
</style>
```