### PR TITLE
Comment API

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1350,6 +1350,14 @@ export interface CommentReaction {
 /**
  * @internal
  */
+export enum CommentMode {
+	Editing = 0,
+	Preview = 1
+}
+
+/**
+ * @internal
+ */
 export interface Comment {
 	readonly commentId: string;
 	readonly body: IMarkdownString;
@@ -1363,6 +1371,7 @@ export interface Comment {
 	readonly isDraft?: boolean;
 	readonly commentReactions?: CommentReaction[];
 	readonly label?: string;
+	readonly mode?: CommentMode;
 }
 
 /**

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1288,6 +1288,7 @@ export interface CommentThread2 {
 	resource: string | null;
 	range: IRange;
 	label: string;
+	contextValue: string | undefined;
 	comments: Comment[] | undefined;
 	onDidChangeComments: Event<Comment[] | undefined>;
 	collapsibleState?: CommentThreadCollapsibleState;
@@ -1326,6 +1327,7 @@ export interface CommentThread {
 	collapsibleState?: CommentThreadCollapsibleState;
 	reply?: Command;
 	isDisposed?: boolean;
+	contextValue?: string;
 }
 
 /**
@@ -1364,6 +1366,7 @@ export interface Comment {
 	readonly body: IMarkdownString;
 	readonly userName: string;
 	readonly userIconPath?: string;
+	readonly contextValue?: string;
 	readonly canEdit?: boolean;
 	readonly canDelete?: boolean;
 	readonly selectCommand?: Command;

--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -1360,6 +1360,7 @@ export enum CommentMode {
  */
 export interface Comment {
 	readonly commentId: string;
+	readonly uniqueIdInThread?: number;
 	readonly body: IMarkdownString;
 	readonly userName: string;
 	readonly userIconPath?: string;

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -95,6 +95,10 @@ export const enum MenuId {
 	TouchBarContext,
 	ViewItemContext,
 	ViewTitle,
+	CommentThreadTitle,
+	CommentThreadActions,
+	CommentTitle,
+	CommentActions
 }
 
 export interface IMenuActionOptions {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -9098,7 +9098,7 @@ declare module 'vscode' {
 		dispose(): void;
 	}
 
-	namespace comment {
+	namespace comments {
 		/**
 		 * Creates a new [comment controller](#CommentController) instance.
 		 *

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -8958,8 +8958,18 @@ declare module 'vscode' {
 		Expanded = 1
 	}
 
+	/**
+	 * Comment mode of a [comment](#Comment)
+	 */
 	export enum CommentMode {
+		/**
+		 * Displays the comment editor
+		 */
 		Editing = 0,
+
+		/**
+		 * Displays the preview of the comment
+		 */
 		Preview = 1
 	}
 
@@ -9046,10 +9056,13 @@ declare module 'vscode' {
 		 */
 		body: string | MarkdownString;
 
+		/**
+		 * [Comment mode](#CommentMode) of the comment
+		 */
 		mode: CommentMode;
 
 		/**
-		 * The author information of the comment
+		 * The [author information](#CommentAuthorInformation) of the comment
 		 */
 		author: CommentAuthorInformation;
 
@@ -9080,9 +9093,18 @@ declare module 'vscode' {
 		label?: string;
 	}
 
+	/**
+	 * Command argument for actions registered in `comments/commentThread/actions`.
+	 */
 	export interface CommentReply {
+		/**
+		 * The active [comment thread](#CommentThread)
+		 */
 		thread: CommentThread;
 
+		/**
+		 * The value in the comment editor
+		 */
 		text: string;
 	}
 
@@ -9114,7 +9136,7 @@ declare module 'vscode' {
 		/**
 		 * Optional commenting range provider. Provide a list [ranges](#Range) which support commenting to any given resource uri.
 		 *
-		 * If not provided and `emptyCommentThreadFactory` exits, users can leave comments in any document opened in the editor.
+		 * If not provided, users can leave comments in any document opened in the editor.
 		 */
 		commentingRangeProvider?: CommentingRangeProvider;
 
@@ -9122,7 +9144,6 @@ declare module 'vscode' {
 		 * Create a [comment thread](#CommentThread). The comment thread will be displayed in visible text editors (if the resource matches)
 		 * and Comments Panel once created.
 		 *
-		 * @param id An `id` for the comment thread.
 		 * @param resource The uri of the document the thread has been created on.
 		 * @param range The range the comment thread is located within the document.
 		 * @param comments The ordered comments of the thread.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -8990,6 +8990,26 @@ declare module 'vscode' {
 		collapsibleState: CommentThreadCollapsibleState;
 
 		/**
+		 * Context value of the comment thread. This can be used to contribute thread specific actions.
+		 * For example, a comment thread is given a context value as `editable`. When contributing actions to `comments/commentThread/title`
+		 * using `menus` extension point, you can specify context value for key `commentThread` in `when` expression like `commentThread == editable`.
+		 * ```
+		 *	"contributes": {
+		 *		"menus": {
+		 *			"comments/commentThread/title": [
+		 *				{
+		 *					"command": "extension.deleteCommentThread",
+		 *					"when": "commentThread == editable"
+		 *				}
+		 *			]
+		 *		}
+		 *	}
+		 * ```
+		 * This will show action `extension.deleteCommentThread` only for comment threads with `contextValue` is `editable`.
+		 */
+		contextValue?: string;
+
+		/**
 		 * The optional human-readable label describing the [Comment Thread](#CommentThread)
 		 */
 		label?: string;
@@ -9032,6 +9052,26 @@ declare module 'vscode' {
 		 * The author information of the comment
 		 */
 		author: CommentAuthorInformation;
+
+		/**
+		 * Context value of the comment. This can be used to contribute comment specific actions.
+		 * For example, a comment is given a context value as `editable`. When contributing actions to `comments/comment/title`
+		 * using `menus` extension point, you can specify context value for key `comment` in `when` expression like `comment == editable`.
+		 * ```
+		 *	"contributes": {
+		 *		"menus": {
+		 *			"comments/comment/title": [
+		 *				{
+		 *					"command": "extension.deleteComment",
+		 *					"when": "comment == editable"
+		 *				}
+		 *			]
+		 *		}
+		 *	}
+		 * ```
+		 * This will show action `extension.deleteComment` only for comments with `contextValue` is `editable`.
+		 */
+		contextValue?: string;
 
 		/**
 		 * Optional label describing the [Comment](#Comment)

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -8976,7 +8976,7 @@ declare module 'vscode' {
 		 * The range the comment thread is located within the document. The thread icon will be shown
 		 * at the first line of the range.
 		 */
-		readonly range: Range;
+		range: Range;
 
 		/**
 		 * The ordered comments of the thread.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -8940,6 +8940,176 @@ declare module 'vscode' {
 		 */
 		export const onDidChange: Event<void>;
 	}
+
+	//#region Comments
+
+	/**
+	 * Collapsible state of a [comment thread](#CommentThread)
+	 */
+	export enum CommentThreadCollapsibleState {
+		/**
+		 * Determines an item is collapsed
+		 */
+		Collapsed = 0,
+
+		/**
+		 * Determines an item is expanded
+		 */
+		Expanded = 1
+	}
+
+	export enum CommentMode {
+		Editing = 0,
+		Preview = 1
+	}
+
+	/**
+	 * A collection of [comments](#Comment) representing a conversation at a particular range in a document.
+	 */
+	export interface CommentThread {
+		/**
+		 * The uri of the document the thread has been created on.
+		 */
+		readonly resource: Uri;
+
+		/**
+		 * The range the comment thread is located within the document. The thread icon will be shown
+		 * at the first line of the range.
+		 */
+		readonly range: Range;
+
+		/**
+		 * The ordered comments of the thread.
+		 */
+		comments: ReadonlyArray<Comment>;
+
+		/**
+		 * Whether the thread should be collapsed or expanded when opening the document.
+		 * Defaults to Collapsed.
+		 */
+		collapsibleState: CommentThreadCollapsibleState;
+
+		/**
+		 * The optional human-readable label describing the [Comment Thread](#CommentThread)
+		 */
+		label?: string;
+
+		/**
+		 * Dispose this comment thread.
+		 *
+		 * Once disposed, this comment thread will be removed from visible editors and Comment Panel when approriate.
+		 */
+		dispose(): void;
+	}
+
+	/**
+	 * Author information of a [comment](#Comment)
+	 */
+	export interface CommentAuthorInformation {
+		/**
+		 * The display name of the author of the comment
+		 */
+		name: string;
+
+		/**
+		 * The optional icon path for the author
+		 */
+		iconPath?: Uri;
+	}
+
+	/**
+	 * A comment is displayed within the editor or the Comments Panel, depending on how it is provided.
+	 */
+	export interface Comment {
+		/**
+		 * The human-readable comment body
+		 */
+		body: string | MarkdownString;
+
+		mode: CommentMode;
+
+		/**
+		 * The author information of the comment
+		 */
+		author: CommentAuthorInformation;
+
+		/**
+		 * Optional label describing the [Comment](#Comment)
+		 * Label will be rendered next to authorName if exists.
+		 */
+		label?: string;
+	}
+
+	export interface CommentReply {
+		thread: CommentThread;
+
+		text: string;
+	}
+
+	/**
+	 * Commenting range provider for a [comment controller](#CommentController).
+	 */
+	export interface CommentingRangeProvider {
+		/**
+		 * Provide a list of ranges which allow new comment threads creation or null for a given document
+		 */
+		provideCommentingRanges(document: TextDocument, token: CancellationToken): ProviderResult<Range[]>;
+	}
+
+	/**
+	 * A comment controller is able to provide [comments](#CommentThread) support to the editor and
+	 * provide users various ways to interact with comments.
+	 */
+	export interface CommentController {
+		/**
+		 * The id of this comment controller.
+		 */
+		readonly id: string;
+
+		/**
+		 * The human-readable label of this comment controller.
+		 */
+		readonly label: string;
+
+		/**
+		 * Optional commenting range provider. Provide a list [ranges](#Range) which support commenting to any given resource uri.
+		 *
+		 * If not provided and `emptyCommentThreadFactory` exits, users can leave comments in any document opened in the editor.
+		 */
+		commentingRangeProvider?: CommentingRangeProvider;
+
+		/**
+		 * Create a [comment thread](#CommentThread). The comment thread will be displayed in visible text editors (if the resource matches)
+		 * and Comments Panel once created.
+		 *
+		 * @param id An `id` for the comment thread.
+		 * @param resource The uri of the document the thread has been created on.
+		 * @param range The range the comment thread is located within the document.
+		 * @param comments The ordered comments of the thread.
+		 */
+		createCommentThread(uri: Uri, range: Range, comments: Comment[]): CommentThread;
+
+		/**
+		 * Dispose this comment controller.
+		 *
+		 * Once disposed, all [comment threads](#CommentThread) created by this comment controller will also be removed from the editor
+		 * and Comments Panel.
+		 */
+		dispose(): void;
+	}
+
+	namespace comment {
+		/**
+		 * Creates a new [comment controller](#CommentController) instance.
+		 *
+		 * @param id An `id` for the comment controller.
+		 * @param label A human-readable string for the comment controller.
+		 * @return An instance of [comment controller](#CommentController).
+		 */
+		export function createCommentController(id: string, label: string): CommentController;
+	}
+
+	//#endregion
 }
 
 /**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -939,15 +939,6 @@ declare module 'vscode' {
 		reactionProvider?: CommentReactionProvider;
 	}
 
-	export interface CommentController {
-		/**
-		 * The active [comment thread](#CommentThread) or `undefined`. The `activeCommentThread` is the comment thread of
-		 * the comment widget that currently has focus. It's `undefined` when the focus is not in any comment thread widget, or
-		 * the comment widget created from [comment thread template](#CommentThreadTemplate).
-		 */
-		readonly activeCommentThread: CommentThread | undefined;
-	}
-
 	namespace workspace {
 		/**
 		 * DEPRECATED
@@ -959,21 +950,6 @@ declare module 'vscode' {
 		 * Use vscode.comment.createCommentController instead and we don't differentiate document comments and workspace comments anymore.
 		 */
 		export function registerWorkspaceCommentProvider(provider: WorkspaceCommentProvider): Disposable;
-	}
-
-	/**
-	 * Collapsible state of a [comment thread](#CommentThread)
-	 */
-	export enum CommentThreadCollapsibleState {
-		/**
-		 * Determines an item is collapsed
-		 */
-		Collapsed = 0,
-
-		/**
-		 * Determines an item is expanded
-		 */
-		Expanded = 1
 	}
 
 	/**
@@ -991,28 +967,6 @@ declare module 'vscode' {
 		readonly uri: Uri;
 
 		/**
-		 * The range the comment thread is located within the document. The thread icon will be shown
-		 * at the first line of the range.
-		 */
-		readonly range: Range;
-
-		/**
-		 * The ordered comments of the thread.
-		 */
-		comments: Comment[];
-
-		/**
-		 * Whether the thread should be collapsed or expanded when opening the document.
-		 * Defaults to Collapsed.
-		 */
-		collapsibleState: CommentThreadCollapsibleState;
-
-		/**
-		 * The optional human-readable label describing the [Comment Thread](#CommentThread)
-		 */
-		label?: string;
-
-		/**
 		 * Optional accept input command
 		 *
 		 * `acceptInputCommand` is the default action rendered on Comment Widget, which is always placed rightmost.
@@ -1020,46 +974,6 @@ declare module 'vscode' {
 		 * This command will disabled when the comment editor is empty.
 		 */
 		acceptInputCommand?: Command;
-
-
-		/**
-		 * Dispose this comment thread.
-		 *
-		 * Once disposed, this comment thread will be removed from visible editors and Comment Panel when approriate.
-		 */
-		dispose(): void;
-	}
-
-	/**
-	 * Author information of a [comment](#Comment)
-	 */
-
-	export interface CommentAuthorInformation {
-		/**
-		 * The display name of the author of the comment
-		 */
-		name: string;
-
-		/**
-		 * The optional icon path for the author
-		 */
-		iconPath?: Uri;
-	}
-
-	/**
-	 * Author information of a [comment](#Comment)
-	 */
-
-	export interface CommentAuthorInformation {
-		/**
-		 * The display name of the author of the comment
-		 */
-		name: string;
-
-		/**
-		 * The optional icon path for the author
-		 */
-		iconPath?: Uri;
 	}
 
 	/**
@@ -1070,22 +984,6 @@ declare module 'vscode' {
 		 * The id of the comment
 		 */
 		id: string;
-
-		/**
-		 * The human-readable comment body
-		 */
-		body: MarkdownString;
-
-		/**
-		 * The author information of the comment
-		 */
-		author: CommentAuthorInformation;
-
-		/**
-		 * Optional label describing the [Comment](#Comment)
-		 * Label will be rendered next to authorName if exists.
-		 */
-		label?: string;
 
 		/**
 		 * The command to be executed if the comment is selected in the Comments Panel
@@ -1106,16 +1004,6 @@ declare module 'vscode' {
 		 * Setter and getter for the contents of the comment input box
 		 */
 		value: string;
-
-		/**
-		 * The uri of the document comment input box has been created on
-		 */
-		resource: Uri;
-
-		/**
-		 * The range the comment input box is located within the document
-		 */
-		range: Range;
 	}
 
 	/**
@@ -1128,36 +1016,12 @@ declare module 'vscode' {
 		provideCommentingRanges(document: TextDocument, token: CancellationToken): ProviderResult<Range[]>;
 	}
 
-	/**
-	 * Comment thread template for new comment thread creation.
-	 */
-	export interface CommentThreadTemplate {
+	export interface EmptyCommentThreadFactory {
 		/**
-		 * The human-readable label describing the [Comment Thread](#CommentThread)
+		 * The method `createEmptyCommentThread` is called when users attempt to create new comment thread from the gutter or command palette.
+		 * Extensions still need to call `createCommentThread` inside this call when appropriate.
 		 */
-		readonly label: string;
-
-		/**
-		 * Optional accept input command
-		 *
-		 * `acceptInputCommand` is the default action rendered on Comment Widget, which is always placed rightmost.
-		 * This command will be invoked when users the user accepts the value in the comment editor.
-		 * This command will disabled when the comment editor is empty.
-		 */
-		readonly acceptInputCommand?: Command;
-
-		/**
-		 * Optional additonal commands.
-		 *
-		 * `additionalCommands` are the secondary actions rendered on Comment Widget.
-		 */
-		readonly additionalCommands?: Command[];
-
-		/**
-		 * The command to be executed when users try to delete the comment thread. Currently, this is only called
-		 * when the user collapses a comment thread that has no comments in it.
-		 */
-		readonly deleteCommand?: Command;
+		createEmptyCommentThread(document: TextDocument, range: Range): ProviderResult<void>;
 	}
 
 	/**
@@ -1165,41 +1029,12 @@ declare module 'vscode' {
 	 * provide users various ways to interact with comments.
 	 */
 	export interface CommentController {
-		/**
-		 * The id of this comment controller.
-		 */
-		readonly id: string;
-
-		/**
-		 * The human-readable label of this comment controller.
-		 */
-		readonly label: string;
 
 		/**
 		 * The active [comment input box](#CommentInputBox) or `undefined`. The active `inputBox` is the input box of
 		 * the comment thread widget that currently has focus. It's `undefined` when the focus is not in any CommentInputBox.
 		 */
-		readonly inputBox: CommentInputBox | undefined;
-
-		/**
-		 * Optional comment thread template information.
-		 *
-		 * The comment controller will use this information to create the comment widget when users attempt to create new comment thread
-		 * from the gutter or command palette.
-		 *
-		 * When users run `CommentThreadTemplate.acceptInputCommand` or `CommentThreadTemplate.additionalCommands`, extensions should create
-		 * the approriate [CommentThread](#CommentThread).
-		 *
-		 * If not provided, users won't be able to create new comment threads in the editor.
-		 */
-		template?: CommentThreadTemplate;
-
-		/**
-		 * Optional commenting range provider. Provide a list [ranges](#Range) which support commenting to any given resource uri.
-		 *
-		 * If not provided and `emptyCommentThreadFactory` exits, users can leave comments in any document opened in the editor.
-		 */
-		commentingRangeProvider?: CommentingRangeProvider;
+		readonly inputBox?: CommentInputBox;
 
 		/**
 		 * Create a [comment thread](#CommentThread). The comment thread will be displayed in visible text editors (if the resource matches)
@@ -1211,6 +1046,16 @@ declare module 'vscode' {
 		 * @param comments The ordered comments of the thread.
 		 */
 		createCommentThread(id: string, uri: Uri, range: Range, comments: Comment[]): CommentThread;
+
+		/**
+		 * Optional new comment thread factory.
+		 */
+		emptyCommentThreadFactory?: EmptyCommentThreadFactory;
+
+		/**
+		 * Optional reaction provider
+		 */
+		reactionProvider?: CommentReactionProvider;
 
 		/**
 		 * Dispose this comment controller.

--- a/src/vs/workbench/api/browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/browser/mainThreadComments.ts
@@ -25,8 +25,6 @@ import { PanelRegistry, Extensions as PanelExtensions, PanelDescriptor } from 'v
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { Emitter, Event } from 'vs/base/common/event';
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/commentContextKeys';
 
 export class MainThreadDocumentCommentProvider implements modes.DocumentCommentProvider {
 	private readonly _proxy: ExtHostCommentsShape;
@@ -450,12 +448,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 	private _handlers = new Map<number, string>();
 	private _commentControllers = new Map<number, MainThreadCommentController>();
 
-	private _activeCommentThread?: MainThreadCommentThread;
-	private _input?: modes.CommentInput;
 	private _openPanelListener: IDisposable | null;
-
-	private _commentThreadEmpty: IContextKey<boolean>;
-	private _commentEmpty: IContextKey<boolean>;
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -469,35 +462,6 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 		this._disposables = [];
 		this._activeCommentThreadDisposables = [];
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostComments);
-
-		this._commentThreadEmpty = CommentContextKeys.commentThreadIsEmpty.bindTo(_commentService.contextKeyService);
-		this._commentEmpty = CommentContextKeys.commentIsEmpty.bindTo(_commentService.contextKeyService);
-		this._commentThreadEmpty.set(true);
-		this._commentEmpty.set(true);
-
-		this._disposables.push(this._commentService.onDidChangeActiveCommentThread(async thread => {
-			let handle = (thread as MainThreadCommentThread).controllerHandle;
-			let controller = this._commentControllers.get(handle);
-
-			if (!controller) {
-				return;
-			}
-
-			this._activeCommentThreadDisposables = dispose(this._activeCommentThreadDisposables);
-			this._activeCommentThread = thread as MainThreadCommentThread;
-			controller.activeCommentThread = this._activeCommentThread;
-
-			this._commentThreadEmpty.set(controller.activeCommentThread.comments!.length === 0);
-
-			this._activeCommentThreadDisposables.push(this._activeCommentThread.onDidChangeInput(input => { // todo, dispose
-				this._input = input;
-				this._proxy.$onCommentWidgetInputChange(handle, URI.parse(this._activeCommentThread!.resource), this._activeCommentThread!.range, this._input ? this._input.value : undefined);
-				this._commentEmpty.set(this._input ? true : this._input!.value.length === 0);
-			}));
-
-			await this._proxy.$onActiveCommentThreadChange(controller.handle, controller.activeCommentThread.commentThreadHandle);
-			await this._proxy.$onCommentWidgetInputChange(controller.handle, URI.parse(this._activeCommentThread!.resource), this._activeCommentThread.range, this._input ? this._input.value : undefined);
-		}));
 	}
 
 	$registerCommentController(handle: number, id: string, label: string): void {

--- a/src/vs/workbench/api/browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/browser/mainThreadComments.ts
@@ -106,6 +106,16 @@ export class MainThreadCommentThread implements modes.CommentThread2 {
 		this._onDidChangeLabel.fire(this._label);
 	}
 
+	private _contextValue: string | undefined;
+
+	get contextValue(): string | undefined {
+		return this._contextValue;
+	}
+
+	set contextValue(context: string | undefined) {
+		this._contextValue = context;
+	}
+
 	private _onDidChangeLabel = new Emitter<string>();
 	get onDidChangeLabel(): Event<string> { return this._onDidChangeLabel.event; }
 
@@ -204,6 +214,7 @@ export class MainThreadCommentThread implements modes.CommentThread2 {
 	batchUpdate(
 		range: IRange,
 		label: string,
+		contextValue: string | undefined,
 		comments: modes.Comment[],
 		acceptInputCommand: modes.Command | undefined,
 		additionalCommands: modes.Command[],
@@ -211,6 +222,7 @@ export class MainThreadCommentThread implements modes.CommentThread2 {
 		collapsibleState: modes.CommentThreadCollapsibleState) {
 		this._range = range;
 		this._label = label;
+		this._contextValue = contextValue;
 		this._comments = comments;
 		this._acceptInputCommand = acceptInputCommand;
 		this._additionalCommands = additionalCommands;
@@ -323,13 +335,14 @@ export class MainThreadCommentController {
 		resource: UriComponents,
 		range: IRange,
 		label: string,
+		contextValue: string | undefined,
 		comments: modes.Comment[],
 		acceptInputCommand: modes.Command | undefined,
 		additionalCommands: modes.Command[],
 		deleteCommand: modes.Command | undefined,
 		collapsibleState: modes.CommentThreadCollapsibleState): void {
 		let thread = this.getKnownThread(commentThreadHandle);
-		thread.batchUpdate(range, label, comments, acceptInputCommand, additionalCommands, deleteCommand, collapsibleState);
+		thread.batchUpdate(range, label, contextValue, comments, acceptInputCommand, additionalCommands, deleteCommand, collapsibleState);
 
 		this._commentService.updateComments(this._uniqueId, {
 			added: [],
@@ -521,6 +534,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 		resource: UriComponents,
 		range: IRange,
 		label: string,
+		contextValue: string | undefined,
 		comments: modes.Comment[],
 		acceptInputCommand: modes.Command | undefined,
 		additionalCommands: modes.Command[],
@@ -532,7 +546,7 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 			return undefined;
 		}
 
-		return provider.updateCommentThread(commentThreadHandle, threadId, resource, range, label, comments, acceptInputCommand, additionalCommands, deleteCommand, collapsibleState);
+		return provider.updateCommentThread(commentThreadHandle, threadId, resource, range, label, contextValue, comments, acceptInputCommand, additionalCommands, deleteCommand, collapsibleState);
 	}
 
 	$deleteCommentThread(handle: number, commentThreadHandle: number) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -138,7 +138,7 @@ export interface MainThreadCommentsShape extends IDisposable {
 	$unregisterCommentController(handle: number): void;
 	$updateCommentControllerFeatures(handle: number, features: CommentProviderFeatures): void;
 	$createCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange): modes.CommentThread2 | undefined;
-	$updateCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, label: string, comments: modes.Comment[], acceptInputCommand: modes.Command | undefined, additionalCommands: modes.Command[], deleteCommand: modes.Command | undefined, collapseState: modes.CommentThreadCollapsibleState): void;
+	$updateCommentThread(handle: number, commentThreadHandle: number, threadId: string, resource: UriComponents, range: IRange, label: string, contextValue: string | undefined, comments: modes.Comment[], acceptInputCommand: modes.Command | undefined, additionalCommands: modes.Command[], deleteCommand: modes.Command | undefined, collapseState: modes.CommentThreadCollapsibleState): void;
 	$deleteCommentThread(handle: number, commentThreadHandle: number): void;
 	$setInputValue(handle: number, input: string): void;
 	$registerDocumentCommentProvider(handle: number, features: CommentProviderFeatures): void;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1212,7 +1212,6 @@ export interface ExtHostCommentsShape {
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Promise<modes.CommentThread | null>;
 	$createCommentThreadTemplate(commentControllerHandle: number, uriComponents: UriComponents, range: IRange): void;
 	$onCommentWidgetInputChange(commentControllerHandle: number, document: UriComponents, range: IRange, input: string | undefined): Promise<number | undefined>;
-	$onActiveCommentThreadChange(commentControllerHandle: number, threadHandle: number | undefined): Promise<number | undefined>;
 	$provideCommentingRanges(commentControllerHandle: number, uriComponents: UriComponents, token: CancellationToken): Promise<IRange[] | undefined>;
 	$checkStaticContribution(commentControllerHandle: number): Promise<boolean>;
 	$provideReactionGroup(commentControllerHandle: number): Promise<modes.CommentReaction[] | undefined>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1210,9 +1210,11 @@ export interface ExtHostProgressShape {
 export interface ExtHostCommentsShape {
 	$provideDocumentComments(handle: number, document: UriComponents): Promise<modes.CommentInfo | null>;
 	$createNewCommentThread(handle: number, document: UriComponents, range: IRange, text: string): Promise<modes.CommentThread | null>;
+	$createCommentThreadTemplate(commentControllerHandle: number, uriComponents: UriComponents, range: IRange): void;
 	$onCommentWidgetInputChange(commentControllerHandle: number, document: UriComponents, range: IRange, input: string | undefined): Promise<number | undefined>;
 	$onActiveCommentThreadChange(commentControllerHandle: number, threadHandle: number | undefined): Promise<number | undefined>;
 	$provideCommentingRanges(commentControllerHandle: number, uriComponents: UriComponents, token: CancellationToken): Promise<IRange[] | undefined>;
+	$checkStaticContribution(commentControllerHandle: number): Promise<boolean>;
 	$provideReactionGroup(commentControllerHandle: number): Promise<modes.CommentReaction[] | undefined>;
 	$toggleReaction(commentControllerHandle: number, threadHandle: number, uri: UriComponents, comment: modes.Comment, reaction: modes.CommentReaction): Promise<void>;
 	$createNewCommentWidgetCallback(commentControllerHandle: number, uriComponents: UriComponents, range: IRange, token: CancellationToken): Promise<void>;

--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -451,6 +451,10 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 	readonly handle = ExtHostCommentThread._handlePool++;
 	public commentHandle: number = 0;
 
+	set threadId(id: string) {
+		this._id = id;
+	}
+
 	get threadId(): string {
 		return this._id!;
 	}

--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -496,6 +496,17 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 		this._onDidUpdateCommentThread.fire();
 	}
 
+	private _contextValue: string | undefined;
+
+	get contextValue(): string | undefined {
+		return this._contextValue;
+	}
+
+	set contextValue(context: string | undefined) {
+		this._contextValue = context;
+		this._onDidUpdateCommentThread.fire();
+	}
+
 	get comments(): vscode.Comment[] {
 		return this._comments;
 	}
@@ -592,6 +603,7 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 	eventuallyUpdateCommentThread(): void {
 		const commentThreadRange = extHostTypeConverter.Range.from(this._range);
 		const label = this.label;
+		const contextValue = this.contextValue;
 		const comments = this._comments.map(cmt => { return convertToModeComment2(this, this._commentController, cmt, this._commandsConverter, this._commentsMap); });
 		const acceptInputCommand = this._acceptInputCommand ? this._commandsConverter.toInternal(this._acceptInputCommand) : undefined;
 		const additionalCommands = this._additionalCommands ? this._additionalCommands.map(x => this._commandsConverter.toInternal(x)) : [];
@@ -605,6 +617,7 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 			this._uri,
 			commentThreadRange,
 			label,
+			contextValue,
 			comments,
 			acceptInputCommand,
 			additionalCommands,
@@ -851,6 +864,7 @@ function convertToModeComment2(thread: ExtHostCommentThread, commentController: 
 	return {
 		commentId: vscodeComment.id || vscodeComment.commentId,
 		mode: vscodeComment.mode,
+		contextValue: vscodeComment.contextValue,
 		uniqueIdInThread: commentUniqueId,
 		body: extHostTypeConverter.MarkdownString.from(vscodeComment.body),
 		userName: vscodeComment.author ? vscodeComment.author.name : vscodeComment.userName,

--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -126,17 +126,6 @@ export class ExtHostComments implements ExtHostCommentsShape {
 		return Promise.resolve(commentControllerHandle);
 	}
 
-	$onActiveCommentThreadChange(commentControllerHandle: number, threadHandle: number): Promise<number | undefined> {
-		const commentController = this._commentControllers.get(commentControllerHandle);
-
-		if (!commentController) {
-			return Promise.resolve(undefined);
-		}
-
-		commentController.$onActiveCommentThreadChange(threadHandle);
-		return Promise.resolve(threadHandle);
-	}
-
 	$provideCommentingRanges(commentControllerHandle: number, uriComponents: UriComponents, token: CancellationToken): Promise<IRange[] | undefined> {
 		const commentController = this._commentControllers.get(commentControllerHandle);
 
@@ -644,15 +633,6 @@ class ExtHostCommentController implements vscode.CommentController {
 	}
 
 	public inputBox: ExtHostCommentInputBox | undefined;
-	private _activeCommentThread: ExtHostCommentThread | undefined;
-
-	public get activeCommentThread(): ExtHostCommentThread | undefined {
-		if (this._activeCommentThread && this._activeCommentThread.isDisposed) {
-			this._activeCommentThread = undefined;
-		}
-
-		return this._activeCommentThread;
-	}
 
 	public activeCommentingRange?: vscode.Range;
 
@@ -714,10 +694,6 @@ class ExtHostCommentController implements vscode.CommentController {
 		} else {
 			this.inputBox.setInput(URI.revive(uriComponents), extHostTypeConverter.Range.to(range), input);
 		}
-	}
-
-	$onActiveCommentThreadChange(threadHandle: number) {
-		this._activeCommentThread = this.getCommentThread(threadHandle);
 	}
 
 	getCommentThread(handle: number) {

--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -86,6 +86,53 @@ export class ExtHostComments implements ExtHostCommentsShape {
 						thread: commentThread,
 						text: arg.text
 					};
+				} else if (arg && arg.$mid === 9) {
+					const commentController = this._commentControllers.get(arg.thread.commentControlHandle);
+
+					if (!commentController) {
+						return arg;
+					}
+
+					const commentThread = commentController.getCommentThread(arg.thread.commentThreadHandle);
+
+					if (!commentThread) {
+						return arg;
+					}
+
+					let commentUniqueId = arg.commentUniqueId;
+
+					let comment = commentThread.getCommentByUniqueId(commentUniqueId);
+
+					if (!comment) {
+						return arg;
+					}
+
+					return comment;
+
+				} else if (arg && arg.$mid === 10) {
+					const commentController = this._commentControllers.get(arg.thread.commentControlHandle);
+
+					if (!commentController) {
+						return arg;
+					}
+
+					const commentThread = commentController.getCommentThread(arg.thread.commentThreadHandle);
+
+					if (!commentThread) {
+						return arg;
+					}
+
+					let body = arg.text;
+					let commentUniqueId = arg.commentUniqueId;
+
+					let comment = commentThread.getCommentByUniqueId(commentUniqueId);
+
+					if (!comment) {
+						return arg;
+					}
+
+					comment.body = body;
+					return comment;
 				}
 
 				return arg;
@@ -572,6 +619,18 @@ export class ExtHostCommentThread implements vscode.CommentThread {
 		return undefined;
 	}
 
+	getCommentByUniqueId(uniqueId: number): vscode.Comment | undefined {
+		for (let key of this._commentsMap) {
+			let comment = key[0];
+			let id = key[1];
+			if (uniqueId === id) {
+				return comment;
+			}
+		}
+
+		return;
+	}
+
 	dispose() {
 		this._localDisposables.forEach(disposable => disposable.dispose());
 		this._proxy.$deleteCommentThread(
@@ -787,6 +846,7 @@ function convertToModeComment2(thread: ExtHostCommentThread, commentController: 
 
 	return {
 		commentId: vscodeComment.id || vscodeComment.commentId,
+		mode: vscodeComment.mode,
 		uniqueIdInThread: commentUniqueId,
 		body: extHostTypeConverter.MarkdownString.from(vscodeComment.body),
 		userName: vscodeComment.author ? vscodeComment.author.name : vscodeComment.userName,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2297,6 +2297,12 @@ export enum CommentThreadCollapsibleState {
 	 */
 	Expanded = 1
 }
+
+export enum CommentMode {
+	Editing = 0,
+	Preview = 1
+}
+
 //#endregion
 
 @es5ClassCompat

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -46,10 +46,10 @@ namespace schema {
 			case 'statusBar/windowIndicator': return MenuId.StatusBarWindowIndicatorMenu;
 			case 'view/title': return MenuId.ViewTitle;
 			case 'view/item/context': return MenuId.ViewItemContext;
-			case 'commentThread/title': return MenuId.CommentThreadTitle;
-			case 'commentThread/actions': return MenuId.CommentThreadActions;
-			case 'comment/title': return MenuId.CommentTitle;
-			case 'comment/actions': return MenuId.CommentActions;
+			case 'comments/commentThread/title': return MenuId.CommentThreadTitle;
+			case 'comments/commentThread/actions': return MenuId.CommentThreadActions;
+			case 'comments/comment/title': return MenuId.CommentTitle;
+			case 'comments/comment/actions': return MenuId.CommentActions;
 		}
 
 		return undefined;
@@ -196,22 +196,22 @@ namespace schema {
 				type: 'array',
 				items: menuItem
 			},
-			'commentThread/title': {
+			'comments/commentThread/title': {
 				description: localize('commentThread.title', "The contributed comment thread title menu"),
 				type: 'array',
 				items: menuItem
 			},
-			'commentThread/actions': {
+			'comments/commentThread/actions': {
 				description: localize('commentThread.actions', "The contributed comment thread actions"),
 				type: 'array',
 				items: menuItem
 			},
-			'comment/title': {
+			'comments/comment/title': {
 				description: localize('comment.title', "The contributed comment title menu"),
 				type: 'array',
 				items: menuItem
 			},
-			'comment/actions': {
+			'comments/comment/actions': {
 				description: localize('comment.actions', "The contributed comment actions"),
 				type: 'array',
 				items: menuItem

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -45,6 +45,10 @@ namespace schema {
 			case 'statusBar/windowIndicator': return MenuId.StatusBarWindowIndicatorMenu;
 			case 'view/title': return MenuId.ViewTitle;
 			case 'view/item/context': return MenuId.ViewItemContext;
+			case 'commentThread/title': return MenuId.CommentThreadTitle;
+			case 'commentThread/actions': return MenuId.CommentThreadActions;
+			case 'comment/title': return MenuId.CommentTitle;
+			case 'comment/actions': return MenuId.CommentActions;
 		}
 
 		return undefined;
@@ -182,7 +186,27 @@ namespace schema {
 				description: localize('view.itemContext', "The contributed view item context menu"),
 				type: 'array',
 				items: menuItem
-			}
+			},
+			'commentThread/title': {
+				description: localize('commentThread.title', "The contributed comment thread title menu"),
+				type: 'array',
+				items: menuItem
+			},
+			'commentThread/actions': {
+				description: localize('commentThread.actions', "The contributed comment thread actions"),
+				type: 'array',
+				items: menuItem
+			},
+			'comment/title': {
+				description: localize('comment.title', "The contributed comment title menu"),
+				type: 'array',
+				items: menuItem
+			},
+			'comment/actions': {
+				description: localize('comment.actions', "The contributed comment actions"),
+				type: 'array',
+				items: menuItem
+			},
 		}
 	};
 

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -21,6 +21,7 @@ namespace schema {
 	export interface IUserFriendlyMenuItem {
 		command: string;
 		alt?: string;
+		precondition?: string;
 		when?: string;
 		group?: string;
 	}
@@ -78,6 +79,10 @@ namespace schema {
 				collector.error(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'alt'));
 				return false;
 			}
+			if (item.precondition && typeof item.precondition !== 'string') {
+				collector.error(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'precondition'));
+				return false;
+			}
 			if (item.when && typeof item.when !== 'string') {
 				collector.error(localize('optstring', "property `{0}` can be omitted or must be of type `string`", 'when'));
 				return false;
@@ -100,6 +105,10 @@ namespace schema {
 			},
 			alt: {
 				description: localize('vscode.extension.contributes.menuItem.alt', 'Identifier of an alternative command to execute. The command must be declared in the \'commands\'-section'),
+				type: 'string'
+			},
+			precondition: {
+				description: localize('vscode.extension.contributes.menuItem.precondition', 'Condition which must be true to enable this item'),
 				type: 'string'
 			},
 			when: {
@@ -423,6 +432,14 @@ ExtensionsRegistry.registerExtensionPoint<{ [loc: string]: schema.IUserFriendlyM
 					} else {
 						group = item.group;
 					}
+				}
+
+				if (item.precondition) {
+					command.precondition = ContextKeyExpr.deserialize(item.precondition);
+				}
+
+				if (item.alt && alt && item.precondition) {
+					alt.precondition = command.precondition;
 				}
 
 				const registration = MenuRegistry.appendMenuItem(menu, {

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -47,9 +47,9 @@ namespace schema {
 			case 'view/title': return MenuId.ViewTitle;
 			case 'view/item/context': return MenuId.ViewItemContext;
 			case 'comments/commentThread/title': return MenuId.CommentThreadTitle;
-			case 'comments/commentThread/actions': return MenuId.CommentThreadActions;
+			case 'comments/commentThread/context': return MenuId.CommentThreadActions;
 			case 'comments/comment/title': return MenuId.CommentTitle;
-			case 'comments/comment/actions': return MenuId.CommentActions;
+			case 'comments/comment/context': return MenuId.CommentActions;
 		}
 
 		return undefined;

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -438,7 +438,7 @@ ExtensionsRegistry.registerExtensionPoint<{ [loc: string]: schema.IUserFriendlyM
 					command.precondition = ContextKeyExpr.deserialize(item.precondition);
 				}
 
-				if (item.alt && alt && item.precondition) {
+				if (alt && item.precondition) {
 					alt.precondition = command.precondition;
 				}
 

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -771,6 +771,7 @@ export function createApiFactory(
 			ColorInformation: extHostTypes.ColorInformation,
 			ColorPresentation: extHostTypes.ColorPresentation,
 			CommentThreadCollapsibleState: extHostTypes.CommentThreadCollapsibleState,
+			CommentMode: extHostTypes.CommentMode,
 			CompletionItem: extHostTypes.CompletionItem,
 			CompletionItemKind: extHostTypes.CompletionItemKind,
 			CompletionList: extHostTypes.CompletionList,

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -673,6 +673,8 @@ export function createApiFactory(
 			}
 		};
 
+		const comments = comment;
+
 		// namespace: debug
 		const debug: typeof vscode.debug = {
 			get activeDebugSession() {
@@ -756,6 +758,7 @@ export function createApiFactory(
 			languages,
 			scm,
 			comment,
+			comments,
 			tasks,
 			window,
 			workspace,

--- a/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+import { Button } from 'vs/base/browser/ui/button/button';
+import { IAction } from 'vs/base/common/actions';
+import { Disposable, dispose } from 'vs/base/common/lifecycle';
+import { IMenu } from 'vs/platform/actions/common/actions';
+import { attachButtonStyler } from 'vs/platform/theme/common/styler';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+
+export class CommentFormActions extends Disposable {
+	private _buttonElements: HTMLElement[] = [];
+
+	constructor(
+		private container: HTMLElement,
+		private actionHandler: (action: IAction) => void,
+		private themeService: IThemeService
+	) {
+		super();
+	}
+
+	setActions(menu: IMenu) {
+		dispose(this._toDispose);
+		this._buttonElements.forEach(b => DOM.removeNode(b));
+
+		const groups = menu.getActions({ shouldForwardArgs: true });
+		for (const group of groups) {
+			const [, actions] = group;
+
+			actions.forEach(action => {
+				const button = new Button(this.container);
+				this._buttonElements.push(button.element);
+
+				this._toDispose.push(button);
+				this._toDispose.push(attachButtonStyler(button, this.themeService));
+				this._toDispose.push(button.onDidClick(() => this.actionHandler(action)));
+
+				button.enabled = action.enabled;
+				button.label = action.label;
+			});
+		}
+	}
+}

--- a/src/vs/workbench/contrib/comments/browser/commentMenus.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentMenus.ts
@@ -42,6 +42,7 @@ export class CommentMenus implements IDisposable {
 
 	private getMenu(menuId: MenuId, contextKeyService: IContextKeyService): IMenu {
 		const menu = this.menuService.createMenu(menuId, contextKeyService);
+
 		const primary: IAction[] = [];
 		const secondary: IAction[] = [];
 		const result = { primary, secondary };

--- a/src/vs/workbench/contrib/comments/browser/commentMenus.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentMenus.ts
@@ -5,7 +5,7 @@
 
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
+import { IMenuService, MenuId, IMenu } from 'vs/platform/actions/common/actions';
 import { IAction } from 'vs/base/common/actions';
 import { MainThreadCommentController } from 'vs/workbench/api/browser/mainThreadComments';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -24,23 +24,23 @@ export class CommentMenus implements IDisposable {
 		commentControllerKey.set(controller.contextValue);
 	}
 
-	getCommentThreadTitleActions(commentThread: CommentThread2, contextKeyService: IContextKeyService): IAction[] {
-		return this.getActions(MenuId.CommentThreadTitle, contextKeyService).primary;
+	getCommentThreadTitleActions(commentThread: CommentThread2, contextKeyService: IContextKeyService): IMenu {
+		return this.getMenu(MenuId.CommentThreadTitle, contextKeyService);
 	}
 
-	getCommentThreadActions(commentThread: CommentThread2, contextKeyService: IContextKeyService): IAction[] {
-		return this.getActions(MenuId.CommentThreadActions, contextKeyService).primary;
+	getCommentThreadActions(commentThread: CommentThread2, contextKeyService: IContextKeyService): IMenu {
+		return this.getMenu(MenuId.CommentThreadActions, contextKeyService);
 	}
 
-	getCommentTitleActions(comment: Comment, contextKeyService: IContextKeyService): IAction[] {
-		return this.getActions(MenuId.CommentTitle, contextKeyService).primary;
+	getCommentTitleActions(comment: Comment, contextKeyService: IContextKeyService): IMenu {
+		return this.getMenu(MenuId.CommentTitle, contextKeyService);
 	}
 
-	getCommentActions(comment: Comment, contextKeyService: IContextKeyService): IAction[] {
-		return this.getActions(MenuId.CommentActions, contextKeyService).primary;
+	getCommentActions(comment: Comment, contextKeyService: IContextKeyService): IMenu {
+		return this.getMenu(MenuId.CommentActions, contextKeyService);
 	}
 
-	private getActions(menuId: MenuId, contextKeyService: IContextKeyService) {
+	private getMenu(menuId: MenuId, contextKeyService: IContextKeyService): IMenu {
 		const menu = this.menuService.createMenu(menuId, contextKeyService);
 		const primary: IAction[] = [];
 		const secondary: IAction[] = [];
@@ -48,8 +48,7 @@ export class CommentMenus implements IDisposable {
 
 		fillInContextMenuActions(menu, { shouldForwardArgs: true }, result, this.contextMenuService, g => true);
 
-		menu.dispose();
-		return result;
+		return menu;
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/comments/browser/commentMenus.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentMenus.ts
@@ -30,25 +30,23 @@ export class CommentMenus implements IDisposable {
 	}
 
 	getCommentThreadTitleActions(commentThread: CommentThread2): IAction[] {
-		return this.getActions(MenuId.CommentThreadTitle, commentThread).primary;
+		return this.getActions(MenuId.CommentThreadTitle).primary;
 	}
 
 	getCommentThreadActions(commentThread: CommentThread2): IAction[] {
-		return [];
+		return this.getActions(MenuId.CommentThreadActions).primary;
 	}
 
 	getCommentTitleActions(comment: Comment): IAction[] {
-		return [];
+		return this.getActions(MenuId.CommentTitle).primary;
 	}
 
 	getCommentActions(comment: Comment): IAction[] {
-		return [];
+		return this.getActions(MenuId.CommentActions).primary;
 	}
 
-
-	private getActions(menuId: MenuId, thread: CommentThread2) {
+	private getActions(menuId: MenuId) {
 		const contextKeyService = this.contextKeyService.createScoped();
-		// contextKeyService.createKey('commentThread', thread.threadId);
 
 		const menu = this.menuService.createMenu(menuId, contextKeyService);
 		const primary: IAction[] = [];

--- a/src/vs/workbench/contrib/comments/browser/commentMenus.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentMenus.ts
@@ -5,7 +5,7 @@
 
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IMenu, IMenuService, MenuId } from 'vs/platform/actions/common/actions';
+import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
 import { IAction } from 'vs/base/common/actions';
 import { MainThreadCommentController } from 'vs/workbench/api/browser/mainThreadComments';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -13,14 +13,9 @@ import { Comment, CommentThread2 } from 'vs/editor/common/modes';
 import { fillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 
 export class CommentMenus implements IDisposable {
-	private titleMenu: IMenu;
-	private titleActions: IAction[] = [];
-
-	private readonly disposables: IDisposable[] = [];
-
 	constructor(
 		controller: MainThreadCommentController,
-		private contextKeyService: IContextKeyService,
+		@IContextKeyService private contextKeyService: IContextKeyService,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService
 	) {
@@ -29,25 +24,23 @@ export class CommentMenus implements IDisposable {
 		commentControllerKey.set(controller.contextValue);
 	}
 
-	getCommentThreadTitleActions(commentThread: CommentThread2): IAction[] {
-		return this.getActions(MenuId.CommentThreadTitle).primary;
+	getCommentThreadTitleActions(commentThread: CommentThread2, contextKeyService: IContextKeyService): IAction[] {
+		return this.getActions(MenuId.CommentThreadTitle, contextKeyService).primary;
 	}
 
-	getCommentThreadActions(commentThread: CommentThread2): IAction[] {
-		return this.getActions(MenuId.CommentThreadActions).primary;
+	getCommentThreadActions(commentThread: CommentThread2, contextKeyService: IContextKeyService): IAction[] {
+		return this.getActions(MenuId.CommentThreadActions, contextKeyService).primary;
 	}
 
-	getCommentTitleActions(comment: Comment): IAction[] {
-		return this.getActions(MenuId.CommentTitle).primary;
+	getCommentTitleActions(comment: Comment, contextKeyService: IContextKeyService): IAction[] {
+		return this.getActions(MenuId.CommentTitle, contextKeyService).primary;
 	}
 
-	getCommentActions(comment: Comment): IAction[] {
-		return this.getActions(MenuId.CommentActions).primary;
+	getCommentActions(comment: Comment, contextKeyService: IContextKeyService): IAction[] {
+		return this.getActions(MenuId.CommentActions, contextKeyService).primary;
 	}
 
-	private getActions(menuId: MenuId) {
-		const contextKeyService = this.contextKeyService.createScoped();
-
+	private getActions(menuId: MenuId, contextKeyService: IContextKeyService) {
 		const menu = this.menuService.createMenu(menuId, contextKeyService);
 		const primary: IAction[] = [];
 		const secondary: IAction[] = [];
@@ -56,10 +49,7 @@ export class CommentMenus implements IDisposable {
 		fillInContextMenuActions(menu, { shouldForwardArgs: true }, result, this.contextMenuService, g => true);
 
 		menu.dispose();
-		contextKeyService.dispose();
-
 		return result;
-
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/comments/browser/commentMenus.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentMenus.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDisposable } from 'vs/base/common/lifecycle';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IMenu, IMenuService, MenuId } from 'vs/platform/actions/common/actions';
+import { IAction } from 'vs/base/common/actions';
+import { MainThreadCommentController } from 'vs/workbench/api/browser/mainThreadComments';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { Comment, CommentThread2 } from 'vs/editor/common/modes';
+import { fillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+
+export class CommentMenus implements IDisposable {
+	private titleMenu: IMenu;
+	private titleActions: IAction[] = [];
+
+	private readonly disposables: IDisposable[] = [];
+
+	constructor(
+		controller: MainThreadCommentController,
+		private contextKeyService: IContextKeyService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService
+	) {
+		const commentControllerKey = this.contextKeyService.createKey<string | undefined>('commentController', undefined);
+
+		commentControllerKey.set(controller.contextValue);
+	}
+
+	getCommentThreadTitleActions(commentThread: CommentThread2): IAction[] {
+		return this.getActions(MenuId.CommentThreadTitle, commentThread).primary;
+	}
+
+	getCommentThreadActions(commentThread: CommentThread2): IAction[] {
+		return [];
+	}
+
+	getCommentTitleActions(comment: Comment): IAction[] {
+		return [];
+	}
+
+	getCommentActions(comment: Comment): IAction[] {
+		return [];
+	}
+
+
+	private getActions(menuId: MenuId, thread: CommentThread2) {
+		const contextKeyService = this.contextKeyService.createScoped();
+		// contextKeyService.createKey('commentThread', thread.threadId);
+
+		const menu = this.menuService.createMenu(menuId, contextKeyService);
+		const primary: IAction[] = [];
+		const secondary: IAction[] = [];
+		const result = { primary, secondary };
+
+		fillInContextMenuActions(menu, { shouldForwardArgs: true }, result, this.contextMenuService, g => true);
+
+		menu.dispose();
+		contextKeyService.dispose();
+
+		return result;
+
+	}
+
+	dispose(): void {
+
+	}
+}

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -176,7 +176,6 @@ export class CommentNode extends Disposable {
 		this._toDispose.push(menu);
 		this._toDispose.push(menu.onDidChange(e => {
 			const contributedActions = menu.getActions({ shouldForwardArgs: true }).reduce((r, [, actions]) => [...r, ...actions], <MenuItemAction[]>[]);
-			// TODO ensure original actions are properly disposed
 			this.toolbar.setActions(contributedActions);
 		}));
 

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -403,14 +403,14 @@ export class CommentNode extends Disposable {
 				uri: this._commentEditor.getModel()!.uri,
 				value: this.comment.body.value
 			};
-			this.commentService.setActiveCommentThread(commentThread);
+			this.commentService.onDidChangeActiveCommentThread(commentThread);
 
 			this._commentEditorDisposables.push(this._commentEditor.onDidFocusEditorWidget(() => {
 				commentThread.input = {
 					uri: this._commentEditor!.getModel()!.uri,
 					value: this.comment.body.value
 				};
-				this.commentService.setActiveCommentThread(commentThread);
+				this.commentService.onDidChangeActiveCommentThread(commentThread);
 			}));
 
 			this._commentEditorDisposables.push(this._commentEditor.onDidChangeModelContent(e => {
@@ -462,7 +462,7 @@ export class CommentNode extends Disposable {
 					uri: this._commentEditor.getModel()!.uri,
 					value: newBody
 				};
-				this.commentService.setActiveCommentThread(commentThread);
+				this.commentService.onDidChangeActiveCommentThread(commentThread);
 				let commandId = this.comment.editCommand.id;
 				let args = this.comment.editCommand.arguments || [];
 
@@ -500,7 +500,6 @@ export class CommentNode extends Disposable {
 				if (result.confirmed) {
 					try {
 						if (this.comment.deleteCommand) {
-							this.commentService.setActiveCommentThread(this.commentThread as modes.CommentThread2);
 							let commandId = this.comment.deleteCommand.id;
 							let args = this.comment.deleteCommand.arguments || [];
 

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -38,7 +38,7 @@ import { ICommentThreadWidget } from 'vs/workbench/contrib/comments/common/comme
 import { MenuItemAction } from 'vs/platform/actions/common/actions';
 import { ContextAwareMenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { CommentFormActions } from 'vs/workbench/contrib/comments/browser/commentFormActions';
 
 const UPDATE_COMMENT_LABEL = nls.localize('label.updateComment', "Update comment");
@@ -63,6 +63,7 @@ export class CommentNode extends Disposable {
 	private _errorEditingContainer: HTMLElement;
 	private _isPendingLabel: HTMLElement;
 	private _contextKeyService: IContextKeyService;
+	private _commentContextValue: IContextKey<string>;
 
 	private _deleteAction: Action;
 	protected actionRunner?: IActionRunner;
@@ -101,6 +102,8 @@ export class CommentNode extends Disposable {
 
 		this._domNode = dom.$('div.review-comment');
 		this._contextKeyService = contextKeyService.createScoped(this._domNode);
+		this._commentContextValue = this._contextKeyService.createKey('comment', comment.contextValue);
+
 		this._domNode.tabIndex = 0;
 		const avatar = dom.append(this._domNode, dom.$('div.avatar-container'));
 		if (comment.userIconPath) {
@@ -688,6 +691,12 @@ export class CommentNode extends Disposable {
 
 		if (this.comment.commentReactions && this.comment.commentReactions.length) {
 			this.createReactionsContainer(this._commentDetailsContainer);
+		}
+
+		if (this.comment.contextValue) {
+			this._commentContextValue.set(this.comment.contextValue);
+		} else {
+			this._commentContextValue.reset();
 		}
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -441,7 +441,10 @@ export class CommentNode extends Disposable {
 		}
 		this._body.classList.remove('hidden');
 
-		this._commentEditorModel.dispose();
+		if (this._commentEditorModel) {
+			this._commentEditorModel.dispose();
+		}
+
 		this._commentEditorDisposables.forEach(dispose => dispose.dispose());
 		this._commentEditorDisposables = [];
 		if (this._commentEditor) {
@@ -539,9 +542,16 @@ export class CommentNode extends Disposable {
 		this._body.classList.add('hidden');
 		this._commentEditContainer = dom.append(this._commentDetailsContainer, dom.$('.edit-container'));
 		this.createCommentEditor();
-
 		this._errorEditingContainer = dom.append(this._commentEditContainer, dom.$('.validation-error.hidden'));
 		const formActions = dom.append(this._commentEditContainer, dom.$('.form-actions'));
+
+		// const cancelEditButton = new Button(formActions);
+		// cancelEditButton.label = nls.localize('label.cancel', "Cancel");
+		// this._toDispose.push(attachButtonStyler(cancelEditButton, this.themeService));
+
+		// this._toDispose.push(cancelEditButton.onDidClick(_ => {
+		// 	this.removeCommentEditor();
+		// }));
 
 		let menus = this.commentService.getCommentMenus(this.owner);
 		let actions = menus.getCommentActions(this.comment);
@@ -641,6 +651,14 @@ export class CommentNode extends Disposable {
 			this._body.appendChild(this._md);
 		}
 
+		if (newComment.mode !== undefined && newComment.mode !== this.comment.mode) {
+			if (newComment.mode === modes.CommentMode.Editing) {
+				this.switchToEditMode();
+			} else {
+				this.removeCommentEditor();
+			}
+		}
+
 		const shouldUpdateActions = newComment.editCommand !== this.comment.editCommand || newComment.deleteCommand !== this.comment.deleteCommand;
 		this.comment = newComment;
 
@@ -669,14 +687,6 @@ export class CommentNode extends Disposable {
 
 		if (this.comment.commentReactions && this.comment.commentReactions.length) {
 			this.createReactionsContainer(this._commentDetailsContainer);
-		}
-
-		if (this.comment.mode !== undefined) {
-			if (this.comment.mode === modes.CommentMode.Editing) {
-				this.switchToEditMode();
-			} else {
-				this.removeCommentEditor();
-			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentService.ts
@@ -46,6 +46,7 @@ export interface ICommentService {
 	removeWorkspaceComments(owner: string): void;
 	registerCommentController(owner: string, commentControl: MainThreadCommentController): void;
 	unregisterCommentController(owner: string): void;
+	getCommentController(owner: string): MainThreadCommentController | undefined;
 	createCommentThreadTemplate(owner: string, resource: URI, range: Range): void;
 	getCommentMenus(owner: string): CommentMenus;
 	registerDataProvider(owner: string, commentProvider: DocumentCommentProvider): void;
@@ -127,6 +128,10 @@ export class CommentService extends Disposable implements ICommentService {
 	unregisterCommentController(owner: string): void {
 		this._commentControls.delete(owner);
 		this._onDidDeleteDataProvider.fire(owner);
+	}
+
+	getCommentController(owner: string): MainThreadCommentController | undefined {
+		return this._commentControls.get(owner);
 	}
 
 	createCommentThreadTemplate(owner: string, resource: URI, range: Range): void {

--- a/src/vs/workbench/contrib/comments/browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentService.ts
@@ -15,8 +15,6 @@ import { assign } from 'vs/base/common/objects';
 import { ICommentThreadChangedEvent } from 'vs/workbench/contrib/comments/common/commentModel';
 import { MainThreadCommentController } from 'vs/workbench/api/browser/mainThreadComments';
 import { CommentMenus } from 'vs/workbench/contrib/comments/browser/commentMenus';
-import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/commentContextKeys';
 
 export const ICommentService = createDecorator<ICommentService>('commentService');
 
@@ -43,7 +41,6 @@ export interface ICommentService {
 	readonly onDidChangeActiveCommentingRange: Event<{ range: Range, commentingRangesInfo: CommentingRanges }>;
 	readonly onDidSetDataProvider: Event<void>;
 	readonly onDidDeleteDataProvider: Event<string>;
-	readonly contextKeyService: IContextKeyService;
 	setDocumentComments(resource: URI, commentInfos: ICommentInfo[]): void;
 	setWorkspaceComments(owner: string, commentsByResource: CommentThread[] | CommentThread2[]): void;
 	removeWorkspaceComments(owner: string): void;
@@ -70,7 +67,6 @@ export interface ICommentService {
 	deleteReaction(owner: string, resource: URI, comment: Comment, reaction: CommentReaction): Promise<void>;
 	getReactionGroup(owner: string): CommentReaction[] | undefined;
 	toggleReaction(owner: string, resource: URI, thread: CommentThread2, comment: Comment, reaction: CommentReaction): Promise<void>;
-	onDidChangeActiveCommentThread(commentThread: CommentThread | null): void;
 }
 
 export class CommentService extends Disposable implements ICommentService {
@@ -105,21 +101,10 @@ export class CommentService extends Disposable implements ICommentService {
 	private _commentControls = new Map<string, MainThreadCommentController>();
 	private _commentMenus = new Map<string, CommentMenus>();
 
-	private _activeThreadIsEmpty: IContextKey<boolean>;
-
-	contextKeyService: IContextKeyService;
-
 	constructor(
-		@IInstantiationService protected instantiationService: IInstantiationService,
-		@IContextKeyService contextKeyService: IContextKeyService
+		@IInstantiationService protected instantiationService: IInstantiationService
 	) {
 		super();
-		this.contextKeyService = contextKeyService.createScoped();
-		this._activeThreadIsEmpty = CommentContextKeys.commentThreadIsEmpty.bindTo(this.contextKeyService);
-	}
-
-	onDidChangeActiveCommentThread(commentThread: CommentThread | null) {
-		this._activeThreadIsEmpty.set(!!commentThread && !!commentThread.comments && !!commentThread.comments.length);
 	}
 
 	setDocumentComments(resource: URI, commentInfos: ICommentInfo[]): void {
@@ -161,7 +146,7 @@ export class CommentService extends Disposable implements ICommentService {
 
 		let controller = this._commentControls.get(owner);
 
-		let menu = this.instantiationService.createInstance(CommentMenus, controller!, this.contextKeyService);
+		let menu = this.instantiationService.createInstance(CommentMenus, controller!);
 		this._commentMenus.set(owner, menu);
 		return menu;
 	}

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -5,7 +5,7 @@
 
 import * as nls from 'vs/nls';
 import * as dom from 'vs/base/browser/dom';
-import { ActionBar, ActionViewItem, ActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
+import { ActionBar, ActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { Action, IAction } from 'vs/base/common/actions';
 import * as arrays from 'vs/base/common/arrays';

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -724,6 +724,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 
 		actions.forEach(action => {
 			const button = new Button(container);
+			button.enabled = action.enabled;
 			this._disposables.push(attachButtonStyler(button, this.themeService));
 
 			button.label = action.label;

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -251,6 +251,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 
 	private setActionBarActions(menu: IMenu): void {
 		const groups = menu.getActions({ shouldForwardArgs: true }).reduce((r, [, actions]) => [...r, ...actions], <MenuItemAction[]>[]);
+		this._actionbarWidget.clear();
 		this._actionbarWidget.push([...groups, this._collapseAction], { label: false, icon: true });
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -40,10 +40,10 @@ import { ICommentThreadWidget } from 'vs/workbench/contrib/comments/common/comme
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { CommentMenus } from 'vs/workbench/contrib/comments/browser/commentMenus';
 import { MenuItemAction } from 'vs/platform/actions/common/actions';
-import { MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { ContextAwareMenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 
 export const COMMENTEDITOR_DECORATION_KEY = 'commenteditordecoration';
 const COLLAPSE_ACTION_CLASS = 'expand-review-action octicon octicon-chevron-up';
@@ -213,7 +213,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		this._actionbarWidget = new ActionBar(actionsContainer, {
 			actionViewItemProvider: (action: IAction) => {
 				if (action instanceof MenuItemAction) {
-					let item = new MenuEntryActionViewItem(action, this.keybindingService, this.notificationService, this.contextMenuService);
+					let item = new ContextAwareMenuEntryActionViewItem(action, this.keybindingService, this.notificationService, this.contextMenuService);
 					return item;
 				} else {
 					let item = new ActionViewItem({}, action, { label: false, icon: true });

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -199,7 +199,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		container.appendChild(this._bodyElement);
 
 		dom.addDisposableListener(this._bodyElement, dom.EventType.FOCUS_IN, e => {
-			this.commentService.setActiveCommentThread(this._commentThread);
+			this.commentService.onDidChangeActiveCommentThread(this._commentThread);
 		});
 	}
 
@@ -243,7 +243,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			} else {
 				const deleteCommand = (this._commentThread as modes.CommentThread2).deleteCommand;
 				if (deleteCommand) {
-					this.commentService.setActiveCommentThread(this._commentThread);
+					this.commentService.onDidChangeActiveCommentThread(this._commentThread);
 					return this.commandService.executeCommand(deleteCommand.id, ...(deleteCommand.arguments || []));
 				} else if (this._commentEditor.getValue() === '') {
 					this.dispose();
@@ -475,7 +475,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 				uri: this._commentEditor.getModel()!.uri,
 				value: this._commentEditor.getValue()
 			};
-			this.commentService.setActiveCommentThread(this._commentThread);
+			this.commentService.onDidChangeActiveCommentThread(this._commentThread);
 		}));
 
 		this._commentThreadDisposables.push(this._commentEditor.getModel()!.onDidChangeContent(() => {
@@ -687,7 +687,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 					uri: this._commentEditor.getModel()!.uri,
 					value: this._commentEditor.getValue()
 				};
-				this.commentService.setActiveCommentThread(this._commentThread);
+				this.commentService.onDidChangeActiveCommentThread(this._commentThread);
 				await this.commandService.executeCommand(acceptInputCommand.id, ...(acceptInputCommand.arguments || []));
 			}));
 
@@ -712,7 +712,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 						uri: this._commentEditor.getModel()!.uri,
 						value: this._commentEditor.getValue()
 					};
-					this.commentService.setActiveCommentThread(this._commentThread);
+					this.commentService.onDidChangeActiveCommentThread(this._commentThread);
 					await this.commandService.executeCommand(command.id, ...(command.arguments || []));
 				}));
 			});
@@ -783,7 +783,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 						uri: this._commentEditor.getModel()!.uri,
 						value: this._commentEditor.getValue()
 					};
-					this.commentService.setActiveCommentThread(this._commentThread);
+					this.commentService.onDidChangeActiveCommentThread(this._commentThread);
 					let commandId = commentThread.acceptInputCommand.id;
 					let args = commentThread.acceptInputCommand.arguments || [];
 

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -420,7 +420,13 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			extensionId: this.extensionId,
 			commentThreadId: this.commentThread.threadId
 		});
-		const resource = URI.parse(`${COMMENT_SCHEME}:commentinput-${modeId}.md?${params}`);
+
+		let resource = URI.parse(`${COMMENT_SCHEME}://${this.extensionId}/commentinput-${modeId}.md?${params}`); // TODO. Remove params once extensions adopt authority.
+		let commentController = this.commentService.getCommentController(this.owner);
+		if (commentController) {
+			resource = resource.with({ authority: commentController.id });
+		}
+
 		const model = this.modelService.createModel(this._pendingComment || '', this.modeService.createByFilepathOrFirstLine(resource.path), resource, false);
 		this._disposables.push(model);
 		this._commentEditor.setModel(model);

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -81,6 +81,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 	private _error: HTMLElement;
 	private _contextKeyService: IContextKeyService;
 	private _threadIsEmpty: IContextKey<boolean>;
+	private _commentThreadContextValue: IContextKey<string>;
 	private _commentEditorIsEmpty: IContextKey<boolean>;
 	private _commentFormActions: CommentFormActions;
 
@@ -123,6 +124,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		this._contextKeyService = contextKeyService.createScoped(this.domNode);
 		this._threadIsEmpty = CommentContextKeys.commentThreadIsEmpty.bindTo(this._contextKeyService);
 		this._threadIsEmpty.set(!_commentThread.comments || !_commentThread.comments.length);
+		this._commentThreadContextValue = contextKeyService.createKey('commentThread', _commentThread.contextValue);
 
 		this._resizeObserver = null;
 		this._isExpanded = _commentThread.collapsibleState ? _commentThread.collapsibleState === modes.CommentThreadCollapsibleState.Expanded : undefined;
@@ -380,6 +382,12 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			} else {
 				this.hide();
 			}
+		}
+
+		if (this._commentThread.contextValue) {
+			this._commentThreadContextValue.set(this._commentThread.contextValue);
+		} else {
+			this._commentThreadContextValue.reset();
 		}
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -423,7 +423,7 @@ export class ReviewController implements IEditorContribution {
 			}
 
 			removed.forEach(thread => {
-				let matchedZones = this._commentWidgets.filter(zoneWidget => zoneWidget.owner === e.owner && zoneWidget.commentThread.threadId === thread.threadId);
+				let matchedZones = this._commentWidgets.filter(zoneWidget => zoneWidget.owner === e.owner && zoneWidget.commentThread.threadId === thread.threadId && zoneWidget.commentThread.threadId !== '');
 				if (matchedZones.length) {
 					let matchedZone = matchedZones[0];
 					let index = this._commentWidgets.indexOf(matchedZone);

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -64,7 +64,7 @@ class CommentingRangeDecoration {
 		return this._decorationId;
 	}
 
-	constructor(private _editor: ICodeEditor, private _ownerId: string, private _extensionId: string | undefined, private _label: string | undefined, private _range: IRange, private _reply: modes.Command | undefined, commentingOptions: ModelDecorationOptions, private _template: modes.CommentThreadTemplate | undefined, private commentingRangesInfo?: modes.CommentingRanges) {
+	constructor(private _editor: ICodeEditor, private _ownerId: string, private _extensionId: string | undefined, private _label: string | undefined, private _range: IRange, private _reply: modes.Command | undefined, commentingOptions: ModelDecorationOptions, private commentingRangesInfo?: modes.CommentingRanges) {
 		const startLineNumber = _range.startLineNumber;
 		const endLineNumber = _range.endLineNumber;
 		let commentingRangeDecorations = [{
@@ -81,14 +81,13 @@ class CommentingRangeDecoration {
 		}
 	}
 
-	public getCommentAction(): { replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, label: string | undefined, commentingRangesInfo: modes.CommentingRanges | undefined, template: modes.CommentThreadTemplate | undefined } {
+	public getCommentAction(): { replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, label: string | undefined, commentingRangesInfo: modes.CommentingRanges | undefined } {
 		return {
 			extensionId: this._extensionId,
 			label: this._label,
 			replyCommand: this._reply,
 			ownerId: this._ownerId,
-			commentingRangesInfo: this.commentingRangesInfo,
-			template: this._template
+			commentingRangesInfo: this.commentingRangesInfo
 		};
 	}
 
@@ -125,11 +124,11 @@ class CommentingRangeDecorator {
 		for (const info of commentInfos) {
 			if (Array.isArray(info.commentingRanges)) {
 				info.commentingRanges.forEach(range => {
-					commentingRangeDecorations.push(new CommentingRangeDecoration(editor, info.owner, info.extensionId, info.label, range, info.reply, this.decorationOptions, info.template));
+					commentingRangeDecorations.push(new CommentingRangeDecoration(editor, info.owner, info.extensionId, info.label, range, info.reply, this.decorationOptions));
 				});
 			} else {
 				(info.commentingRanges ? info.commentingRanges.ranges : []).forEach(range => {
-					commentingRangeDecorations.push(new CommentingRangeDecoration(editor, info.owner, info.extensionId, info.label, range, undefined, this.decorationOptions, info.template, info.commentingRanges as modes.CommentingRanges));
+					commentingRangeDecorations.push(new CommentingRangeDecoration(editor, info.owner, info.extensionId, info.label, range, undefined, this.decorationOptions, info.commentingRanges as modes.CommentingRanges));
 				});
 			}
 		}
@@ -449,7 +448,7 @@ export class ReviewController implements IEditorContribution {
 				let matchedNewCommentThreadZones = this._commentWidgets.filter(zoneWidget => zoneWidget.owner === e.owner && (zoneWidget.commentThread as any).commentThreadHandle === -1 && Range.equalsRange(zoneWidget.commentThread.range, thread.range));
 
 				if (matchedNewCommentThreadZones.length) {
-					matchedNewCommentThreadZones[0].update(thread, true);
+					matchedNewCommentThreadZones[0].update(thread);
 					return;
 				}
 
@@ -467,22 +466,6 @@ export class ReviewController implements IEditorContribution {
 		const zoneWidget = this.instantiationService.createInstance(ReviewZoneWidget, this.editor, owner, thread, pendingComment, draftMode);
 		zoneWidget.display(thread.range.startLineNumber);
 		this._commentWidgets.push(zoneWidget);
-	}
-
-	private addCommentThreadFromTemplate(lineNumber: number, ownerId: string): ReviewZoneWidget {
-		let templateCommentThread = this.commentService.getCommentThreadFromTemplate(ownerId, this.editor.getModel()!.uri, {
-			startLineNumber: lineNumber,
-			startColumn: 1,
-			endLineNumber: lineNumber,
-			endColumn: 1
-		})!;
-
-		templateCommentThread.collapsibleState = modes.CommentThreadCollapsibleState.Expanded;
-		templateCommentThread.comments = [];
-
-		let templateReviewZoneWidget = this.instantiationService.createInstance(ReviewZoneWidget, this.editor, ownerId, templateCommentThread, '', modes.DraftMode.NotSupported);
-
-		return templateReviewZoneWidget;
 	}
 
 	private addComment(lineNumber: number, replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, draftMode: modes.DraftMode | undefined, pendingComment: string | null) {
@@ -640,16 +623,16 @@ export class ReviewController implements IEditorContribution {
 					const commentInfos = newCommentInfos.filter(info => info.ownerId === pick.id);
 
 					if (commentInfos.length) {
-						const { replyCommand, ownerId, extensionId, commentingRangesInfo, template } = commentInfos[0];
-						this.addCommentAtLine2(lineNumber, replyCommand, ownerId, extensionId, commentingRangesInfo, template);
+						const { replyCommand, ownerId, extensionId, commentingRangesInfo } = commentInfos[0];
+						this.addCommentAtLine2(lineNumber, replyCommand, ownerId, extensionId, commentingRangesInfo);
 					}
 				}).then(() => {
 					this._addInProgress = false;
 				});
 			}
 		} else {
-			const { replyCommand, ownerId, extensionId, commentingRangesInfo, template } = newCommentInfos[0]!;
-			this.addCommentAtLine2(lineNumber, replyCommand, ownerId, extensionId, commentingRangesInfo, template);
+			const { replyCommand, ownerId, extensionId, commentingRangesInfo } = newCommentInfos[0]!;
+			this.addCommentAtLine2(lineNumber, replyCommand, ownerId, extensionId, commentingRangesInfo);
 		}
 
 		return Promise.resolve();
@@ -668,11 +651,11 @@ export class ReviewController implements IEditorContribution {
 		return picks;
 	}
 
-	private getContextMenuActions(commentInfos: { replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, label: string | undefined, commentingRangesInfo: modes.CommentingRanges | undefined, template: modes.CommentThreadTemplate | undefined }[], lineNumber: number): (IAction | ContextSubMenu)[] {
+	private getContextMenuActions(commentInfos: { replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, label: string | undefined, commentingRangesInfo: modes.CommentingRanges | undefined }[], lineNumber: number): (IAction | ContextSubMenu)[] {
 		const actions: (IAction | ContextSubMenu)[] = [];
 
 		commentInfos.forEach(commentInfo => {
-			const { replyCommand, ownerId, extensionId, label, commentingRangesInfo, template } = commentInfo;
+			const { replyCommand, ownerId, extensionId, label, commentingRangesInfo } = commentInfo;
 
 			actions.push(new Action(
 				'addCommentThread',
@@ -680,7 +663,7 @@ export class ReviewController implements IEditorContribution {
 				undefined,
 				true,
 				() => {
-					this.addCommentAtLine2(lineNumber, replyCommand, ownerId, extensionId, commentingRangesInfo, template);
+					this.addCommentAtLine2(lineNumber, replyCommand, ownerId, extensionId, commentingRangesInfo);
 					return Promise.resolve();
 				}
 			));
@@ -688,23 +671,10 @@ export class ReviewController implements IEditorContribution {
 		return actions;
 	}
 
-	public addCommentAtLine2(lineNumber: number, replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, commentingRangesInfo: modes.CommentingRanges | undefined, template: modes.CommentThreadTemplate | undefined) {
+	public addCommentAtLine2(lineNumber: number, replyCommand: modes.Command | undefined, ownerId: string, extensionId: string | undefined, commentingRangesInfo: modes.CommentingRanges | undefined) {
 		if (commentingRangesInfo) {
 			let range = new Range(lineNumber, 1, lineNumber, 1);
-			if (template) {
-				// create comment widget through template
-				let commentThreadWidget = this.addCommentThreadFromTemplate(lineNumber, ownerId);
-				commentThreadWidget.display(lineNumber, true);
-				this._commentWidgets.push(commentThreadWidget);
-				commentThreadWidget.onDidClose(() => {
-					this._commentWidgets = this._commentWidgets.filter(zoneWidget => !(
-						zoneWidget.owner === commentThreadWidget.owner &&
-						(zoneWidget.commentThread as any).commentThreadHandle === -1 &&
-						Range.equalsRange(zoneWidget.commentThread.range, commentThreadWidget.commentThread.range)
-					));
-				});
-				this.processNextThreadToAdd();
-			} else if (commentingRangesInfo.newCommentThreadCallback) {
+			if (commentingRangesInfo.newCommentThreadCallback) {
 				return commentingRangesInfo.newCommentThreadCallback(this.editor.getModel()!.uri, range)
 					.then(_ => {
 						this.processNextThreadToAdd();
@@ -713,6 +683,11 @@ export class ReviewController implements IEditorContribution {
 						this.notificationService.error(nls.localize('commentThreadAddFailure', "Adding a new comment thread failed: {0}.", e.message));
 						this.processNextThreadToAdd();
 					});
+			} else {
+				// latest api, no comments creation callback
+				this.commentService.createCommentThreadTemplate(ownerId, this.editor.getModel()!.uri, range);
+				this.processNextThreadToAdd();
+				return;
 			}
 		} else {
 			const commentInfo = this._commentInfos.filter(info => info.owner === ownerId);

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -198,6 +198,16 @@
 	background-image: url(./reaction-hc.svg);
 }
 
+.monaco-editor .review-widget .body .review-comment .comment-title .action-label {
+	display: block;
+	height: 18px;
+	line-height: 18px;
+	min-width: 28px;
+	background-size: 16px;
+	background-position: center center;
+	background-repeat: no-repeat;
+}
+
 .monaco-editor .review-widget .body .review-comment .comment-title .action-label.toolbar-toggle-pickReactions {
 	background-image: url(./reaction.svg);
 	width: 18px;

--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -58,15 +58,13 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 
 		super(domElement, options, codeEditorWidgetOptions, instantiationService, codeEditorService, commandService, contextKeyService, themeService, notificationService, accessibilityService);
 
-		this._commentEditorFocused = ctxCommentEditorFocused.bindTo(this._contextKeyService);
-		this._commentEditorEmpty = CommentContextKeys.commentIsEmpty.bindTo(this._contextKeyService);
+		this._commentEditorFocused = ctxCommentEditorFocused.bindTo(contextKeyService);
+		this._commentEditorEmpty = CommentContextKeys.commentIsEmpty.bindTo(contextKeyService);
+		this._commentEditorEmpty.set(!this.getValue());
 		this._parentEditor = parentEditor;
 		this._parentThread = parentThread;
 
-		this._register(this.onDidFocusEditorWidget(_ => {
-			this._commentEditorFocused.set(true);
-			this._commentEditorEmpty.set(!this.getValue());
-		}));
+		this._register(this.onDidFocusEditorWidget(_ => this._commentEditorFocused.set(true)));
 
 		this._register(this.onDidChangeModelContent(e => this._commentEditorEmpty.set(!this.getValue())));
 		this._register(this.onDidBlurEditorWidget(_ => this._commentEditorFocused.reset()));

--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -22,6 +22,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { ICommentThreadWidget } from 'vs/workbench/contrib/comments/common/commentThreadWidget';
+import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/commentContextKeys';
 
 export const ctxCommentEditorFocused = new RawContextKey<boolean>('commentEditorFocused', false);
 
@@ -30,6 +31,7 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 	private _parentEditor: ICodeEditor;
 	private _parentThread: ICommentThreadWidget;
 	private _commentEditorFocused: IContextKey<boolean>;
+	private _commentEditorEmpty: IContextKey<boolean>;
 
 	constructor(
 		domElement: HTMLElement,
@@ -57,10 +59,16 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 		super(domElement, options, codeEditorWidgetOptions, instantiationService, codeEditorService, commandService, contextKeyService, themeService, notificationService, accessibilityService);
 
 		this._commentEditorFocused = ctxCommentEditorFocused.bindTo(this._contextKeyService);
+		this._commentEditorEmpty = CommentContextKeys.commentIsEmpty.bindTo(this._contextKeyService);
 		this._parentEditor = parentEditor;
 		this._parentThread = parentThread;
 
-		this._register(this.onDidFocusEditorWidget(_ => this._commentEditorFocused.set(true)));
+		this._register(this.onDidFocusEditorWidget(_ => {
+			this._commentEditorFocused.set(true);
+			this._commentEditorEmpty.set(!this.getValue());
+		}));
+
+		this._register(this.onDidChangeModelContent(e => this._commentEditorEmpty.set(!this.getValue())));
 		this._register(this.onDidBlurEditorWidget(_ => this._commentEditorFocused.reset()));
 	}
 

--- a/src/vs/workbench/contrib/comments/common/commentContextKeys.ts
+++ b/src/vs/workbench/contrib/comments/common/commentContextKeys.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ContextKeyExpr, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 export namespace CommentContextKeys {
 	/**

--- a/src/vs/workbench/contrib/comments/common/commentContextKeys.ts
+++ b/src/vs/workbench/contrib/comments/common/commentContextKeys.ts
@@ -7,11 +7,11 @@ import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 export namespace CommentContextKeys {
 	/**
-	 * A context key that is set when the editor's text has focus (cursor is blinking).
+	 * A context key that is set when the comment thread has no comments.
 	 */
 	export const commentThreadIsEmpty = new RawContextKey<boolean>('commentThreadIsEmpty', false);
 	/**
-	 * A context key that is set when the editor's text or an editor's widget has focus.
+	 * A context key that is set when the comment has no input.
 	 */
 	export const commentIsEmpty = new RawContextKey<boolean>('commentIsEmpty', false);
 }

--- a/src/vs/workbench/contrib/comments/common/commentContextKeys.ts
+++ b/src/vs/workbench/contrib/comments/common/commentContextKeys.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ContextKeyExpr, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+
+export namespace CommentContextKeys {
+	/**
+	 * A context key that is set when the editor's text has focus (cursor is blinking).
+	 */
+	export const commentThreadIsEmpty = new RawContextKey<boolean>('commentThreadIsEmpty', false);
+	/**
+	 * A context key that is set when the editor's text or an editor's widget has focus.
+	 */
+	export const commentIsEmpty = new RawContextKey<boolean>('commentIsEmpty', false);
+}


### PR DESCRIPTION
The finalized comment api (🤞 ) of last week's team effort.

Changes we made to ensure functionalities can be all implemented correctly are 

* `CommentThread.contextValue`
* `Comment.contextValue`

which are necessary if we want to have permission control of individual comment thread or comment. 

In addition to the code api, we added below `menu` contributions and context keys:

### Menus
* `comments/commentThread/title`
* `comments/commentThread/actions`
* `comments/comment/title`
* `comments/comment/actions`

### Context Keys
* `commentController` (similar to `scmProvider`)
* `commentIsEmpty`
* `commentThreadIsEmpty`
* `comment`, which used to check the `contextValue` of `Comment`
* `commentThread`, which used to check the `contextValue` of `CommentThread` 