### PR TITLE
Prevent Explorer from refreshing nodes which were never resolved

### DIFF
--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -412,6 +412,10 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 		await this.refreshAndRenderNode(this.getDataNode(element), recursive, ChildrenResolutionReason.Refresh, viewStateContext);
 	}
 
+	hasNode(element: T): boolean {
+		return this.renderedNodes.has(element);
+	}
+
 	// View
 
 	refresh(element: T): void {

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerView.ts
@@ -430,6 +430,12 @@ export class ExplorerView extends ViewletPanel {
 			this.shouldRefresh = true;
 			return Promise.resolve(undefined);
 		}
+
+		// Tree node doesn't exist yet
+		if (item && !this.tree.hasNode(item)) {
+			return Promise.resolve(undefined);
+		}
+
 		const recursive = !item;
 		const toRefresh = item || this.tree.getInput();
 


### PR DESCRIPTION
@isidorn Introduced a new issue when fixing #67733: we started attempting to refresh nodes which were never known by the tree. @mjbvz uncovered this with his good steps.

The error itself is harmless: no consequence in behavior, no broken state. But we should still prevent it in the release otherwise we'll get it in error telemetry.

The fix for this involved exposing a `hasNode` tree method which serves the purpose to knowing whether a certain model element is known by the tree. In the case of handling the explorer's `onDidChange` event, this is important, because it will be fired for files/folders which the tree doesn't yet know about but is about to, thanks to the `onDidSelect` event. The second part of the fix is about calling this new method and avoiding a `refresh` call if the tree doesn't know about the element. It is the right fix because there's nothing to refresh, if it was never previously rendered.

cc @dbaeumer 