### PR TITLE
Pine/78404

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -971,7 +971,9 @@ export class SettingsEditor2 extends BaseEditor {
 			if (key) {
 				const focusedKey = focusedSetting.getAttribute(AbstractSettingRenderer.SETTING_KEY_ATTR);
 				if (focusedKey === key &&
-					!DOM.hasClass(focusedSetting, 'setting-item-list')) { // update `list`s live, as they have a separate "submit edit" step built in before this
+					// update `list`s live, as they have a separate "submit edit" step built in before this
+					(focusedSetting.parentElement && !DOM.hasClass(focusedSetting.parentElement, 'setting-item-list'))
+				) {
 
 					this.updateModifiedLabelForKey(key);
 					this.scheduleRefresh(focusedSetting, key);

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -970,15 +970,8 @@ export class SettingsEditor2 extends BaseEditor {
 			// If a single setting is being refreshed, it's ok to refresh now if that is not the focused setting
 			if (key) {
 				const focusedKey = focusedSetting.getAttribute(AbstractSettingRenderer.SETTING_KEY_ATTR);
-				/**
-				 * Update `list`s live if focused item is whole list or list item,
-				 * as they have a separate "submit edit" step built in before this
-				 */
-				if (
-					focusedKey === key &&
-					!DOM.hasClass(focusedSetting, 'setting-item-list') &&
-					!DOM.hasClass(focusedSetting, 'setting-item-contents')
-				) {
+				if (focusedKey === key &&
+					!DOM.hasClass(focusedSetting, 'setting-item-list')) { // update `list`s live, as they have a separate "submit edit" step built in before this
 
 					this.updateModifiedLabelForKey(key);
 					this.scheduleRefresh(focusedSetting, key);


### PR DESCRIPTION
Explanation:

When an item such as a string setting is being edited, a refresh is scheduled later so we don't lose focus.
This logic is avoided when we see list items, as list items have a separate "confirmation dialog" that would force refresh anyway.

However the code that checks whether current focus DOM element is the list/exclude widget is not detecting the class correctly. `this.settingRenderers.getSettingDOMElementForDOMElement` finds closest parent that has class `setting-item-contents`. However only the parent of it would have class `setting-item-list` or `setting-item-exclude`.

![image](https://user-images.githubusercontent.com/4033249/62397519-fed2ea00-b52a-11e9-8ee3-d7ae977b409e.png)

![image](https://user-images.githubusercontent.com/4033249/62397528-05f9f800-b52b-11e9-975e-109c2ba3390a.png)
