### PR TITLE
Skip using vscode's encoding for port forwarded uris

### DIFF
--- a/src/vs/workbench/contrib/webview/common/portMapping.ts
+++ b/src/vs/workbench/contrib/webview/common/portMapping.ts
@@ -47,16 +47,16 @@ export class WebviewPortMappingManager extends Disposable {
 				if (this.extensionLocation && this.extensionLocation.scheme === REMOTE_HOST_SCHEME) {
 					const tunnel = await this.getOrCreateTunnel(mapping.extensionHostPort);
 					if (tunnel) {
-						return uri.with({
+						return encodeURI(uri.with({
 							authority: `127.0.0.1:${tunnel.tunnelLocalPort}`,
-						}).toString();
+						}).toString(true));
 					}
 				}
 
 				if (mapping.webviewPort !== mapping.extensionHostPort) {
-					return uri.with({
+					return encodeURI(uri.with({
 						authority: `${requestLocalHostInfo.address}:${mapping.extensionHostPort}`
-					}).toString();
+					}).toString(true));
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote-release/issues/1132

In 1.37, i believe how we encode uris changed which broke port forwarding if the forwarded uri uses query parameters. To fix this, I switch from using VS Code's encoding for URIs to encoding the uri ourselves