### PR TITLE
fixes #69755

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -61,7 +61,6 @@ export class ExplorerView extends ViewletPanel {
 
 	// Refresh is needed on the initial explorer open
 	private shouldRefresh = true;
-	private setTreeInputPromise = Promise.resolve();
 	private dragHandler: DelayedDragHandler;
 	private decorationProvider: ExplorerDecorationsProvider;
 	private autoReveal = false;
@@ -166,7 +165,7 @@ export class ExplorerView extends ViewletPanel {
 			this.refresh();
 		}));
 
-		this.disposables.push(this.explorerService.onDidChangeRoots(() => this.setTreeInputPromise = this.setTreeInput()));
+		this.disposables.push(this.explorerService.onDidChangeRoots(() => this.setTreeInput()));
 		this.disposables.push(this.explorerService.onDidChangeItem(e => this.refresh(e)));
 		this.disposables.push(this.explorerService.onDidChangeEditable(async e => {
 			const isEditing = !!this.explorerService.getEditableData(e);
@@ -206,8 +205,7 @@ export class ExplorerView extends ViewletPanel {
 				// If a refresh was requested and we are now visible, run it
 				if (this.shouldRefresh) {
 					this.shouldRefresh = false;
-					this.setTreeInputPromise = this.setTreeInput();
-					await this.setTreeInputPromise;
+					await this.setTreeInput();
 				}
 				// Find resource to focus from active editor input if set
 				this.selectActiveFile(false, true);
@@ -231,22 +229,21 @@ export class ExplorerView extends ViewletPanel {
 	}
 
 	focus(): void {
-		this.setTreeInputPromise.then(() => {
-			this.tree.domFocus();
-			const focused = this.tree.getFocus();
-			if (focused.length === 1) {
-				if (this.autoReveal) {
-					this.tree.reveal(focused[0], 0.5);
-				}
+		this.tree.domFocus();
 
-				const activeFile = this.getActiveFile();
-				if (!activeFile && !focused[0].isDirectory) {
-					// Open the focused element in the editor if there is currently no file opened #67708
-					this.editorService.openEditor({ resource: focused[0].resource, options: { preserveFocus: true, revealIfVisible: true } })
-						.then(undefined, onUnexpectedError);
-				}
+		const focused = this.tree.getFocus();
+		if (focused.length === 1) {
+			if (this.autoReveal) {
+				this.tree.reveal(focused[0], 0.5);
 			}
-		});
+
+			const activeFile = this.getActiveFile();
+			if (!activeFile && !focused[0].isDirectory) {
+				// Open the focused element in the editor if there is currently no file opened #67708
+				this.editorService.openEditor({ resource: focused[0].resource, options: { preserveFocus: true, revealIfVisible: true } })
+					.then(undefined, onUnexpectedError);
+			}
+		}
 	}
 
 	private selectActiveFile(deselect?: boolean, reveal = this.autoReveal): void {


### PR DESCRIPTION
This PR basically reverts the original fix for https://github.com/Microsoft/vscode/issues/68101
The fix was that the focus needs to wait for the refresh to happen before focusing.
However since in the meantime I have fixed file events handling, this fix is no longer needed - the file will get picked up as deleted and will no longer exist in the tree.

This is good because that fixed caused https://github.com/Microsoft/vscode/issues/69755
Basically since we were focusing with a timeout the explorer was stealling focus from the open editors view.

I have verified that this indeed fixes 69755 and that 68101 remains fixed.