### PR TITLE
Revert "debt - adopt new fs.readdir with stat info"

### DIFF
--- a/src/vs/base/node/pfs.ts
+++ b/src/vs/base/node/pfs.ts
@@ -138,20 +138,6 @@ export async function readdir(path: string): Promise<string[]> {
 	return handleDirectoryChildren(await promisify(fs.readdir)(path));
 }
 
-export async function readdirWithFileTypes(path: string): Promise<fs.Dirent[]> {
-	const children = await promisify(fs.readdir)(path, { withFileTypes: true });
-
-	// Mac: uses NFD unicode form on disk, but we want NFC
-	// See also https://github.com/nodejs/node/issues/2165
-	if (platform.isMacintosh) {
-		for (const child of children) {
-			child.name = normalizeNFC(child.name);
-		}
-	}
-
-	return children;
-}
-
 export function readdirSync(path: string): string[] {
 	return handleDirectoryChildren(fs.readdirSync(path));
 }

--- a/src/vs/base/test/node/pfs/pfs.test.ts
+++ b/src/vs/base/test/node/pfs/pfs.test.ts
@@ -16,7 +16,6 @@ import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { isWindows, isLinux } from 'vs/base/common/platform';
 import { canNormalize } from 'vs/base/common/normalization';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { join } from 'path';
 
 const chunkSize = 64 * 1024;
 const readError = 'Error while reading';
@@ -382,31 +381,6 @@ suite('PFS', () => {
 
 			const children = await pfs.readdir(path.join(parentDir, 'pfs', id));
 			assert.equal(children.some(n => n === 'öäü'), true); // Mac always converts to NFD, so
-
-			await pfs.rimraf(parentDir);
-		}
-	});
-
-	test('readdirWithFileTypes', async () => {
-		if (canNormalize && typeof process.versions['electron'] !== 'undefined' /* needs electron */) {
-			const id = uuid.generateUuid();
-			const parentDir = path.join(os.tmpdir(), 'vsctests', id);
-			const testDir = join(parentDir, 'pfs', id);
-
-			const newDir = path.join(testDir, 'öäü');
-			await pfs.mkdirp(newDir, 493);
-
-			await pfs.writeFile(join(testDir, 'somefile.txt'), 'contents');
-
-			assert.ok(fs.existsSync(newDir));
-
-			const children = await pfs.readdirWithFileTypes(testDir);
-
-			assert.equal(children.some(n => n.name === 'öäü'), true); // Mac always converts to NFD, so
-			assert.equal(children.some(n => n.isDirectory()), true);
-
-			assert.equal(children.some(n => n.name === 'somefile.txt'), true);
-			assert.equal(children.some(n => n.isFile()), true);
 
 			await pfs.rimraf(parentDir);
 		}

--- a/src/vs/platform/files/node/diskFileSystemProvider.ts
+++ b/src/vs/platform/files/node/diskFileSystemProvider.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { mkdir, open, close, read, write, fdatasync, Dirent, Stats } from 'fs';
+import { mkdir, open, close, read, write, fdatasync } from 'fs';
 import { promisify } from 'util';
 import { IDisposable, Disposable, toDisposable, dispose, combinedDisposable } from 'vs/base/common/lifecycle';
 import { IFileSystemProvider, FileSystemProviderCapabilities, IFileChange, IWatchOptions, IStat, FileType, FileDeleteOptions, FileOverwriteOptions, FileWriteOptions, FileOpenOptions, FileSystemProviderErrorCode, createFileSystemProviderError, FileSystemProviderError } from 'vs/platform/files/common/files';
 import { URI } from 'vs/base/common/uri';
 import { Event, Emitter } from 'vs/base/common/event';
 import { isLinux, isWindows } from 'vs/base/common/platform';
-import { statLink, unlink, move, copy, readFile, truncate, rimraf, RimRafMode, exists, readdirWithFileTypes } from 'vs/base/node/pfs';
+import { statLink, readdir, unlink, move, copy, readFile, truncate, rimraf, RimRafMode, exists } from 'vs/base/node/pfs';
 import { normalize, basename, dirname } from 'vs/base/common/path';
 import { joinPath } from 'vs/base/common/resources';
 import { isEqual } from 'vs/base/common/extpath';
@@ -62,8 +62,15 @@ export class DiskFileSystemProvider extends Disposable implements IFileSystemPro
 		try {
 			const { stat, isSymbolicLink } = await statLink(this.toFilePath(resource)); // cannot use fs.stat() here to support links properly
 
+			let type: number;
+			if (isSymbolicLink) {
+				type = FileType.SymbolicLink | (stat.isDirectory() ? FileType.Directory : FileType.File);
+			} else {
+				type = stat.isFile() ? FileType.File : stat.isDirectory() ? FileType.Directory : FileType.Unknown;
+			}
+
 			return {
-				type: this.toType(stat, isSymbolicLink),
+				type,
 				ctime: stat.ctime.getTime(),
 				mtime: stat.mtime.getTime(),
 				size: stat.size
@@ -75,19 +82,13 @@ export class DiskFileSystemProvider extends Disposable implements IFileSystemPro
 
 	async readdir(resource: URI): Promise<[string, FileType][]> {
 		try {
-			const children = await readdirWithFileTypes(this.toFilePath(resource));
+			const children = await readdir(this.toFilePath(resource));
 
 			const result: [string, FileType][] = [];
 			await Promise.all(children.map(async child => {
 				try {
-					let type: FileType;
-					if (child.isSymbolicLink()) {
-						type = (await this.stat(joinPath(resource, child.name))).type; // always resolve target the link points to if any
-					} else {
-						type = this.toType(child);
-					}
-
-					result.push([child.name, type]);
+					const stat = await this.stat(joinPath(resource, child));
+					result.push([child, stat.type]);
 				} catch (error) {
 					this.logService.trace(error); // ignore errors for individual entries that can arise from permission denied
 				}
@@ -97,14 +98,6 @@ export class DiskFileSystemProvider extends Disposable implements IFileSystemPro
 		} catch (error) {
 			throw this.toFileSystemProviderError(error);
 		}
-	}
-
-	private toType(entry: Stats | Dirent, isSymbolicLink = entry.isSymbolicLink()): FileType {
-		if (isSymbolicLink) {
-			return FileType.SymbolicLink | (entry.isDirectory() ? FileType.Directory : FileType.File);
-		}
-
-		return entry.isFile() ? FileType.File : entry.isDirectory() ? FileType.Directory : FileType.Unknown;
 	}
 
 	//#endregion


### PR DESCRIPTION
This reverts commit da5fb7d5b865aa522abc7e82c10b746834b98639.

@isidorn this restores the code for reading directories as it used to be to fix https://github.com/microsoft/vscode/issues/78743