### PR TITLE
snapcaft.yaml: Set the AppStream ID in the Snap metadata

### DIFF
--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -51,6 +51,7 @@ apps:
   @@NAME@@:
     command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@
     desktop: usr/share/applications/@@NAME@@.desktop
+    common-id: @@NAME@@.desktop
     environment:
       DISABLE_WAYLAND: 1
       GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas


### PR DESCRIPTION
This allows software store to recognise this snap matches Visual Studio Code in
other formats (.deb, .rpm, Flatpak etc). It also means reviews on ODRS are
grouped together.