### PR TITLE
[XML] Use the same HTML language configuration for XML

### DIFF
--- a/extensions/xml/xml.language-configuration.json
+++ b/extensions/xml/xml.language-configuration.json
@@ -1,31 +1,34 @@
 {
 	"comments": {
-		"lineComment": "",
-		"blockComment": ["<!--", "-->"]
+		"blockComment": [ "<!--", "-->" ]
 	},
 	"brackets": [
-		["<", ">"]
+		["<!--", "-->"],
+		["<", ">"],
+		["{", "}"],
+		["(", ")"]
 	],
 	"autoClosingPairs": [
-		["<", ">"],
-		["'", "'"],
-		["\"", "\""]
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "<!--", "close": "-->", "notIn": [ "comment", "string" ]},
+		{ "open": "<![CDATA[", "close": "]]>", "notIn": [ "comment", "string" ]}
 	],
 	"surroundingPairs": [
-		["<", ">"],
-		["'", "'"],
-		["\"", "\""]
-	]
-
-	// enhancedBrackets: [{
-	// 	tokenType: 'tag.tag-$1.xml',
-	// 	openTrigger: '>',
-	// 	open: /<(\w[\w\d]*)([^\/>]*(?!\/)>)[^<>]*$/i,
-	// 	closeComplete: '</$1>',
-	// 	closeTrigger: '>',
-	// 	close: /<\/(\w[\w\d]*)\s*>$/i
-	// }],
-
-	// autoClosingPairs:  [['\'', '\''], ['"', '"'] ]
-
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" }
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*<!--\\s*#region\\b.*-->",
+			"end": "^\\s*<!--\\s*#endregion\\b.*-->"
+		}
+	}
 }


### PR DESCRIPTION
This PR is a copy/paste of the HTML language configuration to have for instance autoClosingPairs for Comments and adds autoClosingPairs for CDATA.