### PR TITLE
Fix-73465 Toggle search view position should also appear in empty search view

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -683,10 +683,6 @@ export class SearchView extends ViewletPanel {
 	}
 
 	private onContextMenu(e: ITreeContextMenuEvent<RenderableMatch | null>): void {
-		// if (!e.element) {
-		// 	return;
-		// }
-
 		if (!this.contextMenu) {
 			this.contextMenu = this._register(this.menuService.createMenu(MenuId.SearchContext, this.contextKeyService));
 		}
@@ -1327,8 +1323,6 @@ export class SearchView extends ViewletPanel {
 				// Indicate as status to ARIA
 				aria.status(message);
 
-				//dom.hide(this.resultsElement);
-
 				const messageEl = this.clearMessage();
 				const p = dom.append(messageEl, $('p', undefined, message));
 
@@ -1358,12 +1352,12 @@ export class SearchView extends ViewletPanel {
 
 					const learnMoreLink = dom.append(p, $('a.pointer.prominent', { tabindex: 0 }, nls.localize('openSettings.learnMore', "Learn More")));
 					this.addClickEvents(learnMoreLink, this.onLearnMore);
-					this.reLayout();
 				}
 
 				if (this.contextService.getWorkbenchState() === WorkbenchState.EMPTY) {
 					this.showSearchWithoutFolderMessage();
 				}
+				this.reLayout();
 			} else {
 				this.viewModel.searchResult.toggleHighlights(this.isVisible()); // show highlights
 

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -683,9 +683,9 @@ export class SearchView extends ViewletPanel {
 	}
 
 	private onContextMenu(e: ITreeContextMenuEvent<RenderableMatch | null>): void {
-		if (!e.element) {
-			return;
-		}
+		// if (!e.element) {
+		// 	return;
+		// }
 
 		if (!this.contextMenu) {
 			this.contextMenu = this._register(this.menuService.createMenu(MenuId.SearchContext, this.contextKeyService));
@@ -1327,7 +1327,7 @@ export class SearchView extends ViewletPanel {
 				// Indicate as status to ARIA
 				aria.status(message);
 
-				dom.hide(this.resultsElement);
+				//dom.hide(this.resultsElement);
 
 				const messageEl = this.clearMessage();
 				const p = dom.append(messageEl, $('p', undefined, message));
@@ -1358,6 +1358,7 @@ export class SearchView extends ViewletPanel {
 
 					const learnMoreLink = dom.append(p, $('a.pointer.prominent', { tabindex: 0 }, nls.localize('openSettings.learnMore', "Learn More")));
 					this.addClickEvents(learnMoreLink, this.onLearnMore);
+					this.reLayout();
 				}
 
 				if (this.contextService.getWorkbenchState() === WorkbenchState.EMPTY) {


### PR DESCRIPTION
@roblourens , Tweaked Toggle Search Position Feature to work on empty tree and No Search Results as per our discussion to fix #73465 . ( I have just commented the lines and not removed them , just one addition of calling `reLayout()` again)
Please review it and let me know if there are any changes. I have attached a video showing all use cases.

https://drive.google.com/file/d/1EJCRRuven-pmXS20Pr1e3-4aocrM5i-c/view?usp=sharing