### PR TITLE
Fix quick fix problems menu button when using custom context menus

### DIFF
--- a/src/vs/editor/contrib/codeAction/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionCommands.ts
@@ -24,6 +24,9 @@ import { IMarkerService } from 'vs/platform/markers/common/markers';
 import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { CodeActionModel, CodeActionsState, SUPPORTED_CODE_ACTIONS } from './codeActionModel';
 import { CodeActionAutoApply, CodeActionFilter, CodeActionKind, CodeActionTrigger } from './codeActionTrigger';
+import { CodeActionSet } from 'vs/editor/contrib/codeAction/codeAction';
+import { IAnchor } from 'vs/base/browser/ui/contextview/contextview';
+import { IPosition } from 'vs/editor/common/core/position';
 
 function contextKeyForSupportedActions(kind: CodeActionKind) {
 	return ContextKeyExpr.regex(
@@ -58,7 +61,7 @@ export class QuickFixController extends Disposable implements IEditorContributio
 
 		this._editor = editor;
 		this._model = this._register(new CodeActionModel(this._editor, markerService, contextKeyService, progressService));
-		this._register(this._model.onDidChangeState((newState) => this._onDidChangeCodeActionsState(newState)));
+		this._register(this._model.onDidChangeState((newState) => this.update(newState)));
 
 		this._ui = this._register(new CodeActionUi(editor, QuickFixAction.Id, {
 			applyCodeAction: async (action, retrigger) => {
@@ -73,8 +76,12 @@ export class QuickFixController extends Disposable implements IEditorContributio
 		}, contextMenuService, keybindingService));
 	}
 
-	private _onDidChangeCodeActionsState(newState: CodeActionsState.State): void {
+	private update(newState: CodeActionsState.State): void {
 		this._ui.update(newState);
+	}
+
+	public showCodeActions(actions: Promise<CodeActionSet>, at: IAnchor | IPosition) {
+		return this._ui.showCodeActionList(actions, at);
 	}
 
 	public getId(): string {

--- a/src/vs/editor/contrib/codeAction/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionModel.ts
@@ -107,7 +107,7 @@ class CodeActionOracle extends Disposable {
 				}
 			}
 		}
-		return selection ? selection : undefined;
+		return selection;
 	}
 
 	private _createEventAndSignalChange(trigger: CodeActionTrigger, selection: Selection | undefined): TriggeredCodeAction {

--- a/src/vs/editor/contrib/codeAction/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionUi.ts
@@ -15,6 +15,8 @@ import { CodeActionsState } from './codeActionModel';
 import { CodeActionAutoApply } from './codeActionTrigger';
 import { CodeActionWidget } from './codeActionWidget';
 import { LightBulbWidget } from './lightBulbWidget';
+import { IPosition } from 'vs/editor/common/core/position';
+import { IAnchor } from 'vs/base/browser/ui/contextview/contextview';
 
 export class CodeActionUi extends Disposable {
 
@@ -91,6 +93,18 @@ export class CodeActionUi extends Disposable {
 				this._activeCodeActions.value = actions;
 			}
 		}
+	}
+
+	public async showCodeActionList(codeActions: Promise<CodeActionSet>, at?: IAnchor | IPosition): Promise<void> {
+		let actions: CodeActionSet;
+		try {
+			actions = await codeActions;
+		} catch (e) {
+			onUnexpectedError(e);
+			return;
+		}
+
+		this._codeActionWidget.show(actions, at);
 	}
 
 	private _handleLightBulbSelect(e: { x: number, y: number, actions: CodeActionSet }): void {

--- a/src/vs/editor/contrib/codeAction/codeActionWidget.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionWidget.ts
@@ -7,12 +7,13 @@ import { getDomNodePagePosition } from 'vs/base/browser/dom';
 import { Action } from 'vs/base/common/actions';
 import { canceled } from 'vs/base/common/errors';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { Position } from 'vs/editor/common/core/position';
+import { Position, IPosition } from 'vs/editor/common/core/position';
 import { ScrollType } from 'vs/editor/common/editorCommon';
 import { CodeAction } from 'vs/editor/common/modes';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { CodeActionSet } from 'vs/editor/contrib/codeAction/codeAction';
 import { Disposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { IAnchor } from 'vs/base/browser/ui/contextview/contextview';
 
 interface CodeActionWidgetDelegate {
 	onSelectCodeAction: (action: CodeAction) => Promise<any>;
@@ -31,7 +32,7 @@ export class CodeActionWidget extends Disposable {
 		super();
 	}
 
-	public async show(codeActions: CodeActionSet, at?: { x: number; y: number } | Position): Promise<void> {
+	public async show(codeActions: CodeActionSet, at?: IAnchor | IPosition): Promise<void> {
 		if (!codeActions.actions.length) {
 			this._visible = false;
 			return;
@@ -72,7 +73,7 @@ export class CodeActionWidget extends Disposable {
 		return this._visible;
 	}
 
-	private _toCoords(position: Position): { x: number, y: number } {
+	private _toCoords(position: IPosition): { x: number, y: number } {
 		if (!this._editor.hasModel()) {
 			return { x: 0, y: 0 };
 		}

--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -25,9 +25,6 @@ import { editorHoverBackground, editorHoverBorder, editorHoverHighlight, textCod
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
-import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
 
 export class ModesHoverController implements IEditorContribution {
@@ -68,9 +65,6 @@ export class ModesHoverController implements IEditorContribution {
 		@IModeService private readonly _modeService: IModeService,
 		@IMarkerDecorationsService private readonly _markerDecorationsService: IMarkerDecorationsService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
-		@IBulkEditService private readonly _bulkEditService: IBulkEditService,
-		@ICommandService private readonly _commandService: ICommandService,
 		@IThemeService private readonly _themeService: IThemeService
 	) {
 		this._isMouseDown = false;
@@ -211,7 +205,7 @@ export class ModesHoverController implements IEditorContribution {
 	}
 
 	private _createHoverWidget() {
-		this._contentWidget = new ModesContentHoverWidget(this._editor, this._markerDecorationsService, this._themeService, this._keybindingService, this._contextMenuService, this._bulkEditService, this._commandService, this._modeService, this._openerService);
+		this._contentWidget = new ModesContentHoverWidget(this._editor, this._markerDecorationsService, this._themeService, this._keybindingService, this._modeService, this._openerService);
 		this._glyphWidget = new ModesGlyphHoverWidget(this._editor, this._modeService, this._openerService);
 	}
 

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -13,7 +13,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
-import { DocumentColorProvider, Hover as MarkdownHover, HoverProviderRegistry, IColor } from 'vs/editor/common/modes';
+import { DocumentColorProvider, Hover as MarkdownHover, HoverProviderRegistry, IColor, CodeAction } from 'vs/editor/common/modes';
 import { getColorPresentations } from 'vs/editor/contrib/colorPicker/color';
 import { ColorDetector } from 'vs/editor/contrib/colorPicker/colorDetector';
 import { ColorPickerModel } from 'vs/editor/contrib/colorPicker/colorPickerModel';
@@ -31,13 +31,9 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { IOpenerService, NullOpenerService } from 'vs/platform/opener/common/opener';
 import { MarkerController, NextMarkerAction } from 'vs/editor/contrib/gotoError/gotoError';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
-import { IBulkEditService } from 'vs/editor/browser/services/bulkEditService';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { CancelablePromise, createCancelablePromise } from 'vs/base/common/async';
-import { getCodeActions } from 'vs/editor/contrib/codeAction/codeAction';
-import { applyCodeAction, QuickFixAction } from 'vs/editor/contrib/codeAction/codeActionCommands';
-import { Action } from 'vs/base/common/actions';
+import { getCodeActions, CodeActionSet } from 'vs/editor/contrib/codeAction/codeAction';
+import { QuickFixAction, QuickFixController } from 'vs/editor/contrib/codeAction/codeActionCommands';
 import { CodeActionKind } from 'vs/editor/contrib/codeAction/codeActionTrigger';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IIdentifiedSingleEditOperation } from 'vs/editor/common/model';
@@ -187,10 +183,6 @@ class ModesContentComputer implements IHoverComputer<HoverPart[]> {
 	}
 }
 
-interface ActionSet extends IDisposable {
-	readonly actions: Action[];
-}
-
 export class ModesContentHoverWidget extends ContentHoverWidget {
 
 	static readonly ID = 'editor.contrib.modesContentHoverWidget';
@@ -211,9 +203,6 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 		markerDecorationsService: IMarkerDecorationsService,
 		private readonly _themeService: IThemeService,
 		private readonly _keybindingService: IKeybindingService,
-		private readonly _contextMenuService: IContextMenuService,
-		private readonly _bulkEditService: IBulkEditService,
-		private readonly _commandService: ICommandService,
 		private readonly _modeService: IModeService,
 		private readonly _openerService: IOpenerService | null = NullOpenerService,
 	) {
@@ -535,12 +524,12 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 			run: async (target) => {
 				const codeActionsPromise = this.getCodeActions(markerHover.marker);
 				disposables.add(toDisposable(() => codeActionsPromise.cancel()));
-				const actions = await codeActionsPromise;
-				disposables.add(actions);
+
+				const controller = QuickFixController.get(this._editor);
 				const elementPosition = dom.getDomNodePagePosition(target);
-				this._contextMenuService.showContextMenu({
-					getAnchor: () => ({ x: elementPosition.left + 6, y: elementPosition.top + elementPosition.height + 6 }),
-					getActions: () => actions.actions
+				controller.showCodeActions(codeActionsPromise, {
+					x: elementPosition.left + 6,
+					y: elementPosition.top + elementPosition.height + 6
 				});
 			}
 		}));
@@ -559,30 +548,22 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 		return hoverElement;
 	}
 
-	private getCodeActions(marker: IMarker): CancelablePromise<ActionSet> {
-		return createCancelablePromise(async cancellationToken => {
-			const codeActions = await getCodeActions(this._editor.getModel()!, new Range(marker.startLineNumber, marker.startColumn, marker.endLineNumber, marker.endColumn), { type: 'manual', filter: { kind: CodeActionKind.QuickFix } }, cancellationToken);
-			if (codeActions.actions.length) {
-				const actions: Action[] = [];
-				for (const codeAction of codeActions.actions) {
-					actions.push(new Action(
-						codeAction.command ? codeAction.command.id : codeAction.title,
-						codeAction.title,
-						undefined,
-						true,
-						() => applyCodeAction(codeAction, this._bulkEditService, this._commandService)));
-				}
-				return {
-					actions: actions,
-					dispose: () => codeActions.dispose()
-				};
-			}
+	private getCodeActions(marker: IMarker): CancelablePromise<CodeActionSet> {
+		const noAction: CodeAction = {
+			title: nls.localize('editor.action.quickFix.noneMessage', "No code actions available"),
+			kind: CodeActionKind.QuickFix.value,
+		};
+		return createCancelablePromise(async (cancellationToken): Promise<CodeActionSet> => {
+			const result = await getCodeActions(
+				this._editor.getModel()!,
+				new Range(marker.startLineNumber, marker.startColumn, marker.endLineNumber, marker.endColumn),
+				{ type: 'manual', filter: { kind: CodeActionKind.QuickFix } },
+				cancellationToken);
 
 			return {
-				actions: [
-					new Action('', nls.localize('editor.action.quickFix.noneMessage', "No code actions available"))
-				],
-				dispose() { }
+				actions: result.actions.length ? result.actions : [noAction],
+				hasAutoFix: result.hasAutoFix,
+				dispose: () => result.dispose(),
 			};
 		});
 	}


### PR DESCRIPTION
Fixes #77018

**Bug**
In VS code 1.36, a lifecycle was added to code actions. The `quick fix` button in the problems hover view manages the life cycle of its code actions by disposing of the code actions it computes when the hover is closed

When using native context menus, clicking the `quick fix` button in a problem hover keeps the hover open. However when using custom context menus, the hover is closed when you click on the `quick fix` button. This means that the list of code actions we are now displaying has been disposed of and will not function as expected

**Fix**
Refactor to route the UI for showing the code actions menu through the code actions controller, which properly handles the lifecycle of code actions. This also somewhat reduces code duplication