### PR TITLE
Upgrade to electron@3.0.14

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "3.0.13"
+target "3.0.14"
 runtime "electron"

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -48,7 +48,7 @@
 				"git": {
 					"name": "libchromiumcontent",
 					"repositoryUrl": "https://github.com/electron/libchromiumcontent",
-					"commitHash": "e38e22ed9f48e6e395f2e9faa93d2d7411f52de4"
+					"commitHash": "1b74a92a80c2077fb0848d81b58ee6f0e4db752d"
 				}
 			},
 			"isOnlyProductionDependency": true,
@@ -73,12 +73,12 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "f26dcaeaf39e9b829aa0d4fb5a5cb59c5c314b33"
+					"commitHash": "f1f8fda78aa41578928d77e0ae0713ebf4384b77"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "3.0.13"
+			"version": "3.0.14"
 		},
 		{
 			"component": {

--- a/src/typings/electron.d.ts
+++ b/src/typings/electron.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Electron 3.0.13
+// Type definitions for Electron 3.0.14
 // Project: http://electronjs.org/
 // Definitions by: The Electron Team <https://github.com/electron/electron>
 // Definitions: https://github.com/electron/electron-typescript-definitions

--- a/test/smoke/package.json
+++ b/test/smoke/package.json
@@ -22,7 +22,7 @@
     "@types/webdriverio": "4.6.1",
     "concurrently": "^3.5.1",
     "cpx": "^1.5.0",
-    "electron": "3.0.13",
+    "electron": "3.0.14",
     "htmlparser2": "^3.9.2",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",

--- a/test/smoke/yarn.lock
+++ b/test/smoke/yarn.lock
@@ -596,10 +596,10 @@ electron-download@^4.1.0:
     semver "^5.4.1"
     sumchecker "^2.0.2"
 
-electron@3.0.13:
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.13.tgz#7b065a3d130c6b6379dc78d49515e03f392c1303"
-  integrity sha512-tfx5jFgXhCmpe6oPjcesaRj7geHqQxrJdbpseanRzL9BbyYUtsj0HoxwPAUvCx4+52P6XryBwWTvne/1eBVf9Q==
+electron@3.0.14:
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.14.tgz#d54c51de3651c0fe48a6a6e9aef1ca98e5ea5796"
+  integrity sha512-1fG9bE0LzL5QXeEq2MC0dHdVO0pbZOnNlVAIyOyJaCFAu/TjLhxQfWj38bFUEojzuVlaR87tZz0iy2qlVZj3sw==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^4.1.0"


### PR DESCRIPTION
This upgrades to electron 3.0.14, which fixes native menubar foreground colors on Linux,
fixes #64137, #62593, #63559, #63385, #63545 and #60600 (and maybe more that I missed)