### PR TITLE
Fix infinite relayout of comment widget.

### DIFF
--- a/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/commentThreadWidget.ts
@@ -622,7 +622,6 @@ export class ReviewZoneWidget extends ZoneWidget {
 			const lineHeight = this.editor.getConfiguration().lineHeight;
 			const arrowHeight = Math.round(lineHeight / 3);
 			const frameThickness = Math.round(lineHeight / 9) * 2;
-			console.log(dimensions);
 
 			const computedLinesNumber = Math.ceil((headHeight + dimensions.height + arrowHeight + frameThickness + 8 /** margin bottom to avoid margin collapse */) / lineHeight);
 			this._relayout(computedLinesNumber);

--- a/src/vs/workbench/parts/comments/electron-browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/parts/comments/electron-browser/simpleCommentEditor.ts
@@ -63,7 +63,6 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 				verticalHasArrows: false,
 				horizontalHasArrows: false
 			},
-			automaticLayout: true,
 			overviewRulerLanes: 2,
 			lineDecorationsWidth: 0,
 			scrollBeyondLastLine: false,


### PR DESCRIPTION
Fix https://github.com/Microsoft/vscode-pull-request-github/issues/913. I turned on auto layout of the comment editor and since the mutation observer will try to resize the container DOM node and the calculation is not precise, it leads to an infinite relayout of the comment editor.

The code change is reverting the flag and removing one stray log.