### PR TITLE
Show breakpoint as verified if any debug session did verify it; see #55106

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -24,7 +24,7 @@ import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { BreakpointWidget } from 'vs/workbench/contrib/debug/browser/breakpointWidget';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { MarkdownString } from 'vs/base/common/htmlContent';
-import { getBreakpointMessageAndClassName } from 'vs/workbench/contrib/debug/browser/breakpointsView';
+import { getBreakpointStatus } from 'vs/workbench/contrib/debug/browser/breakpointsView';
 
 interface IBreakpointDecoration {
 	decorationId: string;
@@ -58,7 +58,7 @@ function createBreakpointDecorations(model: ITextModel, breakpoints: ReadonlyArr
 }
 
 function getBreakpointDecorationOptions(model: ITextModel, breakpoint: IBreakpoint, debugService: IDebugService): IModelDecorationOptions {
-	const { className, message } = getBreakpointMessageAndClassName(debugService, breakpoint);
+	const { className, message } = getBreakpointStatus(debugService, breakpoint);
 	let glyphMarginHoverMessage: MarkdownString | undefined;
 
 	if (message) {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -336,11 +336,16 @@ export interface IBreakpointUpdateData {
 	readonly column?: number;
 }
 
+export interface IBreakpointPerSessionStatus {
+	readonly message?: string;
+	readonly verified: boolean;
+}
+
 export interface IBaseBreakpoint extends IEnablement {
 	readonly condition?: string;
 	readonly hitCondition?: string;
 	readonly logMessage?: string;
-	readonly verified: boolean;
+	getStatusPerSession(): Map<string, IBreakpointPerSessionStatus>;
 	getIdFromAdapter(sessionId: string): number | undefined;
 }
 
@@ -350,7 +355,7 @@ export interface IBreakpoint extends IBaseBreakpoint {
 	readonly endLineNumber?: number;
 	readonly column?: number;
 	readonly endColumn?: number;
-	readonly message?: string;
+	readonly dirty: boolean;
 	readonly adapterData: any;
 	readonly sessionAgnosticData: { lineNumber: number, column: number | undefined };
 }


### PR DESCRIPTION
When multiple sessions are active, we show status from each one when hovering
over breakpoint. If breakpoint is not supported/verified in all sessions, we
change the icon to indicate that. 

Example with multiple debug sessions active and partially verified breakpoint:
<img width="673" alt="Screen Shot 2019-09-17 at 1 42 42 PM" src="https://user-images.githubusercontent.com/9881434/65078058-16d2c180-d951-11e9-98d8-ad504631876a.png">

@weinand @roblourens @isidorn What do you think of this?