### PR TITLE
make caching more robust; fixes #69534

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadDebugService.ts
@@ -285,6 +285,12 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 
 	// dto helpers
 
+	public $sessionCached(sessionID: string) {
+		// remember that the EH has cached the session and we do not have to send it again
+		this._sessions.add(sessionID);
+	}
+
+
 	getSessionDto(session: undefined): undefined;
 	getSessionDto(session: IDebugSession): IDebugSessionDto;
 	getSessionDto(session: IDebugSession | undefined): IDebugSessionDto | undefined;
@@ -294,7 +300,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 			if (this._sessions.has(sessionID)) {
 				return sessionID;
 			} else {
-				this._sessions.add(sessionID);
+				// this._sessions.add(sessionID); 	// #69534: see $sessionCached above
 				return {
 					id: sessionID,
 					type: session.configuration.type,

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -635,6 +635,7 @@ export type DebugSessionUUID = string;
 
 export interface MainThreadDebugServiceShape extends IDisposable {
 	$registerDebugTypes(debugTypes: string[]): void;
+	$sessionCached(sessionID: string): void;
 	$acceptDAMessage(handle: number, message: DebugProtocol.ProtocolMessage): void;
 	$acceptDAError(handle: number, name: string, message: string, stack: string): void;
 	$acceptDAExit(handle: number, code: number, signal: string): void;

--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -794,19 +794,23 @@ export class ExtHostDebugService implements ExtHostDebugServiceShape {
 			if (typeof dto === 'string') {
 				return this._debugSessions.get(dto);
 			} else {
-				const folder = await this.getFolder(dto.folderUri);
-				const debugSession = new ExtHostDebugSession(this._debugServiceProxy, dto.id, dto.type, dto.name, folder, dto.configuration);
-				this._debugSessions.set(debugSession.id, debugSession);
-				return debugSession;
+				let ds = this._debugSessions.get(dto.id);
+				if (!ds) {
+					const folder = await this.getFolder(dto.folderUri);
+					ds = new ExtHostDebugSession(this._debugServiceProxy, dto.id, dto.type, dto.name, folder, dto.configuration);
+					this._debugSessions.set(ds.id, ds);
+					this._debugServiceProxy.$sessionCached(ds.id);
+				}
+				return ds;
 			}
 		}
 		return undefined;
 	}
 
-	private async getFolder(_folderUri: UriComponents | undefined): Promise<vscode.WorkspaceFolder | undefined> {
+	private getFolder(_folderUri: UriComponents | undefined): Promise<vscode.WorkspaceFolder | undefined> {
 		if (_folderUri) {
 			const folderURI = URI.revive(_folderUri);
-			return await this._workspaceService.resolveWorkspaceFolder(folderURI);
+			return this._workspaceService.resolveWorkspaceFolder(folderURI);
 		}
 		return undefined;
 	}


### PR DESCRIPTION
This PR fixes #69534.

When talking to the EH I was sending the debug session data only once in the first request that needed it. Then EH cached the data. 

For subsequent request I'm sending only the session ID (and the EH looks up the session object from the cache). VS Code made the decision whether to send the full data or just the ID base on a "Set" data structure: after sending the data once, the ID is added to the Set. 

After "workspaceService.resolveWorkspaceFolder()" had become asynchronous, the timing behavior has changed and now the EH cache does not have the data when a session ID arrives and needs to be looked up. This results in a "null" session and the error message on the console. 

The fix is to introduce a robust (but still synchronous) caching protocol. For this the EH sends a new request "sessionCached" back to VS Code when it has cached the data. And VS Code only stops sending the full data if it has received the "sessionCached" request.
