### PR TITLE
Update statusBarItem.prominentBackground

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -287,8 +287,8 @@ export const STATUS_BAR_ITEM_HOVER_BACKGROUND = registerColor('statusBarItem.hov
 }, nls.localize('statusBarItemHoverBackground', "Status bar item background color when hovering. The status bar is shown in the bottom of the window."));
 
 export const STATUS_BAR_PROMINENT_ITEM_BACKGROUND = registerColor('statusBarItem.prominentBackground', {
-	dark: '#388A34',
-	light: '#388A34',
+	dark: Color.black.transparent(0.5),
+	light: Color.black.transparent(0.5),
 	hc: '#3883A4'
 }, nls.localize('statusBarProminentItemBackground', "Status bar prominent items background color. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window."));
 


### PR DESCRIPTION
This updates `statusBarItem.prominentBackground` to better blend with various backgrounds:

<img width="445" alt="image" src="https://user-images.githubusercontent.com/35271042/54706985-613bc880-4afd-11e9-9ccf-5b4d48da50d2.png">