### PR TITLE
storage - refactor: GlobalStorageDatabaseChannel should dependents in IStorageMainService

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -560,7 +560,7 @@ export class CodeApplication extends Disposable {
 		electronIpcServer.registerChannel('url', urlChannel);
 
 		const storageMainService = accessor.get(IStorageMainService);
-		const storageChannel = this._register(new GlobalStorageDatabaseChannel(this.logService, storageMainService as StorageMainService));
+		const storageChannel = this._register(new GlobalStorageDatabaseChannel(this.logService, storageMainService));
 		electronIpcServer.registerChannel('storage', storageChannel);
 
 		// Log level management

--- a/src/vs/platform/storage/node/storageIpc.ts
+++ b/src/vs/platform/storage/node/storageIpc.ts
@@ -5,7 +5,7 @@
 
 import { IChannel, IServerChannel } from 'vs/base/parts/ipc/common/ipc';
 import { Event, Emitter } from 'vs/base/common/event';
-import { StorageMainService, IStorageChangeEvent } from 'vs/platform/storage/node/storageMainService';
+import { IStorageChangeEvent, IStorageMainService } from 'vs/platform/storage/node/storageMainService';
 import { IUpdateRequest, IStorageDatabase, IStorageItemsChangeEvent } from 'vs/base/parts/storage/common/storage';
 import { mapToSerializable, serializableToMap, values } from 'vs/base/common/map';
 import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -38,7 +38,7 @@ export class GlobalStorageDatabaseChannel extends Disposable implements IServerC
 
 	constructor(
 		private logService: ILogService,
-		private storageMainService: StorageMainService
+		private storageMainService: IStorageMainService
 	) {
 		super();
 

--- a/src/vs/platform/storage/node/storageMainService.ts
+++ b/src/vs/platform/storage/node/storageMainService.ts
@@ -34,6 +34,10 @@ export interface IStorageMainService {
 	 */
 	readonly onWillSaveState: Event<void>;
 
+	readonly items: Map<string, string>;
+
+	initialize(): Promise<void>;
+
 	/**
 	 * Retrieve an element stored with the given key from storage. Use
 	 * the provided defaultValue if the element is null or undefined.


### PR DESCRIPTION
I am learning the vscode source code and seeing that this is better, so I submitted the pr. If there is a problem with pr, you can close it directly.

