### PR TITLE
Put current git branch name as value when renaming

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1563,7 +1563,7 @@ export class CommandCenter {
 		const name = await window.showInputBox({
 			placeHolder: localize('branch name', "Branch name"),
 			prompt: localize('provide branch name', "Please provide a branch name"),
-			value: (repository.HEAD && repository.HEAD.name) || undefined
+			value: repository.HEAD && repository.HEAD.name
 		});
 
 		if (!name || name.trim().length === 0) {

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1560,8 +1560,11 @@ export class CommandCenter {
 
 	@command('git.renameBranch', { repository: true })
 	async renameBranch(repository: Repository): Promise<void> {
-		const placeHolder = localize('provide branch name', "Please provide a branch name");
-		const name = await window.showInputBox({ placeHolder });
+		const name = await window.showInputBox({
+			placeHolder: localize('branch name', "Branch name"),
+			prompt: localize('provide branch name', "Please provide a branch name"),
+			value: (repository.HEAD && repository.HEAD.name) || undefined
+		});
 
 		if (!name || name.trim().length === 0) {
 			return;


### PR DESCRIPTION
Currently when you rename a branch you get an empty input box, and if you just want to fix a typo in the branch name, you need to retype the branch name from scratch.

This is a simple change to put the current branch name in the input box when renaming with the text selected, so current workflows don't need to be changed (it also seems to fit other commands in VS Code).

Please let me know if there's anything else I need to do / add.

![image](https://user-images.githubusercontent.com/10238474/56849147-850edd00-68f9-11e9-930d-7dc9449de94a.png)
