### PR TITLE
#68074: Only add padding to inputBox if find options are enabled in findInput

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -358,6 +358,10 @@ export class FindInput extends Widget {
 			this._onCaseSensitiveKeyDown.fire(e);
 		}));
 
+		if (this._showOptionButtons) {
+			this.inputBox.inputElement.style.paddingRight = (this.caseSensitive.width() + this.wholeWords.width() + this.regex.width()) + 'px';
+		}
+
 		// Arrow-Key support to navigate between options
 		let indexes = [this.caseSensitive.domNode, this.wholeWords.domNode, this.regex.domNode];
 		this.onkeydown(this.domNode, (event: IKeyboardEvent) => {

--- a/src/vs/editor/contrib/find/findWidget.css
+++ b/src/vs/editor/contrib/find/findWidget.css
@@ -81,7 +81,6 @@
 
 .monaco-editor .find-widget > .find-part .monaco-inputbox > .wrapper > .input {
 	width: 100% !important;
-	padding-right: 66px;
 }
 .monaco-editor .find-widget > .find-part .monaco-inputbox > .wrapper > .input,
 .monaco-editor .find-widget > .replace-part .monaco-inputbox > .wrapper > .input {

--- a/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.css
+++ b/src/vs/workbench/contrib/terminal/browser/terminalFindWidget.css
@@ -5,5 +5,4 @@
 
 .monaco-workbench .simple-find-part .monaco-inputbox > .wrapper > .input {
 	width: 100% !important;
-	padding-right: 66px;
 }


### PR DESCRIPTION
This PR removes the (unneeded) padding from the `findWidget` input when there are no find options.

Fixes #68074 
@mjbvz My apologies for the bad explanation in the issue. Hopefully this clears up any confusion.