### PR TITLE
Fix quick terminal splitting for tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -986,6 +986,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 			for (const terminal of values(this.terminals)) {
 				if (terminal.group === group) {
 					const originalInstance = terminal.terminal;
+					await originalInstance.waitForTitle();
 					const config = this.currentTask.shellLaunchConfig;
 					result = this.terminalService.splitInstance(originalInstance, config);
 					if (result) {


### PR DESCRIPTION
Looks like there is a timing issue with trying to split terminals too quickly. By the time that tasks gets the terminal instance back, it isn't guaranteed to have a height and width yet, which means it can't be split. Waiting until there is a title on the terminal is long enough for it to have dimensions.
Part of #76611