### PR TITLE
update bug_report.md to reflect snap app's name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,5 +15,6 @@ Steps to Reproduce:
 1.
 2.
 
-<!-- Launch with `code --disable-extensions` to check. -->
+<!-- If it's snap app, launch with `vscode --disable-extensions` to check. -->
+<!-- Else, launch with `code --disable-extensions` to check. -->
 Does this issue occur when all extensions are disabled?: Yes/No


### PR DESCRIPTION
The name of command is `vscode` if it's installed from snap store by `snap install vscode`.