### PR TITLE
Change `ITheme.getColor` to returned `Color | undefined`

### DIFF
--- a/src/vs/editor/contrib/find/findOptionsWidget.ts
+++ b/src/vs/editor/contrib/find/findOptionsWidget.ts
@@ -46,7 +46,7 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 		this._domNode.setAttribute('role', 'presentation');
 		this._domNode.setAttribute('aria-hidden', 'true');
 
-		const inputActiveOptionBorderColor = themeService.getTheme().getColor(inputActiveOptionBorder) || undefined;
+		const inputActiveOptionBorderColor = themeService.getTheme().getColor(inputActiveOptionBorder);
 
 		this.caseSensitive = this._register(new CaseSensitiveCheckbox({
 			appendTitle: this._keybindingLabelFor(FIND_IDS.ToggleCaseSensitiveCommand),
@@ -179,7 +179,7 @@ export class FindOptionsWidget extends Widget implements IOverlayWidget {
 	}
 
 	private _applyTheme(theme: ITheme) {
-		let inputStyles = { inputActiveOptionBorder: theme.getColor(inputActiveOptionBorder) || undefined };
+		let inputStyles = { inputActiveOptionBorder: theme.getColor(inputActiveOptionBorder) };
 		this.caseSensitive.style(inputStyles);
 		this.wholeWords.style(inputStyles);
 		this.regex.style(inputStyles);

--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -530,19 +530,19 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 
 	private _applyTheme(theme: ITheme) {
 		let inputStyles: IFindInputStyles = {
-			inputActiveOptionBorder: theme.getColor(inputActiveOptionBorder) || undefined,
-			inputBackground: theme.getColor(inputBackground) || undefined,
-			inputForeground: theme.getColor(inputForeground) || undefined,
-			inputBorder: theme.getColor(inputBorder) || undefined,
-			inputValidationInfoBackground: theme.getColor(inputValidationInfoBackground) || undefined,
-			inputValidationInfoForeground: theme.getColor(inputValidationInfoForeground) || undefined,
-			inputValidationInfoBorder: theme.getColor(inputValidationInfoBorder) || undefined,
-			inputValidationWarningBackground: theme.getColor(inputValidationWarningBackground) || undefined,
-			inputValidationWarningForeground: theme.getColor(inputValidationWarningForeground) || undefined,
-			inputValidationWarningBorder: theme.getColor(inputValidationWarningBorder) || undefined,
-			inputValidationErrorBackground: theme.getColor(inputValidationErrorBackground) || undefined,
-			inputValidationErrorForeground: theme.getColor(inputValidationErrorForeground) || undefined,
-			inputValidationErrorBorder: theme.getColor(inputValidationErrorBorder) || undefined,
+			inputActiveOptionBorder: theme.getColor(inputActiveOptionBorder),
+			inputBackground: theme.getColor(inputBackground),
+			inputForeground: theme.getColor(inputForeground),
+			inputBorder: theme.getColor(inputBorder),
+			inputValidationInfoBackground: theme.getColor(inputValidationInfoBackground),
+			inputValidationInfoForeground: theme.getColor(inputValidationInfoForeground),
+			inputValidationInfoBorder: theme.getColor(inputValidationInfoBorder),
+			inputValidationWarningBackground: theme.getColor(inputValidationWarningBackground),
+			inputValidationWarningForeground: theme.getColor(inputValidationWarningForeground),
+			inputValidationWarningBorder: theme.getColor(inputValidationWarningBorder),
+			inputValidationErrorBackground: theme.getColor(inputValidationErrorBackground),
+			inputValidationErrorForeground: theme.getColor(inputValidationErrorForeground),
+			inputValidationErrorBorder: theme.getColor(inputValidationErrorBorder),
 		};
 		this._findInput.style(inputStyles);
 		this._replaceInputBox.style(inputStyles);
@@ -1130,7 +1130,7 @@ export class SimpleButton extends Widget {
 // theming
 
 registerThemingParticipant((theme, collector) => {
-	const addBackgroundColorRule = (selector: string, color: Color | null): void => {
+	const addBackgroundColorRule = (selector: string, color: Color | undefined): void => {
 		if (color) {
 			collector.addRule(`.monaco-editor ${selector} { background-color: ${color}; }`);
 		}

--- a/src/vs/editor/contrib/find/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/simpleFindWidget.ts
@@ -160,19 +160,19 @@ export abstract class SimpleFindWidget extends Widget {
 
 	public updateTheme(theme: ITheme): void {
 		const inputStyles: IFindInputStyles = {
-			inputActiveOptionBorder: theme.getColor(inputActiveOptionBorder) || undefined,
-			inputBackground: theme.getColor(inputBackground) || undefined,
-			inputForeground: theme.getColor(inputForeground) || undefined,
-			inputBorder: theme.getColor(inputBorder) || undefined,
-			inputValidationInfoBackground: theme.getColor(inputValidationInfoBackground) || undefined,
-			inputValidationInfoForeground: theme.getColor(inputValidationInfoForeground) || undefined,
-			inputValidationInfoBorder: theme.getColor(inputValidationInfoBorder) || undefined,
-			inputValidationWarningBackground: theme.getColor(inputValidationWarningBackground) || undefined,
-			inputValidationWarningForeground: theme.getColor(inputValidationWarningForeground) || undefined,
-			inputValidationWarningBorder: theme.getColor(inputValidationWarningBorder) || undefined,
-			inputValidationErrorBackground: theme.getColor(inputValidationErrorBackground) || undefined,
-			inputValidationErrorForeground: theme.getColor(inputValidationErrorForeground) || undefined,
-			inputValidationErrorBorder: theme.getColor(inputValidationErrorBorder) || undefined
+			inputActiveOptionBorder: theme.getColor(inputActiveOptionBorder),
+			inputBackground: theme.getColor(inputBackground),
+			inputForeground: theme.getColor(inputForeground),
+			inputBorder: theme.getColor(inputBorder),
+			inputValidationInfoBackground: theme.getColor(inputValidationInfoBackground),
+			inputValidationInfoForeground: theme.getColor(inputValidationInfoForeground),
+			inputValidationInfoBorder: theme.getColor(inputValidationInfoBorder),
+			inputValidationWarningBackground: theme.getColor(inputValidationWarningBackground),
+			inputValidationWarningForeground: theme.getColor(inputValidationWarningForeground),
+			inputValidationWarningBorder: theme.getColor(inputValidationWarningBorder),
+			inputValidationErrorBackground: theme.getColor(inputValidationErrorBackground),
+			inputValidationErrorForeground: theme.getColor(inputValidationErrorForeground),
+			inputValidationErrorBorder: theme.getColor(inputValidationErrorBorder)
 		};
 		this._findInput.style(inputStyles);
 	}

--- a/src/vs/editor/contrib/gotoError/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/gotoErrorWidget.ts
@@ -185,7 +185,7 @@ export class MarkerNavigationWidget extends ZoneWidget {
 	}
 
 	private _applyTheme(theme: ITheme) {
-		this._backgroundColor = theme.getColor(editorMarkerNavigationBackground) || undefined;
+		this._backgroundColor = theme.getColor(editorMarkerNavigationBackground);
 		let colorId = editorMarkerNavigationError;
 		if (this._severity === MarkerSeverity.Warning) {
 			colorId = editorMarkerNavigationWarning;

--- a/src/vs/editor/contrib/referenceSearch/referencesWidget.ts
+++ b/src/vs/editor/contrib/referenceSearch/referencesWidget.ts
@@ -279,8 +279,8 @@ export class ReferenceWidget extends PeekViewWidget {
 			arrowColor: borderColor,
 			frameColor: borderColor,
 			headerBackgroundColor: theme.getColor(peekViewTitleBackground) || Color.transparent,
-			primaryHeadingColor: theme.getColor(peekViewTitleForeground) || undefined,
-			secondaryHeadingColor: theme.getColor(peekViewTitleInfoForeground) || undefined
+			primaryHeadingColor: theme.getColor(peekViewTitleForeground),
+			secondaryHeadingColor: theme.getColor(peekViewTitleInfoForeground)
 		});
 	}
 

--- a/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
@@ -28,7 +28,7 @@ class StandaloneTheme implements IStandaloneTheme {
 
 	private themeData: IStandaloneThemeData;
 	private colors: { [colorId: string]: Color } | null;
-	private defaultColors: { [colorId: string]: Color | null; };
+	private defaultColors: { [colorId: string]: Color | undefined; };
 	private _tokenTheme: TokenTheme | null;
 
 	constructor(name: string, standaloneThemeData: IStandaloneThemeData) {
@@ -77,7 +77,7 @@ class StandaloneTheme implements IStandaloneTheme {
 		return this.colors;
 	}
 
-	public getColor(colorId: ColorIdentifier, useDefault?: boolean): Color | null {
+	public getColor(colorId: ColorIdentifier, useDefault?: boolean): Color | undefined {
 		const color = this.getColors()[colorId];
 		if (color) {
 			return color;
@@ -85,10 +85,10 @@ class StandaloneTheme implements IStandaloneTheme {
 		if (useDefault !== false) {
 			return this.getDefault(colorId);
 		}
-		return null;
+		return undefined;
 	}
 
-	private getDefault(colorId: ColorIdentifier): Color | null {
+	private getDefault(colorId: ColorIdentifier): Color | undefined {
 		let color = this.defaultColors[colorId];
 		if (color) {
 			return color;

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -27,7 +27,7 @@ export interface ColorContribution {
 
 
 export interface ColorFunction {
-	(theme: ITheme): Color | null;
+	(theme: ITheme): Color | undefined;
 }
 
 export interface ColorDefaults {
@@ -71,7 +71,7 @@ export interface IColorRegistry {
 	/**
 	 * Gets the default color of the given id
 	 */
-	resolveDefaultColor(id: ColorIdentifier, theme: ITheme): Color | null;
+	resolveDefaultColor(id: ColorIdentifier, theme: ITheme): Color | undefined;
 
 	/**
 	 * JSON schema for an object to assign color values to one of the color contributions.
@@ -131,13 +131,13 @@ class ColorRegistry implements IColorRegistry {
 		return Object.keys(this.colorsById).map(id => this.colorsById[id]);
 	}
 
-	public resolveDefaultColor(id: ColorIdentifier, theme: ITheme): Color | null {
+	public resolveDefaultColor(id: ColorIdentifier, theme: ITheme): Color | undefined {
 		const colorDesc = this.colorsById[id];
 		if (colorDesc && colorDesc.defaults) {
 			const colorValue = colorDesc.defaults[theme.type];
 			return resolveColorValue(colorValue, theme);
 		}
-		return null;
+		return undefined;
 	}
 
 	public getColorSchema(): IJSONSchema {
@@ -385,7 +385,7 @@ export function darken(colorValue: ColorValue, factor: number): ColorFunction {
 		if (color) {
 			return color.darken(factor);
 		}
-		return null;
+		return undefined;
 	};
 }
 
@@ -395,7 +395,7 @@ export function lighten(colorValue: ColorValue, factor: number): ColorFunction {
 		if (color) {
 			return color.lighten(factor);
 		}
-		return null;
+		return undefined;
 	};
 }
 
@@ -405,7 +405,7 @@ export function transparent(colorValue: ColorValue, factor: number): ColorFuncti
 		if (color) {
 			return color.transparent(factor);
 		}
-		return null;
+		return undefined;
 	};
 }
 
@@ -417,7 +417,7 @@ export function oneOf(...colorValues: ColorValue[]): ColorFunction {
 				return color;
 			}
 		}
-		return null;
+		return undefined;
 	};
 }
 
@@ -434,7 +434,7 @@ function lessProminent(colorValue: ColorValue, backgroundColorValue: ColorValue,
 			}
 			return from.transparent(factor * transparency);
 		}
-		return null;
+		return undefined;
 	};
 }
 
@@ -443,9 +443,9 @@ function lessProminent(colorValue: ColorValue, backgroundColorValue: ColorValue,
 /**
  * @param colorValue Resolve a color value in the context of a theme
  */
-function resolveColorValue(colorValue: ColorValue | null, theme: ITheme): Color | null {
+function resolveColorValue(colorValue: ColorValue | null, theme: ITheme): Color | undefined {
 	if (colorValue === null) {
-		return null;
+		return undefined;
 	} else if (typeof colorValue === 'string') {
 		if (colorValue[0] === '#') {
 			return Color.fromHex(colorValue);
@@ -456,7 +456,7 @@ function resolveColorValue(colorValue: ColorValue | null, theme: ITheme): Color 
 	} else if (typeof colorValue === 'function') {
 		return colorValue(theme);
 	}
-	return null;
+	return undefined;
 }
 
 export const workbenchColorsSchemaId = 'vscode://schemas/workbench-colors';

--- a/src/vs/platform/theme/common/styler.ts
+++ b/src/vs/platform/theme/common/styler.ts
@@ -9,7 +9,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { Color } from 'vs/base/common/color';
 import { mixin } from 'vs/base/common/objects';
 
-export type styleFn = (colors: { [name: string]: Color | null }) => void;
+export type styleFn = (colors: { [name: string]: Color | undefined }) => void;
 
 export interface IStyleOverrides {
 	[color: string]: ColorIdentifier | undefined;
@@ -24,7 +24,7 @@ export interface IColorMapping {
 }
 
 export interface IComputedStyles {
-	[color: string]: Color | null;
+	[color: string]: Color | undefined;
 }
 
 export function computeStyles(theme: ITheme, styleMap: IColorMapping): IComputedStyles {

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -52,7 +52,7 @@ export interface ITheme {
 	 * @param color the id of the color
 	 * @param useDefault specifies if the default color should be used. If not set, the default is used.
 	 */
-	getColor(color: ColorIdentifier, useDefault?: boolean): Color | null;
+	getColor(color: ColorIdentifier, useDefault?: boolean): Color | undefined;
 
 	/**
 	 * Returns whether the theme defines a value for the color. If not, that means the

--- a/src/vs/platform/theme/test/common/testThemeService.ts
+++ b/src/vs/platform/theme/test/common/testThemeService.ts
@@ -12,12 +12,12 @@ export class TestTheme implements ITheme {
 	constructor(private colors: { [id: string]: string; } = {}, public type = DARK) {
 	}
 
-	getColor(color: string, useDefault?: boolean): Color | null {
+	getColor(color: string, useDefault?: boolean): Color | undefined {
 		let value = this.colors[color];
 		if (value) {
 			return Color.fromHex(value);
 		}
-		return null;
+		return undefined;
 	}
 
 	defines(color: string): boolean {

--- a/src/vs/workbench/browser/parts/quickinput/quickInputBox.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInputBox.ts
@@ -100,18 +100,18 @@ export class QuickInputBox {
 
 	style(theme: ITheme) {
 		this.inputBox.style({
-			inputForeground: theme.getColor(inputForeground) || undefined,
-			inputBackground: theme.getColor(inputBackground) || undefined,
-			inputBorder: theme.getColor(inputBorder) || undefined,
-			inputValidationInfoBackground: theme.getColor(inputValidationInfoBackground) || undefined,
-			inputValidationInfoForeground: theme.getColor(inputValidationInfoForeground) || undefined,
-			inputValidationInfoBorder: theme.getColor(inputValidationInfoBorder) || undefined,
-			inputValidationWarningBackground: theme.getColor(inputValidationWarningBackground) || undefined,
-			inputValidationWarningForeground: theme.getColor(inputValidationWarningForeground) || undefined,
-			inputValidationWarningBorder: theme.getColor(inputValidationWarningBorder) || undefined,
-			inputValidationErrorBackground: theme.getColor(inputValidationErrorBackground) || undefined,
-			inputValidationErrorForeground: theme.getColor(inputValidationErrorForeground) || undefined,
-			inputValidationErrorBorder: theme.getColor(inputValidationErrorBorder) || undefined,
+			inputForeground: theme.getColor(inputForeground),
+			inputBackground: theme.getColor(inputBackground),
+			inputBorder: theme.getColor(inputBorder),
+			inputValidationInfoBackground: theme.getColor(inputValidationInfoBackground),
+			inputValidationInfoForeground: theme.getColor(inputValidationInfoForeground),
+			inputValidationInfoBorder: theme.getColor(inputValidationInfoBorder),
+			inputValidationWarningBackground: theme.getColor(inputValidationWarningBackground),
+			inputValidationWarningForeground: theme.getColor(inputValidationWarningForeground),
+			inputValidationWarningBorder: theme.getColor(inputValidationWarningBorder),
+			inputValidationErrorBackground: theme.getColor(inputValidationErrorBackground),
+			inputValidationErrorForeground: theme.getColor(inputValidationErrorForeground),
+			inputValidationErrorBorder: theme.getColor(inputValidationErrorBorder),
 		});
 	}
 

--- a/src/vs/workbench/parts/scm/electron-browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/parts/scm/electron-browser/dirtydiffDecorator.ts
@@ -156,7 +156,7 @@ function getChangeType(change: IChange): ChangeType {
 	}
 }
 
-function getChangeTypeColor(theme: ITheme, changeType: ChangeType): Color | null {
+function getChangeTypeColor(theme: ITheme, changeType: ChangeType): Color | undefined {
 	switch (changeType) {
 		case ChangeType.Modify: return theme.getColor(editorGutterModifiedBackground);
 		case ChangeType.Add: return theme.getColor(editorGutterAddedBackground);
@@ -365,8 +365,8 @@ class DirtyDiffWidget extends PeekViewWidget {
 			arrowColor: borderColor,
 			frameColor: borderColor,
 			headerBackgroundColor: theme.getColor(peekViewTitleBackground) || Color.transparent,
-			primaryHeadingColor: theme.getColor(peekViewTitleForeground) || undefined,
-			secondaryHeadingColor: theme.getColor(peekViewTitleInfoForeground) || undefined
+			primaryHeadingColor: theme.getColor(peekViewTitleForeground),
+			secondaryHeadingColor: theme.getColor(peekViewTitleInfoForeground)
 		});
 	}
 

--- a/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
@@ -57,8 +57,8 @@ export class ColorThemeData implements IColorTheme {
 	private colorMap: IColorMap = {};
 	private customColorMap: IColorMap = {};
 
-	public getColor(colorId: ColorIdentifier, useDefault?: boolean): Color | null {
-		let color: Color | null = this.customColorMap[colorId];
+	public getColor(colorId: ColorIdentifier, useDefault?: boolean): Color | undefined {
+		let color: Color | undefined = this.customColorMap[colorId];
 		if (color) {
 			return color;
 		}
@@ -69,7 +69,7 @@ export class ColorThemeData implements IColorTheme {
 		return color;
 	}
 
-	public getDefault(colorId: ColorIdentifier): Color | null {
+	public getDefault(colorId: ColorIdentifier): Color | undefined {
 		return colorRegistry.resolveDefaultColor(colorId, this);
 	}
 


### PR DESCRIPTION
**Problem**
`ITheme.getColor` is one of the major users of the type `null` in our codebase. However this function is used in many places that expected an `undefined` type instead. With the strict null work, this means that we have to write code such as `theme.getColor(...) || undefined` in some cases or have to work with  `Color | null | undefined` types.

**Fix**
`undefined` is generally better supported by TypeScript and more natural to work with in JavaScript. This change makes `ITheme.getColor` return `Color | undefined` instead of `Color | null`.