### PR TITLE
Update Contribution section of README and Contribution Wiki 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ please see the document [How to Contribute](https://github.com/Microsoft/vscode/
 * [Submitting pull requests](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests)
 * [Contributing to translations](https://aka.ms/vscodeloc)
 
+Are you completely new to contributing to GitHub? Take a look at these resources on common terminology and developer workflow
+* [GitHub Glossary](https://help.github.com/en/articles/github-glossary) - Learn all the version control terminology
+* [Understanding issues](https://guides.github.com/features/issues/) - Determine how to find issues and their labeling
+* [What are PRs/Pull Requests](https://help.github.com/en/articles/about-pull-requests) - Understand how to open up a new issue 
+
 Please also see our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Feedback


### PR DESCRIPTION
Currently, it is difficult for first time users to understand the contribution guidelines if they do not have previous exposure to GitHub and version control terminology, such as forking, PR, commits, etc. 

Proposing an addition to the README and wiki to guide new users to appropriate locations within GitHub help guides if they are unsure how to proceed on how to contribute to an issue. README has been updated to contain URLs to guide new users to relevant sections, such as a glossary of GitHub and git terminology to better understand the overall layout of the issues page. 