### PR TITLE
[monaco] close reference search widget with esc

### DIFF
--- a/src/vs/editor/standalone/browser/referenceSearch/standaloneReferenceSearch.ts
+++ b/src/vs/editor/standalone/browser/referenceSearch/standaloneReferenceSearch.ts
@@ -25,7 +25,7 @@ export class StandaloneReferencesController extends ReferencesController {
 		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super(
-			true,
+			false,
 			editor,
 			contextKeyService,
 			editorService,


### PR DESCRIPTION
fix microsoft/monaco-editor#1557