### PR TITLE
Use jsonc.parse instead of JSON.parse when parsing tsconfig.json, fixing bug where `-b` flag is not activated when tsconfig.json contains comments.

### DIFF
--- a/extensions/typescript-language-features/src/features/task.ts
+++ b/extensions/typescript-language-features/src/features/task.ts
@@ -7,6 +7,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
+import * as jsonc from 'jsonc-parser';
 import { ITypeScriptServiceClient } from '../typescriptService';
 import { Lazy } from '../utils/lazy';
 import { isImplicitProjectConfigFile } from '../utils/tsconfig';
@@ -217,7 +218,7 @@ class TscTaskProvider implements vscode.TaskProvider {
 				}
 
 				try {
-					const tsconfig = JSON.parse(result.toString());
+					const tsconfig = jsonc.parse(result.toString());
 					if (tsconfig.references) {
 						return resolve(['-b', project.path]);
 					}


### PR DESCRIPTION
This fixes a problem where the `typescript` VSCode task runs `tsc` with `-p`
when it should run `-b` when `tsconfig.json` has the `"references"` property.

```js
{
  "extends": "./tsconfig.app.json",
  // meow
  "references": [{ "path": "./tsconfig.lib.json" }]
}
```

This bug happens because while `tsconfig.json` file allows comment, the
parsing logic here uses vanilla `JSON.parse` which cannot parse comments.

This commit fixes it by using `jsonc.parse` instead.