### PR TITLE
feat: add TM_DIRECTORY_BASE var

### DIFF
--- a/src/vs/editor/contrib/snippet/snippetVariables.ts
+++ b/src/vs/editor/contrib/snippet/snippetVariables.ts
@@ -34,6 +34,7 @@ export const KnownSnippetVariableNames = Object.freeze({
 	'TM_FILENAME': true,
 	'TM_FILENAME_BASE': true,
 	'TM_DIRECTORY': true,
+	'TM_DIRECTORY_BASE': true,
 	'TM_FILEPATH': true,
 	'BLOCK_COMMENT_START': true,
 	'BLOCK_COMMENT_END': true,
@@ -148,6 +149,9 @@ export class ModelBasedVariableResolver implements VariableResolver {
 			const dir = dirname(this._model.uri.fsPath);
 			return dir !== '.' ? dir : '';
 
+		} else if (name === 'TM_DIRECTORY_BASE') {
+			const parentDirname = basename(dirname(this._model.uri.fsPath));
+			return parentDirname;
 		} else if (name === 'TM_FILEPATH') {
 			return this._model.uri.fsPath;
 		}

--- a/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
@@ -54,7 +54,6 @@ suite('Snippet Variables Resolver', function () {
 		assertVariableResolve(resolver, 'TM_FILENAME', 'text.txt');
 		if (!isWindows) {
 			assertVariableResolve(resolver, 'TM_DIRECTORY', '/foo/files');
-			assertVariableResolve(resolver, 'TM_DIRECTORY_BASE', 'files');
 			assertVariableResolve(resolver, 'TM_FILEPATH', '/foo/files/text.txt');
 		}
 

--- a/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetVariables.test.ts
@@ -54,6 +54,7 @@ suite('Snippet Variables Resolver', function () {
 		assertVariableResolve(resolver, 'TM_FILENAME', 'text.txt');
 		if (!isWindows) {
 			assertVariableResolve(resolver, 'TM_DIRECTORY', '/foo/files');
+			assertVariableResolve(resolver, 'TM_DIRECTORY_BASE', 'files');
 			assertVariableResolve(resolver, 'TM_FILEPATH', '/foo/files/text.txt');
 		}
 
@@ -63,6 +64,7 @@ suite('Snippet Variables Resolver', function () {
 		assertVariableResolve(resolver, 'TM_FILENAME', 'ghi');
 		if (!isWindows) {
 			assertVariableResolve(resolver, 'TM_DIRECTORY', '/abc/def');
+			assertVariableResolve(resolver, 'TM_DIRECTORY_BASE', 'def');
 			assertVariableResolve(resolver, 'TM_FILEPATH', '/abc/def/ghi');
 		}
 
@@ -70,6 +72,7 @@ suite('Snippet Variables Resolver', function () {
 			TextModel.createFromString('', undefined, undefined, URI.parse('mem:fff.ts'))
 		);
 		assertVariableResolve(resolver, 'TM_DIRECTORY', '');
+		assertVariableResolve(resolver, 'TM_DIRECTORY_BASE', '');
 		assertVariableResolve(resolver, 'TM_FILEPATH', 'fff.ts');
 
 	});


### PR DESCRIPTION
my React project directory structure like this:

```bash
- package.json
- src
	- Header
		- index.tsx
	- Footer
		- index.tsx
```

so there's no such variable that I can set the parent dirname as my React component name.

![image](https://user-images.githubusercontent.com/13595509/53385993-66ed3500-39bb-11e9-9c4a-3a39b47b0510.png)
