### PR TITLE
Fixed intellisense details not able to scroll vertically

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -965,8 +965,8 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 		this.expandSideOrBelow();
 
 		show(this.details.element);
-		this.details.render(this.list.getFocusedElements()[0]);
 		this.details.element.style.maxHeight = this.maxWidgetHeight + 'px';
+		this.details.render(this.list.getFocusedElements()[0]);
 
 		// Reset margin-top that was set as Fix for #26416
 		this.listElement.style.marginTop = '0px';


### PR DESCRIPTION
Fixed a bug where the intellisense details were not able to be scrolled vertically the first time they were shown. Fixes #66185. 