### PR TITLE
Support %w print verb/placeholder in Go

### DIFF
--- a/extensions/go/syntaxes/go.tmLanguage.json
+++ b/extensions/go/syntaxes/go.tmLanguage.json
@@ -587,7 +587,7 @@
 		"string_placeholder": {
 			"patterns": [
 				{
-					"match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGsp]",
+					"match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGspw]",
 					"name": "constant.other.placeholder.go"
 				}
 			]


### PR DESCRIPTION
- This verb is used for wrapping errors in go 1.13