### PR TITLE
Fix-76141 Add border around image in image preview

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
+++ b/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
@@ -22,6 +22,7 @@
 	padding: 0;
 	background-position: 0 0, 8px 8px;
 	background-size: 16px 16px;
+	border: 1px solid;
 }
 
 .vs .monaco-resource-viewer.image img {

--- a/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
+++ b/src/vs/workbench/browser/parts/editor/media/resourceviewer.css
@@ -22,7 +22,6 @@
 	padding: 0;
 	background-position: 0 0, 8px 8px;
 	background-size: 16px 16px;
-	border: 1px solid;
 }
 
 .vs .monaco-resource-viewer.image img {

--- a/src/vs/workbench/browser/parts/editor/resourceViewer.ts
+++ b/src/vs/workbench/browser/parts/editor/resourceViewer.ts
@@ -21,6 +21,8 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/platform/statusbar/common/statusbar';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ITheme, registerThemingParticipant, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
+import { IMAGE_PREVIEW_BORDER } from 'vs/workbench/common/theme';
 
 export interface IResourceDescriptor {
 	readonly resource: URI;
@@ -66,6 +68,11 @@ interface ResourceViewerDelegate {
 	openExternalClb?(uri: URI): void;
 	metadataClb(meta: string): void;
 }
+
+registerThemingParticipant((theme: ITheme, collector: ICssStyleCollector) => {
+	const borderColor = theme.getColor(IMAGE_PREVIEW_BORDER);
+	collector.addRule(`.monaco-resource-viewer.image img { border : 1px solid ${borderColor ? borderColor.toString() : ''}; }`);
+});
 
 /**
  * Helper to actually render the given resource into the provided container. Will adjust scrollbar (if provided) automatically based on loading

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -200,7 +200,13 @@ export const EDITOR_DRAG_AND_DROP_BACKGROUND = registerColor('editorGroup.dropBa
 	hc: null
 }, nls.localize('editorDragAndDropBackground', "Background color when dragging editors around. The color should have transparency so that the editor contents can still shine through."));
 
+// < --- Resource Viewer --- >
 
+export const IMAGE_PREVIEW_BORDER = registerColor('imagePreview.border', {
+	dark: Color.fromHex('#808080').transparent(0.35),
+	light: Color.fromHex('#808080').transparent(0.35),
+	hc: contrastBorder
+}, nls.localize('imagePreviewBorder', "Border color for image in image preview."));
 
 // < --- Panels --- >
 


### PR DESCRIPTION
@mjbvz , Added the border property accordingly to fix #76141  and kept it default as I could not find the panel color that was mentioned [in this comment](https://github.com/microsoft/vscode/issues/74710#issuecomment-505568760)

I will change it if you can provide me the color code.

This is how it looks for default border `1px solid`

![image](https://user-images.githubusercontent.com/17094832/60413243-d08f8100-9bf1-11e9-8972-63dbdd1b85e1.png)
