### PR TITLE
Fix #72862

### DIFF
--- a/src/vs/editor/contrib/snippet/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/snippetController2.ts
@@ -19,7 +19,6 @@ import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ILogService } from 'vs/platform/log/common/log';
 import { SnippetSession } from './snippetSession';
-import { EditorState, CodeEditorStateFlag } from 'vs/editor/browser/core/editorState';
 
 export class SnippetController2 implements IEditorContribution {
 
@@ -114,26 +113,10 @@ export class SnippetController2 implements IEditorContribution {
 
 		this._updateState();
 
-		// we listen on model and selection changes. usually
-		// both events come in together and this is to prevent
-		// that we don't call _updateState twice.
-		let state: EditorState;
-		let dedupedUpdateState = () => {
-			if (!state || !state.validate(this._editor)) {
-				this._updateState();
-				state = new EditorState(this._editor, CodeEditorStateFlag.Selection | CodeEditorStateFlag.Value);
-			}
-		};
 		this._snippetListener = [
-			this._editor.onDidChangeModelContent(e => {
-				if (e.isFlush) {
-					this.cancel();
-				} else {
-					setTimeout(dedupedUpdateState, 0);
-				}
-			}),
-			this._editor.onDidChangeCursorSelection(dedupedUpdateState),
+			this._editor.onDidChangeModelContent(e => e.isFlush && this.cancel()),
 			this._editor.onDidChangeModel(() => this.cancel()),
+			this._editor.onDidChangeCursorSelection(() => this._updateState())
 		];
 	}
 

--- a/src/vs/editor/contrib/snippet/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/snippetSession.ts
@@ -198,6 +198,10 @@ export class OneSnippet {
 			let ranges: Range[] | undefined;
 
 			for (const placeholder of placeholdersWithEqualIndex) {
+				if (placeholder.isFinalTabstop) {
+					// ignore those
+					break;
+				}
 
 				if (!ranges) {
 					ranges = [];
@@ -568,12 +572,6 @@ export class SnippetSession {
 			if (allPossibleSelections.size === 0) {
 				// return false if we couldn't associate a selection to
 				// this (the first) snippet
-				return false;
-			}
-
-			if (allPossibleSelections.has(0)) {
-				// selection overlaps with a final tab stop which means
-				// we done
 				return false;
 			}
 

--- a/src/vs/editor/contrib/snippet/test/snippetController2.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetController2.test.ts
@@ -11,7 +11,6 @@ import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKe
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { Handler } from 'vs/editor/common/editorCommon';
-import { timeout } from 'vs/base/common/async';
 
 suite('SnippetController2', function () {
 
@@ -134,11 +133,11 @@ suite('SnippetController2', function () {
 		assertSelections(editor, new Selection(1, 1, 1, 7), new Selection(2, 5, 2, 11));
 
 		editor.trigger('test', 'cut', {});
-		assertContextKeys(contextKeys, false, false, false);
+		assertContextKeys(contextKeys, true, false, true);
 		assertSelections(editor, new Selection(1, 1, 1, 1), new Selection(2, 5, 2, 5));
 
 		editor.trigger('test', 'type', { text: 'abc' });
-		assertContextKeys(contextKeys, false, false, false);
+		assertContextKeys(contextKeys, true, false, true);
 
 		ctrl.next();
 		assertContextKeys(contextKeys, false, false, false);
@@ -160,9 +159,9 @@ suite('SnippetController2', function () {
 		assertSelections(editor, new Selection(1, 4, 1, 4), new Selection(2, 8, 2, 8));
 		assertContextKeys(contextKeys, true, false, true);
 
-		// ctrl.next();
-		// assertSelections(editor, new Selection(1, 7, 1, 7), new Selection(2, 11, 2, 11));
-		// assertContextKeys(contextKeys, true, true, true);
+		ctrl.next();
+		assertSelections(editor, new Selection(1, 7, 1, 7), new Selection(2, 11, 2, 11));
+		assertContextKeys(contextKeys, true, true, true);
 
 		ctrl.next();
 		assertSelections(editor, new Selection(1, 7, 1, 7), new Selection(2, 11, 2, 11));
@@ -177,10 +176,10 @@ suite('SnippetController2', function () {
 
 		ctrl.insert('farboo');
 		assertSelections(editor, new Selection(1, 7, 1, 7), new Selection(2, 11, 2, 11));
-		// assertContextKeys(contextKeys, true, false, true);
+		assertContextKeys(contextKeys, true, false, true);
 
-		// ctrl.next();
-		// assertSelections(editor, new Selection(1, 7, 1, 7), new Selection(2, 11, 2, 11));
+		ctrl.next();
+		assertSelections(editor, new Selection(1, 7, 1, 7), new Selection(2, 11, 2, 11));
 		assertContextKeys(contextKeys, false, false, false);
 	});
 
@@ -401,24 +400,5 @@ suite('SnippetController2', function () {
 		ctrl.cancel(true);
 		assertContextKeys(contextKeys, false, false, false);
 		assertSelections(editor, new Selection(1, 22, 1, 22));
-	});
-
-	test('A little confusing visual effect of highlighting for snippet tabstop #43270', async function () {
-		const ctrl = new SnippetController2(editor, logService, contextKeys);
-		model.setValue('');
-		editor.setSelection(new Selection(1, 1, 1, 1));
-
-		ctrl.insert('background-color: ${1:fff};$0');
-		assertSelections(editor, new Selection(1, 19, 1, 22));
-
-		editor.setSelection(new Selection(1, 22, 1, 22));
-		assertContextKeys(contextKeys, true, false, true);
-		editor.trigger('', 'deleteRight', null);
-
-		assert.equal(model.getValue(), 'background-color: fff');
-
-		await timeout(0); // this depends on re-scheduling of events...
-
-		assertContextKeys(contextKeys, false, false, false);
 	});
 });

--- a/src/vs/editor/contrib/snippet/test/snippetController2.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetController2.test.ts
@@ -401,4 +401,13 @@ suite('SnippetController2', function () {
 		assertContextKeys(contextKeys, false, false, false);
 		assertSelections(editor, new Selection(1, 22, 1, 22));
 	});
+
+	test('User defined snippet tab stops ignored #72862', function () {
+		const ctrl = new SnippetController2(editor, logService, contextKeys);
+		model.setValue('');
+		editor.setSelection(new Selection(1, 1, 1, 1));
+
+		ctrl.insert('export default $1');
+		assertContextKeys(contextKeys, true, false, true);
+	});
 });

--- a/src/vs/editor/contrib/snippet/test/snippetSession.test.ts
+++ b/src/vs/editor/contrib/snippet/test/snippetSession.test.ts
@@ -331,7 +331,7 @@ suite('SnippetSession', function () {
 
 		// reset selection to placeholder
 		session.next();
-		assert.equal(session.isSelectionWithinPlaceholders(), false);
+		assert.equal(session.isSelectionWithinPlaceholders(), true);
 		assert.equal(session.isAtLastPlaceholder, true);
 		assertSelections(editor, new Selection(1, 13, 1, 13), new Selection(2, 17, 2, 17));
 	});


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/vscode/issues/72862 by reverting the changes for https://github.com/Microsoft/vscode/issues/43270. The issue with #43270 is that typing (without) cursor changes can reach the final tabstop which should then cancel snippet more. However, the changes made cause snippet mode to be cancelled when a 'normal' tabstop touches the final tabstop. 