### PR TITLE
Add git.showCommitInput config option (#79074)

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1410,6 +1410,12 @@
           ],
           "default": "committerdate",
           "description": "%config.branchSortOrder%"
+        },
+        "git.showCommitInput": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "%config.showCommitInput%"
         }
       }
     },

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -128,6 +128,7 @@
 	"config.openDiffOnClick": "Controls whether the diff editor should be opened when clicking a change. Otherwise the regular editor will be opened.",
 	"config.supportCancellation": "Controls whether a notification comes up when running the Sync action, which allows the user to cancel the operation.",
 	"config.branchSortOrder": "Controls the sort order for branches.",
+	"config.showCommitInput": "Controls whether to show the commit input in the Git source control panel.",
 	"colors.added": "Color for added resources.",
 	"colors.modified": "Color for modified resources.",
 	"colors.deleted": "Color for deleted resources.",

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -701,7 +701,6 @@ export class Repository implements Disposable {
 		onConfigListenerForBranchSortOrder(this.updateModelState, this, this.disposables);
 
 		const updateInputBoxVisibility = () => {
-			console.log('this is running!');
 			const config = workspace.getConfiguration('git', root);
 			const inputConfig = config.get<boolean>('showCommitInput');
 			this._sourceControl.inputBox.visible = (inputConfig === undefined) ? true : inputConfig;

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -700,6 +700,18 @@ export class Repository implements Disposable {
 		const onConfigListenerForBranchSortOrder = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.branchSortOrder', root));
 		onConfigListenerForBranchSortOrder(this.updateModelState, this, this.disposables);
 
+		const updateInputBoxVisibility = () => {
+			console.log('this is running!');
+			const config = workspace.getConfiguration('git', root);
+			const inputConfig = config.get<boolean>('showCommitInput');
+			this._sourceControl.inputBox.visible = (inputConfig === undefined) ? true : inputConfig;
+		};
+
+		const onConfigListenerForInputBoxVisibility = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.showCommitInput', root));
+		onConfigListenerForInputBoxVisibility(updateInputBoxVisibility, this, this.disposables);
+		updateInputBoxVisibility();
+
+
 		this.mergeGroup.hideWhenEmpty = true;
 
 		this.disposables.push(this.mergeGroup);


### PR DESCRIPTION
Adds feature requested in #79074.

To implement this, I mostly followed the pattern for the 'git.branchSortOrder' option and used VS Code's SourceControl API to toggle visibility of the input box. 