### PR TITLE
code.sh: avoid macOS Mojave window duplication (sometimes).

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,9 +3,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
-CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
-ELECTRON="$CONTENTS/MacOS/Electron"
-CLI="$CONTENTS/Resources/app/out/cli.js"
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+if [[ "$@" == *"-"* ]]
+then
+  function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
+  CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
+  ELECTRON="$CONTENTS/MacOS/Electron"
+  CLI="$CONTENTS/Resources/app/out/cli.js"
+  ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+else
+  open -b com.microsoft.VSCode "$@"
+fi
 exit $?


### PR DESCRIPTION
This avoids the duplicate windows on the simple `code .` case while still allowing e.g. `code --list-extensions` to behave as expected.

Inspired by the approach taken by Atom: https://github.com/atom/atom/blob/master/atom.sh#L146

Looking at Atom's version it's possible VS Code could be modified to always accept arguments as expected when using `open`.

Fixes #60579