### PR TITLE
Improve extension activation failure messages

### DIFF
--- a/src/vs/workbench/api/electron-browser/mainThreadExtensionService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadExtensionService.ts
@@ -75,12 +75,14 @@ export class MainThreadExtensionService implements MainThreadExtensionServiceSha
 
 	private async _handleMissingDependency(extensionId: ExtensionIdentifier, missingDependency: string): Promise<void> {
 		const extension = await this._extensionService.getExtension(extensionId.value);
-		const local = await this._extensionsWorkbenchService.queryLocal();
-		const installedDependency = local.filter(i => areSameExtensions(i.identifier, { id: missingDependency }))[0];
-		if (installedDependency) {
-			await this._handleMissingInstalledDependency(extension, installedDependency);
-		} else {
-			await this._handleMissingNotInstalledDependency(extension, missingDependency);
+		if (extension) {
+			const local = await this._extensionsWorkbenchService.queryLocal();
+			const installedDependency = local.filter(i => areSameExtensions(i.identifier, { id: missingDependency }))[0];
+			if (installedDependency) {
+				await this._handleMissingInstalledDependency(extension, installedDependency);
+			} else {
+				await this._handleMissingNotInstalledDependency(extension, missingDependency);
+			}
 		}
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadExtensionService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadExtensionService.ts
@@ -69,7 +69,7 @@ export class MainThreadExtensionService implements MainThreadExtensionServiceSha
 		if (typeof activationError === 'string') {
 			this._extensionService._logOrShowMessage(Severity.Error, activationError);
 		} else {
-			this._handleMissingDependency(extensionId, activationError.dependencies[0]);
+			this._handleMissingDependency(extensionId, activationError.dependency);
 		}
 	}
 

--- a/src/vs/workbench/api/electron-browser/mainThreadExtensionService.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadExtensionService.ts
@@ -44,9 +44,6 @@ export class MainThreadExtensionService implements MainThreadExtensionServiceSha
 	public dispose(): void {
 	}
 
-	$localShowMessage(severity: Severity, msg: string): void {
-		this._extensionService._logOrShowMessage(severity, msg);
-	}
 	$activateExtension(extensionId: ExtensionIdentifier, activationEvent: string): Promise<void> {
 		return this._extensionService._activateById(extensionId, activationEvent);
 	}

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -571,7 +571,6 @@ export interface MainThreadTaskShape extends IDisposable {
 }
 
 export interface MainThreadExtensionServiceShape extends IDisposable {
-	$localShowMessage(severity: Severity, msg: string): void;
 	$activateExtension(extensionId: ExtensionIdentifier, activationEvent: string | null): Promise<void>;
 	$onWillActivateExtension(extensionId: ExtensionIdentifier): void;
 	$onDidActivateExtension(extensionId: ExtensionIdentifier, startup: boolean, codeLoadingTime: number, activateCallTime: number, activateResolvedTime: number, activationEvent: string | null): void;

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -36,7 +36,7 @@ import { ITreeItem, IRevealOptions } from 'vs/workbench/common/views';
 import { IAdapterDescriptor, IConfig, ITerminalSettings } from 'vs/workbench/contrib/debug/common/debug';
 import { ITextQueryBuilderOptions } from 'vs/workbench/contrib/search/common/queryBuilder';
 import { ITerminalDimensions } from 'vs/workbench/contrib/terminal/common/terminal';
-import { IExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
+import { IExtensionDescription, ExtensionActivationError } from 'vs/workbench/services/extensions/common/extensions';
 import { IRPCProtocol, createExtHostContextProxyIdentifier as createExtId, createMainContextProxyIdentifier as createMainId } from 'vs/workbench/services/extensions/node/proxyIdentifier';
 import { IProgressOptions, IProgressStep } from 'vs/platform/progress/common/progress';
 import { SaveReason } from 'vs/workbench/services/textfile/common/textfiles';
@@ -575,7 +575,7 @@ export interface MainThreadExtensionServiceShape extends IDisposable {
 	$activateExtension(extensionId: ExtensionIdentifier, activationEvent: string | null): Promise<void>;
 	$onWillActivateExtension(extensionId: ExtensionIdentifier): void;
 	$onDidActivateExtension(extensionId: ExtensionIdentifier, startup: boolean, codeLoadingTime: number, activateCallTime: number, activateResolvedTime: number, activationEvent: string | null): void;
-	$onExtensionActivationFailed(extensionId: ExtensionIdentifier): void;
+	$onExtensionActivationError(extensionId: ExtensionIdentifier, error: ExtensionActivationError): Promise<void>;
 	$onExtensionRuntimeError(extensionId: ExtensionIdentifier, error: SerializedError): void;
 }
 

--- a/src/vs/workbench/api/node/extHostExtensionActivator.ts
+++ b/src/vs/workbench/api/node/extHostExtensionActivator.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { ExtensionDescriptionRegistry } from 'vs/workbench/services/extensions/node/extensionDescriptionRegistry';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
-import { ExtensionActivationError, MissingDependenciesError } from 'vs/workbench/services/extensions/common/extensions';
+import { ExtensionActivationError, MissingDependencyError } from 'vs/workbench/services/extensions/common/extensions';
 
 const NO_OP_VOID_PROMISE = Promise.resolve<void>(undefined);
 
@@ -305,7 +305,7 @@ export class ExtensionsActivator {
 			}
 
 			// Error condition 1: unknown dependency
-			this._host.onExtensionActivationError(currentExtension.identifier, new MissingDependenciesError([depId]));
+			this._host.onExtensionActivationError(currentExtension.identifier, new MissingDependencyError(depId));
 			const error = new Error(`Unknown dependency '${depId}'`);
 			this._activatedExtensions.set(ExtensionIdentifier.toKey(currentExtension.identifier), new FailedExtension(error));
 			return;

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -46,9 +46,9 @@ export interface IExtensionsStatus {
 	runtimeErrors: Error[];
 }
 
-export type ExtensionActivationError = string | MissingDependenciesError;
-export class MissingDependenciesError {
-	constructor(readonly dependencies: string[]) { }
+export type ExtensionActivationError = string | MissingDependencyError;
+export class MissingDependencyError {
+	constructor(readonly dependency: string) { }
 }
 
 /**

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -46,6 +46,11 @@ export interface IExtensionsStatus {
 	runtimeErrors: Error[];
 }
 
+export type ExtensionActivationError = string | MissingDependenciesError;
+export class MissingDependenciesError {
+	constructor(readonly dependencies: string[]) { }
+}
+
 /**
  * e.g.
  * ```


### PR DESCRIPTION
Fixes #70546

Improved activation failure messages to show actions to the user 

![image](https://user-images.githubusercontent.com/10746682/54421102-032d7080-470c-11e9-8621-32de96a520ee.png)


