### PR TITLE
Have linkComputer handle bold/italic links in markdown files

### DIFF
--- a/src/vs/editor/common/modes/linkComputer.ts
+++ b/src/vs/editor/common/modes/linkComputer.ts
@@ -157,6 +157,7 @@ export class LinkComputer {
 		} while (lastIncludedCharIndex > linkBeginIndex);
 
 		// Handle links enclosed in parens, square brackets and curlys.
+		// Handle links enclosed in asterisks (bold and italicized links)
 		if (linkBeginIndex > 0) {
 			const charCodeBeforeLink = line.charCodeAt(linkBeginIndex - 1);
 			const lastCharCodeInLink = line.charCodeAt(lastIncludedCharIndex);
@@ -169,6 +170,14 @@ export class LinkComputer {
 				// Do not end in ) if ( is before the link start
 				// Do not end in ] if [ is before the link start
 				// Do not end in } if { is before the link start
+				lastIncludedCharIndex--;
+			}
+
+			let i = 1;
+			while (line.charCodeAt(linkBeginIndex - i) === CharCode.Asterisk
+				&& line.charCodeAt(lastIncludedCharIndex - (i - 1)) === CharCode.Asterisk) {
+				// Do not end in * while there is a matching * before the link start
+				// Handles *italic*, **bold**, and ***bold and italic*** links
 				lastIncludedCharIndex--;
 			}
 		}

--- a/src/vs/editor/test/common/modes/linkComputer.test.ts
+++ b/src/vs/editor/test/common/modes/linkComputer.test.ts
@@ -187,6 +187,22 @@ suite('Editor Modes - Link Computer', () => {
 			'let url = `http://***/_api/web/lists/GetByTitle(\'Teambuildingaanvragen\')/items`;',
 			'           http://***/_api/web/lists/GetByTitle(\'Teambuildingaanvragen\')/items  '
 		);
+
+		// Issue #70254: Fix bold/italicized links
+		assertLink(
+			'*http://foo.bar*',
+			' http://foo.bar '
+		);
+
+		assertLink(
+			'**http://foo.bar**',
+			'  http://foo.bar  '
+		);
+
+		assertLink(
+			'***http://foo.bar***',
+			'   http://foo.bar   '
+		);
 	});
 
 	test('issue #7855', () => {


### PR DESCRIPTION
Addresses issue #70254 by having linkComputer.ts check link indices for numbers of * surrounding the link.

Correctly addresses any number of matching * pairs around a link such as:

\*http://github.com* (Italicized link)
\*\*http://github.com** (Bold link)
\*\*\*http://github.com*** (Bold and italicized link)

And will continue to exclude continued * pairs surrounding a link.