### PR TITLE
Fix-79658 New pattern to Preserve Case ( underscore separated variables)

### DIFF
--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -12,8 +12,12 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 		} else if (matches[0].toLowerCase() === matches[0]) {
 			return pattern.toLowerCase();
 		} else if (strings.containsUppercaseCharacter(matches[0][0])) {
-			if (validateSpecificSpecialCharacter(matches, pattern, '-')) {
+			const containsHyphens = validateSpecificSpecialCharacter(matches, pattern, '-');
+			const containsUnderscores = validateSpecificSpecialCharacter(matches, pattern, '_');
+			if (containsHyphens && !containsUnderscores) {
 				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '-');
+			} else if (!containsHyphens && containsUnderscores) {
+				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '_');
 			} else {
 				return pattern[0].toUpperCase() + pattern.substr(1);
 			}

--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -31,8 +31,8 @@ export function buildReplaceStringWithCasePreserved(matches: string[] | null, pa
 }
 
 function validateSpecificSpecialCharacter(matches: string[], pattern: string, specialCharacter: string): boolean {
-	const doesConatinSpecialCharacter = matches[0].indexOf(specialCharacter) !== -1 && pattern.indexOf(specialCharacter) !== -1;
-	return doesConatinSpecialCharacter && matches[0].split(specialCharacter).length === pattern.split(specialCharacter).length;
+	const doesContainSpecialCharacter = matches[0].indexOf(specialCharacter) !== -1 && pattern.indexOf(specialCharacter) !== -1;
+	return doesContainSpecialCharacter && matches[0].split(specialCharacter).length === pattern.split(specialCharacter).length;
 }
 
 function buildReplaceStringForSpecificSpecialCharacter(matches: string[], pattern: string, specialCharacter: string): string {

--- a/src/vs/editor/contrib/find/test/replacePattern.test.ts
+++ b/src/vs/editor/contrib/find/test/replacePattern.test.ts
@@ -183,6 +183,15 @@ suite('Replace Pattern test', () => {
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar-newabc'), 'Newfoo-Newbar-Newabc');
 		actual = ['Foo-Bar-abc'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-newbar');
+
+		actual = ['Foo_Bar'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_Newbar');
+		actual = ['Foo_Bar_Abc'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar_newabc'), 'Newfoo_Newbar_Newabc');
+		actual = ['Foo_Bar_abc'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_newbar');
+		actual = ['Foo_Bar-abc'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar-abc'), 'Newfoo_newbar-abc');
 	});
 
 	test('preserve case', () => {
@@ -217,5 +226,21 @@ suite('Replace Pattern test', () => {
 		replacePattern = parseReplaceString('newfoo-newbar');
 		actual = replacePattern.buildReplaceString(['Foo-Bar-abc'], true);
 		assert.equal(actual, 'Newfoo-newbar');
+
+		replacePattern = parseReplaceString('newfoo_newbar');
+		actual = replacePattern.buildReplaceString(['Foo_Bar'], true);
+		assert.equal(actual, 'Newfoo_Newbar');
+
+		replacePattern = parseReplaceString('newfoo_newbar_newabc');
+		actual = replacePattern.buildReplaceString(['Foo_Bar_Abc'], true);
+		assert.equal(actual, 'Newfoo_Newbar_Newabc');
+
+		replacePattern = parseReplaceString('newfoo_newbar');
+		actual = replacePattern.buildReplaceString(['Foo_Bar_abc'], true);
+		assert.equal(actual, 'Newfoo_newbar');
+
+		replacePattern = parseReplaceString('newfoo_newbar-abc');
+		actual = replacePattern.buildReplaceString(['Foo_Bar-abc'], true);
+		assert.equal(actual, 'Newfoo_newbar-abc');
 	});
 });


### PR DESCRIPTION
@roblourens and @rebornix , Here is the implementation to handle underscore characters as well to fix #79658 ( As mentioned implemented it as two disjoint sets of replacement )
Please review this and let me know , Thanks :) 

PS : if you feel the request itself is not a valid one then feel free to close it :) ( I thought underscore was also useful in some places ) 