### PR TITLE
New colors for host badge

### DIFF
--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -309,17 +309,17 @@ export const STATUS_BAR_PROMINENT_ITEM_HOVER_BACKGROUND = registerColor('statusB
 	hc: Color.black.transparent(0.3),
 }, nls.localize('statusBarProminentItemHoverBackground', "Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window."));
 
-export const STATUS_BAR_HOST_NAME_BACKGROUND = registerColor('statusBarItem.hostBackground', {
+export const STATUS_BAR_HOST_NAME_BACKGROUND = registerColor('statusBarItem.remoteBackground', {
 	dark: '#C40057',
 	light: '#C40057',
 	hc: '#C40057'
-}, nls.localize('statusBarItemHostBackground', "Background color for the host indicator on the status bar."));
+}, nls.localize('statusBarItemHostBackground', "Background color for the remote indicator on the status bar."));
 
-export const STATUS_BAR_HOST_NAME_FOREGROUND = registerColor('statusBarItem.hostForeground', {
+export const STATUS_BAR_HOST_NAME_FOREGROUND = registerColor('statusBarItem.remoteForeground', {
 	dark: '#FFFFFF',
 	light: '#FFFFFF',
 	hc: '#FFFFFF'
-}, nls.localize('statusBarItemHostForeground', "Foreground color for the host indicator on the status bar."));
+}, nls.localize('statusBarItemHostForeground', "Foreground color for the remote indicator on the status bar."));
 
 
 // < --- Activity Bar --- >
@@ -366,17 +366,17 @@ export const ACTIVITY_BAR_BADGE_FOREGROUND = registerColor('activityBarBadge.for
 	hc: Color.white
 }, nls.localize('activityBarBadgeForeground', "Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
-export const HOST_BADGE_BACKGROUND = registerColor('hostBadge.background', {
+export const EXTENSION_BADGE_REMOTE_BACKGROUND = registerColor('extensionBadge.remoteBackground', {
 	dark: ACTIVITY_BAR_BADGE_BACKGROUND,
 	light: ACTIVITY_BAR_BADGE_BACKGROUND,
 	hc: ACTIVITY_BAR_BADGE_BACKGROUND
-}, nls.localize('hostBadgeBackground', "Background color for the host badge in the extensions view"));
+}, nls.localize('extensionBadge.remoteBackground', "Background color for the remote badge in the extensions view"));
 
-export const HOST_BADGE_FOREGROUND = registerColor('hostBadge.foreground', {
+export const EXTENSION_BADGE_REMOTE_FOREGROUND = registerColor('extensionBadge.remoteForeground', {
 	dark: ACTIVITY_BAR_BADGE_FOREGROUND,
 	light: ACTIVITY_BAR_BADGE_FOREGROUND,
 	hc: ACTIVITY_BAR_BADGE_FOREGROUND
-}, nls.localize('hostBadgeForeground', "Foreground color for the host badge in the extensions view"));
+}, nls.localize('extensionBadge.remoteForeground', "Foreground color for the remote badge in the extensions view"));
 
 
 // < --- Side Bar --- >

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -366,6 +366,18 @@ export const ACTIVITY_BAR_BADGE_FOREGROUND = registerColor('activityBarBadge.for
 	hc: Color.white
 }, nls.localize('activityBarBadgeForeground', "Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
 
+export const HOST_BADGE_BACKGROUND = registerColor('hostBadge.background', {
+	dark: ACTIVITY_BAR_BADGE_BACKGROUND,
+	light: ACTIVITY_BAR_BADGE_BACKGROUND,
+	hc: ACTIVITY_BAR_BADGE_BACKGROUND
+}, nls.localize('hostBadgeBackground', "Background color for the host badge in the extensions view"));
+
+export const HOST_BADGE_FOREGROUND = registerColor('hostBadge.foreground', {
+	dark: ACTIVITY_BAR_BADGE_FOREGROUND,
+	light: ACTIVITY_BAR_BADGE_FOREGROUND,
+	hc: ACTIVITY_BAR_BADGE_FOREGROUND
+}, nls.localize('hostBadgeForeground', "Foreground color for the host badge in the extensions view"));
+
 
 // < --- Side Bar --- >
 

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsWidgets.ts
@@ -13,7 +13,7 @@ import { IExtensionManagementServerService, IExtensionTipsService } from 'vs/pla
 import { ILabelService } from 'vs/platform/label/common/label';
 import { extensionButtonProminentBackground, extensionButtonProminentForeground, DisabledLabelAction, ReloadAction } from 'vs/workbench/contrib/extensions/electron-browser/extensionsActions';
 import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
-import { STATUS_BAR_HOST_NAME_BACKGROUND, STATUS_BAR_HOST_NAME_FOREGROUND } from 'vs/workbench/common/theme';
+import { HOST_BADGE_BACKGROUND, HOST_BADGE_FOREGROUND } from 'vs/workbench/common/theme';
 import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -323,8 +323,8 @@ class RemoteBadge extends Disposable {
 			if (!this.element) {
 				return;
 			}
-			const bgColor = this.themeService.getTheme().getColor(STATUS_BAR_HOST_NAME_BACKGROUND);
-			const fgColor = this.themeService.getTheme().getColor(STATUS_BAR_HOST_NAME_FOREGROUND);
+			const bgColor = this.themeService.getTheme().getColor(HOST_BADGE_BACKGROUND);
+			const fgColor = this.themeService.getTheme().getColor(HOST_BADGE_FOREGROUND);
 			this.element.style.backgroundColor = bgColor ? bgColor.toString() : '';
 			this.element.style.color = fgColor ? fgColor.toString() : '';
 		};

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsWidgets.ts
@@ -13,7 +13,7 @@ import { IExtensionManagementServerService, IExtensionTipsService } from 'vs/pla
 import { ILabelService } from 'vs/platform/label/common/label';
 import { extensionButtonProminentBackground, extensionButtonProminentForeground, DisabledLabelAction, ReloadAction } from 'vs/workbench/contrib/extensions/electron-browser/extensionsActions';
 import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
-import { HOST_BADGE_BACKGROUND, HOST_BADGE_FOREGROUND } from 'vs/workbench/common/theme';
+import { EXTENSION_BADGE_REMOTE_BACKGROUND, EXTENSION_BADGE_REMOTE_FOREGROUND } from 'vs/workbench/common/theme';
 import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -323,8 +323,8 @@ class RemoteBadge extends Disposable {
 			if (!this.element) {
 				return;
 			}
-			const bgColor = this.themeService.getTheme().getColor(HOST_BADGE_BACKGROUND);
-			const fgColor = this.themeService.getTheme().getColor(HOST_BADGE_FOREGROUND);
+			const bgColor = this.themeService.getTheme().getColor(EXTENSION_BADGE_REMOTE_BACKGROUND);
+			const fgColor = this.themeService.getTheme().getColor(EXTENSION_BADGE_REMOTE_FOREGROUND);
 			this.element.style.backgroundColor = bgColor ? bgColor.toString() : '';
 			this.element.style.color = fgColor ? fgColor.toString() : '';
 		};


### PR DESCRIPTION
Defined new colors for host badge by default derived from existing badge bg and fg color:

- `extensionBadge.remoteBackground`: Background color for the remote badge in the extensions view
- `extensionBadge.remoteForeground`: Foreground color for the remote badge in the extensions view

- `statusBarItem.remoteBackground`: Background color for the remote indicator on the status bar
- `statusBarItem.remoteForeground`: Foreground color for the remote indicator on the status bar

@misolori FYI, note the new id of the status bar remote indicator.