### PR TITLE
Fix file system providers from extensions to resolve save conflicts

### DIFF
--- a/src/vs/workbench/contrib/files/browser/saveErrorHandler.ts
+++ b/src/vs/workbench/contrib/files/browser/saveErrorHandler.ts
@@ -19,7 +19,7 @@ import { ResourceMap } from 'vs/base/common/map';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 import { IContextKeyService, IContextKey, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { FileOnDiskContentProvider } from 'vs/workbench/contrib/files/common/files';
+import { FileOnDiskContentProvider, resourceToFileOnDisk } from 'vs/workbench/contrib/files/common/files';
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { SAVE_FILE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL } from 'vs/workbench/contrib/files/browser/fileCommands';
@@ -248,7 +248,7 @@ class ResolveSaveConflictAction extends Action {
 
 			return this.editorService.openEditor(
 				{
-					leftResource: resource.with({ scheme: CONFLICT_RESOLUTION_SCHEME }),
+					leftResource: resourceToFileOnDisk(CONFLICT_RESOLUTION_SCHEME, resource),
 					rightResource: resource,
 					label: editorLabel,
 					options: { pinned: true }

--- a/src/vs/workbench/contrib/files/test/common/fileOnDiskProvider.test.ts
+++ b/src/vs/workbench/contrib/files/test/common/fileOnDiskProvider.test.ts
@@ -5,24 +5,36 @@
 
 import * as assert from 'assert';
 import { URI } from 'vs/base/common/uri';
-import { workbenchInstantiationService } from 'vs/workbench/test/workbenchTestServices';
+import { workbenchInstantiationService, TestFileService } from 'vs/workbench/test/workbenchTestServices';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { FileOnDiskContentProvider, resourceToFileOnDisk } from 'vs/workbench/contrib/files/common/files';
 import { snapshotToString } from 'vs/workbench/services/textfile/common/textfiles';
+import { IFileService } from 'vs/platform/files/common/files';
+
+class ServiceAccessor {
+	constructor(
+		@IFileService public fileService: TestFileService
+	) {
+	}
+}
 
 suite('Files - FileOnDiskContentProvider', () => {
 
 	let instantiationService: IInstantiationService;
+	let accessor: ServiceAccessor;
 
 	setup(() => {
 		instantiationService = workbenchInstantiationService();
+		accessor = instantiationService.createInstance(ServiceAccessor);
 	});
 
 	test('provideTextContent', async () => {
 		const provider = instantiationService.createInstance(FileOnDiskContentProvider);
+		const uri = URI.parse('testFileOnDiskContentProvider://foo');
 
-		const content = await provider.provideTextContent(resourceToFileOnDisk('conflictResolution', URI.parse('testFileOnDiskContentProvider://foo')));
+		const content = await provider.provideTextContent(resourceToFileOnDisk('conflictResolution', uri));
 
 		assert.equal(snapshotToString(content.createSnapshot()), 'Hello Html');
+		assert.equal(accessor.fileService.getLastReadFileUri().toString(), uri.toString());
 	});
 });

--- a/src/vs/workbench/contrib/files/test/common/fileOnDiskProvider.test.ts
+++ b/src/vs/workbench/contrib/files/test/common/fileOnDiskProvider.test.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { URI } from 'vs/base/common/uri';
+import { workbenchInstantiationService } from 'vs/workbench/test/workbenchTestServices';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { FileOnDiskContentProvider, resourceToFileOnDisk } from 'vs/workbench/contrib/files/common/files';
+import { snapshotToString } from 'vs/workbench/services/textfile/common/textfiles';
+
+suite('Files - FileOnDiskContentProvider', () => {
+
+	let instantiationService: IInstantiationService;
+
+	setup(() => {
+		instantiationService = workbenchInstantiationService();
+	});
+
+	test('provideTextContent', async () => {
+		const provider = instantiationService.createInstance(FileOnDiskContentProvider);
+
+		const content = await provider.provideTextContent(resourceToFileOnDisk('conflictResolution', URI.parse('testFileOnDiskContentProvider://foo')));
+
+		assert.equal(snapshotToString(content.createSnapshot()), 'Hello Html');
+	});
+});

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -899,6 +899,7 @@ export class TestFileService implements IFileService {
 	readonly onError: Event<Error> = Event.None;
 
 	private content = 'Hello Html';
+	private lastReadFileUri: URI;
 
 	constructor() {
 		this._onFileChanges = new Emitter<FileChangesEvent>();
@@ -911,6 +912,10 @@ export class TestFileService implements IFileService {
 
 	public getContent(): string {
 		return this.content;
+	}
+
+	public getLastReadFileUri(): URI {
+		return this.lastReadFileUri;
 	}
 
 	public get onFileChanges(): Event<FileChangesEvent> {
@@ -952,6 +957,8 @@ export class TestFileService implements IFileService {
 	}
 
 	readFile(resource: URI, options?: IReadFileOptions | undefined): Promise<IFileContent> {
+		this.lastReadFileUri = resource;
+
 		return Promise.resolve({
 			resource: resource,
 			value: VSBuffer.fromString(this.content),
@@ -964,6 +971,8 @@ export class TestFileService implements IFileService {
 	}
 
 	readFileStream(resource: URI, options?: IReadFileOptions | undefined): Promise<IFileStreamContent> {
+		this.lastReadFileUri = resource;
+
 		return Promise.resolve({
 			resource: resource,
 			value: {


### PR DESCRIPTION
@isidorn the fix is to really preserve the URI as it was instead of using the `toLocalResource` which does not help for remote resources that are coming in from extensions.