### PR TITLE
Preserve tree state in debug Variables view

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -122,9 +122,9 @@
 			"type": "chrome",
 			"request": "launch",
 			"name": "Launch VS Code",
-			"timeout": 20000,
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/code.bat",
+				"timeout": 20000
 			},
 			"osx": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/code.sh"
@@ -136,7 +136,7 @@
 				"VSCODE_EXTHOST_WILL_SEND_SOCKET": null
 			},
 			"breakOnLoad": false,
-			//"urlFilter": "*workbench.html*",
+			"urlFilter": "*workbench.html*",
 			"runtimeArgs": [
 				"--inspect=5875",
 				"--no-cached-data"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -122,9 +122,9 @@
 			"type": "chrome",
 			"request": "launch",
 			"name": "Launch VS Code",
+			"timeout": 20000,
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/code.bat",
-				"timeout": 20000
 			},
 			"osx": {
 				"runtimeExecutable": "${workspaceFolder}/scripts/code.sh"
@@ -136,7 +136,7 @@
 				"VSCODE_EXTHOST_WILL_SEND_SOCKET": null
 			},
 			"breakOnLoad": false,
-			"urlFilter": "*workbench.html*",
+			//"urlFilter": "*workbench.html*",
 			"runtimeArgs": [
 				"--inspect=5875",
 				"--no-cached-data"

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -63,7 +63,7 @@ export class VariablesView extends ViewletPanel {
 				this.savedViewState = undefined;
 			} else {
 				if (!stackFrame) {
-					// We have no stackFrame; save tree state before it is cleared
+					// We have no stackFrame, save tree state before it is cleared
 					this.savedViewState = this.tree.getViewState();
 				}
 				this.tree.updateChildren().then(() => {

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -62,7 +62,7 @@ export class VariablesView extends ViewletPanel {
 				this.tree.setInput(this.debugService.getViewModel(), this.savedViewState).then(null, onUnexpectedError);
 				this.savedViewState = undefined;
 			} else {
-				if (!stackFrame && !this.savedViewState) {
+				if (!stackFrame) {
 					// We have no stackFrame, save tree state before it is cleared
 					this.savedViewState = this.tree.getViewState();
 				}

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -63,7 +63,7 @@ export class VariablesView extends ViewletPanel {
 				this.savedViewState = undefined;
 			} else {
 				if (!stackFrame) {
-					// We have no stackFrame, save tree state before it is cleared
+					// We have no stackFrame; save tree state before it is cleared
 					this.savedViewState = this.tree.getViewState();
 				}
 				this.tree.updateChildren().then(() => {


### PR DESCRIPTION
This fixes issues #76427 and #25652 (duplicates). I mentioned in detail what was causing the issue in  #76427. 

We save and restore the tree state between a `stopped->running` transition and back to `stopped` in conjunction with the Call Stack window which keeps track of the current thread/frame context.

It also preserves the visually nice feature of not flashing if those transitions happen quickly (within a half a second) but longer periods between transitions will clear the Variables window (so the user cannot interact with it). The only difference is that if eventually, the debugger stops, we restore the tree instead of going back to the default state.

I tested it with cpptools (MIEngine) and the typescript debuggers.
