### PR TITLE
Make indent consistent

### DIFF
--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -1144,7 +1144,7 @@ configurationRegistry.registerConfiguration({
 			'type': 'number',
 			'default': 8,
 			minimum: 0,
-			maximum: 20,
+			maximum: 40,
 			'description': localize('tree indent setting', "Controls tree indentation in pixels.")
 		},
 		[keyboardNavigationSettingKey]: {


### PR DESCRIPTION
Indent must be set in two places:
- src/vs/base/browser/ui/tree/abstractTree.ts
- src/vs/platform/list/browser/listService.ts

Fixes commit 79b4ea2 in issue 67576 (it changed only abstractTree.ts)