### PR TITLE
Fix #71707

### DIFF
--- a/src/vs/editor/contrib/format/format.ts
+++ b/src/vs/editor/contrib/format/format.ts
@@ -214,7 +214,7 @@ export async function formatDocumentWithSelectedProvider(
 	const provider = getRealAndSyntheticDocumentFormattersOrdered(model);
 	const selected = await FormattingConflicts.select(provider, model, mode);
 	if (selected) {
-		await instaService.invokeFunction(formatDocumentWithProvider, selected, editorOrModel, token);
+		await instaService.invokeFunction(formatDocumentWithProvider, selected, editorOrModel, mode, token);
 	}
 }
 
@@ -222,6 +222,7 @@ export async function formatDocumentWithProvider(
 	accessor: ServicesAccessor,
 	provider: DocumentFormattingEditProvider,
 	editorOrModel: ITextModel | IActiveCodeEditor,
+	mode: FormattingMode,
 	token: CancellationToken
 ): Promise<boolean> {
 	const workerService = accessor.get(IEditorWorkerService);
@@ -257,10 +258,13 @@ export async function formatDocumentWithProvider(
 	if (isCodeEditor(editorOrModel)) {
 		// use editor to apply edits
 		FormattingEdit.execute(editorOrModel, edits);
-		alertFormattingEdits(edits);
-		editorOrModel.pushUndoStop();
-		editorOrModel.focus();
-		editorOrModel.revealPositionInCenterIfOutsideViewport(editorOrModel.getPosition(), editorCommon.ScrollType.Immediate);
+
+		if (mode !== FormattingMode.Silent) {
+			alertFormattingEdits(edits);
+			editorOrModel.pushUndoStop();
+			editorOrModel.focus();
+			editorOrModel.revealPositionInCenterIfOutsideViewport(editorOrModel.getPosition(), editorCommon.ScrollType.Immediate);
+		}
 
 	} else {
 		// use model to apply edits

--- a/src/vs/workbench/api/browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/browser/mainThreadSaveParticipant.ts
@@ -211,6 +211,7 @@ class FormatOnSaveParticipant implements ISaveParticipantParticipant {
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		// Nothing
@@ -227,8 +228,9 @@ class FormatOnSaveParticipant implements ISaveParticipantParticipant {
 
 		return new Promise<any>((resolve, reject) => {
 			const source = new CancellationTokenSource();
+			const editorOrModel = findEditor(model, this._codeEditorService) || model;
 			const timeout = this._configurationService.getValue<number>('editor.formatOnSaveTimeout', overrides);
-			const request = this._instantiationService.invokeFunction(formatDocumentWithSelectedProvider, model, FormattingMode.Silent, source.token);
+			const request = this._instantiationService.invokeFunction(formatDocumentWithSelectedProvider, editorOrModel, FormattingMode.Silent, source.token);
 
 			setTimeout(() => {
 				reject(localize('timeout.formatOnSave', "Aborted format on save after {0}ms", timeout));

--- a/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
@@ -254,7 +254,7 @@ registerEditorAction(class FormatDocumentMultipleAction extends EditorAction {
 		const provider = getRealAndSyntheticDocumentFormattersOrdered(model);
 		const pick = await instaService.invokeFunction(showFormatterPick, model, provider);
 		if (pick) {
-			await instaService.invokeFunction(formatDocumentWithProvider, provider[pick], editor, CancellationToken.None);
+			await instaService.invokeFunction(formatDocumentWithProvider, provider[pick], editor, FormattingMode.Explicit, CancellationToken.None);
 		}
 		logFormatterTelemetry(telemetryService, 'document', provider, typeof pick === 'number' && provider[pick] || undefined);
 	}


### PR DESCRIPTION
This PR is to fix #71707. It is two changes which restores the old format on save behaviour (the 1.32 and before [code](https://github.com/Microsoft/vscode/blob/f5fd4f69c69af5973a69cf4dc418d1a233c1692e/src/vs/editor/contrib/format/format.ts#L157))

* try to apply format-on-save-edits with an editor when possible, e.g when the saved document is showing in an editor
* honour the silent mode and don't active the editor when set