### PR TITLE
Add DirtyWorkTree git error matching to git exec

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -306,6 +306,8 @@ function getGitErrorCode(stderr: string): string | undefined {
 		return GitErrorCodes.BranchAlreadyExists;
 	} else if (/'.+' is not a valid branch name/.test(stderr)) {
 		return GitErrorCodes.InvalidBranchName;
+	} else if (/Please,? commit your changes or stash them/.test(stderr)) {
+		return GitErrorCodes.DirtyWorkTree;
 	}
 
 	return undefined;


### PR DESCRIPTION
When running `branch` with the git extension, if `checkout` is passed it will execute git checkout

```ts
	async branch(name: string, checkout: boolean, ref?: string): Promise<void> {
		const args = checkout ? ['checkout', '-q', '-b', name, '--no-track'] : ['branch', '-q', name];
```

Since this can throw a dirty working tree error, the `getGitErrorCode` function should also handle this case

Fixes https://github.com/Microsoft/vscode-pull-request-github/issues/1123