### PR TITLE
Fix #48403 broken UNC paths in markdown images

### DIFF
--- a/src/vs/workbench/contrib/webview/common/resourceLoader.ts
+++ b/src/vs/workbench/contrib/webview/common/resourceLoader.ts
@@ -5,7 +5,7 @@
 
 import { VSBuffer } from 'vs/base/common/buffer';
 import { sep } from 'vs/base/common/path';
-import { startsWith } from 'vs/base/common/strings';
+import { startsWith, endsWith } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { IFileService } from 'vs/platform/files/common/files';
 import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
@@ -45,10 +45,11 @@ export async function loadLocalResource(
 	extensionLocation: URI | undefined,
 	getRoots: () => ReadonlyArray<URI>
 ): Promise<LocalResourceResponse> {
-	const requestPath = requestUri.path;
+	const requestPath = requestUri.authority ? `//${requestUri.authority}${requestUri.path}` : requestUri.path;
 	const normalizedPath = URI.file(requestPath);
 	for (const root of getRoots()) {
-		if (!startsWith(normalizedPath.fsPath, root.fsPath + sep)) {
+		const rootPath = root.fsPath + (endsWith(root.fsPath, sep) ? '' : sep);
+		if (!startsWith(normalizedPath.fsPath, rootPath)) {
 			continue;
 		}
 


### PR DESCRIPTION
Fix #48403.

It's my first PR in this repo, I don't know if it could be fixed in a better way, if so, please tell me.

The problem is:

```ts
contents.session.protocol.registerBufferProtocol(protocol, (request, callback: any) => {
	const requestPath = URI.parse(request.url).path;
	//request.url = "vscode-resource://desktop-9su47m5/test-vscode-issue/350x150.png"
	//requestPath = /test-vscode-issue/350x150.png
	const normalizedPath = URI.file(requestPath);
	for (const root of getRoots()) {
		if (!startsWith(normalizedPath.fsPath, root.fsPath + sep)) {
			continue;
		}
		// ...
```

`normalizedPath.fsPath` won't have the `//desktop-9su47m5` part of the path, because `normalizedPath` variable is constructed with `URI.file("/test-vscode-issue/350x150.png")`, so the condition `!startsWith(normalizedPath.fsPath, root.fsPath + sep)` will never be false with UNC paths.
