### PR TITLE
Does not restore webview focus when switching back to VS Code window

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
@@ -136,15 +136,6 @@ export class WebviewEditor extends BaseEditor {
 
 	public focus(): void {
 		super.focus();
-		if (!this._onFocusWindowHandler) {
-
-			// Make sure we restore focus when switching back to a VS Code window
-			this._onFocusWindowHandler = this._windowService.onDidChangeFocus(focused => {
-				if (focused && this._editorService.activeControl === this) {
-					this.focus();
-				}
-			});
-		}
 		this.withWebview(webview => webview.focus());
 	}
 

--- a/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
@@ -12,14 +12,12 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { IWindowService } from 'vs/platform/windows/common/windows';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { EditorOptions } from 'vs/workbench/common/editor';
 import { WebviewEditorInput } from 'vs/workbench/contrib/webview/browser/webviewEditorInput';
 import { IWebviewService, Webview, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE } from 'vs/workbench/contrib/webview/common/webview';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 
 export class WebviewEditor extends BaseEditor {
@@ -47,8 +45,6 @@ export class WebviewEditor extends BaseEditor {
 		@IContextKeyService private _contextKeyService: IContextKeyService,
 		@IWebviewService private readonly _webviewService: IWebviewService,
 		@IWorkspaceContextService private readonly _contextService: IWorkspaceContextService,
-		@IEditorService private readonly _editorService: IEditorService,
-		@IWindowService private readonly _windowService: IWindowService,
 		@IStorageService storageService: IStorageService
 	) {
 		super(WebviewEditor.ID, telemetryService, themeService, storageService);


### PR DESCRIPTION
When vscode loses focus, clicking on the title menu or setting button focus will be robbed by the webview. Does not happen without a webview window.
(PS:If click on the blank area above the vscode window, it will not affect the webview focus.)
abnormal:
![vscode1](https://user-images.githubusercontent.com/15615524/56335546-8a6c7900-61cf-11e9-8776-54f5d3f447da.gif)
normal:
![vscode2](https://user-images.githubusercontent.com/15615524/56335659-fd75ef80-61cf-11e9-9d7e-5eb77d054260.gif)
