### PR TITLE
Fix: Settings editor renders all tree elements at once

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -281,6 +281,11 @@ export class SettingsEditor2 extends BaseEditor {
 
 	layout(dimension: DOM.Dimension): void {
 		this.dimension = dimension;
+
+		if (!this.isVisible()) {
+			return;
+		}
+
 		this.layoutTrees(dimension);
 
 		const innerWidth = Math.min(1000, dimension.width) - 24 * 2; // 24px padding on left and right;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/78505

Fix is to avoid laying out the settings tree when the editor isn't visible. This is usually not an issue for trees/lists **except** when using the dynamic heights feature which relies on DOM elements to actually have a height when probed. When the settings editor is hidden, calling layout will probe elements for their height... but editors aren't placed into the DOM at that point in time... so when probing for elements' heights, we get 0 for each one... thus rendering them all at once.