### PR TITLE
Issue #79599 - CSS LS fails if InitializationOptions.dataPaths not set

### DIFF
--- a/extensions/css-language-features/server/src/cssServerMain.ts
+++ b/extensions/css-language-features/server/src/cssServerMain.ts
@@ -103,7 +103,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 		}
 	}
 
-	const dataPaths: string[] = params.initializationOptions.dataPaths;
+	const dataPaths: string[] = params.initializationOptions.dataPaths || [];
 	const customDataProviders = getDataProviders(dataPaths);
 
 	function getClientCapability<T>(name: string, def: T) {


### PR DESCRIPTION
Signed-off-by: Mickael Istria <mistria@redhat.com>