### PR TITLE
Remove acquireFileService hack

### DIFF
--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -198,8 +198,7 @@ export class Workbench extends Layout {
 
 			// TODO@Sandeep debt around cyclic dependencies
 			const configurationService = accessor.get(IConfigurationService) as any;
-			if (typeof configurationService.acquireFileService === 'function') {
-				configurationService.acquireFileService(fileService);
+			if (typeof configurationService.acquireInstantiationService === 'function') {
 				configurationService.acquireInstantiationService(instantiationService);
 			}
 

--- a/src/vs/workbench/electron-browser/main.ts
+++ b/src/vs/workbench/electron-browser/main.ts
@@ -52,6 +52,7 @@ import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
 import { DefaultConfigurationExportHelper } from 'vs/workbench/services/configuration/node/configurationExportHelper';
 import { ConfigurationCache } from 'vs/workbench/services/configuration/node/configurationCache';
 import { ConfigurationFileService } from 'vs/workbench/services/configuration/node/configurationFileService';
+import { IConfigurationFileService } from 'vs/workbench/services/configuration/common/configuration';
 
 class CodeRendererMain extends Disposable {
 
@@ -209,8 +210,11 @@ class CodeRendererMain extends Disposable {
 			fileService.registerProvider(REMOTE_HOST_SCHEME, remoteFileSystemProvider);
 		}
 
+		const configurationFileService = new ConfigurationFileService();
+		fileService.whenReady.then(() => configurationFileService.fileService = fileService);
+
 		return this.resolveWorkspaceInitializationPayload(environmentService).then(payload => Promise.all([
-			this.createWorkspaceService(payload, environmentService, remoteAgentService, logService).then(service => {
+			this.createWorkspaceService(payload, environmentService, configurationFileService, remoteAgentService, logService).then(service => {
 
 				// Workspace
 				serviceCollection.set(IWorkspaceContextService, service);
@@ -301,8 +305,8 @@ class CodeRendererMain extends Disposable {
 		}, error => onUnexpectedError(error));
 	}
 
-	private createWorkspaceService(payload: IWorkspaceInitializationPayload, environmentService: IEnvironmentService, remoteAgentService: IRemoteAgentService, logService: ILogService): Promise<WorkspaceService> {
-		const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), remoteAuthority: this.configuration.remoteAuthority, configurationCache: new ConfigurationCache(environmentService) }, new ConfigurationFileService(), remoteAgentService);
+	private createWorkspaceService(payload: IWorkspaceInitializationPayload, environmentService: IEnvironmentService, configurationFileService: IConfigurationFileService, remoteAgentService: IRemoteAgentService, logService: ILogService): Promise<WorkspaceService> {
+		const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), remoteAuthority: this.configuration.remoteAuthority, configurationCache: new ConfigurationCache(environmentService) }, configurationFileService, remoteAgentService);
 
 		return workspaceService.initialize(payload).then(() => workspaceService, error => {
 			onUnexpectedError(error);

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -13,7 +13,6 @@ import { Queue, Barrier } from 'vs/base/common/async';
 import { IJSONContributionRegistry, Extensions as JSONExtensions } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import { IWorkspaceContextService, Workspace, WorkbenchState, IWorkspaceFolder, toWorkspaceFolders, IWorkspaceFoldersChangeEvent, WorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { isLinux } from 'vs/base/common/platform';
-import { IFileService } from 'vs/platform/files/common/files';
 import { ConfigurationChangeEvent, ConfigurationModel, DefaultConfigurationModel } from 'vs/platform/configuration/common/configurationModels';
 import { IConfigurationChangeEvent, ConfigurationTarget, IConfigurationOverrides, keyFromOverrideIdentifier, isConfigurationOverrides, IConfigurationData, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Configuration, WorkspaceConfigurationChangeEvent, AllKeysConfigurationChangeEvent } from 'vs/workbench/services/configuration/common/configurationModels';
@@ -288,10 +287,6 @@ export class WorkspaceService extends Disposable implements IConfigurationServic
 			.then(workspace => this.updateWorkspaceAndInitializeConfiguration(workspace)).then(() => {
 				mark('didInitWorkspaceService');
 			});
-	}
-
-	acquireFileService(fileService: IFileService): void {
-		this.configurationFileService.fileService = fileService;
 	}
 
 	acquireInstantiationService(instantiationService: IInstantiationService): void {

--- a/src/vs/workbench/services/configuration/test/electron-browser/configurationService.test.ts
+++ b/src/vs/workbench/services/configuration/test/electron-browser/configurationService.test.ts
@@ -219,14 +219,16 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 				const environmentService = new SettingsTestEnvironmentService(parseArgs(process.argv), process.execPath, path.join(parentDir, 'settings.json'));
 				const remoteAgentService = instantiationService.createInstance(RemoteAgentService, {});
 				instantiationService.stub(IRemoteAgentService, remoteAgentService);
-				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, new ConfigurationFileService(), remoteAgentService);
+				const fileService = new FileService2(new NullLogService());
+				const configurationFileService = new ConfigurationFileService();
+				fileService.whenReady.then(() => configurationFileService.fileService = fileService);
+				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, configurationFileService, remoteAgentService);
 
 				instantiationService.stub(IWorkspaceContextService, workspaceService);
 				instantiationService.stub(IConfigurationService, workspaceService);
 				instantiationService.stub(IEnvironmentService, environmentService);
 
 				return workspaceService.initialize(getWorkspaceIdentifier(configPath)).then(() => {
-					const fileService = new FileService2(new NullLogService());
 					fileService.registerProvider(Schemas.file, new DiskFileSystemProvider(new NullLogService()));
 					fileService.setLegacyService(new LegacyFileService(
 						fileService,
@@ -238,7 +240,6 @@ suite('WorkspaceContextService - Workspace Editing', () => {
 					instantiationService.stub(ITextFileService, instantiationService.createInstance(TestTextFileService));
 					instantiationService.stub(ITextModelService, <ITextModelService>instantiationService.createInstance(TextModelResolverService));
 					workspaceService.acquireInstantiationService(instantiationService);
-					workspaceService.acquireFileService(fileService);
 
 					testObject = workspaceService;
 				});
@@ -485,13 +486,15 @@ suite('WorkspaceService - Initialization', () => {
 				const environmentService = new SettingsTestEnvironmentService(parseArgs(process.argv), process.execPath, globalSettingsFile);
 				const remoteAgentService = instantiationService.createInstance(RemoteAgentService, {});
 				instantiationService.stub(IRemoteAgentService, remoteAgentService);
-				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, new ConfigurationFileService(), remoteAgentService);
+				const fileService = new FileService2(new NullLogService());
+				const configurationFileService = new ConfigurationFileService();
+				fileService.whenReady.then(() => configurationFileService.fileService = fileService);
+				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, configurationFileService, remoteAgentService);
 				instantiationService.stub(IWorkspaceContextService, workspaceService);
 				instantiationService.stub(IConfigurationService, workspaceService);
 				instantiationService.stub(IEnvironmentService, environmentService);
 
 				return workspaceService.initialize({ id: '' }).then(() => {
-					const fileService = new FileService2(new NullLogService());
 					fileService.registerProvider(Schemas.file, new DiskFileSystemProvider(new NullLogService()));
 					fileService.setLegacyService(new LegacyFileService(
 						fileService,
@@ -503,7 +506,6 @@ suite('WorkspaceService - Initialization', () => {
 					instantiationService.stub(ITextFileService, instantiationService.createInstance(TestTextFileService));
 					instantiationService.stub(ITextModelService, <ITextModelService>instantiationService.createInstance(TextModelResolverService));
 					workspaceService.acquireInstantiationService(instantiationService);
-					workspaceService.acquireFileService(fileService);
 					testObject = workspaceService;
 				});
 			});
@@ -749,13 +751,15 @@ suite('WorkspaceConfigurationService - Folder', () => {
 				const environmentService = new SettingsTestEnvironmentService(parseArgs(process.argv), process.execPath, globalSettingsFile);
 				const remoteAgentService = instantiationService.createInstance(RemoteAgentService, {});
 				instantiationService.stub(IRemoteAgentService, remoteAgentService);
-				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, new ConfigurationFileService(), remoteAgentService);
+				const fileService = new FileService2(new NullLogService());
+				const configurationFileService = new ConfigurationFileService();
+				fileService.whenReady.then(() => configurationFileService.fileService = fileService);
+				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, configurationFileService, remoteAgentService);
 				instantiationService.stub(IWorkspaceContextService, workspaceService);
 				instantiationService.stub(IConfigurationService, workspaceService);
 				instantiationService.stub(IEnvironmentService, environmentService);
 
 				return workspaceService.initialize(convertToWorkspacePayload(URI.file(folderDir))).then(() => {
-					const fileService = new FileService2(new NullLogService());
 					fileService.registerProvider(Schemas.file, new DiskFileSystemProvider(new NullLogService()));
 					fileService.setLegacyService(new LegacyFileService(
 						fileService,
@@ -767,7 +771,6 @@ suite('WorkspaceConfigurationService - Folder', () => {
 					instantiationService.stub(ITextFileService, instantiationService.createInstance(TestTextFileService));
 					instantiationService.stub(ITextModelService, <ITextModelService>instantiationService.createInstance(TextModelResolverService));
 					workspaceService.acquireInstantiationService(instantiationService);
-					workspaceService.acquireFileService(fileService);
 					testObject = workspaceService;
 				});
 			});
@@ -1046,14 +1049,16 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 				environmentService = new SettingsTestEnvironmentService(parseArgs(process.argv), process.execPath, path.join(parentDir, 'settings.json'));
 				const remoteAgentService = instantiationService.createInstance(RemoteAgentService, {});
 				instantiationService.stub(IRemoteAgentService, remoteAgentService);
-				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, new ConfigurationFileService(), remoteAgentService);
+				const fileService = new FileService2(new NullLogService());
+				const configurationFileService = new ConfigurationFileService();
+				fileService.whenReady.then(() => configurationFileService.fileService = fileService);
+				const workspaceService = new WorkspaceService({ userSettingsResource: URI.file(environmentService.appSettingsPath), configurationCache: new ConfigurationCache(environmentService) }, configurationFileService, remoteAgentService);
 
 				instantiationService.stub(IWorkspaceContextService, workspaceService);
 				instantiationService.stub(IConfigurationService, workspaceService);
 				instantiationService.stub(IEnvironmentService, environmentService);
 
 				return workspaceService.initialize(getWorkspaceIdentifier(configPath)).then(() => {
-					const fileService = new FileService2(new NullLogService());
 					fileService.registerProvider(Schemas.file, new DiskFileSystemProvider(new NullLogService()));
 					fileService.setLegacyService(new LegacyFileService(
 						fileService,
@@ -1065,7 +1070,6 @@ suite('WorkspaceConfigurationService-Multiroot', () => {
 					instantiationService.stub(ITextFileService, instantiationService.createInstance(TestTextFileService));
 					instantiationService.stub(ITextModelService, <ITextModelService>instantiationService.createInstance(TextModelResolverService));
 					workspaceService.acquireInstantiationService(instantiationService);
-					workspaceService.acquireFileService(fileService);
 
 					workspaceContextService = workspaceService;
 					jsonEditingServce = instantiationService.createInstance(JSONEditingService);

--- a/src/vs/workbench/services/files2/common/fileService2.ts
+++ b/src/vs/workbench/services/files2/common/fileService2.ts
@@ -24,6 +24,8 @@ export class FileService2 extends Disposable implements IFileService {
 	private joinOnLegacy: Promise<ILegacyFileService>;
 	private joinOnImplResolve: (service: ILegacyFileService) => void;
 
+	get whenReady(): Promise<void> { return this.joinOnLegacy.then(() => undefined); }
+
 	setLegacyService(legacy: ILegacyFileService): void {
 		this._legacy = this._register(legacy);
 


### PR DESCRIPTION
Fixes: https://github.com/Microsoft/vscode/issues/69230

Removed the hack in `ConfigurationService` to `acquireFileService`. There is a new service `ConfigurationFileService` that takes care of 

- reading files when file service is not available
- adopting to file service when gets access to it

This happens outside `ConfigurationService` which makes it cleaner and removes the hack we have.

@bpasero 

It needed a change in `FileService2` to expose when it is ready so that `ConfigurationFileService` also changes its behaviour accordingly. 
