### PR TITLE
Show context for diff view of merge conflict and introduce compareAll.

### DIFF
--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -81,12 +81,6 @@
         "title": "%command.compare%",
         "original": "Compare Current Conflict",
         "command": "merge-conflict.compare"
-      },
-      {
-        "category": "%command.category%",
-        "title": "%command.compareAll%",
-        "original": "Compare All Conflict in Current Editor",
-        "command": "merge-conflict.compareAll"
       }
     ],
     "menus": {
@@ -120,11 +114,6 @@
           "type": "boolean",
           "description": "%config.autoNavigateNextConflictEnabled%",
           "default": false
-        },
-        "merge-conflict.diffViewContext": {
-          "type": "number",
-          "description": "%config.diffViewContext%",
-          "default": 0
         },
         "merge-conflict.openDiffInNewEditor": {
           "type": "boolean",

--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -81,6 +81,12 @@
         "title": "%command.compare%",
         "original": "Compare Current Conflict",
         "command": "merge-conflict.compare"
+      },
+      {
+        "category": "%command.category%",
+        "title": "%command.compareAll%",
+        "original": "Compare All Conflict in Current Editor",
+        "command": "merge-conflict.compareAll"
       }
     ],
     "menus": {
@@ -114,6 +120,11 @@
           "type": "boolean",
           "description": "%config.autoNavigateNextConflictEnabled%",
           "default": false
+        },
+        "merge-conflict.diffViewContext": {
+          "type": "number",
+          "description": "%config.diffViewContext%",
+          "default": 0
         }
       }
     }

--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -115,10 +115,15 @@
           "description": "%config.autoNavigateNextConflictEnabled%",
           "default": false
         },
-        "merge-conflict.openDiffInNewEditor": {
-          "type": "boolean",
-          "description": "%config.openDiffInNewEditor%",
-          "default": false
+        "merge-conflict.diffViewPosition": {
+          "type": "string",
+          "enum": [
+            "Current",
+            "Beside",
+            "Below"
+          ],
+          "description": "%config.diffViewPosition%",
+          "default": "Current"
         }
       }
     }

--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -125,6 +125,11 @@
           "type": "number",
           "description": "%config.diffViewContext%",
           "default": 0
+        },
+        "merge-conflict.openDiffInNewEditor": {
+          "type": "boolean",
+          "description": "%config.openDiffInNewEditor%",
+          "default": false
         }
       }
     }

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -12,8 +12,10 @@
 	"command.next": "Next Conflict",
 	"command.previous": "Previous Conflict",
 	"command.compare": "Compare Current Conflict",
+	"command.compareAll": "Compare All Conflict in Current Editor",
 	"config.title": "Merge Conflict",
 	"config.autoNavigateNextConflictEnabled": "Whether to automatically navigate to the next merge conflict after resolving a merge conflict.",
 	"config.codeLensEnabled": "Create a Code Lens for merge conflict blocks within editor.",
-	"config.decoratorsEnabled": "Create decorators for merge conflict blocks within editor."
+	"config.decoratorsEnabled": "Create decorators for merge conflict blocks within editor.",
+	"config.diffViewContext": "Controls how many unchanged lines around the merge conflict should be displayed in the diff view."
 }

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -12,11 +12,9 @@
 	"command.next": "Next Conflict",
 	"command.previous": "Previous Conflict",
 	"command.compare": "Compare Current Conflict",
-	"command.compareAll": "Compare All Conflict in Current Editor",
 	"config.title": "Merge Conflict",
 	"config.autoNavigateNextConflictEnabled": "Whether to automatically navigate to the next merge conflict after resolving a merge conflict.",
 	"config.codeLensEnabled": "Create a Code Lens for merge conflict blocks within editor.",
 	"config.decoratorsEnabled": "Create decorators for merge conflict blocks within editor.",
-	"config.diffViewContext": "Controls how many unchanged lines around the merge conflict should be displayed in the diff view.",
 	"config.openDiffInNewEditor": "Controls if the diff view should be opened in a new editor group when comparing changes in merge conflicts."
 }

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -16,5 +16,5 @@
 	"config.autoNavigateNextConflictEnabled": "Whether to automatically navigate to the next merge conflict after resolving a merge conflict.",
 	"config.codeLensEnabled": "Create a Code Lens for merge conflict blocks within editor.",
 	"config.decoratorsEnabled": "Create decorators for merge conflict blocks within editor.",
-	"config.openDiffInNewEditor": "Controls if the diff view should be opened in a new editor group when comparing changes in merge conflicts."
+	"config.diffViewPosition": "Controls where the diff view should be opened when comparing changes in merge conflicts."
 }

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -17,5 +17,6 @@
 	"config.autoNavigateNextConflictEnabled": "Whether to automatically navigate to the next merge conflict after resolving a merge conflict.",
 	"config.codeLensEnabled": "Create a Code Lens for merge conflict blocks within editor.",
 	"config.decoratorsEnabled": "Create decorators for merge conflict blocks within editor.",
-	"config.diffViewContext": "Controls how many unchanged lines around the merge conflict should be displayed in the diff view."
+	"config.diffViewContext": "Controls how many unchanged lines around the merge conflict should be displayed in the diff view.",
+	"config.openDiffInNewEditor": "Controls if the diff view should be opened in a new editor group when comparing changes in merge conflicts."
 }

--- a/extensions/merge-conflict/src/codelensProvider.ts
+++ b/extensions/merge-conflict/src/codelensProvider.ts
@@ -85,17 +85,11 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 				arguments: [conflict]
 			};
 
-			let diffAllCommand: vscode.Command = {
-				command: 'merge-conflict.compareAll',
-				title: localize('compareAllChanges', 'Compare All Changes')
-			};
-
 			items.push(
 				new vscode.CodeLens(conflict.range, acceptCurrentCommand),
 				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 1 })), acceptIncomingCommand),
 				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 2 })), acceptBothCommand),
-				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 3 })), diffCommand),
-				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 4 })), diffAllCommand)
+				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 3 })), diffCommand)
 			);
 		});
 

--- a/extensions/merge-conflict/src/codelensProvider.ts
+++ b/extensions/merge-conflict/src/codelensProvider.ts
@@ -85,11 +85,17 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 				arguments: [conflict]
 			};
 
+			let diffAllCommand: vscode.Command = {
+				command: 'merge-conflict.compareAll',
+				title: localize('compareAllChanges', 'Compare All Changes')
+			};
+
 			items.push(
 				new vscode.CodeLens(conflict.range, acceptCurrentCommand),
 				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 1 })), acceptIncomingCommand),
 				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 2 })), acceptBothCommand),
-				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 3 })), diffCommand)
+				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 3 })), diffCommand),
+				new vscode.CodeLens(conflict.range.with(conflict.range.start.with({ character: conflict.range.start.character + 4 })), diffAllCommand)
 			);
 		});
 

--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -100,7 +100,12 @@ export default class CommandHandler implements vscode.Disposable {
 		const rightUri = leftUri.with({ query: JSON.stringify({ scheme, range, fullRange: conflict.range }) });
 
 		const title = localize('compareChangesTitle', '{0}: Current Changes ⟷ Incoming Changes', fileName);
-		vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title);
+		const mergeConflictConfig = vscode.workspace.getConfiguration('merge-conflict');
+		const openToTheside = mergeConflictConfig.get<boolean>('openDiffInNewEditor');
+		const opts: vscode.TextDocumentShowOptions = {
+			viewColumn: openToTheside ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active
+		};
+		vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title, opts);
 	}
 
 	async compareAll(editor: vscode.TextEditor) {
@@ -125,7 +130,13 @@ export default class CommandHandler implements vscode.Disposable {
 		const rightUri = leftUri.with({ query: JSON.stringify({ type: 'full', scheme, ranges: rightRanges }) });
 
 		const title = localize('compareChangesTitle', '{0}: Current Changes ⟷ Incoming Changes', fileName);
-		vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title);
+		const mergeConflictConfig = vscode.workspace.getConfiguration('merge-conflict');
+		const openToTheside = mergeConflictConfig.get<boolean>('openDiffInNewEditor');
+		const opts: vscode.TextDocumentShowOptions = {
+			viewColumn: openToTheside ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active
+		};
+
+		vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title, opts);
 	}
 
 	navigateNext(editor: vscode.TextEditor): Promise<void> {

--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -127,11 +127,15 @@ export default class CommandHandler implements vscode.Disposable {
 		const mergeConflictConfig = vscode.workspace.getConfiguration('merge-conflict');
 		const openToTheSide = mergeConflictConfig.get<boolean>('openDiffInNewEditor');
 		const opts: vscode.TextDocumentShowOptions = {
-			viewColumn: openToTheSide ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active,
+			viewColumn: vscode.ViewColumn.Active,
 			selection
 		};
 
-		vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title, opts);
+		if (openToTheSide) {
+			await vscode.commands.executeCommand('workbench.action.newGroupBelow');
+		}
+
+		await vscode.commands.executeCommand('vscode.diff', leftUri, rightUri, title, opts);
 	}
 
 	navigateNext(editor: vscode.TextEditor): Promise<void> {

--- a/extensions/merge-conflict/src/commandHandler.ts
+++ b/extensions/merge-conflict/src/commandHandler.ts
@@ -125,13 +125,13 @@ export default class CommandHandler implements vscode.Disposable {
 
 		const title = localize('compareChangesTitle', '{0}: Current Changes ⟷ Incoming Changes', fileName);
 		const mergeConflictConfig = vscode.workspace.getConfiguration('merge-conflict');
-		const openToTheSide = mergeConflictConfig.get<boolean>('openDiffInNewEditor');
+		const openToTheSide = mergeConflictConfig.get<string>('diffViewPosition');
 		const opts: vscode.TextDocumentShowOptions = {
-			viewColumn: vscode.ViewColumn.Active,
+			viewColumn: openToTheSide === 'Beside' ? vscode.ViewColumn.Beside : vscode.ViewColumn.Active,
 			selection
 		};
 
-		if (openToTheSide) {
+		if (openToTheSide === 'Below') {
 			await vscode.commands.executeCommand('workbench.action.newGroupBelow');
 		}
 

--- a/extensions/merge-conflict/src/contentProvider.ts
+++ b/extensions/merge-conflict/src/contentProvider.ts
@@ -23,40 +23,28 @@ export default class MergeConflictContentProvider implements vscode.TextDocument
 
 	async provideTextDocumentContent(uri: vscode.Uri): Promise<string | null> {
 		try {
-			const { type, scheme, range, fullRange, ranges } = JSON.parse(uri.query) as { type: string, scheme: string; range: { line: number, character: number }[], fullRange: { line: number, character: number }[], ranges: [{ line: number, character: number }[], { line: number, character: number }[]][] };
+			const { scheme, ranges } = JSON.parse(uri.query) as { scheme: string, ranges: [{ line: number, character: number }[], { line: number, character: number }[]][] };
 
-			if (type === 'full') {
-				// complete diff
-				const document = await vscode.workspace.openTextDocument(uri.with({ scheme, query: '' }));
+			// complete diff
+			const document = await vscode.workspace.openTextDocument(uri.with({ scheme, query: '' }));
 
-				let text = '';
-				let lastPosition = new vscode.Position(0, 0);
-				ranges.forEach(rangeObj => {
-					let [range, fullRange] = rangeObj;
-					const [start, end] = range;
-					const [fullStart, fullEnd] = fullRange;
+			let text = '';
+			let lastPosition = new vscode.Position(0, 0);
 
-					text += document.getText(new vscode.Range(lastPosition.line, lastPosition.character, fullStart.line, fullStart.character));
-					text += document.getText(new vscode.Range(start.line, start.character, end.line, end.character));
-					lastPosition = new vscode.Position(fullEnd.line, fullEnd.character);
-				});
-
-				let documentEnd = document.lineAt(document.lineCount - 1).range.end;
-				text += document.getText(new vscode.Range(lastPosition.line, lastPosition.character, documentEnd.line, documentEnd.character));
-
-				return text;
-			} else {
-				const [start, end] = range;
+			ranges.forEach(rangeObj => {
+				let [conflictRange, fullRange] = rangeObj;
+				const [start, end] = conflictRange;
 				const [fullStart, fullEnd] = fullRange;
-				const mergeConflictConfig = vscode.workspace.getConfiguration('merge-conflict');
-				const context = Math.max(0, mergeConflictConfig.get<number>('diffViewContext') || 0);
-				const document = await vscode.workspace.openTextDocument(uri.with({ scheme, query: '' }));
-				const text =
-					document.getText(new vscode.Range(Math.max(0, fullStart.line - context), 0, fullStart.line, fullStart.character))
-					+ document.getText(new vscode.Range(start.line, start.character, end.line, end.character))
-					+ document.getText(new vscode.Range(fullEnd.line, fullEnd.character, Math.min(document.lineCount, fullEnd.line + context + 1), 0));
-				return text;
-			}
+
+				text += document.getText(new vscode.Range(lastPosition.line, lastPosition.character, fullStart.line, fullStart.character));
+				text += document.getText(new vscode.Range(start.line, start.character, end.line, end.character));
+				lastPosition = new vscode.Position(fullEnd.line, fullEnd.character);
+			});
+
+			let documentEnd = document.lineAt(document.lineCount - 1).range.end;
+			text += document.getText(new vscode.Range(lastPosition.line, lastPosition.character, documentEnd.line, documentEnd.character));
+
+			return text;
 		}
 		catch (ex) {
 			await vscode.window.showErrorMessage('Unable to show comparison');


### PR DESCRIPTION
To improve the merge conflict resolve experience, a new setting `merge-conflict.diffViewContext` was added to show the context around the conflict

Before: there is no context around the diff
![compare-withoutcontext](https://user-images.githubusercontent.com/876920/58287661-7c79bd00-7d66-11e9-8a6a-18ab0401ec3c.gif)

After: with `"merge-conflict.diffViewContext": 3`
![compare-with-context](https://user-images.githubusercontent.com/876920/58287490-ffe6de80-7d65-11e9-82c4-fa1fe14d23fd.gif)


A new command *Compare All* is introduced to display the full compare between current workspace and incoming changes, with which you can compare the old content, the incoming one, and the latest local content on disk

![compare-all](https://user-images.githubusercontent.com/876920/58287780-bcd93b00-7d66-11e9-8060-f3cc1d55c79c.gif)

