### PR TITLE
use alt+d instead of alt+D

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -231,7 +231,7 @@ export class DeleteWordRightTerminalAction extends BaseSendTextTerminalAction {
 		label: string,
 		@ITerminalService terminalService: ITerminalService
 	) {
-		// Send alt+D
+		// Send alt+d
 		super(id, label, '\x1bd', terminalService);
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -232,7 +232,7 @@ export class DeleteWordRightTerminalAction extends BaseSendTextTerminalAction {
 		@ITerminalService terminalService: ITerminalService
 	) {
 		// Send alt+D
-		super(id, label, '\x1bD', terminalService);
+		super(id, label, '\x1bd', terminalService);
 	}
 }
 


### PR DESCRIPTION
We should use Alt+d instead of alt+D since the combo is normally used without shift and PSReadLine can adopt it

/cc @TylerLeonhardt 