### PR TITLE
Initialize viewletService in Workbench

### DIFF
--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -916,7 +916,7 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 		this.editorService = accessor.get(IEditorService);
 		this.editorGroupService = accessor.get(IEditorGroupsService);
 		this.panelService = accessor.get(IPanelService);
-		this.viewletService= accessor.get(IViewletService);
+		this.viewletService = accessor.get(IViewletService);
 
 		// Fullscreen
 		this.state.fullscreen = isFullscreen();

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -916,6 +916,7 @@ export class Workbench extends Disposable implements IWorkbenchLayoutService {
 		this.editorService = accessor.get(IEditorService);
 		this.editorGroupService = accessor.get(IEditorGroupsService);
 		this.panelService = accessor.get(IPanelService);
+		this.viewletService= accessor.get(IViewletService);
 
 		// Fullscreen
 		this.state.fullscreen = isFullscreen();


### PR DESCRIPTION
Need to initialize viewletService in Workbench class. Otherwise getting "TypeError: Cannot read property "getActiveViewlet" of undefined" error message 