### PR TITLE
correct message for global and snippet templates

### DIFF
--- a/src/vs/workbench/parts/snippets/electron-browser/configureSnippets.ts
+++ b/src/vs/workbench/parts/snippets/electron-browser/configureSnippets.ts
@@ -202,17 +202,17 @@ CommandsRegistry.registerCommand(id, async (accessor): Promise<any> => {
 	const picks = await computePicks(snippetService, envService, modeService);
 	const existing: QuickPickInput[] = picks.existing;
 
-	type GlobalSnippetPick = IQuickPickItem & { uri: URI };
-	const globalSnippetPicks: GlobalSnippetPick[] = [{
+	type SnippetPick = IQuickPickItem & { uri: URI } & { scope: string };
+	const globalSnippetPicks: SnippetPick[] = [{
+		scope: nls.localize('new.global_scope', 'global'),
 		label: nls.localize('new.global', "New Global Snippets file..."),
 		uri: URI.file(join(envService.appSettingsHome, 'snippets'))
 	}];
 
-	type WorkspaceSnippetPick = IQuickPickItem & { uri: URI } & { name: string };
-	const workspaceSnippetPicks: WorkspaceSnippetPick[] = [];
+	const workspaceSnippetPicks: SnippetPick[] = [];
 	for (const folder of workspaceService.getWorkspace().folders) {
 		workspaceSnippetPicks.push({
-			name: folder.name,
+			scope: nls.localize('new.workspace_scope', "{0} workspace", folder.name),
 			label: nls.localize('new.folder', "New Snippets file for '{0}'...", folder.name),
 			uri: folder.toResource('.vscode')
 		});
@@ -230,10 +230,10 @@ CommandsRegistry.registerCommand(id, async (accessor): Promise<any> => {
 		matchOnDescription: true
 	});
 
-	if (globalSnippetPicks.indexOf(pick as GlobalSnippetPick) >= 0) {
-		return createSnippetFile('global', (pick as GlobalSnippetPick).uri, windowService, notificationService, fileService, opener);
-	} else if (workspaceSnippetPicks.indexOf(pick as WorkspaceSnippetPick) >= 0) {
-		return createSnippetFile((pick as WorkspaceSnippetPick).name + ' workspace', (pick as WorkspaceSnippetPick).uri, windowService, notificationService, fileService, opener);
+	if (globalSnippetPicks.indexOf(pick as SnippetPick) >= 0) {
+		return createSnippetFile((pick as SnippetPick).scope, (pick as SnippetPick).uri, windowService, notificationService, fileService, opener);
+	} else if (workspaceSnippetPicks.indexOf(pick as SnippetPick) >= 0) {
+		return createSnippetFile((pick as SnippetPick).scope, (pick as SnippetPick).uri, windowService, notificationService, fileService, opener);
 	} else if (ISnippetPick.is(pick)) {
 		if (pick.hint) {
 			await createLanguageSnippetFile(pick, fileService);


### PR DESCRIPTION
When creating snippets, the user is asked whether they want to create a `Global`, `<current_workspace>` or language-specific snippet. Choosing the `<current_workspace>` option resulted in a file with `global` 

Previous
![old](https://user-images.githubusercontent.com/3910877/51681706-c388b900-1fe5-11e9-8a07-4256c1544451.gif)


Current 

![new](https://user-images.githubusercontent.com/3910877/51681725-cc798a80-1fe5-11e9-8d31-0d0819783138.gif)
