### PR TITLE
Add folding from end of region

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -959,6 +959,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.contribInfo.showFoldingControls,
 			'description': nls.localize('showFoldingControls', "Controls whether the fold controls on the gutter are automatically hidden.")
 		},
+		'editor.foldingFromEnd': {
+			'type': 'boolean',
+			'default': EDITOR_DEFAULTS.contribInfo.foldingFromEnd,
+			'description': nls.localize('foldingFromEnd', "Allow folding from the end of a region.")
+		},
 		'editor.matchBrackets': {
 			'type': 'boolean',
 			'default': EDITOR_DEFAULTS.contribInfo.matchBrackets,

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -959,10 +959,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': EDITOR_DEFAULTS.contribInfo.showFoldingControls,
 			'description': nls.localize('showFoldingControls', "Controls whether the fold controls on the gutter are automatically hidden.")
 		},
-		'editor.foldingFromEnd': {
-			'type': 'boolean',
-			'default': EDITOR_DEFAULTS.contribInfo.foldingFromEnd,
-			'description': nls.localize('foldingFromEnd', "Allow folding from the end of a region.")
+		'editor.foldingControls': {
+			'type': 'string',
+			'enum': ['classic', 'top-bottom'],
+			'default': EDITOR_DEFAULTS.contribInfo.foldingControls,
+			'description': nls.localize('foldingControls', "Controls the style of folding controls shown when folding is enabled.")
 		},
 		'editor.matchBrackets': {
 			'type': 'boolean',

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -656,6 +656,11 @@ export interface IEditorOptions {
 	 */
 	showFoldingControls?: 'always' | 'mouseover';
 	/**
+	 * Enable code folding from end of region
+	 * Defaults to false.
+	 */
+	foldingFromEnd?: boolean;
+	/**
 	 * Enable highlighting of matching brackets.
 	 * Defaults to true.
 	 */
@@ -1036,6 +1041,7 @@ export interface EditorContribOptions {
 	readonly folding: boolean;
 	readonly foldingStrategy: 'auto' | 'indentation';
 	readonly showFoldingControls: 'always' | 'mouseover';
+	readonly foldingFromEnd: boolean;
 	readonly matchBrackets: boolean;
 	readonly find: InternalEditorFindOptions;
 	readonly colorDecorators: boolean;
@@ -1463,6 +1469,7 @@ export class InternalEditorOptions {
 			&& a.folding === b.folding
 			&& a.foldingStrategy === b.foldingStrategy
 			&& a.showFoldingControls === b.showFoldingControls
+			&& a.foldingFromEnd === b.foldingFromEnd
 			&& a.matchBrackets === b.matchBrackets
 			&& this._equalFindOptions(a.find, b.find)
 			&& a.colorDecorators === b.colorDecorators
@@ -2118,6 +2125,7 @@ export class EditorOptionsValidator {
 			folding: _boolean(opts.folding, defaults.folding),
 			foldingStrategy: _stringSet<'auto' | 'indentation'>(opts.foldingStrategy, defaults.foldingStrategy, ['auto', 'indentation']),
 			showFoldingControls: _stringSet<'always' | 'mouseover'>(opts.showFoldingControls, defaults.showFoldingControls, ['always', 'mouseover']),
+			foldingFromEnd: _boolean(opts.foldingFromEnd, defaults.foldingFromEnd),
 			matchBrackets: _boolean(opts.matchBrackets, defaults.matchBrackets),
 			find: find,
 			colorDecorators: _boolean(opts.colorDecorators, defaults.colorDecorators),
@@ -2232,6 +2240,7 @@ export class InternalEditorOptionsFactory {
 				folding: (accessibilityIsOn ? false : opts.contribInfo.folding), // DISABLED WHEN SCREEN READER IS ATTACHED
 				foldingStrategy: opts.contribInfo.foldingStrategy,
 				showFoldingControls: opts.contribInfo.showFoldingControls,
+				foldingFromEnd: opts.contribInfo.foldingFromEnd,
 				matchBrackets: (accessibilityIsOn ? false : opts.contribInfo.matchBrackets), // DISABLED WHEN SCREEN READER IS ATTACHED
 				find: opts.contribInfo.find,
 				colorDecorators: opts.contribInfo.colorDecorators,
@@ -2728,6 +2737,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 		folding: true,
 		foldingStrategy: 'auto',
 		showFoldingControls: 'mouseover',
+		foldingFromEnd: false,
 		matchBrackets: true,
 		find: {
 			seedSearchStringFromSelection: true,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -656,10 +656,10 @@ export interface IEditorOptions {
 	 */
 	showFoldingControls?: 'always' | 'mouseover';
 	/**
-	 * Enable code folding from end of region
-	 * Defaults to false.
+	 * Controls the style of folding controls shown when folding is enabled.
+	 * Defaults to 'classic'.
 	 */
-	foldingFromEnd?: boolean;
+	foldingControls?: 'classic' | 'top-bottom';
 	/**
 	 * Enable highlighting of matching brackets.
 	 * Defaults to true.
@@ -1041,7 +1041,7 @@ export interface EditorContribOptions {
 	readonly folding: boolean;
 	readonly foldingStrategy: 'auto' | 'indentation';
 	readonly showFoldingControls: 'always' | 'mouseover';
-	readonly foldingFromEnd: boolean;
+	readonly foldingControls: 'classic' | 'top-bottom';
 	readonly matchBrackets: boolean;
 	readonly find: InternalEditorFindOptions;
 	readonly colorDecorators: boolean;
@@ -1469,7 +1469,7 @@ export class InternalEditorOptions {
 			&& a.folding === b.folding
 			&& a.foldingStrategy === b.foldingStrategy
 			&& a.showFoldingControls === b.showFoldingControls
-			&& a.foldingFromEnd === b.foldingFromEnd
+			&& a.foldingControls === b.foldingControls
 			&& a.matchBrackets === b.matchBrackets
 			&& this._equalFindOptions(a.find, b.find)
 			&& a.colorDecorators === b.colorDecorators
@@ -2125,7 +2125,7 @@ export class EditorOptionsValidator {
 			folding: _boolean(opts.folding, defaults.folding),
 			foldingStrategy: _stringSet<'auto' | 'indentation'>(opts.foldingStrategy, defaults.foldingStrategy, ['auto', 'indentation']),
 			showFoldingControls: _stringSet<'always' | 'mouseover'>(opts.showFoldingControls, defaults.showFoldingControls, ['always', 'mouseover']),
-			foldingFromEnd: _boolean(opts.foldingFromEnd, defaults.foldingFromEnd),
+			foldingControls: _stringSet<'classic' | 'top-bottom'>(opts.foldingControls, defaults.foldingControls, ['classic', 'top-bottom']),
 			matchBrackets: _boolean(opts.matchBrackets, defaults.matchBrackets),
 			find: find,
 			colorDecorators: _boolean(opts.colorDecorators, defaults.colorDecorators),
@@ -2240,7 +2240,7 @@ export class InternalEditorOptionsFactory {
 				folding: (accessibilityIsOn ? false : opts.contribInfo.folding), // DISABLED WHEN SCREEN READER IS ATTACHED
 				foldingStrategy: opts.contribInfo.foldingStrategy,
 				showFoldingControls: opts.contribInfo.showFoldingControls,
-				foldingFromEnd: opts.contribInfo.foldingFromEnd,
+				foldingControls: opts.contribInfo.foldingControls,
 				matchBrackets: (accessibilityIsOn ? false : opts.contribInfo.matchBrackets), // DISABLED WHEN SCREEN READER IS ATTACHED
 				find: opts.contribInfo.find,
 				colorDecorators: opts.contribInfo.colorDecorators,
@@ -2737,7 +2737,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 		folding: true,
 		foldingStrategy: 'auto',
 		showFoldingControls: 'mouseover',
-		foldingFromEnd: false,
+		foldingControls: 'classic',
 		matchBrackets: true,
 		find: {
 			seedSearchStringFromSelection: true,

--- a/src/vs/editor/contrib/folding/folding.css
+++ b/src/vs/editor/contrib/folding/folding.css
@@ -67,10 +67,6 @@
 	z-index: -1;
 }
 
-.monaco-editor .margin-view-overlays .foldingEnd.collapsed {
-	z-index: -2;
-}
-
 .monaco-editor.vs-dark .margin-view-overlays .folding.collapsed {
 	background-image: url('tree-collapsed-dark.svg');
 }

--- a/src/vs/editor/contrib/folding/folding.css
+++ b/src/vs/editor/contrib/folding/folding.css
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-editor .margin-view-overlays .folding {
+.monaco-editor .margin-view-overlays .folding,
+.monaco-editor .margin-view-overlays .foldingEnd {
 	cursor: pointer;
 	background-repeat: no-repeat;
 	background-origin: border-box;
@@ -17,13 +18,26 @@
 	background-image: url('tree-expanded-light.svg');
 }
 
+.monaco-editor .margin-view-overlays .foldingEnd {
+	background-image: url('tree-expanded-end-light.svg');
+}
+
 .monaco-editor.hc-black .margin-view-overlays .folding,
 .monaco-editor.vs-dark .margin-view-overlays .folding {
 	background-image: url('tree-expanded-dark.svg');
 }
 
+.monaco-editor.hc-black .margin-view-overlays .foldingEnd,
+.monaco-editor.vs-dark .margin-view-overlays .foldingEnd {
+	background-image: url('tree-expanded-end-dark.svg');
+}
+
 .monaco-editor.hc-black .margin-view-overlays .folding {
 	background-image: url('tree-expanded-hc.svg');
+}
+
+.monaco-editor.hc-black .margin-view-overlays .foldingEnd {
+	background-image: url('tree-expanded-end-hc.svg');
 }
 
 .monaco-editor .margin-view-overlays:hover .folding,
@@ -31,9 +45,30 @@
 	opacity: 1;
 }
 
+.monaco-editor .margin-view-overlays:hover .foldingEnd,
+.monaco-editor .margin-view-overlays .foldingEnd.alwaysShowFoldIcons {
+	opacity: .50;
+}
+
+.monaco-editor .margin-view-overlays:hover .foldingEnd:hover,
+.monaco-editor .margin-view-overlays .foldingEnd.alwaysShowFoldIcons:hover {
+	opacity: 1;
+}
+
 .monaco-editor .margin-view-overlays .folding.collapsed {
 	background-image: url('tree-collapsed-light.svg');
 	opacity: 1;
+}
+
+.monaco-editor .margin-view-overlays .folding + .foldingEnd,
+.monaco-editor .margin-view-overlays .foldingEnd.collapsed {
+	opacity: 0;
+	cursor: default;
+	z-index: -1;
+}
+
+.monaco-editor .margin-view-overlays .foldingEnd.collapsed {
+	z-index: -2;
 }
 
 .monaco-editor.vs-dark .margin-view-overlays .folding.collapsed {

--- a/src/vs/editor/contrib/folding/folding.ts
+++ b/src/vs/editor/contrib/folding/folding.ts
@@ -88,7 +88,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 		super();
 		this.editor = editor;
 		this._isEnabled = this.editor.getConfiguration().contribInfo.folding;
-		this._isFoldFromEndEnabled = this.editor.getConfiguration().contribInfo.foldingFromEnd;
+		this._isFoldFromEndEnabled = this.editor.getConfiguration().contribInfo.foldingControls === 'top-bottom';
 		this._autoHideFoldingControls = this.editor.getConfiguration().contribInfo.showFoldingControls === 'mouseover';
 		this._useFoldingProviders = this.editor.getConfiguration().contribInfo.foldingStrategy !== 'indentation';
 
@@ -109,7 +109,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 					this.onModelChanged();
 				}
 				let oldIsFoldFromEndEnabled = this._isFoldFromEndEnabled;
-				this._isFoldFromEndEnabled = this.editor.getConfiguration().contribInfo.foldingFromEnd;
+				this._isFoldFromEndEnabled = this.editor.getConfiguration().contribInfo.foldingControls === 'top-bottom';
 				if (oldIsFoldFromEndEnabled !== this._isFoldFromEndEnabled) {
 					this.onModelChanged();
 				}

--- a/src/vs/editor/contrib/folding/foldingDecorations.ts
+++ b/src/vs/editor/contrib/folding/foldingDecorations.ts
@@ -26,18 +26,46 @@ export class FoldingDecorationProvider implements IDecorationProvider {
 		linesDecorationsClassName: 'folding alwaysShowFoldIcons'
 	});
 
+	private static COLLAPSED_VISUAL_DECORATION_END = ModelDecorationOptions.register({
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		linesDecorationsClassName: 'foldingEnd collapsed'
+	});
+
+	private static EXPANDED_AUTO_HIDE_VISUAL_DECORATION_END = ModelDecorationOptions.register({
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		linesDecorationsClassName: 'foldingEnd'
+	});
+
+	private static EXPANDED_VISUAL_DECORATION_END = ModelDecorationOptions.register({
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		linesDecorationsClassName: 'foldingEnd alwaysShowFoldIcons'
+	});
+
+	private static VISUAL_DECORATION_HIDDEN = ModelDecorationOptions.register({
+		stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+		linesDecorationsClassName: ''
+	});
+
 	public autoHideFoldingControls: boolean = true;
 
 	constructor(private readonly editor: ICodeEditor) {
 	}
 
-	getDecorationOption(isCollapsed: boolean): ModelDecorationOptions {
-		if (isCollapsed) {
-			return FoldingDecorationProvider.COLLAPSED_VISUAL_DECORATION;
+	getDecorationOption(isCollapsed: boolean, isEnd: boolean = false, isHidden: boolean = false): ModelDecorationOptions {
+		if (isHidden) {
+			return FoldingDecorationProvider.VISUAL_DECORATION_HIDDEN;
+		} else if (isCollapsed) {
+			return isEnd ?
+				FoldingDecorationProvider.COLLAPSED_VISUAL_DECORATION_END :
+				FoldingDecorationProvider.COLLAPSED_VISUAL_DECORATION;
 		} else if (this.autoHideFoldingControls) {
-			return FoldingDecorationProvider.EXPANDED_AUTO_HIDE_VISUAL_DECORATION;
+			return isEnd ?
+				FoldingDecorationProvider.EXPANDED_AUTO_HIDE_VISUAL_DECORATION_END :
+				FoldingDecorationProvider.EXPANDED_AUTO_HIDE_VISUAL_DECORATION;
 		} else {
-			return FoldingDecorationProvider.EXPANDED_VISUAL_DECORATION;
+			return isEnd ?
+				FoldingDecorationProvider.EXPANDED_VISUAL_DECORATION_END :
+				FoldingDecorationProvider.EXPANDED_VISUAL_DECORATION;
 		}
 	}
 

--- a/src/vs/editor/contrib/folding/foldingModel.ts
+++ b/src/vs/editor/contrib/folding/foldingModel.ts
@@ -71,12 +71,12 @@ export class FoldingModel {
 
 							if (insideRegionDecorationIdEnd && !processed[insideRegionDecorationIdEnd]) {
 								processed[insideRegionDecorationIdEnd] = true;
-								accessor.changeDecorationOptions(insideRegionDecorationIdEnd, this._decorationProvider.getDecorationOption(newCollapseState, true, region.isCollapsed));
+								accessor.changeDecorationOptions(insideRegionDecorationIdEnd, this._decorationProvider.getDecorationOption(insideRegion.isCollapsed, true, region.isCollapsed));
 							}
 						});
 
 						processed[editorDecorationIdEnd] = true;
-						accessor.changeDecorationOptions(editorDecorationIdEnd, this._decorationProvider.getDecorationOption(newCollapseState, true));
+						accessor.changeDecorationOptions(editorDecorationIdEnd, this._decorationProvider.getDecorationOption(newCollapseState, true, region.isCollapsed));
 					}
 				}
 			}
@@ -243,29 +243,16 @@ export class FoldingModel {
 	}
 
 	getTopEndRegionAtLine(lineNumber: number): FoldingRegion | null {
-		let endRegions = this.getAllRegionsAtLine(lineNumber, region => {
-			return region.endLineNumber === lineNumber;
-		});
-
-		if (!endRegions) {
-			return null;
+		let resultIndex = -1;
+		let index = this._regions.findRange(lineNumber);
+		while (index >= 0 && this._regions.getEndLineNumber(index) === lineNumber) {
+			resultIndex = index;
+			index = this._regions.getParentIndex(index);
 		}
-
-		if (endRegions.length === 1) {
-			return endRegions[0];
+		if (resultIndex >= 0) {
+			return this._regions.toRegion(resultIndex);
 		}
-
-		let topLevelRegion: FoldingRegion = endRegions[0];
-
-		for (let index = 0; index < endRegions.length; index++) {
-			const currentRegion = endRegions[index];
-
-			if (currentRegion.regionIndex < topLevelRegion.regionIndex) {
-				topLevelRegion = currentRegion;
-			}
-		}
-
-		return topLevelRegion;
+		return null;
 	}
 
 	getRegionsInside(region: FoldingRegion | null, filter?: (r: FoldingRegion, level?: number) => boolean): FoldingRegion[] {

--- a/src/vs/editor/contrib/folding/tree-expanded-end-dark.svg
+++ b/src/vs/editor/contrib/folding/tree-expanded-end-dark.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 -16 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path transform="scale(1,-1)" fill-rule="evenodd" clip-rule="evenodd" d="M7.97603 10.0719L12.3333 5.71461L12.9521 6.33333L8.28539 11L7.66667 11L3 6.33333L3.61872 5.71461L7.97603 10.0719Z" fill="#C5C5C5"/>
+</svg>

--- a/src/vs/editor/contrib/folding/tree-expanded-end-hc.svg
+++ b/src/vs/editor/contrib/folding/tree-expanded-end-hc.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 -16 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path transform="scale(1,-1)" fill-rule="evenodd" clip-rule="evenodd" d="M7.97603 10.0719L12.3333 5.71461L12.9521 6.33333L8.28539 11L7.66667 11L3 6.33333L3.61872 5.71461L7.97603 10.0719Z" fill="white"/>
+</svg>

--- a/src/vs/editor/contrib/folding/tree-expanded-end-light.svg
+++ b/src/vs/editor/contrib/folding/tree-expanded-end-light.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 -16 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path transform="scale(1,-1)" fill-rule="evenodd" clip-rule="evenodd" d="M7.97603 10.0719L12.3333 5.71461L12.9521 6.33333L8.28539 11L7.66667 11L3 6.33333L3.61872 5.71461L7.97603 10.0719Z" fill="#424242"/>
+</svg>

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3023,10 +3023,10 @@ declare namespace monaco.editor {
 		 */
 		showFoldingControls?: 'always' | 'mouseover';
 		/**
-		 * Enable code folding from end of region
-		 * Defaults to false.
+		 * Controls the style of folding controls shown when folding is enabled.
+		 * Defaults to 'classic'.
 		 */
-		foldingFromEnd?: boolean;
+		foldingControls?: 'classic' | 'top-bottom';
 		/**
 		 * Enable highlighting of matching brackets.
 		 * Defaults to true.
@@ -3349,7 +3349,7 @@ declare namespace monaco.editor {
 		readonly folding: boolean;
 		readonly foldingStrategy: 'auto' | 'indentation';
 		readonly showFoldingControls: 'always' | 'mouseover';
-		readonly foldingFromEnd: boolean;
+		readonly foldingControls: 'classic' | 'top-bottom';
 		readonly matchBrackets: boolean;
 		readonly find: InternalEditorFindOptions;
 		readonly colorDecorators: boolean;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3023,6 +3023,11 @@ declare namespace monaco.editor {
 		 */
 		showFoldingControls?: 'always' | 'mouseover';
 		/**
+		 * Enable code folding from end of region
+		 * Defaults to false.
+		 */
+		foldingFromEnd?: boolean;
+		/**
 		 * Enable highlighting of matching brackets.
 		 * Defaults to true.
 		 */
@@ -3344,6 +3349,7 @@ declare namespace monaco.editor {
 		readonly folding: boolean;
 		readonly foldingStrategy: 'auto' | 'indentation';
 		readonly showFoldingControls: 'always' | 'mouseover';
+		readonly foldingFromEnd: boolean;
 		readonly matchBrackets: boolean;
 		readonly find: InternalEditorFindOptions;
 		readonly colorDecorators: boolean;

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -145,7 +145,7 @@ const configurationValueWhitelist = [
 	'editor.codeLens',
 	'editor.folding',
 	'editor.showFoldingControls',
-	'editor.foldingFromEnd',
+	'editor.foldingControls',
 	'editor.matchBrackets',
 	'editor.glyphMargin',
 	'editor.useTabStops',

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -145,6 +145,7 @@ const configurationValueWhitelist = [
 	'editor.codeLens',
 	'editor.folding',
 	'editor.showFoldingControls',
+	'editor.foldingFromEnd',
 	'editor.matchBrackets',
 	'editor.glyphMargin',
 	'editor.useTabStops',


### PR DESCRIPTION
This is a simple to understand enhancement: allow folding code from the end of a region.  A gif is worth a thousand words, so here's what it looks like in action:

![Fold From End 1](https://user-images.githubusercontent.com/9710256/61186426-6d5f0f00-a633-11e9-995a-c427f230f3b9.gif)

High-level details on the implementation:

- Disabled by default
- When region ends intersect, the outer-most region is collapsed on click
- As you can see I chose to de-emphasize the end fold icon a bit

I hope you will consider pulling in this change, as I quite like being able to fold up a large region when I'm at its end to give a better idea of context around it.  If you don't want to implement this or some form of it, I've at least enjoyed playing around in the code a bit. It was a nice night of fun.