### PR TITLE
Proposed Feature: Control StatusBar background color

### DIFF
--- a/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
+++ b/src/vs/platform/keybinding/test/common/abstractKeybindingService.test.ts
@@ -160,6 +160,9 @@ suite('AbstractKeybindingService', () => {
 							statusMessageCallsDisposed!.push(message);
 						}
 					};
+				},
+				setBackgroundColor(color: string) {
+					return { dispose() { } };
 				}
 			};
 

--- a/src/vs/platform/statusbar/common/statusbar.ts
+++ b/src/vs/platform/statusbar/common/statusbar.ts
@@ -71,4 +71,9 @@ export interface IStatusbarService {
 	 * Prints something to the status bar area with optional auto dispose and delay.
 	 */
 	setStatusMessage(message: string, autoDisposeAfter?: number, delayBy?: number): IDisposable;
+
+	/**
+	 * Set background color of the status bar
+	 */
+	setBackgroundColor(color: string): IDisposable;
 }

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6477,6 +6477,9 @@ declare module 'vscode' {
 		 */
 		export function createWebviewPanel(viewType: string, title: string, showOptions: ViewColumn | { viewColumn: ViewColumn, preserveFocus?: boolean }, options?: WebviewPanelOptions & WebviewOptions): WebviewPanel;
 
+		// §TODO: disposable that reset color
+		export function setStatusBarBackground(color: string): Disposable;
+
 		/**
 		 * Set a message to the status bar. This is a short hand for the more powerful
 		 * status bar [items](#window.createStatusBarItem).

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4562,6 +4562,13 @@ declare module 'vscode' {
 		dispose(): void;
 	}
 
+	export interface StatusBarStyle {
+		backgroundColor: string | ThemeColor | undefined;
+		// §todo: add documentation and other stuff
+		apply(): void;
+		dispose(): void;
+	}
+
 	/**
 	 * Defines a generalized way of reporting progress updates.
 	 */

--- a/src/vs/workbench/api/electron-browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadStatusBar.ts
@@ -10,16 +10,23 @@ import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 
+type ColorItem = {
+	id: number,
+	disposable: IDisposable
+};
+
 @extHostNamedCustomer(MainContext.MainThreadStatusBar)
 export class MainThreadStatusBar implements MainThreadStatusBarShape {
 
 	private readonly _entries: { [id: number]: IDisposable };
+	private _stackColor: ColorItem[];
 
 	constructor(
 		extHostContext: IExtHostContext,
 		@IStatusbarService private readonly _statusbarService: IStatusbarService
 	) {
 		this._entries = Object.create(null);
+		this._stackColor = [];
 	}
 
 	dispose(): void {
@@ -38,10 +45,20 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 		this._entries[id] = entry;
 	}
 
-	$setBackground(color: string): void {
-		this._statusbarService.setBackgroundColor(color);
+	$setBackground(id: number, color: string): void {
+		const disposable = this._statusbarService.setBackgroundColor(color);
+		this._stackColor.push({ id, disposable });
 	}
+	$disposeBackground(id: number) {
+		let index; // find not working
+		this._stackColor.forEach((e, idx) => { if (e.id === id) { index = idx; });
 
+		if (index /*&& index === this._stackColor.length -1*/) {
+			this._stackColor[index].disposable.dispose();
+		}
+
+		this._stackColor = this._stackColor.filter(e => e.id === id);
+	}
 	$dispose(id: number) {
 		const disposeable = this._entries[id];
 		if (disposeable) {

--- a/src/vs/workbench/api/electron-browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadStatusBar.ts
@@ -51,7 +51,7 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 	}
 	$disposeBackground(id: number) {
 		let index; // find not working
-		this._stackColor.forEach((e, idx) => { if (e.id === id) { index = idx; });
+		this._stackColor.forEach((e, idx) => { if (e.id === id) { index = idx; } });
 
 		if (index /*&& index === this._stackColor.length -1*/) {
 			this._stackColor[index].disposable.dispose();

--- a/src/vs/workbench/api/electron-browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/electron-browser/mainThreadStatusBar.ts
@@ -38,6 +38,10 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 		this._entries[id] = entry;
 	}
 
+	$setBackground(color: string): void {
+		this._statusbarService.setBackgroundColor(color);
+	}
+
 	$dispose(id: number) {
 		const disposeable = this._entries[id];
 		if (disposeable) {

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -450,6 +450,9 @@ export function createApiFactory(
 			showSaveDialog(options) {
 				return extHostDialogs.showSaveDialog(options);
 			},
+			setStatusBarBackground(color: string): vscode.Disposable {
+				return extHostStatusBar.setStatusBarBackground(color);
+			},
 			createStatusBarItem(position?: vscode.StatusBarAlignment, priority?: number): vscode.StatusBarItem {
 				return extHostStatusBar.createStatusBarEntry(extension.identifier, <number>position, priority);
 			},

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -469,6 +469,7 @@ export interface MainThreadQuickOpenShape extends IDisposable {
 
 export interface MainThreadStatusBarShape extends IDisposable {
 	$setEntry(id: number, extensionId: ExtensionIdentifier | undefined, text: string, tooltip: string, command: string, color: string | ThemeColor, alignment: MainThreadStatusBarAlignment, priority: number | undefined): void;
+	$setBackground(color: string): void;
 	$dispose(id: number): void;
 }
 

--- a/src/vs/workbench/api/node/extHost.protocol.ts
+++ b/src/vs/workbench/api/node/extHost.protocol.ts
@@ -469,7 +469,8 @@ export interface MainThreadQuickOpenShape extends IDisposable {
 
 export interface MainThreadStatusBarShape extends IDisposable {
 	$setEntry(id: number, extensionId: ExtensionIdentifier | undefined, text: string, tooltip: string, command: string, color: string | ThemeColor, alignment: MainThreadStatusBarAlignment, priority: number | undefined): void;
-	$setBackground(color: string): void;
+	$setBackground(id: number, color: string | ThemeColor): void;
+	$disposeBackground(id: number): void;
 	$dispose(id: number): void;
 }
 

--- a/src/vs/workbench/api/node/extHostStatusBar.ts
+++ b/src/vs/workbench/api/node/extHostStatusBar.ts
@@ -157,18 +157,49 @@ class StatusBarMessage {
 	}
 }
 
+class StatusBarBackground {
+	private _color: string;
+	private _statusBar: ExtHostStatusBar;
+
+	constructor(statusBar: ExtHostStatusBar) {
+		this._statusBar = statusBar;
+	}
+
+	dispose() { }
+
+	setBackground(color: string): Disposable {
+		this._color = color;
+		this._update();
+		return new Disposable(() => { });
+	}
+
+	private _update() {
+		this._statusBar.updateBackground(this._color);
+	}
+}
 export class ExtHostStatusBar {
 
 	private _proxy: MainThreadStatusBarShape;
 	private _statusMessage: StatusBarMessage;
+	private _statusBarBackground: StatusBarBackground;
 
 	constructor(mainContext: IMainContext) {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadStatusBar);
 		this._statusMessage = new StatusBarMessage(this);
+		this._statusBarBackground = new StatusBarBackground(this);
+	}
+
+	updateBackground(color: string) {
+		this._proxy.$setBackground(color);
 	}
 
 	createStatusBarEntry(extensionId: ExtensionIdentifier | undefined, alignment?: ExtHostStatusBarAlignment, priority?: number): StatusBarItem {
 		return new ExtHostStatusBarEntry(this._proxy, extensionId, alignment, priority);
+	}
+
+	setStatusBarBackground(color: string): Disposable {
+		this._statusBarBackground.setBackground(color);
+		return new Disposable(() => { });
 	}
 
 	setStatusBarMessage(text: string, timeoutOrThenable?: number | Thenable<any>): Disposable {

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -231,8 +231,13 @@ export class StatusbarPart extends Part implements IStatusbarService {
 	}
 
 	public setBackgroundColor(color: string): IDisposable {
+		const originalColor = document.getElementById('workbench.parts.statusbar').style.backgroundColor;
 		document.getElementById('workbench.parts.statusbar').style.backgroundColor = color;
-		return { dispose: () => { } };
+		return {
+			dispose: () => {
+				document.getElementById('workbench.parts.statusbar').style.backgroundColor = originalColor;
+			}
+		};
 	}
 
 	layout(width: number, height: number): void {

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -230,6 +230,11 @@ export class StatusbarPart extends Part implements IStatusbarService {
 		return dispose;
 	}
 
+	public setBackgroundColor(color: string): IDisposable {
+		document.getElementById('workbench.parts.statusbar').style.backgroundColor = color;
+		return { dispose: () => { } };
+	}
+
 	layout(width: number, height: number): void {
 		super.layoutContents(width, height);
 	}

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -49,6 +49,8 @@ export class StatusbarPart extends Part implements IStatusbarService {
 	private statusMsgDispose: IDisposable;
 	private styleElement: HTMLStyleElement;
 
+	private _currentBackgroundColor: string;
+
 	constructor(
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IThemeService themeService: IThemeService,
@@ -231,11 +233,15 @@ export class StatusbarPart extends Part implements IStatusbarService {
 	}
 
 	public setBackgroundColor(color: string): IDisposable {
-		const originalColor = document.getElementById('workbench.parts.statusbar').style.backgroundColor;
-		document.getElementById('workbench.parts.statusbar').style.backgroundColor = color;
+		const el = document.getElementById('workbench.parts.statusbar');
+		const originalColor = el.style.backgroundColor;
+		el.style.backgroundColor = color;
+		this._currentBackgroundColor = color;
 		return {
 			dispose: () => {
-				document.getElementById('workbench.parts.statusbar').style.backgroundColor = originalColor;
+				if (this._currentBackgroundColor === color) {
+					el.style.backgroundColor = originalColor;
+				}
 			}
 		};
 	}


### PR DESCRIPTION
This PR introduce an **API to modify the color of the status Bar** 🌈, so that it can be used by extensions. 
One of the main example use (and reason I implement it), is to *modify the statusBar color based on vim mode*: (cf https://github.com/VSCodeVim/Vim#vim-airline)
So far current implementation modify the settings with cause huge overhead (https://github.com/VSCodeVim/Vim/issues/2021#issuecomment-465729996)

**This is a draft, any feedback is more than welcome.**
I wait there is consensus on the API to write both the detailed documentation and the tests.
(Speaking of test I might need some guidance about where to write them)

One can try out by getting the following commit: https://github.com/AdrieanKhisbe/vscode/commit/8d821316fc1191afff1ec2870a8f81588d50efe1, that add command to set statusbar in green, red, or blue(for some duration)