### PR TITLE
Add only tracked files can be auto staged flag [Fix #70091]

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1222,6 +1222,12 @@
           "default": false,
           "description": "%config.alwaysShowStagedChangesResourceGroup%"
         },
+        "git.onlyTrackedFilesCanBeAutoStaged": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "description": "%config.onlyTrackedFilesCanBeAutoStaged%"
+        },
         "git.alwaysSignOff": {
           "type": "boolean",
           "scope": "resource",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -104,6 +104,7 @@
 	"config.detectSubmodules": "Controls whether to automatically detect git submodules.",
 	"config.detectSubmodulesLimit": "Controls the limit of git submodules detected.",
 	"config.alwaysShowStagedChangesResourceGroup": "Always show the Staged Changes resource group.",
+	"config.onlyTrackedFilesCanBeAutoStaged": "Only tracked files can be auto staged",
 	"config.alwaysSignOff": "Controls the signoff flag for all commits.",
 	"config.ignoredRepositories": "List of git repositories to ignore.",
 	"config.scanRepositories": "List of paths to search for git repositories in.",


### PR DESCRIPTION
Hi @joaomoreno, based on your suggestion [here](https://github.com/Microsoft/vscode/issues/70091#issuecomment-471433402), I made this PR to fix issue #70091, feel free to let me know what do you think about it :)

BTW: do you have any idea about this build error?

```
Error: An unexpected error occurred while trying to download the package. Exit code(1) and error({"@t":"2019-03-15T06:55:50.1467950Z","@m":"An error occurred on the service. User 'b330eefa-83ef-4da3-afd4-02e072b17832' lacks permission to complete this action. You need to have 'ReadPackages'.","@i":"bed2a20a","@l":"Error","SourceContext":"ArtifactTool.Program","UtcTimestamp":"2019-03-15 06:55:50.146Z"})

```

seems other PRs have same issue