### PR TITLE
Add newsletter signup to welcome page

### DIFF
--- a/src/vs/platform/product/node/product.ts
+++ b/src/vs/platform/product/node/product.ts
@@ -61,6 +61,7 @@ export interface IProductConfiguration {
 	keyboardShortcutsUrlWin: string;
 	introductoryVideosUrl: string;
 	tipsAndTricksUrl: string;
+	newsletterSignupUrl: string;
 	twitterUrl: string;
 	requestFeatureUrl: string;
 	reportIssueUrl: string;

--- a/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
@@ -44,6 +44,7 @@ export default () => `
 						<li><a href="command:workbench.action.openDocumentationUrl">${escape(localize('welcomePage.productDocumentation', "Product documentation"))}</a></li>
 						<li><a href="https://github.com/Microsoft/vscode">${escape(localize('welcomePage.gitHubRepository', "GitHub repository"))}</a></li>
 						<li><a href="http://stackoverflow.com/questions/tagged/vscode?sort=votes&pageSize=50">${escape(localize('welcomePage.stackOverflow', "Stack Overflow"))}</a></li>
+						<li><a href="command:workbench.action.openNewsletterSignupUrl">${escape(localize('welcomePage.newsletterSignup', "Join our Newsletter"))}</a></li>
 					</ul>
 				</div>
 				<p class="showOnStartup"><input type="checkbox" id="showOnStartup" class="checkbox"> <label class="caption" for="showOnStartup">${escape(localize('welcomePage.showOnStartup', "Show welcome page on startup"))}</label></p>

--- a/src/vs/workbench/electron-browser/actions/helpActions.ts
+++ b/src/vs/workbench/electron-browser/actions/helpActions.ts
@@ -7,6 +7,7 @@ import { Action } from 'vs/base/common/actions';
 import * as nls from 'vs/nls';
 import product from 'vs/platform/product/node/product';
 import { isMacintosh, isLinux, language } from 'vs/base/common/platform';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 export class KeybindingsReferenceAction extends Action {
 
@@ -91,7 +92,31 @@ export class OpenTipsAndTricksUrlAction extends Action {
 
 	run(): Promise<void> {
 		window.open(OpenTipsAndTricksUrlAction.URL);
+		return Promise.resolve();
+	}
+}
 
+export class OpenNewsletterSignupUrlAction extends Action {
+
+	static readonly ID = 'workbench.action.openNewsletterSignupUrl';
+	static readonly LABEL = nls.localize('newsletterSignup', "Signup for VS Code Newsletter");
+	telemetryService: ITelemetryService;
+	private static readonly URL = product.newsletterSignupUrl;
+	static readonly AVAILABLE = !!OpenNewsletterSignupUrlAction.URL;
+
+	constructor(
+		id: string,
+		label: string,
+		@ITelemetryService telemetryService: ITelemetryService
+	) {
+		super(id, label);
+		this.telemetryService = telemetryService;
+	}
+
+	run(): Promise<void> {
+		this.telemetryService.getTelemetryInfo().then(info => {
+			window.open(`${OpenNewsletterSignupUrlAction.URL}?machineId=${encodeURIComponent(info.machineId)}`);
+		});
 		return Promise.resolve();
 	}
 }

--- a/src/vs/workbench/electron-browser/actions/helpActions.ts
+++ b/src/vs/workbench/electron-browser/actions/helpActions.ts
@@ -100,7 +100,7 @@ export class OpenNewsletterSignupUrlAction extends Action {
 
 	static readonly ID = 'workbench.action.openNewsletterSignupUrl';
 	static readonly LABEL = nls.localize('newsletterSignup', "Signup for the VS Code Newsletter");
-	telemetryService: ITelemetryService;
+	private telemetryService: ITelemetryService;
 	private static readonly URL = product.newsletterSignupUrl;
 	static readonly AVAILABLE = !!OpenNewsletterSignupUrlAction.URL;
 

--- a/src/vs/workbench/electron-browser/actions/helpActions.ts
+++ b/src/vs/workbench/electron-browser/actions/helpActions.ts
@@ -99,7 +99,7 @@ export class OpenTipsAndTricksUrlAction extends Action {
 export class OpenNewsletterSignupUrlAction extends Action {
 
 	static readonly ID = 'workbench.action.openNewsletterSignupUrl';
-	static readonly LABEL = nls.localize('newsletterSignup', "Signup for VS Code Newsletter");
+	static readonly LABEL = nls.localize('newsletterSignup', "Signup for the VS Code Newsletter");
 	telemetryService: ITelemetryService;
 	private static readonly URL = product.newsletterSignupUrl;
 	static readonly AVAILABLE = !!OpenNewsletterSignupUrlAction.URL;

--- a/src/vs/workbench/electron-browser/main.contribution.ts
+++ b/src/vs/workbench/electron-browser/main.contribution.ts
@@ -11,7 +11,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions, Configur
 import { IWorkbenchActionRegistry, Extensions } from 'vs/workbench/common/actions';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { isWindows, isLinux, isMacintosh } from 'vs/base/common/platform';
-import { KeybindingsReferenceAction, OpenDocumentationUrlAction, OpenIntroductoryVideosUrlAction, OpenTipsAndTricksUrlAction, OpenTwitterUrlAction, OpenRequestFeatureUrlAction, OpenPrivacyStatementUrlAction, OpenLicenseUrlAction } from 'vs/workbench/electron-browser/actions/helpActions';
+import { KeybindingsReferenceAction, OpenDocumentationUrlAction, OpenIntroductoryVideosUrlAction, OpenTipsAndTricksUrlAction, OpenTwitterUrlAction, OpenRequestFeatureUrlAction, OpenPrivacyStatementUrlAction, OpenLicenseUrlAction, OpenNewsletterSignupUrlAction } from 'vs/workbench/electron-browser/actions/helpActions';
 import { ToggleSharedProcessAction, InspectContextKeysAction, ToggleScreencastModeAction, ToggleDevToolsAction } from 'vs/workbench/electron-browser/actions/developerActions';
 import { ShowAboutDialogAction, ZoomResetAction, ZoomOutAction, ZoomInAction, ToggleFullScreenAction, CloseCurrentWindowAction, SwitchWindow, NewWindowAction, QuickSwitchWindow, QuickOpenRecentAction, inRecentFilesPickerContextKey, OpenRecentAction, ReloadWindowWithExtensionsDisabledAction, NewWindowTabHandler, ReloadWindowAction, ShowPreviousWindowTabHandler, ShowNextWindowTabHandler, MoveWindowTabToNewWindowHandler, MergeWindowTabsHandlerHandler, ToggleWindowTabsBarHandler } from 'vs/workbench/electron-browser/actions/windowActions';
 import { AddRootFolderAction, GlobalRemoveRootFolderAction, OpenWorkspaceAction, SaveWorkspaceAsAction, OpenWorkspaceConfigFileAction, DuplicateWorkspaceInNewWindowAction, OpenFileFolderAction, OpenFileAction, OpenFolderAction, CloseWorkspaceAction, OpenLocalFileAction, OpenLocalFolderAction, OpenLocalFileFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
@@ -201,6 +201,10 @@ import { LogStorageAction } from 'vs/platform/storage/node/storageService';
 
 		if (OpenTipsAndTricksUrlAction.AVAILABLE) {
 			registry.registerWorkbenchAction(new SyncActionDescriptor(OpenTipsAndTricksUrlAction, OpenTipsAndTricksUrlAction.ID, OpenTipsAndTricksUrlAction.LABEL), 'Help: Tips and Tricks', helpCategory);
+		}
+
+		if (OpenNewsletterSignupUrlAction.AVAILABLE) {
+			registry.registerWorkbenchAction(new SyncActionDescriptor(OpenNewsletterSignupUrlAction, OpenNewsletterSignupUrlAction.ID, OpenNewsletterSignupUrlAction.LABEL), 'Help: Tips and Tricks', helpCategory);
 		}
 
 		registry.registerWorkbenchAction(new SyncActionDescriptor(OpenTwitterUrlAction, OpenTwitterUrlAction.ID, OpenTwitterUrlAction.LABEL), 'Help: Join Us on Twitter', helpCategory);


### PR DESCRIPTION
Visual Studio and other teams have been able to increase new user retention and engagement rates by offering a regular newsletter that contains existing content (release notes, tips and tricks, public road maps, etc). 

We want to run an experiment to see if the same is true for VS Code users. 

We already added a question to the post download survey to gauge general interest in signing up for a newsletter. Surprisingly, out of 190 users who left us their email, 140 also opted in to the newsletter. So it's clear there is general interest in a newsletter.

Unfortunately we don't have the user's `machineId` in the post download survey, so we can't compare the engagement of new users who are subscribed to the newsletter with users who are not subscribed.

To address this, this PR adds a link to the welcome page that redirects the user to another survey which also gets the user's `machineId` passed in.

![image](https://user-images.githubusercontent.com/820883/58137735-3696ea80-7be8-11e9-85fb-9454aa8e86a4.png)


![image](https://user-images.githubusercontent.com/820883/58137754-4a425100-7be8-11e9-8852-63033d573059.png)
(note the machineId in the url params)

This change requires the URL to be added to `product.json`. [Link to that PR](https://github.com/microsoft/vscode-distro/pull/173)

I acknowledge that barely anyone reads this far down on the welcome page. Currently we just want to experiment with building out a newsletter and testing whether our users respond positively to newsletter content. If we can prove this is useful, then we will look into making the newsletter signup more discoverable. 
