### PR TITLE
Fix two typos

### DIFF
--- a/extensions/typescript-language-features/src/test/functionCallSnippet.test.ts
+++ b/extensions/typescript-language-features/src/test/functionCallSnippet.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import 'mocha';
 import * as vscode from 'vscode';
-import { snippetForFunctionCall } from "../utils/snippetForFunctionCall";
+import { snippetForFunctionCall } from '../utils/snippetForFunctionCall';
 
 suite('typescript function call snippets', () => {
 	test('Should use label as function name', async () => {

--- a/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/electron-browser/task.contribution.ts
@@ -2012,7 +2012,7 @@ class TaskService extends Disposable implements ITaskService {
 			Severity.Info,
 			nls.localize('TaskService.ignoredFolder', 'The following workspace folders are ignored since they use task version 0.1.0: {0}', this.ignoredWorkspaceFolders.map(f => f.name).join(', ')),
 			[{
-				label: nls.localize('TaskService.notAgain', 'Don\'t Show Again'),
+				label: nls.localize('TaskService.notAgain', "Don't Show Again"),
 				isSecondary: true,
 				run: () => {
 					this.storageService.store(TaskService.IgnoreTask010DonotShowAgain_key, true, StorageScope.WORKSPACE);


### PR DESCRIPTION
According to the Coding Guidelines, the path might use 'single quotes', and the string which needs to be externalized should use 'double quotes'.