### PR TITLE
List select expands selection

### DIFF
--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -592,8 +592,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		// List
 		if (focused instanceof List || focused instanceof PagedList) {
 			const list = focused;
-			list.setSelection(list.getFocus());
-			list.open(list.getFocus());
+			const newSelection = list.getSelection().concat(list.getFocus());
+			list.setSelection(newSelection);
+			list.open(newSelection);
 		}
 
 		// ObjectTree
@@ -616,8 +617,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 				}
 			}
 
-			list.setSelection(focus, fakeKeyboardEvent);
-			list.open(focus, fakeKeyboardEvent);
+			const newSelection = list.getSelection().concat(focus);
+			list.setSelection(newSelection, fakeKeyboardEvent);
+			list.open(newSelection, fakeKeyboardEvent);
 		}
 
 		// Tree
@@ -626,7 +628,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 			const focus = tree.getFocus();
 
 			if (focus) {
-				tree.setSelection([focus], { origin: 'keyboard' });
+				const newSelection = tree.getSelection().concat([focus]);
+				tree.setSelection(newSelection, { origin: 'keyboard' });
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -320,15 +320,17 @@ export class ExplorerView extends ViewletPanel {
 			// Do not react if the user is expanding selection via keyboard.
 			// Check if the item was previously also selected, if yes the user is simply expanding / collapsing current selection #66589.
 			const shiftDown = e.browserEvent instanceof KeyboardEvent && e.browserEvent.shiftKey;
-			if (selection.length === 1 && !shiftDown) {
-				if (selection[0].isDirectory || this.explorerService.isEditable(undefined)) {
-					// Do not react if user is clicking on explorer items while some are being edited #70276
-					// Do not react if clicking on directories
-					return;
-				}
-				this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: 'workbench.files.openFile', from: 'explorer' });
-				this.editorService.openEditor({ resource: selection[0].resource, options: { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned } }, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP)
-					.then(undefined, onUnexpectedError);
+			if (!shiftDown) {
+				selection.map(s => {
+					if (s.isDirectory || this.explorerService.isEditable(undefined)) {
+						// Do not react if user is clicking on explorer items while some are being edited #70276
+						// Do not react if clicking on directories
+						return;
+					}
+					this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: 'workbench.files.openFile', from: 'explorer' });
+					this.editorService.openEditor({ resource: s.resource, options: { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned || selection.length > 1 } }, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP)
+						.then(undefined, onUnexpectedError);
+				});
 			}
 		}));
 


### PR DESCRIPTION
This PR:
1. Changes the `list.select` command such that it expands the selection, and not to set the selection to 1 element like before
2. Changes that the list fires the `open` event for all the newly selected elements (not just one)
3. Adopts the explorer to react to this, thus fixing #42573

fixes #42573