### PR TITLE
Fix empty outline view

### DIFF
--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -522,8 +522,6 @@ export class OutlinePanel extends ViewletPanel {
 			await this._tree.setInput(newModel, state);
 		}
 
-		this._tree.layout();
-
 		// transfer focus from domNode to the tree
 		if (this._domNode === document.activeElement) {
 			this._tree.domFocus();


### PR DESCRIPTION
This rogue `layout()` call was triggering element measurments at a time in which the outline body container would be of zero height. Removing it makes sense since the tree's always being laid out via the panel's `layoutBody` calls.

Fixes #69667