### PR TITLE
refactor(extension.git): replace disposables.forEach by using utils/dispose

### DIFF
--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -5,7 +5,7 @@
 
 import { workspace, Disposable, EventEmitter, Memento, window, MessageItem, ConfigurationTarget, Uri } from 'vscode';
 import { Repository, Operation } from './repository';
-import { eventToPromise, filterEvent, onceEvent } from './util';
+import { eventToPromise, filterEvent, onceEvent, dispose } from './util';
 import * as nls from 'vscode-nls';
 import { GitErrorCodes } from './api/git';
 
@@ -120,6 +120,6 @@ export class AutoFetcher {
 
 	dispose(): void {
 		this.disable();
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 	}
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -8,7 +8,7 @@ import { Git, CommitOptions, Stash, ForcePushMode } from './git';
 import { Repository, Resource, ResourceGroupType } from './repository';
 import { Model } from './model';
 import { toGitUri, fromGitUri } from './uri';
-import { grep, isDescendant, pathEquals } from './util';
+import { grep, isDescendant, pathEquals, dispose } from './util';
 import { applyLineChanges, intersectDiffWithRange, toLineRanges, invertLineChange, getModifiedRange } from './staging';
 import * as path from 'path';
 import { lstat, Stats } from 'fs';
@@ -2182,6 +2182,6 @@ export class CommandCenter {
 	}
 
 	dispose(): void {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 	}
 }

--- a/extensions/git/src/contentProvider.ts
+++ b/extensions/git/src/contentProvider.ts
@@ -7,7 +7,7 @@ import { workspace, Uri, Disposable, Event, EventEmitter, window } from 'vscode'
 import { debounce, throttle } from './decorators';
 import { fromGitUri, toGitUri } from './uri';
 import { Model, ModelChangeEvent, OriginalResourceChangeEvent } from './model';
-import { filterEvent, eventToPromise, isDescendant, pathEquals } from './util';
+import { filterEvent, eventToPromise, isDescendant, pathEquals, dispose } from './util';
 
 interface CacheRow {
 	uri: Uri;
@@ -145,6 +145,6 @@ export class GitContentProvider {
 	}
 
 	dispose(): void {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 	}
 }

--- a/extensions/git/src/decorationProvider.ts
+++ b/extensions/git/src/decorationProvider.ts
@@ -83,7 +83,7 @@ class GitIgnoreDecorationProvider implements DecorationProvider {
 	}
 
 	dispose(): void {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 		this.queue.clear();
 	}
 }
@@ -145,7 +145,7 @@ class GitDecorationProvider implements DecorationProvider {
 	}
 
 	dispose(): void {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 	}
 }
 

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -413,10 +413,7 @@ export class Model {
 	}
 
 	dispose(): void {
-		const openRepositories = [...this.openRepositories];
-		openRepositories.forEach(r => r.dispose());
-		this.openRepositories = [];
-
+		this.openRepositories = dispose(this.openRepositories);
 		this.possibleGitRepositoryPaths.clear();
 		this.disposables = dispose(this.disposables);
 	}

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -34,7 +34,7 @@ class CheckoutStatusBar {
 	}
 
 	dispose(): void {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 	}
 }
 
@@ -132,7 +132,7 @@ class SyncStatusBar {
 	}
 
 	dispose(): void {
-		this.disposables.forEach(d => d.dispose());
+		this.disposables = dispose(this.disposables);
 	}
 }
 


### PR DESCRIPTION
I'm reading the source code of the git extension, and I find it's safe to replace some `disposables.forEach` by using the `utils/dispose` function, such as some of the source like [protocolHandler](https://github.com/Microsoft/vscode/blob/master/extensions/git/src/protocolHandler.ts#L35) did.

I think the reason that my last pull request #68976 was closed is I just saw the single file, and this time I checked all the dispose method in the git extension and create this pull request.

By the way, I really learn a lot by reading the source of vscode, such as the design of `CommandCenter`, thanks a lot for your work.