### PR TITLE
Create browser version of telemetry service

### DIFF
--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -13,6 +13,7 @@ let _isWeb = false;
 let _locale: string | undefined = undefined;
 let _language: string = LANGUAGE_DEFAULT;
 let _translationsConfigFile: string | undefined = undefined;
+let _userAgent: string | undefined = undefined;
 
 interface NLSConfig {
 	locale: string;
@@ -48,10 +49,10 @@ const isElectronRenderer = (typeof process !== 'undefined' && typeof process.ver
 
 // OS detection
 if (typeof navigator === 'object' && !isElectronRenderer) {
-	const userAgent = navigator.userAgent;
-	_isWindows = userAgent.indexOf('Windows') >= 0;
-	_isMacintosh = userAgent.indexOf('Macintosh') >= 0;
-	_isLinux = userAgent.indexOf('Linux') >= 0;
+	_userAgent = navigator.userAgent;
+	_isWindows = _userAgent.indexOf('Windows') >= 0;
+	_isMacintosh = _userAgent.indexOf('Macintosh') >= 0;
+	_isLinux = _userAgent.indexOf('Linux') >= 0;
 	_isWeb = true;
 	_locale = navigator.language;
 	_language = _locale;
@@ -108,6 +109,7 @@ export const isLinux = _isLinux;
 export const isNative = _isNative;
 export const isWeb = _isWeb;
 export const platform = _platform;
+export const userAgent = _userAgent;
 
 export function isRootUser(): boolean {
 	return _isNative && !_isWindows && (process.getuid() === 0);

--- a/src/vs/code/browser/workbench/workbench.html
+++ b/src/vs/code/browser/workbench/workbench.html
@@ -10,7 +10,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
 
 		<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; img-src 'self' https: data: blob: vscode-remote:; media-src 'none'; child-src 'self' {{WEBVIEW_ENDPOINT}}; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: https:; font-src 'self' blob: vscode-remote:;">
+		content="default-src 'none'; img-src 'self' https: data: blob: vscode-remote:; media-src 'none'; child-src 'self' {{WEBVIEW_ENDPOINT}}; script-src 'self' https://az416426.vo.msecnd.net 'unsafe-eval'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: https:; font-src 'self' blob: vscode-remote:;">
 
 		<meta id="vscode-workbench-web-configuration" data-settings="{{WORKBENCH_WEB_CONGIGURATION}}">
 
@@ -26,6 +26,9 @@
 
 	<body aria-label="">
 	</body>
+
+	<!-- Application insights telemetry library -->
+	<script src="https://az416426.vo.msecnd.net/scripts/a/ai.0.js"></script>
 
 	<!-- Require our AMD loader -->
 	<script src="./out/vs/loader.js"></script>

--- a/src/vs/platform/product/browser/productService.ts
+++ b/src/vs/platform/product/browser/productService.ts
@@ -19,7 +19,7 @@ export class ProductService implements IProductService {
 
 	get version(): string { return '1.35.0'; }
 
-	get commit(): string | undefined { return undefined; }
+	get commit(): string | undefined { return this.productConfiguration ? this.productConfiguration.commit : undefined; }
 
 	get nameLong(): string { return ''; }
 
@@ -44,4 +44,6 @@ export class ProductService implements IProductService {
 	get extensionKeywords(): { [extension: string]: readonly string[]; } | undefined { return this.productConfiguration ? this.productConfiguration.extensionKeywords : undefined; }
 
 	get extensionAllowedBadgeProviders(): readonly string[] | undefined { return this.productConfiguration ? this.productConfiguration.extensionAllowedBadgeProviders : undefined; }
+
+	get aiConfig() { return this.productConfiguration ? this.productConfiguration.aiConfig : undefined; }
 }

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -37,6 +37,10 @@ export interface IProductService {
 	readonly experimentsUrl?: string;
 	readonly extensionKeywords?: { [extension: string]: readonly string[]; };
 	readonly extensionAllowedBadgeProviders?: readonly string[];
+
+	readonly aiConfig?: {
+		readonly asimovKey: string;
+	};
 }
 
 export interface IProductConfiguration {

--- a/src/vs/platform/telemetry/browser/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/browser/workbenchCommonProperties.ts
@@ -13,8 +13,22 @@ export const lastSessionDateStorageKey = 'telemetry.lastSessionDate';
 import * as Platform from 'vs/base/common/platform';
 import * as uuid from 'vs/base/common/uuid';
 
-export function resolveCommonProperties(commit: string | undefined, version: string | undefined, machineId: string | undefined): { [name: string]: string | undefined; } {
+export async function resolveWorkbenchCommonProperties(storageService: IStorageService, commit: string | undefined, version: string | undefined, machineId: string, remoteAuthority?: string): Promise<{ [name: string]: string | undefined }> {
 	const result: { [name: string]: string | undefined; } = Object.create(null);
+	const instanceId = storageService.get(instanceStorageKey, StorageScope.GLOBAL)!;
+	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.GLOBAL)!;
+	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.GLOBAL)!;
+
+	// __GDPR__COMMON__ "common.firstSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.firstSessionDate'] = firstSessionDate;
+	// __GDPR__COMMON__ "common.lastSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.lastSessionDate'] = lastSessionDate || '';
+	// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
+	// __GDPR__COMMON__ "common.instanceId" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.instanceId'] = instanceId;
+	// __GDPR__COMMON__ "common.remoteAuthority" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+	result['common.remoteAuthority'] = cleanRemoteAuthority(remoteAuthority);
 
 	// __GDPR__COMMON__ "common.machineId" : { "endPoint": "MacAddressHash", "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
 	result['common.machineId'] = machineId;
@@ -51,26 +65,6 @@ export function resolveCommonProperties(commit: string | undefined, version: str
 			enumerable: true
 		}
 	});
-
-	return result;
-}
-
-export async function resolveWorkbenchCommonProperties(storageService: IStorageService, commit: string | undefined, version: string | undefined, machineId: string, remoteAuthority?: string): Promise<{ [name: string]: string | undefined }> {
-	const result = resolveCommonProperties(commit, version, machineId);
-	const instanceId = storageService.get(instanceStorageKey, StorageScope.GLOBAL)!;
-	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.GLOBAL)!;
-	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.GLOBAL)!;
-
-	// __GDPR__COMMON__ "common.firstSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-	result['common.firstSessionDate'] = firstSessionDate;
-	// __GDPR__COMMON__ "common.lastSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-	result['common.lastSessionDate'] = lastSessionDate || '';
-	// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-	result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
-	// __GDPR__COMMON__ "common.instanceId" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-	result['common.instanceId'] = instanceId;
-	// __GDPR__COMMON__ "common.remoteAuthority" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
-	result['common.remoteAuthority'] = cleanRemoteAuthority(remoteAuthority);
 
 	return result;
 }

--- a/src/vs/platform/telemetry/browser/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/browser/workbenchCommonProperties.ts
@@ -1,0 +1,92 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+
+export const instanceStorageKey = 'telemetry.instanceId';
+export const currentSessionDateStorageKey = 'telemetry.currentSessionDate';
+export const firstSessionDateStorageKey = 'telemetry.firstSessionDate';
+export const lastSessionDateStorageKey = 'telemetry.lastSessionDate';
+
+import * as Platform from 'vs/base/common/platform';
+import * as uuid from 'vs/base/common/uuid';
+
+export function resolveCommonProperties(commit: string | undefined, version: string | undefined, machineId: string | undefined): { [name: string]: string | undefined; } {
+	const result: { [name: string]: string | undefined; } = Object.create(null);
+
+	// __GDPR__COMMON__ "common.machineId" : { "endPoint": "MacAddressHash", "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
+	result['common.machineId'] = machineId;
+	// __GDPR__COMMON__ "sessionID" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['sessionID'] = uuid.generateUuid() + Date.now();
+	// __GDPR__COMMON__ "commitHash" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+	result['commitHash'] = commit;
+	// __GDPR__COMMON__ "version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['version'] = version;
+	// __GDPR__COMMON__ "common.platform" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.platform'] = Platform.PlatformToString(Platform.platform);
+	// __GDPR__COMMON__ "common.product" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+	result['common.product'] = 'web';
+	// __GDPR__COMMON__ "common.userAgent" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.userAgent'] = Platform.userAgent;
+
+	// dynamic properties which value differs on each call
+	let seq = 0;
+	const startTime = Date.now();
+	Object.defineProperties(result, {
+		// __GDPR__COMMON__ "timestamp" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		'timestamp': {
+			get: () => new Date(),
+			enumerable: true
+		},
+		// __GDPR__COMMON__ "common.timesincesessionstart" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
+		'common.timesincesessionstart': {
+			get: () => Date.now() - startTime,
+			enumerable: true
+		},
+		// __GDPR__COMMON__ "common.sequence" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
+		'common.sequence': {
+			get: () => seq++,
+			enumerable: true
+		}
+	});
+
+	return result;
+}
+
+export async function resolveWorkbenchCommonProperties(storageService: IStorageService, commit: string | undefined, version: string | undefined, machineId: string, remoteAuthority?: string): Promise<{ [name: string]: string | undefined }> {
+	const result = resolveCommonProperties(commit, version, machineId);
+	const instanceId = storageService.get(instanceStorageKey, StorageScope.GLOBAL)!;
+	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.GLOBAL)!;
+	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.GLOBAL)!;
+
+	// __GDPR__COMMON__ "common.firstSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.firstSessionDate'] = firstSessionDate;
+	// __GDPR__COMMON__ "common.lastSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.lastSessionDate'] = lastSessionDate || '';
+	// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
+	// __GDPR__COMMON__ "common.instanceId" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	result['common.instanceId'] = instanceId;
+	// __GDPR__COMMON__ "common.remoteAuthority" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+	result['common.remoteAuthority'] = cleanRemoteAuthority(remoteAuthority);
+
+	return result;
+}
+
+function cleanRemoteAuthority(remoteAuthority?: string): string {
+	if (!remoteAuthority) {
+		return 'none';
+	}
+
+	let ret = 'other';
+	// Whitelisted remote authorities
+	['ssh-remote', 'dev-container', 'wsl'].forEach((res: string) => {
+		if (remoteAuthority!.indexOf(`${res}+`) === 0) {
+			ret = res;
+		}
+	});
+
+	return ret;
+}

--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -9,6 +9,8 @@ import { IKeybindingService, KeybindingSource } from 'vs/platform/keybinding/com
 import { ITelemetryService, ITelemetryInfo, ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ClassifiedEvent, StrictPropertyCheck, GDPRClassification } from 'vs/platform/telemetry/common/gdprTypings';
+import { safeStringify } from 'vs/base/common/objects';
+import { isObject } from 'vs/base/common/types';
 
 export const NullTelemetryService = new class implements ITelemetryService {
 	_serviceBrand: undefined;
@@ -241,6 +243,77 @@ export function keybindingsTelemetry(telemetryService: ITelemetryService, keybin
 			});
 		}
 	});
+}
+
+
+export interface Properties {
+	[key: string]: string;
+}
+
+export interface Measurements {
+	[key: string]: number;
+}
+
+export function validateTelemetryData(data?: any): { properties: Properties, measurements: Measurements } {
+
+	const properties: Properties = Object.create(null);
+	const measurements: Measurements = Object.create(null);
+
+	const flat = Object.create(null);
+	flatten(data, flat);
+
+	for (let prop in flat) {
+		// enforce property names less than 150 char, take the last 150 char
+		prop = prop.length > 150 ? prop.substr(prop.length - 149) : prop;
+		const value = flat[prop];
+
+		if (typeof value === 'number') {
+			measurements[prop] = value;
+
+		} else if (typeof value === 'boolean') {
+			measurements[prop] = value ? 1 : 0;
+
+		} else if (typeof value === 'string') {
+			//enforce property value to be less than 1024 char, take the first 1024 char
+			properties[prop] = value.substring(0, 1023);
+
+		} else if (typeof value !== 'undefined' && value !== null) {
+			properties[prop] = value;
+		}
+	}
+
+	return {
+		properties,
+		measurements
+	};
+}
+
+function flatten(obj: any, result: { [key: string]: any }, order: number = 0, prefix?: string): void {
+	if (!obj) {
+		return;
+	}
+
+	for (let item of Object.getOwnPropertyNames(obj)) {
+		const value = obj[item];
+		const index = prefix ? prefix + item : item;
+
+		if (Array.isArray(value)) {
+			result[index] = safeStringify(value);
+
+		} else if (value instanceof Date) {
+			// TODO unsure why this is here and not in _getData
+			result[index] = value.toISOString();
+
+		} else if (isObject(value)) {
+			if (order < 2) {
+				flatten(value, result, order + 1, index + '.');
+			} else {
+				result[index] = safeStringify(value);
+			}
+		} else {
+			result[index] = value;
+		}
+	}
 }
 
 function flattenKeys(value: Object | undefined): string[] {

--- a/src/vs/platform/telemetry/node/appInsightsAppender.ts
+++ b/src/vs/platform/telemetry/node/appInsightsAppender.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as appInsights from 'applicationinsights';
-import { isObject } from 'vs/base/common/types';
-import { safeStringify, mixin } from 'vs/base/common/objects';
-import { ITelemetryAppender } from 'vs/platform/telemetry/common/telemetryUtils';
+import { mixin } from 'vs/base/common/objects';
+import { ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
 import { ILogService } from 'vs/platform/log/common/log';
 
 function getClient(aiKey: string): appInsights.TelemetryClient {
@@ -35,13 +34,6 @@ function getClient(aiKey: string): appInsights.TelemetryClient {
 	return client;
 }
 
-interface Properties {
-	[key: string]: string;
-}
-
-interface Measurements {
-	[key: string]: number;
-}
 
 export class AppInsightsAppender implements ITelemetryAppender {
 
@@ -64,74 +56,12 @@ export class AppInsightsAppender implements ITelemetryAppender {
 		}
 	}
 
-	private static _getData(data?: any): { properties: Properties, measurements: Measurements } {
-
-		const properties: Properties = Object.create(null);
-		const measurements: Measurements = Object.create(null);
-
-		const flat = Object.create(null);
-		AppInsightsAppender._flaten(data, flat);
-
-		for (let prop in flat) {
-			// enforce property names less than 150 char, take the last 150 char
-			prop = prop.length > 150 ? prop.substr(prop.length - 149) : prop;
-			const value = flat[prop];
-
-			if (typeof value === 'number') {
-				measurements[prop] = value;
-
-			} else if (typeof value === 'boolean') {
-				measurements[prop] = value ? 1 : 0;
-
-			} else if (typeof value === 'string') {
-				//enforce property value to be less than 1024 char, take the first 1024 char
-				properties[prop] = value.substring(0, 1023);
-
-			} else if (typeof value !== 'undefined' && value !== null) {
-				properties[prop] = value;
-			}
-		}
-
-		return {
-			properties,
-			measurements
-		};
-	}
-
-	private static _flaten(obj: any, result: { [key: string]: any }, order: number = 0, prefix?: string): void {
-		if (!obj) {
-			return;
-		}
-
-		for (let item of Object.getOwnPropertyNames(obj)) {
-			const value = obj[item];
-			const index = prefix ? prefix + item : item;
-
-			if (Array.isArray(value)) {
-				result[index] = safeStringify(value);
-
-			} else if (value instanceof Date) {
-				// TODO unsure why this is here and not in _getData
-				result[index] = value.toISOString();
-
-			} else if (isObject(value)) {
-				if (order < 2) {
-					AppInsightsAppender._flaten(value, result, order + 1, index + '.');
-				} else {
-					result[index] = safeStringify(value);
-				}
-			} else {
-				result[index] = value;
-			}
-		}
-	}
-
 	log(eventName: string, data?: any): void {
 		if (!this._aiClient) {
 			return;
 		}
 		data = mixin(data, this._defaultData);
-		data = AppInsightsAppender._getData(data);
+		data = validateTelemetryData(data);
 
 		if (this._logService) {
 			this._logService.trace(`telemetry/${eventName}`, data);

--- a/src/vs/workbench/browser/web.simpleservices.ts
+++ b/src/vs/workbench/browser/web.simpleservices.ts
@@ -14,7 +14,6 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { IGalleryExtension, IExtensionIdentifier, IReportedExtension, IExtensionManagementService, ILocalExtension, IGalleryMetadata, IExtensionTipsService, ExtensionRecommendationReason, IExtensionRecommendation, IExtensionEnablementService, EnablementState } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionType, ExtensionIdentifier, IExtension } from 'vs/platform/extensions/common/extensions';
 import { IURLHandler, IURLService } from 'vs/platform/url/common/url';
-import { ITelemetryService, ITelemetryData, ITelemetryInfo } from 'vs/platform/telemetry/common/telemetry';
 import { ConsoleLogService, ILogService } from 'vs/platform/log/common/log';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
@@ -35,7 +34,6 @@ import { pathsToEditors } from 'vs/workbench/common/editor';
 import { IFileService } from 'vs/platform/files/common/files';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ParsedArgs } from 'vs/platform/environment/common/environment';
-import { ClassifiedEvent, StrictPropertyCheck, GDPRClassification } from 'vs/platform/telemetry/common/gdprTypings';
 import { IProcessEnvironment } from 'vs/base/common/platform';
 import { toStoreData, restoreRecentlyOpened } from 'vs/platform/history/common/historyStorage';
 // tslint:disable-next-line: import-patterns
@@ -270,38 +268,6 @@ export class SimpleMultiExtensionsManagementService implements IExtensionManagem
 		return Promise.resolve(undefined);
 	}
 }
-
-//#endregion
-
-//#region Telemetry
-
-export class SimpleTelemetryService implements ITelemetryService {
-
-	_serviceBrand: undefined;
-
-	isOptedIn: true;
-
-	publicLog(eventName: string, data?: ITelemetryData) {
-		return Promise.resolve(undefined);
-	}
-
-	publicLog2<E extends ClassifiedEvent<T> = never, T extends GDPRClassification<T> = never>(eventName: string, data?: StrictPropertyCheck<T, E>) {
-		return this.publicLog(eventName, data as ITelemetryData);
-	}
-
-	setEnabled(value: boolean): void {
-	}
-
-	getTelemetryInfo(): Promise<ITelemetryInfo> {
-		return Promise.resolve({
-			instanceId: 'someValue.instanceId',
-			sessionId: 'someValue.sessionId',
-			machineId: 'someValue.machineId'
-		});
-	}
-}
-
-registerSingleton(ITelemetryService, SimpleTelemetryService);
 
 //#endregion
 

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITelemetryService, ITelemetryInfo, ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
+import { NullTelemetryService, combinedAppender, LogAppender, ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { ILogService } from 'vs/platform/log/common/log';
+import { TelemetryService as BaseTelemetryService, ITelemetryServiceConfig } from 'vs/platform/telemetry/common/telemetryService';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { ClassifiedEvent, StrictPropertyCheck, GDPRClassification } from 'vs/platform/telemetry/common/gdprTypings';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { resolveWorkbenchCommonProperties } from 'vs/platform/telemetry/browser/workbenchCommonProperties';
+import { IProductService } from 'vs/platform/product/common/product';
+
+interface IConfig {
+	instrumentationKey?: string;
+	endpointUrl?: string;
+	emitLineDelimitedJson?: boolean;
+	accountId?: string;
+	sessionRenewalMs?: number;
+	sessionExpirationMs?: number;
+	maxBatchSizeInBytes?: number;
+	maxBatchInterval?: number;
+	enableDebug?: boolean;
+	disableExceptionTracking?: boolean;
+	disableTelemetry?: boolean;
+	verboseLogging?: boolean;
+	diagnosticLogInterval?: number;
+	samplingPercentage?: number;
+	autoTrackPageVisitTime?: boolean;
+	disableAjaxTracking?: boolean;
+	overridePageViewDuration?: boolean;
+	maxAjaxCallsPerView?: number;
+	disableDataLossAnalysis?: boolean;
+	disableCorrelationHeaders?: boolean;
+	correlationHeaderExcludedDomains?: string[];
+	disableFlushOnBeforeUnload?: boolean;
+	enableSessionStorageBuffer?: boolean;
+	isCookieUseDisabled?: boolean;
+	cookieDomain?: string;
+	isRetryDisabled?: boolean;
+	url?: string;
+	isStorageUseDisabled?: boolean;
+	isBeaconApiDisabled?: boolean;
+	sdkExtension?: string;
+	isBrowserLinkTrackingEnabled?: boolean;
+	appId?: string;
+	enableCorsCorrelation?: boolean;
+}
+
+declare class Microsoft {
+	public static ApplicationInsights: {
+		Initialization: {
+			new(init: { config: IConfig }): AppInsights;
+		}
+	};
+}
+
+declare interface IAppInsightsClient {
+	config: IConfig;
+
+	/** Log a user action or other occurrence. */
+	trackEvent: (name: string, properties?: { [key: string]: string }, measurements?: { [key: string]: number }) => void;
+
+	/** Immediately send all queued telemetry. Synchronous. */
+	flush(): void;
+}
+
+interface AppInsights {
+	loadAppInsights: () => IAppInsightsClient;
+}
+
+export class WebTelemetryAppender implements ITelemetryAppender {
+	private _aiClient?: IAppInsightsClient;
+
+	constructor(aiKey: string, private _logService: ILogService) {
+		const initConfig = {
+			config: {
+				instrumentationKey: aiKey,
+				endpointUrl: 'https://vortex.data.microsoft.com/collect/v1',
+				emitLineDelimitedJson: true,
+				autoTrackPageVisitTime: false,
+				disableExceptionTracking: true,
+				disableAjaxTracking: true
+			}
+		};
+
+		const appInsights = new Microsoft.ApplicationInsights.Initialization(initConfig);
+		this._aiClient = appInsights.loadAppInsights();
+	}
+
+	log(eventName: string, data: any): void {
+		if (!this._aiClient) {
+			return;
+		}
+
+		data = validateTelemetryData(data);
+		this._logService.trace(`telemetry/${eventName}`, data);
+
+		this._aiClient.trackEvent('monacoworkbench/' + eventName, data.properties, data.measurements);
+	}
+
+	dispose(): Promise<any> | undefined {
+		if (this._aiClient) {
+			return new Promise(resolve => {
+				this._aiClient!.flush();
+				this._aiClient = undefined;
+				resolve(undefined);
+			});
+		}
+
+		return undefined;
+	}
+}
+
+export class TelemetryService extends Disposable implements ITelemetryService {
+
+	_serviceBrand: any;
+
+	private impl: ITelemetryService;
+
+	constructor(
+		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
+		@ILogService logService: ILogService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IStorageService storageService: IStorageService,
+		@IProductService productService: IProductService
+	) {
+		super();
+
+		const aiKey = productService.aiConfig && productService.aiConfig.asimovKey;
+		if (!environmentService.isExtensionDevelopment && !environmentService.args['disable-telemetry'] && !!productService.enableTelemetry && !!aiKey) {
+			const config: ITelemetryServiceConfig = {
+				appender: combinedAppender(new WebTelemetryAppender(aiKey, logService), new LogAppender(logService)),
+				commonProperties: resolveWorkbenchCommonProperties(storageService, productService.commit, productService.version, environmentService.configuration.machineId, environmentService.configuration.remoteAuthority),
+				piiPaths: [environmentService.appRoot]
+			};
+
+			this.impl = this._register(new BaseTelemetryService(config, configurationService));
+		} else {
+			this.impl = NullTelemetryService;
+		}
+	}
+
+	setEnabled(value: boolean): void {
+		return this.impl.setEnabled(value);
+	}
+
+	get isOptedIn(): boolean {
+		return this.impl.isOptedIn;
+	}
+
+	publicLog(eventName: string, data?: ITelemetryData, anonymizeFilePaths?: boolean): Promise<void> {
+		return this.impl.publicLog(eventName, data, anonymizeFilePaths);
+	}
+
+	publicLog2<E extends ClassifiedEvent<T> = never, T extends GDPRClassification<T> = never>(eventName: string, data?: StrictPropertyCheck<T, E>, anonymizeFilePaths?: boolean) {
+		return this.publicLog(eventName, data as ITelemetryData, anonymizeFilePaths);
+	}
+
+	getTelemetryInfo(): Promise<ITelemetryInfo> {
+		return this.impl.getTelemetryInfo();
+	}
+}
+
+registerSingleton(ITelemetryService, TelemetryService);

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -73,8 +73,6 @@ import { DialogService } from 'vs/platform/dialogs/browser/dialogService';
 // import { ILocalizationsService } from 'vs/platform/localizations/common/localizations';
 // import { LocalizationsService } from 'vs/platform/localizations/electron-browser/localizationsService';
 // import { ISharedProcessService, SharedProcessService } from 'vs/platform/ipc/electron-browser/sharedProcessService';
-// import { IProductService } from 'vs/platform/product/common/product';
-// import { ProductService } from 'vs/platform/product/node/productService';
 // import { IWindowsService } from 'vs/platform/windows/common/windows';
 // import { WindowsService } from 'vs/platform/windows/electron-browser/windowsService';
 // import { IUpdateService } from 'vs/platform/update/common/update';
@@ -128,7 +126,7 @@ import 'vs/workbench/services/extensionManagement/common/extensionManagementServ
 // import 'vs/workbench/services/remote/electron-browser/remoteAgentServiceImpl';
 import 'vs/workbench/services/notification/common/notificationService';
 // import 'vs/workbench/services/window/electron-browser/windowService';
-// import 'vs/workbench/services/telemetry/electron-browser/telemetryService';
+import 'vs/workbench/services/telemetry/browser/telemetryService';
 import 'vs/workbench/services/configurationResolver/browser/configurationResolverService';
 import { IContextViewService, IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { ContextMenuService } from 'vs/platform/contextview/browser/contextMenuService';


### PR DESCRIPTION
Create a new version of the telemetry service in `browser` that uses the app insights js library to send events.

Some of the data for the common properties still isn’t coming through since it’s undefined in the browser version of the product or environment service, `machineId` is an important one of those. So still need to revisit that.