### PR TITLE
git ext. - feature git.useRawRootPath

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1298,6 +1298,12 @@
           "scope": "resource",
           "default": true,
           "description": "%config.openDiffOnClick%"
+        },
+        "git.useRawRootPath": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "description": "%config.useRawRootPath%"
         }
       }
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -117,6 +117,7 @@
 	"config.useForcePushWithLease": "Controls whether force pushing uses the safer force-with-lease variant.",
 	"config.confirmForcePush": "Controls whether to ask for confirmation before force-pushing.",
 	"config.openDiffOnClick": "Controls whether the diff editor should be opened when clicking a change. Otherwise the regular editor will be opened.",
+	"config.useRawRootPath": "Using raw root path. In case of false <git rev-parse --show-toplevel> would be used",
 	"colors.added": "Color for added resources.",
 	"colors.modified": "Color for modified resources.",
 	"colors.deleted": "Color for deleted resources.",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -326,8 +326,8 @@ export class Git {
 		this.env = options.env || {};
 	}
 
-	open(repository: string): Repository {
-		return new Repository(this, repository);
+	open(repository: string, rawpath?: string): Repository {
+		return new Repository(this, repository, rawpath);
 	}
 
 	async init(repository: string): Promise<void> {
@@ -645,7 +645,8 @@ export class Repository {
 
 	constructor(
 		private _git: Git,
-		private repositoryRoot: string
+		private repositoryRoot: string,
+		private repositoryRawRoot?: string
 	) { }
 
 	get git(): Git {
@@ -653,7 +654,13 @@ export class Repository {
 	}
 
 	get root(): string {
-		return this.repositoryRoot;
+		return this.repositoryRawRoot ?
+			this.repositoryRawRoot :
+			this.repositoryRoot;
+	}
+
+	get isRawRootPath(): boolean {
+		return typeof this.repositoryRawRoot === 'string';
 	}
 
 	// TODO@Joao: rename to exec

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -543,6 +543,10 @@ export class Repository implements Disposable {
 		return this.repository.root;
 	}
 
+	get isRawRootPath(): boolean {
+		return this.repository.isRawRootPath;
+	}
+
 	private isRepositoryHuge = false;
 	private didWarnAboutLimit = false;
 	private isFreshRepository: boolean | undefined = undefined;


### PR DESCRIPTION
This feature allows to open project behind the symlink and show the path to file with symlink instead of real. Can be usefull for php-debug with docker environment.
It also shouldn't affect the previous behavior