### PR TITLE
Treat .swcrc file as json

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -24,6 +24,7 @@
           ".jshintrc",
           ".jscsrc",
           ".eslintrc",
+          ".swcrc",
           ".webmanifest",
           ".js.map",
           ".css.map"


### PR DESCRIPTION
[The swc project][swc] (an alternative for babel) uses `.swcrc` for configuration.
It seems like there's no way to mark a file as json from extension.


[swc]:https://github.com/swc-project/swc