### PR TITLE
Fixes #63813

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -568,7 +568,10 @@ export interface ITerminalSettings {
 	external: {
 		windowsExec: string,
 		osxExec: string,
-		linuxExec: string
+		linuxExec: string,
+		linux: {
+			pressAnyKeyToContinue: boolean
+		}
 	};
 	integrated: {
 		shell: {

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -186,6 +186,8 @@ class LinuxTerminalService extends TerminalLauncher {
 	runInTerminal0(title: string, dir: string, args: string[], envVars: env.IProcessEnvironment, configuration: ITerminalSettings): Promise<number | undefined> {
 
 		const terminalConfig = configuration.external;
+		const pressAnyKeyToContinue = terminalConfig.linux.pressAnyKeyToContinue;
+		// const pressAnyKeyToContinue = (envVars['VSCODE_TERMLAUNCHER_WAIT'] !== undefined);
 		const execThenable: Promise<string> = terminalConfig.linuxExec ? Promise.resolve(terminalConfig.linuxExec) : getDefaultTerminalLinuxReady();
 
 		return new Promise<number | undefined>((c, e) => {
@@ -202,7 +204,7 @@ class LinuxTerminalService extends TerminalLauncher {
 				termArgs.push('bash');
 				termArgs.push('-c');
 
-				const bashCommand = `${quote(args)}; echo; read -p "${LinuxTerminalService.WAIT_MESSAGE}" -n1;`;
+				const bashCommand = `${quote(args)}` + (pressAnyKeyToContinue ? `; echo; read -p "${LinuxTerminalService.WAIT_MESSAGE}" -n1;` : ``);
 				termArgs.push(`''${bashCommand}''`);	// wrapping argument in two sets of ' because node is so "friendly" that it removes one set...
 
 				// merge environment variables into a copy of the process.env

--- a/src/vs/workbench/contrib/externalTerminal/electron-browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/electron-browser/externalTerminal.contribution.ts
@@ -74,6 +74,11 @@ getDefaultTerminalLinuxReady().then(defaultTerminalLinux => {
 				description: nls.localize('terminal.external.linuxExec', "Customizes which terminal to run on Linux."),
 				default: defaultTerminalLinux,
 				scope: ConfigurationScope.APPLICATION
+			},
+			'terminal.external.linux.pressAnyKeyToContinue': {
+				description: nls.localize('terminal.external.linux.pressAnyKeyToContinue', "Controls whether to ask to press any key to continue."),
+				type: 'boolean',
+				default: false
 			}
 		}
 	});


### PR DESCRIPTION
This is pull request slash invitation to discussion.

#63813 seems to be stalled and i seem to be stuck on cpptools 0.19 where this bug isn't reproducible. I can't use cpptools past 0.19 because it spawns unwanted terminals which is major distraction/productivity killer. Also i'm not really a TS programmer, i'm only doing this because i have to, so please be considerate when reviewing.

PR adds `terminal.external.linux.pressAnyKeyToContinue: true` option (opt-in) to enable "Press any key to continue..." message at the end of launch/debugging session on Linux (specifically related to vscode-cpptools).

Note this line:

```ts
// const pressAnyKeyToContinue = (envVars['VSCODE_TERMLAUNCHER_WAIT'] !== undefined);
```

This is alternative variant of the same without the need to introduce any options, terminal launcher behavior can be adjusted by setting "environment variable" (actually key in env vars map) `VSCODE_TERMLAUNCHER_WAIT` in `launch.json` like this:

```json
"environment": [{
                    "name": "VSCODE_TERMLAUNCHER_WAIT",
                    "value": "NONONO",
                }],
```

This is also opt-in.

Does it look good or what is need to be fixed?

CC: @weinand @pieandcakes 