### PR TITLE
Add reverse colors option to text diff editor

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -61,7 +61,7 @@ interface IEditorsZones {
 }
 
 interface IDiffEditorWidgetStyle {
-	getEditorsDiffDecorations(lineChanges: editorCommon.ILineChange[], ignoreTrimWhitespace: boolean, renderIndicators: boolean, originalWhitespaces: IEditorWhitespace[], modifiedWhitespaces: IEditorWhitespace[], originalEditor: editorBrowser.ICodeEditor, modifiedEditor: editorBrowser.ICodeEditor): IEditorsDiffDecorationsWithZones;
+	getEditorsDiffDecorations(lineChanges: editorCommon.ILineChange[], ignoreTrimWhitespace: boolean, renderIndicators: boolean, originalWhitespaces: IEditorWhitespace[], modifiedWhitespaces: IEditorWhitespace[], originalEditor: editorBrowser.ICodeEditor, modifiedEditor: editorBrowser.ICodeEditor, reverse?: boolean): IEditorsDiffDecorationsWithZones;
 	setEnableSplitViewResizing(enableSplitViewResizing: boolean): void;
 	applyColors(theme: ITheme): boolean;
 	layout(): number;
@@ -193,6 +193,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 	private readonly _notificationService: INotificationService;
 
 	private readonly _reviewPane: DiffReview;
+	private _options: editorOptions.IDiffEditorOptions;
 
 	constructor(
 		domElement: HTMLElement,
@@ -212,6 +213,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		this._contextKeyService.createKey('isInDiffEditor', true);
 		this._themeService = themeService;
 		this._notificationService = notificationService;
+		this._options = options;
 
 		this.id = (++DIFF_EDITOR_ID);
 
@@ -927,8 +929,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		let foreignOriginal = this._originalEditorState.getForeignViewZones(this.originalEditor.getWhitespaces());
 		let foreignModified = this._modifiedEditorState.getForeignViewZones(this.modifiedEditor.getWhitespaces());
 
-		let diffDecorations = this._strategy.getEditorsDiffDecorations(lineChanges, this._ignoreTrimWhitespace, this._renderIndicators, foreignOriginal, foreignModified, this.originalEditor, this.modifiedEditor);
-
+		let diffDecorations = this._strategy.getEditorsDiffDecorations(lineChanges, this._ignoreTrimWhitespace, this._renderIndicators, foreignOriginal, foreignModified, this.originalEditor, this.modifiedEditor, this._options.reverse);
 		try {
 			this._currentlyChangingViewZones = true;
 			this._originalEditorState.apply(this.originalEditor, this._originalOverviewRuler, diffDecorations.original, false);
@@ -1203,7 +1204,7 @@ abstract class DiffEditorWidgetStyle extends Disposable implements IDiffEditorWi
 		return hasChanges;
 	}
 
-	public getEditorsDiffDecorations(lineChanges: editorCommon.ILineChange[], ignoreTrimWhitespace: boolean, renderIndicators: boolean, originalWhitespaces: IEditorWhitespace[], modifiedWhitespaces: IEditorWhitespace[], originalEditor: editorBrowser.ICodeEditor, modifiedEditor: editorBrowser.ICodeEditor): IEditorsDiffDecorationsWithZones {
+	public getEditorsDiffDecorations(lineChanges: editorCommon.ILineChange[], ignoreTrimWhitespace: boolean, renderIndicators: boolean, originalWhitespaces: IEditorWhitespace[], modifiedWhitespaces: IEditorWhitespace[], originalEditor: editorBrowser.ICodeEditor, modifiedEditor: editorBrowser.ICodeEditor, reverse?:boolean): IEditorsDiffDecorationsWithZones {
 		// Get view zones
 		modifiedWhitespaces = modifiedWhitespaces.sort((a, b) => {
 			return a.afterLineNumber - b.afterLineNumber;
@@ -1211,6 +1212,52 @@ abstract class DiffEditorWidgetStyle extends Disposable implements IDiffEditorWi
 		originalWhitespaces = originalWhitespaces.sort((a, b) => {
 			return a.afterLineNumber - b.afterLineNumber;
 		});
+
+		// if we need to reverse coloring
+		if (reverse === true) {
+			// change lines to be highlighted
+			let revertedLineChanges: editorCommon.ILineChange[] = lineChanges.map(linechange => {
+				return {
+					modifiedStartLineNumber: linechange.originalStartLineNumber,
+					modifiedEndLineNumber: linechange.originalEndLineNumber,
+					originalStartLineNumber: linechange.modifiedStartLineNumber,
+					originalEndLineNumber: linechange.modifiedEndLineNumber,
+					charChanges: (linechange.charChanges) ?
+						linechange.charChanges.map(charchange => {
+							return {
+								originalStartColumn: charchange.modifiedStartColumn,
+								originalEndColumn: charchange.modifiedEndColumn,
+								modifiedStartColumn: charchange.originalStartColumn,
+								modifiedEndColumn: charchange.originalEndColumn,
+								modifiedStartLineNumber: charchange.originalStartLineNumber,
+								modifiedEndLineNumber: charchange.originalEndLineNumber,
+								originalStartLineNumber: charchange.modifiedStartLineNumber,
+								originalEndLineNumber: charchange.modifiedEndLineNumber,
+							};
+						}) : undefined
+				};
+			});
+
+			let zones = this._getViewZones(lineChanges, originalWhitespaces, modifiedWhitespaces, originalEditor, modifiedEditor, renderIndicators);
+
+			// Get decorations & overview ruler zones
+			let modifiedDecorations = this._getOriginalEditorDecorations(revertedLineChanges, ignoreTrimWhitespace, renderIndicators, modifiedEditor, originalEditor);
+			let originalDecorations = this._getModifiedEditorDecorations(revertedLineChanges, ignoreTrimWhitespace, renderIndicators, modifiedEditor, originalEditor);
+
+			return {
+				original: {
+					decorations: originalDecorations.decorations, // change decorations
+					overviewZones: originalDecorations.overviewZones,
+					zones: zones.original
+				},
+				modified: {
+					decorations: modifiedDecorations.decorations,
+					overviewZones: modifiedDecorations.overviewZones,
+					zones: zones.modified
+				}
+			};
+		}
+
 		let zones = this._getViewZones(lineChanges, originalWhitespaces, modifiedWhitespaces, originalEditor, modifiedEditor, renderIndicators);
 
 		// Get decorations & overview ruler zones

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1204,7 +1204,7 @@ abstract class DiffEditorWidgetStyle extends Disposable implements IDiffEditorWi
 		return hasChanges;
 	}
 
-	public getEditorsDiffDecorations(lineChanges: editorCommon.ILineChange[], ignoreTrimWhitespace: boolean, renderIndicators: boolean, originalWhitespaces: IEditorWhitespace[], modifiedWhitespaces: IEditorWhitespace[], originalEditor: editorBrowser.ICodeEditor, modifiedEditor: editorBrowser.ICodeEditor, reverse?:boolean): IEditorsDiffDecorationsWithZones {
+	public getEditorsDiffDecorations(lineChanges: editorCommon.ILineChange[], ignoreTrimWhitespace: boolean, renderIndicators: boolean, originalWhitespaces: IEditorWhitespace[], modifiedWhitespaces: IEditorWhitespace[], originalEditor: editorBrowser.ICodeEditor, modifiedEditor: editorBrowser.ICodeEditor, reverse?: boolean): IEditorsDiffDecorationsWithZones {
 		// Get view zones
 		modifiedWhitespaces = modifiedWhitespaces.sort((a, b) => {
 			return a.afterLineNumber - b.afterLineNumber;

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1214,7 +1214,7 @@ abstract class DiffEditorWidgetStyle extends Disposable implements IDiffEditorWi
 		});
 
 		// if we need to reverse coloring
-		if (reverse === true) {
+		if (reverse) {
 			// change lines to be highlighted
 			let revertedLineChanges: editorCommon.ILineChange[] = lineChanges.map(linechange => {
 				return {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -745,10 +745,10 @@ export interface IDiffEditorOptions extends IEditorOptions {
 	 */
 	originalEditable?: boolean;
 
- 	/**
+	/**
 	 * Adding option to reverse coloring in diff editor
 	 */
-	reverse?:boolean;
+	reverse?: boolean;
 }
 
 export const enum RenderMinimap {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -744,6 +744,11 @@ export interface IDiffEditorOptions extends IEditorOptions {
 	 * Defaults to false.
 	 */
 	originalEditable?: boolean;
+
+ 	/**
+	 * Adding option to reverse coloring in diff editor
+	 */
+	reverse?:boolean;
 }
 
 export const enum RenderMinimap {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3079,6 +3079,11 @@ declare namespace monaco.editor {
 		 * Defaults to false.
 		 */
 		originalEditable?: boolean;
+
+		/**
+		 * Adding option to reverse coloring in diff editor
+		 */
+		reverse?: boolean;
 	}
 
 	export enum RenderMinimap {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -42,6 +42,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 
 	private diffNavigator: DiffNavigator;
 	private diffNavigatorDisposables: IDisposable[] = [];
+	private reverseColor: boolean;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -69,7 +70,16 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 		return nls.localize('textDiffEditor', "Text Diff Editor");
 	}
 
+	reverseColoring() : void	{
+		this.reverseColor = true;
+	}
+
 	createEditorControl(parent: HTMLElement, configuration: ICodeEditorOptions): IDiffEditor {
+		if(this.reverseColor === true)
+		{
+			(configuration as IDiffEditorOptions).reverse = true;
+		}
+
 		return this.instantiationService.createInstance(DiffEditorWidget, parent, configuration);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -75,7 +75,7 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 	}
 
 	createEditorControl(parent: HTMLElement, configuration: ICodeEditorOptions): IDiffEditor {
-		if (this.reverseColor === true) {
+		if (this.reverseColor) {
 			(configuration as IDiffEditorOptions).reverse = true;
 		}
 

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -70,13 +70,12 @@ export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
 		return nls.localize('textDiffEditor', "Text Diff Editor");
 	}
 
-	reverseColoring() : void	{
+	reverseColoring(): void {
 		this.reverseColor = true;
 	}
 
 	createEditorControl(parent: HTMLElement, configuration: ICodeEditorOptions): IDiffEditor {
-		if(this.reverseColor === true)
-		{
+		if (this.reverseColor === true) {
 			(configuration as IDiffEditorOptions).reverse = true;
 		}
 


### PR DESCRIPTION
This changeset adds the color reversing option as an optional parameter for the diff editor. This was requested in #69629 

How the reversed colors look when the reverse parameter is set to true when using the diff editor:
![image](https://user-images.githubusercontent.com/31145923/54842862-52394f80-4c90-11e9-8528-9a514eceeb73.png)

![image](https://user-images.githubusercontent.com/31145923/54842892-62512f00-4c90-11e9-996c-dad9f4c8d641.png)

![image](https://user-images.githubusercontent.com/31145923/54853212-5e330a80-4cac-11e9-9d60-e2afa4d2917d.png)
