### PR TITLE
Use system python for path in code.sh

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,8 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-function realpath() { python -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1],'..','..','..','..')))" "$0"; }
-CONTENTS="$(realpath "$0")"
+CONTENTS="$(python -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1],'..','..','..','..')))" "$0")"
 ELECTRON="$CONTENTS/MacOS/Electron"
 CLI="$CONTENTS/Resources/app/out/cli.js"
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"

--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,8 +3,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
-CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
+function realpath() { python -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1],'..','..','..','..')))" "$0"; }
+CONTENTS="$(realpath "$0")"
 ELECTRON="$CONTENTS/MacOS/Electron"
 CLI="$CONTENTS/Resources/app/out/cli.js"
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"

--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-CONTENTS="$(python -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1],'..','..','..','..')))" "$0")"
+CONTENTS="$(unset PYTHONPATH;/usr/bin/python -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1],'..','..','..','..')))" "$0")"
 ELECTRON="$CONTENTS/MacOS/Electron"
 CLI="$CONTENTS/Resources/app/out/cli.js"
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"


### PR DESCRIPTION
If script already uses python -- why not to use it all the way to get path of the CONTENTS folder?