### PR TITLE
buildSnapPackage: use the default snapcraft target

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -238,7 +238,8 @@ function prepareSnapPackage(arch) {
 
 function buildSnapPackage(arch) {
 	const snapBuildPath = getSnapBuildPath(arch);
-	return shell.task(`cd ${snapBuildPath} && snapcraft build`);
+	// Default target for snapcraft runs: pull, build, stage and prime, and finally assembles the snap.
+	return shell.task(`cd ${snapBuildPath} && snapcraft`);
 }
 
 const BUILD_TARGETS = [


### PR DESCRIPTION
Use the default snap target for snapcraft to create the snap (build is an
intermediate lifecycle step).

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>