### PR TITLE
Correct kb validation for windows ctrl.

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.ts
+++ b/src/vs/editor/contrib/find/findWidget.ts
@@ -67,6 +67,7 @@ let FIND_ALL_CONTROLS_WIDTH = 17/** Find Input margin-left */ + (MAX_MATCHES_COU
 const FIND_INPUT_AREA_HEIGHT = 33; // The height of Find Widget when Replace Input is not visible.
 const ctrlEnterReplaceAllWarningPromptedKey = 'ctrlEnterReplaceAll.windows.donotask';
 
+const ctrlKeyMod = (platform.isMacintosh ? KeyMod.WinCtrl : KeyMod.CtrlCmd);
 export class FindWidgetViewZone implements IViewZone {
 	public readonly afterLineNumber: number;
 	public heightInPx: number;
@@ -775,7 +776,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 	}
 
 	private _onFindInputKeyDown(e: IKeyboardEvent): void {
-		if (e.equals(KeyMod.WinCtrl | KeyCode.Enter)) {
+		if (e.equals(ctrlKeyMod | KeyCode.Enter)) {
 			const inputElement = this._findInput.inputBox.inputElement;
 			const start = inputElement.selectionStart;
 			const end = inputElement.selectionEnd;
@@ -817,7 +818,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 	}
 
 	private _onReplaceInputKeyDown(e: IKeyboardEvent): void {
-		if (e.equals(KeyMod.WinCtrl | KeyCode.Enter)) {
+		if (e.equals(ctrlKeyMod | KeyCode.Enter)) {
 			if (platform.isWindows && platform.isNative && !this._ctrlEnterReplaceAllWarningPrompted) {
 				// this is the first time when users press Ctrl + Enter to replace all
 				this._notificationService.info(
@@ -835,7 +836,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IHorizontalSas
 			const end = inputElement.selectionEnd;
 			const content = inputElement.value;
 
-			if (start && end) {
+			if (start !== null && end !== null) {
 				const value = content.substr(0, start) + '\n' + content.substr(end);
 				this._replaceInput.inputBox.value = value;
 				inputElement.setSelectionRange(start + 1, start + 1);


### PR DESCRIPTION
`Ctrl+Enter` is not handled by Find Widget on Windows, the reason for that is we use different key code for Ctrl for macOS and Windows, the right way to check if Ctrl is being pressed is checking 

```
const ctrlKeyMod = (platform.isMacintosh ? KeyMod.WinCtrl : KeyMod.CtrlCmd);
```
