### PR TITLE
Focus correct SCM repo when restoring editors

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmActivity.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmActivity.ts
@@ -114,7 +114,11 @@ export class SCMStatusController implements IWorkbenchContribution {
 		this.disposables.push(disposable);
 
 		if (!this.focusedRepository) {
-			this.onDidFocusRepository(repository);
+			if (this.editorService.activeEditor) {
+				this.onDidActiveEditorChange();
+			} else {
+				this.onDidFocusRepository(repository);
+			}
 		}
 	}
 


### PR DESCRIPTION
When adding repositories during restore, we automatically focus the first added in the SCM status bar. This is incorrect when there are open editors from a different repository. Check this before focussing and give active editor priority, but still auto-focus new repository if no active editor exists.

Closes #67670.