### PR TITLE
Fix #20768: Don't seed search without selection

### DIFF
--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -36,17 +36,11 @@ export function getSelectionSearchString(editor: ICodeEditor): string | null {
 
 	const selection = editor.getSelection();
 	// if selection spans multiple lines, default search string to empty
-	if (selection.startLineNumber === selection.endLineNumber) {
-		if (selection.isEmpty()) {
-			let wordAtPosition = editor.getModel().getWordAtPosition(selection.getStartPosition());
-			if (wordAtPosition) {
-				return wordAtPosition.word;
-			}
-		} else {
-			if (editor.getModel().getValueLengthInRange(selection) < SEARCH_STRING_MAX_LENGTH) {
-				return editor.getModel().getValueInRange(selection);
-			}
-		}
+	if (selection.startLineNumber === selection.endLineNumber
+		&& !selection.isEmpty()
+		&& editor.getModel().getValueLengthInRange(selection) < SEARCH_STRING_MAX_LENGTH
+	) {
+		return editor.getModel().getValueInRange(selection);
 	}
 
 	return null;

--- a/src/vs/editor/contrib/find/test/find.test.ts
+++ b/src/vs/editor/contrib/find/test/find.test.ts
@@ -20,17 +20,12 @@ suite('Find', () => {
 
 			// The cursor is at the very top, of the file, at the first ABC
 			let searchStringAtTop = getSelectionSearchString(editor);
-			assert.equal(searchStringAtTop, 'ABC');
+			assert.equal(searchStringAtTop, null);
 
 			// Move cursor to the end of ABC
 			editor.setPosition(new Position(1, 3));
 			let searchStringAfterABC = getSelectionSearchString(editor);
-			assert.equal(searchStringAfterABC, 'ABC');
-
-			// Move cursor to DEF
-			editor.setPosition(new Position(1, 5));
-			let searchStringInsideDEF = getSelectionSearchString(editor);
-			assert.equal(searchStringInsideDEF, 'DEF');
+			assert.equal(searchStringAfterABC, null);
 
 		});
 	});

--- a/src/vs/editor/contrib/find/test/findController.test.ts
+++ b/src/vs/editor/contrib/find/test/findController.test.ts
@@ -218,9 +218,11 @@ suite('FindController', () => {
 			let findController = editor.registerAndInstantiateContribution<TestFindController>(TestFindController);
 			let nextMatchFindAction = new NextMatchFindAction();
 
-			editor.setPosition({
-				lineNumber: 1,
-				column: 9
+			editor.setSelection({
+				startLineNumber: 1,
+				startColumn: 8,
+				endLineNumber: 1,
+				endColumn: 11
 			});
 
 			nextMatchFindAction.run(null, editor);


### PR DESCRIPTION
Fixes #20768. This makes CMD/CTRL+F consistent with other editors/IDEs (actually, almost all software on all platforms).

Without any text selected, the current behavior (with `seedSearchStringFromSelection` enabled) is to search for whatever word is under the cursor. This is unexpected because all (>99%) other software simply keeps the search field unchanged, so you can continue searching. Try it in some JetBrains IDE, Eclipse, NetBeans, Sublime, Notepad++, Firefox or Chrome in an input field, MS Word, or any other popular software. Nobody does that except for VS Code, so it breaks common user expectations and makes a very common use-case annoying (i.e. continuing from the last search).

That's why I have fully removed the old behavior. If you want to search for the word under the cursor you can simply select it before pressing CMD/CTRL+F like in almost every other application.