### PR TITLE
Adjust Code Tab Size to 4 in Markdown Preview

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -186,6 +186,7 @@ pre.hljs code > div {
 
 pre code {
 	color: var(--vscode-editor-foreground);
+	tab-size: 4;
 }
 
 


### PR DESCRIPTION
Sets the tab size to 4 in the Markdown preview for code blocks in Markdown documents. I consider a tab size of 4 being standard and the default of 8 being unbearable. The few people, if any, using a different tab size than 4 can use the custom markdown preview style feature, if it is going to be fixed anytime (https://github.com/microsoft/vscode/issues/77290).

[`tab-size` is still marked *experimental* in the MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size), but it doesn't hurt, if not supported. However, in the used Chromium version it is supported.