### PR TITLE
Changed keybinding to select current line -issue 59003

### DIFF
--- a/src/vs/editor/browser/controller/coreCommands.ts
+++ b/src/vs/editor/browser/controller/coreCommands.ts
@@ -1336,7 +1336,7 @@ export namespace CoreNavigationCommands {
 				kbOpts: {
 					weight: CORE_WEIGHT,
 					kbExpr: EditorContextKeys.textInputFocus,
-					primary: KeyMod.CtrlCmd | KeyCode.KEY_I
+					primary: KeyMod.CtrlCmd | KeyCode.KEY_L
 				}
 			});
 		}


### PR DESCRIPTION
Hi there,

As described in issue [#59003](https://github.com/Microsoft/vscode/issues/59003), I changed the default keybinding to select current line to CTRL + L (changes were made in the '_coreCommands.ts_' file). 

I followed the steps in the [contributing guidelines](https://github.com/Microsoft/vscode/wiki/How-to-Contribute), I tested the code and it worked. I also ran the tests in '/scripts/test.sh' and found no errors.



