### PR TITLE
mark .config/git/config as properties file

### DIFF
--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -19,7 +19,7 @@
 			"id": "properties",
 			"extensions": [ ".properties", ".cfg", ".conf", ".desktop", ".directory" ],
 			"filenames": [ ".gitattributes", ".gitconfig", "gitconfig", ".editorconfig" ],
-			"filenamePatterns": [ "**/.git/config" ],
+			"filenamePatterns": [ "**/.config/git/config", "**/.git/config" ],
 			"aliases": [ "Properties", "properties" ],
 			"configuration": "./properties.language-configuration.json"
 		}],


### PR DESCRIPTION
Git suppots the XDG base directory standard for its global configuration file. This defaults to ~/.config/git/config. Now VSCode also highlights this file properly as long as it’s in the default location.