### PR TITLE
Add '.ent' and '.mod' file extensions  for the XML language

### DIFF
--- a/extensions/xml/package.json
+++ b/extensions/xml/package.json
@@ -23,6 +23,8 @@
 				".dita",
 				".ditamap",
 				".dtd",
+        ".ent",
+        ".mod",
 				".dtml",
 				".fsproj",
 				".fxml",


### PR DESCRIPTION
This PR adds `.ent` and `.mod` file extensions which are used as DTD file.

Signed-off-by: Angelo ZERR <azerr@redhat.com>