### PR TITLE
Fixed #62968

### DIFF
--- a/src/vs/editor/common/controller/cursorTypeOperations.ts
+++ b/src/vs/editor/common/controller/cursorTypeOperations.ts
@@ -526,7 +526,7 @@ export class TypeOperations {
 			const lineText = model.getLineContent(position.lineNumber);
 
 			// Do not auto-close ' or " after a word character
-			if (chIsQuote && position.column > 1) {
+			if ((chIsQuote && position.column > 1) && autoCloseConfig !== 'always') {
 				const wordSeparators = getMapForWordSeparators(config.wordSeparators);
 				const characterBeforeCode = lineText.charCodeAt(position.column - 2);
 				const characterBeforeType = wordSeparators.get(characterBeforeCode);


### PR DESCRIPTION
This PR fixes this issue: https://github.com/Microsoft/vscode/issues/62968.

It makes it so that when typing some text and inputting a literal quote  while ` "editor.autoClosingQuotes": "always" ` is set, it will now auto complete the text.

Before:
![61070-notfixed](https://user-images.githubusercontent.com/16523071/53123764-dbd9ee00-3527-11e9-9497-eefe36b8b08f.gif)

After:
![61070-fixed](https://user-images.githubusercontent.com/16523071/53123798-e72d1980-3527-11e9-9877-574508121a79.gif)
