### PR TITLE
Add License field to package.jsons #68423

### DIFF
--- a/build/lib/watch/package.json
+++ b/build/lib/watch/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "author": "Microsoft ",
   "private": true,
+  "license": "MIT",
   "devDependencies": {
     "gulp-watch": "^4.3.9"
   }

--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,7 @@
 {
   "name": "code-oss-dev-build",
   "version": "1.0.0",
+  "license": "MIT",
   "devDependencies": {
     "@types/ansi-colors": "^3.2.0",
     "@types/azure": "0.9.19",

--- a/extensions/bat/package.json
+++ b/extensions/bat/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js mmims/language-batchfile grammars/batchfile.cson ./syntaxes/batchfile.tmLanguage.json"

--- a/extensions/clojure/package.json
+++ b/extensions/clojure/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-clojure grammars/clojure.cson ./syntaxes/clojure.tmLanguage.json"

--- a/extensions/coffeescript/package.json
+++ b/extensions/coffeescript/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-coffee-script grammars/coffeescript.cson ./syntaxes/coffeescript.tmLanguage.json"

--- a/extensions/configuration-editing/package.json
+++ b/extensions/configuration-editing/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "^1.0.0"
   },

--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ./build/update-grammars.js"

--- a/extensions/csharp/package.json
+++ b/extensions/csharp/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/css-language-features/package.json
+++ b/extensions/css-language-features/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "^1.29.0"
   },

--- a/extensions/css/package.json
+++ b/extensions/css/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/debug-auto-launch/package.json
+++ b/extensions/debug-auto-launch/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "^1.5.0"
 	},

--- a/extensions/docker/package.json
+++ b/extensions/docker/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js moby/moby contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage ./syntaxes/docker.tmLanguage.json"

--- a/extensions/emmet/package.json
+++ b/extensions/emmet/package.json
@@ -3,7 +3,8 @@
     "displayName": "Emmet",
     "description": "%description%",
     "version": "1.0.0",
-    "publisher": "vscode",
+	"publisher": "vscode",
+	"license": "MIT",
     "engines": {
         "vscode": "^1.13.0"
     },

--- a/extensions/extension-editing/package.json
+++ b/extensions/extension-editing/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "^1.4.0"
 	},

--- a/extensions/fsharp/package.json
+++ b/extensions/fsharp/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js ionide/ionide-fsgrammar grammar/fsharp.json ./syntaxes/fsharp.tmLanguage.json"

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -3,6 +3,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "publisher": "vscode",
+  "license": "MIT",
   "version": "1.0.0",
   "engines": {
     "vscode": "^1.5.0"

--- a/extensions/go/package.json
+++ b/extensions/go/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-go grammars/go.cson ./syntaxes/go.tmLanguage.json"

--- a/extensions/groovy/package.json
+++ b/extensions/groovy/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
   "scripts": {
     "update-grammar": "node ../../build/npm/update-grammar.js textmate/groovy.tmbundle Syntaxes/Groovy.tmLanguage ./syntaxes/groovy.tmLanguage.json"

--- a/extensions/grunt/package.json
+++ b/extensions/grunt/package.json
@@ -5,6 +5,7 @@
   "displayName": "Grunt support for VS Code",
   "version": "1.0.0",
   "icon": "images/grunt.png",
+  "license": "MIT",
   "engines": {
     "vscode": "*"
   },

--- a/extensions/gulp/package.json
+++ b/extensions/gulp/package.json
@@ -5,6 +5,7 @@
   "displayName": "%displayName%",
   "version": "1.0.0",
   "icon": "images/gulp.png",
+  "license": "MIT",
   "engines": {
     "vscode": "*"
   },

--- a/extensions/handlebars/package.json
+++ b/extensions/handlebars/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/hlsl/package.json
+++ b/extensions/hlsl/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js tgjones/shaders-tmLanguage grammars/hlsl.json ./syntaxes/hlsl.tmLanguage.json"

--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -5,6 +5,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "engines": {
     "vscode": "0.10.x"

--- a/extensions/html/package.json
+++ b/extensions/html/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js textmate/ini.tmbundle Syntaxes/Ini.plist ./syntaxes/ini.tmLanguage.json"

--- a/extensions/jake/package.json
+++ b/extensions/jake/package.json
@@ -5,6 +5,7 @@
   "displayName": "%displayName%",
   "icon": "images/cowboy_hat.png",
   "version": "1.0.0",
+  "license": "MIT",
   "engines": {
     "vscode": "*"
   },

--- a/extensions/java/package.json
+++ b/extensions/java/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-java grammars/java.cson ./syntaxes/java.tmLanguage.json"

--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "engines": {
     "vscode": "0.10.x"

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -4,6 +4,7 @@
   "description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/less/package.json
+++ b/extensions/less/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-less grammars/less.cson ./syntaxes/less.tmLanguage.json"

--- a/extensions/log/package.json
+++ b/extensions/log/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/lua/package.json
+++ b/extensions/lua/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js textmate/lua.tmbundle Syntaxes/Lua.plist ./syntaxes/lua.tmLanguage.json"

--- a/extensions/make/package.json
+++ b/extensions/make/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/markdown-basics/package.json
+++ b/extensions/markdown-basics/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "^1.20.0"
 	},

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -5,6 +5,7 @@
 	"version": "1.0.0",
 	"icon": "icon.png",
 	"publisher": "vscode",
+	"license": "MIT",
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"engines": {
 		"vscode": "^1.20.0"

--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -5,6 +5,7 @@
   "description": "%description%",
   "icon": "resources/icons/merge-conflict.png",
   "version": "1.0.0",
+  "license": "MIT",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "engines": {
     "vscode": "^1.5.0"

--- a/extensions/npm/package.json
+++ b/extensions/npm/package.json
@@ -4,6 +4,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "version": "1.0.1",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },

--- a/extensions/objective-c/package.json
+++ b/extensions/objective-c/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/perl/package.json
+++ b/extensions/perl/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js textmate/perl.tmbundle Syntaxes/Perl.plist ./syntaxes/perl.tmLanguage.json Syntaxes/Perl%206.tmLanguage ./syntaxes/perl6.tmLanguage.json"

--- a/extensions/php-language-features/package.json
+++ b/extensions/php-language-features/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"icon": "icons/logo.png",
 	"engines": {
 		"vscode": "0.10.x"

--- a/extensions/php/package.json
+++ b/extensions/php/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "0.10.x"
 	},

--- a/extensions/powershell/package.json
+++ b/extensions/powershell/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"languages": [{

--- a/extensions/pug/package.json
+++ b/extensions/pug/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js davidrios/pug-tmbundle Syntaxes/Pug.JSON-tmLanguage ./syntaxes/pug.tmLanguage.json"

--- a/extensions/python/package.json
+++ b/extensions/python/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"activationEvents": ["onLanguage:python"],
 	"main": "./out/pythonMain",

--- a/extensions/r/package.json
+++ b/extensions/r/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js Ikuyadeu/vscode-R syntax/r.json ./syntaxes/r.tmLanguage.json"

--- a/extensions/razor/package.json
+++ b/extensions/razor/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
   "version": "1.0.0",
   "publisher": "vscode",
+  "license": "MIT",
   "engines": {
     "vscode": "0.10.x"
   },
@@ -25,7 +26,7 @@
 			"embeddedLanguages": {
 				"section.embedded.source.cshtml": "csharp",
           "source.css": "css",
-          "source.js": "javascript"				
+          "source.js": "javascript"
 			}
 		}]
   }

--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js textmate/ruby.tmbundle Syntaxes/Ruby.plist ./syntaxes/ruby.tmLanguage.json"

--- a/extensions/rust/package.json
+++ b/extensions/rust/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js zargony/atom-language-rust grammars/rust.cson ./syntaxes/rust.tmLanguage.json"

--- a/extensions/scss/package.json
+++ b/extensions/scss/package.json
@@ -4,6 +4,7 @@
 	  "description": "%description%",
     "version": "1.0.0",
     "publisher": "vscode",
+    "license": "MIT",
     "engines": { "vscode": "*" },
     "scripts": {
         "update-grammar": "node ../../build/npm/update-grammar.js atom/language-sass grammars/scss.cson ./syntaxes/scss.tmLanguage.json grammars/sassdoc.cson ./syntaxes/sassdoc.tmLanguage.json"

--- a/extensions/shaderlab/package.json
+++ b/extensions/shaderlab/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js atom/language-shellscript grammars/shell-unix-bash.cson ./syntaxes/shell-unix-bash.tmLanguage.json"

--- a/extensions/sql/package.json
+++ b/extensions/sql/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js Microsoft/vscode-mssql syntaxes/SQL.plist ./syntaxes/sql.tmLanguage.json"

--- a/extensions/swift/package.json
+++ b/extensions/swift/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js textmate/swift.tmbundle Syntaxes/Swift.tmLanguage ./syntaxes/swift.tmLanguage.json"

--- a/extensions/theme-abyss/package.json
+++ b/extensions/theme-abyss/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/theme-defaults/package.json
+++ b/extensions/theme-defaults/package.json
@@ -5,6 +5,7 @@
 	"categories": [ "Themes" ],
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/theme-kimbie-dark/package.json
+++ b/extensions/theme-kimbie-dark/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/theme-monokai-dimmed/package.json
+++ b/extensions/theme-monokai-dimmed/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/theme-monokai/package.json
+++ b/extensions/theme-monokai/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/theme-quietlight/package.json
+++ b/extensions/theme-quietlight/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/extensions/theme-red/package.json
+++ b/extensions/theme-red/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/theme-seti/package.json
+++ b/extensions/theme-seti/package.json
@@ -5,6 +5,7 @@
 	"displayName": "%displayName%",
 	"description": "%description%",
 	"publisher": "vscode",
+	"license": "MIT",
 	"icon": "icons/seti-circular-128x128.png",
 	"scripts": {
 		"update": "node ./build/update-icon-theme.js"

--- a/extensions/theme-solarized-dark/package.json
+++ b/extensions/theme-solarized-dark/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/theme-solarized-light/package.json
+++ b/extensions/theme-solarized-light/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/theme-tomorrow-night-blue/package.json
+++ b/extensions/theme-tomorrow-night-blue/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"themes": [

--- a/extensions/vb/package.json
+++ b/extensions/vb/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"scripts": {
 		"update-grammar": "node ../../build/npm/update-grammar.js textmate/asp.vb.net.tmbundle Syntaxes/ASP%20VB.net.plist ./syntaxes/asp-vb-net.tmlanguage.json"

--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -3,6 +3,7 @@
 	"description": "API tests for VS Code",
 	"version": "0.0.1",
 	"publisher": "vscode",
+	"license": "MIT",
 	"enableProposedApi": true,
 	"private": true,
 	"main": "horse",

--- a/extensions/vscode-colorize-tests/package.json
+++ b/extensions/vscode-colorize-tests/package.json
@@ -3,6 +3,7 @@
 	"description": "Colorize tests for VS Code",
 	"version": "0.0.1",
 	"publisher": "vscode",
+	"license": "MIT",
 	"private": true,
 	"engines": {
 		"vscode": "*"

--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": { "vscode": "*" },
 	"contributes": {
 		"languages": [{

--- a/extensions/yaml/package.json
+++ b/extensions/yaml/package.json
@@ -4,6 +4,7 @@
 	"description": "%description%",
 	"version": "1.0.0",
 	"publisher": "vscode",
+	"license": "MIT",
 	"engines": {
 		"vscode": "*"
 	},

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": {
     "name": "Microsoft Corporation"
   },
+  "license": "MIT",
   "main": "./out/main",
   "private": true,
   "scripts": {


### PR DESCRIPTION
it should avoid to have "warning XXX: No license field" during yarn
build

Signed-off-by: Aurélien Pupier <apupier@redhat.com>