### PR TITLE
fixes #73218

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -244,6 +244,9 @@ export class ContextView extends Disposable {
 		// if view intersects vertically with anchor, shift it horizontally
 		if (Range.intersects({ start: top, end: top + viewSizeHeight }, { start: verticalAnchor.offset, end: verticalAnchor.offset + verticalAnchor.size })) {
 			horizontalAnchor.size = around.width;
+			if (anchorAlignment === AnchorAlignment.RIGHT) {
+				horizontalAnchor.offset = around.left;
+			}
 		}
 
 		const left = layout(window.innerWidth, viewSizeWidth, horizontalAnchor);


### PR DESCRIPTION
When the anchor is overlapped vertically, we need to shift it horizontally. This is taken care of but the anchor adjustment was slightly off.