### PR TITLE
Use normalized  path for loading remote webview resources

### DIFF
--- a/src/vs/workbench/contrib/webview/common/resourceLoader.ts
+++ b/src/vs/workbench/contrib/webview/common/resourceLoader.ts
@@ -60,7 +60,7 @@ export async function loadLocalResource(
 				authority: extensionLocation.authority,
 				path: '/vscode-resource',
 				query: JSON.stringify({
-					requestResourcePath: requestUri.path
+					requestResourcePath: normalizedPath.path
 				})
 			});
 			return resolveContent(fileService, redirectedUri, getWebviewContentMimeType(requestUri));


### PR DESCRIPTION
This PR fixes #82336

With the new asWebviewUri function, the raw uri is in a format the the remote file system will not be able to understand. Make sure we use the normalized path which is in the correct format
