### PR TITLE
Fix searching words in brackets in the command palette

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -119,6 +119,15 @@ function isWhitespace(code: number): boolean {
 	);
 }
 
+const wordSeparators = new Set<number>();
+'`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?'
+	.split('')
+	.forEach(s => wordSeparators.add(s.charCodeAt(0)));
+
+function isWordSeparator(code: number): boolean {
+	return wordSeparators.has(code);
+}
+
 function isAlphanumeric(code: number): boolean {
 	return isLower(code) || isUpper(code) || isNumber(code);
 }
@@ -308,7 +317,8 @@ function _matchesWords(word: string, target: string, i: number, j: number, conti
 function nextWord(word: string, start: number): number {
 	for (let i = start; i < word.length; i++) {
 		const c = word.charCodeAt(i);
-		if (isWhitespace(c) || (i > 0 && isWhitespace(word.charCodeAt(i - 1)))) {
+		if (isWhitespace(c) || (i > 0 && isWhitespace(word.charCodeAt(i - 1))) ||
+			isWordSeparator(c) || (i > 0 && isWordSeparator(word.charCodeAt(i - 1)))) {
 			return i;
 		}
 	}


### PR DESCRIPTION
This modifies matchesWords to also split words on punctuation marks, using the default set of wordSeparators from the editor.

As is, this will affect local settings search and keybindings search too but that seems fine with me.

This could change the results that some people get for queries that they have in their muscle memory, and we don't really want to break that, but I think the benefit is large and the number of queries that it would affect is not huge. But, we need Insiders feedback and would not ship this in March.

![image](https://user-images.githubusercontent.com/323878/54727680-56e9f080-4b36-11e9-9aa2-b1ad75dc59fd.png)

Will add tests if we want to go this route.

Fixes #27636