### PR TITLE
fix(sash): dragging being difficult with iframe-containing extensions

### DIFF
--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -212,7 +212,13 @@ export class Sash extends Disposable {
 			return;
 		}
 
-		const iframes = getElementsByTagName('iframe');
+		// Select both iframes and webviews; internally Electron nests an iframe
+		// in its <webview> component, but this isn't queryable.
+		const iframes = [
+			...getElementsByTagName('iframe'),
+			...getElementsByTagName('webview'),
+		];
+
 		for (const iframe of iframes) {
 			iframe.style.pointerEvents = 'none'; // disable mouse events on iframes as long as we drag the sash
 		}

--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -286,7 +286,6 @@ export class Sash extends Disposable {
 
 			dispose(disposables);
 
-			const iframes = getElementsByTagName('iframe');
 			for (const iframe of iframes) {
 				iframe.style.pointerEvents = 'auto';
 			}


### PR DESCRIPTION
It appears that (running querySelector, getElementByTagName) the
contents of electron's `<webviews>`, which contain the iframe, are
inaccessible. We were already disabling pointer events on iframes, this PR
makes sure we do so on webviews as well.

![Kapture 2019-07-10 at 10 32 10](https://user-images.githubusercontent.com/2230985/60991203-ea6e4980-a2fe-11e9-8b2f-e9fa9e856d0b.gif)

Fixes https://github.com/microsoft/vscode/issues/76866