### PR TITLE
Add badge to snapcraft.io/code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Feature Requests](https://img.shields.io/github/issues/Microsoft/vscode/feature-request.svg)](https://github.com/Microsoft/vscode/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request+sort%3Areactions-%2B1-desc)
 [![Bugs](https://img.shields.io/github/issues/Microsoft/vscode/bug.svg)](https://github.com/Microsoft/vscode/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3Abug)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-yellow.svg)](https://gitter.im/Microsoft/vscode)
+[![Visual Studio Code](https://snapcraft.io/code/badge.svg)](https://snapcraft.io/code)
 
 [VS Code](https://code.visualstudio.com) is a type of tool that combines the simplicity of
 a code editor with what developers need for their core edit-build-debug cycle. It provides comprehensive editing and debugging support, an extensibility model, and lightweight integration with existing tools.


### PR DESCRIPTION
This PR simply adds a badge for the [new Code snap](https://code.visualstudio.com/updates/v1_33#_engineering), which shows the current Code version and links off to https://snapcraft.io/code.