### PR TITLE
Fixed command line args with leading zeros

### DIFF
--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -94,7 +94,8 @@ export const options: Option[] = [
 	{ id: 'trace-category-filter', type: 'string' },
 	{ id: 'trace-options', type: 'string' },
 	{ id: 'prof-code-loading', type: 'boolean' },
-	{ id: 'nodeless', type: 'boolean' } // TODO@ben revisit electron5 nodeless support
+	{ id: 'nodeless', type: 'boolean' }, // TODO@ben revisit electron5 nodeless support
+	{ id: '_', type: 'string' }
 ];
 
 export function parseArgs(args: string[], isOptionSupported = (_: Option) => true): ParsedArgs {


### PR DESCRIPTION
Fixed a problem with folder and file command line arguments that had a leading zero not behaving correctly. Fixes #69887. 