### PR TITLE
Ctrl+Click - Either open in Peek or go to definition, not BOTH!

### DIFF
--- a/src/vs/editor/contrib/goToDefinition/goToDefinitionCommands.ts
+++ b/src/vs/editor/contrib/goToDefinition/goToDefinitionCommands.ts
@@ -130,17 +130,13 @@ export class DefinitionAction extends EditorAction {
 		const msg = model.getAriaMessage();
 		alert(msg);
 
-		if (this._configuration.openInPeek) {
+		if (this._configuration.openInPeek || model.references.length > 1) {
 			this._openInPeek(editorService, editor, model);
 		} else if (editor.hasModel()) {
 			const next = model.nearestReference(editor.getModel().uri, editor.getPosition());
 			if (next) {
-				const targetEditor = await this._openReference(editor, editorService, next, this._configuration.openToSide);
-				if (targetEditor && model.references.length > 1) {
-					this._openInPeek(editorService, targetEditor, model);
-				} else {
-					model.dispose();
-				}
+				await this._openReference(editor, editorService, next, this._configuration.openToSide);
+				model.dispose();
 			}
 		}
 	}


### PR DESCRIPTION
The current behavior is if multiple definitions are found, it navigates to the nearest definition and opens peek. Which is super annoying and causes you to loose your place.

* Use peek if there are multiple definitions
* When using peek, will not navigate to the best match in editor and cause you to lose your spot
* If there is only one definition, navigate to  best match and NOT open peek

This addresses the following stack overflow complaint and behavior shown in the screencast

https://stackoverflow.com/questions/41460845/disable-peek-in-visual-studio-code/54559763#54559763

![vscodeannoying](https://user-images.githubusercontent.com/7283693/52386854-5fd2a700-2a4d-11e9-8314-5193884c30a5.gif)

