### PR TITLE
fix #59310: add align config for search result lines

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -753,15 +753,15 @@ configurationRegistry.registerConfiguration({
 			default: 'auto',
 			description: nls.localize('search.actionsPosition', "Controls the positioning of the actionbar on rows in the search view.")
 		},
-		'search.resultAlign': {
+		'search.resultDisplay': {
 			type: 'string',
-			enum: ['left', 'matchWord'],
+			enum: ['fullLine', 'ellipsis'],
 			enumDescriptions: [
-				nls.localize('search.resultAlignLeft', "Show search result starting from the leftmost side of each line."),
-				nls.localize('search.resultAlignMatchWord', "Show matched word in a proper position."),
+				nls.localize('search.resultDisplayFullLine', "Show the full content of each search result line."),
+				nls.localize('search.resultDisplayEllipsis', "Show search result line in a ellipsis way to focus on the matched word."),
 			],
-			default: 'matchWord',
-			description: nls.localize('search.resultAlign', "Controls the align of search result lines in the search view.")
+			default: 'ellipsis',
+			description: nls.localize('search.resultDisplay', "Controls the display of search result lines in the search view.")
 		}
 	}
 });

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -752,6 +752,16 @@ configurationRegistry.registerConfiguration({
 			],
 			default: 'auto',
 			description: nls.localize('search.actionsPosition', "Controls the positioning of the actionbar on rows in the search view.")
+		},
+		'search.resultAlign': {
+			type: 'string',
+			enum: ['left', 'matchWord'],
+			enumDescriptions: [
+				nls.localize('search.resultAlignLeft', "Show search result starting from the leftmost side of each line."),
+				nls.localize('search.resultAlignMatchWord', "Show matched word in a proper position."),
+			],
+			default: 'matchWord',
+			description: nls.localize('search.resultAlign', "Controls the align of search result lines in the search view.")
 		}
 	}
 });

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -249,7 +249,12 @@ export class MatchRenderer extends Disposable implements ITreeRenderer<Match, vo
 
 	renderElement(node: ITreeNode<Match, any>, index: number, templateData: IMatchTemplate): void {
 		const match = node.element;
-		const preview = match.preview();
+
+		const searchConfig = this.configurationService.getValue<ISearchConfigurationProperties>('search');
+		const resultAlign = searchConfig.resultAlign;
+		const showLineNumbers = searchConfig.showLineNumbers;
+
+		const preview = match.preview(resultAlign === 'matchWord');
 		const replace = this.searchModel.isReplaceActive() && !!this.searchModel.replaceString;
 
 		templateData.before.textContent = preview.before;
@@ -262,7 +267,6 @@ export class MatchRenderer extends Disposable implements ITreeRenderer<Match, vo
 		const numLines = match.range().endLineNumber - match.range().startLineNumber;
 		const extraLinesStr = numLines > 0 ? `+${numLines}` : '';
 
-		const showLineNumbers = this.configurationService.getValue<ISearchConfigurationProperties>('search').showLineNumbers;
 		const lineNumberStr = showLineNumbers ? `:${match.range().startLineNumber}` : '';
 		DOM.toggleClass(templateData.lineNumber, 'show', (numLines > 0) || showLineNumbers);
 

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -251,10 +251,10 @@ export class MatchRenderer extends Disposable implements ITreeRenderer<Match, vo
 		const match = node.element;
 
 		const searchConfig = this.configurationService.getValue<ISearchConfigurationProperties>('search');
-		const resultAlign = searchConfig.resultAlign;
+		const resultDisplay = searchConfig.resultDisplay;
 		const showLineNumbers = searchConfig.showLineNumbers;
 
-		const preview = match.preview(resultAlign === 'matchWord');
+		const preview = match.preview(resultDisplay === 'ellipsis');
 		const replace = this.searchModel.isReplaceActive() && !!this.searchModel.replaceString;
 
 		templateData.before.textContent = preview.before;

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -642,7 +642,8 @@ export class SearchView extends ViewletPanel {
 				identityProvider,
 				accessibilityProvider: this.instantiationService.createInstance(SearchAccessibilityProvider, this.viewModel),
 				dnd: this.instantiationService.createInstance(SearchDND),
-				multipleSelectionSupport: false
+				multipleSelectionSupport: false,
+				horizontalScrolling: true
 			}));
 		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));
 

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -74,12 +74,14 @@ export class Match {
 		return this._range;
 	}
 
-	preview(): { before: string; inside: string; after: string; } {
+	preview(alignMatchWord: boolean): { before: string; inside: string; after: string; } {
 		let before = this._oneLinePreviewText.substring(0, this._rangeInPreviewText.startColumn - 1),
 			inside = this.getMatchString(),
 			after = this._oneLinePreviewText.substring(this._rangeInPreviewText.endColumn - 1);
 
-		before = lcut(before, 26);
+		if (alignMatchWord) {
+			before = lcut(before, 26);
+		}
 		before = before.trimLeft();
 
 		let charsRemaining = Match.MAX_PREVIEW_CHARS - before.length;

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -74,20 +74,20 @@ export class Match {
 		return this._range;
 	}
 
-	preview(alignMatchWord: boolean): { before: string; inside: string; after: string; } {
+	preview(ellipsis: boolean): { before: string; inside: string; after: string; } {
 		let before = this._oneLinePreviewText.substring(0, this._rangeInPreviewText.startColumn - 1),
 			inside = this.getMatchString(),
 			after = this._oneLinePreviewText.substring(this._rangeInPreviewText.endColumn - 1);
 
-		if (alignMatchWord) {
+		if (ellipsis) {
 			before = lcut(before, 26);
-		}
-		before = before.trimLeft();
+			before = before.trimLeft();
 
-		let charsRemaining = Match.MAX_PREVIEW_CHARS - before.length;
-		inside = inside.substr(0, charsRemaining);
-		charsRemaining -= inside.length;
-		after = after.substr(0, charsRemaining);
+			let charsRemaining = Match.MAX_PREVIEW_CHARS - before.length;
+			inside = inside.substr(0, charsRemaining);
+			charsRemaining -= inside.length;
+			after = after.substr(0, charsRemaining);
+		}
 
 		return {
 			before,

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -316,7 +316,7 @@ export interface ISearchConfigurationProperties {
 	actionsPosition: 'auto' | 'right';
 	maintainFileSearchCache: boolean;
 	collapseResults: 'auto' | 'alwaysCollapse' | 'alwaysExpand';
-	resultAlign: 'left' | 'matchWord';
+	resultDisplay: 'fullLine' | 'ellipsis';
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -316,6 +316,7 @@ export interface ISearchConfigurationProperties {
 	actionsPosition: 'auto' | 'right';
 	maintainFileSearchCache: boolean;
 	collapseResults: 'auto' | 'alwaysCollapse' | 'alwaysExpand';
+	resultAlign: 'left' | 'matchWord';
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {


### PR DESCRIPTION
- Fix #59310
- Add a `resultAlign` option to determine how the search result preview line align