### PR TITLE
Add `cursorRedo` command (Ctrl+Shift+J)

### DIFF
--- a/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
+++ b/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
@@ -26,81 +26,83 @@ class CursorState {
 	}
 }
 
-export class CursorUndoController extends Disposable implements IEditorContribution {
+export class CursorUndoRedoController extends Disposable implements IEditorContribution {
 
-	public static readonly ID = 'editor.contrib.cursorUndoController';
+	public static readonly ID = 'editor.contrib.cursorUndoRedoController';
 
-	public static get(editor: ICodeEditor): CursorUndoController {
-		return editor.getContribution<CursorUndoController>(CursorUndoController.ID);
+	public static get(editor: ICodeEditor): CursorUndoRedoController {
+		return editor.getContribution<CursorUndoRedoController>(CursorUndoRedoController.ID);
 	}
 
 	private readonly _editor: ICodeEditor;
-	private _isCursorUndo: boolean;
+	private _isCursorUndoRedo: boolean;
 
 	private _undoStack: CursorState[];
+	private _redoStack: CursorState[];
 	private _prevState: CursorState | null;
 
 	constructor(editor: ICodeEditor) {
 		super();
 		this._editor = editor;
-		this._isCursorUndo = false;
+		this._isCursorUndoRedo = false;
 
 		this._undoStack = [];
-		this._prevState = this._readState();
+		this._redoStack = [];
+		this._prevState = null;
 
 		this._register(editor.onDidChangeModel((e) => {
 			this._undoStack = [];
+			this._redoStack = [];
 			this._prevState = null;
 		}));
 		this._register(editor.onDidChangeModelContent((e) => {
 			this._undoStack = [];
+			this._redoStack = [];
 			this._prevState = null;
 		}));
 		this._register(editor.onDidChangeCursorSelection((e) => {
 
-			if (!this._isCursorUndo && this._prevState) {
-				this._undoStack.push(this._prevState);
-				if (this._undoStack.length > 50) {
-					// keep the cursor undo stack bounded
-					this._undoStack.shift();
+			const newState = new CursorState(this._editor.getSelections()!);
+
+			if (!this._isCursorUndoRedo && this._prevState) {
+				const isEqualToLastUndoStack = (this._undoStack.length > 0 && this._undoStack[this._undoStack.length - 1].equals(this._prevState));
+				if (!isEqualToLastUndoStack) {
+					this._undoStack.push(this._prevState);
+					this._redoStack = [];
+					if (this._undoStack.length > 50) {
+						// keep the cursor undo stack bounded
+						this._undoStack.shift();
+					}
 				}
 			}
 
-			this._prevState = this._readState();
+			this._prevState = newState;
 		}));
 	}
 
-	private _readState(): CursorState | null {
-		if (!this._editor.hasModel()) {
-			// no model => no state
-			return null;
-		}
-
-		return new CursorState(this._editor.getSelections());
-	}
-
 	public cursorUndo(): void {
-		if (!this._editor.hasModel()) {
+		if (!this._editor.hasModel() || this._undoStack.length === 0) {
 			return;
 		}
 
-		const currState = new CursorState(this._editor.getSelections());
-
-		while (this._undoStack.length > 0) {
-			const prevState = this._undoStack.pop()!;
-
-			if (!prevState.equals(currState)) {
-				this._isCursorUndo = true;
-				this._editor.setSelections(prevState.selections);
-				this._editor.revealRangeInCenterIfOutsideViewport(prevState.selections[0], ScrollType.Smooth);
-				this._isCursorUndo = false;
-				return;
-			}
-		}
+		this._redoStack.push(new CursorState(this._editor.getSelections()));
+		this._applyState(this._undoStack.pop()!);
 	}
 
 	public cursorRedo(): void {
-		throw new Error('Not implemented!');
+		if (!this._editor.hasModel() || this._redoStack.length === 0) {
+			return;
+		}
+
+		this._undoStack.push(new CursorState(this._editor.getSelections()));
+		this._applyState(this._redoStack.pop()!);
+	}
+
+	private _applyState(state: CursorState): void {
+		this._isCursorUndoRedo = true;
+		this._editor.setSelections(state.selections);
+		this._editor.revealRangeInCenterIfOutsideViewport(state.selections[0], ScrollType.Smooth);
+		this._isCursorUndoRedo = false;
 	}
 }
 
@@ -120,7 +122,7 @@ export class CursorUndo extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
-		CursorUndoController.get(editor).cursorUndo();
+		CursorUndoRedoController.get(editor).cursorUndo();
 	}
 }
 
@@ -135,10 +137,10 @@ export class CursorRedo extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
-		CursorUndoController.get(editor).cursorRedo();
+		CursorUndoRedoController.get(editor).cursorRedo();
 	}
 }
 
-registerEditorContribution(CursorUndoController.ID, CursorUndoController);
+registerEditorContribution(CursorUndoRedoController.ID, CursorUndoRedoController);
 registerEditorAction(CursorUndo);
 registerEditorAction(CursorRedo);

--- a/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
+++ b/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
@@ -98,6 +98,10 @@ export class CursorUndoController extends Disposable implements IEditorContribut
 			}
 		}
 	}
+
+	public cursorRedo(): void {
+		throw new Error('Not implemented!');
+	}
 }
 
 export class CursorUndo extends EditorAction {
@@ -120,5 +124,21 @@ export class CursorUndo extends EditorAction {
 	}
 }
 
+export class CursorRedo extends EditorAction {
+	constructor() {
+		super({
+			id: 'cursorRedo',
+			label: nls.localize('cursor.redo', "Soft Redo"),
+			alias: 'Soft Redo',
+			precondition: undefined
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
+		CursorUndoController.get(editor).cursorRedo();
+	}
+}
+
 registerEditorContribution(CursorUndoController.ID, CursorUndoController);
 registerEditorAction(CursorUndo);
+registerEditorAction(CursorRedo);


### PR DESCRIPTION
There is a command called `cursorUndo` which is used to undo cursor and selection changes.
The undo stack is flushed when the text changes.

This PR adds a `cursorRedo` command to complement `cursorUndo`, and binds it to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> by default.

This fixes #82007

### How to test

1. Open an empty buffer
2. Type some text
3. Move the cursor around with commands that do not modify the text itself. You can also select things and multi-select.
4. Press <kbd>Ctrl</kbd>+<kbd>U</kbd> a couple of times to undo some of those movements
5. Press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd> to redo each movement you just undid.
6. Modify the text - the undo/redo stack should be flushed and you should not be able to use cursorUndo/cursorRedo to get to the previous cursor locations.

### Implementation

To do this I refactored the code to separate the part that interacts with the editor (`CursorUndoController`) from the cursor undo/redo logic (`CursorStateStack`).

Previously a list of cursor states was kept, and to undo the state it would pop the latest state from the list.

This PR changes that to a list of cursor states and an index to where we are currently inside that list.
When undoing or redoing the index is moved without deleting any states from the list.
When the state changes, all the states after where we are currently inside the list are dropped, and the new state is added.
