### PR TITLE
Add `vscode:` URI prefix to knownSchemes in links.ts

### DIFF
--- a/extensions/markdown-language-features/src/util/links.ts
+++ b/extensions/markdown-language-features/src/util/links.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 
-const knownSchemes = ['http:', 'https:', 'file:', 'mailto:', 'data:', 'vscode-resource:'];
+const knownSchemes = ['http:', 'https:', 'file:', 'mailto:', 'data:', 'vscode:', 'vscode-resource:'];
 
 export function getUriForLinkWithKnownExternalScheme(
 	link: string,

--- a/extensions/markdown-language-features/src/util/links.ts
+++ b/extensions/markdown-language-features/src/util/links.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 
-const knownSchemes = ['http:', 'https:', 'file:', 'mailto:', 'data:', 'vscode:', 'vscode-resource:'];
+const knownSchemes = ['http:', 'https:', 'file:', 'mailto:', 'data:', 'vscode:', 'vscode-insiders:', 'vscode-resource:'];
 
 export function getUriForLinkWithKnownExternalScheme(
 	link: string,


### PR DESCRIPTION
I have not yet built and tested this branch. Should fix #71414.