### PR TITLE
Fix-80065 Failed CLI extension installation results in exit code 0 

### DIFF
--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -147,7 +147,7 @@ export class Main {
 		if (installedExtensionsManifests.some(manifest => isLanguagePackExtension(manifest))) {
 			await this.updateLocalizationsCache();
 		}
-		return failed.length ? Promise.reject(localize('installation failed', "Failed Installing Extensions: {0}", failed.join(', '))) : Promise.resolve();
+		return failed.length ? (Promise.reject(localize('installation failed', "Failed Installing Extensions: {0}", failed.join(', '))), process.exit(1)) : Promise.resolve();
 	}
 
 	private async installExtension(extension: string, force: boolean): Promise<IExtensionManifest | null> {


### PR DESCRIPTION
@sandy081 , Here is the fix to make the exit code 1 explicitly when the installation fails to fix #80065 .
Please review this and let me know if anything needs to be changed :) 