### PR TITLE
Fix #82200 - "Preserve Case" button in search viewlet is not tabbable

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -245,7 +245,7 @@ export class SearchView extends ViewletPanel {
 				if (this.searchWidget.isReplaceActive()) {
 					this.searchWidget.focusReplaceAllAction();
 				} else {
-					this.searchWidget.replaceInput.focusOnPreserve();
+					this.searchWidget.isReplaceShown() ? this.searchWidget.replaceInput.focusOnPreserve() : this.searchWidget.focusRegexAction();
 				}
 				dom.EventHelper.stop(e);
 			}

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -245,7 +245,7 @@ export class SearchView extends ViewletPanel {
 				if (this.searchWidget.isReplaceActive()) {
 					this.searchWidget.focusReplaceAllAction();
 				} else {
-					this.searchWidget.focusRegexAction();
+					this.searchWidget.replaceInput.focusOnPreserve();
 				}
 				dom.EventHelper.stop(e);
 			}

--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -513,6 +513,10 @@ export class SearchWidget extends Widget {
 			}
 			keyboardEvent.preventDefault();
 		}
+		else if (KeyMod.Shift | KeyCode.Tab) {
+			this.focusRegexAction();
+			keyboardEvent.preventDefault();
+		}
 	}
 
 	private onReplaceInputKeyDown(keyboardEvent: IKeyboardEvent) {

--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -389,6 +389,7 @@ export class SearchWidget extends Widget {
 		this.replaceInputFocusTracker = this._register(dom.trackFocus(this.replaceInput.inputBox.inputElement));
 		this._register(this.replaceInputFocusTracker.onDidFocus(() => this.replaceInputBoxFocused.set(true)));
 		this._register(this.replaceInputFocusTracker.onDidBlur(() => this.replaceInputBoxFocused.set(false)));
+		this._register(this.replaceInput.onPreserveCaseKeyDown((keyboardEvent: IKeyboardEvent) => this.onPreserveCaseKeyDown(keyboardEvent)));
 	}
 
 	triggerReplaceAll(): Promise<any> {
@@ -495,6 +496,15 @@ export class SearchWidget extends Widget {
 	}
 
 	private onRegexKeyDown(keyboardEvent: IKeyboardEvent) {
+		if (keyboardEvent.equals(KeyCode.Tab)) {
+			if (this.isReplaceShown()) {
+				this.replaceInput.focusOnPreserve();
+				keyboardEvent.preventDefault();
+			}
+		}
+	}
+
+	private onPreserveCaseKeyDown(keyboardEvent: IKeyboardEvent) {
 		if (keyboardEvent.equals(KeyCode.Tab)) {
 			if (this.isReplaceActive()) {
 				this.focusReplaceAllAction();


### PR DESCRIPTION
@roblourens  , Added the tab functionality for the preserve case button in order to fix #82200.

Whatever `onRegexKeyDown` was doing before is now being done in `onPreserveCaseKeyDown` and `onRegexKeyDown` only makes the preserve case to get focussed.