### PR TITLE
Adds a new explorerViewer sort order configuration item, barrelFirst

### DIFF
--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -13,7 +13,7 @@ export function setFileNameComparer(collator: IdleValue<{ collator: Intl.Collato
 	intlFileNameCollator = collator;
 }
 
-export function compareFileNamesForBarrel(one: string | null, other: string | null, caseSensitive = false) {
+export function compareFileNamesForBarrel(one: string | null, other: string | null, caseSensitive = false): number {
 	const defaultSortResult = compareFileNames(one, other, caseSensitive);
 	const oneStartsWithIndex = one && one.indexOf('index') === 0;
 	const otherStartsWithIndex = other && other.indexOf('index') === 0;

--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -13,6 +13,15 @@ export function setFileNameComparer(collator: IdleValue<{ collator: Intl.Collato
 	intlFileNameCollator = collator;
 }
 
+export function compareFileNamesForBarrel(one: string | null, other: string | null, caseSensitive = false) {
+	const defaultSortResult = compareFileNames(one, other, caseSensitive);
+	const oneStartsWithIndex = one && one.indexOf('index') === 0;
+	const otherStartsWithIndex = other && other.indexOf('index') === 0;
+	const oneBeforeOther = oneStartsWithIndex && !otherStartsWithIndex;
+	const otherBeforeOne = otherStartsWithIndex && !oneStartsWithIndex;
+	return oneBeforeOther ? -1 : otherBeforeOne ? 1 : defaultSortResult;
+}
+
 export function compareFileNames(one: string | null, other: string | null, caseSensitive = false): number {
 	if (intlFileNameCollator) {
 		const a = one || '';

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -392,14 +392,15 @@ configurationRegistry.registerConfiguration({
 		},
 		'explorer.sortOrder': {
 			'type': 'string',
-			'enum': [SortOrderConfiguration.DEFAULT, SortOrderConfiguration.MIXED, SortOrderConfiguration.FILES_FIRST, SortOrderConfiguration.TYPE, SortOrderConfiguration.MODIFIED],
+			'enum': [SortOrderConfiguration.DEFAULT, SortOrderConfiguration.MIXED, SortOrderConfiguration.FILES_FIRST, SortOrderConfiguration.TYPE, SortOrderConfiguration.MODIFIED, SortOrderConfiguration.BARREL_FIRST],
 			'default': SortOrderConfiguration.DEFAULT,
 			'enumDescriptions': [
 				nls.localize('sortOrder.default', 'Files and folders are sorted by their names, in alphabetical order. Folders are displayed before files.'),
 				nls.localize('sortOrder.mixed', 'Files and folders are sorted by their names, in alphabetical order. Files are interwoven with folders.'),
 				nls.localize('sortOrder.filesFirst', 'Files and folders are sorted by their names, in alphabetical order. Files are displayed before folders.'),
 				nls.localize('sortOrder.type', 'Files and folders are sorted by their extensions, in alphabetical order. Folders are displayed before files.'),
-				nls.localize('sortOrder.modified', 'Files and folders are sorted by last modified date, in descending order. Folders are displayed before files.')
+				nls.localize('sortOrder.modified', 'Files and folders are sorted by last modified date, in descending order. Folders are displayed before files.'),
+				nls.localize('sortOrder.barrelFirst', 'Folders are sorted by their names, in alphabetical order. Barrel files are displayed before other files.')
 			],
 			'description': nls.localize('sortOrder', "Controls sorting order of files and folders in the explorer.")
 		},

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -29,7 +29,7 @@ import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { equals, deepClone } from 'vs/base/common/objects';
 import * as path from 'vs/base/common/path';
 import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
-import { compareFileExtensions, compareFileNames } from 'vs/base/common/comparers';
+import { compareFileExtensions, compareFileNames, compareFileNamesForBarrel } from 'vs/base/common/comparers';
 import { fillResourceDataTransfers, CodeDataTransfers, extractResources } from 'vs/workbench/browser/dnd';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IDragAndDropData, DataTransfers } from 'vs/base/browser/dnd';
@@ -418,6 +418,9 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 				}
 
 				return compareFileNames(statA.name, statB.name);
+
+			case 'barrelFirst':
+				return compareFileNamesForBarrel(statA.name, statB.name);
 
 			default: /* 'default', 'mixed', 'filesFirst' */
 				return compareFileNames(statA.name, statB.name);

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -128,10 +128,11 @@ export const SortOrderConfiguration = {
 	MIXED: 'mixed',
 	FILES_FIRST: 'filesFirst',
 	TYPE: 'type',
-	MODIFIED: 'modified'
+	MODIFIED: 'modified',
+	BARREL_FIRST: 'barrelFirst'
 };
 
-export type SortOrder = 'default' | 'mixed' | 'filesFirst' | 'type' | 'modified';
+export type SortOrder = 'default' | 'mixed' | 'filesFirst' | 'type' | 'modified' | 'barrelFirst';
 
 export class TextFileContentProvider implements ITextModelContentProvider {
 	private fileWatcherDisposable: IDisposable | undefined;


### PR DESCRIPTION
This setting sorts barrel files (index.js, index.ts, etc.) in alphabetical order above all other files. Folders remain above all files including barrel files.

Partially addresses #27286 (still open but not specifically calling for this) and [a comment requesting this feature](https://github.com/microsoft/vscode/issues/12345#issuecomment-249316536) on a now closed issue, #12345.