### PR TITLE
Fix for #26659.

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -269,6 +269,20 @@
 						"%configuration.markdown.preview.openMarkdownLinks.inEditor%"
 					]
 				},
+				"markdown.editor.openMarkdownLinks": {
+					"type": "string",
+					"default": "currentGroup",
+					"description": "%configuration.markdown.editor.openMarkdownLinks.description%",
+					"scope": "resource",
+					"enum": [
+						"currentGroup",
+						"openToSide"
+					],
+					"enumDescriptions": [
+						"%configuration.markdown.editor.openMarkdownLinks.inCurrentGroup%",
+						"%configuration.markdown.editor.openMarkdownLinks.openToSide%"
+					]
+				},
 				"markdown.trace": {
 					"type": "string",
 					"enum": [

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -23,5 +23,8 @@
 	"markdown.preview.toggleLock.title": "Toggle Preview Locking",
 	"configuration.markdown.preview.openMarkdownLinks.description": "How should clicking on links to markdown files be handled in the preview.",
 	"configuration.markdown.preview.openMarkdownLinks.inEditor": "Try to open links in the editor",
-	"configuration.markdown.preview.openMarkdownLinks.inPreview": "Try to open links in the markdown preview"
+	"configuration.markdown.preview.openMarkdownLinks.inPreview": "Try to open links in the markdown preview",
+	"configuration.markdown.editor.openMarkdownLinks.description": "How following links to markdown files be handled in the editor.",
+	"configuration.markdown.editor.openMarkdownLinks.inCurrentGroup": "Try to open links in the current editor group",
+	"configuration.markdown.editor.openMarkdownLinks.openToSide": "Try to open links to the Side"
 }

--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -52,8 +52,22 @@ export class OpenDocumentLinkCommand implements Command {
 				return this.tryRevealLine(vscode.window.activeTextEditor, args.fragment);
 			}
 		}
+
+		const config = vscode.workspace.getConfiguration('markdown', resource);
+		const openLinks = config.get<string>('editor.openMarkdownLinks', 'currentGroup');
+
+		let column: vscode.ViewColumn;
+		switch (openLinks) {
+			case 'openToSide':
+				column = vscode.ViewColumn.Beside;
+				break;
+			case 'currentGroup':
+			default:
+				column = vscode.ViewColumn.Active;
+		}
+
 		return vscode.workspace.openTextDocument(resource)
-			.then(document => vscode.window.showTextDocument(document, vscode.ViewColumn.Beside))
+			.then(document => vscode.window.showTextDocument(document, column))
 			.then(editor => this.tryRevealLine(editor, args.fragment));
 	}
 

--- a/extensions/markdown-language-features/src/commands/openDocumentLink.ts
+++ b/extensions/markdown-language-features/src/commands/openDocumentLink.ts
@@ -53,7 +53,7 @@ export class OpenDocumentLinkCommand implements Command {
 			}
 		}
 		return vscode.workspace.openTextDocument(resource)
-			.then(vscode.window.showTextDocument)
+			.then(document => vscode.window.showTextDocument(document, vscode.ViewColumn.Beside))
 			.then(editor => this.tryRevealLine(editor, args.fragment));
 	}
 


### PR DESCRIPTION
Clicking on a local file link will open up the editor on a separate editor group _(new or reuse existing one)_ as seen in the [video](https://www.youtube.com/watch?v=p8MBk1kAODg) _(For some reason the mouse pointer is not being recorded but still can an idea on what's happening)_

Fixes #26659