### PR TITLE
Avoid using untracked IDisposables in workbench/contrib/extensions

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionProfileService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionProfileService.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IInstantiationService, ServiceIdentifier } from 'vs/platform/instantiation/common/instantiation';
 import { IExtensionHostProfile, ProfileSession, IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, toDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { StatusbarAlignment, IStatusbarService, IStatusbarEntryAccessor, IStatusbarEntry } from 'vs/platform/statusbar/common/statusbar';
 import { IExtensionHostProfileService, ProfileSessionState } from 'vs/workbench/contrib/extensions/electron-browser/runtimeExtensionsEditor';
@@ -37,7 +37,7 @@ export class ExtensionHostProfileService extends Disposable implements IExtensio
 	private _state: ProfileSessionState;
 
 	private profilingStatusBarIndicator: IStatusbarEntryAccessor | undefined;
-	private profilingStatusBarIndicatorLabelUpdater: IDisposable | undefined;
+	private readonly profilingStatusBarIndicatorLabelUpdater = this._register(new MutableDisposable());
 
 	public get state() { return this._state; }
 	public get lastProfile() { return this._profile; }
@@ -77,10 +77,7 @@ export class ExtensionHostProfileService extends Disposable implements IExtensio
 	}
 
 	private updateProfilingStatusBarIndicator(visible: boolean): void {
-		if (this.profilingStatusBarIndicatorLabelUpdater) {
-			this.profilingStatusBarIndicatorLabelUpdater.dispose();
-			this.profilingStatusBarIndicatorLabelUpdater = undefined;
-		}
+		this.profilingStatusBarIndicatorLabelUpdater.clear();
 
 		if (visible) {
 			const indicator: IStatusbarEntry = {
@@ -95,7 +92,7 @@ export class ExtensionHostProfileService extends Disposable implements IExtensio
 					this.profilingStatusBarIndicator.update({ ...indicator, text: nls.localize('profilingExtensionHostTime', "$(sync~spin) Profiling Extension Host ({0} sec)", Math.round((new Date().getTime() - timeStarted) / 1000)), });
 				}
 			}, 1000);
-			this.profilingStatusBarIndicatorLabelUpdater = toDisposable(() => clearInterval(handle));
+			this.profilingStatusBarIndicatorLabelUpdater.value = toDisposable(() => clearInterval(handle));
 
 			if (!this.profilingStatusBarIndicator) {
 				this.profilingStatusBarIndicator = this._statusbarService.addEntry(indicator, 'status.profiler', nls.localize('status.profiler', "Extension Profiler"), StatusbarAlignment.RIGHT);

--- a/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/contrib/extensions/electron-browser/extensionTipsService.ts
@@ -6,7 +6,7 @@
 import { localize } from 'vs/nls';
 import { join } from 'vs/base/common/path';
 import { forEach } from 'vs/base/common/collections';
-import { IDisposable, dispose, Disposable } from 'vs/base/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { match } from 'vs/base/common/glob';
 import * as json from 'vs/base/common/json';
 import {
@@ -83,7 +83,6 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 	private _globallyIgnoredRecommendations: string[] = [];
 	private _workspaceIgnoredRecommendations: string[] = [];
 	private _extensionsRecommendationsUrl: string;
-	private _disposables: IDisposable[] = [];
 	public loadWorkspaceConfigPromise: Promise<void>;
 	private proactiveRecommendationsFetched: boolean = false;
 
@@ -135,7 +134,7 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 
 		this.loadWorkspaceConfigPromise = this.getWorkspaceRecommendations().then(() => {
 			this.promptWorkspaceRecommendations();
-			this._modelService.onModelAdded(this.promptFiletypeBasedRecommendations, this, this._disposables);
+			this._register(this._modelService.onModelAdded(this.promptFiletypeBasedRecommendations, this));
 			this._modelService.getModels().forEach(model => this.promptFiletypeBasedRecommendations(model));
 		});
 
@@ -1034,9 +1033,5 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 
 	private isExtensionAllowedToBeRecommended(id: string): boolean {
 		return this._allIgnoredRecommendations.indexOf(id.toLowerCase()) === -1;
-	}
-
-	dispose() {
-		this._disposables = dispose(this._disposables);
 	}
 }


### PR DESCRIPTION
- Use DisposableStore for tracking lists of disposables
- Use MutableDisposable to track a value that should be disposed of when the value changes
- Extend Disposable where it makes sense or use existing `_register` method from superclass
- Remove unused disposable member in `MaliciousExtensionChecker `