### PR TITLE
Add shadow root support for isInDOM

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -32,7 +32,7 @@ export function isInDOM(node: Node | null): boolean {
 		if (node === document.body) {
 			return true;
 		}
-		node = node.parentNode;
+		node = node.parentNode || node.host;
 	}
 	return false;
 }


### PR DESCRIPTION
By getting the "host" property when "parentNode" is undefined, the function can properly climb the DOM tree and allow monaco-editor to be used within a shadow root.