### PR TITLE
Removed max-width restrictions from the .monaco-editor-hover #69835

### DIFF
--- a/src/vs/editor/contrib/hover/hover.css
+++ b/src/vs/editor/contrib/hover/hover.css
@@ -27,10 +27,6 @@
 	padding: 4px 8px;
 }
 
-.monaco-editor-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
-	max-width: 500px;
-}
-
 .monaco-editor-hover p,
 .monaco-editor-hover ul {
 	margin: 8px 0;


### PR DESCRIPTION
It seems like that in the latest insider builds the hover width has changed and now it can be wider than 500px. This is an attempt to fix this in hover.css