### PR TITLE
Check for updates only once at launch

### DIFF
--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -85,12 +85,17 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		return updateMode === 'none' ? undefined : product.quality;
 	}
 
-	private scheduleCheckForUpdates(delay = 60 * 60 * 1000): Promise<void> {
+	private scheduleCheckForUpdates(updateMode: string, delay = 60 * 60 * 1000): Promise<void> {
 		return timeout(delay)
 			.then(() => this.checkForUpdates(null))
 			.then(() => {
-				// Check again after 1 hour
-				return this.scheduleCheckForUpdates(60 * 60 * 1000);
+				if (updateMode === 'start') {
+					this.logService.info('update#ctor - startup checks only; automatic updates are disabled by user preference');
+					return;
+				} else {
+					// Check again after 1 hour
+					return this.scheduleCheckForUpdates(60 * 60 * 1000);
+				}
 			});
 	}
 

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -78,14 +78,14 @@ export abstract class AbstractUpdateService implements IUpdateService {
 		}
 
 		// Start checking for updates after 30 seconds
-		this.scheduleCheckForUpdates(30 * 1000).then(undefined, err => this.logService.error(err));
+		this.scheduleCheckForUpdates(30 * 1000, updateMode).then(undefined, err => this.logService.error(err));
 	}
 
 	private getProductQuality(updateMode: string): string | undefined {
 		return updateMode === 'none' ? undefined : product.quality;
 	}
 
-	private scheduleCheckForUpdates(updateMode: string, delay = 60 * 60 * 1000): Promise<void> {
+	private scheduleCheckForUpdates(delay = 60 * 60 * 1000, updateMode: string): Promise<void> {
 		return timeout(delay)
 			.then(() => this.checkForUpdates(null))
 			.then(() => {
@@ -94,7 +94,7 @@ export abstract class AbstractUpdateService implements IUpdateService {
 					return;
 				} else {
 					// Check again after 1 hour
-					return this.scheduleCheckForUpdates(60 * 60 * 1000);
+					return this.scheduleCheckForUpdates(60 * 60 * 1000, updateMode);
 				}
 			});
 	}

--- a/src/vs/platform/update/electron-main/abstractUpdateService.ts
+++ b/src/vs/platform/update/electron-main/abstractUpdateService.ts
@@ -77,25 +77,25 @@ export abstract class AbstractUpdateService implements IUpdateService {
 			return;
 		}
 
-		// Start checking for updates after 30 seconds
-		this.scheduleCheckForUpdates(30 * 1000, updateMode).then(undefined, err => this.logService.error(err));
+		if (updateMode === 'start') {
+			this.logService.info('update#ctor - startup checks only; automatic updates are disabled by user preference');
+			this.checkForUpdates(null);
+		} else {
+			// Create schedule after checking for updates in 30 seconds
+			this.scheduleCheckForUpdates(30 * 1000).then(undefined, err => this.logService.error(err));
+		}
 	}
 
 	private getProductQuality(updateMode: string): string | undefined {
 		return updateMode === 'none' ? undefined : product.quality;
 	}
 
-	private scheduleCheckForUpdates(delay = 60 * 60 * 1000, updateMode: string): Promise<void> {
+	private scheduleCheckForUpdates(delay = 60 * 60 * 1000): Promise<void> {
 		return timeout(delay)
 			.then(() => this.checkForUpdates(null))
 			.then(() => {
-				if (updateMode === 'start') {
-					this.logService.info('update#ctor - startup checks only; automatic updates are disabled by user preference');
-					return;
-				} else {
-					// Check again after 1 hour
-					return this.scheduleCheckForUpdates(60 * 60 * 1000, updateMode);
-				}
+				// Check again after 1 hour
+				return this.scheduleCheckForUpdates(60 * 60 * 1000);
 			});
 	}
 

--- a/src/vs/platform/update/node/update.config.contribution.ts
+++ b/src/vs/platform/update/node/update.config.contribution.ts
@@ -24,6 +24,7 @@ configurationRegistry.registerConfiguration({
 			enumDescriptions: [
 				localize('none', "Disable updates."),
 				localize('manual', "Disable automatic background update checks. Updates will be available if you manually check for updates."),
+				localize('start', "Code will check for updates on launch. Disable automatic background update checks. "),
 				localize('default', "Enable automatic update checks. Code will check for updates automatically and periodically.")
 			]
 		},

--- a/src/vs/platform/update/node/update.config.contribution.ts
+++ b/src/vs/platform/update/node/update.config.contribution.ts
@@ -16,7 +16,7 @@ configurationRegistry.registerConfiguration({
 	properties: {
 		'update.mode': {
 			type: 'string',
-			enum: ['none', 'manual', 'default'],
+			enum: ['none', 'manual', 'start', 'default'],
 			default: 'default',
 			scope: ConfigurationScope.APPLICATION,
 			description: localize('updateMode', "Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."),


### PR DESCRIPTION
This PR creates a new dropdown to check the application once for updates on launch and doesn't check again any further than that. 

Sometimes I work on VPN networks where external endpoints are inaccessible. With the current option, `default`, it will sometimes hang on VPN connections.

We only have the options of `default`, `manual`, and `none`.  I don't want to completely turn off updates and I might forget to check every so often for updates. 

Several applications have this "check for updates on launch" feature so I thought it would be handy for VSCode.
