### PR TITLE
Fix #69972 - use fsPath for untitled schema files

### DIFF
--- a/src/vs/workbench/services/backup/node/backupFileService.ts
+++ b/src/vs/workbench/services/backup/node/backupFileService.ts
@@ -299,6 +299,6 @@ export class InMemoryBackupFileService implements IBackupFileService {
  * Exported only for testing
  */
 export function hashPath(resource: Uri): string {
-	const str = resource.scheme === Schemas.file ? resource.fsPath : resource.toString();
+	const str = resource.scheme === Schemas.file || resource.scheme === Schemas.untitled ? resource.fsPath : resource.toString();
 	return crypto.createHash('md5').update(str).digest('hex');
 }

--- a/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
+++ b/src/vs/workbench/services/backup/test/electron-browser/backupFileService.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as platform from 'vs/base/common/platform';
+import * as crypto from 'crypto';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'vs/base/common/path';
@@ -63,6 +64,31 @@ suite('BackupFileService', () => {
 
 	teardown(() => {
 		return pfs.del(backupHome, os.tmpdir());
+	});
+
+	suite('hashPath', () => {
+		test('should correctly hash the path for untitled scheme URIs', () => {
+			const uri = Uri.from({
+				scheme: 'untitled',
+				path: 'Untitled-1'
+			});
+			const actual = hashPath(uri);
+			// If these hashes change people will lose their backed up files!
+			assert.equal(actual, '13264068d108c6901b3592ea654fcd57');
+			assert.equal(actual, crypto.createHash('md5').update(uri.fsPath).digest('hex'));
+		});
+
+		test('should correctly hash the path for file scheme URIs', () => {
+			const uri = Uri.file('/foo');
+			const actual = hashPath(uri);
+			// If these hashes change people will lose their backed up files!
+			if (platform.isWindows) {
+				assert.equal(actual, 'dec1a583f52468a020bd120c3f01d812');
+			} else {
+				assert.equal(actual, '1effb2475fcfba4f9e8b8a1dbc8f3caf');
+			}
+			assert.equal(actual, crypto.createHash('md5').update(uri.fsPath).digest('hex'));
+		});
 	});
 
 	suite('getBackupResource', () => {


### PR DESCRIPTION
This calculation changed in https://github.com/Microsoft/vscode/commit/a221cdd12b866be90aa987cc5df3b7d1f71fc18d

Fixes #69972