### PR TITLE
Allow multi-line comment auto-closing for C++ files

### DIFF
--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -13,7 +13,8 @@
 		{ "open": "{", "close": "}" },
 		{ "open": "(", "close": ")" },
 		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
-		{ "open": "\"", "close": "\"", "notIn": ["string"] }
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "/*", "close": " */", "notIn": ["string"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],

--- a/extensions/cpp/language-configuration.json
+++ b/extensions/cpp/language-configuration.json
@@ -14,7 +14,7 @@
 		{ "open": "(", "close": ")" },
 		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
 		{ "open": "\"", "close": "\"", "notIn": ["string"] },
-		{ "open": "/*", "close": " */", "notIn": ["string"] }
+		{ "open": "/*", "close": " */", "notIn": ["string", "comment"] }
 	],
 	"surroundingPairs": [
 		["{", "}"],


### PR DESCRIPTION
___
Fixes #72801.
___
**Summary**:
It has been suggested to add support for auto-closing a multi-line comment pair (`/* */`) when typing in a C++ language file. It is now possible to simply type `/*` in a .cpp file and it will auto-complete to `/* */`.
___
![Demonstration of C++ comment auto-completion.](https://user-images.githubusercontent.com/4957200/57880166-b46f8600-77e3-11e9-8087-69b3d42b8dd7.gif)
