### PR TITLE
_validateShellPaths: skip file exists check for empty strings

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalService.ts
@@ -426,6 +426,9 @@ export abstract class TerminalService implements ITerminalService {
 			return Promise.resolve(null);
 		}
 		const current = potentialPaths.shift();
+		if (current! === '') {
+			return this._validateShellPaths(label, potentialPaths);
+		}
 		return this._fileService.exists(URI.file(current!)).then(exists => {
 			if (!exists) {
 				return this._validateShellPaths(label, potentialPaths);


### PR DESCRIPTION
A minor change suggested by @roottool to resolve #72601 