### PR TITLE
Fix-74281 Standard themes force SourceControlResourceGroup titles to UPPERCASE

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -583,9 +583,9 @@ export class Repository implements Disposable {
 		this._sourceControl.inputBox.validateInput = this.validateInput.bind(this);
 		this.disposables.push(this._sourceControl);
 
-		this._mergeGroup = this._sourceControl.createResourceGroup('merge', localize('merge changes', "Merge Changes"));
-		this._indexGroup = this._sourceControl.createResourceGroup('index', localize('staged changes', "Staged Changes"));
-		this._workingTreeGroup = this._sourceControl.createResourceGroup('workingTree', localize('changes', "Changes"));
+		this._mergeGroup = this._sourceControl.createResourceGroup('merge', localize('merge changes', "MERGE CHANGES"));
+		this._indexGroup = this._sourceControl.createResourceGroup('index', localize('staged changes', "STAGED CHANGES"));
+		this._workingTreeGroup = this._sourceControl.createResourceGroup('workingTree', localize('changes', "CHANGES"));
 
 		const updateIndexGroupVisibility = () => {
 			const config = workspace.getConfiguration('git', root);

--- a/src/vs/workbench/contrib/scm/browser/media/scmViewlet.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scmViewlet.css
@@ -73,7 +73,6 @@
 	flex: 1;
 	font-size: 11px;
 	font-weight: bold;
-	text-transform: uppercase;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }


### PR DESCRIPTION
@joaomoreno , removed the styling and explicitly changed to uppercase in 3 SourceControlResourceGroup to fix #74281 , Please review this and let me know if it needs any changes :) 