### PR TITLE
Support object types in `when` conditions

### DIFF
--- a/src/vs/platform/contextkey/test/browser/contextKeyService.test.ts
+++ b/src/vs/platform/contextkey/test/browser/contextKeyService.test.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { Context } from 'vs/platform/contextkey/browser/contextKeyService';
+
+suite('ContextKeyService', () => {
+	test('Context.getValue', () => {
+		const ctx = new Context(1, null);
+
+		ctx.setValue('object', {
+			trueProp: true,
+			falseProp: false,
+			stringProp: 'stringValue',
+			objectProp: {
+				nestedString: 'nestedStringValue',
+				numberProp: 12
+			}
+		});
+
+		assert(ctx.getValue('object.trueProp') === true, 'Expected true value');
+		assert(ctx.getValue('object.falseProp') === false, 'Expected false value');
+		assert(ctx.getValue('object.stringProp') === 'stringValue', 'Expected string value');
+		assert(ctx.getValue('object.objectProp.nestedString') === 'nestedStringValue', 'Expected string value');
+		assert(ctx.getValue('object.objectProp.numberProp') === 12, 'Expected number value');
+		assert(ctx.getValue('object.missingProp') === undefined, 'Expected undefined value');
+		assert(ctx.getValue('object.objectProp.missingNestedProp') === undefined, 'Expected undefined value');
+	});
+});

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2026,7 +2026,7 @@ export class TreeItem {
 	resourceUri?: URI;
 	iconPath?: string | URI | { light: string | URI; dark: string | URI };
 	command?: vscode.Command;
-	contextValue?: string;
+	contextValue?: any;
 	tooltip?: string;
 
 	constructor(label: string | vscode.TreeItemLabel, collapsibleState?: vscode.TreeItemCollapsibleState)

--- a/src/vs/workbench/browser/parts/views/customView.ts
+++ b/src/vs/workbench/browser/parts/views/customView.ts
@@ -863,7 +863,7 @@ class TreeMenus extends Disposable implements IDisposable {
 		return this.getActions(MenuId.ViewItemContext, { key: 'viewItem', value: element.contextValue }).secondary;
 	}
 
-	private getActions(menuId: MenuId, context: { key: string, value?: string }): { primary: IAction[]; secondary: IAction[]; } {
+	private getActions(menuId: MenuId, context: { key: string, value?: any }): { primary: IAction[]; secondary: IAction[]; } {
 		const contextKeyService = this.contextKeyService.createScoped();
 		contextKeyService.createKey('view', this.id);
 		contextKeyService.createKey(context.key, context.value);

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -400,7 +400,7 @@ export interface ITreeItem {
 
 	tooltip?: string;
 
-	contextValue?: string;
+	contextValue?: any;
 
 	command?: Command;
 


### PR DESCRIPTION
This PR implements #74699 

This change allows the `contextValue` property on a `TreeItem` to have `any` type, rather than just `string`. The value is added to the `Context` under the `viewItem` key as before. The implementation of `Context.getValue` has been updated to treat `a.b.c` as a lookup of the key `a` followed by accesses to the `b` property on `a` and the `c` property on the result of `a.b`.

**Backward compatibility concerns**
Are there existing context keys that contain `.`, other than for `config.*`, which is handled in a special `IContext` implementation?

**Testing**
I have not yet implemented any tests for the new feature. It appears that there are existing contextKey tests, but only for the expression parser and evaluator. Should I just add more tests for `Context`? Or should I test this some other way?
