### PR TITLE
Confirm "Undo last commit" if its a merge commit

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1420,6 +1420,15 @@ export class CommandCenter {
 
 		const commit = await repository.getCommit('HEAD');
 
+		if (commit.parents.length > 1) {
+			const yes = localize('undo commit', "Undo merge commit");
+			const result = await window.showWarningMessage(localize('merge commit', "The last commit was a merge commit. Are you sure you want to undo it?"), yes);
+
+			if (result !== yes) {
+				return;
+			}
+		}
+
 		if (commit.parents.length > 0) {
 			await repository.reset('HEAD~');
 		} else {


### PR DESCRIPTION
Added a confirmation notification when trying to undo the last commit if it was a merge commit. Closes #69937.

![confirmMergeUndo](https://user-images.githubusercontent.com/44308390/55304537-8986c980-5411-11e9-9b3c-13145889766f.gif)

