### PR TITLE
fix: spelling mistake correction

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -460,7 +460,7 @@ const editorConfiguration: IConfigurationNode = {
 		'editor.fastScrollSensitivity': {
 			'type': 'number',
 			'default': EDITOR_DEFAULTS.viewInfo.scrollbar.fastScrollSensitivity,
-			'markdownDescription': nls.localize('fastScrollSensitivity', "Scrolling speed mulitiplier when pressing `Alt`.")
+			'markdownDescription': nls.localize('fastScrollSensitivity', "Scrolling speed multiplier when pressing `Alt`.")
 		},
 		'editor.multiCursorModifier': {
 			'type': 'string',


### PR DESCRIPTION
- Correct spelling mistake in `commonEditorConfig.ts` file
  - Change word from `mulitiplier` to `multiplier`

Note:
- Potentially affects _"Get Started - User and Workspace Settings"_
  https://code.visualstudio.com/docs/getstarted/settings
  page's listing of the default editor config parameters,
  as those still include the (probably) generated mispelling.