### PR TITLE
set `TERM` to `xterm-256color`

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -50,6 +50,7 @@ function _mergeEnvironmentValue(env: ITerminalEnvironment, key: string, value: s
 }
 
 export function addTerminalEnvironmentKeys(env: ITerminalEnvironment, version: string | undefined, locale: string | undefined, setLocaleVariables: boolean): void {
+	env['TERM'] = 'xterm-256color';
 	env['TERM_PROGRAM'] = 'vscode';
 	env['TERM_PROGRAM_VERSION'] = version ? version : null;
 	if (setLocaleVariables) {


### PR DESCRIPTION
### Summary
This PR sets `TERM` from `xterm` to `xterm-256color` to be better consistent with other xterm.js-based Terminals

### Other Terminals
- **Hyper:** https://github.com/zeit/hyper/blob/571231e4438cae4eec3e88fa4aab398b5b269433/app/session.js#L32-L36
- **Terminus:** https://github.com/Eugeny/terminus/blob/9e81f0aa0e7274fdddc110ea9c77ca42f500896e/terminus-terminal/src/services/sessions.service.ts#L96-L101

### Review request
- @Tyriar 