### PR TITLE
Toggle Exclude Resource from Context Menus

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -10,7 +10,7 @@ import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTI
 import { SyncActionDescriptor, MenuId, MenuRegistry, ILocalizedString } from 'vs/platform/actions/common/actions';
 import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
-import { openWindowCommand, REVEAL_IN_OS_COMMAND_ID, COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, REVEAL_IN_OS_LABEL, DirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, newWindowCommand } from 'vs/workbench/contrib/files/browser/fileCommands';
+import { openWindowCommand, REVEAL_IN_OS_COMMAND_ID, COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, REVEAL_IN_OS_LABEL, DirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, TOGGLE_EXCLUDE_RESOURCE_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, newWindowCommand } from 'vs/workbench/contrib/files/browser/fileCommands';
 import { CommandsRegistry, ICommandHandler } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -143,9 +143,15 @@ const copyRelativePathCommand = {
 	title: nls.localize('copyRelativePath', "Copy Relative Path")
 };
 
+const toggleExcludeResourceCommand = {
+	id: TOGGLE_EXCLUDE_RESOURCE_COMMAND_ID,
+	title: nls.localize('toggleExcludeResource', "Toggle Exclude Resource")
+};
+
 // Editor Title Context Menu
 appendEditorTitleContextMenuItem(COPY_PATH_COMMAND_ID, copyPathCommand.title, ResourceContextKey.IsFileSystemResource, '1_cutcopypaste');
 appendEditorTitleContextMenuItem(COPY_RELATIVE_PATH_COMMAND_ID, copyRelativePathCommand.title, ResourceContextKey.IsFileSystemResource, '1_cutcopypaste');
+appendEditorTitleContextMenuItem(TOGGLE_EXCLUDE_RESOURCE_COMMAND_ID, toggleExcludeResourceCommand.title, ResourceContextKey.IsFileSystemResource, '2_workspace');
 appendEditorTitleContextMenuItem(REVEAL_IN_OS_COMMAND_ID, REVEAL_IN_OS_LABEL, ResourceContextKey.Scheme.isEqualTo(Schemas.file));
 appendEditorTitleContextMenuItem(REVEAL_IN_EXPLORER_COMMAND_ID, nls.localize('revealInSideBar', "Reveal in Side Bar"), ResourceContextKey.IsFileSystemResource);
 
@@ -244,6 +250,13 @@ MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: '1_cutcopypaste',
 	order: 20,
 	command: copyRelativePathCommand,
+	when: ResourceContextKey.IsFileSystemResource
+});
+
+MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
+	group: '2_workspace',
+	order: 10,
+	command: toggleExcludeResourceCommand,
 	when: ResourceContextKey.IsFileSystemResource
 });
 
@@ -470,6 +483,13 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 	group: '6_copypath',
 	order: 30,
 	command: copyRelativePathCommand,
+	when: ResourceContextKey.IsFileSystemResource
+});
+
+MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
+	group: '2_workspace',
+	order: 10,
+	command: toggleExcludeResourceCommand,
 	when: ResourceContextKey.IsFileSystemResource
 });
 

--- a/src/vs/workbench/contrib/files/browser/settingsEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/settingsEditor.ts
@@ -1,0 +1,49 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { URI } from 'vs/base/common/uri';
+import { isWindows } from 'vs/base/common/platform';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IListService } from 'vs/platform/list/browser/listService';
+import { getMultiSelectedResources } from 'vs/workbench/contrib/files/browser/files';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+
+
+export function getResourceName(resources: URI[], relative: boolean, labelService: ILabelService) {
+	let resourceName;
+	if (resources.length) {
+		const lineDelimiter = isWindows ? '\r\n' : '\n';
+		resourceName = resources.map(resource => labelService.getUriLabel(resource, { relative, noPrefix: true }))
+			.join(lineDelimiter);
+	}
+	return resourceName;
+}
+
+export function toggleExcludeResourceHandler(accessor: ServicesAccessor, resource: URI) {
+	const resources = getMultiSelectedResources(resource, accessor.get(IListService), accessor.get(IEditorService));
+	const contextService = accessor.get(IWorkspaceContextService);
+	const resourceName = getResourceName(resources, true, accessor.get(ILabelService));
+	if (resourceName) {
+		let workspace = contextService.getWorkspace();
+		let resourceFolderPath = resource.path.substring(0, resource.path.length - resourceName.length - 1);
+		for (let folder of workspace.folders) {
+			if (folder.uri.fsPath === resourceFolderPath) {
+				let settingsFile = path.join(resourceFolderPath, '/.vscode/settings.json');
+			const data = fs.readFileSync(settingsFile).toString();
+			const settings = JSON.parse(data);
+
+			if (settings['files.exclude']) {
+				if (settings['files.exclude'].hasOwnProperty(resourceName) && typeof settings['files.exclude'][resourceName] === 'boolean') {
+					settings['files.exclude'][resourceName] = !settings['files.exclude'][resourceName];
+				}
+				else {
+					settings['files.exclude'][resourceName] = true;
+				}
+				fs.writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+			}
+		}
+	}
+	}
+
+}


### PR DESCRIPTION
Implemented Feature Request from Issue #71836 with @TejDNagaraja
User can now toggle files and folders to be hidden from VSCode Explorer via Context Menus (see screenshot)
Passes UI Smoke tests

<img width="483" alt="Screen Shot 2019-04-22 at 5 16 00 PM" src="https://user-images.githubusercontent.com/8039421/56533227-4659db00-6525-11e9-8884-9a3c68bc2bfb.png">
<img width="581" alt="Screen Shot 2019-04-22 at 5 16 11 PM" src="https://user-images.githubusercontent.com/8039421/56533333-75704c80-6525-11e9-8778-78d8ca917144.png">
<img width="815" alt="Screen Shot 2019-04-22 at 5 15 47 PM" src="https://user-images.githubusercontent.com/8039421/56533334-75704c80-6525-11e9-992d-7247ba4953bd.png">
<img width="344" alt="Screen Shot 2019-04-22 at 5 15 29 PM" src="https://user-images.githubusercontent.com/8039421/56533335-7608e300-6525-11e9-9099-6447cb9d1347.png">
<img width="361" alt="Screen Shot 2019-04-22 at 5 15 21 PM" src="https://user-images.githubusercontent.com/8039421/56533336-7608e300-6525-11e9-8596-fe82a852ef14.png">
<img width="685" alt="Screen Shot 2019-04-22 at 5 15 15 PM" src="https://user-images.githubusercontent.com/8039421/56533337-7608e300-6525-11e9-9842-8acd868007eb.png">





