### PR TITLE
linux/bin/code.sh: use command -v instead of which

### DIFF
--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -30,7 +30,7 @@ if [ ! -L $0 ]; then
 	# if path is not a symlink, find relatively
 	VSCODE_PATH="$(dirname $0)/.."
 else
-	if which readlink >/dev/null; then
+	if command -v readlink >/dev/null; then
 		# if readlink exists, follow the symlink and find relatively
 		VSCODE_PATH="$(dirname $(readlink -f $0))/.."
 	else


### PR DESCRIPTION
`command` is a bash-builtin (see the [Bash manual](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html)) that is guaranteed to always be present, in contrast to `which`, which is not required to be available for bash to work.

This dependency on `which` has recently caused an issue for a small percentage of arch linux users where VSCode wouldn't start anymore, see [visual-studio-code-bin](https://aur.archlinux.org/packages/visual-studio-code-bin) on the AUR. By removing the dependency, VSCode becomes a tiny bit more self-contained (unless it's still used somewhere else of course).