### PR TITLE
#15178 Providing API to get notified when a document  is closed (not …

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -7871,6 +7871,11 @@ declare module 'vscode' {
 		export const onDidCloseTextDocument: Event<TextDocument>;
 
 		/**
+		 * An event that is emitted when a [text document](#TextDocument) is closed.
+		 */
+		export const onDidCloseDocument: Event<TextDocument>;
+
+		/**
 		 * An event that is emitted when a [text document](#TextDocument) is changed. This usually happens
 		 * when the [contents](#TextDocument.getText) changes but also when other things like the
 		 * [dirty](#TextDocument.isDirty)-state changes.

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -336,7 +336,7 @@ export class MainThreadDocumentsAndEditors {
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostDocumentsAndEditors);
 
-		const mainThreadDocuments = new MainThreadDocuments(this, extHostContext, this._modelService, modeService, this._textFileService, fileService, textModelResolverService, untitledEditorService, environmentService, this._editorService);
+		const mainThreadDocuments = this._toDispose.add(new MainThreadDocuments(this, extHostContext, this._modelService, modeService, this._textFileService, fileService, textModelResolverService, untitledEditorService, environmentService, this._editorService));
 		extHostContext.set(MainContext.MainThreadDocuments, mainThreadDocuments);
 
 		const mainThreadTextEditors = this._toDispose.add(new MainThreadTextEditors(this, extHostContext, codeEditorService, bulkEditService, this._editorService, this._editorGroupService));

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -30,6 +30,7 @@ import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IUntitledEditorService } from 'vs/workbench/services/untitled/common/untitledEditorService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { EditorServiceImpl } from 'vs/workbench/browser/parts/editor/editor';
 
 namespace delta {
 
@@ -322,7 +323,7 @@ export class MainThreadDocumentsAndEditors {
 		extHostContext: IExtHostContext,
 		@IModelService private readonly _modelService: IModelService,
 		@ITextFileService private readonly _textFileService: ITextFileService,
-		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorService private readonly _editorService: EditorServiceImpl,
 		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IModeService modeService: IModeService,
 		@IFileService fileService: IFileService,
@@ -335,7 +336,7 @@ export class MainThreadDocumentsAndEditors {
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostDocumentsAndEditors);
 
-		const mainThreadDocuments = this._toDispose.add(new MainThreadDocuments(this, extHostContext, this._modelService, modeService, this._textFileService, fileService, textModelResolverService, untitledEditorService, environmentService));
+		const mainThreadDocuments = new MainThreadDocuments(this, extHostContext, this._modelService, modeService, this._textFileService, fileService, textModelResolverService, untitledEditorService, environmentService, this._editorService);
 		extHostContext.set(MainContext.MainThreadDocuments, mainThreadDocuments);
 
 		const mainThreadTextEditors = this._toDispose.add(new MainThreadTextEditors(this, extHostContext, codeEditorService, bulkEditService, this._editorService, this._editorGroupService));

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -768,6 +768,7 @@ export interface ExtHostDocumentsShape {
 	$acceptModelSaved(strURL: UriComponents): void;
 	$acceptDirtyStateChanged(strURL: UriComponents, isDirty: boolean): void;
 	$acceptModelChanged(strURL: UriComponents, e: IModelChangedEvent, isDirty: boolean): void;
+	$acceptDocumentClosed(strURL: UriComponents): void;
 }
 
 export interface ExtHostDocumentSaveParticipantShape {

--- a/src/vs/workbench/api/common/extHostDocuments.ts
+++ b/src/vs/workbench/api/common/extHostDocuments.ts
@@ -17,11 +17,13 @@ export class ExtHostDocuments implements ExtHostDocumentsShape {
 
 	private _onDidAddDocument = new Emitter<vscode.TextDocument>();
 	private _onDidRemoveDocument = new Emitter<vscode.TextDocument>();
+	private _onDidCloseDocument = new Emitter<vscode.TextDocument>();
 	private _onDidChangeDocument = new Emitter<vscode.TextDocumentChangeEvent>();
 	private _onDidSaveDocument = new Emitter<vscode.TextDocument>();
 
 	readonly onDidAddDocument: Event<vscode.TextDocument> = this._onDidAddDocument.event;
 	readonly onDidRemoveDocument: Event<vscode.TextDocument> = this._onDidRemoveDocument.event;
+	readonly onDidCloseDocument: Event<vscode.TextDocument> = this._onDidCloseDocument.event;
 	readonly onDidChangeDocument: Event<vscode.TextDocumentChangeEvent> = this._onDidChangeDocument.event;
 	readonly onDidSaveDocument: Event<vscode.TextDocument> = this._onDidSaveDocument.event;
 
@@ -52,6 +54,16 @@ export class ExtHostDocuments implements ExtHostDocumentsShape {
 
 	public getAllDocumentData(): ExtHostDocumentData[] {
 		return this._documentsAndEditors.allDocuments();
+	}
+
+	public $acceptDocumentClosed(strURL: UriComponents): void {
+		const uri = URI.revive(strURL);
+		const data = this._documentsAndEditors.getDocument(uri);
+		if (!data) {
+			throw new Error('unknown document');
+		}
+
+		this._onDidCloseDocument.fire(data.document);
 	}
 
 	public getDocumentData(resource: vscode.Uri): ExtHostDocumentData | undefined {

--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -660,6 +660,9 @@ export function createApiFactory(
 			onDidCloseTextDocument: (listener, thisArgs?, disposables?) => {
 				return extHostDocuments.onDidRemoveDocument(listener, thisArgs, disposables);
 			},
+			onDidCloseDocument: (listener, thisArgs?, disposables?) => {
+				return extHostDocuments.onDidCloseDocument(listener, thisArgs, disposables);
+			},
 			onDidChangeTextDocument: (listener, thisArgs?, disposables?) => {
 				return extHostDocuments.onDidChangeDocument(listener, thisArgs, disposables);
 			},


### PR DESCRIPTION
…removed)

OnDidCloseTextDocument is fired when a document is removed, not closed, so it could happen a user closes a document, but it takes up to 3 minutes to get this event fired.

That's a problem for many extensions that need to keep track of files open and closed, or even to get a list of open files. That's the goal of this pull request, to fill that gap on the API.

This pull request provides OnDidCloseDocument which is called right away.

IMO, existing OnDidCloseTextDocument should be renamed onDidRemoveDocument, because it's quite confusing.