### PR TITLE
Show dirty state icon when workbench.editor.tabCloseButton is off

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -186,7 +186,7 @@
 	overflow: visible; /* ...but still show the close button on hover, focus and when dirty */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off > .tab-close {
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off:not(.dirty) > .tab-close {
 	display: none; /* hide the close action bar when we are configured to hide it */
 }
 
@@ -233,10 +233,7 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off.dirty:not(.dirty-border-top) {
-	background-repeat: no-repeat;
-	background-position-y: center;
-	background-position-x: calc(100% - 6px); /* to the right of the tab label */
-	padding-right: 28px; /* make room for dirty indication when we are running without close button */
+	padding-right: 0; /* remove extra padding when we are running without close button */
 }
 
 /* Editor Actions */

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -236,6 +236,10 @@
 	padding-right: 0; /* remove extra padding when we are running without close button */
 }
 
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.close-button-off > .tab-close {
+	pointer-events: none; /* don't allow dirty state/close button to be clicked when running without close button */
+}
+
 /* Editor Actions */
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {


### PR DESCRIPTION
Fixes #82213

This fixes an issue where the dirty state icon was hidden when `workbench.editor.tabCloseButton` is set to `off`:

<img width="487" alt="image" src="https://user-images.githubusercontent.com/35271042/66595662-3fb13580-eb50-11e9-9907-872790b6ff1e.png">
