### PR TITLE
Fix-79525 New pattern to Preserve Case ( hyphen separated variables)

### DIFF
--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -28,8 +28,7 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 
 function validateSpecificSpecialCharacter(matches: string[], pattern: string, specialCharacter: string): boolean {
 	const doesConatinSpecialCharacter = matches[0].indexOf(specialCharacter) !== -1 && pattern.indexOf(specialCharacter) !== -1;
-	const doesConatinSameNumberOfSpecialCharacters = matches[0].split(specialCharacter).length === pattern.split(specialCharacter).length;
-	return doesConatinSpecialCharacter && doesConatinSameNumberOfSpecialCharacters;
+	return doesConatinSpecialCharacter && matches[0].split(specialCharacter).length === pattern.split(specialCharacter).length;
 }
 
 function buildReplaceStringForSpecificSpecialCharacter(matches: string[], pattern: string, specialCharacter: string): string {

--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -12,7 +12,11 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 		} else if (matches[0].toLowerCase() === matches[0]) {
 			return pattern.toLowerCase();
 		} else if (strings.containsUppercaseCharacter(matches[0][0])) {
-			return pattern[0].toUpperCase() + pattern.substr(1);
+			if (validateHyphenPattern(matches, pattern)) {
+				return buildReplaceStringForHyphenPatterns(matches, pattern);
+			} else {
+				return pattern[0].toUpperCase() + pattern.substr(1);
+			}
 		} else {
 			// we don't understand its pattern yet.
 			return pattern;
@@ -20,4 +24,21 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 	} else {
 		return pattern;
 	}
+}
+
+function validateHyphenPattern(matches: string[], pattern: string): boolean {
+	const doesConatinHyphen = matches[0].indexOf('-') !== -1 && pattern.indexOf('-') !== -1;
+	const doesConatinSameNumberOfHyphens = matches[0].split('-').length === pattern.split('-').length;
+	return doesConatinHyphen && doesConatinSameNumberOfHyphens;
+}
+
+function buildReplaceStringForHyphenPatterns(matches: string[], pattern: string): string {
+	const splitPatternAtHyphen = pattern.split('-');
+	const splitMatchAtHyphen = matches[0].split('-');
+	let replaceString: string = '';
+
+	splitPatternAtHyphen.forEach((splitValues, index) => {
+		replaceString += buildReplaceStringWithCasePreserved([splitMatchAtHyphen[index]], splitValues) + '-';
+	});
+	return replaceString.slice(0, -1);
 }

--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -12,8 +12,8 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 		} else if (matches[0].toLowerCase() === matches[0]) {
 			return pattern.toLowerCase();
 		} else if (strings.containsUppercaseCharacter(matches[0][0])) {
-			if (validateHyphenPattern(matches, pattern)) {
-				return buildReplaceStringForHyphenPatterns(matches, pattern);
+			if (validateSpecificSpecialCharacter(matches, pattern, '-')) {
+				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '-');
 			} else {
 				return pattern[0].toUpperCase() + pattern.substr(1);
 			}
@@ -26,19 +26,19 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 	}
 }
 
-function validateHyphenPattern(matches: string[], pattern: string): boolean {
-	const doesConatinHyphen = matches[0].indexOf('-') !== -1 && pattern.indexOf('-') !== -1;
-	const doesConatinSameNumberOfHyphens = matches[0].split('-').length === pattern.split('-').length;
-	return doesConatinHyphen && doesConatinSameNumberOfHyphens;
+function validateSpecificSpecialCharacter(matches: string[], pattern: string, specialCharacter: string): boolean {
+	const doesConatinSpecialCharacter = matches[0].indexOf(specialCharacter) !== -1 && pattern.indexOf(specialCharacter) !== -1;
+	const doesConatinSameNumberOfSpecialCharacters = matches[0].split(specialCharacter).length === pattern.split(specialCharacter).length;
+	return doesConatinSpecialCharacter && doesConatinSameNumberOfSpecialCharacters;
 }
 
-function buildReplaceStringForHyphenPatterns(matches: string[], pattern: string): string {
-	const splitPatternAtHyphen = pattern.split('-');
-	const splitMatchAtHyphen = matches[0].split('-');
+function buildReplaceStringForSpecificSpecialCharacter(matches: string[], pattern: string, specialCharacter: string): string {
+	const splitPatternAtSpecialCharacter = pattern.split(specialCharacter);
+	const splitMatchAtSpecialCharacter = matches[0].split(specialCharacter);
 	let replaceString: string = '';
-
-	splitPatternAtHyphen.forEach((splitValues, index) => {
-		replaceString += buildReplaceStringWithCasePreserved([splitMatchAtHyphen[index]], splitValues) + '-';
+	splitPatternAtSpecialCharacter.forEach((splitValue, index) => {
+		replaceString += buildReplaceStringWithCasePreserved([splitMatchAtSpecialCharacter[index]], splitValue) + specialCharacter;
 	});
+
 	return replaceString.slice(0, -1);
 }

--- a/src/vs/editor/contrib/find/test/replacePattern.test.ts
+++ b/src/vs/editor/contrib/find/test/replacePattern.test.ts
@@ -176,6 +176,13 @@ suite('Replace Pattern test', () => {
 		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'Def');
 		actual = ['aBC'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'Def');
+
+		actual = ['Foo-Bar'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-Newbar');
+		actual = ['Foo-Bar-Abc'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar-newabc'), 'Newfoo-Newbar-Newabc');
+		actual = ['Foo-Bar-abc'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-newbar');
 	});
 
 	test('preserve case', () => {
@@ -198,5 +205,17 @@ suite('Replace Pattern test', () => {
 		assert.equal(actual, 'Def');
 		actual = replacePattern.buildReplaceString(['aBC'], true);
 		assert.equal(actual, 'Def');
+
+		replacePattern = parseReplaceString('newfoo-newbar');
+		actual = replacePattern.buildReplaceString(['Foo-Bar'], true);
+		assert.equal(actual, 'Newfoo-Newbar');
+
+		replacePattern = parseReplaceString('newfoo-newbar-newabc');
+		actual = replacePattern.buildReplaceString(['Foo-Bar-Abc'], true);
+		assert.equal(actual, 'Newfoo-Newbar-Newabc');
+
+		replacePattern = parseReplaceString('newfoo-newbar');
+		actual = replacePattern.buildReplaceString(['Foo-Bar-abc'], true);
+		assert.equal(actual, 'Newfoo-newbar');
 	});
 });


### PR DESCRIPTION
@roblourens , Added this logic for hyphen casing example I mentioned in #79525.
I have handled all the edge cases I would think of , Please review this and let me know.

PS : I think underscore will also be an option ( Just like what I have done here for hyphens ) but it has to be either all hyphens or all underscore and not a mix( For example `foo-bar_item` ) and I know no one use names variables like that but handling it in code is complicated. ( Maybe if you say yes to underscore then I can open a new issue and then implement that.

FYI : @rebornix .