### PR TITLE
Expose uriScheme through vscode.env

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -6640,7 +6640,7 @@ declare module 'vscode' {
 		 * be able to handle uris which are directed to the extension itself. A uri must respect
 		 * the following rules:
 		 *
-		 * - The uri-scheme must be the product name;
+		 * - The uri-scheme must be `vscode.env.uriScheme`;
 		 * - The uri-authority must be the extension id (eg. `my.extension`);
 		 * - The uri-path, -query and -fragment parts are arbitrary.
 		 *

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -627,9 +627,9 @@ declare module 'vscode' {
 		export const onDidChangeLogLevel: Event<LogLevel>;
 
 		/**
-		 * The url protocol of the editor, like 'vscode', 'vscode-insiders'.
+		 * The custom uri scheme the editor registers to in system, like 'vscode', 'vscode-insiders'.
 		 */
-		export const urlProtocol: string;
+		export const uriScheme: string;
 	}
 
 	//#endregion

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -625,6 +625,11 @@ declare module 'vscode' {
 		 * An [event](#Event) that fires when the log level has changed.
 		 */
 		export const onDidChangeLogLevel: Event<LogLevel>;
+
+		/**
+		 * The url protocol of the editor, like 'vscode', 'vscode-insiders'.
+		 */
+		export const urlProtocol: string;
 	}
 
 	//#endregion

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -627,7 +627,7 @@ declare module 'vscode' {
 		export const onDidChangeLogLevel: Event<LogLevel>;
 
 		/**
-		 * The custom uri scheme the editor registers to in system, like 'vscode', 'vscode-insiders'.
+		 * The custom uri scheme the editor registers to in the operating system, like 'vscode', 'vscode-insiders'.
 		 */
 		export const uriScheme: string;
 	}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -235,6 +235,7 @@ export function createApiFactory(
 			get language() { return platform.language!; },
 			get appName() { return product.nameLong; },
 			get appRoot() { return initData.environment.appRoot!.fsPath; },
+			get urlProtocol() { return product.urlProtocol; },
 			get logLevel() {
 				checkProposedApiEnabled(extension);
 				return typeConverters.LogLevel.to(extHostLogService.getLevel());

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -235,7 +235,7 @@ export function createApiFactory(
 			get language() { return platform.language!; },
 			get appName() { return product.nameLong; },
 			get appRoot() { return initData.environment.appRoot!.fsPath; },
-			get urlProtocol() { return product.urlProtocol; },
+			get uriScheme() { return product.urlProtocol; },
 			get logLevel() {
 				checkProposedApiEnabled(extension);
 				return typeConverters.LogLevel.to(extHostLogService.getLevel());


### PR DESCRIPTION
Right now when extensions attempt to construct a callback url for themselves, they can only guess by checking the appName, but we should be smart enough to expose this information, for example `vscode`, `code-oss`, `vscode-exoloration`.