### PR TITLE
Increase spacing between keybinding keys

### DIFF
--- a/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
+++ b/src/vs/base/browser/ui/keybindingLabel/keybindingLabel.css
@@ -20,6 +20,15 @@
 	color: #555;
 	font-size: 11px;
 	padding: 3px 5px;
+	margin: 0 2px;
+}
+
+.monaco-keybinding > .monaco-keybinding-key:first-child {
+	margin-left: 0;
+}
+
+.monaco-keybinding > .monaco-keybinding-key:last-child {
+	margin-right: 0;
 }
 
 .hc-black .monaco-keybinding > .monaco-keybinding-key,
@@ -36,5 +45,5 @@
 }
 
 .monaco-keybinding > .monaco-keybinding-key-chord-separator {
-	width: 2px;
+	width: 6px;
 }


### PR DESCRIPTION
I've always been bothered by how our keybinding keys were stacked right next to each other without any spacing (very claustrophobic). Proposing to add a bit of margin and increasing the spacing of the chords (Cmd+K, Cmd+T).

|Before|After|
|---|---|
|<img width="184" alt="image" src="https://user-images.githubusercontent.com/35271042/52141845-d9acff80-260b-11e9-860a-f5abe632252e.png">|<img width="204" alt="image" src="https://user-images.githubusercontent.com/35271042/52141863-e6315800-260b-11e9-8846-fbfc2983a5d0.png">|

And here it is on Windows that adds a plus icon:

|Before|After|
|---|---|
|<img width="236" alt="image" src="https://user-images.githubusercontent.com/35271042/52141985-39a3a600-260c-11e9-89c9-e21fcc9ecc11.png">|<img width="217" alt="image" src="https://user-images.githubusercontent.com/35271042/52142001-445e3b00-260c-11e9-9854-be497a935b60.png">|



cc @bpasero @chrmarti for empty editor screen