### PR TITLE
SelectBox: Fix select title. Fixes: #73844

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -191,6 +191,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 				index: e.target.selectedIndex,
 				selected: e.target.value
 			});
+			if (!!this.options[this.selected] && !!this.options[this.selected].text) {
+				this.selectElement.title = this.options[this.selected].text;
+			}
 		}));
 
 		// Have to implement both keyboard and mouse controllers to handle disabled options
@@ -282,6 +285,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 		}
 
 		this.selectElement.selectedIndex = this.selected;
+		if (!!this.options[this.selected] && !!this.options[this.selected].text) {
+			this.selectElement.title = this.options[this.selected].text;
+		}
 	}
 
 	public setAriaLabel(label: string): void {
@@ -395,7 +401,7 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 			let listBackground = this.styles.selectListBackground ? this.styles.selectListBackground.toString() : background;
 			this.selectDropDownListContainer.style.backgroundColor = listBackground;
 			this.selectionDetailsPane.style.backgroundColor = listBackground;
-			const optionsBorder = this.styles.focusBorder ? this.styles.focusBorder.toString() : null;
+			const optionsBorder = this.styles.focusBorder ? this.styles.focusBorder.toString() : '';
 			this.selectDropDownContainer.style.outlineColor = optionsBorder;
 			this.selectDropDownContainer.style.outlineOffset = '-1px';
 		}
@@ -798,7 +804,11 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 				this._onDidSelect.fire({
 					index: this.selectElement.selectedIndex,
 					selected: this.options[this.selected].text
+
 				});
+				if (!!this.options[this.selected] && !!this.options[this.selected].text) {
+					this.selectElement.title = this.options[this.selected].text;
+				}
 			}
 
 			this.hideSelectDropDown(true);
@@ -891,6 +901,9 @@ export class SelectBoxList implements ISelectBoxDelegate, IListVirtualDelegate<I
 				index: this.selectElement.selectedIndex,
 				selected: this.options[this.selected].text
 			});
+			if (!!this.options[this.selected] && !!this.options[this.selected].text) {
+				this.selectElement.title = this.options[this.selected].text;
+			}
 		}
 
 		this.hideSelectDropDown(true);


### PR DESCRIPTION
Restores title attribute for custom SelectBox.
Fixes: #73844 

Note: Screen readers will typically announce both the aria-label and the title attribute.
Given these are always the same it is redundant but, unavoidable without some unknown
method to disable reading the title.  
