### PR TITLE
Fix-80525 "Preserve case in Search and Replace" Icon Overlapping With Text

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -33,6 +33,7 @@
 .search-view .search-widget .monaco-inputbox > .wrapper > textarea.input {
 	padding: 3px;
 	padding-left: 4px;
+	padding-right: 22px;
 }
 
 .search-view .search-widget .monaco-inputbox > .wrapper > .mirror {


### PR DESCRIPTION
@roblourens , Adding padding-right works like a charm to resolve #80525  , Thanks for that :) 
