### PR TITLE
Enclose paths with quotes #68413

### DIFF
--- a/extensions/gulp/src/main.ts
+++ b/extensions/gulp/src/main.ts
@@ -122,7 +122,7 @@ class FolderDetector {
 		if (platform === 'win32' && await exists(path.join(rootPath!, 'node_modules', '.bin', 'gulp.cmd'))) {
 			const globalGulp = path.join(process.env.APPDATA ? process.env.APPDATA : '', 'npm', 'gulp.cmd');
 			if (await exists(globalGulp)) {
-				gulpCommand = globalGulp;
+				gulpCommand = '"' + globalGulp + '"';
 			} else {
 				gulpCommand = path.join('.', 'node_modules', '.bin', 'gulp.cmd');
 			}


### PR DESCRIPTION
it will allow to have it working when path contains space

Please note that I wasn't able to launch any tests locally (but a problem with my workspace environment, not with the PR)

I have not put the quotes around the ${gulpCommand} line 135, because in case of the line 135, it is not 
a path which is used