### PR TITLE
Fixes #82359 for recovery build

### DIFF
--- a/src/vs/workbench/services/extensions/node/extensionPoints.ts
+++ b/src/vs/workbench/services/extensions/node/extensionPoints.ts
@@ -51,7 +51,7 @@ class ExtensionManifestParser extends ExtensionManifestHandler {
 		return pfs.readFile(this._absoluteManifestPath).then((manifestContents) => {
 			const errors: json.ParseError[] = [];
 			const manifest = json.parse(manifestContents.toString(), errors);
-			if (errors.length === 0) {
+			if (!!manifest && errors.length === 0) {
 				if (manifest.__metadata) {
 					manifest.uuid = manifest.__metadata.id;
 				}


### PR DESCRIPTION
This PR fixes #82359

@aeschli https://github.com/microsoft/vscode/commit/479563e361f3face96b36220e7fe75384377e17f was a dangerous change because while `JSON.parse` would throw on parse errors, our custom `json.parse` doesn't and while its documentation reads `On invalid input, the parser tries to be as fault tolerant as possible, but still return a result.` it seems that there are cases in which the result it returns is `undefined`, which is what is happening here. The code happily continues and assumes `manifest` is an object.