### PR TITLE
Fix PHP in HTML style tags

### DIFF
--- a/extensions/php/build/update-grammar.js
+++ b/extensions/php/build/update-grammar.js
@@ -8,8 +8,9 @@ const updateGrammar = require('../../../build/npm/update-grammar');
 
 function adaptInjectionScope(grammar) {
 	// we're using the HTML grammar from https://github.com/textmate/html.tmbundle which has moved away from source.js.embedded.html
+	// also we need to add source.css scope for PHP code in <style> tags, which are handled differently in atom
 	const oldInjectionKey = "text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js.embedded.html - (meta.embedded.block.php | meta.embedded.line.php))";
-	const newInjectionKey = "text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php))";
+	const newInjectionKey = "text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))";
 
 	const injections = grammar.injections;
 	const injection = injections[oldInjectionKey];

--- a/extensions/php/syntaxes/html.tmLanguage.json
+++ b/extensions/php/syntaxes/html.tmLanguage.json
@@ -109,7 +109,7 @@
 				}
 			]
 		},
-		"text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php))": {
+		"text.html.php - (meta.embedded | meta.tag), L:((text.html.php meta.tag) - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.js - (meta.embedded.block.php | meta.embedded.line.php)), L:(source.css - (meta.embedded.block.php | meta.embedded.line.php))": {
 			"patterns": [
 				{
 					"include": "#php-tag"


### PR DESCRIPTION
Change will fix behavior from this comment: https://github.com/microsoft/vscode/issues/33519#issuecomment-326043262

This problem does not appear in `atom` because of different html grammar and imo change will be better suited here rather than upstream.

There is pr on atom/language-php https://github.com/atom/language-php/pull/350 however in atom this don't have any effect, because `source.css` does not exist and problem itself is not present.

Edit:
_Of course grammar have to be updated after merge._