### PR TITLE
#56286 Add a configuration option to show/hide icons in the breadcrumbs view

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -71,6 +71,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static FilePath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.filePath');
 	static SymbolPath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.symbolPath');
 	static SymbolSortOrder = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.symbolSortOrder');
+	static Icons = BreadcrumbsConfig._stub<boolean>('breadcrumbs.icons');
 
 	static FileExcludes = BreadcrumbsConfig._stub<glob.IExpression>('files.exclude');
 
@@ -160,6 +161,11 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 				localize('symbolSortOrder.name', "Show symbol outline in alphabetical order."),
 				localize('symbolSortOrder.type', "Show symbol outline in symbol type order."),
 			]
+		},
+		'breadcrumbs.icons': {
+			description: localize('icons', "Render breadcrumb items with icons."),
+			type: 'boolean',
+			default: true
 		}
 	}
 });

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -143,6 +143,7 @@ export class BreadcrumbsControl {
 	private readonly _ckBreadcrumbsActive: IContextKey<boolean>;
 
 	private readonly _cfUseQuickPick: BreadcrumbsConfig<boolean>;
+	private readonly _cfShowIcons: BreadcrumbsConfig<boolean>;
 
 	readonly domNode: HTMLDivElement;
 	private readonly _widget: BreadcrumbsWidget;
@@ -185,6 +186,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsActive = BreadcrumbsControl.CK_BreadcrumbsActive.bindTo(this._contextKeyService);
 
 		this._cfUseQuickPick = BreadcrumbsConfig.UseQuickPick.bindTo(_configurationService);
+		this._cfShowIcons = BreadcrumbsConfig.Icons.bindTo(_configurationService);
 
 		this._disposables.add(breadcrumbsService.register(this._editorGroup.id, this._widget));
 	}
@@ -196,6 +198,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsVisible.reset();
 		this._ckBreadcrumbsActive.reset();
 		this._cfUseQuickPick.dispose();
+		this._cfShowIcons.dispose();
 		this._widget.dispose();
 		this.domNode.remove();
 	}
@@ -246,15 +249,23 @@ export class BreadcrumbsControl {
 		dom.toggleClass(this.domNode, 'backslash-path', this._labelService.getSeparator(uri.scheme, uri.authority) === '\\');
 
 		const updateBreadcrumbs = () => {
-			const items = model.getElements().map(element => new Item(element, this._options, this._instantiationService));
+			const showIcons = this._cfShowIcons.getValue();
+			const options: IBreadcrumbsControlOptions = {
+				...this._options,
+				showFileIcons: this._options.showFileIcons && showIcons,
+				showSymbolIcons: this._options.showSymbolIcons && showIcons
+			};
+			const items = model.getElements().map(element => new Item(element, options, this._instantiationService));
 			this._widget.setItems(items);
 			this._widget.reveal(items[items.length - 1]);
 		};
 		const listener = model.onDidUpdate(updateBreadcrumbs);
+		const configListener = this._cfShowIcons.onDidChange(updateBreadcrumbs);
 		updateBreadcrumbs();
 		this._breadcrumbsDisposables.clear();
 		this._breadcrumbsDisposables.add(model);
 		this._breadcrumbsDisposables.add(listener);
+		this._breadcrumbsDisposables.add(configListener);
 
 		// close picker on hide/update
 		this._breadcrumbsDisposables.add({

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -69,7 +69,9 @@ class Item extends BreadcrumbsItem {
 			return false;
 		}
 		if (this.element instanceof FileElement && other.element instanceof FileElement) {
-			return isEqual(this.element.uri, other.element.uri, false);
+			return (isEqual(this.element.uri, other.element.uri, false) &&
+				this.options.showFileIcons === other.options.showFileIcons &&
+				this.options.showSymbolIcons === other.options.showSymbolIcons);
 		}
 		if (this.element instanceof TreeElement && other.element instanceof TreeElement) {
 			return this.element.id === other.element.id;


### PR DESCRIPTION
Issue #56286.

Adds a config option, breadcrumbs.icons, which controls whether or not icons are shown in the breadcrumbs view