### PR TITLE
Feature/pin close others

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -628,6 +628,10 @@ function registerCloseEditorCommands() {
 
 			const { group, editor } = resolveCommandsContext(editorGroupService, getCommandsContext(resourceOrContext, context));
 			if (group && editor) {
+				if (group.activeEditor) {
+					group.pinEditor(group.activeEditor);
+				}
+
 				return group.closeEditors({ direction: CloseDirection.RIGHT, except: editor });
 			}
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -606,6 +606,10 @@ function registerCloseEditorCommands() {
 						.map(context => typeof context.editorIndex === 'number' ? group.getEditor(context.editorIndex) : group.activeEditor);
 					const editorsToClose = group.editors.filter(e => editors.indexOf(e) === -1);
 
+					if (group.activeEditor) {
+						group.pinEditor(group.activeEditor);
+					}
+
 					return group.closeEditors(editorsToClose);
 				}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Currently when someone selects 'Close Others' on an unpinned editor, the editor remains unpinned.

That behavior seemed inconsistent to me since moving an editor around in a group or to a new group pins it. I think it makes sense that if someone is saying to close all editors apart from one, that the one editor should be pinned.

I also made it so an editor is pinned if someone selects 'Close to the right', but I'm less sure of that behavior. If this behavior remains, does it make sense to pin any unpinned editors to the left?

I don't have a problem adding tests, but I didn't see where the relevant tests were.

Here's the new behavior
![close others vscode](https://user-images.githubusercontent.com/3896310/66792611-234e2980-eebf-11e9-97d4-6c8b2d7414c7.gif)
