### PR TITLE
Fix hasTrailingPathSeparator for Windows drives

### DIFF
--- a/src/vs/base/common/resources.ts
+++ b/src/vs/base/common/resources.ts
@@ -179,7 +179,7 @@ export function isAbsolutePath(resource: URI): boolean {
 export function hasTrailingPathSeparator(resource: URI): boolean {
 	if (resource.scheme === Schemas.file) {
 		const fsp = originalFSPath(resource);
-		return fsp.length > extpath.getRoot(fsp).length && fsp[fsp.length - 1] === paths.sep;
+		return fsp.length >= extpath.getRoot(fsp).length && fsp[fsp.length - 1] === paths.sep;
 	} else {
 		const p = resource.path;
 		return p.length > 1 && p.charCodeAt(p.length - 1) === CharCode.Slash; // ignore the slash at offset 0

--- a/src/vs/base/common/resources.ts
+++ b/src/vs/base/common/resources.ts
@@ -176,28 +176,46 @@ export function isAbsolutePath(resource: URI): boolean {
 /**
  * Returns true if the URI path has a trailing path separator
  */
-export function hasTrailingPathSeparator(resource: URI): boolean {
+export function hasTrailingPathSeparator(resource: URI, sep: string = paths.sep): boolean {
 	if (resource.scheme === Schemas.file) {
 		const fsp = originalFSPath(resource);
-		return fsp.length >= extpath.getRoot(fsp).length && fsp[fsp.length - 1] === paths.sep;
+		return fsp.length > extpath.getRoot(fsp).length && fsp[fsp.length - 1] === sep;
 	} else {
 		const p = resource.path;
 		return p.length > 1 && p.charCodeAt(p.length - 1) === CharCode.Slash; // ignore the slash at offset 0
 	}
 }
 
-
 /**
- * Removes a trailing path seperator, if theres one.
+ * Removes a trailing path separator, if there's one.
  * Important: Doesn't remove the first slash, it would make the URI invalid
  */
-export function removeTrailingPathSeparator(resource: URI): URI {
-	if (hasTrailingPathSeparator(resource)) {
+export function removeTrailingPathSeparator(resource: URI, sep: string = paths.sep): URI {
+	if (hasTrailingPathSeparator(resource, sep)) {
 		return resource.with({ path: resource.path.substr(0, resource.path.length - 1) });
 	}
 	return resource;
 }
 
+/**
+ * Adds a trailing path separator to the URI if there isn't one already.
+ * For example, c:\ would be unchanged, but c:\users would become c:\users\
+ */
+export function addTrailingPathSeparator(resource: URI, sep: string = paths.sep): URI {
+	let isRootSep: boolean = false;
+	if (resource.scheme === Schemas.file) {
+		const fsp = originalFSPath(resource);
+		isRootSep = ((fsp !== undefined) && (fsp.length === extpath.getRoot(fsp).length) && (fsp[fsp.length - 1] === sep));
+	} else {
+		sep = '/';
+		const p = resource.path;
+		isRootSep = p.length === 1 && p.charCodeAt(p.length - 1) === CharCode.Slash;
+	}
+	if (!isRootSep && !hasTrailingPathSeparator(resource, sep)) {
+		return resource.with({ path: resource.path + '/' });
+	}
+	return resource;
+}
 
 /**
  * Returns a relative path between two URIs. If the URIs don't have the same schema or authority, `undefined` is returned.

--- a/src/vs/base/test/common/resources.test.ts
+++ b/src/vs/base/test/common/resources.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { dirname, basename, distinctParents, joinPath, isEqual, isEqualOrParent, hasToIgnoreCase, normalizePath, isAbsolutePath, relativePath, removeTrailingPathSeparator, hasTrailingPathSeparator, resolvePath } from 'vs/base/common/resources';
+import { dirname, basename, distinctParents, joinPath, isEqual, isEqualOrParent, hasToIgnoreCase, normalizePath, isAbsolutePath, relativePath, removeTrailingPathSeparator, hasTrailingPathSeparator, resolvePath, addTrailingPathSeparator } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { isWindows } from 'vs/base/common/platform';
 import { toSlashes } from 'vs/base/common/extpath';
@@ -178,6 +178,9 @@ suite('Resources', () => {
 		assertEqualURI(removeTrailingPathSeparator(u1), expected, u1.toString());
 	}
 
+	function assertAddTrailingSeparator(u1: URI, expected: URI) {
+		assertEqualURI(addTrailingPathSeparator(u1), expected, u1.toString());
+	}
 
 	test('trailingPathSeparator', () => {
 		assertTrailingSeparator(URI.parse('foo://a/foo'), false);
@@ -189,6 +192,11 @@ suite('Resources', () => {
 		assertRemoveTrailingSeparator(URI.parse('foo://a/foo/'), URI.parse('foo://a/foo'));
 		assertRemoveTrailingSeparator(URI.parse('foo://a/'), URI.parse('foo://a/'));
 		assertRemoveTrailingSeparator(URI.parse('foo://a'), URI.parse('foo://a'));
+
+		assertAddTrailingSeparator(URI.parse('foo://a/foo'), URI.parse('foo://a/foo/'));
+		assertAddTrailingSeparator(URI.parse('foo://a/foo/'), URI.parse('foo://a/foo/'));
+		assertAddTrailingSeparator(URI.parse('foo://a/'), URI.parse('foo://a/'));
+		assertAddTrailingSeparator(URI.parse('foo://a'), URI.parse('foo://a/'));
 
 		if (isWindows) {
 			assertTrailingSeparator(URI.file('c:\\a\\foo'), false);
@@ -202,6 +210,12 @@ suite('Resources', () => {
 			assertRemoveTrailingSeparator(URI.file('c:\\'), URI.file('c:\\'));
 			assertRemoveTrailingSeparator(URI.file('\\\\server\\share\\some\\'), URI.file('\\\\server\\share\\some'));
 			assertRemoveTrailingSeparator(URI.file('\\\\server\\share\\'), URI.file('\\\\server\\share\\'));
+
+			assertAddTrailingSeparator(URI.file('c:\\a\\foo'), URI.file('c:\\a\\foo\\'));
+			assertAddTrailingSeparator(URI.file('c:\\a\\foo\\'), URI.file('c:\\a\\foo\\'));
+			assertAddTrailingSeparator(URI.file('c:\\'), URI.file('c:\\'));
+			assertAddTrailingSeparator(URI.file('\\\\server\\share\\some'), URI.file('\\\\server\\share\\some\\'));
+			assertAddTrailingSeparator(URI.file('\\\\server\\share\\some\\'), URI.file('\\\\server\\share\\some\\'));
 		} else {
 			assertTrailingSeparator(URI.file('/foo/bar'), false);
 			assertTrailingSeparator(URI.file('/foo/bar/'), true);
@@ -210,12 +224,16 @@ suite('Resources', () => {
 			assertRemoveTrailingSeparator(URI.file('/foo/bar'), URI.file('/foo/bar'));
 			assertRemoveTrailingSeparator(URI.file('/foo/bar/'), URI.file('/foo/bar'));
 			assertRemoveTrailingSeparator(URI.file('/'), URI.file('/'));
+
+			assertAddTrailingSeparator(URI.file('/foo/bar'), URI.file('/foo/bar/'));
+			assertAddTrailingSeparator(URI.file('/foo/bar/'), URI.file('/foo/bar/'));
+			assertAddTrailingSeparator(URI.file('/'), URI.file('/'));
 		}
 	});
 
 	function assertEqualURI(actual: URI, expected: URI, message?: string) {
 		if (!isEqual(expected, actual)) {
-			assert.equal(expected.toString(), actual.toString(), message);
+			assert.equal(actual.toString(), expected.toString(), message);
 		}
 	}
 


### PR DESCRIPTION
hasTrailingPathSeparator returns false for "d:\\", even though it clearly ends with a trailing separator. 
extpath.getRoot returns "d:\\"
Is this a reasonable fix for this?