### PR TITLE
Node module resolution for CSS import

### DIFF
--- a/extensions/css-language-features/server/src/utils/documentContext.ts
+++ b/extensions/css-language-features/server/src/utils/documentContext.ts
@@ -40,11 +40,15 @@ export function getDocumentContext(documentUri: string, workspaceFolders: Worksp
 					}
 				}
 			}
+			// Following [css-loader](https://github.com/webpack-contrib/css-loader#url)
+			// and [sass-loader's](https://github.com/webpack-contrib/sass-loader#imports)
+			// convention, if an import path starts with ~ then use node module resolution
+			// *unless* it starts with "~/" as this refers to the user's home directory.
 			if (ref[0] === '~' && ref[1] !== '/') {
 				const moduleName = getModuleNameFromPath(ref.substring(1));
 				const modulePath = require.resolve(moduleName, { paths: [base] });
-				const pathInModule = ref.substring(moduleName.length + 2);
-				return url.resolve(modulePath, pathInModule);
+				const pathWithinModule = ref.substring(moduleName.length + 2);
+				return url.resolve(modulePath, pathWithinModule);
 			}
 			return url.resolve(base, ref);
 		},

--- a/extensions/css-language-features/server/src/utils/documentContext.ts
+++ b/extensions/css-language-features/server/src/utils/documentContext.ts
@@ -19,9 +19,15 @@ function getModuleNameFromPath(path: string) {
 function resolvePathToModule(moduleName: string, relativeTo: string) {
 	// if we require.resolve('my-module') then it will follow the main property in the linked package.json
 	// but we want the root of the module so resolve to the package.json and then trim
-	return require
-		.resolve(`${moduleName}/package.json`, { paths: [relativeTo] })
-		.slice(0, -12); // remove trailing `package.json`
+	let resolved;
+	try {
+		resolved = require
+			.resolve(`${moduleName}/package.json`, { paths: [relativeTo] });
+	}
+	catch (ex) {
+		return null;
+	}
+	return resolved.slice(0, -12); // remove trailing `package.json`
 }
 
 export function getDocumentContext(documentUri: string, workspaceFolders: WorkspaceFolder[]): DocumentContext {
@@ -55,8 +61,10 @@ export function getDocumentContext(documentUri: string, workspaceFolders: Worksp
 			if (ref[0] === '~' && ref[1] !== '/') {
 				const moduleName = getModuleNameFromPath(ref.substring(1));
 				const modulePath = resolvePathToModule(moduleName, base);
-				const pathWithinModule = ref.substring(moduleName.length + 2);
-				return url.resolve(modulePath, pathWithinModule);
+				if (modulePath) {
+					const pathWithinModule = ref.substring(moduleName.length + 2);
+					return url.resolve(modulePath, pathWithinModule);
+				}
 			}
 			return url.resolve(base, ref);
 		},


### PR DESCRIPTION
Add 'Go to definition' support for
```css
@import "~bootstrap/dist/css/bootstrap";
```
as per
- https://github.com/webpack-contrib/sass-loader#imports
- https://github.com/webpack-contrib/css-loader#import

Fixes Microsoft/vscode-css-languageservice#136

Also see https://stackoverflow.com/questions/48499853/how-to-jump-to-definition-for-a-file-in-node-modules-from-vs-code