### PR TITLE
Fix 81779 Preserve Case Hyphen and Underscore replacement issues 

### DIFF
--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -7,20 +7,19 @@ import * as strings from './strings';
 
 export function buildReplaceStringWithCasePreserved(matches: string[] | null, pattern: string): string {
 	if (matches && (matches[0] !== '')) {
+		const containsHyphens = validateSpecificSpecialCharacter(matches, pattern, '-');
+		const containsUnderscores = validateSpecificSpecialCharacter(matches, pattern, '_');
+		if (containsHyphens && !containsUnderscores) {
+			return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '-');
+		} else if (!containsHyphens && containsUnderscores) {
+			return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '_');
+		}
 		if (matches[0].toUpperCase() === matches[0]) {
 			return pattern.toUpperCase();
 		} else if (matches[0].toLowerCase() === matches[0]) {
 			return pattern.toLowerCase();
 		} else if (strings.containsUppercaseCharacter(matches[0][0])) {
-			const containsHyphens = validateSpecificSpecialCharacter(matches, pattern, '-');
-			const containsUnderscores = validateSpecificSpecialCharacter(matches, pattern, '_');
-			if (containsHyphens && !containsUnderscores) {
-				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '-');
-			} else if (!containsHyphens && containsUnderscores) {
-				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '_');
-			} else {
-				return pattern[0].toUpperCase() + pattern.substr(1);
-			}
+			return pattern[0].toUpperCase() + pattern.substr(1);
 		} else {
 			// we don't understand its pattern yet.
 			return pattern;

--- a/src/vs/base/common/search.ts
+++ b/src/vs/base/common/search.ts
@@ -7,19 +7,20 @@ import * as strings from './strings';
 
 export function buildReplaceStringWithCasePreserved(matches: string[] | null, pattern: string): string {
 	if (matches && (matches[0] !== '')) {
-		const containsHyphens = validateSpecificSpecialCharacter(matches, pattern, '-');
-		const containsUnderscores = validateSpecificSpecialCharacter(matches, pattern, '_');
-		if (containsHyphens && !containsUnderscores) {
-			return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '-');
-		} else if (!containsHyphens && containsUnderscores) {
-			return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '_');
-		}
 		if (matches[0].toUpperCase() === matches[0]) {
 			return pattern.toUpperCase();
 		} else if (matches[0].toLowerCase() === matches[0]) {
 			return pattern.toLowerCase();
 		} else if (strings.containsUppercaseCharacter(matches[0][0])) {
-			return pattern[0].toUpperCase() + pattern.substr(1);
+			const containsHyphens = validateSpecificSpecialCharacter(matches, pattern, '-');
+			const containsUnderscores = validateSpecificSpecialCharacter(matches, pattern, '_');
+			if (containsHyphens && !containsUnderscores) {
+				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '-');
+			} else if (!containsHyphens && containsUnderscores) {
+				return buildReplaceStringForSpecificSpecialCharacter(matches, pattern, '_');
+			} else {
+				return pattern[0].toUpperCase() + pattern.substr(1);
+			}
 		} else {
 			// we don't understand its pattern yet.
 			return pattern;

--- a/src/vs/editor/contrib/find/test/replacePattern.test.ts
+++ b/src/vs/editor/contrib/find/test/replacePattern.test.ts
@@ -183,10 +183,6 @@ suite('Replace Pattern test', () => {
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar-newabc'), 'Newfoo-Newbar-Newabc');
 		actual = ['Foo-Bar-abc'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-newbar');
-		actual = ['foo-Bar'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'newfoo-Newbar');
-		actual = ['foo-BAR'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'newfoo-NEWBAR');
 
 		actual = ['Foo_Bar'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_Newbar');
@@ -196,10 +192,6 @@ suite('Replace Pattern test', () => {
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_newbar');
 		actual = ['Foo_Bar-abc'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar-abc'), 'Newfoo_newbar-abc');
-		actual = ['foo_Bar'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'newfoo_Newbar');
-		actual = ['Foo_BAR'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_NEWBAR');
 	});
 
 	test('preserve case', () => {
@@ -235,14 +227,6 @@ suite('Replace Pattern test', () => {
 		actual = replacePattern.buildReplaceString(['Foo-Bar-abc'], true);
 		assert.equal(actual, 'Newfoo-newbar');
 
-		replacePattern = parseReplaceString('newfoo-newbar');
-		actual = replacePattern.buildReplaceString(['foo-Bar'], true);
-		assert.equal(actual, 'newfoo-Newbar');
-
-		replacePattern = parseReplaceString('newfoo-newbar');
-		actual = replacePattern.buildReplaceString(['foo-BAR'], true);
-		assert.equal(actual, 'newfoo-NEWBAR');
-
 		replacePattern = parseReplaceString('newfoo_newbar');
 		actual = replacePattern.buildReplaceString(['Foo_Bar'], true);
 		assert.equal(actual, 'Newfoo_Newbar');
@@ -258,13 +242,5 @@ suite('Replace Pattern test', () => {
 		replacePattern = parseReplaceString('newfoo_newbar-abc');
 		actual = replacePattern.buildReplaceString(['Foo_Bar-abc'], true);
 		assert.equal(actual, 'Newfoo_newbar-abc');
-
-		replacePattern = parseReplaceString('newfoo_newbar');
-		actual = replacePattern.buildReplaceString(['foo_Bar'], true);
-		assert.equal(actual, 'newfoo_Newbar');
-
-		replacePattern = parseReplaceString('newfoo_newbar');
-		actual = replacePattern.buildReplaceString(['foo_BAR'], true);
-		assert.equal(actual, 'newfoo_NEWBAR');
 	});
 });

--- a/src/vs/editor/contrib/find/test/replacePattern.test.ts
+++ b/src/vs/editor/contrib/find/test/replacePattern.test.ts
@@ -183,6 +183,10 @@ suite('Replace Pattern test', () => {
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar-newabc'), 'Newfoo-Newbar-Newabc');
 		actual = ['Foo-Bar-abc'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-newbar');
+		actual = ['foo-Bar'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'newfoo-Newbar');
+		actual = ['foo-BAR'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'newfoo-NEWBAR');
 
 		actual = ['Foo_Bar'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_Newbar');
@@ -192,6 +196,10 @@ suite('Replace Pattern test', () => {
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_newbar');
 		actual = ['Foo_Bar-abc'];
 		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar-abc'), 'Newfoo_newbar-abc');
+		actual = ['foo_Bar'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'newfoo_Newbar');
+		actual = ['Foo_BAR'];
+		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_NEWBAR');
 	});
 
 	test('preserve case', () => {
@@ -227,6 +235,14 @@ suite('Replace Pattern test', () => {
 		actual = replacePattern.buildReplaceString(['Foo-Bar-abc'], true);
 		assert.equal(actual, 'Newfoo-newbar');
 
+		replacePattern = parseReplaceString('newfoo-newbar');
+		actual = replacePattern.buildReplaceString(['foo-Bar'], true);
+		assert.equal(actual, 'newfoo-Newbar');
+
+		replacePattern = parseReplaceString('newfoo-newbar');
+		actual = replacePattern.buildReplaceString(['foo-BAR'], true);
+		assert.equal(actual, 'newfoo-NEWBAR');
+
 		replacePattern = parseReplaceString('newfoo_newbar');
 		actual = replacePattern.buildReplaceString(['Foo_Bar'], true);
 		assert.equal(actual, 'Newfoo_Newbar');
@@ -242,5 +258,13 @@ suite('Replace Pattern test', () => {
 		replacePattern = parseReplaceString('newfoo_newbar-abc');
 		actual = replacePattern.buildReplaceString(['Foo_Bar-abc'], true);
 		assert.equal(actual, 'Newfoo_newbar-abc');
+
+		replacePattern = parseReplaceString('newfoo_newbar');
+		actual = replacePattern.buildReplaceString(['foo_Bar'], true);
+		assert.equal(actual, 'newfoo_Newbar');
+
+		replacePattern = parseReplaceString('newfoo_newbar');
+		actual = replacePattern.buildReplaceString(['foo_BAR'], true);
+		assert.equal(actual, 'newfoo_NEWBAR');
 	});
 });


### PR DESCRIPTION
@roblourens , This fixes #81779 .
I have changed the ordering of condition checking ( first we check for hyphen and underscore variables so that we don't return initially itself and miss replace foo_Bar to newfoo_newbar )

CC : @ArturoDent , This fixes the comment you had raised.