### PR TITLE
Propagate context information on CopyValueAction evaluate requests

### DIFF
--- a/src/vs/workbench/contrib/debug/electron-browser/electronDebugActions.ts
+++ b/src/vs/workbench/contrib/debug/electron-browser/electronDebugActions.ts
@@ -13,9 +13,11 @@ import { isWindows } from 'vs/base/common/platform';
 export class CopyValueAction extends Action {
 	static readonly ID = 'workbench.debug.viewlet.action.copyValue';
 	static LABEL = nls.localize('copyValue', "Copy Value");
+	private context: string;
 
-	constructor(id: string, label: string, private value: any, @IDebugService private readonly debugService: IDebugService) {
+	constructor(id: string, label: string, private value: any, @IDebugService private readonly debugService: IDebugService, context?: string) {
 		super(id, label, 'debug-action copy-value');
+		this.context = context;
 		this._enabled = typeof this.value === 'string' || (this.value instanceof Variable && !!this.value.evaluateName);
 	}
 
@@ -23,7 +25,7 @@ export class CopyValueAction extends Action {
 		if (this.value instanceof Variable) {
 			const frameId = this.debugService.getViewModel().focusedStackFrame.frameId;
 			const session = this.debugService.getViewModel().focusedSession;
-			return session.evaluate(this.value.evaluateName, frameId).then(result => {
+			return session.evaluate(this.value.evaluateName, frameId, this.context).then(result => {
 				clipboard.writeText(result.body.result);
 			}, err => clipboard.writeText(this.value.value));
 		}

--- a/src/vs/workbench/contrib/debug/electron-browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/electron-browser/variablesView.ts
@@ -138,9 +138,9 @@ export class VariablesView extends ViewletPanel {
 		const element = e.element;
 		if (element instanceof Variable && !!element.value) {
 			const actions: IAction[] = [];
-			const variable = <Variable>element;
+			const variable = element as Variable;
 			actions.push(new SetValueAction(SetValueAction.ID, SetValueAction.LABEL, variable, this.debugService, this.keybindingService));
-			actions.push(new CopyValueAction(CopyValueAction.ID, CopyValueAction.LABEL, variable, this.debugService));
+			actions.push(new CopyValueAction(CopyValueAction.ID, CopyValueAction.LABEL, variable, this.debugService, 'variables'));
 			actions.push(new CopyEvaluatePathAction(CopyEvaluatePathAction.ID, CopyEvaluatePathAction.LABEL, variable));
 			actions.push(new Separator());
 			actions.push(new AddToWatchExpressionsAction(AddToWatchExpressionsAction.ID, AddToWatchExpressionsAction.LABEL, variable, this.debugService, this.keybindingService));

--- a/src/vs/workbench/contrib/debug/electron-browser/watchExpressionsView.ts
+++ b/src/vs/workbench/contrib/debug/electron-browser/watchExpressionsView.ts
@@ -148,7 +148,7 @@ export class WatchExpressionsView extends ViewletPanel {
 			actions.push(new AddWatchExpressionAction(AddWatchExpressionAction.ID, AddWatchExpressionAction.LABEL, this.debugService, this.keybindingService));
 			actions.push(new EditWatchExpressionAction(EditWatchExpressionAction.ID, EditWatchExpressionAction.LABEL, this.debugService, this.keybindingService));
 			if (!expression.hasChildren) {
-				actions.push(new CopyValueAction(CopyValueAction.ID, CopyValueAction.LABEL, expression.value, this.debugService));
+				actions.push(new CopyValueAction(CopyValueAction.ID, CopyValueAction.LABEL, expression.value, this.debugService, 'watch'));
 			}
 			actions.push(new Separator());
 
@@ -157,9 +157,9 @@ export class WatchExpressionsView extends ViewletPanel {
 		} else {
 			actions.push(new AddWatchExpressionAction(AddWatchExpressionAction.ID, AddWatchExpressionAction.LABEL, this.debugService, this.keybindingService));
 			if (element instanceof Variable) {
-				const variable = <Variable>element;
+				const variable = element as Variable;
 				if (!variable.hasChildren) {
-					actions.push(new CopyValueAction(CopyValueAction.ID, CopyValueAction.LABEL, variable, this.debugService));
+					actions.push(new CopyValueAction(CopyValueAction.ID, CopyValueAction.LABEL, variable, this.debugService, 'watch'));
 				}
 				actions.push(new Separator());
 			}


### PR DESCRIPTION
This PR adds support for context values on the CopyValueActions requests made to the debug adapter

Per the [debug protocol API](https://github.com/Microsoft/vscode/blob/b5ff5a17fd22e273aa989b1697d40492d6bc244d/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts#L957-L973), a context parameter is supported to give additional information to the adapter implementation about the caller

Such capability is required for some features in extensions' debuggers, as discussed in https://github.com/Microsoft/vscode-go/issues/2205