### PR TITLE
Fixed wrong tooltip on extension page uninstall button after installing extension.

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsActions.ts
@@ -387,6 +387,7 @@ export class UninstallAction extends ExtensionAction {
 			return;
 		}
 
+		this.tooltip = UninstallAction.UninstallLabel;
 		this.label = UninstallAction.UninstallLabel;
 		this.class = UninstallAction.UninstallClass;
 


### PR DESCRIPTION
Fixed wrong tooltip on extension page uninstall button after installing extension.
![image](https://user-images.githubusercontent.com/20482956/56400184-62593600-6220-11e9-9230-dfb2d40c2f06.png)

Fixes #72585


