### PR TITLE
Fixes some capital S typoes with JS/TS

### DIFF
--- a/extensions/json/syntaxes/JSON.tmLanguage.json
+++ b/extensions/json/syntaxes/JSON.tmLanguage.json
@@ -5,7 +5,7 @@
 		"Once accepted there, we are happy to receive an update request."
 	],
 	"version": "https://github.com/Microsoft/vscode-JSON.tmLanguage/commit/9bd83f1c252b375e957203f21793316203f61f70",
-	"name": "JSON (Javascript Next)",
+	"name": "JSON (JavaScript Next)",
 	"scopeName": "source.json",
 	"patterns": [
 		{

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -7,7 +7,7 @@
 	"typescript.tsdk.desc": "Specifies the folder path containing the tsserver and lib*.d.ts files to use.",
 	"typescript.disableAutomaticTypeAcquisition": "Disables automatic type acquisition. Automatic type acquisition fetches `@types` packages from npm to improve IntelliSense for external libraries.",
 	"typescript.tsserver.log": "Enables logging of the TS server to a file. This log can be used to diagnose TS Server issues. The log may contain file paths, source code, and other potentially sensitive information from your project.",
-	"typescript.tsserver.pluginPaths": "Additional paths to discover Typescript Language Service plugins. Requires using TypeScript 2.3.0 or newer in the workspace.",
+	"typescript.tsserver.pluginPaths": "Additional paths to discover TypeScript Language Service plugins. Requires using TypeScript 2.3.0 or newer in the workspace.",
 	"typescript.tsserver.pluginPaths.item": "Either an absolute or relative path. Relative path will be resolved against workspace folder(s).",
 	"typescript.tsserver.trace": "Enables tracing of messages sent to the TS server. This trace can be used to diagnose TS Server issues. The trace may contain file paths, source code, and other potentially sensitive information from your project.",
 	"typescript.validate.enable": "Enable/disable TypeScript validation.",

--- a/extensions/typescript-language-features/src/features/task.ts
+++ b/extensions/typescript-language-features/src/features/task.ts
@@ -75,7 +75,7 @@ export default class TscTaskProvider implements vscode.TaskProvider {
 		const badTsconfig = /\\tsconfig.*\.json/;
 		if (badTsconfig.exec(definition.tsconfig) !== null) {
 			// Warn that the task has the wrong slash type
-			vscode.window.showWarningMessage(localize('badTsConfig', "Typescript Task in tasks.json contains \"\\\\\". Typescript tasks tsconfig must use \"/\""));
+			vscode.window.showWarningMessage(localize('badTsConfig', "TypeScript Task in tasks.json contains \"\\\\\". TypeScript tasks tsconfig must use \"/\""));
 			return undefined;
 		}
 

--- a/src/main.js
+++ b/src/main.js
@@ -102,7 +102,7 @@ function onReady() {
 				});
 			};
 
-			// We recevied a valid nlsConfig from a user defined locale
+			// We received a valid nlsConfig from a user defined locale
 			if (nlsConfig) {
 				startup(nlsConfig);
 			}

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -218,3 +218,5 @@ export const knownAcronyms = new Set<string>();
 export const knownTermMappings = new Map<string, string>();
 knownTermMappings.set('power shell', 'PowerShell');
 knownTermMappings.set('powershell', 'PowerShell');
+knownTermMappings.set('javascript', 'JavaScript');
+knownTermMappings.set('typescript', 'TypeScript');


### PR DESCRIPTION
The settings one is where I caught it, then just did a quick audit of user-facing cases with a lowercase S.

After -> Before
![Screen Shot 2019-09-12 at 9 55 07 AM](https://user-images.githubusercontent.com/49038/64790343-f1eee080-d543-11e9-91e4-7f84ee20d1db.png)