### PR TITLE
Unsaved files are opened in two windows when reopening vscode.

### DIFF
--- a/src/vs/code/electron-main/windows.ts
+++ b/src/vs/code/electron-main/windows.ts
@@ -686,8 +686,9 @@ export class WindowsManager implements IWindowsMainService {
 		}
 
 		// Handle empty to restore
-		if (emptyToRestore.length > 0) {
-			emptyToRestore.forEach(emptyWindowBackupInfo => {
+		const allEmptyToRestore = arrays.distinct(emptyToRestore, info => info.backupFolder); // prevent duplicates
+		if (allEmptyToRestore.length > 0) {
+			allEmptyToRestore.forEach(emptyWindowBackupInfo => {
 				const remoteAuthority = emptyWindowBackupInfo.remoteAuthority;
 				const fileInputsForWindow = (fileInputs && fileInputs.remoteAuthority === remoteAuthority) ? fileInputs : undefined;
 


### PR DESCRIPTION
 Fixes #70006