### PR TITLE
Remove some dead code in base/parts/tree/

### DIFF
--- a/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
+++ b/src/vs/base/parts/quickopen/browser/quickOpenModel.ts
@@ -9,7 +9,7 @@ import { URI } from 'vs/base/common/uri';
 import { ITree, IActionProvider } from 'vs/base/parts/tree/browser/tree';
 import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
 import { IQuickNavigateConfiguration, IModel, IDataSource, IFilter, IAccessiblityProvider, IRenderer, IRunner, Mode, IEntryRunContext } from 'vs/base/parts/quickopen/common/quickOpen';
-import { Action, IAction, IActionRunner, IActionItem } from 'vs/base/common/actions';
+import { IAction, IActionRunner } from 'vs/base/common/actions';
 import { compareAnything } from 'vs/base/common/comparers';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { HighlightedLabel } from 'vs/base/browser/ui/highlightedlabel/highlightedLabel';
@@ -290,18 +290,6 @@ class NoActionProvider implements IActionProvider {
 
 	getActions(tree: ITree, element: any): IAction[] | null {
 		return null;
-	}
-
-	hasSecondaryActions(tree: ITree, element: any): boolean {
-		return false;
-	}
-
-	getSecondaryActions(tree: ITree, element: any): IAction[] | null {
-		return null;
-	}
-
-	getActionItem(tree: ITree, element: any, action: Action): IActionItem | undefined {
-		return undefined;
 	}
 }
 

--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -9,7 +9,7 @@ import * as Keyboard from 'vs/base/browser/keyboardEvent';
 import { INavigator } from 'vs/base/common/iterator';
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { Event } from 'vs/base/common/event';
-import { IAction, IActionItem } from 'vs/base/common/actions';
+import { IAction } from 'vs/base/common/actions';
 import { Color } from 'vs/base/common/color';
 import { IItemCollapseEvent, IItemExpandEvent } from 'vs/base/parts/tree/browser/treeModel';
 import { IDragAndDropData } from 'vs/base/browser/dnd';
@@ -170,44 +170,9 @@ export interface ITree {
 	getHighlight(includeHidden?: boolean): any;
 
 	/**
-	 * Returns whether an element is highlighted or not.
-	 */
-	isHighlighted(element: any): boolean;
-
-	/**
 	 * Clears the highlight.
 	 */
 	clearHighlight(eventPayload?: any): void;
-
-	/**
-	 * Selects an element.
-	 */
-	select(element: any, eventPayload?: any): void;
-
-	/**
-	 * Selects a range of elements.
-	 */
-	selectRange(fromElement: any, toElement: any, eventPayload?: any): void;
-
-	/**
-	 * Deselects a range of elements.
-	 */
-	deselectRange(fromElement: any, toElement: any, eventPayload?: any): void;
-
-	/**
-	 * Selects several elements.
-	 */
-	selectAll(elements: any[], eventPayload?: any): void;
-
-	/**
-	 * Deselects an element.
-	 */
-	deselect(element: any, eventPayload?: any): void;
-
-	/**
-	 * Deselects several elements.
-	 */
-	deselectAll(elements: any[], eventPayload?: any): void;
 
 	/**
 	 * Replaces the current selection with the given elements.
@@ -215,34 +180,9 @@ export interface ITree {
 	setSelection(elements: any[], eventPayload?: any): void;
 
 	/**
-	 * Toggles the element's selection.
-	 */
-	toggleSelection(element: any, eventPayload?: any): void;
-
-	/**
 	 * Returns the currently selected elements.
 	 */
 	getSelection(includeHidden?: boolean): any[];
-
-	/**
-	 * Returns whether an element is selected or not.
-	 */
-	isSelected(element: any): boolean;
-
-	/**
-	 * Selects the next `count`-nth element, in visible order.
-	 */
-	selectNext(count?: number, clearSelection?: boolean, eventPayload?: any): void;
-
-	/**
-	 * Selects the previous `count`-nth element, in visible order.
-	 */
-	selectPrevious(count?: number, clearSelection?: boolean, eventPayload?: any): void;
-
-	/**
-	 * Selects the currently selected element's parent.
-	 */
-	selectParent(clearSelection?: boolean, eventPayload?: any): void;
 
 	/**
 	 * Clears the selection.
@@ -253,11 +193,6 @@ export interface ITree {
 	 * Sets the focused element.
 	 */
 	setFocus(element?: any, eventPayload?: any): void;
-
-	/**
-	 * Returns whether an element is focused or not.
-	 */
-	isFocused(element: any): boolean;
 
 	/**
 	 * Returns focused element.
@@ -315,26 +250,6 @@ export interface ITree {
 	 * Clears the focus.
 	 */
 	clearFocus(eventPayload?: any): void;
-
-	/**
-	 * Adds the trait to elements.
-	 */
-	addTraits(trait: string, elements: any[]): void;
-
-	/**
-	 * Removes the trait from elements.
-	 */
-	removeTraits(trait: string, elements: any[]): void;
-
-	/**
-	 * Toggles the element's trait.
-	 */
-	toggleTrait(trait: string, element: any): void;
-
-	/**
-	 * Returns whether the element has the trait or not.
-	 */
-	hasTrait(trait: string, element: any): boolean;
 
 	/**
 	 * Returns a navigator which allows to discover the visible and
@@ -582,13 +497,6 @@ export interface IDragOverReaction {
 	autoExpand?: boolean;
 }
 
-export const DRAG_OVER_REJECT: IDragOverReaction = { accept: false };
-export const DRAG_OVER_ACCEPT: IDragOverReaction = { accept: true };
-export const DRAG_OVER_ACCEPT_BUBBLE_UP: IDragOverReaction = { accept: true, bubble: DragOverBubble.BUBBLE_UP };
-export const DRAG_OVER_ACCEPT_BUBBLE_DOWN = (autoExpand = false) => ({ accept: true, bubble: DragOverBubble.BUBBLE_DOWN, autoExpand });
-export const DRAG_OVER_ACCEPT_BUBBLE_UP_COPY: IDragOverReaction = { accept: true, bubble: DragOverBubble.BUBBLE_UP, effect: DragOverEffect.COPY };
-export const DRAG_OVER_ACCEPT_BUBBLE_DOWN_COPY = (autoExpand = false) => ({ accept: true, bubble: DragOverBubble.BUBBLE_DOWN, effect: DragOverEffect.COPY, autoExpand });
-
 export interface IDragAndDrop {
 
 	/**
@@ -626,12 +534,6 @@ export interface IFilter {
 	 */
 	isVisible(tree: ITree, element: any): boolean;
 }
-
-export interface IElementCallback {
-	(tree: ITree, element: any): void;
-}
-
-export type ICallback = () => void;
 
 export interface ISorter {
 
@@ -722,19 +624,4 @@ export interface IActionProvider {
 	 * Returns a promise of an array with the actions of the element that should show up in place right to the element in the tree.
 	 */
 	getActions(tree: ITree | null, element: any): IAction[] | null;
-
-	/**
-	 * Returns whether or not the element has secondary actions. These show up once the user has expanded the element's action bar.
-	 */
-	hasSecondaryActions(tree: ITree, element: any): boolean;
-
-	/**
-	 * Returns a promise of an array with the secondary actions of the element that should show up once the user has expanded the element's action bar.
-	 */
-	getSecondaryActions(tree: ITree, element: any): IAction[] | null;
-
-	/**
-	 * Returns an action item to render an action.
-	 */
-	getActionItem(tree: ITree, element: any, action: IAction): IActionItem | undefined;
 }

--- a/src/vs/base/parts/tree/browser/treeImpl.ts
+++ b/src/vs/base/parts/tree/browser/treeImpl.ts
@@ -230,48 +230,12 @@ export class Tree implements _.ITree {
 		return this.model.getHighlight();
 	}
 
-	public isHighlighted(element: any): boolean {
-		return this.model.isFocused(element);
-	}
-
 	public clearHighlight(eventPayload?: any): void {
 		this.model.setHighlight(null, eventPayload);
 	}
 
-	public select(element: any, eventPayload?: any): void {
-		this.model.select(element, eventPayload);
-	}
-
-	public selectRange(fromElement: any, toElement: any, eventPayload?: any): void {
-		this.model.selectRange(fromElement, toElement, eventPayload);
-	}
-
-	public deselectRange(fromElement: any, toElement: any, eventPayload?: any): void {
-		this.model.deselectRange(fromElement, toElement, eventPayload);
-	}
-
-	public selectAll(elements: any[], eventPayload?: any): void {
-		this.model.selectAll(elements, eventPayload);
-	}
-
-	public deselect(element: any, eventPayload?: any): void {
-		this.model.deselect(element, eventPayload);
-	}
-
-	public deselectAll(elements: any[], eventPayload?: any): void {
-		this.model.deselectAll(elements, eventPayload);
-	}
-
 	public setSelection(elements: any[], eventPayload?: any): void {
 		this.model.setSelection(elements, eventPayload);
-	}
-
-	public toggleSelection(element: any, eventPayload?: any): void {
-		this.model.toggleSelection(element, eventPayload);
-	}
-
-	public isSelected(element: any): boolean {
-		return this.model.isSelected(element);
 	}
 
 	public getSelection(): any[] {
@@ -282,24 +246,8 @@ export class Tree implements _.ITree {
 		this.model.setSelection([], eventPayload);
 	}
 
-	public selectNext(count?: number, clearSelection?: boolean, eventPayload?: any): void {
-		this.model.selectNext(count, clearSelection, eventPayload);
-	}
-
-	public selectPrevious(count?: number, clearSelection?: boolean, eventPayload?: any): void {
-		this.model.selectPrevious(count, clearSelection, eventPayload);
-	}
-
-	public selectParent(clearSelection?: boolean, eventPayload?: any): void {
-		this.model.selectParent(clearSelection, eventPayload);
-	}
-
 	public setFocus(element?: any, eventPayload?: any): void {
 		this.model.setFocus(element, eventPayload);
-	}
-
-	public isFocused(element: any): boolean {
-		return this.model.isFocused(element);
 	}
 
 	public getFocus(): any {
@@ -344,23 +292,6 @@ export class Tree implements _.ITree {
 
 	public clearFocus(eventPayload?: any): void {
 		this.model.setFocus(null, eventPayload);
-	}
-
-	public addTraits(trait: string, elements: any[]): void {
-		this.model.addTraits(trait, elements);
-	}
-
-	public removeTraits(trait: string, elements: any[]): void {
-		this.model.removeTraits(trait, elements);
-	}
-
-	public toggleTrait(trait: string, element: any): void {
-		this.model.hasTrait(trait, element) ? this.model.removeTraits(trait, [element])
-			: this.model.addTraits(trait, [element]);
-	}
-
-	public hasTrait(trait: string, element: any): boolean {
-		return this.model.hasTrait(trait, element);
 	}
 
 	getNavigator(fromElement?: any, subTreeOnly?: boolean): INavigator<any> {

--- a/src/vs/base/parts/tree/browser/treeModel.ts
+++ b/src/vs/base/parts/tree/browser/treeModel.ts
@@ -6,7 +6,6 @@
 import * as Assert from 'vs/base/common/assert';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { IDisposable, combinedDisposable } from 'vs/base/common/lifecycle';
-import * as arrays from 'vs/base/common/arrays';
 import { INavigator } from 'vs/base/common/iterator';
 import * as _ from './tree';
 import { Event, Emitter, EventMultiplexer, Relay } from 'vs/base/common/event';
@@ -863,42 +862,6 @@ export class TreeNavigator implements INavigator<Item> {
 	}
 }
 
-function getRange(one: Item, other: Item): Item[] {
-	let oneHierarchy = one.getHierarchy();
-	let otherHierarchy = other.getHierarchy();
-	let length = arrays.commonPrefixLength(oneHierarchy, otherHierarchy);
-	let item: Item | null = oneHierarchy[length - 1];
-	let nav = item.getNavigator();
-
-	let oneIndex: number | null = null;
-	let otherIndex: number | null = null;
-
-	let index = 0;
-	let result: Item[] = [];
-
-	while (item && (oneIndex === null || otherIndex === null)) {
-		result.push(item);
-
-		if (item === one) {
-			oneIndex = index;
-		}
-		if (item === other) {
-			otherIndex = index;
-		}
-
-		index++;
-		item = nav.next();
-	}
-
-	if (oneIndex === null || otherIndex === null) {
-		return [];
-	}
-
-	let min = Math.min(oneIndex, otherIndex);
-	let max = Math.max(oneIndex, otherIndex);
-	return result.slice(min, max + 1);
-}
-
 export interface IBaseEvent {
 	item: Item | null;
 }
@@ -1196,28 +1159,6 @@ export class TreeModel {
 		this.selectAll([element], eventPayload);
 	}
 
-	public selectRange(fromElement: any, toElement: any, eventPayload?: any): void {
-		let fromItem = this.getItem(fromElement);
-		let toItem = this.getItem(toElement);
-
-		if (!fromItem || !toItem) {
-			return;
-		}
-
-		this.selectAll(getRange(fromItem, toItem), eventPayload);
-	}
-
-	public deselectRange(fromElement: any, toElement: any, eventPayload?: any): void {
-		let fromItem = this.getItem(fromElement);
-		let toItem = this.getItem(toElement);
-
-		if (!fromItem || !toItem) {
-			return;
-		}
-
-		this.deselectAll(getRange(fromItem, toItem), eventPayload);
-	}
-
 	public selectAll(elements: any[], eventPayload?: any): void {
 		this.addTraits('selected', elements);
 		let eventData: _.ISelectionEvent = { selection: this.getSelection(), payload: eventPayload };
@@ -1236,12 +1177,6 @@ export class TreeModel {
 
 	public setSelection(elements: any[], eventPayload?: any): void {
 		this.setTraits('selected', elements);
-		let eventData: _.ISelectionEvent = { selection: this.getSelection(), payload: eventPayload };
-		this._onDidSelect.fire(eventData);
-	}
-
-	public toggleSelection(element: any, eventPayload?: any): void {
-		this.toggleTrait('selected', element);
 		let eventData: _.ISelectionEvent = { selection: this.getSelection(), payload: eventPayload };
 		this._onDidSelect.fire(eventData);
 	}
@@ -1312,21 +1247,6 @@ export class TreeModel {
 			this.setSelection([item], eventPayload);
 		} else {
 			this.select(item, eventPayload);
-		}
-	}
-
-	public selectParent(eventPayload?: any, clearSelection: boolean = true): void {
-		let selection = this.getSelection();
-		let item: Item = selection.length > 0 ? selection[0] : this.input;
-		let nav = this.getNavigator(item, false);
-		let parent = nav.parent();
-
-		if (parent) {
-			if (clearSelection) {
-				this.setSelection([parent], eventPayload);
-			} else {
-				this.select(parent, eventPayload);
-			}
 		}
 	}
 
@@ -1501,25 +1421,6 @@ export class TreeModel {
 					delete items[item.id];
 				}
 			}
-		}
-	}
-
-	public hasTrait(trait: string, element: any): boolean {
-		const item = this.getItem(element);
-		return !!(item && item.hasTrait(trait));
-	}
-
-	private toggleTrait(trait: string, element: any): void {
-		let item = this.getItem(element);
-
-		if (!item) {
-			return;
-		}
-
-		if (item.hasTrait(trait)) {
-			this.removeTraits(trait, [element]);
-		} else {
-			this.addTraits(trait, [element]);
 		}
 	}
 

--- a/src/vs/workbench/browser/actions.ts
+++ b/src/vs/workbench/browser/actions.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Registry } from 'vs/platform/registry/common/platform';
-import { Action, IAction } from 'vs/base/common/actions';
-import { BaseActionItem, Separator } from 'vs/base/browser/ui/actionbar/actionbar';
+import { IAction } from 'vs/base/common/actions';
+import { Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import { ITree, IActionProvider } from 'vs/base/parts/tree/browser/tree';
 import { IInstantiationService, IConstructorSignature0, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
@@ -26,27 +26,6 @@ export class ActionBarContributor {
 	 */
 	getActions(context: any): IAction[] {
 		return [];
-	}
-
-	/**
-	 * Returns true if this contributor has secondary actions for the given context.
-	 */
-	hasSecondaryActions(context: any): boolean {
-		return false;
-	}
-
-	/**
-	 * Returns an array of secondary actions in the given context.
-	 */
-	getSecondaryActions(context: any): IAction[] {
-		return [];
-	}
-
-	/**
-	 * Can return a specific IActionItem to render the given action.
-	 */
-	getActionItem(context: any, action: Action): BaseActionItem | null {
-		return null;
 	}
 }
 
@@ -100,50 +79,6 @@ export class ContributableActionProvider implements IActionProvider {
 		}
 
 		return prepareActions(actions);
-	}
-
-	hasSecondaryActions(tree: ITree, element: any): boolean {
-		const context = this.toContext(tree, element);
-
-		const contributors = this.registry.getActionBarContributors(Scope.VIEWER);
-		for (const contributor of contributors) {
-			if (contributor.hasSecondaryActions(context)) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	getSecondaryActions(tree: ITree, element: any): IAction[] {
-		const actions: IAction[] = [];
-		const context = this.toContext(tree, element);
-
-		// Collect Actions
-		const contributors = this.registry.getActionBarContributors(Scope.VIEWER);
-		for (const contributor of contributors) {
-			if (contributor.hasSecondaryActions(context)) {
-				actions.push(...contributor.getSecondaryActions(context));
-			}
-		}
-
-		return prepareActions(actions);
-	}
-
-	getActionItem(tree: ITree, element: any, action: Action): BaseActionItem | undefined {
-		const contributors = this.registry.getActionBarContributors(Scope.VIEWER);
-		const context = this.toContext(tree, element);
-
-		for (let i = contributors.length - 1; i >= 0; i--) {
-			const contributor = contributors[i];
-
-			const itemProvider = contributor.getActionItem(context, action);
-			if (itemProvider) {
-				return itemProvider;
-			}
-		}
-
-		return undefined;
 	}
 }
 
@@ -201,25 +136,6 @@ export const Extensions = {
 };
 
 export interface IActionBarRegistry {
-
-	/**
-	 * Goes through all action bar contributors and asks them for contributed actions for
-	 * the provided scope and context. Supports primary actions.
-	 */
-	getActionBarActionsForContext(scope: string, context: any): IAction[];
-
-	/**
-	 * Goes through all action bar contributors and asks them for contributed actions for
-	 * the provided scope and context. Supports secondary actions.
-	 */
-	getSecondaryActionBarActionsForContext(scope: string, context: any): IAction[];
-
-	/**
-	 * Goes through all action bar contributors and asks them for contributed action item for
-	 * the provided scope and context.
-	 */
-	getActionItemForContext(scope: string, context: any, action: Action): BaseActionItem | null;
-
 	/**
 	 * Registers an Actionbar contributor. It will be called to contribute actions to all the action bars
 	 * that are used in the Workbench in the given scope.
@@ -262,48 +178,6 @@ class ActionBarRegistry implements IActionBarRegistry {
 
 	private getContributors(scope: string): ActionBarContributor[] {
 		return this.actionBarContributorInstances[scope] || [];
-	}
-
-	getActionBarActionsForContext(scope: string, context: any): IAction[] {
-		const actions: IAction[] = [];
-
-		// Go through contributors for scope
-		this.getContributors(scope).forEach((contributor: ActionBarContributor) => {
-
-			// Primary Actions
-			if (contributor.hasActions(context)) {
-				actions.push(...contributor.getActions(context));
-			}
-		});
-
-		return actions;
-	}
-
-	getSecondaryActionBarActionsForContext(scope: string, context: any): IAction[] {
-		const actions: IAction[] = [];
-
-		// Go through contributors
-		this.getContributors(scope).forEach((contributor: ActionBarContributor) => {
-
-			// Secondary Actions
-			if (contributor.hasSecondaryActions(context)) {
-				actions.push(...contributor.getSecondaryActions(context));
-			}
-		});
-
-		return actions;
-	}
-
-	getActionItemForContext(scope: string, context: any, action: Action): BaseActionItem | null {
-		const contributors = this.getContributors(scope);
-		for (const contributor of contributors) {
-			const item = contributor.getActionItem(context, action);
-			if (item) {
-				return item;
-			}
-		}
-
-		return null;
 	}
 
 	registerActionBarContributor(scope: string, ctor: IConstructorSignature0<ActionBarContributor>): void {


### PR DESCRIPTION
There were a few interface methods that were only referenced by their implementation and never actually called. I ran into these while trying to convert some nulls to undefined. 

This change removes these uncalled methods

