### PR TITLE
Strict null check editorService

### DIFF
--- a/src/tsconfig.strictNullChecks.json
+++ b/src/tsconfig.strictNullChecks.json
@@ -412,6 +412,7 @@
 		"./vs/workbench/services/dialogs/electron-browser/dialogService.ts",
 		"./vs/workbench/services/dialogs/electron-browser/remoteFileDialog.ts",
 		"./vs/workbench/services/editor/browser/codeEditorService.ts",
+		"./vs/workbench/services/editor/browser/editorService.ts",
 		"./vs/workbench/services/editor/common/editorGroupsService.ts",
 		"./vs/workbench/services/editor/common/editorService.ts",
 		"./vs/workbench/services/extensionManagement/node/multiExtensionManagement.ts",

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -142,7 +142,7 @@ export interface IEditorControl extends ICompositeControl { }
 
 export interface IFileInputFactory {
 
-	createFileInput(resource: URI, encoding: string, instantiationService: IInstantiationService): IFileEditorInput;
+	createFileInput(resource: URI, encoding: string | undefined, instantiationService: IInstantiationService): IFileEditorInput;
 
 	isFileInput(obj: any): obj is IFileEditorInput;
 }
@@ -516,9 +516,9 @@ export interface IFileEditorInput extends IEditorInput, IEncodingSupport {
 	getResource(): URI;
 
 	/**
-	 * Sets the preferred encodingt to use for this input.
+	 * Sets the preferred encoding to use for this input.
 	 */
-	setPreferredEncoding(encoding: string): void;
+	setPreferredEncoding(encoding: string | undefined): void;
 
 	/**
 	 * Forces this file input to open as binary instead of text.
@@ -534,7 +534,7 @@ export class SideBySideEditorInput extends EditorInput {
 	static readonly ID: string = 'workbench.editorinputs.sidebysideEditorInput';
 
 	constructor(
-		private readonly name: string,
+		private readonly name: string | null,
 		private readonly description: string | null,
 		private readonly _details: EditorInput,
 		private readonly _master: EditorInput
@@ -603,7 +603,7 @@ export class SideBySideEditorInput extends EditorInput {
 		return SideBySideEditorInput.ID;
 	}
 
-	getName(): string {
+	getName(): string | null {
 		return this.name;
 	}
 

--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -18,7 +18,7 @@ export class DiffEditorInput extends SideBySideEditorInput {
 
 	private cachedModel: DiffEditorModel | null;
 
-	constructor(name: string, description: string | null, original: EditorInput, modified: EditorInput, private readonly forceOpenAsBinary?: boolean) {
+	constructor(name: string | null, description: string | null, original: EditorInput, modified: EditorInput, private readonly forceOpenAsBinary?: boolean) {
 		super(name, description, original, modified);
 	}
 

--- a/src/vs/workbench/common/editor/resourceEditorInput.ts
+++ b/src/vs/workbench/common/editor/resourceEditorInput.ts
@@ -22,7 +22,7 @@ export class ResourceEditorInput extends EditorInput {
 	private modelReference: Promise<IReference<ITextEditorModel>> | null;
 
 	constructor(
-		private name: string,
+		private name: string | null,
 		private description: string | null,
 		private readonly resource: URI,
 		@ITextModelService private readonly textModelResolverService: ITextModelService,
@@ -43,11 +43,11 @@ export class ResourceEditorInput extends EditorInput {
 		return ResourceEditorInput.ID;
 	}
 
-	getName(): string {
+	getName(): string | null {
 		return this.name;
 	}
 
-	setName(name: string): void {
+	setName(name: string | null): void {
 		if (this.name !== name) {
 			this.name = name;
 			this._onDidChangeLabel.fire();
@@ -58,7 +58,7 @@ export class ResourceEditorInput extends EditorInput {
 		return this.description;
 	}
 
-	setDescription(description: string): void {
+	setDescription(description: string | null): void {
 		if (this.description !== description) {
 			this.description = description;
 			this._onDidChangeLabel.fire();

--- a/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
@@ -98,8 +98,10 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 		}
 	}
 
-	setPreferredEncoding(encoding: string): void {
-		this.preferredEncoding = encoding;
+	setPreferredEncoding(encoding: string | undefined): void {
+		if (typeof encoding !== 'undefined') {
+			this.preferredEncoding = encoding;
+		}
 
 		if (encoding) {
 			this.forceOpenAsText = true; // encoding is a good hint to open the file as text


### PR DESCRIPTION
Enables strict null checking for editorService. This require some non-trivial changes, and the intent of the code was not always clear to me:

- Annotate where `EditorInput.name` or `EditorInput.description` can be null

- `setPreferredEncoding` can take `undefined`. Not sure about this change. The code definitely can call `setPreferredEncoding(undefined)` but I'm not sure what the expectation of this is

- Convert between nulls and undefines in a few places

- Make `createInput` throw instead of possibly returning null.  I also wasn't too confident in this change.