### PR TITLE
Fix-81729 Preserve case in Search and Replace isn't working when I use group substitution

### DIFF
--- a/src/vs/editor/contrib/find/test/replacePattern.test.ts
+++ b/src/vs/editor/contrib/find/test/replacePattern.test.ts
@@ -156,115 +156,58 @@ suite('Replace Pattern test', () => {
 	});
 
 	test('buildReplaceStringWithCasePreserved test', () => {
-		let replacePattern = 'Def';
-		let actual: string | string[] = 'abc';
+		function assertReplace(target: string[], replaceString: string, expected: string): void {
+			let actual: string = '';
+			actual = buildReplaceStringWithCasePreserved(target, replaceString);
+			assert.equal(actual, expected);
+		}
 
-		assert.equal(buildReplaceStringWithCasePreserved([actual], replacePattern), 'def');
-		actual = 'Abc';
-		assert.equal(buildReplaceStringWithCasePreserved([actual], replacePattern), 'Def');
-		actual = 'ABC';
-		assert.equal(buildReplaceStringWithCasePreserved([actual], replacePattern), 'DEF');
-
-		actual = ['abc', 'Abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'def');
-		actual = ['Abc', 'abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'Def');
-		actual = ['ABC', 'abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'DEF');
-
-		actual = ['AbC'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'Def');
-		actual = ['aBC'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, replacePattern), 'Def');
-
-		actual = ['Foo-Bar'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-Newbar');
-		actual = ['Foo-Bar-Abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar-newabc'), 'Newfoo-Newbar-Newabc');
-		actual = ['Foo-Bar-abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'Newfoo-newbar');
-		actual = ['foo-Bar'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'newfoo-Newbar');
-		actual = ['foo-BAR'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo-newbar'), 'newfoo-NEWBAR');
-
-		actual = ['Foo_Bar'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_Newbar');
-		actual = ['Foo_Bar_Abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar_newabc'), 'Newfoo_Newbar_Newabc');
-		actual = ['Foo_Bar_abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_newbar');
-		actual = ['Foo_Bar-abc'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar-abc'), 'Newfoo_newbar-abc');
-		actual = ['foo_Bar'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'newfoo_Newbar');
-		actual = ['Foo_BAR'];
-		assert.equal(buildReplaceStringWithCasePreserved(actual, 'newfoo_newbar'), 'Newfoo_NEWBAR');
+		assertReplace(['abc'], 'Def', 'def');
+		assertReplace(['Abc'], 'Def', 'Def');
+		assertReplace(['ABC'], 'Def', 'DEF');
+		assertReplace(['abc', 'Abc'], 'Def', 'def');
+		assertReplace(['Abc', 'abc'], 'Def', 'Def');
+		assertReplace(['ABC', 'abc'], 'Def', 'DEF');
+		assertReplace(['AbC'], 'Def', 'Def');
+		assertReplace(['aBC'], 'Def', 'Def');
+		assertReplace(['Foo-Bar'], 'newfoo-newbar', 'Newfoo-Newbar');
+		assertReplace(['Foo-Bar-Abc'], 'newfoo-newbar-newabc', 'Newfoo-Newbar-Newabc');
+		assertReplace(['Foo-Bar-abc'], 'newfoo-newbar', 'Newfoo-newbar');
+		assertReplace(['foo-Bar'], 'newfoo-newbar', 'newfoo-Newbar');
+		assertReplace(['foo-BAR'], 'newfoo-newbar', 'newfoo-NEWBAR');
+		assertReplace(['Foo_Bar'], 'newfoo_newbar', 'Newfoo_Newbar');
+		assertReplace(['Foo_Bar_Abc'], 'newfoo_newbar_newabc', 'Newfoo_Newbar_Newabc');
+		assertReplace(['Foo_Bar_abc'], 'newfoo_newbar', 'Newfoo_newbar');
+		assertReplace(['Foo_Bar-abc'], 'newfoo_newbar-abc', 'Newfoo_newbar-abc');
+		assertReplace(['foo_Bar'], 'newfoo_newbar', 'newfoo_Newbar');
+		assertReplace(['Foo_BAR'], 'newfoo_newbar', 'Newfoo_NEWBAR');
 	});
 
 	test('preserve case', () => {
-		let replacePattern = parseReplaceString('Def');
-		let actual = replacePattern.buildReplaceString(['abc'], true);
-		assert.equal(actual, 'def');
-		actual = replacePattern.buildReplaceString(['Abc'], true);
-		assert.equal(actual, 'Def');
-		actual = replacePattern.buildReplaceString(['ABC'], true);
-		assert.equal(actual, 'DEF');
+		function assertReplace(target: string[], replaceString: string, expected: string): void {
+			let replacePattern = parseReplaceString(replaceString);
+			let actual = replacePattern.buildReplaceString(target, true);
+			assert.equal(actual, expected);
+		}
 
-		actual = replacePattern.buildReplaceString(['abc', 'Abc'], true);
-		assert.equal(actual, 'def');
-		actual = replacePattern.buildReplaceString(['Abc', 'abc'], true);
-		assert.equal(actual, 'Def');
-		actual = replacePattern.buildReplaceString(['ABC', 'abc'], true);
-		assert.equal(actual, 'DEF');
-
-		actual = replacePattern.buildReplaceString(['AbC'], true);
-		assert.equal(actual, 'Def');
-		actual = replacePattern.buildReplaceString(['aBC'], true);
-		assert.equal(actual, 'Def');
-
-		replacePattern = parseReplaceString('newfoo-newbar');
-		actual = replacePattern.buildReplaceString(['Foo-Bar'], true);
-		assert.equal(actual, 'Newfoo-Newbar');
-
-		replacePattern = parseReplaceString('newfoo-newbar-newabc');
-		actual = replacePattern.buildReplaceString(['Foo-Bar-Abc'], true);
-		assert.equal(actual, 'Newfoo-Newbar-Newabc');
-
-		replacePattern = parseReplaceString('newfoo-newbar');
-		actual = replacePattern.buildReplaceString(['Foo-Bar-abc'], true);
-		assert.equal(actual, 'Newfoo-newbar');
-
-		replacePattern = parseReplaceString('newfoo-newbar');
-		actual = replacePattern.buildReplaceString(['foo-Bar'], true);
-		assert.equal(actual, 'newfoo-Newbar');
-
-		replacePattern = parseReplaceString('newfoo-newbar');
-		actual = replacePattern.buildReplaceString(['foo-BAR'], true);
-		assert.equal(actual, 'newfoo-NEWBAR');
-
-		replacePattern = parseReplaceString('newfoo_newbar');
-		actual = replacePattern.buildReplaceString(['Foo_Bar'], true);
-		assert.equal(actual, 'Newfoo_Newbar');
-
-		replacePattern = parseReplaceString('newfoo_newbar_newabc');
-		actual = replacePattern.buildReplaceString(['Foo_Bar_Abc'], true);
-		assert.equal(actual, 'Newfoo_Newbar_Newabc');
-
-		replacePattern = parseReplaceString('newfoo_newbar');
-		actual = replacePattern.buildReplaceString(['Foo_Bar_abc'], true);
-		assert.equal(actual, 'Newfoo_newbar');
-
-		replacePattern = parseReplaceString('newfoo_newbar-abc');
-		actual = replacePattern.buildReplaceString(['Foo_Bar-abc'], true);
-		assert.equal(actual, 'Newfoo_newbar-abc');
-
-		replacePattern = parseReplaceString('newfoo_newbar');
-		actual = replacePattern.buildReplaceString(['foo_Bar'], true);
-		assert.equal(actual, 'newfoo_Newbar');
-
-		replacePattern = parseReplaceString('newfoo_newbar');
-		actual = replacePattern.buildReplaceString(['foo_BAR'], true);
-		assert.equal(actual, 'newfoo_NEWBAR');
+		assertReplace(['abc'], 'Def', 'def');
+		assertReplace(['Abc'], 'Def', 'Def');
+		assertReplace(['ABC'], 'Def', 'DEF');
+		assertReplace(['abc', 'Abc'], 'Def', 'def');
+		assertReplace(['Abc', 'abc'], 'Def', 'Def');
+		assertReplace(['ABC', 'abc'], 'Def', 'DEF');
+		assertReplace(['AbC'], 'Def', 'Def');
+		assertReplace(['aBC'], 'Def', 'Def');
+		assertReplace(['Foo-Bar'], 'newfoo-newbar', 'Newfoo-Newbar');
+		assertReplace(['Foo-Bar-Abc'], 'newfoo-newbar-newabc', 'Newfoo-Newbar-Newabc');
+		assertReplace(['Foo-Bar-abc'], 'newfoo-newbar', 'Newfoo-newbar');
+		assertReplace(['foo-Bar'], 'newfoo-newbar', 'newfoo-Newbar');
+		assertReplace(['foo-BAR'], 'newfoo-newbar', 'newfoo-NEWBAR');
+		assertReplace(['Foo_Bar'], 'newfoo_newbar', 'Newfoo_Newbar');
+		assertReplace(['Foo_Bar_Abc'], 'newfoo_newbar_newabc', 'Newfoo_Newbar_Newabc');
+		assertReplace(['Foo_Bar_abc'], 'newfoo_newbar', 'Newfoo_newbar');
+		assertReplace(['Foo_Bar-abc'], 'newfoo_newbar-abc', 'Newfoo_newbar-abc');
+		assertReplace(['foo_Bar'], 'newfoo_newbar', 'newfoo_Newbar');
+		assertReplace(['foo_BAR'], 'newfoo_newbar', 'newfoo_NEWBAR');
 	});
 });

--- a/src/vs/workbench/services/search/common/replace.ts
+++ b/src/vs/workbench/services/search/common/replace.ts
@@ -63,7 +63,7 @@ export class ReplacePattern {
 				if (match[0] === text) {
 					return text.replace(this._regExp, this.buildReplaceString(match, preserveCase));
 				}
-				let replaceString = text.replace(this._regExp, this.pattern);
+				let replaceString = text.replace(this._regExp, this.buildReplaceString(match, preserveCase));
 				return replaceString.substr(match.index, match[0].length - (text.length - replaceString.length));
 			}
 			return this.buildReplaceString(match, preserveCase);

--- a/src/vs/workbench/services/search/common/replace.ts
+++ b/src/vs/workbench/services/search/common/replace.ts
@@ -61,7 +61,7 @@ export class ReplacePattern {
 		if (match) {
 			if (this.hasParameters) {
 				if (match[0] === text) {
-					return text.replace(this._regExp, this.pattern);
+					return text.replace(this._regExp, this.buildReplaceString(match, preserveCase));
 				}
 				let replaceString = text.replace(this._regExp, this.pattern);
 				return replaceString.substr(match.index, match[0].length - (text.length - replaceString.length));

--- a/src/vs/workbench/services/search/test/common/replace.test.ts
+++ b/src/vs/workbench/services/search/test/common/replace.test.ts
@@ -214,5 +214,21 @@ suite('Replace Pattern test', () => {
 		testObject = new ReplacePattern('$0ah', { pattern: 'b(la)(?=\\stext$)', isRegExp: true });
 		actual = testObject.getReplaceString('this is a bla text');
 		assert.equal('blaah', actual);
+
+		testObject = new ReplacePattern('newrege$1', true, /Testrege(\w*)/);
+		actual = testObject.getReplaceString('Testregex', true);
+		assert.equal('Newregex', actual);
+
+		testObject = new ReplacePattern('newrege$1', true, /TESTREGE(\w*)/);
+		actual = testObject.getReplaceString('TESTREGEX', true);
+		assert.equal('NEWREGEX', actual);
+
+		testObject = new ReplacePattern('new_rege$1', true, /Test_Rege(\w*)/);
+		actual = testObject.getReplaceString('Test_Regex', true);
+		assert.equal('New_Regex', actual);
+
+		testObject = new ReplacePattern('new-rege$1', true, /Test-Rege(\w*)/);
+		actual = testObject.getReplaceString('Test-Regex', true);
+		assert.equal('New-Regex', actual);
 	});
 });


### PR DESCRIPTION
@roblourens , This was not touched upon when preserve case was implemented , I have changed it to make it work for group substitution also . The gist of the change is that instead of returning `text.replace(this._regExp, this.pattern);` we return `text.replace(this._regExp, this.buildReplaceString(match, preserveCase));`

**NOTE : I have changed test methods to the standard used in other functions to make it look cleaner as this was getting pretty messy , and existing test methods would cover this fix test cases**

#81729