### PR TITLE
Comments API refactor

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1224,10 +1224,22 @@ export enum CommentThreadCollapsibleState {
 	Expanded = 1
 }
 
+
+
+/**
+ * @internal
+ */
+export interface CommentWidget {
+	commentThread: CommentThread;
+	comment?: Comment;
+	input: string;
+}
+
 /**
  * @internal
  */
 export interface CommentThread {
+	commentThreadHandle?: number; // use optional type for now to avoid breaking existing api
 	extensionId: string;
 	threadId: string;
 	resource: string;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1318,22 +1318,22 @@ export interface CommentThreadChangedEvent {
 	/**
 	 * Added comment threads.
 	 */
-	readonly added: CommentThread[];
+	readonly added: (CommentThread | CommentThread2)[];
 
 	/**
 	 * Removed comment threads.
 	 */
-	readonly removed: CommentThread[];
+	readonly removed: (CommentThread | CommentThread2)[];
 
 	/**
 	 * Changed comment threads.
 	 */
-	readonly changed: CommentThread[];
+	readonly changed: (CommentThread | CommentThread2)[];
 
 	/**
 	 * changed draft mode.
 	 */
-	readonly draftMode: DraftMode;
+	readonly draftMode?: DraftMode;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1259,7 +1259,6 @@ export interface CommentThread2 {
  * @internal
  */
 export interface CommentThread {
-	commentThreadHandle?: number; // use optional type for now to avoid breaking existing api
 	extensionId: string;
 	threadId: string;
 	resource: string;
@@ -1299,6 +1298,8 @@ export interface Comment {
 	readonly canEdit?: boolean;
 	readonly canDelete?: boolean;
 	readonly command?: Command;
+	readonly editCommand?: Command;
+	readonly deleteCommand?: Command;
 	readonly isDraft?: boolean;
 	readonly commentReactions?: CommentReaction[];
 }

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1196,7 +1196,7 @@ export interface Command {
 export interface CommentInfo {
 	extensionId: string;
 	threads: CommentThread[];
-	commentingRanges?: IRange[];
+	commentingRanges?: (IRange[] | CommentingRanges);
 	reply?: Command;
 	draftMode: DraftMode;
 }
@@ -1269,7 +1269,7 @@ export interface CommentThread2 {
 export interface CommentingRanges {
 	readonly resource: URI;
 	ranges: IRange[];
-	acceptInputCommands: Command[];
+	newCommentThreadCommand: Command;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1248,7 +1248,7 @@ export interface CommentInput {
  * @internal
  */
 export interface CommentThread2 {
-	commentThreadHandle: number; // use optional type for now to avoid breaking existing api
+	commentThreadHandle: number;
 	extensionId: string;
 	threadId: string;
 	resource: string;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1233,6 +1233,26 @@ export interface CommentWidget {
 	commentThread: CommentThread;
 	comment?: Comment;
 	input: string;
+	onDidChangeInput: Event<string>;
+}
+
+/**
+ * @internal
+ */
+
+export interface CommentThread2 {
+	commentThreadHandle: number; // use optional type for now to avoid breaking existing api
+	extensionId: string;
+	threadId: string;
+	resource: string;
+	range: IRange;
+	comments: Comment[];
+	onDidChangeComments: Event<Comment[]>;
+	collapsibleState?: CommentThreadCollapsibleState;
+	input: string;
+	onDidChangeInput: Event<string>;
+	acceptInputCommands: Command[];
+	onDidChangeAcceptInputCommands: Event<Command[]>;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1258,6 +1258,16 @@ export interface CommentThread2 {
 /**
  * @internal
  */
+
+export interface CommentingRanges {
+	readonly resource: URI;
+	ranges: IRange[];
+	acceptInputCommands: Command[];
+}
+
+/**
+ * @internal
+ */
 export interface CommentThread {
 	extensionId: string;
 	threadId: string;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1239,7 +1239,14 @@ export interface CommentWidget {
 /**
  * @internal
  */
+export interface CommentInput {
+	value: string;
+	uri: URI;
+}
 
+/**
+ * @internal
+ */
 export interface CommentThread2 {
 	commentThreadHandle: number; // use optional type for now to avoid breaking existing api
 	extensionId: string;
@@ -1249,8 +1256,8 @@ export interface CommentThread2 {
 	comments: Comment[];
 	onDidChangeComments: Event<Comment[]>;
 	collapsibleState?: CommentThreadCollapsibleState;
-	input: string;
-	onDidChangeInput: Event<string>;
+	input: CommentInput;
+	onDidChangeInput: Event<CommentInput>;
 	acceptInputCommands: Command[];
 	onDidChangeAcceptInputCommands: Event<Command[]>;
 }

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -793,6 +793,7 @@ declare module 'vscode' {
 		 * Whether the thread should be collapsed or expanded when opening the document. Defaults to Collapsed.
 		 */
 		collapsibleState?: CommentThreadCollapsibleState;
+		dispose?(): void;
 	}
 
 	/**
@@ -956,8 +957,8 @@ declare module 'vscode' {
 		readonly id: string;
 		readonly label: string;
 		/**
-	 	 * The active (focused) comment widget.
-	 	 */
+		 * The active (focused) comment widget.
+		 */
 		readonly widget?: CommentWidget;
 		createCommentThread(id: string, resource: Uri, range: Range, comments: Comment[], acceptInputCommands: Command[], collapsibleState?: CommentThreadCollapsibleState): CommentThread;
 		dispose(): void;

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -787,6 +787,7 @@ declare module 'vscode' {
 		 * The ordered comments of the thread.
 		 */
 		comments: Comment[];
+		acceptInputCommands?: Command[];
 
 		/**
 		 * Whether the thread should be collapsed or expanded when opening the document. Defaults to Collapsed.
@@ -942,12 +943,6 @@ declare module 'vscode' {
 		commentThread: CommentThread;
 
 		/*
-		 * Focused Comment
-		 * This comment must be part of CommentWidget.commentThread
-		 */
-		comment?: Comment;
-
-		/*
 		 * Textarea content in the comment widget.
 		 * There is only one active input box in a comment widget.
 		 */
@@ -961,7 +956,7 @@ declare module 'vscode' {
 	 	 * The active (focused) comment widget.
 	 	 */
 		readonly widget?: CommentWidget;
-		createCommentThread(id: string, resource: Uri, range: Range, comments: Comment[], collapsibleState?: CommentThreadCollapsibleState): CommentThread;
+		createCommentThread(id: string, resource: Uri, range: Range, comments: Comment[], acceptInputCommands: Command[], collapsibleState?: CommentThreadCollapsibleState): CommentThread;
 		dispose(): void;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -935,10 +935,45 @@ declare module 'vscode' {
 		onDidChangeCommentThreads: Event<CommentThreadChangedEvent>;
 	}
 
+	export interface CommentWidget {
+		/*
+		 * Comment thread in this Comment Widget
+		 */
+		commentThread: CommentThread;
+
+		/*
+		 * Focused Comment
+		 * This comment must be part of CommentWidget.commentThread
+		 */
+		comment?: Comment;
+
+		/*
+		 * Textarea content in the comment widget.
+		 * There is only one active input box in a comment widget.
+		 */
+		input: string;
+	}
+
+	export interface CommentControl {
+		readonly id: string;
+		readonly label: string;
+		/**
+	 	 * The active (focused) comment widget.
+	 	 */
+		readonly widget?: CommentWidget;
+		createCommentThread(id: string, resource: Uri, range: Range, comments: Comment[], collapsibleState?: CommentThreadCollapsibleState): CommentThread;
+		dispose(): void;
+	}
+
+	namespace comment {
+		export function createCommentControl(id: string, label: string): CommentControl;
+	}
+
 	namespace workspace {
 		export function registerDocumentCommentProvider(provider: DocumentCommentProvider): Disposable;
 		export function registerWorkspaceCommentProvider(provider: WorkspaceCommentProvider): Disposable;
 	}
+
 	//#endregion
 
 	//#region Terminal

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -763,6 +763,12 @@ declare module 'vscode' {
 		Expanded = 1
 	}
 
+	interface CommentingRanges {
+		readonly resource: Uri;
+		ranges: Range[];
+		acceptInputCommands: Command[];
+	}
+
 	/**
 	 * A collection of comments representing a conversation at a particular range in a document.
 	 */
@@ -830,6 +836,8 @@ declare module 'vscode' {
 		 *
 		 * This will be treated as false if the comment is provided by a `WorkspaceCommentProvider`, or
 		 * if it is provided by a `DocumentCommentProvider` and  no `editComment` method is given.
+		 *
+		 * DEPRECATED, use editCommand
 		 */
 		canEdit?: boolean;
 
@@ -838,6 +846,8 @@ declare module 'vscode' {
 		 *
 		 * This will be treated as false if the comment is provided by a `WorkspaceCommentProvider`, or
 		 * if it is provided by a `DocumentCommentProvider` and  no `deleteComment` method is given.
+		 *
+		 * DEPRECATED, use deleteCommand
 		 */
 		canDelete?: boolean;
 
@@ -960,6 +970,7 @@ declare module 'vscode' {
 	 	 */
 		readonly widget?: CommentWidget;
 		createCommentThread(id: string, resource: Uri, range: Range, comments: Comment[], acceptInputCommands: Command[], collapsibleState?: CommentThreadCollapsibleState): CommentThread;
+		createCommentingRanges(resource: Uri, ranges: Range[], acceptInputCommands: Command[]): CommentingRanges;
 		dispose(): void;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -766,7 +766,7 @@ declare module 'vscode' {
 	interface CommentingRanges {
 		readonly resource: Uri;
 		ranges: Range[];
-		acceptInputCommands: Command[];
+		newCommentThreadCommand: Command;
 	}
 
 	/**
@@ -970,8 +970,12 @@ declare module 'vscode' {
 		 * The active (focused) comment widget.
 		 */
 		readonly widget?: CommentWidget;
+		/**
+		 * The active range users attempt to create comments against.
+		 */
+		readonly activeCommentingRange?: Range;
 		createCommentThread(id: string, resource: Uri, range: Range, comments: Comment[], acceptInputCommands: Command[], collapsibleState?: CommentThreadCollapsibleState): CommentThread;
-		createCommentingRanges(resource: Uri, ranges: Range[], acceptInputCommands: Command[]): CommentingRanges;
+		createCommentingRanges(resource: Uri, ranges: Range[], newCommentThreadCommand: Command): CommentingRanges;
 		dispose(): void;
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -846,6 +846,9 @@ declare module 'vscode' {
 		 */
 		command?: Command;
 
+		editCommand?: Command;
+		deleteCommand?: Command;
+
 		isDraft?: boolean;
 		commentReactions?: CommentReaction[];
 	}

--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -94,21 +94,6 @@ export class MainThreadCommentThread implements modes.CommentThread2 {
 	private _onDidChangeInput = new Emitter<modes.CommentInput | undefined>();
 	get onDidChangeInput(): Event<modes.CommentInput | undefined> { return this._onDidChangeInput.event; }
 
-	private _activeComment?: modes.Comment;
-
-	get activeComment(): modes.Comment {
-		return this._activeComment;
-	}
-
-	set activeComment(comment: modes.Comment | undefined) {
-		this._activeComment = comment;
-		this._onDidChangeActiveComment.fire(comment);
-	}
-
-	private _onDidChangeActiveComment = new Emitter<modes.Comment | undefined>();
-	get onDidChangeActiveComment(): Event<modes.Comment | undefined> { return this._onDidChangeActiveComment.event; }
-
-
 	public get comments(): modes.Comment[] {
 		return this._comments;
 	}
@@ -163,6 +148,18 @@ export class MainThreadCommentThread implements modes.CommentThread2 {
 export class MainThreadCommentControl {
 	get handle(): number {
 		return this._handle;
+	}
+
+	get id(): string {
+		return this._id;
+	}
+
+	get proxy(): ExtHostCommentsShape {
+		return this._proxy;
+	}
+
+	get label(): string {
+		return this._label;
 	}
 
 	private _threads: Map<number, MainThreadCommentThread> = new Map<number, MainThreadCommentThread>();
@@ -224,7 +221,7 @@ export class MainThreadCommentControl {
 			}
 		}
 
-		return <ICommentInfo> {
+		return <ICommentInfo>{
 			owner: String(this.handle),
 			threads: ret,
 			commentingRanges: [],
@@ -283,11 +280,6 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 				console.log(this._input.value, Math.random());
 			}));
 
-			this._activeCommentThreadDisposables.push(this._activeCommentThread.onDidChangeActiveComment(comment => { // todo, dispose
-				this._activeComment = comment;
-				this._proxy.$onActiveCommentWidgetChange(control.handle, this._activeCommentThread, this._activeComment, this._input ? this._input.value : undefined);
-			}));
-
 			await this._proxy.$onActiveCommentWidgetChange(control.handle, this._activeCommentThread, this._activeComment, this._input ? this._input.value : undefined);
 		}));
 	}
@@ -302,7 +294,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 		let provider = this._commentControls.get(handle);
 
 		if (!provider) {
-			return;
+			return undefined;
 		}
 
 		return provider.createCommentThread(commentThreadHandle, threadId, resource, range, comments, commands, collapseState);

--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -218,7 +218,7 @@ export class MainThreadCommentControl {
 			if (this._threads.get(thread).resource === resource.toString()) {
 				ret.push(this._threads.get(thread));
 			}
-}
+		}
 
 		return <ICommentInfo> {
 			owner: String(this.handle),
@@ -314,8 +314,8 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 		let provider = this._commentControls.get(handle);
 
 		if (!provider) {
-				return;
-			}
+			return;
+		}
 
 		provider.updateComments(commentThreadHandle, comments);
 	}
@@ -325,7 +325,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 
 		if (!provider) {
 			return;
-	}
+		}
 
 		provider.updateInput(commentThreadHandle, input);
 

--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -277,7 +277,6 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 			this._activeCommentThreadDisposables.push(this._activeCommentThread.onDidChangeInput(input => { // todo, dispose
 				this._input = input;
 				this._proxy.$onActiveCommentWidgetChange(control.handle, this._activeCommentThread, this._activeComment, this._input ? this._input.value : undefined);
-				console.log(this._input.value, Math.random());
 			}));
 
 			await this._proxy.$onActiveCommentWidgetChange(control.handle, this._activeCommentThread, this._activeComment, this._input ? this._input.value : undefined);

--- a/src/vs/workbench/api/electron-browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadComments.ts
@@ -193,7 +193,7 @@ export class MainThreadCommentControl {
 
 	deleteCommentThread(commentThreadHandle: number) {
 		let thread = this._threads.get(commentThreadHandle);
-
+		this._threads.delete(commentThreadHandle);
 		thread.dispose();
 	}
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -115,12 +115,12 @@ export function createApiFactory(
 	const extHostTerminalService = rpcProtocol.set(ExtHostContext.ExtHostTerminalService, new ExtHostTerminalService(rpcProtocol, extHostConfiguration, extHostLogService, extHostCommands));
 	const extHostDebugService = rpcProtocol.set(ExtHostContext.ExtHostDebugService, new ExtHostDebugService(rpcProtocol, extHostWorkspace, extensionService, extHostDocumentsAndEditors, extHostConfiguration, extHostTerminalService, extHostCommands));
 	const extHostSCM = rpcProtocol.set(ExtHostContext.ExtHostSCM, new ExtHostSCM(rpcProtocol, extHostCommands, extHostLogService));
+	const extHostComment = rpcProtocol.set(ExtHostContext.ExtHostComments, new ExtHostComments(rpcProtocol, extHostCommands.converter, extHostDocuments));
 	const extHostSearch = rpcProtocol.set(ExtHostContext.ExtHostSearch, new ExtHostSearch(rpcProtocol, schemeTransformer, extHostLogService));
 	const extHostTask = rpcProtocol.set(ExtHostContext.ExtHostTask, new ExtHostTask(rpcProtocol, extHostWorkspace, extHostDocumentsAndEditors, extHostConfiguration));
 	const extHostWindow = rpcProtocol.set(ExtHostContext.ExtHostWindow, new ExtHostWindow(rpcProtocol));
 	rpcProtocol.set(ExtHostContext.ExtHostExtensionService, extensionService);
 	const extHostProgress = rpcProtocol.set(ExtHostContext.ExtHostProgress, new ExtHostProgress(rpcProtocol.getProxy(MainContext.MainThreadProgress)));
-	const exthostCommentProviders = rpcProtocol.set(ExtHostContext.ExtHostComments, new ExtHostComments(rpcProtocol, extHostCommands.converter, extHostDocuments));
 	const extHostOutputService = rpcProtocol.set(ExtHostContext.ExtHostOutputService, new ExtHostOutputService(initData.logsLocation, rpcProtocol));
 	rpcProtocol.set(ExtHostContext.ExtHostStorage, extHostStorage);
 
@@ -640,10 +640,10 @@ export function createApiFactory(
 				return extHostSearch.registerFileIndexProvider(scheme, provider);
 			}),
 			registerDocumentCommentProvider: proposedApiFunction(extension, (provider: vscode.DocumentCommentProvider) => {
-				return exthostCommentProviders.registerDocumentCommentProvider(extension.identifier, provider);
+				return extHostComment.registerDocumentCommentProvider(extension.identifier, provider);
 			}),
 			registerWorkspaceCommentProvider: proposedApiFunction(extension, (provider: vscode.WorkspaceCommentProvider) => {
-				return exthostCommentProviders.registerWorkspaceCommentProvider(extension.identifier, provider);
+				return extHostComment.registerWorkspaceCommentProvider(extension.identifier, provider);
 			}),
 			registerRemoteAuthorityResolver: proposedApiFunction(extension, (authorityPrefix: string, resolver: vscode.RemoteAuthorityResolver) => {
 				return extensionService.registerRemoteAuthorityResolver(authorityPrefix, resolver);
@@ -665,6 +665,12 @@ export function createApiFactory(
 				return extHostSCM.createSourceControl(extension, id, label, rootUri);
 			}
 		};
+
+		const comment: typeof vscode.comment = {
+			createCommentControl(id: string, label: string) {
+				return extHostComment.createCommentControl(extension, id, label);
+			}
+		}
 
 		// namespace: debug
 		const debug: typeof vscode.debug = {
@@ -748,6 +754,7 @@ export function createApiFactory(
 			extensions,
 			languages,
 			scm,
+			comment,
 			tasks,
 			window,
 			workspace,

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -115,7 +115,7 @@ export function createApiFactory(
 	const extHostTerminalService = rpcProtocol.set(ExtHostContext.ExtHostTerminalService, new ExtHostTerminalService(rpcProtocol, extHostConfiguration, extHostLogService, extHostCommands));
 	const extHostDebugService = rpcProtocol.set(ExtHostContext.ExtHostDebugService, new ExtHostDebugService(rpcProtocol, extHostWorkspace, extensionService, extHostDocumentsAndEditors, extHostConfiguration, extHostTerminalService, extHostCommands));
 	const extHostSCM = rpcProtocol.set(ExtHostContext.ExtHostSCM, new ExtHostSCM(rpcProtocol, extHostCommands, extHostLogService));
-	const extHostComment = rpcProtocol.set(ExtHostContext.ExtHostComments, new ExtHostComments(rpcProtocol, extHostCommands.converter, extHostDocuments));
+	const extHostComment = rpcProtocol.set(ExtHostContext.ExtHostComments, new ExtHostComments(rpcProtocol, extHostCommands, extHostDocuments));
 	const extHostSearch = rpcProtocol.set(ExtHostContext.ExtHostSearch, new ExtHostSearch(rpcProtocol, schemeTransformer, extHostLogService));
 	const extHostTask = rpcProtocol.set(ExtHostContext.ExtHostTask, new ExtHostTask(rpcProtocol, extHostWorkspace, extHostDocumentsAndEditors, extHostConfiguration));
 	const extHostWindow = rpcProtocol.set(ExtHostContext.ExtHostWindow, new ExtHostWindow(rpcProtocol));

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -123,10 +123,10 @@ export interface MainThreadCommentsShape extends IDisposable {
 	$createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, comments: modes.Comment[], commands: modes.Command[], collapseState: modes.CommentThreadCollapsibleState): modes.CommentThread2 | undefined;
 	$deleteCommentThread(handle: number, commentThreadHandle: number): void;
 	$updateComments(handle: number, commentThreadHandle: number, comments: modes.Comment[]): void;
-	$createCommentingRanges(handle: number, commentingRangesHandle: number, resource: UriComponents, ranges: IRange[], commands: modes.Command[]): void;
+	$createCommentingRanges(handle: number, commentingRangesHandle: number, resource: UriComponents, ranges: IRange[], commands: modes.Command): void;
 	$deleteCommentingRanges(handle: number, commentingRangesHandle: number): void;
 	$updateCommentingRanges(handle: number, commentingRangesHandle: number, newRanges: IRange[]): void;
-	$updateCommentingRangesCommands(handle: number, commentingRangesHandle: number, acceptInputCommands: modes.Command[]): void;
+	$updateCommentingRangesCommands(handle: number, commentingRangesHandle: number, command: modes.Command): void;
 	$setInputValue(handle: number, commentThreadHandle: number, input: string): void;
 	$updateCommentThreadCommands(handle: number, commentThreadHandle: number, acceptInputCommands: modes.Command[]): void;
 	$registerDocumentCommentProvider(handle: number, features: CommentProviderFeatures): void;
@@ -1102,7 +1102,7 @@ export interface ExtHostCommentsShape {
 	$provideDocumentComments(handle: number, document: UriComponents): Promise<modes.CommentInfo>;
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Promise<modes.CommentThread>;
 	$onActiveCommentWidgetChange(commentControlhandle: number, commentThread: modes.CommentThread2, comment: modes.Comment | undefined, input: string): Promise<number | undefined>;
-	$onCommentWidgetInputChange(commentControlhandle: number, value: string): Promise<void>;
+	$onActiveCommentingRangeChange(commentControlhandle: number, range: IRange): void;
 	$replyToCommentThread(handle: number, document: UriComponents, range: IRange, commentThread: modes.CommentThread, text: string): Promise<modes.CommentThread>;
 	$editComment(handle: number, document: UriComponents, comment: modes.Comment, text: string): Promise<void>;
 	$deleteComment(handle: number, document: UriComponents, comment: modes.Comment): Promise<void>;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -119,6 +119,8 @@ export interface CommentProviderFeatures {
 }
 
 export interface MainThreadCommentsShape extends IDisposable {
+	$registerCommentControl(handle: number, id: string, label: string): void;
+	$createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, comments: modes.Comment[], collapseState: modes.CommentThreadCollapsibleState): modes.CommentThread | undefined;
 	$registerDocumentCommentProvider(handle: number, features: CommentProviderFeatures): void;
 	$unregisterDocumentCommentProvider(handle: number): void;
 	$registerWorkspaceCommentProvider(handle: number, extensionId: ExtensionIdentifier): void;
@@ -1091,6 +1093,8 @@ export interface ExtHostProgressShape {
 export interface ExtHostCommentsShape {
 	$provideDocumentComments(handle: number, document: UriComponents): Promise<modes.CommentInfo>;
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Promise<modes.CommentThread>;
+	$onActiveCommentWidgetChange(commentControlhandle: number, commentThread: modes.CommentThread, comment: modes.Comment | undefined, input: string): Promise<void>;
+	$onCommentWidgetInputChange(commentControlhandle: number, value: string): Promise<void>;
 	$replyToCommentThread(handle: number, document: UriComponents, range: IRange, commentThread: modes.CommentThread, text: string): Promise<modes.CommentThread>;
 	$editComment(handle: number, document: UriComponents, comment: modes.Comment, text: string): Promise<void>;
 	$deleteComment(handle: number, document: UriComponents, comment: modes.Comment): Promise<void>;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -1097,7 +1097,7 @@ export interface ExtHostProgressShape {
 export interface ExtHostCommentsShape {
 	$provideDocumentComments(handle: number, document: UriComponents): Promise<modes.CommentInfo>;
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Promise<modes.CommentThread>;
-	$onActiveCommentWidgetChange(commentControlhandle: number, commentThread: modes.CommentThread, comment: modes.Comment | undefined, input: string): Promise<void>;
+	$onActiveCommentWidgetChange(commentControlhandle: number, commentThread: modes.CommentThread2, comment: modes.Comment | undefined, input: string): Promise<number | undefined>;
 	$onCommentWidgetInputChange(commentControlhandle: number, value: string): Promise<void>;
 	$replyToCommentThread(handle: number, document: UriComponents, range: IRange, commentThread: modes.CommentThread, text: string): Promise<modes.CommentThread>;
 	$editComment(handle: number, document: UriComponents, comment: modes.Comment, text: string): Promise<void>;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -120,7 +120,11 @@ export interface CommentProviderFeatures {
 
 export interface MainThreadCommentsShape extends IDisposable {
 	$registerCommentControl(handle: number, id: string, label: string): void;
-	$createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, comments: modes.Comment[], collapseState: modes.CommentThreadCollapsibleState): modes.CommentThread | undefined;
+	$createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, comments: modes.Comment[], commands: modes.Command[], collapseState: modes.CommentThreadCollapsibleState): modes.CommentThread2 | undefined;
+	$deleteCommentThread(handle: number, commentThreadHandle: number): void;
+	$updateComments(handle: number, commentThreadHandle: number, comments: modes.Comment[]): void;
+	$setInputValue(handle: number, commentThreadHandle: number, input: string): void;
+	$updateCommentThreadCommands(handle: number, commentThreadHandle: number, acceptInputCommands: modes.Command[]): void;
 	$registerDocumentCommentProvider(handle: number, features: CommentProviderFeatures): void;
 	$unregisterDocumentCommentProvider(handle: number): void;
 	$registerWorkspaceCommentProvider(handle: number, extensionId: ExtensionIdentifier): void;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -123,6 +123,10 @@ export interface MainThreadCommentsShape extends IDisposable {
 	$createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, comments: modes.Comment[], commands: modes.Command[], collapseState: modes.CommentThreadCollapsibleState): modes.CommentThread2 | undefined;
 	$deleteCommentThread(handle: number, commentThreadHandle: number): void;
 	$updateComments(handle: number, commentThreadHandle: number, comments: modes.Comment[]): void;
+	$createCommentingRanges(handle: number, commentingRangesHandle: number, resource: UriComponents, ranges: IRange[], commands: modes.Command[]): void;
+	$deleteCommentingRanges(handle: number, commentingRangesHandle: number): void;
+	$updateCommentingRanges(handle: number, commentingRangesHandle: number, newRanges: IRange[]): void;
+	$updateCommentingRangesCommands(handle: number, commentingRangesHandle: number, acceptInputCommands: modes.Command[]): void;
 	$setInputValue(handle: number, commentThreadHandle: number, input: string): void;
 	$updateCommentThreadCommands(handle: number, commentThreadHandle: number, acceptInputCommands: modes.Command[]): void;
 	$registerDocumentCommentProvider(handle: number, features: CommentProviderFeatures): void;

--- a/src/vs/workbench/api/node/extHostComments.ts
+++ b/src/vs/workbench/api/node/extHostComments.ts
@@ -51,7 +51,7 @@ export class ExtHostComments implements ExtHostCommentsShape {
 
 					if (!commentControl) {
 						return arg;
-	}
+					}
 
 					return commentControl;
 				} else if (arg && arg.$mid === 7) {
@@ -347,7 +347,7 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 			this._commentControlHandle,
 			this.handle
 		);
-}
+	}
 
 }
 export class ExtHostCommentWidget implements vscode.CommentWidget {
@@ -498,7 +498,7 @@ function convertFromComment(comment: modes.Comment): vscode.Comment {
 	};
 }
 
-function convertToModeComment(vscodeComment: vscode.Comment): modes.Comment {
+function convertToModeComment(vscodeComment: vscode.Comment, commandsConverter: CommandsConverter): modes.Comment {
 	const iconPath = vscodeComment.userIconPath ? vscodeComment.userIconPath.toString() : vscodeComment.gravatar;
 
 	return {
@@ -506,7 +506,9 @@ function convertToModeComment(vscodeComment: vscode.Comment): modes.Comment {
 		body: extHostTypeConverter.MarkdownString.from(vscodeComment.body),
 		userName: vscodeComment.userName,
 		userIconPath: iconPath,
-		isDraft: vscodeComment.isDraft
+		isDraft: vscodeComment.isDraft,
+		editCommand: vscodeComment.editCommand ? commandsConverter.toInternal(vscodeComment.editCommand) : undefined,
+		deleteCommand: vscodeComment.editCommand ? commandsConverter.toInternal(vscodeComment.deleteCommand) : undefined
 	};
 }
 

--- a/src/vs/workbench/api/node/extHostComments.ts
+++ b/src/vs/workbench/api/node/extHostComments.ts
@@ -76,7 +76,8 @@ export class ExtHostComments implements ExtHostCommentsShape {
 	}
 
 	createCommentControl(extension: IExtensionDescription, id: string, label: string): vscode.CommentControl {
-		const commentControl = new ExtHostCommentControl(extension, this._commands.converter, this._proxy, id, label);
+		const handle = ExtHostComments.handlePool++;
+		const commentControl = new ExtHostCommentControl(extension, handle, this._commands.converter, this._proxy, id, label);
 		this._commentControls.set(commentControl.handle, commentControl);
 
 		const commentControls = this._commentControlsByExtension.get(ExtensionIdentifier.toKey(extension.identifier)) || [];
@@ -383,8 +384,6 @@ export class ExtHostCommentWidget implements vscode.CommentWidget {
 }
 
 class ExtHostCommentControl implements vscode.CommentControl {
-	private static _handlePool: number = 0;
-
 	get id(): string {
 		return this._id;
 	}
@@ -395,11 +394,15 @@ class ExtHostCommentControl implements vscode.CommentControl {
 
 	public widget?: ExtHostCommentWidget;
 
-	public handle: number = ExtHostCommentControl._handlePool++;
+	public get handle(): number {
+		return this._handle;
+	}
+
 	private _threads: Map<number, ExtHostCommentThread> = new Map<number, ExtHostCommentThread>();
 
 	constructor(
 		_extension: IExtensionDescription,
+		private _handle: number,
 		private readonly _commandsConverter: CommandsConverter,
 		private _proxy: MainThreadCommentsShape,
 		private _id: string,

--- a/src/vs/workbench/api/node/extHostComments.ts
+++ b/src/vs/workbench/api/node/extHostComments.ts
@@ -414,9 +414,6 @@ class ExtHostCommentControl implements vscode.CommentControl {
 	createCommentThread(id: string, resource: vscode.Uri, range: vscode.Range, comments: vscode.Comment[], acceptInputCommands: vscode.Command[], collapsibleState?: vscode.CommentThreadCollapsibleState): vscode.CommentThread {
 		const commentThread = new ExtHostCommentThread(this._proxy, this._commandsConverter, this.handle, id, resource, range, comments, acceptInputCommands, collapsibleState);
 		this._threads.set(commentThread.handle, commentThread);
-
-		// onDidDispose
-
 		return commentThread;
 	}
 
@@ -439,7 +436,12 @@ class ExtHostCommentControl implements vscode.CommentControl {
 	}
 
 	dispose(): void {
-		throw new Error('Method not implemented.');
+		this._threads.forEach(value => {
+			value.dispose();
+		});
+		this._commentingRanges.forEach(value => {
+			value.dispose();
+		});
 	}
 }
 

--- a/src/vs/workbench/contrib/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentNode.ts
@@ -10,7 +10,7 @@ import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ActionsOrientation, ActionItem, ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { Action, IActionRunner } from 'vs/base/common/actions';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -35,6 +35,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { DropdownMenuActionItem } from 'vs/base/browser/ui/dropdown/dropdown';
 import { AnchorAlignment } from 'vs/base/browser/ui/contextview/contextview';
 import { ToggleReactionsAction, ReactionAction, ReactionActionItem } from './reactionsAction';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 const UPDATE_COMMENT_LABEL = nls.localize('label.updateComment', "Update comment");
 const UPDATE_IN_PROGRESS_LABEL = nls.localize('label.updatingComment', "Updating comment...");
@@ -51,6 +52,7 @@ export class CommentNode extends Disposable {
 	private _reactionsActionBar?: ActionBar;
 	private _actionsContainer?: HTMLElement;
 	private _commentEditor: SimpleCommentEditor | null;
+	private _commentEditorDisposables: IDisposable[] = [];
 	private _commentEditorModel: ITextModel;
 	private _updateCommentButton: Button;
 	private _errorEditingContainer: HTMLElement;
@@ -67,6 +69,7 @@ export class CommentNode extends Disposable {
 	}
 
 	constructor(
+		private commentThread: modes.CommentThread | modes.CommentThread2,
 		public comment: modes.Comment,
 		private owner: string,
 		private resource: URI,
@@ -74,6 +77,7 @@ export class CommentNode extends Disposable {
 		private themeService: IThemeService,
 		private instantiationService: IInstantiationService,
 		private commentService: ICommentService,
+		private commandService: ICommandService,
 		private modelService: IModelService,
 		private modeService: IModeService,
 		private dialogService: IDialogService,
@@ -130,13 +134,13 @@ export class CommentNode extends Disposable {
 			actions.push(toggleReactionAction);
 		}
 
-		if (this.comment.canEdit) {
-			this._editAction = this.createEditAction(commentDetailsContainer);
+		if (this.comment.canEdit || this.comment.editCommand) {
+			this._editAction = this.createEditAction(commentDetailsContainer, !!this.comment.editCommand);
 			actions.push(this._editAction);
 		}
 
-		if (this.comment.canDelete) {
-			this._deleteAction = this.createDeleteAction();
+		if (this.comment.canDelete || this.comment.deleteCommand) {
+			this._deleteAction = this.createDeleteAction(!!this.comment.deleteCommand);
 			actions.push(this._deleteAction);
 		}
 
@@ -300,16 +304,29 @@ export class CommentNode extends Disposable {
 		this._commentEditor.setValue(this.comment.body.value);
 		this._commentEditor.layout({ width: container.clientWidth - 14, height: 90 });
 		this._commentEditor.focus();
+
+
 		const lastLine = this._commentEditorModel.getLineCount();
 		const lastColumn = this._commentEditorModel.getLineContent(lastLine).length + 1;
 		this._commentEditor.setSelection(new Selection(lastLine, lastColumn, lastLine, lastColumn));
 
-		this._toDispose.push(this._commentEditor.onKeyDown((e: IKeyboardEvent) => {
+		this._commentEditorDisposables.push(this._commentEditor.onKeyDown((e: IKeyboardEvent) => {
 			const isCmdOrCtrl = isMacintosh ? e.metaKey : e.ctrlKey;
 			if (this._updateCommentButton.enabled && e.keyCode === KeyCode.Enter && isCmdOrCtrl) {
-				this.editComment();
+				this.editComment(!!this.comment.editCommand);
 			}
 		}));
+
+		let commentThread = this.commentThread as modes.CommentThread2;
+		if (commentThread.commentThreadHandle) {
+			commentThread.input = this.comment.body.value;
+			this._commentEditorDisposables.push(this._commentEditor.onDidChangeModelContent(e => {
+				let newVal = this._commentEditor.getValue();
+				if (newVal !== commentThread.input) {
+					commentThread.input = newVal;
+				}
+			}));
+		}
 
 		this._toDispose.push(this._commentEditor);
 		this._toDispose.push(this._commentEditorModel);
@@ -320,6 +337,8 @@ export class CommentNode extends Disposable {
 		this._body.classList.remove('hidden');
 
 		this._commentEditorModel.dispose();
+		this._commentEditorDisposables.forEach(dispose => dispose.dispose());
+		this._commentEditorDisposables = [];
 		if (this._commentEditor) {
 			this._commentEditor.dispose();
 			this._commentEditor = null;
@@ -328,13 +347,24 @@ export class CommentNode extends Disposable {
 		this._commentEditContainer.remove();
 	}
 
-	private async editComment(): Promise<void> {
+	private async editComment(useCommand: boolean): Promise<void> {
 		this._updateCommentButton.enabled = false;
 		this._updateCommentButton.label = UPDATE_IN_PROGRESS_LABEL;
 
 		try {
 			const newBody = this._commentEditor.getValue();
-			await this.commentService.editComment(this.owner, this.resource, this.comment, newBody);
+
+			if (useCommand) {
+				let commentThread = this.commentThread as modes.CommentThread2;
+				commentThread.input = newBody;
+				this.commentService.setActiveCommentThread(commentThread);
+				let commandId = this.comment.editCommand!.id;
+				let args = this.comment.editCommand!.arguments || [];
+
+				await this.commandService.executeCommand(commandId, ...args);
+			} else {
+				await this.commentService.editComment(this.owner, this.resource, this.comment, newBody);
+			}
 
 			this._updateCommentButton.enabled = true;
 			this._updateCommentButton.label = UPDATE_COMMENT_LABEL;
@@ -355,7 +385,7 @@ export class CommentNode extends Disposable {
 		}
 	}
 
-	private createDeleteAction(): Action {
+	private createDeleteAction(useCommand: boolean): Action {
 		return new Action('comment.delete', nls.localize('label.delete', "Delete"), 'octicon octicon-x', true, () => {
 			return this.dialogService.confirm({
 				message: nls.localize('confirmDelete', "Delete comment?"),
@@ -364,11 +394,19 @@ export class CommentNode extends Disposable {
 			}).then(async result => {
 				if (result.confirmed) {
 					try {
-						const didDelete = await this.commentService.deleteComment(this.owner, this.resource, this.comment);
-						if (didDelete) {
-							this._onDidDelete.fire(this);
+						if (useCommand) {
+							this.commentService.setActiveCommentThread(this.commentThread as modes.CommentThread2);
+							let commandId = this.comment.deleteCommand!.id;
+							let args = this.comment.deleteCommand!.arguments || [];
+
+							await this.commandService.executeCommand(commandId, ...args);
 						} else {
-							throw Error();
+							const didDelete = await this.commentService.deleteComment(this.owner, this.resource, this.comment);
+							if (didDelete) {
+								this._onDidDelete.fire(this);
+							} else {
+								throw Error();
+							}
 						}
 					} catch (e) {
 						const error = e.message
@@ -381,7 +419,7 @@ export class CommentNode extends Disposable {
 		});
 	}
 
-	private createEditAction(commentDetailsContainer: HTMLElement): Action {
+	private createEditAction(commentDetailsContainer: HTMLElement, useCommand: boolean): Action {
 		return new Action('comment.edit', nls.localize('label.edit', "Edit"), 'octicon octicon-pencil', true, () => {
 			this._body.classList.add('hidden');
 			this._commentEditContainer = dom.append(commentDetailsContainer, dom.$('.edit-container'));
@@ -403,10 +441,10 @@ export class CommentNode extends Disposable {
 			this._toDispose.push(attachButtonStyler(this._updateCommentButton, this.themeService));
 
 			this._toDispose.push(this._updateCommentButton.onDidClick(_ => {
-				this.editComment();
+				this.editComment(useCommand);
 			}));
 
-			this._toDispose.push(this._commentEditor!.onDidChangeModelContent(_ => {
+			this._commentEditorDisposables.push(this._commentEditor!.onDidChangeModelContent(_ => {
 				this._updateCommentButton.enabled = !!this._commentEditor!.getValue();
 			}));
 

--- a/src/vs/workbench/contrib/comments/electron-browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentNode.ts
@@ -499,13 +499,14 @@ export class CommentNode extends Disposable {
 	}
 
 	update(newComment: modes.Comment) {
-		this.comment = newComment;
 
 		if (newComment.body !== this.comment.body) {
 			this._body.removeChild(this._md);
 			this._md = this.markdownRenderer.render(newComment.body).element;
 			this._body.appendChild(this._md);
 		}
+
+		this.comment = newComment;
 
 		if (newComment.isDraft) {
 			this._isPendingLabel.innerText = 'Pending';

--- a/src/vs/workbench/contrib/comments/electron-browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentService.ts
@@ -35,6 +35,8 @@ export interface ICommentService {
 	readonly onDidSetResourceCommentInfos: Event<IResourceCommentThreadEvent>;
 	readonly onDidSetAllCommentThreads: Event<IWorkspaceCommentThreadsEvent>;
 	readonly onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent>;
+	readonly onDidChangeActiveCommentThread: Event<CommentThread | null>;
+	readonly onDidChangeInput: Event<string>;
 	readonly onDidSetDataProvider: Event<void>;
 	readonly onDidDeleteDataProvider: Event<string>;
 	setDocumentComments(resource: URI, commentInfos: ICommentInfo[]): void;
@@ -57,6 +59,8 @@ export interface ICommentService {
 	addReaction(owner: string, resource: URI, comment: Comment, reaction: CommentReaction): Promise<void>;
 	deleteReaction(owner: string, resource: URI, comment: Comment, reaction: CommentReaction): Promise<void>;
 	getReactionGroup(owner: string): CommentReaction[] | undefined;
+	setActiveCommentThread(commentThread: CommentThread | null);
+	setInput(input: string);
 }
 
 export class CommentService extends Disposable implements ICommentService {
@@ -77,10 +81,24 @@ export class CommentService extends Disposable implements ICommentService {
 	private readonly _onDidUpdateCommentThreads: Emitter<ICommentThreadChangedEvent> = this._register(new Emitter<ICommentThreadChangedEvent>());
 	readonly onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent> = this._onDidUpdateCommentThreads.event;
 
+	private readonly _onDidChangeActiveCommentThread: Emitter<CommentThread> = this._register(new Emitter<CommentThread>());
+	readonly onDidChangeActiveCommentThread: Event<CommentThread | null> = this._onDidChangeActiveCommentThread.event;
+
+	private readonly _onDidChangeInput: Emitter<string> = this._register(new Emitter<string>());
+	readonly onDidChangeInput: Event<string> = this._onDidChangeInput.event;
+
 	private _commentProviders = new Map<string, DocumentCommentProvider>();
 
 	constructor() {
 		super();
+	}
+
+	setActiveCommentThread(commentThread: CommentThread | null) {
+		this._onDidChangeActiveCommentThread.fire(commentThread);
+	}
+
+	setInput(input: string) {
+		this._onDidChangeInput.fire(input);
 	}
 
 	setDocumentComments(resource: URI, commentInfos: ICommentInfo[]): void {

--- a/src/vs/workbench/contrib/comments/electron-browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CommentThread, DocumentCommentProvider, CommentThreadChangedEvent, CommentInfo, Comment, CommentReaction } from 'vs/editor/common/modes';
+import { CommentThread, DocumentCommentProvider, CommentThreadChangedEvent, CommentInfo, Comment, CommentReaction, CommentingRanges } from 'vs/editor/common/modes';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Event, Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
@@ -37,6 +37,7 @@ export interface ICommentService {
 	readonly onDidSetAllCommentThreads: Event<IWorkspaceCommentThreadsEvent>;
 	readonly onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent>;
 	readonly onDidChangeActiveCommentThread: Event<CommentThread | null>;
+	readonly onDidChangeActiveCommentingRange: Event<{ range: Range, commentingRangesInfo: CommentingRanges }>;
 	readonly onDidChangeInput: Event<string>;
 	readonly onDidSetDataProvider: Event<void>;
 	readonly onDidDeleteDataProvider: Event<string>;
@@ -63,6 +64,7 @@ export interface ICommentService {
 	getReactionGroup(owner: string): CommentReaction[] | undefined;
 	setActiveCommentThread(commentThread: CommentThread | null);
 	setInput(input: string);
+	setActiveCommentingRange(range: Range, commentingRangesInfo: CommentingRanges);
 }
 
 export class CommentService extends Disposable implements ICommentService {
@@ -88,6 +90,14 @@ export class CommentService extends Disposable implements ICommentService {
 
 	private readonly _onDidChangeInput: Emitter<string> = this._register(new Emitter<string>());
 	readonly onDidChangeInput: Event<string> = this._onDidChangeInput.event;
+	private readonly _onDidChangeActiveCommentingRange: Emitter<{
+		range: Range, commentingRangesInfo:
+		CommentingRanges
+	}> = this._register(new Emitter<{
+		range: Range, commentingRangesInfo:
+		CommentingRanges
+	}>());
+	readonly onDidChangeActiveCommentingRange: Event<{ range: Range, commentingRangesInfo: CommentingRanges }> = this._onDidChangeActiveCommentingRange.event;
 
 	private _commentProviders = new Map<string, DocumentCommentProvider>();
 
@@ -103,6 +113,11 @@ export class CommentService extends Disposable implements ICommentService {
 
 	setInput(input: string) {
 		this._onDidChangeInput.fire(input);
+	}
+
+	setActiveCommentingRange(range: Range, commentingRangesInfo:
+		CommentingRanges) {
+		this._onDidChangeActiveCommentingRange.fire({ range: range, commentingRangesInfo: commentingRangesInfo });
 	}
 
 	setDocumentComments(resource: URI, commentInfos: ICommentInfo[]): void {

--- a/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
@@ -342,12 +342,12 @@ export class ReviewZoneWidget extends ZoneWidget {
 		this._localToDispose.push(this._commentEditor);
 		this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => this.setCommentEditorDecorations()));
 		if ((this._commentThread as modes.CommentThread2).commentThreadHandle !== undefined) {
-		this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => {
+			this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => {
 				let modelContent = this._commentEditor.getValue();
 				if ((this._commentThread as modes.CommentThread2).input !== modelContent) {
 					(this._commentThread as modes.CommentThread2).input = modelContent;
 				}
-		}));
+			}));
 
 			this._localToDispose.push((this._commentThread as modes.CommentThread2).onDidChangeInput(input => {
 				if (this._commentEditor.getValue() !== input) {
@@ -414,7 +414,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 				this.createCommentWidgetActions2(this._formActions, model);
 			}));
 		} else {
-		this.createCommentWidgetActions(this._formActions, model);
+			this.createCommentWidgetActions(this._formActions, model);
 		}
 
 		this._resizeObserver = new MutationObserver(this._refresh.bind(this));
@@ -431,7 +431,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 		}
 
 		// If there are no existing comments, place focus on the text area. This must be done after show, which also moves focus.
-		if (this._commentThread.reply && !this._commentThread.comments.length) {
+		if ((this._commentThread as modes.CommentThread).reply && !this._commentThread.comments.length) {
 			this._commentEditor.focus();
 		} else if (this._commentEditor.getModel().getValueLength() > 0) {
 			if (!dom.hasClass(this._commentForm, 'expand')) {
@@ -564,6 +564,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 
 	private createNewCommentNode(comment: modes.Comment): CommentNode {
 		let newCommentNode = new CommentNode(
+			this._commentThread,
 			comment,
 			this.owner,
 			this.editor.getModel().uri,
@@ -571,6 +572,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 			this.themeService,
 			this.instantiationService,
 			this.commentService,
+			this.commandService,
 			this.modelService,
 			this.modeService,
 			this.dialogService,
@@ -676,7 +678,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 		if ((this._commentThread as modes.CommentThread2).commentThreadHandle !== undefined) {
 			// this._reviewThreadReplyButton.title = (this._commentThread as modes.CommentThread2).acceptInputCommands.title;
 		} else {
-		this._reviewThreadReplyButton.title = nls.localize('reply', "Reply...");
+			this._reviewThreadReplyButton.title = nls.localize('reply', "Reply...");
 		}
 		this._reviewThreadReplyButton.textContent = nls.localize('reply', "Reply...");
 		// bind click/escape actions for reviewThreadReplyButton and textArea

--- a/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
@@ -258,6 +258,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 			let currentComment = commentThread.comments[i];
 			let oldCommentNode = this._commentElements.filter(commentNode => commentNode.comment.commentId === currentComment.commentId);
 			if (oldCommentNode.length) {
+				oldCommentNode[0].update(currentComment);
 				lastCommentElement = oldCommentNode[0].domNode;
 				newCommentNodeList.unshift(oldCommentNode[0]);
 			} else {

--- a/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
@@ -342,18 +342,36 @@ export class ReviewZoneWidget extends ZoneWidget {
 		this._localToDispose.push(this._commentEditor);
 		this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => this.setCommentEditorDecorations()));
 		if ((this._commentThread as modes.CommentThread2).commentThreadHandle !== undefined) {
+			this._localToDispose.push(this._commentEditor.onDidFocusEditorWidget(() => {
+				let commentThread = this._commentThread as modes.CommentThread2;
+				commentThread.input = {
+					uri: this._commentEditor.getModel().uri,
+					value: this._commentEditor.getValue()
+				};
+				this.commentService.setActiveCommentThread(this._commentThread);
+			}));
+
 			this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => {
 				let modelContent = this._commentEditor.getValue();
-				if ((this._commentThread as modes.CommentThread2).input !== modelContent) {
-					(this._commentThread as modes.CommentThread2).input = modelContent;
+				let thread = (this._commentThread as modes.CommentThread2);
+				if (thread.input.uri === this._commentEditor.getModel().uri && thread.input.value !== modelContent) {
+					let newInput: modes.CommentInput = thread.input;
+					newInput.value = modelContent;
+					thread.input = newInput;
 				}
 			}));
 
 			this._localToDispose.push((this._commentThread as modes.CommentThread2).onDidChangeInput(input => {
-				if (this._commentEditor.getValue() !== input) {
-					this._commentEditor.setValue(input);
+				let thread = (this._commentThread as modes.CommentThread2);
 
-					if (input === '') {
+				if (thread.input.uri !== this._commentEditor.getModel().uri) {
+					return;
+				}
+
+				if (this._commentEditor.getValue() !== input.value) {
+					this._commentEditor.setValue(input.value);
+
+					if (input.value === '') {
 						this._pendingComment = '';
 						if (dom.hasClass(this._commentForm, 'expand')) {
 							dom.removeClass(this._commentForm, 'expand');
@@ -554,9 +572,11 @@ export class ReviewZoneWidget extends ZoneWidget {
 			let commandId = command.id;
 			let args = command.arguments || [];
 			this._localToDispose.push(button.onDidClick(async () => {
-				commentThread.input = this._commentEditor.getValue();
+				commentThread.input = {
+					uri: this._commentEditor.getModel().uri,
+					value: this._commentEditor.getValue()
+				};
 				this.commentService.setActiveCommentThread(this._commentThread);
-
 				await this.commandService.executeCommand(commandId, ...args);
 			}));
 		});

--- a/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
@@ -211,7 +211,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 		this._disposables.push(this._actionbarWidget);
 
 		this._collapseAction = new Action('review.expand', nls.localize('label.collapse', "Collapse"), COLLAPSE_ACTION_CLASS, true, () => {
-			if (this._commentThread.comments.length === 0) {
+			if (this._commentThread.comments.length === 0 && (this._commentThread as modes.CommentThread2).commentThreadHandle === undefined) {
 				this.dispose();
 				return null;
 			}
@@ -283,6 +283,10 @@ export class ReviewZoneWidget extends ZoneWidget {
 		const lineNumber = this._commentThread.range.startLineNumber;
 		if (this._commentGlyph.getPosition().position.lineNumber !== lineNumber) {
 			this._commentGlyph.setLineNumber(lineNumber);
+		}
+
+		if (!this._reviewThreadReplyButton) {
+			this.createReplyButton();
 		}
 
 		if (!this._isCollapsed) {
@@ -401,12 +405,11 @@ export class ReviewZoneWidget extends ZoneWidget {
 			}
 		}
 
-
 		this._localToDispose.push(this._commentEditor.onKeyDown((ev: IKeyboardEvent) => {
 			const hasExistingComments = this._commentThread.comments.length > 0;
 
 			if (this._commentEditor.getModel().getValueLength() === 0 && ev.keyCode === KeyCode.Escape) {
-				if (hasExistingComments) {
+				if (hasExistingComments || (this._commentThread as modes.CommentThread2).commentThreadHandle !== undefined) {
 					if (dom.hasClass(this._commentForm, 'expand')) {
 						dom.removeClass(this._commentForm, 'expand');
 					}

--- a/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
@@ -192,6 +192,10 @@ export class ReviewZoneWidget extends ZoneWidget {
 
 		this._bodyElement = <HTMLDivElement>dom.$('.body');
 		container.appendChild(this._bodyElement);
+
+		dom.addDisposableListener(this._bodyElement, dom.EventType.FOCUS_IN, e => {
+			this.commentService.setActiveCommentThread(this._commentThread);
+		});
 	}
 
 	protected _fillHead(container: HTMLElement): void {
@@ -335,6 +339,9 @@ export class ReviewZoneWidget extends ZoneWidget {
 		this._commentEditor.setModel(model);
 		this._localToDispose.push(this._commentEditor);
 		this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => this.setCommentEditorDecorations()));
+		this._localToDispose.push(this._commentEditor.getModel().onDidChangeContent(() => {
+			this.commentService.setInput(this._commentEditor.getModel().getValue());
+		}));
 		this.setCommentEditorDecorations();
 
 		// Only add the additional step of clicking a reply button to expand the textarea when there are existing comments

--- a/src/vs/workbench/contrib/comments/electron-browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentsEditorContribution.ts
@@ -37,6 +37,7 @@ import { CancelablePromise, createCancelablePromise } from 'vs/base/common/async
 import { overviewRulerCommentingRangeForeground } from 'vs/workbench/contrib/comments/electron-browser/commentGlyphWidget';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { STATUS_BAR_ITEM_HOVER_BACKGROUND, STATUS_BAR_ITEM_ACTIVE_BACKGROUND } from 'vs/workbench/common/theme';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 export const ctxReviewPanelVisible = new RawContextKey<boolean>('reviewPanelVisible', false);
 
@@ -171,6 +172,7 @@ export class ReviewController implements IEditorContribution {
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService private readonly themeService: IThemeService,
 		@ICommentService private readonly commentService: ICommentService,
+		@ICommandService private readonly _commandService: ICommandService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModeService private readonly modeService: IModeService,
@@ -396,7 +398,7 @@ export class ReviewController implements IEditorContribution {
 				}
 			});
 			added.forEach(thread => {
-				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.notificationService, this.contextMenuService, this.editor, e.owner, thread, null, draftMode);
+				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this._commandService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.notificationService, this.contextMenuService, this.editor, e.owner, thread, null, draftMode);
 				zoneWidget.display(thread.range.startLineNumber);
 				this._commentWidgets.push(zoneWidget);
 				this._commentInfos.filter(info => info.owner === e.owner)[0].threads.push(thread);
@@ -415,7 +417,7 @@ export class ReviewController implements IEditorContribution {
 
 		// add new comment
 		this._reviewPanelVisible.set(true);
-		this._newCommentWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.notificationService, this.contextMenuService, this.editor, ownerId, {
+		this._newCommentWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this._commandService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.notificationService, this.contextMenuService, this.editor, ownerId, {
 			extensionId: extensionId,
 			threadId: null,
 			resource: null,
@@ -573,7 +575,7 @@ export class ReviewController implements IEditorContribution {
 					thread.collapsibleState = modes.CommentThreadCollapsibleState.Expanded;
 				}
 
-				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.notificationService, this.contextMenuService, this.editor, info.owner, thread, pendingComment, info.draftMode);
+				let zoneWidget = new ReviewZoneWidget(this.instantiationService, this.modeService, this._commandService, this.modelService, this.themeService, this.commentService, this.openerService, this.dialogService, this.notificationService, this.contextMenuService, this.editor, info.owner, thread, pendingComment, info.draftMode);
 				zoneWidget.display(thread.range.startLineNumber);
 				this._commentWidgets.push(zoneWidget);
 			});


### PR DESCRIPTION
Since we can guarantee that GH PR extension is updated the same time as VS Code, now VS Code supports both the old provider like API and new SCM like API. Once GH PR is on the new one, we can remove the provider like API and all related code.