### PR TITLE
DialogService show support checkbox

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -28,7 +28,7 @@ import { CommandsRegistry, ICommand, ICommandEvent, ICommandHandler, ICommandSer
 import { IConfigurationChangeEvent, IConfigurationData, IConfigurationOverrides, IConfigurationService, IConfigurationModel } from 'vs/platform/configuration/common/configuration';
 import { Configuration, ConfigurationModel, DefaultConfigurationModel } from 'vs/platform/configuration/common/configurationModels';
 import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IConfirmation, IConfirmationResult, IDialogOptions, IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IConfirmation, IConfirmationResult, IDialogOptions, IDialogService, IShowResult } from 'vs/platform/dialogs/common/dialogs';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { AbstractKeybindingService } from 'vs/platform/keybinding/common/abstractKeybindingService';
 import { IKeybindingEvent, IKeyboardEvent, KeybindingSource } from 'vs/platform/keybinding/common/keybinding';
@@ -183,8 +183,8 @@ export class SimpleDialogService implements IDialogService {
 		return Promise.resolve(window.confirm(messageText));
 	}
 
-	public show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions): Promise<number> {
-		return Promise.resolve(0);
+	public show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions): Promise<IShowResult> {
+		return Promise.resolve({ choice: 0 });
 	}
 }
 

--- a/src/vs/platform/dialogs/browser/dialogService.ts
+++ b/src/vs/platform/dialogs/browser/dialogService.ts
@@ -97,7 +97,9 @@ export class DialogService implements IDialogService {
 							EventHelper.stop(event, true);
 						}
 					}
-				}
+				},
+				checkboxLabel: options && options.checkbox ? options.checkbox.label : undefined,
+				checkboxChecked: options && options.checkbox ? options.checkbox.checked : undefined
 			});
 
 		dialogDisposables.add(dialog);
@@ -107,7 +109,8 @@ export class DialogService implements IDialogService {
 		dialogDisposables.dispose();
 
 		return {
-			choice: result.button
+			choice: result.button,
+			checkboxChecked: result.checkboxChecked
 		};
 	}
 }

--- a/src/vs/platform/dialogs/browser/dialogService.ts
+++ b/src/vs/platform/dialogs/browser/dialogService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import { IDialogService, IDialogOptions, IConfirmation, IConfirmationResult, DialogType } from 'vs/platform/dialogs/common/dialogs';
+import { IDialogService, IDialogOptions, IConfirmation, IConfirmationResult, DialogType, IShowResult } from 'vs/platform/dialogs/common/dialogs';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { ILogService } from 'vs/platform/log/common/log';
 import Severity from 'vs/base/common/severity';
@@ -78,7 +78,7 @@ export class DialogService implements IDialogService {
 		return (severity === Severity.Info) ? 'question' : (severity === Severity.Error) ? 'error' : (severity === Severity.Warning) ? 'warning' : 'none';
 	}
 
-	async show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions): Promise<number> {
+	async show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions): Promise<IShowResult> {
 		this.logService.trace('DialogService#show', message);
 
 		const dialogDisposables = new DisposableStore();
@@ -106,6 +106,8 @@ export class DialogService implements IDialogService {
 		const result = await dialog.show();
 		dialogDisposables.dispose();
 
-		return result.button;
+		return {
+			choice: result.button
+		};
 	}
 }

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -41,6 +41,22 @@ export interface IConfirmationResult {
 	checkboxChecked?: boolean;
 }
 
+export interface IShowResult {
+
+	/**
+	 * Selected choice index. If the user refused to choose,
+	 * then a promise with index of `cancelId` option is returned. If there is no such
+	 * option then promise with index `0` is returned.
+	 */
+	choice: number;
+
+	/**
+	 * This will only be defined if the confirmation was created
+	 * with the checkbox option defined.
+	 */
+	checkboxChecked?: boolean;
+}
+
 export interface IPickAndOpenOptions {
 	forceNewWindow?: boolean;
 	defaultUri?: URI;
@@ -151,7 +167,7 @@ export interface IDialogService {
 	 * then a promise with index of `cancelId` option is returned. If there is no such
 	 * option then promise with index `0` is returned.
 	 */
-	show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions): Promise<number>;
+	show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions): Promise<IShowResult>;
 }
 
 export const IFileDialogService = createDecorator<IFileDialogService>('fileDialogService');

--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -143,6 +143,10 @@ export const IDialogService = createDecorator<IDialogService>('dialogService');
 export interface IDialogOptions {
 	cancelId?: number;
 	detail?: string;
+	checkbox?: {
+		label: string;
+		checked?: boolean;
+	};
 }
 
 /**

--- a/src/vs/platform/dialogs/node/dialogIpc.ts
+++ b/src/vs/platform/dialogs/node/dialogIpc.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IChannel, IServerChannel } from 'vs/base/parts/ipc/common/ipc';
-import { IDialogService, IConfirmation, IConfirmationResult } from 'vs/platform/dialogs/common/dialogs';
+import { IDialogService, IConfirmation, IConfirmationResult, IShowResult } from 'vs/platform/dialogs/common/dialogs';
 import Severity from 'vs/base/common/severity';
 import { Event } from 'vs/base/common/event';
 
@@ -31,7 +31,7 @@ export class DialogChannelClient implements IDialogService {
 
 	constructor(private channel: IChannel) { }
 
-	show(severity: Severity, message: string, options: string[]): Promise<number> {
+	show(severity: Severity, message: string, options: string[]): Promise<IShowResult> {
 		return this.channel.call('show', [severity, message, options]);
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadMessageService.ts
+++ b/src/vs/workbench/api/browser/mainThreadMessageService.ts
@@ -97,7 +97,7 @@ export class MainThreadMessageService implements MainThreadMessageServiceShape {
 		});
 	}
 
-	private _showModalMessage(severity: Severity, message: string, commands: { title: string; isCloseAffordance: boolean; handle: number; }[]): Promise<number | undefined> {
+	private async _showModalMessage(severity: Severity, message: string, commands: { title: string; isCloseAffordance: boolean; handle: number; }[]): Promise<number | undefined> {
 		let cancelId: number | undefined = undefined;
 
 		const buttons = commands.map((command, index) => {
@@ -118,7 +118,7 @@ export class MainThreadMessageService implements MainThreadMessageServiceShape {
 			cancelId = buttons.length - 1;
 		}
 
-		return this._dialogService.show(severity, message, buttons, { cancelId })
-			.then(result => result === commands.length ? undefined : commands[result].handle);
+		const { choice } = await this._dialogService.show(severity, message, buttons, { cancelId });
+		return choice === commands.length ? undefined : commands[choice].handle;
 	}
 }

--- a/src/vs/workbench/browser/web.simpleservices.ts
+++ b/src/vs/workbench/browser/web.simpleservices.ts
@@ -632,9 +632,9 @@ export class SimpleWindowsService implements IWindowsService {
 			navigator.userAgent
 		);
 
-		const result = await this.dialogService.show(Severity.Info, this.productService.nameLong, [localize('copy', "Copy"), localize('ok', "OK")], { detail });
+		const { choice } = await this.dialogService.show(Severity.Info, this.productService.nameLong, [localize('copy', "Copy"), localize('ok', "OK")], { detail });
 
-		if (result === 0) {
+		if (choice === 0) {
 			this.clipboardService.writeText(detail);
 		}
 	}

--- a/src/vs/workbench/contrib/cli/node/cli.contribution.ts
+++ b/src/vs/workbench/contrib/cli/node/cli.contribution.ts
@@ -101,8 +101,8 @@ class InstallAction extends Action {
 		return new Promise<void>((resolve, reject) => {
 			const buttons = [nls.localize('ok', "OK"), nls.localize('cancel2', "Cancel")];
 
-			this.dialogService.show(Severity.Info, nls.localize('warnEscalation', "Code will now prompt with 'osascript' for Administrator privileges to install the shell command."), buttons, { cancelId: 1 }).then(choice => {
-				switch (choice) {
+			this.dialogService.show(Severity.Info, nls.localize('warnEscalation', "Code will now prompt with 'osascript' for Administrator privileges to install the shell command."), buttons, { cancelId: 1 }).then(result => {
+				switch (result.choice) {
 					case 0 /* OK */:
 						const command = 'osascript -e "do shell script \\"mkdir -p /usr/local/bin && ln -sf \'' + getSource() + '\' \'' + this.target + '\'\\" with administrator privileges"';
 
@@ -165,23 +165,22 @@ class UninstallAction extends Action {
 	}
 
 	private deleteSymlinkAsAdmin(): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
+		return new Promise<void>(async (resolve, reject) => {
 			const buttons = [nls.localize('ok', "OK"), nls.localize('cancel2', "Cancel")];
 
-			this.dialogService.show(Severity.Info, nls.localize('warnEscalationUninstall', "Code will now prompt with 'osascript' for Administrator privileges to uninstall the shell command."), buttons, { cancelId: 1 }).then(choice => {
-				switch (choice) {
-					case 0 /* OK */:
-						const command = 'osascript -e "do shell script \\"rm \'' + this.target + '\'\\" with administrator privileges"';
+			const { choice } = await this.dialogService.show(Severity.Info, nls.localize('warnEscalationUninstall', "Code will now prompt with 'osascript' for Administrator privileges to uninstall the shell command."), buttons, { cancelId: 1 });
+			switch (choice) {
+				case 0 /* OK */:
+					const command = 'osascript -e "do shell script \\"rm \'' + this.target + '\'\\" with administrator privileges"';
 
-						promisify(cp.exec)(command, {})
-							.then(undefined, _ => Promise.reject(new Error(nls.localize('cantUninstall', "Unable to uninstall the shell command '{0}'.", this.target))))
-							.then(resolve, reject);
-						break;
-					case 1 /* Cancel */:
-						reject(new Error(nls.localize('aborted', "Aborted")));
-						break;
-				}
-			});
+					promisify(cp.exec)(command, {})
+						.then(undefined, _ => Promise.reject(new Error(nls.localize('cantUninstall', "Unable to uninstall the shell command '{0}'.", this.target))))
+						.then(resolve, reject);
+					break;
+				case 1 /* Cancel */:
+					reject(new Error(nls.localize('aborted', "Aborted")));
+					break;
+			}
 		});
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -168,7 +168,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 	}
 
 	private registerListeners(): void {
-		this.toDispose.push(this.editor.onMouseDown((e: IEditorMouseEvent) => {
+		this.toDispose.push(this.editor.onMouseDown(async (e: IEditorMouseEvent) => {
 			const data = e.target.detail as IMarginData;
 			const model = this.editor.getModel();
 			if (!e.target.position || !model || e.target.type !== MouseTargetType.GUTTER_GLYPH_MARGIN || data.isAfterLines || !this.marginFreeFromNonDebugDecorations(e.target.position.lineNumber)) {
@@ -213,18 +213,18 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 							logPoint ? nls.localize('message', "message") : nls.localize('condition', "condition")
 						);
 
-						this.dialogService.show(severity.Info, disable ? disabling : enabling, [
+						const { choice } = await this.dialogService.show(severity.Info, disable ? disabling : enabling, [
 							nls.localize('removeLogPoint', "Remove {0}", breakpointType),
 							nls.localize('disableLogPoint', "{0} {1}", disable ? nls.localize('disable', "Disable") : nls.localize('enable', "Enable"), breakpointType),
 							nls.localize('cancel', "Cancel")
-						], { cancelId: 2 }).then(choice => {
-							if (choice === 0) {
-								breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
-							}
-							if (choice === 1) {
-								breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!disable, bp));
-							}
-						});
+						], { cancelId: 2 });
+
+						if (choice === 0) {
+							breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
+						}
+						if (choice === 1) {
+							breakpoints.forEach(bp => this.debugService.enableOrDisableBreakpoints(!disable, bp));
+						}
 					} else {
 						breakpoints.forEach(bp => this.debugService.removeBreakpoints(bp.getId()));
 					}

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -706,19 +706,20 @@ export class DebugService implements IDebugService {
 					? nls.localize('preLaunchTaskError', "Error exists after running preLaunchTask '{0}'.", taskLabel)
 					: nls.localize('preLaunchTaskExitCode', "The preLaunchTask '{0}' terminated with exit code {1}.", taskLabel, taskSummary.exitCode);
 
-			return this.dialogService.confirm({
+			return this.dialogService.show(severity.Warning, message, [nls.localize('debugAnyway', "Debug Anyway"), nls.localize('showErrors', "Show Errors"), nls.localize('cancel', "Cancel")], {
 				checkbox: {
 					label: nls.localize('remember', "Remember my choice in user settings"),
 				},
-				message,
-				type: 'warning',
-				primaryButton: nls.localize('debugAnyway', "Debug Anyway"),
-				secondaryButton: nls.localize('showErrors', "Show Errors"),
+				cancelId: 2
 			}).then(result => {
-				if (result.checkboxChecked) {
-					this.configurationService.updateValue('debug.onTaskErrors', result.confirmed ? 'debugAnyway' : 'showErrors');
+				if (result.choice === 2) {
+					return Promise.resolve(TaskRunResult.Failure);
 				}
-				if (result.confirmed) {
+				const debugAnyway = result.choice === 0;
+				if (result.checkboxChecked) {
+					this.configurationService.updateValue('debug.onTaskErrors', debugAnyway ? 'debugAnyway' : 'showErrors');
+				}
+				if (debugAnyway) {
 					return TaskRunResult.Success;
 				}
 

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -670,16 +670,15 @@ export class DebugService implements IDebugService {
 		return Promise.resolve(config);
 	}
 
-	private showError(message: string, errorActions: ReadonlyArray<IAction> = []): Promise<void> {
+	private async showError(message: string, errorActions: ReadonlyArray<IAction> = []): Promise<void> {
 		const configureAction = this.instantiationService.createInstance(debugactions.ConfigureAction, debugactions.ConfigureAction.ID, debugactions.ConfigureAction.LABEL);
 		const actions = [...errorActions, configureAction];
-		return this.dialogService.show(severity.Error, message, actions.map(a => a.label).concat(nls.localize('cancel', "Cancel")), { cancelId: actions.length }).then(choice => {
-			if (choice < actions.length) {
-				return actions[choice].run();
-			}
+		const { choice } = await this.dialogService.show(severity.Error, message, actions.map(a => a.label).concat(nls.localize('cancel', "Cancel")), { cancelId: actions.length });
+		if (choice < actions.length) {
+			return actions[choice].run();
+		}
 
-			return undefined;
-		});
+		return undefined;
 	}
 
 	//---- task management

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -630,7 +630,7 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 					: localize('dropFolder', "Do you want to copy '{0}' or add '{0}' as a folder to the workspace?", basename(folders[0].uri));
 			}
 
-			const choice = await this.dialogService.show(Severity.Info, message, buttons);
+			const { choice } = await this.dialogService.show(Severity.Info, message, buttons);
 			if (choice === buttons.length - 3) {
 				return this.workspaceEditingService.addFolders(folders);
 			}

--- a/src/vs/workbench/contrib/remote/electron-browser/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-browser/remote.contribution.ts
@@ -416,9 +416,9 @@ class RemoteAgentConnectionStatusListener implements IWorkbenchContribution {
 						hideProgress();
 						progressReporter = null;
 
-						dialogService.show(Severity.Error, nls.localize('reconnectionPermanentFailure', "Cannot reconnect. Please reload the window."), [nls.localize('reloadWindow', "Reload Window"), nls.localize('cancel', "Cancel")], { cancelId: 1 }).then(choice => {
+						dialogService.show(Severity.Error, nls.localize('reconnectionPermanentFailure', "Cannot reconnect. Please reload the window."), [nls.localize('reloadWindow', "Reload Window"), nls.localize('cancel', "Cancel")], { cancelId: 1 }).then(result => {
 							// Reload the window
-							if (choice === 0) {
+							if (result.choice === 0) {
 								commandService.executeCommand(ReloadWindowAction.ID);
 							}
 						});

--- a/src/vs/workbench/contrib/url/common/url.contribution.ts
+++ b/src/vs/workbench/contrib/url/common/url.contribution.ts
@@ -180,7 +180,7 @@ class OpenerValidatorContributions implements IWorkbenchContribution {
 		if (isURLDomainTrusted(resource, trustedDomains)) {
 			return true;
 		} else {
-			const choice = await this._dialogService.show(
+			const { choice } = await this._dialogService.show(
 				Severity.Info,
 				localize(
 					'openExternalLinkAt',

--- a/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
@@ -9,7 +9,7 @@ import Severity from 'vs/base/common/severity';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 import { IWindowService } from 'vs/platform/windows/common/windows';
 import { mnemonicButtonLabel } from 'vs/base/common/labels';
-import { IDialogService, IConfirmation, IConfirmationResult, IDialogOptions } from 'vs/platform/dialogs/common/dialogs';
+import { IDialogService, IConfirmation, IConfirmationResult, IDialogOptions, IShowResult } from 'vs/platform/dialogs/common/dialogs';
 import { DialogService as HTMLDialogService } from 'vs/platform/dialogs/browser/dialogService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
@@ -63,7 +63,7 @@ export class DialogService implements IDialogService {
 	confirm(confirmation: IConfirmation): Promise<IConfirmationResult> {
 		return this.impl.confirm(confirmation);
 	}
-	show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions | undefined): Promise<number> {
+	show(severity: Severity, message: string, buttons: string[], options?: IDialogOptions | undefined): Promise<IShowResult> {
 		return this.impl.show(severity, message, buttons, options);
 	}
 }
@@ -129,7 +129,7 @@ class NativeDialogService implements IDialogService {
 		return opts;
 	}
 
-	async show(severity: Severity, message: string, buttons: string[], dialogOptions?: IDialogOptions): Promise<number> {
+	async show(severity: Severity, message: string, buttons: string[], dialogOptions?: IDialogOptions): Promise<IShowResult> {
 		this.logService.trace('DialogService#show', message);
 
 		const { options, buttonIndexMap } = this.massageMessageBoxOptions({
@@ -141,7 +141,7 @@ class NativeDialogService implements IDialogService {
 		});
 
 		const result = await this.windowService.showMessageBox(options);
-		return buttonIndexMap[result.button];
+		return { choice: buttonIndexMap[result.button] };
 	}
 
 	private massageMessageBoxOptions(options: Electron.MessageBoxOptions): IMassagedMessageBoxOptions {

--- a/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/dialogService.ts
@@ -137,11 +137,13 @@ class NativeDialogService implements IDialogService {
 			buttons,
 			type: (severity === Severity.Info) ? 'question' : (severity === Severity.Error) ? 'error' : (severity === Severity.Warning) ? 'warning' : 'none',
 			cancelId: dialogOptions ? dialogOptions.cancelId : undefined,
-			detail: dialogOptions ? dialogOptions.detail : undefined
+			detail: dialogOptions ? dialogOptions.detail : undefined,
+			checkboxLabel: dialogOptions && dialogOptions.checkbox ? dialogOptions.checkbox.label : undefined,
+			checkboxChecked: dialogOptions && dialogOptions.checkbox ? dialogOptions.checkbox.checked : undefined
 		});
 
 		const result = await this.windowService.showMessageBox(options);
-		return { choice: buttonIndexMap[result.button] };
+		return { choice: buttonIndexMap[result.button], checkboxChecked: result.checkboxChecked };
 	}
 
 	private massageMessageBoxOptions(options: Electron.MessageBoxOptions): IMassagedMessageBoxOptions {

--- a/src/vs/workbench/services/textfile/common/textFileService.ts
+++ b/src/vs/workbench/services/textfile/common/textFileService.ts
@@ -588,12 +588,12 @@ export abstract class TextFileService extends Disposable implements ITextFileSer
 			nls.localize('cancel', "Cancel")
 		];
 
-		const index = await this.dialogService.show(Severity.Warning, message, buttons, {
+		const { choice } = await this.dialogService.show(Severity.Warning, message, buttons, {
 			cancelId: 2,
 			detail: nls.localize('saveChangesDetail', "Your changes will be lost if you don't save them.")
 		});
 
-		switch (index) {
+		switch (choice) {
 			case 0: return ConfirmResult.SAVE;
 			case 1: return ConfirmResult.DONT_SAVE;
 			default: return ConfirmResult.CANCEL;

--- a/src/vs/workbench/services/workspace/electron-browser/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspace/electron-browser/workspaceEditingService.ts
@@ -108,9 +108,9 @@ export class WorkspaceEditingService implements IWorkspaceEditingService {
 		const detail = nls.localize('saveWorkspaceDetail', "Save your workspace if you plan to open it again.");
 		const cancelId = buttons.indexOf(cancel);
 
-		const res = await this.dialogService.show(Severity.Warning, message, buttons.map(button => button.label), { detail, cancelId });
+		const { choice } = await this.dialogService.show(Severity.Warning, message, buttons.map(button => button.label), { detail, cancelId });
 
-		switch (buttons[res].result) {
+		switch (buttons[choice].result) {
 
 			// Cancel: veto unload
 			case ConfirmResult.CANCEL:

--- a/src/vs/workbench/test/electron-browser/api/extHostMessagerService.test.ts
+++ b/src/vs/workbench/test/electron-browser/api/extHostMessagerService.test.ts
@@ -102,7 +102,7 @@ suite('ExtHostMessageService', function () {
 					assert.equal(message, 'h');
 					assert.equal(buttons.length, 2);
 					assert.equal(buttons[1], 'Cancel');
-					return Promise.resolve(0);
+					return Promise.resolve({ choice: 0 });
 				}
 			} as IDialogService);
 
@@ -113,7 +113,7 @@ suite('ExtHostMessageService', function () {
 		test('returns undefined when cancelled', async () => {
 			const service = new MainThreadMessageService(null!, emptyNotificationService, emptyCommandService, new class extends mock<IDialogService>() {
 				show() {
-					return Promise.resolve(1);
+					return Promise.resolve({ choice: 1 });
 				}
 			} as IDialogService);
 
@@ -125,7 +125,7 @@ suite('ExtHostMessageService', function () {
 			const service = new MainThreadMessageService(null!, emptyNotificationService, emptyCommandService, new class extends mock<IDialogService>() {
 				show(severity: Severity, message: string, buttons: string[]) {
 					assert.equal(buttons.length, 1);
-					return Promise.resolve(0);
+					return Promise.resolve({ choice: 0 });
 				}
 			} as IDialogService);
 

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -50,7 +50,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { MockContextKeyService, MockKeybindingService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 import { ITextBufferFactory, DefaultEndOfLine, EndOfLinePreference, IModelDecorationOptions, ITextModel, ITextSnapshot } from 'vs/editor/common/model';
 import { Range } from 'vs/editor/common/core/range';
-import { IConfirmation, IConfirmationResult, IDialogService, IDialogOptions, IPickAndOpenOptions, ISaveDialogOptions, IOpenDialogOptions, IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IConfirmation, IConfirmationResult, IDialogService, IDialogOptions, IPickAndOpenOptions, ISaveDialogOptions, IOpenDialogOptions, IFileDialogService, IShowResult } from 'vs/platform/dialogs/common/dialogs';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { IExtensionService, NullExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -399,8 +399,8 @@ export class TestDialogService implements IDialogService {
 		return Promise.resolve({ confirmed: false });
 	}
 
-	public show(_severity: Severity, _message: string, _buttons: string[], _options?: IDialogOptions): Promise<number> {
-		return Promise.resolve(0);
+	public show(_severity: Severity, _message: string, _buttons: string[], _options?: IDialogOptions): Promise<IShowResult> {
+		return Promise.resolve({ choice: 0 });
 	}
 }
 


### PR DESCRIPTION
Fixes #80403 

This PR does the following:
* Changes the result of the `show` to be the `IShowResult` - thus no logner just a number. This is also adopted now across the workbench
* Adds an option to the `show` to be able to render checkboxes
* Adopts this in the debug service (example picture below)

fyi @bpasero 

![Screenshot 2019-09-11 at 12 56 11](https://user-images.githubusercontent.com/1926584/64691666-8baa8500-d493-11e9-93d3-de973504941d.png)
