### PR TITLE
Fix jSDocCompletion deprecation message

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -362,7 +362,7 @@
           "type": "boolean",
           "default": true,
           "description": "%jsDocCompletion.enabled%",
-          "deprecationMessage": "jsDocCompletion.deprecationMessage",
+          "deprecationMessage": "%jsDocCompletion.deprecationMessage%",
           "scope": "resource"
         },
         "javascript.implicitProjectConfig.checkJs": {


### PR DESCRIPTION
Missing % around message name.

Displayed as:

![image](https://user-images.githubusercontent.com/12818376/51932526-33b38800-23b4-11e9-9d9b-2bd59353b18d.png)
