### PR TITLE
Add scopes for cpptools colorization, to light_vs and dark_vs

### DIFF
--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -291,6 +291,7 @@
 		{
 			"scope": [
 				"keyword.operator.new",
+				"keyword.operator.delete.cpp",
 				"keyword.operator.expression",
 				"keyword.operator.cast",
 				"keyword.operator.sizeof",
@@ -347,108 +348,221 @@
 			}
 		},
 		{
-			"scope": "entity.name.function.preprocessor",
+			"scope": [
+				"entity.name.function.preprocessor.cpp",
+				"entity.name.function.preprocessor.c"
+			],
 			"settings": {
 				"foreground": "#BD63C5"
 			}
 		},
 		{
-			"scope": "variable.other.enummember",
+			"scope": [
+				"variable.other.enummember.cpp",
+				"variable.other.enummember.c"
+			],
 			"settings": {
 				"foreground": "#B8D7A3"
 			}
 		},
 		{
-			"scope":"variable.parameter",
+			"scope": [
+				"variable.parameter.cpp",
+				"variable.parameter.c"
+			],
 			"settings": {
 				"foreground": "#7F7F7F"
 			}
 		},
 		{
 			"scope": [
-				"entity.name.type",
-				"entity.name.class"
+				"entity.name.class.reference.cpp",
+				"entity.name.class.reference.c"
 			],
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": "entity.name.class.reference",
+			"scope": [
+				"entity.name.class.value.cpp",
+				"entity.name.class.value.c"
+			],
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": "entity.name.class.value",
-			"settings": {
-				"foreground": "#4EC9B0"
-			}
-		},
-		{
-			"scope": "entity.name.function",
-			"settings": {
-				"foreground": "#C8C8C8"
-			}
-		},
-		{
-			"scope": "variable.other.member",
+			"scope": [
+				"variable.other.member.cpp",
+				"variable.other.member.c"
+			],
 			"settings": {
 				"foreground": "#DADADA"
 			}
 		},
 		{
-			"scope": "variable.other.event",
+			"scope": [
+				"variable.other.event.cpp",
+				"variable.other.event.c"
+			],
 			"settings": {
 				"foreground": "#C8C8C8"
 			}
 		},
 		{
-			"scope": "entity.name.class.template",
+			"scope": [
+				"entity.name.class.template.cpp",
+				"entity.name.class.template.c"
+			],
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": "entity.name.class.generic",
+			"scope": [
+				"entity.name.class.generic.cpp",
+				"entity.name.class.generic.c"
+			],
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": "entity.name.type.namespace",
+			"scope": [
+				"entity.name.type.namespace.cpp",
+				"entity.name.type.namespace.c"
+			],
 			"settings": {
 				"foreground": "#c8c8c8"
 			}
 		},
 		{
-			"scope": "entity.name.label",
+			"scope": [
+				"entity.name.label.cpp",
+				"entity.name.label.c"
+			],
 			"settings": {
 				"foreground": "#c8c8c8"
 			}
 		},
 		{
-			"scope": "entity.name.user-defined-literal",
+			"scope": [
+				"entity.name.user-defined-literal.cpp",
+				"entity.name.user-defined-literal.c"
+			],
 			"settings": {
 				"foreground": "#DADADA"
 			}
 		},
 		{
-			"scope": "entity.name.user-defined-literal.string",
+			"scope": [
+				"entity.name.user-defined-literal.string.cpp",
+				"entity.name.user-defined-literal.string.c"
+			],
 			"settings": {
 				"foreground": "#D69D85"
 			}
 		},
 		{
-			"scope": "entity.name.user-defined-literal.number",
+			"scope": [
+				"entity.name.user-defined-literal.number.cpp",
+				"entity.name.user-defined-literal.number.c"
+			],
 			"settings": {
 				"foreground": "#B5CEA8"
 			}
 		},
 		{
-			"scope": "entity.name.function.operator",
+			"scope": [
+				"entity.name.function.operator.cpp",
+				"entity.name.function.operator.c"
+			],
 			"settings": {
 				"foreground": "#B4B4B4"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.member.cpp",
+				"keyword.operator.member.c"
+			],
+			"settings": {
+				"foreground": "#B4B4B4"
+			}
+		},
+		{
+			"scope": [
+				"keyword.control.directive.conditional.cpp",
+				"keyword.control.directive.conditional.c",
+				"keyword.control.directive.define.cpp",
+				"keyword.control.directive.define.c",
+				"keyword.control.directive.line.cpp",
+				"keyword.control.directive.line.c",
+				"keyword.control.directive.pragma.cpp",
+				"keyword.control.directive.pragma.c",
+				"keyword.control.directive.pragma.pragma-mark.cpp",
+				"keyword.control.directive.pragma.pragma-mark.c",
+				"keyword.control.directive.undef.cpp",
+				"keyword.control.directive.undef.c",
+				"keyword.control.directive.include.cpp",
+				"keyword.control.directive.include.c"
+			],
+			"settings": {
+				"foreground": "#9B9B9B"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.type.cpp",
+				"entity.name.type.c",
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"comment.block.cpp",
+				"comment.block.c",
+				"comment.line.banner.cpp",
+				"comment.line.banner.c",
+				"comment.line.double-slash.cpp",
+				"comment.line.double-slash.c"
+			],
+			"settings": {
+				"foreground": "#57A64A"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.cpp",
+				"keyword.operator.c"
+			],
+			"settings": {
+				"foreground": "#B4B4B4"
+			}
+		},
+		{
+			"scope": [
+				"variable.cpp",
+				"variable.c"
+			],
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		},
+		{
+			"scope": [
+				"string.quoted.double.cpp",
+				"string.quoted.double.include.cpp",
+				"string.quoted.double.raw.cpp",
+				"string.quoted.other.lt-gt.include.cpp",
+				"string.quoted.single.cpp",
+				"string.unquoted.single.cpp"
+			],
+			"settings": {
+				"foreground": "#D69D85"
 			}
 		}
 	]

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -33,7 +33,7 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#57A64A"
+				"foreground": "#6A9955"
 			}
 		},
 		{
@@ -285,7 +285,7 @@
 		{
 			"scope": "keyword.operator",
 			"settings": {
-				"foreground": "#B4B4B4"
+				"foreground": "#d4d4d4"
 			}
 		},
 		{

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -347,30 +347,6 @@
 			}
 		},
 		{
-			"scope": "keyword.control.directive",
-			"settings": {
-				"foreground": "#9B9B9B"
-			}
-		},
-		{
-			"scope": "variable",
-			"settings": {
-				"foreground": "#C8C8C8"
-			}
-		},
-		{
-			"scope": "string.quoted",
-			"settings": {
-				"foreground": "#D69D85"
-			}
-		},
-		{
-			"scope": "comment.xml.doc",
-			"settings": {
-				"foreground": "#57A64A"
-			}
-		},
-		{
 			"scope": "entity.name.function.preprocessor",
 			"settings": {
 				"foreground": "#BD63C5"

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -33,15 +33,6 @@
 		{
 			"scope": "comment",
 			"settings": {
-				"foreground": "#6A9955"
-			}
-		},
-		{
-			"scope": [
-				"comment.cpp",
-				"comment.c"
-			],
-			"settings": {
 				"foreground": "#57A64A"
 			}
 		},
@@ -294,15 +285,6 @@
 		{
 			"scope": "keyword.operator",
 			"settings": {
-				"foreground": "#d4d4d4"
-			}
-		},
-		{
-			"scope": [
-				"keyword.operator.cpp",
-				"keyword.operator.c"
-			],
-			"settings": {
 				"foreground": "#B4B4B4"
 			}
 		},
@@ -365,190 +347,130 @@
 			}
 		},
 		{
-			"scope": [
-				"keyword.control.directive.cpp",
-				"keyword.control.directive.c"
-			],
+			"scope": "keyword.control.directive",
 			"settings": {
 				"foreground": "#9B9B9B"
 			}
 		},
 		{
-			"scope": [
-				"variable.cpp",
-				"variable.c"
-			],
+			"scope": "variable",
 			"settings": {
 				"foreground": "#C8C8C8"
 			}
 		},
 		{
-			"scope": [
-				"string.quoted.cpp",
-				"string-quoted.c"
-			],
+			"scope": "string.quoted",
 			"settings": {
 				"foreground": "#D69D85"
 			}
 		},
 		{
-			"scope": [
-				"comment.xml.doc.cpp",
-				"comment.xml.doc.c"
-			],
+			"scope": "comment.xml.doc",
 			"settings": {
 				"foreground": "#57A64A"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.function.preprocessor.cpp",
-				"entity.name.function.preprocessor.c"
-			],
+			"scope": "entity.name.function.preprocessor",
 			"settings": {
 				"foreground": "#BD63C5"
 			}
 		},
 		{
-			"scope": [
-				"variable.other.enummember.cpp",
-				"variable.other.enummember.c"
-			],
+			"scope": "variable.other.enummember",
 			"settings": {
 				"foreground": "#B8D7A3"
 			}
 		},
 		{
-			"scope": [
-				"variable.parameter.cpp",
-				"variable.parameter.c"
-			],
+			"scope":"variable.parameter",
 			"settings": {
 				"foreground": "#7F7F7F"
 			}
 		},
 		{
 			"scope": [
-				"entity.name.type.cpp",
-				"entity.name.type.c"
+				"entity.name.type",
+				"entity.name.class"
 			],
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.reference.cpp",
-				"entity.name.class.reference.c"
-			],
+			"scope": "entity.name.class.reference",
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.value.cpp",
-				"entity.name.class.value.c"
-			],
+			"scope": "entity.name.class.value",
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.function.cpp",
-				"entity.name.function.c"
-			],
+			"scope": "entity.name.function",
 			"settings": {
 				"foreground": "#C8C8C8"
 			}
 		},
 		{
-			"scope": [
-				"variable.other.member.cpp",
-				"variable.other.member.c"
-			],
+			"scope": "variable.other.member",
 			"settings": {
 				"foreground": "#DADADA"
 			}
 		},
 		{
-			"scope": [
-				"variable.other.event.cpp",
-				"variable.other.event.c"
-			],
+			"scope": "variable.other.event",
 			"settings": {
 				"foreground": "#C8C8C8"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.template.cpp",
-				"entity.name.class.template.c"
-			],
+			"scope": "entity.name.class.template",
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.generic.cpp",
-				"entity.name.class.generic.c"
-			],
+			"scope": "entity.name.class.generic",
 			"settings": {
 				"foreground": "#4EC9B0"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.namespace.cpp",
-				"entity.name.namespace.c"
-			],
+			"scope": "entity.name.type.namespace",
 			"settings": {
 				"foreground": "#c8c8c8"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.label.cpp",
-				"entity.name.label.c"
-			],
+			"scope": "entity.name.label",
 			"settings": {
 				"foreground": "#c8c8c8"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.user-defined-literal.cpp",
-				"entity.name.user-defined-literal.c"
-			],
+			"scope": "entity.name.user-defined-literal",
 			"settings": {
 				"foreground": "#DADADA"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.user-defined-literal.string.cpp",
-				"entity.name.user-defined-literal.string.c"
-			],
+			"scope": "entity.name.user-defined-literal.string",
 			"settings": {
 				"foreground": "#D69D85"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.user-defined-literal.number.cpp",
-				"entity.name.user-defined-literal.number.c"
-			],
+			"scope": "entity.name.user-defined-literal.number",
 			"settings": {
 				"foreground": "#B5CEA8"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.function.operator.cpp",
-				"entity.name.function.operator.c"
-			],
+			"scope": "entity.name.function.operator",
 			"settings": {
 				"foreground": "#B4B4B4"
 			}

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -37,6 +37,15 @@
 			}
 		},
 		{
+			"scope": [
+				"comment.cpp",
+				"comment.c"
+			],
+			"settings": {
+				"foreground": "#57A64A"
+			}
+		},
+		{
 			"scope": "constant.language",
 			"settings": {
 				"foreground": "#569cd6"
@@ -290,6 +299,15 @@
 		},
 		{
 			"scope": [
+				"keyword.operator.cpp",
+				"keyword.operator.c"
+			],
+			"settings": {
+				"foreground": "#B4B4B4"
+			}
+		},
+		{
+			"scope": [
 				"keyword.operator.new",
 				"keyword.operator.expression",
 				"keyword.operator.cast",
@@ -344,6 +362,195 @@
 			"scope": "variable.language",
 			"settings": {
 				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"keyword.control.directive.cpp",
+				"keyword.control.directive.c"
+			],
+			"settings": {
+				"foreground": "#9B9B9B"
+			}
+		},
+		{
+			"scope": [
+				"variable.cpp",
+				"variable.c"
+			],
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		},
+		{
+			"scope": [
+				"string.quoted.cpp",
+				"string-quoted.c"
+			],
+			"settings": {
+				"foreground": "#D69D85"
+			}
+		},
+		{
+			"scope": [
+				"comment.xml.doc.cpp",
+				"comment.xml.doc.c"
+			],
+			"settings": {
+				"foreground": "#57A64A"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function.preprocessor.cpp",
+				"entity.name.function.preprocessor.c"
+			],
+			"settings": {
+				"foreground": "#BD63C5"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.enummember.cpp",
+				"variable.other.enummember.c"
+			],
+			"settings": {
+				"foreground": "#B8D7A3"
+			}
+		},
+		{
+			"scope": [
+				"variable.parameter.cpp",
+				"variable.parameter.c"
+			],
+			"settings": {
+				"foreground": "#7F7F7F"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.type.cpp",
+				"entity.name.type.c"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.reference.cpp",
+				"entity.name.class.reference.c"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.value.cpp",
+				"entity.name.class.value.c"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function.cpp",
+				"entity.name.function.c"
+			],
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.member.cpp",
+				"variable.other.member.c"
+			],
+			"settings": {
+				"foreground": "#DADADA"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.event.cpp",
+				"variable.other.event.c"
+			],
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.template.cpp",
+				"entity.name.class.template.c"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.generic.cpp",
+				"entity.name.class.generic.c"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.namespace.cpp",
+				"entity.name.namespace.c"
+			],
+			"settings": {
+				"foreground": "#c8c8c8"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.label.cpp",
+				"entity.name.label.c"
+			],
+			"settings": {
+				"foreground": "#c8c8c8"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.user-defined-literal.cpp",
+				"entity.name.user-defined-literal.c"
+			],
+			"settings": {
+				"foreground": "#DADADA"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.user-defined-literal.string.cpp",
+				"entity.name.user-defined-literal.string.c"
+			],
+			"settings": {
+				"foreground": "#D69D85"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.user-defined-literal.number.cpp",
+				"entity.name.user-defined-literal.number.c"
+			],
+			"settings": {
+				"foreground": "#B5CEA8"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function.operator.cpp",
+				"entity.name.function.operator.c"
+			],
+			"settings": {
+				"foreground": "#B4B4B4"
 			}
 		}
 	]

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -40,18 +40,7 @@
 			}
 		},
 		{
-			"scope": [
-				"constant.numeric"
-			],
-			"settings": {
-				"foreground": "#09885a"
-			}
-		},
-		{
-			"scope": [
-				"constant.numeric.cpp",
-				"constant.numeric.c"
-			],
+			"scope": "constant.numeric",
 			"settings": {
 				"foreground": "#000000"
 			}
@@ -377,208 +366,139 @@
 			}
 		},
 		{
-			"scope": [
-				"keyword.control.directive.cpp",
-				"keyword.control.directive.c"
-			],
+			"scope": "keyword.control.directive",
 			"settings": {
 				"foreground": "#808080"
 			}
 		},
 		{
-			"scope": [
-				"variable.cpp",
-				"variable.c"
-			],
+			"scope": "variable",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"string.quoted.cpp",
-				"string.quoted.c"
-			],
+			"scope": "string.quoted",
 			"settings": {
 				"foreground": "#A31515"
 			}
 		},
 		{
-			"scope": [
-				"comment.xml.doc.cpp",
-				"comment.xml.doc.c"
-			],
+			"scope": "comment.xml.doc",
 			"settings": {
 				"foreground": "#006400"
 			}
 		},
 		{
-			"scope": [
-				"comment.xml.doc.tag.cpp",
-				"comment.xml.doc.tag.c"
-			],
+			"scope": "comment.xml.doc.tag",
 			"settings": {
 				"foreground": "#A9A9A9"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.function.preprocessor.cpp",
-				"entity.name.function.preprocessor.c"
-			],
+			"scope": "entity.name.function.preprocessor",
 			"settings": {
 				"foreground": "#6F0026"
 			}
 		},
 		{
-			"scope": [
-				"variable.other.enummember.cpp",
-				"variable.other.enummember.c"
-			],
+			"scope": "variable.other.enummember",
 			"settings": {
 				"foreground": "#2F4F4F"
 			}
 		},
 		{
-			"scope": [
-				"variable.parameter.cpp",
-				"variable.parameter.c"
-			],
+			"scope": "variable.parameter",
 			"settings": {
 				"foreground": "#808080"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.type.cpp",
-				"entity.name.type.c"
-			],
+			"scope": "entity.name.type",
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.reference.cpp",
-				"entity.name.class.reference.c"
-			],
+			"scope": "entity.name.class.reference",
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.value.cpp",
-				"entity.name.class.value.c"
-			],
+			"scope": "entity.name.class.value",
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.function.cpp",
-				"entity.name.function.c"
-			],
+			"scope": "entity.name.function",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"variable.other.member.cpp",
-				"variable.other.member.c"
-			],
+			"scope": "variable.other.member",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"variable.other.event.cpp",
-				"variable.other.event.c"
-			],
+			"scope": "variable.other.event",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.template.cpp",
-				"entity.name.class.template.c"
-			],
+			"scope": "entity.name.class.template",
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.class.generic.cpp",
-				"entity.name.class.generic.c"
-			],
+			"scope": "entity.name.class.generic",
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.namespace.cpp",
-				"entity.name.namespace.c"
-			],
+			"scope": "entity.name.type.namespace",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.label.cpp",
-				"entity.name.label.c"
-			],
+			"scope": "entity.name.label",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.user-defined-literal.cpp",
-				"entity.name.user-defined-literal.c"
-			],
+			"scope": "entity.name.user-defined-literal",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.user-defined-literal.string.cpp",
-				"entity.name.user-defined-literal.string.c"
-			],
+			"scope": "entity.name.user-defined-literal.string",
 			"settings": {
 				"foreground": "#A31515"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.user-defined-literal.number.cpp",
-				"entity.name.user-defined-literal.number.c"
-			],
+			"scope": "entity.name.user-defined-literal.number",
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": [
-				"entity.name.function.operator.cpp",
-				"entity.name.function.operator.c"
-			],
+			"scope": "entity.name.function.operator",
 			"settings": {
 				"foreground": "#008080"
 			}
 		},
 		{
-			"scope": [
-				"keyword.operator.member.cpp",
-				"keyword.operator.member.c"
-			],
+			"scope": "keyword.operator.member",
 			"settings": {
 				"foreground": "#008080"
 			}

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -366,36 +366,6 @@
 			}
 		},
 		{
-			"scope": "keyword.control.directive",
-			"settings": {
-				"foreground": "#808080"
-			}
-		},
-		{
-			"scope": "variable",
-			"settings": {
-				"foreground": "#000000"
-			}
-		},
-		{
-			"scope": "string.quoted",
-			"settings": {
-				"foreground": "#A31515"
-			}
-		},
-		{
-			"scope": "comment.xml.doc",
-			"settings": {
-				"foreground": "#006400"
-			}
-		},
-		{
-			"scope": "comment.xml.doc.tag",
-			"settings": {
-				"foreground": "#A9A9A9"
-			}
-		},
-		{
 			"scope": "entity.name.function.preprocessor",
 			"settings": {
 				"foreground": "#6F0026"

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -42,7 +42,7 @@
 		{
 			"scope": "constant.numeric",
 			"settings": {
-				"foreground": "#000000"
+				"foreground": "#09885a"
 			}
 		},
 		{

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -48,6 +48,15 @@
 			}
 		},
 		{
+			"scope": [
+				"constant.numeric.cpp",
+				"constant.numeric.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
 			"scope": "constant.regexp",
 			"settings": {
 				"foreground": "#811f3f"
@@ -365,6 +374,213 @@
 			"scope": "variable.language",
 			"settings": {
 				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"keyword.control.directive.cpp",
+				"keyword.control.directive.c"
+			],
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"variable.cpp",
+				"variable.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"string.quoted.cpp",
+				"string.quoted.c"
+			],
+			"settings": {
+				"foreground": "#A31515"
+			}
+		},
+		{
+			"scope": [
+				"comment.xml.doc.cpp",
+				"comment.xml.doc.c"
+			],
+			"settings": {
+				"foreground": "#006400"
+			}
+		},
+		{
+			"scope": [
+				"comment.xml.doc.tag.cpp",
+				"comment.xml.doc.tag.c"
+			],
+			"settings": {
+				"foreground": "#A9A9A9"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function.preprocessor.cpp",
+				"entity.name.function.preprocessor.c"
+			],
+			"settings": {
+				"foreground": "#6F0026"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.enummember.cpp",
+				"variable.other.enummember.c"
+			],
+			"settings": {
+				"foreground": "#2F4F4F"
+			}
+		},
+		{
+			"scope": [
+				"variable.parameter.cpp",
+				"variable.parameter.c"
+			],
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.type.cpp",
+				"entity.name.type.c"
+			],
+			"settings": {
+				"foreground": "#2B91AF"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.reference.cpp",
+				"entity.name.class.reference.c"
+			],
+			"settings": {
+				"foreground": "#2B91AF"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.value.cpp",
+				"entity.name.class.value.c"
+			],
+			"settings": {
+				"foreground": "#2B91AF"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function.cpp",
+				"entity.name.function.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.member.cpp",
+				"variable.other.member.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.event.cpp",
+				"variable.other.event.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.template.cpp",
+				"entity.name.class.template.c"
+			],
+			"settings": {
+				"foreground": "#2B91AF"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.generic.cpp",
+				"entity.name.class.generic.c"
+			],
+			"settings": {
+				"foreground": "#2B91AF"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.namespace.cpp",
+				"entity.name.namespace.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.label.cpp",
+				"entity.name.label.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.user-defined-literal.cpp",
+				"entity.name.user-defined-literal.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.user-defined-literal.string.cpp",
+				"entity.name.user-defined-literal.string.c"
+			],
+			"settings": {
+				"foreground": "#A31515"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.user-defined-literal.number.cpp",
+				"entity.name.user-defined-literal.number.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.function.operator.cpp",
+				"entity.name.function.operator.c"
+			],
+			"settings": {
+				"foreground": "#008080"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.member.cpp",
+				"keyword.operator.member.c"
+			],
+			"settings": {
+				"foreground": "#008080"
 			}
 		}
 	]

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -310,6 +310,7 @@
 		{
 			"scope": [
 				"keyword.operator.new",
+				"keyword.operator.delete.cpp",
 				"keyword.operator.expression",
 				"keyword.operator.cast",
 				"keyword.operator.sizeof",
@@ -366,111 +367,194 @@
 			}
 		},
 		{
-			"scope": "entity.name.function.preprocessor",
+			"scope": [
+				"entity.name.function.preprocessor.cpp",
+				"entity.name.function.preprocessor.c"
+			],
 			"settings": {
 				"foreground": "#6F0026"
 			}
 		},
 		{
-			"scope": "variable.other.enummember",
+			"scope": [
+				"variable.other.enummember.cpp",
+				"variable.other.enummember.c"
+			],
 			"settings": {
 				"foreground": "#2F4F4F"
 			}
 		},
 		{
-			"scope": "variable.parameter",
+			"scope": [
+				"variable.parameter.cpp",
+				"variable.parameter.c"
+			],
 			"settings": {
 				"foreground": "#808080"
 			}
 		},
 		{
-			"scope": "entity.name.type",
+			"scope": [
+				"entity.name.class.reference.cpp",
+				"entity.name.class.reference.c"
+			],
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": "entity.name.class.reference",
+			"scope": [
+				"entity.name.class.value.cpp",
+				"entity.name.class.value.c"
+			],
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": "entity.name.class.value",
+			"scope": [
+				"variable.other.member.cpp",
+				"variable.other.member.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"variable.other.event.cpp",
+				"variable.other.event.c"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.class.template.cpp",
+				"entity.name.class.template.c"
+			],
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": "entity.name.function",
-			"settings": {
-				"foreground": "#000000"
-			}
-		},
-		{
-			"scope": "variable.other.member",
-			"settings": {
-				"foreground": "#000000"
-			}
-		},
-		{
-			"scope": "variable.other.event",
-			"settings": {
-				"foreground": "#000000"
-			}
-		},
-		{
-			"scope": "entity.name.class.template",
+			"scope": [
+				"entity.name.class.generic.cpp",
+				"entity.name.class.generic.c"
+			],
 			"settings": {
 				"foreground": "#2B91AF"
 			}
 		},
 		{
-			"scope": "entity.name.class.generic",
-			"settings": {
-				"foreground": "#2B91AF"
-			}
-		},
-		{
-			"scope": "entity.name.type.namespace",
+			"scope": [
+				"entity.name.type.namespace.cpp",
+				"entity.name.type.namespace.c"
+			],
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": "entity.name.label",
+			"scope": [
+				"entity.name.label.cpp",
+				"entity.name.label.c"
+			],
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": "entity.name.user-defined-literal",
+			"scope": [
+				"entity.name.user-defined-literal.cpp",
+				"entity.name.user-defined-literal.c"
+			],
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": "entity.name.user-defined-literal.string",
+			"scope": [
+				"entity.name.user-defined-literal.string.cpp",
+				"entity.name.user-defined-literal.string.c"
+			],
 			"settings": {
 				"foreground": "#A31515"
 			}
 		},
 		{
-			"scope": "entity.name.user-defined-literal.number",
+			"scope": [
+				"entity.name.user-defined-literal.number.cpp",
+				"entity.name.user-defined-literal.number.c"
+			],
 			"settings": {
 				"foreground": "#000000"
 			}
 		},
 		{
-			"scope": "entity.name.function.operator",
+			"scope": [
+				"entity.name.function.operator.cpp",
+				"entity.name.function.operator.c"
+			],
 			"settings": {
 				"foreground": "#008080"
 			}
 		},
 		{
-			"scope": "keyword.operator.member",
+			"scope": [
+				"keyword.operator.member.cpp",
+				"keyword.operator.member.c"
+			],
 			"settings": {
 				"foreground": "#008080"
+			}
+		},
+		{
+			"scope": [
+				"keyword.control.directive.conditional.cpp",
+				"keyword.control.directive.conditional.c",
+				"keyword.control.directive.define.cpp",
+				"keyword.control.directive.define.c",
+				"keyword.control.directive.line.cpp",
+				"keyword.control.directive.line.c",
+				"keyword.control.directive.pragma.cpp",
+				"keyword.control.directive.pragma.c",
+				"keyword.control.directive.pragma.pragma-mark.cpp",
+				"keyword.control.directive.pragma.pragma-mark.c",
+				"keyword.control.directive.undef.cpp",
+				"keyword.control.directive.undef.c",
+				"keyword.control.directive.include.cpp",
+				"keyword.control.directive.include.c"
+			],
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.type.cpp",
+				"entity.name.type.c",
+			],
+			"settings": {
+				"foreground": "#2B91AF"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric.cpp",
+				"constant.numeric.c",
+				"constant.numeric.binary.cpp",
+				"constant.numeric.decimal.cpp",
+				"constant.numeric.decimal.point.cpp",
+				"constant.numeric.exponent.decimal.cpp",
+				"constant.numeric.exponent.hexadecimal.cpp",
+				"constant.numeric.hexadecimal.cpp",
+				"constant.numeric.octal.cpp",
+				"constant.numeric.preprocessor.cpp"
+			],
+			"settings": {
+				"foreground": "#000000"
 			}
 		}
 	]


### PR DESCRIPTION
We've added colorization to cpptools, using TextEditorDecorations.  We are leveraging the existing system for theming and customization.  A list of scopes we are using to retrieve color settings are here: https://github.com/microsoft/vscode-cpptools/blob/master/Documentation/LanguageServer/colorization.md

This PR is to add those scopes to the default VS Light and Dark themes.  The scopes are specifically for C and CPP, so should not affect other languages.  Scopes for the default TextMate grammar for C/CPP are limited, so very few of these will be applied if the cpptools extension is not present and enhancedColorization enabled.

I would be very interested in feedback regarding the scope names we have chosen.  As there are not strict guidelines for scope naming, these are a best effort to use appropriate names.  But, I would be interested in hearing from someone with more experience with TextMate scopes on whether these are the most appropriate names.

A list of all of the known issues we have encountered with attempting to do colorization this way, are here:

• VSCode: TextEditorDecoration applied to incorrect range if racing with user edit
https://github.com/microsoft/vscode/issues/74094
		
• VSCode: TextEditorDecorators should also be rendered in minimap
https://github.com/microsoft/vscode/issues/73140
		
• VSCode: Text selection highlight is not shown on decorations w/background colors
https://github.com/microsoft/vscode/issues/75642  
	
• VSCode: Option to not style rendered whitespace with TextEditorDecorationType 
https://github.com/microsoft/vscode/issues/49462

Related issues:
• VSCode: Provide an API for advanced/semantic source highlighting
https://github.com/microsoft/vscode/issues/585
	
• VSCode: Dynamic injection grammar contributions
https://github.com/Microsoft/vscode/issues/53885
We are overwriting the package.json instead, which requires a reload.
		
• VSCode: [theming] Access theme's colors programmatically
https://github.com/Microsoft/vscode/issues/32813
We are loading theme files, scanning token color and textMateRule override settings, and compositing cascaded styles, ourselves.
		
• Language-server-protocol: Support semantic highlighting
https://github.com/microsoft/language-server-protocol/issues/18

