### PR TITLE
Fixed explorer modified sort order not working in some cases

### DIFF
--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -155,7 +155,7 @@ export class ExplorerService implements IExplorerService {
 		}
 
 		// Stat needs to be resolved first and then revealed
-		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: false };
+		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: this.sortOrder === 'modified' ? true : false };
 		const workspaceFolder = this.contextService.getWorkspaceFolder(resource);
 		const rootUri = workspaceFolder ? workspaceFolder.uri : this.roots[0].resource;
 		const root = this.roots.filter(r => r.resource.toString() === rootUri.toString()).pop()!;

--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -155,7 +155,7 @@ export class ExplorerService implements IExplorerService {
 		}
 
 		// Stat needs to be resolved first and then revealed
-		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: this.sortOrder === 'modified' ? true : false };
+		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: this.sortOrder === 'modified' };
 		const workspaceFolder = this.contextService.getWorkspaceFolder(resource);
 		const rootUri = workspaceFolder ? workspaceFolder.uri : this.roots[0].resource;
 		const root = this.roots.filter(r => r.resource.toString() === rootUri.toString()).pop()!;


### PR DESCRIPTION
Fixed explorer modified sort order not working in some cases due to metadata not being loaded. Fixes #72474.