### PR TITLE
Fix opening of tree items with keyboard

### DIFF
--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -602,9 +602,9 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 		return nodes.map(n => n!.element as T);
 	}
 
-	open(elements: T[]): void {
+	open(elements: T[], browserEvent?: UIEvent): void {
 		const nodes = elements.map(e => this.getDataNode(e));
-		this.tree.open(nodes);
+		this.tree.open(nodes, browserEvent);
 	}
 
 	reveal(element: T, relativeTop?: number): void {


### PR DESCRIPTION
Up until very recently, the custom tree used a TreeResourceNavigator2 with openOnSelection: true. This caused command to be executed twice on clicks though. Once on the selection and once on the click. Setting that to false caused the enter key to stop causing commands to run though. This was because the enter key was only causing the selection to trigger, not the open. The Open event was getting swallowed before it made it out of the tree because it was missing a UIEvent. Adding the UIEvent in here fixes that

Fixes #78174