### PR TITLE
Use right arch in distro dependencies

### DIFF
--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -60,6 +60,8 @@ steps:
 - powershell: |
     . build/azure-pipelines/win32/exec.ps1
     $ErrorActionPreference = "Stop"
+    $env:npm_config_arch="$(VSCODE_ARCH)"
+    $env:CHILD_CONCURRENCY="1"
     exec { node build/azure-pipelines/common/installDistroDependencies.js }
     exec { node build/azure-pipelines/common/installDistroDependencies.js remote }
     exec { node build/lib/builtInExtensions.js }


### PR DESCRIPTION
Candidate fix for https://github.com/microsoft/vscode/issues/76740

We need to set the `npm_config_arch` env to the right architecture on Windows builds, since that build template is used for both x64 and ia32. This broke recently, since the `installDistroDependencies` script was split into another build task than `yarn install`, which sets the correct env. We should set the `npm_config_arch` env in that new task as well.