### PR TITLE
Fix #82203 for recovery

### DIFF
--- a/src/vs/base/common/resourceTree.ts
+++ b/src/vs/base/common/resourceTree.ts
@@ -69,6 +69,10 @@ class BranchNode<T, C> extends Node<C> implements IBranchNode<T, C> {
 	delete(path: string): void {
 		this._children.delete(path);
 	}
+
+	clear(): void {
+		this._children.clear();
+	}
 }
 
 class LeafNode<T, C> extends Node<C> implements ILeafNode<T, C> {
@@ -194,5 +198,9 @@ export class ResourceTree<T extends NonNullable<any>, C> {
 
 		node.delete(name);
 		return child.element;
+	}
+
+	clear(): void {
+		this.root.clear();
 	}
 }

--- a/src/vs/workbench/contrib/scm/browser/repositoryPanel.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPanel.ts
@@ -402,6 +402,17 @@ class ViewModel {
 	get mode(): ViewModelMode { return this._mode; }
 	set mode(mode: ViewModelMode) {
 		this._mode = mode;
+
+		for (const item of this.items) {
+			item.tree.clear();
+
+			if (mode === ViewModelMode.Tree) {
+				for (const resource of item.resources) {
+					item.tree.add(resource.sourceUri, resource);
+				}
+			}
+		}
+
 		this.refresh();
 		this._onDidChangeMode.fire(mode);
 	}
@@ -428,10 +439,12 @@ class ViewModel {
 				group.onDidSplice(splice => this.onDidSpliceGroup(item, splice))
 			);
 
-			const item = { group, resources, tree, disposable };
+			const item: IGroupItem = { group, resources, tree, disposable };
 
-			for (const resource of resources) {
-				item.tree.add(resource.sourceUri, resource);
+			if (this._mode === ViewModelMode.Tree) {
+				for (const resource of resources) {
+					item.tree.add(resource.sourceUri, resource);
+				}
 			}
 
 			itemsToInsert.push(item);
@@ -447,14 +460,18 @@ class ViewModel {
 	}
 
 	private onDidSpliceGroup(item: IGroupItem, { start, deleteCount, toInsert }: ISplice<ISCMResource>): void {
-		for (const resource of toInsert) {
-			item.tree.add(resource.sourceUri, resource);
+		if (this._mode === ViewModelMode.Tree) {
+			for (const resource of toInsert) {
+				item.tree.add(resource.sourceUri, resource);
+			}
 		}
 
 		const deleted = item.resources.splice(start, deleteCount, ...toInsert);
 
-		for (const resource of deleted) {
-			item.tree.delete(resource.sourceUri);
+		if (this._mode === ViewModelMode.Tree) {
+			for (const resource of deleted) {
+				item.tree.delete(resource.sourceUri);
+			}
 		}
 
 		this.refresh(item);

--- a/src/vs/workbench/contrib/scm/browser/repositoryPanel.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPanel.ts
@@ -713,15 +713,21 @@ export class RepositoryPanel extends ViewletPanel {
 		this._register(this.tree.onContextMenu(this.onListContextMenu, this));
 		this._register(this.tree);
 
-		let mode = this.configurationService.getValue<'tree' | 'list'>('scm.defaultViewMode') === 'list' ? ViewModelMode.List : ViewModelMode.Tree;
+		let mode: ViewModelMode;
 
-		const rootUri = this.repository.provider.rootUri;
+		if (this.repository.provider.contextValue !== 'git') {
+			mode = ViewModelMode.List;
+		} else {
+			mode = this.configurationService.getValue<'tree' | 'list'>('scm.defaultViewMode') === 'list' ? ViewModelMode.List : ViewModelMode.Tree;
 
-		if (typeof rootUri !== 'undefined') {
-			const storageMode = this.storageService.get(`scm.repository.viewMode:${rootUri.toString()}`, StorageScope.WORKSPACE) as ViewModelMode;
+			const rootUri = this.repository.provider.rootUri;
 
-			if (typeof storageMode === 'string') {
-				mode = storageMode;
+			if (typeof rootUri !== 'undefined') {
+				const storageMode = this.storageService.get(`scm.repository.viewMode:${rootUri.toString()}`, StorageScope.WORKSPACE) as ViewModelMode;
+
+				if (typeof storageMode === 'string') {
+					mode = storageMode;
+				}
 			}
 		}
 
@@ -735,8 +741,10 @@ export class RepositoryPanel extends ViewletPanel {
 		this._register(this.themeService.onDidFileIconThemeChange(this.updateIndentStyles, this));
 		this._register(this.viewModel.onDidChangeMode(this.onDidChangeMode, this));
 
-		this.toggleViewModelModeAction = new ToggleViewModeAction(this.viewModel);
-		this._register(this.toggleViewModelModeAction);
+		if (this.repository.provider.contextValue === 'git') {
+			this.toggleViewModelModeAction = new ToggleViewModeAction(this.viewModel);
+			this._register(this.toggleViewModelModeAction);
+		}
 
 		this._register(this.onDidChangeBodyVisibility(this._onDidChangeVisibility, this));
 


### PR DESCRIPTION
This prevents other SCM providers from using the tree rendering. This was the safest change to fix https://github.com/microsoft/vscode/issues/82203.

Moving forward we should do this: https://github.com/microsoft/vscode/issues/82264