### PR TITLE
Update spacing on settings editor array editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsWidgets.css
@@ -29,7 +29,7 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-value,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-sibling {
 	display: inline-block;
-	line-height: 22px;
+	line-height: 24px;
 }
 
 /* Use monospace to display glob patterns in exclude widget */
@@ -49,12 +49,11 @@
 	display: none;
 	position: absolute;
 	right: 0px;
-	margin-top: 1px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row {
 	position: relative;
-	max-height: 22px;
+	max-height: 24px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row:focus {
@@ -68,7 +67,7 @@
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-row .monaco-action-bar .action-label {
 	width: 16px;
-	height: 16px;
+	height: 20px;
 	padding: 2px;
 	margin-right: 2px;
 }
@@ -103,6 +102,7 @@
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .monaco-text-button.setting-list-addButton {
+	margin-top: 4px;
 	margin-right: 10px;
 }
 
@@ -112,7 +112,7 @@
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-valueInput,
 .settings-editor > .settings-body > .settings-tree-container .setting-item.setting-item-list .setting-list-siblingInput {
-	height: 22px;
+	height: 24px;
 	max-width: 320px;
 	flex: 1;
 	margin-right: 10px;

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -346,7 +346,7 @@ export class ListSettingWidget extends Disposable {
 			.map((item, i) => this.renderItem(item, i, focused))
 			.forEach(itemElement => this.listElement.appendChild(itemElement));
 
-		const listHeight = 22 * this.model.items.length;
+		const listHeight = 24 * this.model.items.length;
 		this.listElement.style.height = listHeight + 'px';
 	}
 


### PR DESCRIPTION
I noticed that we don't have consistent spacing with the "Add New" button in the settings editor (especially when an input field is above it). I also that the list height is different (22px) than the Keyboard Shortcuts (24px):

![image](https://user-images.githubusercontent.com/35271042/62549409-4dc79a80-b81d-11e9-94f9-d76e8ee24878.png)

So here I attempted to update the spacing and the height of the rows so they're the same, let me know what you think:

![Untitled 2019-08-06 10_02_40](https://user-images.githubusercontent.com/35271042/62560173-588c2a80-b831-11e9-9e81-addb81be09c9.gif)


CC @octref 