### PR TITLE
Make an error message easier to understand

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -228,7 +228,7 @@ function hygiene(some) {
 			let formatted = result.dest.replace(/\r\n/gm, '\n');
 
 			if (original !== formatted) {
-				console.error('File not formatted with tsfmt:', file.relative);
+				console.error("File not formatted. Run the 'Format Document' command to fix it:", file.relative);
 				errorCount++;
 			}
 			cb(null, file);

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -228,7 +228,7 @@ function hygiene(some) {
 			let formatted = result.dest.replace(/\r\n/gm, '\n');
 
 			if (original !== formatted) {
-				console.error('File not formatted:', file.relative);
+				console.error('File not formatted with tsfmt:', file.relative);
 				errorCount++;
 			}
 			cb(null, file);


### PR DESCRIPTION
The error message `File not formatted` is confusing. It does not tell us what we should do.