### PR TITLE
Fixed #72425(Replace the position of Command Prompt and PowerShell of Default Shell selection UI on Windows)

### DIFF
--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalService.ts
@@ -132,8 +132,8 @@ export class TerminalService extends BrowserTerminalService implements ITerminal
 		}
 
 		const expectedLocations = {
+			'PowerShell': [`${system32Path}\\WindowsPowerShell\\v1.0\\powershell.exe`],
 			'Command Prompt': [`${system32Path}\\cmd.exe`],
-			PowerShell: [`${system32Path}\\WindowsPowerShell\\v1.0\\powershell.exe`],
 			'WSL Bash': [`${system32Path}\\${useWSLexe ? 'wsl.exe' : 'bash.exe'}`],
 			'Git Bash': [
 				`${process.env['ProgramW6432']}\\Git\\bin\\bash.exe`,


### PR DESCRIPTION
## Issue number
#72425 

## Description
This PR replaces the position of Command Prompt and PowerShell of Default Shell selection UI on Windows.

### Screenshot
![changeDefaultShell](https://user-images.githubusercontent.com/11808736/56231536-ada50480-60b9-11e9-97d1-11701acc7069.jpg)
