### PR TITLE
ObjectTree/List: Add ariaRootRole option.  Addresses: #65939

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -63,7 +63,7 @@ export interface IIdentityProvider<T> {
 }
 
 // Default tree/list root role 'tree' does not support interactive element labeling, 'form' does
-export enum EListAriaRootRole {
+export enum ListAriaRootRole {
 	TREE = 'tree',		// default tree structure role
 	FORM = 'form'		// unstructured - allows interactive elements within tree/list structure
 }

--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -62,6 +62,12 @@ export interface IIdentityProvider<T> {
 	getId(element: T): { toString(): string; };
 }
 
+// Default tree/list root role 'tree' does not support interactive element labeling, 'form' does
+export enum EListAriaRootRole {
+	TREE = 'tree',		// default tree structure role
+	FORM = 'form'		// unstructured - allows interactive elements within tree/list structure
+}
+
 export interface IKeyboardNavigationLabelProvider<T> {
 	getKeyboardNavigationLabel(element: T): { toString(): string; };
 	mightProducePrintableCharacter?(event: IKeyboardEvent): boolean;

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -16,7 +16,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { Event, Emitter, EventBufferer } from 'vs/base/common/event';
 import { domEvent } from 'vs/base/browser/event';
-import { IListVirtualDelegate, IListRenderer, IListEvent, IListContextMenuEvent, IListMouseEvent, IListTouchEvent, IListGestureEvent, IIdentityProvider, IKeyboardNavigationLabelProvider, IListDragAndDrop, IListDragOverReaction } from './list';
+import { IListVirtualDelegate, IListRenderer, IListEvent, IListContextMenuEvent, IListMouseEvent, IListTouchEvent, IListGestureEvent, IIdentityProvider, IKeyboardNavigationLabelProvider, IListDragAndDrop, IListDragOverReaction, EListAriaRootRole } from './list';
 import { ListView, IListViewOptions, IListViewDragAndDrop } from './listView';
 import { Color } from 'vs/base/common/color';
 import { mixin } from 'vs/base/common/objects';
@@ -779,11 +779,13 @@ export class DefaultStyleController implements IStyleController {
 	}
 }
 
+
 export interface IListOptions<T> extends IListStyles {
 	readonly identityProvider?: IIdentityProvider<T>;
 	readonly dnd?: IListDragAndDrop<T>;
 	readonly enableKeyboardNavigation?: boolean;
 	readonly keyboardNavigationLabelProvider?: IKeyboardNavigationLabelProvider<T>;
+	readonly ariaRootRole?: EListAriaRootRole;
 	readonly ariaLabel?: string;
 	readonly keyboardSupport?: boolean;
 	readonly multipleSelectionSupport?: boolean;
@@ -843,7 +845,8 @@ const DefaultOptions = {
 		onDragStart(): void { },
 		onDragOver() { return false; },
 		drop() { }
-	}
+	},
+	ariaRootRole: EListAriaRootRole.TREE
 };
 
 // TODO@Joao: move these utils into a SortedArray class
@@ -1163,7 +1166,13 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		};
 
 		this.view = new ListView(container, virtualDelegate, renderers, viewOptions);
-		this.view.domNode.setAttribute('role', 'tree');
+
+		if (typeof _options.ariaRootRole !== 'string') {
+			this.view.domNode.setAttribute('role', EListAriaRootRole.TREE);
+		} else {
+			this.view.domNode.setAttribute('role', _options.ariaRootRole);
+		}
+
 		DOM.addClass(this.view.domNode, this.idPrefix);
 		this.view.domNode.tabIndex = 0;
 

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -16,7 +16,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { Event, Emitter, EventBufferer } from 'vs/base/common/event';
 import { domEvent } from 'vs/base/browser/event';
-import { IListVirtualDelegate, IListRenderer, IListEvent, IListContextMenuEvent, IListMouseEvent, IListTouchEvent, IListGestureEvent, IIdentityProvider, IKeyboardNavigationLabelProvider, IListDragAndDrop, IListDragOverReaction, EListAriaRootRole } from './list';
+import { IListVirtualDelegate, IListRenderer, IListEvent, IListContextMenuEvent, IListMouseEvent, IListTouchEvent, IListGestureEvent, IIdentityProvider, IKeyboardNavigationLabelProvider, IListDragAndDrop, IListDragOverReaction, ListAriaRootRole } from './list';
 import { ListView, IListViewOptions, IListViewDragAndDrop } from './listView';
 import { Color } from 'vs/base/common/color';
 import { mixin } from 'vs/base/common/objects';
@@ -785,7 +785,7 @@ export interface IListOptions<T> extends IListStyles {
 	readonly dnd?: IListDragAndDrop<T>;
 	readonly enableKeyboardNavigation?: boolean;
 	readonly keyboardNavigationLabelProvider?: IKeyboardNavigationLabelProvider<T>;
-	readonly ariaRootRole?: EListAriaRootRole;
+	readonly ariaRole?: ListAriaRootRole;
 	readonly ariaLabel?: string;
 	readonly keyboardSupport?: boolean;
 	readonly multipleSelectionSupport?: boolean;
@@ -846,7 +846,7 @@ const DefaultOptions = {
 		onDragOver() { return false; },
 		drop() { }
 	},
-	ariaRootRole: EListAriaRootRole.TREE
+	ariaRootRole: ListAriaRootRole.TREE
 };
 
 // TODO@Joao: move these utils into a SortedArray class
@@ -1167,10 +1167,10 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 
 		this.view = new ListView(container, virtualDelegate, renderers, viewOptions);
 
-		if (typeof _options.ariaRootRole !== 'string') {
-			this.view.domNode.setAttribute('role', EListAriaRootRole.TREE);
+		if (typeof _options.ariaRole !== 'string') {
+			this.view.domNode.setAttribute('role', ListAriaRootRole.TREE);
 		} else {
-			this.view.domNode.setAttribute('role', _options.ariaRootRole);
+			this.view.domNode.setAttribute('role', _options.ariaRole);
 		}
 
 		DOM.addClass(this.view.domNode, this.idPrefix);

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -12,7 +12,7 @@ import { alert as ariaAlert } from 'vs/base/browser/ui/aria/aria';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { Checkbox } from 'vs/base/browser/ui/checkbox/checkbox';
 import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
-import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { IListVirtualDelegate, EListAriaRootRole } from 'vs/base/browser/ui/list/list';
 import { ISelectOptionItem, SelectBox } from 'vs/base/browser/ui/selectBox/selectBox';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { IObjectTreeOptions, ObjectTree } from 'vs/base/browser/ui/tree/objectTree';
@@ -437,11 +437,6 @@ export abstract class AbstractSettingRenderer implements ITreeRenderer<SettingsT
 		template.deprecationWarningElement.innerText = element.setting.deprecationMessage || '';
 		this.renderValue(element, <ISettingItemTemplate>template, onChange);
 
-		// Remove tree attributes - sometimes overridden by tree - should be managed there
-		template.containerElement.parentElement.parentElement.removeAttribute('role');
-		template.containerElement.parentElement.parentElement.removeAttribute('aria-level');
-		template.containerElement.parentElement.parentElement.removeAttribute('aria-posinset');
-		template.containerElement.parentElement.parentElement.removeAttribute('aria-setsize');
 	}
 
 	private renderDescriptionMarkdown(element: SettingsTreeSettingElement, text: string, disposeables: IDisposable[]): HTMLElement {
@@ -1292,11 +1287,14 @@ export class SettingsTree extends ObjectTree<SettingsTreeElement> {
 	) {
 		const treeClass = 'settings-editor-tree';
 
+		// Must use role = EListAriaRootRole.FORM for interactive elements in settingsTree
+
 		super(container,
 			new SettingsTreeDelegate(),
 			renderers,
 			{
 				supportDynamicHeights: true,
+				ariaRootRole: EListAriaRootRole.FORM,
 				ariaLabel: localize('treeAriaLabel', "Settings"),
 				identityProvider: {
 					getId(e) {

--- a/src/vs/workbench/parts/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/parts/preferences/browser/settingsTree.ts
@@ -12,7 +12,7 @@ import { alert as ariaAlert } from 'vs/base/browser/ui/aria/aria';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { Checkbox } from 'vs/base/browser/ui/checkbox/checkbox';
 import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
-import { IListVirtualDelegate, EListAriaRootRole } from 'vs/base/browser/ui/list/list';
+import { IListVirtualDelegate, ListAriaRootRole } from 'vs/base/browser/ui/list/list';
 import { ISelectOptionItem, SelectBox } from 'vs/base/browser/ui/selectBox/selectBox';
 import { ToolBar } from 'vs/base/browser/ui/toolbar/toolbar';
 import { IObjectTreeOptions, ObjectTree } from 'vs/base/browser/ui/tree/objectTree';
@@ -1294,7 +1294,7 @@ export class SettingsTree extends ObjectTree<SettingsTreeElement> {
 			renderers,
 			{
 				supportDynamicHeights: true,
-				ariaRootRole: EListAriaRootRole.FORM,
+				ariaRole: ListAriaRootRole.FORM,
 				ariaLabel: localize('treeAriaLabel', "Settings"),
 				identityProvider: {
 					getId(e) {

--- a/src/vs/workbench/parts/preferences/electron-browser/settingsEditor2.ts
+++ b/src/vs/workbench/parts/preferences/electron-browser/settingsEditor2.ts
@@ -605,10 +605,6 @@ export class SettingsEditor2 extends BaseEditor {
 			this.settingRenderers.allRenderers));
 		this.settingsTree.getHTMLElement().attributes.removeNamedItem('tabindex');
 
-		// Have to redefine role of the tree widget to form for input elements
-		// TODO:CDL make this an option for tree
-		this.settingsTree.getHTMLElement().setAttribute('role', 'form');
-
 		// this._register(this.settingsTree.onDidScroll(() => {
 		// 	this.updateTreeScrollSync();
 		// }));


### PR DESCRIPTION
@joaomoreno 
@roblourens 

Addresses:  #65939

- Add new enum EListAriaRootRole for ariaRootRole option (mixed feelings about 'E' prefix)

```ts
// Default tree/list root role 'tree' does not support interactive element labeling, 'form' does
export enum EListAriaRootRole {
	TREE = 'tree',		// default tree structure role
	FORM = 'form'		// unstructured - allows interactive elements within tree/list structure
}
```

- Use EListAriaRootRole.TREE as default role, no need to change other clients
- Update settingsTree/settingsEditor2 to use EListAriaRootRole.FORM
- Handle the two valid roles in listWidget
- Remove all aria attribute manipulation in Settings Editor

Note:

Reader behavior related to this issue has changed with different versions of readers, Electron
and Chromium.  It it appears from testing (both NVDA & Voiceover) that the readers
will ignore the tree related attributes if the root role != 'tree'.  I therefore decided
NOT to alter any application logic for those attributes: item role, aria-level, aria-posinset, aria-setsize

I think this is the conservative approach and the minimal amount of changes. I could see 
needing to change the item role in the future possibly, but for now works.

Tested:
- Windows 10, NVDA 2018.4.1 - latest
- OS X Mojave, Voiceover
