### PR TITLE
Candidate: Fix input box text selection in Explorer

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -552,9 +552,9 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 
 		const uri = this.dnd.getDragURI(item.element);
 		item.dragStartDisposable.dispose();
+		item.row.domNode!.draggable = !!uri;
 
 		if (uri) {
-			item.row.domNode!.draggable = true;
 			const onDragStart = domEvent(item.row.domNode!, 'dragstart');
 			item.dragStartDisposable = onDragStart(event => this.onDragStart(item.element, uri, event));
 		}

--- a/src/vs/workbench/parts/files/electron-browser/explorerService.ts
+++ b/src/vs/workbench/parts/files/electron-browser/explorerService.ts
@@ -108,8 +108,13 @@ export class ExplorerService implements IExplorerService {
 		return this.model.findClosest(resource);
 	}
 
-	setEditable(stat: ExplorerItem, data: IEditableData): void {
-		this.editableStats.set(stat, data);
+	setEditable(stat: ExplorerItem, data: IEditableData | null): void {
+		if (!data) {
+			this.editableStats.delete(stat);
+		} else {
+			this.editableStats.set(stat, data);
+		}
+
 		this._onDidChangeEditable.fire(stat);
 	}
 

--- a/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/parts/files/electron-browser/views/explorerViewer.ts
@@ -533,7 +533,11 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		return false;
 	}
 
-	getDragURI(element: ExplorerItem): string {
+	getDragURI(element: ExplorerItem): string | null {
+		if (this.explorerService.isEditable(element)) {
+			return null;
+		}
+
 		return element.resource.toString();
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/68028

The tree's drag and drop feature is hijacking normal text selection in input boxes.

The old tree fixed this by having the `highlight` trait, which the new tree does not. But we can fix it in the new tree by just having the Explorer tell the tree "hey, this element can't be dragged right now", because the Explorer knows when stats are editable.

More comments inline.