### PR TITLE
Add flag for including tags with git pull

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1258,6 +1258,12 @@
           "default": false,
           "description": "%config.fetchOnPull%"
         },
+        "git.includeTagsWithPull": {
+          "type": "boolean",
+          "default": "true",
+          "scope": "resource",
+          "description": "%config.includeTagsWithPull%"
+        },
         "git.autoStash": {
           "type": "boolean",
           "scope": "resource",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -111,6 +111,7 @@
 	"config.rebaseWhenSync": "Force git to use rebase when running the sync command.",
 	"config.confirmEmptyCommits": "Always confirm the creation of empty commits.",
 	"config.fetchOnPull": "Fetch all branches when pulling or just the current one.",
+	"config.includeTagsWithPull": "Include tags when pulling. The pull will abort if remote tags and local tags conflict.",
 	"config.autoStash": "Stash any changes before pulling and restore them after successful pull.",
 	"config.allowForcePush": "Controls whether force push (with or without lease) is enabled.",
 	"config.useForcePushWithLease": "Controls whether force pushing uses the safer force-with-lease variant.",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -633,6 +633,7 @@ export interface CommitOptions {
 }
 
 export interface PullOptions {
+	includeTagsWithPull?: boolean;
 	unshallow?: boolean;
 }
 
@@ -1360,7 +1361,11 @@ export class Repository {
 	}
 
 	async pull(rebase?: boolean, remote?: string, branch?: string, options: PullOptions = {}): Promise<void> {
-		const args = ['pull', '--tags'];
+		const args = ['pull'];
+
+		if (options.includeTagsWithPull) {
+			args.push('--tags');
+		}
 
 		if (options.unshallow) {
 			args.push('--unshallow');

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -979,11 +979,12 @@ export class Repository implements Disposable {
 			await this.maybeAutoStash(async () => {
 				const config = workspace.getConfiguration('git', Uri.file(this.root));
 				const fetchOnPull = config.get<boolean>('fetchOnPull');
+				const includeTagsWithPull = config.get<boolean>('includeTagsWithPull');
 
 				if (fetchOnPull) {
-					await this.repository.pull(rebase, undefined, undefined, { unshallow });
+					await this.repository.pull(rebase, undefined, undefined, { includeTagsWithPull, unshallow });
 				} else {
-					await this.repository.pull(rebase, remote, branch, { unshallow });
+					await this.repository.pull(rebase, remote, branch, { includeTagsWithPull, unshallow });
 				}
 			});
 		});
@@ -1039,11 +1040,12 @@ export class Repository implements Disposable {
 			await this.maybeAutoStash(async () => {
 				const config = workspace.getConfiguration('git', Uri.file(this.root));
 				const fetchOnPull = config.get<boolean>('fetchOnPull');
+				const includeTagsWithPull = config.get<boolean>('includeTagsWithPull');
 
 				if (fetchOnPull) {
-					await this.repository.pull(rebase);
+					await this.repository.pull(rebase, undefined, undefined, { includeTagsWithPull });
 				} else {
-					await this.repository.pull(rebase, remoteName, pullBranch);
+					await this.repository.pull(rebase, remoteName, pullBranch, { includeTagsWithPull });
 				}
 
 				const remote = this.remotes.find(r => r.name === remoteName);


### PR DESCRIPTION
Resolves #67424 /cc @joaomoreno 

Currently, the `Git: Pull` command always pulls down tags from git (`git pull --tags`). That causes the command to fail if any remote tags conflict with local tags. This makes the command almost unusable for frontend developers at my company: We use a `prod` tag that always points at the latest commit deployed to production, so conflicting tags are very common. Other folks on the issue mentioned above describe similar circumstances.

This PR adds a new flag to the Git extension, `includeTagsWithPull`, so that this behavior can be disabled:

![](https://user-images.githubusercontent.com/224895/54547651-8b19b180-497c-11e9-914d-fcb73ea7a74b.png)

---

This is my first PR to VS Code. Please let me know if there's anything else you need from me!