### PR TITLE
Input box escape \n, \r etc in the setter

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -161,7 +161,7 @@ export abstract class AbstractExpressionsRenderer implements ITreeRenderer<IExpr
 			});
 			const styler = attachInputBoxStyler(inputBox, this.themeService);
 
-			inputBox.value = options.initialValue;
+			inputBox.value = replaceWhitespace(options.initialValue);
 			inputBox.focus();
 			inputBox.select();
 


### PR DESCRIPTION
This PR aims to resolve #73975 

When settings a value with newline chars to a html input element, the new line chars are getting removed.

To prevent this, just before the assignment, escaping the string value results in the expected behavior.