### PR TITLE
Fix clicking on webviews does not dismiss custom title bar menu

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -150,11 +150,9 @@ export class MenuBar extends Disposable {
 		this._register(DOM.addDisposableListener(this.container, DOM.EventType.FOCUS_OUT, (e) => {
 			let event = e as FocusEvent;
 
-			if (event.relatedTarget) {
-				if (!this.container.contains(event.relatedTarget as HTMLElement)) {
-					this.focusToReturn = undefined;
-					this.setUnfocusedState();
-				}
+			if (!event.relatedTarget || !this.container.contains(event.relatedTarget as HTMLElement)) {
+				this.focusToReturn = undefined;
+				this.setUnfocusedState();
 			}
 		}));
 


### PR DESCRIPTION
Fixes #68313

When clicking into a webview, the `relatedTarget` property of the corresponding blur event  fired is `undefined`. This fix makes it so that an empty `relatedTarget` also dismisses menus