### PR TITLE
Fixes #76369

### DIFF
--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -527,7 +527,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 	}
 
 	mightProducePrintableCharacter(event: IKeyboardEvent): boolean {
-		if (event.ctrlKey || event.metaKey) {
+		if (event.ctrlKey || event.metaKey || event.altKey) {
 			// ignore ctrl/cmd-combination but not shift/alt-combinatios
 			return false;
 		}


### PR DESCRIPTION
This catches alt key events, letting them be used as keybindings.