### PR TITLE
Updated git branch tooltip to display full branch name instead of "checkout..."

### DIFF
--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -27,7 +27,7 @@ class CheckoutStatusBar {
 
 		return {
 			command: 'git.checkout',
-			tooltip: localize('checkout', 'Checkout...'),
+			tooltip: `${this.repository.headLabel}`,
 			title,
 			arguments: [this.repository.sourceControl]
 		};


### PR DESCRIPTION
___
Fixes #71304.
___
**Summary**:
It has been suggested to display the full branch name for the git branch name tooltip instead of "Checkout...". This is due to long names being concatenated, and the tooltip would be a useful way to show the user the full name.
___
**Before**:
![image](https://user-images.githubusercontent.com/4957200/56087929-10d53380-5e3b-11e9-992d-b5915ab8f2b8.png)

**After**:
![image](https://user-images.githubusercontent.com/4957200/56087911-b8059b00-5e3a-11e9-9921-958f4d6130cf.png)
___