### PR TITLE
Change default openFoldersInNewWindow to on

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -315,7 +315,7 @@ import { isMacintosh, isWindows, isLinux, isWeb } from 'vs/base/common/platform'
 					nls.localize('window.openFoldersInNewWindow.off', "Folders will replace the last active window."),
 					nls.localize('window.openFoldersInNewWindow.default', "Folders will open in a new window unless a folder is picked from within the application (e.g. via the File menu).")
 				],
-				'default': 'default',
+				'default': isWeb ? 'on' : 'default',
 				'scope': ConfigurationScope.APPLICATION,
 				'markdownDescription': nls.localize('openFoldersInNewWindow', "Controls whether folders should open in a new window or replace the last active window.\nNote that there can still be cases where this setting is ignored (e.g. when using the `--new-window` or `--reuse-window` command line option).")
 			}


### PR DESCRIPTION
Follow up from https://github.com/microsoft/vscode/pull/75804

It's a bit weird to change the default to "on" when there is a "default" value, but the other options are also not ideal:

- Remove "default" in web, this would give warnings for settings files shared across machines
- Change "default"'s descriptions and behavior to "on" on web, this would make it behave exactly the same