### PR TITLE
Add missing spaces to view mode switcher tooltip

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/repositoryPanel.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPanel.ts
@@ -493,7 +493,7 @@ class ViewModel {
 export class ToggleViewModeAction extends Action {
 
 	static readonly ID = 'workbench.scm.action.toggleViewMode';
-	static readonly LABEL = localize('toggleViewMode', "ToggleViewMode");
+	static readonly LABEL = localize('toggleViewMode', "Toggle View Mode");
 
 	constructor(private viewModel: ViewModel) {
 		super(ToggleViewModeAction.ID, ToggleViewModeAction.LABEL);


### PR DESCRIPTION
@joaomoreno thanks for the feature!

And it's great that view mode can be easily switched (until I'll find what mode works better for me).

However tooltip on this button doesn't have any spaces which I suppose is not what it should be.