### PR TITLE
style: format the style of gulp-flatmap.d.ts

### DIFF
--- a/build/lib/typings/gulp-flatmap.d.ts
+++ b/build/lib/typings/gulp-flatmap.d.ts
@@ -1,12 +1,12 @@
 declare module 'gulp-flatmap' {
 	import File = require('vinyl');
-	function f(fn:(stream:NodeJS.ReadWriteStream, file:File)=>NodeJS.ReadWriteStream): NodeJS.ReadWriteStream;
+	function f(fn: (stream: NodeJS.ReadWriteStream, file: File) => NodeJS.ReadWriteStream): NodeJS.ReadWriteStream;
 
 	/**
 	 * This is required as per:
 	 * https://github.com/Microsoft/TypeScript/issues/5073
 	 */
-	namespace f {}
+	namespace f { }
 
 	export = f;
 }


### PR DESCRIPTION
format this file: `build/lib/typings/gulp-flatmap.d.ts`.