### PR TITLE
List possible categories

### DIFF
--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -112,7 +112,7 @@ export class Main {
 
 	private async listExtensions(showVersions: boolean, category?: string): Promise<void> {
 		let extensions = await this.extensionManagementService.getInstalled(ExtensionType.User);
-		if (category) {
+		if (category && category !== '') {
 			extensions = extensions.filter(e => {
 				if (e.manifest.categories) {
 					const lowerCaseCategories: string[] = e.manifest.categories.map(c => c.toLowerCase());
@@ -120,6 +120,13 @@ export class Main {
 				}
 				return false;
 			});
+		} else if (category === '') {
+			const categories = ['"programming languages"', 'snippets', 'linters', 'themes', 'debuggers', 'formatters', 'keymaps', '"scm providers"', 'other', '"extension packs"', '"language packs"'];
+			console.log('Possible Categories: ');
+			categories.forEach(category => {
+				console.log(category);
+			});
+			return;
 		}
 		extensions.forEach(e => console.log(getId(e.manifest, showVersions)));
 	}

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -112,7 +112,13 @@ export class Main {
 
 	private async listExtensions(showVersions: boolean, category?: string): Promise<void> {
 		let extensions = await this.extensionManagementService.getInstalled(ExtensionType.User);
+		// TODO: we should save this array in a common place so that the command and extensionQuery can use it that way changing it is easier
+		const categories = ['"programming languages"', 'snippets', 'linters', 'themes', 'debuggers', 'formatters', 'keymaps', '"scm providers"', 'other', '"extension packs"', '"language packs"'];
 		if (category && category !== '') {
+			if (categories.indexOf(category.toLowerCase()) < 0) {
+				console.log('Invalid category please enter a valid category. To list valid categories run --category without a category specified');
+				return;
+			}
 			extensions = extensions.filter(e => {
 				if (e.manifest.categories) {
 					const lowerCaseCategories: string[] = e.manifest.categories.map(c => c.toLowerCase());
@@ -121,8 +127,6 @@ export class Main {
 				return false;
 			});
 		} else if (category === '') {
-			// TODO: we should save this array in a common place so that the command and extensionQuery can use it that way changing it is easier
-			const categories = ['"programming languages"', 'snippets', 'linters', 'themes', 'debuggers', 'formatters', 'keymaps', '"scm providers"', 'other', '"extension packs"', '"language packs"'];
 			console.log('Possible Categories: ');
 			categories.forEach(category => {
 				console.log(category);

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -121,6 +121,7 @@ export class Main {
 				return false;
 			});
 		} else if (category === '') {
+			// TODO: we should save this array in a common place so that the command and extensionQuery can use it that way changing it is easier
 			const categories = ['"programming languages"', 'snippets', 'linters', 'themes', 'debuggers', 'formatters', 'keymaps', '"scm providers"', 'other', '"extension packs"', '"language packs"'];
 			console.log('Possible Categories: ');
 			categories.forEach(category => {


### PR DESCRIPTION
If no category is specified in `--list-extensions --category` list the possible categories that can be substituted in. Close https://github.com/microsoft/vscode/issues/78194
Also provided error message for invalid category. Closes https://github.com/microsoft/vscode/issues/78172