### PR TITLE
Fix for Issue #71798: Terminal jumps using US International Keyboard and custom lineHeight

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -88,7 +88,8 @@ function _getLangEnvVariable(locale?: string) {
 			ko: 'KR',
 			pl: 'PL',
 			ru: 'RU',
-			zh: 'CN'
+			zh: 'CN',
+			gb: 'GB'
 		};
 		if (parts[0] in languageVariants) {
 			parts.push(languageVariants[parts[0]]);

--- a/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
+++ b/src/vs/workbench/services/keybinding/common/macLinuxKeyboardMapper.ts
@@ -949,6 +949,7 @@ export class MacLinuxKeyboardMapper implements IKeyboardMapper {
 				|| constantKeyCode === KeyCode.US_OPEN_SQUARE_BRACKET
 				|| constantKeyCode === KeyCode.US_BACKSLASH
 				|| constantKeyCode === KeyCode.US_CLOSE_SQUARE_BRACKET
+				|| constantKeyCode === KeyCode.US_QUOTE
 			);
 
 			if (isOEMKey) {

--- a/src/vs/workbench/services/keybinding/test/macLinuxKeyboardMapper.test.ts
+++ b/src/vs/workbench/services/keybinding/test/macLinuxKeyboardMapper.test.ts
@@ -1251,6 +1251,40 @@ suite('keyboardMapper', () => {
 		);
 	});
 
+	test('issue #71798: Terminal jumps using US International Keyboard and custom lineHeight', () => {
+		let mapper = new MacLinuxKeyboardMapper(false, {
+			'Singlequote': {
+				'value': '\'',
+				'withShift': '"',
+				'withAltGr': '',
+				'withShiftAltGr': '|'
+			}
+		}, OperatingSystem.Macintosh);
+
+		assertResolveKeyboardEvent(
+			mapper,
+			{
+				_standardKeyboardEventBrand: true,
+				ctrlKey: true,
+				shiftKey: false,
+				altKey: false,
+				metaKey: false,
+				keyCode: -1,
+				code: 'Singlequote'.
+			},
+			{
+				label: 'Ctrl+\'',
+				ariaLabel: 'Control+\'',
+				electronAccelerator: null,
+				userSettingsLabel: 'ctrl+\'',
+				isWYSIWYG: true,
+				isChord: false,
+				dispatchParts: ['ctrl+[Singlequote]'],
+			}
+		);
+
+	});
+
 	test('issue #24064: NumLock/NumPad keys stopped working in 1.11 on Linux', () => {
 		let mapper = new MacLinuxKeyboardMapper(false, {}, OperatingSystem.Linux);
 


### PR DESCRIPTION
Attempt at fix for issue #71798. Added a test case for single quotes, and cases for US International keyboards. 