### PR TITLE
Show extension origin in `source` column of keybindings GUI

### DIFF
--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -902,7 +902,10 @@ class SourceColumn extends Column {
 	render(keybindingItemEntry: IKeybindingItemEntry): void {
 		DOM.clearNode(this.sourceColumn);
 		this.sourceColumn.setAttribute('aria-label', this.getAriaLabel(keybindingItemEntry));
-		new HighlightedLabel(this.sourceColumn, false).set(keybindingItemEntry.keybindingItem.source, keybindingItemEntry.sourceMatches);
+		const sourceLabel = new HighlightedLabel(this.sourceColumn, false);
+		sourceLabel.set(keybindingItemEntry.keybindingItem.source, keybindingItemEntry.sourceMatches);
+		this.sourceColumn.title = keybindingItemEntry.keybindingItem.source;
+		sourceLabel.element.title = keybindingItemEntry.keybindingItem.source;
 	}
 
 	private getAriaLabel(keybindingItemEntry: IKeybindingItemEntry): string {

--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -401,6 +401,7 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 			$('.header.command', null, localize('command', "Command")),
 			$('.header.keybinding', null, localize('keybinding', "Keybinding")),
 			$('.header.source', null, localize('source', "Source")),
+			$('.header.extension', null, localize('extension', "Extension")),
 			$('.header.when', null, localize('when', "When")));
 	}
 
@@ -457,6 +458,12 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 						return undefined;
 					}
 
+					this.renderKeybindingsEntries(false, preserveFocus);
+				})
+				.then(() => {
+					return this.keybindingsEditorModel.updateExtensionColumn();
+				})
+				.then(() => {
 					this.renderKeybindingsEntries(false, preserveFocus);
 				});
 		}
@@ -715,6 +722,7 @@ interface KeybindingItemTemplate {
 	command: CommandColumn;
 	keybinding: KeybindingColumn;
 	source: SourceColumn;
+	extension: ExtensionColumn;
 	when: WhenColumn;
 }
 
@@ -730,6 +738,7 @@ class KeybindingItemRenderer implements IListRenderer<IKeybindingItemEntry, Keyb
 		const command = new CommandColumn(container, this.keybindingsEditor);
 		const keybinding = new KeybindingColumn(container, this.keybindingsEditor);
 		const source = new SourceColumn(container, this.keybindingsEditor);
+		const extension = new ExtensionColumn(container, this.keybindingsEditor);
 		const when = new WhenColumn(container, this.keybindingsEditor);
 		container.setAttribute('aria-labelledby', [command.id, keybinding.id, source.id, when.id].join(' '));
 		return {
@@ -738,6 +747,7 @@ class KeybindingItemRenderer implements IListRenderer<IKeybindingItemEntry, Keyb
 			command,
 			keybinding,
 			source,
+			extension,
 			when
 		};
 	}
@@ -748,6 +758,7 @@ class KeybindingItemRenderer implements IListRenderer<IKeybindingItemEntry, Keyb
 		template.command.render(keybindingEntry);
 		template.keybinding.render(keybindingEntry);
 		template.source.render(keybindingEntry);
+		template.extension.render(keybindingEntry);
 		template.when.render(keybindingEntry);
 	}
 
@@ -901,6 +912,33 @@ class SourceColumn extends Column {
 
 	private getAriaLabel(keybindingItemEntry: IKeybindingItemEntry): string {
 		return localize('sourceAriaLabel', "Source is {0}.", keybindingItemEntry.keybindingItem.source);
+	}
+}
+
+class ExtensionColumn extends Column {
+
+	private extensionColumn: HTMLElement;
+
+	create(parent: HTMLElement): HTMLElement {
+		this.extensionColumn = DOM.append(parent, $('.column.extension', { id: 'extension_' + ++Column.COUNTER }));
+		return this.extensionColumn;
+	}
+
+	render(keybindingItemEntry: IKeybindingItemEntry): void {
+		DOM.clearNode(this.extensionColumn);
+		this.extensionColumn.setAttribute('aria-label', this.getAriaLabel(keybindingItemEntry));
+		if (keybindingItemEntry.keybindingItem.extension) {
+			const extensionLabel = new HighlightedLabel(this.extensionColumn, false);
+			extensionLabel.set(keybindingItemEntry.keybindingItem.extension, keybindingItemEntry.extensionMatches);
+			this.extensionColumn.title = keybindingItemEntry.keybindingItem.extension;
+			extensionLabel.element.title = keybindingItemEntry.keybindingItem.extension;
+		} else {
+			this.extensionColumn.title = '';
+		}
+	}
+
+	private getAriaLabel(keybindingItemEntry: IKeybindingItemEntry): string {
+		return keybindingItemEntry.keybindingItem.extension ? localize('fromExtensionAriaLabel', "Originates from extension: {0}.", keybindingItemEntry.keybindingItem.when) : localize('notFromExtension', "Built-in command or keybinding.");
 	}
 }
 

--- a/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/parts/preferences/browser/keybindingsEditor.ts
@@ -401,7 +401,6 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 			$('.header.command', null, localize('command', "Command")),
 			$('.header.keybinding', null, localize('keybinding', "Keybinding")),
 			$('.header.source', null, localize('source', "Source")),
-			$('.header.extension', null, localize('extension', "Extension")),
 			$('.header.when', null, localize('when', "When")));
 	}
 
@@ -722,7 +721,6 @@ interface KeybindingItemTemplate {
 	command: CommandColumn;
 	keybinding: KeybindingColumn;
 	source: SourceColumn;
-	extension: ExtensionColumn;
 	when: WhenColumn;
 }
 
@@ -738,7 +736,6 @@ class KeybindingItemRenderer implements IListRenderer<IKeybindingItemEntry, Keyb
 		const command = new CommandColumn(container, this.keybindingsEditor);
 		const keybinding = new KeybindingColumn(container, this.keybindingsEditor);
 		const source = new SourceColumn(container, this.keybindingsEditor);
-		const extension = new ExtensionColumn(container, this.keybindingsEditor);
 		const when = new WhenColumn(container, this.keybindingsEditor);
 		container.setAttribute('aria-labelledby', [command.id, keybinding.id, source.id, when.id].join(' '));
 		return {
@@ -747,7 +744,6 @@ class KeybindingItemRenderer implements IListRenderer<IKeybindingItemEntry, Keyb
 			command,
 			keybinding,
 			source,
-			extension,
 			when
 		};
 	}
@@ -758,7 +754,6 @@ class KeybindingItemRenderer implements IListRenderer<IKeybindingItemEntry, Keyb
 		template.command.render(keybindingEntry);
 		template.keybinding.render(keybindingEntry);
 		template.source.render(keybindingEntry);
-		template.extension.render(keybindingEntry);
 		template.when.render(keybindingEntry);
 	}
 
@@ -912,33 +907,6 @@ class SourceColumn extends Column {
 
 	private getAriaLabel(keybindingItemEntry: IKeybindingItemEntry): string {
 		return localize('sourceAriaLabel', "Source is {0}.", keybindingItemEntry.keybindingItem.source);
-	}
-}
-
-class ExtensionColumn extends Column {
-
-	private extensionColumn: HTMLElement;
-
-	create(parent: HTMLElement): HTMLElement {
-		this.extensionColumn = DOM.append(parent, $('.column.extension', { id: 'extension_' + ++Column.COUNTER }));
-		return this.extensionColumn;
-	}
-
-	render(keybindingItemEntry: IKeybindingItemEntry): void {
-		DOM.clearNode(this.extensionColumn);
-		this.extensionColumn.setAttribute('aria-label', this.getAriaLabel(keybindingItemEntry));
-		if (keybindingItemEntry.keybindingItem.extension) {
-			const extensionLabel = new HighlightedLabel(this.extensionColumn, false);
-			extensionLabel.set(keybindingItemEntry.keybindingItem.extension, keybindingItemEntry.extensionMatches);
-			this.extensionColumn.title = keybindingItemEntry.keybindingItem.extension;
-			extensionLabel.element.title = keybindingItemEntry.keybindingItem.extension;
-		} else {
-			this.extensionColumn.title = '';
-		}
-	}
-
-	private getAriaLabel(keybindingItemEntry: IKeybindingItemEntry): string {
-		return keybindingItemEntry.keybindingItem.extension ? localize('fromExtensionAriaLabel', "Originates from extension: {0}.", keybindingItemEntry.keybindingItem.when) : localize('notFromExtension', "Built-in command or keybinding.");
 	}
 }
 

--- a/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
@@ -167,7 +167,6 @@
 	flex: 1;
 }
 
-
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row > .when .empty {
 	padding-left: 4px;
 }

--- a/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
@@ -167,12 +167,18 @@
 	flex: 1;
 }
 
+.keybindings-editor > .keybindings-body > .keybindings-list-header > .extension,
+.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row > .extension {
+	flex: 0.3;
+}
+
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row > .when .empty {
 	padding-left: 4px;
 }
 
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .command .monaco-highlighted-label,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .source .monaco-highlighted-label,
+.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .extension .monaco-highlighted-label,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .when .monaco-highlighted-label {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/parts/preferences/browser/media/keybindingsEditor.css
@@ -159,7 +159,7 @@
 
 .keybindings-editor > .keybindings-body > .keybindings-list-header > .source,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .source {
-	flex: 0 0 100px;
+	flex: 0 0 140px;
 }
 
 .keybindings-editor > .keybindings-body > .keybindings-list-header > .when,
@@ -167,10 +167,6 @@
 	flex: 1;
 }
 
-.keybindings-editor > .keybindings-body > .keybindings-list-header > .extension,
-.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row > .extension {
-	flex: 0.3;
-}
 
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row > .when .empty {
 	padding-left: 4px;
@@ -178,7 +174,6 @@
 
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .command .monaco-highlighted-label,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .source .monaco-highlighted-label,
-.keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .extension .monaco-highlighted-label,
 .keybindings-editor > .keybindings-body > .keybindings-list-container .monaco-list-row .when .monaco-highlighted-label {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
@@ -198,8 +198,8 @@ export class KeybindingsEditorModel extends EditorModel {
 				}
 			}
 			if (Array.isArray(contributes.keybindings)) {
-				for (const command of contributes.keybindings) {
-					contributed[command.command] = extensionName;
+				for (const keybinding of contributes.keybindings) {
+					contributed[keybinding.command] = extensionName;
 				}
 			}
 		}
@@ -207,7 +207,7 @@ export class KeybindingsEditorModel extends EditorModel {
 		for (const keybinding of this._keybindingItems) {
 			if (keybinding.command in contributed) {
 				if (keybinding.source.indexOf(SOURCE_USER) !== -1) {
-					keybinding.source = `User ⮜ ${contributed[keybinding.command]}`;
+					keybinding.source = `${SOURCE_USER} ⮜ ${contributed[keybinding.command]}`;
 				} else {
 					keybinding.source = contributed[keybinding.command];
 				}

--- a/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
@@ -114,13 +114,17 @@ export class KeybindingsEditorModel extends EditorModel {
 		if (/@user/i.test(searchValue)) {
 			return keybindingItems.filter(k => k.source === SOURCE_USER);
 		}
-		if (/@source:\s*"(.+?)"\s?/i.test(searchValue)) {
-			const match = searchValue.match(/@source:\s*"(.+?)"\s?/i);
+		const quotesRegex = /@source:\s*"(.+?)"\s?/i;
+		if (quotesRegex.test(searchValue)) {
+			const match = searchValue.match(quotesRegex);
+			if (!match) { return keybindingItems; }
 			const extensionQuery = new RegExp(match[1], 'i');
 			return keybindingItems.filter(k => extensionQuery.test(k.source));
 		}
-		if (/@source:\s*([\S]+)\s?/i.test(searchValue)) {
-			const match = searchValue.match(/@source:\s*([\S]+)\s?/i);
+		const withoutQuotesRegex = /@source:\s*([\S]+)\s?/i;
+		if (withoutQuotesRegex.test(searchValue)) {
+			const match = searchValue.match(withoutQuotesRegex);
+			if (!match) { return keybindingItems; }
 			const extensionQuery = new RegExp(match[1], 'i');
 			return keybindingItems.filter(k => extensionQuery.test(k.source));
 		}

--- a/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
+++ b/src/vs/workbench/services/preferences/common/keybindingsEditorModel.ts
@@ -93,7 +93,7 @@ export class KeybindingsEditorModel extends EditorModel {
 	fetch(searchValue: string, sortByPrecedence: boolean = false): IKeybindingItemEntry[] {
 		let keybindingItems = sortByPrecedence ? this._keybindingItemsSortedByPrecedence : this._keybindingItems;
 
-		const sourceRegex = /(@user)|(@default)|(@source:\s*"(.+?)"\s?)|(@source:\s*([\S]+)\s?)/i;
+		const sourceRegex = /(@user)|(@default)|(@extension)|(@source:\s*"(.+?)"\s?)|(@source:\s*([\S]+)\s?)/i;
 		if (sourceRegex.test(searchValue)) {
 			keybindingItems = this.filterBySource(keybindingItems, searchValue);
 			searchValue = searchValue.replace(sourceRegex, '');
@@ -113,6 +113,9 @@ export class KeybindingsEditorModel extends EditorModel {
 		}
 		if (/@user/i.test(searchValue)) {
 			return keybindingItems.filter(k => k.source === SOURCE_USER);
+		}
+		if (/@extension/i.test(searchValue)) {
+			return keybindingItems.filter(k => k.source !== SOURCE_USER && k.source !== SOURCE_DEFAULT);
 		}
 		const quotesRegex = /@source:\s*"(.+?)"\s?/i;
 		if (quotesRegex.test(searchValue)) {


### PR DESCRIPTION
Fixes #37034

This PR adds Extension column to keybindings editor.

![demo](https://user-images.githubusercontent.com/9638156/52182496-ce75f180-280e-11e9-8f45-ad5e855ddaee.png)

It's still possible to distinct User/Default origin of command/keybinding and at the same time to see if it was contributed by an extension.

- [x] Size is not that big `flex: 0.3`
- [x] `title` attribute is specified to be able to fully see name of the extension
- [x] Search works for the column
- [x] All contributed commands/keybindings have Extension specified
- [x] Built-in extensions excluded

It was taking > 1second to load on editor startup if the code was inside `KeybindingsEditorModel.resolve()` so it's living in the separate function that runs after.

If you have a better way of obtaining extensions list (with contributions commands & keybindings), I'll update PR.