### PR TITLE
Center remote badge icon

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/electron-browser/media/extensionsViewlet.css
@@ -110,11 +110,9 @@
 	height: 22px;
 	line-height: 22px;
 	border-radius: 20px;
-	text-align: center;
-}
-
-.extensions-viewlet > .extensions .monaco-list-row > .extension > .icon-container .extension-remote-badge > .octicon {
-	vertical-align: middle
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .extensions-viewlet > .extensions .monaco-list-row > .extension > .details > .header-container > .header > .extension-remote-badge-container {


### PR DESCRIPTION
This centers the remote badge icon via flexbox.