### PR TITLE
fix for links in markdown broken if url contains encoded parameters

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -284,6 +284,17 @@ export class URI implements UriComponents {
 		if (!match) {
 			return new _URI(_empty, _empty, _empty, _empty, _empty);
 		}
+		// fix #79474, if http/https resource save query string to avoid decoding/encoding
+		if (match[2] && (match[2] === 'http' || match[2] === 'https')) {
+			return new _URI(
+				match[2] || _empty,
+				decodeURIComponent(match[4] || _empty),
+				decodeURIComponent(match[5] || _empty),
+				match[7],
+				decodeURIComponent(match[9] || _empty),
+				_strict
+			);
+		}
 		return new _URI(
 			match[2] || _empty,
 			decodeURIComponent(match[4] || _empty),
@@ -659,7 +670,11 @@ function _asFormatted(uri: URI, skipEncoding: boolean): string {
 	}
 	if (query) {
 		res += '?';
-		res += encoder(query, false);
+		if (scheme === 'http' || scheme === 'https') {
+			res += query;
+		} else {
+			res += encoder(query, false);
+		}
 	}
 	if (fragment) {
 		res += '#';

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1355,7 +1355,8 @@ declare module 'vscode' {
 		 * the `skipEncoding`-argument: `uri.toString(true)`.
 		 *
 		 * @param skipEncoding Do not percentage-encode the result, defaults to `false`. Note that
-		 *	the `#` and `?` characters occurring in the path will always be encoded.
+		 *	the `#` and `?` characters occurring in the path will always be encoded unless characters
+		 *	are included in query string of a http/https resource.
 		 * @returns A string representation of this Uri.
 		 */
 		toString(skipEncoding?: boolean): string;

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -373,7 +373,13 @@ export class ElectronWindow extends Disposable {
 				const scheme = resource.scheme.toLowerCase();
 				const preferOpenExternal = (scheme === Schemas.mailto || scheme === Schemas.http || scheme === Schemas.https);
 				if ((options && options.openExternal) || preferOpenExternal) {
-					const success = await $this.windowsService.openExternal(encodeURI(resource.toString(true)));
+					let resourceUri: string = encodeURI(resource.toString(true));
+
+					// don't decode resource if http/https resource
+					if (scheme === 'http' || scheme === 'https') {
+						resourceUri = resource.toString(true);
+					}
+					const success = await $this.windowsService.openExternal(resourceUri);
 					if (!success && resource.scheme === Schemas.file) {
 						// if opening failed, and this is a file, we can still try to reveal it
 						await $this.windowsService.showItemInFolder(resource);


### PR DESCRIPTION
fix hover link in #79474 , original query string is preserved
