### PR TITLE
Update build refs to include codicon

### DIFF
--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -45,6 +45,7 @@ var editorResources = [
 	'!out-build/vs/base/browser/ui/splitview/**/*',
 	'!out-build/vs/base/browser/ui/toolbar/**/*',
 	'!out-build/vs/base/browser/ui/octiconLabel/**/*',
+	'!out-build/vs/base/browser/ui/codiconLabel/**/*',
 	'!out-build/vs/workbench/**',
 	'!**/test/**'
 ];
@@ -91,6 +92,7 @@ const extractEditorSrcTask = task.define('extract-editor-src', () => {
 		],
 		redirects: {
 			'vs/base/browser/ui/octiconLabel/octiconLabel': 'vs/base/browser/ui/octiconLabel/octiconLabel.mock',
+			'vs/base/browser/ui/codiconLabel/codiconLabel': 'vs/base/browser/ui/codiconLabel/codiconLabel.mock',
 		},
 		shakeLevel: 2, // 0-Files, 1-InnerFile, 2-ClassMembers
 		importIgnorePattern: /(^vs\/css!)|(promise-polyfill\/polyfill)/,

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -72,6 +72,7 @@ const indentationFilter = [
 
 	// except multiple specific folders
 	'!**/octicons/**',
+	'!**/codicon/**',
 	'!**/fixtures/**',
 	'!**/lib/**',
 	'!extensions/**/out/**',

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -68,6 +68,7 @@ const vscodeResources = [
 	'out-build/vs/base/node/languagePacks.js',
 	'out-build/vs/base/node/{stdForkStart.js,terminateProcess.sh,cpuUsage.sh,ps.sh}',
 	'out-build/vs/base/browser/ui/octiconLabel/octicons/**',
+	'out-build/vs/base/browser/ui/codiconLabel/codicon/**',
 	'out-build/vs/workbench/browser/media/*-theme.css',
 	'out-build/vs/workbench/contrib/debug/**/*.json',
 	'out-build/vs/workbench/contrib/externalTerminal/**/*.scpt',


### PR DESCRIPTION
This adds `Codicon` to the list of refs for our builds, similar to how Octicons are referenced. 