### PR TITLE
Allow terminal to be launched with a clean environment on Mac and Linux

### DIFF
--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -500,7 +500,10 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 			variableResolver,
 			isWorkspaceShellAllowed,
 			pkg.version,
-			terminalConfig.get<boolean>('setLocaleVariables', false)
+			terminalConfig.get<boolean>('setLocaleVariables', false),
+			// Always inherit the environment as we need to be running in a login shell, this may
+			// change when macOS servers are supported
+			true
 		);
 
 		// Fork the process and listen for messages

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -503,7 +503,7 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 			terminalConfig.get<boolean>('setLocaleVariables', false),
 			// Always inherit the environment as we need to be running in a login shell, this may
 			// change when macOS servers are supported
-			true
+			process.env as platform.IProcessEnvironment
 		);
 
 		// Fork the process and listen for messages

--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -229,7 +229,7 @@ configurationRegistry.registerConfiguration({
 			default: []
 		},
 		'terminal.integrated.inheritEnv': {
-			markdownDescription: nls.localize('terminal.integrated.inheritEnv', "TODO"),
+			markdownDescription: nls.localize('terminal.integrated.inheritEnv', "Whether new shells should inherit their environment from VS Code."),
 			type: 'boolean',
 			default: true
 		},

--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -228,6 +228,11 @@ configurationRegistry.registerConfiguration({
 			},
 			default: []
 		},
+		'terminal.integrated.inheritEnv': {
+			markdownDescription: nls.localize('terminal.integrated.inheritEnv', "TODO"),
+			type: 'boolean',
+			default: true
+		},
 		'terminal.integrated.env.osx': {
 			markdownDescription: nls.localize('terminal.integrated.env.osx', "Object with environment variables that will be added to the VS Code process to be used by the terminal on macOS. Set to `null` to delete the environment variable."),
 			type: 'object',

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -26,6 +26,7 @@ export interface ITerminalInstanceService {
 	createWindowsShellHelper(shellProcessId: number, instance: ITerminalInstance, xterm: XTermTerminal): IWindowsShellHelper;
 	createTerminalProcess(shellLaunchConfig: IShellLaunchConfig, cwd: string, cols: number, rows: number, env: IProcessEnvironment, windowsEnableConpty: boolean): ITerminalChildProcess;
 	getDefaultShell(p: Platform): string;
+	getMainProcessParentEnv(): Promise<IProcessEnvironment>;
 }
 
 export interface IBrowserTerminalConfigHelper extends ITerminalConfigHelper {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -8,6 +8,7 @@ import { IWindowsShellHelper, ITerminalChildProcess } from 'vs/workbench/contrib
 import { Terminal as XTermTerminal } from 'xterm';
 import { WebLinksAddon as XTermWebLinksAddon } from 'xterm-addon-web-links';
 import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
+import { IProcessEnvironment } from 'vs/base/common/platform';
 
 let Terminal: typeof XTermTerminal;
 let WebLinksAddon: typeof XTermWebLinksAddon;
@@ -49,5 +50,9 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	public getDefaultShell(): string {
 		throw new Error('Not implemented');
+	}
+
+	public async getMainProcessParentEnv(): Promise<IProcessEnvironment> {
+		return {};
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -171,8 +171,8 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 		const lastActiveWorkspace = activeWorkspaceRootUri ? this._workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri) : null;
 		const envFromConfigValue = this._workspaceConfigurationService.inspect<ITerminalEnvironment | undefined>(`terminal.integrated.env.${platformKey}`);
 		const isWorkspaceShellAllowed = this._configHelper.checkWorkspaceShellPermissions();
-		this._terminalInstanceService.getMainProcessParentEnv();
-		const env = terminalEnvironment.createTerminalEnvironment(shellLaunchConfig, lastActiveWorkspace, envFromConfigValue, this._configurationResolverService, isWorkspaceShellAllowed, this._productService.version, this._configHelper.config.setLocaleVariables, this._configHelper.config.inheritEnv);
+		const baseEnv = this._configHelper.config.inheritEnv ? process.env as platform.IProcessEnvironment : this._terminalInstanceService.getMainProcessParentEnv();
+		const env = terminalEnvironment.createTerminalEnvironment(shellLaunchConfig, lastActiveWorkspace, envFromConfigValue, this._configurationResolverService, isWorkspaceShellAllowed, this._productService.version, this._configHelper.config.setLocaleVariables, baseEnv);
 
 		const useConpty = this._configHelper.config.windowsEnableConpty;
 		return this._terminalInstanceService.createTerminalProcess(shellLaunchConfig, initialCwd, cols, rows, env, useConpty);

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -171,7 +171,8 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 		const lastActiveWorkspace = activeWorkspaceRootUri ? this._workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri) : null;
 		const envFromConfigValue = this._workspaceConfigurationService.inspect<ITerminalEnvironment | undefined>(`terminal.integrated.env.${platformKey}`);
 		const isWorkspaceShellAllowed = this._configHelper.checkWorkspaceShellPermissions();
-		const env = terminalEnvironment.createTerminalEnvironment(shellLaunchConfig, lastActiveWorkspace, envFromConfigValue, this._configurationResolverService, isWorkspaceShellAllowed, this._productService.version, this._configHelper.config.setLocaleVariables);
+		this._terminalInstanceService.getMainProcessParentEnv();
+		const env = terminalEnvironment.createTerminalEnvironment(shellLaunchConfig, lastActiveWorkspace, envFromConfigValue, this._configurationResolverService, isWorkspaceShellAllowed, this._productService.version, this._configHelper.config.setLocaleVariables, this._configHelper.config.inheritEnv);
 
 		const useConpty = this._configHelper.config.windowsEnableConpty;
 		return this._terminalInstanceService.createTerminalProcess(shellLaunchConfig, initialCwd, cols, rows, env, useConpty);

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -96,11 +96,11 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 		}
 	}
 
-	public createProcess(
+	public async createProcess(
 		shellLaunchConfig: IShellLaunchConfig,
 		cols: number,
 		rows: number
-	): void {
+	): Promise<void> {
 		const forceExtHostProcess = (this._configHelper.config as any).extHostProcess;
 		if (shellLaunchConfig.cwd && typeof shellLaunchConfig.cwd === 'object') {
 			this.remoteAuthority = getRemoteAuthority(shellLaunchConfig.cwd);
@@ -126,7 +126,7 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 			const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot();
 			this._process = this._instantiationService.createInstance(TerminalProcessExtHostProxy, this._terminalId, shellLaunchConfig, activeWorkspaceRootUri, cols, rows, this._configHelper);
 		} else {
-			this._process = this._launchProcess(shellLaunchConfig, cols, rows);
+			this._process = await this._launchProcess(shellLaunchConfig, cols, rows);
 		}
 		this.processState = ProcessState.LAUNCHING;
 
@@ -159,7 +159,7 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 		}, LAUNCHING_DURATION);
 	}
 
-	private _launchProcess(shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number): ITerminalChildProcess {
+	private async _launchProcess(shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number): Promise<ITerminalChildProcess> {
 		if (!shellLaunchConfig.executable) {
 			this._configHelper.mergeDefaultShellPathAndArgs(shellLaunchConfig, this._terminalInstanceService.getDefaultShell(platform.platform));
 		}
@@ -171,7 +171,7 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 		const lastActiveWorkspace = activeWorkspaceRootUri ? this._workspaceContextService.getWorkspaceFolder(activeWorkspaceRootUri) : null;
 		const envFromConfigValue = this._workspaceConfigurationService.inspect<ITerminalEnvironment | undefined>(`terminal.integrated.env.${platformKey}`);
 		const isWorkspaceShellAllowed = this._configHelper.checkWorkspaceShellPermissions();
-		const baseEnv = this._configHelper.config.inheritEnv ? process.env as platform.IProcessEnvironment : this._terminalInstanceService.getMainProcessParentEnv();
+		const baseEnv = this._configHelper.config.inheritEnv ? process.env as platform.IProcessEnvironment : await this._terminalInstanceService.getMainProcessParentEnv();
 		const env = terminalEnvironment.createTerminalEnvironment(shellLaunchConfig, lastActiveWorkspace, envFromConfigValue, this._configurationResolverService, isWorkspaceShellAllowed, this._productService.version, this._configHelper.config.setLocaleVariables, baseEnv);
 
 		const useConpty = this._configHelper.config.windowsEnableConpty;

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -94,6 +94,7 @@ export interface ITerminalConfiguration {
 	cwd: string;
 	confirmOnExit: boolean;
 	enableBell: boolean;
+	inheritEnv: boolean;
 	env: {
 		linux: { [key: string]: string };
 		osx: { [key: string]: string };

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -690,7 +690,7 @@ export interface ITerminalProcessManager extends IDisposable {
 	readonly onProcessExit: Event<number>;
 
 	dispose(immediate?: boolean): void;
-	createProcess(shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number): void;
+	createProcess(shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number): Promise<void>;
 	write(data: string): void;
 	setDimensions(cols: number, rows: number): void;
 

--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -198,7 +198,8 @@ export function createTerminalEnvironment(
 	configurationResolverService: IConfigurationResolverService | undefined,
 	isWorkspaceShellAllowed: boolean,
 	version: string | undefined,
-	setLocaleVariables: boolean
+	setLocaleVariables: boolean,
+	inheritEnv: boolean
 ): platform.IProcessEnvironment {
 	// Create a terminal environment based on settings, launch config and permissions
 	let env: platform.IProcessEnvironment = {};
@@ -207,7 +208,7 @@ export function createTerminalEnvironment(
 		mergeNonNullKeys(env, shellLaunchConfig.env);
 	} else {
 		// Merge process env with the env from config and from shellLaunchConfig
-		mergeNonNullKeys(env, process.env);
+		mergeNonNullKeys(env, inheritEnv ? process.env : {});
 
 		// const platformKey = platform.isWindows ? 'windows' : (platform.isMacintosh ? 'osx' : 'linux');
 		// const envFromConfigValue = this._workspaceConfigurationService.inspect<ITerminalEnvironment | undefined>(`terminal.integrated.env.${platformKey}`);

--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -199,7 +199,7 @@ export function createTerminalEnvironment(
 	isWorkspaceShellAllowed: boolean,
 	version: string | undefined,
 	setLocaleVariables: boolean,
-	inheritEnv: boolean
+	baseEnv: platform.IProcessEnvironment
 ): platform.IProcessEnvironment {
 	// Create a terminal environment based on settings, launch config and permissions
 	let env: platform.IProcessEnvironment = {};
@@ -208,7 +208,7 @@ export function createTerminalEnvironment(
 		mergeNonNullKeys(env, shellLaunchConfig.env);
 	} else {
 		// Merge process env with the env from config and from shellLaunchConfig
-		mergeNonNullKeys(env, inheritEnv ? process.env : {});
+		mergeNonNullKeys(env, baseEnv);
 
 		// const platformKey = platform.isWindows ? 'windows' : (platform.isMacintosh ? 'osx' : 'linux');
 		// const envFromConfigValue = this._workspaceConfigurationService.inspect<ITerminalEnvironment | undefined>(`terminal.integrated.env.${platformKey}`);

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -7,12 +7,14 @@ import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/
 import { ITerminalInstance, IWindowsShellHelper, IShellLaunchConfig, ITerminalChildProcess } from 'vs/workbench/contrib/terminal/common/terminal';
 import { WindowsShellHelper } from 'vs/workbench/contrib/terminal/node/windowsShellHelper';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IProcessEnvironment, Platform } from 'vs/base/common/platform';
+import { IProcessEnvironment, Platform, isLinux, isMacintosh, isWindows } from 'vs/base/common/platform';
 import { TerminalProcess } from 'vs/workbench/contrib/terminal/node/terminalProcess';
 import { getDefaultShell } from 'vs/workbench/contrib/terminal/node/terminal';
 import { Terminal as XTermTerminal } from 'xterm';
 import { WebLinksAddon as XTermWebLinksAddon } from 'xterm-addon-web-links';
 import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
+import { readFile } from 'vs/base/node/pfs';
+import { basename } from 'vs/base/common/path';
 
 let Terminal: typeof XTermTerminal;
 let WebLinksAddon: typeof XTermWebLinksAddon;
@@ -20,6 +22,8 @@ let SearchAddon: typeof XTermSearchAddon;
 
 export class TerminalInstanceService implements ITerminalInstanceService {
 	public _serviceBrand: any;
+
+	private _mainProcessParentEnv: IProcessEnvironment | undefined;
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
@@ -57,5 +61,54 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	public getDefaultShell(p: Platform): string {
 		return getDefaultShell(p);
+	}
+
+	public async getMainProcessParentEnv(): Promise<IProcessEnvironment> {
+		if (this._mainProcessParentEnv) {
+			return this._mainProcessParentEnv;
+		}
+
+		// For Linux use /proc/<pid>/status to get the parent of the main process and then fetch its
+		// env using /proc/<pid>/environ.
+		if (isLinux) {
+			const mainProcessId = process.ppid;
+			const codeProcessName = basename(process.argv[0]);
+			let pid: number = 0;
+			let ppid: number = mainProcessId;
+			let name: string = codeProcessName;
+			do {
+				pid = ppid;
+				const status = await readFile(`/proc/${pid}/status`, 'utf8');
+				const splitByLine = status.split('\n');
+				splitByLine.forEach(line => {
+					if (line.indexOf('Name:') === 0) {
+						name = line.replace(/^Name:\s+/, '');
+					}
+					if (line.indexOf('PPid:') === 0) {
+						ppid = parseInt(line.replace(/^PPid:\s+/, ''));
+					}
+				});
+			} while (name === codeProcessName);
+			const rawEnv = await readFile(`/proc/${pid}/environ`, 'utf8');
+			const env = {};
+			rawEnv.split('\0').forEach(e => {
+				const i = e.indexOf('=');
+				env[e.substr(0, i)] = e.substr(i + 1);
+			});
+			this._mainProcessParentEnv = env;
+		}
+
+		// For macOS just return the root environment which seems to always be {}, this is the
+		// parent of the main process when code is launched from the dock.
+		if (isMacintosh) {
+			this._mainProcessParentEnv = {};
+		}
+
+		// TODO: Windows should return a fresh environment block, might need native code?
+		if (isWindows) {
+			this._mainProcessParentEnv = process.env as IProcessEnvironment;
+		}
+
+		return this._mainProcessParentEnv!;
 	}
 }

--- a/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -49,8 +49,9 @@ class MockTerminalInstanceService implements ITerminalInstanceService {
 	getDefaultShell(p: Platform): string {
 		throw new Error('Method not implemented.');
 	}
-
-
+	getMainProcessParentEnv(): any {
+		throw new Error('Method not implemented.');
+	}
 }
 
 interface LinkFormatInfo {


### PR DESCRIPTION
Fixes #70248

---

Example on Linux, before:

```
$ env
...
SHLVL=3
...
PATH=/home/daniel/.npm-packages/bin:/home/daniel/tools/node-v10.15.1-linux-x64/bin:/snap/bin:/home/daniel/.npm-packages/bin:/home/daniel/tools/node-v10.15.1-linux-x64/bin:/snap/bin:/sbin:/bin:/usr/bin:/usr/local/bin:/snap/bin
```

After:

```
$ env
...
SHLVL=1
...
PATH=/home/daniel/.npm-packages/bin:/home/daniel/tools/node-v10.15.1-linux-x64/bin:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```