### PR TITLE
Don't update js ts diagnostics if they have not changed

### DIFF
--- a/extensions/typescript-language-features/src/features/diagnostics.ts
+++ b/extensions/typescript-language-features/src/features/diagnostics.ts
@@ -18,12 +18,12 @@ function diagnosticsEquals(a: vscode.Diagnostic, b: vscode.Diagnostic): boolean 
 		&& a.severity === b.severity
 		&& a.source === b.source
 		&& a.range.isEqual(b.range)
-		&& arrays.equals(a.relatedInformation || [], b.relatedInformation || [], (a, b) => {
+		&& arrays.equals(a.relatedInformation || arrays.empty, b.relatedInformation || arrays.empty, (a, b) => {
 			return a.message === b.message
 				&& a.location.range.isEqual(b.location.range)
 				&& a.location.uri.fsPath === b.location.uri.fsPath;
 		})
-		&& arrays.equals(a.tags || [], b.tags || []);
+		&& arrays.equals(a.tags || arrays.empty, b.tags || arrays.empty);
 }
 
 export const enum DiagnosticKind {
@@ -51,7 +51,7 @@ class FileDiagnostics {
 		}
 
 		const existing = this._diagnostics.get(kind);
-		if (arrays.equals(existing || [], diagnostics, diagnosticsEquals)) {
+		if (arrays.equals(existing || arrays.empty, diagnostics, diagnosticsEquals)) {
 			// No need to update
 			return false;
 		}

--- a/extensions/typescript-language-features/src/features/diagnostics.ts
+++ b/extensions/typescript-language-features/src/features/diagnostics.ts
@@ -6,6 +6,25 @@
 import * as vscode from 'vscode';
 import { ResourceMap } from '../utils/resourceMap';
 import { DiagnosticLanguage, allDiagnosticLanguages } from '../utils/languageDescription';
+import * as arrays from '../utils/arrays';
+
+function diagnosticsEquals(a: vscode.Diagnostic, b: vscode.Diagnostic): boolean {
+	if (a === b) {
+		return true;
+	}
+
+	return a.code === b.code
+		&& a.message === b.message
+		&& a.severity === b.severity
+		&& a.source === b.source
+		&& a.range.isEqual(b.range)
+		&& arrays.equals(a.relatedInformation || [], b.relatedInformation || [], (a, b) => {
+			return a.message === b.message
+				&& a.location.range.isEqual(b.location.range)
+				&& a.location.uri.fsPath === b.location.uri.fsPath;
+		})
+		&& arrays.equals(a.tags || [], b.tags || []);
+}
 
 export const enum DiagnosticKind {
 	Syntax,
@@ -31,12 +50,10 @@ class FileDiagnostics {
 			this.language = language;
 		}
 
-		if (diagnostics.length === 0) {
-			const existing = this._diagnostics.get(kind);
-			if (!existing || existing && existing.length === 0) {
-				// No need to update
-				return false;
-			}
+		const existing = this._diagnostics.get(kind);
+		if (arrays.equals(existing || [], diagnostics, diagnosticsEquals)) {
+			// No need to update
+			return false;
 		}
 
 		this._diagnostics.set(kind, diagnostics);

--- a/extensions/typescript-language-features/src/utils/arrays.ts
+++ b/extensions/typescript-language-features/src/utils/arrays.ts
@@ -2,18 +2,19 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-export function equals<T>(one: ReadonlyArray<T>, other: ReadonlyArray<T>, itemEquals: (a: T, b: T) => boolean = (a, b) => a === b): boolean {
-	if (one.length !== other.length) {
+
+export function equals<T>(
+	a: ReadonlyArray<T>,
+	b: ReadonlyArray<T>,
+	itemEquals: (a: T, b: T) => boolean = (a, b) => a === b
+): boolean {
+	if (a === b) {
+		return true;
+	}
+	if (a.length !== b.length) {
 		return false;
 	}
-
-	for (let i = 0, len = one.length; i < len; i++) {
-		if (!itemEquals(one[i], other[i])) {
-			return false;
-		}
-	}
-
-	return true;
+	return a.every((x, i) => itemEquals(x, b[i]));
 }
 
 export function flatten<T>(arr: ReadonlyArray<T>[]): T[] {

--- a/extensions/typescript-language-features/src/utils/arrays.ts
+++ b/extensions/typescript-language-features/src/utils/arrays.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+export const empty = Object.freeze([]);
+
 export function equals<T>(
 	a: ReadonlyArray<T>,
 	b: ReadonlyArray<T>,

--- a/extensions/typescript-language-features/src/utils/arrays.ts
+++ b/extensions/typescript-language-features/src/utils/arrays.ts
@@ -18,5 +18,5 @@ export function equals<T>(
 }
 
 export function flatten<T>(arr: ReadonlyArray<T>[]): T[] {
-	return ([] as T[]).concat.apply([], arr);
+	return Array.prototype.concat.apply([], arr);
 }


### PR DESCRIPTION
Fixes #74633

This was the indirect cause of  #74633. See that issue for an explaination of why it was problematic.  In summary, updating diagnostics can retrigger code actions even if the user facing diagnostics have not actually changed