### PR TITLE
Stop propagation on minimap slider

### DIFF
--- a/src/vs/editor/browser/viewParts/minimap/minimap.ts
+++ b/src/vs/editor/browser/viewParts/minimap/minimap.ts
@@ -527,6 +527,7 @@ export class Minimap extends ViewPart {
 
 		this._sliderMouseDownListener = dom.addStandardDisposableListener(this._slider.domNode, 'mousedown', (e) => {
 			e.preventDefault();
+			e.stopPropagation();
 			if (e.leftButton && this._lastRenderData) {
 
 				const initialMousePosition = e.posy;


### PR DESCRIPTION
When you click the slider in the minimal, the scroll position in VS Code should not change.