### PR TITLE
Allowing a user to change screencast mode overlay position and height/width from settings.

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -100,6 +100,11 @@ export const tocData: ITOCEntry = {
 					id: 'workbench/zenmode',
 					label: localize('zenMode', "Zen Mode"),
 					settings: ['zenmode.*']
+				},
+				{
+					id: 'application/screencastmode',
+					label: localize('screencastMode', "Screencast Mode"),
+					settings: ['screencastMode.location.*', 'screencastMode.overlay.*']
 				}
 			]
 		},

--- a/src/vs/workbench/electron-browser/actions/developerActions.ts
+++ b/src/vs/workbench/electron-browser/actions/developerActions.ts
@@ -16,6 +16,7 @@ import { Context } from 'vs/platform/contextkey/browser/contextKeyService';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { timeout } from 'vs/base/common/async';
 import { IPartService } from 'vs/workbench/services/part/common/partService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class ToggleDevToolsAction extends Action {
 
@@ -120,7 +121,8 @@ export class ToggleScreencastModeAction extends Action {
 		id: string,
 		label: string,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
-		@IPartService private readonly partService: IPartService
+		@IPartService private readonly partService: IPartService,
+		@IConfigurationService private readonly configurationService: IConfigurationService
 	) {
 		super(id, label);
 	}
@@ -170,10 +172,10 @@ export class ToggleScreencastModeAction extends Action {
 		const keyboardMarker = append(container, $('div'));
 		keyboardMarker.style.position = 'absolute';
 		keyboardMarker.style.backgroundColor = 'rgba(0, 0, 0 ,0.5)';
-		keyboardMarker.style.width = '100%';
-		keyboardMarker.style.height = '100px';
-		keyboardMarker.style.bottom = '20%';
-		keyboardMarker.style.left = '0';
+		keyboardMarker.style.width = `${this.configurationService.getValue<Number>('screencastMode.overlay.width')}%`;
+		keyboardMarker.style.height = `${this.configurationService.getValue<Number>('screencastMode.overlay.height')}%`;
+		keyboardMarker.style.bottom = `${this.configurationService.getValue<Number>('screencastMode.location.verticalPosition')}%`;
+		keyboardMarker.style.left = `${this.configurationService.getValue<Number>('screencastMode.location.horizontalPosition')}%`;
 		keyboardMarker.style.zIndex = '100000';
 		keyboardMarker.style.pointerEvents = 'none';
 		keyboardMarker.style.color = 'white';

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -677,6 +677,36 @@ import { LogStorageAction } from 'vs/platform/storage/node/storageService';
 		}
 	});
 
+	// Screencast Mode
+	registry.registerConfiguration({
+		'id': 'screencastMode',
+		'order': 9,
+		'title': nls.localize('screencastModeConfigurationTitle', "Screencast Mode"),
+		'type': 'object',
+		'properties': {
+			'screencastMode.location.verticalPosition': {
+				'type': 'number',
+				'default': 20,
+				'description': nls.localize('screencastMode.location.verticalPosition', "Controls the vertical position of the screencast mode overlay from the bottom as a percentage of the editor height.")
+			},
+			'screencastMode.location.horizontalPosition': {
+				'type': 'number',
+				'default': 0,
+				'description': nls.localize('screencastMode.location.horizontalPosition', "Controls the horizontal position of the screencast mode overlay from the left as a percentage of the editor width.")
+			},
+			'screencastMode.overlay.height': {
+				'type': 'number',
+				'default': 12,
+				'description': nls.localize('screencastMode.overlay.height', "Controls the height of the screencast overlay as a percentage of the editor height..")
+			},
+			'screencastMode.overlay.width': {
+				'type': 'number',
+				'default': 100,
+				'description': nls.localize('screencastMode.overlay.width', "Controls the width of the screencast overlay as a percentage of the editor width.")
+			}
+		}
+	});
+
 	// Telemetry
 	registry.registerConfiguration({
 		'id': 'telemetry',


### PR DESCRIPTION
* Added a new category to the workbench settings, `Screencast Mode` underneath `Zen Mode`.  This gives us a place to put future screencast mode settings as more are requested.

* Added 4 new settings to the `Screencast Mode` category, `Vertical Position`, `Horizontal Position`, `Height`, and `Width`, with default values that match the current hard coded values. 

* Updated `developerActions.ts` to pull the styles used for this overlay from the settings.

This fixes issue #66676.  

