### PR TITLE
Add sk to locales than need region

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -106,6 +106,7 @@ function _getLangEnvVariable(locale?: string) {
 			ko: 'KR',
 			pl: 'PL',
 			ru: 'RU',
+			sk: 'SK',
 			zh: 'CN'
 		};
 		if (parts[0] in languageVariants) {


### PR DESCRIPTION
This adds 'SK' among locales, that have their region added. Same problem as #7301 or #13834, which were fixed by hardcoding a set of locales to add a region to.