### PR TITLE
fixup! Toggle for disabling autofocus on debugger stop

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -675,7 +675,7 @@ export class DebugSession implements IDebugSession {
 									this.viewletService.openViewlet(VIEWLET_ID);
 								}
 
-								if (this.configurationService.getValue<boolean>('debug.autoFocusEditor')) {
+								if (this.configurationService.getValue<boolean>('debug.focusWindowOnBreak')) {
 									this.windowService.focusWindow();
 								}
 							}


### PR DESCRIPTION
The settings item `debug.autoFocusEditor` was renamed to
`debug.focusWindowOnBreak` on the settings definition, but not on the
code using it.

Corrects #77213