### PR TITLE
Polish host colors and badge

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -310,15 +310,15 @@ export const STATUS_BAR_PROMINENT_ITEM_HOVER_BACKGROUND = registerColor('statusB
 }, nls.localize('statusBarProminentItemHoverBackground', "Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window."));
 
 export const STATUS_BAR_HOST_NAME_BACKGROUND = registerColor('statusBarItem.hostBackground', {
-	dark: STATUS_BAR_PROMINENT_ITEM_BACKGROUND,
-	light: STATUS_BAR_PROMINENT_ITEM_BACKGROUND,
-	hc: STATUS_BAR_PROMINENT_ITEM_BACKGROUND
+	dark: '#C40057',
+	light: '#C40057',
+	hc: '#C40057'
 }, nls.localize('statusBarItemHostBackground', "Background color for the host indicator on the status bar."));
 
 export const STATUS_BAR_HOST_NAME_FOREGROUND = registerColor('statusBarItem.hostForeground', {
-	dark: STATUS_BAR_PROMINENT_ITEM_FOREGROUND,
-	light: STATUS_BAR_PROMINENT_ITEM_FOREGROUND,
-	hc: STATUS_BAR_PROMINENT_ITEM_FOREGROUND
+	dark: '#FFFFFF',
+	light: '#FFFFFF',
+	hc: '#FFFFFF'
 }, nls.localize('statusBarItemHostForeground', "Foreground color for the host indicator on the status bar."));
 
 

--- a/src/vs/workbench/contrib/extensions/electron-browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/electron-browser/media/extensionEditor.css
@@ -41,11 +41,13 @@
 	line-height: 38px;
 	border-radius: 20px;
 	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .extension-editor > .header > .icon-container .extension-remote-badge .octicon {
-	font-size: 32px;
-	vertical-align: middle;
+	font-size: 28px;
 }
 
 .extension-editor > .header > .details {

--- a/src/vs/workbench/contrib/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/electron-browser/media/extensionsViewlet.css
@@ -123,11 +123,13 @@
 	line-height: 14px;
 	border-radius: 20px;
 	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .extensions-viewlet > .extensions .monaco-list-row > .extension > .details > .header-container > .header .extension-remote-badge > .octicon {
-	font-size: 13px;
-	vertical-align: middle;
+	font-size: 12px;
 }
 
 .extensions-viewlet.narrow > .extensions .extension > .icon-container,


### PR DESCRIPTION
This updates `statusBarItem.hostBackground` and `statusBarItem.hostForeground` to use their own colors, as previously discussed. This also polishes the `extension-remote-badge` to make it centered.

cc @kieferrm 