### PR TITLE
Fix #79047 - Wasted stat call on workspace root 

### DIFF
--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -158,12 +158,10 @@ export class ExplorerService implements IExplorerService {
 		// Stat needs to be resolved first and then revealed
 		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: this.sortOrder === 'modified' };
 		const workspaceFolder = this.contextService.getWorkspaceFolder(resource);
-		const rootUri = workspaceFolder ? workspaceFolder.uri : this.roots[0].resource;
-
-		// Do not waste time looking in a different scheme
-		if (resource.scheme !== rootUri.scheme) {
+		if (workspaceFolder === null) {
 			return Promise.resolve(undefined);
 		}
+		const rootUri = workspaceFolder.uri;
 
 		const root = this.roots.filter(r => r.resource.toString() === rootUri.toString()).pop()!;
 

--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -159,6 +159,12 @@ export class ExplorerService implements IExplorerService {
 		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: this.sortOrder === 'modified' };
 		const workspaceFolder = this.contextService.getWorkspaceFolder(resource);
 		const rootUri = workspaceFolder ? workspaceFolder.uri : this.roots[0].resource;
+
+		// Do not waste time looking in a different scheme
+		if (resource.scheme !== rootUri.scheme) {
+			return Promise.resolve(undefined);
+		}
+
 		const root = this.roots.filter(r => r.resource.toString() === rootUri.toString()).pop()!;
 
 		try {


### PR DESCRIPTION
This fix prevents a wasted stat call being made to a FileSystemProvider in specific circumstances. See #79047