### PR TITLE
Update services for #78285

### DIFF
--- a/extensions/css-language-features/server/package.json
+++ b/extensions/css-language-features/server/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./out/cssServerMain",
   "dependencies": {
-    "vscode-css-languageservice": "^4.0.3-next.1",
+    "vscode-css-languageservice": "^4.0.3-next.3",
     "vscode-languageserver": "^5.3.0-next.8"
   },
   "devDependencies": {

--- a/extensions/css-language-features/server/yarn.lock
+++ b/extensions/css-language-features/server/yarn.lock
@@ -781,10 +781,10 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-vscode-css-languageservice@^4.0.3-next.1:
-  version "4.0.3-next.1"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-4.0.3-next.1.tgz#e89d01ce0d79b3e6c2642f5e3ad73cb8160d38d9"
-  integrity sha512-Zrm5TeraVUJ8vRikWhFt259dQu+WK+Ie3K5UA8BB4kqcanoM+1mcnIt8fPkTXlZLbiEWElrkJ9yuYbDNkufeBg==
+vscode-css-languageservice@^4.0.3-next.3:
+  version "4.0.3-next.3"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-4.0.3-next.3.tgz#eb7f642f2785d388d74a1a98fd14f7736a11e316"
+  integrity sha512-6j/y9ccecrq7/APLPEijx+uWHsEdTFH5ZQHG4ZMKjZx6euny27B1wvLCjpxKnZCWcHgmi7cMDLWpUdElvHjjPQ==
   dependencies:
     vscode-languageserver-types "^3.15.0-next.2"
     vscode-nls "^4.1.1"

--- a/extensions/html-language-features/server/package.json
+++ b/extensions/html-language-features/server/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./out/htmlServerMain",
   "dependencies": {
-    "vscode-css-languageservice": "^4.0.3-next.1",
+    "vscode-css-languageservice": "^4.0.3-next.3",
     "vscode-html-languageservice": "^3.0.4-next.0",
     "vscode-languageserver": "^5.3.0-next.8",
     "vscode-languageserver-types": "3.15.0-next.2",

--- a/extensions/html-language-features/server/yarn.lock
+++ b/extensions/html-language-features/server/yarn.lock
@@ -229,10 +229,10 @@ supports-color@5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
-vscode-css-languageservice@^4.0.3-next.1:
-  version "4.0.3-next.1"
-  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-4.0.3-next.1.tgz#e89d01ce0d79b3e6c2642f5e3ad73cb8160d38d9"
-  integrity sha512-Zrm5TeraVUJ8vRikWhFt259dQu+WK+Ie3K5UA8BB4kqcanoM+1mcnIt8fPkTXlZLbiEWElrkJ9yuYbDNkufeBg==
+vscode-css-languageservice@^4.0.3-next.3:
+  version "4.0.3-next.3"
+  resolved "https://registry.yarnpkg.com/vscode-css-languageservice/-/vscode-css-languageservice-4.0.3-next.3.tgz#eb7f642f2785d388d74a1a98fd14f7736a11e316"
+  integrity sha512-6j/y9ccecrq7/APLPEijx+uWHsEdTFH5ZQHG4ZMKjZx6euny27B1wvLCjpxKnZCWcHgmi7cMDLWpUdElvHjjPQ==
   dependencies:
     vscode-languageserver-types "^3.15.0-next.2"
     vscode-nls "^4.1.1"


### PR DESCRIPTION
Actual change: https://github.com/microsoft/vscode-css-languageservice/commit/8c72819096fd80313a9046a4a07c401c8c80737d

Explanation: Old implementation of CSS hover goes from top of AST to the leaf. Once a hover-able item is found, we immediately return it.
With new addition to hover we added in this milestone, we accumulate hover over the path. However, for selector preview, we should use the top most hover-able Node's content, so in SCSS we show the `div` hover for `div { span {} }` but not the `span` hover.