### PR TITLE
Fix SVG links in Webview

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -153,7 +153,7 @@ module.exports = function createWebviewManager(host) {
 						scrollTarget.scrollIntoView();
 					}
 				} else {
-					host.postMessage('did-click-link', node.href);
+					host.postMessage('did-click-link', node.href.baseVal || node.href);
 				}
 				event.preventDefault();
 				break;


### PR DESCRIPTION
Currently, the links in SVGs in Webviews doesn’t work, because the value of `href` property might be a `SVGAnimatedString`.

Fixes #73601