### PR TITLE
Lower telemetry tooling commit

### DIFF
--- a/build/azure-pipelines/common/extract-telemetry.sh
+++ b/build/azure-pipelines/common/extract-telemetry.sh
@@ -4,7 +4,7 @@ set -e
 cd $BUILD_STAGINGDIRECTORY
 git clone https://github.com/microsoft/vscode-telemetry-extractor.git
 cd vscode-telemetry-extractor
-git checkout 3e0ace196871f93a20f4a7f5ec3ae0cf5e431d78
+git checkout f538e3157c84d1bd0b239dfc5ebccac226006d58
 npm i
 npm run setup-extension-repos
 node ./out/cli-extract.js --sourceDir $BUILD_SOURCESDIRECTORY --excludedDirPattern extensions  --outputDir . --applyEndpoints --includeIsMeasurement --patchWebsiteEvents


### PR DESCRIPTION
New telemetry tooling commit breaks builds. Looking into a fix, but for now this lowers the commit back to its original state.