### PR TITLE
Moves buildTelemetryMessage out of argv.ts

### DIFF
--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -41,7 +41,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { LocalizationsService } from 'vs/platform/localizations/node/localizations';
 import { Schemas } from 'vs/base/common/network';
 import { SpdLogService } from 'vs/platform/log/node/spdlogService';
-import { buildTelemetryMessage } from 'vs/platform/environment/node/argv';
+import { buildTelemetryMessage } from 'vs/platform/telemetry/node/telemetry';
 
 const notFound = (id: string) => localize('notFound', "Extension '{0}' not found.", id);
 const notInstalled = (id: string) => localize('notInstalled', "Extension '{0}' is not installed.", id);

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -8,8 +8,7 @@ import * as os from 'os';
 import { localize } from 'vs/nls';
 import { ParsedArgs } from 'vs/platform/environment/common/environment';
 import { join } from 'vs/base/common/path';
-import { statSync, readFileSync } from 'fs';
-import { writeFileSync, readdirSync } from 'vs/base/node/pfs';
+import { writeFileSync } from 'vs/base/node/pfs';
 
 /**
  * This code is also used by standalone cli's. Avoid adding any other dependencies.
@@ -217,41 +216,6 @@ export function buildHelpMessage(productName: string, executableName: string, ve
 
 export function buildVersionMessage(version: string | undefined, commit: string | undefined): string {
 	return `${version || localize('unknownVersion', "Unknown version")}\n${commit || localize('unknownCommit', "Unknown commit")}\n${process.arch}`;
-}
-
-export function buildTelemetryMessage(appRoot: string, extensionsPath: string): string {
-	// Gets all the directories inside the extension directory
-	const dirs = readdirSync(extensionsPath).filter(files => {
-		// This handles case where broken symbolic links can cause statSync to throw and error
-		try {
-			return statSync(join(extensionsPath, files)).isDirectory();
-		} catch {
-			return false;
-		}
-	});
-	const telemetryJsonFolders: string[] = [];
-	dirs.forEach((dir) => {
-		const files = readdirSync(join(extensionsPath, dir)).filter(file => file === 'telemetry.json');
-		// We know it contains a telemetry.json file so we add it to the list of folders which have one
-		if (files.length === 1) {
-			telemetryJsonFolders.push(dir);
-		}
-	});
-	const mergedTelemetry = Object.create(null);
-	// Simple function to merge the telemetry into one json object
-	const mergeTelemetry = (contents: string, dirName: string) => {
-		const telemetryData = JSON.parse(contents);
-		mergedTelemetry[dirName] = telemetryData;
-	};
-	telemetryJsonFolders.forEach((folder) => {
-		const contents = readFileSync(join(extensionsPath, folder, 'telemetry.json')).toString();
-		mergeTelemetry(contents, folder);
-	});
-	let contents = readFileSync(join(appRoot, 'telemetry-core.json')).toString();
-	mergeTelemetry(contents, 'vscode-core');
-	contents = readFileSync(join(appRoot, 'telemetry-extensions.json')).toString();
-	mergeTelemetry(contents, 'vscode-extensions');
-	return JSON.stringify(mergedTelemetry, null, 4);
 }
 
 /**

--- a/src/vs/platform/telemetry/node/telemetry.ts
+++ b/src/vs/platform/telemetry/node/telemetry.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { readdirSync } from 'vs/base/node/pfs';
+import { statSync, readFileSync } from 'fs';
+import { join } from 'vs/base/common/path';
+
+export function buildTelemetryMessage(appRoot: string, extensionsPath: string): string {
+	// Gets all the directories inside the extension directory
+	const dirs = readdirSync(extensionsPath).filter(files => {
+		// This handles case where broken symbolic links can cause statSync to throw and error
+		try {
+			return statSync(join(extensionsPath, files)).isDirectory();
+		} catch {
+			return false;
+		}
+	});
+	const telemetryJsonFolders: string[] = [];
+	dirs.forEach((dir) => {
+		const files = readdirSync(join(extensionsPath, dir)).filter(file => file === 'telemetry.json');
+		// We know it contains a telemetry.json file so we add it to the list of folders which have one
+		if (files.length === 1) {
+			telemetryJsonFolders.push(dir);
+		}
+	});
+	const mergedTelemetry = Object.create(null);
+	// Simple function to merge the telemetry into one json object
+	const mergeTelemetry = (contents: string, dirName: string) => {
+		const telemetryData = JSON.parse(contents);
+		mergedTelemetry[dirName] = telemetryData;
+	};
+	telemetryJsonFolders.forEach((folder) => {
+		const contents = readFileSync(join(extensionsPath, folder, 'telemetry.json')).toString();
+		mergeTelemetry(contents, folder);
+	});
+	let contents = readFileSync(join(appRoot, 'telemetry-core.json')).toString();
+	mergeTelemetry(contents, 'vscode-core');
+	contents = readFileSync(join(appRoot, 'telemetry-extensions.json')).toString();
+	mergeTelemetry(contents, 'vscode-extensions');
+	return JSON.stringify(mergedTelemetry, null, 4);
+}


### PR DESCRIPTION
Complete my part of #76239. This moves the telemetry message into `src/vs/platform/telemetry/node/telemetry.ts`