### PR TITLE
Clarified that CompletionItem.sortText is coverted to lower case

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -3329,7 +3329,7 @@ declare module 'vscode' {
 		/**
 		 * A string that should be used when comparing this item
 		 * with other items. When `falsy` the [label](#CompletionItem.label)
-		 * is used.
+		 * is used. The string will be converted to lower case when comparing.
 		 */
 		sortText?: string;
 


### PR DESCRIPTION
Clarified that `CompletionItem.sortText` is coverted to lower case.

- https://github.com/Microsoft/vscode/blob/master/src/vs/editor/contrib/suggest/suggest.ts#L53