### PR TITLE
Initialize disposables array in commentThreadWidget

### DIFF
--- a/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/electron-browser/commentThreadWidget.ts
@@ -117,7 +117,7 @@ export class ReviewZoneWidget extends ZoneWidget {
 		this._draftMode = draftMode;
 		this._isCollapsed = commentThread.collapsibleState !== modes.CommentThreadCollapsibleState.Expanded;
 		this._globalToDispose = [];
-		this._disposables = [];
+		this._submitActionsDisposables = [];
 		this._formActions = null;
 		this.create();
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode/issues/69756

Introduced this issue with https://github.com/Microsoft/vscode/commit/52306b406d9231a0667c758e536bd177e5570180#diff-2faf002ebb1ddfaa1054127e2034a503 with a bad rename, already fixed in master