### PR TITLE
Updated JSDoc Tip to be more clear in Interactive Playground

### DIFF
--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.md
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.md
@@ -84,7 +84,7 @@ function Book(title, author) {
 }
 ```
 
-> **JSDoc Tip:** The example above also showcased another way to get IntelliSense hints by using `JSDoc` comments.  You can try this out by invoking the `Book` function and seeing the enhanced context in the IntelliSense menu for the function as well as parameters.
+> **JSDoc Tip:** The example above also showcased another way to get IntelliSense hints by using `JSDoc` comments.  You can try this out by adding a new reference of the `Book` function and seeing the enhanced context in the IntelliSense menu for the function as well as parameters.
 
 
 ### Refactoring via Extraction


### PR DESCRIPTION
This is to fix issue #71023. I changed the words from "invoking" the 'Book' function to be more clear to a new user that a new reference should be added under the two example references of Book to invoke the function.