### PR TITLE
Fixes #71688

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-browser/webviewEditorService.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewEditorService.ts
@@ -220,7 +220,7 @@ export class WebviewEditorService implements IWebviewEditorService {
 
 		// Revived webviews may not have an actively registered reviver but we still want to presist them
 		// since a reviver should exist when it is actually needed.
-		return !(webview instanceof RevivedWebviewEditorInput);
+		return webview instanceof RevivedWebviewEditorInput;
 	}
 
 	private async tryRevive(


### PR DESCRIPTION
Invert conditional on restoring webviews without serializer. We only want to restore webviews that:

* have a serializer registered
* Or were previously serialized (and thus are instances of `RevivedWebviewEditorInput `)