### PR TITLE
Remove telemetry command

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -61,21 +61,6 @@ steps:
 
 - script: |
     set -e
-    cd $BUILD_STAGINGDIRECTORY
-    git clone https://github.com/microsoft/vscode-telemetry-extractor.git
-    cd vscode-telemetry-extractor
-    git checkout 3b04aba5bfdfcca1a5426cd2c51a90d18740d0bc
-    npm i
-    npm run setup-extension-repos
-    node ./out/cli-extract.js --sourceDir $BUILD_SOURCESDIRECTORY --excludedDirPattern extensions  --outputDir . --applyEndpoints --includeIsMeasurement --patchWebsiteEvents
-    node ./out/cli-extract-extensions.js --sourceDir ./src/telemetry-sources --outputDir . --applyEndpoints --includeIsMeasurement
-    mkdir -p $BUILD_SOURCESDIRECTORY/.build/telemetry
-    mv declarations-resolved.json $BUILD_SOURCESDIRECTORY/.build/telemetry/telemetry-core.json
-    mv declarations-extensions-resolved.json $BUILD_SOURCESDIRECTORY/.build/telemetry/telemetry-extensions.json
-  displayName: Extract Telemetry
-
-- script: |
-    set -e
     VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)" \
     AZURE_STORAGE_ACCESS_KEY="$(ticino-storage-key)" \
     ./build/azure-pipelines/darwin/build.sh

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -62,21 +62,6 @@ steps:
 
 - script: |
     set -e
-    cd $BUILD_STAGINGDIRECTORY
-    git clone https://github.com/microsoft/vscode-telemetry-extractor.git
-    cd vscode-telemetry-extractor
-    git checkout 3b04aba5bfdfcca1a5426cd2c51a90d18740d0bc
-    npm i
-    npm run setup-extension-repos
-    node ./out/cli-extract.js --sourceDir $BUILD_SOURCESDIRECTORY --excludedDirPattern extensions  --outputDir . --applyEndpoints --includeIsMeasurement --patchWebsiteEvents
-    node ./out/cli-extract-extensions.js --sourceDir ./src/telemetry-sources --outputDir . --applyEndpoints --includeIsMeasurement
-    mkdir -p $BUILD_SOURCESDIRECTORY/.build/telemetry
-    mv declarations-resolved.json $BUILD_SOURCESDIRECTORY/.build/telemetry/telemetry-core.json
-    mv declarations-extensions-resolved.json $BUILD_SOURCESDIRECTORY/.build/telemetry/telemetry-extensions.json
-  displayName: Extract Telemetry
-
-- script: |
-    set -e
     VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)" \
     ./build/azure-pipelines/linux/build.sh
   displayName: Build

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -68,22 +68,6 @@ steps:
 - powershell: |
     . build/azure-pipelines/win32/exec.ps1
     $ErrorActionPreference = "Stop"
-    cd $env:BUILD_STAGINGDIRECTORY
-    git clone https://github.com/microsoft/vscode-telemetry-extractor.git
-    cd vscode-telemetry-extractor
-    git checkout 3b04aba5bfdfcca1a5426cd2c51a90d18740d0bc
-    npm i
-    npm run setup-extension-repos
-    node .\out\cli-extract.js --sourceDir $env:BUILD_SOURCESDIRECTORY --excludedDirPattern extensions  --outputDir . --applyEndpoints --includeIsMeasurement --patchWebsiteEvents
-    node .\out\cli-extract-extensions.js --sourceDir .\src\telemetry-sources --outputDir . --applyEndpoints --includeIsMeasurement
-    mkdir $env:BUILD_SOURCESDIRECTORY\.build\telemetry -ea 0
-    mv declarations-resolved.json $env:BUILD_SOURCESDIRECTORY\.build\telemetry\telemetry-core.json
-    mv declarations-extensions-resolved.json $env:BUILD_SOURCESDIRECTORY\.build\telemetry\telemetry-extensions.json
-  displayName: Extract Telemetry
-
-- powershell: |
-    . build/azure-pipelines/win32/exec.ps1
-    $ErrorActionPreference = "Stop"
     $env:VSCODE_MIXIN_PASSWORD="$(github-distro-mixin-password)"
     .\build\azure-pipelines\win32\build.ps1
   displayName: Build

--- a/resources/completions/zsh/_code
+++ b/resources/completions/zsh/_code
@@ -14,7 +14,6 @@ arguments=(
 	'--user-data-dir[specify the directory that user data is kept in]:directory:_directories'
 	'(- *)'{-v,--version}'[print version]'
 	'(- *)'{-h,--help}'[print usage]'
-	'(- *)'{--telemetry}'[Shows all telemetry events which VS code collects.]'
 	'--extensions-dir[set the root path for extensions]:root path:_directories'
 	'--list-extensions[list the installed extensions]'
 	'--show-versions[show versions of installed extensions, when using --list-extension]'

--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -25,8 +25,7 @@ function shouldSpawnCliProcess(argv: ParsedArgs): boolean {
 		|| !!argv['list-extensions']
 		|| !!argv['install-extension']
 		|| !!argv['uninstall-extension']
-		|| !!argv['locate-extension']
-		|| !!argv['telemetry'];
+		|| !!argv['locate-extension'];
 }
 
 interface IMainCli {

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -41,7 +41,6 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { LocalizationsService } from 'vs/platform/localizations/node/localizations';
 import { Schemas } from 'vs/base/common/network';
 import { SpdLogService } from 'vs/platform/log/node/spdlogService';
-import { buildTelemetryMessage } from 'vs/platform/environment/node/argv';
 
 const notFound = (id: string) => localize('notFound', "Extension '{0}' not found.", id);
 const notInstalled = (id: string) => localize('notInstalled', "Extension '{0}' is not installed.", id);
@@ -95,8 +94,6 @@ export class Main {
 			const arg = argv['locate-extension'];
 			const ids: string[] = typeof arg === 'string' ? [arg] : arg;
 			await this.locateExtension(ids);
-		} else if (argv['telemetry']) {
-			console.log(buildTelemetryMessage(this.environmentService.appRoot, this.environmentService.extensionsPath));
 		}
 	}
 


### PR DESCRIPTION
This removes the telemetry command and the telemetry extractor from the build pipeline as node module issues have made it not yet ready for stable release.