### PR TITLE
Fix the "tsc watch" task when references are used

### DIFF
--- a/extensions/typescript-language-features/src/features/task.ts
+++ b/extensions/typescript-language-features/src/features/task.ts
@@ -197,7 +197,7 @@ class TscTaskProvider implements vscode.TaskProvider {
 				project.workspaceFolder || vscode.TaskScope.Workspace,
 				localize('buildAndWatchTscLabel', 'watch - {0}', label),
 				'tsc',
-				new vscode.ShellExecution(command, ['--watch', ...args]),
+				new vscode.ShellExecution(command, [...args, '--watch']),
 				'$tsc-watch');
 			watchTask.group = vscode.TaskGroup.Build;
 			watchTask.isBackground = true;


### PR DESCRIPTION
Moves the `--watch` option at the end of the `tsc` invocation, as `--build`
is required to be the first option on the call.

Fixes #66875