### PR TITLE
Handle multiple users with /tmp/vscode-typescript

### DIFF
--- a/extensions/typescript-language-features/src/utils/electron.ts
+++ b/extensions/typescript-language-features/src/utils/electron.ts
@@ -7,13 +7,14 @@ import * as temp from './temp';
 import path = require('path');
 import fs = require('fs');
 import cp = require('child_process');
+import process = require('process');
 
 
 const getRootTempDir = (() => {
 	let dir: string | undefined;
 	return () => {
 		if (!dir) {
-			dir = temp.getTempFile(`vscode-typescript`);
+			dir = temp.getTempFile(`vscode-typescript${process.getuid ? process.getuid() : ''}`);
 		}
 		if (!fs.existsSync(dir)) {
 			fs.mkdirSync(dir);


### PR DESCRIPTION
This fixes an issue where the typescript language server fails to load if multiple users launch VS Code on the same Linux machine.

Steps to reproduce:
- Log in as user1
- Launch VS Code
- Log out
- Log in as user2
- Launch VS Code
- It tries to write to files in /tmp/vscode-typescript, but that directory is not writeable because it is owned by user1
- You cannot use TypeScript intellisense

This fix namespaces the directory with the current uid so that each user will get their own. 

On Windows, this shouldn't be an issue anyway since each user gets their own temp directory.