### PR TITLE
Fixes #82257 for recovery

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scmViewlet.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scmViewlet.css
@@ -106,6 +106,7 @@
 	height: 100%;
 	background-repeat: no-repeat;
 	background-position: 50% 50%;
+	margin-right: 8px;
 }
 
 .scm-viewlet .monaco-list .monaco-list-row .resource > .name > .monaco-icon-label > .actions {


### PR DESCRIPTION
Other SCM providers use a different type of decoration which had bad margins when used in the tree.

Fixes #82257 for recovery