### PR TITLE
Strict null check textFileService

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -489,6 +489,7 @@
 		"./vs/workbench/services/textMate/electron-browser/textMateService.ts",
 		"./vs/workbench/services/textfile/common/textFileEditorModel.ts",
 		"./vs/workbench/services/textfile/common/textFileEditorModelManager.ts",
+		"./vs/workbench/services/textfile/common/textFileService.ts",
 		"./vs/workbench/services/textfile/common/textfiles.ts",
 		"./vs/workbench/services/textfile/node/textResourcePropertiesService.ts",
 		"./vs/workbench/services/textmodelResolver/common/textModelResolverService.ts",

--- a/src/vs/workbench/services/textfile/common/textFileService.ts
+++ b/src/vs/workbench/services/textfile/common/textFileService.ts
@@ -796,7 +796,7 @@ export class TextFileService extends Disposable implements ITextFileService {
 	}
 
 	private suggestFileName(untitledResource: URI): URI {
-		const untitledFileName = this.untitledEditorService.suggestFileName(untitledResource) || 'untitled';
+		const untitledFileName = this.untitledEditorService.suggestFileName(untitledResource);
 		const remoteAuthority = this.windowService.getConfiguration().remoteAuthority;
 		const schemeFilter = remoteAuthority ? REMOTE_HOST_SCHEME : Schemas.file;
 

--- a/src/vs/workbench/services/textfile/common/textfiles.ts
+++ b/src/vs/workbench/services/textfile/common/textfiles.ts
@@ -101,7 +101,7 @@ export interface IResult {
 }
 
 export interface IAutoSaveConfiguration {
-	autoSaveDelay: number;
+	autoSaveDelay?: number;
 	autoSaveFocusChange: boolean;
 	autoSaveApplicationChange: boolean;
 }
@@ -257,6 +257,8 @@ export interface ITextFileEditorModel extends ITextEditorModel, IEncodingSupport
 
 export interface IResolvedTextFileEditorModel extends ITextFileEditorModel {
 	readonly textEditorModel: ITextModel;
+
+	createSnapshot(): ITextSnapshot;
 }
 
 
@@ -317,9 +319,9 @@ export interface ITextFileService extends IDisposable {
 	 * @param resource the resource to save as.
 	 * @param targetResource the optional target to save to.
 	 * @param options optional save options
-	 * @return true if the file was saved.
+	 * @return Path of the saved resource.
 	 */
-	saveAs(resource: URI, targetResource?: URI, options?: ISaveOptions): Promise<URI>;
+	saveAs(resource: URI, targetResource?: URI, options?: ISaveOptions): Promise<URI | undefined>;
 
 	/**
 	 * Saves the set of resources and returns a promise with the operation result.

--- a/src/vs/workbench/services/untitled/common/untitledEditorService.ts
+++ b/src/vs/workbench/services/untitled/common/untitledEditorService.ts
@@ -15,6 +15,7 @@ import { UntitledEditorModel } from 'vs/workbench/common/editor/untitledEditorMo
 import { Schemas } from 'vs/base/common/network';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { basename } from 'vs/base/common/resources';
 
 export const IUntitledEditorService = createDecorator<IUntitledEditorService>('untitledEditorService');
 
@@ -269,7 +270,7 @@ export class UntitledEditorService extends Disposable implements IUntitledEditor
 	suggestFileName(resource: URI): string {
 		const input = this.get(resource);
 
-		return input ? input.suggestFileName() : 'untitled';
+		return input ? input.suggestFileName() : basename(resource);
 	}
 
 	getEncoding(resource: URI): string | undefined {

--- a/src/vs/workbench/services/untitled/common/untitledEditorService.ts
+++ b/src/vs/workbench/services/untitled/common/untitledEditorService.ts
@@ -96,7 +96,7 @@ export interface IUntitledEditorService {
 	/**
 	 * Suggests a filename for the given untitled resource if it is known.
 	 */
-	suggestFileName(resource: URI): string | undefined;
+	suggestFileName(resource: URI): string;
 
 	/**
 	 * Get the configured encoding for the given untitled resource if any.
@@ -266,10 +266,10 @@ export class UntitledEditorService extends Disposable implements IUntitledEditor
 		return this.mapResourceToAssociatedFilePath.has(resource);
 	}
 
-	suggestFileName(resource: URI): string | undefined {
+	suggestFileName(resource: URI): string {
 		const input = this.get(resource);
 
-		return input ? input.suggestFileName() : undefined;
+		return input ? input.suggestFileName() : 'untitled';
 	}
 
 	getEncoding(resource: URI): string | undefined {


### PR DESCRIPTION
- Adds annotations to return types and parameters that can be undefined
- Add conditional guards. This is usually better than adding a null suppression, even if we know that logically the value should never be null (such as on a few calls to `Map.get`)
- Converting a few `return undefined` to `return false`. Based on how these values are used, I don't think this should change the behavior

The fact that `createSnapshot` can return null is pretty annoying. One fix would be to use `IResolvedTextFileEditorModel` in more places in our code base, but I am not confident in making this change.