### PR TITLE
Fixes #74579 - Enable break word for hovers

### DIFF
--- a/src/vs/editor/contrib/hover/hover.css
+++ b/src/vs/editor/contrib/hover/hover.css
@@ -29,6 +29,7 @@
 
 .monaco-editor-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
 	max-width: 500px;
+	word-wrap: break-word;
 }
 
 .monaco-editor-hover p,


### PR DESCRIPTION
Enable break word for hovers. This prevents super long words from causing wrapping

Fixes #74579