### PR TITLE
Fix docblock for FileSystemError

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -5500,8 +5500,8 @@ declare module 'vscode' {
 	/**
 	 * A type that filesystem providers should use to signal errors.
 	 *
-	 * This class has factory methods for common error-cases, like `EntryNotFound` when
-	 * a file or folder doesn't exist, use them like so: `throw vscode.FileSystemError.EntryNotFound(someUri);`
+	 * This class has factory methods for common error-cases, like `FileNotFound` when
+	 * a file or folder doesn't exist, use them like so: `throw vscode.FileSystemError.FileNotFound(someUri);`
 	 */
 	export class FileSystemError extends Error {
 


### PR DESCRIPTION
This change is a simple fix to the doc block for FileSystemError.  The current doc block seems to reference an old error type that was likely missed as a part of: https://github.com/microsoft/vscode/commit/bf6155555d6276ce479b3cfafaff4f3a62073ef2#diff-4878e8b25d41f2ab7c2715852b1b97aa