### PR TITLE
Fix #69729 - Diff editor view position not being restored

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -929,11 +929,14 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 
 		let diffDecorations = this._strategy.getEditorsDiffDecorations(lineChanges, this._ignoreTrimWhitespace, this._renderIndicators, foreignOriginal, foreignModified, this.originalEditor, this.modifiedEditor);
 
+		const prevState = this.modifiedEditor.saveViewState();
+
 		try {
 			this._currentlyChangingViewZones = true;
 			this._originalEditorState.apply(this.originalEditor, this._originalOverviewRuler, diffDecorations.original, false);
 			this._modifiedEditorState.apply(this.modifiedEditor, this._modifiedOverviewRuler, diffDecorations.modified, true);
 		} finally {
+			this.modifiedEditor.restoreViewState(prevState);
 			this._currentlyChangingViewZones = false;
 		}
 	}
@@ -1029,8 +1032,8 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		let computedRepresentableSize = Math.max(0, computedAvailableSize - 2 * 0);
 		let computedRatio = scrollHeight > 0 ? (computedRepresentableSize / scrollHeight) : 0;
 
-		let computedSliderSize = Math.max(0, Math.floor(layoutInfo.contentHeight * computedRatio));
-		let computedSliderPosition = Math.floor(scrollTop * computedRatio);
+		let computedSliderSize = Math.max(0, Math.round(layoutInfo.contentHeight * computedRatio));
+		let computedSliderPosition = Math.round(scrollTop * computedRatio);
 
 		return {
 			height: computedSliderSize,


### PR DESCRIPTION
Restore the diff editor view position when switching back to the diff editor. Fixes #69729. Also fixes a minor error in diff slider position calculation. 