### PR TITLE
Sync languages provided by Typescript plugins

### DIFF
--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -24,6 +24,7 @@ import { PluginManager } from './utils/plugins';
 import * as typeConverters from './utils/typeConverters';
 import TypingsStatus, { AtaProgressReporter } from './utils/typingsStatus';
 import VersionStatus from './utils/versionStatus';
+import { flatten } from './utils/arrays';
 
 // Style check diagnostics that can be reported as warnings
 const styleCheckDiagnostics = [
@@ -68,7 +69,7 @@ export default class TypeScriptServiceClientHost extends Disposable {
 		configFileWatcher.onDidDelete(handleProjectCreateOrDelete, this, this._disposables);
 		configFileWatcher.onDidChange(handleProjectChange, this, this._disposables);
 
-		const allModeIds = this.getAllModeIds(descriptions);
+		const allModeIds = this.getAllModeIds(descriptions, pluginManager);
 		this.client = this._register(new TypeScriptServiceClient(
 			workspaceState,
 			version => this.versionStatus.onDidChangeTypeScriptVersion(version),
@@ -138,11 +139,11 @@ export default class TypeScriptServiceClientHost extends Disposable {
 		this.configurationChanged();
 	}
 
-	private getAllModeIds(descriptions: LanguageDescription[]) {
-		const allModeIds: string[] = [];
-		for (const description of descriptions) {
-			allModeIds.push(...description.modeIds);
-		}
+	private getAllModeIds(descriptions: LanguageDescription[], pluginManager: PluginManager) {
+		const allModeIds = flatten([
+			...descriptions.map(x => x.modeIds),
+			...pluginManager.plugins.map(x => x.languages)
+		]);
 		return allModeIds;
 	}
 


### PR DESCRIPTION
Fixes [#75088](https://github.com/microsoft/vscode/issues/75088).  It will fix broken functionality of  [prototype](https://github.com/microsoft/vscode/issues/25740#issuecomment-301637859) for supporting additional language types for Typescript plugins.