### PR TITLE
Fixes #69583

### DIFF
--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -210,9 +210,10 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 		if (platform.isLinux) {
 			return new Promise<string>(resolve => {
 				fs.readlink('/proc/' + this._ptyProcess.pid + '/cwd', (err, linkedstr) => {
-					if (linkedstr) {
-						resolve(linkedstr);
+					if (err) {
+						resolve(this._initialCwd);
 					}
+					resolve(linkedstr);
 				});
 			});
 		}

--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -7,6 +7,7 @@ import * as os from 'os';
 import * as path from 'vs/base/common/path';
 import * as platform from 'vs/base/common/platform';
 import * as pty from 'node-pty';
+import * as fs from 'fs';
 import { Event, Emitter } from 'vs/base/common/event';
 import { ITerminalChildProcess } from 'vs/workbench/contrib/terminal/node/terminal';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -196,18 +197,28 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 	}
 
 	public getCwd(): Promise<string> {
-		if (platform.isWindows) {
+		if (platform.isMacintosh) {
 			return new Promise<string>(resolve => {
-				resolve(this._initialCwd);
+				exec('lsof -p ' + this._ptyProcess.pid + ' | grep cwd', (error, stdout, stderr) => {
+					if (stdout !== '') {
+						resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
+					}
+				});
+			});
+		}
+
+		if (platform.isLinux) {
+			return new Promise<string>(resolve => {
+				fs.readlink('/proc/' + this._ptyProcess.pid + '/cwd', (err, linkedstr) => {
+					if (linkedstr) {
+						resolve(linkedstr);
+					}
+				});
 			});
 		}
 
 		return new Promise<string>(resolve => {
-			exec('lsof -p ' + this._ptyProcess.pid + ' | grep cwd', (error, stdout, stderr) => {
-				if (stdout !== '') {
-					resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
-				}
-			});
+			resolve(this._initialCwd);
 		});
 	}
 }


### PR DESCRIPTION
FIxes #69583 

This patch removes the need to use lsof on linux platforms and instead uses the default readlink function in fs. It then reads directly the symbolic link in /proc. For all Linux based systems this should be fine.
http://man7.org/linux/man-pages/man5/proc.5.html

This approach should also be a lot faster compared to the previous lsof command. It also seems to work even if the user has remounted proc to hidepids.

ie mount -o remount,rw,hidepid=2 /proc

This solution will solve the case when users don't have lsof installed.


For OS X, I have kept the old lsof mechanism as they don't have a /proc directory.

EDIT:
Sorry, just refactored the code to make a little more sense. In this case, only run the commands if it is known to work on the respective platforms, otherwise fallback to just return _initialCwd.