### PR TITLE
Selectbox: Remove explicit select role (Electron 2 workaround)

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -123,12 +123,6 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 
 		this.selectElement = document.createElement('select');
 
-		// Workaround for Electron 2.x
-		// Native select should not require explicit role attribute, however, Electron 2.x
-		// incorrectly exposes select as menuItem which interferes with labeling and results
-		// in the unlabeled not been read.  Electron 3 appears to fix.
-		// this.selectElement.setAttribute('role', 'combobox');
-
 		// Use custom CSS vars for padding calculation
 		this.selectElement.className = 'monaco-select-box monaco-select-box-dropdown-padding';
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -127,7 +127,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 		// Native select should not require explicit role attribute, however, Electron 2.x
 		// incorrectly exposes select as menuItem which interferes with labeling and results
 		// in the unlabeled not been read.  Electron 3 appears to fix.
-		this.selectElement.setAttribute('role', 'combobox');
+		// this.selectElement.setAttribute('role', 'combobox');
 
 		// Use custom CSS vars for padding calculation
 		this.selectElement.className = 'monaco-select-box monaco-select-box-dropdown-padding';

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -33,7 +33,7 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 		// Native select should not require explicit role attribute, however, Electron 2.x
 		// incorrectly exposes select as menuItem which interferes with labeling and results
 		// in the unlabeled not been read.  Electron 3 appears to fix.
-		this.selectElement.setAttribute('role', 'combobox');
+		// this.selectElement.setAttribute('role', 'combobox');
 
 		this.selectElement.className = 'monaco-select-box';
 

--- a/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxNative.ts
@@ -29,12 +29,6 @@ export class SelectBoxNative implements ISelectBoxDelegate {
 
 		this.selectElement = document.createElement('select');
 
-		// Workaround for Electron 2.x
-		// Native select should not require explicit role attribute, however, Electron 2.x
-		// incorrectly exposes select as menuItem which interferes with labeling and results
-		// in the unlabeled not been read.  Electron 3 appears to fix.
-		// this.selectElement.setAttribute('role', 'combobox');
-
 		this.selectElement.className = 'monaco-select-box';
 
 		if (typeof this.selectBoxOptions.ariaLabel === 'string') {


### PR DESCRIPTION
@bpasero 

Tested and working under NVDA and Voiceover.

Note:
NVDA announces SelectBox as 'ComboBox'
Voiceover announces 'button' (yet different behavior)
