### PR TITLE
Add setting to turn off bracket-swallowing while autoclose is active

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -565,6 +565,21 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.autoSurround,
 			'description': nls.localize('autoSurround', "Controls whether the editor should automatically surround selections.")
 		},
+
+		'editor.disregardCorrespondingAutoclosedPairs': {
+			type: 'string',
+			enum: ['always', 'brackets', 'quotes', 'never'],
+			enumDescriptions: [
+				nls.localize('editor.disregardCorrespondingAutoclosedPairs.always', "Always disregard input that could be extrenous due to autoclosing."),
+				nls.localize('editor.disregardCorrespondingAutoclosedPairs.brackets', "Disregard input that could be extrenous due to autoclosing brackets."),
+				nls.localize('editor.disregardCorrespondingAutoclosedPairs.quotes', "Disregard input that could be extrenous due to autoclosing quotes."),
+				nls.localize('editor.disregardCorrespondingAutoclosedPairs.never', "Never disregard input that could be extrenous due to autoclosing."),
+				''
+			],
+			'default': EDITOR_DEFAULTS.disregardCorrespondingAutoclosedPairs,
+			'description': nls.localize('autoSurround', "Controls whether the editor should automatically surround selections.")
+		},
+
 		'editor.formatOnType': {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.contribInfo.formatOnType,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -109,6 +109,11 @@ export type EditorAutoClosingStrategy = 'always' | 'languageDefined' | 'beforeWh
 export type EditorAutoSurroundStrategy = 'languageDefined' | 'quotes' | 'brackets' | 'never';
 
 /**
+ * Configuration options for swallowing characters that may be repeats of auto-closed characters
+ */
+export type EditorDisregardCorrespondingAutoclosedPairsStrategy = 'always' | 'quotes' | 'brackets' | 'never';
+
+/**
  * Configuration options for editor minimap
  */
 export interface IEditorMinimapOptions {
@@ -539,6 +544,11 @@ export interface IEditorOptions {
 	 * Defaults to language defined behavior.
 	 */
 	autoClosingQuotes?: EditorAutoClosingStrategy;
+	/**
+	 * Options for controlling if characters are disregarded when they could be repeating what was inserted by an auto-closing strategy
+	 * Defaults to always disregard characters which could be repeats.
+	 */
+	disregardCorrespondingAutoclosedPairs?: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 	/**
 	 * Options for auto surrounding.
 	 * Defaults to always allowing auto surrounding.
@@ -1067,6 +1077,7 @@ export interface IValidatedEditorOptions {
 	readonly wordWrapBreakObtrusiveCharacters: string;
 	readonly autoClosingBrackets: EditorAutoClosingStrategy;
 	readonly autoClosingQuotes: EditorAutoClosingStrategy;
+	readonly disregardCorrespondingAutoclosedPairs: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 	readonly autoSurround: EditorAutoSurroundStrategy;
 	readonly autoIndent: boolean;
 	readonly dragAndDrop: boolean;
@@ -1105,6 +1116,7 @@ export class InternalEditorOptions {
 	readonly wordSeparators: string;
 	readonly autoClosingBrackets: EditorAutoClosingStrategy;
 	readonly autoClosingQuotes: EditorAutoClosingStrategy;
+	readonly disregardCorrespondingAutoclosedPairs: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 	readonly autoSurround: EditorAutoSurroundStrategy;
 	readonly autoIndent: boolean;
 	readonly useTabStops: boolean;
@@ -1135,6 +1147,7 @@ export class InternalEditorOptions {
 		wordSeparators: string;
 		autoClosingBrackets: EditorAutoClosingStrategy;
 		autoClosingQuotes: EditorAutoClosingStrategy;
+		disregardCorrespondingAutoclosedPairs: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 		autoSurround: EditorAutoSurroundStrategy;
 		autoIndent: boolean;
 		useTabStops: boolean;
@@ -1160,6 +1173,7 @@ export class InternalEditorOptions {
 		this.wordSeparators = source.wordSeparators;
 		this.autoClosingBrackets = source.autoClosingBrackets;
 		this.autoClosingQuotes = source.autoClosingQuotes;
+		this.disregardCorrespondingAutoclosedPairs = source.disregardCorrespondingAutoclosedPairs;
 		this.autoSurround = source.autoSurround;
 		this.autoIndent = source.autoIndent;
 		this.useTabStops = source.useTabStops;
@@ -1191,6 +1205,7 @@ export class InternalEditorOptions {
 			&& this.wordSeparators === other.wordSeparators
 			&& this.autoClosingBrackets === other.autoClosingBrackets
 			&& this.autoClosingQuotes === other.autoClosingQuotes
+			&& this.disregardCorrespondingAutoclosedPairs === other.disregardCorrespondingAutoclosedPairs
 			&& this.autoSurround === other.autoSurround
 			&& this.autoIndent === other.autoIndent
 			&& this.useTabStops === other.useTabStops
@@ -1223,6 +1238,7 @@ export class InternalEditorOptions {
 			wordSeparators: (this.wordSeparators !== newOpts.wordSeparators),
 			autoClosingBrackets: (this.autoClosingBrackets !== newOpts.autoClosingBrackets),
 			autoClosingQuotes: (this.autoClosingQuotes !== newOpts.autoClosingQuotes),
+			disregardCorrespondingAutoclosedPairs: (this.disregardCorrespondingAutoclosedPairs !== newOpts.disregardCorrespondingAutoclosedPairs),
 			autoSurround: (this.autoSurround !== newOpts.autoSurround),
 			autoIndent: (this.autoIndent !== newOpts.autoIndent),
 			useTabStops: (this.useTabStops !== newOpts.useTabStops),
@@ -1627,6 +1643,7 @@ export interface IConfigurationChangedEvent {
 	readonly wordSeparators: boolean;
 	readonly autoClosingBrackets: boolean;
 	readonly autoClosingQuotes: boolean;
+	readonly disregardCorrespondingAutoclosedPairs: boolean;
 	readonly autoSurround: boolean;
 	readonly autoIndent: boolean;
 	readonly useTabStops: boolean;
@@ -1810,6 +1827,7 @@ export class EditorOptionsValidator {
 		let autoClosingBrackets: EditorAutoClosingStrategy;
 		let autoClosingQuotes: EditorAutoClosingStrategy;
 		let autoSurround: EditorAutoSurroundStrategy;
+
 		if (typeof opts.autoClosingBrackets === 'boolean' && opts.autoClosingBrackets === false) {
 			// backwards compatibility: disable all on boolean false
 			autoClosingBrackets = 'never';
@@ -1820,6 +1838,7 @@ export class EditorOptionsValidator {
 			autoClosingQuotes = _stringSet<EditorAutoClosingStrategy>(opts.autoClosingQuotes, defaults.autoClosingQuotes, ['always', 'languageDefined', 'beforeWhitespace', 'never']);
 			autoSurround = _stringSet<EditorAutoSurroundStrategy>(opts.autoSurround, defaults.autoSurround, ['languageDefined', 'brackets', 'quotes', 'never']);
 		}
+
 
 		return {
 			inDiffEditor: _boolean(opts.inDiffEditor, defaults.inDiffEditor),
@@ -1839,6 +1858,7 @@ export class EditorOptionsValidator {
 			wordWrapBreakObtrusiveCharacters: _string(opts.wordWrapBreakObtrusiveCharacters, defaults.wordWrapBreakObtrusiveCharacters),
 			autoClosingBrackets,
 			autoClosingQuotes,
+			disregardCorrespondingAutoclosedPairs: _stringSet<EditorDisregardCorrespondingAutoclosedPairsStrategy>(opts.disregardCorrespondingAutoclosedPairs, defaults.disregardCorrespondingAutoclosedPairs, ['always', 'brackets', 'quotes', 'never']),
 			autoSurround,
 			autoIndent: _boolean(opts.autoIndent, defaults.autoIndent),
 			dragAndDrop: _boolean(opts.dragAndDrop, defaults.dragAndDrop),
@@ -2155,6 +2175,7 @@ export class InternalEditorOptionsFactory {
 			autoClosingBrackets: opts.autoClosingBrackets,
 			autoClosingQuotes: opts.autoClosingQuotes,
 			autoSurround: opts.autoSurround,
+			disregardCorrespondingAutoclosedPairs: opts.disregardCorrespondingAutoclosedPairs,
 			autoIndent: opts.autoIndent,
 			dragAndDrop: opts.dragAndDrop,
 			emptySelectionClipboard: opts.emptySelectionClipboard,
@@ -2382,6 +2403,7 @@ export class InternalEditorOptionsFactory {
 			autoClosingBrackets: opts.autoClosingBrackets,
 			autoClosingQuotes: opts.autoClosingQuotes,
 			autoSurround: opts.autoSurround,
+			disregardCorrespondingAutoclosedPairs: opts.disregardCorrespondingAutoclosedPairs,
 			autoIndent: opts.autoIndent,
 			useTabStops: opts.useTabStops,
 			tabFocusMode: opts.readOnly ? true : env.tabFocusMode,
@@ -2619,6 +2641,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 	autoClosingBrackets: 'languageDefined',
 	autoClosingQuotes: 'languageDefined',
 	autoSurround: 'languageDefined',
+	disregardCorrespondingAutoclosedPairs: 'always',
 	autoIndent: true,
 	dragAndDrop: true,
 	emptySelectionClipboard: true,

--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -6,7 +6,7 @@
 import { CharCode } from 'vs/base/common/charCode';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import * as strings from 'vs/base/common/strings';
-import { EditorAutoClosingStrategy, EditorAutoSurroundStrategy, IConfigurationChangedEvent } from 'vs/editor/common/config/editorOptions';
+import { EditorAutoClosingStrategy, EditorAutoSurroundStrategy, IConfigurationChangedEvent, EditorDisregardCorrespondingAutoclosedPairsStrategy } from 'vs/editor/common/config/editorOptions';
 import { CursorChangeReason } from 'vs/editor/common/controller/cursorEvents';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
@@ -86,6 +86,7 @@ export class CursorConfiguration {
 	public readonly autoClosingBrackets: EditorAutoClosingStrategy;
 	public readonly autoClosingQuotes: EditorAutoClosingStrategy;
 	public readonly autoSurround: EditorAutoSurroundStrategy;
+	public readonly disregardCorrespondingAutoclosedPairs: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 	public readonly autoIndent: boolean;
 	public readonly autoClosingPairsOpen: CharacterMap;
 	public readonly autoClosingPairsClose: CharacterMap;
@@ -103,6 +104,7 @@ export class CursorConfiguration {
 			|| e.multiCursorMergeOverlapping
 			|| e.autoClosingBrackets
 			|| e.autoClosingQuotes
+			|| e.disregardCorrespondingAutoclosedPairs
 			|| e.autoSurround
 			|| e.useTabStops
 			|| e.lineHeight
@@ -132,6 +134,7 @@ export class CursorConfiguration {
 		this.multiCursorMergeOverlapping = c.multiCursorMergeOverlapping;
 		this.autoClosingBrackets = c.autoClosingBrackets;
 		this.autoClosingQuotes = c.autoClosingQuotes;
+		this.disregardCorrespondingAutoclosedPairs = c.disregardCorrespondingAutoclosedPairs;
 		this.autoSurround = c.autoSurround;
 		this.autoIndent = c.autoIndent;
 

--- a/src/vs/editor/common/controller/cursorTypeOperations.ts
+++ b/src/vs/editor/common/controller/cursorTypeOperations.ts
@@ -432,8 +432,10 @@ export class TypeOperations {
 
 	private static _isAutoClosingCloseCharType(config: CursorConfiguration, model: ITextModel, selections: Selection[], ch: string): boolean {
 		const autoCloseConfig = isQuote(ch) ? config.autoClosingQuotes : config.autoClosingBrackets;
+		const swallowingDisabled = config.disregardCorrespondingAutoclosedPairs === 'never' ||
+			config.disregardCorrespondingAutoclosedPairs === (isQuote(ch) ? 'quotes' : 'brackets');
 
-		if (autoCloseConfig === 'never' || !config.autoClosingPairsClose.hasOwnProperty(ch)) {
+		if (swallowingDisabled || autoCloseConfig === 'never' || !config.autoClosingPairsClose.hasOwnProperty(ch)) {
 			return false;
 		}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2456,6 +2456,11 @@ declare namespace monaco.editor {
 	export type EditorAutoSurroundStrategy = 'languageDefined' | 'quotes' | 'brackets' | 'never';
 
 	/**
+	 * Configuration options for swallowing characters that may be repeats of auto-closed characters
+	 */
+	export type EditorDisregardCorrespondingAutoclosedPairsStrategy = 'always' | 'quotes' | 'brackets' | 'never';
+
+	/**
 	 * Configuration options for editor minimap
 	 */
 	export interface IEditorMinimapOptions {
@@ -2878,6 +2883,11 @@ declare namespace monaco.editor {
 		 * Defaults to language defined behavior.
 		 */
 		autoClosingQuotes?: EditorAutoClosingStrategy;
+		/**
+		 * Options for controlling if characters are disregarded when they could be repeating what was inserted by an auto-closing strategy
+		 * Defaults to always disregard characters which could be repeats.
+		 */
+		disregardCorrespondingAutoclosedPairs?: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 		/**
 		 * Options for auto surrounding.
 		 * Defaults to always allowing auto surrounding.
@@ -3340,6 +3350,7 @@ declare namespace monaco.editor {
 		readonly wordSeparators: string;
 		readonly autoClosingBrackets: EditorAutoClosingStrategy;
 		readonly autoClosingQuotes: EditorAutoClosingStrategy;
+		readonly disregardCorrespondingAutoclosedPairs: EditorDisregardCorrespondingAutoclosedPairsStrategy;
 		readonly autoSurround: EditorAutoSurroundStrategy;
 		readonly autoIndent: boolean;
 		readonly useTabStops: boolean;
@@ -3481,6 +3492,7 @@ declare namespace monaco.editor {
 		readonly wordSeparators: boolean;
 		readonly autoClosingBrackets: boolean;
 		readonly autoClosingQuotes: boolean;
+		readonly disregardCorrespondingAutoclosedPairs: boolean;
 		readonly autoSurround: boolean;
 		readonly autoIndent: boolean;
 		readonly useTabStops: boolean;


### PR DESCRIPTION
As @jkyeung eloquently stated below:
Disabling bracket-swallowing is a partial solution to the "autoclosing problems" in issue #37315. There are inherent issues if we go forward with this partial solution, and the code in this PR demonstrates these issues, which I have touched on already in the discussion for #37315).