### PR TITLE
trigger workspace contains activation event on new folders

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/browser/mainThreadWorkspace.ts
@@ -179,10 +179,9 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 		return search;
 	}
 
-	$checkExists(includes: string[], token: CancellationToken): Promise<boolean> {
+	$checkExists(folders: UriComponents[], includes: string[], token: CancellationToken): Promise<boolean> {
 		const queryBuilder = this._instantiationService.createInstance(QueryBuilder);
-		const folders = this._contextService.getWorkspace().folders.map(folder => folder.uri);
-		const query = queryBuilder.file(folders, {
+		const query = queryBuilder.file(folders.map(folder => URI.revive(folder)), {
 			_reason: 'checkExists',
 			includePattern: includes.join(', '),
 			expandPatterns: true,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -578,7 +578,7 @@ export interface ITextSearchComplete {
 export interface MainThreadWorkspaceShape extends IDisposable {
 	$startFileSearch(includePattern: string | undefined, includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false | undefined, maxResults: number | undefined, token: CancellationToken): Promise<UriComponents[] | undefined>;
 	$startTextSearch(query: search.IPatternInfo, options: ITextQueryBuilderOptions, requestId: number, token: CancellationToken): Promise<ITextSearchComplete>;
-	$checkExists(includes: string[], token: CancellationToken): Promise<boolean>;
+	$checkExists(folders: UriComponents[], includes: string[], token: CancellationToken): Promise<boolean>;
 	$saveAll(includeUntitled?: boolean): Promise<boolean>;
 	$updateWorkspaceFolders(extensionName: string, index: number, deleteCount: number, workspaceFoldersToAdd: { uri: UriComponents, name?: string }[]): Promise<void>;
 	$resolveProxy(url: string): Promise<string | undefined>;

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import * as path from 'vs/base/common/path';
 import { originalFSPath } from 'vs/base/common/resources';
 import { Barrier } from 'vs/base/common/async';
-import { dispose, toDisposable } from 'vs/base/common/lifecycle';
+import { dispose, toDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { TernarySearchTree } from 'vs/base/common/map';
 import { URI } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -26,7 +26,6 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import * as errors from 'vs/base/common/errors';
 import * as vscode from 'vscode';
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
-import { IWorkspace } from 'vs/platform/workspace/common/workspace';
 import { Schemas } from 'vs/base/common/network';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { VSBuffer } from 'vs/base/common/buffer';
@@ -81,6 +80,8 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 
 	private _started: boolean;
 
+	private readonly _disposables: DisposableStore;
+
 	constructor(
 		hostUtils: IHostUtils,
 		initData: IInitData,
@@ -98,6 +99,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		this._extHostConfiguration = extHostConfiguration;
 		this._environment = environment;
 		this._extHostLogService = extHostLogService;
+		this._disposables = new DisposableStore();
 
 		this._mainThreadWorkspaceProxy = this._extHostContext.getProxy(MainContext.MainThreadWorkspace);
 		this._mainThreadTelemetryProxy = this._extHostContext.getProxy(MainContext.MainThreadTelemetry);
@@ -414,24 +416,29 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 			console.error(err);
 		});
 
-		return this._handleWorkspaceContainsEagerExtensions(this._extHostWorkspace.workspace);
+		this._extHostWorkspace.onDidChangeWorkspace(({ added }) => this._handleWorkspaceContainsEagerExtensions(added), this, this._disposables);
+		const folders = this._extHostWorkspace.workspace ? this._extHostWorkspace.workspace.folders : [];
+		return this._handleWorkspaceContainsEagerExtensions(folders);
 	}
 
-	private _handleWorkspaceContainsEagerExtensions(workspace: IWorkspace | undefined): Promise<void> {
-		if (!workspace || workspace.folders.length === 0) {
+	private _handleWorkspaceContainsEagerExtensions(folders: ReadonlyArray<vscode.WorkspaceFolder>): Promise<void> {
+		if (folders.length === 0) {
 			return Promise.resolve(undefined);
 		}
-
 		return Promise.all(
 			this._registry.getAllExtensionDescriptions().map((desc) => {
-				return this._handleWorkspaceContainsEagerExtension(workspace, desc);
+				return this._handleWorkspaceContainsEagerExtension(folders, desc);
 			})
 		).then(() => { });
 	}
 
-	private _handleWorkspaceContainsEagerExtension(workspace: IWorkspace, desc: IExtensionDescription): Promise<void> {
+	private _handleWorkspaceContainsEagerExtension(folders: ReadonlyArray<vscode.WorkspaceFolder>, desc: IExtensionDescription): Promise<void> {
 		const activationEvents = desc.activationEvents;
 		if (!activationEvents) {
+			return Promise.resolve(undefined);
+		}
+
+		if (this.isActivated(desc.identifier)) {
 			return Promise.resolve(undefined);
 		}
 
@@ -453,16 +460,16 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 			return Promise.resolve(undefined);
 		}
 
-		const fileNamePromise = Promise.all(fileNames.map((fileName) => this._activateIfFileName(workspace, desc.identifier, fileName))).then(() => { });
-		const globPatternPromise = this._activateIfGlobPatterns(desc.identifier, globPatterns);
+		const fileNamePromise = Promise.all(fileNames.map((fileName) => this._activateIfFileName(folders, desc.identifier, fileName))).then(() => { });
+		const globPatternPromise = this._activateIfGlobPatterns(desc.identifier, folders, globPatterns);
 
 		return Promise.all([fileNamePromise, globPatternPromise]).then(() => { });
 	}
 
-	private async _activateIfFileName(workspace: IWorkspace, extensionId: ExtensionIdentifier, fileName: string): Promise<void> {
+	private async _activateIfFileName(folders: ReadonlyArray<vscode.WorkspaceFolder>, extensionId: ExtensionIdentifier, fileName: string): Promise<void> {
 
 		// find exact path
-		for (const { uri } of workspace.folders) {
+		for (const { uri } of folders) {
 			if (await this._hostUtils.exists(path.join(URI.revive(uri).fsPath, fileName))) {
 				// the file was found
 				return (
@@ -475,7 +482,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		return undefined;
 	}
 
-	private async _activateIfGlobPatterns(extensionId: ExtensionIdentifier, globPatterns: string[]): Promise<void> {
+	private async _activateIfGlobPatterns(extensionId: ExtensionIdentifier, folders: ReadonlyArray<vscode.WorkspaceFolder>, globPatterns: string[]): Promise<void> {
 		this._extHostLogService.trace(`extensionHostMain#activateIfGlobPatterns: fileSearch, extension: ${extensionId.value}, entryPoint: workspaceContains`);
 
 		if (globPatterns.length === 0) {
@@ -483,7 +490,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		}
 
 		const tokenSource = new CancellationTokenSource();
-		const searchP = this._mainThreadWorkspaceProxy.$checkExists(globPatterns, tokenSource.token);
+		const searchP = this._mainThreadWorkspaceProxy.$checkExists(folders.map(folder => folder.uri), globPatterns, tokenSource.token);
 
 		const timer = setTimeout(async () => {
 			tokenSource.cancel();

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -416,7 +416,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 			console.error(err);
 		});
 
-		this._extHostWorkspace.onDidChangeWorkspace(({ added }) => this._handleWorkspaceContainsEagerExtensions(added), this, this._disposables);
+		this._disposables.add(this._extHostWorkspace.onDidChangeWorkspace((e) => this._handleWorkspaceContainsEagerExtensions(e.added)));
 		const folders = this._extHostWorkspace.workspace ? this._extHostWorkspace.workspace.folders : [];
 		return this._handleWorkspaceContainsEagerExtensions(folders);
 	}
@@ -425,6 +425,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		if (folders.length === 0) {
 			return Promise.resolve(undefined);
 		}
+
 		return Promise.all(
 			this._registry.getAllExtensionDescriptions().map((desc) => {
 				return this._handleWorkspaceContainsEagerExtension(folders, desc);
@@ -461,7 +462,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		}
 
 		const fileNamePromise = Promise.all(fileNames.map((fileName) => this._activateIfFileName(folders, desc.identifier, fileName))).then(() => { });
-		const globPatternPromise = this._activateIfGlobPatterns(desc.identifier, folders, globPatterns);
+		const globPatternPromise = this._activateIfGlobPatterns(folders, desc.identifier, globPatterns);
 
 		return Promise.all([fileNamePromise, globPatternPromise]).then(() => { });
 	}
@@ -482,7 +483,7 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 		return undefined;
 	}
 
-	private async _activateIfGlobPatterns(extensionId: ExtensionIdentifier, folders: ReadonlyArray<vscode.WorkspaceFolder>, globPatterns: string[]): Promise<void> {
+	private async _activateIfGlobPatterns(folders: ReadonlyArray<vscode.WorkspaceFolder>, extensionId: ExtensionIdentifier, globPatterns: string[]): Promise<void> {
 		this._extHostLogService.trace(`extensionHostMain#activateIfGlobPatterns: fileSearch, extension: ${extensionId.value}, entryPoint: workspaceContains`);
 
 		if (globPatterns.length === 0) {


### PR DESCRIPTION
### Problem

As mentioned in #74859, extension having workspace contains events are not getting activated when a new root folder that matches extension's workspace contains rule is added to the workspace.

### Fix

Listen to workspace change event and run the workspace contains activation event on newly added folders for the extensions which are not yet activated.