### PR TITLE
Change markdown.api.render argument

### DIFF
--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Uri, workspace } from 'vscode';
 import { Command } from '../commandManager';
 import { MarkdownEngine } from '../markdownEngine';
-import { SkinnyTextDocument } from '../tableOfContentsProvider';
 
 export class RenderDocument implements Command {
 	public readonly id = 'markdown.api.render';
@@ -14,7 +14,8 @@ export class RenderDocument implements Command {
 		private readonly engine: MarkdownEngine
 	) { }
 
-	public async execute(document: SkinnyTextDocument | string): Promise<string> {
+	public async execute(arg: Uri | string): Promise<string> {
+		const document = arg instanceof Uri ? await workspace.openTextDocument(arg) : arg;
 		return this.engine.render(document);
 	}
 }

--- a/extensions/markdown-language-features/src/commands/renderDocument.ts
+++ b/extensions/markdown-language-features/src/commands/renderDocument.ts
@@ -6,6 +6,7 @@
 import { Uri, workspace } from 'vscode';
 import { Command } from '../commandManager';
 import { MarkdownEngine } from '../markdownEngine';
+import { SkinnyTextDocument } from '../tableOfContentsProvider';
 
 export class RenderDocument implements Command {
 	public readonly id = 'markdown.api.render';
@@ -14,7 +15,7 @@ export class RenderDocument implements Command {
 		private readonly engine: MarkdownEngine
 	) { }
 
-	public async execute(arg: Uri | string): Promise<string> {
+	public async execute(arg: Uri | SkinnyTextDocument | string): Promise<string> {
 		const document = arg instanceof Uri ? await workspace.openTextDocument(arg) : arg;
 		return this.engine.render(document);
 	}


### PR DESCRIPTION
Changed the markdown.api.render commands's argument from TextDocument | string
to Uri | string. To render a text document, you must now pass its Uri instead of
the document itself.

The documentation for executeCommand() incorrectly states that it is safe to
pass arguments of any type to commands contributed by extensions. When running a
command contributed by an extension that is not yet loaded, the arguments are
serialized and sent via RPC while the extension is loaded. TextDocument does not
survive serialization with all its methods intact, so the markdown.api.render
command previously could fail the first time and then work afterwards.

Fixes #80338