### PR TITLE
Add support for `git-crypt`

### DIFF
--- a/extensions/git/src/util.ts
+++ b/extensions/git/src/util.ts
@@ -411,3 +411,23 @@ export class Limiter<T> {
 		}
 	}
 }
+
+export function isGitCryptEncrypted(buf: Buffer) {
+	// \0GITCRYPT\0 is a magic word at the beginning of encrypted files
+	return buf.length >= 10 && buf.toString().startsWith('\u0000GITCRYPT\u0000');
+}
+
+export async function decryptGitCrypt(buf: Buffer, cwd: string): Promise<Buffer> {
+	const c = cp.spawn('git-crypt', ['smudge'], { cwd });
+	c.stdin.write(buf);
+	c.stdin.end();
+	let buffer = await readBytes(c.stdout, 4100);
+
+	try {
+		c.kill();
+	} catch (err) {
+		// noop
+	}
+
+	return buffer;
+}


### PR DESCRIPTION
This PR resolves #34330 by adding support for [git-crypt](https://github.com/AGWA/git-crypt/), a tool which encrypts and decrypts files as a git filter.

Currently VS Code does not properly show diffs for files that are encrypted on the `remote` but decrypted locally.

Here is some of the current behavior:

A file will have no changes (see below that `production.yaml` doesn't show up in the `git status` panel) but will show in the editor that the whole file was modified:

![image](https://user-images.githubusercontent.com/549323/66243607-0002cd80-e6ba-11e9-94ad-d827f300813c.png)

We can see here when bringing up the inline diffs, that it's comparing the decrypted local file with the encrypted `HEAD` version:

![image](https://user-images.githubusercontent.com/549323/66243651-2a548b00-e6ba-11e9-9a6c-e4a5a5bfeb2a.png)

Lastly, when the file is changed (shown below as showing up in the `git status` on the panel), and the `git diff` is opened, the diff isn't shown because the left side is the binary version:

![image](https://user-images.githubusercontent.com/549323/66243697-67208200-e6ba-11e9-8d08-48fe61039ced.png)

This PR is fairly simple, and doesn't attempt to solve the total scope of adding generic support for any and all filters. However, I hope this can get accepted in the meantime before that solution is realized to support this specific issue.

This PR checks after a `git show` to see if the buffer contains a [magic word](https://github.com/AGWA/git-crypt/blob/master/commands.cpp#L460) that indicates it is a `git-crypt` encrypted blob. If it is, then it runs it into `git-crypt smudge` which will decrypt the contents appropriately. This resolves all of the cases mentioned above.

A potential implementation for solving the generic issue would be to read `.gitattributes` for the file being `git show`'d and see what the `filter` is and hand that as the program to execute the blob on. However, this would require significantly more testing which was out of scope for the work I'm doing.