### PR TITLE
Candidate: Fix twistie click in doubleClick open mode

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -7,7 +7,7 @@ import 'vs/css!./media/tree';
 import { IDisposable, dispose, Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { IListOptions, List, IListStyles, mightProducePrintableCharacter } from 'vs/base/browser/ui/list/listWidget';
 import { IListVirtualDelegate, IListRenderer, IListMouseEvent, IListEvent, IListContextMenuEvent, IListDragAndDrop, IListDragOverReaction, IKeyboardNavigationLabelProvider } from 'vs/base/browser/ui/list/list';
-import { append, $, toggleClass, getDomNodePagePosition, removeClass, addClass } from 'vs/base/browser/dom';
+import { append, $, toggleClass, getDomNodePagePosition, removeClass, addClass, hasClass } from 'vs/base/browser/dom';
 import { Event, Relay, Emitter, EventBufferer } from 'vs/base/common/event';
 import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
@@ -1167,7 +1167,9 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 			return;
 		}
 
-		if (!this.openOnSingleClick && e.browserEvent.detail !== 2) {
+		const onTwistie = hasClass(e.browserEvent.target as HTMLElement, 'monaco-tl-twistie');
+
+		if (!this.openOnSingleClick && e.browserEvent.detail !== 2 && !onTwistie) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/68050

When in `doubleClick` `openMode` (known to the tree as `!this.openOnSingleClick`), the tree should expand/collapse when simple clicking on the twistie.