### PR TITLE
Use env path to resolve executable in TerminalProcess

### DIFF
--- a/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -11,12 +11,10 @@ import * as fs from 'fs';
 import { Event, Emitter } from 'vs/base/common/event';
 import { getWindowsBuildNumber } from 'vs/workbench/contrib/terminal/node/terminal';
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { IShellLaunchConfig, ITerminalChildProcess, SHELL_PATH_INVALID_EXIT_CODE, SHELL_PATH_DIRECTORY_EXIT_CODE, SHELL_CWD_INVALID_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
+import { IShellLaunchConfig, ITerminalChildProcess, SHELL_CWD_INVALID_EXIT_CODE } from 'vs/workbench/contrib/terminal/common/terminal';
 import { exec } from 'child_process';
 import { ILogService } from 'vs/platform/log/common/log';
 import { stat } from 'vs/base/node/pfs';
-import { findExecutable } from 'vs/workbench/contrib/terminal/node/terminalEnvironment';
-import { URI } from 'vs/base/common/uri';
 
 export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 	private _exitCode: number;
@@ -80,21 +78,7 @@ export class TerminalProcess implements ITerminalChildProcess, IDisposable {
 			}
 		});
 
-		const exectuableVerification = stat(shellLaunchConfig.executable!).then(async stat => {
-			if (!stat.isFile() && !stat.isSymbolicLink()) {
-				return Promise.reject(stat.isDirectory() ? SHELL_PATH_DIRECTORY_EXIT_CODE : SHELL_PATH_INVALID_EXIT_CODE);
-			}
-		}, async (err) => {
-			if (err && err.code === 'ENOENT') {
-				let cwd = shellLaunchConfig.cwd instanceof URI ? shellLaunchConfig.cwd.path : shellLaunchConfig.cwd!;
-				const executable = await findExecutable(shellLaunchConfig.executable!, cwd);
-				if (!executable) {
-					return Promise.reject(SHELL_PATH_INVALID_EXIT_CODE);
-				}
-			}
-		});
-
-		Promise.all([cwdVerification, exectuableVerification]).then(() => {
+		Promise.all([cwdVerification]).then(() => {
 			this.setupPtyProcess(shellLaunchConfig, options);
 		}).catch((exitCode: number) => {
 			return this._launchFailed(exitCode);


### PR DESCRIPTION
Candidate fix for #78898

A more complete fix in master would be to use the env to resolve the executable in the TerminalProcess.