### PR TITLE
Bump top-level @types/node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/keytar": "^4.4.0",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "2.2.39",
-    "@types/node": "^10.12.12",
+    "@types/node": "^10.14.8",
     "@types/semver": "^5.5.0",
     "@types/sinon": "^1.16.36",
     "@types/webpack": "^4.4.10",

--- a/src/typings/es6-promise.d.ts
+++ b/src/typings/es6-promise.d.ts
@@ -8,7 +8,9 @@ interface Thenable<T> {
 	then<U>(onFulfilled?: (value: T) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
 }
 
-declare class Promise<T> implements Thenable<T> {
+declare var Promise: PromiseConstructor;
+
+interface PromiseConstructor {
 	/**
 	 * If you call resolve in the body of the callback passed to the constructor,
 	 * your promise is fulfilled with result object passed to resolve.
@@ -16,8 +18,48 @@ declare class Promise<T> implements Thenable<T> {
 	 * For consistency and debugging (eg stack traces), obj should be an instanceof Error.
 	 * Any errors thrown in the constructor callback will be implicitly passed to reject().
 	 */
-	constructor(callback: (resolve: (value?: T | Thenable<T>) => void, reject: (error?: any) => void) => void);
+	new <T>(callback: (resolve: (value?: T | Thenable<T>) => void, reject: (error?: any) => void) => void): Promise<T>;
 
+	/**
+	 * Make a new promise from the thenable.
+	 * A thenable is promise-like in as far as it has a "then" method.
+	 */
+	resolve<T>(value: T | Thenable<T>): Promise<T>;
+
+	/**
+	 *
+	 */
+	resolve(): Promise<void>;
+
+	/**
+	 * Make a promise that rejects to obj. For consistency and debugging (eg stack traces), obj should be an instanceof Error
+	 */
+	reject(error: any): Promise<any>;
+	reject<T>(error: T): Promise<T>;
+
+	/**
+	 * Make a promise that fulfills when every item in the array fulfills, and rejects if (and when) any item rejects.
+	 * the array passed to all can be a mixture of promise-like objects and other objects.
+	 * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
+	 */
+	all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>, T8 | Thenable<T8>, T9 | Thenable<T9>, T10 | Thenable<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+	all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>, T8 | Thenable<T8>, T9 | Thenable<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+	all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>, T8 | Thenable<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+	all<T1, T2, T3, T4, T5, T6, T7>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+	all<T1, T2, T3, T4, T5, T6>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>;
+	all<T1, T2, T3, T4, T5>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>]): Promise<[T1, T2, T3, T4, T5]>;
+	all<T1, T2, T3, T4>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>]): Promise<[T1, T2, T3, T4]>;
+	all<T1, T2, T3>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>]): Promise<[T1, T2, T3]>;
+	all<T1, T2>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>]): Promise<[T1, T2]>;
+	all<T>(values: (T | Thenable<T>)[]): Promise<T[]>;
+
+	/**
+	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
+	 */
+	race<T>(promises: (T | Thenable<T>)[]): Promise<T>;
+}
+
+interface Promise<T> extends Thenable<T> {
 	/**
 	 * onFulfilled is called when/if "promise" resolves. onRejected is called when/if "promise" rejects.
 	 * Both are optional, if either/both are omitted the next onFulfilled/onRejected in the chain is called.
@@ -37,46 +79,6 @@ declare class Promise<T> implements Thenable<T> {
 	 * @param onRejected called when/if "promise" rejects
 	 */
 	catch<U>(onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
-}
-
-declare namespace Promise {
-	/**
-	 * Make a new promise from the thenable.
-	 * A thenable is promise-like in as far as it has a "then" method.
-	 */
-	function resolve<T>(value: T | Thenable<T>): Promise<T>;
-
-	/**
-	 *
-	 */
-	function resolve(): Promise<void>;
-
-	/**
-	 * Make a promise that rejects to obj. For consistency and debugging (eg stack traces), obj should be an instanceof Error
-	 */
-	function reject(error: any): Promise<any>;
-	function reject<T>(error: T): Promise<T>;
-
-	/**
-	 * Make a promise that fulfills when every item in the array fulfills, and rejects if (and when) any item rejects.
-	 * the array passed to all can be a mixture of promise-like objects and other objects.
-	 * The fulfillment value is an array (in order) of fulfillment values. The rejection value is the first rejection value.
-	 */
-	function all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>, T8 | Thenable<T8>, T9 | Thenable<T9>, T10 | Thenable<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
-	function all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>, T8 | Thenable<T8>, T9 | Thenable<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
-	function all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>, T8 | Thenable<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
-	function all<T1, T2, T3, T4, T5, T6, T7>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>, T7 | Thenable<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
-	function all<T1, T2, T3, T4, T5, T6>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>, T6 | Thenable<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>;
-	function all<T1, T2, T3, T4, T5>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>, T5 | Thenable<T5>]): Promise<[T1, T2, T3, T4, T5]>;
-	function all<T1, T2, T3, T4>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>, T4 | Thenable<T4>]): Promise<[T1, T2, T3, T4]>;
-	function all<T1, T2, T3>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>, T3 | Thenable<T3>]): Promise<[T1, T2, T3]>;
-	function all<T1, T2>(values: [T1 | Thenable<T1>, T2 | Thenable<T2>]): Promise<[T1, T2]>;
-	function all<T>(values: (T | Thenable<T>)[]): Promise<T[]>;
-
-	/**
-	 * Make a Promise that fulfills when any item fulfills, and rejects if any item rejects.
-	 */
-	function race<T>(promises: (T | Thenable<T>)[]): Promise<T>;
 }
 
 declare module 'es6-promise' {

--- a/src/typings/lib.ie11_safe_es6.d.ts
+++ b/src/typings/lib.ie11_safe_es6.d.ts
@@ -25,7 +25,7 @@ interface Map<K, V> {
 
 interface MapConstructor {
 	new <K, V>(): Map<K, V>;
-	prototype: Map<any, any>;
+	readonly prototype: Map<any, any>;
 
 	// not supported on IE11:
 	// new <K, V>(iterable: Iterable<[K, V]>): Map<K, V>;
@@ -51,7 +51,7 @@ interface Set<T> {
 
 interface SetConstructor {
 	new <T>(): Set<T>;
-	prototype: Set<any>;
+	readonly prototype: Set<any>;
 
 	// not supported on IE11:
 	// new <T>(iterable: Iterable<T>): Set<T>;

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -35,6 +35,7 @@ export function createCancelablePromise<T>(callback: (token: CancellationToken) 
 	});
 
 	return new class implements CancelablePromise<T> {
+		[Symbol.toStringTag] = 'CancelablePromise';
 		cancel() {
 			source.cancel();
 		}

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -35,7 +35,7 @@ export function createCancelablePromise<T>(callback: (token: CancellationToken) 
 	});
 
 	return new class implements CancelablePromise<T> {
-		[Symbol.toStringTag] = 'CancelablePromise';
+		[Symbol.toStringTag]!: string;
 		cancel() {
 			source.cancel();
 		}

--- a/src/vs/base/common/types.ts
+++ b/src/vs/base/common/types.ts
@@ -2,6 +2,12 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+declare global {
+	interface SymbolConstructor {
+		readonly toStringTag: symbol;
+	}
+	var Symbol: SymbolConstructor;
+}
 
 const _typeof = {
 	number: 'number',

--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -398,7 +398,7 @@ function doWriteFileStreamAndFlush(path: string, reader: NodeJS.ReadableStream, 
 // not in some cache.
 //
 // See https://github.com/nodejs/node/blob/v5.10.0/lib/fs.js#L1194
-function doWriteFileAndFlush(path: string, data: string | Buffer | Uint8Array, options: IEnsuredWriteFileOptions, callback: (error?: Error) => void): void {
+function doWriteFileAndFlush(path: string, data: string | Buffer | Uint8Array, options: IEnsuredWriteFileOptions, callback: (error?: Error | null) => void): void {
 	if (options.encoding) {
 		data = encode(data instanceof Uint8Array ? Buffer.from(data) : data, options.encoding.charset, { addBOM: options.encoding.addBOM });
 	}
@@ -655,6 +655,7 @@ export async function mkdirp(path: string, mode?: number, token?: CancellationTo
 				throw error; // rethrow original error
 			}
 		}
+		return;
 	};
 
 	// stop at root

--- a/src/vs/base/test/node/pfs/pfs.test.ts
+++ b/src/vs/base/test/node/pfs/pfs.test.ts
@@ -532,6 +532,7 @@ suite('PFS', () => {
 		assert.equal(readable.read(), 'Hello World');
 
 		await pfs.rimraf(parentDir);
+		return;
 	});
 
 	test('writeFile (stream, error handling READERROR)', async () => {
@@ -555,6 +556,7 @@ suite('PFS', () => {
 		}
 
 		await pfs.rimraf(parentDir);
+		return;
 	});
 
 	test('writeFile (stream, error handling EACCES)', async () => {
@@ -613,6 +615,7 @@ suite('PFS', () => {
 		}
 
 		await pfs.rimraf(parentDir);
+		return;
 	});
 
 	test('writeFileSync', async () => {

--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -371,7 +371,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 								e => Promise.reject(new Error(nls.localize('removeError', "Error while removing the extension: {0}. Please Quit and Start VS Code before trying again.", toErrorMessage(e))))));
 				}
 				return Promise.reject(new Error(nls.localize('Not a Marketplace extension', "Only Marketplace Extensions can be reinstalled")));
-			});
+			}).then(() => undefined);
 	}
 
 	private getTelemetryEvent(operation: InstallOperation): string {
@@ -495,7 +495,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 			});
 	}
 
-	private async installDependenciesAndPackExtensions(installed: ILocalExtension, existing: ILocalExtension | null): Promise<void> {
+	private async installDependenciesAndPackExtensions(installed: ILocalExtension, existing: ILocalExtension | null): Promise<unknown> {
 		if (this.galleryService.isEnabled()) {
 			const dependenciesAndPackExtensions: string[] = installed.manifest.extensionDependencies || [];
 			if (installed.manifest.extensionPack) {
@@ -546,7 +546,7 @@ export class ExtensionManagementService extends Disposable implements IExtension
 				} else {
 					return Promise.reject(new Error(nls.localize('notInstalled', "Extension '{0}' is not installed.", extension.manifest.displayName || extension.manifest.name)));
 				}
-			}));
+			})).then(() => undefined);
 	}
 
 	updateMetadata(local: ILocalExtension, metadata: IGalleryMetadata): Promise<ILocalExtension> {

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -41,7 +41,7 @@ export class LinuxUpdateService extends AbstractUpdateService {
 
 		this.setState(State.CheckingForUpdates(context));
 		this.requestService.request({ url: this.url }, CancellationToken.None)
-			.then<IUpdate>(asJson)
+			.then<IUpdate | null>(asJson)
 			.then(update => {
 				if (!update || !update.url || !update.version || !update.productVersion) {
 					this.telemetryService.publicLog2<{ explicit: boolean }, UpdateNotAvailableClassification>('update:notAvailable', { explicit: !!context });

--- a/src/vs/platform/update/electron-main/updateService.win32.ts
+++ b/src/vs/platform/update/electron-main/updateService.win32.ts
@@ -109,7 +109,7 @@ export class Win32UpdateService extends AbstractUpdateService {
 		this.setState(State.CheckingForUpdates(context));
 
 		this.requestService.request({ url: this.url }, CancellationToken.None)
-			.then<IUpdate>(asJson)
+			.then<IUpdate | null>(asJson)
 			.then(update => {
 				const updateType = getUpdateType();
 

--- a/src/vs/workbench/api/browser/mainThreadFileSystem.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystem.ts
@@ -67,7 +67,7 @@ export class MainThreadFileSystem implements MainThreadFileSystemShape {
 				err.name = FileSystemProviderErrorCode.FileNotADirectory;
 				throw err;
 			}
-			return !stat.children ? [] : stat.children.map(child => [child.name, MainThreadFileSystem._getFileType(child)]);
+			return !stat.children ? [] : stat.children.map(child => [child.name, MainThreadFileSystem._getFileType(child)] as [string, FileType]);
 		}).catch(MainThreadFileSystem._handleError);
 	}
 
@@ -80,19 +80,19 @@ export class MainThreadFileSystem implements MainThreadFileSystemShape {
 	}
 
 	$writeFile(uri: UriComponents, content: VSBuffer): Promise<void> {
-		return this._fileService.writeFile(URI.revive(uri), content).catch(MainThreadFileSystem._handleError);
+		return this._fileService.writeFile(URI.revive(uri), content).catch(MainThreadFileSystem._handleError).then(() => undefined);
 	}
 
 	$rename(source: UriComponents, target: UriComponents, opts: FileOverwriteOptions): Promise<void> {
-		return this._fileService.move(URI.revive(source), URI.revive(target), opts.overwrite).catch(MainThreadFileSystem._handleError);
+		return this._fileService.move(URI.revive(source), URI.revive(target), opts.overwrite).catch(MainThreadFileSystem._handleError).then(() => undefined);
 	}
 
 	$copy(source: UriComponents, target: UriComponents, opts: FileOverwriteOptions): Promise<void> {
-		return this._fileService.copy(URI.revive(source), URI.revive(target), opts.overwrite).catch(MainThreadFileSystem._handleError);
+		return this._fileService.copy(URI.revive(source), URI.revive(target), opts.overwrite).catch(MainThreadFileSystem._handleError).then(() => undefined);
 	}
 
 	$mkdir(uri: UriComponents): Promise<void> {
-		return this._fileService.createFolder(URI.revive(uri)).catch(MainThreadFileSystem._handleError);
+		return this._fileService.createFolder(URI.revive(uri)).catch(MainThreadFileSystem._handleError).then(() => undefined);
 	}
 
 	$delete(uri: UriComponents, opts: FileDeleteOptions): Promise<void> {

--- a/src/vs/workbench/api/browser/mainThreadSaveParticipant.ts
+++ b/src/vs/workbench/api/browser/mainThreadSaveParticipant.ts
@@ -343,7 +343,7 @@ class ExtHostSaveParticipant implements ISaveParticipantParticipant {
 
 		return new Promise<any>((resolve, reject) => {
 			setTimeout(() => reject(localize('timeout.onWillSave', "Aborted onWillSaveTextDocument-event after 1750ms")), 1750);
-			this._proxy.$participateInSave(editorModel.getResource(), env.reason).then(values => {
+			this._proxy.$participateInSave(editorModel.getResource(), env.reason).then<undefined>(values => {
 				for (const success of values) {
 					if (!success) {
 						return Promise.reject(new Error('listener failed'));

--- a/src/vs/workbench/api/browser/mainThreadWorkspace.ts
+++ b/src/vs/workbench/api/browser/mainThreadWorkspace.ts
@@ -123,11 +123,11 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 
 	// --- search ---
 
-	$startFileSearch(includePattern: string | null, _includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false | null, maxResults: number | null, token: CancellationToken): Promise<UriComponents[] | null> {
+	$startFileSearch(includePattern: string | undefined, _includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false | undefined, maxResults: number | undefined, token: CancellationToken): Promise<UriComponents[] | undefined> {
 		const includeFolder = URI.revive(_includeFolder);
 		const workspace = this._contextService.getWorkspace();
 		if (!workspace.folders.length) {
-			return Promise.resolve(null);
+			return Promise.resolve(undefined);
 		}
 
 		const query = this._queryBuilder.file(
@@ -152,7 +152,7 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 		});
 	}
 
-	$startTextSearch(pattern: IPatternInfo, options: ITextQueryBuilderOptions, requestId: number, token: CancellationToken): Promise<ITextSearchComplete> {
+	$startTextSearch(pattern: IPatternInfo, options: ITextQueryBuilderOptions, requestId: number, token: CancellationToken): Promise<ITextSearchComplete | undefined> {
 		const workspace = this._contextService.getWorkspace();
 		const folders = workspace.folders.map(folder => folder.uri);
 
@@ -165,7 +165,7 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 			}
 		};
 
-		const search = this._searchService.textSearch(query, token, onProgress).then(
+		const search = this._searchService.textSearch(query, token, onProgress).then<ITextSearchComplete, undefined>(
 			result => {
 				return { limitHit: result.limitHit };
 			},
@@ -191,14 +191,14 @@ export class MainThreadWorkspace implements MainThreadWorkspaceShape {
 
 		return this._searchService.fileSearch(query, token).then(
 			result => {
-				return result.limitHit;
+				return !!result.limitHit;
 			},
 			err => {
 				if (!isPromiseCanceledError(err)) {
 					return Promise.reject(err);
 				}
 
-				return undefined;
+				return false;
 			});
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -579,8 +579,8 @@ export interface ITextSearchComplete {
 }
 
 export interface MainThreadWorkspaceShape extends IDisposable {
-	$startFileSearch(includePattern: string | null, includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false | null, maxResults: number | null, token: CancellationToken): Promise<UriComponents[] | null>;
-	$startTextSearch(query: search.IPatternInfo, options: ITextQueryBuilderOptions, requestId: number, token: CancellationToken): Promise<ITextSearchComplete>;
+	$startFileSearch(includePattern: string | undefined, includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false | undefined, maxResults: number | undefined, token: CancellationToken): Promise<UriComponents[] | undefined>;
+	$startTextSearch(query: search.IPatternInfo, options: ITextQueryBuilderOptions, requestId: number, token: CancellationToken): Promise<ITextSearchComplete | undefined>;
 	$checkExists(folders: UriComponents[], includes: string[], token: CancellationToken): Promise<boolean>;
 	$saveAll(includeUntitled?: boolean): Promise<boolean>;
 	$updateWorkspaceFolders(extensionName: string, index: number, deleteCount: number, workspaceFoldersToAdd: { uri: UriComponents, name?: string }[]): Promise<void>;

--- a/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
+++ b/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
@@ -140,7 +140,7 @@ export class ExtHostDocumentSaveParticipant implements ExtHostDocumentSavePartic
 				reject(err);
 			});
 
-		}).then(values => {
+		}).then<boolean | undefined>(values => {
 
 			const resourceEdit: ResourceTextEditDto = {
 				resource: document.uri,

--- a/src/vs/workbench/api/common/extHostDocuments.ts
+++ b/src/vs/workbench/api/common/extHostDocuments.ts
@@ -84,7 +84,7 @@ export class ExtHostDocuments implements ExtHostDocumentsShape {
 		if (!promise) {
 			promise = this._proxy.$tryOpenDocument(uri).then(() => {
 				this._documentLoader.delete(uri.toString());
-				return this._documentsAndEditors.getDocument(uri);
+				return this._documentsAndEditors.getDocument(uri)!; // TODO: Is this non-null cast valid?
 			}, err => {
 				this._documentLoader.delete(uri.toString());
 				return Promise.reject(err);

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -135,7 +135,7 @@ export class ExtHostQuickOpen implements ExtHostQuickOpenShape {
 
 	// ---- input
 
-	showInput(options?: InputBoxOptions, token: CancellationToken = CancellationToken.None): Promise<string> {
+	showInput(options?: InputBoxOptions, token: CancellationToken = CancellationToken.None): Promise<string | undefined> {
 
 		// global validate fn used in callback below
 		this._validateInput = options ? options.validateInput : undefined;

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -374,7 +374,7 @@ class ExtHostTreeView<T> extends Disposable {
 				// check if an ancestor of extElement is already in the elements to update list
 				let currentNode: TreeNode | undefined = elementNode;
 				while (currentNode && currentNode.parent && !elementsToUpdate.has(currentNode.parent.item.handle)) {
-					const parentElement = this.elements.get(currentNode.parent.item.handle);
+					const parentElement = this.elements.get(currentNode.parent.item.handle) as T; // TODO: This cast should _not_ be required
 					currentNode = parentElement ? this.nodes.get(parentElement) : undefined;
 				}
 				if (currentNode && !currentNode.parent) {

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -24,7 +24,6 @@ import { ExtHostWorkspaceShape, IWorkspaceData, MainThreadMessageServiceShape, M
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { Barrier } from 'vs/base/common/async';
 import { Schemas } from 'vs/base/common/network';
-import { withUndefinedAsNull } from 'vs/base/common/types';
 
 export interface IExtHostWorkspaceProvider {
 	getWorkspaceFolder2(uri: vscode.Uri, resolveParent?: boolean): Promise<vscode.WorkspaceFolder | undefined>;
@@ -440,10 +439,10 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 		}
 
 		return this._proxy.$startFileSearch(
-			withUndefinedAsNull(includePattern),
-			withUndefinedAsNull(includeFolder),
-			withUndefinedAsNull(excludePatternOrDisregardExcludes),
-			withUndefinedAsNull(maxResults),
+			includePattern,
+			includeFolder,
+			excludePatternOrDisregardExcludes,
+			maxResults,
 			token
 		)
 			.then(data => Array.isArray(data) ? data.map(d => URI.revive(d)) : []);

--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -760,7 +760,7 @@ export class ExtHostDebugService implements ExtHostDebugServiceShape {
 				}
 				return undefined;
 			}),
-			new Promise((resolve, reject) => {
+			new Promise<undefined>((resolve, reject) => {
 				const timeout = setTimeout(() => {
 					clearTimeout(timeout);
 					reject(new Error('timeout'));

--- a/src/vs/workbench/contrib/cli/node/cli.contribution.ts
+++ b/src/vs/workbench/contrib/cli/node/cli.contribution.ts
@@ -97,8 +97,8 @@ class InstallAction extends Action {
 			.then(undefined, ignore('ENOENT', false));
 	}
 
-	private createBinFolderAndSymlinkAsAdmin(): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
+	private createBinFolderAndSymlinkAsAdmin(): Promise<unknown> {
+		return new Promise<unknown>((resolve, reject) => {
 			const buttons = [nls.localize('ok', "OK"), nls.localize('cancel2', "Cancel")];
 
 			this.dialogService.show(Severity.Info, nls.localize('warnEscalation', "Code will now prompt with 'osascript' for Administrator privileges to install the shell command."), buttons, { cancelId: 1 }).then(choice => {
@@ -164,8 +164,8 @@ class UninstallAction extends Action {
 		});
 	}
 
-	private deleteSymlinkAsAdmin(): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
+	private deleteSymlinkAsAdmin(): Promise<unknown> {
+		return new Promise<unknown>((resolve, reject) => {
 			const buttons = [nls.localize('ok', "OK"), nls.localize('cancel2', "Cancel")];
 
 			this.dialogService.show(Severity.Info, nls.localize('warnEscalationUninstall', "Code will now prompt with 'osascript' for Administrator privileges to uninstall the shell command."), buttons, { cancelId: 1 }).then(choice => {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -396,7 +396,7 @@ export class DebugService implements IDebugService {
 								.then(() => false);
 						}
 
-						return launch && launch.openConfigFile(false, true).then(() => false);
+						return launch ? launch.openConfigFile(false, true).then(() => false) : Promise.resolve(false);
 					});
 				}
 
@@ -719,7 +719,7 @@ export class DebugService implements IDebugService {
 
 			// If a task is missing the problem matcher the promise will never complete, so we need to have a workaround #35340
 			let taskStarted = false;
-			const promise: Promise<ITaskSummary | null> = this.taskService.getActiveTasks().then(tasks => {
+			const promise: Promise<ITaskSummary | null | undefined> = this.taskService.getActiveTasks().then(tasks => {
 				if (tasks.filter(t => t._id === task._id).length) {
 					// task is already running - nothing to do.
 					return Promise.resolve(null);

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -278,6 +278,7 @@ CommandsRegistry.registerCommand({
 		} catch (e) {
 			onUnexpectedError(e);
 		}
+		return;
 	}
 });
 

--- a/src/vs/workbench/contrib/files/browser/editors/fileEditorTracker.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/fileEditorTracker.ts
@@ -306,7 +306,7 @@ export class FileEditorTracker extends Disposable implements IWorkbenchContribut
 		// to have a size of 2 (1 running load and 1 queued load).
 		const queue = this.modelLoadQueue.queueFor(model.getResource());
 		if (queue.size <= 1) {
-			queue.queue(() => model.load().then<void>(undefined, onUnexpectedError));
+			queue.queue(() => model.load().then(undefined, onUnexpectedError));
 		}
 	}
 

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -141,7 +141,7 @@ export class GlobalNewUntitledFileAction extends Action {
 	}
 }
 
-function deleteFiles(textFileService: ITextFileService, dialogService: IDialogService, configurationService: IConfigurationService, fileService: IFileService, elements: ExplorerItem[], useTrash: boolean, skipConfirm = false): Promise<void> {
+function deleteFiles(textFileService: ITextFileService, dialogService: IDialogService, configurationService: IConfigurationService, fileService: IFileService, elements: ExplorerItem[], useTrash: boolean, skipConfirm = false): Promise<void | void[]> {
 	let primaryButton: string;
 	if (useTrash) {
 		primaryButton = isWindows ? nls.localize('deleteButtonLabelRecycleBin', "&&Move to Recycle Bin") : nls.localize({ key: 'deleteButtonLabelTrash', comment: ['&& denotes a mnemonic'] }, "&&Move to Trash");

--- a/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
@@ -615,7 +615,7 @@ class PreferencesRenderersController extends Disposable {
 						this.telemetryService.publicLog('defaultSettings.searchError', { message, filter });
 						this.logService.info('Setting search error: ' + message);
 					}
-					return undefined;
+					return Promise.resolve(undefined);
 				}
 			})
 			.then(searchResult => {
@@ -634,7 +634,7 @@ class PreferencesRenderersController extends Disposable {
 
 				if (filterResult) {
 					filterResult.query = filter;
-					filterResult.exactMatch = searchResult && searchResult.exactMatch;
+					filterResult.exactMatch = !!searchResult && searchResult.exactMatch;
 				}
 
 				return filterResult;

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -630,7 +630,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		});
 	}
 
-	public run(task: Task | undefined, options?: ProblemMatcherRunOptions, runSource: TaskRunSource = TaskRunSource.System): Promise<ITaskSummary> {
+	public run(task: Task | undefined, options?: ProblemMatcherRunOptions, runSource: TaskRunSource = TaskRunSource.System): Promise<ITaskSummary | undefined> {
 		if (!task) {
 			throw new TaskError(Severity.Info, nls.localize('TaskServer.noTask', 'Task to execute is undefined'), TaskErrors.TaskNotFound);
 		}

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -58,7 +58,7 @@ export interface ITaskService {
 	configureAction(): Action;
 	build(): Promise<ITaskSummary>;
 	runTest(): Promise<ITaskSummary>;
-	run(task: Task | undefined, options?: ProblemMatcherRunOptions): Promise<ITaskSummary>;
+	run(task: Task | undefined, options?: ProblemMatcherRunOptions): Promise<ITaskSummary | undefined>;
 	inTerminal(): boolean;
 	isActive(): Promise<boolean>;
 	getActiveTasks(): Promise<Task[]>;

--- a/src/vs/workbench/contrib/tasks/node/processRunnerDetector.ts
+++ b/src/vs/workbench/contrib/tasks/node/processRunnerDetector.ts
@@ -179,7 +179,7 @@ export class ProcessRunnerDetector {
 				commandExecutable, isShellCommand, config.matcher, ProcessRunnerDetector.DefaultProblemMatchers, list));
 		} else {
 			if (detectSpecific) {
-				let detectorPromise: Promise<DetectorResult>;
+				let detectorPromise: Promise<DetectorResult | null>;
 				if ('gulp' === detectSpecific) {
 					detectorPromise = this.tryDetectGulp(this._workspaceRoot, list);
 				} else if ('jake' === detectSpecific) {
@@ -229,7 +229,7 @@ export class ProcessRunnerDetector {
 		return result;
 	}
 
-	private tryDetectGulp(workspaceFolder: IWorkspaceFolder, list: boolean): Promise<DetectorResult> {
+	private tryDetectGulp(workspaceFolder: IWorkspaceFolder, list: boolean): Promise<DetectorResult | null> {
 		return Promise.resolve(this.fileService.resolve(workspaceFolder.toResource('gulpfile.js'))).then((stat) => { // TODO@Dirk (https://github.com/Microsoft/vscode/issues/29454)
 			let config = ProcessRunnerDetector.detectorConfig('gulp');
 			let process = new LineProcess('gulp', [config.arg, '--no-color'], true, { cwd: this._cwd });
@@ -239,7 +239,7 @@ export class ProcessRunnerDetector {
 		});
 	}
 
-	private tryDetectGrunt(workspaceFolder: IWorkspaceFolder, list: boolean): Promise<DetectorResult> {
+	private tryDetectGrunt(workspaceFolder: IWorkspaceFolder, list: boolean): Promise<DetectorResult | null> {
 		return Promise.resolve(this.fileService.resolve(workspaceFolder.toResource('Gruntfile.js'))).then((stat) => { // TODO@Dirk (https://github.com/Microsoft/vscode/issues/29454)
 			let config = ProcessRunnerDetector.detectorConfig('grunt');
 			let process = new LineProcess('grunt', [config.arg, '--no-color'], true, { cwd: this._cwd });
@@ -249,7 +249,7 @@ export class ProcessRunnerDetector {
 		});
 	}
 
-	private tryDetectJake(workspaceFolder: IWorkspaceFolder, list: boolean): Promise<DetectorResult> {
+	private tryDetectJake(workspaceFolder: IWorkspaceFolder, list: boolean): Promise<DetectorResult | null> {
 		let run = () => {
 			let config = ProcessRunnerDetector.detectorConfig('jake');
 			let process = new LineProcess('jake', [config.arg], true, { cwd: this._cwd });

--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -72,18 +72,21 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			if (!stat.isDirectory()) {
 				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
 			}
+			return;
 		}, async err => {
 			if (err && err.code === 'ENOENT') {
 				// So we can include in the error message the specified CWD
 				shellLaunchConfig.cwd = cwd;
 				return Promise.reject(SHELL_CWD_INVALID_EXIT_CODE);
 			}
+			return;
 		});
 
 		const exectuableVerification = stat(shellLaunchConfig.executable!).then(async stat => {
 			if (!stat.isFile() && !stat.isSymbolicLink()) {
 				return Promise.reject(stat.isDirectory() ? SHELL_PATH_DIRECTORY_EXIT_CODE : SHELL_PATH_INVALID_EXIT_CODE);
 			}
+			return;
 		}, async (err) => {
 			if (err && err.code === 'ENOENT') {
 				let cwd = shellLaunchConfig.cwd instanceof URI ? shellLaunchConfig.cwd.path : shellLaunchConfig.cwd!;
@@ -92,6 +95,7 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 					return Promise.reject(SHELL_PATH_INVALID_EXIT_CODE);
 				}
 			}
+			return;
 		});
 
 		Promise.all([cwdVerification, exectuableVerification]).then(() => {

--- a/src/vs/workbench/services/configuration/common/configurationEditingService.ts
+++ b/src/vs/workbench/services/configuration/common/configurationEditingService.ts
@@ -158,7 +158,7 @@ export class ConfigurationEditingService {
 	writeConfiguration(target: EditableConfigurationTarget, value: IConfigurationValue, options: IConfigurationEditingOptions = {}): Promise<void> {
 		const operation = this.getConfigurationEditOperation(target, value, options.scopes || {});
 		return Promise.resolve(this.queue.queue(() => this.doWriteConfiguration(operation, options) // queue up writes to prevent race conditions
-			.then(() => null,
+			.then(() => undefined,
 				error => {
 					if (!options.donotNotifyError) {
 						this.onError(error, operation, options.scopes);

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -54,7 +54,7 @@ export class TestEditorInput extends EditorInput implements IFileEditorInput {
 	constructor(private resource: URI) { super(); }
 
 	getTypeId() { return 'testEditorInputForEditorService'; }
-	resolve(): Promise<IEditorModel> { return !this.fails ? Promise.resolve(null) : Promise.reject(new Error('fails')); }
+	resolve(): Promise<IEditorModel | null> { return !this.fails ? Promise.resolve(null) : Promise.reject(new Error('fails')); }
 	matches(other: TestEditorInput): boolean { return other && other.resource && this.resource.toString() === other.resource.toString() && other instanceof TestEditorInput; }
 	setEncoding(encoding: string) { }
 	getEncoding(): string { return null!; }

--- a/src/vs/workbench/services/extensions/common/lazyPromise.ts
+++ b/src/vs/workbench/services/extensions/common/lazyPromise.ts
@@ -6,7 +6,7 @@
 import { onUnexpectedError } from 'vs/base/common/errors';
 
 export class LazyPromise implements Promise<any> {
-	[Symbol.toStringTag] = 'LazyPromise';
+	[Symbol.toStringTag]!: string;
 	private _actual: Promise<any> | null;
 	private _actualOk: ((value?: any) => any) | null;
 	private _actualErr: ((err?: any) => any) | null;

--- a/src/vs/workbench/services/extensions/common/lazyPromise.ts
+++ b/src/vs/workbench/services/extensions/common/lazyPromise.ts
@@ -6,7 +6,7 @@
 import { onUnexpectedError } from 'vs/base/common/errors';
 
 export class LazyPromise implements Promise<any> {
-
+	[Symbol.toStringTag] = 'LazyPromise';
 	private _actual: Promise<any> | null;
 	private _actualOk: ((value?: any) => any) | null;
 	private _actualErr: ((err?: any) => any) | null;

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -380,7 +380,7 @@ export class SearchService implements IRawSearchService {
 	 */
 	private preventCancellation<C>(promise: CancelablePromise<C>): CancelablePromise<C> {
 		return new class implements CancelablePromise<C> {
-			[Symbol.toStringTag] = 'CancelablePromise';
+			[Symbol.toStringTag]!: string;
 			cancel() {
 				// Do nothing
 			}

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -380,13 +380,14 @@ export class SearchService implements IRawSearchService {
 	 */
 	private preventCancellation<C>(promise: CancelablePromise<C>): CancelablePromise<C> {
 		return new class implements CancelablePromise<C> {
+			[Symbol.toStringTag] = 'CancelablePromise';
 			cancel() {
 				// Do nothing
 			}
-			then(resolve: any, reject: any) {
+			then<TResult1 = C, TResult2 = never>(resolve?: (value: C) => TResult1 | PromiseLike<TResult1>, reject?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null) {
 				return promise.then(resolve, reject);
 			}
-			catch(reject?: any) {
+			catch<TResult = never>(reject?: ((reason: any) => TResult | Promise<TResult>) | undefined | null): Promise<C | TResult> {
 				return this.then(undefined, reject);
 			}
 			finally(onFinally: any) {

--- a/src/vs/workbench/test/electron-browser/api/extHostWorkspace.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostWorkspace.test.ts
@@ -573,13 +573,13 @@ suite('ExtHostWorkspace', function () {
 
 		let mainThreadCalled = false;
 		rpcProtocol.set(MainContext.MainThreadWorkspace, new class extends mock<MainThreadWorkspace>() {
-			$startFileSearch(includePattern: string, _includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | null> {
+			$startFileSearch(includePattern: string, _includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | undefined> {
 				mainThreadCalled = true;
 				assert.equal(includePattern, 'foo');
-				assert.equal(_includeFolder, null);
-				assert.equal(excludePatternOrDisregardExcludes, null);
+				assert.equal(_includeFolder, undefined);
+				assert.equal(excludePatternOrDisregardExcludes, undefined);
 				assert.equal(maxResults, 10);
-				return Promise.resolve(null);
+				return Promise.resolve(undefined);
 			}
 		});
 
@@ -595,12 +595,12 @@ suite('ExtHostWorkspace', function () {
 
 		let mainThreadCalled = false;
 		rpcProtocol.set(MainContext.MainThreadWorkspace, new class extends mock<MainThreadWorkspace>() {
-			$startFileSearch(includePattern: string, _includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | null> {
+			$startFileSearch(includePattern: string, _includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | undefined> {
 				mainThreadCalled = true;
 				assert.equal(includePattern, 'glob/**');
 				assert.deepEqual(_includeFolder, URI.file('/other/folder').toJSON());
-				assert.equal(excludePatternOrDisregardExcludes, null);
-				return Promise.resolve(null);
+				assert.equal(excludePatternOrDisregardExcludes, undefined);
+				return Promise.resolve(undefined);
 			}
 		});
 
@@ -616,12 +616,12 @@ suite('ExtHostWorkspace', function () {
 
 		let mainThreadCalled = false;
 		rpcProtocol.set(MainContext.MainThreadWorkspace, new class extends mock<MainThreadWorkspace>() {
-			$startFileSearch(includePattern: string, _includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | null> {
+			$startFileSearch(includePattern: string, _includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | undefined> {
 				mainThreadCalled = true;
 				assert.equal(includePattern, 'glob/**');
 				assert.deepEqual(_includeFolder, URI.file('/other/folder').toJSON());
 				assert.equal(excludePatternOrDisregardExcludes, false);
-				return Promise.resolve(null);
+				return Promise.resolve(undefined);
 			}
 		});
 
@@ -637,9 +637,9 @@ suite('ExtHostWorkspace', function () {
 
 		let mainThreadCalled = false;
 		rpcProtocol.set(MainContext.MainThreadWorkspace, new class extends mock<MainThreadWorkspace>() {
-			$startFileSearch(includePattern: string, _includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | null> {
+			$startFileSearch(includePattern: string, _includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | undefined> {
 				mainThreadCalled = true;
-				return Promise.resolve(null);
+				return Promise.resolve(undefined);
 			}
 		});
 
@@ -657,10 +657,10 @@ suite('ExtHostWorkspace', function () {
 
 		let mainThreadCalled = false;
 		rpcProtocol.set(MainContext.MainThreadWorkspace, new class extends mock<MainThreadWorkspace>() {
-			$startFileSearch(includePattern: string, _includeFolder: UriComponents | null, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | null> {
+			$startFileSearch(includePattern: string, _includeFolder: UriComponents | undefined, excludePatternOrDisregardExcludes: string | false, maxResults: number, token: CancellationToken): Promise<URI[] | undefined> {
 				mainThreadCalled = true;
 				assert(excludePatternOrDisregardExcludes, 'glob/**'); // Note that the base portion is ignored, see #52651
-				return Promise.resolve(null);
+				return Promise.resolve(undefined);
 			}
 		});
 

--- a/src/vs/workbench/test/electron-browser/api/mainThreadWorkspace.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/mainThreadWorkspace.test.ts
@@ -39,7 +39,7 @@ suite('MainThreadWorkspace', () => {
 		});
 
 		const mtw: MainThreadWorkspace = instantiationService.createInstance(<any>MainThreadWorkspace, SingleProxyRPCProtocol({ $initializeWorkspace: () => { } }));
-		return mtw.$startFileSearch('foo', null, null, 10, new CancellationTokenSource().token);
+		return mtw.$startFileSearch('foo', undefined, undefined, 10, new CancellationTokenSource().token);
 	});
 
 	test('exclude defaults', () => {
@@ -61,7 +61,7 @@ suite('MainThreadWorkspace', () => {
 		});
 
 		const mtw: MainThreadWorkspace = instantiationService.createInstance(<any>MainThreadWorkspace, SingleProxyRPCProtocol({ $initializeWorkspace: () => { } }));
-		return mtw.$startFileSearch('', null, null, 10, new CancellationTokenSource().token);
+		return mtw.$startFileSearch('', undefined, undefined, 10, new CancellationTokenSource().token);
 	});
 
 	test('disregard excludes', () => {
@@ -82,7 +82,7 @@ suite('MainThreadWorkspace', () => {
 		});
 
 		const mtw: MainThreadWorkspace = instantiationService.createInstance(<any>MainThreadWorkspace, SingleProxyRPCProtocol({ $initializeWorkspace: () => { } }));
-		return mtw.$startFileSearch('', null, false, 10, new CancellationTokenSource().token);
+		return mtw.$startFileSearch('', undefined, false, 10, new CancellationTokenSource().token);
 	});
 
 	test('exclude string', () => {
@@ -96,6 +96,6 @@ suite('MainThreadWorkspace', () => {
 		});
 
 		const mtw: MainThreadWorkspace = instantiationService.createInstance(<any>MainThreadWorkspace, SingleProxyRPCProtocol({ $initializeWorkspace: () => { } }));
-		return mtw.$startFileSearch('', null, 'exclude/**', 10, new CancellationTokenSource().token);
+		return mtw.$startFileSearch('', undefined, 'exclude/**', 10, new CancellationTokenSource().token);
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,10 +132,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.21.tgz#7e8a0c34cf29f4e17a36e9bd0ea72d45ba03908e"
   integrity sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==
 
-"@types/node@^10.12.12":
-  version "10.12.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
-  integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
+"@types/node@^10.14.8":
+  version "10.14.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.13.tgz#ac786d623860adf39a3f51d629480aacd6a6eec7"
+  integrity sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==
 
 "@types/semver@^5.4.0", "@types/semver@^5.5.0":
   version "5.5.0"


### PR DESCRIPTION
Followup to #77784, since the same error happens upon `yarn compile` once `yarn` is fixed due to a slightly out of date `@types/node` dependency version in the vscode root~

With this change, _every_ `package.json` inside the vscode repo has an `@types/node` version of `^10.14.8`. It'd be nice if they could somehow be kept in sync~