### PR TITLE
Strip a path list out of an error message

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/serverError.ts
+++ b/extensions/typescript-language-features/src/tsServer/serverError.ts
@@ -40,7 +40,16 @@ export class TypeScriptServerError extends Error {
 		if (errorText) {
 			const errorPrefix = 'Error processing request. ';
 			if (errorText.startsWith(errorPrefix)) {
-				const prefixFreeErrorText = errorText.substr(errorPrefix.length);
+				let prefixFreeErrorText = errorText.substr(errorPrefix.length);
+
+				// Prior to https://github.com/microsoft/TypeScript/pull/32785, this error
+				// returned and excessively long and detailed list of paths.  Since server-side
+				// filtering doesn't have sufficient granularity to drop these specific
+				// messages, we sanitize them here.
+				if (prefixFreeErrorText.indexOf('Could not find sourceFile') >= 0) {
+					prefixFreeErrorText = prefixFreeErrorText.replace(/ in \[[^\]]*\]/g, '');
+				}
+
 				const newlineIndex = prefixFreeErrorText.indexOf('\n');
 				if (newlineIndex >= 0) {
 					// Newline expected between message and stack.


### PR DESCRIPTION
The error, which happens quite frequently, contains an excessively long path list.  The message itself was cleaned up in https://github.com/microsoft/TypeScript/pull/32785 but we add some additional filtering to the editor since older server versions are still in use.