### PR TITLE
Use command -v to detect git

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -63,7 +63,7 @@ function findSpecificGit(path: string, onLookup: (path: string) => void): Promis
 
 function findGitDarwin(onLookup: (path: string) => void): Promise<IGit> {
 	return new Promise<IGit>((c, e) => {
-		cp.exec('which git', (err, gitPathBuffer) => {
+		cp.exec('command -v git', (err, gitPathBuffer) => {
 			if (err) {
 				return e('git not found');
 			}


### PR DESCRIPTION
Version details:

```
Version: 1.39.1
Commit: 88f15d17dca836346e787762685a40bb5cce75a8
Date: 2019-10-10T23:35:11.314Z
Electron: 4.2.10
Chrome: 69.0.3497.128
Node.js: 10.11.0
V8: 6.9.427.31-electron.0
OS: Darwin x64 18.7.0
```

## What I expect to happen

VS Code's Git extension finds + uses Git

## What actually happens

VS Code says it cannot find Git:

![image](https://user-images.githubusercontent.com/2687/66799232-03207800-ef5c-11e9-9928-2cc408a44bd5.png)

## Steps to reproduce

TL;DR: VS Code should use `command -v` to detect commands, not `which`.

This is a bit tricky, so bear with me:

There is a node package called which:

https://www.npmjs.com/package/which

If this package is installed through Node, _and_ a user is using asdf, this which-from-node can take precedence in $PATH. This will cause issues if there is no default Node version specified for asdf. An error like this can appear:

```
asdf: No version set for command which
you might want to add one of the following in your .tool-versions file:

nodejs 8.14.0
```

(I suspect this is only an issue on 'zsh' terminals -- I am unable to reproduce it in Bash)

To work around this which-conflict, we should use the built-in 'command' command. This comes standard in every shell program and is a viable alternative to 'which'.

When my shell works correctly, here's the output of `which -a which`:

```
which: shell built-in command
/Users/ryanbigg/.asdf/shims/which
/usr/bin/which
```

However, when it is misbehaving, I _suspect_ the order is like this:

```
/Users/ryanbigg/.asdf/shims/which
which: shell built-in command
/usr/bin/which
```

And that's why it's trying to use the node `which`. When no node version is configured for `asdf`, then it fails to run that node-which, which then causes this extension to claim that it can't find git.

This PR (likely) fixes #81287 -- although I'm not 100% sure of that.
