### PR TITLE
Add new remote option when publishing branch

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -126,6 +126,20 @@ class HEADItem implements QuickPickItem {
 	get alwaysShow(): boolean { return true; }
 }
 
+class AddRemoteItem implements QuickPickItem {
+
+	constructor(private cc: CommandCenter) { }
+
+	get label(): string { return localize('add remote', '$(plus) Add a new remote...'); }
+	get description(): string { return ''; }
+
+	get alwaysShow(): boolean { return true; }
+
+	async run(repository: Repository): Promise<void> {
+		await this.cc.addRemote(repository);
+	}
+}
+
 interface CommandOptions {
 	repository?: boolean;
 	diff?: boolean;
@@ -1832,7 +1846,7 @@ export class CommandCenter {
 	}
 
 	@command('git.addRemote', { repository: true })
-	async addRemote(repository: Repository): Promise<void> {
+	async addRemote(repository: Repository): Promise<string | undefined> {
 		const remotes = repository.remotes;
 
 		const sanitize = (name: string) => {
@@ -1874,6 +1888,8 @@ export class CommandCenter {
 		}
 
 		await repository.addRemote(name, url);
+
+		return name;
 	}
 
 	@command('git.removeRemote', { repository: true })
@@ -1963,19 +1979,31 @@ export class CommandCenter {
 			return;
 		}
 
+		const addRemote = new AddRemoteItem(this);
+
 		const branchName = repository.HEAD && repository.HEAD.name || '';
-		const selectRemote = async () => {
-			const picks = repository.remotes.map(r => r.name);
-			const placeHolder = localize('pick remote', "Pick a remote to publish the branch '{0}' to:", branchName);
-			return await window.showQuickPick(picks, { placeHolder });
-		};
-		const choice = remotes.length === 1 ? remotes[0].name : await selectRemote();
+
+		const picks = [...repository.remotes.map(r => ({ label: r.name, description: '' })), addRemote];
+		const placeHolder = localize('pick remote', "Pick a remote to publish the branch '{0}' to:", branchName);
+		const choice = await window.showQuickPick(picks, { placeHolder });
 
 		if (!choice) {
 			return;
 		}
 
-		await repository.pushTo(choice, branchName, true);
+		let remote = choice.label;
+
+		if (choice === addRemote) {
+			const newRemote = await this.addRemote(repository);
+
+			if (newRemote) {
+				remote = newRemote;
+			} else {
+				return;
+			}
+		}
+
+		await repository.pushTo(remote, branchName, true);
 	}
 
 	@command('git.ignore')


### PR DESCRIPTION
Added the ability to add a new remote when publishing a branch. Closes #71242. Here is an example of creating a new branch, selecting the publish branch command, and creating a new remote. The branch gets published to that new remote.

![publishBranch](https://user-images.githubusercontent.com/44308390/55209224-7a084600-51af-11e9-99f5-dd0b0f66c08d.gif)

I had a few questions about some ways to make the remote experience more consistent:
- Should the ability to add a remote be an option on the "Push to.." and "Pull from..." menus as well?
![Screenshot (19)](https://user-images.githubusercontent.com/44308390/55209176-3ad9f500-51af-11e9-92b0-2995681e13c1.png)

- Should the remotes on the "Publish branch" command show the remote URL, like the  "Push to.." and "Pull from..." menus do?
![Screenshot (20)_LI](https://user-images.githubusercontent.com/44308390/55209196-593ff080-51af-11e9-8b07-58e952d55103.jpg)
