### PR TITLE
Add support for APKBUILD

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -14,7 +14,7 @@
 			"id": "shellscript",
 			"aliases": ["Shell Script", "shellscript", "bash", "sh", "zsh", "ksh"],
 			"extensions": [".sh", ".bash", ".bashrc", ".bash_aliases", ".bash_profile", ".bash_login", ".ebuild", ".install", ".profile", ".bash_logout", ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv", ".zsh-theme", ".ksh"],
-			"filenames": ["PKGBUILD"],
+			"filenames": ["APKBUILD", "PKGBUILD"],
 			"firstLine": "^#!.*\\b(bash|zsh|sh|tcsh|ksh|ash|qsh).*|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-",
 			"configuration": "./language-configuration.json",
 			"mimetypes": ["text/x-shellscript"]


### PR DESCRIPTION
APKBUILD is the build shell script format for Alpine Linux aports (packages - .apk) - https://wiki.alpinelinux.org/wiki/APKBUILD_Reference