### PR TITLE
Fix-72938 Searching in specified path only works when another folder is already open

### DIFF
--- a/src/vs/workbench/contrib/search/common/queryBuilder.ts
+++ b/src/vs/workbench/contrib/search/common/queryBuilder.ts
@@ -274,7 +274,7 @@ export class QueryBuilder {
 	 * Split search paths (./ or ../ or absolute paths in the includePatterns) into absolute paths and globs applied to those paths
 	 */
 	private expandSearchPathPatterns(searchPaths: string[]): ISearchPathPattern[] {
-		if (this.workspaceContextService.getWorkbenchState() === WorkbenchState.EMPTY || !searchPaths || !searchPaths.length) {
+		if (!searchPaths || !searchPaths.length) {
 			// No workspace => ignore search paths
 			return [];
 		}


### PR DESCRIPTION
@roblourens , removing the empty workspace check in **expandSearchPathPatterns** function will fix #72938.
Please review this and let me know if this is fine ? 