### PR TITLE
Add optional sortByLabel to QuickPick to control whether to re-sort results

### DIFF
--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -58,6 +58,11 @@ export interface IPickOptions<T extends IQuickPickItem> {
 	matchOnLabel?: boolean;
 
 	/**
+	 * an optional flag to sort the final results by index of first query match in label. Defaults to true.
+	 */
+	sortByLabel?: boolean;
+
+	/**
 	 * an option flag to control whether focus is always automatically brought to a list item. Defaults to true.
 	 */
 	autoFocusOnList?: boolean;
@@ -187,6 +192,8 @@ export interface IQuickPick<T extends IQuickPickItem> extends IQuickInput {
 	matchOnDetail: boolean;
 
 	matchOnLabel: boolean;
+
+	sortByLabel: boolean;
 
 	autoFocusOnList: boolean;
 

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1617,11 +1617,6 @@ declare module 'vscode' {
 		matchOnDetail?: boolean;
 
 		/**
-		 * An optional flag to sort the final results by index of first query match in label, defaults to true.
-		 */
-		sortByLabel?: boolean;
-
-		/**
 		 * An optional string to show as place holder in the input box to guide the user what to pick on.
 		 */
 		placeHolder?: string;
@@ -7331,11 +7326,6 @@ declare module 'vscode' {
 		 * If the filter text should also be matched against the detail of the items. Defaults to false.
 		 */
 		matchOnDetail: boolean;
-
-		/**
-		 * An optional flag to sort the final results by index of first query match in label. Defaults to true.
-		 */
-		sortByLabel: boolean;
 
 		/**
 		 * Active items. This can be read and updated by the extension.

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1617,6 +1617,11 @@ declare module 'vscode' {
 		matchOnDetail?: boolean;
 
 		/**
+		 * An optional flag to sort the final results by index of first query match in label, defaults to true.
+		 */
+		sortByLabel?: boolean;
+
+		/**
 		 * An optional string to show as place holder in the input box to guide the user what to pick on.
 		 */
 		placeHolder?: string;
@@ -7326,6 +7331,11 @@ declare module 'vscode' {
 		 * If the filter text should also be matched against the detail of the items. Defaults to false.
 		 */
 		matchOnDetail: boolean;
+
+		/**
+		 * An optional flag to sort the final results by index of first query match in label. Defaults to true.
+		 */
+		sortByLabel: boolean;
 
 		/**
 		 * Active items. This can be read and updated by the extension.

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1299,4 +1299,21 @@ declare module 'vscode' {
 	}
 
 	//#endregion
+
+	//#region pelmers - allow QuickPicks to skip sorting
+
+	export interface QuickPick<T extends QuickPickItem> extends QuickInput {
+		/**
+		* An optional flag to sort the final results by index of first query match in label. Defaults to true.
+		*/
+		sortByLabel: boolean;
+	}
+	export interface QuickPickOptions {
+		/**
+		* An optional flag to sort the final results by index of first query match in label, defaults to true.
+		*/
+		sortByLabel?: boolean;
+	}
+
+	//#endregion
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -459,6 +459,8 @@ export interface TransferQuickPick extends BaseTransferQuickInput {
 
 	matchOnDescription?: boolean;
 
+	sortByLabel?: boolean;
+
 	matchOnDetail?: boolean;
 }
 

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -54,6 +54,7 @@ export class ExtHostQuickOpen implements ExtHostQuickOpenShape {
 			placeHolder: options && options.placeHolder,
 			matchOnDescription: options && options.matchOnDescription,
 			matchOnDetail: options && options.matchOnDetail,
+			sortByLabel: options && options.sortByLabel,
 			ignoreFocusLost: options && options.ignoreFocusOut,
 			canPickMany: options && options.canPickMany
 		}, token);
@@ -485,6 +486,7 @@ class ExtHostQuickPick<T extends QuickPickItem> extends ExtHostQuickInput implem
 	private _canSelectMany = false;
 	private _matchOnDescription = true;
 	private _matchOnDetail = true;
+	private _sortByLabel = true;
 	private _activeItems: T[] = [];
 	private _onDidChangeActiveEmitter = new Emitter<T[]>();
 	private _selectedItems: T[] = [];
@@ -548,6 +550,15 @@ class ExtHostQuickPick<T extends QuickPickItem> extends ExtHostQuickInput implem
 	set matchOnDetail(matchOnDetail: boolean) {
 		this._matchOnDetail = matchOnDetail;
 		this.update({ matchOnDetail });
+	}
+
+	get sortByLabel() {
+		return this._sortByLabel;
+	}
+
+	set sortByLabel(sortByLabel: boolean) {
+		this._sortByLabel = sortByLabel;
+		this.update({ sortByLabel });
 	}
 
 	get activeItems() {

--- a/src/vs/workbench/browser/parts/quickinput/quickInput.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInput.ts
@@ -335,6 +335,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 	private _matchOnDescription = false;
 	private _matchOnDetail = false;
 	private _matchOnLabel = true;
+	private _sortByLabel = true;
 	private _autoFocusOnList = true;
 	private _activeItems: T[] = [];
 	private activeItemsUpdated = false;
@@ -425,6 +426,16 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		this._matchOnLabel = matchOnLabel;
 		this.update();
 	}
+
+	get sortByLabel() {
+		return this._sortByLabel;
+	}
+
+	set sortByLabel(sortByLabel: boolean) {
+		this._sortByLabel = sortByLabel;
+		this.update();
+	}
+
 
 	get autoFocusOnList() {
 		return this._autoFocusOnList;
@@ -753,6 +764,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		this.ui.list.matchOnDescription = this.matchOnDescription;
 		this.ui.list.matchOnDetail = this.matchOnDetail;
 		this.ui.list.matchOnLabel = this.matchOnLabel;
+		this.ui.list.sortByLabel = this.sortByLabel;
 		this.ui.setComboboxAccessibility(true);
 		this.ui.inputBox.setAttribute('aria-label', QuickPick.INPUT_BOX_ARIA_LABEL);
 		this.ui.setVisibilities(this.canSelectMany ? { title: !!this.title || !!this.step, checkAll: true, inputBox: true, visibleCount: true, count: true, ok: true, list: true, message: !!this.validationMessage } : { title: !!this.title || !!this.step, inputBox: true, visibleCount: true, list: true, message: !!this.validationMessage, customButton: this.customButton, ok: this.ok });
@@ -1249,6 +1261,7 @@ export class QuickInputService extends Component implements IQuickInputService {
 			input.matchOnDescription = !!options.matchOnDescription;
 			input.matchOnDetail = !!options.matchOnDetail;
 			input.matchOnLabel = (options.matchOnLabel === undefined) || options.matchOnLabel; // default to true
+			input.sortByLabel = (options.sortByLabel === undefined) || options.sortByLabel; // default to true
 			input.autoFocusOnList = (options.autoFocusOnList === undefined) || options.autoFocusOnList; // default to true
 			input.quickNavigate = options.quickNavigate;
 			input.contextKey = options.contextKey;
@@ -1368,6 +1381,7 @@ export class QuickInputService extends Component implements IQuickInputService {
 		this.ui.list.matchOnDescription = false;
 		this.ui.list.matchOnDetail = false;
 		this.ui.list.matchOnLabel = true;
+		this.ui.list.sortByLabel = true;
 		this.ui.ignoreFocusOut = false;
 		this.setComboboxAccessibility(false);
 		this.ui.inputBox.removeAttribute('aria-label');

--- a/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
+++ b/src/vs/workbench/browser/parts/quickinput/quickInputList.ts
@@ -222,6 +222,7 @@ export class QuickInputList {
 	matchOnDescription = false;
 	matchOnDetail = false;
 	matchOnLabel = true;
+	sortByLabel = true;
 	private _onChangedAllVisibleChecked = new Emitter<boolean>();
 	onChangedAllVisibleChecked: Event<boolean> = this._onChangedAllVisibleChecked.event;
 	private _onChangedCheckedCount = new Emitter<number>();
@@ -515,7 +516,7 @@ export class QuickInputList {
 		const shownElements = this.elements.filter(element => !element.hidden);
 
 		// Sort by value
-		if (query) {
+		if (this.sortByLabel && query) {
 			const normalizedSearchValue = query.toLowerCase();
 			shownElements.sort((a, b) => {
 				return compareEntries(a, b, normalizedSearchValue);


### PR DESCRIPTION
Address issue #73904 by adding an optional `sortByLabel` to the QuickPick class which determines whether the picker re-sorts the result list when the user types in the input field.

If true, the picker applies a sort to order results by the index of the first appearance of the input in the label.

For backwards compatibility, this field is true by default.

@chrmarti, @roblourens 

Notes: 
This is just a first pass the implements my initial request -- it doesn't add more fields for highlighting or behaviors that touch fields other than the `label`.

And I realize that most of the API makes optional params 'false' by default, I'm happy to rename this one to fit that pattern too if requested (e.g. `disableSortByLabel: false`).

Tested with both 'createQuickPick' and 'showQuickPick' from an extension.