### PR TITLE
Incorrect wording of Outline drawer default message

### DIFF
--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -456,7 +456,7 @@ export class OutlinePanel extends ViewletPanel {
 		}
 
 		if (!editor || !editor.hasModel() || !DocumentSymbolProviderRegistry.has(editor.getModel())) {
-			return this._showMessage(localize('no-editor', "There are no editors open that can provide outline information."));
+			return this._showMessage(localize('no-editor', "The currently focused editor can not provide outline information."));
 		}
 
 		let textModel = editor.getModel();

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -456,7 +456,7 @@ export class OutlinePanel extends ViewletPanel {
 		}
 
 		if (!editor || !editor.hasModel() || !DocumentSymbolProviderRegistry.has(editor.getModel())) {
-			return this._showMessage(localize('no-editor', "The currently focused editor can not provide outline information."));
+			return this._showMessage(localize('no-editor', "The active editor cannot provide outline information."));
 		}
 
 		let textModel = editor.getModel();


### PR DESCRIPTION
Steps to reproduce:

1. Open an editor tab for a file with a format that parser of Outline drawer supports (eg. `.md`, `.php` or `.js`).
2. Open another editor tab for a file with a format that parser of Outline drawer _does not_ supports (eg. `.yml` or `.twig`).
3. While the latter editor tab is focused, the text in the Outline drawer reads:

> "There are no editors open that can provide outline information."

4. I do feel that this wording can be considered a bit misleading: in opposition what is currently means, the real fact that there is (at least – in the above scenario – one) editor tab open, which holds data that Outline parser can understand. Although, it's unfocused currently, indeed.
5. Therefore I suggest wording something similar like this:

> The currently focused editor can not provide outline information.

As far as I searched, this message line occurs in code at /src/vs/workbench/contrib/outline/browser/[outlinePanel.ts](https://github.com/Microsoft/vscode/blob/2699f06fb904008667d3713c5d295c9c58118e26/src/vs/workbench/contrib/outline/browser/outlinePanel.ts#L459) at line :459

- VSCode Version: 1.33.1
- OS Version: 10.13.6 (17G6030)

_(Ps. issue [#73213](https://github.com/Microsoft/vscode/issues/73213) was created first before the PR, sorry.)_