### PR TITLE
Fix incrementing of variables in cpuUsage.sh

### DIFF
--- a/src/vs/base/node/cpuUsage.sh
+++ b/src/vs/base/node/cpuUsage.sh
@@ -30,7 +30,7 @@ for PID in "$@"; do
   fi
 
   PROCESS_BEFORE_TIMES[$ITER]=$PROCESS_TIME_BEFORE
-  ((ITER++))
+  ((++ITER))
 done
 
 # Wait for a second
@@ -60,5 +60,5 @@ for PID in "$@"; do
 
   # Parent script reads from stdout, so echo result to be read
   echo $CPU_USAGE
-  ((ITER++))
+  ((++ITER))
 done


### PR DESCRIPTION
((x++)) will fail if x is 0, as ((..)) fails if the result is 0.
Using ((++x)) avoids this case.

Reference: https://askubuntu.com/questions/385528/how-to-increment-a-variable-in-bash#comment573516_385532

Without the fix the Process Explorer wouldn't show any numbers for the remote host when using ssh remote.