### PR TITLE
Applied shellcheck linting suggestions to bash scripts

### DIFF
--- a/scripts/code-cli.sh
+++ b/scripts/code-cli.sh
@@ -1,48 +1,48 @@
 #!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
-	ROOT=$(dirname $(dirname $(realpath "$0")))
+        realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
+        ROOT="$(dirname "$(dirname "$(realpath "$0")")")"
 else
-	ROOT=$(dirname $(dirname $(readlink -f $0)))
+        ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
 fi
 
 function code() {
-	cd $ROOT
+        cd "$ROOT" || exit
 
-	if [[ "$OSTYPE" == "darwin"* ]]; then
-		NAME=`node -p "require('./product.json').nameLong"`
-		CODE="./.build/electron/$NAME.app/Contents/MacOS/Electron"
-	else
-		NAME=`node -p "require('./product.json').applicationName"`
-		CODE=".build/electron/$NAME"
-	fi
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+                NAME=$(node -p "require('./product.json').nameLong")
+                CODE="./.build/electron/$NAME.app/Contents/MacOS/Electron"
+        else
+                NAME=$(node -p "require('./product.json').applicationName")
+                CODE=".build/electron/$NAME"
+        fi
 
-	# Node modules
-	test -d node_modules || yarn
+        # Node modules
+        test -d node_modules || yarn
 
-	# Get electron
-	node build/lib/electron.js || ./node_modules/.bin/gulp electron
+        # Get electron
+        node build/lib/electron.js || ./node_modules/.bin/gulp electron
 
 
-	# Manage built-in extensions
-	if [[ "$1" == "--builtin" ]]; then
-		exec "$CODE" build/builtin
-		return
-	fi
+        # Manage built-in extensions
+        if [[ "$1" == "--builtin" ]]; then
+                exec "$CODE" build/builtin
+                exit
+        fi
 
-	# Sync built-in extensions
-	node build/lib/builtInExtensions.js
+        # Sync built-in extensions
+        node build/lib/builtInExtensions.js
 
-	# Build
-	test -d out || ./node_modules/.bin/gulp compile
+        # Build
+        test -d out || ./node_modules/.bin/gulp compile
 
-	ELECTRON_RUN_AS_NODE=1 \
-	NODE_ENV=development \
-	VSCODE_DEV=1 \
-	ELECTRON_ENABLE_LOGGING=1 \
-	ELECTRON_ENABLE_STACK_DUMPING=1 \
-	"$CODE" --inspect=5874 "$ROOT/out/cli.js" . "$@"
+        ELECTRON_RUN_AS_NODE=1 \
+        NODE_ENV=development \
+        VSCODE_DEV=1 \
+        ELECTRON_ENABLE_LOGGING=1 \
+        ELECTRON_ENABLE_STACK_DUMPING=1 \
+        "$CODE" --inspect=5874 "$ROOT/out/cli.js" . "$@"
 }
 
 code "$@"

--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -8,17 +8,17 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	# a freeze so we only enable this flag on macOS
 	export ELECTRON_ENABLE_LOGGING=1
 else
-	ROOT=$(dirname "$(dirname "$(readlink -f $0)")")
+	ROOT=$(dirname "$(dirname "$(readlink -f "$0")")")
 fi
 
 function code() {
-	cd "$ROOT"
+	cd "$ROOT" || exit
 
 	if [[ "$OSTYPE" == "darwin"* ]]; then
-		NAME=`node -p "require('./product.json').nameLong"`
+		NAME=$(node -p "require('./product.json').nameLong")
 		CODE="./.build/electron/$NAME.app/Contents/MacOS/Electron"
 	else
-		NAME=`node -p "require('./product.json').applicationName"`
+		NAME=$(node -p "require('./product.json').applicationName")
 		CODE=".build/electron/$NAME"
 	fi
 
@@ -31,7 +31,7 @@ function code() {
 	# Manage built-in extensions
 	if [[ "$1" == "--builtin" ]]; then
 		exec "$CODE" build/builtin
-		return
+		exit
 	fi
 
 	# Sync built-in extensions

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export npm_config_disturl=https://atom.io/download/electron
-export npm_config_target=$(node -p "require('./build/lib/electron').getElectronVersion();")
+npm_config_target=$(node -p "require('./build/lib/electron').getElectronVersion();")
+export npm_config_target
 export npm_config_runtime=electron
 export npm_config_cache="$HOME/.npm-electron"
 mkdir -p "$npm_config_cache"

--- a/scripts/node-electron.sh
+++ b/scripts/node-electron.sh
@@ -1,26 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
-	ROOT=$(dirname $(dirname $(realpath "$0")))
+	ROOT="$(dirname "$(dirname "$(realpath "$0")")")"
 else
-	ROOT=$(dirname $(dirname $(readlink -f $0)))
+	ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
 fi
 
-pushd $ROOT
+pushd "$ROOT" || exit
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	NAME=`node -p "require('./product.json').nameLong"`
+	NAME=$(node -p "require('./product.json').nameLong")
 	CODE="$ROOT/.build/electron/$NAME.app/Contents/MacOS/Electron"
 else
-	NAME=`node -p "require('./product.json').applicationName"`
+	NAME=$(node -p "require('./product.json').applicationName")
 	CODE="$ROOT/.build/electron/$NAME"
 fi
 
 # Get electron
 node build/lib/electron.js || ./node_modules/.bin/gulp electron
 
-popd
+popd || exit
 
 export VSCODE_DEV=1
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/npm.sh
+++ b/scripts/npm.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-yarn $*
+yarn "$@"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,32 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
-	ROOT=$(dirname $(dirname $(realpath "$0")))
-	VSCODEUSERDATADIR=`mktemp -d -t 'myuserdatadir'`
+	ROOT="$(dirname "$(dirname "$(realpath "$0")")")"
+	VSCODEUSERDATADIR=$(mktemp -d -t 'myuserdatadir')
 else
-	ROOT=$(dirname $(dirname $(readlink -f $0)))
-	VSCODEUSERDATADIR=`mktemp -d 2>/dev/null`
+	ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
+	VSCODEUSERDATADIR=$(mktemp -d 2>/dev/null)
 fi
 
-cd $ROOT
+cd "$ROOT"
 
 # Integration tests in AMD
 ./scripts/test.sh --runGlob **/*.integrationTest.js "$@"
 
 # Tests in the extension host
-./scripts/code.sh $ROOT/extensions/vscode-api-tests/testWorkspace --extensionDevelopmentPath=$ROOT/extensions/vscode-api-tests --extensionTestsPath=$ROOT/extensions/vscode-api-tests/out/singlefolder-tests --disableExtensions --user-data-dir=$VSCODEUSERDATADIR --skip-getting-started
-./scripts/code.sh $ROOT/extensions/vscode-api-tests/testworkspace.code-workspace --extensionDevelopmentPath=$ROOT/extensions/vscode-api-tests --extensionTestsPath=$ROOT/extensions/vscode-api-tests/out/workspace-tests --disableExtensions --user-data-dir=$VSCODEUSERDATADIR --skip-getting-started
-./scripts/code.sh $ROOT/extensions/vscode-colorize-tests/test --extensionDevelopmentPath=$ROOT/extensions/vscode-colorize-tests --extensionTestsPath=$ROOT/extensions/vscode-colorize-tests/out --disableExtensions --user-data-dir=$VSCODEUSERDATADIR --skip-getting-started
-./scripts/code.sh $ROOT/extensions/markdown-language-features/test-fixtures --extensionDevelopmentPath=$ROOT/extensions/markdown-language-features --extensionTestsPath=$ROOT/extensions/markdown-language-features/out/test --disableExtensions --user-data-dir=$VSCODEUSERDATADIR --skip-getting-started
+./scripts/code.sh "$ROOT"/extensions/vscode-api-tests/testWorkspace --extensionDevelopmentPath="$ROOT"/extensions/vscode-api-tests --extensionTestsPath="$ROOT"/extensions/vscode-api-tests/out/singlefolder-tests --disableExtensions --user-data-dir="$VSCODEUSERDATADIR" --skip-getting-started
+./scripts/code.sh "$ROOT"/extensions/vscode-api-tests/testworkspace.code-workspace --extensionDevelopmentPath="$ROOT"/extensions/vscode-api-tests --extensionTestsPath="$ROOT"/extensions/vscode-api-tests/out/workspace-tests --disableExtensions --user-data-dir="$VSCODEUSERDATADIR" --skip-getting-started
+./scripts/code.sh "$ROOT"/extensions/vscode-colorize-tests/test --extensionDevelopmentPath="$ROOT"/extensions/vscode-colorize-tests --extensionTestsPath="$ROOT"/extensions/vscode-colorize-tests/out --disableExtensions --user-data-dir="$VSCODEUSERDATADIR" --skip-getting-started
+./scripts/code.sh "$ROOT"/extensions/markdown-language-features/test-fixtures --extensionDevelopmentPath="$ROOT"/extensions/markdown-language-features --extensionTestsPath="$ROOT"/extensions/markdown-language-features/out/test --disableExtensions --user-data-dir="$VSCODEUSERDATADIR" --skip-getting-started
 
-mkdir $ROOT/extensions/emmet/test-fixtures
-./scripts/code.sh $ROOT/extensions/emmet/test-fixtures --extensionDevelopmentPath=$ROOT/extensions/emmet --extensionTestsPath=$ROOT/extensions/emmet/out/test --disableExtensions --user-data-dir=$VSCODEUSERDATADIR --skip-getting-started .
-rm -r $ROOT/extensions/emmet/test-fixtures
+mkdir "$ROOT"/extensions/emmet/test-fixtures
+./scripts/code.sh "$ROOT"/extensions/emmet/test-fixtures --extensionDevelopmentPath="$ROOT"/extensions/emmet --extensionTestsPath="$ROOT"/extensions/emmet/out/test --disableExtensions --user-data-dir="$VSCODEUSERDATADIR" --skip-getting-started .
+rm -r "$ROOT"/extensions/emmet/test-fixtures
 
 # Tests in commonJS
-cd $ROOT/extensions/css-language-features/server && $ROOT/scripts/node-electron.sh test/index.js
-cd $ROOT/extensions/html-language-features/server && $ROOT/scripts/node-electron.sh test/index.js
+cd "$ROOT"/extensions/css-language-features/server && "$ROOT"/scripts/node-electron.sh test/index.js
+cd "$ROOT"/extensions/html-language-features/server && "$ROOT"/scripts/node-electron.sh test/index.js
 
-rm -r $VSCODEUSERDATADIR
+rm -r "$VSCODEUSERDATADIR"

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -1,19 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
-	ROOT=$(dirname $(dirname $(realpath "$0")))
-	VSCODEUSERDATADIR=`mktemp -d -t 'myuserdatadir'`
+	ROOT="$(dirname "$(dirname "$(realpath "$0")")")"
+	VSCODEUSERDATADIR=$(mktemp -d -t 'myuserdatadir')
 else
-	ROOT=$(dirname $(dirname $(readlink -f $0)))
-	VSCODEUSERDATADIR=`mktemp -d 2>/dev/null`
+	ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
+	VSCODEUSERDATADIR=$(mktemp -d 2>/dev/null)
 fi
 
-cd $ROOT
+cd "$ROOT"
 
 # Tests in AMD
 ./scripts/test.sh --runGlob **/*.releaseTest.js "$@"
 
 
-rm -r $VSCODEUSERDATADIR
+rm -r "$VSCODEUSERDATADIR"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,24 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	realpath() { [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"; }
-	ROOT=$(dirname $(dirname $(realpath "$0")))
+	ROOT="$(dirname "$(dirname "$(realpath "$0")")")"
 
 	# On Linux with Electron 2.0.x running out of a VM causes
 	# a freeze so we only enable this flag on macOS
 	export ELECTRON_ENABLE_LOGGING=1
 else
-	ROOT=$(dirname $(dirname $(readlink -f $0)))
+	ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
 fi
 
-cd $ROOT
+cd "$ROOT" || exit
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	NAME=`node -p "require('./product.json').nameLong"`
+	NAME=$(node -p "require('./product.json').nameLong")
 	CODE="./.build/electron/$NAME.app/Contents/MacOS/Electron"
 else
-	NAME=`node -p "require('./product.json').applicationName"`
+	NAME=$(node -p "require('./product.json').applicationName")
 	CODE=".build/electron/$NAME"
 fi
 
@@ -30,11 +30,11 @@ node build/lib/electron.js || ./node_modules/.bin/gulp electron
 
 # Unit Tests
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	cd $ROOT ; ulimit -n 4096 ; \
+	cd "$ROOT" || exit ; ulimit -n 4096 ; \
 		"$CODE" \
 		test/electron/index.js "$@"
 else
-	cd $ROOT ; \
+	cd "$ROOT" || exit ; \
 		"$CODE" \
 		test/electron/index.js "$@"
 fi


### PR DESCRIPTION
Hello again,

This change set just fixes a lot of shellcheck issues across all the shell scripts to introduce consistency and uniformity. A lot of these are minor but I feel bash scripts are one of those areas which can quickly result in dangerous actions, especially rm -r. 

These scripts only addressed the issues raised from shellcheck, a static analysis tool for bash scripts.

Things changed:

1) Changed all the shebangs to be /usr/bin/env bash for consistency and to avoid issues on systems which don't have bash located in /bin/bash.

2) Applied quoting around things that need to be quoted to prevent globbing.

3)Changed return to exit after exec

4) Added exit to cd in case a command fails

5) Moved from legacy backtick to $() notation

I  am sorry for this rather big set of changes and I can completely understand if this PR is completely rejected. I just wanted an easy small task to get into the habit of contributing. 