### PR TITLE
Temporarily resolve "command palette, color theme, file icon theme, user segment" and webview focus conflicts.

### DIFF
--- a/src/vs/platform/contextview/browser/contextMenuHandler.ts
+++ b/src/vs/platform/contextview/browser/contextMenuHandler.ts
@@ -123,7 +123,7 @@ export class ContextMenuHandler {
 					this.block = null;
 				}
 
-				if (this.focusToReturn) {
+				if (this.focusToReturn && this.focusToReturn.localName !== 'webview') {  // Temporarily resolve "command palette, color theme, file icon theme, user segment" and webview focus conflicts.
 					this.focusToReturn.focus();
 				}
 			}
@@ -144,7 +144,7 @@ export class ContextMenuHandler {
 		this.contextViewService.hideContextView(false);
 
 		// Restore focus here
-		if (this.focusToReturn) {
+		if (this.focusToReturn && this.focusToReturn.localName !== 'webview') {  // Temporarily resolve "command palette, color theme, file icon theme, user segment" and webview focus conflicts.
 			this.focusToReturn.focus();
 		}
 	}


### PR DESCRIPTION
Temporarily resolve "command palette, color theme, file icon theme, user segment" and webview focus conflicts.

The same problem: [Theme selection menu does not work #68019](https://github.com/Microsoft/vscode/issues/68019)

@mjbvz, Hello, this focus of webview can be handled temporarily like this? Before the "upstream issue" was resolved. Webview is now used in a lot of places, and the existence of this problem will cause problems for many users.