### PR TITLE
Suppress MsgBox when Wizard is running in silent mode

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1034,7 +1034,7 @@ begin
       AltArch := '32';
     end;
 
-    if not Result then begin
+    if not Result and not WizardSilent() then begin
       MsgBox('Please uninstall the ' + AltArch + '-bit version of {#NameShort} before installing this ' + ThisArch + '-bit version.', mbInformation, MB_OK);
     end;
   end;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/75281

I have been able to reproduce the issue with both system and user installers of last stable version (1.35.1).

I have been testing building the setup binary with the fix and the bug is fixed. Following the steps in the issue with this fixes results with exit code 1 with no message boxes or dialogs (as expected, because other installation for other arch is installed).