### PR TITLE
Replace getDefaultShell and mergeDefaultShellPathAndArgs with getDefaultShellAndArgs

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalService.ts
@@ -49,9 +49,6 @@ export class MainThreadTerminalService implements MainThreadTerminalServiceShape
 		this._toDispose.push(_terminalService.onRequestAvailableShells(r => this._proxy.$requestAvailableShells().then(e => r(e))));
 
 		// ITerminalInstanceService listeners
-		if (terminalInstanceService.onRequestDefaultShell) {
-			this._toDispose.push(terminalInstanceService.onRequestDefaultShell(r => this._proxy.$requestDefaultShell().then(e => r(e))));
-		}
 		if (terminalInstanceService.onRequestDefaultShellAndArgs) {
 			this._toDispose.push(terminalInstanceService.onRequestDefaultShellAndArgs(r => this._proxy.$requestDefaultShellAndArgs().then(e => r(e.shell, e.args))));
 		}

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1129,6 +1129,7 @@ export interface ExtHostTerminalServiceShape {
 	$acceptProcessRequestLatency(id: number): number;
 	$acceptWorkspacePermissionsChanged(isAllowed: boolean): void;
 	$requestAvailableShells(): Promise<IShellDefinitionDto[]>;
+	$requestDefaultShell(): Promise<string>;
 }
 
 export interface ExtHostSCMShape {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1111,6 +1111,11 @@ export interface IShellDefinitionDto {
 	path: string;
 }
 
+export interface IShellAndArgsDto {
+	shell: string;
+	args: string[] | string | undefined;
+}
+
 export interface ExtHostTerminalServiceShape {
 	$acceptTerminalClosed(id: number): void;
 	$acceptTerminalOpened(id: number, name: string): void;
@@ -1130,6 +1135,7 @@ export interface ExtHostTerminalServiceShape {
 	$acceptWorkspacePermissionsChanged(isAllowed: boolean): void;
 	$requestAvailableShells(): Promise<IShellDefinitionDto[]>;
 	$requestDefaultShell(): Promise<string>;
+	$requestDefaultShellAndArgs(): Promise<IShellAndArgsDto>;
 }
 
 export interface ExtHostSCMShape {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1134,7 +1134,6 @@ export interface ExtHostTerminalServiceShape {
 	$acceptProcessRequestLatency(id: number): number;
 	$acceptWorkspacePermissionsChanged(isAllowed: boolean): void;
 	$requestAvailableShells(): Promise<IShellDefinitionDto[]>;
-	$requestDefaultShell(): Promise<string>;
 	$requestDefaultShellAndArgs(): Promise<IShellAndArgsDto>;
 }
 

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -495,20 +495,8 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 		const platformKey = platform.isWindows ? 'windows' : (platform.isMacintosh ? 'osx' : 'linux');
 		const configProvider = await this._extHostConfiguration.getConfigProvider();
 		if (!shellLaunchConfig.executable) {
-			const fetchSetting = (key: string) => {
-				const setting = configProvider
-					.getConfiguration(key.substr(0, key.lastIndexOf('.')))
-					.inspect<string | string[]>(key.substr(key.lastIndexOf('.') + 1));
-				return this._apiInspectConfigToPlain<string | string[]>(setting);
-			};
-			terminalEnvironment.mergeDefaultShellPathAndArgs(
-				shellLaunchConfig,
-				fetchSetting,
-				isWorkspaceShellAllowed || false,
-				getSystemShell(platform.platform),
-				process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432'),
-				process.env.windir
-			);
+			shellLaunchConfig.executable = this.getDefaultShell(configProvider);
+			shellLaunchConfig.args = this._getDefaultShellArgs(configProvider);
 		}
 
 		// Get the initial cwd

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -589,11 +589,6 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 		return detectAvailableShells();
 	}
 
-	// TODO: Remove this once requestDefaultShellAndArgs is working
-	public $requestDefaultShell(): Promise<string> {
-		return Promise.resolve(getSystemShell(platform.platform));
-	}
-
 	public async $requestDefaultShellAndArgs(): Promise<IShellAndArgsDto> {
 		const configProvider = await this._extHostConfiguration.getConfigProvider();
 		return Promise.resolve({

--- a/src/vs/workbench/api/node/extHostTerminalService.ts
+++ b/src/vs/workbench/api/node/extHostTerminalService.ts
@@ -579,6 +579,10 @@ export class ExtHostTerminalService implements ExtHostTerminalServiceShape {
 		return detectAvailableShells();
 	}
 
+	public $requestDefaultShell(): Promise<string> {
+		return Promise.resolve(getDefaultShell(platform.platform));
+	}
+
 	private _onProcessExit(id: number, exitCode: number): void {
 		// Remove listeners
 		this._terminalProcesses[id].dispose();

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -10,7 +10,7 @@ import * as pfs from 'vs/base/node/pfs';
 import { assign } from 'vs/base/common/objects';
 import { ITerminalLauncher, ITerminalSettings } from 'vs/workbench/contrib/debug/common/debug';
 import { getPathFromAmdModule } from 'vs/base/common/amd';
-import { getDefaultShell } from 'vs/workbench/contrib/terminal/node/terminal';
+import { getSystemShell } from 'vs/workbench/contrib/terminal/node/terminal';
 
 const TERMINAL_TITLE = nls.localize('console.title', "VS Code Console");
 
@@ -315,13 +315,13 @@ export function prepareCommand(args: DebugProtocol.RunInTerminalRequestArguments
 	let shell: string;
 	const shell_config = config.integrated.shell;
 	if (env.isWindows) {
-		shell = shell_config.windows || getDefaultShell(env.Platform.Windows);
+		shell = shell_config.windows || getSystemShell(env.Platform.Windows);
 		shellType = ShellType.cmd;
 	} else if (env.isLinux) {
-		shell = shell_config.linux || getDefaultShell(env.Platform.Linux);
+		shell = shell_config.linux || getSystemShell(env.Platform.Linux);
 		shellType = ShellType.bash;
 	} else if (env.isMacintosh) {
-		shell = shell_config.osx || getDefaultShell(env.Platform.Mac);
+		shell = shell_config.osx || getSystemShell(env.Platform.Mac);
 		shellType = ShellType.bash;
 	} else {
 		throw new Error('Unknown platform');

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -778,8 +778,8 @@ export class TerminalTaskSystem implements ITaskSystem {
 		let terminalName = this.createTerminalName(task);
 		let originalCommand = task.command.name;
 		if (isShellCommand) {
-			shellLaunchConfig = { name: terminalName, executable: undefined, args: undefined, waitOnExit };
-			this.terminalInstanceService.mergeDefaultShellPathAndArgs(shellLaunchConfig, await this.terminalInstanceService.getDefaultShell(), this.terminalService.configHelper, platform);
+			const defaultConfig = await this.terminalInstanceService.getDefaultShellAndArgs();
+			shellLaunchConfig = { name: terminalName, executable: defaultConfig.shell, args: defaultConfig.args, waitOnExit };
 			let shellSpecified: boolean = false;
 			let shellOptions: ShellConfiguration | undefined = task.command.options && task.command.options.shell;
 			if (shellOptions) {

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -763,25 +763,6 @@ export class TerminalTaskSystem implements ITaskSystem {
 		return nls.localize('TerminalTaskSystem.terminalName', 'Task - {0}', needsFolderQualification ? task.getQualifiedLabel() : task.configurationProperties.name);
 	}
 
-	private getDefaultShell(platform: Platform.Platform): string {
-		let defaultShell: string | undefined = undefined;
-		try {
-			defaultShell = this.terminalInstanceService.getDefaultShell(platform);
-		} catch {
-			// Do nothing
-		}
-		if (!defaultShell) {
-			// Make up a guess for the default shell.
-			if (platform === Platform.Platform.Windows) {
-				defaultShell = 'cmd.exe';
-			} else {
-				defaultShell = 'bash';
-			}
-			console.warn('Cannot get the default shell.');
-		}
-		return defaultShell;
-	}
-
 	private async getUserHome(): Promise<URI> {
 		const env = await this.remoteAgentService.getEnvironment();
 		if (env) {
@@ -798,7 +779,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 		let originalCommand = task.command.name;
 		if (isShellCommand) {
 			shellLaunchConfig = { name: terminalName, executable: undefined, args: undefined, waitOnExit };
-			this.terminalInstanceService.mergeDefaultShellPathAndArgs(shellLaunchConfig, this.getDefaultShell(platform), this.terminalService.configHelper, platform);
+			this.terminalInstanceService.mergeDefaultShellPathAndArgs(shellLaunchConfig, await this.terminalInstanceService.getDefaultShell(), this.terminalService.configHelper, platform);
 			let shellSpecified: boolean = false;
 			let shellOptions: ShellConfiguration | undefined = task.command.options && task.command.options.shell;
 			if (shellOptions) {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -21,7 +21,6 @@ export const ITerminalInstanceService = createDecorator<ITerminalInstanceService
 export interface ITerminalInstanceService {
 	_serviceBrand: any;
 
-	onRequestDefaultShell?: Event<(defaultShell: string) => void>;
 	onRequestDefaultShellAndArgs?: Event<IDefaultShellAndArgsRequest>;
 
 	getXtermConstructor(): Promise<typeof XTermTerminal>;
@@ -34,7 +33,6 @@ export interface ITerminalInstanceService {
 	 */
 	mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride?: Platform): void;
 
-	getDefaultShell(): Promise<string>;
 	getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }>;
 	getMainProcessParentEnv(): Promise<IProcessEnvironment>;
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -6,7 +6,7 @@
 import { Terminal as XTermTerminal } from 'xterm';
 import { WebLinksAddon as XTermWebLinksAddon } from 'xterm-addon-web-links';
 import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
-import { ITerminalInstance, IWindowsShellHelper, ITerminalConfigHelper, ITerminalChildProcess, IShellLaunchConfig } from 'vs/workbench/contrib/terminal/common/terminal';
+import { ITerminalInstance, IWindowsShellHelper, ITerminalConfigHelper, ITerminalChildProcess, IShellLaunchConfig, IDefaultShellAndArgsRequest } from 'vs/workbench/contrib/terminal/common/terminal';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IProcessEnvironment, Platform } from 'vs/base/common/platform';
 import { Event } from 'vs/base/common/event';
@@ -22,6 +22,7 @@ export interface ITerminalInstanceService {
 	_serviceBrand: any;
 
 	onRequestDefaultShell?: Event<(defaultShell: string) => void>;
+	onRequestDefaultShellAndArgs?: Event<IDefaultShellAndArgsRequest>;
 
 	getXtermConstructor(): Promise<typeof XTermTerminal>;
 	getXtermWebLinksConstructor(): Promise<typeof XTermWebLinksAddon>;
@@ -34,6 +35,7 @@ export interface ITerminalInstanceService {
 	mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride?: Platform): void;
 
 	getDefaultShell(): Promise<string>;
+	getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }>;
 	getMainProcessParentEnv(): Promise<IProcessEnvironment>;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -9,6 +9,7 @@ import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
 import { ITerminalInstance, IWindowsShellHelper, ITerminalConfigHelper, ITerminalChildProcess, IShellLaunchConfig } from 'vs/workbench/contrib/terminal/common/terminal';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IProcessEnvironment, Platform } from 'vs/base/common/platform';
+import { Event } from 'vs/base/common/event';
 
 export const ITerminalInstanceService = createDecorator<ITerminalInstanceService>('terminalInstanceService');
 
@@ -20,16 +21,19 @@ export const ITerminalInstanceService = createDecorator<ITerminalInstanceService
 export interface ITerminalInstanceService {
 	_serviceBrand: any;
 
+	onRequestDefaultShell?: Event<(defaultShell: string) => void>;
+
 	getXtermConstructor(): Promise<typeof XTermTerminal>;
 	getXtermWebLinksConstructor(): Promise<typeof XTermWebLinksAddon>;
 	getXtermSearchConstructor(): Promise<typeof XTermSearchAddon>;
 	createWindowsShellHelper(shellProcessId: number, instance: ITerminalInstance, xterm: XTermTerminal): IWindowsShellHelper;
 	createTerminalProcess(shellLaunchConfig: IShellLaunchConfig, cwd: string, cols: number, rows: number, env: IProcessEnvironment, windowsEnableConpty: boolean): ITerminalChildProcess;
-	getDefaultShell(p: Platform): string;
 	/**
 	 * Merges the default shell path and args into the provided launch configuration
 	 */
 	mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride?: Platform): void;
+
+	getDefaultShell(): Promise<string>;
 	getMainProcessParentEnv(): Promise<IProcessEnvironment>;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -8,7 +8,7 @@ import { WebLinksAddon as XTermWebLinksAddon } from 'xterm-addon-web-links';
 import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
 import { ITerminalInstance, IWindowsShellHelper, ITerminalConfigHelper, ITerminalChildProcess, IShellLaunchConfig, IDefaultShellAndArgsRequest } from 'vs/workbench/contrib/terminal/common/terminal';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IProcessEnvironment, Platform } from 'vs/base/common/platform';
+import { IProcessEnvironment } from 'vs/base/common/platform';
 import { Event } from 'vs/base/common/event';
 
 export const ITerminalInstanceService = createDecorator<ITerminalInstanceService>('terminalInstanceService');
@@ -28,10 +28,6 @@ export interface ITerminalInstanceService {
 	getXtermSearchConstructor(): Promise<typeof XTermSearchAddon>;
 	createWindowsShellHelper(shellProcessId: number, instance: ITerminalInstance, xterm: XTermTerminal): IWindowsShellHelper;
 	createTerminalProcess(shellLaunchConfig: IShellLaunchConfig, cwd: string, cols: number, rows: number, env: IProcessEnvironment, windowsEnableConpty: boolean): ITerminalChildProcess;
-	/**
-	 * Merges the default shell path and args into the provided launch configuration
-	 */
-	mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride?: Platform): void;
 
 	getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }>;
 	getMainProcessParentEnv(): Promise<IProcessEnvironment>;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -59,7 +59,4 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 	public async getMainProcessParentEnv(): Promise<IProcessEnvironment> {
 		return {};
 	}
-
-	public mergeDefaultShellPathAndArgs(): void {
-	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
-import { IWindowsShellHelper, ITerminalChildProcess } from 'vs/workbench/contrib/terminal/common/terminal';
+import { IWindowsShellHelper, ITerminalChildProcess, IDefaultShellAndArgsRequest } from 'vs/workbench/contrib/terminal/common/terminal';
 import { Terminal as XTermTerminal } from 'xterm';
 import { WebLinksAddon as XTermWebLinksAddon } from 'xterm-addon-web-links';
 import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
@@ -20,6 +20,8 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	private readonly _onRequestDefaultShell = new Emitter<(defaultShell: string) => void>();
 	public get onRequestDefaultShell(): Event<(defaultShell: string) => void> { return this._onRequestDefaultShell.event; }
+	private readonly _onRequestDefaultShellAndArgs = new Emitter<IDefaultShellAndArgsRequest>();
+	public get onRequestDefaultShellAndArgs(): Event<IDefaultShellAndArgsRequest> { return this._onRequestDefaultShellAndArgs.event; }
 
 	constructor() { }
 
@@ -54,6 +56,10 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	public getDefaultShell(): Promise<string> {
 		return new Promise(r => this._onRequestDefaultShell.fire(r));
+	}
+
+	public getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }> {
+		return new Promise(r => this._onRequestDefaultShellAndArgs.fire((shell, args) => r({ shell, args })));
 	}
 
 	public async getMainProcessParentEnv(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -18,8 +18,6 @@ let SearchAddon: typeof XTermSearchAddon;
 export class TerminalInstanceService implements ITerminalInstanceService {
 	public _serviceBrand: any;
 
-	private readonly _onRequestDefaultShell = new Emitter<(defaultShell: string) => void>();
-	public get onRequestDefaultShell(): Event<(defaultShell: string) => void> { return this._onRequestDefaultShell.event; }
 	private readonly _onRequestDefaultShellAndArgs = new Emitter<IDefaultShellAndArgsRequest>();
 	public get onRequestDefaultShellAndArgs(): Event<IDefaultShellAndArgsRequest> { return this._onRequestDefaultShellAndArgs.event; }
 
@@ -52,10 +50,6 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	public createTerminalProcess(): ITerminalChildProcess {
 		throw new Error('Not implemented');
-	}
-
-	public getDefaultShell(): Promise<string> {
-		return new Promise(r => this._onRequestDefaultShell.fire(r));
 	}
 
 	public getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -9,6 +9,7 @@ import { Terminal as XTermTerminal } from 'xterm';
 import { WebLinksAddon as XTermWebLinksAddon } from 'xterm-addon-web-links';
 import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
 import { IProcessEnvironment } from 'vs/base/common/platform';
+import { Emitter, Event } from 'vs/base/common/event';
 
 let Terminal: typeof XTermTerminal;
 let WebLinksAddon: typeof XTermWebLinksAddon;
@@ -16,6 +17,9 @@ let SearchAddon: typeof XTermSearchAddon;
 
 export class TerminalInstanceService implements ITerminalInstanceService {
 	public _serviceBrand: any;
+
+	private readonly _onRequestDefaultShell = new Emitter<(defaultShell: string) => void>();
+	public get onRequestDefaultShell(): Event<(defaultShell: string) => void> { return this._onRequestDefaultShell.event; }
 
 	constructor() { }
 
@@ -48,8 +52,8 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 		throw new Error('Not implemented');
 	}
 
-	public getDefaultShell(): string {
-		throw new Error('Not implemented');
+	public getDefaultShell(): Promise<string> {
+		return new Promise(r => this._onRequestDefaultShell.fire(r));
 	}
 
 	public async getMainProcessParentEnv(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -163,7 +163,9 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 
 	private async _launchProcess(shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number): Promise<ITerminalChildProcess> {
 		if (!shellLaunchConfig.executable) {
-			this._terminalInstanceService.mergeDefaultShellPathAndArgs(shellLaunchConfig, await this._terminalInstanceService.getDefaultShell(), this._configHelper);
+			const defaultConfig = await this._terminalInstanceService.getDefaultShellAndArgs();
+			shellLaunchConfig.executable = defaultConfig.shell;
+			shellLaunchConfig.args = defaultConfig.args;
 		}
 
 		const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot(Schemas.file);

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -163,7 +163,7 @@ export class TerminalProcessManager implements ITerminalProcessManager {
 
 	private async _launchProcess(shellLaunchConfig: IShellLaunchConfig, cols: number, rows: number): Promise<ITerminalChildProcess> {
 		if (!shellLaunchConfig.executable) {
-			this._terminalInstanceService.mergeDefaultShellPathAndArgs(shellLaunchConfig, this._terminalInstanceService.getDefaultShell(platform.platform), this._configHelper);
+			this._terminalInstanceService.mergeDefaultShellPathAndArgs(shellLaunchConfig, await this._terminalInstanceService.getDefaultShell(), this._configHelper);
 		}
 
 		const activeWorkspaceRootUri = this._historyService.getLastActiveWorkspaceRoot(Schemas.file);

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -790,3 +790,7 @@ export interface ITerminalChildProcess {
 	getCwd(): Promise<string>;
 	getLatency(): Promise<number>;
 }
+
+export interface IDefaultShellAndArgsRequest {
+	(shell: string, args: string[] | string | undefined): void;
+}

--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -203,20 +203,6 @@ export function getDefaultShellArgs(
 	return args;
 }
 
-// TODO: Remove this?
-export function mergeDefaultShellPathAndArgs(
-	shell: IShellLaunchConfig,
-	fetchSetting: (key: string) => { user: string | string[] | undefined, value: string | string[] | undefined, default: string | string[] | undefined },
-	isWorkspaceShellAllowed: boolean,
-	defaultShell: string,
-	isWoW64: boolean,
-	windir: string | undefined,
-	platformOverride: platform.Platform = platform.platform
-): void {
-	shell.executable = getDefaultShell(fetchSetting, isWorkspaceShellAllowed, defaultShell, isWoW64, windir, platformOverride);
-	shell.args = getDefaultShellArgs(fetchSetting, isWorkspaceShellAllowed, platformOverride);
-}
-
 export function createTerminalEnvironment(
 	shellLaunchConfig: IShellLaunchConfig,
 	lastActiveWorkspace: IWorkspaceFolder | null,

--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -192,7 +192,7 @@ export function getDefaultShell(
 	return executable;
 }
 
-function getDefaultShellArgs(
+export function getDefaultShellArgs(
 	fetchSetting: (key: string) => { user: string | string[] | undefined, value: string | string[] | undefined, default: string | string[] | undefined },
 	isWorkspaceShellAllowed: boolean,
 	platformOverride: platform.Platform = platform.platform
@@ -203,6 +203,7 @@ function getDefaultShellArgs(
 	return args;
 }
 
+// TODO: Remove this?
 export function mergeDefaultShellPathAndArgs(
 	shell: IShellLaunchConfig,
 	fetchSetting: (key: string) => { user: string | string[] | undefined, value: string | string[] | undefined, default: string | string[] | undefined },

--- a/src/vs/workbench/contrib/terminal/common/terminalShellConfig.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalShellConfig.ts
@@ -8,7 +8,7 @@ import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/co
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Platform } from 'vs/base/common/platform';
 
-export function registerShellConfiguration(getDefaultShell?: (p: Platform) => string): void {
+export function registerShellConfiguration(getSystemShell?: (p: Platform) => string): void {
 	const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
 	configurationRegistry.registerConfiguration({
 		id: 'terminal',
@@ -18,24 +18,24 @@ export function registerShellConfiguration(getDefaultShell?: (p: Platform) => st
 		properties: {
 			'terminal.integrated.shell.linux': {
 				markdownDescription:
-					getDefaultShell
-						? nls.localize('terminal.integrated.shell.linux', "The path of the shell that the terminal uses on Linux (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getDefaultShell(Platform.Linux))
+					getSystemShell
+						? nls.localize('terminal.integrated.shell.linux', "The path of the shell that the terminal uses on Linux (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getSystemShell(Platform.Linux))
 						: nls.localize('terminal.integrated.shell.linux.noDefault', "The path of the shell that the terminal uses on Linux. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
 				type: ['string', 'null'],
 				default: null
 			},
 			'terminal.integrated.shell.osx': {
 				markdownDescription:
-					getDefaultShell
-						? nls.localize('terminal.integrated.shell.osx', "The path of the shell that the terminal uses on macOS (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getDefaultShell(Platform.Mac))
+					getSystemShell
+						? nls.localize('terminal.integrated.shell.osx', "The path of the shell that the terminal uses on macOS (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getSystemShell(Platform.Mac))
 						: nls.localize('terminal.integrated.shell.osx.noDefault', "The path of the shell that the terminal uses on macOS. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
 				type: ['string', 'null'],
 				default: null
 			},
 			'terminal.integrated.shell.windows': {
 				markdownDescription:
-					getDefaultShell
-						? nls.localize('terminal.integrated.shell.windows', "The path of the shell that the terminal uses on Windows (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getDefaultShell(Platform.Windows))
+					getSystemShell
+						? nls.localize('terminal.integrated.shell.windows', "The path of the shell that the terminal uses on Windows (default: {0}). [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration).", getSystemShell(Platform.Windows))
 						: nls.localize('terminal.integrated.shell.windows.noDefault', "The path of the shell that the terminal uses on Windows. [Read more about configuring the shell](https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration)."),
 				type: ['string', 'null'],
 				default: null

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminal.contribution.ts
@@ -6,11 +6,11 @@
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { TerminalInstanceService } from 'vs/workbench/contrib/terminal/electron-browser/terminalInstanceService';
-import { getDefaultShell } from 'vs/workbench/contrib/terminal/node/terminal';
+import { getSystemShell } from 'vs/workbench/contrib/terminal/node/terminal';
 import { registerShellConfiguration } from 'vs/workbench/contrib/terminal/common/terminalShellConfig';
 import { TerminalNativeService } from 'vs/workbench/contrib/terminal/electron-browser/terminalNativeService';
 import { ITerminalNativeService } from 'vs/workbench/contrib/terminal/common/terminal';
 
-registerShellConfiguration(getDefaultShell);
+registerShellConfiguration(getSystemShell);
 registerSingleton(ITerminalNativeService, TerminalNativeService, true);
 registerSingleton(ITerminalInstanceService, TerminalInstanceService, true);

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -75,12 +75,6 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 		);
 	}
 
-	public getDefaultShell(): Promise<string> {
-		// Don't go via ext host as that would delay terminal start up until after the extension
-		// host is ready.
-		return Promise.resolve(getSystemShell(platform));
-	}
-
 	public getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }> {
 		// TODO: Pull the workspace shell permissions setting
 		const isWorkspaceShellAllowed = false; // configHelper.checkWorkspaceShellPermissions(platform);

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
-import { ITerminalInstance, IWindowsShellHelper, IShellLaunchConfig, ITerminalChildProcess, ITerminalConfigHelper, IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY } from 'vs/workbench/contrib/terminal/common/terminal';
+import { ITerminalInstance, IWindowsShellHelper, IShellLaunchConfig, ITerminalChildProcess, IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY } from 'vs/workbench/contrib/terminal/common/terminal';
 import { WindowsShellHelper } from 'vs/workbench/contrib/terminal/node/windowsShellHelper';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IProcessEnvironment, Platform, isLinux, isMacintosh, isWindows, OperatingSystem, platform } from 'vs/base/common/platform';
+import { IProcessEnvironment, isLinux, isMacintosh, isWindows, platform } from 'vs/base/common/platform';
 import { TerminalProcess } from 'vs/workbench/contrib/terminal/node/terminalProcess';
 import { getSystemShell } from 'vs/workbench/contrib/terminal/node/terminal';
 import { Terminal as XTermTerminal } from 'xterm';
@@ -16,7 +16,7 @@ import { SearchAddon as XTermSearchAddon } from 'xterm-addon-search';
 import { readFile } from 'vs/base/node/pfs';
 import { basename } from 'vs/base/common/path';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { mergeDefaultShellPathAndArgs, getDefaultShell, getDefaultShellArgs } from 'vs/workbench/contrib/terminal/common/terminalEnvironment';
+import { getDefaultShell, getDefaultShellArgs } from 'vs/workbench/contrib/terminal/common/terminalEnvironment';
 import { StorageScope, IStorageService } from 'vs/platform/storage/common/storage';
 
 let Terminal: typeof XTermTerminal;
@@ -66,19 +66,6 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	private _isWorkspaceShellAllowed(): boolean {
 		return this._storageService.getBoolean(IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY, StorageScope.WORKSPACE, false);
-	}
-
-	public mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride: Platform = platform): void {
-		const isWorkspaceShellAllowed = configHelper.checkWorkspaceShellPermissions(platformOverride === Platform.Windows ? OperatingSystem.Windows : (platformOverride === Platform.Mac ? OperatingSystem.Macintosh : OperatingSystem.Linux));
-		mergeDefaultShellPathAndArgs(
-			shell,
-			(key) => this._configurationService.inspect(key),
-			isWorkspaceShellAllowed,
-			defaultShell,
-			process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432'),
-			process.env.windir,
-			platformOverride
-		);
 	}
 
 	public getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }> {

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -62,10 +62,6 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 		return this._instantiationService.createInstance(TerminalProcess, shellLaunchConfig, cwd, cols, rows, env, windowsEnableConpty);
 	}
 
-	public getDefaultShell(p: Platform): string {
-		return getDefaultShell(p);
-	}
-
 	public mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride: Platform = platform): void {
 		const isWorkspaceShellAllowed = configHelper.checkWorkspaceShellPermissions(platformOverride === Platform.Windows ? OperatingSystem.Windows : (platformOverride === Platform.Mac ? OperatingSystem.Macintosh : OperatingSystem.Linux));
 		mergeDefaultShellPathAndArgs(
@@ -77,6 +73,12 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 			process.env.windir,
 			platformOverride
 		);
+	}
+
+	public getDefaultShell(): Promise<string> {
+		// Don't go via ext host as that would delay terminal start up until after the extension
+		// host is ready.
+		return Promise.resolve(getDefaultShell(platform));
 	}
 
 	public async getMainProcessParentEnv(): Promise<IProcessEnvironment> {

--- a/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-browser/terminalInstanceService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
-import { ITerminalInstance, IWindowsShellHelper, IShellLaunchConfig, ITerminalChildProcess, ITerminalConfigHelper } from 'vs/workbench/contrib/terminal/common/terminal';
+import { ITerminalInstance, IWindowsShellHelper, IShellLaunchConfig, ITerminalChildProcess, ITerminalConfigHelper, IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY } from 'vs/workbench/contrib/terminal/common/terminal';
 import { WindowsShellHelper } from 'vs/workbench/contrib/terminal/node/windowsShellHelper';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IProcessEnvironment, Platform, isLinux, isMacintosh, isWindows, OperatingSystem, platform } from 'vs/base/common/platform';
@@ -17,6 +17,7 @@ import { readFile } from 'vs/base/node/pfs';
 import { basename } from 'vs/base/common/path';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { mergeDefaultShellPathAndArgs, getDefaultShell, getDefaultShellArgs } from 'vs/workbench/contrib/terminal/common/terminalEnvironment';
+import { StorageScope, IStorageService } from 'vs/platform/storage/common/storage';
 
 let Terminal: typeof XTermTerminal;
 let WebLinksAddon: typeof XTermWebLinksAddon;
@@ -29,7 +30,8 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 
 	constructor(
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IStorageService private readonly _storageService: IStorageService
 	) {
 	}
 
@@ -62,6 +64,10 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 		return this._instantiationService.createInstance(TerminalProcess, shellLaunchConfig, cwd, cols, rows, env, windowsEnableConpty);
 	}
 
+	private _isWorkspaceShellAllowed(): boolean {
+		return this._storageService.getBoolean(IS_WORKSPACE_SHELL_ALLOWED_STORAGE_KEY, StorageScope.WORKSPACE, false);
+	}
+
 	public mergeDefaultShellPathAndArgs(shell: IShellLaunchConfig, defaultShell: string, configHelper: ITerminalConfigHelper, platformOverride: Platform = platform): void {
 		const isWorkspaceShellAllowed = configHelper.checkWorkspaceShellPermissions(platformOverride === Platform.Windows ? OperatingSystem.Windows : (platformOverride === Platform.Mac ? OperatingSystem.Macintosh : OperatingSystem.Linux));
 		mergeDefaultShellPathAndArgs(
@@ -76,8 +82,7 @@ export class TerminalInstanceService implements ITerminalInstanceService {
 	}
 
 	public getDefaultShellAndArgs(): Promise<{ shell: string, args: string[] | string | undefined }> {
-		// TODO: Pull the workspace shell permissions setting
-		const isWorkspaceShellAllowed = false; // configHelper.checkWorkspaceShellPermissions(platform);
+		const isWorkspaceShellAllowed = this._isWorkspaceShellAllowed();
 		const shell = getDefaultShell(
 			(key) => this._configurationService.inspect(key),
 			isWorkspaceShellAllowed,

--- a/src/vs/workbench/contrib/terminal/node/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminal.ts
@@ -11,10 +11,15 @@ import { LinuxDistro, IShellDefinition } from 'vs/workbench/contrib/terminal/com
 import { coalesce } from 'vs/base/common/arrays';
 import { normalize, basename } from 'vs/base/common/path';
 
-export function getDefaultShell(p: platform.Platform): string {
+/**
+ * Gets the detected default shell for the _system_, not to be confused with VS Code's _default_
+ * shell that the terminal uses by default.
+ * @param p The platform to detect the shell of.
+ */
+export function getSystemShell(p: platform.Platform): string {
 	if (p === platform.Platform.Windows) {
 		if (platform.isWindows) {
-			return getTerminalDefaultShellWindows();
+			return getSystemShellWindows();
 		}
 		// Don't detect Windows shell when not on Windows
 		return processes.getWindowsShell();
@@ -23,11 +28,11 @@ export function getDefaultShell(p: platform.Platform): string {
 	if (platform.isLinux && p === platform.Platform.Mac || platform.isMacintosh && p === platform.Platform.Linux) {
 		return '/bin/bash';
 	}
-	return getTerminalDefaultShellUnixLike();
+	return getSystemShellUnixLike();
 }
 
 let _TERMINAL_DEFAULT_SHELL_UNIX_LIKE: string | null = null;
-function getTerminalDefaultShellUnixLike(): string {
+function getSystemShellUnixLike(): string {
 	if (!_TERMINAL_DEFAULT_SHELL_UNIX_LIKE) {
 		let unixLikeTerminal = 'sh';
 		if (!platform.isWindows && process.env.SHELL) {
@@ -46,7 +51,7 @@ function getTerminalDefaultShellUnixLike(): string {
 }
 
 let _TERMINAL_DEFAULT_SHELL_WINDOWS: string | null = null;
-function getTerminalDefaultShellWindows(): string {
+function getSystemShellWindows(): string {
 	if (!_TERMINAL_DEFAULT_SHELL_WINDOWS) {
 		const isAtLeastWindows10 = platform.isWindows && parseFloat(os.release()) >= 10;
 		const is32ProcessOn64Windows = process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432');

--- a/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -35,10 +35,6 @@ class MockTerminalInstanceService implements ITerminalInstanceService {
 	getDefaultShellAndArgs(): Promise<{ shell: string; args: string | string[] | undefined; }> {
 		throw new Error('Method not implemented.');
 	}
-	onRequestDefaultShell: any;
-	getDefaultShell(): Promise<string> {
-		throw new Error('Method not implemented.');
-	}
 	mergeDefaultShellPathAndArgs(): void {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -35,9 +35,6 @@ class MockTerminalInstanceService implements ITerminalInstanceService {
 	getDefaultShellAndArgs(): Promise<{ shell: string; args: string | string[] | undefined; }> {
 		throw new Error('Method not implemented.');
 	}
-	mergeDefaultShellPathAndArgs(): void {
-		throw new Error('Method not implemented.');
-	}
 	_serviceBrand: any;
 	getXtermConstructor(): Promise<any> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -8,6 +8,7 @@ import { OperatingSystem } from 'vs/base/common/platform';
 import { TerminalLinkHandler, LineColumnInfo } from 'vs/workbench/contrib/terminal/browser/terminalLinkHandler';
 import * as strings from 'vs/base/common/strings';
 import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { Event } from 'vs/base/common/event';
 
 class TestTerminalLinkHandler extends TerminalLinkHandler {
 	public get localLinkRegex(): RegExp {
@@ -30,6 +31,10 @@ class TestXterm {
 }
 
 class MockTerminalInstanceService implements ITerminalInstanceService {
+	onRequestDefaultShellAndArgs?: Event<any> | undefined;
+	getDefaultShellAndArgs(): Promise<{ shell: string; args: string | string[] | undefined; }> {
+		throw new Error('Method not implemented.');
+	}
 	onRequestDefaultShell: any;
 	getDefaultShell(): Promise<string> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/electron-browser/terminalLinkHandler.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Platform, OperatingSystem } from 'vs/base/common/platform';
+import { OperatingSystem } from 'vs/base/common/platform';
 import { TerminalLinkHandler, LineColumnInfo } from 'vs/workbench/contrib/terminal/browser/terminalLinkHandler';
 import * as strings from 'vs/base/common/strings';
 import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/terminal';
@@ -30,6 +30,10 @@ class TestXterm {
 }
 
 class MockTerminalInstanceService implements ITerminalInstanceService {
+	onRequestDefaultShell: any;
+	getDefaultShell(): Promise<string> {
+		throw new Error('Method not implemented.');
+	}
 	mergeDefaultShellPathAndArgs(): void {
 		throw new Error('Method not implemented.');
 	}
@@ -47,9 +51,6 @@ class MockTerminalInstanceService implements ITerminalInstanceService {
 		throw new Error('Method not implemented.');
 	}
 	createTerminalProcess(): any {
-		throw new Error('Method not implemented.');
-	}
-	getDefaultShell(p: Platform): string {
 		throw new Error('Method not implemented.');
 	}
 	getMainProcessParentEnv(): any {


### PR DESCRIPTION
All consumers of these calls wanted both shell and args, so instead of having both, move to a more simpler approach that just requested the defaults. There are 3 ways that shell and args can now be fetched:

- Local: `electron-browser/ITerminalInstanceService` calls directly (we don't want to move this to ext host as that would delay the first terminal creation until after the ext host is up)
- Web: `browser/ITerminalInstanceService` proxies the call to the ext host
- Remote: `ExtHostTerminalService` calls directly when the process is being created on the ext host

This also renames `getDefaultShell` in node/terminal.ts to `getSystemShell` in order to differentiate the system shell (detected system default) with the default shell (default for vscode, based on settings + system).

Fixes #75795