### PR TITLE
Fix-81877 Image preview should not zoom on first click if unfocused 

### DIFF
--- a/extensions/image-preview/media/main.js
+++ b/extensions/image-preview/media/main.js
@@ -70,6 +70,7 @@
 	let ctrlPressed = false;
 	let altPressed = false;
 	let hasLoadedImage = false;
+	let firstClick = true;
 
 	// Elements
 	const container = document.body;
@@ -158,6 +159,11 @@
 		}
 
 		if (e.button !== 0) {
+			return;
+		}
+
+		if (firstClick) {
+			firstClick = false;
 			return;
 		}
 


### PR DESCRIPTION
@mjbvz , Here is the fix for #81877 .
I am not sure if this is the solution you wanted but just wanted to know if this is towards the right direction. ( Because you have mentioned about focus , I am not quite sure how to get that info here )
Thanks :) 