### PR TITLE
Open existing keybindings in new editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -35,7 +35,7 @@ import { IContextKeyService, IContextKey, ContextKeyExpr } from 'vs/platform/con
 import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode, ResolvedKeybinding } from 'vs/base/common/keyCodes';
 import { listHighlightForeground, badgeBackground, contrastBorder, badgeForeground, listActiveSelectionForeground, listInactiveSelectionForeground, listHoverForeground, listFocusForeground, editorBackground } from 'vs/platform/theme/common/colorRegistry';
-import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { WorkbenchList } from 'vs/platform/list/browser/listService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
@@ -308,8 +308,19 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 		this.overlayContainer.style.zIndex = '10';
 		this.defineKeybindingWidget = this._register(this.instantiationService.createInstance(DefineKeybindingWidget, this.overlayContainer));
 		this._register(this.defineKeybindingWidget.onDidChange(keybindingStr => this.defineKeybindingWidget.printExisting(this.keybindingsEditorModel!.fetch(`"${keybindingStr}"`).length)));
-		this._register(this.defineKeybindingWidget.onShowExistingKeybidings(keybindingStr => this.searchWidget.setValue(`"${keybindingStr}"`)));
+		this._register(this.defineKeybindingWidget.onShowExistingKeybidings(keybindingStr => this.openNewKeybindingsEditor(`"${keybindingStr}"`)));
 		this.hideOverlayContainer();
+	}
+
+	private openNewKeybindingsEditor(searchValue: string) {
+		const keybindingsEditorInput = this.instantiationService.createInstance(KeybindingsEditorInput);
+		keybindingsEditorInput.searchOptions = {
+			searchValue: searchValue,
+			recordKeybindings: false,
+			sortByPrecedence: false
+		};
+
+		return this.editorService.openEditor(keybindingsEditorInput, { forceReload: true }, SIDE_GROUP).then(() => undefined);
 	}
 
 	private showOverlayContainer() {


### PR DESCRIPTION
Closes #77696

When setting a keybinding, the desired key combination can already exist. A button is
provided to go to that list. Before this PR, clicking on the button would trigger a search on the
current _Keyboard Shortcuts_ tab, therefore removing the command for which you were trying to
set a shortcut.
This PR modifies that functionnality, and opens a new _Keyboard Shortcuts_ tab, in different editor
group.