### PR TITLE
Ensure relative order of DAP messages and repl elements; #33822; #79196

### DIFF
--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -374,7 +374,17 @@ export class MockRawSession {
 	}
 
 	evaluate(args: DebugProtocol.EvaluateArguments): Promise<DebugProtocol.EvaluateResponse> {
-		return Promise.resolve(null!);
+		return Promise.resolve({
+			seq: 1,
+			type: 'response',
+			request_seq: 1,
+			success: true,
+			command: 'evaluate',
+			body: {
+				result: '=' + args.expression,
+				variablesReference: 0
+			}
+		});
 	}
 
 	public custom(request: string, args: any): Promise<DebugProtocol.Response> {


### PR DESCRIPTION
Three fixes:
- handle each DAP message in a separate task to ensure that all microtasks run in between;
- append repl elements in sequential order by chaining their async processing;
- fire `onDidChangeREPLElements` directly in `ReplModel` to ensure it is fired at the right time.

@isidorn What do you think about this approach? Seems to resolve all test cases for me:
- `console.log([1, 2]); 3`
- `console.log([1, 2]); console.log(3); setTimeout(() => console.log(5), 0); 4`
- `setTimeout(() => console.log(5), 0); Array(1000).fill(0)`
