### PR TITLE
Open New Terminal -> Open New External Terminal

### DIFF
--- a/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
@@ -130,13 +130,13 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 	command: {
 		id: OPEN_NATIVE_CONSOLE_COMMAND_ID,
-		title: { value: nls.localize('globalConsoleAction', "Open New Terminal"), original: 'Open New Terminal' }
+		title: { value: nls.localize('globalConsoleAction', "Open New External Terminal"), original: 'Open New External Terminal' }
 	}
 });
 
 const openConsoleCommand = {
 	id: OPEN_IN_TERMINAL_COMMAND_ID,
-	title: nls.localize('scopedConsoleAction', "Open in Terminal")
+	title: nls.localize('scopedConsoleAction', "Open in External Terminal")
 };
 MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: 'navigation',

--- a/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
+++ b/src/vs/workbench/contrib/externalTerminal/browser/externalTerminal.contribution.ts
@@ -136,7 +136,7 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 
 const openConsoleCommand = {
 	id: OPEN_IN_TERMINAL_COMMAND_ID,
-	title: nls.localize('scopedConsoleAction', "Open in External Terminal")
+	title: nls.localize('scopedConsoleAction', "Open in Terminal")
 };
 MenuRegistry.appendMenuItem(MenuId.OpenEditorsContext, {
 	group: 'navigation',


### PR DESCRIPTION
Open New Terminal command palette action is confusing since people expect it to open internal terminal, but it opens external terminal instead. I changed the title to make it less confusing.

Also, what do you think about assigning it to Cmd+Shift+` on the Mac so that we have some kind of uniformity in shortcuts?