### PR TITLE
Lowercase 'For' in 'Checking For Updates...' menu item

### DIFF
--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -550,7 +550,7 @@ export class Menubar {
 				})];
 
 			case StateType.CheckingForUpdates:
-				return [new MenuItem({ label: nls.localize('miCheckingForUpdates', "Checking For Updates..."), enabled: false })];
+				return [new MenuItem({ label: nls.localize('miCheckingForUpdates', "Checking for Updates..."), enabled: false })];
 
 			case StateType.AvailableForDownload:
 				return [new MenuItem({

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -586,7 +586,7 @@ export class CustomMenubarControl extends MenubarControl {
 					this.updateService.checkForUpdates({ windowId }));
 
 			case StateType.CheckingForUpdates:
-				return new Action('update.checking', nls.localize('checkingForUpdates', "Checking For Updates..."), undefined, false);
+				return new Action('update.checking', nls.localize('checkingForUpdates', "Checking for Updates..."), undefined, false);
 
 			case StateType.AvailableForDownload:
 				return new Action('update.downloadNow', nls.localize({ key: 'download now', comment: ['&& denotes a mnemonic'] }, "D&&ownload Now"), undefined, true, () =>

--- a/src/vs/workbench/contrib/update/electron-browser/update.ts
+++ b/src/vs/workbench/contrib/update/electron-browser/update.ts
@@ -484,7 +484,7 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			group: '5_update',
 			command: {
 				id: 'update.checking',
-				title: nls.localize('checkingForUpdates', "Checking For Updates..."),
+				title: nls.localize('checkingForUpdates', "Checking for Updates..."),
 				precondition: FalseContext
 			},
 			when: CONTEXT_UPDATE_STATE.isEqualTo(StateType.CheckingForUpdates)


### PR DESCRIPTION
Fixed remaining upper case 'For' in similar menu item which is reported and fixed at #27532. Please let me know if you need new issue for this small pull request. Thank you.