### PR TITLE
Strict null check extHostStatusBar

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -113,6 +113,7 @@
 		"./vs/workbench/api/node/extHostQuickOpen.ts",
 		"./vs/workbench/api/node/extHostSCM.ts",
 		"./vs/workbench/api/node/extHostSearch.ts",
+		"./vs/workbench/api/node/extHostStatusBar.ts",
 		"./vs/workbench/api/node/extHostStorage.ts",
 		"./vs/workbench/api/node/extHostTextEditor.ts",
 		"./vs/workbench/api/node/extHostTextEditors.ts",

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4517,7 +4517,7 @@ declare module 'vscode' {
 		 * The priority of this item. Higher value means the item should
 		 * be shown more to the left.
 		 */
-		readonly priority: number;
+		readonly priority?: number;
 
 		/**
 		 * The text to show for the entry. You can embed icons in the text by leveraging the syntax:

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -466,7 +466,7 @@ export interface MainThreadQuickOpenShape extends IDisposable {
 }
 
 export interface MainThreadStatusBarShape extends IDisposable {
-	$setEntry(id: number, extensionId: ExtensionIdentifier, text: string, tooltip: string, command: string, color: string | ThemeColor, alignment: MainThreadStatusBarAlignment, priority: number): void;
+	$setEntry(id: number, extensionId: ExtensionIdentifier | undefined, text: string, tooltip: string, command: string, color: string | ThemeColor, alignment: MainThreadStatusBarAlignment, priority: number | undefined): void;
 	$dispose(id: number): void;
 }
 

--- a/src/vs/workbench/api/node/extHostStatusBar.ts
+++ b/src/vs/workbench/api/node/extHostStatusBar.ts
@@ -14,7 +14,7 @@ export class ExtHostStatusBarEntry implements StatusBarItem {
 
 	private _id: number;
 	private _alignment: number;
-	private _priority: number;
+	private _priority?: number;
 	private _disposed: boolean;
 	private _visible: boolean;
 
@@ -26,9 +26,9 @@ export class ExtHostStatusBarEntry implements StatusBarItem {
 	private _timeoutHandle: any;
 	private _proxy: MainThreadStatusBarShape;
 
-	private _extensionId: ExtensionIdentifier;
+	private _extensionId?: ExtensionIdentifier;
 
-	constructor(proxy: MainThreadStatusBarShape, extensionId: ExtensionIdentifier, alignment: ExtHostStatusBarAlignment = ExtHostStatusBarAlignment.Left, priority?: number) {
+	constructor(proxy: MainThreadStatusBarShape, extensionId: ExtensionIdentifier | undefined, alignment: ExtHostStatusBarAlignment = ExtHostStatusBarAlignment.Left, priority?: number) {
 		this._id = ExtHostStatusBarEntry.ID_GEN++;
 		this._proxy = proxy;
 		this._alignment = alignment;
@@ -44,7 +44,7 @@ export class ExtHostStatusBarEntry implements StatusBarItem {
 		return this._alignment;
 	}
 
-	public get priority(): number {
+	public get priority(): number | undefined {
 		return this._priority;
 	}
 
@@ -167,7 +167,7 @@ export class ExtHostStatusBar {
 		this._statusMessage = new StatusBarMessage(this);
 	}
 
-	createStatusBarEntry(extensionId: ExtensionIdentifier, alignment?: ExtHostStatusBarAlignment, priority?: number): StatusBarItem {
+	createStatusBarEntry(extensionId: ExtensionIdentifier | undefined, alignment?: ExtHostStatusBarAlignment, priority?: number): StatusBarItem {
 		return new ExtHostStatusBarEntry(this._proxy, extensionId, alignment, priority);
 	}
 


### PR DESCRIPTION
Makes the following changes

- Priority can be undefined. Update public api to match this
- We also use an undefined `extensionId`. Update typings for this


@jrieken Please review since this is a public api change. I confirmed that `priority` can be undefined:

```js
import * as vscode from 'vscode'

const item = vscode.window.createStatusBarItem();
item.priority; // undefined
```