### PR TITLE
Fix-76662 add *.hpp.in to the file.associations in vscode out of the box

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -18,7 +18,7 @@
 		},
 		{
 			"id": "cpp",
-			"extensions": [ ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".ino", ".inl", ".ipp" ],
+			"extensions": [ ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".ino", ".inl", ".ipp", ".hpp.in", ".h.in" ],
 			"aliases": [ "C++", "Cpp", "cpp"],
 			"configuration": "./language-configuration.json"
 		}],


### PR DESCRIPTION
@alexr00 , This add hpp.in and h.in to file associations for cpp to fix #76662