### PR TITLE
Don't show quick fix link in problem hovers until we know we have quick fixes

### DIFF
--- a/src/vs/editor/contrib/codeAction/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionCommands.ts
@@ -80,7 +80,7 @@ export class QuickFixController extends Disposable implements IEditorContributio
 		this._ui.update(newState);
 	}
 
-	public showCodeActions(actions: Promise<CodeActionSet>, at: IAnchor | IPosition) {
+	public showCodeActions(actions: CodeActionSet, at: IAnchor | IPosition) {
 		return this._ui.showCodeActionList(actions, at);
 	}
 

--- a/src/vs/editor/contrib/codeAction/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/codeActionUi.ts
@@ -95,15 +95,7 @@ export class CodeActionUi extends Disposable {
 		}
 	}
 
-	public async showCodeActionList(codeActions: Promise<CodeActionSet>, at?: IAnchor | IPosition): Promise<void> {
-		let actions: CodeActionSet;
-		try {
-			actions = await codeActions;
-		} catch (e) {
-			onUnexpectedError(e);
-			return;
-		}
-
+	public async showCodeActionList(actions: CodeActionSet, at?: IAnchor | IPosition): Promise<void> {
 		this._codeActionWidget.show(actions, at);
 	}
 

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -531,12 +531,19 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 		}
 
 		const quickfixPlaceholderElement = dom.append(actionsElement, $('div'));
+		quickfixPlaceholderElement.style.opacity = '0';
+		quickfixPlaceholderElement.style.transition = 'opacity 0.2s';
+		setTimeout(() => quickfixPlaceholderElement.style.opacity = '1', 200);
 		quickfixPlaceholderElement.textContent = nls.localize('checkingForQuickFixes', "Checking for quick fixes...");
 		disposables.add(toDisposable(() => quickfixPlaceholderElement.remove()));
+
 
 		const codeActionsPromise = this.getCodeActions(markerHover.marker);
 		disposables.add(toDisposable(() => codeActionsPromise.cancel()));
 		codeActionsPromise.then(actions => {
+			quickfixPlaceholderElement.style.transition = '';
+			quickfixPlaceholderElement.style.opacity = '1';
+
 			if (!actions.actions.length) {
 				actions.dispose();
 				quickfixPlaceholderElement.textContent = nls.localize('noQuickFixes', "No quick fixes available");

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -530,15 +530,21 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 			}));
 		}
 
+		const quickfixPlaceholderElement = dom.append(actionsElement, $('div'));
+		quickfixPlaceholderElement.textContent = nls.localize('checkingForQuickFixes', "Checking for quick fixes...");
+		disposables.add(toDisposable(() => quickfixPlaceholderElement.remove()));
+
 		const codeActionsPromise = this.getCodeActions(markerHover.marker);
 		disposables.add(toDisposable(() => codeActionsPromise.cancel()));
 		codeActionsPromise.then(actions => {
 			if (!actions.actions.length) {
 				actions.dispose();
+				quickfixPlaceholderElement.textContent = nls.localize('noQuickFixes', "No quick fixes available");
 				return;
 			}
-			let showing = false;
+			quickfixPlaceholderElement.remove();
 
+			let showing = false;
 			disposables.add(toDisposable(() => {
 				if (!showing) {
 					actions.dispose();

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -13,7 +13,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
-import { DocumentColorProvider, Hover as MarkdownHover, HoverProviderRegistry, IColor, CodeAction } from 'vs/editor/common/modes';
+import { DocumentColorProvider, Hover as MarkdownHover, HoverProviderRegistry, IColor } from 'vs/editor/common/modes';
 import { getColorPresentations } from 'vs/editor/contrib/colorPicker/color';
 import { ColorDetector } from 'vs/editor/contrib/colorPicker/colorDetector';
 import { ColorPickerModel } from 'vs/editor/contrib/colorPicker/colorPickerModel';
@@ -518,21 +518,6 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 		const hoverElement = $('div.hover-row.status-bar');
 		const disposables = new DisposableStore();
 		const actionsElement = dom.append(hoverElement, $('div.actions'));
-		disposables.add(this.renderAction(actionsElement, {
-			label: nls.localize('quick fixes', "Quick Fix..."),
-			commandId: QuickFixAction.Id,
-			run: async (target) => {
-				const codeActionsPromise = this.getCodeActions(markerHover.marker);
-				disposables.add(toDisposable(() => codeActionsPromise.cancel()));
-
-				const controller = QuickFixController.get(this._editor);
-				const elementPosition = dom.getDomNodePagePosition(target);
-				controller.showCodeActions(codeActionsPromise, {
-					x: elementPosition.left + 6,
-					y: elementPosition.top + elementPosition.height + 6
-				});
-			}
-		}));
 		if (markerHover.marker.severity === MarkerSeverity.Error || markerHover.marker.severity === MarkerSeverity.Warning || markerHover.marker.severity === MarkerSeverity.Info) {
 			disposables.add(this.renderAction(actionsElement, {
 				label: nls.localize('peek problem', "Peek Problem"),
@@ -544,27 +529,48 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 				}
 			}));
 		}
+
+		const codeActionsPromise = this.getCodeActions(markerHover.marker);
+		disposables.add(toDisposable(() => codeActionsPromise.cancel()));
+		codeActionsPromise.then(actions => {
+			if (!actions.actions.length) {
+				actions.dispose();
+				return;
+			}
+			let showing = false;
+
+			disposables.add(toDisposable(() => {
+				if (!showing) {
+					actions.dispose();
+				}
+			}));
+
+			disposables.add(this.renderAction(actionsElement, {
+				label: nls.localize('quick fixes', "Quick Fix..."),
+				commandId: QuickFixAction.Id,
+				run: (target) => {
+					showing = true;
+					const controller = QuickFixController.get(this._editor);
+					const elementPosition = dom.getDomNodePagePosition(target);
+					controller.showCodeActions(actions, {
+						x: elementPosition.left + 6,
+						y: elementPosition.top + elementPosition.height + 6
+					});
+				}
+			}));
+		});
+
 		this.renderDisposable.value = disposables;
 		return hoverElement;
 	}
 
 	private getCodeActions(marker: IMarker): CancelablePromise<CodeActionSet> {
-		const noAction: CodeAction = {
-			title: nls.localize('editor.action.quickFix.noneMessage', "No code actions available"),
-			kind: CodeActionKind.QuickFix.value,
-		};
-		return createCancelablePromise(async (cancellationToken): Promise<CodeActionSet> => {
-			const result = await getCodeActions(
+		return createCancelablePromise(cancellationToken => {
+			return getCodeActions(
 				this._editor.getModel()!,
 				new Range(marker.startLineNumber, marker.startColumn, marker.endLineNumber, marker.endColumn),
 				{ type: 'manual', filter: { kind: CodeActionKind.QuickFix } },
 				cancellationToken);
-
-			return {
-				actions: result.actions.length ? result.actions : [noAction],
-				hasAutoFix: result.hasAutoFix,
-				dispose: () => result.dispose(),
-			};
 		});
 	}
 


### PR DESCRIPTION
Fixes #71579

**Bug**
We currently always show the `quick fix` button in problem hovers. This has confused a lot of users (see #71579) because we lead them to think that every error has a quick fix

**Fix**
Only show the quick fix button when we have known quick fixes