### PR TITLE
Adding three finger swipe with various options.

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -33,7 +33,6 @@ import { IDialogMainService } from 'vs/platform/dialogs/electron-main/dialogs';
 import { mnemonicButtonLabel } from 'vs/base/common/labels';
 import { IWorkbenchEditorConfiguration } from 'vs/workbench/common/editor';
 
-
 const RUN_TEXTMATE_IN_WORKER = false;
 
 export interface IWindowCreationOptions {
@@ -398,12 +397,10 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 			this._lastFocusTime = Date.now();
 		});
 
-
 		// Simple fullscreen doesn't resize automatically when the resolution changes so as a workaround
 		// we need to detect when display metrics change or displays are added/removed and toggle the
 		// fullscreen manually.
 		if (isMacintosh) {
-
 			const simpleFullScreenScheduler = this._register(new RunOnceScheduler(() => {
 				if (!this._win) {
 					return; // disposed
@@ -565,16 +562,18 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 			this.setMenuBarVisibility(newMenuBarVisibility);
 		}
 
-		const config = this.configurationService.getValue<IWorkbenchEditorConfiguration>().workbench.editor.swipeToNavigate;
-
+		const config = this.configurationService.getValue<IWorkbenchEditorConfiguration>();
 		this._win.removeAllListeners('swipe');
 		this._win.removeAllListeners('app-command');
-		if (config && config !== 'off') {
-			if (isMacintosh) {
-				this.registerSwipeNavigationListener('swipe', 'left', 'right', config);
-			}
-			else {
-				this.registerSwipeNavigationListener('app-command', 'browser-backward', 'browser-forward', config);
+		if (config && config.workbench && config.workbench.editor) {
+			let swipeConfig = config.workbench.editor.swipeToNavigate;
+			if (swipeConfig && swipeConfig !== 'off') {
+				if (isMacintosh) {
+					this.registerSwipeNavigationListener('swipe', 'left', 'right', swipeConfig);
+				}
+				else {
+					this.registerSwipeNavigationListener('app-command', 'browser-backward', 'browser-forward', swipeConfig);
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -37,7 +37,8 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	openSideBySideDirection: 'right',
 	closeEmptyGroups: true,
 	labelFormat: 'default',
-	iconTheme: 'vs-seti'
+	iconTheme: 'vs-seti',
+	swipeToNavigate: 'off'
 };
 
 export function impactsEditorPartOptions(event: IConfigurationChangeEvent): boolean {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -113,6 +113,20 @@ import { isMacintosh, isWindows, isLinux, isWeb, isNative } from 'vs/base/common
 				'default': true,
 				'included': !isMacintosh
 			},
+			'workbench.editor.swipeToNavigate': {
+				'type': 'string',
+				'enum': ['off', 'actions', 'tabs', 'recent-tabs', 'grouped-tabs'],
+				'enumDescriptions': [
+					nls.localize('workbench.editor.swipeToNavigate.off', "Swipes are disabled."),
+					nls.localize('workbench.editor.swipeToNavigate.actions', "Swipes will navigate recent action history."),
+					nls.localize('workbench.editor.swipeToNavigate.tabs', "Swipes will navigate currently opened tabs."),
+					nls.localize('workbench.editor.swipeToNavigate.recent-tabs', "Swipes will navigate recent tab history."),
+					nls.localize('workbench.editor.swipeToNavigate.grouped-tabs', "Swipes will navigate currently opened tabs in selected group."),
+				],
+				'default': 'off',
+				'description': nls.localize('swipeToNavigate', "Control what a three finger swipe will navigate between."),
+
+			},
 			'workbench.editor.restoreViewState': {
 				'type': 'boolean',
 				'description': nls.localize('restoreViewState', "Restores the last view state (e.g. scroll position) when re-opening files after they have been closed."),

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1023,6 +1023,7 @@ interface IEditorPartConfiguration {
 	closeEmptyGroups?: boolean;
 	revealIfOpen?: boolean;
 	mouseBackForwardToNavigate?: boolean;
+	swipeToNavigate?: 'off' | 'actions' | 'tabs' | 'recent-tabs' | 'grouped-tabs';
 	labelFormat?: 'default' | 'short' | 'medium' | 'long';
 	restoreViewState?: boolean;
 }


### PR DESCRIPTION
Following options have been added: 
* `'actions'` -> `Swipes will navigate recent action history.`
* `'tabs'` -> `Swipes will navigate currently opened tabs.` 
* `'recent-tabs'` -> `Swipes will navigate recent tab history.`
* `'grouped-tabs'` -> `Swipes will navigate currently opened tabs in selected group.`

Fix: https://github.com/microsoft/vscode/issues/4803 (again) 
Based on changes from: https://github.com/microsoft/vscode/commit/e368b34ac39fc1ca51e553d91a08ae2cf13048d2 from @bpasero  & and my own PR https://github.com/microsoft/vscode/pull/23663 

Also fixes the confusion on what a swipe is supposed to do.
It seems most people just want **or** expect it to move between tabs, while I like it to function in similar fashion as Xcode. 
These added options allows user to toggle their preferred setting. But it only works with a *three* **(3)** finger Swipe, as that's what the exposed Electron API uses. 

Discussions: 
https://github.com/microsoft/vscode/issues/40526
https://github.com/microsoft/vscode/issues/25447
https://github.com/microsoft/vscode/issues/25325
https://github.com/microsoft/vscode/issues/25449

Edit: Made an [extension](https://marketplace.visualstudio.com/items?itemName=Seivan.swipe-to-navigate) out of it which is a good compromise. 
