### PR TITLE
fixed replace field width to change dynamically when resizing

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -616,7 +616,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 			this._domNode.style.maxWidth = `${editorWidth - 28 - minimapWidth - 15}px`;
 		}
 
-		if (this._resized) {
+		if (!this._resized) {
 			let findInputWidth = dom.getTotalWidth(this._findInput.inputBox.inputElement);
 			if (findInputWidth > 0) {
 				this._replaceInputBox.inputElement.style.width = `${findInputWidth}px`;


### PR DESCRIPTION
fixes [#46135](https://github.com/Microsoft/vscode/issues/46135)
Fixed resizing of width for replace textbox when the find and replace dialog box was resized with the vertical separator.

Before:
![static-width](https://user-images.githubusercontent.com/16291290/55357578-512bcd80-549b-11e9-95af-9f7e20ab0a94.gif)

After:
![dynamic-width](https://user-images.githubusercontent.com/16291290/55357584-54bf5480-549b-11e9-8998-e3dd444c84c3.gif)
