### PR TITLE
Relaunch Workspaces After Windows Restart for Updates

### DIFF
--- a/build/.nativeignore
+++ b/build/.nativeignore
@@ -67,6 +67,11 @@ windows-process-tree/build/**
 windows-process-tree/src/**
 !windows-process-tree/**/*.node
 
+windows-register-restart/binding.gyp
+windows-register-restart/build/**
+windows-register-restart/src/**
+!windows-register-restart/**/*.node
+
 gc-signals/binding.gyp
 gc-signals/build/**
 gc-signals/src/**

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "vscode-windows-registry": "1.0.1",
     "windows-foreground-love": "0.1.0",
     "windows-mutex": "0.2.1",
-    "windows-process-tree": "0.2.3"
+    "windows-process-tree": "0.2.3",
+    "windows-register-restart": "^0.1.0"
   }
 }

--- a/src/typings/windows-register-restart.d.ts
+++ b/src/typings/windows-register-restart.d.ts
@@ -1,0 +1,36 @@
+
+declare module 'windows-register-restart' {
+	export enum NoRestart {
+		/**
+		 * Do not restart the process if it terminates due to an unhandled exception.
+		 */
+		OnCrash = 1,
+		/**
+		 * Do not restart the process if it terminates due to the application not responding.
+		 */
+		OnHang = 2,
+		/**
+		 * Do not restart the process if it terminates due to the installation of an update.
+		 */
+		OnPatch = 4,
+		/**
+		 * Do not restart the process if the computer is restarted as the result of an update.
+		 */
+		OnReboot = 8
+	}
+
+	/**
+	 * Registers the active instance of an application for restart.
+	 *
+	 * @param commandLine The command line arguments for the application when it is restarted. Do not include the name of the executable in the command line; the function adds it for you.
+	 * @param noRestart Flags that are used to prevent the application from restarting in specific scenarios.
+	 *
+	 * @returns Whether the registration was succesfull.
+	 */
+	export function registerApplicationRestart(commandLine?: string, noRestart?: NoRestart): boolean;
+
+	/**
+	 * Removes the active instance of an application from the restart list.
+	 */
+	export function unregisterApplicationRestart(): boolean;
+}

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -76,6 +76,7 @@ import { IBackupMainService } from 'vs/platform/backup/common/backup';
 import { HistoryMainService } from 'vs/platform/history/electron-main/historyMainService';
 import { URLService } from 'vs/platform/url/common/urlService';
 import { WorkspacesMainService } from 'vs/platform/workspaces/electron-main/workspacesMainService';
+import { OsRestartService, IOsRestartService } from 'vs/platform/osRestart/electron-main/osRestartService';
 import { RemoteAgentConnectionContext } from 'vs/platform/remote/common/remoteAgentEnvironment';
 import { nodeWebSocketFactory } from 'vs/platform/remote/node/nodeWebSocketFactory';
 import { VSBuffer } from 'vs/base/common/buffer';
@@ -363,6 +364,13 @@ export class CodeApplication extends Disposable {
 		// Open Windows
 		const windows = appInstantiationService.invokeFunction(accessor => this.openFirstWindow(accessor, electronIpcServer, sharedProcessClient));
 
+		appInstantiationService.invokeFunction(accessor => {
+			let osRestartService = accessor.get(IOsRestartService);
+			if (osRestartService) {
+				osRestartService.ready();
+			}
+		});
+
 		// Post Open Windows Tasks
 		this.afterWindowOpen();
 
@@ -423,6 +431,7 @@ export class CodeApplication extends Disposable {
 		services.set(IHistoryMainService, new SyncDescriptor(HistoryMainService));
 		services.set(IURLService, new SyncDescriptor(URLService));
 		services.set(IWorkspacesMainService, new SyncDescriptor(WorkspacesMainService));
+		services.set(IOsRestartService, new SyncDescriptor(OsRestartService));
 
 		// Telemetry
 		if (!this.environmentService.isExtensionDevelopment && !this.environmentService.args['disable-telemetry'] && !!product.enableTelemetry) {

--- a/src/vs/platform/osRestart/electron-main/osRestartService.ts
+++ b/src/vs/platform/osRestart/electron-main/osRestartService.ts
@@ -54,7 +54,7 @@ export class OsRestartService extends Disposable implements IOsRestartService {
 		};
 
 		const windowClosed = (id: number) => {
-			if (this.hookedWindow.id === id) {
+			if (this.hookedWindow && this.hookedWindow.id === id) {
 				this.removeWindowHook();
 			}
 

--- a/src/vs/platform/osRestart/electron-main/osRestartService.ts
+++ b/src/vs/platform/osRestart/electron-main/osRestartService.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IWindowsMainService, ICodeWindow } from 'vs/platform/windows/electron-main/windows';
+import { ILifecycleService } from 'vs/platform/lifecycle/electron-main/lifecycleMain';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { registerApplicationRestart, NoRestart } from 'windows-register-restart';
+import { isWindows } from 'vs/base/common/platform';
+
+const WM_ENDSESSION = 0x0016;
+
+export const IOsRestartService = createDecorator<IOsRestartService>('osRestartService');
+
+export interface IOsRestartService {
+	readonly isRegistered: boolean;
+	ready(): void;
+}
+
+export class OsRestartService extends Disposable implements IOsRestartService {
+
+	private hookedWindow?: ICodeWindow;
+	private _isRegistered = false;
+
+	constructor(
+		@IWindowsMainService private readonly _windowsMainService: IWindowsMainService,
+		@ILifecycleService private readonly _lifecycleMainService: ILifecycleService
+	) {
+		super();
+	}
+
+	get isRegistered(): boolean {
+		return this._isRegistered;
+	}
+
+	ready(): void {
+		if (!isWindows || this._isRegistered) {
+			return;
+		}
+
+		registerApplicationRestart('', NoRestart.OnCrash | NoRestart.OnHang | NoRestart.OnPatch);
+		this._isRegistered = true;
+
+		if (this._windowsMainService.getWindowCount() > 0) {
+			this.addWindowHook(this._windowsMainService.getWindows()[0]);
+		}
+
+		const windowReady = (window: ICodeWindow) => {
+			if (!this.hookedWindow) {
+				this.addWindowHook(window);
+			}
+		};
+
+		const windowClosed = (id: number) => {
+			if (this.hookedWindow.id === id) {
+				this.removeWindowHook();
+			}
+
+			if (this._windowsMainService.getWindowCount() > 0) {
+				this.addWindowHook(this._windowsMainService.getWindows()[0]);
+			}
+		};
+
+		this._register(this._windowsMainService.onWindowReady(windowReady));
+		this._register(this._windowsMainService.onWindowClose(windowClosed));
+	}
+
+	private addWindowHook(window: ICodeWindow): void {
+		if (!this.hookedWindow) {
+			window.win.hookWindowMessage(WM_ENDSESSION, () => this.onShutdownImminent());
+			this.hookedWindow = window;
+		}
+	}
+
+	private removeWindowHook(): void {
+		if (this.hookedWindow) {
+			this.hookedWindow.win.unhookWindowMessage(WM_ENDSESSION);
+			this.hookedWindow = undefined;
+		}
+	}
+
+	private onShutdownImminent(): void {
+		this._lifecycleMainService.quit(true);
+	}
+}

--- a/src/vs/platform/osRestart/electron-main/osRestartService.ts
+++ b/src/vs/platform/osRestart/electron-main/osRestartService.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ILogService } from 'vs/platform/log/common/log';
 import { IWindowsMainService, ICodeWindow } from 'vs/platform/windows/electron-main/windows';
 import { ILifecycleService } from 'vs/platform/lifecycle/electron-main/lifecycleMain';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { registerApplicationRestart, NoRestart } from 'windows-register-restart';
 import { isWindows } from 'vs/base/common/platform';
 
 const WM_ENDSESSION = 0x0016;
@@ -25,6 +25,7 @@ export class OsRestartService extends Disposable implements IOsRestartService {
 	private _isRegistered = false;
 
 	constructor(
+		@ILogService private readonly _logService: ILogService,
 		@IWindowsMainService private readonly _windowsMainService: IWindowsMainService,
 		@ILifecycleService private readonly _lifecycleMainService: ILifecycleService
 	) {
@@ -40,7 +41,18 @@ export class OsRestartService extends Disposable implements IOsRestartService {
 			return;
 		}
 
-		registerApplicationRestart('', NoRestart.OnCrash | NoRestart.OnHang | NoRestart.OnPatch);
+		try {
+			const registerApplicationRestart = (require.__$__nodeRequire('windows-register-restart') as any).registerApplicationRestart;
+			const NoRestart = (require.__$__nodeRequire('windows-register-restart') as any).NoRestart;
+
+			registerApplicationRestart('', NoRestart.OnCrash | NoRestart.OnHang | NoRestart.OnPatch);
+		} catch (e) {
+			this._logService.error(`Unable to register for application restart, ${e.message}`);
+
+			// don't attempt any window hooks.
+			return;
+		}
+
 		this._isRegistered = true;
 
 		if (this._windowsMainService.getWindowCount() > 0) {
@@ -76,7 +88,12 @@ export class OsRestartService extends Disposable implements IOsRestartService {
 
 	private removeWindowHook(): void {
 		if (this.hookedWindow) {
-			this.hookedWindow.win.unhookWindowMessage(WM_ENDSESSION);
+
+			// on application quit, win can already be destroyed.
+			if (this.hookedWindow.win) {
+				this.hookedWindow.win.unhookWindowMessage(WM_ENDSESSION);
+			}
+
 			this.hookedWindow = undefined;
 		}
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9791,10 +9791,10 @@ windows-process-tree@0.2.3:
   dependencies:
     nan "^2.10.0"
 
-windows-register-restart@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/windows-register-restart/-/windows-register-restart-0.1.0.tgz#9436a7be83c1c288e45a3d4272c0ee4f2084ac27"
-  integrity sha512-FVR8Wt0UVytmMkJ/oUePCrOKQh/w/WpSbp2dsWhV52R5cuzba0X+idue4A6VFxh4U0LqPUySInsfEe+lCC4U0A==
+windows-register-restart@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/windows-register-restart/-/windows-register-restart-0.1.2.tgz#c865342af1608cfb292cd8f36e5c9d1fbea922a7"
+  integrity sha512-9XL/NSsFxd+hNNEHXcnSZrwLO2JEAMgye6IBp0CEUioFLJ40Z1CPvjfpUeObBB8cxrFBByAPdtZdFIBTPF646A==
 
 wordwrap@0.0.2:
   version "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9791,6 +9791,11 @@ windows-process-tree@0.2.3:
   dependencies:
     nan "^2.10.0"
 
+windows-register-restart@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/windows-register-restart/-/windows-register-restart-0.1.0.tgz#9436a7be83c1c288e45a3d4272c0ee4f2084ac27"
+  integrity sha512-FVR8Wt0UVytmMkJ/oUePCrOKQh/w/WpSbp2dsWhV52R5cuzba0X+idue4A6VFxh4U0LqPUySInsfEe+lCC4U0A==
+
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"


### PR DESCRIPTION
# Summary
This pull request implements a lightweight service that registers Visual Studio Code for application restart in Windows. This is only observed when the system reboots itself; usually for a Windows update.

[Example Here](https://i.imgur.com/0WUn4oA.gifv)

Resolves #12630 

### Testing
1. Run `yarn gulp vscode-win32-x64` to package the application
1. Navigate to the package output (`..\VSCode-win32-x64`)
1. Run `Code - OSS.exe`
1. Run `shutdown /g /t 0` to simulate a restart from Windows update.

This will only properly work from a packaged version of Visual Studio Code. Having a virtual machine to test in is also useful.

### Changes
In order to use the [`RegisterApplicationRestart`](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-registerapplicationrestart) method, I had to create a [Node.js extension](https://github.com/kdelorey/node-windows-register-restart) for the method. I'm happy to transfer ownership of the extension to the Microsoft GitHub organization if required.

A service was then added that handles the registration of Visual Studio Code for restart. It also hooks into one of the opened code windows to listen for `WM_ENDSESSION`. The `WM_ENDSESSION` is triggered before a shutdown. I use this opportunity to ask the `LifecycleService` to `quit(fromUpdate: true)`. I use the `fromUpdate` argument in order to save all of the opened workspaces into the `storage.json` file.
