### PR TITLE
Fix commandless tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -471,7 +471,8 @@ export class TerminalTaskSystem implements ITaskSystem {
 		const resolvedVariables = this.resolveVariablesFromSet(this.currentTask.systemInfo, this.currentTask.workspaceFolder!, task, variables);
 
 		return resolvedVariables.then((resolvedVariables) => {
-			if (resolvedVariables && task.command && task.command.name && task.command.runtime) {
+			const isCustomExecution = task.command.runtime === RuntimeType.CustomExecution;
+			if (resolvedVariables && task.command && task.command.runtime && (isCustomExecution || task.command.name)) {
 				this.currentTask.resolvedVariables = resolvedVariables;
 				return this.executeInTerminal(task, trigger, new VariableResolver(this.currentTask.workspaceFolder!, this.currentTask.systemInfo, resolvedVariables.variables, this.configurationResolverService));
 			} else {

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -471,7 +471,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 		const resolvedVariables = this.resolveVariablesFromSet(this.currentTask.systemInfo, this.currentTask.workspaceFolder!, task, variables);
 
 		return resolvedVariables.then((resolvedVariables) => {
-			if (resolvedVariables && task.command && task.command.runtime) {
+			if (resolvedVariables && task.command && task.command.name && task.command.runtime) {
 				this.currentTask.resolvedVariables = resolvedVariables;
 				return this.executeInTerminal(task, trigger, new VariableResolver(this.currentTask.workspaceFolder!, this.currentTask.systemInfo, resolvedVariables.variables, this.configurationResolverService));
 			} else {


### PR DESCRIPTION
Tasks without a command have always been permitted. They are most commonly used to create composite tasks that only run other tasks. Recently though, all tasks have been given a command so that they could have a presentation. However, this means that they should be check for an actual command name.

Part of #76611