### PR TITLE
Fix #72587 suggestWidget no scroll on first open

### DIFF
--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -965,8 +965,10 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 		this.expandSideOrBelow();
 
 		show(this.details.element);
-		this.details.render(this.list.getFocusedElements()[0]);
+
+		// Set maxHeight before .render() as Fix for #72587
 		this.details.element.style.maxHeight = this.maxWidgetHeight + 'px';
+		this.details.render(this.list.getFocusedElements()[0]);
 
 		// Reset margin-top that was set as Fix for #26416
 		this.listElement.style.marginTop = '0px';


### PR DESCRIPTION
If the first time the suggestWidget was opened (ctrl+space) its
content vertically overflowed, it would not scroll. This commit fixes
suggestWidget so that it scrolls tall content even on first use.
The maxHeight must be set before scanDomNode checks clientHeight.