### PR TITLE
feat(markdown): add render command (fixes #75612)

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -24,6 +24,7 @@
 		"onCommand:markdown.showLockedPreviewToSide",
 		"onCommand:markdown.showSource",
 		"onCommand:markdown.showPreviewSecuritySelector",
+		"onCommand:markdown.render",
 		"onWebviewPanel:markdown.preview"
 	],
 	"contributes": {

--- a/extensions/markdown-language-features/src/commands/index.ts
+++ b/extensions/markdown-language-features/src/commands/index.ts
@@ -10,3 +10,4 @@ export { RefreshPreviewCommand } from './refreshPreview';
 export { ShowPreviewSecuritySelectorCommand } from './showPreviewSecuritySelector';
 export { MoveCursorToPositionCommand } from './moveCursorToPosition';
 export { ToggleLockCommand } from './toggleLock';
+export { RenderDocument } from './renderDocument';

--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+import { Command } from '../commandManager';
+import { MarkdownEngine } from '../markdownEngine';
+import { SkinnyTextDocument } from '../tableOfContentsProvider';
+
+export class RenderDocument implements Command {
+	public readonly id = 'markdown.render';
+
+	public constructor(
+		private readonly engine: MarkdownEngine
+	) { }
+
+	public async execute(document?: SkinnyTextDocument): Promise<string | undefined> {
+		if (!document) {
+			if (!vscode.window.activeTextEditor) {
+				return;
+			}
+
+			document = vscode.window.activeTextEditor.document;
+		}
+
+		return this.engine.render(document);
+	}
+}

--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -16,7 +16,7 @@ export class RenderDocument implements Command {
 		private readonly engine: MarkdownEngine
 	) { }
 
-	public async execute(document?: SkinnyTextDocument): Promise<string | undefined> {
+	public async execute(document?: SkinnyTextDocument | string): Promise<string | undefined> {
 		if (!document) {
 			if (!vscode.window.activeTextEditor) {
 				return;

--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -83,6 +83,7 @@ function registerMarkdownCommands(
 	commandManager.register(new commands.ShowPreviewSecuritySelectorCommand(previewSecuritySelector, previewManager));
 	commandManager.register(new commands.OpenDocumentLinkCommand(engine));
 	commandManager.register(new commands.ToggleLockCommand(previewManager));
+	commandManager.register(new commands.RenderDocument(engine));
 	return commandManager;
 }
 

--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -118,7 +118,7 @@ export class MarkdownEngine {
 		return md;
 	}
 
-	private tokenize(
+	private tokenizeDocument(
 		document: SkinnyTextDocument,
 		config: MarkdownItConfig,
 		engine: MarkdownIt
@@ -131,16 +131,23 @@ export class MarkdownEngine {
 		this.currentDocument = document.uri;
 		this._slugCount = new Map<string, number>();
 
-		const text = document.getText();
-		const tokens = engine.parse(text.replace(UNICODE_NEWLINE_REGEX, ''), {});
+		const tokens = this.tokenizeString(document.getText(), engine);
 		this._tokenCache.update(document, config, tokens);
 		return tokens;
 	}
 
-	public async render(document: SkinnyTextDocument): Promise<string> {
-		const config = this.getConfig(document.uri);
+	private tokenizeString(text: string, engine: MarkdownIt) {
+		return engine.parse(text.replace(UNICODE_NEWLINE_REGEX, ''), {});
+	}
+
+	public async render(document: SkinnyTextDocument | string): Promise<string> {
+		const config = this.getConfig(typeof document === 'string' ? undefined : document.uri);
 		const engine = await this.getEngine(config);
-		return engine.renderer.render(this.tokenize(document, config, engine), {
+		const tokens = typeof document === 'string'
+			? this.tokenizeString(document, engine)
+			: this.tokenizeDocument(document, config, engine);
+
+		return engine.renderer.render(tokens, {
 			...(engine as any).options,
 			...config
 		}, {});
@@ -149,14 +156,14 @@ export class MarkdownEngine {
 	public async parse(document: SkinnyTextDocument): Promise<Token[]> {
 		const config = this.getConfig(document.uri);
 		const engine = await this.getEngine(config);
-		return this.tokenize(document, config, engine);
+		return this.tokenizeDocument(document, config, engine);
 	}
 
 	public cleanCache(): void {
 		this._tokenCache.clean();
 	}
 
-	private getConfig(resource: vscode.Uri): MarkdownItConfig {
+	private getConfig(resource?: vscode.Uri): MarkdownItConfig {
 		const config = vscode.workspace.getConfiguration('markdown', resource);
 		return {
 			breaks: config.get<boolean>('preview.breaks', false),

--- a/extensions/markdown-language-features/src/test/engine.test.ts
+++ b/extensions/markdown-language-features/src/test/engine.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import 'mocha';
+
+import { InMemoryDocument } from './inMemoryDocument';
+import { createNewMarkdownEngine } from './engine';
+
+const testFileName = vscode.Uri.file('test.md');
+
+suite('markdown.engine', () => {
+	suite('rendering', () => {
+		const input = '# hello\n\nworld!';
+		const output = '<h1 id="hello" data-line="0" class="code-line">hello</h1>\n'
+			+ '<p data-line="2" class="code-line">world!</p>\n';
+
+		test('Renders a document', async () => {
+			const doc = new InMemoryDocument(testFileName, input);
+			const engine = createNewMarkdownEngine();
+			assert.strictEqual(await engine.render(doc), output);
+		});
+
+		test('Renders a string', async () => {
+			const engine = createNewMarkdownEngine();
+			assert.strictEqual(await engine.render(input), output);
+		});
+	});
+});


### PR DESCRIPTION
This adds a command which renders the provided document, or the active
editor if one is available. Following the pattern of some of the preview
commands, it returned `undefined` if there's no document provided and
no active text editor. Otherwise, seems to work...

```ts
const html = await vscode.commands.executeCommand<string>('markdown.render');
```

A way to render arbitrary strings in addition to documents may be useful at
some point in the future. However, I didn't implement that here as that'd
require some refactoring of the markdown engine. If we're interested though
I could certainly give that a shot.

Fixes #75612