### PR TITLE
Make EditStack correctly report canUndo

### DIFF
--- a/src/vs/editor/common/model/editStack.ts
+++ b/src/vs/editor/common/model/editStack.ts
@@ -210,7 +210,7 @@ export class EditStack {
 	}
 
 	public canUndo(): boolean {
-		return (this.past.length > 0);
+		return (this.past.length > 0) || this.currentOpenStackElement !== null;
 	}
 
 	public redo(): IUndoRedoResult | null {


### PR DESCRIPTION
Currently, `canUndo()` will incorrectly return false in the case that `this.past.length` is `0` and `this.currentOpenStackElement` is populated.

You can call `undo()` and it will do the right thing but there's no indication that you should be able to do it as `canUndo()` returns false.