### PR TITLE
fixes #68549

### DIFF
--- a/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
@@ -410,7 +410,7 @@ export class BulkEditService implements IBulkEditService {
 			}
 		}
 
-		const bulkEdit = new BulkEdit(codeEditor, options.progress, this._logService, this._textModelService, this._fileService, this._textFileService, this._labelService, this._configurationService);
+		const bulkEdit = new BulkEdit(options.editor, options.progress, this._logService, this._textModelService, this._fileService, this._textFileService, this._labelService, this._configurationService);
 		bulkEdit.add(edits);
 
 		return bulkEdit.perform().then(() => {

--- a/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
@@ -410,7 +410,11 @@ export class BulkEditService implements IBulkEditService {
 			}
 		}
 
-		const bulkEdit = new BulkEdit(options.editor, options.progress, this._logService, this._textModelService, this._fileService, this._textFileService, this._labelService, this._configurationService);
+		if (codeEditor && codeEditor.getConfiguration().readOnly) {
+			// If the code editor is readonly still alow bulk edits to be applied #68549
+			codeEditor = undefined;
+		}
+		const bulkEdit = new BulkEdit(codeEditor, options.progress, this._logService, this._textModelService, this._fileService, this._textFileService, this._labelService, this._configurationService);
 		bulkEdit.add(edits);
 
 		return bulkEdit.perform().then(() => {


### PR DESCRIPTION
https://github.com/Microsoft/vscode/issues/68549

By bisecting I found that the initial cause of this issue is 
https://github.com/Microsoft/vscode/commit/952faa486a3d1ac95e54031eb70e8df7ce93cffd

So a strict null change. Upon closer inspection the only functional difference is the change to use `codeEditor` instead of `options.editor`. I am not sure what was the intention of the change, but I think it was not intentional and happend as an accident. @mattbierner can confirm this

This PR simply reverts that unintentonal change.
I have confirmed this indeed fixes the LiveShare issue.
fyi @kieferrm 