### PR TITLE
Support staging for new files

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -353,11 +353,11 @@ export class CommandCenter {
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_RENAMED:
-			case Status.UNTRACKED:
 			case Status.INDEX_ADDED:
 				return this.getURI(resource.original, 'HEAD');
 
 			case Status.MODIFIED:
+			case Status.UNTRACKED:
 				return this.getURI(resource.resourceUri, '~');
 
 			case Status.DELETED_BY_THEM:

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -353,6 +353,8 @@ export class CommandCenter {
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_RENAMED:
+			case Status.UNTRACKED:
+			case Status.INDEX_ADDED:
 				return this.getURI(resource.original, 'HEAD');
 
 			case Status.MODIFIED:
@@ -414,6 +416,7 @@ export class CommandCenter {
 		switch (resource.type) {
 			case Status.INDEX_MODIFIED:
 			case Status.INDEX_RENAMED:
+			case Status.INDEX_ADDED:
 				return `${basename} (Index)`;
 
 			case Status.MODIFIED:
@@ -426,6 +429,10 @@ export class CommandCenter {
 
 			case Status.DELETED_BY_THEM:
 				return `${basename} (Ours)`;
+
+			case Status.UNTRACKED:
+
+				return `${basename} (Untracked)`;
 		}
 
 		return '';

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1116,15 +1116,17 @@ export class Repository {
 		}
 
 		let mode: string;
+		let add: string = '';
 
 		try {
 			const details = await this.getObjectDetails('HEAD', path);
 			mode = details.mode;
 		} catch (err) {
 			mode = '100644';
+			add = '--add';
 		}
 
-		await this.run(['update-index', '--cacheinfo', mode, hash, path]);
+		await this.run(['update-index', add, '--cacheinfo', mode, hash, path]);
 	}
 
 	async checkout(treeish: string, paths: string[], opts: { track?: boolean } = Object.create(null)): Promise<void> {


### PR DESCRIPTION
Addresses #78046

@joaomoreno the real 'fix' or 'feature' was adding the `--add` arg to the `update-index` when an error was thrown by `getObjectDetails()`.  This may not be the best way to go about this, but I recorded the behavior for this PR.  The diff editor was utilized to get the context menu items to show up.

![stagechanges](https://user-images.githubusercontent.com/644628/62545220-4b6e3c00-b82f-11e9-9a6b-739cd58f4be2.gif)
