### PR TITLE
Fix spelling of the example abbreviation (e.g.)

### DIFF
--- a/build/lib/i18n.ts
+++ b/build/lib/i18n.ts
@@ -25,7 +25,7 @@ function log(message: any, ...rest: any[]): void {
 
 export interface Language {
 	id: string; // language id, e.g. zh-tw, de
-	translationId?: string; // language id used in translation tools, e.g zh-hant, de (optional, if not set, the id is used)
+	translationId?: string; // language id used in translation tools, e.g. zh-hant, de (optional, if not set, the id is used)
 	folderName?: string; // language specific folder name, e.g. cht, deu  (optional, if not set, the id is used)
 }
 

--- a/extensions/emmet/src/abbreviationActions.ts
+++ b/extensions/emmet/src/abbreviationActions.ts
@@ -491,7 +491,7 @@ export function isValidLocationForEmmetAbbreviation(document: vscode.TextDocumen
 	}
 
 	let valid = true;
-	let foundSpace = false; // If < is found before finding whitespace, then its valid abbreviation. Eg: <div|
+	let foundSpace = false; // If < is found before finding whitespace, then its valid abbreviation. E.g.: <div|
 	let i = textToBackTrack.length - 1;
 	if (textToBackTrack[i] === startAngle) {
 		return false;

--- a/extensions/emmet/src/util.ts
+++ b/extensions/emmet/src/util.ts
@@ -95,7 +95,7 @@ export function getMappingForIncludedLanguages(): any {
 
 /**
 * Get the corresponding emmet mode for given vscode language mode
-* Eg: jsx for typescriptreact/javascriptreact or pug for jade
+* E.g.: jsx for typescriptreact/javascriptreact or pug for jade
 * If the language is not supported by emmet or has been excluded via `excludeLanguages` setting,
 * then nothing is returned
 *

--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -331,7 +331,7 @@ export class URI implements UriComponents {
 
 		// normalize to fwd-slashes on windows,
 		// on other systems bwd-slashes are valid
-		// filename character, eg /f\oo/ba\r.txt
+		// filename character, e.g. /f\oo/ba\r.txt
 		if (isWindows) {
 			path = path.replace(/\\/g, _slash);
 		}

--- a/src/vs/base/parts/tree/browser/tree.ts
+++ b/src/vs/base/parts/tree/browser/tree.ts
@@ -231,7 +231,7 @@ export interface IDataSource {
 	 *
 	 * You should not attempt to "move" an element to a different
 	 * parent by keeping its ID. The idea here is to have tree location
-	 * related IDs (eg. full file path, in the Explorer example).
+	 * related IDs (e.g. full file path, in the Explorer example).
 	 */
 	getId(tree: ITree, element: any): string;
 

--- a/src/vs/code/electron-browser/workbench/workbench.js
+++ b/src/vs/code/electron-browser/workbench/workbench.js
@@ -70,7 +70,7 @@ function showPartsSplash(configuration) {
 		}
 	}
 
-	// high contrast mode has been turned on from the outside, e.g OS -> ignore stored colors and layouts
+	// high contrast mode has been turned on from the outside, e.g. OS -> ignore stored colors and layouts
 	if (data && configuration.highContrast && data.baseTheme !== 'hc-black') {
 		data = undefined;
 	}

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -44,7 +44,7 @@ import { SpdLogService } from 'vs/platform/log/node/spdlogService';
 
 const notFound = (id: string) => localize('notFound', "Extension '{0}' not found.", id);
 const notInstalled = (id: string) => localize('notInstalled', "Extension '{0}' is not installed.", id);
-const useId = localize('useId', "Make sure you use the full extension ID, including the publisher, eg: {0}", 'ms-vscode.csharp');
+const useId = localize('useId', "Make sure you use the full extension ID, including the publisher, e.g.: {0}", 'ms-vscode.csharp');
 
 function getId(manifest: IExtensionManifest, withVersion?: boolean): string {
 	if (withVersion) {

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -250,7 +250,7 @@ export interface IEncodedLineTokens {
 	 *  - f = foreground ColorId (9 bits)
 	 *  - b = background ColorId (9 bits)
 	 *  - The color value for each colorId is defined in IStandaloneThemeData.customTokenColors:
-	 * e.g colorId = 1 is stored in IStandaloneThemeData.customTokenColors[1]. Color id = 0 means no color,
+	 * e.g. colorId = 1 is stored in IStandaloneThemeData.customTokenColors[1]. Color id = 0 means no color,
 	 * id = 1 is for the default foreground color, id = 2 for the default background.
 	 */
 	tokens: Uint32Array;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4271,7 +4271,7 @@ declare namespace monaco.languages {
 		 *  - f = foreground ColorId (9 bits)
 		 *  - b = background ColorId (9 bits)
 		 *  - The color value for each colorId is defined in IStandaloneThemeData.customTokenColors:
-		 * e.g colorId = 1 is stored in IStandaloneThemeData.customTokenColors[1]. Color id = 0 means no color,
+		 * e.g. colorId = 1 is stored in IStandaloneThemeData.customTokenColors[1]. Color id = 0 means no color,
 		 * id = 1 is for the default foreground color, id = 2 for the default background.
 		 */
 		tokens: Uint32Array;

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1101,7 +1101,7 @@ declare module 'vscode' {
 
 		/**
 		 * The column in which this editor shows. Will be `undefined` in case this
-		 * isn't one of the main editors, e.g an embedded editor, or when the editor
+		 * isn't one of the main editors, e.g. an embedded editor, or when the editor
 		 * column is larger than three.
 		 */
 		viewColumn?: ViewColumn;
@@ -1900,7 +1900,7 @@ declare module 'vscode' {
 	 *
 	 * *Note* that a document selector that is just a language identifier selects *all*
 	 * documents, even those that are not saved on disk. Only use such selectors when
-	 * a feature works without further context, e.g without the need to resolve related
+	 * a feature works without further context, e.g. without the need to resolve related
 	 * 'files'.
 	 *
 	 * @sample `let sel:DocumentSelector = { scheme: 'file', language: 'typescript' }`;
@@ -2595,7 +2595,7 @@ declare module 'vscode' {
 		name: string;
 
 		/**
-		 * More detail for this symbol, e.g the signature of a function.
+		 * More detail for this symbol, e.g. the signature of a function.
 		 */
 		detail: string;
 
@@ -2605,12 +2605,12 @@ declare module 'vscode' {
 		kind: SymbolKind;
 
 		/**
-		 * The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g comments and code.
+		 * The range enclosing this symbol not including leading/trailing whitespace but everything else, e.g. comments and code.
 		 */
 		range: Range;
 
 		/**
-		 * The range that should be selected and reveal when this symbol is being picked, e.g the name of a function.
+		 * The range that should be selected and reveal when this symbol is being picked, e.g. the name of a function.
 		 * Must be contained by the [`range`](#DocumentSymbol.range).
 		 */
 		selectionRange: Range;
@@ -3649,7 +3649,7 @@ declare module 'vscode' {
 	 *
 	 * For some languages one color can have multiple presentations, e.g. css can represent the color red with
 	 * the constant `Red`, the hex-value `#ff0000`, or in rgba and hsla forms. In csharp other representations
-	 * apply, e.g `System.Drawing.Color.Red`.
+	 * apply, e.g. `System.Drawing.Color.Red`.
 	 */
 	export class ColorPresentation {
 
@@ -4235,7 +4235,7 @@ declare module 'vscode' {
 
 	/**
 	 * Represents a related message and source code location for a diagnostic. This should be
-	 * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+	 * used to point to code locations that cause or related to a diagnostics, e.g. when duplicating
 	 * a symbol in a scope.
 	 */
 	export class DiagnosticRelatedInformation {
@@ -6680,7 +6680,7 @@ declare module 'vscode' {
 		 * the following rules:
 		 *
 		 * - The uri-scheme must be `vscode.env.uriScheme`;
-		 * - The uri-authority must be the extension id (eg. `my.extension`);
+		 * - The uri-authority must be the extension id (e.g. `my.extension`);
 		 * - The uri-path, -query and -fragment parts are arbitrary.
 		 *
 		 * For example, if the `my.extension` extension registers a uri handler, it will only
@@ -8421,9 +8421,9 @@ declare module 'vscode' {
 		/**
 		 * Creates a new [source control](#SourceControl) instance.
 		 *
-		 * @param id An `id` for the source control. Something short, eg: `git`.
-		 * @param label A human-readable string for the source control. Eg: `Git`.
-		 * @param rootUri An optional Uri of the root of the source control. Eg: `Uri.parse(workspaceRoot)`.
+		 * @param id An `id` for the source control. Something short, e.g.: `git`.
+		 * @param label A human-readable string for the source control. E.g.: `Git`.
+		 * @param rootUri An optional Uri of the root of the source control. E.g.: `Uri.parse(workspaceRoot)`.
 		 * @return An instance of [source control](#SourceControl).
 		 */
 		export function createSourceControl(id: string, label: string, rootUri?: Uri): SourceControl;

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -162,7 +162,7 @@ export function createApiFactory(
 
 		// Check document selectors for being overly generic. Technically this isn't a problem but
 		// in practice many extensions say they support `fooLang` but need fs-access to do so. Those
-		// extension should specify then the `file`-scheme, e.g `{ scheme: 'fooLang', language: 'fooLang' }`
+		// extension should specify then the `file`-scheme, e.g. `{ scheme: 'fooLang', language: 'fooLang' }`
 		// We only inform once, it is not a warning because we just want to raise awareness and because
 		// we cannot say if the extension is doing it right or wrong...
 		const checkSelector = (function () {

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -176,7 +176,7 @@ export class ExtHostTerminal extends BaseExtHostTerminal implements vscode.Termi
 			this._pidPromiseComplete(processId);
 			this._pidPromiseComplete = null;
 		} else {
-			// Recreate the promise if this is the nth processId set (eg. reused task terminals)
+			// Recreate the promise if this is the nth processId set (e.g. reused task terminals)
 			this._pidPromise.then(pid => {
 				if (pid !== processId) {
 					this._pidPromise = Promise.resolve(processId);

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -19,7 +19,7 @@ export class LinkDetector {
 		// group 2: drive letter on windows with trailing backslash or leading slash on mac/linux
 		// group 3: line number, matched by (:(\d+))
 		// group 4: column number, matched by ((?::(\d+))?)
-		// eg: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
+		// e.g.: at Context.<anonymous> (c:\Users\someone\Desktop\mocha-runner\test\test.js:26:11)
 		/(?![\(])(?:file:\/\/)?((?:([a-zA-Z]+:)|[^\(\)<>\'\"\[\]:\s]+)(?:[\\/][^\(\)<>\'\"\[\]:]*)?\.[a-zA-Z]+[0-9]*):(\d+)(?::(\d+))?/g
 	];
 

--- a/src/vs/workbench/contrib/debug/common/debugSchemas.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSchemas.ts
@@ -47,7 +47,7 @@ export const debuggersExtPoint = extensionsRegistry.ExtensionsRegistry.registerE
 					type: 'array'
 				},
 				variables: {
-					description: nls.localize('vscode.extension.contributes.debuggers.variables', "Mapping from interactive variables (e.g ${action.pickProcess}) in `launch.json` to a command."),
+					description: nls.localize('vscode.extension.contributes.debuggers.variables', "Mapping from interactive variables (e.g. ${action.pickProcess}) in `launch.json` to a command."),
 					type: 'object'
 				},
 				initialConfigurations: {

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
@@ -432,7 +432,7 @@ CommandsRegistry.registerCommand({
 			const installed = await extensionManagementService.getInstalled(ExtensionType.User);
 			const [extensionToUninstall] = installed.filter(e => areSameExtensions(e.identifier, { id }));
 			if (!extensionToUninstall) {
-				return Promise.reject(new Error(localize('notInstalled', "Extension '{0}' is not installed. Make sure you use the full extension ID, including the publisher, eg: ms-vscode.csharp.", id)));
+				return Promise.reject(new Error(localize('notInstalled', "Extension '{0}' is not installed. Make sure you use the full extension ID, including the publisher, e.g.: ms-vscode.csharp.", id)));
 			}
 			await extensionManagementService.uninstall(extensionToUninstall, true);
 		} catch (e) {

--- a/src/vs/workbench/contrib/markers/browser/messages.ts
+++ b/src/vs/workbench/contrib/markers/browser/messages.ts
@@ -28,7 +28,7 @@ export default class Messages {
 	public static MARKERS_PANEL_ACTION_TOOLTIP_FILTER: string = nls.localize('markers.panel.action.filter', "Filter Problems");
 	public static MARKERS_PANEL_ACTION_TOOLTIP_QUICKFIX: string = nls.localize('markers.panel.action.quickfix', "Show fixes");
 	public static MARKERS_PANEL_FILTER_ARIA_LABEL: string = nls.localize('markers.panel.filter.ariaLabel', "Filter Problems");
-	public static MARKERS_PANEL_FILTER_PLACEHOLDER: string = nls.localize('markers.panel.filter.placeholder', "Filter. Eg: text, **/*.ts, !**/node_modules/**");
+	public static MARKERS_PANEL_FILTER_PLACEHOLDER: string = nls.localize('markers.panel.filter.placeholder', "Filter. E.g.: text, **/*.ts, !**/node_modules/**");
 	public static MARKERS_PANEL_FILTER_ERRORS: string = nls.localize('markers.panel.filter.errors', "errors");
 	public static MARKERS_PANEL_FILTER_WARNINGS: string = nls.localize('markers.panel.filter.warnings', "warnings");
 	public static MARKERS_PANEL_FILTER_INFOS: string = nls.localize('markers.panel.filter.infos', "infos");

--- a/src/vs/workbench/contrib/search/common/queryBuilder.ts
+++ b/src/vs/workbench/contrib/search/common/queryBuilder.ts
@@ -288,7 +288,7 @@ export class QueryBuilder {
 					globPortion = normalizeGlobPattern(globPortion);
 				}
 
-				// One pathPortion to multiple expanded search paths (eg duplicate matching workspace folders)
+				// One pathPortion to multiple expanded search paths (e.g. duplicate matching workspace folders)
 				const oneExpanded = this.expandOneSearchPath(pathPortion);
 
 				// Expanded search paths to multiple resolved patterns (with ** and without)

--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -43,7 +43,7 @@ const languageScopeSchema: IJSONSchema = {
 				type: ['string', 'array']
 			},
 			body: {
-				description: nls.localize('snippetSchema.json.body', 'The snippet content. Use \'$1\', \'${1:defaultText}\' to define cursor positions, use \'$0\' for the final cursor position. Insert variable values with \'${varName}\' and \'${varName:defaultText}\', e.g \'This is file: $TM_FILENAME\'.'),
+				description: nls.localize('snippetSchema.json.body', 'The snippet content. Use \'$1\', \'${1:defaultText}\' to define cursor positions, use \'$0\' for the final cursor position. Insert variable values with \'${varName}\' and \'${varName:defaultText}\', e.g. \'This is file: $TM_FILENAME\'.'),
 				type: ['string', 'array'],
 				items: {
 					type: 'string'
@@ -78,11 +78,11 @@ const globalSchema: IJSONSchema = {
 				type: ['string', 'array']
 			},
 			scope: {
-				description: nls.localize('snippetSchema.json.scope', "A list of language names to which this snippet applies, e.g 'typescript,javascript'."),
+				description: nls.localize('snippetSchema.json.scope', "A list of language names to which this snippet applies, e.g. 'typescript,javascript'."),
 				type: 'string'
 			},
 			body: {
-				description: nls.localize('snippetSchema.json.body', 'The snippet content. Use \'$1\', \'${1:defaultText}\' to define cursor positions, use \'$0\' for the final cursor position. Insert variable values with \'${varName}\' and \'${varName:defaultText}\', e.g \'This is file: $TM_FILENAME\'.'),
+				description: nls.localize('snippetSchema.json.body', 'The snippet content. Use \'$1\', \'${1:defaultText}\' to define cursor positions, use \'$0\' for the final cursor position. Insert variable values with \'${varName}\' and \'${varName:defaultText}\', e.g. \'This is file: $TM_FILENAME\'.'),
 				type: ['string', 'array'],
 				items: {
 					type: 'string'

--- a/src/vs/workbench/contrib/stats/node/workspaceStats.ts
+++ b/src/vs/workbench/contrib/stats/node/workspaceStats.ts
@@ -458,7 +458,7 @@ export class WorkspaceStats implements IWorkbenchContribution {
 				if (PyModulesToLookFor.indexOf(packageName) > -1) {
 					tags['workspace.py.' + packageName] = true;
 				}
-				// cognitive services has a lot of tiny packages. eg. 'azure-cognitiveservices-search-autosuggest'
+				// cognitive services has a lot of tiny packages. e.g. 'azure-cognitiveservices-search-autosuggest'
 				if (packageName.indexOf('azure-cognitiveservices') > -1) {
 					tags['workspace.py.azure-cognitiveservices'] = true;
 				}

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -617,7 +617,7 @@ export class CustomTask extends CommonTask {
 	type: '$customized'; // CUSTOMIZED_TASK_TYPE
 
 	/**
-	 * Indicated the source of the task (e.g tasks.json or extension)
+	 * Indicated the source of the task (e.g. tasks.json or extension)
 	 */
 	_source: WorkspaceTaskSource;
 
@@ -724,7 +724,7 @@ export class CustomTask extends CommonTask {
 export class ConfiguringTask extends CommonTask {
 
 	/**
-	 * Indicated the source of the task (e.g tasks.json or extension)
+	 * Indicated the source of the task (e.g. tasks.json or extension)
 	 */
 	_source: WorkspaceTaskSource;
 
@@ -750,7 +750,7 @@ export class ConfiguringTask extends CommonTask {
 export class ContributedTask extends CommonTask {
 
 	/**
-	 * Indicated the source of the task (e.g tasks.json or extension)
+	 * Indicated the source of the task (e.g. tasks.json or extension)
 	 */
 	_source: ExtensionTaskSource;
 
@@ -817,7 +817,7 @@ export class ContributedTask extends CommonTask {
 
 export class InMemoryTask extends CommonTask {
 	/**
-	 * Indicated the source of the task (e.g tasks.json or extension)
+	 * Indicated the source of the task (e.g. tasks.json or extension)
 	 */
 	_source: InMemoryTaskSource;
 

--- a/src/vs/workbench/contrib/terminal/browser/media/xterm.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/xterm.css
@@ -128,7 +128,7 @@
 }
 
 .xterm.enable-mouse-events {
-	/* When mouse events are enabled (eg. tmux), revert to the standard pointer cursor */
+	/* When mouse events are enabled (e.g. tmux), revert to the standard pointer cursor */
 	cursor: default;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -763,7 +763,7 @@ export class TerminalInstance implements ITerminalInstance {
 
 	public rendererExit(exitCode: number): void {
 		// The use of this API is for cases where there is no backing process behind a terminal
-		// instance (eg. a custom execution task).
+		// instance (e.g. a custom execution task).
 		if (!this.shellLaunchConfig.isRendererOnly) {
 			throw new Error('rendererExit is only expected to be called on a renderer only terminal');
 		}
@@ -947,7 +947,7 @@ export class TerminalInstance implements ITerminalInstance {
 
 	/**
 	 * Called when either a process tied to a terminal has exited or when a terminal renderer
-	 * simulates a process exiting (eg. custom execution task).
+	 * simulates a process exiting (e.g. custom execution task).
 	 * @param exitCode The exit code of the process, this is undefined when the terminal was exited
 	 * through user action.
 	 */

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -161,7 +161,7 @@ export interface IShellLaunchConfig {
 	env?: ITerminalEnvironment;
 
 	/**
-	 * Whether to ignore a custom cwd from the `terminal.integrated.cwd` settings key (eg. if the
+	 * Whether to ignore a custom cwd from the `terminal.integrated.cwd` settings key (e.g. if the
 	 * shell is being launched by an extension).
 	 */
 	ignoreConfigurationCwd?: boolean;
@@ -434,7 +434,7 @@ export interface ITerminalInstance {
 
 	/**
 	 * Whether to disable layout for the terminal. This is useful when the size of the terminal is
-	 * being manipulating (eg. adding a split pane) and we want the terminal to ignore particular
+	 * being manipulating (e.g. adding a split pane) and we want the terminal to ignore particular
 	 * resize events.
 	 */
 	disableLayout: boolean;

--- a/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts
@@ -215,7 +215,7 @@ let keybindingType: IJSONSchema = {
 			description: nls.localize('vscode.extension.contributes.keybindings.args', "Arguments to pass to the command to execute.")
 		},
 		key: {
-			description: nls.localize('vscode.extension.contributes.keybindings.key', 'Key or key sequence (separate keys with plus-sign and sequences with space, e.g Ctrl+O and Ctrl+L L for a chord).'),
+			description: nls.localize('vscode.extension.contributes.keybindings.key', 'Key or key sequence (separate keys with plus-sign and sequences with space, e.g. Ctrl+O and Ctrl+L L for a chord).'),
 			type: 'string'
 		},
 		mac: {

--- a/src/vs/workbench/services/timer/electron-browser/timerService.ts
+++ b/src/vs/workbench/services/timer/electron-browser/timerService.ts
@@ -209,7 +209,7 @@ export interface IStartupMetrics {
 		readonly ellapsedWorkspaceServiceInit: number;
 
 		/**
-		 * The time it took to load the main-bundle of the workbench, e.g `workbench.main.js`.
+		 * The time it took to load the main-bundle of the workbench, e.g. `workbench.main.js`.
 		 *
 		 * * Happens in the renderer-process
 		 * * Measured with the `willLoadWorkbenchMain` and `didLoadWorkbenchMain` performance marks.

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -22,7 +22,7 @@ yarn smoketest --build PATH_TO_NEW_BUILD_PARENT_FOLDER --remote
 
 ### Run for a release
 
-You must always run the smoketest version which matches the release you are testing. So, if you want to run the smoketest for a release build (eg `release/1.22`), you need that version of the smoke tests too:
+You must always run the smoketest version which matches the release you are testing. So, if you want to run the smoketest for a release build (e.g. `release/1.22`), you need that version of the smoke tests too:
 
 ```bash
 git checkout release/1.22

--- a/test/smoke/src/application.ts
+++ b/test/smoke/src/application.ts
@@ -144,7 +144,7 @@ export class Application {
 		}
 
 		// wait a bit, since focus might be stolen off widgets
-		// as soon as they open (eg quick open)
+		// as soon as they open (e.g. quick open)
 		await new Promise(c => setTimeout(c, 1000));
 	}
 }


### PR DESCRIPTION
Most of the instances of this abbreviation already use the "e.g." form.
This commit changes the non-conforming ones to match.

Note that although this commit changes 29 files, almost all of these changes are in code comments. The only user-visible ones are in the README, and in localizable strings on the following six files:

- [src/vs/code/node/cliProcessMain.ts](https://github.com/microsoft/vscode/pull/74785/files#diff-c2fcc1d716c7f3f8e760e4923daba7ba)
- [src/vs/workbench/contrib/debug/common/debugSchemas.ts](https://github.com/microsoft/vscode/pull/74785/files#diff-2b34e7988e23ea73f5fed5bcb0bb2cfd)
- [src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts](https://github.com/microsoft/vscode/pull/74785/files#diff-9267db309226a9b7d772350586cce351)
- [src/vs/workbench/contrib/markers/browser/messages.ts](https://github.com/microsoft/vscode/pull/74785/files#diff-d99f77eba286403d5e3f2a2f6fc6f606)
- [src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts](https://github.com/microsoft/vscode/pull/74785/files#diff-17ceef10bb7f25f818675b1c07f0aa01)
- [src/vs/workbench/services/keybinding/electron-browser/keybindingService.ts](https://github.com/microsoft/vscode/pull/74785/files#diff-15b94ff607048c9375b2982e7d6af63e)