### PR TITLE
Add option to ignore file locally for git

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -346,6 +346,11 @@
         "category": "Git"
       },
       {
+        "command": "git.localIgnore",
+        "title": "%command.localIgnore%",
+        "category": "Git"
+      },
+      {
         "command": "git.stashIncludeUntracked",
         "title": "%command.stashIncludeUntracked%",
         "category": "Git"
@@ -588,6 +593,10 @@
         },
         {
           "command": "git.ignore",
+          "when": "config.git.enabled && gitOpenRepositoryCount != 0"
+        },
+        {
+          "command": "git.localIgnore",
           "when": "config.git.enabled && gitOpenRepositoryCount != 0"
         },
         {
@@ -924,6 +933,11 @@
         },
         {
           "command": "git.ignore",
+          "when": "scmProvider == git && scmResourceGroup == workingTree",
+          "group": "1_modification@3"
+        },
+        {
+          "command": "git.localIgnore",
           "when": "scmProvider == git && scmResourceGroup == workingTree",
           "group": "1_modification@3"
         }

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -53,6 +53,7 @@
 	"command.publish": "Publish Branch",
 	"command.showOutput": "Show Git Output",
 	"command.ignore": "Add File to .gitignore",
+	"command.localIgnore": "Ignore File Locally",
 	"command.stashIncludeUntracked": "Stash (Include Untracked)",
 	"command.stash": "Stash",
 	"command.stashPop": "Pop Stash...",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1907,6 +1907,31 @@ export class CommandCenter {
 		await this.runByRepository(resources, async (repository, resources) => repository.ignore(resources));
 	}
 
+	@command('git.localIgnore')
+	async localIgnore(...resourceStates: SourceControlResourceState[]): Promise<void> {
+		resourceStates = resourceStates.filter(s => !!s);
+
+		if (resourceStates.length === 0 || (resourceStates[0] && !(resourceStates[0].resourceUri instanceof Uri))) {
+			const resource = this.getSCMResource();
+
+			if (!resource) {
+				return;
+			}
+
+			resourceStates = [resource];
+		}
+
+		const resources = resourceStates
+			.filter(s => s instanceof Resource)
+			.map(r => r.resourceUri);
+
+		if (!resources.length) {
+			return;
+		}
+
+		await this.runByRepository(resources, async (repository, resources) => repository.localIgnore(resources));
+	}
+
 	private async _stash(repository: Repository, includeUntracked = false): Promise<void> {
 		const noUnstagedChanges = repository.workingTreeGroup.resourceStates.length === 0;
 		const noStagedChanges = repository.indexGroup.resourceStates.length === 0;


### PR DESCRIPTION
Adds an "Ignore File Locally" option to the context menu in the same manner as the "Add File to .gitignore" option. This works by adding the file to `.git/info/exclude`. Fixes #68340.  