### PR TITLE
Makefile test case about the bug fix with "@,-,+" colorizing in the recipe

### DIFF
--- a/extensions/make/cgmanifest.json
+++ b/extensions/make/cgmanifest.json
@@ -6,7 +6,7 @@
 				"git": {
 					"name": "fadeevab/make.tmbundle",
 					"repositoryUrl": "https://github.com/fadeevab/make.tmbundle",
-					"commitHash": "21e9108e9dce13b798667806bb105d852ac0a58c"
+					"commitHash": "bd71f44ea55d61be711bd7676e600a7333cc79ea"
 				}
 			},
 			"licenseDetail": [

--- a/extensions/make/syntaxes/make.tmLanguage.json
+++ b/extensions/make/syntaxes/make.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/fadeevab/make.tmbundle/commit/21e9108e9dce13b798667806bb105d852ac0a58c",
+	"version": "https://github.com/fadeevab/make.tmbundle/commit/bd71f44ea55d61be711bd7676e600a7333cc79ea",
 	"name": "Makefile",
 	"scopeName": "source.makefile",
 	"patterns": [
@@ -320,7 +320,7 @@
 			]
 		},
 		"recipe": {
-			"begin": "^\\t([+-@]*)",
+			"begin": "^\\t([+\\-@]*)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.control.$1.makefile"

--- a/extensions/make/test/colorize-fixtures/makefile
+++ b/extensions/make/test/colorize-fixtures/makefile
@@ -38,6 +38,7 @@ echo:
 	@-+-+echo Error will be ignored here; invalidcommand
 	# And we can see variables are highlited as supposed to be:
 	@echo '$(CC) $(shell echo "123") -o $@'
+	@-./point-and-slash-should-not-be-highlighted
 
 define defined
   $(info Checking existance of $(1) $(flavor $(1)))

--- a/extensions/make/test/colorize-results/makefile.json
+++ b/extensions/make/test/colorize-results/makefile.json
@@ -1155,6 +1155,39 @@
 		}
 	},
 	{
+		"c": "\t",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "@-",
+		"t": "source.makefile meta.scope.recipe.makefile keyword.control.@-.makefile",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": "./point-and-slash-should-not-be-highlighted",
+		"t": "source.makefile meta.scope.recipe.makefile",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
 		"c": "define",
 		"t": "source.makefile meta.scope.conditional.makefile keyword.control.define.makefile",
 		"r": {


### PR DESCRIPTION
I updated make.tmbundle, there is a little bugfix. So need to update test cases in VSCode.

Bug: regex [@-+] means "from @ to +", so "." and "\" was also colorized.

Bug is fixed in make.tmbundle, test case is added to vscode.