### PR TITLE
Fix #79240 - Duplicated '(read-only)' suffix on titlebar name

### DIFF
--- a/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
@@ -203,17 +203,20 @@ export class FileEditorInput extends EditorInput implements IFileEditorInput {
 		switch (verbosity) {
 			case Verbosity.SHORT:
 				title = this.shortTitle;
+				// already decorated by getName()
 				break;
 			default:
 			case Verbosity.MEDIUM:
 				title = this.mediumTitle;
+				title = this.decorateLabel(title);
 				break;
 			case Verbosity.LONG:
 				title = this.longTitle;
+				title = this.decorateLabel(title);
 				break;
 		}
 
-		return this.decorateLabel(title);
+		return title;
 	}
 
 	private decorateLabel(label: string): string {


### PR DESCRIPTION
This fixes #79240, the '(read-only) (read-only)' suffix that appears in the window titlebar when a file is opened from a read-only FileSystemProvider