### PR TITLE
Fix #74668, old comment API not adding comments

### DIFF
--- a/src/vs/workbench/browser/web.simpleservices.ts
+++ b/src/vs/workbench/browser/web.simpleservices.ts
@@ -619,6 +619,7 @@ export class SimpleCommentService implements ICommentService {
 	onDidSetAllCommentThreads: Event<IWorkspaceCommentThreadsEvent> = Event.None;
 	onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent> = Event.None;
 	onDidChangeActiveCommentingRange: Event<{ range: Range; commentingRangesInfo: CommentingRanges; }> = Event.None;
+	onDidChangeActiveCommentThread: Event<any> = Event.None;
 	onDidSetDataProvider: Event<void> = Event.None;
 	onDidDeleteDataProvider: Event<string> = Event.None;
 	setDocumentComments: any;
@@ -649,6 +650,7 @@ export class SimpleCommentService implements ICommentService {
 	deleteReaction: any;
 	getReactionGroup: any;
 	toggleReaction: any;
+	setActiveCommentThread: any;
 }
 registerSingleton(ICommentService, SimpleCommentService, true);
 //#endregion

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -424,12 +424,14 @@ export class CommentNode extends Disposable {
 				uri: this._commentEditor.getModel()!.uri,
 				value: this.comment.body.value
 			};
+			this.commentService.setActiveCommentThread(commentThread);
 
 			this._commentEditorDisposables.push(this._commentEditor.onDidFocusEditorWidget(() => {
 				commentThread.input = {
 					uri: this._commentEditor!.getModel()!.uri,
 					value: this.comment.body.value
 				};
+				this.commentService.setActiveCommentThread(commentThread);
 			}));
 
 			this._commentEditorDisposables.push(this._commentEditor.onDidChangeModelContent(e => {
@@ -439,6 +441,7 @@ export class CommentNode extends Disposable {
 						let input = commentThread.input;
 						input.value = newVal;
 						commentThread.input = input;
+						this.commentService.setActiveCommentThread(commentThread);
 					}
 				}
 			}));
@@ -486,6 +489,7 @@ export class CommentNode extends Disposable {
 					uri: this._commentEditor.getModel()!.uri,
 					value: newBody
 				};
+				this.commentService.setActiveCommentThread(commentThread);
 				let commandId = this.comment.editCommand.id;
 				let args = this.comment.editCommand.arguments || [];
 
@@ -523,6 +527,7 @@ export class CommentNode extends Disposable {
 				if (result.confirmed) {
 					try {
 						if (this.comment.deleteCommand) {
+							this.commentService.setActiveCommentThread(this.commentThread);
 							let commandId = this.comment.deleteCommand.id;
 							let args = this.comment.deleteCommand.arguments || [];
 

--- a/src/vs/workbench/contrib/comments/browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentService.ts
@@ -38,6 +38,7 @@ export interface ICommentService {
 	readonly onDidSetResourceCommentInfos: Event<IResourceCommentThreadEvent>;
 	readonly onDidSetAllCommentThreads: Event<IWorkspaceCommentThreadsEvent>;
 	readonly onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent>;
+	readonly onDidChangeActiveCommentThread: Event<CommentThread | null>;
 	readonly onDidChangeActiveCommentingRange: Event<{ range: Range, commentingRangesInfo: CommentingRanges }>;
 	readonly onDidSetDataProvider: Event<void>;
 	readonly onDidDeleteDataProvider: Event<string>;
@@ -69,6 +70,7 @@ export interface ICommentService {
 	deleteReaction(owner: string, resource: URI, comment: Comment, reaction: CommentReaction): Promise<void>;
 	getReactionGroup(owner: string): CommentReaction[] | undefined;
 	toggleReaction(owner: string, resource: URI, thread: CommentThread2, comment: Comment, reaction: CommentReaction): Promise<void>;
+	setActiveCommentThread(commentThread: CommentThread | null): void;
 }
 
 export class CommentService extends Disposable implements ICommentService {
@@ -89,6 +91,9 @@ export class CommentService extends Disposable implements ICommentService {
 	private readonly _onDidUpdateCommentThreads: Emitter<ICommentThreadChangedEvent> = this._register(new Emitter<ICommentThreadChangedEvent>());
 	readonly onDidUpdateCommentThreads: Event<ICommentThreadChangedEvent> = this._onDidUpdateCommentThreads.event;
 
+	private readonly _onDidChangeActiveCommentThread = this._register(new Emitter<CommentThread | null>());
+	readonly onDidChangeActiveCommentThread = this._onDidChangeActiveCommentThread.event;
+
 	private readonly _onDidChangeActiveCommentingRange: Emitter<{
 		range: Range, commentingRangesInfo:
 		CommentingRanges
@@ -107,6 +112,10 @@ export class CommentService extends Disposable implements ICommentService {
 		@IInstantiationService protected instantiationService: IInstantiationService
 	) {
 		super();
+	}
+
+	setActiveCommentThread(commentThread: CommentThread | null) {
+		this._onDidChangeActiveCommentThread.fire(commentThread);
 	}
 
 	setDocumentComments(resource: URI, commentInfos: ICommentInfo[]): void {

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -211,6 +211,10 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 
 		this._bodyElement = <HTMLDivElement>dom.$('.body');
 		container.appendChild(this._bodyElement);
+
+		dom.addDisposableListener(this._bodyElement, dom.EventType.FOCUS_IN, e => {
+			this.commentService.setActiveCommentThread(this._commentThread);
+		});
 	}
 
 	protected _fillHead(container: HTMLElement): void {
@@ -265,6 +269,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			} else {
 				const deleteCommand = (this._commentThread as modes.CommentThread2).deleteCommand;
 				if (deleteCommand) {
+					this.commentService.setActiveCommentThread(this._commentThread);
 					return this.commandService.executeCommand(deleteCommand.id, ...(deleteCommand.arguments || []));
 				} else if (this._commentEditor.getValue() === '') {
 					this.commentService.disposeCommentThread(this._owner, this._commentThread.threadId!);
@@ -516,6 +521,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 				uri: this._commentEditor.getModel()!.uri,
 				value: this._commentEditor.getValue()
 			};
+			this.commentService.setActiveCommentThread(this._commentThread);
 		}));
 
 		this._commentThreadDisposables.push(this._commentEditor.getModel()!.onDidChangeContent(() => {
@@ -526,6 +532,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 				newInput.value = modelContent;
 				thread.input = newInput;
 			}
+			this.commentService.setActiveCommentThread(this._commentThread);
 		}));
 
 		this._commentThreadDisposables.push((this._commentThread as modes.CommentThread2).onDidChangeInput(input => {
@@ -727,6 +734,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 					uri: this._commentEditor.getModel()!.uri,
 					value: this._commentEditor.getValue()
 				};
+				this.commentService.setActiveCommentThread(this._commentThread);
 				await this.commandService.executeCommand(acceptInputCommand.id, ...(acceptInputCommand.arguments || []));
 			}));
 
@@ -751,6 +759,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 						uri: this._commentEditor.getModel()!.uri,
 						value: this._commentEditor.getValue()
 					};
+					this.commentService.setActiveCommentThread(this._commentThread);
 					await this.commandService.executeCommand(command.id, ...(command.arguments || []));
 				}));
 			});
@@ -821,6 +830,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 						uri: this._commentEditor.getModel()!.uri,
 						value: this._commentEditor.getValue()
 					};
+					this.commentService.setActiveCommentThread(this._commentThread);
 					let commandId = commentThread.acceptInputCommand.id;
 					let args = commentThread.acceptInputCommand.arguments || [];
 


### PR DESCRIPTION
Bring back the `onDidChangeActiveCommentThread` event so that the value of `inputBox` on the comment controller gets updated