### PR TITLE
Provide full TS symbol range when previewing definitions in VSCode

### DIFF
--- a/extensions/typescript-language-features/src/features/definitions.ts
+++ b/extensions/typescript-language-features/src/features/definitions.ts
@@ -37,10 +37,18 @@ export default class TypeScriptDefinitionProvider extends DefinitionProviderBase
 			return response.body.definitions
 				.map((location): vscode.DefinitionLink => {
 					const target = typeConverters.Location.fromTextSpan(this.client.toResource(location.file), location);
+					if ((location as any).contextStart) {
+						return {
+							originSelectionRange: span,
+							targetRange: typeConverters.Range.fromLocations((location as any).contextStart, (location as any).contextEnd),
+							targetUri: target.uri,
+							targetSelectionRange: target.range,
+						};
+					}
 					return {
 						originSelectionRange: span,
 						targetRange: target.range,
-						targetUri: target.uri,
+						targetUri: target.uri
 					};
 				});
 		}

--- a/extensions/typescript-language-features/src/utils/typeConverters.ts
+++ b/extensions/typescript-language-features/src/utils/typeConverters.ts
@@ -13,9 +13,12 @@ import { ITypeScriptServiceClient } from '../typescriptService';
 
 export namespace Range {
 	export const fromTextSpan = (span: Proto.TextSpan): vscode.Range =>
+		fromLocations(span.start, span.end);
+
+	export const fromLocations = (start: Proto.Location, end: Proto.Location): vscode.Range =>
 		new vscode.Range(
-			Math.max(0, span.start.line - 1), Math.max(span.start.offset - 1, 0),
-			Math.max(0, span.end.line - 1), Math.max(0, span.end.offset - 1));
+			Math.max(0, start.line - 1), Math.max(start.offset - 1, 0),
+			Math.max(0, end.line - 1), Math.max(0, end.offset - 1));
 
 	export const toFileRangeRequestArgs = (file: string, range: vscode.Range): Proto.FileRangeRequestArgs => ({
 		file,

--- a/src/vs/editor/contrib/goToDefinition/goToDefinitionMouse.ts
+++ b/src/vs/editor/contrib/goToDefinition/goToDefinitionMouse.ts
@@ -10,7 +10,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { MarkdownString } from 'vs/base/common/htmlContent';
 import { IModeService } from 'vs/editor/common/services/modeService';
-import { Range } from 'vs/editor/common/core/range';
+import { Range, IRange } from 'vs/editor/common/core/range';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { DefinitionProviderRegistry, LocationLink } from 'vs/editor/common/modes';
 import { ICodeEditor, IMouseTarget, MouseTargetType } from 'vs/editor/browser/editorBrowser';
@@ -150,7 +150,7 @@ class GotoDefinitionWithMouseEditorContribution implements editorCommon.IEditorC
 						return;
 					}
 
-					const previewValue = this.getPreviewValue(textEditorModel, startLineNumber);
+					const previewValue = this.getPreviewValue(textEditorModel, startLineNumber, result);
 
 					let wordRange: Range;
 					if (result.originSelectionRange) {
@@ -170,8 +170,8 @@ class GotoDefinitionWithMouseEditorContribution implements editorCommon.IEditorC
 		}).then(undefined, onUnexpectedError);
 	}
 
-	private getPreviewValue(textEditorModel: ITextModel, startLineNumber: number) {
-		let rangeToUse = this.getPreviewRangeBasedOnBrackets(textEditorModel, startLineNumber);
+	private getPreviewValue(textEditorModel: ITextModel, startLineNumber: number, result: LocationLink) {
+		let rangeToUse = result.targetSelectionRange ? result.range : this.getPreviewRangeBasedOnBrackets(textEditorModel, startLineNumber);
 		const numberOfLinesInRange = rangeToUse.endLineNumber - rangeToUse.startLineNumber;
 		if (numberOfLinesInRange >= GotoDefinitionWithMouseEditorContribution.MAX_SOURCE_PREVIEW_LINES) {
 			rangeToUse = this.getPreviewRangeBasedOnIndentation(textEditorModel, startLineNumber);
@@ -181,7 +181,7 @@ class GotoDefinitionWithMouseEditorContribution implements editorCommon.IEditorC
 		return previewValue;
 	}
 
-	private stripIndentationFromPreviewRange(textEditorModel: ITextModel, startLineNumber: number, previewRange: Range) {
+	private stripIndentationFromPreviewRange(textEditorModel: ITextModel, startLineNumber: number, previewRange: IRange) {
 		const startIndent = textEditorModel.getLineFirstNonWhitespaceColumn(startLineNumber);
 		let minIndent = startIndent;
 


### PR DESCRIPTION
Fixes #72017

Has two fixes:

- Hooks up the JS/TS extension to consume the full symbol range provided by https://github.com/microsoft/TypeScript/pull/31587

- Makes the go the definition mouse implementation use the locationLink to compute the preview range. If a`targetSelectionRange` is provided, this means we use the normal `range` to get the preview range. Currently I believe we always use bracket matching