### PR TITLE
Find in selection: Don't expand a multiline find scope to line start/end (#80008)

### DIFF
--- a/src/vs/editor/contrib/find/findModel.ts
+++ b/src/vs/editor/contrib/find/findModel.ts
@@ -178,9 +178,6 @@ export class FindModelBoundToEditorModel {
 			if (findScope.startLineNumber !== findScope.endLineNumber) {
 				if (findScope.endColumn === 1) {
 					findScope = new Range(findScope.startLineNumber, 1, findScope.endLineNumber - 1, this._editor.getModel().getLineMaxColumn(findScope.endLineNumber - 1));
-				} else {
-					// multiline find scope => expand to line starts / ends
-					findScope = new Range(findScope.startLineNumber, 1, findScope.endLineNumber, this._editor.getModel().getLineMaxColumn(findScope.endLineNumber));
 				}
 			}
 		}


### PR DESCRIPTION
Re #80008.

## Previous behavior
When we had a multiline selection, it would automatically be expanded to the start of the first line / end of the last line before a "Find in selection" was attempted (same goes for a Replace).

This behavior may lead to confusion as to why results _outside_ the specified selection are found/replaced (imho, the use case presented in #80008 is entirely reasonable).

## New behavior
The selection is taken as-is, without expansion. Thus, only results inside the selection range are found/replaced.

## Notes
The previous behavior was introduced in https://github.com/microsoft/vscode/commit/1f0afd63edd445b74203a0bd445289e52fce04cf.
Maybe @rebornix can take a look and chime in as to why this change was made in the first place?
In my testing, I have not come across any issues with this change, but I may miss something here.