### PR TITLE
Adopt path.normalize()

### DIFF
--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -12,81 +12,6 @@ function isPathSeparator(code: number) {
 	return code === CharCode.Slash || code === CharCode.Backslash;
 }
 
-const _posixBadPath = /(\/\.\.?\/)|(\/\.\.?)$|^(\.\.?\/)|(\/\/+)|(\\)/;
-const _winBadPath = /(\\\.\.?\\)|(\\\.\.?)$|^(\.\.?\\)|(\\\\+)|(\/)/;
-
-function _isNormal(path: string, win: boolean): boolean {
-	return win
-		? !_winBadPath.test(path)
-		: !_posixBadPath.test(path);
-}
-
-export function normalize(path: undefined, toOSPath?: boolean): undefined;
-export function normalize(path: null, toOSPath?: boolean): null;
-export function normalize(path: string, toOSPath?: boolean): string;
-export function normalize(path: string | null | undefined, toOSPath?: boolean): string | null | undefined {
-
-	if (path === null || path === undefined) {
-		return path;
-	}
-
-	const len = path.length;
-	if (len === 0) {
-		return '.';
-	}
-
-	const wantsBackslash = !!(isWindows && toOSPath);
-	if (_isNormal(path, wantsBackslash)) {
-		return path;
-	}
-
-	const sep = wantsBackslash ? '\\' : '/';
-	const root = getRoot(path, sep);
-
-	// skip the root-portion of the path
-	let start = root.length;
-	let skip = false;
-	let res = '';
-
-	for (let end = root.length; end <= len; end++) {
-
-		// either at the end or at a path-separator character
-		if (end === len || isPathSeparator(path.charCodeAt(end))) {
-
-			if (streql(path, start, end, '..')) {
-				// skip current and remove parent (if there is already something)
-				let prev_start = res.lastIndexOf(sep);
-				let prev_part = res.slice(prev_start + 1);
-				if ((root || prev_part.length > 0) && prev_part !== '..') {
-					res = prev_start === -1 ? '' : res.slice(0, prev_start);
-					skip = true;
-				}
-			} else if (streql(path, start, end, '.') && (root || res || end < len - 1)) {
-				// skip current (if there is already something or if there is more to come)
-				skip = true;
-			}
-
-			if (!skip) {
-				let part = path.slice(start, end);
-				if (res !== '' && res[res.length - 1] !== sep) {
-					res += sep;
-				}
-				res += part;
-			}
-			start = end + 1;
-			skip = false;
-		}
-	}
-
-	return root + res;
-}
-
-function streql(value: string, start: number, end: number, other: string): boolean {
-	return start + other.length === end && value.indexOf(other, start) === start;
-}
-
-// #region extpath
-
 /**
  * Computes the _root_ this path, like `getRoot('c:\files') === c:\`,
  * `getRoot('files:///files/path') === files:///`,
@@ -290,5 +215,3 @@ export function isEqualOrParent(path: string, candidate: string, ignoreCase?: bo
 export function isWindowsDriveLetter(char0: number): boolean {
 	return char0 >= CharCode.A && char0 <= CharCode.Z || char0 >= CharCode.a && char0 <= CharCode.z;
 }
-
-// #endregion

--- a/src/vs/base/common/labels.ts
+++ b/src/vs/base/common/labels.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
-import { normalize } from 'vs/base/common/extpath';
-import { sep, posix } from 'vs/base/common/path';
+import { sep, posix, normalize } from 'vs/base/common/path';
 import { endsWith, ltrim, startsWithIgnoreCase, rtrim, startsWith } from 'vs/base/common/strings';
 import { Schemas } from 'vs/base/common/network';
 import { isLinux, isWindows, isMacintosh } from 'vs/base/common/platform';
@@ -40,7 +39,7 @@ export function getPathLabel(resource: URI | string, userHomeProvider?: IUserHom
 			if (isEqual(baseResource.uri, resource, !isLinux)) {
 				pathLabel = ''; // no label if paths are identical
 			} else {
-				pathLabel = normalize(ltrim(resource.path.substr(baseResource.uri.path.length), posix.sep)!, true);
+				pathLabel = normalize(ltrim(resource.path.substr(baseResource.uri.path.length), posix.sep)!);
 			}
 
 			if (hasMultipleRoots) {
@@ -59,11 +58,11 @@ export function getPathLabel(resource: URI | string, userHomeProvider?: IUserHom
 
 	// convert c:\something => C:\something
 	if (hasDriveLetter(resource.fsPath)) {
-		return normalize(normalizeDriveLetter(resource.fsPath), true);
+		return normalize(normalizeDriveLetter(resource.fsPath));
 	}
 
 	// normalize and tildify (macOS, Linux only)
-	let res = normalize(resource.fsPath, true);
+	let res = normalize(resource.fsPath);
 	if (!isWindows && userHomeProvider) {
 		res = tildify(res, userHomeProvider.userHome);
 	}

--- a/src/vs/base/test/common/extpath.test.ts
+++ b/src/vs/base/test/common/extpath.test.ts
@@ -8,51 +8,7 @@ import * as platform from 'vs/base/common/platform';
 
 suite('Paths', () => {
 
-	test('normalize', () => {
-		assert.equal(extpath.normalize(''), '.');
-		assert.equal(extpath.normalize('.'), '.');
-		assert.equal(extpath.normalize('.'), '.');
-		assert.equal(extpath.normalize('../../far'), '../../far');
-		assert.equal(extpath.normalize('../bar'), '../bar');
-		assert.equal(extpath.normalize('../far'), '../far');
-		assert.equal(extpath.normalize('./'), './');
-		assert.equal(extpath.normalize('./././'), './');
-		assert.equal(extpath.normalize('./ff/./'), 'ff/');
-		assert.equal(extpath.normalize('./foo'), 'foo');
-		assert.equal(extpath.normalize('/'), '/');
-		assert.equal(extpath.normalize('/..'), '/');
-		assert.equal(extpath.normalize('///'), '/');
-		assert.equal(extpath.normalize('//foo'), '/foo');
-		assert.equal(extpath.normalize('//foo//'), '/foo/');
-		assert.equal(extpath.normalize('/foo'), '/foo');
-		assert.equal(extpath.normalize('/foo/bar.test'), '/foo/bar.test');
-		assert.equal(extpath.normalize('\\\\\\'), '/');
-		assert.equal(extpath.normalize('c:/../ff'), 'c:/ff');
-		assert.equal(extpath.normalize('c:\\./'), 'c:/');
-		assert.equal(extpath.normalize('foo/'), 'foo/');
-		assert.equal(extpath.normalize('foo/../../bar'), '../bar');
-		assert.equal(extpath.normalize('foo/./'), 'foo/');
-		assert.equal(extpath.normalize('foo/./bar'), 'foo/bar');
-		assert.equal(extpath.normalize('foo//'), 'foo/');
-		assert.equal(extpath.normalize('foo//'), 'foo/');
-		assert.equal(extpath.normalize('foo//bar'), 'foo/bar');
-		assert.equal(extpath.normalize('foo//bar/far'), 'foo/bar/far');
-		assert.equal(extpath.normalize('foo/bar/../../far'), 'far');
-		assert.equal(extpath.normalize('foo/bar/../far'), 'foo/far');
-		assert.equal(extpath.normalize('foo/far/../../bar'), 'bar');
-		assert.equal(extpath.normalize('foo/far/../../bar'), 'bar');
-		assert.equal(extpath.normalize('foo/xxx/..'), 'foo');
-		assert.equal(extpath.normalize('foo/xxx/../bar'), 'foo/bar');
-		assert.equal(extpath.normalize('foo/xxx/./..'), 'foo');
-		assert.equal(extpath.normalize('foo/xxx/./../bar'), 'foo/bar');
-		assert.equal(extpath.normalize('foo/xxx/./bar'), 'foo/xxx/bar');
-		assert.equal(extpath.normalize('foo\\bar'), 'foo/bar');
-		assert.equal(extpath.normalize(null), null);
-		assert.equal(extpath.normalize(undefined), undefined);
-	});
-
 	test('getRootLength', () => {
-
 		assert.equal(extpath.getRoot('/user/far'), '/');
 		assert.equal(extpath.getRoot('\\\\server\\share\\some\\path'), '//server/share/');
 		assert.equal(extpath.getRoot('//server/share/some/path'), '//server/share/');
@@ -65,7 +21,6 @@ suite('Paths', () => {
 		assert.equal(extpath.getRoot('http://www/'), 'http://www/');
 		assert.equal(extpath.getRoot('file:///foo'), 'file:///');
 		assert.equal(extpath.getRoot('file://foo'), '');
-
 	});
 
 	test('isUNC', () => {

--- a/src/vs/base/test/common/path.test.ts
+++ b/src/vs/base/test/common/path.test.ts
@@ -719,6 +719,87 @@ suite('Paths (Node Implementation)', () => {
 			'../../../../baz'
 		);
 		assert.strictEqual(path.posix.normalize('foo/bar\\baz'), 'foo/bar\\baz');
+
+		// Tests from VSCode
+		assert.equal(path.posix.normalize(''), '.');
+		assert.equal(path.posix.normalize('.'), '.');
+		assert.equal(path.posix.normalize('.'), '.');
+
+		assert.equal(path.win32.normalize(''), '.');
+		assert.equal(path.win32.normalize('.'), '.');
+		assert.equal(path.win32.normalize('.'), '.');
+
+
+		assert.equal(path.posix.normalize('../../far'), '../../far');
+		assert.equal(path.posix.normalize('../bar'), '../bar');
+		assert.equal(path.posix.normalize('../far'), '../far');
+		assert.equal(path.posix.normalize('./'), './');
+		assert.equal(path.posix.normalize('./././'), './');
+		assert.equal(path.posix.normalize('./ff/./'), 'ff/');
+		assert.equal(path.posix.normalize('./foo'), 'foo');
+		assert.equal(path.posix.normalize('/'), '/');
+		assert.equal(path.posix.normalize('/..'), '/');
+		assert.equal(path.posix.normalize('///'), '/');
+		assert.equal(path.posix.normalize('//foo'), '/foo');
+		assert.equal(path.posix.normalize('//foo//'), '/foo/');
+		assert.equal(path.posix.normalize('/foo'), '/foo');
+		assert.equal(path.posix.normalize('/foo/bar.test'), '/foo/bar.test');
+
+		assert.equal(path.win32.normalize('..\\..\\far'), '..\\..\\far');
+		assert.equal(path.win32.normalize('..\\bar'), '..\\bar');
+		assert.equal(path.win32.normalize('..\\far'), '..\\far');
+		assert.equal(path.win32.normalize('.\\'), '.\\');
+		assert.equal(path.win32.normalize('.\\.\\.\\'), '.\\');
+		assert.equal(path.win32.normalize('.\\ff\\.\\'), 'ff\\');
+		assert.equal(path.win32.normalize('.\\foo'), 'foo');
+		assert.equal(path.win32.normalize('\\'), '\\');
+		assert.equal(path.win32.normalize('\\..'), '\\');
+		assert.equal(path.win32.normalize('\\'), '\\');
+		assert.equal(path.win32.normalize('\\foo'), '\\foo');
+		assert.equal(path.win32.normalize('\\foo\\'), '\\foo\\');
+		assert.equal(path.win32.normalize('\\foo'), '\\foo');
+		assert.equal(path.win32.normalize('\\foo\\bar.test'), '\\foo\\bar.test');
+
+		assert.equal(path.posix.normalize('\\\\\\'), '\\\\\\');
+
+		assert.equal(path.win32.normalize('c:/../ff'), 'c:\\ff');
+		assert.equal(path.win32.normalize('c:\\./'), 'c:\\');
+
+		assert.equal(path.posix.normalize('foo/'), 'foo/');
+		assert.equal(path.posix.normalize('foo/../../bar'), '../bar');
+		assert.equal(path.posix.normalize('foo/./'), 'foo/');
+		assert.equal(path.posix.normalize('foo/./bar'), 'foo/bar');
+		assert.equal(path.posix.normalize('foo//'), 'foo/');
+		assert.equal(path.posix.normalize('foo//'), 'foo/');
+		assert.equal(path.posix.normalize('foo//bar'), 'foo/bar');
+		assert.equal(path.posix.normalize('foo//bar/far'), 'foo/bar/far');
+		assert.equal(path.posix.normalize('foo/bar/../../far'), 'far');
+		assert.equal(path.posix.normalize('foo/bar/../far'), 'foo/far');
+		assert.equal(path.posix.normalize('foo/far/../../bar'), 'bar');
+		assert.equal(path.posix.normalize('foo/far/../../bar'), 'bar');
+		assert.equal(path.posix.normalize('foo/xxx/..'), 'foo');
+		assert.equal(path.posix.normalize('foo/xxx/../bar'), 'foo/bar');
+		assert.equal(path.posix.normalize('foo/xxx/./..'), 'foo');
+		assert.equal(path.posix.normalize('foo/xxx/./../bar'), 'foo/bar');
+		assert.equal(path.posix.normalize('foo/xxx/./bar'), 'foo/xxx/bar');
+
+		assert.equal(path.win32.normalize('foo\\'), 'foo\\');
+		assert.equal(path.win32.normalize('foo\\..\\..\\bar'), '..\\bar');
+		assert.equal(path.win32.normalize('foo\\.\\'), 'foo\\');
+		assert.equal(path.win32.normalize('foo\\.\\bar'), 'foo\\bar');
+		assert.equal(path.win32.normalize('foo\\\\'), 'foo\\');
+		assert.equal(path.win32.normalize('foo\\\\'), 'foo\\');
+		assert.equal(path.win32.normalize('foo\\\\bar'), 'foo\\bar');
+		assert.equal(path.win32.normalize('foo\\\\bar\\far'), 'foo\\bar\\far');
+		assert.equal(path.win32.normalize('foo\\bar\\..\\..\\far'), 'far');
+		assert.equal(path.win32.normalize('foo\\bar\\..\\far'), 'foo\\far');
+		assert.equal(path.win32.normalize('foo\\far\\..\\..\\bar'), 'bar');
+		assert.equal(path.win32.normalize('foo\\far\\..\\..\\bar'), 'bar');
+		assert.equal(path.win32.normalize('foo\\xxx\\..'), 'foo');
+		assert.equal(path.win32.normalize('foo\\xxx\\..\\bar'), 'foo\\bar');
+		assert.equal(path.win32.normalize('foo\\xxx\\.\\..'), 'foo');
+		assert.equal(path.win32.normalize('foo\\xxx\\.\\..\\bar'), 'foo\\bar');
+		assert.equal(path.win32.normalize('foo\\xxx\\.\\bar'), 'foo\\xxx\\bar');
 	});
 
 	test('isAbsolute', () => {

--- a/src/vs/base/test/common/uri.test.ts
+++ b/src/vs/base/test/common/uri.test.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import { URI } from 'vs/base/common/uri';
-import { normalize } from 'vs/base/common/extpath';
+import { normalize } from 'vs/base/common/path';
 import { isWindows } from 'vs/base/common/platform';
-
 
 suite('URI', () => {
 	test('file#toString', () => {
@@ -141,7 +140,7 @@ suite('URI', () => {
 		assert.equal(value.scheme, 'http');
 		assert.equal(value.authority, 'api');
 		assert.equal(value.path, '/files/test.me');
-		assert.equal(value.fsPath, normalize('/files/test.me', true));
+		assert.equal(value.fsPath, normalize('/files/test.me'));
 		assert.equal(value.query, 't=1234');
 		assert.equal(value.fragment, '');
 
@@ -151,7 +150,7 @@ suite('URI', () => {
 		assert.equal(value.path, '/c:/test/me');
 		assert.equal(value.fragment, '');
 		assert.equal(value.query, '');
-		assert.equal(value.fsPath, normalize('c:/test/me', true));
+		assert.equal(value.fsPath, normalize('c:/test/me'));
 
 		value = URI.parse('file://shares/files/c%23/p.cs');
 		assert.equal(value.scheme, 'file');
@@ -159,7 +158,7 @@ suite('URI', () => {
 		assert.equal(value.path, '/files/c#/p.cs');
 		assert.equal(value.fragment, '');
 		assert.equal(value.query, '');
-		assert.equal(value.fsPath, normalize('//shares/files/c#/p.cs', true));
+		assert.equal(value.fsPath, normalize('//shares/files/c#/p.cs'));
 
 		value = URI.parse('file:///c:/Source/Z%C3%BCrich%20or%20Zurich%20(%CB%88zj%CA%8A%C9%99r%C9%AAk,/Code/resources/app/plugins/c%23/plugin.json');
 		assert.equal(value.scheme, 'file');
@@ -360,7 +359,7 @@ suite('URI', () => {
 	test('correctFileUriToFilePath2', () => {
 
 		const test = (input: string, expected: string) => {
-			expected = normalize(expected, true);
+			expected = normalize(expected);
 			const value = URI.parse(input);
 			assert.equal(value.fsPath, expected, 'Result for ' + input);
 			const value2 = URI.file(value.fsPath);

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -8,7 +8,7 @@ import { localize } from 'vs/nls';
 import { Event } from 'vs/base/common/event';
 import { IWorkspaceFolder, IWorkspace } from 'vs/platform/workspace/common/workspace';
 import { URI, UriComponents } from 'vs/base/common/uri';
-import { isEqualOrParent, normalize } from 'vs/base/common/extpath';
+import { isEqualOrParent } from 'vs/base/common/extpath';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
 import { isAbsolute, relative, posix, resolve, extname } from 'vs/base/common/path';
 import { normalizeDriveLetter } from 'vs/base/common/labels';
@@ -179,7 +179,7 @@ export function massageFolderPathForWorkspace(absoluteFolderPath: string, target
 		if (isWindows) {
 			if (isAbsolute(absoluteFolderPath)) {
 				if (shouldUseSlashForPath(existingFolders)) {
-					absoluteFolderPath = normalize(absoluteFolderPath, false /* do not use OS path separator */);
+					absoluteFolderPath = posix.normalize(absoluteFolderPath); // do not use OS path separator;
 				}
 
 				absoluteFolderPath = normalizeDriveLetter(absoluteFolderPath);

--- a/src/vs/platform/workspaces/common/workspaces.ts
+++ b/src/vs/platform/workspaces/common/workspaces.ts
@@ -179,7 +179,7 @@ export function massageFolderPathForWorkspace(absoluteFolderPath: string, target
 		if (isWindows) {
 			if (isAbsolute(absoluteFolderPath)) {
 				if (shouldUseSlashForPath(existingFolders)) {
-					absoluteFolderPath = posix.normalize(absoluteFolderPath); // do not use OS path separator;
+					absoluteFolderPath = posix.normalize(absoluteFolderPath); // do not use OS path separator
 				}
 
 				absoluteFolderPath = normalizeDriveLetter(absoluteFolderPath);
@@ -189,7 +189,7 @@ export function massageFolderPathForWorkspace(absoluteFolderPath: string, target
 		}
 	} else {
 		if (isEqualOrParent(absoluteFolderPath, targetConfigFolderURI.path)) {
-			absoluteFolderPath = posix.relative(absoluteFolderPath, targetConfigFolderURI.path) || '.';
+			absoluteFolderPath = relative(absoluteFolderPath, targetConfigFolderURI.path) || '.';
 		}
 	}
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -8,7 +8,7 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import * as errors from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { TernarySearchTree } from 'vs/base/common/map';
-import * as extpath from 'vs/base/common/extpath';
+import * as path from 'vs/base/common/path';
 import * as platform from 'vs/base/common/platform';
 import Severity from 'vs/base/common/severity';
 import { URI } from 'vs/base/common/uri';
@@ -857,7 +857,7 @@ class Extension<T> implements vscode.Extension<T> {
 		this._extensionService = extensionService;
 		this._identifier = description.identifier;
 		this.id = description.identifier.value;
-		this.extensionPath = extpath.normalize(originalFSPath(description.extensionLocation), true);
+		this.extensionPath = path.normalize(originalFSPath(description.extensionLocation));
 		this.packageJSON = description;
 	}
 

--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as extpath from 'vs/base/common/extpath';
+import * as path from 'vs/base/common/path';
 import { Schemas } from 'vs/base/common/network';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -881,7 +881,7 @@ export class ExtHostVariableResolverService extends AbstractVariableResolverServ
 				if (activeEditor) {
 					const resource = activeEditor.document.uri;
 					if (resource.scheme === Schemas.file) {
-						return extpath.normalize(resource.fsPath, true);
+						return path.normalize(resource.fsPath);
 					}
 				}
 				return undefined;

--- a/src/vs/workbench/api/node/extHostWorkspace.ts
+++ b/src/vs/workbench/api/node/extHostWorkspace.ts
@@ -3,13 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { join, relative } from 'vs/base/common/path';
+import { join, relative, normalize } from 'vs/base/common/path';
 import { delta as arrayDelta, mapArrayOrNot } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter, Event } from 'vs/base/common/event';
 import { TernarySearchTree } from 'vs/base/common/map';
 import { Counter } from 'vs/base/common/numbers';
-import { normalize } from 'vs/base/common/extpath';
 import { isLinux } from 'vs/base/common/platform';
 import { basenameOrAuthority, dirname, isEqual } from 'vs/base/common/resources';
 import { compare } from 'vs/base/common/strings';
@@ -354,7 +353,7 @@ export class ExtHostWorkspaceProvider {
 		if (includeWorkspace) {
 			result = `${folder.name}/${result}`;
 		}
-		return normalize(result, true);
+		return normalize(result);
 	}
 
 	private trySetWorkspaceFolders(folders: vscode.WorkspaceFolder[]): void {

--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { hasWorkspaceFileExtension, IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
-import { normalize } from 'vs/base/common/extpath';
+import { normalize } from 'vs/base/common/path';
 import { basename, basenameOrAuthority } from 'vs/base/common/resources';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWindowsService, IWindowService, IURIToOpen } from 'vs/platform/windows/common/windows';
@@ -368,7 +368,7 @@ export function fillResourceDataTransfers(accessor: ServicesAccessor, resources:
 
 	// Text: allows to paste into text-capable areas
 	const lineDelimiter = isWindows ? '\r\n' : '\n';
-	event.dataTransfer.setData(DataTransfers.TEXT, sources.map(source => source.resource.scheme === Schemas.file ? normalize(normalizeDriveLetter(source.resource.fsPath), true) : source.resource.toString()).join(lineDelimiter));
+	event.dataTransfer.setData(DataTransfers.TEXT, sources.map(source => source.resource.scheme === Schemas.file ? normalize(normalizeDriveLetter(source.resource.fsPath)) : source.resource.toString()).join(lineDelimiter));
 
 	// Download URL: enables support to drag a tab as file to desktop (only single file supported)
 	if (firstSource.resource.scheme === Schemas.file) {

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsPicker.ts
@@ -11,8 +11,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { createMatches, FuzzyScore } from 'vs/base/common/filters';
 import * as glob from 'vs/base/common/glob';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
-import { posix } from 'vs/base/common/path';
-import { basename, dirname, isEqual } from 'vs/base/common/resources';
+import { basename, dirname, isEqual, joinPath } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./media/breadcrumbscontrol';
 import { OutlineElement, OutlineModel, TreeElement } from 'vs/editor/contrib/documentSymbols/outlineModel';
@@ -299,7 +298,7 @@ class FileFilter implements ITreeFilter<IWorkspaceFolder | IFileStat> {
 						continue;
 					}
 					let patternAbs = pattern.indexOf('**/') !== 0
-						? posix.join(folder.uri.path, pattern)
+						? joinPath(folder.uri, pattern).path
 						: pattern;
 
 					adjustedConfig[patternAbs] = excludesConfig[pattern];

--- a/src/vs/workbench/common/resources.ts
+++ b/src/vs/workbench/common/resources.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
-import * as extpath from 'vs/base/common/extpath';
 import * as objects from 'vs/base/common/objects';
 import { Event, Emitter } from 'vs/base/common/event';
-import { relative } from 'vs/base/common/path';
+import { posix, relative } from 'vs/base/common/path';
 import { basename, extname } from 'vs/base/common/resources';
 import { RawContextKey, IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IModeService } from 'vs/editor/common/services/modeService';
@@ -197,7 +196,7 @@ export class ResourceGlobMatcher extends Disposable {
 		// but can match on "src/file.txt"
 		let resourcePathToMatch: string;
 		if (folder) {
-			resourcePathToMatch = extpath.normalize(relative(folder.uri.fsPath, resource.fsPath));
+			resourcePathToMatch = posix.normalize(relative(folder.uri.fsPath, resource.fsPath));
 		} else {
 			resourcePathToMatch = resource.fsPath;
 		}

--- a/src/vs/workbench/contrib/debug/test/common/debugSource.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugSource.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { URI as uri } from 'vs/base/common/uri';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
-import { normalize } from 'vs/base/common/extpath';
+import { normalize } from 'vs/base/common/path';
 
 suite('Debug - Source', () => {
 
@@ -48,8 +48,8 @@ suite('Debug - Source', () => {
 			assert.equal(sessionId, expectedSessionId);
 		};
 
-		checkData(uri.file('a/b/c/d'), 'd', normalize('/a/b/c/d', true), undefined, undefined);
-		checkData(uri.from({ scheme: 'file', path: '/my/path/test.js', query: 'ref=1&session=2' }), 'test.js', normalize('/my/path/test.js', true), undefined, undefined);
+		checkData(uri.file('a/b/c/d'), 'd', normalize('/a/b/c/d'), undefined, undefined);
+		checkData(uri.from({ scheme: 'file', path: '/my/path/test.js', query: 'ref=1&session=2' }), 'test.js', normalize('/my/path/test.js'), undefined, undefined);
 
 		checkData(uri.from({ scheme: 'http', authority: 'www.msft.com', path: '/my/path' }), 'path', 'http://www.msft.com/my/path', undefined, undefined);
 		checkData(uri.from({ scheme: 'debug', authority: 'www.msft.com', path: '/my/path', query: 'ref=100' }), 'path', '/my/path', 100, undefined);

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -14,6 +14,9 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { IExtensionManifest, ExtensionType } from 'vs/platform/extensions/common/extensions';
+import { posix } from 'vs/base/common/path';
+
+export const EXTENSIONS_JSON_PATH = posix.join('.vscode', 'extensions.json');
 
 export const VIEWLET_ID = 'workbench.view.extensions';
 export const VIEW_CONTAINER: ViewContainer = Registry.as<IViewContainersRegistry>(ViewContainerExtensions.ViewContainersRegistry).registerViewContainer(VIEWLET_ID);

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { join, posix } from 'vs/base/common/path';
+import { join } from 'vs/base/common/path';
 import { forEach } from 'vs/base/common/collections';
 import { IDisposable, dispose, Disposable } from 'vs/base/common/lifecycle';
 import { match } from 'vs/base/common/glob';
@@ -22,7 +22,7 @@ import { ShowRecommendedExtensionsAction, InstallWorkspaceRecommendedExtensionsA
 import Severity from 'vs/base/common/severity';
 import { IWorkspaceContextService, IWorkspaceFolder, IWorkspace, IWorkspaceFoldersChangeEvent, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IFileService } from 'vs/platform/files/common/files';
-import { IExtensionsConfiguration, ConfigurationKey, ShowRecommendationsOnlyOnDemandKey, IExtensionsViewlet, IExtensionsWorkbenchService } from 'vs/workbench/contrib/extensions/common/extensions';
+import { IExtensionsConfiguration, ConfigurationKey, ShowRecommendationsOnlyOnDemandKey, IExtensionsViewlet, IExtensionsWorkbenchService, EXTENSIONS_JSON_PATH } from 'vs/workbench/contrib/extensions/common/extensions';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import * as pfs from 'vs/base/node/pfs';
@@ -334,7 +334,7 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 	 * Parse the extensions.json files for given workspace folder and return the recommendations
 	 */
 	private resolveWorkspaceFolderExtensionConfig(workspaceFolder: IWorkspaceFolder): Promise<IExtensionsConfigContent | null> {
-		const extensionsJsonUri = workspaceFolder.toResource(posix.join('.vscode', 'extensions.json'));
+		const extensionsJsonUri = workspaceFolder.toResource(EXTENSIONS_JSON_PATH);
 
 		return Promise.resolve(this.fileService.resolveFile(extensionsJsonUri)
 			.then(() => this.fileService.resolveContent(extensionsJsonUri))

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsActions.ts
@@ -14,7 +14,7 @@ import * as json from 'vs/base/common/json';
 import { ActionItem, Separator, IActionItemOptions } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IDisposable, dispose, Disposable } from 'vs/base/common/lifecycle';
-import { IExtension, ExtensionState, IExtensionsWorkbenchService, VIEWLET_ID, IExtensionsViewlet, AutoUpdateConfigurationKey, IExtensionContainer } from 'vs/workbench/contrib/extensions/common/extensions';
+import { IExtension, ExtensionState, IExtensionsWorkbenchService, VIEWLET_ID, IExtensionsViewlet, AutoUpdateConfigurationKey, IExtensionContainer, EXTENSIONS_JSON_PATH } from 'vs/workbench/contrib/extensions/common/extensions';
 import { ExtensionsConfigurationInitialContent } from 'vs/workbench/contrib/extensions/common/extensionsFileTemplate';
 import { IExtensionEnablementService, IExtensionTipsService, EnablementState, ExtensionsLabel, IExtensionRecommendation, IGalleryExtension, IExtensionsConfigContent, IExtensionGalleryService, INSTALL_ERROR_MALICIOUS, INSTALL_ERROR_INCOMPATIBLE, IGalleryExtensionVersion, ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
@@ -2042,7 +2042,7 @@ export class ConfigureWorkspaceRecommendedExtensionsAction extends AbstractConfi
 	public run(): Promise<void> {
 		switch (this.contextService.getWorkbenchState()) {
 			case WorkbenchState.FOLDER:
-				return this.openExtensionsFile(this.contextService.getWorkspace().folders[0].toResource(path.posix.join('.vscode', 'extensions.json')));
+				return this.openExtensionsFile(this.contextService.getWorkspace().folders[0].toResource(EXTENSIONS_JSON_PATH));
 			case WorkbenchState.WORKSPACE:
 				return this.openWorkspaceConfigurationFile(this.contextService.getWorkspace().configuration!);
 		}
@@ -2087,7 +2087,7 @@ export class ConfigureWorkspaceFolderRecommendedExtensionsAction extends Abstrac
 		return Promise.resolve(pickFolderPromise)
 			.then(workspaceFolder => {
 				if (workspaceFolder) {
-					return this.openExtensionsFile(workspaceFolder.toResource(path.posix.join('.vscode', 'extensions.json')));
+					return this.openExtensionsFile(workspaceFolder.toResource(EXTENSIONS_JSON_PATH));
 				}
 				return null;
 			});
@@ -2140,7 +2140,7 @@ export class AddToWorkspaceFolderRecommendationsAction extends AbstractConfigure
 				if (!workspaceFolder) {
 					return Promise.resolve();
 				}
-				const configurationFile = workspaceFolder.toResource(path.posix.join('.vscode', 'extensions.json'));
+				const configurationFile = workspaceFolder.toResource(EXTENSIONS_JSON_PATH);
 				return this.getWorkspaceFolderExtensionsConfigContent(configurationFile).then(content => {
 					const extensionIdLowerCase = extensionId.id.toLowerCase();
 					if (shouldRecommend) {

--- a/src/vs/workbench/contrib/files/electron-browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/electron-browser/fileCommands.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import * as extpath from 'vs/base/common/extpath';
+import * as path from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
 import { toResource, IEditorCommandsContext } from 'vs/workbench/common/editor';
 import { IWindowsService, IWindowService, IURIToOpen } from 'vs/platform/windows/common/windows';
@@ -358,9 +358,9 @@ CommandsRegistry.registerCommand({
 
 function revealResourcesInOS(resources: URI[], windowsService: IWindowsService, notificationService: INotificationService, workspaceContextService: IWorkspaceContextService): void {
 	if (resources.length) {
-		sequence(resources.map(r => () => windowsService.showItemInFolder(extpath.normalize(r.fsPath, true))));
+		sequence(resources.map(r => () => windowsService.showItemInFolder(path.normalize(r.fsPath))));
 	} else if (workspaceContextService.getWorkspace().folders.length) {
-		windowsService.showItemInFolder(extpath.normalize(workspaceContextService.getWorkspace().folders[0].uri.fsPath, true));
+		windowsService.showItemInFolder(path.normalize(workspaceContextService.getWorkspace().folders[0].uri.fsPath));
 	} else {
 		notificationService.info(nls.localize('openFileToReveal', "Open a file first to reveal"));
 	}

--- a/src/vs/workbench/contrib/files/electron-browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/electron-browser/views/explorerViewer.ts
@@ -26,7 +26,6 @@ import { localize } from 'vs/nls';
 import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
 import { once } from 'vs/base/common/functional';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
-import { normalize } from 'vs/base/common/extpath';
 import { equals, deepClone } from 'vs/base/common/objects';
 import * as path from 'vs/base/common/path';
 import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
@@ -313,7 +312,7 @@ export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
 
 		// Hide those that match Hidden Patterns
 		const cached = this.hiddenExpressionPerRoot.get(stat.root.resource.toString());
-		if (cached && cached.parsed(normalize(path.relative(stat.root.resource.path, stat.resource.path), true), stat.name, name => !!stat.parent.getChild(name))) {
+		if (cached && cached.parsed(path.normalize(path.relative(stat.root.resource.path, stat.resource.path)), stat.name, name => !!stat.parent.getChild(name))) {
 			return false; // hidden through pattern
 		}
 

--- a/src/vs/workbench/contrib/markers/electron-browser/markersPanel.ts
+++ b/src/vs/workbench/contrib/markers/electron-browser/markersPanel.ts
@@ -287,7 +287,7 @@ export class MarkersPanel extends Panel implements IMarkerFilterController {
 		return Object.keys(expr)
 			.reduce((absExpr: IExpression, key: string) => {
 				if (expr[key] && !isAbsolute(key)) {
-					const absPattern = posix.join(root, key);
+					const absPattern = posix.join(root, key); // enforce posix: glob is always using "/" for path separator
 					absExpr[absPattern] = expr[key];
 				}
 

--- a/src/vs/workbench/contrib/output/common/outputLinkComputer.ts
+++ b/src/vs/workbench/contrib/output/common/outputLinkComputer.ts
@@ -6,7 +6,7 @@
 import { IMirrorModel, IWorkerContext } from 'vs/editor/common/services/editorSimpleWorker';
 import { ILink } from 'vs/editor/common/modes';
 import { URI } from 'vs/base/common/uri';
-import * as extpath from 'vs/base/common/extpath';
+import * as path from 'vs/base/common/path';
 import * as resources from 'vs/base/common/resources';
 import * as strings from 'vs/base/common/strings';
 import * as arrays from 'vs/base/common/arrays';
@@ -88,8 +88,8 @@ export class OutputLinkComputer {
 
 		const workspaceFolderPath = workspaceFolder.scheme === 'file' ? workspaceFolder.fsPath : workspaceFolder.path;
 		const workspaceFolderVariants = arrays.distinct([
-			extpath.normalize(workspaceFolderPath, true),
-			extpath.normalize(workspaceFolderPath, false)
+			path.normalize(workspaceFolderPath),
+			path.posix.normalize(workspaceFolderPath)
 		]);
 
 		workspaceFolderVariants.forEach(workspaceFolderVariant => {

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -5,8 +5,7 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { posix } from 'vs/base/common/path';
-import { ISettingsEditorModel, ISearchResult } from 'vs/workbench/services/preferences/common/preferences';
+import { ISettingsEditorModel, ISearchResult, FOLDER_SETTINGS_PATH as COMMON_FOLDER_SETTINGS_PATH } from 'vs/workbench/services/preferences/common/preferences';
 import { IEditor } from 'vs/workbench/common/editor';
 import { IKeybindingItemEntry } from 'vs/workbench/services/preferences/common/keybindingsEditorModel';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -106,7 +105,7 @@ export const KEYBINDINGS_EDITOR_CLEAR_INPUT = 'keybindings.editor.showDefaultKey
 export const KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS = 'keybindings.editor.showDefaultKeybindings';
 export const KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS = 'keybindings.editor.showUserKeybindings';
 
-export const FOLDER_SETTINGS_PATH = posix.join('.vscode', 'settings.json');
+export const FOLDER_SETTINGS_PATH = COMMON_FOLDER_SETTINGS_PATH;
 export const DEFAULT_SETTINGS_EDITOR_SETTING = 'workbench.settings.openDefaultSettings';
 
 export const MODIFIED_SETTING_TAG = 'modified';

--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -9,7 +9,7 @@ import { INavigator } from 'vs/base/common/iterator';
 import { createKeybinding, ResolvedKeybinding } from 'vs/base/common/keyCodes';
 import { normalizeDriveLetter } from 'vs/base/common/labels';
 import { Schemas } from 'vs/base/common/network';
-import { normalize } from 'vs/base/common/extpath';
+import { normalize } from 'vs/base/common/path';
 import { isWindows, OS } from 'vs/base/common/platform';
 import { repeat } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
@@ -640,7 +640,7 @@ export class ReplaceAction extends AbstractSearchAndReplaceAction {
 }
 
 function uriToClipboardString(resource: URI): string {
-	return resource.scheme === Schemas.file ? normalize(normalizeDriveLetter(resource.fsPath), true) : resource.toString();
+	return resource.scheme === Schemas.file ? normalize(normalizeDriveLetter(resource.fsPath)) : resource.toString();
 }
 
 export const copyPathCommand: ICommandHandler = (accessor, fileMatch: FileMatch | FolderMatch) => {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -17,7 +17,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Iterator } from 'vs/base/common/iterator';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
-import * as extpath from 'vs/base/common/extpath';
+import { posix } from 'vs/base/common/path';
 import * as env from 'vs/base/common/platform';
 import * as strings from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
@@ -1085,7 +1085,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 				let folderPath: string;
 				if (this.contextService.getWorkbenchState() === WorkbenchState.FOLDER) {
 					// Show relative path from the root for single-root mode
-					folderPath = extpath.normalize(pathToRelative(workspace.folders[0].uri.fsPath, resource.fsPath));
+					folderPath = posix.normalize(pathToRelative(workspace.folders[0].uri.fsPath, resource.fsPath));
 					if (folderPath && folderPath !== '.') {
 						folderPath = './' + folderPath;
 					}
@@ -1097,7 +1097,7 @@ export class SearchView extends Viewlet implements IViewlet, IPanel {
 						// If this root is the only one with its basename, use a relative ./ path. If there is another, use an absolute path
 						const isUniqueFolder = workspace.folders.filter(folder => folder.name === owningRootName).length === 1;
 						if (isUniqueFolder) {
-							const relativePath = extpath.normalize(pathToRelative(owningFolder.uri.fsPath, resource.fsPath));
+							const relativePath = posix.normalize(pathToRelative(owningFolder.uri.fsPath, resource.fsPath));
 							if (relativePath === '.') {
 								folderPath = `./${owningFolder.name}`;
 							} else {

--- a/src/vs/workbench/contrib/tasks/node/processRunnerDetector.ts
+++ b/src/vs/workbench/contrib/tasks/node/processRunnerDetector.ts
@@ -5,7 +5,7 @@
 
 import * as Collections from 'vs/base/common/collections';
 import * as Objects from 'vs/base/common/objects';
-import * as Extpath from 'vs/base/common/extpath';
+import { normalize } from 'vs/base/common/path';
 import { CommandOptions, ErrorData, Source } from 'vs/base/common/processes';
 import * as Strings from 'vs/base/common/strings';
 import { LineData, LineProcess } from 'vs/base/node/processes';
@@ -156,7 +156,7 @@ export class ProcessRunnerDetector {
 		this._workspaceRoot = workspaceFolder;
 		this._stderr = [];
 		this._stdout = [];
-		this._cwd = this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY ? Extpath.normalize(this._workspaceRoot.uri.fsPath, true) : '';
+		this._cwd = this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY ? normalize(this._workspaceRoot.uri.fsPath) : '';
 	}
 
 	public get stderr(): string[] {

--- a/src/vs/workbench/contrib/welcome/page/electron-browser/welcomePage.ts
+++ b/src/vs/workbench/contrib/welcome/page/electron-browser/welcomePage.ts
@@ -41,6 +41,7 @@ import { areSameExtensions } from 'vs/platform/extensionManagement/common/extens
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ExtensionType } from 'vs/platform/extensions/common/extensions';
+import { joinPath } from 'vs/base/common/resources';
 
 used();
 
@@ -73,9 +74,7 @@ export class WelcomePageContribution implements IWorkbenchContribution {
 								.then(files => {
 									const file = arrays.find(files.sort(), file => strings.startsWith(file.toLowerCase(), 'readme'));
 									if (file) {
-										return folderUri.with({
-											path: path.posix.join(folderUri.path, file)
-										});
+										return joinPath(folderUri, file);
 									}
 									return undefined;
 								}, onUnexpectedError);

--- a/src/vs/workbench/services/configuration/node/configuration.ts
+++ b/src/vs/workbench/services/configuration/node/configuration.ts
@@ -23,7 +23,7 @@ import * as extfs from 'vs/base/node/extfs';
 import { JSONEditingService } from 'vs/workbench/services/configuration/node/jsonEditingService';
 import { WorkbenchState, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
-import { join, relative, extname } from 'vs/base/common/path';
+import { posix, join, relative, extname } from 'vs/base/common/path';
 import { equals } from 'vs/base/common/objects';
 import { Schemas } from 'vs/base/common/network';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
@@ -532,11 +532,11 @@ export class FileServiceBasedFolderConfiguration extends AbstractFolderConfigura
 	private toFolderRelativePath(resource: URI): string | null {
 		if (resource.scheme === Schemas.file) {
 			if (extpath.isEqualOrParent(resource.fsPath, this.folderConfigurationPath.fsPath, !isLinux /* ignorecase */)) {
-				return extpath.normalize(relative(this.folderConfigurationPath.fsPath, resource.fsPath));
+				return posix.normalize(relative(this.folderConfigurationPath.fsPath, resource.fsPath));
 			}
 		} else {
 			if (resources.isEqualOrParent(resource, this.folderConfigurationPath)) {
-				return extpath.normalize(relative(this.folderConfigurationPath.path, resource.path));
+				return posix.normalize(relative(this.folderConfigurationPath.path, resource.path));
 			}
 		}
 		return null;

--- a/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
@@ -5,7 +5,7 @@
 
 import { URI as uri } from 'vs/base/common/uri';
 import * as nls from 'vs/nls';
-import * as extpath from 'vs/base/common/extpath';
+import { normalize } from 'vs/base/common/path';
 import * as platform from 'vs/base/common/platform';
 import * as Types from 'vs/base/common/types';
 import { Schemas } from 'vs/base/common/network';
@@ -58,7 +58,7 @@ export class ConfigurationResolverService extends AbstractVariableResolverServic
 				if (!fileResource) {
 					return undefined;
 				}
-				return extpath.normalize(fileResource.fsPath, true);
+				return normalize(fileResource.fsPath);
 			},
 			getSelectedText: (): string | undefined => {
 				const activeTextEditorWidget = editorService.activeTextEditorWidget;

--- a/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/electron-browser/colorThemeData.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as Extpath from 'vs/base/common/extpath';
-import { basename } from 'vs/base/common/path';
+import { basename, posix } from 'vs/base/common/path';
 import * as Json from 'vs/base/common/json';
 import { Color } from 'vs/base/common/color';
 import { ExtensionData, ITokenColorCustomizations, ITokenColorizationRule, IColorTheme, IColorMap, IThemeExtensionPoint, VS_LIGHT_THEME, VS_HC_THEME } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -259,7 +258,7 @@ export class ColorThemeData implements IColorTheme {
 	static fromExtensionTheme(theme: IThemeExtensionPoint, colorThemeLocation: URI, extensionData: ExtensionData): ColorThemeData {
 		let baseTheme: string = theme['uiTheme'] || 'vs-dark';
 
-		let themeSelector = toCSSSelector(extensionData.extensionId + '-' + Extpath.normalize(theme.path));
+		let themeSelector = toCSSSelector(extensionData.extensionId + '-' + posix.normalize(theme.path));
 		let themeData = new ColorThemeData();
 		themeData.id = `${baseTheme} ${themeSelector}`;
 		themeData.label = theme.label || basename(theme.path);

--- a/src/vs/workbench/test/electron-browser/api/extHostWorkspace.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostWorkspace.test.ts
@@ -5,10 +5,9 @@
 
 import * as assert from 'assert';
 import { URI } from 'vs/base/common/uri';
-import { basename } from 'vs/base/common/path';
+import { basename, normalize } from 'vs/base/common/path';
 import { ExtHostWorkspaceProvider } from 'vs/workbench/api/node/extHostWorkspace';
 import { TestRPCProtocol } from './testRPCProtocol';
-import { normalize } from 'vs/base/common/extpath';
 import { IWorkspaceFolderData } from 'vs/platform/workspace/common/workspace';
 import { IExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 import { NullLogService } from 'vs/platform/log/common/log';
@@ -35,7 +34,7 @@ suite('ExtHostWorkspace', function () {
 		if (actual === expected) {
 			assert.ok(true);
 		} else {
-			assert.equal(actual, normalize(expected, true));
+			assert.equal(actual, normalize(expected));
 		}
 	}
 


### PR DESCRIPTION
I left `posix` in for places where we use relative paths but maybe we should follow up on this to have a helper class for relative paths.

https://github.com/Microsoft/vscode/pull/68615/commits/e861b90c80d2a807456b25c22682cb1b00a71aef is the change where we used to use the `normalize` without OS path. The other changes are less controversal because they already used `normalize(path, true:toOSPath)`