### PR TITLE
Avoid any in TestInstantiationService.stub

### DIFF
--- a/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts
@@ -35,12 +35,12 @@ export class TestInstantiationService extends InstantiationService {
 		return <T>this._create(service, { mock: true });
 	}
 
-	public stub<T>(service: ServiceIdentifier<T>, ctor?: any): T;
-	public stub<T>(service: ServiceIdentifier<T>, obj?: any): T;
-	public stub<T>(service: ServiceIdentifier<T>, ctor?: any, property?: string, value?: any): sinon.SinonStub;
-	public stub<T>(service: ServiceIdentifier<T>, obj?: any, property?: string, value?: any): sinon.SinonStub;
-	public stub<T>(service: ServiceIdentifier<T>, property?: string, value?: any): sinon.SinonStub;
-	public stub<T>(serviceIdentifier: ServiceIdentifier<T>, arg2?: any, arg3?: string, arg4?: any): sinon.SinonStub {
+	public stub<T>(service: ServiceIdentifier<T>, ctor: Function): T;
+	public stub<T>(service: ServiceIdentifier<T>, obj: Partial<T>): T;
+	public stub<T>(service: ServiceIdentifier<T>, ctor: Function, property: string, value: any): sinon.SinonStub;
+	public stub<T>(service: ServiceIdentifier<T>, obj: Partial<T>, property: string, value: any): sinon.SinonStub;
+	public stub<T>(service: ServiceIdentifier<T>, property: string, value: any): sinon.SinonStub;
+	public stub<T>(serviceIdentifier: ServiceIdentifier<T>, arg2: any, arg3?: string, arg4?: any): sinon.SinonStub {
 		let service = typeof arg2 !== 'string' ? arg2 : undefined;
 		let serviceMock: IServiceMock<any> = { id: serviceIdentifier, service: service };
 		let property = typeof arg2 === 'string' ? arg2 : arg3;

--- a/src/vs/workbench/contrib/experiments/test/electron-browser/experimentService.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-browser/experimentService.test.ts
@@ -24,7 +24,7 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { assign } from 'vs/base/common/objects';
 import { URI } from 'vs/base/common/uri';
-import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { lastSessionDateStorageKey } from 'vs/platform/telemetry/node/workbenchCommonProperties';
 import { getGalleryExtensionId } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { ExtensionType } from 'vs/platform/extensions/common/extensions';
@@ -86,11 +86,11 @@ suite('Experiment Service', () => {
 		testConfigurationService = new TestConfigurationService();
 		instantiationService.stub(IConfigurationService, testConfigurationService);
 		instantiationService.stub(ILifecycleService, new TestLifecycleService());
-		instantiationService.stub(IStorageService, { get: (a, b, c) => c, getBoolean: (a, b, c) => c, store: () => { }, remove: () => { } });
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{ get: (a: string, b: StorageScope, c?: string) => c, getBoolean: (a: string, b: StorageScope, c?: boolean) => c, store: () => { }, remove: () => { } });
 
 		setup(() => {
 			instantiationService.stub(IEnvironmentService, {});
-			instantiationService.stub(IStorageService, { get: (a, b, c) => c, getBoolean: (a, b, c) => c, store: () => { }, remove: () => { } });
+			instantiationService.stub(IStorageService, <Partial<IStorageService>>{ get: (a: string, b: StorageScope, c?: string) => c, getBoolean: (a: string, b: StorageScope, c?: boolean) => c, store: () => { }, remove: () => { } });
 		});
 
 		teardown(() => {
@@ -196,11 +196,11 @@ suite('Experiment Service', () => {
 			]
 		};
 
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c?: string) => {
 				return a === lastSessionDateStorageKey ? 'some-date' : undefined;
 			},
-			getBoolean: (a, b, c) => c, store: () => { }, remove: () => { }
+			getBoolean: (a: string, b: StorageScope, c?: boolean) => c, store: () => { }, remove: () => { }
 		});
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
@@ -240,11 +240,11 @@ suite('Experiment Service', () => {
 			]
 		};
 
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c: string | undefined) => {
 				return a === lastSessionDateStorageKey ? 'some-date' : undefined;
 			},
-			getBoolean: (a, b, c) => c, store: () => { }, remove: () => { }
+			getBoolean: (a: string, b: StorageScope, c?: boolean) => c, store: () => { }, remove: () => { }
 		});
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
@@ -372,9 +372,9 @@ suite('Experiment Service', () => {
 			]
 		};
 
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => a === 'experiments.experiment1' ? JSON.stringify({ state: ExperimentState.Complete }) : c,
-			store: (a, b, c) => { }
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c?: string) => a === 'experiments.experiment1' ? JSON.stringify({ state: ExperimentState.Complete }) : c,
+			store: () => { }
 		});
 
 		testObject = instantiationService.createInstance(TestExperimentService);
@@ -400,9 +400,9 @@ suite('Experiment Service', () => {
 			]
 		};
 
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => a === 'experiments.experiment1' ? JSON.stringify({ enabled: true, state: ExperimentState.Run }) : c,
-			store: (a, b, c) => { }
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c?: string) => a === 'experiments.experiment1' ? JSON.stringify({ enabled: true, state: ExperimentState.Run }) : c,
+			store: () => { }
 		});
 		testObject = instantiationService.createInstance(TestExperimentService);
 		return testObject.getExperimentById('experiment1').then(result => {
@@ -508,8 +508,8 @@ suite('Experiment Service', () => {
 		let storageDataExperiment1: ExperimentSettings | null = { enabled: false };
 		let storageDataExperiment2: ExperimentSettings | null = { enabled: false };
 		let storageDataAllExperiments: string[] | null = ['experiment1', 'experiment2', 'experiment3'];
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c?: string) => {
 				switch (a) {
 					case 'experiments.experiment1':
 						return JSON.stringify(storageDataExperiment1);
@@ -522,7 +522,7 @@ suite('Experiment Service', () => {
 				}
 				return c;
 			},
-			store: (a, b, c) => {
+			store: (a: string, b: any, c: StorageScope) => {
 				switch (a) {
 					case 'experiments.experiment1':
 						storageDataExperiment1 = JSON.parse(b);
@@ -537,7 +537,7 @@ suite('Experiment Service', () => {
 						break;
 				}
 			},
-			remove: a => {
+			remove: (a: string) => {
 				switch (a) {
 					case 'experiments.experiment1':
 						storageDataExperiment1 = null;
@@ -580,8 +580,8 @@ suite('Experiment Service', () => {
 		let storageDataExperiment3: ExperimentSettings | null = { enabled: true, state: ExperimentState.Evaluating };
 		let storageDataExperiment4: ExperimentSettings | null = { enabled: true, state: ExperimentState.Complete };
 		let storageDataAllExperiments: string[] | null = ['experiment1', 'experiment2', 'experiment3', 'experiment4'];
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c?: string) => {
 				switch (a) {
 					case 'experiments.experiment1':
 						return JSON.stringify(storageDataExperiment1);
@@ -601,19 +601,19 @@ suite('Experiment Service', () => {
 			store: (a, b, c) => {
 				switch (a) {
 					case 'experiments.experiment1':
-						storageDataExperiment1 = JSON.parse(b);
+						storageDataExperiment1 = JSON.parse(b + '');
 						break;
 					case 'experiments.experiment2':
-						storageDataExperiment2 = JSON.parse(b);
+						storageDataExperiment2 = JSON.parse(b + '');
 						break;
 					case 'experiments.experiment3':
-						storageDataExperiment3 = JSON.parse(b);
+						storageDataExperiment3 = JSON.parse(b + '');
 						break;
 					case 'experiments.experiment4':
-						storageDataExperiment4 = JSON.parse(b);
+						storageDataExperiment4 = JSON.parse(b + '');
 						break;
 					case 'allExperiments':
-						storageDataAllExperiments = JSON.parse(b);
+						storageDataAllExperiments = JSON.parse(b + '');
 						break;
 					default:
 						break;
@@ -768,8 +768,8 @@ suite('Experiment Service', () => {
 
 		let storageDataExperiment3 = { enabled: true, state: ExperimentState.Evaluating };
 		let storageDataExperiment4 = { enabled: true, state: ExperimentState.Evaluating };
-		instantiationService.stub(IStorageService, {
-			get: (a, b, c) => {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
+			get: (a: string, b: StorageScope, c?: string) => {
 				switch (a) {
 					case 'currentOrPreviouslyRunExperiments':
 						return JSON.stringify(['experiment1', 'experiment2']);
@@ -781,10 +781,10 @@ suite('Experiment Service', () => {
 			store: (a, b, c) => {
 				switch (a) {
 					case 'experiments.experiment3':
-						storageDataExperiment3 = JSON.parse(b);
+						storageDataExperiment3 = JSON.parse(b + '');
 						break;
 					case 'experiments.experiment4':
-						storageDataExperiment4 = JSON.parse(b);
+						storageDataExperiment4 = JSON.parse(b + '');
 						break;
 					default:
 						break;

--- a/src/vs/workbench/contrib/experiments/test/electron-browser/experimentalPrompts.test.ts
+++ b/src/vs/workbench/contrib/experiments/test/electron-browser/experimentalPrompts.test.ts
@@ -95,6 +95,7 @@ suite('Experimental Prompts', () => {
 				assert.equal(b, promptText);
 				assert.equal(c.length, 2);
 				c[0].run();
+				return undefined!;
 			}
 		});
 
@@ -119,6 +120,7 @@ suite('Experimental Prompts', () => {
 				assert.equal(b, promptText);
 				assert.equal(c.length, 2);
 				c[1].run();
+				return undefined!;
 			}
 		});
 
@@ -143,6 +145,7 @@ suite('Experimental Prompts', () => {
 				assert.equal(b, promptText);
 				assert.equal(c.length, 2);
 				options.onCancel();
+				return undefined!;
 			}
 		});
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsTipsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsTipsService.test.ts
@@ -228,7 +228,7 @@ suite('ExtensionsTipsService Test', () => {
 	});
 
 	setup(() => {
-		instantiationService.stub(IEnvironmentService, { extensionDevelopmentPath: false });
+		instantiationService.stub(IEnvironmentService, <Partial<IEnvironmentService>>{ extensionDevelopmentPath: false });
 		instantiationService.stubPromise(IExtensionManagementService, 'getInstalled', []);
 		instantiationService.stub(IExtensionGalleryService, 'isEnabled', true);
 		instantiationService.stubPromise(IExtensionGalleryService, 'query', aPage<IGalleryExtension>(...mockExtensionGallery));
@@ -245,7 +245,7 @@ suite('ExtensionsTipsService Test', () => {
 		instantiationService.stub(INotificationService, new TestNotificationService2());
 
 		testConfigurationService.setUserConfiguration(ConfigurationKey, { ignoreRecommendations: false, showRecommendationsOnlyOnDemand: false });
-		instantiationService.stub(IStorageService, { get: (a: string, b: StorageScope, c?: string) => c, getBoolean: (a: string, b: StorageScope, c: boolean) => c, store: () => { } });
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{ get: (a: string, b: StorageScope, c?: string) => c, getBoolean: (a: string, b: StorageScope, c: boolean) => c, store: () => { } });
 		instantiationService.stub(IModelService, <IModelService>{
 			getModels(): any { return []; },
 			onModelAdded: onModelAddedEvent.event
@@ -315,7 +315,7 @@ suite('ExtensionsTipsService Test', () => {
 	});
 
 	test('ExtensionTipsService: No Prompt for valid workspace recommendations during extension development', () => {
-		instantiationService.stub(IEnvironmentService, { extensionDevelopmentLocationURI: true });
+		instantiationService.stub(IEnvironmentService, { extensionDevelopmentLocationURI: URI.file('/folder/file') });
 		return testNoPromptOrRecommendationsForValidRecommendations(mockTestData.validRecommendedExtensions);
 	});
 
@@ -366,7 +366,7 @@ suite('ExtensionsTipsService Test', () => {
 	});
 
 	test('ExtensionTipsService: No Prompt for valid workspace recommendations if ignoreRecommendations is set for current workspace', () => {
-		instantiationService.stub(IStorageService, { get: (a: string, b: StorageScope, c?: string) => c, getBoolean: (a: string, b: StorageScope, c?: boolean) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c });
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{ get: (a: string, b: StorageScope, c?: string) => c, getBoolean: (a: string, b: StorageScope, c?: boolean) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c });
 		return testNoPromptForValidRecommendations(mockTestData.validRecommendedExtensions);
 	});
 
@@ -379,9 +379,9 @@ suite('ExtensionsTipsService Test', () => {
 			return c;
 		};
 
-		instantiationService.stub(IStorageService, {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
 			get: storageGetterStub,
-			getBoolean: (a: string, _: StorageScope, c?: string) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c
+			getBoolean: (a: string, _: StorageScope, c?: boolean) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c
 		});
 
 		return setUpFolderWorkspace('myFolder', mockTestData.validRecommendedExtensions).then(() => {
@@ -399,7 +399,7 @@ suite('ExtensionsTipsService Test', () => {
 	test('ExtensionTipsService: No Recommendations of workspace ignored recommendations', () => {
 		const ignoredRecommendations = ['ms-vscode.csharp', 'mockpublisher2.mockextension2']; // ignore a stored recommendation and a workspace recommendation.
 		const storedRecommendations = '["ms-vscode.csharp", "ms-python.python"]';
-		instantiationService.stub(IStorageService, {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
 			get: (a: string, b: StorageScope, c?: string) => a === 'extensionsAssistant/recommendations' ? storedRecommendations : c,
 			getBoolean: (a: string, _: StorageScope, c?: boolean) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c
 		});
@@ -427,7 +427,7 @@ suite('ExtensionsTipsService Test', () => {
 		};
 
 		const workspaceIgnoredRecommendations = ['ms-vscode.csharp']; // ignore a stored recommendation and a workspace recommendation.
-		instantiationService.stub(IStorageService, {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
 			get: storageGetterStub,
 			getBoolean: (a: string, _: StorageScope, c?: boolean) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c
 		});
@@ -453,7 +453,7 @@ suite('ExtensionsTipsService Test', () => {
 			return c;
 		};
 
-		instantiationService.stub(IStorageService, {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
 			get: storageGetterStub,
 			store: () => { },
 			getBoolean: (a: string, _: StorageScope, c?: boolean) => a === 'extensionsAssistant/workspaceRecommendationsIgnore' || c
@@ -491,7 +491,7 @@ suite('ExtensionsTipsService Test', () => {
 		const storageSetterTarget = sinon.spy();
 		const changeHandlerTarget = sinon.spy();
 		const ignoredExtensionId = 'Some.Extension';
-		instantiationService.stub(IStorageService, {
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{
 			get: (a: string, b: StorageScope, c?: boolean) => a === 'extensionsAssistant/ignored_recommendations' ? '["ms-vscode.vscode"]' : c,
 			store: (...args: any[]) => {
 				storageSetterTarget(...args);
@@ -511,7 +511,7 @@ suite('ExtensionsTipsService Test', () => {
 
 	test('ExtensionTipsService: Get file based recommendations from storage (old format)', () => {
 		const storedRecommendations = '["ms-vscode.csharp", "ms-python.python", "ms-vscode.vscode-typescript-tslint-plugin"]';
-		instantiationService.stub(IStorageService, { get: (a: string, b: StorageScope, c?: string) => a === 'extensionsAssistant/recommendations' ? storedRecommendations : c });
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{ get: (a: string, b: StorageScope, c?: string) => a === 'extensionsAssistant/recommendations' ? storedRecommendations : c });
 
 		return setUpFolderWorkspace('myFolder', []).then(() => {
 			testObject = instantiationService.createInstance(ExtensionTipsService);
@@ -530,7 +530,7 @@ suite('ExtensionsTipsService Test', () => {
 		const now = Date.now();
 		const tenDaysOld = 10 * milliSecondsInADay;
 		const storedRecommendations = `{"ms-vscode.csharp": ${now}, "ms-python.python": ${now}, "ms-vscode.vscode-typescript-tslint-plugin": ${now}, "lukehoban.Go": ${tenDaysOld}}`;
-		instantiationService.stub(IStorageService, { get: (a: string, b: StorageScope, c?: string) => a === 'extensionsAssistant/recommendations' ? storedRecommendations : c });
+		instantiationService.stub(IStorageService, <Partial<IStorageService>>{ get: (a: string, b: StorageScope, c?: string) => a === 'extensionsAssistant/recommendations' ? storedRecommendations : c });
 
 		return setUpFolderWorkspace('myFolder', []).then(() => {
 			testObject = instantiationService.createInstance(ExtensionTipsService);

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
@@ -124,7 +124,7 @@ suite('ExtensionsListView Tests', () => {
 		instantiationService.stubPromise(IExperimentService, 'getExperimentsByType', []);
 
 		instantiationService.stub(IExtensionService, {
-			getExtensions: () => {
+			getExtensions: (): any => { // TODO remove any
 				return Promise.resolve([
 					{ identifier: new ExtensionIdentifier(localEnabledTheme.identifier.id) },
 					{ identifier: new ExtensionIdentifier(localEnabledLanguage.identifier.id) },

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsViews.test.ts
@@ -38,7 +38,7 @@ import { IExperimentService, ExperimentService, ExperimentState, ExperimentActio
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { RemoteAgentService } from 'vs/workbench/services/remote/electron-browser/remoteAgentServiceImpl';
 import { ExtensionManagementServerService } from 'vs/workbench/services/extensions/electron-browser/extensionManagementServerService';
-import { ExtensionIdentifier, ExtensionType } from 'vs/platform/extensions/common/extensions';
+import { ExtensionIdentifier, ExtensionType, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { ISharedProcessService } from 'vs/platform/ipc/electron-browser/sharedProcessService';
 
 
@@ -124,13 +124,13 @@ suite('ExtensionsListView Tests', () => {
 		instantiationService.stubPromise(IExperimentService, 'getExperimentsByType', []);
 
 		instantiationService.stub(IExtensionService, {
-			getExtensions: (): any => { // TODO remove any
+			getExtensions: (): Promise<IExtensionDescription[]> => {
 				return Promise.resolve([
-					{ identifier: new ExtensionIdentifier(localEnabledTheme.identifier.id) },
-					{ identifier: new ExtensionIdentifier(localEnabledLanguage.identifier.id) },
-					{ identifier: new ExtensionIdentifier(localRandom.identifier.id) },
-					{ identifier: new ExtensionIdentifier(builtInTheme.identifier.id) },
-					{ identifier: new ExtensionIdentifier(builtInBasic.identifier.id) }
+					toExtensionDescription(localEnabledTheme),
+					toExtensionDescription(localEnabledLanguage),
+					toExtensionDescription(localRandom),
+					toExtensionDescription(builtInTheme),
+					toExtensionDescription(builtInBasic)
 				]);
 			}
 		});
@@ -522,6 +522,16 @@ suite('ExtensionsListView Tests', () => {
 
 	function aPage<T>(...objects: T[]): IPager<T> {
 		return { firstPage: objects, total: objects.length, pageSize: objects.length, getPage: () => null! };
+	}
+
+	function toExtensionDescription(local: ILocalExtension): IExtensionDescription {
+		return {
+			identifier: new ExtensionIdentifier(local.identifier.id),
+			isBuiltin: local.type === ExtensionType.System,
+			isUnderDevelopment: false,
+			extensionLocation: local.location,
+			...local.manifest
+		};
 	}
 });
 

--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsWorkbenchService.test.ts
@@ -70,10 +70,8 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 
 		instantiationService.stub(IWorkspaceContextService, new TestContextService());
 		instantiationService.stub(IConfigurationService, {
-			onDidUpdateConfiguration: () => { },
-			onDidChangeConfiguration: () => { },
-			getConfiguration: () => ({}),
-			getValue: (key) => {
+			onDidChangeConfiguration: () => { return undefined!; },
+			getValue: (key?) => {
 				return (key === AutoCheckUpdatesConfigurationKey || key === AutoUpdateConfigurationKey) ? true : undefined;
 			}
 		});
@@ -91,7 +89,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 
 		instantiationService.set(IExtensionTipsService, instantiationService.createInstance(ExtensionTipsService));
 
-		instantiationService.stub(INotificationService, { prompt: () => null });
+		instantiationService.stub(INotificationService, { prompt: () => null! });
 	});
 
 	setup(async () => {

--- a/src/vs/workbench/contrib/welcome/gettingStarted/test/common/gettingStarted.test.ts
+++ b/src/vs/workbench/contrib/welcome/gettingStarted/test/common/gettingStarted.test.ts
@@ -9,24 +9,14 @@ import { IStorageService } from 'vs/platform/storage/common/storage';
 
 suite('Workbench - GettingStarted', () => {
 	let instantiation: TestInstantiationService | null = null;
-	let welcomePageEnvConfig: string | null = null;
 	let hideWelcomeSettingsValue: string | null = null;
-	// let machineId: string | null = null;
-	let appName: string | null = null;
 
 	suiteSetup(() => {
 		instantiation = new TestInstantiationService();
 		instantiation.stub(IWorkspaceContextService, {
-			getConfiguration: () => {
-				return {
-					env: {
-						welcomePage: welcomePageEnvConfig,
-						appName: appName
-					}
-				};
-			}
+
 		});
-		instantiation.stub(IStorageService, {
+		instantiation.stub(IStorageService, <Partial<IStorageService>>{
 			get: () => hideWelcomeSettingsValue,
 			store: (value) => hideWelcomeSettingsValue = value
 		});
@@ -37,8 +27,6 @@ suite('Workbench - GettingStarted', () => {
 	});
 
 	setup(() => {
-		welcomePageEnvConfig = null;
 		hideWelcomeSettingsValue = null;
-		appName = null;
 	});
 });


### PR DESCRIPTION
The use of the `any` type in the `stub` method for tests was causing a few issues:

- Lots of implicit `any` (#70352)
- Methods / properties were being stubbed with wrong types
- Non-existant methods/properties were being stubbed

The fix is to require that the passed in stub is either a `Function` (the ctor case) or a `partial` of the type being stubbed