### PR TITLE
feat(coffeescript): Add `.iced` extension

### DIFF
--- a/extensions/coffeescript/package.json
+++ b/extensions/coffeescript/package.json
@@ -11,7 +11,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "coffeescript",
-			"extensions": [ ".coffee", ".cson" ],
+			"extensions": [ ".coffee", ".cson", ".iced" ],
 			"aliases": [ "CoffeeScript", "coffeescript", "coffee" ],
 			"configuration": "./language-configuration.json"
 		}],


### PR DESCRIPTION
This adds support for the [`.iced` CoffeeScript](http://maxtaco.github.io/coffee-script/) file extension, which adds top‑level `await` and the `defer` function.
