### PR TITLE
Fixes #68201 - adds qs.* label formatting tokens

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -68,7 +68,7 @@ const resourceLabelFormattersExtPoint = ExtensionsRegistry.registerExtensionPoin
 });
 
 const sepRegexp = /\//g;
-const labelMatchingRegexp = /\$\{scheme\}|\$\{authority\}|\$\{path\}/g;
+const labelMatchingRegexp = /\$\{(scheme|authority|path|(qs)\.(.+?))\}/g;
 
 function hasDriveLetter(path: string): boolean {
 	return !!(isWindows && path && path[2] === ':');
@@ -222,12 +222,23 @@ export class LabelService implements ILabelService {
 	}
 
 	private formatUri(resource: URI, formatting: ResourceLabelFormatting, forceNoTildify?: boolean): string {
-		let label = formatting.label.replace(labelMatchingRegexp, match => {
-			switch (match) {
-				case '${scheme}': return resource.scheme;
-				case '${authority}': return resource.authority;
-				case '${path}': return resource.path;
-				default: return '';
+		let label = formatting.label.replace(labelMatchingRegexp, (match, token, qsToken, qsValue) => {
+			switch (token) {
+				case 'scheme': return resource.scheme;
+				case 'authority': return resource.authority;
+				case 'path': return resource.path;
+				default: {
+					if (qsToken === 'qs') {
+						const { query } = resource;
+						if (query && query[0] === '{' && query[query.length - 1] === '}') {
+							try {
+								return JSON.parse(query)[qsValue] || '';
+							}
+							catch { }
+						}
+					}
+					return '';
+				}
 			}
 		});
 

--- a/src/vs/workbench/services/label/test/label.test.ts
+++ b/src/vs/workbench/services/label/test/label.test.ts
@@ -97,4 +97,64 @@ suite('URI Label', () => {
 		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
 		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'second');
 	});
+
+	test('custom qs', function () {
+		labelService.registerFormatter({
+			scheme: 'vscode',
+			formatting: {
+				label: 'LABEL${qs.prefix}: ${qs.path}/END',
+				separator: '/',
+				tildify: true,
+				normalizeDriveLetter: true
+			}
+		});
+
+		const uri1 = URI.parse(`vscode://microsoft.com/1/2/3/4/5?${encodeURIComponent(JSON.stringify({ prefix: 'prefix', path: 'path' }))}`);
+		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABELprefix: path/END');
+	});
+
+	test('custom qs without value', function () {
+		labelService.registerFormatter({
+			scheme: 'vscode',
+			formatting: {
+				label: 'LABEL${qs.prefix}: ${qs.path}/END',
+				separator: '/',
+				tildify: true,
+				normalizeDriveLetter: true
+			}
+		});
+
+		const uri1 = URI.parse(`vscode://microsoft.com/1/2/3/4/5?${encodeURIComponent(JSON.stringify({ path: 'path' }))}`);
+		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: path/END');
+	});
+
+	test('custom qs without query json', function () {
+		labelService.registerFormatter({
+			scheme: 'vscode',
+			formatting: {
+				label: 'LABEL${qs.prefix}: ${qs.path}/END',
+				separator: '/',
+				tildify: true,
+				normalizeDriveLetter: true
+			}
+		});
+
+		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5?path=foo');
+		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
+	});
+
+	test('custom qs without query', function () {
+		labelService.registerFormatter({
+			scheme: 'vscode',
+			formatting: {
+				label: 'LABEL${qs.prefix}: ${qs.path}/END',
+				separator: '/',
+				tildify: true,
+				normalizeDriveLetter: true
+			}
+		});
+
+		const uri1 = URI.parse('vscode://microsoft.com/1/2/3/4/5');
+		assert.equal(labelService.getUriLabel(uri1, { relative: false }), 'LABEL: /END');
+	});
 });


### PR DESCRIPTION
Addresses https://github.com/Microsoft/vscode/issues/68201

Allows `${qs.*}` tokens in the `resourceLabelFormatters.formatting.label`, where the `*` is resolved to a property of the querystring json object (assuming it is a json object)

/cc @isidorn 