### PR TITLE
Update remote background defaults

### DIFF
--- a/extensions/theme-defaults/themes/dark_defaults.json
+++ b/extensions/theme-defaults/themes/dark_defaults.json
@@ -15,6 +15,8 @@
 		"settings.textInputBackground": "#292929",
 		"settings.numberInputBackground": "#292929",
 		"menu.background": "#252526",
-		"menu.foreground": "#CCCCCC"
+		"menu.foreground": "#CCCCCC",
+		"statusBarItem.remoteForeground": "#FFF",
+		"statusBarItem.remoteBackground": "#16825D"
 	}
 }

--- a/extensions/theme-defaults/themes/light_defaults.json
+++ b/extensions/theme-defaults/themes/light_defaults.json
@@ -14,6 +14,8 @@
 		"list.hoverBackground": "#E8E8E8",
 		"input.placeholderForeground": "#767676",
 		"settings.textInputBorder": "#CECECE",
-		"settings.numberInputBorder": "#CECECE"
+		"settings.numberInputBorder": "#CECECE",
+		"statusBarItem.remoteForeground": "#FFF",
+		"statusBarItem.remoteBackground": "#16825D"
 	}
 }

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -309,19 +309,6 @@ export const STATUS_BAR_PROMINENT_ITEM_HOVER_BACKGROUND = registerColor('statusB
 	hc: Color.black.transparent(0.3),
 }, nls.localize('statusBarProminentItemHoverBackground', "Status bar prominent items background color when hovering. Prominent items stand out from other status bar entries to indicate importance. Change mode `Toggle Tab Key Moves Focus` from command palette to see an example. The status bar is shown in the bottom of the window."));
 
-export const STATUS_BAR_HOST_NAME_BACKGROUND = registerColor('statusBarItem.remoteBackground', {
-	dark: '#16825D',
-	light: '#16825D',
-	hc: '#FFFFFF00'
-}, nls.localize('statusBarItemHostBackground', "Background color for the remote indicator on the status bar."));
-
-export const STATUS_BAR_HOST_NAME_FOREGROUND = registerColor('statusBarItem.remoteForeground', {
-	dark: '#FFFFFF',
-	light: '#FFFFFF',
-	hc: '#FFFFFF'
-}, nls.localize('statusBarItemHostForeground', "Foreground color for the remote indicator on the status bar."));
-
-
 // < --- Activity Bar --- >
 
 export const ACTIVITY_BAR_BACKGROUND = registerColor('activityBar.background', {
@@ -365,6 +352,21 @@ export const ACTIVITY_BAR_BADGE_FOREGROUND = registerColor('activityBarBadge.for
 	light: Color.white,
 	hc: Color.white
 }, nls.localize('activityBarBadgeForeground', "Activity notification badge foreground color. The activity bar is showing on the far left or right and allows to switch between views of the side bar."));
+
+
+// < --- Remote --- >
+
+export const STATUS_BAR_HOST_NAME_BACKGROUND = registerColor('statusBarItem.remoteBackground', {
+	dark: ACTIVITY_BAR_BADGE_BACKGROUND,
+	light: ACTIVITY_BAR_BADGE_BACKGROUND,
+	hc: ACTIVITY_BAR_BADGE_BACKGROUND
+}, nls.localize('statusBarItemHostBackground', "Background color for the remote indicator on the status bar."));
+
+export const STATUS_BAR_HOST_NAME_FOREGROUND = registerColor('statusBarItem.remoteForeground', {
+	dark: ACTIVITY_BAR_BADGE_FOREGROUND,
+	light: ACTIVITY_BAR_BADGE_FOREGROUND,
+	hc: ACTIVITY_BAR_BADGE_FOREGROUND
+}, nls.localize('statusBarItemHostForeground', "Foreground color for the remote indicator on the status bar."));
 
 export const EXTENSION_BADGE_REMOTE_BACKGROUND = registerColor('extensionBadge.remoteBackground', {
 	dark: ACTIVITY_BAR_BADGE_BACKGROUND,


### PR DESCRIPTION
This updates the default colors for the remote background & foreground to inherit the colors from `activityBarBadge.background` and `activityBarBadge.foreground`, while also defining the colors in our default theme (@jrieken originally suggested this). This works as a better default otherwise all themes will inherit the green (a graceful fallback) until themes designate a color for it.

![gif](https://user-images.githubusercontent.com/35271042/57173492-86527500-6de5-11e9-9c90-49ba21440bdc.gif)

cc @bpasero @kieferrm 