### PR TITLE
Revert strict null changes around getting empty description

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -700,8 +700,8 @@ export class TabsTitleControl extends TitleControl {
 		const labels = this.group.editors.map(editor => ({
 			editor,
 			name: editor.getName()!,
-			description: editor.getDescription(verbosity) || undefined,
-			title: editor.getTitle(Verbosity.LONG) || undefined
+			description: editor.getDescription(verbosity)!,
+			title: editor.getTitle(Verbosity.LONG)!
 		}));
 
 		// Shorten labels as needed
@@ -753,7 +753,7 @@ export class TabsTitleControl extends TitleControl {
 			if (useLongDescriptions) {
 				mapDescriptionToDuplicates.clear();
 				duplicateTitles.forEach(label => {
-					label.description = label.editor.getDescription(Verbosity.LONG) || undefined;
+					label.description = label.editor.getDescription(Verbosity.LONG)!;
 					getOrSet(mapDescriptionToDuplicates, label.description, []).push(label);
 				});
 			}


### PR DESCRIPTION
Fixes #70113

Switch to using null suppressions instead of converting to undefined. This makes sure we treat empty strings properly

Will check in better fix for master