### PR TITLE
Extension recommendations based on workspace remotes

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -287,7 +287,8 @@ export type DynamicRecommendation = 'dynamic';
 export type ExecutableRecommendation = 'executable';
 export type CachedRecommendation = 'cached';
 export type ApplicationRecommendation = 'application';
-export type ExtensionRecommendationSource = IWorkspace | IWorkspaceFolder | URI | DynamicRecommendation | ExecutableRecommendation | CachedRecommendation | ApplicationRecommendation;
+export type GitRemoteRecommendation = 'remote';
+export type ExtensionRecommendationSource = IWorkspace | IWorkspaceFolder | URI | DynamicRecommendation | ExecutableRecommendation | CachedRecommendation | ApplicationRecommendation | GitRemoteRecommendation;
 
 export interface IExtensionRecommendation {
 	extensionId: string;
@@ -313,6 +314,7 @@ export const enum ExtensionRecommendationReason {
 	File,
 	Executable,
 	DynamicWorkspace,
+	GitRemote,
 	Experimental
 }
 

--- a/src/vs/platform/node/product.ts
+++ b/src/vs/platform/node/product.ts
@@ -56,6 +56,7 @@ export interface IProductConfiguration {
 	};
 	documentationUrl: string;
 	releaseNotesUrl: string;
+	remoteBasedExtensionTips: { [id: string]: string; };
 	keyboardShortcutsUrlMac: string;
 	keyboardShortcutsUrlLinux: string;
 	keyboardShortcutsUrlWin: string;

--- a/src/vs/workbench/contrib/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/contrib/stats/node/workspaceStats.ts
@@ -121,7 +121,7 @@ function extractDomain(url: string): string | null {
 	return null;
 }
 
-export function getDomainsOfRemotes(text: string, whitelist: string[]): string[] {
+export function getDomainsOfRemotes(text: string, whitelist: string[] = SecondLevelDomainWhitelist): string[] {
 	const domains = new Set<string>();
 	let match: RegExpExecArray | null;
 	while (match = RemoteMatcher.exec(text)) {


### PR DESCRIPTION
Adds support for a `remoteBasedExtensionTips` property in the `product.json`, which contains key-value pairs of an extension id and a pattern to match the workspace remotes against.

I'm not sure who the feature owner of this area is now, so apologies if I've assigned the wrong person