### PR TITLE
remove trailing '/' from repo url for baseFolderName

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -339,7 +339,7 @@ export class Git {
 	}
 
 	async clone(url: string, parentPath: string, cancellationToken?: CancellationToken): Promise<string> {
-		let baseFolderName = decodeURI(url).replace(/^.*\//, '').replace(/\.git$/, '') || 'repository';
+		let baseFolderName = decodeURI(url).replace(/[\/]+$/, '').replace(/^.*\//, '').replace(/\.git$/, '') || 'repository';
 		let folderName = baseFolderName;
 		let folderPath = path.join(parentPath, folderName);
 		let count = 1;


### PR DESCRIPTION
Fixes #75574 

**Problem:**

When using the `git clone` command, if a given repository URL has a trailing '/', the repository baseFolder name would get set to default ("repository"). In determining the folder name, a series of regex replaces is done to remove all but the repository name from the URL. If the trailing '/' is present, the first replace will remove the entire string, thus defaulting the folder name.

**Solution:**

Remove all trailing '/' before we do the other regex removals. This ensures we get a repository name for valid repository URLs that have a trailing '/'.