### PR TITLE
Register the URL protocol only when installing (Windows)

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -953,6 +953,11 @@ Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}Source
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}SourceFile\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\resources\app\resources\win32\default.ico"
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\{#RegValueName}SourceFile\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""
 
+Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\vscode"; ValueType: string; ValueName: ""; ValueData: "URL:Custom Protocol"; Flags: uninsdeletekey
+Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\vscode"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\vscode\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\resources\app\resources\win32\default.ico"
+Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\vscode\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" --open-url -- ""%1"""
+
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\Applications\{#ExeBasename}.exe"; ValueType: none; ValueName: ""; Flags: uninsdeletekey
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\Applications\{#ExeBasename}.exe\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\resources\app\resources\win32\default.ico"
 Root: {#SoftwareClassesRootKey}; Subkey: "Software\Classes\Applications\{#ExeBasename}.exe\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#ExeBasename}.exe"" ""%1"""

--- a/src/vs/platform/url/electron-main/electronUrlListener.ts
+++ b/src/vs/platform/url/electron-main/electronUrlListener.ts
@@ -5,12 +5,10 @@
 
 import { Event } from 'vs/base/common/event';
 import { IURLService } from 'vs/platform/url/common/url';
-import product from 'vs/platform/product/node/product';
 import { app } from 'electron';
 import { URI } from 'vs/base/common/uri';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
-import { isWindows } from 'vs/base/common/platform';
 import { coalesce } from 'vs/base/common/arrays';
 
 function uriFromRawUrl(url: string): URI | null {
@@ -42,10 +40,6 @@ export class ElectronURLListener {
 				urlService.open(uri);
 			}
 		});
-
-		if (isWindows) {
-			app.setAsDefaultProtocolClient(product.urlProtocol, process.execPath, ['--open-url', '--']);
-		}
 
 		const onOpenElectronUrl = Event.map(
 			Event.fromNodeEventEmitter(app, 'open-url', (event: Electron.Event, url: string) => ({ event, url })),


### PR DESCRIPTION
The current flow use Electron's setAsDefaultProtocolClient for the registration of vscode URL protocol on windows on every startup.
This change move the registration to the setup files (like it is done with linux).