### PR TITLE
Use yarn compile for start scripts

### DIFF
--- a/scripts/code-cli.bat
+++ b/scripts/code-cli.bat
@@ -24,7 +24,7 @@ if "%1"=="--builtin" goto builtin
 node build\lib\builtInExtensions.js
 
 :: Build
-if not exist out node .\node_modules\gulp\bin\gulp.js compile
+if not exist out yarn compile
 
 :: Configuration
 set ELECTRON_RUN_AS_NODE=1

--- a/scripts/code-cli.sh
+++ b/scripts/code-cli.sh
@@ -35,7 +35,7 @@ function code() {
 	node build/lib/builtInExtensions.js
 
 	# Build
-	test -d out || ./node_modules/.bin/gulp compile
+	test -d out || yarn compile
 
 	ELECTRON_RUN_AS_NODE=1 \
 	NODE_ENV=development \

--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -24,7 +24,7 @@ if "%1"=="--builtin" goto builtin
 node build\lib\builtInExtensions.js
 
 :: Build
-if not exist out node .\node_modules\gulp\bin\gulp.js compile
+if not exist out yarn compile
 
 :: Configuration
 set NODE_ENV=development

--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -39,7 +39,7 @@ function code() {
 	node build/lib/builtInExtensions.js
 
 	# Build
-	test -d out || ./node_modules/.bin/gulp compile
+	test -d out || yarn compile
 
 	# Configuration
 	export NODE_ENV=development


### PR DESCRIPTION
Building and running Code by steps in [contributing guide](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#run) causes `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` error on compiling step. However, compiling with npm run compile works fine. This is because the compile script from package.json has `max_old_space_size argument set`.
```
"compile": "gulp compile --max_old_space_size=4095"
```
This PR adds the same argument to the compile step in scripts.