### PR TITLE
Add rnpm-plugin-windows and pom.xml check

### DIFF
--- a/src/vs/workbench/contrib/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/contrib/stats/node/workspaceStats.ts
@@ -53,6 +53,7 @@ const ModulesToLookFor = [
 	// JS frameworks
 	'react',
 	'react-native',
+	'rnpm-plugin-windows',
 	'@angular/core',
 	'@ionic',
 	'vue',
@@ -268,6 +269,7 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			"workspace.npm.hapi" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.socket.io" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.restify" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+			"workspace.npm.rnpm-plugin-windows" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.react" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.@angular/core" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.npm.vue" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
@@ -288,6 +290,7 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			"workspace.reactNative" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.ionic" : { "classification" : "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": "true" },
 			"workspace.nativeScript" : { "classification" : "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": "true" },
+			"workspace.java.pom" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.requirements" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.requirements.star" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 			"workspace.py.Pipfile" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
@@ -386,6 +389,8 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			tags['workspace.unity'] = nameSet.has('assets') && nameSet.has('library') && nameSet.has('projectsettings');
 			tags['workspace.npm'] = nameSet.has('package.json') || nameSet.has('node_modules');
 			tags['workspace.bower'] = nameSet.has('bower.json') || nameSet.has('bower_components');
+
+			tags['workspace.java.pom'] = nameSet.has('pom.xml');
 
 			tags['workspace.yeoman.code.ext'] = nameSet.has('vsc-extension-quickstart.md');
 
@@ -502,18 +507,18 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			const packageJsonPromises = getFilePromises('package.json', this.fileService, this.textFileService, content => {
 				try {
 					const packageJsonContents = JSON.parse(content.value);
-					if (packageJsonContents['dependencies']) {
+					if (packageJsonContents['dependencies'] || packageJsonContents['devDependencies']) {
 						for (let module of ModulesToLookFor) {
 							if ('react-native' === module) {
-								if (packageJsonContents['dependencies'][module]) {
+								if (packageJsonContents['dependencies'][module] || packageJsonContents['devDependencies'][module]) {
 									tags['workspace.reactNative'] = true;
 								}
 							} else if ('tns-core-modules' === module) {
-								if (packageJsonContents['dependencies'][module]) {
+								if (packageJsonContents['dependencies'][module] || packageJsonContents['devDependencies'][module]) {
 									tags['workspace.nativescript'] = true;
 								}
 							} else {
-								if (packageJsonContents['dependencies'][module]) {
+								if (packageJsonContents['dependencies'][module] || packageJsonContents['devDependencies'][module]) {
 									tags['workspace.npm.' + module] = true;
 								}
 							}
@@ -527,6 +532,7 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			return Promise.all([...packageJsonPromises, ...requirementsTxtPromises, ...pipfilePromises]).then(() => tags);
 		});
 	}
+
 
 	private handleWorkspaceFiles(rootFiles: string[]): void {
 		const state = this.contextService.getWorkbenchState();

--- a/src/vs/workbench/contrib/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/contrib/stats/node/workspaceStats.ts
@@ -507,23 +507,24 @@ export class WorkspaceStats implements IWorkbenchContribution {
 			const packageJsonPromises = getFilePromises('package.json', this.fileService, this.textFileService, content => {
 				try {
 					const packageJsonContents = JSON.parse(content.value);
-					if (packageJsonContents['dependencies'] || packageJsonContents['devDependencies']) {
-						for (let module of ModulesToLookFor) {
-							if ('react-native' === module) {
-								if (packageJsonContents['dependencies'][module] || packageJsonContents['devDependencies'][module]) {
-									tags['workspace.reactNative'] = true;
-								}
-							} else if ('tns-core-modules' === module) {
-								if (packageJsonContents['dependencies'][module] || packageJsonContents['devDependencies'][module]) {
-									tags['workspace.nativescript'] = true;
-								}
-							} else {
-								if (packageJsonContents['dependencies'][module] || packageJsonContents['devDependencies'][module]) {
-									tags['workspace.npm.' + module] = true;
-								}
+					let dependencies = packageJsonContents['dependencies'];
+					let devDependencies = packageJsonContents['devDependencies'];
+					for (let module of ModulesToLookFor) {
+						if ('react-native' === module) {
+							if ((dependencies && dependencies[module]) || (devDependencies && devDependencies[module])) {
+								tags['workspace.reactNative'] = true;
+							}
+						} else if ('tns-core-modules' === module) {
+							if ((dependencies && dependencies[module]) || (devDependencies && devDependencies[module])) {
+								tags['workspace.nativescript'] = true;
+							}
+						} else {
+							if ((dependencies && dependencies[module]) || (devDependencies && devDependencies[module])) {
+								tags['workspace.npm.' + module] = true;
 							}
 						}
 					}
+
 				}
 				catch (e) {
 					// Ignore errors when resolving file or parsing file contents

--- a/src/vs/workbench/contrib/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/contrib/stats/node/workspaceStats.ts
@@ -533,7 +533,6 @@ export class WorkspaceStats implements IWorkbenchContribution {
 		});
 	}
 
-
 	private handleWorkspaceFiles(rootFiles: string[]): void {
 		const state = this.contextService.getWorkbenchState();
 		const workspace = this.contextService.getWorkspace();


### PR DESCRIPTION
add windows react native npm package to track for mobile extension team and pom.xml for java extension team

also added `devDependencies` as a check location for npm packages because `rnpm-plugin-windows` is typically installed there.