### PR TITLE
Fixing Intelisense verbosity with screen readers

### DIFF
--- a/src/vs/base/browser/ui/aria/aria.ts
+++ b/src/vs/base/browser/ui/aria/aria.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./aria';
-import * as nls from 'vs/nls';
 import { isMacintosh } from 'vs/base/common/platform';
 import * as dom from 'vs/base/browser/dom';
 
@@ -48,27 +47,10 @@ export function status(msg: string): void {
 	}
 }
 
-let repeatedTimes = 0;
-let prevText: string | undefined = undefined;
 function insertMessage(target: HTMLElement, msg: string): void {
 	if (!ariaContainer) {
 		// console.warn('ARIA support needs a container. Call setARIAContainer() first.');
 		return;
-	}
-
-	if (prevText === msg) {
-		repeatedTimes++;
-	}
-	else {
-		prevText = msg;
-		repeatedTimes = 0;
-	}
-
-
-	switch (repeatedTimes) {
-		case 0: break;
-		case 1: msg = nls.localize('repeated', "{0} (occurred again)", msg); break;
-		default: msg = nls.localize('repeatedNtimes', "{0} (occurred {1} times)", msg, repeatedTimes); break;
 	}
 
 	dom.clearNode(target);

--- a/src/vs/base/browser/ui/aria/aria.ts
+++ b/src/vs/base/browser/ui/aria/aria.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./aria';
+import * as nls from 'vs/nls';
 import { isMacintosh } from 'vs/base/common/platform';
 import * as dom from 'vs/base/browser/dom';
 
@@ -47,10 +48,27 @@ export function status(msg: string): void {
 	}
 }
 
+let repeatedTimes = 0;
+let prevText: string | undefined = undefined;
 function insertMessage(target: HTMLElement, msg: string): void {
 	if (!ariaContainer) {
 		// console.warn('ARIA support needs a container. Call setARIAContainer() first.');
 		return;
+	}
+
+	if (prevText === msg) {
+		repeatedTimes++;
+	}
+	else {
+		prevText = msg;
+		repeatedTimes = 0;
+	}
+
+
+	switch (repeatedTimes) {
+		case 0: break;
+		case 1: msg = nls.localize('repeated', "{0} (occurred again)", msg); break;
+		default: msg = nls.localize('repeatedNtimes', "{0} (occurred {1} times)", msg, repeatedTimes); break;
 	}
 
 	dom.clearNode(target);

--- a/src/vs/editor/contrib/suggest/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/suggestController.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { alert } from 'vs/base/browser/ui/aria/aria';
 import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
@@ -291,8 +292,10 @@ export class SuggestController implements IEditorContribution {
 	}
 
 	private _alertCompletionItem({ completion: suggestion }: CompletionItem): void {
-		// A temporary fix for too verbose, unnecesary screen reader alerts.
-		// Todo: Remove calls to this empty method body.
+		if (isNonEmptyArray(suggestion.additionalTextEdits)) {
+			let msg = nls.localize('arai.alert.snippet', "Accepting '{0}' made {1} additional edits", suggestion.label, suggestion.additionalTextEdits.length);
+			alert(msg);
+		}
 	}
 
 	triggerSuggest(onlyFrom?: CompletionItemProvider[]): void {

--- a/src/vs/editor/contrib/suggest/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/suggestController.ts
@@ -292,7 +292,8 @@ export class SuggestController implements IEditorContribution {
 	}
 
 	private _alertCompletionItem({ completion: suggestion }: CompletionItem): void {
-		let msg = nls.localize('arai.alert.snippet', "Accepting '{0}' did insert the following text: {1}", suggestion.label, suggestion.insertText);
+		// @todo Remove alert support. Assigning an empty string temporarly to silence alers.
+		let msg = null;
 		alert(msg);
 	}
 

--- a/src/vs/editor/contrib/suggest/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/suggestController.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { alert } from 'vs/base/browser/ui/aria/aria';
 import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
@@ -292,9 +291,8 @@ export class SuggestController implements IEditorContribution {
 	}
 
 	private _alertCompletionItem({ completion: suggestion }: CompletionItem): void {
-		// @todo Remove alert support. Assigning an empty string temporarly to silence alers.
-		let msg = null;
-		alert(msg);
+		// A temporary fix for too verbose, unnecesary screen reader alerts.
+		// Todo: Remove calls to this empty method body.
 	}
 
 	triggerSuggest(onlyFrom?: CompletionItemProvider[]): void {

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -540,20 +540,10 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 	}
 
 	private _getSuggestionAriaAlertLabel(item: CompletionItem): string {
-		// It is not so important to know the type of completion: regular or snippet.
-		// Snippets can be identified by their names.
-		// They are usually created by users themselves.
-		const isSnippet = item.completion.kind === CompletionItemKind.Snippet;
-
-		if (!canExpandCompletionItem(item)) {
-			return isSnippet ? item.completion.label
-				: item.completion.label;
-		} else if (this.expandDocsSettingFromStorage()) {
-			return isSnippet ? nls.localize('ariaCurrentSnippeSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, this.details.getAriaLabel())
-				: nls.localize('ariaCurrenttSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, this.details.getAriaLabel());
+		if (this.expandDocsSettingFromStorage()) {
+			return nls.localize('ariaCurrenttSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, this.details.getAriaLabel());
 		} else {
-			return isSnippet ? item.completion.label
-				: item.completion.label;
+			return item.completion.label;
 		}
 	}
 

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -535,23 +535,25 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 
 		item.resolve(CancellationToken.None).then(() => {
 			this.onDidSelectEmitter.fire({ item, index, model: completionModel });
-			alert(nls.localize('suggestionAriaAccepted', "{0}, accepted", item.completion.label));
 			this.editor.focus();
 		});
 	}
 
 	private _getSuggestionAriaAlertLabel(item: CompletionItem): string {
+		// It is not so important to know the type of completion: regular or snippet.
+		// Snippets can be identified by their names.
+		// They are usually created by users themselves.
 		const isSnippet = item.completion.kind === CompletionItemKind.Snippet;
 
 		if (!canExpandCompletionItem(item)) {
-			return isSnippet ? nls.localize('ariaCurrentSnippetSuggestion', "{0}, snippet suggestion", item.completion.label)
-				: nls.localize('ariaCurrentSuggestion', "{0}, suggestion", item.completion.label);
+			return isSnippet ? item.completion.label
+				: item.completion.label;
 		} else if (this.expandDocsSettingFromStorage()) {
-			return isSnippet ? nls.localize('ariaCurrentSnippeSuggestionReadDetails', "{0}, snippet suggestion. Reading details. {1}", item.completion.label, this.details.getAriaLabel())
-				: nls.localize('ariaCurrenttSuggestionReadDetails', "{0}, suggestion. Reading details. {1}", item.completion.label, this.details.getAriaLabel());
+			return isSnippet ? nls.localize('ariaCurrentSnippeSuggestionReadDetails', "{0}: {1}", item.completion.label, this.details.getAriaLabel())
+				: nls.localize('ariaCurrenttSuggestionReadDetails', "{0}: {1}", item.completion.label, this.details.getAriaLabel());
 		} else {
-			return isSnippet ? nls.localize('ariaCurrentSnippetSuggestionWithDetails', "{0}, snippet suggestion, has details", item.completion.label)
-				: nls.localize('ariaCurrentSuggestionWithDetails', "{0}, suggestion, has details", item.completion.label);
+			return isSnippet ? item.completion.label
+				: item.completion.label;
 		}
 	}
 

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -549,8 +549,8 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 			return isSnippet ? item.completion.label
 				: item.completion.label;
 		} else if (this.expandDocsSettingFromStorage()) {
-			return isSnippet ? nls.localize('ariaCurrentSnippeSuggestionReadDetails', "{0}: {1}", item.completion.label, this.details.getAriaLabel())
-				: nls.localize('ariaCurrenttSuggestionReadDetails', "{0}: {1}", item.completion.label, this.details.getAriaLabel());
+			return isSnippet ? nls.localize('ariaCurrentSnippeSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, this.details.getAriaLabel())
+				: nls.localize('ariaCurrenttSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, this.details.getAriaLabel());
 		} else {
 			return isSnippet ? item.completion.label
 				: item.completion.label;


### PR DESCRIPTION
#65499 65499 
The following simple fixes improve usability and accessibility with screen readers. I am currently working on an NVDA screen reader add-on module to make more improvements.
I am not a TypeScript developer, and therefore someone more knowledgeable will need to clean my code. I am available to give feedback and do testing.
### Fixed the alert implementation, which was reporting how many times a particular spoken item occured. It is too verbose, for example when editing code and navigating possible choices by typing and removing item names to quickly hear what is suggested.
### Fixed the suggestion controller, which was inserting an alert reporting accepted item, and also reporting that it was inserted into the document. It made the experience almost unusable for this sentence was read out on every insert. Such information is easily reported by screen readers in much better way, for it is also integrated with braille display handling.
### Fixes to the suggestion list pop-up and documentation.
***Need review and further implementation***:
When suggestion appeard it reported with an alert the type of suggestion regular / snippet, and if the item had details - namely type information, or more expanded documentation.
While sighted users are not much interrupted by such hints, for they can observe them in parallel, screen readers, report everything, and on every item change.
Providing the **completion item** label **only** is sufficient.
### Further fixes to the documentation widget appearing with contents.
Case 1: The details are simple: just a type / a few words hint.
It can be reported via the alert, ofr it is very breaif, and does not interrupt the flow.
Case 2: If the documentation details are longer, and rendered from markdown, or inserted from HTML documentation, the widget may/should have the **aria-role="dialogue" added during the element creation. The focus should be placed at the beginning of the dialogue.
**Read more** / ** Read less** / **Close** link buttons should have **tabindex** properties manually set, starting from 0 as it is in the specification.
Pressing either **escape** or **keyboard activation** of one of **close** button should return the focus to the last possition in the editor.
***Important***: We need to figure out how to split automatic reporting of short strings, and creating a dialogue when activating the documentation with a shortcut: Ctrl+Space.
A temporary work-around is to disable automatic parameter hints, and use them on demand, which in many cases may be prefered by the screen reader users.