### PR TITLE
fix parsed JSDoc author tag

### DIFF
--- a/extensions/typescript-language-features/src/utils/previewer.ts
+++ b/extensions/typescript-language-features/src/utils/previewer.ts
@@ -28,7 +28,15 @@ function getTagBodyText(tag: Proto.JSDocTagInfo): string | undefined {
 			} else {
 				return makeCodeblock(tag.text);
 			}
+		case 'author':
+			// fix obsucated email address, #80898
+			const emailMatch = tag.text.match(/(.+)\s<([-.\w]+@[-.\w]+)>/);
 
+			if (emailMatch === null) {
+				return tag.text;
+			} else {
+				return `${emailMatch[1]} ${emailMatch[2]}`;
+			}
 		case 'default':
 			return makeCodeblock(tag.text);
 	}

--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -806,14 +806,16 @@ InlineLexer.prototype.output = function(src) {
     // autolink
     if (cap = this.rules.autolink.exec(src)) {
       src = src.substring(cap[0].length);
+      title = null;
       if (cap[2] === '@') {
         text = escape(this.mangle(cap[1]));
         href = 'mailto:' + text;
+        title = 'mailto:' + cap[1];
       } else {
         text = escape(cap[1]);
         href = text;
       }
-      out += this.renderer.link(href, null, text);
+      out += this.renderer.link(href, title, text);
       continue;
     }
 

--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -806,16 +806,14 @@ InlineLexer.prototype.output = function(src) {
     // autolink
     if (cap = this.rules.autolink.exec(src)) {
       src = src.substring(cap[0].length);
-      title = null;
       if (cap[2] === '@') {
         text = escape(this.mangle(cap[1]));
         href = 'mailto:' + text;
-        title = 'mailto:' + cap[1];
       } else {
         text = escape(cap[1]);
         href = text;
       }
-      out += this.renderer.link(href, title, text);
+      out += this.renderer.link(href, null, text);
       continue;
     }
 


### PR DESCRIPTION
addresses #80790 

I believe this is the best method of rendering the hover JSDoc author tag email address correctly, but open to any suggestions.

Also, I am unsure whether this issue also pertains to https://github.com/microsoft/vscode/blob/7aff0c42c8e2012bd2eab6e25bd6fed25c5b05be/src/vs/base/common/marked/marked.js#L820-L841 since both if statements handle `mailto`