### PR TITLE
fix #78465 Markdown Preview scroll remains same after clicking on some other…

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -286,6 +286,8 @@ export class MarkdownPreview extends Disposable {
 		const editor = vscode.window.activeTextEditor;
 		if (editor && editor.document.uri.fsPath === resource.fsPath) {
 			this.line = getVisibleLine(editor);
+		} else {
+			this.line = 0;
 		}
 
 		// If we have changed resources, cancel any pending updates


### PR DESCRIPTION
Fix #78465 , vertical scroll is reset if opening hyperlink to another doc from markdown preview