### PR TITLE
Option for find widget to have max width

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -399,6 +399,11 @@ const editorConfiguration: IConfigurationNode = {
 			'default': true,
 			'description': nls.localize('find.addExtraSpaceOnTop', "Controls whether the Find Widget should add extra lines on top of the editor. When true, you can scroll beyond the first line when the Find Widget is visible.")
 		},
+		'editor.find.alwaysUseMaxWidth': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('find.alwaysUseMaxWidth', "Controls whether the Find Widget should always be the maximum width.")
+		},
 		'editor.wordWrap': {
 			'type': 'string',
 			'enum': ['off', 'on', 'wordWrapColumn', 'bounded'],

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -96,6 +96,10 @@ export interface IEditorFindOptions {
 	 * Controls if the Find Widget should read or modify the shared find clipboard on macOS
 	 */
 	globalFindClipboard: boolean;
+	/*
+	 * Controls whether the Find Widget should always use the max width.
+	 */
+	alwaysUseMaxWidth?: boolean;
 }
 
 /**
@@ -923,6 +927,7 @@ export interface InternalEditorFindOptions {
 	readonly seedSearchStringFromSelection: boolean;
 	readonly autoFindInSelection: boolean;
 	readonly addExtraSpaceOnTop: boolean;
+	readonly alwaysUseMaxWidth: boolean;
 	/**
 	 * @internal
 	 */
@@ -1362,6 +1367,7 @@ export class InternalEditorOptions {
 			&& a.autoFindInSelection === b.autoFindInSelection
 			&& a.globalFindClipboard === b.globalFindClipboard
 			&& a.addExtraSpaceOnTop === b.addExtraSpaceOnTop
+			&& a.alwaysUseMaxWidth === b.alwaysUseMaxWidth
 		);
 	}
 
@@ -1904,7 +1910,8 @@ export class EditorOptionsValidator {
 			seedSearchStringFromSelection: _boolean(opts.seedSearchStringFromSelection, defaults.seedSearchStringFromSelection),
 			autoFindInSelection: _boolean(opts.autoFindInSelection, defaults.autoFindInSelection),
 			globalFindClipboard: _boolean(opts.globalFindClipboard, defaults.globalFindClipboard),
-			addExtraSpaceOnTop: _boolean(opts.addExtraSpaceOnTop, defaults.addExtraSpaceOnTop)
+			addExtraSpaceOnTop: _boolean(opts.addExtraSpaceOnTop, defaults.addExtraSpaceOnTop),
+			alwaysUseMaxWidth: _boolean(opts.alwaysUseMaxWidth, defaults.alwaysUseMaxWidth)
 		};
 	}
 
@@ -2733,7 +2740,8 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 			seedSearchStringFromSelection: true,
 			autoFindInSelection: false,
 			globalFindClipboard: false,
-			addExtraSpaceOnTop: true
+			addExtraSpaceOnTop: true,
+			alwaysUseMaxWidth: false
 		},
 		colorDecorators: true,
 		lightbulbEnabled: true,

--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -154,7 +154,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 				}
 				this._updateButtons();
 			}
-			if (e.layoutInfo) {
+			if (e.layoutInfo || e.contribInfo) {
 				this._tryUpdateWidgetWidth();
 			}
 
@@ -582,8 +582,20 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 		if (!this._isVisible) {
 			return;
 		}
+
+		let configMaxWidth = this._codeEditor.getConfiguration().contribInfo.find.alwaysUseMaxWidth;
 		let editorWidth = this._codeEditor.getConfiguration().layoutInfo.width;
 		let minimapWidth = this._codeEditor.getConfiguration().layoutInfo.minimapWidth;
+		let maxWidthVal = `${editorWidth - 28 - minimapWidth - 15}px`;
+
+		if (configMaxWidth) {
+			// Use min width so that if the user toggles the option off while the widget is open, it remembers its width
+			this._domNode.style.minWidth = maxWidthVal;
+			// Hide the drag-scroll widget
+			(this._domNode.getElementsByClassName('monaco-sash')[0] as HTMLElement).style.display = 'none';
+			return;
+		}
+
 		let collapsedFindWidget = false;
 		let reducedFindWidget = false;
 		let narrowFindWidget = false;
@@ -593,7 +605,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 
 			if (widgetWidth > FIND_WIDGET_INITIAL_WIDTH) {
 				// as the widget is resized by users, we may need to change the max width of the widget as the editor width changes.
-				this._domNode.style.maxWidth = `${editorWidth - 28 - minimapWidth - 15}px`;
+				this._domNode.style.maxWidth = maxWidthVal;
 				this._replaceInputBox.inputElement.style.width = `${dom.getTotalWidth(this._findInput.inputBox.inputElement)}px`;
 				return;
 			}
@@ -623,6 +635,9 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 				this._replaceInputBox.inputElement.style.width = `${findInputWidth}px`;
 			}
 		}
+
+		(this._domNode.getElementsByClassName('monaco-sash')[0] as HTMLElement).style.display = '';
+		this._domNode.style.minWidth = '';
 	}
 
 	// ----- Public

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2471,6 +2471,7 @@ declare namespace monaco.editor {
 		 */
 		autoFindInSelection: boolean;
 		addExtraSpaceOnTop?: boolean;
+		alwaysUseMaxWidth?: boolean;
 	}
 
 	/**
@@ -3231,6 +3232,7 @@ declare namespace monaco.editor {
 		readonly seedSearchStringFromSelection: boolean;
 		readonly autoFindInSelection: boolean;
 		readonly addExtraSpaceOnTop: boolean;
+		readonly alwaysUseMaxWidth: boolean;
 	}
 
 	export interface InternalEditorHoverOptions {


### PR DESCRIPTION
If this is enabled, the find widget will always be the maximum size.

----

The default width is so narrow, and I always end up having to resize it to be longer. There is no reason for it not to be as wide as possible, imo.