### PR TITLE
Fix for issue #35245

### DIFF
--- a/extensions/markdown-language-features/src/features/documentLinkProvider.ts
+++ b/extensions/markdown-language-features/src/features/documentLinkProvider.ts
@@ -79,9 +79,9 @@ function extractDocumentLink(
 }
 
 export default class LinkProvider implements vscode.DocumentLinkProvider {
-	private readonly linkPattern = /(\[((!\[[^\]]*?\]\(\s*)([^\s\(\)]+?)\s*\)\]|[^\]]*\])\(\s*)(([^\s\(\)]|\(\S*?\))+)\s*(".*?")?\)/g;
-	private readonly referenceLinkPattern = /(\[([^\]]+)\]\[\s*?)([^\s\]]*?)\]/g;
-	private readonly definitionPattern = /^([\t ]*\[([^\]]+)\]:\s*)(\S+)/gm;
+	private readonly linkPattern = /(\[((!\[[^\]]*?\]\(\s*)([^\s\(\)]+?)\s*\)\]|(?:\\\]|[^\]])*\])\(\s*)(([^\s\(\)]|\(\S*?\))+)\s*(".*?")?\)/g;
+	private readonly referenceLinkPattern = /(\[((?:\\\]|[^\]])+)\]\[\s*?)([^\s\]]*?)\]/g;
+	private readonly definitionPattern = /^([\t ]*\[((?:\\\]|[^\]])+)\]:\s*)(\S+)/gm;
 
 	public provideDocumentLinks(
 		document: vscode.TextDocument,

--- a/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
+++ b/extensions/markdown-language-features/src/test/documentLinkProvider.test.ts
@@ -72,6 +72,14 @@ suite('markdown.DocumentLinkProvider', () => {
 		assertRangeEqual(link.range, new vscode.Range(0, 6, 0, 25));
 	});
 
+	// #35245
+	test('Should handle links with escaped characters in name', () => {
+		const links = getLinksForFile('a [b\\]](./file)');
+		assert.strictEqual(links.length, 1);
+		const [link] = links;
+		assertRangeEqual(link.range, new vscode.Range(0, 8, 0, 14));
+	});
+
 
 	test('Should handle links with balanced parens', () => {
 		{


### PR DESCRIPTION
Edited the regular expressions to include the case where there are escaped square brackets inside the reference link. Used non-capture groups to avoid messing up the existing capture groups.

Fixes #35245