### PR TITLE
fix/69830

### DIFF
--- a/src/vs/base/browser/ui/menu/menubar.ts
+++ b/src/vs/base/browser/ui/menu/menubar.ts
@@ -954,6 +954,16 @@ class ModifierKeyEmitter extends Emitter<IModifierKeyStatus> {
 			this._keyStatus.lastKeyPressed = undefined;
 		}));
 
+		this._subscriptions.push(domEvent(document.body, 'mouseup', true)(e => {
+			this._keyStatus.lastKeyPressed = undefined;
+		}));
+
+		this._subscriptions.push(domEvent(document.body, 'mousemove', true)(e => {
+			if (e.buttons) {
+				this._keyStatus.lastKeyPressed = undefined;
+			}
+		}));
+
 		this._subscriptions.push(domEvent(window, 'blur')(e => {
 			this._keyStatus.lastKeyPressed = undefined;
 			this._keyStatus.lastKeyReleased = undefined;


### PR DESCRIPTION
fixes https://github.com/Microsoft/vscode/issues/69830

The fix here is to clear our alt-key listener on mouse moves when a mouse button is pressed. We could have attempted to track the button state with just mouseup/down/leave/enter, but it is easy to get into a bad state when the mouse leaves the window. 

I was a little worried about perf with this but I used `performance.now()` to sum the total the amount of time spent in the `mousemove` handler. Over 50s of constantly moving the mouse, we spent 3ms.

There is still one case the menubar will steal focus:
1. Use Alt+Mouse column selection
2. Release Alt without releasing the selection with mouse
3. Do not move the mouse at all
4. Press and release Alt again

You would expect this to not steal focus as user, but you also probably won't do this as a user.