### PR TITLE
Use explicit type instead of `object` for the momento object

### DIFF
--- a/src/vs/workbench/browser/parts/editor/baseEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/baseEditor.ts
@@ -15,6 +15,7 @@ import { URI } from 'vs/base/common/uri';
 import { Event } from 'vs/base/common/event';
 import { isEmptyObject } from 'vs/base/common/types';
 import { DEFAULT_EDITOR_MIN_DIMENSIONS, DEFAULT_EDITOR_MAX_DIMENSIONS } from 'vs/workbench/browser/parts/editor/editor';
+import { MementoObject } from 'vs/workbench/common/memento';
 
 /**
  * The base class of editors in the workbench. Editors register themselves for specific editor inputs.
@@ -177,7 +178,7 @@ export class EditorMemento<T> implements IEditorMemento<T> {
 	constructor(
 		private _id: string,
 		private key: string,
-		private memento: object,
+		private memento: MementoObject,
 		private limit: number,
 		private editorGroupService: IEditorGroupsService
 	) { }

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -31,6 +31,7 @@ import { IView, orthogonal, LayoutPriority } from 'vs/base/browser/ui/grid/gridv
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Parts, IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { MementoObject } from 'vs/workbench/common/memento';
 
 interface IEditorPartUIState {
 	serializedGrid: ISerializedGrid;
@@ -118,8 +119,8 @@ export class EditorPart extends Part implements IEditorGroupsService, IEditorGro
 
 	private _preferredSize: Dimension | undefined;
 
-	private workspaceMemento: object;
-	private globalMemento: object;
+	private readonly workspaceMemento: MementoObject;
+	private readonly globalMemento: MementoObject;
 
 	private _partOptions: IEditorPartOptions;
 

--- a/src/vs/workbench/browser/parts/views/viewsViewlet.ts
+++ b/src/vs/workbench/browser/parts/views/viewsViewlet.ts
@@ -29,14 +29,15 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { localize } from 'vs/nls';
 import { IAddedViewDescriptorRef, IViewDescriptorRef, PersistentContributableViewsModel } from 'vs/workbench/browser/parts/views/views';
 import { Registry } from 'vs/platform/registry/common/platform';
+import { MementoObject } from 'vs/workbench/common/memento';
 
 export interface IViewletViewOptions extends IViewletPanelOptions {
-	viewletState: object;
+	viewletState: MementoObject;
 }
 
 export abstract class ViewContainerViewlet extends PanelViewlet implements IViewsViewlet {
 
-	private readonly viewletState: object;
+	private readonly viewletState: MementoObject;
 	private didLayout = false;
 	private dimension: DOM.Dimension;
 	private areExtensionsReady: boolean = false;

--- a/src/vs/workbench/common/component.ts
+++ b/src/vs/workbench/common/component.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Memento } from 'vs/workbench/common/memento';
+import { Memento, MementoObject } from 'vs/workbench/common/memento';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { Themable } from 'vs/workbench/common/theme';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
@@ -35,7 +35,7 @@ export class Component extends Themable {
 		return this.id;
 	}
 
-	protected getMemento(scope: StorageScope): object {
+	protected getMemento(scope: StorageScope): MementoObject {
 		return this.memento.getMemento(scope);
 	}
 

--- a/src/vs/workbench/common/memento.ts
+++ b/src/vs/workbench/common/memento.ts
@@ -6,6 +6,8 @@
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { isEmptyObject } from 'vs/base/common/types';
 
+export type MementoObject = { [key: string]: any };
+
 export class Memento {
 
 	private static readonly globalMementos = new Map<string, ScopedMemento>();
@@ -19,7 +21,7 @@ export class Memento {
 		this.id = Memento.COMMON_PREFIX + id;
 	}
 
-	getMemento(scope: StorageScope): object {
+	getMemento(scope: StorageScope): MementoObject {
 
 		// Scope by Workspace
 		if (scope === StorageScope.WORKSPACE) {
@@ -59,17 +61,17 @@ export class Memento {
 }
 
 class ScopedMemento {
-	private readonly mementoObj: object;
+	private readonly mementoObj: MementoObject;
 
 	constructor(private id: string, private scope: StorageScope, private storageService: IStorageService) {
 		this.mementoObj = this.load();
 	}
 
-	getMemento(): object {
+	getMemento(): MementoObject {
 		return this.mementoObj;
 	}
 
-	private load(): object {
+	private load(): MementoObject {
 		const memento = this.storageService.get(this.id, this.scope);
 		if (memento) {
 			return JSON.parse(memento);

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionsViewlet.ts
@@ -58,6 +58,7 @@ import { RemoteAuthorityContext } from 'vs/workbench/browser/contextkeys';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
 import { ILabelService } from 'vs/platform/label/common/label';
+import { MementoObject } from 'vs/workbench/common/memento';
 
 interface SearchInputEvent extends Event {
 	target: HTMLInputElement;
@@ -339,7 +340,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 	private primaryActions: IAction[];
 	private secondaryActions: IAction[] | null;
 	private disposables: IDisposable[] = [];
-	private searchViewletState: object;
+	private readonly searchViewletState: MementoObject;
 
 	constructor(
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,

--- a/src/vs/workbench/contrib/markers/browser/markersPanel.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersPanel.ts
@@ -44,6 +44,7 @@ import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { ResourceLabels } from 'vs/workbench/browser/labels';
 import { IMarker } from 'vs/platform/markers/common/markers';
 import { withUndefinedAsNull } from 'vs/base/common/types';
+import { MementoObject } from 'vs/workbench/common/memento';
 
 function createModelIterator(model: MarkersModel): Iterator<ITreeElement<TreeElement>> {
 	const resourcesIt = Iterator.fromArray(model.resourceMarkers);
@@ -79,7 +80,7 @@ export class MarkersPanel extends Panel implements IMarkerFilterController {
 	private treeContainer: HTMLElement;
 	private messageBoxContainer: HTMLElement;
 	private ariaLabelElement: HTMLElement;
-	private panelState: object;
+	private readonly panelState: MementoObject;
 	private panelFoucusContextKey: IContextKey<boolean>;
 
 	private filter: Filter;

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -59,7 +59,7 @@ import { relativePath } from 'vs/base/common/resources';
 import { IAccessibilityService, AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
 import { ViewletPanel, IViewletPanelOptions } from 'vs/workbench/browser/parts/views/panelViewlet';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { Memento } from 'vs/workbench/common/memento';
+import { Memento, MementoObject } from 'vs/workbench/common/memento';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 
 const $ = dom.$;
@@ -102,8 +102,8 @@ export class SearchView extends ViewletPanel {
 
 	private tree: WorkbenchObjectTree<RenderableMatch>;
 	private treeLabels: ResourceLabels;
-	private viewletState: object;
-	private globalMemento: object;
+	private viewletState: MementoObject;
+	private globalMemento: MementoObject;
 	private messagesElement: HTMLElement;
 	private messageDisposables: IDisposable[] = [];
 	private searchWidgetsContainerElement: HTMLElement;


### PR DESCRIPTION
Using the `object` type causes errors if we disable `suppressImplicitAnyIndexErrors` if you use index accessors on the object. Instead, we should use an explicit type with an index signature