### PR TITLE
Implement custom sorting based on rules.

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -418,7 +418,7 @@ configurationRegistry.registerConfiguration({
 							'groupId': {
 								'type': 'string',
 								'default': '',
-								'description': nls.localize('explorer.sortRules.groupId', "Allows similar files keep together. Grouping is based on first capturing group from pattern or you can freeze it by 'static' property. Hence to make it work RegExp capturing group must occur in regexp.")
+								'description': nls.localize('explorer.sortRules.groupId', "Allows similar files keep together. Grouping is based on first capturing group from pattern or you can freeze it by 'groupName' property. Hence to make it work RegExp capturing group must occur in regexp.")
 							},
 							'groupName': {
 								'type': 'string',
@@ -438,14 +438,16 @@ configurationRegistry.registerConfiguration({
 								'description': nls.localize('explorer.sortRules.specificity', "Determines override precedence when multiple rules applies.")
 							}
 						},
-						'dependencies':{
+						'dependencies': {
 							'groupId': {
 								'oneOf': [
 									{
 										'properties': {
 											'regexp': {
-												// Purpose of this regex is to ensure that #/explorer.sortRules/items/properties/regexp contain at least one capturing group.
-												// Regexp is not perfect and will fail with escaped brackets, without negative lookbehind it's impossbile to write proper one.
+												/*
+												 * Purpose of this regex is to ensure that #/explorer.sortRules/items/properties/regexp contain at least one capturing group.
+												 * Regexp is not perfect and will fail with escaped brackets, without negative lookbehind it's impossbile to write proper one.
+												 */
 												'pattern': '\\(.+\\)',
 												'patternErrorMessage': nls.localize('explorer.sortRules.dependencies.group.errorMessage', "To make grouping working regex must contain RegExp capturing group or use 'groupName' property.")
 											}

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -346,7 +346,7 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 		let position = Number.POSITIVE_INFINITY;
 		for (let rule of sortRules) {
 			let match = name.match(rule.regexp);
-			if (match === null ) {
+			if (match === null) {
 				// This rule doesn't apply to this entry:
 				continue;
 			}
@@ -358,7 +358,7 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 			}
 
 			if (rule.groupId !== undefined) {
-				if (rule.groupName !== undefined ) {
+				if (rule.groupName !== undefined) {
 					group = rule.groupName;
 				} else {
 					group = (match.length > 1) ? match[1] : '';
@@ -366,7 +366,7 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 			}
 		}
 
-		return {position: position, group: group} as ISortPosition;
+		return { position: position, group: group } as ISortPosition;
 	}
 
 	public compare(statA: ExplorerItem, statB: ExplorerItem): number {
@@ -385,7 +385,7 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 
 		const sortOrder = this.explorerService.sortOrder;
 
-		if (sortOrder === 'custom'){
+		if (sortOrder === 'custom') {
 			let positionRuleForA = this.resolvePosition(statA.name);
 			let positionRuleForB = this.resolvePosition(statB.name);
 
@@ -401,7 +401,7 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 
 			// Position entries by rule:
 			if (positionRuleForA.position !== positionRuleForB.position) {
-				return positionRuleForA.position > positionRuleForB.position ? 1 : -1;
+				return (positionRuleForA.position > positionRuleForB.position) ? 1 : -1;
 			}
 
 			// Defined rules aren't enough to differ this two entries, continue allowing default sorting to be applied.

--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -52,9 +52,8 @@ export class ExplorerService implements IExplorerService {
 		@IEditorService private editorService: IEditorService
 	) {
 		this._sortOrder = this.configurationService.getValue('explorer.sortOrder');
-
-		let sortRules = this.configurationService.getValue<ISortRule[]>('explorer.sortRules') ;
-			sortRules = this.fillSortRulesWithComputedValues(sortRules);
+		let sortRules = this.configurationService.getValue<ISortRule[]>('explorer.sortRules');
+		sortRules = this.fillSortRulesWithComputedValues(sortRules);
 		this._sortRules = sortRules;
 	}
 
@@ -387,7 +386,7 @@ export class ExplorerService implements IExplorerService {
 		}
 
 		let configSortRules = configuration && configuration.explorer && configuration.explorer.sortRules || [];
-			configSortRules = this.fillSortRulesWithComputedValues(configSortRules);
+		configSortRules = this.fillSortRulesWithComputedValues(configSortRules);
 		if (!equals(this._sortRules, configSortRules)) {
 			shouldFire = shouldFire || this._sortRules !== undefined;
 			this._sortRules = configSortRules;

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -41,6 +41,7 @@ export interface IExplorerService {
 	_serviceBrand: any;
 	readonly roots: ExplorerItem[];
 	readonly sortOrder: SortOrder;
+	readonly sortRules: ISortRule[];
 	readonly onDidChangeRoots: Event<void>;
 	readonly onDidChangeItem: Event<ExplorerItem | undefined>;
 	readonly onDidChangeEditable: Event<ExplorerItem>;
@@ -116,6 +117,7 @@ export interface IFilesConfiguration extends IFilesConfiguration, IWorkbenchEdit
 		enableDragAndDrop: boolean;
 		confirmDelete: boolean;
 		sortOrder: SortOrder;
+		sortRules: ISortRule[];
 		decorations: {
 			colors: boolean;
 			badges: boolean;
@@ -129,15 +131,24 @@ export interface IFileResource {
 	isDirectory?: boolean;
 }
 
+export interface ISortRule {
+	regexp: string;
+	groupId: string;
+	groupName: string;
+	position: number;
+	specificity: number;
+}
+
 export const SortOrderConfiguration = {
 	DEFAULT: 'default',
 	MIXED: 'mixed',
 	FILES_FIRST: 'filesFirst',
 	TYPE: 'type',
-	MODIFIED: 'modified'
+	MODIFIED: 'modified',
+	CUSTOM: 'custom'
 };
 
-export type SortOrder = 'default' | 'mixed' | 'filesFirst' | 'type' | 'modified';
+export type SortOrder = 'default' | 'mixed' | 'filesFirst' | 'type' | 'modified' | 'custom';
 
 export class FileOnDiskContentProvider implements ITextModelContentProvider {
 	private fileWatcher: IDisposable;


### PR DESCRIPTION
SortRules allows us position file whatever we like, based on Regexp match.

It's very useful in finding files when you know exactly where they will occur in hierarchy in explorer. E.g.: Interfaces will always placed at the top.

![diff](https://user-images.githubusercontent.com/11600464/53306347-57230300-388c-11e9-90b9-41432ba897b0.jpg)
