### PR TITLE
Fix settings centering issue

### DIFF
--- a/src/vs/workbench/parts/preferences/electron-browser/media/settingsEditor2.css
+++ b/src/vs/workbench/parts/preferences/electron-browser/media/settingsEditor2.css
@@ -113,7 +113,6 @@
 	text-decoration: underline;
 }
 
-.settings-editor.no-toc-search > .settings-body .settings-tree-container .monaco-list-rows,
 .settings-editor.narrow-width > .settings-body .settings-tree-container .monaco-list-rows {
 	margin-left: 0px;
 }


### PR DESCRIPTION
Fixes #67002.

This CSS change fixes the settings issue. Problem was simply that no matter what the width of the search, no-toc-search was setting the left margin to 0 instead of auto.

Removing this line allows it to default back to the default setting of auto.