### PR TITLE
Allow svgs by default in webviews

### DIFF
--- a/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
+++ b/src/vs/workbench/parts/webview/electron-browser/webviewEditor.ts
@@ -223,6 +223,7 @@ export class WebviewEditor extends BaseWebviewEditor {
 				this._partService.getContainer(Parts.EDITOR_PART),
 				{
 					enableWrappedPostMessage: true,
+					allowSvgs: true,
 					useSameOriginForRoot: false,
 					extensionLocation: input.extensionLocation
 				});


### PR DESCRIPTION
Fixes #68033

`allowSvgs` was already set as the default value after the webview was created. Due to an unrelated refactoring, the initial default value did not include `allowSvgs`