### PR TITLE
Treat null as valid metadata property

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -141,7 +141,7 @@ interface StateDelta {
 	indentation?: string;
 	tabFocusMode?: boolean;
 	screenReaderMode?: boolean;
-	metadata?: string;
+	metadata?: string | null;
 }
 
 class State {
@@ -669,7 +669,7 @@ export class EditorStatus implements IStatusbarItem {
 		const update: StateDelta = { metadata: undefined };
 
 		if (editor instanceof BaseBinaryResourceEditor || editor instanceof BinaryResourceDiffEditor) {
-			update.metadata = editor.getMetadata() || undefined;
+			update.metadata = editor.getMetadata();
 		}
 
 		this.updateState(update);


### PR DESCRIPTION
Fixes #70194

This is another place in the code where undefined and null are treated differently. This small fix reverts the automatic conversion to undefined.

We should refactor this code to eliminate this hazard 