### PR TITLE
Fix typo in spelling of Preferences.

### DIFF
--- a/src/vs/workbench/contrib/preferences/electron-browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/electron-browser/preferences.contribution.ts
@@ -477,7 +477,7 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 	command: {
 		id: OpenFolderSettingsAction.ID,
 		title: { value: `${category}: ${OpenFolderSettingsAction.LABEL}`, original: 'Preferences: Open Folder Settings' },
-		category: nls.localize('preferencesCategory', "Prefernces")
+		category: nls.localize('preferencesCategory', "Preferences")
 	},
 	when: WorkbenchStateContext.isEqualTo('workspace')
 });
@@ -489,7 +489,7 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 	command: {
 		id: OpenWorkspaceSettingsAction.ID,
 		title: { value: `${category}: ${OpenWorkspaceSettingsAction.LABEL}`, original: 'Preferences: Open Workspace Settings' },
-		category: nls.localize('preferencesCategory', "Prefernces")
+		category: nls.localize('preferencesCategory', "Preferences")
 	},
 	when: WorkbenchStateContext.notEqualsTo('empty')
 });


### PR DESCRIPTION
Small typo that looks new - just noticed in a recent Insider's build, and the blame results indicate those lines were touched recently.