### PR TITLE
Remove minimum terminal split width guard

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -65,7 +65,7 @@ export interface ITerminalTab {
 	setVisible(visible: boolean): void;
 	layout(width: number, height: number): void;
 	addDisposable(disposable: IDisposable): void;
-	split(terminalFocusContextKey: IContextKey<boolean>, configHelper: ITerminalConfigHelper, shellLaunchConfig: IShellLaunchConfig): ITerminalInstance | undefined;
+	split(terminalFocusContextKey: IContextKey<boolean>, configHelper: ITerminalConfigHelper, shellLaunchConfig: IShellLaunchConfig): ITerminalInstance;
 }
 
 export interface ITerminalService {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -394,11 +394,6 @@ export class TerminalService implements ITerminalService {
 		}
 
 		const instance = tab.split(this._terminalFocusContextKey, this.configHelper, shellLaunchConfig);
-		if (!instance) {
-			this._showNotEnoughSpaceToast();
-			return null;
-		}
-
 		this._initInstanceListeners(instance);
 		this._onInstancesChanged.fire();
 
@@ -493,10 +488,6 @@ export class TerminalService implements ITerminalService {
 			type: 'warning',
 		});
 		return !res.confirmed;
-	}
-
-	protected _showNotEnoughSpaceToast(): void {
-		this._notificationService.info(nls.localize('terminal.minWidth', "Not enough space to split terminal."));
 	}
 
 	protected _validateShellPaths(label: string, potentialPaths: string[]): Promise<[string, string] | null> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalTab.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTab.ts
@@ -14,7 +14,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ITerminalInstance, Direction, ITerminalTab, ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
 
 const SPLIT_PANE_MIN_SIZE = 120;
-const TERMINAL_MIN_USEFUL_SIZE = 250;
 
 class SplitPaneContainer extends Disposable {
 	private _height: number;
@@ -374,14 +373,11 @@ export class TerminalTab extends Disposable implements ITerminalTab {
 		terminalFocusContextKey: IContextKey<boolean>,
 		configHelper: ITerminalConfigHelper,
 		shellLaunchConfig: IShellLaunchConfig
-	): ITerminalInstance | undefined {
+	): ITerminalInstance {
 		if (!this._container) {
 			throw new Error('Cannot split terminal that has not been attached');
 		}
-		const newTerminalSize = ((this._panelPosition === Position.BOTTOM ? this._container.clientWidth : this._container.clientHeight) / (this._terminalInstances.length + 1));
-		if (newTerminalSize < TERMINAL_MIN_USEFUL_SIZE) {
-			return undefined;
-		}
+
 		const instance = this._terminalService.createInstance(undefined, shellLaunchConfig);
 		this._terminalInstances.splice(this._activeInstanceIndex + 1, 0, instance);
 		this._initInstanceListeners(instance);


### PR DESCRIPTION
Several people complained, removing it aligns with how 'overflow' in
the editor works.

Fixes #72649

FYI @alexr00 