### PR TITLE
Toggle for disabling autofocus on debugger stop

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -259,6 +259,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces."),
 			default: { configurations: [], compounds: [] },
 			$ref: launchSchemaId
+		},
+		'debug.autoFocusEditor': {
+			type: 'boolean',
+			description: nls.localize('debug.autoFocusEditor', "Controls whether the workbench window should be focused when the debugger stops."),
+			default: true
 		}
 	}
 });

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -676,7 +676,10 @@ export class DebugSession implements IDebugSession {
 								if (this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak') {
 									this.viewletService.openViewlet(VIEWLET_ID);
 								}
-								this.windowService.focusWindow();
+
+								if (this.configurationService.getValue<boolean>('debug.autoFocusEditor')) {
+									this.windowService.focusWindow();
+								}
 							}
 						}
 					};


### PR DESCRIPTION
Add boolean config to control whether the workbench window should be
focused when the debugger stops.

Fixes #23117

Co-authored-by: @joaomoreno.
