### PR TITLE
Fire onDidChangeReplElements directly from ReplModel

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -86,6 +86,7 @@ export class DebugSession implements IDebugSession {
 		} else {
 			this.repl = (this.parentSession as DebugSession).repl;
 		}
+		this.repl.onDidChangeElements(() => this._onDidChangeREPLElements.fire());
 	}
 
 	getId(): string {
@@ -967,25 +968,19 @@ export class DebugSession implements IDebugSession {
 
 	removeReplExpressions(): void {
 		this.repl.removeReplExpressions();
-		this._onDidChangeREPLElements.fire();
 	}
 
 	async addReplExpression(stackFrame: IStackFrame | undefined, name: string): Promise<void> {
-		const expressionEvaluated = this.repl.addReplExpression(this, stackFrame, name);
-		this._onDidChangeREPLElements.fire();
-		await expressionEvaluated;
-		this._onDidChangeREPLElements.fire();
+		await this.repl.addReplExpression(this, stackFrame, name);
 		// Evaluate all watch expressions and fetch variables again since repl evaluation might have changed some.
 		variableSetEmitter.fire();
 	}
 
 	appendToRepl(data: string | IExpression, severity: severity, source?: IReplElementSource): void {
 		this.repl.appendToRepl(this, data, severity, source);
-		this._onDidChangeREPLElements.fire();
 	}
 
 	logToRepl(sev: severity, args: any[], frame?: { uri: URI, line: number, column: number }) {
 		this.repl.logToRepl(this, sev, args, frame);
-		this._onDidChangeREPLElements.fire();
 	}
 }

--- a/src/vs/workbench/contrib/debug/common/replModel.ts
+++ b/src/vs/workbench/contrib/debug/common/replModel.ts
@@ -12,6 +12,7 @@ import { basenameOrAuthority } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { endsWith } from 'vs/base/common/strings';
 import { generateUuid } from 'vs/base/common/uuid';
+import { Emitter } from 'vs/base/common/event';
 
 const MAX_REPL_LENGTH = 10000;
 let topReplElementCounter = 0;
@@ -108,6 +109,8 @@ export class ReplEvaluationResult extends ExpressionContainer implements IReplEl
 
 export class ReplModel {
 	private replElements: IReplElement[] = [];
+	private readonly _onDidChangeElements = new Emitter<void>();
+	readonly onDidChangeElements = this._onDidChangeElements.event;
 
 	getReplElements(): IReplElement[] {
 		return this.replElements;
@@ -150,6 +153,7 @@ export class ReplModel {
 		if (this.replElements.length > MAX_REPL_LENGTH) {
 			this.replElements.splice(0, this.replElements.length - MAX_REPL_LENGTH);
 		}
+		this._onDidChangeElements.fire();
 	}
 
 	logToRepl(session: IDebugSession, sev: severity, args: any[], frame?: { uri: URI, line: number, column: number }) {
@@ -228,6 +232,7 @@ export class ReplModel {
 	removeReplExpressions(): void {
 		if (this.replElements.length > 0) {
 			this.replElements = [];
+			this._onDidChangeElements.fire();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/debug/test/browser/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugModel.test.ts
@@ -513,7 +513,11 @@ suite('Debug - Model', () => {
 		const grandChild = createMockSession(model, 'grandChild', { parentSession: child2, repl: 'mergeWithParent' });
 		const child3 = createMockSession(model, 'child3', { parentSession: parent });
 
+		let parentChanges = 0;
+		parent.onDidChangeReplElements(() => ++parentChanges);
+
 		parent.appendToRepl('1\n', severity.Info);
+		assert.equal(parentChanges, 1);
 		assert.equal(parent.getReplElements().length, 1);
 		assert.equal(child1.getReplElements().length, 0);
 		assert.equal(child2.getReplElements().length, 1);
@@ -521,6 +525,7 @@ suite('Debug - Model', () => {
 		assert.equal(child3.getReplElements().length, 0);
 
 		grandChild.appendToRepl('1\n', severity.Info);
+		assert.equal(parentChanges, 2);
 		assert.equal(parent.getReplElements().length, 2);
 		assert.equal(child1.getReplElements().length, 0);
 		assert.equal(child2.getReplElements().length, 2);
@@ -528,6 +533,7 @@ suite('Debug - Model', () => {
 		assert.equal(child3.getReplElements().length, 0);
 
 		child3.appendToRepl('1\n', severity.Info);
+		assert.equal(parentChanges, 2);
 		assert.equal(parent.getReplElements().length, 2);
 		assert.equal(child1.getReplElements().length, 0);
 		assert.equal(child2.getReplElements().length, 2);
@@ -535,6 +541,7 @@ suite('Debug - Model', () => {
 		assert.equal(child3.getReplElements().length, 1);
 
 		child1.appendToRepl('1\n', severity.Info);
+		assert.equal(parentChanges, 2);
 		assert.equal(parent.getReplElements().length, 2);
 		assert.equal(child1.getReplElements().length, 1);
 		assert.equal(child2.getReplElements().length, 2);


### PR DESCRIPTION
This way debug sessions sharing a single repl will all be notified about new repl elements and UI will be updated.

@isidorn Please take a look. This is a part of #81196 which makes sense by itself.