### PR TITLE
Fix opening extension from extension pack tab

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewer.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewer.ts
@@ -173,7 +173,7 @@ class OpenExtensionAction extends Action {
 	}
 }
 
-export class ExtensionsTree extends WorkbenchAsyncDataTree<IExtensionData, any> {
+export class ExtensionsTree extends WorkbenchAsyncDataTree<IExtensionData, IExtensionData> {
 
 	constructor(
 		input: IExtensionData,
@@ -212,7 +212,9 @@ export class ExtensionsTree extends WorkbenchAsyncDataTree<IExtensionData, any> 
 		this.setInput(input);
 
 		this.disposables.push(this.onDidChangeSelection(event => {
-			extensionsWorkdbenchService.open(event.elements[0], event.browserEvent instanceof MouseEvent && (event.browserEvent.ctrlKey || event.browserEvent.metaKey || event.browserEvent.altKey));
+			if (event.browserEvent && event.browserEvent instanceof KeyboardEvent) {
+				extensionsWorkdbenchService.open(event.elements[0].extension, false);
+			}
 		}));
 	}
 }


### PR DESCRIPTION
fix #73215

Fix is to pass `IExtension` instead of `IExtensionData` to open. 

In addition, restricted opening the extension only when selected through keyboard and removed opening to the side. It was like this before adopting to new tree and is changed after wrongly.

**Note:** Opening through mouse is handled separately using a link on the label