### PR TITLE
Fix issue with CustomExecutions not working through tasks.executeTask

### DIFF
--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -695,5 +695,11 @@ export class ExtHostTask implements ExtHostTaskShape {
 		if (extensionCallback2) {
 			this._activeCustomExecutions2.delete(execution.id);
 		}
+
+		// Technically we don't really need to do this, however, if an extension
+		// is executing a task through "executeTask" over and over again
+		// with different properties in the task definition, then this list
+		// could grow indefinitely, something we don't want.
+		this._providedCustomExecutions2.clear();
 	}
 }

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -696,10 +696,16 @@ export class ExtHostTask implements ExtHostTaskShape {
 			this._activeCustomExecutions2.delete(execution.id);
 		}
 
+		const lastCustomExecution = this._providedCustomExecutions2.get(execution.id);
 		// Technically we don't really need to do this, however, if an extension
 		// is executing a task through "executeTask" over and over again
 		// with different properties in the task definition, then this list
 		// could grow indefinitely, something we don't want.
 		this._providedCustomExecutions2.clear();
+		// We do still need to hang on to the last custom execution so that the
+		// Rerun Task command doesn't choke when it tries to rerun a custom execution
+		if (lastCustomExecution) {
+			this._providedCustomExecutions2.set(execution.id, lastCustomExecution);
+		}
 	}
 }

--- a/src/vs/workbench/api/node/extHostTask.ts
+++ b/src/vs/workbench/api/node/extHostTask.ts
@@ -444,6 +444,14 @@ export class ExtHostTask implements ExtHostTaskShape {
 			if (dto === undefined) {
 				return Promise.reject(new Error('Task is not valid'));
 			}
+
+			// If this task is a custom execution, then we need to save it away
+			// in the provided custom execution map that is cleaned up after the
+			// task is executed.
+			if (CustomExecution2DTO.is(dto.execution)) {
+				await this.addCustomExecution2(dto, <vscode.Task2>task);
+			}
+
 			return this._proxy.$executeTask(dto).then(value => this.getTaskExecution(value, task));
 		}
 	}
@@ -528,11 +536,6 @@ export class ExtHostTask implements ExtHostTaskShape {
 		if (!handler) {
 			return Promise.reject(new Error('no handler found'));
 		}
-
-		// For custom execution tasks, we need to store the execution objects locally
-		// since we obviously cannot send callback functions through the proxy.
-		// So, clear out any existing ones.
-		this._providedCustomExecutions2.clear();
 
 		// Set up a list of task ID promises that we can wait on
 		// before returning the provided tasks. The ensures that


### PR DESCRIPTION
This address issue #79123 

The extension task host was not storing the custom execution object from the extension inside the map it maintain for custom executions. So when the extension task host was asked to execute the custom execution, it wouldn't be able to locate it. That the first problem.

The second issue is that after executeTask is called, it delegates to the main thread task service which called provide tasks on the extension. Immediately before calling the extension, the extension host would clear out the map mentioned above (thereby completely removing the one added during executeTask).

Talked this over with @alexr00 and we agreed that there was no reason to clear that map in the first place since the entries are just re-set every time anyway. However, the executeTask scenario is a little different as it allows executeTask to be called with tasks that were not "provided" by the task provider's "provideTask" apis. So you could end up with a lot of entries in that map that never get completed. So, to prevent that from happening, when a custom execution completes, the map is cleared.