### PR TITLE
Use newer version of yauzl that fixes deprecation Buffer() warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "vscode-sqlite3": "4.0.7",
     "vscode-textmate": "^4.1.1",
     "vscode-xterm": "3.14.0-beta5",
-    "yauzl": "^2.9.1",
+    "yauzl": "^2.9.2",
     "yazl": "^2.4.3"
   },
   "devDependencies": {

--- a/remote/package.json
+++ b/remote/package.json
@@ -21,7 +21,7 @@
     "vscode-proxy-agent": "0.4.0",
     "vscode-ripgrep": "^1.2.5",
     "vscode-textmate": "^4.1.1",
-    "yauzl": "^2.9.1",
+    "yauzl": "^2.9.2",
     "yazl": "^2.4.3"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Use newer version of yauzl that fixes deprecation Buffer() warning

Fix https://github.com/microsoft/vscode/issues/67534