### PR TITLE
Fixes #80336

### DIFF
--- a/src/vs/base/browser/ui/splitview/splitview.css
+++ b/src/vs/base/browser/ui/splitview/splitview.css
@@ -51,7 +51,6 @@
 
 .monaco-split-view2.horizontal > .split-view-container > .split-view-view {
 	height: 100%;
-	display: inline-block;
 }
 
 .monaco-split-view2.separator-border > .split-view-container > .split-view-view:not(:first-child)::before {

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -903,7 +903,7 @@ export class SplitView extends Disposable {
 			position += this.viewItems[i].size;
 
 			if (this.sashItems[i].sash === sash) {
-				return position;
+				return Math.min(position, this.contentSize - 2);
 			}
 		}
 


### PR DESCRIPTION
Fixes #80336 

There was a rogue CSS `display:` directive overriding the `display: none` on the splitview view.