### PR TITLE
search: remove unused config settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -132,7 +132,7 @@ export const tocData: ITOCEntry = {
 				{
 					id: 'features/search',
 					label: localize('search', "Search"),
-					settings: ['search.*', 'searchRipgrep.*']
+					settings: ['search.*']
 				}
 				,
 				{

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -760,17 +760,6 @@ configurationRegistry.registerConfiguration({
 			default: false,
 			description: nls.localize('search.showLineNumbers', "Controls whether to show line numbers for search results."),
 		},
-		'searchRipgrep.enable': {
-			type: 'boolean',
-			default: false,
-			deprecationMessage: nls.localize('search.searchRipgrepEnableDeprecated', "Deprecated. Use \"search.runInExtensionHost\" instead"),
-			description: nls.localize('search.searchRipgrepEnable', "Whether to run search in the extension host")
-		},
-		'search.runInExtensionHost': {
-			type: 'boolean',
-			default: false,
-			description: nls.localize('search.runInExtensionHost', "Whether to run search in the extension host. Requires a restart to take effect.")
-		},
 		'search.usePCRE2': {
 			type: 'boolean',
 			default: false,


### PR DESCRIPTION
`searchRipgrep.enable` and `search.runInExtensionHost` are no longer
used. A code search for `searchRipgrep` and `runInExtensionHost` shows
no matches.

While they were originally used to determine if searches should be run
with ripgrep, they were later replaced with `search.useRipgrep`. That
setting itself is now deprecated and does the same thing as
`search.usePCRE2` (so it actually doesn't disable ripgrep), but at least
it does something.

So delete these settings that are beyond deprecation - they do nothing.

cc @roblourens 