### PR TITLE
allow multiple parameters on c++ pure virtuals

### DIFF
--- a/extensions/cpp/syntaxes/cpp.tmLanguage.json
+++ b/extensions/cpp/syntaxes/cpp.tmLanguage.json
@@ -1025,7 +1025,7 @@
 			"name": "storage.modifier.specifier.functional.pre-parameters.$0.cpp"
 		},
 		"qualifiers_and_specifiers_post_parameters": {
-			"match": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((?<!\\w)(?:final|override|volatile|const|noexcept)(?!\\w)(?=\\s*(?:(?:\\{|;)|[\\n\\r])))",
+			"match": "((?:(?:(?>\\s+)|(\\/\\*)((?>(?:[^\\*]|(?>\\*+)[^\\/])*)((?>\\*+)\\/)))+?|(?:(?:(?:(?:\\b|(?<=\\W))|(?=\\W))|\\A)|\\Z)))((?<!\\w)(?:final|override|volatile|const|noexcept)(?!\\w)(?=\\s*(?:(?:\\{|;|=)|[\\n\\r])))",
 			"captures": {
 				"1": {
 					"patterns": [


### PR DESCRIPTION
Fixes c++ syntax definition to allow multiple post parameters on pure virtual methods.

Fixes #77107