### PR TITLE
fixes https://github.com/Microsoft/monaco-editor/issues/1353

### DIFF
--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -5,6 +5,7 @@
 
 import 'vs/css!./media/scrollbars';
 import * as dom from 'vs/base/browser/dom';
+import * as browser from 'vs/base/browser/browser';
 import { FastDomNode, createFastDomNode } from 'vs/base/browser/fastDomNode';
 import { IMouseEvent, StandardWheelEvent, IMouseWheelEvent } from 'vs/base/browser/mouseEvent';
 import { ScrollbarHost } from 'vs/base/browser/ui/scrollbar/abstractScrollbar';
@@ -311,8 +312,11 @@ export abstract class AbstractScrollableElement extends Widget {
 			let onMouseWheel = (browserEvent: IMouseWheelEvent) => {
 				this._onMouseWheel(new StandardWheelEvent(browserEvent));
 			};
-
-			this._mouseWheelToDispose.push(dom.addDisposableListener(this._listenOnDomNode, 'mousewheel', onMouseWheel));
+			if (browser.isFirefox) {
+				this._register(dom.addDisposableListener(this._listenOnDomNode, 'DOMMouseScroll', onMouseWheel, true));
+			} else {
+				this._register(dom.addDisposableListener(this._listenOnDomNode, 'mousewheel', onMouseWheel, true));
+			}
 		}
 	}
 

--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -123,7 +123,11 @@ export class MouseHandler extends ViewEventHandler {
 				e.stopPropagation();
 			}
 		};
-		this._register(dom.addDisposableListener(this.viewHelper.viewDomNode, 'mousewheel', onMouseWheel, true));
+		if (browser.isFirefox) {
+			this._register(dom.addDisposableListener(this.viewHelper.viewDomNode, 'DOMMouseScroll', onMouseWheel, true));
+		} else {
+			this._register(dom.addDisposableListener(this.viewHelper.viewDomNode, 'mousewheel', onMouseWheel, true));
+		}
 
 		this._context.addEventHandler(this);
 	}


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/monaco-editor/issues/1353 based on the suggestion from  @cgillis-aras here: https://github.com/Microsoft/monaco-editor/issues/1353#issuecomment-476683672

Unfortunately, the follow-up comment from @yishn did not work out -- just changing from `'mousewheel'` to `'wheel'` did not work on Firefox.

This PR follows the pattern used in several other vscode files of using `browser.isFirefox` rather than registering multiple listeners (from the original suggestion).

Tested and working in vscode and Monaco. Feedback welcome and appreciated! :-)