### PR TITLE
Move checked bg in resource viewer under the image

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
+++ b/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
@@ -14,19 +14,23 @@
 
 .monaco-resource-viewer.image {
 	padding: 0;
-	background-position: 0 0, 8px 8px;
-	background-size: 16px 16px;
 	display: flex;
 	box-sizing: border-box;
 }
 
-.vs .monaco-resource-viewer.image {
+.monaco-resource-viewer.image img {
+	padding: 0;
+	background-position: 0 0, 8px 8px;
+	background-size: 16px 16px;
+}
+
+.vs .monaco-resource-viewer.image img {
 	background-image:
 		linear-gradient(45deg, rgb(230, 230, 230) 25%, transparent 25%, transparent 75%, rgb(230, 230, 230) 75%, rgb(230, 230, 230)),
 		linear-gradient(45deg, rgb(230, 230, 230) 25%, transparent 25%, transparent 75%, rgb(230, 230, 230) 75%, rgb(230, 230, 230));
 }
 
-.vs-dark .monaco-resource-viewer.image {
+.vs-dark .monaco-resource-viewer.image img {
 	background-image:
 		linear-gradient(45deg, rgb(20, 20, 20) 25%, transparent 25%, transparent 75%, rgb(20, 20, 20) 75%, rgb(20, 20, 20)),
 		linear-gradient(45deg, rgb(20, 20, 20) 25%, transparent 25%, transparent 75%, rgb(20, 20, 20) 75%, rgb(20, 20, 20));


### PR DESCRIPTION
Fixes #74710

<img width="571" alt="Screen Shot 2019-06-03 at 7 50 09 PM" src="https://user-images.githubusercontent.com/2193314/58847783-095f2900-8639-11e9-8053-66dc228a547e.png">
<img width="559" alt="Screen Shot 2019-06-03 at 7 50 26 PM" src="https://user-images.githubusercontent.com/2193314/58847786-0b28ec80-8639-11e9-84c9-9fc43fa96894.png">
