### PR TITLE
Provide API to get access to the workspace configuration file (#37421)

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
@@ -36,10 +36,12 @@ suite('workspace-namespace', () => {
 	});
 
 	test('rootPath', () => {
-		if (vscode.workspace.rootPath) {
-			assert.ok(pathEquals(vscode.workspace.rootPath, join(__dirname, '../../testWorkspace')));
-		}
+		assert.ok(pathEquals(vscode.workspace.rootPath!, join(__dirname, '../../testWorkspace')));
 		assert.throws(() => (vscode.workspace as any).rootPath = 'farboo');
+	});
+
+	test('workspaceFile', () => {
+		assert.ok(!vscode.workspace.workspaceFile);
 	});
 
 	test('workspaceFolders', () => {

--- a/extensions/vscode-api-tests/src/workspace-tests/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/workspace-tests/workspace.test.ts
@@ -13,18 +13,18 @@ suite('workspace-namespace', () => {
 	teardown(closeAllEditors);
 
 	test('rootPath', () => {
-		if (vscode.workspace.rootPath) {
-			assert.ok(pathEquals(vscode.workspace.rootPath, join(__dirname, '../../testWorkspace')));
-		}
+		assert.ok(pathEquals(vscode.workspace.rootPath!, join(__dirname, '../../testWorkspace')));
+	});
+
+	test('workspaceFile', () => {
+		assert.ok(pathEquals(vscode.workspace.workspaceFile!.fsPath, join(__dirname, '../../testworkspace.code-workspace')));
 	});
 
 	test('workspaceFolders', () => {
-		if (vscode.workspace.workspaceFolders) {
-			assert.equal(vscode.workspace.workspaceFolders.length, 2);
-			assert.ok(pathEquals(vscode.workspace.workspaceFolders[0].uri.fsPath, join(__dirname, '../../testWorkspace')));
-			assert.ok(pathEquals(vscode.workspace.workspaceFolders[1].uri.fsPath, join(__dirname, '../../testWorkspace2')));
-			assert.ok(pathEquals(vscode.workspace.workspaceFolders[1].name, 'Test Workspace 2'));
-		}
+		assert.equal(vscode.workspace.workspaceFolders!.length, 2);
+		assert.ok(pathEquals(vscode.workspace.workspaceFolders![0].uri.fsPath, join(__dirname, '../../testWorkspace')));
+		assert.ok(pathEquals(vscode.workspace.workspaceFolders![1].uri.fsPath, join(__dirname, '../../testWorkspace2')));
+		assert.ok(pathEquals(vscode.workspace.workspaceFolders![1].name, 'Test Workspace 2'));
 	});
 
 	test('getWorkspaceFolder', () => {

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1371,4 +1371,34 @@ declare module 'vscode' {
 		group?: string;
 	}
 	//#endregion
+
+	//#region Workspace URI Ben
+
+	export namespace workspace {
+
+		/**
+		 * The location of the workspace file. Depending on the workspace that
+		 * is opened, the value will be:
+		 *  * `undefined` when no workspace or  a single folder is opened
+		 *  * the path of the workspace file as `Uri` otherwise. if the workspace
+		 * is untitled, the returned URI will use the `untitled:` scheme
+		 *
+		 * The location can e.g. be used with the `vscode.openFolder` command to
+		 * open the workspace again after it has been closed.
+		 *
+		 * **Example:**
+		 * ```typescript
+		 * vscode.commands.executeCommand('vscode.openFolder', uriOfWorkspace);
+		 * ```
+		 *
+		 * **Note:** it is not advised to use `workspace.workspaceFile` to write
+		 * configuration data into the file. You can use `workspace.getConfiguration().update()`
+		 * for that purpose which will work both when a single folder is opened as
+		 * well as an untitled or saved workspace.
+		 */
+		export const workspaceFile: Uri | undefined;
+	}
+
+	//#endregion
+
 }

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1377,8 +1377,17 @@ declare module 'vscode' {
 	export namespace workspace {
 
 		/**
-		 * The location of the workspace file. Depending on the workspace that
-		 * is opened, the value will be:
+		 * The location of the workspace file, for example:
+		 *
+		 * `file:///Users/name/Development/myProject.code-workspace`
+		 *
+		 * or
+		 *
+		 * `untitled:1555503116870`
+		 *
+		 * for a workspace that is untitled and not yet saved.
+		 *
+		 * Depending on the workspace that is opened, the value will be:
 		 *  * `undefined` when no workspace or  a single folder is opened
 		 *  * the path of the workspace file as `Uri` otherwise. if the workspace
 		 * is untitled, the returned URI will use the `untitled:` scheme

--- a/src/vs/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/browser/mainThreadWorkspace.ts
@@ -22,6 +22,8 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IWorkspaceEditingService } from 'vs/workbench/services/workspace/common/workspaceEditing';
 import { ExtHostContext, ExtHostWorkspaceShape, IExtHostContext, MainContext, MainThreadWorkspaceShape, IWorkspaceData, ITextSearchComplete } from '../common/extHost.protocol';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { isEqualOrParent } from 'vs/base/common/resources';
 
 @extHostNamedCustomer(MainContext.MainThreadWorkspace)
 export class MainThreadWorkspace implements MainThreadWorkspaceShape {
@@ -40,7 +42,8 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 		@IStatusbarService private readonly _statusbarService: IStatusbarService,
 		@IWindowService private readonly _windowService: IWindowService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ILabelService private readonly _labelService: ILabelService
+		@ILabelService private readonly _labelService: ILabelService,
+		@IEnvironmentService private readonly _environmentService: IEnvironmentService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostWorkspace);
 		this._contextService.getCompleteWorkspace().then(workspace => this._proxy.$initializeWorkspace(this.getWorkspaceData(workspace)));
@@ -110,6 +113,7 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 		}
 		return {
 			configuration: workspace.configuration || undefined,
+			isUntitled: workspace.configuration ? isEqualOrParent(workspace.configuration, this._environmentService.untitledWorkspacesHome) : false,
 			folders: workspace.folders,
 			id: workspace.id,
 			name: this._labelService.getWorkspaceLabel(workspace)

--- a/src/vs/workbench/api/common/apiCommands.ts
+++ b/src/vs/workbench/api/common/apiCommands.ts
@@ -15,6 +15,7 @@ import { IWindowsService, IOpenSettings, IURIToOpen } from 'vs/platform/windows/
 import { IDownloadService } from 'vs/platform/download/common/download';
 import { IWorkspacesService, hasWorkspaceFileExtension } from 'vs/platform/workspaces/common/workspaces';
 import { IRecent } from 'vs/platform/history/common/history';
+import { Schemas } from 'vs/base/common/network';
 
 // -----------------------------------------------------------------
 // The following commands are registered on both sides separately.
@@ -51,7 +52,7 @@ export class OpenFolderAPICommand {
 		}
 		const options: IOpenSettings = { forceNewWindow: arg.forceNewWindow, noRecentEntry: arg.noRecentEntry };
 		uri = URI.revive(uri);
-		const uriToOpen: IURIToOpen = hasWorkspaceFileExtension(uri.path) ? { workspaceUri: uri } : { folderUri: uri };
+		const uriToOpen: IURIToOpen = (hasWorkspaceFileExtension(uri.path) || uri.scheme === Schemas.untitled) ? { workspaceUri: uri } : { folderUri: uri };
 		return executor.executeCommand('_files.windowOpen', [uriToOpen], options);
 	}
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -65,6 +65,7 @@ export interface IStaticWorkspaceData {
 	id: string;
 	name: string;
 	configuration?: UriComponents | null;
+	isUntitled?: boolean | null;
 }
 
 export interface IWorkspaceData extends IStaticWorkspaceData {

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -10,7 +10,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { TernarySearchTree } from 'vs/base/common/map';
 import { Counter } from 'vs/base/common/numbers';
 import { isLinux } from 'vs/base/common/platform';
-import { basenameOrAuthority, dirname, isEqual, relativePath } from 'vs/base/common/resources';
+import { basenameOrAuthority, dirname, isEqual, relativePath, basename } from 'vs/base/common/resources';
 import { compare } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
@@ -204,11 +204,11 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 
 	get workspaceFile(): vscode.Uri | undefined {
 		if (this._actualWorkspace) {
-			if (this._actualWorkspace.isUntitled) {
-				return URI.from({ scheme: Schemas.untitled, path: this._actualWorkspace.id }); // Untitled Worspace: return untitled URI
-			}
-
 			if (this._actualWorkspace.configuration) {
+				if (this._actualWorkspace.isUntitled) {
+					return URI.from({ scheme: Schemas.untitled, path: basename(dirname(this._actualWorkspace.configuration)) }); // Untitled Worspace: return untitled URI
+				}
+
 				return this._actualWorkspace.configuration; // Workspace: return the configuration location
 			}
 		}

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -24,6 +24,7 @@ import * as vscode from 'vscode';
 import { ExtHostWorkspaceShape, IWorkspaceData, MainThreadMessageServiceShape, MainThreadWorkspaceShape, IMainContext, MainContext, IStaticWorkspaceData } from './extHost.protocol';
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { Barrier } from 'vs/base/common/async';
+import { Schemas } from 'vs/base/common/network';
 
 export interface IExtHostWorkspaceProvider {
 	getWorkspaceFolder2(uri: vscode.Uri, resolveParent?: boolean): Promise<vscode.WorkspaceFolder | undefined>;
@@ -67,7 +68,7 @@ class ExtHostWorkspaceImpl extends Workspace {
 			return { workspace: null, added: [], removed: [] };
 		}
 
-		const { id, name, folders } = data;
+		const { id, name, folders, configuration, isUntitled } = data;
 		const newWorkspaceFolders: vscode.WorkspaceFolder[] = [];
 
 		// If we have an existing workspace, we try to find the folders that match our
@@ -95,7 +96,7 @@ class ExtHostWorkspaceImpl extends Workspace {
 		// make sure to restore sort order based on index
 		newWorkspaceFolders.sort((f1, f2) => f1.index < f2.index ? -1 : 1);
 
-		const workspace = new ExtHostWorkspaceImpl(id, name, newWorkspaceFolders);
+		const workspace = new ExtHostWorkspaceImpl(id, name, newWorkspaceFolders, configuration ? URI.revive(configuration) : null, !!isUntitled);
 		const { added, removed } = delta(oldWorkspace ? oldWorkspace.workspaceFolders : [], workspace.workspaceFolders, compareWorkspaceFolderByUri);
 
 		return { workspace, added, removed };
@@ -115,8 +116,8 @@ class ExtHostWorkspaceImpl extends Workspace {
 	private readonly _workspaceFolders: vscode.WorkspaceFolder[] = [];
 	private readonly _structure = TernarySearchTree.forPaths<vscode.WorkspaceFolder>();
 
-	constructor(id: string, private _name: string, folders: vscode.WorkspaceFolder[]) {
-		super(id, folders.map(f => new WorkspaceFolder(f)));
+	constructor(id: string, private _name: string, folders: vscode.WorkspaceFolder[], configuration: URI | null, private _isUntitled: boolean) {
+		super(id, folders.map(f => new WorkspaceFolder(f)), configuration);
 
 		// setup the workspace folder data structure
 		folders.forEach(folder => {
@@ -127,6 +128,10 @@ class ExtHostWorkspaceImpl extends Workspace {
 
 	get name(): string {
 		return this._name;
+	}
+
+	get isUntitled(): boolean {
+		return this._isUntitled;
 	}
 
 	get workspaceFolders(): vscode.WorkspaceFolder[] {
@@ -175,7 +180,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 
 		this._proxy = mainContext.getProxy(MainContext.MainThreadWorkspace);
 		this._messageService = mainContext.getProxy(MainContext.MainThreadMessageService);
-		this._confirmedWorkspace = data ? new ExtHostWorkspaceImpl(data.id, data.name, []) : undefined;
+		this._confirmedWorkspace = data ? new ExtHostWorkspaceImpl(data.id, data.name, [], data.configuration ? URI.revive(data.configuration) : null, !!data.isUntitled) : undefined;
 	}
 
 	$initializeWorkspace(data: IWorkspaceData): void {
@@ -195,6 +200,20 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 
 	get name(): string | undefined {
 		return this._actualWorkspace ? this._actualWorkspace.name : undefined;
+	}
+
+	get workspaceFile(): vscode.Uri | undefined {
+		if (this._actualWorkspace) {
+			if (this._actualWorkspace.isUntitled) {
+				return URI.from({ scheme: Schemas.untitled, path: this._actualWorkspace.id }); // Untitled Worspace: return untitled URI
+			}
+
+			if (this._actualWorkspace.configuration) {
+				return this._actualWorkspace.configuration; // Workspace: return the configuration location
+			}
+		}
+
+		return undefined;
 	}
 
 	private get _actualWorkspace(): ExtHostWorkspaceImpl | undefined {
@@ -365,7 +384,8 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 				id: this._actualWorkspace.id,
 				name: this._actualWorkspace.name,
 				configuration: this._actualWorkspace.configuration,
-				folders
+				folders,
+				isUntitled: this._actualWorkspace.isUntitled
 			} as IWorkspaceData, this._actualWorkspace).workspace || undefined;
 		}
 	}

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -532,6 +532,12 @@ export function createApiFactory(
 			set name(value) {
 				throw errors.readonly();
 			},
+			get workspaceFile() {
+				return extHostWorkspace.workspaceFile;
+			},
+			set workspaceFile(value) {
+				throw errors.readonly();
+			},
 			updateWorkspaceFolders: (index, deleteCount, ...workspaceFoldersToAdd) => {
 				return extHostWorkspace.updateWorkspaceFolders(extension, index, deleteCount || 0, ...workspaceFoldersToAdd);
 			},

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -6,7 +6,7 @@
 import * as nls from 'vs/nls';
 import { URI } from 'vs/base/common/uri';
 import { toResource, IEditorCommandsContext, SideBySideEditor } from 'vs/workbench/common/editor';
-import { IWindowsService, IWindowService, IURIToOpen, IOpenSettings, INewWindowOptions } from 'vs/platform/windows/common/windows';
+import { IWindowsService, IWindowService, IURIToOpen, IOpenSettings, INewWindowOptions, isWorkspaceToOpen } from 'vs/platform/windows/common/windows';
 import { ServicesAccessor, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -38,9 +38,11 @@ import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { onUnexpectedError } from 'vs/base/common/errors';
-import { basename, toLocalResource } from 'vs/base/common/resources';
+import { basename, toLocalResource, joinPath } from 'vs/base/common/resources';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { UNTITLED_WORKSPACE_NAME } from 'vs/platform/workspaces/common/workspaces';
 
 // Commands
 
@@ -81,6 +83,19 @@ export const REMOVE_ROOT_FOLDER_LABEL = nls.localize('removeFolderFromWorkspace'
 export const openWindowCommand = (accessor: ServicesAccessor, urisToOpen: IURIToOpen[], options?: IOpenSettings) => {
 	if (Array.isArray(urisToOpen)) {
 		const windowService = accessor.get(IWindowService);
+		const environmentService = accessor.get(IEnvironmentService);
+
+		// rewrite untitled: workspace URIs to the absolute path on disk
+		urisToOpen = urisToOpen.map(uriToOpen => {
+			if (isWorkspaceToOpen(uriToOpen) && uriToOpen.workspaceUri.scheme === Schemas.untitled) {
+				return {
+					workspaceUri: joinPath(environmentService.untitledWorkspacesHome, uriToOpen.workspaceUri.path, UNTITLED_WORKSPACE_NAME)
+				};
+			}
+
+			return uriToOpen;
+		});
+
 		windowService.openWindow(urisToOpen, options);
 	}
 };

--- a/src/vs/workbench/services/extensions/electron-browser/extensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionHost.ts
@@ -38,6 +38,7 @@ import { parseExtensionDevOptions } from '../common/extensionDevOptions';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { IExtensionHostDebugService } from 'vs/workbench/services/extensions/common/extensionHostDebug';
 import { IExtensionHostStarter } from 'vs/workbench/services/extensions/common/extensions';
+import { isEqualOrParent } from 'vs/base/common/resources';
 
 export class ExtensionHostProcessWorker implements IExtensionHostStarter {
 
@@ -400,7 +401,8 @@ export class ExtensionHostProcessWorker implements IExtensionHostStarter {
 					workspace: this._contextService.getWorkbenchState() === WorkbenchState.EMPTY ? undefined : {
 						configuration: withNullAsUndefined(workspace.configuration),
 						id: workspace.id,
-						name: this._labelService.getWorkspaceLabel(workspace)
+						name: this._labelService.getWorkspaceLabel(workspace),
+						isUntitled: workspace.configuration ? isEqualOrParent(workspace.configuration, this._environmentService.untitledWorkspacesHome) : false
 					},
 					resolvedExtensions: [],
 					hostExtensions: [],


### PR DESCRIPTION
@jrieken I like the idea of `untitled:` and added that. The URI will be `untitled:<id>` and then be massaged to `untitled-workspace-home/<id>/workspace.json` in `vscode.openFolder`. Otherwise the `URI` is not really useful for untitled workspaces at least. 