### PR TITLE
Fix-80080 Show more detailed error message for "Regex parse error" in search

### DIFF
--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -152,15 +152,11 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 
 export function buildRegexParseError(lines: string[]): string {
 	let errorMessage: string[] = ['Regex parse error'];
-	lines.forEach(line => {
-		if (startsWith(line, 'PCRE2:')) {
-			// Just show the error without PCRE2 label
-			let pcre2ErrorMessage = line.replace('PCRE2:', '');
-			let pcre2ActualErrorMessage = pcre2ErrorMessage.split(':')[1];
-			errorMessage.push(pcre2ActualErrorMessage);
-		}
-	});
-	return errorMessage.join(' : ');
+	let pcre2ErrorLine = lines.filter(l => (startsWith(l, 'PCRE2:')))[0];
+	let pcre2ErrorMessage = pcre2ErrorLine.replace('PCRE2:', '');
+	let pcre2ActualErrorMessage = pcre2ErrorMessage.split(':')[1];
+	errorMessage.push(pcre2ActualErrorMessage);
+	return errorMessage.join(':');
 }
 
 

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -152,16 +152,15 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 
 export function buildRegexParseError(lines: string[]): string {
 	let errorMessage: string[] = ['Regex parse error'];
-	errorMessage.push(lines[0].trim());
 	lines.forEach(line => {
-		if (startsWith(line, 'error:')) {
-			errorMessage.push(line);
-		} else if (startsWith(line, 'PCRE2:')) {
+		if (startsWith(line, 'PCRE2:')) {
 			// Just show the error without PCRE2 label
-			errorMessage.push(line.replace('PCRE2:', ''));
+			let pcre2ErrorMessage = line.replace('PCRE2:', '');
+			let pcre2ActualErrorMessage = pcre2ErrorMessage.split(':')[1];
+			errorMessage.push(pcre2ActualErrorMessage);
 		}
 	});
-	return errorMessage.join(' ; ');
+	return errorMessage.join(' : ');
 }
 
 

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -152,11 +152,16 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 
 export function buildRegexParseError(lines: string[]): string {
 	let errorMessage: string[] = ['Regex parse error'];
-	let pcre2ErrorLine = lines.filter(l => (startsWith(l, 'PCRE2:')))[0];
-	let pcre2ErrorMessage = pcre2ErrorLine.replace('PCRE2:', '');
-	let pcre2ActualErrorMessage = pcre2ErrorMessage.split(':')[1];
-	errorMessage.push(pcre2ActualErrorMessage);
-	return errorMessage.join(':');
+	let pcre2ErrorLine = lines.filter(l => (startsWith(l, 'PCRE2:')));
+	if (pcre2ErrorLine.length >= 1) {
+		let pcre2ErrorMessage = pcre2ErrorLine[0].replace('PCRE2:', '');
+		if (pcre2ErrorMessage.indexOf(':') !== -1 && pcre2ErrorMessage.split(':').length >= 2) {
+			let pcre2ActualErrorMessage = pcre2ErrorMessage.split(':')[1];
+			errorMessage.push(':' + pcre2ActualErrorMessage);
+		}
+	}
+
+	return errorMessage.join('');
 }
 
 

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -150,15 +150,18 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 	return undefined;
 }
 
-function buildRegexParseError(lines: string[]): string {
+export function buildRegexParseError(lines: string[]): string {
 	let errorMessage: string[] = ['Regex parse error'];
 	errorMessage.push(lines[0].trim());
 	lines.forEach(line => {
-		if (startsWith(line, 'error:') || startsWith(line, 'PCRE2:')) {
+		if (startsWith(line, 'error:')) {
 			errorMessage.push(line);
+		} else if (startsWith(line, 'PCRE2:')) {
+			// Just show the error without PCRE2 label
+			errorMessage.push(line.replace('PCRE2:', ''));
 		}
 	});
-	return errorMessage.join('\r\n');
+	return errorMessage.join(' ; ');
 }
 
 

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -125,7 +125,7 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 	const firstLine = lines[0].trim();
 
 	if (lines.some(l => startsWith(l, 'regex parse error'))) {
-		return new SearchError('Regex parse error', SearchErrorCode.regexParseError);
+		return new SearchError(buildRegexParseError(lines), SearchErrorCode.regexParseError);
 	}
 
 	const match = firstLine.match(/grep config error: unknown encoding: (.*)/);
@@ -149,6 +149,18 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 
 	return undefined;
 }
+
+function buildRegexParseError(lines: string[]): string {
+	let errorMessage: string[] = [];
+	errorMessage.push(lines[0].trim());
+	lines.forEach(line => {
+		if (startsWith(line, 'error:') || startsWith(line, 'PCRE2:')) {
+			errorMessage.push(line);
+		}
+	});
+	return errorMessage.join('\n');
+}
+
 
 export class RipgrepParser extends EventEmitter {
 	private remainder = '';

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -151,14 +151,14 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 }
 
 function buildRegexParseError(lines: string[]): string {
-	let errorMessage: string[] = [];
+	let errorMessage: string[] = ['Regex parse error'];
 	errorMessage.push(lines[0].trim());
 	lines.forEach(line => {
 		if (startsWith(line, 'error:') || startsWith(line, 'PCRE2:')) {
 			errorMessage.push(line);
 		}
 	});
-	return errorMessage.join('\n');
+	return errorMessage.join('\r\n');
 }
 
 

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -387,7 +387,7 @@ suite('Search-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err.message);
-				let regexParseErrorForUnclosedParenthesis = 'Regex parse error ; regex could not be compiled with either the default regex engine or with PCRE2. ; error: unopened group ;  error compiling pattern at offset 0: unmatched closing parenthesis';
+				let regexParseErrorForUnclosedParenthesis = 'Regex parse error :  unmatched closing parenthesis';
 				assert.equal(searchError.message, regexParseErrorForUnclosedParenthesis);
 				assert.equal(searchError.code, SearchErrorCode.regexParseError);
 			});
@@ -404,7 +404,7 @@ suite('Search-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err.message);
-				let regexParseErrorForLookAround = 'Regex parse error ; regex could not be compiled with either the default regex engine or with PCRE2. ; error: look-around, including look-ahead and look-behind, is not supported ;  error compiling pattern at offset 0: lookbehind assertion is not fixed length';
+				let regexParseErrorForLookAround = 'Regex parse error :  lookbehind assertion is not fixed length';
 				assert.equal(searchError.message, regexParseErrorForLookAround);
 				assert.equal(searchError.code, SearchErrorCode.regexParseError);
 			});

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -387,7 +387,7 @@ suite('Search-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err.message);
-				let regexParseErrorForUnclosedParenthesis = 'Regex parse error :  unmatched closing parenthesis';
+				let regexParseErrorForUnclosedParenthesis = 'Regex parse error: unmatched closing parenthesis';
 				assert.equal(searchError.message, regexParseErrorForUnclosedParenthesis);
 				assert.equal(searchError.code, SearchErrorCode.regexParseError);
 			});
@@ -404,7 +404,7 @@ suite('Search-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err.message);
-				let regexParseErrorForLookAround = 'Regex parse error :  lookbehind assertion is not fixed length';
+				let regexParseErrorForLookAround = 'Regex parse error: lookbehind assertion is not fixed length';
 				assert.equal(searchError.message, regexParseErrorForLookAround);
 				assert.equal(searchError.code, SearchErrorCode.regexParseError);
 			});

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -376,7 +376,7 @@ suite('Search-integration', function () {
 			});
 		});
 
-		test('invalid regex', () => {
+		test('invalid regex case 1', () => {
 			const config: ITextQuery = {
 				type: QueryType.Text,
 				folderQueries: ROOT_FOLDER_QUERY,
@@ -387,10 +387,29 @@ suite('Search-integration', function () {
 				throw new Error('expected fail');
 			}, err => {
 				const searchError = deserializeSearchError(err.message);
-				assert.equal(searchError.message, 'Regex parse error');
+				let regexParseErrorForUnclosedParenthesis = 'Regex parse error ; regex could not be compiled with either the default regex engine or with PCRE2. ; error: unopened group ;  error compiling pattern at offset 0: unmatched closing parenthesis';
+				assert.equal(searchError.message, regexParseErrorForUnclosedParenthesis);
 				assert.equal(searchError.code, SearchErrorCode.regexParseError);
 			});
 		});
+
+		test('invalid regex case 2', () => {
+			const config: ITextQuery = {
+				type: QueryType.Text,
+				folderQueries: ROOT_FOLDER_QUERY,
+				contentPattern: { pattern: '(?<!a.*)', isRegExp: true },
+			};
+
+			return doSearchTest(config, 0).then(() => {
+				throw new Error('expected fail');
+			}, err => {
+				const searchError = deserializeSearchError(err.message);
+				let regexParseErrorForLookAround = 'Regex parse error ; regex could not be compiled with either the default regex engine or with PCRE2. ; error: look-around, including look-ahead and look-behind, is not supported ;  error compiling pattern at offset 0: lookbehind assertion is not fixed length';
+				assert.equal(searchError.message, regexParseErrorForLookAround);
+				assert.equal(searchError.code, SearchErrorCode.regexParseError);
+			});
+		});
+
 
 		test('invalid glob', () => {
 			const config: ITextQuery = {


### PR DESCRIPTION
@roblourens , Here is the PR to close #80080.
I thought the below format would be good.

**"Regex Parse Error"
"regex could not be compiled with either the default regex engine or with PCRE2."
"error: " related to default regex
"PCRE2: " related to PCRE2 .**

I need help on one more thing which I am not able to figure out.
**By adding "\n" , the contents are not coming up in new line !**