### PR TITLE
Add option to hide git sync button in status bar

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1149,6 +1149,11 @@
           "default": true,
           "description": "%config.decorations.enabled%"
         },
+        "git.statusBarSync.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.statusBarSync.enabled%"
+        },
         "git.promptToSaveFilesBeforeCommit": {
           "type": "boolean",
           "scope": "resource",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -91,6 +91,7 @@
 	"config.enableCommitSigning": "Enables commit signing with GPG.",
 	"config.discardAllScope": "Controls what changes are discarded by the `Discard all changes` command. `all` discards all changes. `tracked` discards only tracked files. `prompt` shows a prompt dialog every time the action is run.",
 	"config.decorations.enabled": "Controls whether Git contributes colors and badges to the explorer and the open editors view.",
+	"config.statusBarSync.enabled": "Controls whether Git sync appears in the status bar.",
 	"config.promptToSaveFilesBeforeCommit": "Controls whether Git should check for unsaved files before committing.",
 	"config.postCommitCommand": "Runs a git command after a successful commit.",
 	"config.postCommitCommand.none": "Don't run any command after a commit.",

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -5,7 +5,7 @@
 
 import { Disposable, Command, EventEmitter, Event, workspace, Uri } from 'vscode';
 import { Repository, Operation } from './repository';
-import { anyEvent, dispose } from './util';
+import { anyEvent, dispose, filterEvent } from './util';
 import * as nls from 'vscode-nls';
 import { Branch } from './api/git';
 
@@ -39,6 +39,7 @@ class CheckoutStatusBar {
 }
 
 interface SyncStatusBarState {
+	isEnabled: boolean;
 	isSyncRunning: boolean;
 	hasRemotes: boolean;
 	HEAD: Branch | undefined;
@@ -47,6 +48,7 @@ interface SyncStatusBarState {
 class SyncStatusBar {
 
 	private static StartState: SyncStatusBarState = {
+		isEnabled: true,
 		isSyncRunning: false,
 		hasRemotes: false,
 		HEAD: undefined
@@ -66,7 +68,21 @@ class SyncStatusBar {
 	constructor(private repository: Repository) {
 		repository.onDidRunGitStatus(this.onModelChange, this, this.disposables);
 		repository.onDidChangeOperations(this.onOperationsChange, this, this.disposables);
+
+		const onEnablementChange = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.statusBarSync.enabled'));
+		onEnablementChange(this.updateEnablement, this, this.disposables);
+
 		this._onDidChange.fire();
+	}
+
+	private updateEnablement(): void {
+		const isEnabled = workspace.getConfiguration('git').get('statusBarSync.enabled');
+
+		if (isEnabled) {
+			this.state = { ... this.state, isEnabled: true };
+		} else {
+			this.state = { ... this.state, isEnabled: false };
+		}
 	}
 
 	private onOperationsChange(): void {
@@ -86,7 +102,7 @@ class SyncStatusBar {
 	}
 
 	get command(): Command | undefined {
-		if (!this.state.hasRemotes) {
+		if (!this.state.isEnabled || !this.state.hasRemotes) {
 			return undefined;
 		}
 


### PR DESCRIPTION
This PR adds the option `git.statusBarSync.enabled` which when set to `false` will hide the `SyncStatusBar` icon that is, by default, visible in the status bar. 

Resolves #70604