### PR TITLE
Print a message before installing dependencies in npm post install

### DIFF
--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -17,6 +17,7 @@ function yarnInstall(location, opts) {
 	opts.cwd = location;
 	opts.stdio = 'inherit';
 
+	console.log('Installing dependencies in \'%s\'.', location);
 	const result = cp.spawnSync(yarn, ['install'], opts);
 
 	if (result.error || result.status !== 0) {


### PR DESCRIPTION
Should make it easier to see what it's doing and debugging failures.