### PR TITLE
Fix another LGTM.com warning

### DIFF
--- a/extensions/merge-conflict/src/documentTracker.ts
+++ b/extensions/merge-conflict/src/documentTracker.ts
@@ -127,7 +127,7 @@ export default class DocumentMergeConflictTracker implements vscode.Disposable, 
 	}
 
 	private getCacheKey(document: vscode.TextDocument): string | null {
-		if (document.uri && document.uri) {
+		if (document.uri) {
 			return document.uri.toString();
 		}
 


### PR DESCRIPTION
This fixes another warning from LGTM.com. 

I don't think there are any mkore which I can fix but some of the other warning look fairly relevant such as the incomplete string encoding [alerts](https://lgtm.com/projects/g/Microsoft/vscode/alerts/?mode=tree&ruleFocus=1506222917439). Many of them seem like bugs.

If you want to prevent issues like this appearing you can use [automated code review](https://lgtm.com/projects/g/Microsoft/vscode/ci/) to check every pull request before it enters the repository.

_(Disclaimer: I work for semmle, the company behind LGTM.com)_