### PR TITLE
Filter extensions by category

### DIFF
--- a/build/azure-pipelines/common/extract-telemetry.sh
+++ b/build/azure-pipelines/common/extract-telemetry.sh
@@ -4,7 +4,7 @@ set -e
 cd $BUILD_STAGINGDIRECTORY
 git clone https://github.com/microsoft/vscode-telemetry-extractor.git
 cd vscode-telemetry-extractor
-git checkout 3e0ace196871f93a20f4a7f5ec3ae0cf5e431d78
+git checkout f538e3157c84d1bd0b239dfc5ebccac226006d58
 npm i
 npm run setup-extension-repos
 node ./out/cli-extract.js --sourceDir $BUILD_SOURCESDIRECTORY --excludedDirPattern extensions  --outputDir . --applyEndpoints --includeIsMeasurement --patchWebsiteEvents

--- a/build/azure-pipelines/common/extract-telemetry.sh
+++ b/build/azure-pipelines/common/extract-telemetry.sh
@@ -4,7 +4,7 @@ set -e
 cd $BUILD_STAGINGDIRECTORY
 git clone https://github.com/microsoft/vscode-telemetry-extractor.git
 cd vscode-telemetry-extractor
-git checkout f538e3157c84d1bd0b239dfc5ebccac226006d58
+git checkout 4e64f3de30f8fccb58ebdc0d85c4861a135d46cf
 npm i
 npm run compile
 cd src

--- a/build/azure-pipelines/common/extract-telemetry.sh
+++ b/build/azure-pipelines/common/extract-telemetry.sh
@@ -4,7 +4,7 @@ set -e
 cd $BUILD_STAGINGDIRECTORY
 git clone https://github.com/microsoft/vscode-telemetry-extractor.git
 cd vscode-telemetry-extractor
-git checkout 4e64f3de30f8fccb58ebdc0d85c4861a135d46cf
+git checkout f538e3157c84d1bd0b239dfc5ebccac226006d58
 npm i
 npm run compile
 cd src

--- a/resources/completions/zsh/_code
+++ b/resources/completions/zsh/_code
@@ -17,6 +17,7 @@ arguments=(
 	'(- *)'{--telemetry}'[Shows all telemetry events which VS code collects.]'
 	'--extensions-dir[set the root path for extensions]:root path:_directories'
 	'--list-extensions[list the installed extensions]'
+	'--category[filters instaled extension list by category, when using --list-extension]'
 	'--show-versions[show versions of installed extensions, when using --list-extension]'
 	'--install-extension[install an extension]:id or path:_files -g "*.vsix(-.)"'
 	'--uninstall-extension[uninstall an extension]:id or path:_files -g "*.vsix(-.)"'

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -84,7 +84,7 @@ export class Main {
 			await this.setInstallSource(argv['install-source']);
 
 		} else if (argv['list-extensions']) {
-			await this.listExtensions(!!argv['show-versions']);
+			await this.listExtensions(!!argv['show-versions'], argv['category']);
 
 		} else if (argv['install-extension']) {
 			const arg = argv['install-extension'];
@@ -108,8 +108,11 @@ export class Main {
 		return writeFile(this.environmentService.installSourcePath, installSource.slice(0, 30));
 	}
 
-	private async listExtensions(showVersions: boolean): Promise<void> {
-		const extensions = await this.extensionManagementService.getInstalled(ExtensionType.User);
+	private async listExtensions(showVersions: boolean, category?: string): Promise<void> {
+		let extensions = await this.extensionManagementService.getInstalled(ExtensionType.User);
+		if (category) {
+			extensions = extensions.filter(e => e.manifest.categories && e.manifest.categories.indexOf(category) > -1);
+		}
 		extensions.forEach(e => console.log(getId(e.manifest, showVersions)));
 	}
 

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -111,7 +111,13 @@ export class Main {
 	private async listExtensions(showVersions: boolean, category?: string): Promise<void> {
 		let extensions = await this.extensionManagementService.getInstalled(ExtensionType.User);
 		if (category) {
-			extensions = extensions.filter(e => e.manifest.categories && e.manifest.categories.indexOf(category) > -1);
+			extensions = extensions.filter(e => {
+				if (e.manifest.categories) {
+					const lowerCaseCategories: string[] = e.manifest.categories.map(c => c.toLowerCase());
+					return lowerCaseCategories.indexOf(category.toLowerCase()) > -1;
+				}
+				return false;
+			});
 		}
 		extensions.forEach(e => console.log(getId(e.manifest, showVersions)));
 	}

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -47,6 +47,7 @@ export interface ParsedArgs {
 	'disable-extension'?: string | string[];
 	'list-extensions'?: boolean;
 	'show-versions'?: boolean;
+	'category'?: string;
 	'install-extension'?: string | string[];
 	'uninstall-extension'?: string | string[];
 	'locate-extension'?: string | string[];

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -48,6 +48,7 @@ export const options: Option[] = [
 	{ id: 'extensions-dir', type: 'string', deprecates: 'extensionHomePath', cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
 	{ id: 'list-extensions', type: 'boolean', cat: 'e', description: localize('listExtensions', "List the installed extensions.") },
 	{ id: 'show-versions', type: 'boolean', cat: 'e', description: localize('showVersions', "Show versions of installed extensions, when using --list-extension.") },
+	{ id: 'category', type: 'string', cat: 'e', description: localize('category', "Filters installed extensions by provided category, when using --list-extension.") },
 	{ id: 'install-extension', type: 'string', cat: 'e', args: 'extension-id | path-to-vsix', description: localize('installExtension', "Installs or updates the extension. Use `--force` argument to avoid prompts.") },
 	{ id: 'uninstall-extension', type: 'string', cat: 'e', args: 'extension-id', description: localize('uninstallExtension', "Uninstalls an extension.") },
 	{ id: 'enable-proposed-api', type: 'string', cat: 'e', args: 'extension-id', description: localize('experimentalApis', "Enables proposed API features for extensions. Can receive one or more extension IDs to enable individually.") },


### PR DESCRIPTION
Closes #77220. This allows the user to also provide a `--category` flag with `--list-extensions` to filter the extensions down to just the ones in the category which you have provided.