### PR TITLE
Remove trailing slash from git URL before inferring repo name

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -338,7 +338,7 @@ export class Git {
 	}
 
 	async clone(url: string, parentPath: string, cancellationToken?: CancellationToken): Promise<string> {
-		let baseFolderName = decodeURI(url).replace(/^.*\//, '').replace(/\.git$/, '') || 'repository';
+		let baseFolderName = decodeURI(url).replace(/\/$/, '').replace(/^.*\//, '').replace(/\.git$/, '') || 'repository';
 		let folderName = baseFolderName;
 		let folderPath = path.join(parentPath, folderName);
 		let count = 1;


### PR DESCRIPTION
Fixes: #71722

While cloning a repo from github with a trailing slash works just fine, VSCode fails to infer the repo name correctly, because it starts looking after the last slash. This PR removes trailing slashes before doing that work, so URLs like https://github.com/ioBroker/testing/ have the correct repo name inferred.

/cc @joaomoreno 