### PR TITLE
Use hard quotes rather than soft quotes #61902

### DIFF
--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -385,23 +385,21 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 			break;
 
 		case ShellType.bash:
-
 			quote = (s: string) => {
-				s = s.replace(/\"/g, '\\"');
-				return (s.indexOf(' ') >= 0 || s.indexOf('\\') >= 0) ? `"${s}"` : s;
+				return `'${s.replace(/'/g, '\'\\\'\'')}'`;
 			};
 
 			if (args.cwd) {
-				command += `cd ${quote(args.cwd)} ; `;
+				command += `cd ${quote(args.cwd)} && `;
 			}
 			if (args.env) {
 				command += 'env';
 				for (let key in args.env) {
 					const value = args.env[key];
 					if (value === null) {
-						command += ` -u "${key}"`;
+						command += ` -u ${quote(key)}`;
 					} else {
-						command += ` "${key}=${value}"`;
+						command += ` ${quote(`${key}=${value}`)}`;
 					}
 				}
 				command += ' ';

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -385,21 +385,27 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 			break;
 
 		case ShellType.bash:
+
 			quote = (s: string) => {
-				return `'${s.replace(/'/g, '\'\\\'\'')}'`;
+				s = s.replace(/\"/g, '\\"');
+				return (s.indexOf(' ') >= 0 || s.indexOf('\\') >= 0) ? `"${s}"` : s;
+			};
+
+			hardQuote = (s: string) => {
+				return /[^\w%\/+=,.:^-]/.test(s) ? `'${s.replace(/'/g, '\'\\\'\'')}'` : s;
 			};
 
 			if (args.cwd) {
-				command += `cd ${quote(args.cwd)} && `;
+				command += `cd ${hardQuote(args.cwd)} && `;
 			}
 			if (args.env) {
 				command += 'env';
 				for (let key in args.env) {
 					const value = args.env[key];
 					if (value === null) {
-						command += ` -u ${quote(key)}`;
+						command += ` -u ${hardQuote(key)}`;
 					} else {
-						command += ` ${quote(`${key}=${value}`)}`;
+						command += ` ${hardQuote(`${key}=${value}`)}`;
 					}
 				}
 				command += ' ';

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -320,6 +320,7 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 	}
 
 	let quote: (s: string) => string;
+	let hardQuote: (s: string) => string;
 	let command = '';
 
 	switch (shellType) {

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -393,7 +393,7 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 			};
 
 			hardQuote = (s: string) => {
-				return /[^\w%\/+=,.:^-]/.test(s) ? `'${s.replace(/'/g, '\'\\\'\'')}'` : s;
+				return /[^\w@%\/+=,.:^-]/.test(s) ? `'${s.replace(/'/g, '\'\\\'\'')}'` : s;
 			};
 
 			if (args.cwd) {


### PR DESCRIPTION
The current code encloses arguments in soft quotes (`"..."`) before injecting them into the shell. Soft quotes prevent some expansions from occuring, but not all. Hard quotes (`'...'`) on the other hand, treats everything literally, making it a much safer choice.