### PR TITLE
updated preinstall to require node 9 and above.

### DIFF
--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -7,8 +7,8 @@ let err = false;
 
 const majorNodeVersion = parseInt(/^(\d+)\./.exec(process.versions.node)[1]);
 
-if (majorNodeVersion < 8 || majorNodeVersion >= 11) {
-	console.error('\033[1;31m*** Please use node >=8 and <11.\033[0;0m');
+if (majorNodeVersion < 9 || majorNodeVersion >= 11) {
+	console.error('\033[1;31m*** Please use node >=9 and <11.\033[0;0m');
 	err = true;
 }
 


### PR DESCRIPTION
builds are now using node 10. With the dependencies updated, tests pass with node 9 and 10.