### PR TITLE
set screencast to display 15 characters

### DIFF
--- a/src/vs/workbench/electron-browser/actions/developerActions.ts
+++ b/src/vs/workbench/electron-browser/actions/developerActions.ts
@@ -184,7 +184,7 @@ export class ToggleScreencastModeAction extends Action {
 			const keybinding = this.keybindingService.resolveKeyboardEvent(event);
 			const label = keybinding.getLabel();
 
-			if (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && this.keybindingService.mightProducePrintableCharacter(event) && label) {
+			if (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && (this.keybindingService.mightProducePrintableCharacter(event) || !keyboardMarker.textContent || keyboardMarker.textContent.length < 15) && label) {
 				keyboardMarker.textContent += ' ' + label;
 			} else {
 				keyboardMarker.textContent = label;


### PR DESCRIPTION
fixes #66675

Sets screencast to display up to 15 total characters, unless ctrl, alt, meta, or shift is typed. Not sure if 15 is a good length, but it seems better than it was.