### PR TITLE
ignore trailing white-spaces in LINE_COLON_PATTERN

### DIFF
--- a/src/vs/workbench/contrib/search/browser/openAnythingHandler.ts
+++ b/src/vs/workbench/contrib/search/browser/openAnythingHandler.ts
@@ -32,7 +32,7 @@ export class OpenAnythingHandler extends QuickOpenHandler {
 
 	static readonly ID = 'workbench.picker.anything';
 
-	private static readonly LINE_COLON_PATTERN = /[#:\(](\d*)([#:,](\d*))?\)?$/;
+	private static readonly LINE_COLON_PATTERN = /[#:\(](\d*)([#:,](\d*))?\)?\s*$/;
 
 	private static readonly TYPING_SEARCH_DELAY = 200; // This delay accommodates for the user typing a word and then stops typing to start searching
 


### PR DESCRIPTION
Closes #61831

Ignore trailing white-spaces when matching `LINE_COLON_PATTERN`
Added `\s*` pattern at the end of regex.

Updated regex:
`LINE_COLON_PATTERN = /[#:\(](\d*)([#:,](\d*))?\)?\s*$/;`


cc: @bpasero, @chrmarti