### PR TITLE
Fix settings tree filter not cleared when leaving search mode

### DIFF
--- a/src/vs/workbench/contrib/preferences/electron-browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/electron-browser/settingsEditor2.ts
@@ -1066,6 +1066,7 @@ export class SettingsEditor2 extends BaseEditor {
 			}
 
 			this.tocTree.setFocus([]);
+			this.viewState.filterToCategory = undefined;
 			this.tocTreeModel.currentSearchModel = this.searchResultModel;
 			this.onSearchModeToggled();
 
@@ -1207,6 +1208,7 @@ export class SettingsEditor2 extends BaseEditor {
 			}
 
 			this.tocTree.setFocus([]);
+			this.viewState.filterToCategory = undefined;
 			this.tocTree.expandAll();
 
 			this.renderTree(undefined, true);


### PR DESCRIPTION
Fix #73334

This just reverts part of the change from https://github.com/microsoft/vscode/issues/72778 and is safe.