### PR TITLE
WIP: Make VS-Code not suggest to install the PowerShell extension when the PowerShell-preview extension is installed

### DIFF
--- a/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsTipsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-browser/extensionsTipsService.test.ts
@@ -217,8 +217,12 @@ suite('ExtensionsTipsService Test', () => {
 				'name': 'Python',
 				'pattern': '{**/*.py}'
 			},
-			'ms-vscode.PowerShell': {
+			'ms-vscode.powershell': {
 				'name': 'PowerShell',
+				'pattern': '{**/*.ps,**/*.ps1}'
+			},
+			'ms-vscode.powershell-preview': {
+				'name': 'PowerShell Preview',
 				'pattern': '{**/*.ps,**/*.ps1}'
 			}
 		};


### PR DESCRIPTION
When opening a PowerShell file or setting language mode to `PowerShell`, VS-Code recommends the PowerShell extension, even when one has the preview extension installed, which is annoying in this case
![image](https://user-images.githubusercontent.com/9250262/61461232-3b69e780-a968-11e9-864b-5e92d6973730.png)

I am not sure if this change is the right change to make VS-Code still prompt for the PowerShell extension when no PowerShell extension is installed but to not prompt when the PowerShell-preview is installed.
I also corrected the casings to be lower-case to match their actual casing. I'd appreciate some help where and how you'd like the 'proper' change to be. Unfortunately, the build does not upload the built product as an artifact in the PR here, so I cannot even test it easily without having to setup a dev environment

cc @TylerLeonhardt 

