### PR TITLE
comment thread user request handler

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1292,6 +1292,7 @@ export interface CommentThread2 {
 	onDidChangeComments: Event<Comment[] | undefined>;
 	collapsibleState?: CommentThreadCollapsibleState;
 	input?: CommentInput;
+	activeComment?: Comment;
 	onDidChangeInput: Event<CommentInput | undefined>;
 	acceptInputCommand?: Command;
 	additionalCommands?: Command[];

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -9088,6 +9088,15 @@ declare module 'vscode' {
 		 * Setter and getter for the contents of the comment input box
 		 */
 		value: string;
+
+		/**
+		 * The target object the comment input box is created for. It's
+		 * 1. `CommentThread` when users are replying to a comment thread
+		 * 2. `Comment` when users are editing a comment
+		 * 3. `CommentThreadTemplate` when users are creating a new comment thread
+		 * 4. `undefined` when there is no visible comment input box yet.
+		 */
+		target: CommentThread | Comment | CommentThreadTemplate | undefined;
 	}
 
 	/**
@@ -9119,17 +9128,10 @@ declare module 'vscode' {
 		readonly acceptInputCommand?: Command;
 
 		/**
-		 * Optional additonal commands.
-		 *
-		 * `additionalCommands` are the secondary actions rendered on Comment Widget.
+		 * When users attempt to create a new comment thread from the gutter or command palette, this callback will be invoked and
+		 * extensions should create a new comment thread by running `CommentController.createCommentThread` for the given document and range.
 		 */
-		readonly additionalCommands?: Command[];
-
-		/**
-		 * The command to be executed when users try to delete the comment thread. Currently, this is only called
-		 * when the user collapses a comment thread that has no comments in it.
-		 */
-		readonly deleteCommand?: Command;
+		handleCommentThreadCreationRequest(document: TextDocument, range: Range): void;
 	}
 
 	/**
@@ -9148,8 +9150,8 @@ declare module 'vscode' {
 		readonly label: string;
 
 		/**
-		 * The active [comment input box](#CommentInputBox). The active `inputBox` is the input box ofthe comment thread widget
-		 *  that currently has focus. `CommentInputBox.value` is empty string when the focus is not in any CommentInputBox.
+		 * The active [comment input box](#CommentInputBox). The active `inputBox` is the input box of the comment thread widget
+		 * that currently has focus. `CommentInputBox.value` is empty string when the focus is not in any CommentInputBox.
 		 */
 		readonly inputBox: CommentInputBox;
 
@@ -9158,9 +9160,6 @@ declare module 'vscode' {
 		 *
 		 * The comment controller will use this information to create the comment widget when users attempt to create new comment thread
 		 * from the gutter or command palette.
-		 *
-		 * When users run `CommentThreadTemplate.acceptInputCommand` or `CommentThreadTemplate.additionalCommands`, extensions should create
-		 * the approriate [CommentThread](#CommentThread).
 		 *
 		 * If not provided, users won't be able to create new comment threads in the editor.
 		 */

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -9088,16 +9088,6 @@ declare module 'vscode' {
 		 * Setter and getter for the contents of the comment input box
 		 */
 		value: string;
-
-		/**
-		 * The uri of the document comment input box has been created on
-		 */
-		resource: Uri;
-
-		/**
-		 * The range the comment input box is located within the document
-		 */
-		range: Range;
 	}
 
 	/**
@@ -9158,10 +9148,10 @@ declare module 'vscode' {
 		readonly label: string;
 
 		/**
-		 * The active [comment input box](#CommentInputBox) or `undefined`. The active `inputBox` is the input box of
-		 * the comment thread widget that currently has focus. It's `undefined` when the focus is not in any CommentInputBox.
+		 * The active [comment input box](#CommentInputBox). The active `inputBox` is the input box ofthe comment thread widget
+		 *  that currently has focus. `CommentInputBox.value` is empty string when the focus is not in any CommentInputBox.
 		 */
-		readonly inputBox: CommentInputBox | undefined;
+		readonly inputBox: CommentInputBox;
 
 		/**
 		 * Optional comment thread template information.

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -939,15 +939,6 @@ declare module 'vscode' {
 		reactionProvider?: CommentReactionProvider;
 	}
 
-	export interface CommentController {
-		/**
-		 * The active [comment thread](#CommentThread) or `undefined`. The `activeCommentThread` is the comment thread of
-		 * the comment widget that currently has focus. It's `undefined` when the focus is not in any comment thread widget, or
-		 * the comment widget created from [comment thread template](#CommentThreadTemplate).
-		 */
-		readonly activeCommentThread: CommentThread | undefined;
-	}
-
 	namespace workspace {
 		/**
 		 * DEPRECATED

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1211,7 +1211,7 @@ export interface ExtHostCommentsShape {
 	$provideDocumentComments(handle: number, document: UriComponents): Promise<modes.CommentInfo | null>;
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Promise<modes.CommentThread | null>;
 	$onCommentWidgetInputChange(commentControllerHandle: number, document: UriComponents, range: IRange, input: string | undefined): Promise<number | undefined>;
-	$onActiveCommentThreadChange(commentControllerHandle: number, threadHandle: number | undefined): Promise<number | undefined>;
+	$onActiveCommentThreadChange(commentControllerHandle: number, threadHandle: number | undefined, comment: modes.Comment | undefined): Promise<number | undefined>;
 	$provideCommentingRanges(commentControllerHandle: number, uriComponents: UriComponents, token: CancellationToken): Promise<IRange[] | undefined>;
 	$provideReactionGroup(commentControllerHandle: number): Promise<modes.CommentReaction[] | undefined>;
 	$toggleReaction(commentControllerHandle: number, threadHandle: number, uri: UriComponents, comment: modes.Comment, reaction: modes.CommentReaction): Promise<void>;

--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -550,11 +550,11 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 }
 
 export class ExtHostCommentInputBox implements vscode.CommentInputBox {
-	get resource(): vscode.Uri {
+	get resource(): vscode.Uri | undefined {
 		return this._resource;
 	}
 
-	get range(): vscode.Range {
+	get range(): vscode.Range | undefined {
 		return this._range;
 	}
 
@@ -577,13 +577,13 @@ export class ExtHostCommentInputBox implements vscode.CommentInputBox {
 	constructor(
 		private _proxy: MainThreadCommentsShape,
 		public commentControllerHandle: number,
-		private _resource: vscode.Uri,
-		private _range: vscode.Range,
+		private _resource: vscode.Uri | undefined,
+		private _range: vscode.Range | undefined,
 		private _value: string
 	) {
 	}
 
-	setInput(resource: vscode.Uri, range: vscode.Range, input: string) {
+	setInput(resource: vscode.Uri | undefined, range: vscode.Range | undefined, input: string) {
 		this._resource = resource;
 		this._range = range;
 		this._value = input;
@@ -598,7 +598,7 @@ class ExtHostCommentController implements vscode.CommentController {
 		return this._label;
 	}
 
-	public inputBox: ExtHostCommentInputBox | undefined;
+	public inputBox: ExtHostCommentInputBox;
 	private _activeCommentThread: ExtHostCommentThread | undefined;
 
 	public get activeCommentThread(): ExtHostCommentThread | undefined {
@@ -664,6 +664,7 @@ class ExtHostCommentController implements vscode.CommentController {
 		private _label: string
 	) {
 		this._proxy.$registerCommentController(this.handle, _id, _label);
+		this.inputBox = new ExtHostCommentInputBox(this._proxy, this.handle, undefined, undefined, '');
 	}
 
 	createCommentThread(id: string, resource: vscode.Uri, range: vscode.Range, comments: vscode.Comment[]): vscode.CommentThread {
@@ -673,11 +674,7 @@ class ExtHostCommentController implements vscode.CommentController {
 	}
 
 	$onCommentWidgetInputChange(uriComponents: UriComponents, range: IRange, input: string) {
-		if (!this.inputBox) {
-			this.inputBox = new ExtHostCommentInputBox(this._proxy, this.handle, URI.revive(uriComponents), extHostTypeConverter.Range.to(range), input);
-		} else {
-			this.inputBox.setInput(URI.revive(uriComponents), extHostTypeConverter.Range.to(range), input);
-		}
+		this.inputBox.setInput(URI.revive(uriComponents), extHostTypeConverter.Range.to(range), input);
 	}
 
 	$onActiveCommentThreadChange(threadHandle: number) {

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -392,6 +392,7 @@ export class CommentNode extends Disposable {
 				value: this.comment.body.value
 			};
 			this.commentService.setActiveCommentThread(commentThread);
+			commentThread.activeComment = this.comment;
 
 			this._commentEditorDisposables.push(this._commentEditor.onDidFocusEditorWidget(() => {
 				commentThread.input = {
@@ -421,6 +422,11 @@ export class CommentNode extends Disposable {
 		this.isEditing = false;
 		this._editAction.enabled = true;
 		this._body.classList.remove('hidden');
+
+		let commentThread = this.commentThread as modes.CommentThread2;
+		if (commentThread.commentThreadHandle !== undefined) {
+			commentThread.activeComment = undefined;
+		}
 
 		this._commentEditorModel.dispose();
 		this._commentEditorDisposables.forEach(dispose => dispose.dispose());

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -695,6 +695,7 @@ export class ReviewController implements IEditorContribution {
 				// create comment widget through template
 				let commentThreadWidget = this.addCommentThreadFromTemplate(lineNumber, ownerId);
 				commentThreadWidget.display(lineNumber, true);
+				commentingRangesInfo.newCommentThreadCallback!(this.editor.getModel()!.uri, range);
 				this._commentWidgets.push(commentThreadWidget);
 				commentThreadWidget.onDidClose(() => {
 					this._commentWidgets = this._commentWidgets.filter(zoneWidget => !(


### PR DESCRIPTION
This PR demonstrates our ideas of having a simple `CommentInputBox` without document and range info, and introduces back the handler/factory function for new comment thread creation request. Changes for `vscode.d.ts` are like below

```typescript
export interface CommentInputBox {
	/**
	 * Setter and getter for the contents of the comment input box
	 */
	value: string;

	/**
	 * The target object the comment input box is created for. It's
	 * 1. `CommentThread` when users are replying to a comment thread
	 * 2. `Comment` when users are editing a comment
	 * 3. `CommentThreadTemplate` when users are creating a new comment thread
	 * 4. `undefined` when there is no visible comment input box yet.
	 */
	target: CommentThread | Comment | CommentThreadTemplate | undefined;
}

export interface CommentThreadTemplate {
	/**
	 * The human-readable label describing the [Comment Thread](#CommentThread)
	 */
	readonly label: string;

	/**
	 * Optional accept input command
	 *
	 * `acceptInputCommand` is the default action rendered on Comment Widget, which is always placed rightmost.
	 * This command will be invoked when users the user accepts the value in the comment editor.
	 * This command will disabled when the comment editor is empty.
	 */
	readonly acceptInputCommand?: Command;

	/**
	 * When users attempt to create a new comment thread from the gutter or command palette, this callback will be invoked and
	 * extensions should create a new comment thread by running `CommentController.createCommentThread` for the given document and range.
	 */
	handleCommentThreadCreationRequest(document: TextDocument, range: Range): void;
}
```

The idea behind this is 

* `CommentInputBox` should be simple enough and should not be bind to any `document or `range`. One good example is when users are editing a comment, `range` property doesn't make too much sense. 
* If we are going to remove `document` and `range` from `CommentInputBox`, the extensions need a way to be notified by the creation of new comment thread, we introduce `handleCommentThreadCreationRequest(document: TextDocument, range: Range): void;`. It can be a method on `CommentThreadTemplate` or a property on `CommentController`.
* `CommentInputBox` is never `undefined`, and the value of it is empty string when there is no focused comment editor.
* We discussed about having a `target` property for `CommentInputBox`, which points to either `CommentThread` when users are replying, a `Comment` when users are editing a comment, or `CommentThreadTemplate` when users just hit `+` button. It can be `undefined` as again, there is no target when there is no visible/active comment editor. Right now I don't see any valid reason why we have to have this property but @jrieken can remind on this.

---
@jrieken we may get more proposals from Zurich's standup but to get the `document`/`range` information when users try to create a new comment thread, we already tried

* a callback/handler, like `handleCommentThreadCreationRequest(document: TextDocument, range: Range): void`.
* we maintain the focused comment widget position `document`/`range` somewhere, like `CommentInputBox.uri`/`CommentInputBox.range`

It would be great if we have opinions/discussion around the pros and cons of these two approaches.