### PR TITLE
added explorer.openToBottom

### DIFF
--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -26,6 +26,9 @@ export type ACTIVE_GROUP_TYPE = typeof ACTIVE_GROUP;
 export const SIDE_GROUP = -2;
 export type SIDE_GROUP_TYPE = typeof SIDE_GROUP;
 
+export const BOTTOM_GROUP = -3;
+export type BOTTOM_GROUP_TYPE = typeof BOTTOM_GROUP;
+
 export interface IOpenEditorOverrideHandler {
 	(editor: IEditorInput, options: IEditorOptions | ITextEditorOptions | undefined, group: IEditorGroup): IOpenEditorOverride | undefined;
 }


### PR DESCRIPTION
Creates an action called explorer.openToBottom which will open files to the bottom split screen.

This action can have a keybinding assigned to it.