### PR TITLE
remove wsl2 workaround

### DIFF
--- a/resources/win32/bin/code.sh
+++ b/resources/win32/bin/code.sh
@@ -26,7 +26,7 @@ if grep -qi Microsoft /proc/version; then
 		# use the Remote WSL extension if installed
 		WSL_EXT_ID="ms-vscode-remote.remote-wsl"
 
-		if [ $WSL_BUILD -ge 41955 ]; then
+		if [ $WSL_BUILD -ge 41955 -a $WSL_BUILD -lt 41959 ]; then
 			# WSL2 in workaround for https://github.com/microsoft/WSL/issues/4337
 			CWD="$(pwd)"
 			cd "$VSCODE_PATH"


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/80717

The wsl2 workaround is no longer needed and causes issues on certain setups.

See https://github.com/microsoft/vscode-remote-release/issues/1380