### PR TITLE
Use MutableDisposable for managing editorStatus items

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -14,7 +14,7 @@ import { Action } from 'vs/base/common/actions';
 import { Language } from 'vs/base/common/platform';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { IFileEditorInput, EncodingMode, IEncodingSupport, toResource, SideBySideEditorInput, IEditor as IBaseEditor, IEditorInput, SideBySideEditor, IModeSupport } from 'vs/workbench/common/editor';
-import { IDisposable, dispose, Disposable } from 'vs/base/common/lifecycle';
+import { IDisposable, dispose, Disposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { IEditorAction } from 'vs/editor/common/editorCommon';
 import { EndOfLineSequence } from 'vs/editor/common/model';
@@ -276,14 +276,14 @@ const nlsEOLLF = nls.localize('endOfLineLineFeed', "LF");
 const nlsEOLCRLF = nls.localize('endOfLineCarriageReturnLineFeed', "CRLF");
 
 export class EditorStatus extends Disposable implements IWorkbenchContribution {
-	private tabFocusModeElement?: IStatusbarEntryAccessor;
-	private screenRedearModeElement?: IStatusbarEntryAccessor;
-	private indentationElement?: IStatusbarEntryAccessor;
-	private selectionElement?: IStatusbarEntryAccessor;
-	private encodingElement?: IStatusbarEntryAccessor;
-	private eolElement?: IStatusbarEntryAccessor;
-	private modeElement?: IStatusbarEntryAccessor;
-	private metadataElement?: IStatusbarEntryAccessor;
+	private readonly tabFocusModeElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly screenRedearModeElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly indentationElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly selectionElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly encodingElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly eolElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly modeElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
+	private readonly metadataElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
 
 	private readonly state = new State();
 	private readonly activeEditorListeners: IDisposable[] = [];
@@ -382,45 +382,35 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 
 	private updateTabFocusModeElement(visible: boolean): void {
 		if (visible) {
-			if (!this.tabFocusModeElement) {
-				this.tabFocusModeElement = this.statusbarService.addEntry({
+			if (!this.tabFocusModeElement.value) {
+				this.tabFocusModeElement.value = this.statusbarService.addEntry({
 					text: nls.localize('tabFocusModeEnabled', "Tab Moves Focus"),
 					tooltip: nls.localize('disableTabMode', "Disable Accessibility Mode"),
 					command: 'editor.action.toggleTabFocusMode'
 				}, 'status.editor.tabFocusMode', nls.localize('status.editor.tabFocusMode', "Accessibility Mode"), StatusbarAlignment.RIGHT, 100.7);
 			}
 		} else {
-			if (this.tabFocusModeElement) {
-				this.tabFocusModeElement.dispose();
-				this.tabFocusModeElement = undefined;
-			}
+			this.tabFocusModeElement.clear();
 		}
 	}
 
 	private updateScreenReaderModeElement(visible: boolean): void {
 		if (visible) {
-			if (!this.screenRedearModeElement) {
-				this.screenRedearModeElement = this.statusbarService.addEntry({
+			if (!this.screenRedearModeElement.value) {
+				this.screenRedearModeElement.value = this.statusbarService.addEntry({
 					text: nls.localize('screenReaderDetected', "Screen Reader Optimized"),
 					tooltip: nls.localize('screenReaderDetectedExtra', "If you are not using a Screen Reader, please change the setting `editor.accessibilitySupport` to \"off\"."),
 					command: 'showEditorScreenReaderNotification'
 				}, 'status.editor.screenReaderMode', nls.localize('status.editor.screenReaderMode', "Screen Reader Mode"), StatusbarAlignment.RIGHT, 100.6);
 			}
 		} else {
-			if (this.screenRedearModeElement) {
-				this.screenRedearModeElement.dispose();
-				this.screenRedearModeElement = undefined;
-			}
+			this.screenRedearModeElement.clear();
 		}
 	}
 
 	private updateSelectionElement(text: string | undefined): void {
 		if (!text) {
-			if (this.selectionElement) {
-				dispose(this.selectionElement);
-				this.selectionElement = undefined;
-			}
-
+			this.selectionElement.clear();
 			return;
 		}
 
@@ -430,16 +420,12 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			command: 'workbench.action.gotoLine'
 		};
 
-		this.selectionElement = this.updateElement(this.selectionElement, props, 'status.editor.selection', nls.localize('status.editor.selection', "Editor Selection"), StatusbarAlignment.RIGHT, 100.5);
+		this.updateElement(this.selectionElement, props, 'status.editor.selection', nls.localize('status.editor.selection', "Editor Selection"), StatusbarAlignment.RIGHT, 100.5);
 	}
 
 	private updateIndentationElement(text: string | undefined): void {
 		if (!text) {
-			if (this.indentationElement) {
-				dispose(this.indentationElement);
-				this.indentationElement = undefined;
-			}
-
+			this.indentationElement.clear();
 			return;
 		}
 
@@ -449,16 +435,12 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			command: 'changeEditorIndentation'
 		};
 
-		this.indentationElement = this.updateElement(this.indentationElement, props, 'status.editor.indentation', nls.localize('status.editor.indentation', "Editor Indentation"), StatusbarAlignment.RIGHT, 100.4);
+		this.updateElement(this.indentationElement, props, 'status.editor.indentation', nls.localize('status.editor.indentation', "Editor Indentation"), StatusbarAlignment.RIGHT, 100.4);
 	}
 
 	private updateEncodingElement(text: string | undefined): void {
 		if (!text) {
-			if (this.encodingElement) {
-				dispose(this.encodingElement);
-				this.encodingElement = undefined;
-			}
-
+			this.encodingElement.clear();
 			return;
 		}
 
@@ -468,16 +450,12 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			command: 'workbench.action.editor.changeEncoding'
 		};
 
-		this.encodingElement = this.updateElement(this.encodingElement, props, 'status.editor.encoding', nls.localize('status.editor.encoding', "Editor Encoding"), StatusbarAlignment.RIGHT, 100.3);
+		this.updateElement(this.encodingElement, props, 'status.editor.encoding', nls.localize('status.editor.encoding', "Editor Encoding"), StatusbarAlignment.RIGHT, 100.3);
 	}
 
 	private updateEOLElement(text: string | undefined): void {
 		if (!text) {
-			if (this.eolElement) {
-				dispose(this.eolElement);
-				this.eolElement = undefined;
-			}
-
+			this.eolElement.clear();
 			return;
 		}
 
@@ -487,16 +465,12 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			command: 'workbench.action.editor.changeEOL'
 		};
 
-		this.eolElement = this.updateElement(this.eolElement, props, 'status.editor.eol', nls.localize('status.editor.eol', "Editor End of Line"), StatusbarAlignment.RIGHT, 100.2);
+		this.updateElement(this.eolElement, props, 'status.editor.eol', nls.localize('status.editor.eol', "Editor End of Line"), StatusbarAlignment.RIGHT, 100.2);
 	}
 
 	private updateModeElement(text: string | undefined): void {
 		if (!text) {
-			if (this.modeElement) {
-				dispose(this.modeElement);
-				this.modeElement = undefined;
-			}
-
+			this.modeElement.clear();
 			return;
 		}
 
@@ -506,16 +480,12 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			command: 'workbench.action.editor.changeLanguageMode'
 		};
 
-		this.modeElement = this.updateElement(this.modeElement, props, 'status.editor.mode', nls.localize('status.editor.mode', "Editor Language"), StatusbarAlignment.RIGHT, 100.1);
+		this.updateElement(this.modeElement, props, 'status.editor.mode', nls.localize('status.editor.mode', "Editor Language"), StatusbarAlignment.RIGHT, 100.1);
 	}
 
 	private updateMetadataElement(text: string | undefined): void {
 		if (!text) {
-			if (this.metadataElement) {
-				dispose(this.metadataElement);
-				this.metadataElement = undefined;
-			}
-
+			this.metadataElement.clear();
 			return;
 		}
 
@@ -524,17 +494,15 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			tooltip: nls.localize('fileInfo', "File Information")
 		};
 
-		this.metadataElement = this.updateElement(this.metadataElement, props, 'status.editor.info', nls.localize('status.editor.info', "File Information"), StatusbarAlignment.RIGHT, 100);
+		this.updateElement(this.metadataElement, props, 'status.editor.info', nls.localize('status.editor.info', "File Information"), StatusbarAlignment.RIGHT, 100);
 	}
 
-	private updateElement(element: IStatusbarEntryAccessor | undefined, props: IStatusbarEntry, id: string, name: string, alignment: StatusbarAlignment, priority: number): IStatusbarEntryAccessor | undefined {
-		if (!element) {
-			element = this.statusbarService.addEntry(props, id, name, alignment, priority);
+	private updateElement(element: MutableDisposable<IStatusbarEntryAccessor>, props: IStatusbarEntry, id: string, name: string, alignment: StatusbarAlignment, priority: number) {
+		if (!element.value) {
+			element.value = this.statusbarService.addEntry(props, id, name, alignment, priority);
 		} else {
-			element.update(props);
+			element.value.update(props);
 		}
-
-		return element;
 	}
 
 	private updateState(update: StateDelta): void {


### PR DESCRIPTION
The `MutableDisposable` class helps manage a disposable value that may change over time. I noticed that editorStatus is  manually managing its disposable `IStatusbarEntryAccessor` elements and think `MutableDisposable` can help here. The class  prevents mistakes such as forgetting to dispose of a property before re-assigning it. It also lets us use `_register` to ensure these values are cleaned up properly when the class is disposed of