### PR TITLE
Fix #69368

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -42,7 +42,7 @@ import { Constants } from 'vs/editor/common/core/uint';
 import { CLOSE_EDITORS_AND_GROUP_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { coalesce } from 'vs/base/common/arrays';
 import { AsyncDataTree } from 'vs/base/browser/ui/tree/asyncDataTree';
-import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
+import { ExplorerItem, NewExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { sequence } from 'vs/base/common/async';
 
@@ -137,7 +137,7 @@ export class NewFileAction extends BaseErrorReportingAction {
 			return Promise.reject(new Error('Parent folder is readonly.'));
 		}
 
-		const stat = new ExplorerItem(PLACEHOLDER_URI, folder, false);
+		const stat = new NewExplorerItem(PLACEHOLDER_URI, folder, false);
 		return folder.fetchChildren(this.fileService, this.explorerService).then(() => {
 			folder.addChild(stat);
 
@@ -205,7 +205,7 @@ export class NewFolderAction extends BaseErrorReportingAction {
 			return Promise.reject(new Error('Parent folder is readonly.'));
 		}
 
-		const stat = new ExplorerItem(PLACEHOLDER_URI, folder, true);
+		const stat = new NewExplorerItem(PLACEHOLDER_URI, folder, true);
 		return folder.fetchChildren(this.fileService, this.explorerService).then(() => {
 			folder.addChild(stat);
 

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -94,7 +94,6 @@ export class BaseErrorReportingAction extends Action {
 	}
 }
 
-const PLACEHOLDER_URI = URI.file('');
 function refreshIfSeparator(value: string, explorerService: IExplorerService): void {
 	if (value && ((value.indexOf('/') >= 0) || (value.indexOf('\\') >= 0))) {
 		// New input contains separator, multiple resources will get created workaround for #68204
@@ -137,7 +136,7 @@ export class NewFileAction extends BaseErrorReportingAction {
 			return Promise.reject(new Error('Parent folder is readonly.'));
 		}
 
-		const stat = new NewExplorerItem(PLACEHOLDER_URI, folder, false);
+		const stat = new NewExplorerItem(folder, false);
 		return folder.fetchChildren(this.fileService, this.explorerService).then(() => {
 			folder.addChild(stat);
 
@@ -205,7 +204,7 @@ export class NewFolderAction extends BaseErrorReportingAction {
 			return Promise.reject(new Error('Parent folder is readonly.'));
 		}
 
-		const stat = new NewExplorerItem(PLACEHOLDER_URI, folder, true);
+		const stat = new NewExplorerItem(folder, true);
 		return folder.fetchChildren(this.fileService, this.explorerService).then(() => {
 			folder.addChild(stat);
 

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -37,7 +37,7 @@ import { ITreeContextMenuEvent } from 'vs/base/browser/ui/tree/tree';
 import { IMenuService, MenuId, IMenu } from 'vs/platform/actions/common/actions';
 import { fillInContextMenuActions } from 'vs/platform/actions/browser/menuItemActionItem';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
+import { ExplorerItem, NewExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { ResourceLabels, IResourceLabelsContainer } from 'vs/workbench/browser/labels';
 import { createFileIconThemableTreeContainerScope } from 'vs/workbench/browser/parts/views/views';
@@ -281,7 +281,13 @@ export class ExplorerView extends ViewletPanel {
 				accessibilityProvider: new ExplorerAccessibilityProvider(),
 				ariaLabel: nls.localize('treeAriaLabel', "Files Explorer"),
 				identityProvider: {
-					getId: (stat: ExplorerItem) => stat.resource
+					getId: (stat: ExplorerItem) => {
+						if (stat instanceof NewExplorerItem) {
+							return `new:${stat.resource}`;
+						}
+
+						return stat.resource;
+					}
 				},
 				keyboardNavigationLabelProvider: {
 					getKeyboardNavigationLabel: (stat: ExplorerItem) => {

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -367,3 +367,5 @@ export class ExplorerItem {
 		return null;
 	}
 }
+
+export class NewExplorerItem extends ExplorerItem { }

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -368,4 +368,8 @@ export class ExplorerItem {
 	}
 }
 
-export class NewExplorerItem extends ExplorerItem { }
+export class NewExplorerItem extends ExplorerItem {
+	constructor(parent: ExplorerItem, isDirectory: boolean) {
+		super(URI.file(''), parent, isDirectory);
+	}
+}


### PR DESCRIPTION
@isidorn This bug occurs because `new file` and `new folder` stats seem to have the same tree item ID as their parents. We need to distinguish them.