### PR TITLE
Fix cross-compilation for armv7l

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -199,7 +199,7 @@ function getElectron(arch) {
 	return () => {
 		const electronOpts = _.extend({}, config, {
 			platform: process.platform,
-			arch,
+			arch: getElectronArch(arch),
 			ffmpegChromium: true,
 			keepDefaultApp: true
 		});
@@ -212,11 +212,20 @@ function getElectron(arch) {
 	};
 }
 
+function getElectronArch(arch) {
+	switch (arch) {
+		case 'arm':
+			return 'armv7l';
+		default:
+			return arch;
+	}
+}
+
+
 gulp.task(task.define('electron', task.series(util.rimraf('.build/electron'), getElectron(process.arch))));
-gulp.task(task.define('electron-ia32', task.series(util.rimraf('.build/electron'), getElectron('ia32'))));
-gulp.task(task.define('electron-x64', task.series(util.rimraf('.build/electron'), getElectron('x64'))));
-gulp.task(task.define('electron-arm', task.series(util.rimraf('.build/electron'), getElectron('armv7l'))));
-gulp.task(task.define('electron-arm64', task.series(util.rimraf('.build/electron'), getElectron('arm64'))));
+['ia32', 'x64', 'arm', 'arm64'].forEach(arch => {
+	gulp.task(task.define(`electron-${arch}`, task.series(util.rimraf('.build/electron'), getElectron(arch))));
+});
 
 /**
  * Compute checksums for some files.
@@ -394,7 +403,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		let result = all
 			.pipe(util.skipDirectories())
 			.pipe(util.fixWin32DirectoryPermissions())
-			.pipe(electron(_.extend({}, config, { platform, arch, ffmpegChromium: true })))
+			.pipe(electron(_.extend({}, config, { platform, arch: getElectronArch(arch), ffmpegChromium: true })))
 			.pipe(filter(['**', '!LICENSE', '!LICENSES.chromium.html', '!version']));
 
 		// result = es.merge(result, gulp.src('resources/completions/**', { base: '.' }));


### PR DESCRIPTION
Electron recently changed their file naming such that the download for "arm" architecture is no longer found.

This PR refactors the `electron-arm` gulp task (along with other defined architectures) and the underlying `getElectron()` method, to use an explicit method to map to an "electron arch". While this specific line for the `electron-arm` task was previously fixed with the mapping to "armv7l", `packageTask()` was not updated.

By extracting a common `getElectronArch()` method, we can use the same logic in both locations.