### PR TITLE
Make centerEditorLayout do not call layout

### DIFF
--- a/src/vs/workbench/browser/workbench.ts
+++ b/src/vs/workbench/browser/workbench.ts
@@ -414,7 +414,7 @@ export class Workbench extends Layout {
 
 		// Restore Editor Center Mode
 		if (this.state.editor.restoreCentered) {
-			this.centerEditorLayout(true);
+			this.centerEditorLayout(true, true);
 		}
 
 		// Emit a warning after 10s if restore does not complete


### PR DESCRIPTION
Not sure if this is the right fix but it seems to not break anything. Maybe need to call layout later?
Fixes #76494.