### PR TITLE
Fix to allow for optional chain token in completions

### DIFF
--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -416,7 +416,7 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider 
 			isNewIdentifierLocation = response.body.isNewIdentifierLocation;
 			isMemberCompletion = response.body.isMemberCompletion;
 			if (isMemberCompletion) {
-				const dotMatch = line.text.slice(0, position.character).match(/\.\s*$/) || undefined;
+				const dotMatch = line.text.slice(0, position.character).match(/\??\.\s*$/) || undefined;
 				if (dotMatch) {
 					const range = new vscode.Range(position.translate({ characterDelta: -dotMatch[0].length }), position);
 					const text = document.getText(range);


### PR DESCRIPTION
Fixes an issue where completions for non-identifier member names are ignored because the TypeScriptCompletionItemProvider was only looking for the preceding `.` token and did not include the optional chain token `?.`. This resulted in an incorrect filter text when applied to the list of available completions:

![image](https://user-images.githubusercontent.com/3902892/65554263-eacdb800-dedd-11e9-9f1b-b9a84af52f72.png)

With this change, the completion list is filtered properly:

![image](https://user-images.githubusercontent.com/3902892/65554322-13ee4880-dede-11e9-8820-4a6ea0a6edf2.png)
