### PR TITLE
Fix Unit Test launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -194,8 +194,8 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Unit Tests",
-			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"name": "Run Unit Tests",
+			"program": "${workspaceFolder}/test/electron/index.js",
 			"runtimeExecutable": "${workspaceFolder}/.build/electron/Code - OSS.app/Contents/MacOS/Electron",
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/.build/electron/Code - OSS.exe"
@@ -205,14 +205,9 @@
 			},
 			"outputCapture": "std",
 			"args": [
-				"--delay",
-				"--timeout",
-				"2000"
+				"--remote-debugging-port=9222"
 			],
 			"cwd": "${workspaceFolder}",
-			"env": {
-				"ELECTRON_RUN_AS_NODE": "true"
-			},
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			]
@@ -269,6 +264,13 @@
 				"Launch VS Code",
 				"Attach to Extension Host"
 			]
-		}
+		},
+		{
+			"name": "Debug Unit Tests",
+			"configurations": [
+				"Attach to VS Code",
+				"Run Unit Tests"
+			]
+		},
 	]
 }


### PR DESCRIPTION
This is my attempt to fix #63464 by updating the Unit Test launch configuration so that it runs unit tests and setting up a compound "Debug Unit Tests" configuration that allows you to debug the tests from within VS Code.

I tried getting it all working from a single configuration but the pass/fail output gets messy when it has to go through Chrome.

It's the same setup we use for Azure Data Studio and it's working reliably for us so I figured I would contribute it back to fix that issue. Let me know if there are any problems.