### PR TITLE
Add css.completion.triggerPropertyValueCompletion setting

### DIFF
--- a/extensions/css-language-features/package.json
+++ b/extensions/css-language-features/package.json
@@ -42,6 +42,12 @@
             },
             "scope": "resource"
           },
+          "css.completion.triggerPropertyValueCompletion": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": true,
+            "description": "%css.completion.triggerPropertyValueCompletion.desc%"
+          },
           "css.validate": {
             "type": "boolean",
             "scope": "resource",

--- a/extensions/css-language-features/package.nls.json
+++ b/extensions/css-language-features/package.nls.json
@@ -2,6 +2,7 @@
 	"displayName": "CSS Language Features",
 	"description": "Provides rich language support for CSS, LESS and SCSS files.",
 	"css.title": "CSS",
+	"css.completion.triggerPropertyValueCompletion.desc": "By default, VS Code triggers property value completion after selecting a CSS property. Use this setting to disable this behavior.",
 	"css.lint.argumentsInColorFunction.desc": "Invalid number of parameters.",
 	"css.lint.boxModel.desc": "Do not use `width` or `height` when using `padding` or `border`.",
 	"css.lint.compatibleVendorPrefixes.desc": "When using a vendor-specific prefix make sure to also include all other vendor-specific properties.",


### PR DESCRIPTION
Since https://github.com/Microsoft/vscode-css-languageservice/pull/149 is merged we are able to add this setting to VS Code. I'm still waiting for `vscode-css-languageservice` version bump because we should update version in `extensions/css-language-features/server/package.json`

Fixes https://github.com/Microsoft/vscode/issues/68495

/cc @octref 