### PR TITLE
save workspace on renderer

### DIFF
--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -167,7 +167,7 @@ export class WindowsManager implements IWindowsMainService {
 		}
 
 		this.dialogs = new Dialogs(environmentService, telemetryService, stateService, this);
-		this.workspacesManager = new WorkspacesManager(workspacesMainService, backupMainService, environmentService, this);
+		this.workspacesManager = new WorkspacesManager(workspacesMainService, backupMainService, environmentService, historyMainService, this);
 	}
 
 	private getWindowsState(): IWindowsState {
@@ -1955,7 +1955,8 @@ class WorkspacesManager {
 		private workspacesMainService: IWorkspacesMainService,
 		private backupMainService: IBackupMainService,
 		private environmentService: IEnvironmentService,
-		private windowsMainService: IWindowsMainService
+		private historyMainService: IHistoryMainService,
+		private windowsMainService: IWindowsMainService,
 	) {
 	}
 
@@ -2090,7 +2091,11 @@ class WorkspacesManager {
 						defaultPath: this.getUntitledWorkspaceSaveDialogDefaultPath(workspace)
 					}, window).then(target => {
 						if (target) {
-							return this.workspacesMainService.saveWorkspace(workspace, target).then(() => false, () => false);
+							return this.workspacesMainService.saveWorkspace(workspace, target).then(savedWorkspace => {
+								this.historyMainService.addRecentlyOpened([savedWorkspace], []);
+								return false;
+							},
+								() => false);
 						}
 
 						return true; // keep veto if no target was provided

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -818,7 +818,7 @@ export class WindowsManager implements IWindowsMainService {
 		if (!openConfig.addMode && isCommandLineOrAPICall) {
 			const foldersToOpen = windowsToOpen.filter(path => !!path.folderUri);
 			if (foldersToOpen.length > 1 && foldersToOpen.every(f => f.folderUri.scheme === Schemas.file)) {
-				const workspace = this.workspacesMainService.createWorkspaceSync(foldersToOpen.map(folder => ({ uri: folder.folderUri })));
+				const workspace = this.workspacesMainService.createUntitledWorkspaceSync(foldersToOpen.map(folder => ({ uri: folder.folderUri })));
 
 				// Add workspace and remove folders thereby
 				windowsToOpen.push({ workspace, remoteAuthority: foldersToOpen[0].remoteAuthority });
@@ -2000,7 +2000,7 @@ class WorkspacesManager {
 				return null; // return early if the workspace is not valid
 			}
 
-			return this.workspacesMainService.createWorkspace(folders).then(workspace => {
+			return this.workspacesMainService.createUntitledWorkspace(folders).then(workspace => {
 				return this.doSaveAndOpenWorkspace(window, workspace, path);
 			});
 		});

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -2010,6 +2010,11 @@ class WorkspacesManager {
 			backupPath = this.backupMainService.registerWorkspaceBackupSync(workspace, window.config.backupPath);
 		}
 
+		// if the window was opened on an untitled workspace, delete it.
+		if (window.openedWorkspace && this.workspacesMainService.isUntitledWorkspace(window.openedWorkspace)) {
+			this.workspacesMainService.deleteUntitledWorkspaceSync(window.openedWorkspace);
+		}
+
 		// Update window configuration properly based on transition to workspace
 		window.config.folderUri = undefined;
 		window.config.workspace = workspace;
@@ -2091,8 +2096,9 @@ class WorkspacesManager {
 						defaultPath: this.getUntitledWorkspaceSaveDialogDefaultPath(workspace)
 					}, window).then(target => {
 						if (target) {
-							return this.workspacesMainService.saveWorkspace(workspace, target).then(savedWorkspace => {
+							return this.workspacesMainService.saveWorkspaceAs(workspace, target).then(savedWorkspace => {
 								this.historyMainService.addRecentlyOpened([savedWorkspace], []);
+								this.workspacesMainService.deleteUntitledWorkspaceSync(workspace);
 								return false;
 							},
 								() => false);

--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -26,7 +26,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWindowsMainService, IOpenConfiguration, IWindowsCountChangedEvent, ICodeWindow, IWindowState as ISingleWindowState, WindowMode } from 'vs/platform/windows/electron-main/windows';
 import { IHistoryMainService } from 'vs/platform/history/common/history';
 import { IProcessEnvironment, isLinux, isMacintosh, isWindows } from 'vs/base/common/platform';
-import { IWorkspacesMainService, IWorkspaceIdentifier, WORKSPACE_FILTER, IWorkspaceFolderCreationData, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspacesMainService, IWorkspaceIdentifier, WORKSPACE_FILTER, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { mnemonicButtonLabel } from 'vs/base/common/labels';
 import { Schemas } from 'vs/base/common/network';
@@ -1470,16 +1470,8 @@ export class WindowsManager implements IWindowsMainService {
 		});
 	}
 
-	saveAndEnterWorkspace(win: ICodeWindow, path: string): Promise<IEnterWorkspaceResult> {
-		return this.workspacesManager.saveAndEnterWorkspace(win, path).then(result => this.doEnterWorkspace(win, result));
-	}
-
 	enterWorkspace(win: ICodeWindow, path: URI): Promise<IEnterWorkspaceResult> {
 		return this.workspacesManager.enterWorkspace(win, path).then(result => this.doEnterWorkspace(win, result));
-	}
-
-	createAndEnterWorkspace(win: ICodeWindow, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult> {
-		return this.workspacesManager.createAndEnterWorkspace(win, folders, path).then(result => this.doEnterWorkspace(win, result));
 	}
 
 	private doEnterWorkspace(win: ICodeWindow, result: IEnterWorkspaceResult): IEnterWorkspaceResult {
@@ -1967,14 +1959,6 @@ class WorkspacesManager {
 	) {
 	}
 
-	saveAndEnterWorkspace(window: ICodeWindow, path: string): Promise<IEnterWorkspaceResult | null> {
-		if (!window || !window.win || !window.isReady || !window.openedWorkspace || !path || !this.isValidTargetWorkspacePath(window, URI.file(path))) {
-			return Promise.resolve(null); // return early if the window is not ready or disposed or does not have a workspace
-		}
-
-		return this.doSaveAndOpenWorkspace(window, window.openedWorkspace, path);
-	}
-
 	enterWorkspace(window: ICodeWindow, path: URI): Promise<IEnterWorkspaceResult | null> {
 		if (!window || !window.win || !window.isReady) {
 			return Promise.resolve(null); // return early if the window is not ready or disposed
@@ -1988,22 +1972,6 @@ class WorkspacesManager {
 			return this.doOpenWorkspace(window, workspaceIdentifier);
 		});
 
-	}
-
-	createAndEnterWorkspace(window: ICodeWindow, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | null> {
-		if (!window || !window.win || !window.isReady || !path) {
-			return Promise.resolve(null); // return early if the window is not ready or disposed
-		}
-
-		return this.isValidTargetWorkspacePath(window, URI.file(path)).then(isValid => {
-			if (!isValid) {
-				return null; // return early if the workspace is not valid
-			}
-
-			return this.workspacesMainService.createUntitledWorkspace(folders).then(workspace => {
-				return this.doSaveAndOpenWorkspace(window, workspace, path);
-			});
-		});
 	}
 
 	private isValidTargetWorkspacePath(window: ICodeWindow, path?: URI): Promise<boolean> {
@@ -2030,17 +1998,6 @@ class WorkspacesManager {
 		}
 
 		return Promise.resolve(true); // OK
-	}
-
-	private doSaveAndOpenWorkspace(window: ICodeWindow, workspace: IWorkspaceIdentifier, path?: string): Promise<IEnterWorkspaceResult> {
-		let savePromise: Promise<IWorkspaceIdentifier>;
-		if (path) {
-			savePromise = this.workspacesMainService.saveWorkspace(workspace, path);
-		} else {
-			savePromise = Promise.resolve(workspace);
-		}
-
-		return savePromise.then(workspace => this.doOpenWorkspace(window, workspace));
 	}
 
 	private doOpenWorkspace(window: ICodeWindow, workspace: IWorkspaceIdentifier): IEnterWorkspaceResult {

--- a/src/vs/platform/history/electron-main/historyMainService.ts
+++ b/src/vs/platform/history/electron-main/historyMainService.ts
@@ -12,7 +12,7 @@ import { getBaseLabel, getPathLabel } from 'vs/base/common/labels';
 import { IPath } from 'vs/platform/windows/common/windows';
 import { Event as CommonEvent, Emitter } from 'vs/base/common/event';
 import { isWindows, isMacintosh, isLinux } from 'vs/base/common/platform';
-import { IWorkspaceIdentifier, IWorkspacesMainService, IWorkspaceSavedEvent, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspaceIdentifier, IWorkspacesMainService, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { IHistoryMainService, IRecentlyOpened } from 'vs/platform/history/common/history';
 import { isEqual } from 'vs/base/common/paths';
 import { RunOnceScheduler } from 'vs/base/common/async';
@@ -54,18 +54,6 @@ export class HistoryMainService implements IHistoryMainService {
 		@IEnvironmentService private readonly environmentService: IEnvironmentService
 	) {
 		this.macOSRecentDocumentsUpdater = new RunOnceScheduler(() => this.updateMacOSRecentDocuments(), 800);
-
-		this.registerListeners();
-	}
-
-	private registerListeners(): void {
-		this.workspacesMainService.onWorkspaceSaved(e => this.onWorkspaceSaved(e));
-	}
-
-	private onWorkspaceSaved(e: IWorkspaceSavedEvent): void {
-
-		// Make sure to add newly saved workspaces to the list of recent workspaces
-		this.addRecentlyOpened([e.workspace], []);
 	}
 
 	addRecentlyOpened(workspaces: Array<IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier>, files: URI[]): void {

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -114,7 +114,7 @@ export interface IWindowsService {
 	openDevTools(windowId: number, options?: IDevToolsOptions): Promise<void>;
 	toggleDevTools(windowId: number): Promise<void>;
 	closeWorkspace(windowId: number): Promise<void>;
-	enterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult | undefined>;
+	enterWorkspace(windowId: number, path: URI): Promise<IEnterWorkspaceResult | undefined>;
 	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | undefined>;
 	saveAndEnterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult | undefined>;
 	toggleFullScreen(windowId: number): Promise<void>;
@@ -207,7 +207,7 @@ export interface IWindowService {
 	toggleDevTools(): Promise<void>;
 	closeWorkspace(): Promise<void>;
 	updateTouchBar(items: ISerializableCommandAction[][]): Promise<void>;
-	enterWorkspace(path: string): Promise<IEnterWorkspaceResult | undefined>;
+	enterWorkspace(path: URI): Promise<IEnterWorkspaceResult | undefined>;
 	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | undefined>;
 	saveAndEnterWorkspace(path: string): Promise<IEnterWorkspaceResult | undefined>;
 	toggleFullScreen(): Promise<void>;

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -8,7 +8,7 @@ import { Event } from 'vs/base/common/event';
 import { ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
 import { IProcessEnvironment, isMacintosh, isWindows } from 'vs/base/common/platform';
 import { ParsedArgs, IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { IWorkspaceIdentifier, IWorkspaceFolderCreationData, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { IRecentlyOpened } from 'vs/platform/history/common/history';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 import { ExportData } from 'vs/base/common/performance';
@@ -115,8 +115,6 @@ export interface IWindowsService {
 	toggleDevTools(windowId: number): Promise<void>;
 	closeWorkspace(windowId: number): Promise<void>;
 	enterWorkspace(windowId: number, path: URI): Promise<IEnterWorkspaceResult | undefined>;
-	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | undefined>;
-	saveAndEnterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult | undefined>;
 	toggleFullScreen(windowId: number): Promise<void>;
 	setRepresentedFilename(windowId: number, fileName: string): Promise<void>;
 	addRecentlyOpened(files: URI[]): Promise<void>;
@@ -208,8 +206,6 @@ export interface IWindowService {
 	closeWorkspace(): Promise<void>;
 	updateTouchBar(items: ISerializableCommandAction[][]): Promise<void>;
 	enterWorkspace(path: URI): Promise<IEnterWorkspaceResult | undefined>;
-	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | undefined>;
-	saveAndEnterWorkspace(path: string): Promise<IEnterWorkspaceResult | undefined>;
 	toggleFullScreen(): Promise<void>;
 	setRepresentedFilename(fileName: string): Promise<void>;
 	getRecentlyOpened(): Promise<IRecentlyOpened>;

--- a/src/vs/platform/windows/electron-browser/windowService.ts
+++ b/src/vs/platform/windows/electron-browser/windowService.ts
@@ -7,7 +7,6 @@ import { Event } from 'vs/base/common/event';
 import { IWindowService, IWindowsService, INativeOpenDialogOptions, IEnterWorkspaceResult, IMessageBoxResult, IWindowConfiguration, IDevToolsOptions, IOpenSettings } from 'vs/platform/windows/common/windows';
 import { IRecentlyOpened } from 'vs/platform/history/common/history';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
-import { IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
 import { ParsedArgs } from 'vs/platform/environment/common/environment';
 import { URI } from 'vs/base/common/uri';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -91,14 +90,6 @@ export class WindowService extends Disposable implements IWindowService {
 
 	enterWorkspace(path: URI): Promise<IEnterWorkspaceResult | undefined> {
 		return this.windowsService.enterWorkspace(this.windowId, path);
-	}
-
-	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | undefined> {
-		return this.windowsService.createAndEnterWorkspace(this.windowId, folders, path);
-	}
-
-	saveAndEnterWorkspace(path: string): Promise<IEnterWorkspaceResult | undefined> {
-		return this.windowsService.saveAndEnterWorkspace(this.windowId, path);
 	}
 
 	openWindow(paths: URI[], options?: IOpenSettings): Promise<void> {

--- a/src/vs/platform/windows/electron-browser/windowService.ts
+++ b/src/vs/platform/windows/electron-browser/windowService.ts
@@ -89,7 +89,7 @@ export class WindowService extends Disposable implements IWindowService {
 		return this.windowsService.closeWorkspace(this.windowId);
 	}
 
-	enterWorkspace(path: string): Promise<IEnterWorkspaceResult | undefined> {
+	enterWorkspace(path: URI): Promise<IEnterWorkspaceResult | undefined> {
 		return this.windowsService.enterWorkspace(this.windowId, path);
 	}
 

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -8,7 +8,7 @@ import { ParsedArgs } from 'vs/platform/environment/common/environment';
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IProcessEnvironment } from 'vs/base/common/platform';
-import { IWorkspaceIdentifier, IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 import { URI } from 'vs/base/common/uri';
 
@@ -95,8 +95,6 @@ export interface IWindowsMainService {
 	ready(initialUserEnv: IProcessEnvironment): void;
 	reload(win: ICodeWindow, cli?: ParsedArgs): void;
 	enterWorkspace(win: ICodeWindow, path: URI): Promise<IEnterWorkspaceResult>;
-	createAndEnterWorkspace(win: ICodeWindow, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult>;
-	saveAndEnterWorkspace(win: ICodeWindow, path: string): Promise<IEnterWorkspaceResult>;
 	closeWorkspace(win: ICodeWindow): void;
 	open(openConfig: IOpenConfiguration): ICodeWindow[];
 	openExtensionDevelopmentHostWindow(openConfig: IOpenConfiguration): void;

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -94,7 +94,7 @@ export interface IWindowsMainService {
 	// methods
 	ready(initialUserEnv: IProcessEnvironment): void;
 	reload(win: ICodeWindow, cli?: ParsedArgs): void;
-	enterWorkspace(win: ICodeWindow, path: string): Promise<IEnterWorkspaceResult>;
+	enterWorkspace(win: ICodeWindow, path: URI): Promise<IEnterWorkspaceResult>;
 	createAndEnterWorkspace(win: ICodeWindow, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult>;
 	saveAndEnterWorkspace(win: ICodeWindow, path: string): Promise<IEnterWorkspaceResult>;
 	closeWorkspace(win: ICodeWindow): void;

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -138,7 +138,7 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		return this.withWindow(windowId, codeWindow => this.windowsMainService.closeWorkspace(codeWindow));
 	}
 
-	async enterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult | undefined> {
+	async enterWorkspace(windowId: number, path: URI): Promise<IEnterWorkspaceResult | undefined> {
 		this.logService.trace('windowsService#enterWorkspace', windowId);
 
 		return this.withWindow(windowId, codeWindow => this.windowsMainService.enterWorkspace(codeWindow, path));

--- a/src/vs/platform/windows/electron-main/windowsService.ts
+++ b/src/vs/platform/windows/electron-main/windowsService.ts
@@ -17,7 +17,7 @@ import { IURLService, IURLHandler } from 'vs/platform/url/common/url';
 import { ILifecycleService } from 'vs/platform/lifecycle/electron-main/lifecycleMain';
 import { IWindowsMainService, ISharedProcess, ICodeWindow } from 'vs/platform/windows/electron-main/windows';
 import { IHistoryMainService, IRecentlyOpened } from 'vs/platform/history/common/history';
-import { IWorkspaceIdentifier, IWorkspaceFolderCreationData, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 import { Schemas } from 'vs/base/common/network';
 import { mnemonicButtonLabel } from 'vs/base/common/labels';
@@ -142,18 +142,6 @@ export class WindowsService implements IWindowsService, IURLHandler, IDisposable
 		this.logService.trace('windowsService#enterWorkspace', windowId);
 
 		return this.withWindow(windowId, codeWindow => this.windowsMainService.enterWorkspace(codeWindow, path));
-	}
-
-	async createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult | undefined> {
-		this.logService.trace('windowsService#createAndEnterWorkspace', windowId);
-
-		return this.withWindow(windowId, codeWindow => this.windowsMainService.createAndEnterWorkspace(codeWindow, folders, path));
-	}
-
-	async saveAndEnterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult | undefined> {
-		this.logService.trace('windowsService#saveAndEnterWorkspace', windowId);
-
-		return this.withWindow(windowId, codeWindow => this.windowsMainService.saveAndEnterWorkspace(codeWindow, path));
 	}
 
 	async toggleFullScreen(windowId: number): Promise<void> {

--- a/src/vs/platform/windows/node/windowsIpc.ts
+++ b/src/vs/platform/windows/node/windowsIpc.ts
@@ -56,7 +56,7 @@ export class WindowsChannel implements IServerChannel {
 			case 'openDevTools': return this.service.openDevTools(arg[0], arg[1]);
 			case 'toggleDevTools': return this.service.toggleDevTools(arg);
 			case 'closeWorkspace': return this.service.closeWorkspace(arg);
-			case 'enterWorkspace': return this.service.enterWorkspace(arg[0], arg[1]);
+			case 'enterWorkspace': return this.service.enterWorkspace(arg[0], URI.revive(arg[1]));
 			case 'createAndEnterWorkspace': {
 				const rawFolders: IWorkspaceFolderCreationData[] = arg[1];
 				let folders: IWorkspaceFolderCreationData[] | undefined = undefined;
@@ -179,7 +179,7 @@ export class WindowsChannelClient implements IWindowsService {
 		return this.channel.call('closeWorkspace', windowId);
 	}
 
-	enterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult> {
+	enterWorkspace(windowId: number, path: URI): Promise<IEnterWorkspaceResult> {
 		return this.channel.call('enterWorkspace', [windowId, path]);
 	}
 

--- a/src/vs/platform/windows/node/windowsIpc.ts
+++ b/src/vs/platform/windows/node/windowsIpc.ts
@@ -6,7 +6,7 @@
 import { Event } from 'vs/base/common/event';
 import { IChannel, IServerChannel } from 'vs/base/parts/ipc/node/ipc';
 import { IWindowsService, INativeOpenDialogOptions, IEnterWorkspaceResult, CrashReporterStartOptions, IMessageBoxResult, MessageBoxOptions, SaveDialogOptions, OpenDialogOptions, IDevToolsOptions, INewWindowOptions } from 'vs/platform/windows/common/windows';
-import { IWorkspaceIdentifier, IWorkspaceFolderCreationData, ISingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { IRecentlyOpened } from 'vs/platform/history/common/history';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 import { URI } from 'vs/base/common/uri';
@@ -57,21 +57,6 @@ export class WindowsChannel implements IServerChannel {
 			case 'toggleDevTools': return this.service.toggleDevTools(arg);
 			case 'closeWorkspace': return this.service.closeWorkspace(arg);
 			case 'enterWorkspace': return this.service.enterWorkspace(arg[0], URI.revive(arg[1]));
-			case 'createAndEnterWorkspace': {
-				const rawFolders: IWorkspaceFolderCreationData[] = arg[1];
-				let folders: IWorkspaceFolderCreationData[] | undefined = undefined;
-				if (Array.isArray(rawFolders)) {
-					folders = rawFolders.map(rawFolder => {
-						return {
-							uri: URI.revive(rawFolder.uri), // convert raw URI back to real URI
-							name: rawFolder.name
-						} as IWorkspaceFolderCreationData;
-					});
-				}
-
-				return this.service.createAndEnterWorkspace(arg[0], folders, arg[2]);
-			}
-			case 'saveAndEnterWorkspace': return this.service.saveAndEnterWorkspace(arg[0], arg[1]);
 			case 'toggleFullScreen': return this.service.toggleFullScreen(arg);
 			case 'setRepresentedFilename': return this.service.setRepresentedFilename(arg[0], arg[1]);
 			case 'addRecentlyOpened': return this.service.addRecentlyOpened(arg.map(URI.revive));
@@ -181,14 +166,6 @@ export class WindowsChannelClient implements IWindowsService {
 
 	enterWorkspace(windowId: number, path: URI): Promise<IEnterWorkspaceResult> {
 		return this.channel.call('enterWorkspace', [windowId, path]);
-	}
-
-	createAndEnterWorkspace(windowId: number, folders?: IWorkspaceFolderCreationData[], path?: string): Promise<IEnterWorkspaceResult> {
-		return this.channel.call('createAndEnterWorkspace', [windowId, folders, path]);
-	}
-
-	saveAndEnterWorkspace(windowId: number, path: string): Promise<IEnterWorkspaceResult> {
-		return this.channel.call('saveAndEnterWorkspace', [windowId, path]);
 	}
 
 	toggleFullScreen(windowId: number): Promise<void> {

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -77,7 +77,6 @@ export interface IWorkspaceFolderCreationData {
 export interface IWorkspacesMainService extends IWorkspacesService {
 	_serviceBrand: any;
 
-	onWorkspaceSaved: Event<IWorkspaceSavedEvent>;
 	onUntitledWorkspaceDeleted: Event<IWorkspaceIdentifier>;
 
 	saveWorkspace(workspace: IWorkspaceIdentifier, target: string): Promise<IWorkspaceIdentifier>;
@@ -101,6 +100,8 @@ export interface IWorkspacesService {
 	_serviceBrand: any;
 
 	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier>;
+
+	deleteIfUntitledWorkspace(workspace: IWorkspaceIdentifier): Promise<any>;
 }
 
 export function isSingleFolderWorkspaceIdentifier(obj: any): obj is ISingleFolderWorkspaceIdentifier {

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -82,7 +82,7 @@ export interface IWorkspacesMainService extends IWorkspacesService {
 
 	saveWorkspace(workspace: IWorkspaceIdentifier, target: string): Promise<IWorkspaceIdentifier>;
 
-	createWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier;
+	createUntitledWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier;
 
 	resolveWorkspaceSync(path: string): IResolvedWorkspace | null;
 
@@ -100,7 +100,7 @@ export interface IWorkspacesMainService extends IWorkspacesService {
 export interface IWorkspacesService {
 	_serviceBrand: any;
 
-	createWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier>;
+	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier>;
 }
 
 export function isSingleFolderWorkspaceIdentifier(obj: any): obj is ISingleFolderWorkspaceIdentifier {

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -79,7 +79,7 @@ export interface IWorkspacesMainService extends IWorkspacesService {
 
 	onUntitledWorkspaceDeleted: Event<IWorkspaceIdentifier>;
 
-	saveWorkspace(workspace: IWorkspaceIdentifier, target: string): Promise<IWorkspaceIdentifier>;
+	saveWorkspaceAs(workspace: IWorkspaceIdentifier, target: string): Promise<IWorkspaceIdentifier>;
 
 	createUntitledWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier;
 
@@ -100,8 +100,6 @@ export interface IWorkspacesService {
 	_serviceBrand: any;
 
 	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier>;
-
-	deleteIfUntitledWorkspace(workspace: IWorkspaceIdentifier): Promise<any>;
 }
 
 export function isSingleFolderWorkspaceIdentifier(obj: any): obj is ISingleFolderWorkspaceIdentifier {

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -84,8 +84,6 @@ export interface IWorkspacesMainService extends IWorkspacesService {
 
 	createWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier;
 
-	resolveWorkspace(path: string): Promise<IResolvedWorkspace | null>;
-
 	resolveWorkspaceSync(path: string): IResolvedWorkspace | null;
 
 	isUntitledWorkspace(workspace: IWorkspaceIdentifier): boolean;
@@ -95,6 +93,8 @@ export interface IWorkspacesMainService extends IWorkspacesService {
 	getUntitledWorkspacesSync(): IWorkspaceIdentifier[];
 
 	getWorkspaceId(workspacePath: string): string;
+
+	getWorkspaceIdentifier(workspacePath: URI): IWorkspaceIdentifier;
 }
 
 export interface IWorkspacesService {

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -107,16 +107,16 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 		return isParent(path, this.environmentService.workspacesHome, !isLinux /* ignore case */);
 	}
 
-	createWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier> {
-		const { workspace, configParent, storedWorkspace } = this.createUntitledWorkspace(folders);
+	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier> {
+		const { workspace, configParent, storedWorkspace } = this.newUntitledWorkspace(folders);
 
 		return mkdirp(configParent).then(() => {
 			return writeFile(workspace.configPath, JSON.stringify(storedWorkspace, null, '\t')).then(() => workspace);
 		});
 	}
 
-	createWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier {
-		const { workspace, configParent, storedWorkspace } = this.createUntitledWorkspace(folders);
+	createUntitledWorkspaceSync(folders?: IWorkspaceFolderCreationData[]): IWorkspaceIdentifier {
+		const { workspace, configParent, storedWorkspace } = this.newUntitledWorkspace(folders);
 
 		if (!existsSync(this.workspacesHome)) {
 			mkdirSync(this.workspacesHome);
@@ -129,7 +129,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 		return workspace;
 	}
 
-	private createUntitledWorkspace(folders: IWorkspaceFolderCreationData[] = []): { workspace: IWorkspaceIdentifier, configParent: string, storedWorkspace: IStoredWorkspace } {
+	private newUntitledWorkspace(folders: IWorkspaceFolderCreationData[] = []): { workspace: IWorkspaceIdentifier, configParent: string, storedWorkspace: IStoredWorkspace } {
 		const randomId = (Date.now() + Math.round(Math.random() * 1000)).toString();
 		const untitledWorkspaceConfigFolder = join(this.workspacesHome, randomId);
 		const untitledWorkspaceConfigPath = join(untitledWorkspaceConfigFolder, UNTITLED_WORKSPACE_NAME);

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -190,7 +190,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 		return this.isInsideWorkspacesHome(workspace.configPath);
 	}
 
-	saveWorkspace(workspace: IWorkspaceIdentifier, targetConfigPath: string): Promise<IWorkspaceIdentifier> {
+	saveWorkspaceAs(workspace: IWorkspaceIdentifier, targetConfigPath: string): Promise<IWorkspaceIdentifier> {
 
 		// Return early if target is same as source
 		if (isEqual(workspace.configPath, targetConfigPath, !isLinux)) {
@@ -203,7 +203,6 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 			const newRawWorkspaceContents = rewriteWorkspaceFileForNewLocation(raw.toString(), URI.file(workspace.configPath), targetConfigPathURI);
 
 			return writeFile(targetConfigPath, newRawWorkspaceContents).then(() => {
-				this.deleteUntitledWorkspaceSync(workspace);
 				return this.getWorkspaceIdentifier(targetConfigPathURI);
 			});
 		});
@@ -219,11 +218,6 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 
 		// Event
 		this._onUntitledWorkspaceDeleted.fire(workspace);
-	}
-
-	deleteIfUntitledWorkspace(workspace: IWorkspaceIdentifier): Promise<any> {
-		this.deleteUntitledWorkspaceSync(workspace);
-		return Promise.resolve();
 	}
 
 	private doDeleteUntitledWorkspaceSync(configPath: string): void {

--- a/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
+++ b/src/vs/platform/workspaces/electron-main/workspacesMainService.ts
@@ -6,7 +6,7 @@
 import { IWorkspacesMainService, IWorkspaceIdentifier, WORKSPACE_EXTENSION, IWorkspaceSavedEvent, UNTITLED_WORKSPACE_NAME, IResolvedWorkspace, IStoredWorkspaceFolder, isRawFileWorkspaceFolder, isStoredWorkspaceFolder, IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
 import { isParent } from 'vs/platform/files/common/files';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { extname, join, dirname, isAbsolute, resolve } from 'path';
+import { join, dirname, isAbsolute, resolve, extname } from 'path';
 import { mkdirp, writeFile, readFile } from 'vs/base/node/pfs';
 import { readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { isLinux, isMacintosh } from 'vs/base/common/platform';
@@ -23,6 +23,7 @@ import { toWorkspaceFolders } from 'vs/platform/workspace/common/workspace';
 import { URI } from 'vs/base/common/uri';
 import { Schemas } from 'vs/base/common/network';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { fsPath, dirname as resourcesDirname } from 'vs/base/common/resources';
 
 export interface IStoredWorkspace {
 	folders: IStoredWorkspaceFolder[];
@@ -49,14 +50,6 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 		this.workspacesHome = environmentService.workspacesHome;
 	}
 
-	resolveWorkspace(path: string): Promise<IResolvedWorkspace | null> {
-		if (!this.isWorkspacePath(path)) {
-			return Promise.resolve(null); // does not look like a valid workspace config file
-		}
-
-		return readFile(path, 'utf8').then(contents => this.doResolveWorkspace(path, contents));
-	}
-
 	resolveWorkspaceSync(path: string): IResolvedWorkspace | null {
 		if (!this.isWorkspacePath(path)) {
 			return null; // does not look like a valid workspace config file
@@ -69,21 +62,21 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 			return null; // invalid workspace
 		}
 
-		return this.doResolveWorkspace(path, contents);
+		return this.doResolveWorkspace(URI.file(path), contents);
 	}
 
 	private isWorkspacePath(path: string): boolean {
 		return this.isInsideWorkspacesHome(path) || extname(path) === `.${WORKSPACE_EXTENSION}`;
 	}
 
-	private doResolveWorkspace(path: string, contents: string): IResolvedWorkspace | null {
+	private doResolveWorkspace(path: URI, contents: string): IResolvedWorkspace | null {
 		try {
 			const workspace = this.doParseStoredWorkspace(path, contents);
-
+			const workspaceIdentifier = this.getWorkspaceIdentifier(path);
 			return {
-				id: this.getWorkspaceId(path),
-				configPath: path,
-				folders: toWorkspaceFolders(workspace.folders, URI.file(dirname(path)))
+				id: workspaceIdentifier.id,
+				configPath: workspaceIdentifier.configPath,
+				folders: toWorkspaceFolders(workspace.folders, resourcesDirname(path)!)
 			};
 		} catch (error) {
 			this.logService.warn(error.toString());
@@ -92,7 +85,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 		return null;
 	}
 
-	private doParseStoredWorkspace(path: string, contents: string): IStoredWorkspace {
+	private doParseStoredWorkspace(path: URI, contents: string): IStoredWorkspace {
 
 		// Parse workspace file
 		let storedWorkspace: IStoredWorkspace = json.parse(contents); // use fault tolerant parser
@@ -104,7 +97,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 
 		// Validate
 		if (!Array.isArray(storedWorkspace.folders)) {
-			throw new Error(`${path} looks like an invalid workspace file.`);
+			throw new Error(`${path.toString()} looks like an invalid workspace file.`);
 		}
 
 		return storedWorkspace;
@@ -148,7 +141,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 
 				// File URI
 				if (folderResource.scheme === Schemas.file) {
-					storedWorkspace = { path: massageFolderPathForWorkspace(folderResource.fsPath, untitledWorkspaceConfigFolder, []) };
+					storedWorkspace = { path: massageFolderPathForWorkspace(fsPath(folderResource), URI.file(untitledWorkspaceConfigFolder), []) };
 				}
 
 				// Any URI
@@ -182,6 +175,21 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 		return createHash('md5').update(workspaceConfigPath).digest('hex');
 	}
 
+	getWorkspaceIdentifier(workspacePath: URI): IWorkspaceIdentifier {
+		if (workspacePath.scheme === Schemas.file) {
+			const configPath = fsPath(workspacePath);
+			return {
+				configPath,
+				id: this.getWorkspaceId(configPath)
+			};
+		}
+		throw new Error('Not yet supported');
+		/*return {
+			configPath: workspacePath
+			id: this.getWorkspaceId(workspacePath.toString());
+		};*/
+	}
+
 	isUntitledWorkspace(workspace: IWorkspaceIdentifier): boolean {
 		return this.isInsideWorkspacesHome(workspace.configPath);
 	}
@@ -198,7 +206,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 			const rawWorkspaceContents = raw.toString();
 			let storedWorkspace: IStoredWorkspace;
 			try {
-				storedWorkspace = this.doParseStoredWorkspace(workspace.configPath, rawWorkspaceContents);
+				storedWorkspace = this.doParseStoredWorkspace(URI.file(workspace.configPath), rawWorkspaceContents);
 			} catch (error) {
 				return Promise.reject(error);
 			}
@@ -214,7 +222,7 @@ export class WorkspacesMainService extends Disposable implements IWorkspacesMain
 					if (!isAbsolute(folder.path)) {
 						folder.path = resolve(sourceConfigFolder, folder.path); // relative paths get resolved against the workspace location
 					}
-					folder.path = massageFolderPathForWorkspace(folder.path, targetConfigFolder, storedWorkspace.folders);
+					folder.path = massageFolderPathForWorkspace(folder.path, URI.file(targetConfigFolder), storedWorkspace.folders);
 				}
 
 			});

--- a/src/vs/platform/workspaces/node/workspaces.ts
+++ b/src/vs/platform/workspaces/node/workspaces.ts
@@ -74,7 +74,7 @@ export function rewriteWorkspaceFileForNewLocation(rawWorkspaceContents: string,
 		if (isRawFileWorkspaceFolder(folder)) {
 			if (sourceConfigFolder.scheme === Schemas.file) {
 				if (!isAbsolute(folder.path)) {
-					folder.path = resolve(sourceConfigFolder.path, folder.path); // relative paths get resolved against the workspace location
+					folder.path = resolve(fsPath(sourceConfigFolder), folder.path); // relative paths get resolved against the workspace location
 				}
 				folder.path = massageFolderPathForWorkspace(folder.path, targetConfigFolder, storedWorkspace.folders);
 			}

--- a/src/vs/platform/workspaces/node/workspaces.ts
+++ b/src/vs/platform/workspaces/node/workspaces.ts
@@ -64,8 +64,8 @@ export function massageFolderPathForWorkspace(absoluteFolderPath: string, target
 export function rewriteWorkspaceFileForNewLocation(rawWorkspaceContents: string, configPathURI: URI, targetConfigPathURI: URI) {
 	let storedWorkspace = doParseStoredWorkspace(configPathURI, rawWorkspaceContents);
 
-	const sourceConfigFolder = dirname(configPathURI);
-	const targetConfigFolder = dirname(targetConfigPathURI);
+	const sourceConfigFolder = dirname(configPathURI)!;
+	const targetConfigFolder = dirname(targetConfigPathURI)!;
 
 	// Rewrite absolute paths to relative paths if the target workspace folder
 	// is a parent of the location of the workspace file itself. Otherwise keep

--- a/src/vs/platform/workspaces/node/workspacesIpc.ts
+++ b/src/vs/platform/workspaces/node/workspacesIpc.ts
@@ -32,11 +32,6 @@ export class WorkspacesChannel implements IServerChannel {
 
 				return this.service.createUntitledWorkspace(folders);
 			}
-			case 'deleteIfUntitledWorkspace': {
-				const rawWorkspace: IWorkspaceIdentifier = arg;
-				// TODO aeschli: resolve IWorkspaceIdentifier when switching to URI
-				return this.service.deleteIfUntitledWorkspace(rawWorkspace);
-			}
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -51,9 +46,5 @@ export class WorkspacesChannelClient implements IWorkspacesService {
 
 	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier> {
 		return this.channel.call('createUntitledWorkspace', folders);
-	}
-
-	deleteIfUntitledWorkspace(workspace: IWorkspaceIdentifier): Promise<void> {
-		return this.channel.call('deleteIfUntitledWorkspace', workspace);
 	}
 }

--- a/src/vs/platform/workspaces/node/workspacesIpc.ts
+++ b/src/vs/platform/workspaces/node/workspacesIpc.ts
@@ -32,6 +32,11 @@ export class WorkspacesChannel implements IServerChannel {
 
 				return this.service.createUntitledWorkspace(folders);
 			}
+			case 'deleteIfUntitledWorkspace': {
+				const rawWorkspace: IWorkspaceIdentifier = arg;
+				// TODO aeschli: resolve IWorkspaceIdentifier when switching to URI
+				return this.service.deleteIfUntitledWorkspace(rawWorkspace);
+			}
 		}
 
 		throw new Error(`Call not found: ${command}`);
@@ -46,5 +51,9 @@ export class WorkspacesChannelClient implements IWorkspacesService {
 
 	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier> {
 		return this.channel.call('createUntitledWorkspace', folders);
+	}
+
+	deleteIfUntitledWorkspace(workspace: IWorkspaceIdentifier): Promise<void> {
+		return this.channel.call('deleteIfUntitledWorkspace', workspace);
 	}
 }

--- a/src/vs/platform/workspaces/node/workspacesIpc.ts
+++ b/src/vs/platform/workspaces/node/workspacesIpc.ts
@@ -18,7 +18,7 @@ export class WorkspacesChannel implements IServerChannel {
 
 	call(_, command: string, arg?: any): Promise<any> {
 		switch (command) {
-			case 'createWorkspace': {
+			case 'createUntitledWorkspace': {
 				const rawFolders: IWorkspaceFolderCreationData[] = arg;
 				let folders: IWorkspaceFolderCreationData[] | undefined = undefined;
 				if (Array.isArray(rawFolders)) {
@@ -30,7 +30,7 @@ export class WorkspacesChannel implements IServerChannel {
 					});
 				}
 
-				return this.service.createWorkspace(folders);
+				return this.service.createUntitledWorkspace(folders);
 			}
 		}
 
@@ -44,7 +44,7 @@ export class WorkspacesChannelClient implements IWorkspacesService {
 
 	constructor(private channel: IChannel) { }
 
-	createWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier> {
-		return this.channel.call('createWorkspace', folders);
+	createUntitledWorkspace(folders?: IWorkspaceFolderCreationData[]): Promise<IWorkspaceIdentifier> {
+		return this.channel.call('createUntitledWorkspace', folders);
 	}
 }

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -12,7 +12,7 @@ import * as pfs from 'vs/base/node/pfs';
 import { EnvironmentService } from 'vs/platform/environment/node/environmentService';
 import { parseArgs } from 'vs/platform/environment/node/argv';
 import { WorkspacesMainService, IStoredWorkspace } from 'vs/platform/workspaces/electron-main/workspacesMainService';
-import { WORKSPACE_EXTENSION, IWorkspaceSavedEvent, IWorkspaceIdentifier, IRawFileWorkspaceFolder, IWorkspaceFolderCreationData, IRawUriWorkspaceFolder } from 'vs/platform/workspaces/common/workspaces';
+import { WORKSPACE_EXTENSION, IWorkspaceIdentifier, IRawFileWorkspaceFolder, IWorkspaceFolderCreationData, IRawUriWorkspaceFolder } from 'vs/platform/workspaces/common/workspaces';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { URI } from 'vs/base/common/uri';
 import { getRandomTestPath } from 'vs/workbench/test/workbenchTestServices';
@@ -224,16 +224,6 @@ suite('WorkspacesMainService', () => {
 	});
 
 	test('saveWorkspace (untitled)', () => {
-		let savedEvent: IWorkspaceSavedEvent;
-		const listener = service.onWorkspaceSaved(e => {
-			savedEvent = e;
-		});
-
-		let deletedEvent: IWorkspaceIdentifier;
-		const listener2 = service.onUntitledWorkspaceDeleted(e => {
-			deletedEvent = e;
-		});
-
 		return createWorkspace([process.cwd(), os.tmpdir(), path.join(os.tmpdir(), 'somefolder')]).then(workspace => {
 			const workspaceConfigPath = path.join(os.tmpdir(), `myworkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 
@@ -249,14 +239,6 @@ suite('WorkspacesMainService', () => {
 				assertPathEquals((<IRawFileWorkspaceFolder>ws.folders[0]).path, process.cwd()); // absolute
 				assertPathEquals((<IRawFileWorkspaceFolder>ws.folders[1]).path, '.'); // relative
 				assertPathEquals((<IRawFileWorkspaceFolder>ws.folders[2]).path, path.relative(path.dirname(workspaceConfigPath), path.join(os.tmpdir(), 'somefolder'))); // relative
-
-				assert.equal(savedWorkspace, savedEvent.workspace);
-				assertPathEquals(workspace.configPath, savedEvent.oldConfigPath);
-
-				assert.deepEqual(deletedEvent, workspace);
-
-				listener.dispose();
-				listener2.dispose();
 
 				extfs.delSync(workspaceConfigPath);
 			});

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -227,7 +227,7 @@ suite('WorkspacesMainService', () => {
 		return createWorkspace([process.cwd(), os.tmpdir(), path.join(os.tmpdir(), 'somefolder')]).then(workspace => {
 			const workspaceConfigPath = path.join(os.tmpdir(), `myworkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 
-			return service.saveWorkspace(workspace, workspaceConfigPath).then(savedWorkspace => {
+			return service.saveWorkspaceAs(workspace, workspaceConfigPath).then(savedWorkspace => {
 				assert.ok(savedWorkspace.id);
 				assert.notEqual(savedWorkspace.id, workspace.id);
 				assert.equal(savedWorkspace.configPath, workspaceConfigPath);
@@ -250,8 +250,8 @@ suite('WorkspacesMainService', () => {
 			const workspaceConfigPath = path.join(os.tmpdir(), `myworkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 			const newWorkspaceConfigPath = path.join(os.tmpdir(), `mySavedWorkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 
-			return service.saveWorkspace(workspace, workspaceConfigPath).then(savedWorkspace => {
-				return service.saveWorkspace(savedWorkspace, newWorkspaceConfigPath).then(newSavedWorkspace => {
+			return service.saveWorkspaceAs(workspace, workspaceConfigPath).then(savedWorkspace => {
+				return service.saveWorkspaceAs(savedWorkspace, newWorkspaceConfigPath).then(newSavedWorkspace => {
 					assert.ok(newSavedWorkspace.id);
 					assert.notEqual(newSavedWorkspace.id, workspace.id);
 					assertPathEquals(newSavedWorkspace.configPath, newWorkspaceConfigPath);
@@ -274,11 +274,11 @@ suite('WorkspacesMainService', () => {
 			const workspaceConfigPath = path.join(os.tmpdir(), `myworkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 			const newWorkspaceConfigPath = path.join(os.tmpdir(), `mySavedWorkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 
-			return service.saveWorkspace(workspace, workspaceConfigPath).then(savedWorkspace => {
+			return service.saveWorkspaceAs(workspace, workspaceConfigPath).then(savedWorkspace => {
 				const contents = fs.readFileSync(savedWorkspace.configPath).toString();
 				fs.writeFileSync(savedWorkspace.configPath, `// this is a comment\n${contents}`);
 
-				return service.saveWorkspace(savedWorkspace, newWorkspaceConfigPath).then(newSavedWorkspace => {
+				return service.saveWorkspaceAs(savedWorkspace, newWorkspaceConfigPath).then(newSavedWorkspace => {
 					assert.ok(newSavedWorkspace.id);
 					assert.notEqual(newSavedWorkspace.id, workspace.id);
 					assertPathEquals(newSavedWorkspace.configPath, newWorkspaceConfigPath);
@@ -298,11 +298,11 @@ suite('WorkspacesMainService', () => {
 			const workspaceConfigPath = path.join(os.tmpdir(), `myworkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 			const newWorkspaceConfigPath = path.join(os.tmpdir(), `mySavedWorkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 
-			return service.saveWorkspace(workspace, workspaceConfigPath).then(savedWorkspace => {
+			return service.saveWorkspaceAs(workspace, workspaceConfigPath).then(savedWorkspace => {
 				const contents = fs.readFileSync(savedWorkspace.configPath).toString();
 				fs.writeFileSync(savedWorkspace.configPath, contents.replace(/[\\]/g, '/')); // convert backslash to slash
 
-				return service.saveWorkspace(savedWorkspace, newWorkspaceConfigPath).then(newSavedWorkspace => {
+				return service.saveWorkspaceAs(savedWorkspace, newWorkspaceConfigPath).then(newSavedWorkspace => {
 					assert.ok(newSavedWorkspace.id);
 					assert.notEqual(newSavedWorkspace.id, workspace.id);
 					assertPathEquals(newSavedWorkspace.configPath, newWorkspaceConfigPath);
@@ -331,7 +331,7 @@ suite('WorkspacesMainService', () => {
 		return createWorkspace([process.cwd(), os.tmpdir()]).then(workspace => {
 			const workspaceConfigPath = path.join(os.tmpdir(), `myworkspace.${Date.now()}.${WORKSPACE_EXTENSION}`);
 
-			return service.saveWorkspace(workspace, workspaceConfigPath).then(savedWorkspace => {
+			return service.saveWorkspaceAs(workspace, workspaceConfigPath).then(savedWorkspace => {
 				assert.ok(fs.existsSync(savedWorkspace.configPath));
 
 				service.deleteUntitledWorkspaceSync(savedWorkspace);

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -232,8 +232,6 @@ suite('WorkspacesMainService', () => {
 				assert.notEqual(savedWorkspace.id, workspace.id);
 				assert.equal(savedWorkspace.configPath, workspaceConfigPath);
 
-				assert.equal(service.deleteWorkspaceCall, workspace);
-
 				const ws = JSON.parse(fs.readFileSync(savedWorkspace.configPath).toString()) as IStoredWorkspace;
 				assert.equal(ws.folders.length, 3);
 				assertPathEquals((<IRawFileWorkspaceFolder>ws.folders[0]).path, process.cwd()); // absolute

--- a/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
+++ b/src/vs/platform/workspaces/test/electron-main/workspacesMainService.test.ts
@@ -40,11 +40,11 @@ suite('WorkspacesMainService', () => {
 	}
 
 	function createWorkspace(folders: string[], names?: string[]) {
-		return service.createWorkspace(folders.map((folder, index) => ({ uri: URI.file(folder), name: names ? names[index] : undefined } as IWorkspaceFolderCreationData)));
+		return service.createUntitledWorkspace(folders.map((folder, index) => ({ uri: URI.file(folder), name: names ? names[index] : undefined } as IWorkspaceFolderCreationData)));
 	}
 
 	function createWorkspaceSync(folders: string[], names?: string[]) {
-		return service.createWorkspaceSync(folders.map((folder, index) => ({ uri: URI.file(folder), name: names ? names[index] : undefined } as IWorkspaceFolderCreationData)));
+		return service.createUntitledWorkspaceSync(folders.map((folder, index) => ({ uri: URI.file(folder), name: names ? names[index] : undefined } as IWorkspaceFolderCreationData)));
 	}
 
 	const environmentService = new TestEnvironmentService(parseArgs(process.argv), process.execPath);
@@ -106,8 +106,8 @@ suite('WorkspacesMainService', () => {
 		});
 	});
 
-	test('createWorkspace (folders as other resource URIs)', () => {
-		return service.createWorkspace([{ uri: URI.from({ scheme: 'myScheme', path: process.cwd() }) }, { uri: URI.from({ scheme: 'myScheme', path: os.tmpdir() }) }]).then(workspace => {
+	test('createUntitledWorkspace (folders as other resource URIs)', () => {
+		return service.createUntitledWorkspace([{ uri: URI.from({ scheme: 'myScheme', path: process.cwd() }) }, { uri: URI.from({ scheme: 'myScheme', path: os.tmpdir() }) }]).then(workspace => {
 			assert.ok(workspace);
 			assert.ok(fs.existsSync(workspace.configPath));
 			assert.ok(service.isUntitledWorkspace(workspace));
@@ -152,8 +152,8 @@ suite('WorkspacesMainService', () => {
 		assert.equal((<IRawFileWorkspaceFolder>ws.folders[1]).name, 'tempdir');
 	});
 
-	test('createWorkspaceSync (folders as other resource URIs)', () => {
-		const workspace = service.createWorkspaceSync([{ uri: URI.from({ scheme: 'myScheme', path: process.cwd() }) }, { uri: URI.from({ scheme: 'myScheme', path: os.tmpdir() }) }]);
+	test('createUntitledWorkspaceSync (folders as other resource URIs)', () => {
+		const workspace = service.createUntitledWorkspaceSync([{ uri: URI.from({ scheme: 'myScheme', path: process.cwd() }) }, { uri: URI.from({ scheme: 'myScheme', path: os.tmpdir() }) }]);
 		assert.ok(workspace);
 		assert.ok(fs.existsSync(workspace.configPath));
 		assert.ok(service.isUntitledWorkspace(workspace));

--- a/src/vs/workbench/api/electron-browser/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadWorkspace.ts
@@ -245,5 +245,5 @@ CommandsRegistry.registerCommand('_workbench.enterWorkspace', async function (ac
 		}
 	}
 
-	return workspaceEditingService.enterWorkspace(workspace.fsPath);
+	return workspaceEditingService.enterWorkspace(workspace);
 });

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -151,7 +151,7 @@ export class SaveWorkspaceAsAction extends Action {
 						return this.workspaceEditingService.createAndEnterWorkspace(folders, configPath);
 
 					case WorkbenchState.WORKSPACE:
-						return this.workspaceEditingService.saveAndEnterWorkspace(configPath);
+						return this.workspaceEditingService.saveAndEnterWorkspace(configPathUri);
 				}
 			}
 		});

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -255,7 +255,7 @@ export class DuplicateWorkspaceInNewWindowAction extends Action {
 	run(): Promise<any> {
 		const folders = this.workspaceContextService.getWorkspace().folders;
 
-		return this.workspacesService.createWorkspace(folders).then(newWorkspace => {
+		return this.workspacesService.createUntitledWorkspace(folders).then(newWorkspace => {
 			return this.workspaceEditingService.copyWorkspaceSettings(newWorkspace).then(() => {
 				return this.windowService.openWindow([URI.file(newWorkspace.configPath)], { forceNewWindow: true });
 			});

--- a/src/vs/workbench/browser/actions/workspaceActions.ts
+++ b/src/vs/workbench/browser/actions/workspaceActions.ts
@@ -143,12 +143,11 @@ export class SaveWorkspaceAsAction extends Action {
 	run(): Promise<any> {
 		return this.getNewWorkspaceConfigPath().then((configPathUri): Promise<void> | void => {
 			if (configPathUri) {
-				const configPath = configPathUri.fsPath;
 				switch (this.contextService.getWorkbenchState()) {
 					case WorkbenchState.EMPTY:
 					case WorkbenchState.FOLDER:
 						const folders = this.contextService.getWorkspace().folders.map(folder => ({ uri: folder.uri }));
-						return this.workspaceEditingService.createAndEnterWorkspace(folders, configPath);
+						return this.workspaceEditingService.createAndEnterWorkspace(folders, configPathUri);
 
 					case WorkbenchState.WORKSPACE:
 						return this.workspaceEditingService.saveAndEnterWorkspace(configPathUri);

--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -295,7 +295,7 @@ export class ResourcesDropHandler {
 
 			// Multiple folders: Create new workspace with folders and open
 			else if (folders.length > 1) {
-				workspacesToOpen = this.workspacesService.createWorkspace(folders.map(folder => ({ uri: folder }))).then(workspace => [URI.file(workspace.configPath)]);
+				workspacesToOpen = this.workspacesService.createUntitledWorkspace(folders.map(folder => ({ uri: folder }))).then(workspace => [URI.file(workspace.configPath)]);
 			}
 
 			// Open

--- a/src/vs/workbench/services/configuration/node/configurationService.ts
+++ b/src/vs/workbench/services/configuration/node/configurationService.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
-import { dirname } from 'path';
 import * as assert from 'vs/base/common/assert';
 import { Event, Emitter } from 'vs/base/common/event';
 import { ResourceMap } from 'vs/base/common/map';
@@ -36,7 +35,7 @@ import { massageFolderPathForWorkspace } from 'vs/platform/workspaces/node/works
 import { UserConfiguration } from 'vs/platform/configuration/node/configuration';
 import { IJSONSchema, IJSONSchemaMap } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';
-import { isEqual } from 'vs/base/common/resources';
+import { isEqual, dirname } from 'vs/base/common/resources';
 import { mark } from 'vs/base/common/performance';
 
 export class WorkspaceService extends Disposable implements IWorkspaceConfigurationService, IWorkspaceContextService {
@@ -162,8 +161,8 @@ export class WorkspaceService extends Disposable implements IWorkspaceConfigurat
 		if (foldersToAdd.length) {
 
 			// Recompute current workspace folders if we have folders to add
-			const workspaceConfigFolder = dirname(this.getWorkspace().configuration.fsPath);
-			currentWorkspaceFolders = toWorkspaceFolders(newStoredFolders, URI.file(workspaceConfigFolder));
+			const workspaceConfigFolder = dirname(this.getWorkspace().configuration);
+			currentWorkspaceFolders = toWorkspaceFolders(newStoredFolders, workspaceConfigFolder);
 			const currentWorkspaceFolderUris = currentWorkspaceFolders.map(folder => folder.uri);
 
 			const storedFoldersToAdd: IStoredWorkspaceFolder[] = [];
@@ -342,7 +341,7 @@ export class WorkspaceService extends Disposable implements IWorkspaceConfigurat
 		return this.workspaceConfiguration.load({ id: workspaceIdentifier.id, configPath: URI.file(workspaceIdentifier.configPath) })
 			.then(() => {
 				const workspaceConfigPath = URI.file(workspaceIdentifier.configPath);
-				const workspaceFolders = toWorkspaceFolders(this.workspaceConfiguration.getFolders(), URI.file(dirname(workspaceConfigPath.fsPath)));
+				const workspaceFolders = toWorkspaceFolders(this.workspaceConfiguration.getFolders(), dirname(workspaceConfigPath));
 				const workspaceId = workspaceIdentifier.id;
 				return new Workspace(workspaceId, workspaceFolders, workspaceConfigPath);
 			});
@@ -535,7 +534,7 @@ export class WorkspaceService extends Disposable implements IWorkspaceConfigurat
 	private onWorkspaceConfigurationChanged(): Promise<void> {
 		if (this.workspace && this.workspace.configuration && this._configuration) {
 			const workspaceConfigurationChangeEvent = this._configuration.compareAndUpdateWorkspaceConfiguration(this.workspaceConfiguration.getConfiguration());
-			let configuredFolders = toWorkspaceFolders(this.workspaceConfiguration.getFolders(), URI.file(dirname(this.workspace.configuration.fsPath)));
+			let configuredFolders = toWorkspaceFolders(this.workspaceConfiguration.getFolders(), dirname(this.workspace.configuration));
 			const changes = this.compareFolders(this.workspace.folders, configuredFolders);
 			if (changes.added.length || changes.removed.length || changes.changed.length) {
 				this.workspace.folders = configuredFolders;

--- a/src/vs/workbench/services/workspace/common/workspaceEditing.ts
+++ b/src/vs/workbench/services/workspace/common/workspaceEditing.ts
@@ -34,7 +34,7 @@ export interface IWorkspaceEditingService {
 	/**
 	 * enters the workspace with the provided path.
 	 */
-	enterWorkspace(path: string): Promise<void>;
+	enterWorkspace(path: URI): Promise<void>;
 
 	/**
 	 * creates a new workspace with the provided folders and opens it. if path is provided
@@ -45,7 +45,7 @@ export interface IWorkspaceEditingService {
 	/**
 	 * saves the workspace to the provided path and opens it. requires a workspace to be opened.
 	 */
-	saveAndEnterWorkspace(path: string): Promise<void>;
+	saveAndEnterWorkspace(path: URI): Promise<void>;
 
 	/**
 	 * copies current workspace settings to the target workspace.

--- a/src/vs/workbench/services/workspace/common/workspaceEditing.ts
+++ b/src/vs/workbench/services/workspace/common/workspaceEditing.ts
@@ -43,7 +43,7 @@ export interface IWorkspaceEditingService {
 	createAndEnterWorkspace(folders: IWorkspaceFolderCreationData[], path?: URI): Promise<void>;
 
 	/**
-	 * saves the workspace to the provided path and opens it. requires a workspace to be opened.
+	 * saves the current workspace to the provided path and opens it. requires a workspace to be opened.
 	 */
 	saveAndEnterWorkspace(path: URI): Promise<void>;
 

--- a/src/vs/workbench/services/workspace/common/workspaceEditing.ts
+++ b/src/vs/workbench/services/workspace/common/workspaceEditing.ts
@@ -40,7 +40,7 @@ export interface IWorkspaceEditingService {
 	 * creates a new workspace with the provided folders and opens it. if path is provided
 	 * the workspace will be saved into that location.
 	 */
-	createAndEnterWorkspace(folders?: IWorkspaceFolderCreationData[], path?: string): Promise<void>;
+	createAndEnterWorkspace(folders: IWorkspaceFolderCreationData[], path?: URI): Promise<void>;
 
 	/**
 	 * saves the workspace to the provided path and opens it. requires a workspace to be opened.

--- a/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
@@ -203,7 +203,6 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		const raw = await this.fileSystemService.resolveContent(configPathURI);
 		const newRawWorkspaceContents = rewriteWorkspaceFileForNewLocation(raw.value, configPathURI, targetConfigPathURI);
 		await this.fileSystemService.createFile(targetConfigPathURI, newRawWorkspaceContents, { overwrite: true });
-		await this.workspaceService.deleteIfUntitledWorkspace(workspace);
 	}
 
 	private handleWorkspaceConfigurationEditingError(error: JSONEditingError): Promise<void> {

--- a/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/node/workspaceEditingService.ts
@@ -7,7 +7,7 @@ import { IWorkspaceEditingService } from 'vs/workbench/services/workspace/common
 import { URI } from 'vs/base/common/uri';
 import * as nls from 'vs/nls';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { IWindowService, IEnterWorkspaceResult, MessageBoxOptions, IWindowsService } from 'vs/platform/windows/common/windows';
+import { IWindowService, MessageBoxOptions, IWindowsService } from 'vs/platform/windows/common/windows';
 import { IJSONEditingService, JSONEditingError, JSONEditingErrorCode } from 'vs/workbench/services/configuration/common/jsonEditing';
 import { IWorkspaceIdentifier, IWorkspaceFolderCreationData, IStoredWorkspace, isStoredWorkspaceFolder, isRawFileWorkspaceFolder, isWorkspaceIdentifier, toWorkspaceIdentifier, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { IWorkspaceConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
@@ -147,10 +147,6 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		}
 
 		return false;
-	}
-
-	enterWorkspace(path: URI): Promise<void> {
-		return this.doEnterWorkspace(() => this.windowService.enterWorkspace(path));
 	}
 
 	async createAndEnterWorkspace(folders: IWorkspaceFolderCreationData[], path?: URI): Promise<void> {
@@ -298,7 +294,7 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		);
 	}
 
-	private doEnterWorkspace(mainSidePromise: () => Promise<IEnterWorkspaceResult>): Promise<void> {
+	enterWorkspace(path: URI): Promise<void> {
 
 		// Stop the extension host first to give extensions most time to shutdown
 		this.extensionService.stopExtensionHost();
@@ -309,7 +305,7 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 			extensionHostStarted = true;
 		};
 
-		return mainSidePromise().then(result => {
+		return this.windowService.enterWorkspace(path).then(result => {
 
 			// Migrate storage and settings if we are to enter a workspace
 			if (result) {

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -1054,7 +1054,7 @@ export class TestWindowService implements IWindowService {
 		return Promise.resolve();
 	}
 
-	enterWorkspace(_path: string): Promise<IEnterWorkspaceResult> {
+	enterWorkspace(_path: URI): Promise<IEnterWorkspaceResult> {
 		return Promise.resolve();
 	}
 
@@ -1223,7 +1223,7 @@ export class TestWindowsService implements IWindowsService {
 		return Promise.resolve();
 	}
 
-	enterWorkspace(_windowId: number, _path: string): Promise<IEnterWorkspaceResult> {
+	enterWorkspace(_windowId: number, _path: URI): Promise<IEnterWorkspaceResult> {
 		return Promise.resolve();
 	}
 

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -44,7 +44,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { generateUuid } from 'vs/base/common/uuid';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
-import { IWorkspaceIdentifier, IWorkspaceFolderCreationData, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
+import { IWorkspaceIdentifier, ISingleFolderWorkspaceIdentifier, isSingleFolderWorkspaceIdentifier } from 'vs/platform/workspaces/common/workspaces';
 import { IRecentlyOpened } from 'vs/platform/history/common/history';
 import { ITextResourceConfigurationService, ITextResourcePropertiesService } from 'vs/editor/common/services/resourceConfiguration';
 import { IPosition, Position as EditorPosition } from 'vs/editor/common/core/position';
@@ -1058,14 +1058,6 @@ export class TestWindowService implements IWindowService {
 		return Promise.resolve();
 	}
 
-	createAndEnterWorkspace(_folders?: IWorkspaceFolderCreationData[], _path?: string): Promise<IEnterWorkspaceResult> {
-		return Promise.resolve();
-	}
-
-	saveAndEnterWorkspace(_path: string): Promise<IEnterWorkspaceResult> {
-		return Promise.resolve();
-	}
-
 	toggleFullScreen(): Promise<void> {
 		return Promise.resolve();
 	}
@@ -1224,14 +1216,6 @@ export class TestWindowsService implements IWindowsService {
 	}
 
 	enterWorkspace(_windowId: number, _path: URI): Promise<IEnterWorkspaceResult> {
-		return Promise.resolve();
-	}
-
-	createAndEnterWorkspace(_windowId: number, _folders?: IWorkspaceFolderCreationData[], _path?: string): Promise<IEnterWorkspaceResult> {
-		return Promise.resolve();
-	}
-
-	saveAndEnterWorkspace(_windowId: number, _path: string): Promise<IEnterWorkspaceResult> {
 		return Promise.resolve();
 	}
 


### PR DESCRIPTION
- Adds IWorkspaceEditingService.saveWorkspaceAs
- IWorkspaceEditingService.saveAndEnterWorkspace and createAndEnterWorkspace no longer use main to save but the new method
- IWorkspaceMainService.saveWorkspace still exists but only used when a window is closed with unsaved WS
- code that manipulated the ws content is shared