### PR TITLE
Add shortcut to Collapse All Trees in Outline View

### DIFF
--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -303,6 +303,24 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'list.collapseAll',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: WorkbenchListFocusContextKey,
+	primary: KeyMod.CtrlCmd | KeyCode.LeftArrow,
+	mac: {
+		primary: KeyMod.CtrlCmd | KeyCode.LeftArrow,
+		secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.UpArrow]
+	},
+	handler: (accessor) => {
+		const focusedTree = accessor.get(IListService).lastFocusedList;
+
+		if (focusedTree && !(focusedTree instanceof List || focusedTree instanceof PagedList)) {
+			focusedTree.collapseAll();
+		}
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.expand',
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: WorkbenchListFocusContextKey,

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -47,7 +47,6 @@ import { basename } from 'vs/base/common/resources';
 import { IDataSource } from 'vs/base/browser/ui/tree/tree';
 import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
-import { ICommandHandler, CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 class RequestState {
 
@@ -274,11 +273,6 @@ export class OutlinePanel extends ViewletPanel {
 		this._contextKeyFiltered = OutlineViewFiltered.bindTo(contextKeyService);
 		this._disposables.push(this.onDidFocus(_ => this._contextKeyFocused.set(true)));
 		this._disposables.push(this.onDidBlur(_ => this._contextKeyFocused.set(false)));
-
-		CommandsRegistry.registerCommand({
-			id: 'outline.collapseAll',
-			handler: this.outlineCollapseAllCommand
-		});
 	}
 
 	dispose(): void {
@@ -296,15 +290,6 @@ export class OutlinePanel extends ViewletPanel {
 			this._tree.domFocus();
 			if (!this._tree.isDOMFocused()) {
 				this._domNode.focus();
-			}
-		}
-	}
-
-	private outlineCollapseAllCommand: ICommandHandler = accessor => {
-		const actions = this.getActions();
-		for (const action of actions) {
-			if (action.id === 'collapse') {
-				action.run();
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -47,7 +47,7 @@ import { basename } from 'vs/base/common/resources';
 import { IDataSource } from 'vs/base/browser/ui/tree/tree';
 import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
-import { ICommandHandler } from 'vs/platform/commands/common/commands';
+import { ICommandHandler, CommandsRegistry } from 'vs/platform/commands/common/commands';
 
 class RequestState {
 
@@ -274,6 +274,11 @@ export class OutlinePanel extends ViewletPanel {
 		this._contextKeyFiltered = OutlineViewFiltered.bindTo(contextKeyService);
 		this._disposables.push(this.onDidFocus(_ => this._contextKeyFocused.set(true)));
 		this._disposables.push(this.onDidBlur(_ => this._contextKeyFocused.set(false)));
+
+		CommandsRegistry.registerCommand({
+			id: 'outline.collapseAll',
+			handler: this.outlineCollapseAllCommand
+		});
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -47,6 +47,7 @@ import { basename } from 'vs/base/common/resources';
 import { IDataSource } from 'vs/base/browser/ui/tree/tree';
 import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
+import { ICommandHandler } from 'vs/platform/commands/common/commands';
 
 class RequestState {
 
@@ -290,6 +291,15 @@ export class OutlinePanel extends ViewletPanel {
 			this._tree.domFocus();
 			if (!this._tree.isDOMFocused()) {
 				this._domNode.focus();
+			}
+		}
+	}
+
+	private outlineCollapseAllCommand: ICommandHandler = accessor => {
+		const actions = this.getActions();
+		for (const action of actions) {
+			if (action.id === 'collapse') {
+				action.run();
 			}
 		}
 	}


### PR DESCRIPTION
___
Fixes #70369.
___
**Summary**:
It has been suggested to add a keybind for collapsing all trees in the Outline View. A command has been created to handle collapsing the trees and has been registered so that a user may assign their own keyboard shortcut to it via Preferences.
___
![Demonstrates all the tree nodes of the Outline view being collapsed via keyboard shortcut.](https://user-images.githubusercontent.com/4957200/58061209-dbf38500-7b3a-11e9-9d38-fec5504a705b.gif)

