### PR TITLE
Fixes #27041

### DIFF
--- a/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
@@ -1973,6 +1973,9 @@ class TaskService extends Disposable implements ITaskService {
 			if ((entries.length === 0) && defaultEntry) {
 				entries.push(defaultEntry);
 			}
+			else if (selectedEntry) {
+				entries.push(selectedEntry);
+			}
 			return entries;
 		}), {
 				placeHolder,
@@ -2195,16 +2198,27 @@ class TaskService extends Disposable implements ITaskService {
 		if (!this.canRunCommand()) {
 			return;
 		}
+		if (arg === 'terminateAll') {
+			this.terminateAll();
+			return;
+		}
 		let runQuickPick = (promise?: Promise<Task[]>) => {
 			this.showQuickPick(promise || this.getActiveTasks(),
 				nls.localize('TaskService.tastToTerminate', 'Select task to terminate'),
 				{
 					label: nls.localize('TaskService.noTaskRunning', 'No task is currently running'),
-					task: null
+					task: undefined
 				},
-				false, true
+				false, true,
+				{
+					label: nls.localize('TaskService.terminateAllRunningTasks', 'All running tasks'),
+					task: null
+				}
 			).then(task => {
 				if (task === undefined || task === null) {
+					if (task === null) {
+						this.terminateAll();
+					}
 					return;
 				}
 				this.terminate(task);

--- a/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
@@ -1961,7 +1961,7 @@ class TaskService extends Disposable implements ITaskService {
 		return entries;
 	}
 
-	private showQuickPick(tasks: Promise<Task[]> | Task[], placeHolder: string, defaultEntry?: TaskQuickPickEntry, group: boolean = false, sort: boolean = false, selectedEntry?: TaskQuickPickEntry): Promise<Task | undefined | null> {
+	private showQuickPick(tasks: Promise<Task[]> | Task[], placeHolder: string, defaultEntry?: TaskQuickPickEntry, group: boolean = false, sort: boolean = false, selectedEntry?: TaskQuickPickEntry, additionalEntries?: TaskQuickPickEntry[]): Promise<TaskQuickPickEntry | undefined | null> {
 		let _createEntries = (): Promise<TaskQuickPickEntry[]> => {
 			if (Array.isArray(tasks)) {
 				return Promise.resolve(this.createTaskQuickPickEntries(tasks, group, sort, selectedEntry));
@@ -1973,8 +1973,8 @@ class TaskService extends Disposable implements ITaskService {
 			if ((entries.length === 0) && defaultEntry) {
 				entries.push(defaultEntry);
 			}
-			else if (selectedEntry) {
-				entries.push(selectedEntry);
+			else if (additionalEntries && additionalEntries.length > 0) {
+				entries.push(additionalEntries[0]);
 			}
 			return entries;
 		}), {
@@ -1989,7 +1989,7 @@ class TaskService extends Disposable implements ITaskService {
 						this.openConfig(task);
 					}
 				}
-			}).then(entry => entry ? entry.task : undefined);
+			});
 	}
 
 	private showIgnoredFoldersMessage(): Promise<void> {
@@ -2049,7 +2049,11 @@ class TaskService extends Disposable implements ITaskService {
 					task: null
 				},
 				true).
-				then((task) => {
+				then((entry) => {
+					if (entry === undefined || entry === null) {
+						return;
+					}
+					let task: Task | undefined | null = entry.task;
 					if (task === undefined) {
 						return;
 					}
@@ -2129,7 +2133,11 @@ class TaskService extends Disposable implements ITaskService {
 						label: nls.localize('TaskService.noBuildTask', 'No build task to run found. Configure Build Task...'),
 						task: null
 					},
-					true).then((task) => {
+					true).then((entry) => {
+						if (entry === undefined || entry === null) {
+							return;
+						}
+						let task: Task | undefined | null = entry.task;
 						if (task === undefined) {
 							return;
 						}
@@ -2177,7 +2185,11 @@ class TaskService extends Disposable implements ITaskService {
 						label: nls.localize('TaskService.noTestTaskTerminal', 'No test task to run found. Configure Tasks...'),
 						task: null
 					}, true
-				).then((task) => {
+				).then((entry) => {
+					if (entry === undefined || entry === null) {
+						return;
+					}
+					let task: Task | undefined | null = entry.task;
 					if (task === undefined) {
 						return;
 					}
@@ -2210,13 +2222,19 @@ class TaskService extends Disposable implements ITaskService {
 					task: undefined
 				},
 				false, true,
-				{
+				undefined,
+				[{
 					label: nls.localize('TaskService.terminateAllRunningTasks', 'All running tasks'),
+					id: '66',
 					task: null
+				}]
+			).then(entry => {
+				if (entry === undefined || entry === null) {
+					return;
 				}
-			).then(task => {
+				let task: Task | undefined | null = entry.task;
 				if (task === undefined || task === null) {
-					if (task === null) {
+					if (entry.id && entry.id === '66') {
 						this.terminateAll();
 					}
 					return;
@@ -2273,7 +2291,11 @@ class TaskService extends Disposable implements ITaskService {
 					task: null
 				},
 				false, true
-			).then(task => {
+			).then(entry => {
+				if (entry === undefined || entry === null) {
+					return;
+				}
+				let task: Task | undefined | null = entry.task;
 				if (task === undefined || task === null) {
 					return;
 				}
@@ -2485,7 +2507,11 @@ class TaskService extends Disposable implements ITaskService {
 				this.showIgnoredFoldersMessage().then(() => {
 					this.showQuickPick(tasks,
 						nls.localize('TaskService.pickDefaultBuildTask', 'Select the task to be used as the default build task'), undefined, true, false, selectedEntry).
-						then((task) => {
+						then((entry) => {
+							if (entry === undefined || entry === null) {
+								return;
+							}
+							let task: Task | undefined | null = entry.task;
 							if ((task === undefined) || (task === null)) {
 								return;
 							}
@@ -2535,7 +2561,11 @@ class TaskService extends Disposable implements ITaskService {
 
 				this.showIgnoredFoldersMessage().then(() => {
 					this.showQuickPick(tasks,
-						nls.localize('TaskService.pickDefaultTestTask', 'Select the task to be used as the default test task'), undefined, true, false, selectedEntry).then((task) => {
+						nls.localize('TaskService.pickDefaultTestTask', 'Select the task to be used as the default test task'), undefined, true, false, selectedEntry).then((entry) => {
+							if (entry === undefined || entry === null) {
+								return;
+							}
+							let task: Task | undefined | null = entry.task;
 							if (!task) {
 								return;
 							}
@@ -2568,7 +2598,11 @@ class TaskService extends Disposable implements ITaskService {
 				task: null
 			},
 			false, true
-		).then((task) => {
+		).then((entry) => {
+			if (entry === undefined || entry === null) {
+				return;
+			}
+			let task: Task | undefined | null = entry.task;
 			if (task === undefined || task === null) {
 				return;
 			}

--- a/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
@@ -1973,7 +1973,7 @@ class TaskService extends Disposable implements ITaskService {
 			if ((entries.length === 0) && defaultEntry) {
 				entries.push(defaultEntry);
 			}
-			else if (additionalEntries && additionalEntries.length > 0) {
+			else if (entries.length > 1 && additionalEntries && additionalEntries.length > 0) {
 				entries.push(additionalEntries[0]);
 			}
 			return entries;
@@ -2050,10 +2050,7 @@ class TaskService extends Disposable implements ITaskService {
 				},
 				true).
 				then((entry) => {
-					if (entry === undefined || entry === null) {
-						return;
-					}
-					let task: Task | undefined | null = entry.task;
+					let task: Task | undefined | null = entry ? entry.task : undefined;
 					if (task === undefined) {
 						return;
 					}
@@ -2134,10 +2131,7 @@ class TaskService extends Disposable implements ITaskService {
 						task: null
 					},
 					true).then((entry) => {
-						if (entry === undefined || entry === null) {
-							return;
-						}
-						let task: Task | undefined | null = entry.task;
+						let task: Task | undefined | null = entry ? entry.task : undefined;
 						if (task === undefined) {
 							return;
 						}
@@ -2186,10 +2180,7 @@ class TaskService extends Disposable implements ITaskService {
 						task: null
 					}, true
 				).then((entry) => {
-					if (entry === undefined || entry === null) {
-						return;
-					}
-					let task: Task | undefined | null = entry.task;
+					let task: Task | undefined | null = entry ? entry.task : undefined;
 					if (task === undefined) {
 						return;
 					}
@@ -2225,16 +2216,13 @@ class TaskService extends Disposable implements ITaskService {
 				undefined,
 				[{
 					label: nls.localize('TaskService.terminateAllRunningTasks', 'All running tasks'),
-					id: '66',
+					id: 'terminateAll',
 					task: null
 				}]
 			).then(entry => {
-				if (entry === undefined || entry === null) {
-					return;
-				}
-				let task: Task | undefined | null = entry.task;
+				let task: Task | undefined | null = entry ? entry.task : undefined;
 				if (task === undefined || task === null) {
-					if (entry.id && entry.id === '66') {
+					if (entry && entry.id === 'terminateAll') {
 						this.terminateAll();
 					}
 					return;
@@ -2292,10 +2280,7 @@ class TaskService extends Disposable implements ITaskService {
 				},
 				false, true
 			).then(entry => {
-				if (entry === undefined || entry === null) {
-					return;
-				}
-				let task: Task | undefined | null = entry.task;
+				let task: Task | undefined | null = entry ? entry.task : undefined;
 				if (task === undefined || task === null) {
 					return;
 				}
@@ -2508,10 +2493,7 @@ class TaskService extends Disposable implements ITaskService {
 					this.showQuickPick(tasks,
 						nls.localize('TaskService.pickDefaultBuildTask', 'Select the task to be used as the default build task'), undefined, true, false, selectedEntry).
 						then((entry) => {
-							if (entry === undefined || entry === null) {
-								return;
-							}
-							let task: Task | undefined | null = entry.task;
+							let task: Task | undefined | null = entry ? entry.task : undefined;
 							if ((task === undefined) || (task === null)) {
 								return;
 							}
@@ -2562,10 +2544,7 @@ class TaskService extends Disposable implements ITaskService {
 				this.showIgnoredFoldersMessage().then(() => {
 					this.showQuickPick(tasks,
 						nls.localize('TaskService.pickDefaultTestTask', 'Select the task to be used as the default test task'), undefined, true, false, selectedEntry).then((entry) => {
-							if (entry === undefined || entry === null) {
-								return;
-							}
-							let task: Task | undefined | null = entry.task;
+							let task: Task | undefined | null = entry ? entry.task : undefined;
 							if (!task) {
 								return;
 							}
@@ -2599,10 +2578,7 @@ class TaskService extends Disposable implements ITaskService {
 			},
 			false, true
 		).then((entry) => {
-			if (entry === undefined || entry === null) {
-				return;
-			}
-			let task: Task | undefined | null = entry.task;
+			let task: Task | undefined | null = entry ? entry.task : undefined;
 			if (task === undefined || task === null) {
 				return;
 			}

--- a/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
@@ -2217,14 +2217,14 @@ class TaskService extends Disposable implements ITaskService {
 				[{
 					label: nls.localize('TaskService.terminateAllRunningTasks', 'All running tasks'),
 					id: 'terminateAll',
-					task: null
+					task: undefined
 				}]
 			).then(entry => {
+				if (entry && entry.id === 'terminateAll') {
+					this.terminateAll();
+				}
 				let task: Task | undefined | null = entry ? entry.task : undefined;
 				if (task === undefined || task === null) {
-					if (entry && entry.id === 'terminateAll') {
-						this.terminateAll();
-					}
 					return;
 				}
 				this.terminate(task);


### PR DESCRIPTION
Fixes #27041. Added quick pick entry to terminate all running tasks along with argument 'terminateAll' which can be used with custom key binding to terminate all tasks via keyboard shortcut.
Possible issues/hacks associated with this fix:
- using difference between `undefined` and `null` to distinguish between "No task is currently running" and terminate "All running tasks" quick pick entries (https://github.com/alpalla/vscode/blob/master/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts#L2219).
- using `showQuickPick()` parameter `selectedEntry` to actually add the terminate "All running tasks" entry to the quick pick (https://github.com/alpalla/vscode/blob/master/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts#L1976).
