### PR TITLE
Fixing Leaving Zen Mode disables line number 

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -684,7 +684,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.centerEditorLayout(false, true);
 			}
 
-			setLineNumbers();
+			setLineNumbers('on');
 
 			// Status bar and activity bar visibility come from settings -> update their visibility.
 			this.doUpdateLayoutConfiguration(true);


### PR DESCRIPTION
## Addressing the issue : #79608

### According to the Issue:
![Untitled](https://user-images.githubusercontent.com/45679674/63494952-7e295d00-c4dc-11e9-8e48-a9ecce050b76.gif)

### After fix :
![Untitled_1](https://user-images.githubusercontent.com/45679674/63494974-88e3f200-c4dc-11e9-8b12-ea2c8d8e9039.gif)

*When all the extensions are disabled.
