### PR TITLE
Add `directory` option to workbench.editor.labelFormat

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -711,7 +711,7 @@ export class TabsTitleControl extends TitleControl {
 
 	private computeTabLabels(): void {
 		const { labelFormat } = this.accessor.partOptions;
-		const { verbosity, shortenDuplicates } = this.getLabelConfigFlags(labelFormat);
+		const { verbosity, shortenDuplicates, swapNameAndDescription } = this.getLabelConfigFlags(labelFormat);
 
 		// Build labels and descriptions for each editor
 		const labels = this.group.editors.map(editor => ({
@@ -724,6 +724,14 @@ export class TabsTitleControl extends TitleControl {
 		// Shorten labels as needed
 		if (shortenDuplicates) {
 			this.shortenTabLabels(labels);
+		}
+
+		if (swapNameAndDescription) {
+			labels.forEach(label => {
+				const labelName = label.name;
+				label.name = label.description;
+				label.description = labelName;
+			});
 		}
 
 		this.tabLabels = labels;
@@ -801,13 +809,15 @@ export class TabsTitleControl extends TitleControl {
 	private getLabelConfigFlags(value: string | undefined) {
 		switch (value) {
 			case 'short':
-				return { verbosity: Verbosity.SHORT, shortenDuplicates: false };
+				return { verbosity: Verbosity.SHORT, shortenDuplicates: false, swapNameAndDescription: false };
 			case 'medium':
-				return { verbosity: Verbosity.MEDIUM, shortenDuplicates: false };
+				return { verbosity: Verbosity.MEDIUM, shortenDuplicates: false, swapNameAndDescription: false };
 			case 'long':
-				return { verbosity: Verbosity.LONG, shortenDuplicates: false };
+				return { verbosity: Verbosity.LONG, shortenDuplicates: false, swapNameAndDescription: false };
+			case 'directory':
+				return { verbosity: Verbosity.SHORT, shortenDuplicates: false, swapNameAndDescription: true };
 			default:
-				return { verbosity: Verbosity.MEDIUM, shortenDuplicates: true };
+				return { verbosity: Verbosity.MEDIUM, shortenDuplicates: true, swapNameAndDescription: false };
 		}
 	}
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -31,12 +31,13 @@ import { isMacintosh } from 'vs/base/common/platform';
 			},
 			'workbench.editor.labelFormat': {
 				'type': 'string',
-				'enum': ['default', 'short', 'medium', 'long'],
+				'enum': ['default', 'short', 'medium', 'long', 'directory'],
 				'enumDescriptions': [
 					nls.localize('workbench.editor.labelFormat.default', "Show the name of the file. When tabs are enabled and two files have the same name in one group the distinguishing sections of each file's path are added. When tabs are disabled, the path relative to the workspace folder is shown if the editor is active."),
 					nls.localize('workbench.editor.labelFormat.short', "Show the name of the file followed by its directory name."),
 					nls.localize('workbench.editor.labelFormat.medium', "Show the name of the file followed by its path relative to the workspace folder."),
-					nls.localize('workbench.editor.labelFormat.long', "Show the name of the file followed by its absolute path.")
+					nls.localize('workbench.editor.labelFormat.long', "Show the name of the file followed by its absolute path."),
+					nls.localize('workbench.editor.labelFormat.directory', "Show the file's directory name followed by the name of the file.")
 				],
 				'default': 'default',
 				'description': nls.localize({

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -971,7 +971,7 @@ interface IEditorPartConfiguration {
 	closeEmptyGroups?: boolean;
 	revealIfOpen?: boolean;
 	swipeToNavigate?: boolean;
-	labelFormat?: 'default' | 'short' | 'medium' | 'long';
+	labelFormat?: 'default' | 'short' | 'medium' | 'long' | 'directory';
 	restoreViewState?: boolean;
 }
 


### PR DESCRIPTION
The `directory` option shows the file's directory name followed by the name of the file.

This option very useful when working in project containing multiple same named files (e.g. index.js and config.yaml) and/or where the folder in which the file is located gives the most context.

For example with React folder structure:
```
Components/
    Feed/
        index.js
        Button.js
    Store /
        index.js
        Button.js
    Post/
        Footer.js
    Button.js
```
the tabbar looks like:
- Feed _index.js_
- Feed _Button.js_
- Store _index.js_
- Store _Button.js_
- Post _Footer.js_
- Components _Button.js_

![Screenshot 2019-03-13 at 20 31 04](https://user-images.githubusercontent.com/2881013/54312519-15ee5b00-45cf-11e9-945a-ec4ee4d12f32.png)
