### PR TITLE
chore: update tsc target

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,7 @@
 		"preserveConstEnums": true,
 		"sourceMap": false,
 		"outDir": "../out",
-		"target": "es6",
+		"target": "es2017",
 		"lib": [
 			"dom",
 			"es5",


### PR DESCRIPTION
Update tsc target to "es2017" since vscode now using electorn 4.2.7
which based on chromium@68 and node@10.11.0.

This will enable more esnext features and reduce the bundle size.

According to: https://kangax.github.io/compat-table/es2016plus/