### PR TITLE
this may fix #51458

### DIFF
--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -357,11 +357,28 @@ export class ReindentSelectedLinesAction extends EditorAction {
 				if (startLineNumber === endLineNumber) {
 					continue;
 				}
-			} else {
-				startLineNumber--;
 			}
-
-			let editOperations = getReindentEditOperations(model, startLineNumber, endLineNumber);
+			const { tabSize, indentSize, insertSpaces } = model.getOptions();
+			const indentConverter = {
+				shiftIndent: (indentation: string) => {
+					return ShiftCommand.shiftIndent(indentation, indentation.length + 1, tabSize, indentSize, insertSpaces);
+				},
+				unshiftIndent: (indentation: string) => {
+					return ShiftCommand.unshiftIndent(indentation, indentation.length + 1, tabSize, indentSize, insertSpaces);
+				}
+			};
+			const inheritedIndent = LanguageConfigurationRegistry.getGoodIndentForLine(
+				model,
+				model.getLanguageIdentifier().id,
+				startLineNumber,
+				indentConverter
+			);
+			let editOperations = getReindentEditOperations(
+				model,
+				startLineNumber,
+				endLineNumber,
+				inheritedIndent || undefined
+			);
 			edits.push(...editOperations);
 		}
 


### PR DESCRIPTION
Hi @rebornix,

😭This commit may or may not fix #51458. I cannot `yarn install` and build VSCode due to `vscode-ripgrep` installation error. There are too few solutions around and time wasting.

😭Just by looking at code and make sure there isn't a TypeScript linter warning or error. Also unit tests are not written.