### PR TITLE
Enable preserveInput by default

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -131,7 +131,7 @@ import { isMacintosh, isWindows, isLinux, isWeb } from 'vs/base/common/platform'
 			'workbench.commandPalette.preserveInput': {
 				'type': 'boolean',
 				'description': nls.localize('preserveInput', "Controls whether the last typed input to the command palette should be restored when opening it the next time."),
-				'default': false
+				'default': true
 			},
 			'workbench.quickOpen.closeOnFocusLost': {
 				'type': 'boolean',
@@ -141,7 +141,7 @@ import { isMacintosh, isWindows, isLinux, isWeb } from 'vs/base/common/platform'
 			'workbench.quickOpen.preserveInput': {
 				'type': 'boolean',
 				'description': nls.localize('workbench.quickOpen.preserveInput', "Controls whether the last typed input to Quick Open should be restored when opening it the next time."),
-				'default': false
+				'default': true
 			},
 			'workbench.settings.openDefaultSettings': {
 				'type': 'boolean',


### PR DESCRIPTION
I can't see any reason why you *wouldn't* want this, and it's [quite unexpected](https://github.com/microsoft/vscode/issues/76234#issuecomment-514334806) that this is a setting at all.