### PR TITLE
#78530: use /usr/bin/python instead of python

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
-function realpath() { python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
+function realpath() { /usr/bin/python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$0"; }
 CONTENTS="$(dirname "$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")")"
 ELECTRON="$CONTENTS/MacOS/Electron"
 CLI="$CONTENTS/Resources/app/out/cli.js"


### PR DESCRIPTION
As commented in [#78530](https://github.com/microsoft/vscode/issues/78530), sometime user-specified python is not stable.
vscode would like to avoid the impact of the user's python environment.

using `/usr/bin/python` instead of `python` in `/usr/local/bin/code` works well. like...

```terminal
$ pwd
/Users/hiroaki/dev/sandbox
$ python
pyenv: version `sandbox' is not installed (set by /Users/hiroaki/dev/sandbox/.python-version)
$ code .
# open vscode well!
```
