### PR TITLE
Fix JSDoc typo: "beginPattern" -> "beginsPattern"

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -688,7 +688,7 @@ export namespace Config {
 		/**
 		* If set to true the watcher is in active mode when the task
 		* starts. This is equals of issuing a line that matches the
-		* beginPattern.
+		* beginsPattern.
 		*/
 		activeOnStart?: boolean;
 
@@ -1591,7 +1591,7 @@ export namespace Schemas {
 				properties: {
 					activeOnStart: {
 						type: 'boolean',
-						description: localize('ProblemMatcherSchema.background.activeOnStart', 'If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginPattern')
+						description: localize('ProblemMatcherSchema.background.activeOnStart', 'If set to true the background monitor is in active mode when the task starts. This is equals of issuing a line that matches the beginsPattern')
 					},
 					beginsPattern: {
 						oneOf: [


### PR DESCRIPTION
The docs for `BackgroundMatcher.activeOnStart` have a significant typo: they refer to another property "beginPattern" which doesn't actually exist. The actual name is `beginsPattern` (with an "s").  This PR fixes this typo.