### PR TITLE
Fix #73021

### DIFF
--- a/src/vs/workbench/browser/parts/editor/resourceViewer.ts
+++ b/src/vs/workbench/browser/parts/editor/resourceViewer.ts
@@ -370,7 +370,7 @@ class InlineImageView {
 			dispose: () => combinedDisposable(disposables).dispose()
 		};
 
-		const cacheKey = descriptor.resource.toString();
+		const cacheKey = descriptor.resource.toString() + descriptor.etag;
 
 		let ctrlPressed = false;
 		let altPressed = false;

--- a/src/vs/workbench/browser/parts/editor/resourceViewer.ts
+++ b/src/vs/workbench/browser/parts/editor/resourceViewer.ts
@@ -370,7 +370,7 @@ class InlineImageView {
 			dispose: () => combinedDisposable(disposables).dispose()
 		};
 
-		const cacheKey = descriptor.resource.toString() + descriptor.etag;
+		const cacheKey = `${descriptor.resource.toString()}:${descriptor.etag}`;
 
 		let ctrlPressed = false;
 		let altPressed = false;


### PR DESCRIPTION
This PR fix #73021 by add etag into `cacheKey`. If the image is modified, the editor will not remember the previous scale.