### PR TITLE
fixes a z-order bug in code insets

### DIFF
--- a/src/vs/workbench/contrib/codeinset/electron-browser/codeInsetWidget.css
+++ b/src/vs/workbench/contrib/codeinset/electron-browser/codeInsetWidget.css
@@ -3,43 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-editor .codelens-decoration {
-	overflow: hidden;
-	display: inline-block;
-	text-overflow: ellipsis;
-}
-
-.monaco-editor .codelens-decoration > span,
-.monaco-editor .codelens-decoration > a {
-	-moz-user-select: none;
-	-webkit-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
-	white-space: nowrap;
-	vertical-align: sub;
-}
-
-.monaco-editor .codelens-decoration > a {
-	text-decoration: none;
-}
-
-.monaco-editor .codelens-decoration > a:hover {
-	text-decoration: underline;
-	cursor: pointer;
-}
-
-.monaco-editor .codelens-decoration.invisible-cl {
-	opacity: 0;
-}
-
-@keyframes fadein { 0% { opacity:0; visibility:visible;} 100% { opacity:1; } }
-@-moz-keyframes fadein { 0% { opacity:0; visibility:visible;} 100% { opacity:1; } }
-@-o-keyframes fadein { 0% { opacity:0; visibility:visible;} 100% { opacity:1; } }
-@-webkit-keyframes fadein { 0% { opacity:0; visibility:visible;} 100% { opacity:1; } }
-
-.monaco-editor .codelens-decoration.fadein {
-	-webkit-animation: fadein 0.5s linear;
-	-moz-animation: fadein 0.5s linear;
-	-o-animation: fadein 0.5s linear;
-	animation: fadein 0.5s linear;
+.monaco-editor .code-inset {
+	z-index: 10;
 }

--- a/src/vs/workbench/contrib/codeinset/electron-browser/codeInsetWidget.ts
+++ b/src/vs/workbench/contrib/codeinset/electron-browser/codeInsetWidget.ts
@@ -155,6 +155,7 @@ export class CodeInsetWidget {
 			}
 
 			const div = document.createElement('div');
+			div.className = 'code-inset';
 			webview.mountTo(div);
 			webview.onMessage((e: { type: string, payload: any }) => {
 				// The webview contents can use a "size-info" message to report its size.


### PR DESCRIPTION
Right now, content inside a code inset can't be interactive, because a z-ordering bug keeps the webview from seeing any user input. This PR both fixes the bug and cleans up codeInsetWidget.css, which previously was just a clone of the codeLensWidget.css (oops). This new version of the style sheet just contains one class needed to fix the z-ordering bug.