### PR TITLE
Automatically adapt to windows: "Color Theme", "File Icon Theme", "User Snippets".

### DIFF
--- a/src/vs/workbench/browser/parts/quickinput/quickInput.css
+++ b/src/vs/workbench/browser/parts/quickinput/quickInput.css
@@ -122,7 +122,6 @@
 
 .quick-input-list .monaco-list {
 	overflow: hidden;
-	max-height: calc(20 * 22px);
 }
 
 .quick-input-list .quick-input-list-entry {

--- a/src/vs/workbench/browser/parts/quickinput/quickInput.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInput.ts
@@ -1306,9 +1306,11 @@ export class QuickInputService extends Component implements IQuickInputService {
 				const distanceFromBelow = 200;  // The distance from the bottom of the window.
 				if (rowsElement !== null && workbench.style.height !== null && rowsElement.style.height !== null) {
 					const workbenchHeight = parseInt(workbench.style.height);
-					const mlRowsHeight = parseInt(rowsElement.style.height);
-					let widgetHeight = workbenchHeight - distanceFromBelow > mlRowsHeight + 40 ? mlRowsHeight + 40 : workbenchHeight - distanceFromBelow;
-					widgetHeight = widgetHeight - 40 < 22 ? 62 : widgetHeight;
+					const rowsHeight = parseInt(rowsElement.style.height);
+					let widgetHeight = workbenchHeight - distanceFromBelow > rowsHeight + 40 ? rowsHeight + 40 : workbenchHeight - distanceFromBelow;
+					if (widgetHeight < 62) {
+						widgetHeight = 62;
+					}
 					this.widget.style.height = `${widgetHeight}px`;
 					this.ui.list.container.style.height = `${widgetHeight - 40}px`;
 				}

--- a/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
@@ -214,7 +214,7 @@ class ListElementDelegate implements IListVirtualDelegate<ListElement> {
 export class QuickInputList {
 
 	readonly id: string;
-	private container: HTMLElement;
+	public container: HTMLElement;
 	private list: WorkbenchList<ListElement>;
 	private inputElements: Array<IQuickPickItem | IQuickPickSeparator>;
 	private elements: ListElement[] = [];


### PR DESCRIPTION
Automatically adapt to windows: "Color Theme", "File Icon Theme", "User Snippets".
The main problem: There are too many "Color Theme" or "File Icon Theme" content, some of which will not be visible.
Before change:
![image](https://user-images.githubusercontent.com/15615524/56454636-7454e900-6386-11e9-9541-71f1749e6efb.png)
After the change:
![image](https://user-images.githubusercontent.com/15615524/56454639-8d5d9a00-6386-11e9-8028-6b7cf1b82669.png)
