### PR TITLE
Added fly-out animation to menu

### DIFF
--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -77,6 +77,7 @@
 
 .monaco-workbench .part > .content {
 	font-size: 13px;
+	transition: width .2s;
 }
 
 .monaco-workbench .part > .content > .monaco-progress-container,

--- a/src/vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay.css
+++ b/src/vs/workbench/contrib/welcome/overlay/browser/welcomeOverlay.css
@@ -16,7 +16,7 @@
 }
 
 #workbench\.parts\.editor {
-	transition: filter .25s, opacity .2s;
+	transition: filter .25s, opacity .2s, left .2s;
 }
 
 .monaco-workbench.blur-background #workbench\.parts\.panel,


### PR DESCRIPTION
Just as it sounds; I changed two lines of CSS to add transitions.

One is to add a transition to the `left` position of the code editor that lasts for 200 milliseconds.
One is to add a transition to the `width` of the code editor that, again, lasts for 200 milliseconds.

Doing just the `left` would add a jittering to the upper-right hand side of the buttons, since the width would be updated immediately. Computing both the `left` and `width` as the menu "flies out" would keep the position of those upper-right hand buttons constant.