### PR TITLE
Added new error code and better error message for terminal CWD

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -25,7 +25,7 @@ import { activeContrastBorder, scrollbarSliderActiveBackground, scrollbarSliderB
 import { ICssStyleCollector, ITheme, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { PANEL_BACKGROUND } from 'vs/workbench/common/theme';
 import { TerminalWidgetManager } from 'vs/workbench/contrib/terminal/browser/terminalWidgetManager';
-import { IShellLaunchConfig, ITerminalDimensions, ITerminalInstance, ITerminalProcessManager, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, NEVER_MEASURE_RENDER_TIME_STORAGE_KEY, ProcessState, TERMINAL_PANEL_ID, IWindowsShellHelper, SHELL_PATH_INVALID_EXIT_CODE, SHELL_PATH_DIRECTORY_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
+import { IShellLaunchConfig, ITerminalDimensions, ITerminalInstance, ITerminalProcessManager, KEYBINDING_CONTEXT_TERMINAL_TEXT_SELECTED, NEVER_MEASURE_RENDER_TIME_STORAGE_KEY, ProcessState, TERMINAL_PANEL_ID, IWindowsShellHelper, SHELL_PATH_INVALID_EXIT_CODE, SHELL_PATH_DIRECTORY_EXIT_CODE, SHELL_CWD_INVALID_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
 import { ansiColorIdentifiers, TERMINAL_BACKGROUND_COLOR, TERMINAL_CURSOR_BACKGROUND_COLOR, TERMINAL_CURSOR_FOREGROUND_COLOR, TERMINAL_FOREGROUND_COLOR, TERMINAL_SELECTION_BACKGROUND_COLOR } from 'vs/workbench/contrib/terminal/common/terminalColorRegistry';
 import { TERMINAL_COMMAND_ID } from 'vs/workbench/contrib/terminal/common/terminalCommands';
 import { TerminalConfigHelper } from 'vs/workbench/contrib/terminal/browser/terminalConfigHelper';
@@ -1009,6 +1009,8 @@ export class TerminalInstance implements ITerminalInstance {
 				exitCodeMessage = nls.localize('terminal.integrated.exitedWithInvalidPath', 'The terminal shell path "{0}" does not exist', this._shellLaunchConfig.executable);
 			} else if (exitCode === SHELL_PATH_DIRECTORY_EXIT_CODE) {
 				exitCodeMessage = nls.localize('terminal.integrated.exitedWithInvalidPathDirectory', 'The terminal shell path "{0}" is a directory', this._shellLaunchConfig.executable);
+			} else if (exitCode === SHELL_CWD_INVALID_EXIT_CODE && this._shellLaunchConfig.cwd) {
+				exitCodeMessage = nls.localize('terminal.integrated.exitedWithInvalidCWD', 'The terminal shell CWD "{0}" does not exist', this._shellLaunchConfig.cwd.toString());
 			} else if (this._processManager && this._processManager.processState === ProcessState.KILLED_DURING_LAUNCH) {
 				let args = '';
 				if (typeof this._shellLaunchConfig.args === 'string') {

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -64,6 +64,7 @@ export const MINIMUM_LETTER_SPACING = -5;
 export const DEFAULT_LINE_HEIGHT = 1;
 export const SHELL_PATH_INVALID_EXIT_CODE = -1;
 export const SHELL_PATH_DIRECTORY_EXIT_CODE = -2;
+export const SHELL_CWD_INVALID_EXIT_CODE = -3;
 
 export type FontWeight = 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
 

--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -73,7 +73,7 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
 			}
 			return;
-		}).catch((err) => {
+		}, err => {
 			if (err && err.code === 'ENOENT') {
 				// So we can include in the error message the specified CWD
 				shellLaunchConfig.cwd = cwd;
@@ -87,7 +87,7 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 				return Promise.reject(stat.isDirectory() ? SHELL_PATH_DIRECTORY_EXIT_CODE : SHELL_PATH_INVALID_EXIT_CODE);
 			}
 			return;
-		}).catch(async (err) => {
+		}, async (err) => {
 			if (err && err.code === 'ENOENT') {
 				let cwd = shellLaunchConfig.cwd instanceof URI ? shellLaunchConfig.cwd.path : shellLaunchConfig.cwd!;
 				const executable = await findExecutable(shellLaunchConfig.executable!, cwd);
@@ -95,7 +95,6 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 					return Promise.reject(SHELL_PATH_INVALID_EXIT_CODE);
 				}
 			}
-			return;
 		});
 
 		Promise.all([cwdVerification, exectuableVerification]).then(() => {

--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -68,7 +68,12 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			conptyInheritCursor: true
 		};
 
-		const cwdVerification = stat(cwd).catch((err) => {
+		const cwdVerification = stat(cwd).then(stat => {
+			if (!stat.isDirectory()) {
+				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
+			}
+			return;
+		}).catch((err) => {
 			if (err && err.code === 'ENOENT') {
 				// So we can include in the error message the specified CWD
 				shellLaunchConfig.cwd = cwd;

--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -68,25 +68,22 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			conptyInheritCursor: true
 		};
 
-		const cwdVerification = stat(cwd).then(stat => {
+		const cwdVerification = stat(cwd).then(async stat => {
 			if (!stat.isDirectory()) {
 				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
 			}
-			return;
-		}, err => {
+		}, async err => {
 			if (err && err.code === 'ENOENT') {
 				// So we can include in the error message the specified CWD
 				shellLaunchConfig.cwd = cwd;
 				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
 			}
-			return;
 		});
 
-		const exectuableVerification = stat(shellLaunchConfig.executable!).then(stat => {
+		const exectuableVerification = stat(shellLaunchConfig.executable!).then(async stat => {
 			if (!stat.isFile() && !stat.isSymbolicLink()) {
 				return Promise.reject(stat.isDirectory() ? SHELL_PATH_DIRECTORY_EXIT_CODE : SHELL_PATH_INVALID_EXIT_CODE);
 			}
-			return;
 		}, async (err) => {
 			if (err && err.code === 'ENOENT') {
 				let cwd = shellLaunchConfig.cwd instanceof URI ? shellLaunchConfig.cwd.path : shellLaunchConfig.cwd!;

--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import { Event, Emitter } from 'vs/base/common/event';
 import { getWindowsBuildNumber } from 'vs/workbench/contrib/terminal/node/terminal';
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { IShellLaunchConfig, ITerminalChildProcess, SHELL_PATH_INVALID_EXIT_CODE, SHELL_PATH_DIRECTORY_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
+import { IShellLaunchConfig, ITerminalChildProcess, SHELL_PATH_INVALID_EXIT_CODE, SHELL_PATH_DIRECTORY_EXIT_CODE, SHELL_CWD_INVALID_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
 import { exec } from 'child_process';
 import { ILogService } from 'vs/platform/log/common/log';
 import { stat } from 'vs/base/node/pfs';
@@ -68,20 +68,35 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			conptyInheritCursor: true
 		};
 
-		stat(shellLaunchConfig.executable!).then(stat => {
-			if (!stat.isFile() && !stat.isSymbolicLink()) {
-				return this._launchFailed(stat.isDirectory() ? SHELL_PATH_DIRECTORY_EXIT_CODE : SHELL_PATH_INVALID_EXIT_CODE);
+		const cwdVerification = stat(cwd).catch((err) => {
+			if (err && err.code === 'ENOENT') {
+				// So we can include in the error message the specified CWD
+				shellLaunchConfig.cwd = cwd;
+				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
 			}
-			this.setupPtyProcess(shellLaunchConfig, options);
-		}, async (err) => {
+			return;
+		});
+
+		const exectuableVerification = stat(shellLaunchConfig.executable!).then(stat => {
+			if (!stat.isFile() && !stat.isSymbolicLink()) {
+				return Promise.reject(stat.isDirectory() ? SHELL_PATH_DIRECTORY_EXIT_CODE : SHELL_PATH_INVALID_EXIT_CODE);
+			}
+			return;
+		}).catch(async (err) => {
 			if (err && err.code === 'ENOENT') {
 				let cwd = shellLaunchConfig.cwd instanceof URI ? shellLaunchConfig.cwd.path : shellLaunchConfig.cwd!;
 				const executable = await findExecutable(shellLaunchConfig.executable!, cwd);
 				if (!executable) {
-					return this._launchFailed(SHELL_PATH_INVALID_EXIT_CODE);
+					return Promise.reject(SHELL_PATH_INVALID_EXIT_CODE);
 				}
 			}
+			return;
+		});
+
+		Promise.all([cwdVerification, exectuableVerification]).then(() => {
 			this.setupPtyProcess(shellLaunchConfig, options);
+		}).catch((exitCode: number) => {
+			return this._launchFailed(exitCode);
 		});
 	}
 


### PR DESCRIPTION
When the `terminal.integrated.cwd` is a bad path currently we just fall back on the default failure of exiting with code 1 which doesn't provide much information to the user. This adds a specific exit code and message when we cannot resolve the CWD specified.

Fixes #17450