### PR TITLE
Add collapse/expand level and expand all to code outline panel

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -11,7 +11,7 @@ import { append, $, toggleClass, getDomNodePagePosition, removeClass, addClass, 
 import { Event, Relay, Emitter, EventBufferer } from 'vs/base/common/event';
 import { StandardKeyboardEvent, IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { ITreeModel, ITreeNode, ITreeRenderer, ITreeEvent, ITreeMouseEvent, ITreeContextMenuEvent, ITreeFilter, ITreeNavigator, ICollapseStateChangeEvent, ITreeDragAndDrop, TreeDragOverBubble, TreeVisibility, TreeFilterResult, ITreeModelSpliceEvent, TreeMouseEventTarget } from 'vs/base/browser/ui/tree/tree';
+import { ITreeModel, ITreeNode, ITreeRenderer, ITreeEvent, ITreeMouseEvent, ITreeContextMenuEvent, ITreeFilter, ITreeNavigator, ICollapseStateChangeEvent, ITreeDragAndDrop, TreeDragOverBubble, TreeVisibility, TreeFilterResult, ITreeModelSpliceEvent, TreeMouseEventTarget, TreeLevelCollapseState } from 'vs/base/browser/ui/tree/tree';
 import { ISpliceable } from 'vs/base/common/sequence';
 import { IDragAndDropData, StaticDND, DragAndDropData } from 'vs/base/browser/dnd';
 import { range, equals, distinctES6 } from 'vs/base/common/arrays';
@@ -1446,7 +1446,7 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		walkNode(this.model.getNode(this.model.rootRef));
 	}
 
-	getLevelCollapsedStates(maxLevel?: number): ('collapsed' | 'expanded' | 'mixed' | 'fixed')[] {
+	getLevelCollapseStates(maxLevel?: number): TreeLevelCollapseState[] {
 		const levels: { hasExpanded: boolean, hasCollapsed: boolean }[] = [];
 
 		const walkNode = (node: ITreeNode<T, any>) => {
@@ -1478,13 +1478,13 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 
 		return levels.map(level => {
 			if (level.hasCollapsed && level.hasExpanded) {
-				return 'mixed';
+				return TreeLevelCollapseState.Mixed;
 			} else if (level.hasCollapsed && !level.hasExpanded) {
-				return 'collapsed';
+				return TreeLevelCollapseState.Collapsed;
 			} else if (!level.hasCollapsed && level.hasExpanded) {
-				return 'expanded';
+				return TreeLevelCollapseState.Expanded;
 			} else {
-				return 'fixed';
+				return TreeLevelCollapseState.Fixed;
 			}
 		});
 	}

--- a/src/vs/base/browser/ui/tree/tree.ts
+++ b/src/vs/base/browser/ui/tree/tree.ts
@@ -196,6 +196,21 @@ export interface ITreeDragAndDrop<T> extends IListDragAndDrop<T> {
 	onDragOver(data: IDragAndDropData, targetElement: T | undefined, targetIndex: number | undefined, originalEvent: DragEvent): boolean | ITreeDragOverReaction;
 }
 
+export const enum TreeLevelCollapseState {
+	/* None of the nodes at this level are collapsible */
+	Fixed,
+
+	/* All nodes at this level are collapsed */
+	Collapsed,
+
+	/* All nodes at this level are expanded */
+	Expanded,
+
+	/* Some nodes at this level are expanded and some are collapsed */
+	Mixed
+}
+
+
 export class TreeError extends Error {
 
 	constructor(user: string, message: string) {

--- a/src/vs/workbench/contrib/files/browser/media/fileactions.css
+++ b/src/vs/workbench/contrib/files/browser/media/fileactions.css
@@ -81,6 +81,19 @@
 	background: url("collapse-all-hc.svg") center center no-repeat;
 }
 
+/* Collapse level */
+.monaco-workbench .explorer-action.collapse-level {
+	background: url('collapse-all-light.svg') center center no-repeat;
+}
+
+.vs-dark .monaco-workbench .explorer-action.collapse-level {
+	background: url('collapse-all-dark.svg') center center no-repeat;
+}
+
+.hc-black .monaco-workbench .explorer-action.collapse-level {
+	background: url('collapse-all-hc.svg') center center no-repeat;
+}
+
 /* Split editor vertical */
 .monaco-workbench .quick-open-sidebyside-vertical {
 	background-image: url("split-editor-vertical-light.svg");

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -420,24 +420,36 @@ export class OutlinePanel extends ViewletPanel {
 					const collapseLevelActions: IAction[] = [];
 					const levelCollapseStates = this._tree.getLevelCollapseStates();
 					for (let i = 0; i < levelCollapseStates.length; i++) {
-						if (levelCollapseStates[i] === TreeLevelCollapseState.Fixed) {
-							continue;
+						switch (levelCollapseStates[i]) {
+							case TreeLevelCollapseState.Collapsed:
+								addAction(this._tree, 'expand', i);
+								break;
+							case TreeLevelCollapseState.Expanded:
+								addAction(this._tree, 'collapse', i);
+								break;
+							case TreeLevelCollapseState.Mixed:
+								addAction(this._tree, 'collapse', i);
+								addAction(this._tree, 'expand', i);
+								break;
+							case TreeLevelCollapseState.Fixed:
+								continue;
 						}
 
-						const expandOrCollapse = levelCollapseStates[i] === TreeLevelCollapseState.Collapsed;
-						const actionLabel = expandOrCollapse ?
-							localize('expandToLevel', "Expand to level {0}", i + 1) :
-							localize('collapseFromLevel', "Collapse from level {0}", i + 1);
+						function addAction(tree: OutlinePanel['_tree'], kind: 'expand' | 'collapse', level: number) {
+							const actionLabel = kind === 'expand' ?
+								localize('expandToLevel', "Expand to level {0}", level + 2) :
+								localize('collapseFromLevel', "Collapse from level {0}", level + 1);
 
-						collapseLevelActions.push(new Action('collapseExpandLevel' + i, actionLabel, undefined, true, () => {
-							if (expandOrCollapse) {
-								this._tree.expandToLevel(i);
-							} else {
-								this._tree.collapseFromLevel(i);
-							}
+							collapseLevelActions.push(new Action('collapseExpandLevel' + level, actionLabel, undefined, true, () => {
+								if (kind === 'expand') {
+									tree.expandToLevel(level);
+								} else {
+									tree.collapseFromLevel(level);
+								}
 
-							return Promise.resolve(undefined);
-						}));
+								return Promise.resolve(undefined);
+							}));
+						}
 					}
 
 					return collapseLevelActions;

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -426,8 +426,8 @@ export class OutlinePanel extends ViewletPanel {
 
 						const expandOrCollapse = levelCollapseStates[i] === TreeLevelCollapseState.Collapsed;
 						const actionLabel = expandOrCollapse ?
-							localize('expandFromLevel', "Expand from level {0}", i + 1) :
-							localize('collapseToLevel', "Collapse to level {0}", i + 1);
+							localize('expandToLevel', "Expand to level {0}", i + 1) :
+							localize('collapseFromLevel', "Collapse from level {0}", i + 1);
 
 						collapseLevelActions.push(new Action('collapseExpandLevel' + i, actionLabel, undefined, true, () => {
 							if (expandOrCollapse) {

--- a/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePanel.ts
@@ -44,7 +44,7 @@ import { OutlineDataSource, OutlineItemComparator, OutlineSortOrder, OutlineVirt
 import { IDataTreeViewState } from 'vs/base/browser/ui/tree/dataTree';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { basename } from 'vs/base/common/resources';
-import { IDataSource } from 'vs/base/browser/ui/tree/tree';
+import { IDataSource, TreeLevelCollapseState } from 'vs/base/browser/ui/tree/tree';
 import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
 import { DropdownMenuActionViewItem, IActionProvider } from 'vs/base/browser/ui/dropdown/dropdown';
@@ -418,18 +418,18 @@ export class OutlinePanel extends ViewletPanel {
 			this._collapseLevelActionsProvider = {
 				getActions: () => {
 					const collapseLevelActions: IAction[] = [];
-					const levelCollapsedStates = this._tree.getLevelCollapsedStates();
-					for (let i = 0; i < levelCollapsedStates.length; i++) {
-						if (levelCollapsedStates[i] === 'fixed') {
+					const levelCollapseStates = this._tree.getLevelCollapseStates();
+					for (let i = 0; i < levelCollapseStates.length; i++) {
+						if (levelCollapseStates[i] === TreeLevelCollapseState.Fixed) {
 							continue;
 						}
 
-						const expandOrCollapse = levelCollapsedStates[i] === 'collapsed';
+						const expandOrCollapse = levelCollapseStates[i] === TreeLevelCollapseState.Collapsed;
 						const actionLabel = expandOrCollapse ?
 							localize('expandFromLevel', "Expand from level {0}", i + 1) :
 							localize('collapseToLevel', "Collapse to level {0}", i + 1);
 
-						collapseLevelActions[i] = new Action('collapseExpandLevel' + i, actionLabel, undefined, true, () => {
+						collapseLevelActions.push(new Action('collapseExpandLevel' + i, actionLabel, undefined, true, () => {
 							if (expandOrCollapse) {
 								this._tree.expandToLevel(i);
 							} else {
@@ -437,7 +437,7 @@ export class OutlinePanel extends ViewletPanel {
 							}
 
 							return Promise.resolve(undefined);
-						});
+						}));
 					}
 
 					return collapseLevelActions;
@@ -463,8 +463,8 @@ export class OutlinePanel extends ViewletPanel {
 	}
 
 	private _updateCollapseAllMenuAction() {
-		const levelCollapsedStates = this._tree.getLevelCollapsedStates(0);
-		const topLevelCollapsed = levelCollapsedStates[0] === 'collapsed';
+		const levelCollapseStates = this._tree.getLevelCollapseStates(0);
+		const topLevelCollapsed = levelCollapseStates[0] === TreeLevelCollapseState.Collapsed;
 
 		if (topLevelCollapsed) {
 			this._collapseAllMenuAction = new Action('collapseAll', localize('expand', "Expand All"), 'explorer-action collapse-explorer', true, () => {


### PR DESCRIPTION
Currently Outline tree is fully expanded by default, so shows e.g. local variables, which is cluttering view.
This PR introduces Collapse/Expand level action, which enables user to collapse tree from given level, or expand tree up to given level (if it was previously collapsed). Additionally, if tree is collapsed at top level, Collapse All action becomes Expand All.

This partially solves #58862

todo: icons