### PR TITLE
Correctly handle succeeding ANSI color codes (fix #70416)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -72,16 +72,20 @@ export function handleANSIOutput(text: string, linkDetector: LinkDetector): HTML
 							styleNames.push('code-italic');
 						} else if (code === 4) {
 							styleNames.push('code-underline');
-						} else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
-							styleNames.push('code-foreground-' + code);
-						} else if (code === 39) {
-							// Remove all foreground colour codes
+						} else if (code === 39 || (code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+							// Remove all previous foreground colour codes
 							styleNames = styleNames.filter(style => !style.match(/^code-foreground-\d+$/));
-						} else if ((code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
-							styleNames.push('code-background-' + code);
-						} else if (code === 49) {
-							// Remove all background colour codes
+
+							if (code !== 39) {
+								styleNames.push('code-foreground-' + code);
+							}
+						} else if (code === 49 || (code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+							// Remove all previous background colour codes
 							styleNames = styleNames.filter(style => !style.match(/^code-background-\d+$/));
+
+							if (code !== 49) {
+								styleNames.push('code-background-' + code);
+							}
 						}
 					}
 

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -130,16 +130,37 @@ suite('Debug - ANSI Handling', () => {
 			});
 		}
 
-		// Codes do not interfere
-		assertSingleSequenceElement('\x1b[1;3;4;30;31;32;33;34;35;36;37m', (child) => {
-			assert.equal(11, child.classList.length);
+		// Different codes do not interfere
+		assertSingleSequenceElement('\x1b[1;3;4;30;41m', (child) => {
+			assert.equal(5, child.classList.length);
 
 			assert(dom.hasClass(child, 'code-bold'));
 			assert(dom.hasClass(child, 'code-italic'));
 			assert(dom.hasClass(child, 'code-underline'));
-			for (let i = 30; i <= 37; i++) {
-				assert(dom.hasClass(child, 'code-foreground-' + i));
-			}
+			assert(dom.hasClass(child, 'code-foreground-30'));
+			assert(dom.hasClass(child, 'code-background-41'));
+		});
+
+		// New foreground color codes remove old codes
+		assertSingleSequenceElement('\x1b[30;31;32;33;34;35;36;37m', (child) => {
+			assert.equal(1, child.classList.length);
+
+			assert(dom.hasClass(child, 'code-foreground-37'));
+		});
+
+		// New background color codes remove old codes
+		assertSingleSequenceElement('\x1b[40;41;42;43;44;45;46;47m', (child) => {
+			assert.equal(1, child.classList.length);
+
+			assert(dom.hasClass(child, 'code-background-47'));
+		});
+
+		// New foreground codes don't remove old background codes and vice versa
+		assertSingleSequenceElement('\x1b[40;31;42;33m', (child) => {
+			assert.equal(2, child.classList.length);
+
+			assert(dom.hasClass(child, 'code-background-42'));
+			assert(dom.hasClass(child, 'code-foreground-33'));
 		});
 
 		// Duplicate codes do not change output


### PR DESCRIPTION
When parsing for ANSI color codes, succeeding codes will remove previous colors instead of adding new classes while ignoring existing ones. This will fix #70416.

Also added some unit tests and modified one existing one to account for the change.