### PR TITLE
fix: support reopen with encoding in browser build.

### DIFF
--- a/src/vs/base/common/buffer.ts
+++ b/src/vs/base/common/buffer.ts
@@ -66,12 +66,12 @@ export class VSBuffer {
 		this.byteLength = this.buffer.byteLength;
 	}
 
-	toString(): string {
+	toString(encoding: string = 'uft8'): string {
 		if (hasBuffer) {
 			return this.buffer.toString();
 		} else {
-			if (!textDecoder) {
-				textDecoder = new TextDecoder();
+			if (!textDecoder || textDecoder.encoding !== encoding) {
+				textDecoder = new TextDecoder(encoding);
 			}
 			return textDecoder.decode(this.buffer);
 		}

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -53,7 +53,7 @@ interface ITextStream {
 }
 
 export function createTextBufferFactoryFromStream(stream: ITextStream, filter?: (chunk: string) => string, validator?: (chunk: string) => Error | undefined): Promise<model.ITextBufferFactory>;
-export function createTextBufferFactoryFromStream(stream: VSBufferReadableStream, filter?: (chunk: VSBuffer) => VSBuffer, validator?: (chunk: VSBuffer) => Error | undefined): Promise<model.ITextBufferFactory>;
+export function createTextBufferFactoryFromStream(stream: VSBufferReadableStream, filter?: (chunk: VSBuffer) => VSBuffer | string, validator?: (chunk: VSBuffer) => Error | undefined): Promise<model.ITextBufferFactory>;
 export function createTextBufferFactoryFromStream(stream: ITextStream | VSBufferReadableStream, filter?: (chunk: any) => string | VSBuffer, validator?: (chunk: any) => Error | undefined): Promise<model.ITextBufferFactory> {
 	return new Promise<model.ITextBufferFactory>((resolve, reject) => {
 		const builder = createTextBufferBuilder();


### PR DESCRIPTION
Hello, I've try the browser (or your call it web) build of vscode and it's awesome !

But I find some problems with "Reopen with Encoding", I've to work with some `gbk` encoded files but the browser build only supports `utf8`, so I write this patch to fix this problem and it can handle the readFile case.

However, to make it works on writeFile case, I need to import a third-party lib called [`text-encoding`](https://github.com/inexorabletash/text-encoding) to handle the encoding of `gbk` strings since the standard `TextEncoder` API only support the `utf8` encoding format. I don't know whether it's appropriate to import this library in vscode. So I just commit the readFile case patch in this pull request.

If you accept my solution for the writeFile case, I will commit the patch of it in this pull request.

Thanks for your work and waiting for your reply.

: )