### PR TITLE
Fixed #69903

### DIFF
--- a/src/vs/editor/contrib/clipboard/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/clipboard.ts
@@ -146,12 +146,10 @@ class ExecCommandCopyAction extends ExecCommandAction {
 		const emptySelectionClipboard = editor.getConfiguration().emptySelectionClipboard;
 
 		if (!emptySelectionClipboard && editor.getSelection().isEmpty()) {
-			return;
-		}
-		// Prevent copying an empty line by accident
-		if (editor.getSelections().length === 1 && editor.getSelection().isEmpty()) {
-			if (editor.getModel().getLineFirstNonWhitespaceColumn(editor.getSelection().positionLineNumber) === 0) {
-				return;
+			if (editor.getSelections().length === 1 && editor.getSelection().isEmpty()) {
+				if (editor.getModel().getLineFirstNonWhitespaceColumn(editor.getSelection().positionLineNumber) === 0) {
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
This fixes https://github.com/Microsoft/vscode/issues/69903.

It makes `editor.emptySelectionClipboard` setting work properly work with copy.

As a note, if you have `editor.emptySelectionClipboard` on with an empty selection and turn it off, it will still keep the empty selection.