### PR TITLE
allow `Git: fetch` command to show password prompt

### DIFF
--- a/extensions/git/src/askpass-main.ts
+++ b/extensions/git/src/askpass-main.ts
@@ -28,10 +28,6 @@ function main(argv: string[]): void {
 		return fatal('Missing pipe');
 	}
 
-	if (process.env['VSCODE_GIT_COMMAND'] === 'fetch') {
-		return fatal('Skip fetch commands');
-	}
-
 	const output = process.env['VSCODE_GIT_ASKPASS_PIPE'] as string;
 	const socketPath = process.env['VSCODE_GIT_ASKPASS_HANDLE'] as string;
 	const request = argv[2];


### PR DESCRIPTION
There was some 2 years old code which was preventing `Git: fetch` command from displaying a password prompt. I've removed this special treatment. Tested, now `Git: fetch` is showing password prompt as expected and the operation is also successful.

Fixes #72613 