### PR TITLE
Replace: honor preserveCase when replacing all

### DIFF
--- a/src/vs/editor/contrib/find/findModel.ts
+++ b/src/vs/editor/contrib/find/findModel.ts
@@ -485,7 +485,7 @@ export class FindModelBoundToEditorModel {
 		let resultText: string;
 		const preserveCase = this._state.preserveCase;
 
-		if (replacePattern.hasReplacementPatterns) {
+		if (replacePattern.hasReplacementPatterns || preserveCase) {
 			resultText = modelText.replace(searchRegex, function () {
 				return replacePattern.buildReplaceString(<string[]><any>arguments, preserveCase);
 			});
@@ -500,7 +500,7 @@ export class FindModelBoundToEditorModel {
 	private _regularReplaceAll(findScope: Range | null): void {
 		const replacePattern = this._getReplacePattern();
 		// Get all the ranges (even more than the highlighted ones)
-		let matches = this._findMatches(findScope, replacePattern.hasReplacementPatterns, Constants.MAX_SAFE_SMALL_INTEGER);
+		let matches = this._findMatches(findScope, replacePattern.hasReplacementPatterns || this._state.preserveCase, Constants.MAX_SAFE_SMALL_INTEGER);
 
 		let replaceStrings: string[] = [];
 		for (let i = 0, len = matches.length; i < len; i++) {

--- a/src/vs/editor/contrib/find/test/findModel.test.ts
+++ b/src/vs/editor/contrib/find/test/findModel.test.ts
@@ -1947,6 +1947,42 @@ suite('FindModel', () => {
 		findState.dispose();
 	});
 
+	findTest('replaceAll preserving case', (editor, cursor) => {
+		let findState = new FindReplaceState();
+		findState.change({ searchString: 'hello', replaceString: 'goodbye', isRegex: false, matchCase: false, preserveCase: true }, false);
+		let findModel = new FindModelBoundToEditorModel(editor, findState);
+
+		assertFindState(
+			editor,
+			[1, 1, 1, 1],
+			null,
+			[
+				[6, 14, 6, 19],
+				[6, 27, 6, 32],
+				[7, 14, 7, 19],
+				[8, 14, 8, 19],
+				[9, 14, 9, 19],
+			]
+		);
+
+		findModel.replaceAll();
+
+		assert.equal(editor.getModel()!.getLineContent(6), '    cout << "goodbye world, Goodbye!" << endl;');
+		assert.equal(editor.getModel()!.getLineContent(7), '    cout << "goodbye world again" << endl;');
+		assert.equal(editor.getModel()!.getLineContent(8), '    cout << "Goodbye world again" << endl;');
+		assert.equal(editor.getModel()!.getLineContent(9), '    cout << "goodbyeworld again" << endl;');
+
+		assertFindState(
+			editor,
+			[1, 1, 1, 1],
+			null,
+			[]
+		);
+
+		findModel.dispose();
+		findState.dispose();
+	});
+
 	findTest('issue #18711 replaceAll with empty string', (editor, cursor) => {
 		let findState = new FindReplaceState();
 		findState.change({ searchString: 'hello', replaceString: '', wholeWord: true }, false);


### PR DESCRIPTION
Previously preserveCase worked when replacing single matches, but not when replacing all matches.

https://github.com/microsoft/vscode/issues/9798