### PR TITLE
Fixed Secondary Action Hidden w/ No Primary Action Bug

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -166,7 +166,7 @@ export class CommentNode extends Disposable {
 			secondaryActions.push(...secondary);
 		}
 
-		if (actions.length) {
+		if (actions.length || secondaryActions.length) {
 			this.toolbar = new ToolBar(this._actionsToolbarContainer, this.contextMenuService, {
 				actionViewItemProvider: action => {
 					if (action.id === ToggleReactionsAction.ID) {


### PR DESCRIPTION
Fixing issue from #77608

Changed check for whether to surface action buttons from only seeing if there are primary actions
```
if (actions.length){
     ...
}
```
to whether there are primary actions OR secondary actions
```
if (actions.length || secondaryActions.length){
     ...
}
```

In cases where developers intended for only secondary actions, they will still surface in the comment GUI.