### PR TITLE
Fix #68464 - bump node2

### DIFF
--- a/build/builtInExtensions.json
+++ b/build/builtInExtensions.json
@@ -16,7 +16,7 @@
 	},
 	{
 		"name": "ms-vscode.node-debug2",
-		"version": "1.31.5",
+		"version": "1.31.6",
 		"repo": "https://github.com/Microsoft/vscode-node-debug2",
 		"metadata": {
 			"id": "36d19e17-7569-4841-a001-947eb18602b2",


### PR DESCRIPTION
Actual change: https://github.com/Microsoft/vscode-chrome-debug-core/commit/6dcf2ffe9fc092ccc9c5db610818634537e2878f