### PR TITLE
Mark events as readonly in VS Code api

### DIFF
--- a/extensions/grunt/src/main.ts
+++ b/extensions/grunt/src/main.ts
@@ -230,7 +230,7 @@ class TaskDetector {
 		this.detectors.clear();
 	}
 
-	private updateWorkspaceFolders(added: vscode.WorkspaceFolder[], removed: vscode.WorkspaceFolder[]): void {
+	private updateWorkspaceFolders(added: readonly vscode.WorkspaceFolder[], removed: readonly vscode.WorkspaceFolder[]): void {
 		for (let remove of removed) {
 			let detector = this.detectors.get(remove.uri.toString());
 			if (detector) {

--- a/extensions/gulp/src/main.ts
+++ b/extensions/gulp/src/main.ts
@@ -209,7 +209,7 @@ class TaskDetector {
 		this.detectors.clear();
 	}
 
-	private updateWorkspaceFolders(added: vscode.WorkspaceFolder[], removed: vscode.WorkspaceFolder[]): void {
+	private updateWorkspaceFolders(added: readonly vscode.WorkspaceFolder[], removed: readonly vscode.WorkspaceFolder[]): void {
 		for (let remove of removed) {
 			let detector = this.detectors.get(remove.uri.toString());
 			if (detector) {

--- a/extensions/html-language-features/client/src/tagClosing.ts
+++ b/extensions/html-language-features/client/src/tagClosing.ts
@@ -32,7 +32,7 @@ export function activateTagClosing(tagProvider: (document: TextDocument, positio
 		isEnabled = true;
 	}
 
-	function onDidChangeTextDocument(document: TextDocument, changes: TextDocumentContentChangeEvent[]) {
+	function onDidChangeTextDocument(document: TextDocument, changes: readonly TextDocumentContentChangeEvent[]) {
 		if (!isEnabled) {
 			return;
 		}

--- a/extensions/jake/src/main.ts
+++ b/extensions/jake/src/main.ts
@@ -208,7 +208,7 @@ class TaskDetector {
 		this.detectors.clear();
 	}
 
-	private updateWorkspaceFolders(added: vscode.WorkspaceFolder[], removed: vscode.WorkspaceFolder[]): void {
+	private updateWorkspaceFolders(added: readonly vscode.WorkspaceFolder[], removed: readonly vscode.WorkspaceFolder[]): void {
 		for (let remove of removed) {
 			let detector = this.detectors.get(remove.uri.toString());
 			if (detector) {

--- a/extensions/typescript-language-features/src/features/bufferSyncSupport.ts
+++ b/extensions/typescript-language-features/src/features/bufferSyncSupport.ts
@@ -75,7 +75,7 @@ class BufferSynchronizer {
 		}
 	}
 
-	public change(filepath: string, events: vscode.TextDocumentContentChangeEvent[]) {
+	public change(filepath: string, events: readonly vscode.TextDocumentContentChangeEvent[]) {
 		if (!events.length) {
 			return;
 		}
@@ -210,7 +210,7 @@ class SyncedBuffer {
 		this.state = BufferState.Closed;
 	}
 
-	public onContentChanged(events: vscode.TextDocumentContentChangeEvent[]): void {
+	public onContentChanged(events: readonly vscode.TextDocumentContentChangeEvent[]): void {
 		if (this.state !== BufferState.Open) {
 			console.error(`Unexpected buffer state: ${this.state}`);
 		}

--- a/extensions/typescript-language-features/src/features/tagClosing.ts
+++ b/extensions/typescript-language-features/src/features/tagClosing.ts
@@ -46,7 +46,7 @@ class TagClosing extends Disposable {
 
 	private onDidChangeTextDocument(
 		document: vscode.TextDocument,
-		changes: vscode.TextDocumentContentChangeEvent[]
+		changes: readonly vscode.TextDocumentContentChangeEvent[]
 	) {
 		const activeDocument = vscode.window.activeTextEditor && vscode.window.activeTextEditor.document;
 		if (document !== activeDocument || changes.length === 0) {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -531,16 +531,16 @@ declare module 'vscode' {
 		/**
 		 * The [text editor](#TextEditor) for which the selections have changed.
 		 */
-		textEditor: TextEditor;
+		readonly textEditor: TextEditor;
 		/**
 		 * The new value for the [text editor's selections](#TextEditor.selections).
 		 */
-		selections: Selection[];
+		readonly selections: ReadonlyArray<Selection>;
 		/**
 		 * The [change kind](#TextEditorSelectionChangeKind) which has triggered this
 		 * event. Can be `undefined`.
 		 */
-		kind?: TextEditorSelectionChangeKind;
+		readonly kind?: TextEditorSelectionChangeKind;
 	}
 
 	/**
@@ -550,11 +550,11 @@ declare module 'vscode' {
 		/**
 		 * The [text editor](#TextEditor) for which the visible ranges have changed.
 		 */
-		textEditor: TextEditor;
+		readonly textEditor: TextEditor;
 		/**
 		 * The new value for the [text editor's visible ranges](#TextEditor.visibleRanges).
 		 */
-		visibleRanges: Range[];
+		readonly visibleRanges: ReadonlyArray<Range>;
 	}
 
 	/**
@@ -564,11 +564,11 @@ declare module 'vscode' {
 		/**
 		 * The [text editor](#TextEditor) for which the options have changed.
 		 */
-		textEditor: TextEditor;
+		readonly textEditor: TextEditor;
 		/**
 		 * The new value for the [text editor's options](#TextEditor.options).
 		 */
-		options: TextEditorOptions;
+		readonly options: TextEditorOptions;
 	}
 
 	/**
@@ -578,11 +578,11 @@ declare module 'vscode' {
 		/**
 		 * The [text editor](#TextEditor) for which the view column has changed.
 		 */
-		textEditor: TextEditor;
+		readonly textEditor: TextEditor;
 		/**
 		 * The new value for the [text editor's view column](#TextEditor.viewColumn).
 		 */
-		viewColumn: ViewColumn;
+		readonly viewColumn: ViewColumn;
 	}
 
 	/**
@@ -4203,7 +4203,7 @@ declare module 'vscode' {
 		/**
 		 * An array of resources for which diagnostics have changed.
 		 */
-		readonly uris: Uri[];
+		readonly uris: ReadonlyArray<Uri>;
 	}
 
 	/**
@@ -5331,7 +5331,7 @@ declare module 'vscode' {
 		/**
 		 * The task item representing the task that got started.
 		 */
-		execution: TaskExecution;
+		readonly execution: TaskExecution;
 	}
 
 	/**
@@ -5343,7 +5343,7 @@ declare module 'vscode' {
 		/**
 		 * The task item representing the task that finished.
 		 */
-		execution: TaskExecution;
+		readonly execution: TaskExecution;
 	}
 
 	/**
@@ -5355,12 +5355,12 @@ declare module 'vscode' {
 		/**
 		 * The task execution for which the process got started.
 		 */
-		execution: TaskExecution;
+		readonly execution: TaskExecution;
 
 		/**
 		 * The underlying process id.
 		 */
-		processId: number;
+		readonly processId: number;
 	}
 
 	/**
@@ -5372,12 +5372,12 @@ declare module 'vscode' {
 		/**
 		 * The task execution for which the process got started.
 		 */
-		execution: TaskExecution;
+		readonly execution: TaskExecution;
 
 		/**
 		 * The process's exit code.
 		 */
-		exitCode: number;
+		readonly exitCode: number;
 	}
 
 	export interface TaskFilter {
@@ -5584,12 +5584,12 @@ declare module 'vscode' {
 		/**
 		 * The type of change.
 		 */
-		type: FileChangeType;
+		readonly type: FileChangeType;
 
 		/**
 		 * The uri of the file that has changed.
 		 */
-		uri: Uri;
+		readonly uri: Uri;
 	}
 
 	/**
@@ -7331,12 +7331,12 @@ declare module 'vscode' {
 		/**
 		 * The affected document.
 		 */
-		document: TextDocument;
+		readonly document: TextDocument;
 
 		/**
 		 * An array of content changes.
 		 */
-		contentChanges: TextDocumentContentChangeEvent[];
+		readonly contentChanges: ReadonlyArray<TextDocumentContentChangeEvent>;
 	}
 
 	/**
@@ -7373,12 +7373,12 @@ declare module 'vscode' {
 		/**
 		 * The document that will be saved.
 		 */
-		document: TextDocument;
+		readonly document: TextDocument;
 
 		/**
 		 * The reason why save was triggered.
 		 */
-		reason: TextDocumentSaveReason;
+		readonly reason: TextDocumentSaveReason;
 
 		/**
 		 * Allows to pause the event loop and to apply [pre-save-edits](#TextEdit).
@@ -7419,12 +7419,12 @@ declare module 'vscode' {
 		/**
 		 * Added workspace folders.
 		 */
-		readonly added: WorkspaceFolder[];
+		readonly added: ReadonlyArray<WorkspaceFolder>;
 
 		/**
 		 * Removed workspace folders.
 		 */
-		readonly removed: WorkspaceFolder[];
+		readonly removed: ReadonlyArray<WorkspaceFolder>;
 	}
 
 	/**
@@ -8500,17 +8500,17 @@ declare module 'vscode' {
 		/**
 		 * The [debug session](#DebugSession) for which the custom event was received.
 		 */
-		session: DebugSession;
+		readonly session: DebugSession;
 
 		/**
 		 * Type of event.
 		 */
-		event: string;
+		readonly event: string;
 
 		/**
 		 * Event specific information.
 		 */
-		body?: any;
+		readonly body?: any;
 	}
 
 	/**
@@ -8707,17 +8707,17 @@ declare module 'vscode' {
 		/**
 		 * Added breakpoints.
 		 */
-		readonly added: Breakpoint[];
+		readonly added: ReadonlyArray<Breakpoint>;
 
 		/**
 		 * Removed breakpoints.
 		 */
-		readonly removed: Breakpoint[];
+		readonly removed: ReadonlyArray<Breakpoint>;
 
 		/**
 		 * Changed breakpoints.
 		 */
-		readonly changed: Breakpoint[];
+		readonly changed: ReadonlyArray<Breakpoint>;
 	}
 
 	/**

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -816,17 +816,17 @@ declare module 'vscode' {
 		/**
 		 * Added comment threads.
 		 */
-		readonly added: CommentThread[];
+		readonly added: ReadonlyArray<CommentThread>;
 
 		/**
 		 * Removed comment threads.
 		 */
-		readonly removed: CommentThread[];
+		readonly removed: ReadonlyArray<CommentThread>;
 
 		/**
 		 * Changed comment threads.
 		 */
-		readonly changed: CommentThread[];
+		readonly changed: ReadonlyArray<CommentThread>;
 
 		/**
 		 * Changed draft mode

--- a/src/vs/workbench/test/electron-browser/api/extHostDocumentSaveParticipant.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostDocumentSaveParticipant.test.ts
@@ -85,7 +85,7 @@ suite('ExtHostDocumentSaveParticipant', () => {
 			sub.dispose();
 
 			assert.ok(event);
-			assert.throws(() => { event.document = null!; });
+			assert.throws(() => { (event.document as any) = null!; });
 		});
 	});
 


### PR DESCRIPTION
Event data should generally not be mutated as any mutations can leak to other listeners. This change marks most event type members as readonly