### PR TITLE
Fix-70945 Optimize the installation prompt and change the install count to the downloads.

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionEditor.ts
@@ -232,7 +232,7 @@ export class ExtensionEditor extends BaseEditor {
 		const subtitle = append(details, $('.subtitle'));
 		this.publisher = append(subtitle, $('span.publisher.clickable', { title: localize('publisher', "Publisher name") }));
 
-		this.installCount = append(subtitle, $('span.install', { title: localize('install count', "Install count") }));
+		this.installCount = append(subtitle, $('span.install', { title: localize('install count', "The total number of installs, including updates.") }));
 
 		this.rating = append(subtitle, $('span.rating.clickable', { title: localize('rating', "Rating") }));
 

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsViewlet.ts
@@ -472,7 +472,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 				this.instantiationService.createInstance(ShowRecommendedExtensionsAction, ShowRecommendedExtensionsAction.ID, ShowRecommendedExtensionsAction.LABEL),
 				this.instantiationService.createInstance(ShowPopularExtensionsAction, ShowPopularExtensionsAction.ID, ShowPopularExtensionsAction.LABEL),
 				new Separator(),
-				this.instantiationService.createInstance(ChangeSortAction, 'extensions.sort.install', localize('sort by installs', "Sort By: Install Count"), this.onSearchChange, 'installs'),
+				this.instantiationService.createInstance(ChangeSortAction, 'extensions.sort.install', localize('sort by installs', "Sort By: Downloads"), this.onSearchChange, 'installs'),
 				this.instantiationService.createInstance(ChangeSortAction, 'extensions.sort.rating', localize('sort by rating', "Sort By: Rating"), this.onSearchChange, 'rating'),
 				this.instantiationService.createInstance(ChangeSortAction, 'extensions.sort.name', localize('sort by name', "Sort By: Name"), this.onSearchChange, 'name'),
 				new Separator(),


### PR DESCRIPTION
issue: [Extension details: Tooltip "Install count" should be "Downloads count" #70945](https://github.com/Microsoft/vscode/issues/70945)

Hi, hello, because the count represents: the total number of installations, including updates. And marketplace is described as downloads, which is more accurate with downloads. I hope to help Vs code.
![image](https://user-images.githubusercontent.com/15615524/56812741-146eae80-686e-11e9-9c97-dfe0c3f7b7a3.png)
