### PR TITLE
Fix wrong folding potentially being invoked when document language changes

### DIFF
--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -193,7 +193,14 @@ export class FoldingController implements IEditorContribution {
 
 		this.cursorChangedScheduler = new RunOnceScheduler(() => this.revealCursor(), 200);
 		this.localToDispose.push(this.cursorChangedScheduler);
-		this.localToDispose.push(this.editor.onDidChangeModelLanguageConfiguration(() => this.onModelContentChanged())); // covers model language changes as well
+		this.localToDispose.push(this.editor.onDidChangeModelLanguageConfiguration(() => { // covers model language changes as well
+			// Clear previous range provider
+			if (this.rangeProvider) {
+				this.rangeProvider.dispose();
+			}
+			this.rangeProvider = null;
+			this.onModelContentChanged();
+		}));
 		this.localToDispose.push(this.editor.onDidChangeModelContent(() => this.onModelContentChanged()));
 		this.localToDispose.push(this.editor.onDidChangeCursorPosition(() => this.onCursorPositionChanged()));
 		this.localToDispose.push(this.editor.onMouseDown(e => this.onEditorMouseDown(e)));


### PR DESCRIPTION
Fixes #67613

**Bug**
See #67613 for repo steps.

Cause of this bug appears to be:

1. Folding is requested for a js file.
1. In `folding.ts`, we set `this.rangeProvider` using `FoldingRangeProviderRegistry.ordered(this.foldingModel.textModel)`
1. Now we change the language mode of the document to `json`.
1. This triggers `onModelContentChanged` in `folding.ts`
1. However this call re-uses the previously set `rangeProvider`. This rangeProvider is now incorrect as it is using the same one computed for the original js file

**Fix**
Fix is to clear the `rangeProvider` when the document language changes.