### PR TITLE
Join Lines Redesigned

### DIFF
--- a/src/vs/editor/contrib/linesOperations/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/linesOperations.ts
@@ -656,6 +656,13 @@ export class DeleteAllRightAction extends AbstractDeleteAllToBoundaryAction {
 	}
 }
 
+interface IJoinLinesOperation {
+	startLineNumber: number;
+	selectionStartColumn: number;
+	endLineNumber: number;
+	positionColumn: number;
+}
+
 export class JoinLinesAction extends EditorAction {
 	constructor() {
 		super({
@@ -672,146 +679,128 @@ export class JoinLinesAction extends EditorAction {
 		});
 	}
 
-	public run(_accessor: ServicesAccessor, editor: ICodeEditor): void {
-		let selections = editor.getSelections();
-		if (selections === null) {
-			return;
+	private joinLines(line: number, model: ITextModel, editor: ICodeEditor): IIdentifiedSingleEditOperation | null {
+		if (line >= model.getLineCount()) {
+			return null;
 		}
-
-		let primaryCursor = editor.getSelection();
-		if (primaryCursor === null) {
-			return;
+		const whitespaceAtEnd = model.getLineContent(line).match(/\s*$/);
+		if (!whitespaceAtEnd) {
+			return null;
 		}
+		const range = new Range(line, model.getLineMaxColumn(line) - whitespaceAtEnd[0].length, line + 1, model.getLineFirstNonWhitespaceColumn(line + 1));
+		if (model.getLineContent(line).length > 0) {
+			return EditOperation.replace(range, ' ');
+		} else {
+			return EditOperation.replace(range, '');
+		}
+	}
 
-		selections.sort(Range.compareRangesUsingStarts);
-		let reducedSelections: Selection[] = [];
+	private _getLinesToJoin(editor: IActiveCodeEditor): IJoinLinesOperation[] {
 
-		let lastSelection = selections.reduce((previousValue, currentValue) => {
-			if (previousValue.isEmpty()) {
-				if (previousValue.endLineNumber === currentValue.startLineNumber) {
-					if (primaryCursor!.equalsSelection(previousValue)) {
-						primaryCursor = currentValue;
-					}
-					return currentValue;
-				}
+		// Construct join operations
+		let operations: IJoinLinesOperation[] = editor.getSelections().map((s) => {
 
-				if (currentValue.startLineNumber > previousValue.endLineNumber + 1) {
-					reducedSelections.push(previousValue);
-					return currentValue;
-				} else {
-					return new Selection(previousValue.startLineNumber, previousValue.startColumn, currentValue.endLineNumber, currentValue.endColumn);
-				}
-			} else {
-				if (currentValue.startLineNumber > previousValue.endLineNumber) {
-					reducedSelections.push(previousValue);
-					return currentValue;
-				} else {
-					return new Selection(previousValue.startLineNumber, previousValue.startColumn, currentValue.endLineNumber, currentValue.endColumn);
-				}
+			let endLineNumber = s.endLineNumber;
+			if (s.startLineNumber < s.endLineNumber && s.endColumn === 1) {
+				endLineNumber -= 1;
 			}
+
+			return {
+				startLineNumber: s.startLineNumber,
+				selectionStartColumn: s.selectionStartColumn,
+				endLineNumber: endLineNumber,
+				positionColumn: s.positionColumn
+			};
 		});
 
-		reducedSelections.push(lastSelection);
+		// Sort join operations
+		operations.sort((a, b) => {
+			if (a.startLineNumber === b.startLineNumber) {
+				return a.endLineNumber - b.endLineNumber;
+			}
+			return a.startLineNumber - b.startLineNumber;
+		});
 
+		// Merge join operations which are adjacent or overlapping
+		let mergedOperations: IJoinLinesOperation[] = [];
+		let previousOperation = operations[0];
+		for (let i = 1; i < operations.length; i++) {
+			if (previousOperation.endLineNumber + 1 >= operations[i].startLineNumber) {
+				// Merge current operations into the previous one
+				previousOperation.endLineNumber = operations[i].endLineNumber;
+			} else {
+				// Push previous operation
+				mergedOperations.push(previousOperation);
+				previousOperation = operations[i];
+			}
+		}
+		// Push the last operation
+		mergedOperations.push(previousOperation);
+
+		return mergedOperations;
+	}
+
+	public run(_accessor: ServicesAccessor, editor: ICodeEditor): void {
+		if (!editor.hasModel()) {
+			return;
+		}
 		let model = editor.getModel();
-		if (model === null) {
+
+		let opss = this._getLinesToJoin(editor);
+		let ops: IIdentifiedSingleEditOperation[] = [];
+		let conString: String[] = [];
+		let cursorState: Selection[] = [];
+
+		for (let i = 0; i < opss.length; i++) {
+			if (opss[i].startLineNumber === opss[i].endLineNumber && opss[i].selectionStartColumn === opss[i].positionColumn) {
+				const range = this.joinLines(opss[i].startLineNumber, model, editor);
+				if (range && i < opss.length) {
+					let string: String[] = [];
+					string.push(model.getLineContent(opss[i].startLineNumber).trim());
+					string.push(model.getLineContent(opss[i].startLineNumber + 1).trim());
+					ops.push(range);
+					conString.push(string.join(' ') + ' ');
+				} else {
+
+				}
+			} else {
+				let string: String[] = [];
+				for (let line = opss[i].startLineNumber; line < opss[i].endLineNumber; line++) {
+					const range = this.joinLines(line, model, editor);
+					if (range && line < opss[i].endLineNumber) {
+						string.push(model.getLineContent(line).trim());
+						ops.push(range);
+					}
+				}
+				if (opss[i].endLineNumber <= model.getLineCount()) {
+					string.push(model.getLineContent(opss[i].endLineNumber));
+				}
+				conString.push(string.join(' ') + ' ');
+			}
+
+		}
+
+		if (ops.length === 0) {
 			return;
 		}
 
-		let edits: IIdentifiedSingleEditOperation[] = [];
-		let endCursorState: Selection[] = [];
-		let endPrimaryCursor = primaryCursor;
-		let lineOffset = 0;
+		let linesDeleted = 0;
+		for (let i = 0; i < opss.length; i++) {
+			const op = opss[i];
 
-		for (let i = 0, len = reducedSelections.length; i < len; i++) {
-			let selection = reducedSelections[i];
-			let startLineNumber = selection.startLineNumber;
-			let startColumn = 1;
-			let columnDeltaOffset = 0;
-			let endLineNumber: number,
-				endColumn: number;
+			let startLineNumber = op.startLineNumber;
+			let endLineNumber = op.endLineNumber;
 
-			let selectionEndPositionOffset = model.getLineContent(selection.endLineNumber).length - selection.endColumn;
-
-			if (selection.isEmpty() || selection.startLineNumber === selection.endLineNumber) {
-				let position = selection.getStartPosition();
-				if (position.lineNumber < model.getLineCount()) {
-					endLineNumber = startLineNumber + 1;
-					endColumn = model.getLineMaxColumn(endLineNumber);
-				} else {
-					endLineNumber = position.lineNumber;
-					endColumn = model.getLineMaxColumn(position.lineNumber);
-				}
+			if (endLineNumber < model.getLineCount()) {
+				cursorState.push(new Selection(startLineNumber - linesDeleted, 1, startLineNumber - linesDeleted, conString[i].length));
+				linesDeleted += (op.endLineNumber - op.startLineNumber);
 			} else {
-				endLineNumber = selection.endLineNumber;
-				endColumn = model.getLineMaxColumn(endLineNumber);
+				cursorState.push(new Selection(startLineNumber - linesDeleted, op.selectionStartColumn, startLineNumber - linesDeleted, op.selectionStartColumn));
 			}
-
-			let trimmedLinesContent = model.getLineContent(startLineNumber);
-
-			for (let i = startLineNumber + 1; i <= endLineNumber; i++) {
-				let lineText = model.getLineContent(i);
-				let firstNonWhitespaceIdx = model.getLineFirstNonWhitespaceColumn(i);
-
-				if (firstNonWhitespaceIdx >= 1) {
-					let insertSpace = true;
-					if (trimmedLinesContent === '') {
-						insertSpace = false;
-					}
-
-					if (insertSpace && (trimmedLinesContent.charAt(trimmedLinesContent.length - 1) === ' ' ||
-						trimmedLinesContent.charAt(trimmedLinesContent.length - 1) === '\t')) {
-						insertSpace = false;
-						trimmedLinesContent = trimmedLinesContent.replace(/[\s\uFEFF\xA0]+$/g, ' ');
-					}
-
-					let lineTextWithoutIndent = lineText.substr(firstNonWhitespaceIdx - 1);
-
-					trimmedLinesContent += (insertSpace ? ' ' : '') + lineTextWithoutIndent;
-
-					if (insertSpace) {
-						columnDeltaOffset = lineTextWithoutIndent.length + 1;
-					} else {
-						columnDeltaOffset = lineTextWithoutIndent.length;
-					}
-				} else {
-					columnDeltaOffset = 0;
-				}
-			}
-
-			let deleteSelection = new Range(startLineNumber, startColumn, endLineNumber, endColumn);
-
-			if (!deleteSelection.isEmpty()) {
-				let resultSelection: Selection;
-
-				if (selection.isEmpty()) {
-					edits.push(EditOperation.replace(deleteSelection, trimmedLinesContent));
-					resultSelection = new Selection(deleteSelection.startLineNumber - lineOffset, trimmedLinesContent.length - columnDeltaOffset + 1, startLineNumber - lineOffset, trimmedLinesContent.length - columnDeltaOffset + 1);
-				} else {
-					if (selection.startLineNumber === selection.endLineNumber) {
-						edits.push(EditOperation.replace(deleteSelection, trimmedLinesContent));
-						resultSelection = new Selection(selection.startLineNumber - lineOffset, selection.startColumn,
-							selection.endLineNumber - lineOffset, selection.endColumn);
-					} else {
-						edits.push(EditOperation.replace(deleteSelection, trimmedLinesContent));
-						resultSelection = new Selection(selection.startLineNumber - lineOffset, selection.startColumn,
-							selection.startLineNumber - lineOffset, trimmedLinesContent.length - selectionEndPositionOffset);
-					}
-				}
-
-				if (Range.intersectRanges(deleteSelection, primaryCursor) !== null) {
-					endPrimaryCursor = resultSelection;
-				} else {
-					endCursorState.push(resultSelection);
-				}
-			}
-
-			lineOffset += deleteSelection.endLineNumber - deleteSelection.startLineNumber;
 		}
 
-		endCursorState.unshift(endPrimaryCursor);
 		editor.pushUndoStop();
-		editor.executeEdits(this.id, edits, endCursorState);
+		editor.executeEdits(this.id, ops, cursorState);
 		editor.pushUndoStop();
 	}
 }

--- a/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
@@ -434,7 +434,7 @@ suite('Editor Contrib - Line Operations', () => {
 
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(1), 'hello my dear world');
-					assert.deepEqual(editor.getSelection(), new Selection(1, 14, 1, 20));
+					assert.deepEqual(editor.getSelection(), new Selection(1, 1, 1, 20));
 
 					editor.trigger('keyboard', Handler.Undo, {});
 					assert.equal(model.getLineContent(1), 'hello my dear');

--- a/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
@@ -434,7 +434,7 @@ suite('Editor Contrib - Line Operations', () => {
 
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(1), 'hello my dear world');
-					assert.deepEqual(editor.getSelection(), new Selection(1, 14, 1, 14));
+					assert.deepEqual(editor.getSelection(), new Selection(1, 14, 1, 20));
 
 					editor.trigger('keyboard', Handler.Undo, {});
 					assert.equal(model.getLineContent(1), 'hello my dear');

--- a/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
@@ -408,10 +408,8 @@ suite('Editor Contrib - Line Operations', () => {
 					assert.deepEqual(editor.getSelections()!.toString(), [
 						/** primary cursor */
 						new Selection(1, 1, 1, 12),
-						new Selection(2, 1, 2, 12),
-						new Selection(3, 1, 3, 12),
-						new Selection(4, 1, 4, 12),
-						new Selection(6, 1, 6, 12)
+						new Selection(2, 1, 2, 36),
+						new Selection(4, 1, 4, 12)
 					].toString(), '002');
 
 					/** primary cursor */

--- a/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
+++ b/src/vs/editor/contrib/linesOperations/test/linesOperations.test.ts
@@ -333,27 +333,28 @@ suite('Editor Contrib - Line Operations', () => {
 					editor.setSelection(new Selection(1, 2, 1, 2));
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(1), 'hello world', '001');
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(1, 6, 1, 6).toString(), '002');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(1, 1, 1, 12).toString(), '002');
 
 					editor.setSelection(new Selection(2, 2, 2, 2));
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(2), 'hello world', '003');
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(2, 7, 2, 7).toString(), '004');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(2, 1, 2, 12).toString(), '004');
 
 					editor.setSelection(new Selection(3, 2, 3, 2));
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(3), 'hello world', '005');
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(3, 7, 3, 7).toString(), '006');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(3, 1, 3, 12).toString(), '006');
 
 					editor.setSelection(new Selection(4, 2, 5, 3));
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(4), 'hello world', '007');
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(4, 2, 4, 8).toString(), '008');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(4, 1, 4, 12).toString(), '008');
 
 					editor.setSelection(new Selection(5, 1, 7, 3));
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(5), 'hello world', '009');
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(5, 1, 5, 3).toString(), '010');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(5, 1, 5, 12).toString(), '010');
+
 				});
 		});
 
@@ -370,7 +371,7 @@ suite('Editor Contrib - Line Operations', () => {
 					joinLinesAction.run(null!, editor);
 					assert.equal(model.getLineContent(1), 'hello', '001');
 					assert.equal(model.getLineContent(2), 'world', '002');
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(2, 6, 2, 6).toString(), '003');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(2, 1, 2, 1).toString(), '003');
 				});
 		});
 
@@ -403,18 +404,18 @@ suite('Editor Contrib - Line Operations', () => {
 					]);
 
 					joinLinesAction.run(null!, editor);
-					assert.equal(model.getLinesContent().join('\n'), 'hello world\nhello world\nhello world\nhello world\n\nhello world', '001');
+					assert.equal(model.getLinesContent().join('\n'), 'hello world\nhello world hello world hello world\n\nhello world', '001');
 					assert.deepEqual(editor.getSelections()!.toString(), [
 						/** primary cursor */
-						new Selection(3, 4, 3, 8),
-						new Selection(1, 6, 1, 6),
-						new Selection(2, 2, 2, 8),
-						new Selection(4, 5, 4, 9),
-						new Selection(6, 1, 6, 1)
+						new Selection(1, 1, 1, 12),
+						new Selection(2, 1, 2, 12),
+						new Selection(3, 1, 3, 12),
+						new Selection(4, 1, 4, 12),
+						new Selection(6, 1, 6, 12)
 					].toString(), '002');
 
 					/** primary cursor */
-					assert.deepEqual(editor.getSelection()!.toString(), new Selection(3, 4, 3, 8).toString(), '003');
+					assert.deepEqual(editor.getSelection()!.toString(), new Selection(1, 1, 1, 12).toString(), '003');
 				});
 		});
 


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/64655.

It redesigns multi-cursor Join Lines to allow for multiple lines to be merged in.

Before:
![JoinLines-TheIssue](https://user-images.githubusercontent.com/16523071/55511227-127a4c80-562e-11e9-901d-67569c7051c1.gif)

Examples:
![JoinLines-3Cursor](https://user-images.githubusercontent.com/16523071/55745335-006d2500-5a05-11e9-8d7a-b2340dc88a20.gif)


![JoinLines-1Cursor-3Select](https://user-images.githubusercontent.com/16523071/55745351-0b27ba00-5a05-11e9-8402-b9141efd6324.gif)


![JoinLines-2Cursor-2Cursor](https://user-images.githubusercontent.com/16523071/55745535-796c7c80-5a05-11e9-881d-cd5e8f3ccb61.gif)


![JoinLines-Merge-Merge](https://user-images.githubusercontent.com/16523071/55745543-7e313080-5a05-11e9-8fc7-e3c76deebe75.gif)


As a note, it will merge in adjacent selections.

![JoinLines-MergeCon](https://user-images.githubusercontent.com/16523071/55745559-84271180-5a05-11e9-84b6-eb57db2fac3b.gif)

