### PR TITLE
Add the .rbi file extension as a Ruby file type

### DIFF
--- a/extensions/ruby/package.json
+++ b/extensions/ruby/package.json
@@ -12,7 +12,7 @@
 	"contributes": {
 		"languages": [{
 			"id": "ruby",
-			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".rake", ".ru", ".erb",".podspec" ],
+			"extensions": [ ".rb", ".rbx", ".rjs", ".gemspec", ".rake", ".ru", ".erb", ".podspec", ".rbi" ],
 			"filenames": [ "rakefile", "gemfile", "guardfile", "podfile", "capfile" ],
 			"aliases": [ "Ruby", "rb" ],
 			"firstLine": "^#!\\s*/.*\\bruby\\b",


### PR DESCRIPTION
`.rbi` files are "Ruby Interface" (type definition) files and they're used by Stripe's [Sorbet](https://sorbet.org) type checker. They're use Ruby's existing syntax, so they don't need anything special to highlight them. Per the docs:

>The syntax of RBI files is the same as normal Ruby files, except that method definitions do not need implementations.

This means that instead of having a method with any actual code in it, like this:

```ruby
def hello
  return 'hello'
end
```

You write it like so:
```ruby
sig { returns(String) }
def hello; end
```

[You can read more about RBI Files in the Sorbet documentation](https://sorbet.org/docs/rbi).

`.rbi` files are planned to be added in the core language with Ruby 3 (Christmas 2020), [as announced at RubyKaigi](https://twitter.com/samphippen/status/1118703270296522752).

There is some risk that the `.rbi` format adopted by Ruby core will differ from the 'primary' Ruby syntax, but if that happens we can always just revert this change.

The existing Ruby highlighting mostly works fine with the syntax proposed in the RubyKaigi talk: 

<img width="385" alt="Screen Shot 2019-06-09 at 10 27 39 AM" src="https://user-images.githubusercontent.com/2977353/59161540-45631580-8aa1-11e9-9a45-4ae3b92b871c.png">