### PR TITLE
Show head label in placeholder of commit message

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -658,7 +658,19 @@ export class Repository implements Disposable {
 
 		const root = Uri.file(repository.root);
 		this._sourceControl = scm.createSourceControl('git', 'Git', root);
-		this._sourceControl.inputBox.placeholder = localize('commitMessage', "Message (press {0} to commit)");
+		this.onDidRunGitStatus(() => {
+			const headLabel = this.headLabel;
+			let placeholder: string;
+
+			if (headLabel !== '') {
+				// '{0}' will be replaced by the corresponding key-command later in the process, which is why it needs to stay.
+				placeholder = localize('commitMessageWithHeadLabel', "Message ({0} to commit to {1})", "{0}", this.headLabel);
+			} else {
+				placeholder = localize('commitMessage', "Message ({0} to commit)");
+			}
+
+			this._sourceControl.inputBox.placeholder = placeholder;
+		});
 		this._sourceControl.acceptInputCommand = { command: 'git.commitWithInput', title: localize('commit', "Commit"), arguments: [this._sourceControl] };
 		this._sourceControl.quickDiffProvider = this;
 		this._sourceControl.inputBox.validateInput = this.validateInput.bind(this);


### PR DESCRIPTION
Resolves #73644

There is already a PR trying to resolve this issue (#74495), but if I'm not mistaken, that solution would break externalisation of the text visible to the user. If I'm right and the author of that PR fixes things, this PR should obviously be closed.

This is my first PR and I'm not sure if I got the whole Event stuff right. Especially creating the listener right there in the constructor... please correct me if I can do something better.