### PR TITLE
avoid extensionTestsLocationURI.fsPath as it normalizes path

### DIFF
--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -5,6 +5,7 @@
 
 import * as nls from 'vs/nls';
 import * as path from 'vs/base/common/path';
+import { originalFSPath } from 'vs/base/common/resources';
 import { Barrier } from 'vs/base/common/async';
 import { IDisposable, dispose, toDisposable } from 'vs/base/common/lifecycle';
 import { TernarySearchTree } from 'vs/base/common/map';
@@ -614,7 +615,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 			return Promise.resolve(undefined);
 		}
 
-		const extensionTestsPath = extensionTestsLocationURI.fsPath;
+		const extensionTestsPath = originalFSPath(extensionTestsLocationURI);
 
 		// Require the test runner via node require from the provided path
 		let testRunner: ITestRunner | undefined;


### PR DESCRIPTION
#69569 reports that there's a regression with extension tests on Windows.

This is very likely caused by my change to use URI for extensionTestsLocation.

`extensionTestsLocationURI.fsPath` normalizes the drive letter, but we should never normalize user provided paths.