### PR TITLE
git: Initial support for filters declared in .gitattributes

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -327,10 +327,11 @@ export class CommandCenter {
 			}
 
 			const { size, object } = await repository.getObjectDetails(gitRef, uri.fsPath);
-			const { mimetype } = await repository.detectObjectType(object);
+			const filter = await repository.getGitFilter(uri.fsPath) || undefined;
+			const { mimetype } = await repository.detectObjectType(object, filter);
 
 			if (mimetype === 'text/plain') {
-				return toGitUri(uri, ref);
+				return toGitUri(uri, ref, { filter });
 			}
 
 			if (size > 1000000) { // 1 MB

--- a/extensions/git/src/contentProvider.ts
+++ b/extensions/git/src/contentProvider.ts
@@ -81,7 +81,7 @@ export class GitContentProvider {
 	}
 
 	async provideTextDocumentContent(uri: Uri): Promise<string> {
-		let { path, ref, submoduleOf } = fromGitUri(uri);
+		let { path, ref, submoduleOf, filter } = fromGitUri(uri);
 
 		if (submoduleOf) {
 			const repository = this.model.getRepository(submoduleOf);
@@ -119,7 +119,7 @@ export class GitContentProvider {
 		}
 
 		try {
-			return await repository.show(ref, path);
+			return await repository.show(ref, path, filter);
 		} catch (err) {
 			return '';
 		}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -670,6 +670,7 @@ export enum ForcePushMode {
 }
 
 export class Repository {
+	private filters = new Set<string>();
 
 	constructor(
 		private _git: Git,
@@ -783,7 +784,7 @@ export class Repository {
 	streamShow(object: string, filter?: string): cp.ChildProcess {
 		const args = ['show', object];
 		const options: SpawnOptions = {};
-		if (filter) {
+		if (filter && this.filters.has(filter)) {
 			args.push('|', filter, 'smudge');
 			options.shell = true;
 		}
@@ -817,7 +818,11 @@ export class Repository {
 
 	async getGitFilter(path: string): Promise<string | null> {
 		const { stdout } = await this.run(['check-attr', '-z', 'filter', '--', path]);
-		return parseGitFilterAttribute(stdout);
+		const filter = parseGitFilterAttribute(stdout);
+		if (filter) {
+			this.filters.add(filter);
+		}
+		return filter;
 	}
 
 	async getObjectDetails(treeish: string, path: string): Promise<{ mode: string, object: string, size: number }> {

--- a/extensions/git/src/test/git.test.ts
+++ b/extensions/git/src/test/git.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'mocha';
-import { GitStatusParser, parseGitCommit, parseGitmodules, parseLsTree, parseLsFiles } from '../git';
+import { GitStatusParser, parseGitCommit, parseGitmodules, parseGitFilterAttribute, parseLsTree, parseLsFiles } from '../git';
 import * as assert from 'assert';
 import { splitInChunks } from '../util';
 
@@ -228,6 +228,20 @@ This is a commit message.`;
 				authorEmail: 'john.doe@mail.com',
 			});
 		});
+	});
+
+	suite('parseGitAttributes', () => {
+		test('unspecified', function() {
+			assert.strictEqual(parseGitFilterAttribute(`engine/bwsafe/README.md\0filter\0unspecified\0`), null);
+		})
+
+		test('executable value returned', function() {
+			assert.strictEqual(parseGitFilterAttribute(`engine/bwsafe/README.md\0filter\0some-tool\0`), 'some-tool');
+		})
+
+		test('not filter attribute',function() {
+			assert.strictEqual(parseGitFilterAttribute(`engine/bwsafe/README.md\0merge\0some-tool\0`), null);
+		})
 	});
 
 	suite('parseLsTree', function () {

--- a/extensions/git/src/uri.ts
+++ b/extensions/git/src/uri.ts
@@ -9,6 +9,7 @@ export interface GitUriParams {
 	path: string;
 	ref: string;
 	submoduleOf?: string;
+	filter?: string;
 }
 
 export function fromGitUri(uri: Uri): GitUriParams {
@@ -18,6 +19,7 @@ export function fromGitUri(uri: Uri): GitUriParams {
 export interface GitUriOptions {
 	replaceFileExtension?: boolean;
 	submoduleOf?: string;
+	filter?: string;
 }
 
 // As a mitigation for extensions like ESLint showing warnings and errors
@@ -26,11 +28,14 @@ export interface GitUriOptions {
 export function toGitUri(uri: Uri, ref: string, options: GitUriOptions = {}): Uri {
 	const params: GitUriParams = {
 		path: uri.fsPath,
-		ref
+		ref,
 	};
 
 	if (options.submoduleOf) {
 		params.submoduleOf = options.submoduleOf;
+	}
+	if (options.filter) {
+		params.filter = options.filter;
 	}
 
 	let path = uri.path;


### PR DESCRIPTION
This is an initial implementation for issue #24883.

**Rationale**

We use [git-crypt](https://github.com/AGWA/git-crypt) to ensure that some propriety code is kept secure. This generally works well but can cause issues with Git functionality in other tools. We use VS Code for development and it's a pain to not have the integrated diff functionality when reviewing changes of encrypted files.

**Current Situation**

The `.gitattributes` file is modified to add the necessary [filter](https://git-scm.com/docs/gitattributes) attribute (amongst others) so git works as expected when checking out, merging etc. Lots of other tools will set attributes as well.

As a result, the basic git commands will work in VS Code but not the diff functionality due to the way the extension uses git show to obtain the file content which bypasses any settings in `.gitattributes`. 

Currently a user will receive the following message:

> The file is not displayed in the editor because it is either binary or uses an unsupported text encoding

Although our use case is for git-crypt specifically, this issue affects any tool that relies on `.gitattributes` being properly supported. We have focused on the `filter` attribute only as this is the only attribute we have discovered a need to support at present.

**Overall Approach**

All changes occur in the git extension (`extensions/git`)

1. *No breaking API changes*. All changes are accomplished via addition of optional parameters so existing functionality will be unaffected. The external extension API interface in `src/api/api1.ts` has deliberately not been modified at present. Once the implementation has been validated and tested then consideration should be given to whether this should be updated. 

2. Support has been added to call [git check-attr](https://git-scm.com/docs/git-check-attr) to check relevant file paths for a `filter` attribute. This is exposed via `getGitFilter`.

3. Git URIs have been modified to support an extra `filter` parameter to indicate if a filter is required to be used to obtain the content of a git object. 

4. `getURI` in `commands.ts` has been modified to check the filter defined (if any) for a given path. If a filter is set, this is passed to `detectObjectType` so it can detect the correct encoding of the content by passing through filter. It is also added to the URI.

5. The `show` in `repository.ts` now takes the optional filter parameter (as provided by URI). This will be cause content to be piped through the filter prior to being returned.

**Some Future Considerations**

1. Would it ever be worthwhile to add a configuration option to skip filter checking in `getURI`?
2. May require further improvements to check for the filter attributes using `.gitattributes` as per the relevant Git reference instead of `HEAD`. However, current functionality is very useful and support for this use case can be added later.
3. Requires use of `shell` option when spawning child process for `git show` so output can be piped to filter (which is in an unknown location). Although there is a possibly security risk here this is arguably not any greater than the user using relevant git commands which will in essence perform the same activity. However, need to ensure this works on all supported platforms and confirm this rationale.