### PR TITLE
Added `cachedScrollTop` to SCM panel

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewlet.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewlet.ts
@@ -865,10 +865,6 @@ export class RepositoryPanel extends ViewletPanel {
 	private onDidChangeVisibility(visible: boolean): void {
 		if (visible) {
 			const listSplicer = new ResourceGroupSplicer(this.repository.provider.groups, this.list);
-			if (this.cachedScrollTop !== undefined) {
-				this.list.scrollTop = Math.min(this.cachedScrollTop, this.list.scrollHeight);
-			}
-
 			this.visibilityDisposables.push(listSplicer);
 		} else {
 			this.cachedScrollTop = this.list.scrollTop;
@@ -899,6 +895,13 @@ export class RepositoryPanel extends ViewletPanel {
 
 			this.listContainer.style.height = `${height}px`;
 			this.list.layout(height, width);
+		}
+
+		if (this.cachedScrollTop !== undefined && this.list.scrollTop !== this.cachedScrollTop) {
+			this.list.scrollTop = Math.min(this.cachedScrollTop, this.list.scrollHeight);
+			// Applying the cached scroll position just once until the next leave.
+			// This, also, avoids the scrollbar to flicker when resizing the sidebar.
+			this.cachedScrollTop = undefined;
 		}
 	}
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewlet.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewlet.ts
@@ -699,6 +699,7 @@ export class RepositoryPanel extends ViewletPanel {
 
 	private cachedHeight: number | undefined = undefined;
 	private cachedWidth: number | undefined = undefined;
+	private cachedScrollTop: number | undefined = undefined;
 	private inputBoxContainer: HTMLElement;
 	private inputBox: InputBox;
 	private listContainer: HTMLElement;
@@ -864,8 +865,13 @@ export class RepositoryPanel extends ViewletPanel {
 	private onDidChangeVisibility(visible: boolean): void {
 		if (visible) {
 			const listSplicer = new ResourceGroupSplicer(this.repository.provider.groups, this.list);
+			if (this.cachedScrollTop !== undefined) {
+				this.list.scrollTop = Math.min(this.cachedScrollTop, this.list.scrollHeight);
+			}
+
 			this.visibilityDisposables.push(listSplicer);
 		} else {
+			this.cachedScrollTop = this.list.scrollTop;
 			this.visibilityDisposables = dispose(this.visibilityDisposables);
 		}
 	}


### PR DESCRIPTION
Fixes #73622

Added the new private property `cachedScrollTop` (to `RepositoryPanel`) to hold the vertical scrollbar position when its visibility changes.

