### PR TITLE
Fix #74902: controls problems panel badge to show all problems or filtered problems

### DIFF
--- a/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
+++ b/src/vs/workbench/contrib/markers/browser/markers.contribution.ts
@@ -85,6 +85,19 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 	}
 });
 
+Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+	'id': 'problems',
+	'order': 101,
+	'title': Messages.PROBLEMS_PANEL_CONFIGURATION_TITLE,
+	'type': 'object',
+	'properties': {
+		'problems.countFilteredProblems': {
+			'description': Messages.PROBLEMS_PANEL_CONFIGURATION_COUNT_FILTERED_BADGE,
+			'type': 'boolean',
+			'default': false
+		}
+	}
+});
 
 // markers panel
 Registry.as<PanelRegistry>(PanelExtensions.Panels).registerPanel(new PanelDescriptor(

--- a/src/vs/workbench/contrib/markers/browser/messages.ts
+++ b/src/vs/workbench/contrib/markers/browser/messages.ts
@@ -16,6 +16,7 @@ export default class Messages {
 
 	public static PROBLEMS_PANEL_CONFIGURATION_TITLE: string = nls.localize('problems.panel.configuration.title', "Problems View");
 	public static PROBLEMS_PANEL_CONFIGURATION_AUTO_REVEAL: string = nls.localize('problems.panel.configuration.autoreveal', "Controls whether Problems view should automatically reveal files when opening them.");
+	public static PROBLEMS_PANEL_CONFIGURATION_COUNT_FILTERED_BADGE: string = nls.localize('problems.panel.configuration.countFilteredProblems', "Controls the problems panel only count filtered problems.");
 
 	public static MARKERS_PANEL_TITLE_PROBLEMS: string = nls.localize('markers.panel.title.problems', "Problems");
 


### PR DESCRIPTION
In vscode, the problems panel badge shows the number of total problems. I add a feature that user can decide the badge will show the number of filtered problems or total problems.