### PR TITLE
Do not allow workspace folders with scheme different than the current…

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -46,7 +46,6 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
 import { findValidPasteFileTarget } from 'vs/workbench/contrib/files/browser/fileActions';
 import { FuzzyScore, createMatches } from 'vs/base/common/filters';
-import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
 export class ExplorerDelegate implements IListVirtualDelegate<ExplorerItem> {
 
@@ -442,8 +441,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@ITextFileService private textFileService: ITextFileService,
 		@IWindowService private windowService: IWindowService,
-		@IWorkspaceEditingService private workspaceEditingService: IWorkspaceEditingService,
-		@IWorkbenchEnvironmentService private environmentService: IWorkbenchEnvironmentService
+		@IWorkspaceEditingService private workspaceEditingService: IWorkspaceEditingService
 	) {
 		this.toDispose = [];
 
@@ -595,11 +593,11 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 
 		// Desktop DND (Import file)
 		if (data instanceof DesktopDragAndDropData) {
-			this.handleExternalDrop(data, target, originalEvent);
+			this.handleExternalDrop(data, target, originalEvent).then(undefined, e => this.notificationService.warn(e));
 		}
 		// In-Explorer DND (Move/Copy file)
 		else {
-			this.handleExplorerDrop(data, target, originalEvent);
+			this.handleExplorerDrop(data, target, originalEvent).then(undefined, e => this.notificationService.warn(e));
 		}
 	}
 

--- a/src/vs/workbench/services/workspace/electron-browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/electron-browser/workspaceEditingService.ts
@@ -216,6 +216,11 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 
 	private async doAddFolders(foldersToAdd: IWorkspaceFolderCreationData[], index?: number, donotNotifyError: boolean = false): Promise<void> {
 		const state = this.contextService.getWorkbenchState();
+		if (this.environmentService.configuration.remoteAuthority) {
+			// Do not allow workspace folders with scheme different than the current remote scheme
+			const schemas = this.contextService.getWorkspace().folders.map(f => f.uri.scheme);
+			foldersToAdd = foldersToAdd.filter(f => schemas.indexOf(f.uri.scheme) >= 0);
+		}
 
 		// If we are in no-workspace or single-folder workspace, adding folders has to
 		// enter a workspace.

--- a/src/vs/workbench/services/workspace/electron-browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/electron-browser/workspaceEditingService.ts
@@ -219,7 +219,9 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		if (this.environmentService.configuration.remoteAuthority) {
 			// Do not allow workspace folders with scheme different than the current remote scheme
 			const schemas = this.contextService.getWorkspace().folders.map(f => f.uri.scheme);
-			foldersToAdd = foldersToAdd.filter(f => schemas.indexOf(f.uri.scheme) >= 0);
+			if (schemas.length && foldersToAdd.some(f => schemas.indexOf(f.uri.scheme) === -1)) {
+				return Promise.reject(new Error(nls.localize('differentSchemeRoots', "Workspace folders from different providers are not allowed in the same workspace.")));
+			}
 		}
 
 		// If we are in no-workspace or single-folder workspace, adding folders has to


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote/issues/1608

I simply put the check in the `doAddFolder` of the worksapceEditingService. That if in the remote context we do not allow to add new folders which bring a new scheme to the story. The newly added folder must have a scheme which is already known.

Let me know what you think and I can change that.
Maybe we should make it more explicit that when `this.environmentService.configuration.remoteAuthority` there is already one folder