### PR TITLE
Give remote resolvers a way to set environment variables in the remote EH

### DIFF
--- a/src/vs/platform/remote/browser/remoteAuthorityResolverService.ts
+++ b/src/vs/platform/remote/browser/remoteAuthorityResolverService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ResolvedAuthority, IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { ResolvedAuthority, IRemoteAuthorityResolverService, ResolverResult } from 'vs/platform/remote/common/remoteAuthorityResolver';
 
 export class RemoteAuthorityResolverService implements IRemoteAuthorityResolverService {
 
@@ -12,12 +12,16 @@ export class RemoteAuthorityResolverService implements IRemoteAuthorityResolverS
 	constructor() {
 	}
 
-	resolveAuthority(authority: string): Promise<ResolvedAuthority> {
+	resolveAuthority(authority: string): Promise<ResolverResult> {
 		if (authority.indexOf(':') >= 0) {
 			const pieces = authority.split(':');
-			return Promise.resolve({ authority, host: pieces[0], port: parseInt(pieces[1], 10) });
+			return Promise.resolve({
+				authority: { authority, host: pieces[0], port: parseInt(pieces[1], 10) }
+			});
 		}
-		return Promise.resolve({ authority, host: authority, port: 80 });
+		return Promise.resolve({
+			authority: { authority, host: authority, port: 80 }
+		});
 	}
 
 	clearResolvedAuthority(authority: string): void {

--- a/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -163,6 +163,7 @@ export interface IRemoteExtensionHostStartParams {
 	debugId?: string;
 	break?: boolean;
 	port?: number | null;
+	env?: { [key: string]: string | null };
 }
 
 interface IExtensionHostConnectionResult {

--- a/src/vs/platform/remote/common/remoteAuthorityResolver.ts
+++ b/src/vs/platform/remote/common/remoteAuthorityResolver.ts
@@ -14,7 +14,7 @@ export interface ResolvedAuthority {
 }
 
 export interface ResolvedOptions {
-	readonly remoteEnv?: { [key: string]: string | null };
+	readonly extensionHostEnv?: { [key: string]: string | null };
 }
 
 export interface ResolverResult {

--- a/src/vs/platform/remote/common/remoteAuthorityResolver.ts
+++ b/src/vs/platform/remote/common/remoteAuthorityResolver.ts
@@ -13,6 +13,15 @@ export interface ResolvedAuthority {
 	readonly port: number;
 }
 
+export interface ResolvedOptions {
+	readonly remoteEnv?: { [key: string]: string | null };
+}
+
+export interface ResolverResult {
+	authority: ResolvedAuthority;
+	options?: ResolvedOptions;
+}
+
 export enum RemoteAuthorityResolverErrorCode {
 	Unknown = 'Unknown',
 	NotAvailable = 'NotAvailable',
@@ -61,9 +70,9 @@ export interface IRemoteAuthorityResolverService {
 
 	_serviceBrand: any;
 
-	resolveAuthority(authority: string): Promise<ResolvedAuthority>;
+	resolveAuthority(authority: string): Promise<ResolverResult>;
 
 	clearResolvedAuthority(authority: string): void;
-	setResolvedAuthority(resolvedAuthority: ResolvedAuthority): void;
+	setResolvedAuthority(resolvedAuthority: ResolvedAuthority, resolvedOptions?: ResolvedOptions): void;
 	setResolvedAuthorityError(authority: string, err: any): void;
 }

--- a/src/vs/platform/remote/electron-browser/remoteAuthorityResolverService.ts
+++ b/src/vs/platform/remote/electron-browser/remoteAuthorityResolverService.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ResolvedAuthority, IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { ResolvedAuthority, IRemoteAuthorityResolverService, ResolverResult, ResolvedOptions } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ipcRenderer as ipc } from 'electron';
 import * as errors from 'vs/base/common/errors';
 
 class PendingResolveAuthorityRequest {
 	constructor(
-		public readonly resolve: (value: ResolvedAuthority) => void,
+		public readonly resolve: (value: ResolverResult) => void,
 		public readonly reject: (err: any) => void,
-		public readonly promise: Promise<ResolvedAuthority>,
+		public readonly promise: Promise<ResolverResult>,
 	) {
 	}
 }
@@ -26,11 +26,11 @@ export class RemoteAuthorityResolverService implements IRemoteAuthorityResolverS
 		this._resolveAuthorityRequests = Object.create(null);
 	}
 
-	resolveAuthority(authority: string): Promise<ResolvedAuthority> {
+	resolveAuthority(authority: string): Promise<ResolverResult> {
 		if (!this._resolveAuthorityRequests[authority]) {
-			let resolve: (value: ResolvedAuthority) => void;
+			let resolve: (value: ResolverResult) => void;
 			let reject: (err: any) => void;
-			let promise = new Promise<ResolvedAuthority>((_resolve, _reject) => {
+			let promise = new Promise<ResolverResult>((_resolve, _reject) => {
 				resolve = _resolve;
 				reject = _reject;
 			});
@@ -46,11 +46,11 @@ export class RemoteAuthorityResolverService implements IRemoteAuthorityResolverS
 		}
 	}
 
-	setResolvedAuthority(resolvedAuthority: ResolvedAuthority) {
+	setResolvedAuthority(resolvedAuthority: ResolvedAuthority, options?: ResolvedOptions) {
 		if (this._resolveAuthorityRequests[resolvedAuthority.authority]) {
 			let request = this._resolveAuthorityRequests[resolvedAuthority.authority];
 			ipc.send('vscode:remoteAuthorityResolved', resolvedAuthority);
-			request.resolve(resolvedAuthority);
+			request.resolve({ authority: resolvedAuthority, options });
 		}
 	}
 

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -95,13 +95,10 @@ declare module 'vscode' {
 	}
 
 	export interface ResolvedOptions {
-		remoteEnv?: { [key: string]: string | null };
+		extensionHostEnv?: { [key: string]: string | null };
 	}
 
-	export interface ResolverResult {
-		authority: ResolvedAuthority;
-		options?: ResolvedOptions;
-	}
+	export type ResolverResult = ResolvedAuthority & ResolvedOptions;
 
 	export class RemoteAuthorityResolverError extends Error {
 		static NotAvailable(message?: string, handled?: boolean): RemoteAuthorityResolverError;

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -94,6 +94,15 @@ declare module 'vscode' {
 		constructor(host: string, port: number);
 	}
 
+	export interface ResolvedOptions {
+		remoteEnv?: { [key: string]: string | null };
+	}
+
+	export interface ResolverResult {
+		authority: ResolvedAuthority;
+		options?: ResolvedOptions;
+	}
+
 	export class RemoteAuthorityResolverError extends Error {
 		static NotAvailable(message?: string, handled?: boolean): RemoteAuthorityResolverError;
 		static TemporarilyNotAvailable(message?: string): RemoteAuthorityResolverError;
@@ -102,7 +111,7 @@ declare module 'vscode' {
 	}
 
 	export interface RemoteAuthorityResolver {
-		resolve(authority: string, context: RemoteAuthorityResolverContext): ResolvedAuthority | Thenable<ResolvedAuthority>;
+		resolve(authority: string, context: RemoteAuthorityResolverContext): ResolverResult | Thenable<ResolverResult>;
 	}
 
 	export interface ResourceLabelFormatter {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -31,7 +31,7 @@ import { LogLevel } from 'vs/platform/log/common/log';
 import { IMarkerData } from 'vs/platform/markers/common/markers';
 import { IProgressOptions, IProgressStep } from 'vs/platform/progress/common/progress';
 import * as quickInput from 'vs/platform/quickinput/common/quickInput';
-import { RemoteAuthorityResolverErrorCode, ResolvedAuthority } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { RemoteAuthorityResolverErrorCode, ResolverResult } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import * as statusbar from 'vs/platform/statusbar/common/statusbar';
 import { ClassifiedEvent, GDPRClassification, StrictPropertyCheck } from 'vs/platform/telemetry/common/gdprTypings';
 import { ITelemetryInfo } from 'vs/platform/telemetry/common/telemetry';
@@ -855,7 +855,7 @@ export interface IResolveAuthorityErrorResult {
 
 export interface IResolveAuthorityOKResult {
 	type: 'ok';
-	value: ResolvedAuthority;
+	value: ResolverResult;
 }
 
 export type IResolveAuthorityResult = IResolveAuthorityErrorResult | IResolveAuthorityOKResult;

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -662,12 +662,24 @@ export class ExtHostExtensionService implements ExtHostExtensionServiceShape {
 
 		try {
 			const result = await resolver.resolve(remoteAuthority, { resolveAttempt });
+
+			// Support the old resolver interface, TODO remove after awhile
+			const authority = typeof (<any>result).host === 'string' ?
+				{
+					authority: remoteAuthority,
+					host: (<any>result).host,
+					port: (<any>result).port
+				} :
+				{
+					authority: remoteAuthority,
+					host: result.authority.host,
+					port: result.authority.port
+				};
 			return {
 				type: 'ok',
 				value: {
-					authority: remoteAuthority,
-					host: result.host,
-					port: result.port,
+					authority,
+					options: result.options
 				}
 			};
 		} catch (err) {

--- a/src/vs/workbench/services/extensions/common/extensionHostProcessManager.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostProcessManager.ts
@@ -14,7 +14,7 @@ import { ExtHostCustomersRegistry } from 'vs/workbench/api/common/extHostCustome
 import { ExtHostContext, ExtHostExtensionServiceShape, IExtHostContext, MainContext } from 'vs/workbench/api/common/extHost.protocol';
 import { ProxyIdentifier } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { IRPCProtocolLogger, RPCProtocol, RequestInitiator, ResponsiveState } from 'vs/workbench/services/extensions/common/rpcProtocol';
-import { ResolvedAuthority, RemoteAuthorityResolverError } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { RemoteAuthorityResolverError, ResolverResult } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import * as nls from 'vs/nls';
 import { Action } from 'vs/base/common/actions';
@@ -247,15 +247,17 @@ export class ExtensionHostProcessManager extends Disposable {
 		return this._extensionHostProcessWorker && Boolean(this._extensionHostProcessWorker.getInspectPort());
 	}
 
-	public async resolveAuthority(remoteAuthority: string): Promise<ResolvedAuthority> {
+	public async resolveAuthority(remoteAuthority: string): Promise<ResolverResult> {
 		const authorityPlusIndex = remoteAuthority.indexOf('+');
 		if (authorityPlusIndex === -1) {
 			// This authority does not need to be resolved, simply parse the port number
 			const pieces = remoteAuthority.split(':');
 			return Promise.resolve({
-				authority: remoteAuthority,
-				host: pieces[0],
-				port: parseInt(pieces[1], 10)
+				authority: {
+					authority: remoteAuthority,
+					host: pieces[0],
+					port: parseInt(pieces[1], 10)
+				}
 			});
 		}
 		const proxy = await this._getExtensionHostProcessProxy();

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHostClient.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHostClient.ts
@@ -76,19 +76,20 @@ export class RemoteExtensionHostClient extends Disposable implements IExtensionH
 			webSocketFactory: this._webSocketFactory,
 			addressProvider: {
 				getAddress: async () => {
-					const { host, port } = await this.remoteAuthorityResolverService.resolveAuthority(this._initDataProvider.remoteAuthority);
-					return { host, port };
+					const { authority } = await this.remoteAuthorityResolverService.resolveAuthority(this._initDataProvider.remoteAuthority);
+					return { host: authority.host, port: authority.port };
 				}
 			},
 			signService: this._signService
 		};
-		return this.remoteAuthorityResolverService.resolveAuthority(this._initDataProvider.remoteAuthority).then((resolvedAuthority) => {
+		return this.remoteAuthorityResolverService.resolveAuthority(this._initDataProvider.remoteAuthority).then((resolverResult) => {
 
 			const startParams: IRemoteExtensionHostStartParams = {
 				language: platform.language,
 				debugId: this._environmentService.debugExtensionHost.debugId,
 				break: this._environmentService.debugExtensionHost.break,
 				port: this._environmentService.debugExtensionHost.port,
+				env: resolverResult.options && resolverResult.options.remoteEnv
 			};
 
 			const extDevLocs = this._environmentService.extensionDevelopmentLocationURI;

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHostClient.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHostClient.ts
@@ -89,7 +89,7 @@ export class RemoteExtensionHostClient extends Disposable implements IExtensionH
 				debugId: this._environmentService.debugExtensionHost.debugId,
 				break: this._environmentService.debugExtensionHost.break,
 				port: this._environmentService.debugExtensionHost.port,
-				env: resolverResult.options && resolverResult.options.remoteEnv
+				env: resolverResult.options && resolverResult.options.extensionHostEnv
 			};
 
 			const extDevLocs = this._environmentService.extensionDevelopmentLocationURI;

--- a/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionService.ts
@@ -19,7 +19,7 @@ import { IExtensionEnablementService } from 'vs/workbench/services/extensionMana
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInitDataProvider, RemoteExtensionHostClient } from 'vs/workbench/services/extensions/common/remoteExtensionHostClient';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
-import { IRemoteAuthorityResolverService, ResolvedAuthority, RemoteAuthorityResolverError } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, ResolverResult } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { isUIExtension } from 'vs/workbench/services/extensions/common/extensionsUtil';
 import { IRemoteAgentEnvironment } from 'vs/platform/remote/common/remoteAgentEnvironment';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -419,8 +419,8 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		const extensionHost = this._extensionHostProcessManagers[0];
 		this._remoteAuthorityResolverService.clearResolvedAuthority(remoteAuthority);
 		try {
-			const resolvedAuthority = await extensionHost.resolveAuthority(remoteAuthority);
-			this._remoteAuthorityResolverService.setResolvedAuthority(resolvedAuthority);
+			const result = await extensionHost.resolveAuthority(remoteAuthority);
+			this._remoteAuthorityResolverService.setResolvedAuthority(result.authority, result.options);
 		} catch (err) {
 			this._remoteAuthorityResolverService.setResolvedAuthorityError(remoteAuthority, err);
 		}
@@ -441,7 +441,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 		localExtensions = localExtensions.filter(extension => this._isEnabled(extension));
 
 		if (remoteAuthority) {
-			let resolvedAuthority: ResolvedAuthority;
+			let resolvedAuthority: ResolverResult;
 
 			try {
 				resolvedAuthority = await extensionHost.resolveAuthority(remoteAuthority);
@@ -463,7 +463,7 @@ export class ExtensionService extends AbstractExtensionService implements IExten
 			}
 
 			// set the resolved authority
-			this._remoteAuthorityResolverService.setResolvedAuthority(resolvedAuthority);
+			this._remoteAuthorityResolverService.setResolvedAuthority(resolvedAuthority.authority, resolvedAuthority.options);
 
 			// monitor for breakage
 			const connection = this._remoteAgentService.getConnection();

--- a/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
+++ b/src/vs/workbench/services/remote/common/abstractRemoteAgentService.ts
@@ -121,8 +121,8 @@ export class RemoteAgentConnection extends Disposable implements IRemoteAgentCon
 					} else {
 						this._onReconnecting.fire(undefined);
 					}
-					const { host, port } = await this._remoteAuthorityResolverService.resolveAuthority(this.remoteAuthority);
-					return { host, port };
+					const { authority } = await this._remoteAuthorityResolverService.resolveAuthority(this.remoteAuthority);
+					return { host: authority.host, port: authority.port };
 				}
 			},
 			signService: this._signService

--- a/src/vs/workbench/services/remote/node/tunnelService.ts
+++ b/src/vs/workbench/services/remote/node/tunnelService.ts
@@ -105,8 +105,8 @@ export class TunnelService implements ITunnelService {
 			webSocketFactory: nodeWebSocketFactory,
 			addressProvider: {
 				getAddress: async () => {
-					const { host, port } = await this.remoteAuthorityResolverService.resolveAuthority(remoteAuthority);
-					return { host, port };
+					const { authority } = await this.remoteAuthorityResolverService.resolveAuthority(remoteAuthority);
+					return { host: authority.host, port: authority.port };
 				}
 			},
 			signService: this.signService


### PR DESCRIPTION
Fix microsoft/vscode#77234, for microsoft/vscode-remote-release#16