### PR TITLE
fix #78153: can't create folder on newly created folder

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -939,8 +939,8 @@ async function openExplorerAndCreate(accessor: ServicesAccessor, isFolder: boole
 		explorerService.setEditable(newStat, {
 			validationMessage: value => validateFileName(newStat, value),
 			onFinish: (value, success) => {
-				folder.removeChild(newStat);
 				explorerService.setEditable(newStat, null);
+				folder.removeChild(newStat);
 				if (success) {
 					onSuccess(value);
 				} else {


### PR DESCRIPTION
Resolves #78153.

The problem here was that, when right-clicking on a newly-created, still-selected folder and selecting 'New Folder', the folder name entry would disappear immediately. This fixes that issue by making sure we still have the temporary folder name entry child when we fire `ExplorerService._onDidChangeEditable`. I don't know this codebase one bit, but I think it's because `_onDidChangeEditable` somehow leads to a rerender.