### PR TITLE
Makes status zoom button a IStatusbarEntry #74454

### DIFF
--- a/src/vs/workbench/browser/parts/editor/binaryEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/binaryEditor.ts
@@ -20,6 +20,8 @@ import { dispose } from 'vs/base/common/lifecycle';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IFileService } from 'vs/platform/files/common/files';
+import { IStatusbarService } from 'vs/platform/statusbar/common/statusbar';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 
 export interface IOpenCallbacks {
 	openInternal: (input: EditorInput, options: EditorOptions) => Promise<void>;
@@ -50,7 +52,9 @@ export abstract class BaseBinaryResourceEditor extends BaseEditor {
 		themeService: IThemeService,
 		@IFileService private readonly fileService: IFileService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
-		@IStorageService storageService: IStorageService
+		@IStorageService storageService: IStorageService,
+		@IStatusbarService private readonly statusbarService: IStatusbarService,
+		@IContextMenuService private readonly contextMenuService: IContextMenuService
 	) {
 		super(id, telemetryService, themeService, storageService);
 
@@ -97,7 +101,7 @@ export abstract class BaseBinaryResourceEditor extends BaseEditor {
 			openInternalClb: () => this.handleOpenInternalCallback(input, options),
 			openExternalClb: this.environmentService.configuration.remoteAuthority ? undefined : resource => this.callbacks.openExternal(resource),
 			metadataClb: meta => this.handleMetadataChanged(meta)
-		});
+		}, this.statusbarService, this.contextMenuService);
 	}
 
 	private async handleOpenInternalCallback(input: EditorInput, options: EditorOptions): Promise<void> {

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -8,8 +8,6 @@ import * as nls from 'vs/nls';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { Action, IAction } from 'vs/base/common/actions';
 import { IEditorQuickOpenEntry, IQuickOpenRegistry, Extensions as QuickOpenExtensions, QuickOpenHandlerDescriptor } from 'vs/workbench/browser/quickopen';
-import { StatusbarItemDescriptor, IStatusbarRegistry, Extensions as StatusExtensions } from 'vs/workbench/browser/parts/statusbar/statusbar';
-import { StatusbarAlignment } from 'vs/platform/statusbar/common/statusbar';
 import { IEditorRegistry, EditorDescriptor, Extensions as EditorExtensions } from 'vs/workbench/browser/editor';
 import { EditorInput, IEditorInputFactory, SideBySideEditorInput, IEditorInputFactoryRegistry, Extensions as EditorInputExtensions, TextCompareEditorActiveContext, EditorPinnedContext, EditorGroupEditorsCountContext } from 'vs/workbench/common/editor';
 import { TextResourceEditor } from 'vs/workbench/browser/parts/editor/textResourceEditor';
@@ -49,7 +47,6 @@ import { isMacintosh } from 'vs/base/common/platform';
 import { AllEditorsPicker, ActiveEditorGroupPicker } from 'vs/workbench/browser/parts/editor/editorPicker';
 import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { OpenWorkspaceButtonContribution } from 'vs/workbench/browser/parts/editor/editorWidgets';
-import { ZoomStatusbarItem } from 'vs/workbench/browser/parts/editor/resourceViewer';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { toLocalResource } from 'vs/base/common/resources';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
@@ -223,16 +220,6 @@ registerEditorContribution(OpenWorkspaceButtonContribution);
 
 // Register Editor Status
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(EditorStatus, LifecyclePhase.Ready);
-
-// Register Zoom Status
-const statusBar = Registry.as<IStatusbarRegistry>(StatusExtensions.Statusbar);
-statusBar.registerStatusbarItem(new StatusbarItemDescriptor(
-	ZoomStatusbarItem,
-	'status.imageZoom',
-	nls.localize('status.imageZoom', "Image Zoom"),
-	StatusbarAlignment.RIGHT,
-	101 /* to the left of editor status (100) */)
-);
 
 // Register Status Actions
 const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);

--- a/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
+++ b/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
@@ -58,10 +58,6 @@
 	cursor: zoom-out;
 }
 
-.monaco-workbench .part.statusbar > .items-container > .statusbar-item > a.zoom-statusbar-item {
-	padding: 0 5px 0 5px;
-}
-
 .monaco-resource-viewer .embedded-link,
 .monaco-resource-viewer .embedded-link:hover {
 	cursor: pointer;

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -604,6 +604,7 @@ export class StatusbarPart extends Part implements IStatusbarService {
 	private doCreateStatusItem(id: string, name: string, alignment: StatusbarAlignment, priority: number = 0, ...extraClasses: string[]): HTMLElement {
 		const itemContainer = document.createElement('div');
 		itemContainer.title = name;
+		itemContainer.id = id;
 
 		addClass(itemContainer, 'statusbar-item');
 		if (extraClasses) {

--- a/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/binaryFileEditor.ts
@@ -16,6 +16,8 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IFileService } from 'vs/platform/files/common/files';
+import { IStatusbarService } from 'vs/platform/statusbar/common/statusbar';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 
 /**
  * An implementation of editor for binary files like images.
@@ -32,6 +34,8 @@ export class BinaryFileEditor extends BaseBinaryResourceEditor {
 		@IStorageService storageService: IStorageService,
 		@IFileService fileService: IFileService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@IStatusbarService statusbarService: IStatusbarService,
+		@IContextMenuService contextMenuService: IContextMenuService
 	) {
 		super(
 			BinaryFileEditor.ID,
@@ -44,6 +48,8 @@ export class BinaryFileEditor extends BaseBinaryResourceEditor {
 			fileService,
 			environmentService,
 			storageService,
+			statusbarService,
+			contextMenuService
 		);
 	}
 


### PR DESCRIPTION
Resolves #74454

ZoomStatusbarItem can now be instantiated, which is done in
InlineImageView, which it uses to update the status bar.
The needed services are passed down via constructors,
starting in BaseBinaryResourceEditor.
Also, the ID of status bar items is now assigned as the
id-attribute of the item's container.