### PR TITLE
Fix retain search panel on reload

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -478,6 +478,14 @@ Registry.as<ViewletRegistry>(ViewletExtensions.Viewlets).registerViewlet(new Vie
 	1
 ));
 
+Registry.as<PanelRegistry>(PanelExtensions.Panels).registerPanel(new PanelDescriptor(
+	SearchPanel,
+	PANEL_ID,
+	nls.localize('name', "Search"),
+	'search',
+	10
+));
+
 class RegisterSearchViewContribution implements IWorkbenchContribution {
 
 	constructor(


### PR DESCRIPTION
Fix https://github.com/Microsoft/vscode/issues/73240

This is the simple fix:

Register the search panel by default. Search location contribution will deregister it based on location.

Real fix is to prepare Panel part for dynamic contributions. I do not think it is worth to do that as a fix for this. It can be done when we support custom contributions to panel.