### PR TITLE
Negative hashtags when submitting negative feedback.

### DIFF
--- a/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
@@ -20,13 +20,14 @@ class TwitterFeedbackService implements IFeedbackDelegate {
 	private static TWITTER_URL: string = 'https://twitter.com/intent/tweet';
 	private static VIA_NAME: string = 'code';
 	private static HASHTAGS: string[] = ['HappyCoding'];
+	private static NEGATIVE_HASHTAGS: string[] = ['IHateCoding'];
 
-	private combineHashTagsAsString(): string {
-		return TwitterFeedbackService.HASHTAGS.join(',');
+	private combineHashTagsAsString(sentient: number): string {
+		return sentient === 1 ? TwitterFeedbackService.HASHTAGS.join(',') : TwitterFeedbackService.NEGATIVE_HASHTAGS.join(',');
 	}
 
 	submitFeedback(feedback: IFeedback, openerService: IOpenerService): void {
-		const queryString = `?${feedback.sentiment === 1 ? `hashtags=${this.combineHashTagsAsString()}&` : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${encodeURIComponent(feedback.feedback)}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
+		const queryString = `?${feedback.sentiment === 1 ? `hashtags=${this.combineHashTagsAsString(feedback.sentiment)}&` : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${encodeURIComponent(feedback.feedback)}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
 		const url = TwitterFeedbackService.TWITTER_URL + queryString;
 
 		openerService.open(URI.parse(url));
@@ -38,6 +39,10 @@ class TwitterFeedbackService implements IFeedbackDelegate {
 			TwitterFeedbackService.HASHTAGS.forEach(element => {
 				length += element.length + 2;
 			});
+		} else {
+			TwitterFeedbackService.NEGATIVE_HASHTAGS.forEach(element => {
+				length += element.length + 2;
+			})
 		}
 
 		if (TwitterFeedbackService.VIA_NAME) {

--- a/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
@@ -27,7 +27,7 @@ class TwitterFeedbackService implements IFeedbackDelegate {
 	}
 
 	submitFeedback(feedback: IFeedback, openerService: IOpenerService): void {
-		const queryString = `?${feedback.sentiment === 1 ? `hashtags=${this.combineHashTagsAsString(feedback.sentiment)}&` : null}ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${encodeURIComponent(feedback.feedback)}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
+		const queryString = `?hashtags=${this.combineHashTagsAsString(feedback.sentiment)}&ref_src=twsrc%5Etfw&related=twitterapi%2Ctwitter&text=${encodeURIComponent(feedback.feedback)}&tw_p=tweetbutton&via=${TwitterFeedbackService.VIA_NAME}`;
 		const url = TwitterFeedbackService.TWITTER_URL + queryString;
 
 		openerService.open(URI.parse(url));

--- a/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
+++ b/src/vs/workbench/contrib/feedback/browser/feedbackStatusbarItem.ts
@@ -42,7 +42,7 @@ class TwitterFeedbackService implements IFeedbackDelegate {
 		} else {
 			TwitterFeedbackService.NEGATIVE_HASHTAGS.forEach(element => {
 				length += element.length + 2;
-			})
+			});
 		}
 
 		if (TwitterFeedbackService.VIA_NAME) {


### PR DESCRIPTION
When submitting a feedback tweet with a positive opinion, it appends `#HappyCoding` to it automatically. The problem is, nothing is appended when you write a negative opinion, which is a big **inconsistency** and a **lost opportunity**. My idea is to use `#IHateCoding` as it has the same number of letters as `#HappyCoding`, but we can come up with something more sophisticated for sure.