### PR TITLE
Replace terse for loop with map and for each

### DIFF
--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -245,7 +245,7 @@ export class BracketMatchingController extends Disposable implements editorCommo
 
 		let newDecorations: IModelDeltaDecoration[] = [], newDecorationsLen = 0;
 		this._lastBracketsData.map(bracketData => bracketData.brackets).forEach(brackets => {
-			if (brackets){
+			if (brackets) {
 				newDecorations[newDecorationsLen] = {
 					range: brackets[0],
 					options: BracketMatchingController._DECORATION_OPTIONS

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -255,6 +255,7 @@ export class BracketMatchingController extends Disposable implements editorCommo
 					range: brackets[0],
 					options: BracketMatchingController._DECORATION_OPTIONS
 				}
+				newDecorations += 1;
 			}
 		});
 		this._decorations = this._editor.deltaDecorations(this._decorations, newDecorations);

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -244,17 +244,19 @@ export class BracketMatchingController extends Disposable implements editorCommo
 		this._recomputeBrackets();
 
 		let newDecorations: IModelDeltaDecoration[] = [], newDecorationsLen = 0;
-		this._lastBracketsData.map(bracketData => bracketData.brackets).filter(brackets => brackets).forEach(brackets => {
-			newDecorations[newDecorationsLen] = {
-				range: brackets[0],
-				options: BracketMatchingController._DECORATION_OPTIONS
-			};
-			newDecorationsLen += 1;
-			newDecorations[newDecorationsLen] = {
-				range: brackets[0],
-				options: BracketMatchingController._DECORATION_OPTIONS
-			};
-			newDecorationsLen += 1;
+		this._lastBracketsData.map(bracketData => bracketData.brackets).forEach(brackets => {
+			if (brackets){
+				newDecorations[newDecorationsLen] = {
+					range: brackets[0],
+					options: BracketMatchingController._DECORATION_OPTIONS
+				};
+				newDecorationsLen += 1;
+				newDecorations[newDecorationsLen] = {
+					range: brackets[0],
+					options: BracketMatchingController._DECORATION_OPTIONS
+				};
+				newDecorationsLen += 1;
+			}
 		});
 		this._decorations = this._editor.deltaDecorations(this._decorations, newDecorations);
 	}

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -244,19 +244,17 @@ export class BracketMatchingController extends Disposable implements editorCommo
 		this._recomputeBrackets();
 
 		let newDecorations: IModelDeltaDecoration[] = [], newDecorationsLen = 0;
-		this._lastBracketData.map(bracketData => bracketData.brackets).forEach(brackets => {
-			if (brackets) {
-				newDecorations[newDecorationsLen] = {
-					range: brackets[0],
-					options: BracketMatchingController._DECORATION_OPTIONS
-				};
-				newDecorations += 1;
-				newDecorations[newDecorationsLen] = {
-					range: brackets[0],
-					options: BracketMatchingController._DECORATION_OPTIONS
-				};
-				newDecorations += 1;
-			}
+		this._lastBracketData.map(bracketData => bracketData.brackets).filter(brackets => brackets).forEach(brackets => {
+			newDecorations[newDecorationsLen] = {
+				range: brackets[0],
+				options: BracketMatchingController._DECORATION_OPTIONS
+			};
+			newDecorations += 1;
+			newDecorations[newDecorationsLen] = {
+				range: brackets[0],
+				options: BracketMatchingController._DECORATION_OPTIONS
+			};
+			newDecorations += 1;
 		});
 		this._decorations = this._editor.deltaDecorations(this._decorations, newDecorations);
 	}

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -244,7 +244,7 @@ export class BracketMatchingController extends Disposable implements editorCommo
 		this._recomputeBrackets();
 
 		let newDecorations: IModelDeltaDecoration[] = [], newDecorationsLen = 0;
-		this._lastBracketData.map(bracketData => bracketData.brackets).forEach(bracket => {
+		this._lastBracketData.map(bracketData => bracketData.brackets).forEach(brackets => {
 			if (brackets) {
 				newDecorations[newDecorationsLen] = {
 					range: brackets[0],

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -249,12 +249,12 @@ export class BracketMatchingController extends Disposable implements editorCommo
 				newDecorations[newDecorationsLen] = {
 					range: brackets[0],
 					options: BracketMatchingController._DECORATION_OPTIONS
-				}
+				};
 				newDecorations += 1;
 				newDecorations[newDecorationsLen] = {
 					range: brackets[0],
 					options: BracketMatchingController._DECORATION_OPTIONS
-				}
+				};
 				newDecorations += 1;
 			}
 		});

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -244,17 +244,17 @@ export class BracketMatchingController extends Disposable implements editorCommo
 		this._recomputeBrackets();
 
 		let newDecorations: IModelDeltaDecoration[] = [], newDecorationsLen = 0;
-		this._lastBracketData.map(bracketData => bracketData.brackets).filter(brackets => brackets).forEach(brackets => {
+		this._lastBracketsData.map(bracketData => bracketData.brackets).filter(brackets => brackets).forEach(brackets => {
 			newDecorations[newDecorationsLen] = {
 				range: brackets[0],
 				options: BracketMatchingController._DECORATION_OPTIONS
 			};
-			newDecorations += 1;
+			newDecorationsLen += 1;
 			newDecorations[newDecorationsLen] = {
 				range: brackets[0],
 				options: BracketMatchingController._DECORATION_OPTIONS
 			};
-			newDecorations += 1;
+			newDecorationsLen += 1;
 		});
 		this._decorations = this._editor.deltaDecorations(this._decorations, newDecorations);
 	}

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -252,7 +252,7 @@ export class BracketMatchingController extends Disposable implements editorCommo
 				};
 				newDecorationsLen += 1;
 				newDecorations[newDecorationsLen] = {
-					range: brackets[0],
+					range: brackets[1],
 					options: BracketMatchingController._DECORATION_OPTIONS
 				};
 				newDecorationsLen += 1;

--- a/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/bracketMatching.ts
@@ -244,14 +244,19 @@ export class BracketMatchingController extends Disposable implements editorCommo
 		this._recomputeBrackets();
 
 		let newDecorations: IModelDeltaDecoration[] = [], newDecorationsLen = 0;
-		for (let i = 0, len = this._lastBracketsData.length; i < len; i++) {
-			let brackets = this._lastBracketsData[i].brackets;
+		this._lastBracketData.map(bracketData => bracketData.brackets).forEach(bracket => {
 			if (brackets) {
-				newDecorations[newDecorationsLen++] = { range: brackets[0], options: BracketMatchingController._DECORATION_OPTIONS };
-				newDecorations[newDecorationsLen++] = { range: brackets[1], options: BracketMatchingController._DECORATION_OPTIONS };
+				newDecorations[newDecorationsLen] = {
+					range: brackets[0],
+					options: BracketMatchingController._DECORATION_OPTIONS
+				}
+				newDecorations += 1;
+				newDecorations[newDecorationsLen] = {
+					range: brackets[0],
+					options: BracketMatchingController._DECORATION_OPTIONS
+				}
 			}
-		}
-
+		});
 		this._decorations = this._editor.deltaDecorations(this._decorations, newDecorations);
 	}
 


### PR DESCRIPTION
I replaced the for loop, which was hard to understand at a glance, with a map and a forEach, which helps get the point across. In addition, I removed the terse ++ operator, replacing it with +=, and made both object declarations multiple lines. This code, while it sacrifices a few milliseconds of performance, allows an easier understanding of what the code does, and how it uses data.