### PR TITLE
Recommend users install EditorConfig extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 	"recommendations": [
 		"ms-vscode.vscode-typescript-tslint-plugin",
 		"dbaeumer.vscode-eslint",
+		"EditorConfig.EditorConfig",
 		"msjsdiag.debugger-for-chrome"
 	]
 }


### PR DESCRIPTION
It'd be a good idea to recommend users install EditorConfig. There is already a `.editorconfig` in the projects root - so recommending this extension be installed can help enforce the code style guide which is better for everyone.