### PR TITLE
Fix-72650 Shell paths should be validated before launched to prevent ambiguous errors - $Path check

### DIFF
--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import { Event, Emitter } from 'vs/base/common/event';
 import { getWindowsBuildNumber } from 'vs/workbench/contrib/terminal/node/terminal';
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { IShellLaunchConfig, ITerminalChildProcess } from 'vs/workbench/contrib/terminal/common/terminal';
+import { IShellLaunchConfig, ITerminalChildProcess, SHELL_PATH_INVALID_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
 import { exec } from 'child_process';
 
 export class TerminalProcess implements ITerminalChildProcess, IDisposable {
@@ -69,16 +69,17 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			experimentalUseConpty: useConpty
 		};
 
-		// TODO: Need to verify whether executable is on $PATH, otherwise things like cmd.exe will break
-		// fs.stat(shellLaunchConfig.executable!, (err) => {
-		// 	if (err && err.code === 'ENOENT') {
-		// 		this._exitCode = SHELL_PATH_INVALID_EXIT_CODE;
-		// 		this._queueProcessExit();
-		// 		this._processStartupComplete = Promise.resolve(undefined);
-		// 		return;
-		// 	}
-		this.setupPtyProcess(shellLaunchConfig, options);
-		// });
+		let envPathVariable: string | undefined = process.env.PATH;
+
+		fs.stat(shellLaunchConfig.executable!, (err) => {
+			if (err && err.code === 'ENOENT' && envPathVariable!.search(shellLaunchConfig.executable!) === -1) {
+				this._exitCode = SHELL_PATH_INVALID_EXIT_CODE;
+				this._queueProcessExit();
+				this._processStartupComplete = Promise.resolve(undefined);
+				return;
+			}
+			this.setupPtyProcess(shellLaunchConfig, options);
+		});
 	}
 
 	private setupPtyProcess(shellLaunchConfig: IShellLaunchConfig, options: pty.IPtyForkOptions): void {


### PR DESCRIPTION
@Tyriar , Added a trivial path check to fix #72650  , Please review if this is good or we need to handle it differently and in a more better way than this naive approach, Thanks :) 