### PR TITLE
Fix-78915 Webview not handing CustomEvent

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -336,7 +336,7 @@ export class ElectronWebviewBasedWebview extends Disposable implements Webview {
 							return;
 						}
 						catch (TypeError) {
-							//CustomEvent was treated as MouseEvent - https://github.com/microsoft/vscode/issues/78915
+							// CustomEvent was treated as MouseEvent so don't do anything - https://github.com/microsoft/vscode/issues/78915
 							return;
 						}
 

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -327,12 +327,19 @@ export class ElectronWebviewBasedWebview extends Disposable implements Webview {
 					{
 						const rawEvent = event.args[0];
 						const bounds = this._webview.getBoundingClientRect();
-						window.dispatchEvent(new MouseEvent(rawEvent.type, {
-							...rawEvent,
-							clientX: rawEvent.clientX + bounds.left,
-							clientY: rawEvent.clientY + bounds.top,
-						}));
-						return;
+						try {
+							window.dispatchEvent(new MouseEvent(rawEvent.type, {
+								...rawEvent,
+								clientX: rawEvent.clientX + bounds.left,
+								clientY: rawEvent.clientY + bounds.top,
+							}));
+							return;
+						}
+						catch (TypeError) {
+							//CustomEvent was treated as MouseEvent - https://github.com/microsoft/vscode/issues/78915
+							return;
+						}
+
 					}
 
 				case 'did-set-content':


### PR DESCRIPTION
@mjbvz , Here is the fix for #78915.
I could have just changed `MouseEvent` to `CustomEvent` [here](https://github.com/microsoft/vscode/blob/02702327c1fea8b6c6425b84adb004c41cb84769/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts#L377) but I thought adding a try catch was a better approach ( Please let me know if you find it otherwise or need some more change)