### PR TITLE
fix: #75693

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -218,22 +218,20 @@ export class FilesRenderer implements ITreeRenderer<ExplorerItem, FuzzyScore, IF
 		const lastDot = value.lastIndexOf('.');
 
 		inputBox.value = value;
-		inputBox.focus();
+		setTimeout(() => inputBox.focus(), 100);
 		inputBox.select({ start: 0, end: lastDot > 0 && !stat.isDirectory ? lastDot : value.length });
 
-		const done = once(async (success: boolean, finishEditing: boolean) => {
+		const done = once(async (success: boolean) => {
 			label.element.style.display = 'none';
 			const value = inputBox.value;
 			dispose(toDispose);
 			container.removeChild(label.element);
-			if (finishEditing) {
-				// Timeout: once done rendering only then re-render #70902
-				setTimeout(() => editableData.onFinish(value, success), 0);
-			}
+			// Timeout: once done rendering only then re-render #70902
+			setTimeout(() => editableData.onFinish(value, success), 0);
 		});
 
 		const blurDisposable = DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.BLUR, () => {
-			done(inputBox.isInputValid(), true);
+			done(inputBox.isInputValid());
 		});
 
 		const toDispose = [
@@ -241,10 +239,10 @@ export class FilesRenderer implements ITreeRenderer<ExplorerItem, FuzzyScore, IF
 			DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: IKeyboardEvent) => {
 				if (e.equals(KeyCode.Enter)) {
 					if (inputBox.validate()) {
-						done(true, true);
+						done(true);
 					}
 				} else if (e.equals(KeyCode.Escape)) {
-					done(false, true);
+					done(false);
 				}
 			}),
 			blurDisposable,
@@ -254,7 +252,7 @@ export class FilesRenderer implements ITreeRenderer<ExplorerItem, FuzzyScore, IF
 
 		return toDisposable(() => {
 			blurDisposable.dispose();
-			done(false, false);
+			done(false);
 		});
 	}
 

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -218,8 +218,17 @@ export class FilesRenderer implements ITreeRenderer<ExplorerItem, FuzzyScore, IF
 		const lastDot = value.lastIndexOf('.');
 
 		inputBox.value = value;
-		setTimeout(() => inputBox.focus(), 100);
-		inputBox.select({ start: 0, end: lastDot > 0 && !stat.isDirectory ? lastDot : value.length });
+
+		let isFinishableDisposeEvent = false;
+		setTimeout(() => {
+			// Check if disposed
+			if (!inputBox.inputElement) {
+				return;
+			}
+			inputBox.focus();
+			inputBox.select({ start: 0, end: lastDot > 0 && !stat.isDirectory ? lastDot : value.length });
+			isFinishableDisposeEvent = true;
+		}, 0);
 
 		const done = once(async (success: boolean) => {
 			label.element.style.display = 'none';
@@ -251,8 +260,12 @@ export class FilesRenderer implements ITreeRenderer<ExplorerItem, FuzzyScore, IF
 		];
 
 		return toDisposable(() => {
-			blurDisposable.dispose();
-			done(false);
+			if (isFinishableDisposeEvent) {
+				done(false);
+			}
+			else {
+				dispose(toDispose);
+			}
 		});
 	}
 


### PR DESCRIPTION
This is a PR for #75693

This problem occurs since after the commitment of the #72627.
Since there' s a [`finishEditing` flag](https://github.com/microsoft/vscode/pull/72627/files#diff-18552b0ae82758a2b0227eb483bdc8d8R221), only the UI event like `blur` or `Enter Key` ACTUALLY finish the editing mode and make File Explorer as active again.
When refreshing File Explorer by external events, like file changes by the asynchronous terminal command, never makes `finishEditing` as true so the [onFinish](https://github.com/microsoft/vscode/blob/master/src/vs/workbench/contrib/files/browser/fileActions.ts#L873) will be never called.

The reason why `finishEditing` exists is that input box will be disposed when `blur` event is called and that `blur` event is called immediately after the creation of the input box for some reason.
The very first approach to resolve this problem was giving the `timeout` for 100ms to prevent disposing the input even `blur` is called.
But that gives [another bug](https://github.com/microsoft/vscode/issues/72626) so `finishEditing` flag was introduced few days ago.

And now it causes another bug which is being stated here so rather than giving a `finishEditing` flag or `timeout` for `blur` event, giving 100ms `timeout` for `focus` after the creation of the input seems to solve the overall problems.