### PR TITLE
Smart select: only add line ranges if they’re contained by the next range

### DIFF
--- a/src/vs/editor/contrib/smartSelect/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/smartSelect.ts
@@ -284,12 +284,12 @@ export function provideSelectionRanges(model: ITextModel, positions: Position[],
 				if (cur.startLineNumber !== prev.startLineNumber || cur.endLineNumber !== prev.endLineNumber) {
 					// add line/block range without leading/failing whitespace
 					const rangeNoWhitespace = new Range(prev.startLineNumber, model.getLineFirstNonWhitespaceColumn(prev.startLineNumber), prev.endLineNumber, model.getLineLastNonWhitespaceColumn(prev.endLineNumber));
-					if (rangeNoWhitespace.containsRange(prev) && !rangeNoWhitespace.equalsRange(prev)) {
+					if (rangeNoWhitespace.containsRange(prev) && !rangeNoWhitespace.equalsRange(prev) && cur.containsRange(rangeNoWhitespace) && !cur.equalsRange(rangeNoWhitespace)) {
 						oneRangesWithTrivia.push(rangeNoWhitespace);
 					}
 					// add line/block range
 					const rangeFull = new Range(prev.startLineNumber, 1, prev.endLineNumber, model.getLineMaxColumn(prev.endLineNumber));
-					if (rangeFull.containsRange(prev) && !rangeFull.equalsRange(rangeNoWhitespace)) {
+					if (rangeFull.containsRange(prev) && !rangeFull.equalsRange(rangeNoWhitespace) && cur.containsRange(rangeFull) && !cur.equalsRange(rangeFull)) {
 						oneRangesWithTrivia.push(rangeFull);
 					}
 				}


### PR DESCRIPTION
Fixes this issue described here: https://github.com/microsoft/TypeScript/issues/29071#issuecomment-493174472 (using typescript@master—PR was just merged today)

**Before**:

![smart select 2](https://user-images.githubusercontent.com/3277153/57889805-98231780-77ea-11e9-938e-ed89b367249a.gif)

**After**:

![smart select 3](https://user-images.githubusercontent.com/3277153/57889967-1c759a80-77eb-11e9-9964-6e16daee4238.gif)

I was looking to add a test in [smartSelect.test.ts](https://github.com/microsoft/vscode/blob/master/src/vs/editor/contrib/smartSelect/test/smartSelect.test.ts), but I'm not sure how to replicate this scenario in a test environment—whatever default set of SelectionRangeProviders that are registered in those tests don’t seem to produce ranges that exhibit the issue. I'm happy to add a test if someone can provide guidance on how I can set one up.