### PR TITLE
Fixed Issue 78731

### DIFF
--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -299,10 +299,14 @@ class LinkDetector implements editorCommon.IEditorContribution {
 			return this.openerService.open(uri, { openToSide });
 
 		}, err => {
-			const messageOrError = err instanceof Error ? (<Error>err).message 
-				: typeof err === 'string' ? err
-				: err ? err.toString()
-				: err;
+			const messageOrError =
+				err instanceof Error
+					? (<Error>err).message
+					: typeof err === "string"
+					? err
+					: err
+					? err.toString()
+					: err;
 			// different error cases
 			if (messageOrError === 'invalid') {
 				this.notificationService.warn(nls.localize('invalid.url', 'Failed to open this link because it is not well-formed: {0}', link.url!.toString()));

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -302,7 +302,7 @@ class LinkDetector implements editorCommon.IEditorContribution {
 			const messageOrError =
 				err instanceof Error
 					? (<Error>err).message
-					: typeof err === "string"
+					: typeof err === 'string'
 					? err
 					: err
 					? err.toString()

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -299,10 +299,12 @@ class LinkDetector implements editorCommon.IEditorContribution {
 			return this.openerService.open(uri, { openToSide });
 
 		}, err => {
+			const errorMessage = err ? err.message : undefined;
+			const messageOrError = errorMessage || err;
 			// different error cases
-			if (err === 'invalid') {
+			if (messageOrError === 'invalid') {
 				this.notificationService.warn(nls.localize('invalid.url', 'Failed to open this link because it is not well-formed: {0}', link.url!.toString()));
-			} else if (err === 'missing') {
+			} else if (messageOrError === 'missing') {
 				this.notificationService.warn(nls.localize('missing.url', 'Failed to open this link because its target is missing.'));
 			} else {
 				onUnexpectedError(err);

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -300,13 +300,7 @@ class LinkDetector implements editorCommon.IEditorContribution {
 
 		}, err => {
 			const messageOrError =
-				err instanceof Error
-					? (<Error>err).message
-					: typeof err === 'string'
-					? err
-					: err
-					? err.toString()
-					: err;
+				err instanceof Error ? (<Error>err).message : err;
 			// different error cases
 			if (messageOrError === 'invalid') {
 				this.notificationService.warn(nls.localize('invalid.url', 'Failed to open this link because it is not well-formed: {0}', link.url!.toString()));

--- a/src/vs/editor/contrib/links/links.ts
+++ b/src/vs/editor/contrib/links/links.ts
@@ -299,8 +299,10 @@ class LinkDetector implements editorCommon.IEditorContribution {
 			return this.openerService.open(uri, { openToSide });
 
 		}, err => {
-			const errorMessage = err ? err.message : undefined;
-			const messageOrError = errorMessage || err;
+			const messageOrError = err instanceof Error ? (<Error>err).message 
+				: typeof err === 'string' ? err
+				: err ? err.toString()
+				: err;
 			// different error cases
 			if (messageOrError === 'invalid') {
 				this.notificationService.warn(nls.localize('invalid.url', 'Failed to open this link because it is not well-formed: {0}', link.url!.toString()));


### PR DESCRIPTION
The error handler for OpenLinkOccurrence handled the case of 'invalid' or 'message', but the function returns an error of new Error('invalid') or new Error('missing') instead of 'invalid' or 'missing'. This causes the editor to throw an unhandled exception instead of a warning message. This fix checks for an err.message as well as err for 'invalid' or 'missing'.
Fixes #78731 
Fixes microsoft/monaco-editor#1520