### PR TITLE
Resolve regression in WSL launch script

### DIFF
--- a/resources/win32/bin/code.sh
+++ b/resources/win32/bin/code.sh
@@ -6,11 +6,23 @@ COMMIT="@@COMMIT@@"
 APP_NAME="@@APPNAME@@"
 QUALITY="@@QUALITY@@"
 NAME="@@NAME@@"
-
+VSCODE_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
+ELECTRON="$VSCODE_PATH/$NAME.exe"
 if grep -qi Microsoft /proc/version; then
 	# in a wsl shell
-	WIN_CODE_CMD=$(wslpath -w "$(dirname "$(realpath "$0")")/$APP_NAME.cmd")
-	if ! [ -z "$WIN_CODE_CMD" ]; then
+	fallback() {
+		# If running under older WSL, don't pass cli.js to Electron as
+		# environment vars cannot be transferred from WSL to Windows
+		# See: https://github.com/Microsoft/BashOnWindows/issues/1363
+		#      https://github.com/Microsoft/BashOnWindows/issues/1494
+		"$ELECTRON" "$@"
+		exit $?
+	}
+	WSL_BUILD=$(uname -r | sed -E 's/^.+-([0-9]+)-Microsoft/\1/')
+	# wslpath is not available prior to WSL build 17046
+	# See: https://docs.microsoft.com/en-us/windows/wsl/release-notes#build-17046
+	if [ -x /bin/wslpath ]; then
+		WIN_CODE_CMD=$(wslpath -w "$(dirname "$(realpath "$0")")/$APP_NAME.cmd")
 		# make sure the cwd is in the windows fs, otherwise there will be a warning from cmd
 		pushd "$(dirname "$0")" > /dev/null
 		WSL_EXT_ID="ms-vscode.remote-wsl"
@@ -21,17 +33,22 @@ if grep -qi Microsoft /proc/version; then
 			WSL_CODE=$(wslpath -u "${WSL_EXT_WLOC%%[[:cntrl:]]}")/scripts/wslCode.sh
 			"$WSL_CODE" $COMMIT $QUALITY "$WIN_CODE_CMD" "$APP_NAME" "$@"
 			exit $?
+		elif [ $WSL_BUILD -ge 17063 ] 2> /dev/null; then
+			# Since WSL build 17063, we just need to set WSLENV so that
+			# ELECTRON_RUN_AS_NODE is visible to the win32 process
+			# See: https://docs.microsoft.com/en-us/windows/wsl/release-notes#build-17063
+			export WSLENV=ELECTRON_RUN_AS_NODE/w:$WSLENV
+			CLI=$(wslpath -m "$VSCODE_PATH/resources/app/out/cli.js")
+		else # $WSL_BUILD ∈ [17046, 17063) OR $WSL_BUILD is indeterminate
+			fallback "$@"
 		fi
+	else
+		fallback "$@"
 	fi
-fi
-
-VSCODE_PATH="$(dirname "$(dirname "$(realpath "$0")")")"
-
-if [ -x "$(command -v cygpath)" ]; then
+elif [ -x "$(command -v cygpath)" ]; then
 	CLI=$(cygpath -m "$VSCODE_PATH/resources/app/out/cli.js")
 else
 	CLI="$VSCODE_PATH/resources/app/out/cli.js"
 fi
-ELECTRON="$VSCODE_PATH/$NAME.exe"
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
 exit $?


### PR DESCRIPTION
As of today the [WSL launch script](https://github.com/Microsoft/vscode/blob/87fd1d45341dfada8b8e41f4b61383be9ab84e4f/resources/win32/bin/code.sh) is not working properly with the Insiders build — the empty `cli.js` (as described in #13138) has re-emerged. The [commit history](https://github.com/Microsoft/vscode/commits/master/resources/win32/bin/code.sh) of the file shows the problem was previously fixed by @Tyriar (9c298b09782e3dddc473bf6368521b81a122d6f4) and @0xabu (8505dcc4694ce23be6b207861384f44ba4f5705b). Upon further investigation, I came to the conclusion that the regression was introduced by b7ec5e8e6cbaa4b5875df6ef246d81aae892d9cb. Although I have no idea how the upcoming `ms-vscode.remote-wsl` extension will come in to play, it is still worth mentioning that right now [L13-L25](https://github.com/Microsoft/vscode/blob/87fd1d45341dfada8b8e41f4b61383be9ab84e4f/resources/win32/bin/code.sh#L13-L25) serves no real purpose. To resolve the issue, I've (re)introduced various checks so as to launch VS Code from the WSL differently as per its build number.