### PR TITLE
Hide simpleFind with visibility to remove from tab order.  Fixes: #67563

### DIFF
--- a/src/vs/editor/contrib/find/simpleFindWidget.css
+++ b/src/vs/editor/contrib/find/simpleFindWidget.css
@@ -16,6 +16,7 @@
 }
 
 .monaco-workbench .simple-find-part {
+	visibility: hidden;		/* Use visibility to maintain flex layout while hidden otherwise interferes with transition */
 	z-index: 10;
 	position: relative;
 	top: -45px;
@@ -27,6 +28,10 @@
 }
 
 .monaco-workbench .simple-find-part.visible {
+	visibility: visible;
+}
+
+.monaco-workbench .simple-find-part.visible-transition {
 	top: 0;
 }
 

--- a/src/vs/editor/contrib/find/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/simpleFindWidget.ts
@@ -228,11 +228,11 @@ export abstract class SimpleFindWidget extends Widget {
 
 	public hide(): void {
 		if (this._isVisible) {
-			this._isVisible = false;
 			dom.removeClass(this._innerDomNode, 'visible-transition');
 			this._innerDomNode.setAttribute('aria-hidden', 'true');
 			// Need to delay toggling visibility until after Transition, then visibility hidden - removes from tabIndex list
 			setTimeout(() => {
+				this._isVisible = false;
 				dom.removeClass(this._innerDomNode, 'visible');
 			}, 200);
 		}

--- a/src/vs/editor/contrib/find/simpleFindWidget.ts
+++ b/src/vs/editor/contrib/find/simpleFindWidget.ts
@@ -204,6 +204,7 @@ export abstract class SimpleFindWidget extends Widget {
 
 		setTimeout(() => {
 			dom.addClass(this._innerDomNode, 'visible');
+			dom.addClass(this._innerDomNode, 'visible-transition');
 			this._innerDomNode.setAttribute('aria-hidden', 'false');
 			setTimeout(() => {
 				this._findInput.select();
@@ -220,6 +221,7 @@ export abstract class SimpleFindWidget extends Widget {
 
 		setTimeout(() => {
 			dom.addClass(this._innerDomNode, 'visible');
+			dom.addClass(this._innerDomNode, 'visible-transition');
 			this._innerDomNode.setAttribute('aria-hidden', 'false');
 		}, 0);
 	}
@@ -227,9 +229,12 @@ export abstract class SimpleFindWidget extends Widget {
 	public hide(): void {
 		if (this._isVisible) {
 			this._isVisible = false;
-
-			dom.removeClass(this._innerDomNode, 'visible');
+			dom.removeClass(this._innerDomNode, 'visible-transition');
 			this._innerDomNode.setAttribute('aria-hidden', 'true');
+			// Need to delay toggling visibility until after Transition, then visibility hidden - removes from tabIndex list
+			setTimeout(() => {
+				dom.removeClass(this._innerDomNode, 'visible');
+			}, 200);
 		}
 	}
 


### PR DESCRIPTION
Fixes: #67563

@Tyriar 
@mjbvz 

simpleFind widget uses a vertical transition to show and hide itself.  It was visually hidden with active
tabIndexes since display: flex is used and the layout is lost if display: none is used.  The layout
does not like to be changed with the simultaneous transition apparently.  Hence simple solution display: none
toggled with .visible doesn't cut it.

Solution:

- Separate visibility from transition classes
- Use visibility: visible/hidden - maintains flex layout and does not interfere with transition
- For  hide() toggle visible.transition class , delay 200ms then toggle visibility

See issue #67563 four verification (easiest to use NVDA or voiceover readers with screen output on
to track focus even for the hidden states)
