### PR TITLE
Fix 'unkown' typos

### DIFF
--- a/src/vs/workbench/api/node/extHostCLIServer.ts
+++ b/src/vs/workbench/api/node/extHostCLIServer.ts
@@ -81,7 +81,7 @@ export class CLIServer {
 					break;
 				default:
 					res.writeHead(404);
-					res.write(`Unkown message type: ${data.type}`, err => {
+					res.write(`Unknown message type: ${data.type}`, err => {
 						if (err) {
 							console.error(err);
 						}

--- a/src/vs/workbench/contrib/tasks/node/processRunnerDetector.ts
+++ b/src/vs/workbench/contrib/tasks/node/processRunnerDetector.ts
@@ -187,7 +187,7 @@ export class ProcessRunnerDetector {
 				} else if ('grunt' === detectSpecific) {
 					detectorPromise = this.tryDetectGrunt(this._workspaceRoot, list);
 				} else {
-					throw new Error('Unkown detector type');
+					throw new Error('Unknown detector type');
 				}
 				return detectorPromise.then((value) => {
 					if (value) {

--- a/src/vs/workbench/contrib/tasks/node/processTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/node/processTaskSystem.ts
@@ -437,7 +437,7 @@ export class ProcessTaskSystem implements ITaskSystem {
 				matcher = value;
 			}
 			if (!matcher) {
-				this.appendOutput(nls.localize('unkownProblemMatcher', 'Problem matcher {0} can\'t be resolved. The matcher will be ignored'));
+				this.appendOutput(nls.localize('unknownProblemMatcher', 'Problem matcher {0} can\'t be resolved. The matcher will be ignored'));
 				return;
 			}
 			if (!matcher.filePrefix) {


### PR DESCRIPTION
Because of this typo, the same localization string was duplicated:
* 'unkownProblemMatcher' referenced in processTaskSystem.ts
* 'unknownProblemMatcher' referenced in terminalTaskSystem.ts