### PR TITLE
"Smart Renaming" is disableable

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -359,70 +359,21 @@ export function findValidPasteFileTarget(targetFolder: ExplorerItem, fileToPaste
 }
 
 export function incrementFileName(name: string, isFolder: boolean): string {
-	const separators = '[\\.\\-_]';
 	const maxNumber = Constants.MAX_SAFE_SMALL_INTEGER;
 
-	// file.1.txt=>file.2.txt
-	let suffixFileRegex = RegExp('(.*' + separators + ')(\\d+)(\\..*)$');
-	if (!isFolder && name.match(suffixFileRegex)) {
-		return name.replace(suffixFileRegex, (match, g1?, g2?, g3?) => {
-			let number = parseInt(g2);
-			return number < maxNumber
-				? g1 + strings.pad(number + 1, g2.length) + g3
-				: strings.format('{0}{1}.1{2}', g1, g2, g3);
-		});
+	if (name.match(/ \(Copy\)(?:\..+)?$/)) {
+		return name.replace(/ \(Copy\)(\..+)?$/, ' (Copy 2)$1');
 	}
 
-	// 1.file.txt=>2.file.txt
-	let prefixFileRegex = RegExp('(\\d+)(' + separators + '.*)(\\..*)$');
-	if (!isFolder && name.match(prefixFileRegex)) {
-		return name.replace(prefixFileRegex, (match, g1?, g2?, g3?) => {
-			let number = parseInt(g1);
-			return number < maxNumber
-				? strings.pad(number + 1, g1.length) + g2 + g3
-				: strings.format('{0}{1}.1{2}', g1, g2, g3);
-		});
+	let m = name.match(/ \(Copy (\d+)\)(?:\..+)?$/);
+	if (m) {
+		let num = +m[1];
+		if (num < maxNumber - 1) {
+			return name.replace(/ \(Copy \d+\)(\..+)?/, strings.format(' (Copy {0})$1', num + 1));
+		}
 	}
 
-	// 1.txt=>2.txt
-	let prefixFileNoNameRegex = RegExp('(\\d+)(\\..*)$');
-	if (!isFolder && name.match(prefixFileNoNameRegex)) {
-		return name.replace(prefixFileNoNameRegex, (match, g1?, g2?) => {
-			let number = parseInt(g1);
-			return number < maxNumber
-				? strings.pad(number + 1, g1.length) + g2
-				: strings.format('{0}.1{1}', g1, g2);
-		});
-	}
-
-	// file.txt=>file.1.txt
-	const lastIndexOfDot = name.lastIndexOf('.');
-	if (!isFolder && lastIndexOfDot >= 0) {
-		return strings.format('{0}.1{1}', name.substr(0, lastIndexOfDot), name.substr(lastIndexOfDot));
-	}
-
-	// folder.1=>folder.2
-	if (isFolder && name.match(/(\d+)$/)) {
-		return name.replace(/(\d+)$/, (match: string, ...groups: any[]) => {
-			let number = parseInt(groups[0]);
-			return number < maxNumber
-				? strings.pad(number + 1, groups[0].length)
-				: strings.format('{0}.1', groups[0]);
-		});
-	}
-
-	// 1.folder=>2.folder
-	if (isFolder && name.match(/^(\d+)/)) {
-		return name.replace(/^(\d+)(.*)$/, (match: string, ...groups: any[]) => {
-			let number = parseInt(groups[0]);
-			return number < maxNumber
-				? strings.pad(number + 1, groups[0].length) + groups[1]
-				: strings.format('{0}{1}.1', groups[0], groups[1]);
-		});
-	}
-
-	// file/folder=>file.1/folder.1
-	return strings.format('{0}.1', name);
+	return name.replace(/(\..+)?$/, ' (Copy)$1');
 }
 
 // Global Compare with

--- a/src/vs/workbench/contrib/files/test/electron-browser/fileActions.test.ts
+++ b/src/vs/workbench/contrib/files/test/electron-browser/fileActions.test.ts
@@ -7,161 +7,68 @@ import * as assert from 'assert';
 import { incrementFileName } from 'vs/workbench/contrib/files/browser/fileActions';
 
 suite('Files - Increment file name', () => {
-
-	test('Increment file name without any version', function () {
+	test('Increment file name', function () {
 		const name = 'test.js';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test.1.js');
+		assert.strictEqual(result, 'test (Copy).js');
 	});
-
-	test('Increment folder name without any version', function () {
+	test('Increment file name without file extension', function () {
 		const name = 'test';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, 'test.1');
-	});
-
-	test('Increment file name with suffix version', function () {
-		const name = 'test.1.js';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test.2.js');
+		assert.strictEqual(result, 'test (Copy)');
 	});
-
-	test('Increment file name with suffix version with trailing zeros', function () {
-		const name = 'test.001.js';
+	test('Increment file name with two file extensions', function () {
+		const name = 'test.tar.gz';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test.002.js');
+		assert.strictEqual(result, 'test (Copy).tar.gz');
 	});
 
-	test('Increment file name with suffix version with trailing zeros, changing length', function () {
-		const name = 'test.009.js';
+	test('Increment second file name', function () {
+		const name = 'test (Copy).js';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test.010.js');
+		assert.strictEqual(result, 'test (Copy 2).js');
 	});
-
-	test('Increment file name with suffix version with `-` as separator', function () {
-		const name = 'test-1.js';
+	test('Increment second file name without file extension', function () {
+		const name = 'test (Copy)';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test-2.js');
+		assert.strictEqual(result, 'test (Copy 2)');
 	});
-
-	test('Increment file name with suffix version with `-` as separator, trailing zeros', function () {
-		const name = 'test-001.js';
+	test('Increment second file name with two file extensions', function () {
+		const name = 'test (Copy).tar.gz';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test-002.js');
+		assert.strictEqual(result, 'test (Copy 2).tar.gz');
 	});
 
-	test('Increment file name with suffix version with `-` as separator, trailing zeros, changnig length', function () {
-		const name = 'test-099.js';
+	test('Increment third file name', function () {
+		const name = 'test (Copy 2).js';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test-100.js');
+		assert.strictEqual(result, 'test (Copy 3).js');
 	});
-
-	test('Increment file name with suffix version with `_` as separator', function () {
-		const name = 'test_1.js';
+	test('Increment third file name without file extension', function () {
+		const name = 'test (Copy 2)';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test_2.js');
+		assert.strictEqual(result, 'test (Copy 3)');
 	});
-
-	test('Increment folder name with suffix version', function () {
-		const name = 'test.1';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, 'test.2');
-	});
-
-	test('Increment folder name with suffix version, trailing zeros', function () {
-		const name = 'test.001';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, 'test.002');
-	});
-
-	test('Increment folder name with suffix version with `-` as separator', function () {
-		const name = 'test-1';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, 'test-2');
-	});
-
-	test('Increment folder name with suffix version with `_` as separator', function () {
-		const name = 'test_1';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, 'test_2');
-	});
-
-	test('Increment file name with suffix version, too big number', function () {
-		const name = 'test.9007199254740992.js';
+	test('Increment third file name with two file extensions', function () {
+		const name = 'test (Copy 2).tar.gz';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, 'test.9007199254740992.1.js');
+		assert.strictEqual(result, 'test (Copy 3).tar.gz');
 	});
 
-	test('Increment folder name with suffix version, too big number', function () {
-		const name = 'test.9007199254740992';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, 'test.9007199254740992.1');
-	});
-
-	test('Increment file name with prefix version', function () {
-		const name = '1.test.js';
+	test('Increment max safe small integer file name', function () {
+		const name = 'test (Copy 1073741824).js';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '2.test.js');
+		assert.strictEqual(result, 'test (Copy 1073741824) (Copy).js');
 	});
-
-	test('Increment file name with just version in name', function () {
-		const name = '1.js';
+	test('Increment max safe small integer file name without file extension', function () {
+		const name = 'test (Copy 1073741824)';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '2.js');
+		assert.strictEqual(result, 'test (Copy 1073741824) (Copy)');
 	});
-
-	test('Increment file name with just version in name, too big number', function () {
-		const name = '9007199254740992.js';
+	test('Increment max safe small integer file name with two file extensions', function () {
+		const name = 'test (Copy 1073741824).tar.gz';
 		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '9007199254740992.1.js');
-	});
-
-	test('Increment file name with prefix version, trailing zeros', function () {
-		const name = '001.test.js';
-		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '002.test.js');
-	});
-
-	test('Increment file name with prefix version with `-` as separator', function () {
-		const name = '1-test.js';
-		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '2-test.js');
-	});
-
-	test('Increment file name with prefix version with `-` as separator', function () {
-		const name = '1_test.js';
-		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '2_test.js');
-	});
-
-	test('Increment file name with prefix version, too big number', function () {
-		const name = '9007199254740992.test.js';
-		const result = incrementFileName(name, false);
-		assert.strictEqual(result, '9007199254740992.test.1.js');
-	});
-
-	test('Increment folder name with prefix version', function () {
-		const name = '1.test';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, '2.test');
-	});
-
-	test('Increment folder name with prefix version, too big number', function () {
-		const name = '9007199254740992.test';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, '9007199254740992.test.1');
-	});
-
-	test('Increment folder name with prefix version, trailing zeros', function () {
-		const name = '001.test';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, '002.test');
-	});
-
-	test('Increment folder name with prefix version  with `-` as separator', function () {
-		const name = '1-test';
-		const result = incrementFileName(name, true);
-		assert.strictEqual(result, '2-test');
+		assert.strictEqual(result, 'test (Copy 1073741824) (Copy).tar.gz');
 	});
 
 });


### PR DESCRIPTION
This is the thing that looks at the filename, and tries to "guess" the
next number up. This change adds an option (enabled by default) which
replaces this behaviour with a more traditional one that adds "(Copy)"
at the end of the filename.

Discussion about this issue is located on issue #55128 .