### PR TITLE
added option horizontalScrollingSCM

### DIFF
--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -111,6 +111,7 @@ function createScopedContextKeyService(contextKeyService: IContextKeyService, wi
 export const multiSelectModifierSettingKey = 'workbench.list.multiSelectModifier';
 export const openModeSettingKey = 'workbench.list.openMode';
 export const horizontalScrollingKey = 'workbench.tree.horizontalScrolling';
+export const horizontalScrollingSCMKey = 'workbench.tree.horizontalScrollingSCM';
 export const keyboardNavigationSettingKey = 'workbench.list.keyboardNavigation';
 const treeIndentKey = 'workbench.tree.indent';
 
@@ -1138,6 +1139,12 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'default': false,
 			'description': localize('horizontalScrolling setting', "Controls whether lists and trees support horizontal scrolling in the workbench.")
+		},
+		[horizontalScrollingSCMKey]: {
+			'type': 'string',
+			'enum': ['inherit', 'true', 'false'],
+			'default': 'inherit',
+			'description': localize('horizontalScrolling setting for SCM', "Controls whether lists and trees support horizontal scrolling in the SCM.")
 		},
 		[treeIndentKey]: {
 			'type': 'number',

--- a/src/vs/workbench/contrib/relauncher/electron-browser/relauncher.contribution.ts
+++ b/src/vs/workbench/contrib/relauncher/electron-browser/relauncher.contribution.ts
@@ -24,7 +24,7 @@ interface IConfiguration extends IWindowsConfiguration {
 	update: { channel: string; };
 	telemetry: { enableCrashReporter: boolean };
 	keyboard: { touchbar: { enabled: boolean } };
-	workbench: { tree: { horizontalScrolling: boolean }, useExperimentalGridLayout: boolean };
+	workbench: { tree: { horizontalScrolling: boolean, horizontalScrollingSCM: string }, useExperimentalGridLayout: boolean };
 	files: { useExperimentalFileWatcher: boolean, watcherExclude: object };
 }
 
@@ -38,6 +38,7 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 	private enableCrashReporter: boolean;
 	private touchbarEnabled: boolean;
 	private treeHorizontalScrolling: boolean;
+	private treeHorizontalScrollingSCM: string;
 	private experimentalFileWatcher: boolean;
 	private fileWatcherExclude: object;
 	private useGridLayout: boolean;
@@ -120,6 +121,13 @@ export class SettingsChangeRelauncher extends Disposable implements IWorkbenchCo
 			this.treeHorizontalScrolling = config.workbench.tree.horizontalScrolling;
 			changed = true;
 		}
+
+		// SCM Tree horizontal scrolling support
+		if (config.workbench && config.workbench.tree && typeof config.workbench.tree.horizontalScrollingSCM === 'string' && config.workbench.tree.horizontalScrollingSCM !== this.treeHorizontalScrollingSCM) {
+			this.treeHorizontalScrollingSCM = config.workbench.tree.horizontalScrollingSCM;
+			changed = true;
+		}
+
 
 		// Workbench Grid Layout
 		if (config.workbench && typeof config.workbench.useExperimentalGridLayout === 'boolean' && config.workbench.useExperimentalGridLayout !== this.useGridLayout) {

--- a/src/vs/workbench/contrib/scm/electron-browser/scmViewlet.ts
+++ b/src/vs/workbench/contrib/scm/electron-browser/scmViewlet.ts
@@ -884,10 +884,20 @@ export class RepositoryPanel extends ViewletPanel {
 			new ResourceRenderer(this.listLabels, actionItemProvider, () => this.getSelectedResources(), this.themeService, this.menus)
 		];
 
-		this.list = this.instantiationService.createInstance(WorkbenchList, this.listContainer, delegate, renderers, {
-			identityProvider: scmResourceIdentityProvider,
-			keyboardNavigationLabelProvider: scmKeyboardNavigationLabelProvider
-		}) as WorkbenchList<ISCMResourceGroup | ISCMResource>;
+		const horizontalScrollingSCM = this.configurationService.getValue('workbench.tree.horizontalScrollingSCM') || 'inherit';
+
+		if (horizontalScrollingSCM === 'inherit') {
+			this.list = this.instantiationService.createInstance(WorkbenchList, this.listContainer, delegate, renderers, {
+				identityProvider: scmResourceIdentityProvider,
+				keyboardNavigationLabelProvider: scmKeyboardNavigationLabelProvider
+			}) as WorkbenchList<ISCMResourceGroup | ISCMResource>;
+		} else {
+			this.list = this.instantiationService.createInstance(WorkbenchList, this.listContainer, delegate, renderers, {
+				identityProvider: scmResourceIdentityProvider,
+				keyboardNavigationLabelProvider: scmKeyboardNavigationLabelProvider,
+				horizontalScrolling: horizontalScrollingSCM === 'true'
+			}) as WorkbenchList<ISCMResourceGroup | ISCMResource>;
+		}
 
 		Event.chain(this.list.onDidOpen)
 			.map(e => e.elements[0])


### PR DESCRIPTION
Fixes #68027 #68131 

Added option `workbench.tree.horizontalScrollingSCM` with following possible values:
 - `inherit`: SCM tree respects value of `workbench.tree.horizontalScrolling`
 - `true`: SCM tree scrolls (horizontally) regardless of value of `workbench.tree.horizontalScrolling`
 - `false`: SCM tree does not scroll (horizontally) regardless of value of `workbench.tree.horizontalScrolling`

`inherit` is default value for `workbench.tree.horizontalScrollingSCM`

Sample `settings.json` file:
```json
{
	"workbench.tree.horizontalScrolling": true,
	"workbench.tree.horizontalScrollingSCM": "inherit"
}
```