### PR TITLE
Update localize JSDoc example to match signature

### DIFF
--- a/src/vs/nls.d.ts
+++ b/src/vs/nls.d.ts
@@ -12,7 +12,7 @@ export interface ILocalizeInfo {
  * Localize a message.
  *
  * `message` can contain `{n}` notation where it is replaced by the nth value in `...args`
- * For example, `localize('hello {0}', name)`
+ * For example, `localize({ key: 'sayHello', comment: ['Welcomes user'] }, 'hello {0}', name)`
  */
 export declare function localize(info: ILocalizeInfo, message: string, ...args: (string | number | boolean | undefined | null)[]): string;
 
@@ -20,6 +20,6 @@ export declare function localize(info: ILocalizeInfo, message: string, ...args: 
  * Localize a message.
  *
  * `message` can contain `{n}` notation where it is replaced by the nth value in `...args`
- * For example, `localize('hello {0}', name)`
+ * For example, `localize('sayHello', 'hello {0}', name)`
  */
 export declare function localize(key: string, message: string, ...args: (string | number | boolean | undefined | null)[]): string;


### PR DESCRIPTION
@octref current `localize` example in JSDoc is a bit confusing because first argument is missing.
This PR updates example to match signature.