### PR TITLE
Detect md image link

### DIFF
--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -70,7 +70,7 @@ function extractDocumentLink(
 }
 
 export default class LinkProvider implements vscode.DocumentLinkProvider {
-	private readonly linkPattern = /(\[((!\[[^\]]*\]\(\s*)([^\s\(\)]+)\s*\)\]|[^\]]*\])\(\s*)(([^\s\(\)]|\(\S*?\))+)\s*(".*?")?\)/g;
+	private readonly linkPattern = /(\[((!\[[^\]]*?\]\(\s*)([^\s\(\)]+?)\s*\)\]|[^\]]*\])\(\s*)(([^\s\(\)]|\(\S*?\))+)\s*(".*?")?\)/g;
 	private readonly referenceLinkPattern = /(\[([^\]]+)\]\[\s*?)([^\s\]]*?)\]/g;
 	private readonly definitionPattern = /^([\t ]*\[([^\]]+)\]:\s*)(\S+)/gm;
 

--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -70,7 +70,7 @@ function extractDocumentLink(
 }
 
 export default class LinkProvider implements vscode.DocumentLinkProvider {
-	private readonly linkPattern = /(\[((!\[(.+)\]\()(.+)\)\]|[^\]]*\])\(\s*)((([^\s\(\)]|\(\S*?\))+))\s*(".*?")?\)/g;
+	private readonly linkPattern = /(\[((!\[[^\]]*\]\(\s*)([^\s\(\)]+)\s*\)\]|[^\]]*\])\(\s*)(([^\s\(\)]|\(\S*?\))+)\s*(".*?")?\)/g;
 	private readonly referenceLinkPattern = /(\[([^\]]+)\]\[\s*?)([^\s\]]*?)\]/g;
 	private readonly definitionPattern = /^([\t ]*\[([^\]]+)\]:\s*)(\S+)/gm;
 
@@ -92,11 +92,11 @@ export default class LinkProvider implements vscode.DocumentLinkProvider {
 	): vscode.DocumentLink[] {
 		const results: vscode.DocumentLink[] = [];
 		for (const match of matchAll(this.linkPattern, text)) {
-			const matchImage = match[5] && extractDocumentLink(document, base, match[3].length + 1, match[5], match.index);
+			const matchImage = match[4] && extractDocumentLink(document, base, match[3].length + 1, match[4], match.index);
 			if (matchImage) {
 				results.push(matchImage);
 			}
-			const matchLink = extractDocumentLink(document, base, match[1].length, match[6], match.index);
+			const matchLink = extractDocumentLink(document, base, match[1].length, match[5], match.index);
 			if (matchLink) {
 				results.push(matchLink);
 			}

--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -92,13 +92,13 @@ export default class LinkProvider implements vscode.DocumentLinkProvider {
 	): vscode.DocumentLink[] {
 		const results: vscode.DocumentLink[] = [];
 		for (const match of matchAll(this.linkPattern, text)) {
-			const urlLink = extractDocumentLink(document, base, match[1].length, match[6], match.index);
-			if (urlLink) {
-				results.push(urlLink);
+			const matchImage = match[5] && extractDocumentLink(document, base, match[3].length + 1, match[5], match.index);
+			if (matchImage) {
+				results.push(matchImage);
 			}
-			const imgLink = match[5] && extractDocumentLink(document, base, match[3].length + 1, match[5], match.index);
-			if (imgLink) {
-				results.push(imgLink);
+			const matchLink = extractDocumentLink(document, base, match[1].length, match[6], match.index);
+			if (matchLink) {
+				results.push(matchLink);
 			}
 		}
 		return results;

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -103,6 +103,14 @@ suite('markdown.DocumentLinkProvider', () => {
 		assertRangeEqual(link1.range, new vscode.Range(0, 10, 0, 14));
 		assertRangeEqual(link2.range, new vscode.Range(0, 23, 0, 28));
 	});
+
+	test('should handle hyperlinked images', () => {
+		const links = getLinksForFile('[![alt text](image.jpg)](https://example.com)');
+		assert.strictEqual(links.length, 2);
+		const [link1, link2] = links;
+		assertRangeEqual(link1.range, new vscode.Range(0,25,0,44));
+		assertRangeEqual(link2.range, new vscode.Range(0,13,0,22));
+	});
 });
 
 

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -104,12 +104,31 @@ suite('markdown.DocumentLinkProvider', () => {
 		assertRangeEqual(link2.range, new vscode.Range(0, 23, 0, 28));
 	});
 
+	// #49238
 	test('should handle hyperlinked images', () => {
-		const links = getLinksForFile('[![alt text](image.jpg)](https://example.com)');
-		assert.strictEqual(links.length, 2);
-		const [link1, link2] = links;
-		assertRangeEqual(link1.range, new vscode.Range(0,25,0,44));
-		assertRangeEqual(link2.range, new vscode.Range(0,13,0,22));
+		{
+			const links = getLinksForFile('[![alt text](image.jpg)](https://example.com)');
+			assert.strictEqual(links.length, 2);
+			const [link1, link2] = links;
+			assertRangeEqual(link1.range, new vscode.Range(0,13,0,22));
+			assertRangeEqual(link2.range, new vscode.Range(0,25,0,44));
+		}
+		{
+			const links = getLinksForFile('[![a]( whitespace.jpg )]( https://whitespace.com )');
+			assert.strictEqual(links.length, 2);
+			const [link1, link2] = links;
+			assertRangeEqual(link1.range, new vscode.Range(0,7,0,21));
+			assertRangeEqual(link2.range, new vscode.Range(0,26,0,48));
+		}
+		{
+			const links = getLinksForFile('[![a](img1.jpg)](file1.txt) text [![a](img2.jpg)](file2.txt)');
+			assert.strictEqual(links.length, 4);
+			const [link1, link2, link3, link4] = links;
+			assertRangeEqual(link1.range, new vscode.Range(0,6,0,14));
+			assertRangeEqual(link2.range, new vscode.Range(0,17,0,26));
+			assertRangeEqual(link3.range, new vscode.Range(0,39,0,47));
+			assertRangeEqual(link4.range, new vscode.Range(0,50,0,59));
+		}
 	});
 });
 


### PR DESCRIPTION
Fixes #49238. I added an option to the regex to have an image instead of text for the link description. Then when iterating over regex matches `providerInlineLinks` will now check to see if an image resource was also matched, and if so add it to results. All the tests pass, as well as a new one I've added. 

Feedback on the regex would be appreciated, also I think perhaps the code I copied [starting here](https://github.com/Microsoft/vscode/blob/2d79ffe0cd84515a4c771fcbd7294c2448d97826/extensions/markdown-language-features/src/features/documentLinkProvider.ts#L76) could be refactored into a separate function.