### PR TITLE
Allow registering lazy editors in the registry

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebview.ts
@@ -9,21 +9,21 @@ import * as map from 'vs/base/common/map';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import * as modes from 'vs/editor/common/modes';
 import { localize } from 'vs/nls';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { ILifecycleService } from 'vs/platform/lifecycle/common/lifecycle';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IProductService } from 'vs/platform/product/common/product';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ExtHostContext, ExtHostWebviewsShape, IExtHostContext, MainContext, MainThreadWebviewsShape, WebviewPanelHandle, WebviewPanelShowOptions } from 'vs/workbench/api/common/extHost.protocol';
 import { editorGroupToViewColumn, EditorViewColumn, viewColumnToEditorGroup } from 'vs/workbench/api/common/shared/editor';
-import { WebviewEditor } from 'vs/workbench/contrib/webview/browser/webviewEditor';
 import { WebviewEditorInput } from 'vs/workbench/contrib/webview/browser/webviewEditorInput';
 import { ICreateWebViewShowOptions, IWebviewEditorService, WebviewInputOptions } from 'vs/workbench/contrib/webview/browser/webviewEditorService';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { ACTIVE_GROUP, IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { extHostNamedCustomer } from '../common/extHostCustomers';
-import { IProductService } from 'vs/platform/product/common/product';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+type WebviewEditor = import('vs/workbench/contrib/webview/browser/webviewEditor').WebviewEditor;
 
 @extHostNamedCustomer(MainContext.MainThreadWebviews)
 export class MainThreadWebviews extends Disposable implements MainThreadWebviewsShape {
@@ -160,7 +160,7 @@ export class MainThreadWebviews extends Disposable implements MainThreadWebviews
 	public async $postMessage(handle: WebviewPanelHandle, message: any): Promise<boolean> {
 		const webview = this.getWebview(handle);
 		const editors = this._editorService.visibleControls
-			.filter(e => e instanceof WebviewEditor)
+			.filter(e => (e as WebviewEditor).isWebviewEditor)
 			.map(e => e as WebviewEditor)
 			.filter(e => e.input!.matches(webview));
 

--- a/src/vs/workbench/browser/editor.ts
+++ b/src/vs/workbench/browser/editor.ts
@@ -11,7 +11,7 @@ import { IConstructorSignature0, IInstantiationService } from 'vs/platform/insta
 import { isArray } from 'vs/base/common/types';
 
 export interface IEditorDescriptor {
-	instantiate(instantiationService: IInstantiationService): BaseEditor;
+	instantiate(instantiationService: IInstantiationService): Promise<BaseEditor>;
 
 	getId(): string;
 	getName(): string;
@@ -54,18 +54,16 @@ export interface IEditorRegistry {
  * can load lazily in the workbench.
  */
 export class EditorDescriptor implements IEditorDescriptor {
-	private ctor: IConstructorSignature0<BaseEditor>;
 	private id: string;
 	private name: string;
 
-	constructor(ctor: IConstructorSignature0<BaseEditor>, id: string, name: string) {
-		this.ctor = ctor;
+	constructor(private readonly ctor: () => Promise<IConstructorSignature0<BaseEditor>>, id: string, name: string) {
 		this.id = id;
 		this.name = name;
 	}
 
-	instantiate(instantiationService: IInstantiationService): BaseEditor {
-		return instantiationService.createInstance(this.ctor);
+	async instantiate(instantiationService: IInstantiationService): Promise<BaseEditor> {
+		return instantiationService.createInstance(await this.ctor());
 	}
 
 	getId(): string {

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -55,7 +55,7 @@ import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 // Register String Editor
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		TextResourceEditor,
+		async () => TextResourceEditor,
 		TextResourceEditor.ID,
 		nls.localize('textEditor', "Text Editor"),
 	),
@@ -68,7 +68,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 // Register Text Diff Editor
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		TextDiffEditor,
+		async () => TextDiffEditor,
 		TextDiffEditor.ID,
 		nls.localize('textDiffEditor', "Text Diff Editor")
 	),
@@ -80,7 +80,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 // Register Binary Resource Diff Editor
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		BinaryResourceDiffEditor,
+		async () => BinaryResourceDiffEditor,
 		BinaryResourceDiffEditor.ID,
 		nls.localize('binaryDiffEditor', "Binary Diff Editor")
 	),
@@ -91,7 +91,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		SideBySideEditor,
+		async () => SideBySideEditor,
 		SideBySideEditor.ID,
 		nls.localize('sideBySideEditor', "Side by Side Editor")
 	),

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -65,14 +65,14 @@ export class EditorControl extends Disposable {
 		if (!descriptor) {
 			throw new Error('No editor descriptor found');
 		}
-		const control = this.doShowEditorControl(descriptor);
+		const control = await this.doShowEditorControl(descriptor);
 
 		// Set input
 		const editorChanged = await this.doSetInput(control, editor, withUndefinedAsNull(options));
 		return { control, editorChanged };
 	}
 
-	private doShowEditorControl(descriptor: IEditorDescriptor): BaseEditor {
+	private async doShowEditorControl(descriptor: IEditorDescriptor): Promise<BaseEditor> {
 
 		// Return early if the currently active editor control can handle the input
 		if (this._activeControl && descriptor.describes(this._activeControl)) {
@@ -83,7 +83,7 @@ export class EditorControl extends Disposable {
 		this.doHideActiveEditorControl();
 
 		// Create editor
-		const control = this.doCreateEditorControl(descriptor);
+		const control = await this.doCreateEditorControl(descriptor);
 
 		// Set editor as active
 		this.doSetActiveControl(control);
@@ -103,10 +103,10 @@ export class EditorControl extends Disposable {
 		return control;
 	}
 
-	private doCreateEditorControl(descriptor: IEditorDescriptor): BaseEditor {
+	private async doCreateEditorControl(descriptor: IEditorDescriptor): Promise<BaseEditor> {
 
 		// Instantiate editor
-		const control = this.doInstantiateEditorControl(descriptor);
+		const control = await this.doInstantiateEditorControl(descriptor);
 
 		// Create editor container as needed
 		if (!control.getContainer()) {
@@ -120,7 +120,7 @@ export class EditorControl extends Disposable {
 		return control;
 	}
 
-	private doInstantiateEditorControl(descriptor: IEditorDescriptor): BaseEditor {
+	private async doInstantiateEditorControl(descriptor: IEditorDescriptor): Promise<BaseEditor> {
 
 		// Return early if already instantiated
 		const existingControl = this.controls.filter(control => descriptor.describes(control))[0];
@@ -129,7 +129,7 @@ export class EditorControl extends Disposable {
 		}
 
 		// Otherwise instantiate new
-		const control = this._register(descriptor.instantiate(this.instantiationService));
+		const control = this._register(await descriptor.instantiate(this.instantiationService));
 		this.controls.push(control);
 
 		return control;

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -178,20 +178,20 @@ export class SideBySideEditor extends BaseEditor {
 		]);
 	}
 
-	private setNewInput(newInput: SideBySideEditorInput, options: EditorOptions, token: CancellationToken): Promise<void> {
-		const detailsEditor = this.doCreateEditor(newInput.details, this.detailsEditorContainer);
-		const masterEditor = this.doCreateEditor(newInput.master, this.masterEditorContainer);
+	private async setNewInput(newInput: SideBySideEditorInput, options: EditorOptions, token: CancellationToken): Promise<void> {
+		const detailsEditor = await this.doCreateEditor(newInput.details, this.detailsEditorContainer);
+		const masterEditor = await this.doCreateEditor(newInput.master, this.masterEditorContainer);
 
 		return this.onEditorsCreated(detailsEditor, masterEditor, newInput.details, newInput.master, options, token);
 	}
 
-	private doCreateEditor(editorInput: EditorInput, container: HTMLElement): BaseEditor {
+	private async doCreateEditor(editorInput: EditorInput, container: HTMLElement): Promise<BaseEditor> {
 		const descriptor = Registry.as<IEditorRegistry>(EditorExtensions.Editors).getEditor(editorInput);
 		if (!descriptor) {
 			throw new Error('No descriptor for editor found');
 		}
 
-		const editor = descriptor.instantiate(this.instantiationService);
+		const editor = await descriptor.instantiate(this.instantiationService);
 		editor.create(container);
 		editor.setVisible(this.isVisible(), this.group);
 

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensions.contribution.ts
@@ -94,7 +94,7 @@ Registry.as<IQuickOpenRegistry>(Extensions.Quickopen).registerQuickOpenHandler(
 
 // Editor
 const editorDescriptor = new EditorDescriptor(
-	ExtensionEditor,
+	async () => ExtensionEditor,
 	ExtensionEditor.ID,
 	localize('extension', "Extension")
 );
@@ -105,7 +105,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors)
 // Running Extensions Editor
 
 const runtimeExtensionsEditorDescriptor = new EditorDescriptor(
-	RuntimeExtensionsEditor,
+	async () => RuntimeExtensionsEditor,
 	RuntimeExtensionsEditor.ID,
 	localize('runtimeExtension', "Running Extensions")
 );

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -101,7 +101,7 @@ registry.registerWorkbenchAction(
 // Register file editors
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		TextFileEditor,
+		async () => TextFileEditor,
 		TextFileEditor.ID,
 		nls.localize('textFileEditor', "Text File Editor")
 	),
@@ -112,7 +112,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		BinaryFileEditor,
+		async () => BinaryFileEditor,
 		BinaryFileEditor.ID,
 		nls.localize('binaryFileEditor', "Binary File Editor")
 	),

--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -52,7 +52,7 @@ Registry.as<PanelRegistry>(Extensions.Panels).registerPanel(new PanelDescriptor(
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		LogViewer,
+		async () => LogViewer,
 		LogViewer.LOG_VIEWER_EDITOR_ID,
 		nls.localize('logViewer', "Log Viewer")
 	),

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -42,7 +42,7 @@ import { REMOTE_HOST_SCHEME } from 'vs/platform/remote/common/remoteHosts';
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		PreferencesEditor,
+		async () => PreferencesEditor,
 		PreferencesEditor.ID,
 		nls.localize('defaultPreferencesEditor', "Default Preferences Editor")
 	),
@@ -53,7 +53,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		SettingsEditor2,
+		async () => SettingsEditor2,
 		SettingsEditor2.ID,
 		nls.localize('settingsEditor2', "Settings Editor 2")
 	),
@@ -64,7 +64,7 @@ Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
-		KeybindingsEditor,
+		async () => KeybindingsEditor,
 		KeybindingsEditor.ID,
 		nls.localize('keybindingsEditor', "Keybindings Editor")
 	),

--- a/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
@@ -842,8 +842,8 @@ class SideBySidePreferencesWidget extends Widget {
 		this._register(focusTracker.onDidFocus(() => this._onFocus.fire()));
 	}
 
-	setInput(defaultPreferencesEditorInput: DefaultPreferencesEditorInput, editablePreferencesEditorInput: EditorInput, options: EditorOptions, token: CancellationToken): Promise<{ defaultPreferencesRenderer?: IPreferencesRenderer<ISetting>, editablePreferencesRenderer?: IPreferencesRenderer<ISetting> }> {
-		this.getOrCreateEditablePreferencesEditor(editablePreferencesEditorInput);
+	async setInput(defaultPreferencesEditorInput: DefaultPreferencesEditorInput, editablePreferencesEditorInput: EditorInput, options: EditorOptions, token: CancellationToken): Promise<{ defaultPreferencesRenderer?: IPreferencesRenderer<ISetting>, editablePreferencesRenderer?: IPreferencesRenderer<ISetting> }> {
+		await this.getOrCreateEditablePreferencesEditor(editablePreferencesEditorInput);
 		this.settingsTargetsWidget.settingsTarget = this.getSettingsTarget(editablePreferencesEditorInput.getResource()!);
 		return Promise.all([
 			this.updateInput(this.defaultPreferencesEditor, defaultPreferencesEditorInput, DefaultSettingsEditorContribution.ID, editablePreferencesEditorInput.getResource()!, options, token),
@@ -911,12 +911,12 @@ class SideBySidePreferencesWidget extends Widget {
 		}
 	}
 
-	private getOrCreateEditablePreferencesEditor(editorInput: EditorInput): BaseEditor {
+	private async getOrCreateEditablePreferencesEditor(editorInput: EditorInput): Promise<BaseEditor> {
 		if (this.editablePreferencesEditor) {
 			return this.editablePreferencesEditor;
 		}
 		const descriptor = Registry.as<IEditorRegistry>(EditorExtensions.Editors).getEditor(editorInput);
-		const editor = descriptor!.instantiate(this.instantiationService);
+		const editor = await descriptor!.instantiate(this.instantiationService);
 		this.editablePreferencesEditor = editor;
 		this.editablePreferencesEditor.create(this.editablePreferencesEditorContainer);
 		this.editablePreferencesEditor.setVisible(this.isVisible, this.group);

--- a/src/vs/workbench/contrib/webview/browser/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.contribution.ts
@@ -15,15 +15,14 @@ import { EditorDescriptor, Extensions as EditorExtensions, IEditorRegistry } fro
 import { Extensions as ActionExtensions, IWorkbenchActionRegistry } from 'vs/workbench/common/actions';
 import { Extensions as EditorInputExtensions, IEditorInputFactoryRegistry } from 'vs/workbench/common/editor';
 import { WebviewEditorInputFactory } from 'vs/workbench/contrib/webview/browser/webviewEditorInputFactory';
-import { KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE, webviewDeveloperCategory } from 'vs/workbench/contrib/webview/common/webview';
+import { KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE, webviewDeveloperCategory, webviewEditorId } from 'vs/workbench/contrib/webview/common/webview';
 import { HideWebViewEditorFindCommand, ReloadWebviewAction, ShowWebViewEditorFindWidgetCommand } from '../browser/webviewCommands';
-import { WebviewEditor } from '../browser/webviewEditor';
 import { WebviewEditorInput } from '../browser/webviewEditorInput';
 import { IWebviewEditorService, WebviewEditorService } from '../browser/webviewEditorService';
 
 (Registry.as<IEditorRegistry>(EditorExtensions.Editors)).registerEditor(new EditorDescriptor(
-	WebviewEditor,
-	WebviewEditor.ID,
+	async () => (await import('../browser/webviewEditor')).WebviewEditor,
+	webviewEditorId,
 	localize('webview.editor.label', "webview editor")),
 	[new SyncDescriptor(WebviewEditorInput)]);
 
@@ -60,7 +59,7 @@ function registerWebViewCommands(editorId: string): void {
 	})).register();
 }
 
-registerWebViewCommands(WebviewEditor.ID);
+registerWebViewCommands(webviewEditorId);
 
 actionRegistry.registerWorkbenchAction(
 	new SyncActionDescriptor(ReloadWebviewAction, ReloadWebviewAction.ID, ReloadWebviewAction.LABEL),

--- a/src/vs/workbench/contrib/webview/browser/webviewCommands.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewCommands.ts
@@ -8,7 +8,7 @@ import { Command } from 'vs/editor/browser/editorExtensions';
 import * as nls from 'vs/nls';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { WebviewEditor } from 'vs/workbench/contrib/webview/browser/webviewEditor';
+type WebviewEditor = import('vs/workbench/contrib/webview/browser/webviewEditor').WebviewEditor;
 
 export class ShowWebViewEditorFindWidgetCommand extends Command {
 	public static readonly ID = 'editor.action.webvieweditor.showFind';

--- a/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
@@ -17,17 +17,14 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { EditorOptions } from 'vs/workbench/common/editor';
 import { WebviewEditorInput } from 'vs/workbench/contrib/webview/browser/webviewEditorInput';
-import { IWebviewService, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE, Webview } from 'vs/workbench/contrib/webview/common/webview';
+import { IWebviewService, KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE, Webview, webviewEditorId } from 'vs/workbench/contrib/webview/common/webview';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-
 
 export class WebviewEditor extends BaseEditor {
 
 	protected _webview: Webview | undefined;
 	protected findWidgetVisible: IContextKey<boolean>;
-
-	public static readonly ID = 'WebviewEditor';
 
 	private _editorFrame: HTMLElement;
 	private _content?: HTMLElement;
@@ -51,7 +48,7 @@ export class WebviewEditor extends BaseEditor {
 		@IWindowService private readonly _windowService: IWindowService,
 		@IStorageService storageService: IStorageService
 	) {
-		super(WebviewEditor.ID, telemetryService, themeService, storageService);
+		super(webviewEditorId, telemetryService, themeService, storageService);
 		if (_contextKeyService) {
 			this.findWidgetVisible = KEYBINDING_CONTEXT_WEBVIEW_FIND_WIDGET_VISIBLE.bindTo(_contextKeyService);
 		}

--- a/src/vs/workbench/contrib/webview/common/webview.ts
+++ b/src/vs/workbench/contrib/webview/common/webview.ts
@@ -79,3 +79,5 @@ export interface Webview extends IDisposable {
 }
 
 export const webviewDeveloperCategory = nls.localize('developer', "Developer");
+
+export const webviewEditorId = 'WebviewEditor';

--- a/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
@@ -12,8 +12,7 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as ActionExtensions, IWorkbenchActionRegistry } from 'vs/workbench/common/actions';
-import { WebviewEditor } from 'vs/workbench/contrib/webview/browser/webviewEditor';
-import { IWebviewService, webviewDeveloperCategory } from 'vs/workbench/contrib/webview/common/webview';
+import { IWebviewService, webviewDeveloperCategory, webviewEditorId } from 'vs/workbench/contrib/webview/common/webview';
 import * as webviewCommands from 'vs/workbench/contrib/webview/electron-browser/webviewCommands';
 import { WebviewService } from 'vs/workbench/contrib/webview/electron-browser/webviewService';
 
@@ -89,4 +88,4 @@ function registerWebViewCommands(editorId: string): void {
 	}
 }
 
-registerWebViewCommands(WebviewEditor.ID);
+registerWebViewCommands(webviewEditorId);

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewCommands.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewCommands.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Action } from 'vs/base/common/actions';
-import * as nls from 'vs/nls';
 import { Command, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
-import { WebviewEditor } from 'vs/workbench/contrib/webview/browser/webviewEditor';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import * as nls from 'vs/nls';
 import { WebviewElement } from 'vs/workbench/contrib/webview/electron-browser/webviewElement';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+type WebviewEditor = import('vs/workbench/contrib/webview/browser/webviewEditor').WebviewEditor;
 
 export class OpenWebviewDeveloperToolsAction extends Action {
 	static readonly ID = 'workbench.action.webview.openDeveloperTools';

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThrough.contribution.ts
@@ -21,7 +21,7 @@ import { KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRe
 
 Registry.as<IEditorRegistry>(EditorExtensions.Editors)
 	.registerEditor(new EditorDescriptor(
-		WalkThroughPart,
+		async () => WalkThroughPart,
 		WalkThroughPart.ID,
 		localize('walkThrough.editor.label', "Interactive Playground"),
 	),

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -80,7 +80,7 @@ suite('EditorGroupsService', () => {
 		}
 
 		(Registry.as<IEditorInputFactoryRegistry>(EditorExtensions.EditorInputFactories)).registerEditorInputFactory('testEditorInputForGroupsService', TestEditorInputFactory);
-		(Registry.as<IEditorRegistry>(Extensions.Editors)).registerEditor(new EditorDescriptor(TestEditorControl, 'MyTestEditorForGroupsService', 'My Test File Editor'), new SyncDescriptor(TestEditorInput));
+		(Registry.as<IEditorRegistry>(Extensions.Editors)).registerEditor(new EditorDescriptor(async () => TestEditorControl, 'MyTestEditorForGroupsService', 'My Test File Editor'), new SyncDescriptor(TestEditorInput));
 	}
 
 	registerTestEditorInput();

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -82,7 +82,7 @@ class FileServiceProvider extends Disposable {
 suite('EditorService', () => {
 
 	function registerTestEditorInput(): void {
-		Registry.as<IEditorRegistry>(Extensions.Editors).registerEditor(new EditorDescriptor(TestEditorControl, 'MyTestEditorForEditorService', 'My Test Editor For Next Editor Service'), new SyncDescriptor(TestEditorInput));
+		Registry.as<IEditorRegistry>(Extensions.Editors).registerEditor(new EditorDescriptor(async () => TestEditorControl, 'MyTestEditorForEditorService', 'My Test Editor For Next Editor Service'), new SyncDescriptor(TestEditorInput));
 	}
 
 	registerTestEditorInput();

--- a/src/vs/workbench/test/browser/parts/editor/baseEditor.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/baseEditor.test.ts
@@ -115,14 +115,14 @@ suite('Workbench base editor', () => {
 	});
 
 	test('EditorDescriptor', () => {
-		let d = new EditorDescriptor(MyEditor, 'id', 'name');
+		let d = new EditorDescriptor(async () => MyEditor, 'id', 'name');
 		assert.strictEqual(d.getId(), 'id');
 		assert.strictEqual(d.getName(), 'name');
 	});
 
 	test('Editor Registration', function () {
-		let d1 = new EditorDescriptor(MyEditor, 'id1', 'name');
-		let d2 = new EditorDescriptor(MyOtherEditor, 'id2', 'name');
+		let d1 = new EditorDescriptor(async () => MyEditor, 'id1', 'name');
+		let d2 = new EditorDescriptor(async () => MyOtherEditor, 'id2', 'name');
 
 		let oldEditorsCnt = EditorRegistry.getEditors().length;
 		let oldInputCnt = (<any>EditorRegistry).getEditorInputs().length;
@@ -141,9 +141,9 @@ suite('Workbench base editor', () => {
 		assert(!EditorRegistry.getEditorById('id3'));
 	});
 
-	test('Editor Lookup favors specific class over superclass (match on specific class)', function () {
-		let d1 = new EditorDescriptor(MyEditor, 'id1', 'name');
-		let d2 = new EditorDescriptor(MyOtherEditor, 'id2', 'name');
+	test('Editor Lookup favors specific class over superclass (match on specific class)', async function () {
+		let d1 = new EditorDescriptor(async () => MyEditor, 'id1', 'name');
+		let d2 = new EditorDescriptor(async () => MyOtherEditor, 'id2', 'name');
 
 		let oldEditors = EditorRegistry.getEditors();
 		(<any>EditorRegistry).setEditors([]);
@@ -153,17 +153,17 @@ suite('Workbench base editor', () => {
 
 		let inst = new TestInstantiationService();
 
-		const editor = EditorRegistry.getEditor(inst.createInstance(MyResourceInput, 'fake', '', URI.file('/fake'), undefined))!.instantiate(inst);
+		const editor = await EditorRegistry.getEditor(inst.createInstance(MyResourceInput, 'fake', '', URI.file('/fake'), undefined))!.instantiate(inst);
 		assert.strictEqual(editor.getId(), 'myEditor');
 
-		const otherEditor = EditorRegistry.getEditor(inst.createInstance(ResourceEditorInput, 'fake', '', URI.file('/fake'), undefined))!.instantiate(inst);
+		const otherEditor = await EditorRegistry.getEditor(inst.createInstance(ResourceEditorInput, 'fake', '', URI.file('/fake'), undefined))!.instantiate(inst);
 		assert.strictEqual(otherEditor.getId(), 'myOtherEditor');
 
 		(<any>EditorRegistry).setEditors(oldEditors);
 	});
 
-	test('Editor Lookup favors specific class over superclass (match on super class)', function () {
-		let d1 = new EditorDescriptor(MyOtherEditor, 'id1', 'name');
+	test('Editor Lookup favors specific class over superclass (match on super class)', async function () {
+		let d1 = new EditorDescriptor(async () => MyOtherEditor, 'id1', 'name');
 
 		let oldEditors = EditorRegistry.getEditors();
 		(<any>EditorRegistry).setEditors([]);
@@ -172,7 +172,7 @@ suite('Workbench base editor', () => {
 
 		let inst = new TestInstantiationService();
 
-		const editor = EditorRegistry.getEditor(inst.createInstance(MyResourceInput, 'fake', '', URI.file('/fake'), undefined))!.instantiate(inst);
+		const editor = await EditorRegistry.getEditor(inst.createInstance(MyResourceInput, 'fake', '', URI.file('/fake'), undefined))!.instantiate(inst);
 		assert.strictEqual('myOtherEditor', editor.getId());
 
 		(<any>EditorRegistry).setEditors(oldEditors);


### PR DESCRIPTION
Fixes #76323

* Changes `EditorRegistery` to take a lazy promise to an editor. This lets us defer importing the actual editor logic until we really need it.

* Changes `WebviewEditor` to take advantage of this new scheme and be  lazily imported

If we think this approach is worthwhile, we should update other editors to take advantage of this as well