### PR TITLE
Use grid descriptors for workbench grid layout

### DIFF
--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -319,9 +319,18 @@ export class Grid<T extends IView = IView> extends Disposable {
 		return this.gridview.resizeView(location, size);
 	}
 
-	getViewSize(view: T): IViewSize {
+	getViewSize(view?: T): IViewSize {
+		if (!view) {
+			return this.gridview.getViewSize();
+		}
+
 		const location = this.getViewLocation(view);
 		return this.gridview.getViewSize(location);
+	}
+
+	getViewCachedVisibleSize(view: T): number | undefined {
+		const location = this.getViewLocation(view);
+		return this.gridview.getViewCachedVisibleSize(location);
 	}
 
 	maximizeViewSize(view: T): void {
@@ -422,7 +431,7 @@ export interface ISerializableView extends IView {
 }
 
 export interface IViewDeserializer<T extends ISerializableView> {
-	fromJSON(json: object | null): T;
+	fromJSON(json: any): T;
 }
 
 interface InitialLayoutContext<T extends ISerializableView> {
@@ -433,7 +442,7 @@ interface InitialLayoutContext<T extends ISerializableView> {
 
 export interface ISerializedLeafNode {
 	type: 'leaf';
-	data: object | null;
+	data: any;
 	size: number;
 	visible?: boolean;
 }

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -762,6 +762,7 @@ export class GridView implements IDisposable {
 		const [, parentIndex] = tail(rest);
 
 		const sibling = parent.children[0];
+		const isSiblingVisible = parent.isChildVisible(0);
 		parent.removeChild(0);
 
 		const sizes = grandParent.children.map((_, i) => grandParent.getChildSize(i));
@@ -776,7 +777,8 @@ export class GridView implements IDisposable {
 			}
 		} else {
 			const newSibling = new LeafNode(sibling.view, orthogonal(sibling.orientation), this.layoutController, sibling.size);
-			grandParent.addChild(newSibling, sibling.orthogonalSize, parentIndex);
+			const sizing = isSiblingVisible ? sibling.orthogonalSize : Sizing.Invisible(sibling.orthogonalSize);
+			grandParent.addChild(newSibling, sizing, parentIndex);
 		}
 
 		for (let i = 0; i < sizes.length; i++) {

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -11,6 +11,7 @@ import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle'
 import { $ } from 'vs/base/browser/dom';
 import { tail2 as tail } from 'vs/base/common/arrays';
 import { Color } from 'vs/base/common/color';
+import { clamp } from 'vs/base/common/numbers';
 
 export { Sizing, LayoutPriority } from 'vs/base/browser/ui/splitview/splitview';
 export { Orientation } from 'vs/base/browser/ui/sash/sash';
@@ -277,9 +278,7 @@ class BranchNode implements ISplitView, IDisposable {
 			throw new Error('Invalid from index');
 		}
 
-		if (to < 0 || to > this.children.length) {
-			throw new Error('Invalid to index');
-		}
+		to = clamp(to, 0, this.children.length);
 
 		if (from < to) {
 			to--;
@@ -300,9 +299,7 @@ class BranchNode implements ISplitView, IDisposable {
 			throw new Error('Invalid from index');
 		}
 
-		if (to < 0 || to >= this.children.length) {
-			throw new Error('Invalid to index');
-		}
+		to = clamp(to, 0, this.children.length);
 
 		this.splitview.swapViews(from, to);
 		[this.children[from].orthogonalStartSash, this.children[from].orthogonalEndSash, this.children[to].orthogonalStartSash, this.children[to].orthogonalEndSash] = [this.children[to].orthogonalStartSash, this.children[to].orthogonalEndSash, this.children[from].orthogonalStartSash, this.children[from].orthogonalEndSash];

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -868,9 +868,23 @@ export class GridView implements IDisposable {
 		}
 	}
 
-	getViewSize(location: number[]): IViewSize {
+	getViewSize(location?: number[]): IViewSize {
+		if (!location) {
+			return { width: this.root.width, height: this.root.height };
+		}
+
 		const [, node] = this.getNode(location);
 		return { width: node.width, height: node.height };
+	}
+
+	getViewCachedVisibleSize(location: number[]): number | undefined {
+		const [, node] = this.getNode(location);
+
+		if (!(node instanceof LeafNode)) {
+			throw new Error('Invalid node');
+		}
+
+		return node.cachedVisibleSize;
 	}
 
 	maximizeViewSize(location: number[]): void {

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -414,9 +414,10 @@ export class SplitView extends Disposable {
 			throw new Error('Cant modify splitview');
 		}
 
-		const size = this.getViewSize(from);
+		const cachedVisibleSize = this.getViewCachedVisibleSize(from);
+		const sizing = typeof cachedVisibleSize === 'undefined' ? this.getViewSize(from) : Sizing.Invisible(cachedVisibleSize);
 		const view = this.removeView(from);
-		this.addView(view, size, to);
+		this.addView(view, sizing, to);
 	}
 
 	swapViews(from: number, to: number): void {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -692,7 +692,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Layout
 		if (!skipLayout) {
 			if (this.workbenchGrid instanceof Grid) {
-				this.layout();
+				this.workbenchGrid.setViewVisible(this.statusBarPartView, !hidden);
 			} else {
 				this.workbenchGrid.layout();
 			}
@@ -896,7 +896,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Layout
 		if (!skipLayout) {
 			if (this.workbenchGrid instanceof Grid) {
-				this.layout();
+				this.workbenchGrid.setViewVisible(this.activityBarPartView, !hidden);
 			} else {
 				this.workbenchGrid.layout();
 			}
@@ -1168,7 +1168,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		const activityBarNode: ISerializedLeafNode = {
 			type: 'leaf',
 			data: { type: 'workbench.parts.activitybar' },
-			size: activityBarWidth
+			size: activityBarWidth,
+			visible: !this.state.activityBar.hidden
 		};
 
 		const sideBarNode: ISerializedLeafNode = {
@@ -1217,7 +1218,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 					{
 						type: 'leaf',
 						data: { type: 'workbench.parts.statusbar' },
-						size: statusBarHeight
+						size: statusBarHeight,
+						visible: !this.state.statusBar.hidden
 					}
 				]
 			},

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -301,11 +301,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		const activityBar = this.getPart(Parts.ACTIVITYBAR_PART);
 		const sideBar = this.getPart(Parts.SIDEBAR_PART);
 		const wasHidden = this.state.sideBar.hidden;
-
-		if (this.state.sideBar.hidden) {
-			this.setSideBarHidden(false, true /* Skip Layout */);
-		}
-
 		const newPositionValue = (position === Position.LEFT) ? 'left' : 'right';
 		const oldPositionValue = (this.state.sideBar.position === Position.LEFT) ? 'left' : 'right';
 		this.state.sideBar.position = position;
@@ -326,11 +321,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.state.sideBar.width = this.workbenchGrid.getViewSize(this.sideBarPartView).width;
 			}
 
-			this.workbenchGrid.removeView(this.sideBarPartView);
-			this.workbenchGrid.removeView(this.activityBarPartView);
-
-			if (!this.state.panel.hidden && this.state.panel.position === Position.BOTTOM) {
-				this.workbenchGrid.removeView(this.panelPartView);
+			if (position === Position.LEFT) {
+				this.workbenchGrid.moveViewTo(this.activityBarPartView, [1, 0]);
+				this.workbenchGrid.moveViewTo(this.sideBarPartView, [1, 1]);
+			} else {
+				this.workbenchGrid.moveViewTo(this.activityBarPartView, [1, 3]);
+				this.workbenchGrid.moveViewTo(this.sideBarPartView, [1, 2]);
 			}
 
 			this.layout();
@@ -740,10 +736,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.container.prepend(workbenchGrid.element);
 			this.workbenchGrid = workbenchGrid;
 
-			this._register((this.sideBarPartView as SidebarPart).onDidVisibilityChange((visible) => {
-				this.setSideBarHidden(!visible, true);
-			}));
-
 			this._register((this.panelPartView as PanelPart).onDidVisibilityChange((visible) => {
 				this.setPanelHidden(!visible, true);
 			}));
@@ -1146,6 +1138,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		// Layout
 		if (this.workbenchGrid instanceof Grid) {
+			// TODO
 			this.workbenchGrid.removeView(this.panelPartView);
 			this.layout();
 		} else {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -800,6 +800,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				// changes that makes the title bar switch visibility
 				this.workbenchGrid.setViewVisible(this.titleBarPartView, this.isVisible(Parts.TITLEBAR_PART));
 
+				// The editor and the panel cannot be hidden at the same time
+				if (this.state.editor.hidden && this.state.panel.hidden) {
+					this.setPanelHidden(false, true);
+				}
+
 				// Layout the grid widget
 				this.workbenchGrid.layout(this._dimension.width, this._dimension.height);
 			} else {
@@ -915,16 +920,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	}
 
 	setEditorHidden(hidden: boolean, skipLayout?: boolean): void {
-		if (!(this.workbenchGrid instanceof Grid) || hidden === this.state.editor.hidden) {
+		if (!(this.workbenchGrid instanceof Grid)) {
 			return;
 		}
 
 		this.state.editor.hidden = hidden;
 
-		// The editor and the panel cannot be hidden at the same time
-		if (this.state.editor.hidden && this.state.panel.hidden) {
-			this.setPanelHidden(false, true);
-		}
+		// Propagate to grid
+		this.workbenchGrid.setViewVisible(this.editorPartView, !hidden);
 
 		if (!skipLayout) {
 			this.layout();
@@ -1151,9 +1154,9 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			const size = this.workbenchGrid.getViewSize(this.panelPartView);
 
 			if (position === Position.BOTTOM) {
-				this.workbenchGrid.moveView(this.panelPartView, size.width, this.editorPartView, Direction.Down);
+				this.workbenchGrid.moveView(this.panelPartView, this.state.editor.hidden ? size.height : size.width, this.editorPartView, Direction.Down);
 			} else {
-				this.workbenchGrid.moveView(this.panelPartView, size.height, this.editorPartView, Direction.Right);
+				this.workbenchGrid.moveView(this.panelPartView, this.state.editor.hidden ? size.width : size.height, this.editorPartView, Direction.Right);
 			}
 		} else {
 			this.workbenchGrid.layout();

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -801,6 +801,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.workbenchGrid.setViewVisible(this.titleBarPartView, this.isVisible(Parts.TITLEBAR_PART));
 
 				// The editor and the panel cannot be hidden at the same time
+				// TODO@steven: this shouldn't happen on every layout, only when something
+				// changes that makes the panel and/or editor switch visibility
 				if (this.state.editor.hidden && this.state.panel.hidden) {
 					this.setPanelHidden(false, true);
 				}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -27,7 +27,7 @@ import { IWindowService, MenuBarVisibility, getTitleBarStyle } from 'vs/platform
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IEditorService, IResourceEditor } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { Sizing, Direction, Grid, SerializableGrid, ISerializableView, ISerializedGrid, Orientation, ISerializedNode, ISerializedBranchNode, ISerializedLeafNode } from 'vs/base/browser/ui/grid/grid';
+import { Grid, SerializableGrid, ISerializableView, ISerializedGrid, Orientation, ISerializedNode, ISerializedBranchNode, ISerializedLeafNode } from 'vs/base/browser/ui/grid/grid';
 import { WorkbenchLegacyLayout } from 'vs/workbench/browser/legacyLayout';
 import { IDimension } from 'vs/platform/layout/browser/layoutService';
 import { Part } from 'vs/workbench/browser/part';
@@ -798,9 +798,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 				// Layout the grid widget
 				this.workbenchGrid.layout(this._dimension.width, this._dimension.height);
-
-				// Layout grid views
-				this.layoutGrid();
 			} else {
 				this.workbenchGrid.layout(options);
 			}
@@ -808,95 +805,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			// Emit as event
 			this._onLayout.fire(this._dimension);
 		}
-	}
-
-	private layoutGrid(): void {
-		if (!(this.workbenchGrid instanceof Grid)) {
-			return;
-		}
-
-		let panelInGrid = this.workbenchGrid.hasView(this.panelPartView);
-		let sidebarInGrid = this.workbenchGrid.hasView(this.sideBarPartView);
-		let activityBarInGrid = this.workbenchGrid.hasView(this.activityBarPartView);
-		let statusBarInGrid = this.workbenchGrid.hasView(this.statusBarPartView);
-		let titlebarInGrid = this.workbenchGrid.hasView(this.titleBarPartView);
-
-		// Add parts to grid
-		if (!statusBarInGrid) {
-			this.workbenchGrid.addView(this.statusBarPartView, Sizing.Split, this.editorPartView, Direction.Down);
-			statusBarInGrid = true;
-		}
-
-		if (!titlebarInGrid) {
-			this.workbenchGrid.addView(this.titleBarPartView, Sizing.Split, this.editorPartView, Direction.Up);
-
-			titlebarInGrid = true;
-		}
-
-		if (!activityBarInGrid) {
-			this.workbenchGrid.addView(this.activityBarPartView, Sizing.Split, panelInGrid && this.state.sideBar.position === this.state.panel.position ? this.panelPartView : this.editorPartView, this.state.sideBar.position === Position.RIGHT ? Direction.Right : Direction.Left);
-			activityBarInGrid = true;
-		}
-
-		if (!sidebarInGrid) {
-			this.workbenchGrid.addView(this.sideBarPartView, this.state.sideBar.width !== undefined ? this.state.sideBar.width : Sizing.Split, this.activityBarPartView, this.state.sideBar.position === Position.LEFT ? Direction.Right : Direction.Left);
-			sidebarInGrid = true;
-		}
-
-		if (!panelInGrid) {
-			this.workbenchGrid.addView(this.panelPartView, Sizing.Split, this.editorPartView, this.state.panel.position === Position.BOTTOM ? Direction.Down : Direction.Right);
-			panelInGrid = true;
-		}
-
-		// // Hide parts
-		// if (this.state.panel.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.panelPartView, false);
-		// }
-
-		// if (this.state.statusBar.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.statusBarPartView, false);
-		// }
-
-		// if (titlebarInGrid && !this.isVisible(Parts.TITLEBAR_PART)) {
-		// 	this.workbenchGrid.setViewVisible(this.titleBarPartView, false);
-		// }
-
-		// if (this.state.activityBar.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.activityBarPartView, false);
-		// }
-
-		// if (this.state.sideBar.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.sideBarPartView, false);
-		// }
-
-		// if (this.state.editor.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.editorPartView, false);
-		// }
-
-		// // Show visible parts
-		// if (!this.state.editor.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.editorPartView, true);
-		// }
-
-		// if (!this.state.statusBar.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.statusBarPartView, true);
-		// }
-
-		// if (this.isVisible(Parts.TITLEBAR_PART)) {
-		// 	this.workbenchGrid.setViewVisible(this.titleBarPartView, true);
-		// }
-
-		// if (!this.state.activityBar.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.activityBarPartView, true);
-		// }
-
-		// if (!this.state.sideBar.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.sideBarPartView, true);
-		// }
-
-		// if (!this.state.panel.hidden) {
-		// 	this.workbenchGrid.setViewVisible(this.panelPartView, true);
-		// }
 	}
 
 	isEditorLayoutCentered(): boolean {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1160,12 +1160,12 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	private createGridDescriptor(): ISerializedGrid {
 		const width = this.storageService.getNumber(Storage.GRID_WIDTH, StorageScope.GLOBAL, 600);
 		const height = this.storageService.getNumber(Storage.GRID_HEIGHT, StorageScope.GLOBAL, 400);
-		const sideBarSize = this.storageService.getNumber(Storage.SIDEBAR_SIZE, StorageScope.GLOBAL, 200);
-		const panelSize = this.storageService.getNumber(Storage.PANEL_SIZE, StorageScope.GLOBAL, 200);
+		const sideBarSize = this.storageService.getNumber(Storage.SIDEBAR_SIZE, StorageScope.GLOBAL, 300);
+		const panelSize = this.storageService.getNumber(Storage.PANEL_SIZE, StorageScope.GLOBAL, 300);
 
-		const titleBarHeight = 30; // TODO
-		const statusBarHeight = 22; // TODO
-		const activityBarWidth = 48; // TODO
+		const titleBarHeight = this.titleBarPartView.minimumHeight;
+		const statusBarHeight = this.statusBarPartView.minimumHeight;
+		const activityBarWidth = this.activityBarPartView.minimumWidth;
 		const middleSectionHeight = height - titleBarHeight - statusBarHeight;
 		const editorSectionWidth = width - activityBarWidth - (this.state.sideBar.hidden ? 0 : sideBarSize);
 

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -965,9 +965,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		// Layout
 		if (!skipLayout) {
-			if (this.workbenchGrid instanceof Grid) {
-				this.layout();
-			} else {
+			if (!(this.workbenchGrid instanceof Grid)) {
 				this.workbenchGrid.layout();
 			}
 		}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -737,18 +737,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			this.workbenchGrid = workbenchGrid;
 
 			this._register((this.sideBarPartView as SidebarPart).onDidVisibilityChange((visible) => {
-				// TODO
-				// this.setPanelHidden(!visible, true);
+				this.setSideBarHidden(!visible, true);
 			}));
 
 			this._register((this.panelPartView as PanelPart).onDidVisibilityChange((visible) => {
-				// TODO
-				// this.setPanelHidden(!visible, true);
+				this.setPanelHidden(!visible, true);
 			}));
 
 			this._register((this.editorPartView as PanelPart).onDidVisibilityChange((visible) => {
-				// TODO
-				// this.setEditorHidden(!visible, true);
+				this.setEditorHidden(!visible, true);
 			}));
 
 			this._register(this.storageService.onWillSaveState(() => {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -795,6 +795,11 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				position(this.container, 0, 0, 0, 0, 'relative');
 				size(this.container, this._dimension.width, this._dimension.height);
 
+				// Update the title bar part visibility
+				// TODO@steven: this shouldn't happen on every layout, only when something
+				// changes that makes the title bar switch visibility
+				this.workbenchGrid.setViewVisible(this.titleBarPartView, this.isVisible(Parts.TITLEBAR_PART));
+
 				// Layout the grid widget
 				this.workbenchGrid.layout(this._dimension.width, this._dimension.height);
 			} else {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -689,11 +689,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			removeClass(this.container, 'nostatusbar');
 		}
 
+		// Propagate to grid
+		if (this.workbenchGrid instanceof Grid) {
+			this.workbenchGrid.setViewVisible(this.statusBarPartView, !hidden);
+		}
+
 		// Layout
 		if (!skipLayout) {
-			if (this.workbenchGrid instanceof Grid) {
-				this.workbenchGrid.setViewVisible(this.statusBarPartView, !hidden);
-			} else {
+			if (!(this.workbenchGrid instanceof Grid)) {
 				this.workbenchGrid.layout();
 			}
 		}
@@ -893,11 +896,14 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 	setActivityBarHidden(hidden: boolean, skipLayout?: boolean): void {
 		this.state.activityBar.hidden = hidden;
 
+		// Propagate to grid
+		if (this.workbenchGrid instanceof Grid) {
+			this.workbenchGrid.setViewVisible(this.activityBarPartView, !hidden);
+		}
+
 		// Layout
 		if (!skipLayout) {
-			if (this.workbenchGrid instanceof Grid) {
-				this.workbenchGrid.setViewVisible(this.activityBarPartView, !hidden);
-			} else {
+			if (!(this.workbenchGrid instanceof Grid)) {
 				this.workbenchGrid.layout();
 			}
 		}
@@ -1019,9 +1025,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 		// Layout
 		if (!skipLayout) {
-			if (this.workbenchGrid instanceof Grid) {
-				this.layout();
-			} else {
+			if (!(this.workbenchGrid instanceof Grid)) {
 				this.workbenchGrid.layout();
 			}
 		}

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -67,9 +67,6 @@ export class SidebarPart extends CompositePart<Viewlet> implements IViewletServi
 
 	get onDidViewletRegister(): Event<ViewletDescriptor> { return <Event<ViewletDescriptor>>this.viewletRegistry.onDidRegister; }
 
-	private _onDidVisibilityChange = this._register(new Emitter<boolean>());
-	readonly onDidVisibilityChange: Event<boolean> = this._onDidVisibilityChange.event;
-
 	private _onDidViewletDeregister = this._register(new Emitter<ViewletDescriptor>());
 	readonly onDidViewletDeregister: Event<ViewletDescriptor> = this._onDidViewletDeregister.event;
 
@@ -270,10 +267,6 @@ export class SidebarPart extends CompositePart<Viewlet> implements IViewletServi
 				});
 			}
 		}
-	}
-
-	setVisible(visible: boolean): void {
-		this._onDidVisibilityChange.fire(visible);
 	}
 
 	toJSON(): object {

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -67,11 +67,11 @@ export class SidebarPart extends CompositePart<Viewlet> implements IViewletServi
 
 	get onDidViewletRegister(): Event<ViewletDescriptor> { return <Event<ViewletDescriptor>>this.viewletRegistry.onDidRegister; }
 
-	private _onDidViewletDeregister = this._register(new Emitter<ViewletDescriptor>());
-	readonly onDidViewletDeregister: Event<ViewletDescriptor> = this._onDidViewletDeregister.event;
-
 	private _onDidVisibilityChange = this._register(new Emitter<boolean>());
 	readonly onDidVisibilityChange: Event<boolean> = this._onDidVisibilityChange.event;
+
+	private _onDidViewletDeregister = this._register(new Emitter<ViewletDescriptor>());
+	readonly onDidViewletDeregister: Event<ViewletDescriptor> = this._onDidViewletDeregister.event;
 
 	get onDidViewletOpen(): Event<IViewlet> { return Event.map(this.onDidCompositeOpen.event, compositeEvent => <IViewlet>compositeEvent.composite); }
 	get onDidViewletClose(): Event<IViewlet> { return this.onDidCompositeClose.event as Event<IViewlet>; }

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -70,6 +70,9 @@ export class SidebarPart extends CompositePart<Viewlet> implements IViewletServi
 	private _onDidViewletDeregister = this._register(new Emitter<ViewletDescriptor>());
 	readonly onDidViewletDeregister: Event<ViewletDescriptor> = this._onDidViewletDeregister.event;
 
+	private _onDidVisibilityChange = this._register(new Emitter<boolean>());
+	readonly onDidVisibilityChange: Event<boolean> = this._onDidVisibilityChange.event;
+
 	get onDidViewletOpen(): Event<IViewlet> { return Event.map(this.onDidCompositeOpen.event, compositeEvent => <IViewlet>compositeEvent.composite); }
 	get onDidViewletClose(): Event<IViewlet> { return this.onDidCompositeClose.event as Event<IViewlet>; }
 
@@ -267,6 +270,10 @@ export class SidebarPart extends CompositePart<Viewlet> implements IViewletServi
 				});
 			}
 		}
+	}
+
+	setVisible(visible: boolean): void {
+		this._onDidVisibilityChange.fire(visible);
 	}
 
 	toJSON(): object {


### PR DESCRIPTION
- [x] Create the grid based on descriptors
- [x] Use `moveView` instead of `addView` and `removeView`.
- [x] Clean up that huge overloaded `layout()` call. Layout should always be as cheap as possible. Currently it is doing much more, like adding views when they aren't there or updating their visibility.
- [x] Make sure all view visibilities work
- [x] Make sure all state is saved and restored