### PR TITLE
Add 'selection' option to render whitespace

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/viewLine.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLine.ts
@@ -16,6 +16,7 @@ import { CharacterMapping, ForeignElementType, RenderLineInput, renderViewLine }
 import { ViewportData } from 'vs/editor/common/viewLayout/viewLinesViewportData';
 import { InlineDecorationType } from 'vs/editor/common/viewModel/viewModel';
 import { HIGH_CONTRAST, ThemeType } from 'vs/platform/theme/common/themeService';
+import { Range } from 'vs/editor/common/core/range';
 
 const canUseFastRenderedViewLine = (function () {
 	if (platform.isNative) {
@@ -69,7 +70,7 @@ export class DomReadingContext {
 
 export class ViewLineOptions {
 	public readonly themeType: ThemeType;
-	public readonly renderWhitespace: 'none' | 'boundary' | 'all';
+	public readonly renderWhitespace: 'none' | 'boundary' | 'selection' | 'all';
 	public readonly renderControlCharacters: boolean;
 	public readonly spaceWidth: number;
 	public readonly useMonospaceOptimizations: boolean;
@@ -152,7 +153,7 @@ export class ViewLine implements IVisibleLine {
 		this._options = newOptions;
 	}
 	public onSelectionChanged(): boolean {
-		if (alwaysRenderInlineSelection || this._options.themeType === HIGH_CONTRAST) {
+		if (alwaysRenderInlineSelection || this._options.themeType === HIGH_CONTRAST || this._options.renderWhitespace === 'selection') {
 			this._isMaybeInvalid = true;
 			return true;
 		}
@@ -171,7 +172,9 @@ export class ViewLine implements IVisibleLine {
 		const options = this._options;
 		const actualInlineDecorations = LineDecoration.filter(lineData.inlineDecorations, lineNumber, lineData.minColumn, lineData.maxColumn);
 
-		if (alwaysRenderInlineSelection || options.themeType === HIGH_CONTRAST) {
+		// Only send selection information when needed for rendering whitespace
+		let selectionsOnLine: Range[] | undefined;
+		if (alwaysRenderInlineSelection || options.themeType === HIGH_CONTRAST || this._options.renderWhitespace === 'selection') {
 			const selections = viewportData.selections;
 			for (const selection of selections) {
 
@@ -184,7 +187,15 @@ export class ViewLine implements IVisibleLine {
 				const endColumn = (selection.endLineNumber === lineNumber ? selection.endColumn : lineData.maxColumn);
 
 				if (startColumn < endColumn) {
-					actualInlineDecorations.push(new LineDecoration(startColumn, endColumn, 'inline-selected-text', InlineDecorationType.Regular));
+					if (this._options.renderWhitespace !== 'selection') {
+						actualInlineDecorations.push(new LineDecoration(startColumn, endColumn, 'inline-selected-text', InlineDecorationType.Regular));
+					} else {
+						if (!selectionsOnLine) {
+							selectionsOnLine = [];
+						}
+
+						selectionsOnLine.push(new Range(lineNumber, startColumn, lineNumber, endColumn));
+					}
 				}
 			}
 		}
@@ -204,7 +215,8 @@ export class ViewLine implements IVisibleLine {
 			options.stopRenderingLineAfter,
 			options.renderWhitespace,
 			options.renderControlCharacters,
-			options.fontLigatures
+			options.fontLigatures,
+			selectionsOnLine
 		);
 
 		if (this._renderedViewLine && this._renderedViewLine.input.equals(renderLineInput)) {

--- a/src/vs/editor/browser/viewParts/lines/viewLine.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLine.ts
@@ -12,11 +12,10 @@ import { IStringBuilder } from 'vs/editor/common/core/stringBuilder';
 import { IConfiguration } from 'vs/editor/common/editorCommon';
 import { HorizontalRange } from 'vs/editor/common/view/renderingContext';
 import { LineDecoration } from 'vs/editor/common/viewLayout/lineDecorations';
-import { CharacterMapping, ForeignElementType, RenderLineInput, renderViewLine } from 'vs/editor/common/viewLayout/viewLineRenderer';
+import { CharacterMapping, ForeignElementType, RenderLineInput, renderViewLine, LineRange } from 'vs/editor/common/viewLayout/viewLineRenderer';
 import { ViewportData } from 'vs/editor/common/viewLayout/viewLinesViewportData';
 import { InlineDecorationType } from 'vs/editor/common/viewModel/viewModel';
 import { HIGH_CONTRAST, ThemeType } from 'vs/platform/theme/common/themeService';
-import { Range } from 'vs/editor/common/core/range';
 
 const canUseFastRenderedViewLine = (function () {
 	if (platform.isNative) {
@@ -173,7 +172,7 @@ export class ViewLine implements IVisibleLine {
 		const actualInlineDecorations = LineDecoration.filter(lineData.inlineDecorations, lineNumber, lineData.minColumn, lineData.maxColumn);
 
 		// Only send selection information when needed for rendering whitespace
-		let selectionsOnLine: Range[] | undefined;
+		let selectionsOnLine: LineRange[] | null = null;
 		if (alwaysRenderInlineSelection || options.themeType === HIGH_CONTRAST || this._options.renderWhitespace === 'selection') {
 			const selections = viewportData.selections;
 			for (const selection of selections) {
@@ -194,7 +193,7 @@ export class ViewLine implements IVisibleLine {
 							selectionsOnLine = [];
 						}
 
-						selectionsOnLine.push(new Range(lineNumber, startColumn, lineNumber, endColumn));
+						selectionsOnLine.push(new LineRange(startColumn - 1, endColumn - 1));
 					}
 				}
 			}

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -2028,7 +2028,7 @@ class InlineViewZonesComputer extends ViewZonesComputer {
 			config.viewInfo.renderWhitespace,
 			config.viewInfo.renderControlCharacters,
 			config.viewInfo.fontLigatures,
-			undefined // Send no selections, original line cannot be selected
+			null // Send no selections, original line cannot be selected
 		), sb);
 
 		sb.appendASCIIString('</div>');

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -2027,7 +2027,8 @@ class InlineViewZonesComputer extends ViewZonesComputer {
 			config.viewInfo.stopRenderingLineAfter,
 			config.viewInfo.renderWhitespace,
 			config.viewInfo.renderControlCharacters,
-			config.viewInfo.fontLigatures
+			config.viewInfo.fontLigatures,
+			undefined // Send no selections, original line cannot be selected
 		), sb);
 
 		sb.appendASCIIString('</div>');

--- a/src/vs/editor/browser/widget/diffReview.ts
+++ b/src/vs/editor/browser/widget/diffReview.ts
@@ -781,7 +781,7 @@ export class DiffReview extends Disposable {
 			config.viewInfo.renderWhitespace,
 			config.viewInfo.renderControlCharacters,
 			config.viewInfo.fontLigatures,
-			undefined
+			null
 		));
 
 		return r.html;

--- a/src/vs/editor/browser/widget/diffReview.ts
+++ b/src/vs/editor/browser/widget/diffReview.ts
@@ -780,7 +780,8 @@ export class DiffReview extends Disposable {
 			config.viewInfo.stopRenderingLineAfter,
 			config.viewInfo.renderWhitespace,
 			config.viewInfo.renderControlCharacters,
-			config.viewInfo.fontLigatures
+			config.viewInfo.fontLigatures,
+			undefined
 		));
 
 		return r.html;

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -905,7 +905,7 @@ const editorConfiguration: IConfigurationNode = {
 			'enumDescriptions': [
 				'',
 				nls.localize('renderWhiteSpace.boundary', "Render whitespace characters except for single spaces between words."),
-				nls.localize('renderWhiteSpace.selection', "Render whitespace characters only on selected text."),
+				nls.localize('renderWhitespace.selection', "Render whitespace characters only on selected text."),
 				''
 			],
 			default: EDITOR_DEFAULTS.viewInfo.renderWhitespace,

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -901,10 +901,11 @@ const editorConfiguration: IConfigurationNode = {
 		},
 		'editor.renderWhitespace': {
 			'type': 'string',
-			'enum': ['none', 'boundary', 'all'],
+			'enum': ['none', 'boundary', 'selection', 'all'],
 			'enumDescriptions': [
 				'',
 				nls.localize('renderWhiteSpace.boundary', "Render whitespace characters except for single spaces between words."),
+				nls.localize('renderWhiteSpace.selection', "Render whitespace characters only on selected text."),
 				''
 			],
 			default: EDITOR_DEFAULTS.viewInfo.renderWhitespace,

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -664,7 +664,7 @@ export interface IEditorOptions {
 	 * Enable rendering of whitespace.
 	 * Defaults to none.
 	 */
-	renderWhitespace?: 'none' | 'boundary' | 'all';
+	renderWhitespace?: 'none' | 'boundary' | 'selection' | 'all';
 	/**
 	 * Enable rendering of control characters.
 	 * Defaults to false.
@@ -999,7 +999,7 @@ export interface InternalEditorViewOptions {
 	readonly scrollBeyondLastColumn: number;
 	readonly smoothScrolling: boolean;
 	readonly stopRenderingLineAfter: number;
-	readonly renderWhitespace: 'none' | 'boundary' | 'all';
+	readonly renderWhitespace: 'none' | 'boundary' | 'selection' | 'all';
 	readonly renderControlCharacters: boolean;
 	readonly fontLigatures: boolean;
 	readonly renderIndentGuides: boolean;
@@ -2017,7 +2017,7 @@ export class EditorOptionsValidator {
 			} else if (<any>renderWhitespace === false) {
 				renderWhitespace = 'none';
 			}
-			renderWhitespace = _stringSet<'none' | 'boundary' | 'all'>(renderWhitespace, defaults.renderWhitespace, ['none', 'boundary', 'all']);
+			renderWhitespace = _stringSet<'none' | 'boundary' | 'selection' | 'all'>(renderWhitespace, defaults.renderWhitespace, ['none', 'boundary', 'selection', 'all']);
 		}
 
 		let renderLineHighlight = opts.renderLineHighlight;

--- a/src/vs/editor/common/viewLayout/viewLineRenderer.ts
+++ b/src/vs/editor/common/viewLayout/viewLineRenderer.ts
@@ -567,14 +567,13 @@ function _applyRenderWhitespace(lineContent: string, len: number, continuesWithW
 		}
 	}
 	tmpIndent = tmpIndent % tabSize;
-
 	let wasInWhitespace = false;
 	let currentSelectionIndex = 0;
 	let currentSelection = selections && selections[currentSelectionIndex];
 	for (let charIndex = fauxIndentLength; charIndex < len; charIndex++) {
 		const chCode = lineContent.charCodeAt(charIndex);
 
-		if (currentSelection && charIndex > currentSelection.endOffset) {
+		if (currentSelection && charIndex >= currentSelection.endOffset) {
 			currentSelectionIndex++;
 			currentSelection = selections && selections[currentSelectionIndex];
 		}

--- a/src/vs/editor/standalone/browser/colorizer.ts
+++ b/src/vs/editor/standalone/browser/colorizer.ts
@@ -129,7 +129,7 @@ export class Colorizer {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 		return renderResult.html;
 	}
@@ -197,7 +197,7 @@ function _fakeColorize(lines: string[], tabSize: number): string {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		html = html.concat(renderResult.html);
@@ -234,7 +234,7 @@ function _actualColorize(lines: string[], tabSize: number, tokenizationSupport: 
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		html = html.concat(renderResult.html);

--- a/src/vs/editor/standalone/browser/colorizer.ts
+++ b/src/vs/editor/standalone/browser/colorizer.ts
@@ -128,7 +128,8 @@ export class Colorizer {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 		return renderResult.html;
 	}
@@ -195,7 +196,8 @@ function _fakeColorize(lines: string[], tabSize: number): string {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		html = html.concat(renderResult.html);
@@ -231,7 +233,8 @@ function _actualColorize(lines: string[], tabSize: number, tokenizationSupport: 
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		html = html.concat(renderResult.html);

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -1172,6 +1172,27 @@ suite('viewLineRenderer.renderLine 2', () => {
 		);
 	});
 
+	test('createLineParts render whitespace for selection with selections next to each other', () => {
+		testCreateLineParts(
+			false,
+			' * S',
+			[
+				createPart(4, 0)
+			],
+			0,
+			'selection',
+			[new LineRange(0, 1), new LineRange(1, 2), new LineRange(2, 3)],
+			[
+				'<span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk0">*</span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk0">S</span>',
+				'</span>',
+			].join('')
+		);
+	});
+
 	test('createLineParts can handle unsorted inline decorations', () => {
 		let actual = renderViewLine(new RenderLineInput(
 			false,

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -12,6 +12,7 @@ import { LineDecoration } from 'vs/editor/common/viewLayout/lineDecorations';
 import { CharacterMapping, RenderLineInput, renderViewLine2 as renderViewLine } from 'vs/editor/common/viewLayout/viewLineRenderer';
 import { InlineDecorationType } from 'vs/editor/common/viewModel/viewModel';
 import { ViewLineToken, ViewLineTokens } from 'vs/editor/test/common/core/viewLineToken';
+import { Range } from 'vs/editor/common/core/range';
 
 function createViewLineTokens(viewLineTokens: ViewLineToken[]): IViewLineTokens {
 	return new ViewLineTokens(viewLineTokens);
@@ -41,7 +42,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span><span class="mtk0">' + expected + '</span></span>');
@@ -90,7 +92,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span>' + expected + '</span>');
@@ -142,7 +145,8 @@ suite('viewLineRenderer.renderLine', () => {
 			6,
 			'boundary',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expectedOutput = [
@@ -233,7 +237,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'boundary',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -295,7 +300,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -357,7 +363,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -396,7 +403,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -426,7 +434,8 @@ suite('viewLineRenderer.renderLine', () => {
 				-1,
 				'none',
 				false,
-				false
+				false,
+				undefined
 			));
 			assert.equal(actual.html, '<span>' + expectedOutput.join('') + '</span>', message);
 		}
@@ -526,7 +535,8 @@ suite('viewLineRenderer.renderLine', () => {
 				-1,
 				'none',
 				false,
-				true
+				true,
+				undefined
 			));
 			assert.equal(actual.html, '<span>' + expectedOutput.join('') + '</span>', message);
 		}
@@ -564,7 +574,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 		let expectedOutput = [
 			'<span class="mtk1">a𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷</span>',
@@ -593,7 +604,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 		assert.equal(actual.html, '<span>' + expectedOutput.join('') + '</span>');
 		assert.equal(actual.containsRTL, true);
@@ -639,7 +651,8 @@ suite('viewLineRenderer.renderLine', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -704,7 +717,7 @@ suite('viewLineRenderer.renderLine', () => {
 
 suite('viewLineRenderer.renderLine 2', () => {
 
-	function testCreateLineParts(fontIsMonospace: boolean, lineContent: string, tokens: ViewLineToken[], fauxIndentLength: number, renderWhitespace: 'none' | 'boundary' | 'all', expected: string): void {
+	function testCreateLineParts(fontIsMonospace: boolean, lineContent: string, tokens: ViewLineToken[], fauxIndentLength: number, renderWhitespace: 'none' | 'boundary' | 'selection' | 'all', selections: Range[] | undefined, expected: string): void {
 		let actual = renderViewLine(new RenderLineInput(
 			fontIsMonospace,
 			true,
@@ -720,7 +733,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			renderWhitespace,
 			false,
-			false
+			false,
+			selections
 		));
 
 		assert.deepEqual(actual.html, expected);
@@ -745,7 +759,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -784,7 +799,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -811,6 +827,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'none',
+			undefined,
 			[
 				'<span>',
 				'<span class="mtk1">Hello\u00a0world!</span>',
@@ -828,6 +845,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'none',
+			undefined,
 			[
 				'<span>',
 				'<span class="mtk1">Hello\u00a0</span>',
@@ -847,6 +865,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u00b7\u00b7\u00b7\u00b7</span>',
@@ -868,6 +887,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u00b7\u00b7\u00b7\u00b7</span>',
@@ -891,6 +911,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u2192\u00a0\u00a0\u00a0</span>',
@@ -913,6 +934,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u00b7\u00b7\u2192\u00a0</span>',
@@ -940,6 +962,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			2,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="">\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0</span>',
@@ -966,6 +989,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			2,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="">\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0</span>',
@@ -989,6 +1013,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
+			undefined,
 			[
 				'<span>',
 				'<span class="mtk1">it</span>',
@@ -1014,6 +1039,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'all',
+			undefined,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
@@ -1022,6 +1048,76 @@ suite('viewLineRenderer.renderLine 2', () => {
 				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
 				'<span class="mtk2">world!</span>',
 				'<span class="vs-whitespace" style="width:30px">\u2192\u00a0\u00a0</span>',
+				'</span>',
+			].join('')
+		);
+	});
+
+	test('createLineParts render whitespace for selection with no selections', () => {
+		testCreateLineParts(
+			false,
+			' Hello world!\t',
+			[
+				createPart(4, 0),
+				createPart(6, 1),
+				createPart(14, 2)
+			],
+			0,
+			'selection',
+			undefined,
+			[
+				'<span>',
+				'<span class="mtk0">\u00a0Hel</span>',
+				'<span class="mtk1">lo</span>',
+				'<span class="mtk2">\u00a0world!\u00a0\u00a0\u00a0</span>',
+				'</span>',
+			].join('')
+		);
+	});
+
+	test('createLineParts render whitespace for selection with whole line selection', () => {
+		testCreateLineParts(
+			false,
+			' Hello world!\t',
+			[
+				createPart(4, 0),
+				createPart(6, 1),
+				createPart(14, 2)
+			],
+			0,
+			'selection',
+			[new Range(0, 0, 0, 14)],
+			[
+				'<span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk0">Hel</span>',
+				'<span class="mtk1">lo</span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk2">world!</span>',
+				'<span class="vs-whitespace" style="width:30px">\u2192\u00a0\u00a0</span>',
+				'</span>',
+			].join('')
+		);
+	});
+
+	test('createLineParts render whitespace for selection with selection spanning part of whitespace', () => {
+		testCreateLineParts(
+			false,
+			' Hello world!\t',
+			[
+				createPart(4, 0),
+				createPart(6, 1),
+				createPart(14, 2)
+			],
+			0,
+			'selection',
+			[new Range(0, 0, 0, 5)],
+			[
+				'<span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk0">Hel</span>',
+				'<span class="mtk1">lo</span>',
+				'<span class="mtk2">\u00a0world!\u00a0\u00a0\u00a0</span>',
 				'</span>',
 			].join('')
 		);
@@ -1047,7 +1143,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		// 01234567890
@@ -1087,7 +1184,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'all',
 			false,
-			true
+			true,
+			undefined
 		));
 
 		let expected = [
@@ -1119,7 +1217,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'all',
 			false,
-			true
+			true,
+			undefined
 		));
 
 		let expected = [
@@ -1152,7 +1251,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'all',
 			false,
-			true
+			true,
+			undefined
 		));
 
 		let expected = [
@@ -1181,7 +1281,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1214,7 +1315,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1246,7 +1348,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1276,7 +1379,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1305,7 +1409,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'all',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1340,7 +1445,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1369,7 +1475,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1400,7 +1507,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1430,7 +1538,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'boundary',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		let expected = [
@@ -1458,7 +1567,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			true
+			true,
+			undefined
 		));
 
 		let expected = [
@@ -1490,7 +1600,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			10000,
 			'none',
 			false,
-			true
+			true,
+			undefined
 		));
 
 		let expected = [
@@ -1518,7 +1629,8 @@ suite('viewLineRenderer.renderLine 2', () => {
 			-1,
 			'none',
 			false,
-			false
+			false,
+			undefined
 		));
 
 		return (partIndex: number, partLength: number, offset: number, expected: number) => {

--- a/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
+++ b/src/vs/editor/test/common/viewLayout/viewLineRenderer.test.ts
@@ -9,10 +9,9 @@ import * as strings from 'vs/base/common/strings';
 import { IViewLineTokens } from 'vs/editor/common/core/lineTokens';
 import { MetadataConsts } from 'vs/editor/common/modes';
 import { LineDecoration } from 'vs/editor/common/viewLayout/lineDecorations';
-import { CharacterMapping, RenderLineInput, renderViewLine2 as renderViewLine } from 'vs/editor/common/viewLayout/viewLineRenderer';
+import { CharacterMapping, RenderLineInput, renderViewLine2 as renderViewLine, LineRange } from 'vs/editor/common/viewLayout/viewLineRenderer';
 import { InlineDecorationType } from 'vs/editor/common/viewModel/viewModel';
 import { ViewLineToken, ViewLineTokens } from 'vs/editor/test/common/core/viewLineToken';
-import { Range } from 'vs/editor/common/core/range';
 
 function createViewLineTokens(viewLineTokens: ViewLineToken[]): IViewLineTokens {
 	return new ViewLineTokens(viewLineTokens);
@@ -43,7 +42,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span><span class="mtk0">' + expected + '</span></span>');
@@ -93,7 +92,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span>' + expected + '</span>');
@@ -146,7 +145,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'boundary',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expectedOutput = [
@@ -238,7 +237,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'boundary',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -301,7 +300,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -364,7 +363,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -404,7 +403,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -435,7 +434,7 @@ suite('viewLineRenderer.renderLine', () => {
 				'none',
 				false,
 				false,
-				undefined
+				null
 			));
 			assert.equal(actual.html, '<span>' + expectedOutput.join('') + '</span>', message);
 		}
@@ -536,7 +535,7 @@ suite('viewLineRenderer.renderLine', () => {
 				'none',
 				false,
 				true,
-				undefined
+				null
 			));
 			assert.equal(actual.html, '<span>' + expectedOutput.join('') + '</span>', message);
 		}
@@ -575,7 +574,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 		let expectedOutput = [
 			'<span class="mtk1">a𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷</span>',
@@ -605,7 +604,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 		assert.equal(actual.html, '<span>' + expectedOutput.join('') + '</span>');
 		assert.equal(actual.containsRTL, true);
@@ -652,7 +651,7 @@ suite('viewLineRenderer.renderLine', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		assert.equal(_actual.html, '<span>' + expectedOutput + '</span>');
@@ -717,7 +716,7 @@ suite('viewLineRenderer.renderLine', () => {
 
 suite('viewLineRenderer.renderLine 2', () => {
 
-	function testCreateLineParts(fontIsMonospace: boolean, lineContent: string, tokens: ViewLineToken[], fauxIndentLength: number, renderWhitespace: 'none' | 'boundary' | 'selection' | 'all', selections: Range[] | undefined, expected: string): void {
+	function testCreateLineParts(fontIsMonospace: boolean, lineContent: string, tokens: ViewLineToken[], fauxIndentLength: number, renderWhitespace: 'none' | 'boundary' | 'selection' | 'all', selections: LineRange[] | null, expected: string): void {
 		let actual = renderViewLine(new RenderLineInput(
 			fontIsMonospace,
 			true,
@@ -760,7 +759,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -800,7 +799,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -827,7 +826,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'none',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="mtk1">Hello\u00a0world!</span>',
@@ -845,7 +844,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'none',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="mtk1">Hello\u00a0</span>',
@@ -865,7 +864,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u00b7\u00b7\u00b7\u00b7</span>',
@@ -887,7 +886,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u00b7\u00b7\u00b7\u00b7</span>',
@@ -911,7 +910,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u2192\u00a0\u00a0\u00a0</span>',
@@ -934,7 +933,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:40px">\u00b7\u00b7\u2192\u00a0</span>',
@@ -962,7 +961,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			2,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="">\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0</span>',
@@ -989,7 +988,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			2,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="">\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0</span>',
@@ -1013,7 +1012,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'boundary',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="mtk1">it</span>',
@@ -1039,7 +1038,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'all',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
@@ -1064,7 +1063,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'selection',
-			undefined,
+			null,
 			[
 				'<span>',
 				'<span class="mtk0">\u00a0Hel</span>',
@@ -1086,7 +1085,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'selection',
-			[new Range(0, 0, 0, 14)],
+			[new LineRange(0, 14)],
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
@@ -1111,13 +1110,63 @@ suite('viewLineRenderer.renderLine 2', () => {
 			],
 			0,
 			'selection',
-			[new Range(0, 0, 0, 5)],
+			[new LineRange(0, 5)],
 			[
 				'<span>',
 				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
 				'<span class="mtk0">Hel</span>',
 				'<span class="mtk1">lo</span>',
 				'<span class="mtk2">\u00a0world!\u00a0\u00a0\u00a0</span>',
+				'</span>',
+			].join('')
+		);
+	});
+
+
+	test('createLineParts render whitespace for selection with multiple selections', () => {
+		testCreateLineParts(
+			false,
+			' Hello world!\t',
+			[
+				createPart(4, 0),
+				createPart(6, 1),
+				createPart(14, 2)
+			],
+			0,
+			'selection',
+			[new LineRange(0, 5), new LineRange(9, 14)],
+			[
+				'<span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk0">Hel</span>',
+				'<span class="mtk1">lo</span>',
+				'<span class="mtk2">\u00a0world!</span>',
+				'<span class="vs-whitespace" style="width:30px">\u2192\u00a0\u00a0</span>',
+				'</span>',
+			].join('')
+		);
+	});
+
+
+	test('createLineParts render whitespace for selection with multiple, initially unsorted selections', () => {
+		testCreateLineParts(
+			false,
+			' Hello world!\t',
+			[
+				createPart(4, 0),
+				createPart(6, 1),
+				createPart(14, 2)
+			],
+			0,
+			'selection',
+			[new LineRange(9, 14), new LineRange(0, 5)],
+			[
+				'<span>',
+				'<span class="vs-whitespace" style="width:10px">\u00b7</span>',
+				'<span class="mtk0">Hel</span>',
+				'<span class="mtk1">lo</span>',
+				'<span class="mtk2">\u00a0world!</span>',
+				'<span class="vs-whitespace" style="width:30px">\u2192\u00a0\u00a0</span>',
 				'</span>',
 			].join('')
 		);
@@ -1144,7 +1193,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		// 01234567890
@@ -1185,7 +1234,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'all',
 			false,
 			true,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1218,7 +1267,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'all',
 			false,
 			true,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1252,7 +1301,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'all',
 			false,
 			true,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1282,7 +1331,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1316,7 +1365,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1349,7 +1398,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1380,7 +1429,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1410,7 +1459,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'all',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1446,7 +1495,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1476,7 +1525,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1508,7 +1557,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1539,7 +1588,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'boundary',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1568,7 +1617,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			true,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1601,7 +1650,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			true,
-			undefined
+			null
 		));
 
 		let expected = [
@@ -1630,7 +1679,7 @@ suite('viewLineRenderer.renderLine 2', () => {
 			'none',
 			false,
 			false,
-			undefined
+			null
 		));
 
 		return (partIndex: number, partLength: number, offset: number, expected: number) => {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3031,7 +3031,7 @@ declare namespace monaco.editor {
 		 * Enable rendering of whitespace.
 		 * Defaults to none.
 		 */
-		renderWhitespace?: 'none' | 'boundary' | 'all';
+		renderWhitespace?: 'none' | 'boundary' | 'selection' | 'all';
 		/**
 		 * Enable rendering of control characters.
 		 * Defaults to false.
@@ -3303,7 +3303,7 @@ declare namespace monaco.editor {
 		readonly scrollBeyondLastColumn: number;
 		readonly smoothScrolling: boolean;
 		readonly stopRenderingLineAfter: number;
-		readonly renderWhitespace: 'none' | 'boundary' | 'all';
+		readonly renderWhitespace: 'none' | 'boundary' | 'selection' | 'all';
 		readonly renderControlCharacters: boolean;
 		readonly fontLigatures: boolean;
 		readonly renderIndentGuides: boolean;


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/1477

![whitespace_selection](https://user-images.githubusercontent.com/3672607/61393879-c5398800-a876-11e9-9fd0-39d31cb7e015.gif)

Since whitespace is rendered as part of the line content and not on the selection layer, and since render line already responds to selection changes in some cases, the change I made is to view line rendering. Now, if the setting is on, any selections that are on the line are part of the line data for rendering. When applying whitespace, it checks the selections to see if the whitespace character is part of that range or not.