### PR TITLE
Fix explorer DND regression

### DIFF
--- a/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/openEditorsView.ts
@@ -39,7 +39,7 @@ import { ViewletPanel, IViewletPanelOptions } from 'vs/workbench/browser/parts/v
 import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
 import { IDragAndDropData } from 'vs/base/browser/dnd';
 import { memoize } from 'vs/base/common/decorators';
-import { DesktopDragAndDropData, ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
+import { ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
 import { URI } from 'vs/base/common/uri';
 
 const $ = dom.$;
@@ -652,15 +652,14 @@ class OpenEditorsDragAndDrop implements IListDragAndDrop<OpenEditor | IEditorGro
 		const group = targetElement instanceof OpenEditor ? targetElement.group : targetElement;
 		const index = targetElement instanceof OpenEditor ? targetElement.group.getIndexOfEditor(targetElement.editor) : 0;
 
-		if (data instanceof DesktopDragAndDropData) {
-			this.dropHandler.handleDrop(originalEvent, () => group, () => group.focus(), index);
-		} else {
-			const elementsData = (data as ElementsDragAndDropData<OpenEditor>).elements;
+		if (data instanceof ElementsDragAndDropData) {
+			const elementsData = data.elements;
 			elementsData.forEach((oe, offset) => {
 				oe.group.moveEditor(oe.editor, group, { index: index + offset, preserveFocus: true });
 			});
 			this.editorGroupService.activateGroup(group);
+		} else {
+			this.dropHandler.handleDrop(originalEvent, () => group, () => group.focus(), index);
 		}
-
 	}
 }


### PR DESCRIPTION
Fixes #67883

When handling the `drop` event on Open Editors, there are three possible data transfer types:

- `ElementsDragAndDropData`
- `ExternalElementsDragAndDropData`
- `DesktopDragAndDropData`

When adopting the new List DND, we only checked for `DesktopDragAndDropData`, leaving the case of dragging files from explorer to open editors broken. The real fix is to just check for `ElementsDragAndDropData`, which catches same-tree dnd operations, and either move files around in open editors or handle external drops in both `ExternalElementsDragAndDropData` and `DesktopDragAndDropData`.