### PR TITLE
Display extensionId as the description in the formatter dropdown

### DIFF
--- a/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
@@ -128,7 +128,7 @@ class DefaultFormatter extends Disposable implements IWorkbenchContribution {
 			return <IIndexedPick>{
 				index,
 				label: formatter.displayName || formatter.extensionId || '?',
-				description: formatter.extensionId || undefined
+				description: formatter.extensionId!.value
 			};
 		});
 		const langName = this._modeService.getLanguageName(document.getModeId()) || document.getModeId();

--- a/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
@@ -127,7 +127,8 @@ class DefaultFormatter extends Disposable implements IWorkbenchContribution {
 		const picks = formatter.map((formatter, index) => {
 			return <IIndexedPick>{
 				index,
-				label: formatter.displayName || formatter.extensionId || '?'
+				label: formatter.displayName || formatter.extensionId || '?',
+				description: formatter.extensionId || undefined
 			};
 		});
 		const langName = this._modeService.getLanguageName(document.getModeId()) || document.getModeId();

--- a/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
@@ -128,7 +128,7 @@ class DefaultFormatter extends Disposable implements IWorkbenchContribution {
 			return <IIndexedPick>{
 				index,
 				label: formatter.displayName || formatter.extensionId || '?',
-				description: formatter.extensionId!.value
+				description: formatter.extensionId && formatter.extensionId.value
 			};
 		});
 		const langName = this._modeService.getLanguageName(document.getModeId()) || document.getModeId();


### PR DESCRIPTION
~~Unfortunately I wasn't able to figure out how to get a locally compiled version of Code working, so I wasn't able to test that this change does what I want.~~ 

Resolves #71904 

Now displays the extension ID next to the formatter's `displayName` (there are supposed to be two formatters here, that's an unrelated thing with the extension I'm using to test this):

<img width="625" alt="Screen Shot 2019-04-07 at 9 37 46 PM" src="https://user-images.githubusercontent.com/2977353/55697212-8ba2d800-597d-11e9-88a9-e86236ab2fbe.png">
