### PR TITLE
Improve template literals support to match TS

### DIFF
--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -328,7 +328,7 @@ namespace CompletionConfiguration {
 
 class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider {
 
-	public static readonly triggerCharacters = ['.', '"', '\'', '/', '@', '<'];
+	public static readonly triggerCharacters = ['.', '"', '\'', '`', '/', '@', '<'];
 
 	constructor(
 		private readonly client: ITypeScriptServiceClient,


### PR DESCRIPTION
PR https://github.com/microsoft/TypeScript/pull/32064 brings several improvements to how template literals are treated.

Currently I'm working on improving handling of template literals in various TS services and will update this PR if any changes needed to support updated functionality.

Current list of changes:
1. Trigger completions when user types `` ` `` in the same way as when they type `'` or `"` (as per suggestion in https://github.com/microsoft/TypeScript/pull/32064#issuecomment-525431859)