### PR TITLE
Stop the Settings tree from jittering

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -11,6 +11,7 @@ export interface IListVirtualDelegate<T> {
 	getHeight(element: T): number;
 	getTemplateId(element: T): string;
 	hasDynamicHeight?(element: T): boolean;
+	setDynamicHeight?(element: T, height: number): void;
 }
 
 export interface IListRenderer<T, TTemplateData> {

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1096,6 +1096,11 @@ export class ListView<T> implements ISpliceable<T>, IDisposable {
 		}
 
 		item.size = row.domNode!.offsetHeight;
+
+		if (this.virtualDelegate.setDynamicHeight) {
+			this.virtualDelegate.setDynamicHeight(item.element, item.size);
+		}
+
 		item.lastDynamicHeightWidth = this.renderWidth;
 		this.rowsContainer.removeChild(row.domNode!);
 		this.cache.release(row);

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -178,6 +178,12 @@ export class ComposedTreeDelegate<T, N extends { element: T }> implements IListV
 	hasDynamicHeight(element: N): boolean {
 		return !!this.delegate.hasDynamicHeight && this.delegate.hasDynamicHeight(element.element);
 	}
+
+	setDynamicHeight(element: N, height: number): void {
+		if (this.delegate.setDynamicHeight) {
+			this.delegate.setDynamicHeight(element.element, height);
+		}
+	}
 }
 
 interface ITreeListTemplateData<T> {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1220,7 +1220,16 @@ export class SettingsTreeFilter implements ITreeFilter<SettingsTreeElement> {
 }
 
 class SettingsTreeDelegate implements IListVirtualDelegate<SettingsTreeGroupChild> {
-	getHeight(element: SettingsTreeElement): number {
+
+	private heightCache = new WeakMap<SettingsTreeGroupChild, number>();
+
+	getHeight(element: SettingsTreeGroupChild): number {
+		const cachedHeight = this.heightCache.get(element);
+
+		if (typeof cachedHeight === 'number') {
+			return cachedHeight;
+		}
+
 		if (element instanceof SettingsTreeGroupElement) {
 			if (element.isFirstGroup) {
 				return 31;
@@ -1272,6 +1281,10 @@ class SettingsTreeDelegate implements IListVirtualDelegate<SettingsTreeGroupChil
 
 	hasDynamicHeight(element: SettingsTreeGroupElement | SettingsTreeSettingElement | SettingsTreeNewExtensionsElement): boolean {
 		return !(element instanceof SettingsTreeGroupElement);
+	}
+
+	setDynamicHeight(element: SettingsTreeGroupChild, height: number): void {
+		this.heightCache.set(element, height);
 	}
 }
 


### PR DESCRIPTION
@roblourens It's tough to fix #68385 automagically, because you're effectively replacing the whole model all the time. But check out this idea:

If your virtual delegate would get called back with the actual measured height, it could start caching them for future `getHeight` calls. For the cache, we can use `WeakMap`, making sure we keep its size in check. This is what this PR implements, which seems to work great. What do you think?

I've set this to April in case you think this is too risky. But feel free to move to March if you like it and everything goes well in your testing of it.