### PR TITLE
Fix Microsoft #71258 - Cannot undo empty commits

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1286,7 +1286,7 @@ export class CommandCenter {
 
 		const message = await getCommitMessage();
 
-		if (!message || /^\s+$/.test(message)) {
+		if (!message) {
 			return false;
 		}
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1286,7 +1286,7 @@ export class CommandCenter {
 
 		const message = await getCommitMessage();
 
-		if (!message) {
+		if (!message || /^\s+$/.test(message)) {
 			return false;
 		}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -584,7 +584,8 @@ export function parseGitmodules(raw: string): Submodule[] {
 }
 
 export function parseGitCommit(raw: string): Commit | null {
-	const match = /^([0-9a-f]{40})\n(.*)\n(.*)\n([^]*)$/m.exec(raw.trim());
+	const match = /^([0-9a-f]{40})\n(.*)\n(.*)$/m.exec(raw.trim());
+
 	if (!match) {
 		return null;
 	}


### PR DESCRIPTION
This is a fix for #71258 

I've noticed that in this bug there are essentially two parts to it. If VS Code tries to undo a commit where there was an empty commit message, or a commit message with only whitespace, the "Bad Commit" error occurs.

Furthermore, there is a way to make a commit with just whitespace through VS Code. If you press the tick by Source Control: Git, enter some whitespace, and then press enter, the commit goes through with the message being whitespace. If you try to undo this, the same error will occur.

- [x] Fix: Cannot undo git commits with only whitespace
- [x] ~~Fix: Can make commits with only whitespace~~
   - ~~I have put this as an error because when filling out a message for a commit in the side bar if there is only whitespace, it will refuse commits. Hence going by that, I am extrapolating that to mean that any commit messages drafted in the top bar should refuse whitespace too.~~

I've removed the second as a requirement because the issue does not explicitly call for a fix on that.

![UndoGitCommits](https://user-images.githubusercontent.com/31773220/56481562-b583f080-648d-11e9-917a-caf25c245d86.PNG)

By testing with different commits it seems the regex matching expression is at fault.

The string that goes into the regex match is as follows:
```
[hash of previous git commit]
emailaddress@domain.com
[hash of this git commit]
[name of this commit]
```
The last part, the name of this commit, is optional, and is not present when there is an empty git commit, but the regex expression looks for it, and hence sees the expression as invalid.

~~Finally the change in commands.ts makes it so that when whitespace is added as a commit message, the function returns and the window is dismissed. This is the same behaviour as when Enter is pressed (without typing anything) and the window is dismissed. Below is a screenshot of the window.~~

![whitespace_commit_part2](https://user-images.githubusercontent.com/31773220/56481728-74d8a700-648e-11e9-9e21-ff4a6edfdee9.PNG)

~~When enter is pressed, the window is dismissed.~~

The above has been reverted to its original behaviour.