### PR TITLE
Modifying ResolvedKeybindingItem to support multiple chords

### DIFF
--- a/src/vs/base/common/keybindingParser.ts
+++ b/src/vs/base/common/keybindingParser.ts
@@ -107,24 +107,17 @@ export class KeybindingParser {
 		return [new SimpleKeybinding(mods.ctrl, mods.shift, mods.alt, mods.meta, keyCode), mods.remains];
 	}
 
-	static parseUserBinding(input: string): Array<SimpleKeybinding | ScanCodeBinding> {
-		// TODO@chords: allow users to define N chords
+	static parseUserBinding(input: string): (SimpleKeybinding | ScanCodeBinding)[] {
 		if (!input) {
 			return [];
 		}
 
-		let parts = [];
-		let remains = input;
-		while (remains.length > 0) {
-			let [part, nextRemains] = this.parseSimpleUserBinding(remains);
+		let parts: (SimpleKeybinding | ScanCodeBinding)[] = [];
+		let part: SimpleKeybinding | ScanCodeBinding;
+
+		while (input.length > 0) {
+			[part, input] = this.parseSimpleUserBinding(input);
 			parts.push(part);
-			// check equality to break out of a possible infinite loop.
-			// if nothing was consumed it implies that an empty keybinding
-			// was returned.
-			if (remains === nextRemains) {
-				break;
-			}
-			remains = nextRemains;
 		}
 		return parts;
 	}

--- a/src/vs/base/common/keybindingParser.ts
+++ b/src/vs/base/common/keybindingParser.ts
@@ -107,17 +107,25 @@ export class KeybindingParser {
 		return [new SimpleKeybinding(mods.ctrl, mods.shift, mods.alt, mods.meta, keyCode), mods.remains];
 	}
 
-	static parseUserBinding(input: string): [SimpleKeybinding | ScanCodeBinding | null, SimpleKeybinding | ScanCodeBinding | null] {
+	static parseUserBinding(input: string): Array<SimpleKeybinding | ScanCodeBinding> {
 		// TODO@chords: allow users to define N chords
 		if (!input) {
-			return [null, null];
+			return [];
 		}
 
-		let [firstPart, remains] = this.parseSimpleUserBinding(input);
-		let chordPart: SimpleKeybinding | ScanCodeBinding | null = null;
-		if (remains.length > 0) {
-			[chordPart] = this.parseSimpleUserBinding(remains);
+		let parts = [];
+		let remains = input;
+		while (remains.length > 0) {
+			let [part, nextRemains] = this.parseSimpleUserBinding(remains);
+			parts.push(part);
+			// check equality to break out of a possible infinite loop.
+			// if nothing was consumed it implies that an empty keybinding
+			// was returned.
+			if (remains === nextRemains) {
+				break;
+			}
+			remains = nextRemains;
 		}
-		return [firstPart, chordPart];
+		return parts;
 	}
 }

--- a/src/vs/platform/driver/electron-main/driver.ts
+++ b/src/vs/platform/driver/electron-main/driver.ts
@@ -83,16 +83,10 @@ export class Driver implements IDriver, IWindowDriverRegistry {
 	async dispatchKeybinding(windowId: number, keybinding: string): Promise<void> {
 		await this.whenUnfrozen(windowId);
 
-		const [first, second] = KeybindingParser.parseUserBinding(keybinding);
+		const parts = KeybindingParser.parseUserBinding(keybinding);
 
-		if (!first) {
-			return;
-		}
-
-		await this._dispatchKeybinding(windowId, first);
-
-		if (second) {
-			await this._dispatchKeybinding(windowId, second);
+		for (let part of parts) {
+			await this._dispatchKeybinding(windowId, part);
 		}
 	}
 

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -45,6 +45,7 @@ export class KeybindingResolver {
 				continue;
 			}
 
+			// TODO@chords
 			this._addKeyPress(k.keypressParts[0], k);
 		}
 	}
@@ -53,9 +54,11 @@ export class KeybindingResolver {
 		if (defaultKb.command !== command) {
 			return false;
 		}
+		// TODO@chords
 		if (keypressFirstPart && defaultKb.keypressParts[0] !== keypressFirstPart) {
 			return false;
 		}
+		// TODO@chords
 		if (keypressChordPart && defaultKb.keypressParts[1] !== keypressChordPart) {
 			return false;
 		}
@@ -84,6 +87,7 @@ export class KeybindingResolver {
 			}
 
 			const command = override.command.substr(1);
+			// TODO@chords
 			const keypressFirstPart = override.keypressParts[0];
 			const keypressChordPart = override.keypressParts[1];
 			const when = override.when;
@@ -117,6 +121,7 @@ export class KeybindingResolver {
 			const conflictIsChord = (conflict.keypressParts.length > 1);
 			const itemIsChord = (item.keypressParts.length > 1);
 
+			// TODO@chords
 			if (conflictIsChord && itemIsChord && conflict.keypressParts[1] !== item.keypressParts[1]) {
 				// The conflict only shares the chord start with this command
 				continue;
@@ -247,6 +252,7 @@ export class KeybindingResolver {
 			lookupMap = [];
 			for (let i = 0, len = candidates.length; i < len; i++) {
 				let candidate = candidates[i];
+				// TODO@chords
 				if (candidate.keypressParts[1] === keypress) {
 					lookupMap.push(candidate);
 				}
@@ -266,6 +272,7 @@ export class KeybindingResolver {
 			return null;
 		}
 
+		// TODO@chords
 		if (currentChord === null && result.keypressParts.length > 1 && result.keypressParts[1] !== null) {
 			return {
 				enterChord: true,

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -40,12 +40,12 @@ export class KeybindingResolver {
 		this._keybindings = KeybindingResolver.combine(defaultKeybindings, overrides);
 		for (let i = 0, len = this._keybindings.length; i < len; i++) {
 			let k = this._keybindings[i];
-			if (k.keypressFirstPart === null) {
+			if (k.keypressParts.length === 0) {
 				// unbound
 				continue;
 			}
 
-			this._addKeyPress(k.keypressFirstPart, k);
+			this._addKeyPress(k.keypressParts[0], k);
 		}
 	}
 
@@ -53,10 +53,10 @@ export class KeybindingResolver {
 		if (defaultKb.command !== command) {
 			return false;
 		}
-		if (keypressFirstPart && defaultKb.keypressFirstPart !== keypressFirstPart) {
+		if (keypressFirstPart && defaultKb.keypressParts[0] !== keypressFirstPart) {
 			return false;
 		}
-		if (keypressChordPart && defaultKb.keypressChordPart !== keypressChordPart) {
+		if (keypressChordPart && defaultKb.keypressParts[1] !== keypressChordPart) {
 			return false;
 		}
 		if (when) {
@@ -84,8 +84,8 @@ export class KeybindingResolver {
 			}
 
 			const command = override.command.substr(1);
-			const keypressFirstPart = override.keypressFirstPart;
-			const keypressChordPart = override.keypressChordPart;
+			const keypressFirstPart = override.keypressParts[0];
+			const keypressChordPart = override.keypressParts[1];
 			const when = override.when;
 			for (let j = defaults.length - 1; j >= 0; j--) {
 				if (this._isTargetedForRemoval(defaults[j], keypressFirstPart, keypressChordPart, command, when)) {
@@ -114,10 +114,10 @@ export class KeybindingResolver {
 				continue;
 			}
 
-			const conflictIsChord = (conflict.keypressChordPart !== null);
-			const itemIsChord = (item.keypressChordPart !== null);
+			const conflictIsChord = (conflict.keypressParts.length > 1);
+			const itemIsChord = (item.keypressParts.length > 1);
 
-			if (conflictIsChord && itemIsChord && conflict.keypressChordPart !== item.keypressChordPart) {
+			if (conflictIsChord && itemIsChord && conflict.keypressParts[1] !== item.keypressParts[1]) {
 				// The conflict only shares the chord start with this command
 				continue;
 			}
@@ -247,7 +247,7 @@ export class KeybindingResolver {
 			lookupMap = [];
 			for (let i = 0, len = candidates.length; i < len; i++) {
 				let candidate = candidates[i];
-				if (candidate.keypressChordPart === keypress) {
+				if (candidate.keypressParts[1] === keypress) {
 					lookupMap.push(candidate);
 				}
 			}
@@ -266,7 +266,7 @@ export class KeybindingResolver {
 			return null;
 		}
 
-		if (currentChord === null && result.keypressChordPart !== null) {
+		if (currentChord === null && result.keypressParts.length > 1 && result.keypressParts[1] !== null) {
 			return {
 				enterChord: true,
 				commandId: null,

--- a/src/vs/platform/keybinding/common/resolvedKeybindingItem.ts
+++ b/src/vs/platform/keybinding/common/resolvedKeybindingItem.ts
@@ -10,9 +10,8 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 export class ResolvedKeybindingItem {
 	_resolvedKeybindingItemBrand: void;
 
+	public readonly keypressParts: string[];
 	public readonly resolvedKeybinding: ResolvedKeybinding | null;
-	public readonly keypressFirstPart: string | null;
-	public readonly keypressChordPart: string | null;
 	public readonly bubble: boolean;
 	public readonly command: string | null;
 	public readonly commandArgs: any;
@@ -22,21 +21,9 @@ export class ResolvedKeybindingItem {
 	constructor(resolvedKeybinding: ResolvedKeybinding | null, command: string | null, commandArgs: any, when: ContextKeyExpr | null, isDefault: boolean) {
 		this.resolvedKeybinding = resolvedKeybinding;
 		if (resolvedKeybinding) {
-			const dispatchParts = resolvedKeybinding.getDispatchParts();
-			// TODO@chords: add support for dispatching N chords here
-			if (dispatchParts.length >= 2) {
-				this.keypressFirstPart = dispatchParts[0];
-				this.keypressChordPart = dispatchParts[1];
-			} else if (dispatchParts.length === 1) {
-				this.keypressFirstPart = dispatchParts[0];
-				this.keypressChordPart = null;
-			} else {
-				this.keypressFirstPart = null;
-				this.keypressChordPart = null;
-			}
+			this.keypressParts = resolvedKeybinding.getDispatchParts();
 		} else {
-			this.keypressFirstPart = null;
-			this.keypressChordPart = null;
+			this.keypressParts = [];
 		}
 		this.bubble = (command ? command.charCodeAt(0) === CharCode.Caret : false);
 		this.command = this.bubble ? command!.substr(1) : command;

--- a/src/vs/platform/keybinding/common/resolvedKeybindingItem.ts
+++ b/src/vs/platform/keybinding/common/resolvedKeybindingItem.ts
@@ -10,8 +10,8 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 export class ResolvedKeybindingItem {
 	_resolvedKeybindingItemBrand: void;
 
-	public readonly keypressParts: string[];
 	public readonly resolvedKeybinding: ResolvedKeybinding | null;
+	public readonly keypressParts: string[];
 	public readonly bubble: boolean;
 	public readonly command: string | null;
 	public readonly commandArgs: any;
@@ -20,15 +20,24 @@ export class ResolvedKeybindingItem {
 
 	constructor(resolvedKeybinding: ResolvedKeybinding | null, command: string | null, commandArgs: any, when: ContextKeyExpr | null, isDefault: boolean) {
 		this.resolvedKeybinding = resolvedKeybinding;
-		if (resolvedKeybinding) {
-			this.keypressParts = resolvedKeybinding.getDispatchParts();
-		} else {
-			this.keypressParts = [];
-		}
+		this.keypressParts = resolvedKeybinding ? removeElementsAfterNulls(resolvedKeybinding.getDispatchParts()) : [];
 		this.bubble = (command ? command.charCodeAt(0) === CharCode.Caret : false);
 		this.command = this.bubble ? command!.substr(1) : command;
 		this.commandArgs = commandArgs;
 		this.when = when;
 		this.isDefault = isDefault;
 	}
+}
+
+export function removeElementsAfterNulls<T>(arr: (T | null)[]): T[] {
+	let result: T[] = [];
+	for (let i = 0, len = arr.length; i < len; i++) {
+		const element = arr[i];
+		if (!element) {
+			// stop processing at first encountered null
+			return result;
+		}
+		result.push(element);
+	}
+	return result;
 }

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditorContribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditorContribution.ts
@@ -265,13 +265,19 @@ export class KeybindingEditorDecorationsRenderer extends Disposable {
 			return true;
 		}
 
-		const [parsedA1, parsedA2] = KeybindingParser.parseUserBinding(a);
-		const [parsedB1, parsedB2] = KeybindingParser.parseUserBinding(b);
+		const aParts = KeybindingParser.parseUserBinding(a);
+		const bParts = KeybindingParser.parseUserBinding(b);
 
-		return (
-			this._userBindingEquals(parsedA1, parsedB1)
-			&& this._userBindingEquals(parsedA2, parsedB2)
-		);
+		if (aParts.length !== bParts.length) {
+			return false;
+		}
+
+		for (let i = 0, length = aParts.length; i < length; i++) {
+			if (!this._userBindingEquals(aParts[i], bParts[i])) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private static _userBindingEquals(a: SimpleKeybinding | ScanCodeBinding, b: SimpleKeybinding | ScanCodeBinding): boolean {

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditorContribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditorContribution.ts
@@ -272,11 +272,12 @@ export class KeybindingEditorDecorationsRenderer extends Disposable {
 			return false;
 		}
 
-		for (let i = 0, length = aParts.length; i < length; i++) {
+		for (let i = 0, len = aParts.length; i < len; i++) {
 			if (!this._userBindingEquals(aParts[i], bParts[i])) {
 				return false;
 			}
 		}
+
 		return true;
 	}
 

--- a/src/vs/workbench/contrib/preferences/test/browser/keybindingsEditorContribution.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/keybindingsEditorContribution.test.ts
@@ -11,6 +11,8 @@ suite('KeybindingsEditorContribution', () => {
 	function assertUserSettingsFuzzyEquals(a: string, b: string, expected: boolean): void {
 		const actual = KeybindingEditorDecorationsRenderer._userSettingsFuzzyEquals(a, b);
 		const message = expected ? `${a} == ${b}` : `${a} != ${b}`;
+		console.log(a);
+		console.log(b);
 		assert.equal(actual, expected, 'fuzzy: ' + message);
 	}
 

--- a/src/vs/workbench/contrib/preferences/test/browser/keybindingsEditorContribution.test.ts
+++ b/src/vs/workbench/contrib/preferences/test/browser/keybindingsEditorContribution.test.ts
@@ -11,8 +11,6 @@ suite('KeybindingsEditorContribution', () => {
 	function assertUserSettingsFuzzyEquals(a: string, b: string, expected: boolean): void {
 		const actual = KeybindingEditorDecorationsRenderer._userSettingsFuzzyEquals(a, b);
 		const message = expected ? `${a} == ${b}` : `${a} != ${b}`;
-		console.log(a);
-		console.log(b);
 		assert.equal(actual, expected, 'fuzzy: ' + message);
 	}
 

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -5,15 +5,13 @@
 
 import { SimpleKeybinding } from 'vs/base/common/keyCodes';
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
-import { OperatingSystem } from 'vs/base/common/platform';
 import { ScanCodeBinding } from 'vs/base/common/scanCode';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IUserFriendlyKeybinding } from 'vs/platform/keybinding/common/keybinding';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 export interface IUserKeybindingItem {
-	firstPart: SimpleKeybinding | ScanCodeBinding | null;
-	chordPart: SimpleKeybinding | ScanCodeBinding | null;
+	parts: (SimpleKeybinding | ScanCodeBinding)[];
 	command: string | null;
 	commandArgs?: any;
 	when: ContextKeyExpr | null;
@@ -21,7 +19,7 @@ export interface IUserKeybindingItem {
 
 export class KeybindingIO {
 
-	public static writeKeybindingItem(out: OutputBuilder, item: ResolvedKeybindingItem, OS: OperatingSystem): void {
+	public static writeKeybindingItem(out: OutputBuilder, item: ResolvedKeybindingItem): void {
 		if (!item.resolvedKeybinding) {
 			return;
 		}
@@ -41,15 +39,13 @@ export class KeybindingIO {
 		out.write('}');
 	}
 
-	public static readUserKeybindingItem(input: IUserFriendlyKeybinding, OS: OperatingSystem): IUserKeybindingItem {
-		// TODO yusuke: replace with keychords.
-		const [firstPart, chordPart] = (typeof input.key === 'string' ? KeybindingParser.parseUserBinding(input.key) : [null, null]);
+	public static readUserKeybindingItem(input: IUserFriendlyKeybinding): IUserKeybindingItem {
+		const parts = (typeof input.key === 'string' ? KeybindingParser.parseUserBinding(input.key) : []);
 		const when = (typeof input.when === 'string' ? ContextKeyExpr.deserialize(input.when) : null);
 		const command = (typeof input.command === 'string' ? input.command : null);
 		const commandArgs = (typeof input.args !== 'undefined' ? input.args : undefined);
 		return {
-			firstPart: firstPart,
-			chordPart: chordPart,
+			parts: parts,
 			command: command,
 			commandArgs: commandArgs,
 			when: when

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -42,6 +42,7 @@ export class KeybindingIO {
 	}
 
 	public static readUserKeybindingItem(input: IUserFriendlyKeybinding, OS: OperatingSystem): IUserKeybindingItem {
+		// TODO yusuke: replace with keychords.
 		const [firstPart, chordPart] = (typeof input.key === 'string' ? KeybindingParser.parseUserBinding(input.key) : [null, null]);
 		const when = (typeof input.when === 'string' ? ContextKeyExpr.deserialize(input.when) : null);
 		const command = (typeof input.command === 'string' ? input.command : null);

--- a/src/vs/workbench/services/keybinding/common/keyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/keyboardMapper.ts
@@ -11,7 +11,7 @@ export interface IKeyboardMapper {
 	dumpDebugInfo(): string;
 	resolveKeybinding(keybinding: Keybinding): ResolvedKeybinding[];
 	resolveKeyboardEvent(keyboardEvent: IKeyboardEvent): ResolvedKeybinding;
-	resolveUserBinding(firstPart: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[];
+	resolveUserBinding(firstPart: (SimpleKeybinding | ScanCodeBinding)[]): ResolvedKeybinding[];
 }
 
 export class CachedKeyboardMapper implements IKeyboardMapper {
@@ -43,7 +43,7 @@ export class CachedKeyboardMapper implements IKeyboardMapper {
 		return this._actual.resolveKeyboardEvent(keyboardEvent);
 	}
 
-	public resolveUserBinding(parts: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
+	public resolveUserBinding(parts: (SimpleKeybinding | ScanCodeBinding)[]): ResolvedKeybinding[] {
 		return this._actual.resolveUserBinding(parts);
 	}
 }

--- a/src/vs/workbench/services/keybinding/common/keyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/keyboardMapper.ts
@@ -11,7 +11,7 @@ export interface IKeyboardMapper {
 	dumpDebugInfo(): string;
 	resolveKeybinding(keybinding: Keybinding): ResolvedKeybinding[];
 	resolveKeyboardEvent(keyboardEvent: IKeyboardEvent): ResolvedKeybinding;
-	resolveUserBinding(firstPart: SimpleKeybinding | ScanCodeBinding | null, chordPart: SimpleKeybinding | ScanCodeBinding | null): ResolvedKeybinding[];
+	resolveUserBinding(firstPart: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[];
 }
 
 export class CachedKeyboardMapper implements IKeyboardMapper {
@@ -43,7 +43,7 @@ export class CachedKeyboardMapper implements IKeyboardMapper {
 		return this._actual.resolveKeyboardEvent(keyboardEvent);
 	}
 
-	public resolveUserBinding(firstPart: SimpleKeybinding | ScanCodeBinding, chordPart: SimpleKeybinding | ScanCodeBinding): ResolvedKeybinding[] {
-		return this._actual.resolveUserBinding(firstPart, chordPart);
+	public resolveUserBinding(parts: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
+		return this._actual.resolveUserBinding(parts);
 	}
 }

--- a/src/vs/workbench/services/keybinding/common/macLinuxFallbackKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxFallbackKeyboardMapper.ts
@@ -9,6 +9,7 @@ import { IMMUTABLE_CODE_TO_KEY_CODE, ScanCode, ScanCodeBinding } from 'vs/base/c
 import { IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
 import { USLayoutResolvedKeybinding } from 'vs/platform/keybinding/common/usLayoutResolvedKeybinding';
 import { IKeyboardMapper } from 'vs/workbench/services/keybinding/common/keyboardMapper';
+import { removeElementsAfterNulls } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 /**
  * A keyboard mapper to be used when reading the keymap from the OS fails.
@@ -117,8 +118,8 @@ export class MacLinuxFallbackKeyboardMapper implements IKeyboardMapper {
 		return new SimpleKeybinding(binding.ctrlKey, binding.shiftKey, binding.altKey, binding.metaKey, keyCode);
 	}
 
-	public resolveUserBinding(input: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
-		let parts: SimpleKeybinding[] = input.map(this._resolveSimpleUserBinding.bind(this));
+	public resolveUserBinding(input: (SimpleKeybinding | ScanCodeBinding)[]): ResolvedKeybinding[] {
+		const parts: SimpleKeybinding[] = removeElementsAfterNulls(input.map(keybinding => this._resolveSimpleUserBinding(keybinding)));
 		if (parts.length > 0) {
 			return [new USLayoutResolvedKeybinding(new ChordKeybinding(parts), this._OS)];
 		}

--- a/src/vs/workbench/services/keybinding/common/macLinuxFallbackKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxFallbackKeyboardMapper.ts
@@ -117,16 +117,8 @@ export class MacLinuxFallbackKeyboardMapper implements IKeyboardMapper {
 		return new SimpleKeybinding(binding.ctrlKey, binding.shiftKey, binding.altKey, binding.metaKey, keyCode);
 	}
 
-	public resolveUserBinding(firstPart: SimpleKeybinding | ScanCodeBinding | null, chordPart: SimpleKeybinding | ScanCodeBinding | null): ResolvedKeybinding[] {
-		const _firstPart = this._resolveSimpleUserBinding(firstPart);
-		const _chordPart = this._resolveSimpleUserBinding(chordPart);
-		let parts: SimpleKeybinding[] = [];
-		if (_firstPart) {
-			parts.push(_firstPart);
-		}
-		if (_chordPart) {
-			parts.push(_chordPart);
-		}
+	public resolveUserBinding(input: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
+		let parts: SimpleKeybinding[] = input.map(this._resolveSimpleUserBinding.bind(this));
 		if (parts.length > 0) {
 			return [new USLayoutResolvedKeybinding(new ChordKeybinding(parts), this._OS)];
 		}

--- a/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
@@ -1053,8 +1053,8 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 		return this.simpleKeybindingToScanCodeBinding(binding);
 	}
 
-	public resolveUserBinding(input: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
-		let parts: ScanCodeBinding[][] = input.map(this._resolveSimpleUserBinding.bind(this));
+	public resolveUserBinding(input: (SimpleKeybinding | ScanCodeBinding)[]): ResolvedKeybinding[] {
+		const parts: ScanCodeBinding[][] = input.map(keybinding => this._resolveSimpleUserBinding(keybinding));
 		let result: NativeResolvedKeybinding[] = [];
 		this._generateResolvedKeybindings(parts, 0, [], result);
 		return result;

--- a/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
@@ -1053,14 +1053,8 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 		return this.simpleKeybindingToScanCodeBinding(binding);
 	}
 
-	public resolveUserBinding(_firstPart: SimpleKeybinding | ScanCodeBinding | null, _chordPart: SimpleKeybinding | ScanCodeBinding | null): ResolvedKeybinding[] {
-		let parts: ScanCodeBinding[][] = [];
-		if (_firstPart) {
-			parts.push(this._resolveSimpleUserBinding(_firstPart));
-		}
-		if (_chordPart) {
-			parts.push(this._resolveSimpleUserBinding(_chordPart));
-		}
+	public resolveUserBinding(input: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
+		let parts: ScanCodeBinding[][] = input.map(this._resolveSimpleUserBinding.bind(this));
 		let result: NativeResolvedKeybinding[] = [];
 		this._generateResolvedKeybindings(parts, 0, [], result);
 		return result;

--- a/src/vs/workbench/services/keybinding/common/windowsKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/windowsKeyboardMapper.ts
@@ -11,6 +11,7 @@ import { IMMUTABLE_CODE_TO_KEY_CODE, ScanCode, ScanCodeBinding, ScanCodeUtils } 
 import { IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
 import { IKeyboardMapper } from 'vs/workbench/services/keybinding/common/keyboardMapper';
 import { BaseResolvedKeybinding } from 'vs/platform/keybinding/common/baseResolvedKeybinding';
+import { removeElementsAfterNulls } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 export interface IWindowsKeyMapping {
 	vkey: string;
@@ -464,8 +465,8 @@ export class WindowsKeyboardMapper implements IKeyboardMapper {
 		return new SimpleKeybinding(binding.ctrlKey, binding.shiftKey, binding.altKey, binding.metaKey, keyCode);
 	}
 
-	public resolveUserBinding(input: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
-		let parts: SimpleKeybinding[] = input.map(this._resolveSimpleUserBinding.bind(this));
+	public resolveUserBinding(input: (SimpleKeybinding | ScanCodeBinding)[]): ResolvedKeybinding[] {
+		const parts: SimpleKeybinding[] = removeElementsAfterNulls(input.map(keybinding => this._resolveSimpleUserBinding(keybinding)));
 		if (parts.length > 0) {
 			return [new WindowsNativeResolvedKeybinding(this, parts)];
 		}

--- a/src/vs/workbench/services/keybinding/common/windowsKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/windowsKeyboardMapper.ts
@@ -464,16 +464,8 @@ export class WindowsKeyboardMapper implements IKeyboardMapper {
 		return new SimpleKeybinding(binding.ctrlKey, binding.shiftKey, binding.altKey, binding.metaKey, keyCode);
 	}
 
-	public resolveUserBinding(firstPart: SimpleKeybinding | ScanCodeBinding | null, chordPart: SimpleKeybinding | ScanCodeBinding | null): ResolvedKeybinding[] {
-		const _firstPart = this._resolveSimpleUserBinding(firstPart);
-		const _chordPart = this._resolveSimpleUserBinding(chordPart);
-		let parts: SimpleKeybinding[] = [];
-		if (_firstPart) {
-			parts.push(_firstPart);
-		}
-		if (_chordPart) {
-			parts.push(_chordPart);
-		}
+	public resolveUserBinding(input: Array<SimpleKeybinding | ScanCodeBinding>): ResolvedKeybinding[] {
+		let parts: SimpleKeybinding[] = input.map(this._resolveSimpleUserBinding.bind(this));
 		if (parts.length > 0) {
 			return [new WindowsNativeResolvedKeybinding(this, parts)];
 		}

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -418,7 +418,11 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 				// This might be a removal keybinding item in user settings => accept it
 				result[resultLen++] = new ResolvedKeybindingItem(null, item.command, item.commandArgs, when, isDefault);
 			} else {
-				const resolvedKeybindings = this._keyboardMapper.resolveUserBinding(firstPart, chordPart);
+				let parts = [firstPart];
+				if (chordPart !== null) {
+					parts.push(chordPart);
+				}
+				const resolvedKeybindings = this._keyboardMapper.resolveUserBinding(parts);
 				for (const resolvedKeybinding of resolvedKeybindings) {
 					result[resultLen++] = new ResolvedKeybindingItem(resolvedKeybinding, item.command, item.commandArgs, when, isDefault);
 				}
@@ -455,8 +459,8 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 	}
 
 	public resolveUserBinding(userBinding: string): ResolvedKeybinding[] {
-		const [firstPart, chordPart] = KeybindingParser.parseUserBinding(userBinding);
-		return this._keyboardMapper.resolveUserBinding(firstPart, chordPart);
+		const parts = KeybindingParser.parseUserBinding(userBinding);
+		return this._keyboardMapper.resolveUserBinding(parts);
 	}
 
 	private _handleKeybindingsExtensionPointUser(isBuiltin: boolean, keybindings: ContributedKeyBinding | ContributedKeyBinding[], collector: ExtensionMessageCollector, result: IKeybindingRule2[]): void {

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -412,16 +412,11 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 		let result: ResolvedKeybindingItem[] = [], resultLen = 0;
 		for (const item of items) {
 			const when = (item.when ? item.when.normalize() : null);
-			const firstPart = item.firstPart;
-			const chordPart = item.chordPart;
-			if (!firstPart) {
+			const parts = item.parts;
+			if (parts.length === 0) {
 				// This might be a removal keybinding item in user settings => accept it
 				result[resultLen++] = new ResolvedKeybindingItem(null, item.command, item.commandArgs, when, isDefault);
 			} else {
-				let parts = [firstPart];
-				if (chordPart !== null) {
-					parts.push(chordPart);
-				}
 				const resolvedKeybindings = this._keyboardMapper.resolveUserBinding(parts);
 				for (const resolvedKeybinding of resolvedKeybindings) {
 					result[resultLen++] = new ResolvedKeybindingItem(resolvedKeybinding, item.command, item.commandArgs, when, isDefault);
@@ -447,7 +442,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 			});
 		}
 
-		return extraUserKeybindings.map((k) => KeybindingIO.readUserKeybindingItem(k, OS));
+		return extraUserKeybindings.map((k) => KeybindingIO.readUserKeybindingItem(k));
 	}
 
 	public resolveKeybinding(kb: Keybinding): ResolvedKeybinding[] {
@@ -540,7 +535,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 
 		let lastIndex = defaultKeybindings.length - 1;
 		defaultKeybindings.forEach((k, index) => {
-			KeybindingIO.writeKeybindingItem(out, k, OS);
+			KeybindingIO.writeKeybindingItem(out, k);
 			if (index !== lastIndex) {
 				out.writeLine(',');
 			} else {

--- a/src/vs/workbench/services/keybinding/test/keybindingIO.test.ts
+++ b/src/vs/workbench/services/keybinding/test/keybindingIO.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import { KeyChord, KeyCode, KeyMod, SimpleKeybinding, createKeybinding } from 'vs/base/common/keyCodes';
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
-import { OS, OperatingSystem } from 'vs/base/common/platform';
+import { OperatingSystem } from 'vs/base/common/platform';
 import { ScanCode, ScanCodeBinding } from 'vs/base/common/scanCode';
 import { IUserFriendlyKeybinding } from 'vs/platform/keybinding/common/keybinding';
 import { USLayoutResolvedKeybinding } from 'vs/platform/keybinding/common/usLayoutResolvedKeybinding';
@@ -126,37 +126,35 @@ suite('keybindingIO', () => {
 	test('issue #10452 - invalid command', () => {
 		let strJSON = `[{ "key": "ctrl+k ctrl+f", "command": ["firstcommand", "seccondcommand"] }]`;
 		let userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
-		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OS);
+		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.equal(keybindingItem.command, null);
 	});
 
 	test('issue #10452 - invalid when', () => {
 		let strJSON = `[{ "key": "ctrl+k ctrl+f", "command": "firstcommand", "when": [] }]`;
 		let userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
-		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OS);
+		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.equal(keybindingItem.when, null);
 	});
 
 	test('issue #10452 - invalid key', () => {
 		let strJSON = `[{ "key": [], "command": "firstcommand" }]`;
 		let userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
-		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OS);
-		assert.equal(keybindingItem.firstPart, null);
-		assert.equal(keybindingItem.chordPart, null);
+		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
+		assert.deepEqual(keybindingItem.parts, []);
 	});
 
 	test('issue #10452 - invalid key 2', () => {
 		let strJSON = `[{ "key": "", "command": "firstcommand" }]`;
 		let userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
-		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OS);
-		assert.equal(keybindingItem.firstPart, null);
-		assert.equal(keybindingItem.chordPart, null);
+		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
+		assert.deepEqual(keybindingItem.parts, []);
 	});
 
 	test('test commands args', () => {
 		let strJSON = `[{ "key": "ctrl+k ctrl+f", "command": "firstcommand", "when": [], "args": { "text": "theText" } }]`;
 		let userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
-		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding, OS);
+		let keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.equal(keybindingItem.commandArgs.text, 'theText');
 	});
 });

--- a/src/vs/workbench/services/keybinding/test/keyboardMapperTestUtils.ts
+++ b/src/vs/workbench/services/keybinding/test/keyboardMapperTestUtils.ts
@@ -44,7 +44,7 @@ export function assertResolveKeyboardEvent(mapper: IKeyboardMapper, keyboardEven
 	assert.deepEqual(actual, expected);
 }
 
-export function assertResolveUserBinding(mapper: IKeyboardMapper, parts: Array<SimpleKeybinding | ScanCodeBinding>, expected: IResolvedKeybinding[]): void {
+export function assertResolveUserBinding(mapper: IKeyboardMapper, parts: (SimpleKeybinding | ScanCodeBinding)[], expected: IResolvedKeybinding[]): void {
 	let actual: IResolvedKeybinding[] = mapper.resolveUserBinding(parts).map(toIResolvedKeybinding);
 	assert.deepEqual(actual, expected);
 }

--- a/src/vs/workbench/services/keybinding/test/keyboardMapperTestUtils.ts
+++ b/src/vs/workbench/services/keybinding/test/keyboardMapperTestUtils.ts
@@ -44,8 +44,8 @@ export function assertResolveKeyboardEvent(mapper: IKeyboardMapper, keyboardEven
 	assert.deepEqual(actual, expected);
 }
 
-export function assertResolveUserBinding(mapper: IKeyboardMapper, firstPart: SimpleKeybinding | ScanCodeBinding, chordPart: SimpleKeybinding | ScanCodeBinding | null, expected: IResolvedKeybinding[]): void {
-	let actual: IResolvedKeybinding[] = mapper.resolveUserBinding(firstPart, chordPart).map(toIResolvedKeybinding);
+export function assertResolveUserBinding(mapper: IKeyboardMapper, parts: Array<SimpleKeybinding | ScanCodeBinding>, expected: IResolvedKeybinding[]): void {
+	let actual: IResolvedKeybinding[] = mapper.resolveUserBinding(parts).map(toIResolvedKeybinding);
 	assert.deepEqual(actual, expected);
 }
 

--- a/src/vs/workbench/services/keybinding/test/macLinuxFallbackKeyboardMapper.test.ts
+++ b/src/vs/workbench/services/keybinding/test/macLinuxFallbackKeyboardMapper.test.ts
@@ -72,9 +72,10 @@ suite('keyboardMapper - MAC fallback', () => {
 
 	test('resolveUserBinding Cmd+[Comma] Cmd+/', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(false, false, false, true, ScanCode.Comma),
-			new SimpleKeybinding(false, false, false, true, KeyCode.US_SLASH),
+			mapper, [
+				new ScanCodeBinding(false, false, false, true, ScanCode.Comma),
+				new SimpleKeybinding(false, false, false, true, KeyCode.US_SLASH),
+			],
 			[{
 				label: '⌘, ⌘/',
 				ariaLabel: 'Command+, Command+/',
@@ -174,9 +175,10 @@ suite('keyboardMapper - LINUX fallback', () => {
 
 	test('resolveUserBinding Ctrl+[Comma] Ctrl+/', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+				new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			],
 			[{
 				label: 'Ctrl+, Ctrl+/',
 				ariaLabel: 'Control+, Control+/',
@@ -191,9 +193,9 @@ suite('keyboardMapper - LINUX fallback', () => {
 
 	test('resolveUserBinding Ctrl+[Comma]', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			null,
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+			],
 			[{
 				label: 'Ctrl+,',
 				ariaLabel: 'Control+,',

--- a/src/vs/workbench/services/keybinding/test/macLinuxKeyboardMapper.test.ts
+++ b/src/vs/workbench/services/keybinding/test/macLinuxKeyboardMapper.test.ts
@@ -307,8 +307,10 @@ suite('keyboardMapper - MAC de_ch', () => {
 	test('resolveUserBinding Cmd+[Comma] Cmd+/', () => {
 		assertResolveUserBinding(
 			mapper,
-			new ScanCodeBinding(false, false, false, true, ScanCode.Comma),
-			new SimpleKeybinding(false, false, false, true, KeyCode.US_SLASH),
+			[
+				new ScanCodeBinding(false, false, false, true, ScanCode.Comma),
+				new SimpleKeybinding(false, false, false, true, KeyCode.US_SLASH),
+			],
 			[{
 				label: '⌘, ⇧⌘7',
 				ariaLabel: 'Command+, Shift+Command+7',
@@ -384,8 +386,10 @@ suite('keyboardMapper - MAC en_us', () => {
 	test('resolveUserBinding Cmd+[Comma] Cmd+/', () => {
 		assertResolveUserBinding(
 			mapper,
-			new ScanCodeBinding(false, false, false, true, ScanCode.Comma),
-			new SimpleKeybinding(false, false, false, true, KeyCode.US_SLASH),
+			[
+				new ScanCodeBinding(false, false, false, true, ScanCode.Comma),
+				new SimpleKeybinding(false, false, false, true, KeyCode.US_SLASH),
+			],
 			[{
 				label: '⌘, ⌘/',
 				ariaLabel: 'Command+, Command+/',
@@ -732,9 +736,10 @@ suite('keyboardMapper - LINUX de_ch', () => {
 
 	test('resolveUserBinding Ctrl+[Comma] Ctrl+/', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+				new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			],
 			[{
 				label: 'Ctrl+, Ctrl+Shift+7',
 				ariaLabel: 'Control+, Control+Shift+7',
@@ -1108,9 +1113,10 @@ suite('keyboardMapper - LINUX en_us', () => {
 
 	test('resolveUserBinding Ctrl+[Comma] Ctrl+/', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+				new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			],
 			[{
 				label: 'Ctrl+, Ctrl+/',
 				ariaLabel: 'Control+, Control+/',
@@ -1125,9 +1131,9 @@ suite('keyboardMapper - LINUX en_us', () => {
 
 	test('resolveUserBinding Ctrl+[Comma]', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			null,
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma)
+			],
 			[{
 				label: 'Ctrl+,',
 				ariaLabel: 'Control+,',

--- a/src/vs/workbench/services/keybinding/test/windowsKeyboardMapper.test.ts
+++ b/src/vs/workbench/services/keybinding/test/windowsKeyboardMapper.test.ts
@@ -272,9 +272,10 @@ suite('keyboardMapper - WINDOWS de_ch', () => {
 
 	test('resolveUserBinding Ctrl+[Comma] Ctrl+/', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+				new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			],
 			[{
 				label: 'Ctrl+, Ctrl+§',
 				ariaLabel: 'Control+, Control+§',
@@ -341,9 +342,10 @@ suite('keyboardMapper - WINDOWS en_us', () => {
 
 	test('resolveUserBinding Ctrl+[Comma] Ctrl+/', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+				new SimpleKeybinding(true, false, false, false, KeyCode.US_SLASH),
+			],
 			[{
 				label: 'Ctrl+, Ctrl+/',
 				ariaLabel: 'Control+, Control+/',
@@ -358,9 +360,9 @@ suite('keyboardMapper - WINDOWS en_us', () => {
 
 	test('resolveUserBinding Ctrl+[Comma]', () => {
 		assertResolveUserBinding(
-			mapper,
-			new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
-			null!,
+			mapper, [
+				new ScanCodeBinding(true, false, false, false, ScanCode.Comma),
+			],
 			[{
 				label: 'Ctrl+,',
 				ariaLabel: 'Control+,',


### PR DESCRIPTION
A continuation of #65826, this handles one of the TODO items thus far (ResolvedKeybindingItem).

Before I move forward I wanted to do a quick preliminary discussion. @alexandrudima as you mentioned, keybindingResolver.ts looks to need a significant refactor to make this work and keep the code clean.

My thoughts from a high-level: 
Instead of having a map of <key, [ResolvedKeybindingItem]> pairs, instead have a nested map of Keys to a multiple [ResolvedKeybindingItem] (multiple because there could multiple matches that satisfy different contexts). E.g. ctrl-x ctrl-z would look like:

```
{
    "ctrl-x": {
        "ctrl-z": [ResolvedKeybindingItem]
    }
}
```

I think this would be faster than a list as you wouldn't have to iterate through all options and check if the keychord matches. Otherwise this will probably be noticeable with really deep keychords.

After that, it's a matter of ensuring that the existing rules around overrides and context matches works as expected. 

Does that sound ok?