### PR TITLE
fix Debug Unit Tests configurations order

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -274,8 +274,8 @@
 		{
 			"name": "Debug Unit Tests",
 			"configurations": [
-				"Attach to VS Code",
-				"Run Unit Tests"
+				"Run Unit Tests",
+				"Attach to VS Code"
 			]
 		},
 	]


### PR DESCRIPTION
We should 'Run Unit Tests' before 'Attach to VS Code'.