### PR TITLE
Allow `file` and `vscode-remote` schemes for links in markdown content

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -14,6 +14,7 @@ import { parse } from 'vs/base/common/marshalling';
 import { cloneAndChange } from 'vs/base/common/objects';
 import { escape } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
+import { Schemas } from 'vs/base/common/network';
 
 export interface MarkdownRenderOptions extends FormattedTextRenderOptions {
 	codeBlockRenderer?: (modeId: string, value: string) => Promise<string>;
@@ -172,7 +173,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 		renderer
 	};
 
-	const allowedSchemes = ['http', 'https', 'mailto', 'data'];
+	const allowedSchemes = ['http', 'https', 'mailto', 'data', Schemas.file, Schemas.vscodeRemote];
 	if (markdown.isTrusted) {
 		allowedSchemes.push('command');
 	}


### PR DESCRIPTION
Fixes #80352