### PR TITLE
Fixed css refresh issue with the integrated terminal.

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -102,7 +102,6 @@
 }
 
 .monaco-workbench .panel.integrated-terminal .xterm {
-	position: absolute;
 	bottom: 0;
 	left: 0;
 	user-select: none;
@@ -123,7 +122,6 @@
 	display: block;
 	content: "";
 	border: 1px solid;
-	position: absolute;
 	left: -5px;
 	top: 0;
 	right: -5px;


### PR DESCRIPTION
This issue fixed a problem in which the integrated terminal doesn't seem to update it's position when the terminal is resized. This can be better seen in the following gifs.

Bugged version:
![bug](https://user-images.githubusercontent.com/8430304/60740334-35820880-9f5d-11e9-8b0a-1b7808a225b3.gif)

In the above version, when the terminal resizes it takes a long time before being updated to the correct position.

Fixed version:
![fixed](https://user-images.githubusercontent.com/8430304/60740354-4599e800-9f5d-11e9-84e6-65a937d03445.gif)

In this version, the terminal appears to react to the terminal being resized. 

Note I don't know why the terminal seems to add newlines in non-active split terminals. That behavior seems to occur with vscode-insiders anyway. (Note I seem to have found the issue, it's mostly weird behavior with QEMU.)


The main issue in this case being the Position: absolute being used for the css elements.

I have tested with opening programs, such as nano, and up to 5 terminals and it seems to work fine. 
![other](https://user-images.githubusercontent.com/8430304/60740617-5e56cd80-9f5e-11e9-8498-d0e91243efb3.gif)

It also seems to work fine for right sided terminals.

![right](https://user-images.githubusercontent.com/8430304/60743894-6832fd80-9f6b-11e9-9793-5020ed10a586.gif)


Hopefully the above would give a better impression of vscode being smoother and snappy.
