### PR TITLE
object literal type to the interface type

### DIFF
--- a/src/vs/platform/instantiation/common/instantiation.ts
+++ b/src/vs/platform/instantiation/common/instantiation.ts
@@ -125,7 +125,7 @@ function storeServiceDependency(id: Function, target: Function, index: number, o
 /**
  * A *only* valid way to create a {{ServiceIdentifier}}.
  */
-export function createDecorator<T>(serviceId: string): { (...args: any[]): void; type: T; } {
+export function createDecorator<T>(serviceId: string): ServiceIdentifier<T> {
 
 	if (_util.serviceIds.has(serviceId)) {
 		return _util.serviceIds.get(serviceId)!;


### PR DESCRIPTION
more readable & predictable

is it intendly that use the object literal type? but it seems to be looks better to use the interface for consistency.