### PR TITLE
Fix the condition used to determine if we should shift focus while debugging

### DIFF
--- a/src/vs/workbench/parts/debug/electron-browser/debugService.ts
+++ b/src/vs/workbench/parts/debug/electron-browser/debugService.ts
@@ -492,12 +492,12 @@ export class DebugService implements IDebugService {
 		const sessionRunningScheduler = new RunOnceScheduler(() => {
 			// Do not immediatly focus another session or thread if a session is running
 			// Stepping in a session should preserve that session focused even if some continued events happen
-			if (session.state === State.Running && this.viewModel.focusedSession === session) {
+			if (session.state !== State.Running || this.viewModel.focusedSession !== session) {
 				this.focusStackFrame(undefined);
 			}
 		}, 200);
 		this.toDispose.push(session.onDidChangeState(() => {
-			if (session.state === State.Running && this.viewModel.focusedSession === session) {
+			if (session.state !== State.Running || this.viewModel.focusedSession !== session) {
 				sessionRunningScheduler.schedule();
 			}
 			if (session === this.viewModel.focusedSession) {


### PR DESCRIPTION
Not sure if that's the correct condition. I simply flipped what was there as that seemed to be what was intended. I think this will still allow events from other concurrent debug session to steal the focus even while stepping in the currently focused session. That may be intended, but be sure that it is.

Fixes #65920

@isidorn @ramya-rao-a 

P.S. @isidorn Why is this code doing a `shift`?
https://github.com/Microsoft/vscode/blob/96ab284b4e5f7a1d77c1be6e127be3c6accb3a0a/src/vs/workbench/parts/debug/electron-browser/debugService.ts#L762 https://github.com/Microsoft/vscode/blob/96ab284b4e5f7a1d77c1be6e127be3c6accb3a0a/src/vs/workbench/parts/debug/electron-browser/debugService.ts#L772
Why the **second** stopped debugging session/thread?