### PR TITLE
Added toggle read-only mode (Alt + Shift +R)

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -419,10 +419,10 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	 */
 	onDidAttemptReadOnlyEdit(listener: () => void): IDisposable;
 	/**
- 	* An event emitted when editing failed because the editor is in read-only mode.
- 	* @event
- 	* @internal
- 	*/
+	 * An event emitted when editing failed because the editor is in read-only mode.
+	 * @event
+	 * @internal
+	 */
 	onDidAttemptReadOnlyMode(listener: () => void): IDisposable;
 	/**
 	 * An event emitted when users paste text in the editor.

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -419,6 +419,12 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	 */
 	onDidAttemptReadOnlyEdit(listener: () => void): IDisposable;
 	/**
+ 	* An event emitted when editing failed because the editor is in read-only mode.
+ 	* @event
+ 	* @internal
+ 	*/
+	onDidAttemptReadOnlyMode(listener: () => void): IDisposable;
+	/**
 	 * An event emitted when users paste text in the editor.
 	 * @event
 	 * @internal

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -140,6 +140,9 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	private readonly _onDidAttemptReadOnlyEdit: Emitter<void> = this._register(new Emitter<void>());
 	public readonly onDidAttemptReadOnlyEdit: Event<void> = this._onDidAttemptReadOnlyEdit.event;
 
+	private readonly _onDidAttemptReadOnlyMode: Emitter<void> = this._register(new Emitter<void>());
+	public readonly onDidAttemptReadOnlyMode: Event<void> = this._onDidAttemptReadOnlyMode.event;
+
 	private readonly _onDidLayoutChange: Emitter<EditorLayoutInfo> = this._register(new Emitter<EditorLayoutInfo>());
 	public readonly onDidLayoutChange: Event<EditorLayoutInfo> = this._onDidLayoutChange.event;
 
@@ -1342,6 +1345,10 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 		listenersToRemove.push(cursor.onDidAttemptReadOnlyEdit(() => {
 			this._onDidAttemptReadOnlyEdit.fire(undefined);
+		}));
+
+		listenersToRemove.push(cursor.onDidAttemptReadOnlyMode(() => {
+			this._onDidAttemptReadOnlyMode.fire(undefined);
 		}));
 
 		listenersToRemove.push(cursor.onDidChange((e: CursorStateChangedEvent) => {

--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -48,6 +48,32 @@ export const TabFocus: ITabFocus = new class implements ITabFocus {
 	}
 };
 
+export interface IReadOnly {
+	onDidChangeReadOnly: Event<boolean>;
+	getReadOnlyMode(): boolean;
+	setReadOnlyMode(readOnlyMode: boolean): void;
+}
+
+export const ReadOnly: IReadOnly = new class implements IReadOnly {
+	private _readOnly: boolean = false;
+
+	private readonly _onDidChangeReadOnly = new Emitter<boolean>();
+	public readonly onDidChangeReadOnly: Event<boolean> = this._onDidChangeReadOnly.event;
+
+	public getReadOnlyMode(): boolean {
+		return this._readOnly;
+	}
+
+	public setReadOnlyMode(readOnlyMode: boolean): void {
+		if (this._readOnly === readOnlyMode) {
+			return;
+		}
+
+		this._readOnly = readOnlyMode;
+		this._onDidChangeReadOnly.fire(this._readOnly);
+	}
+};
+
 export interface IEnvConfiguration {
 	extraEditorClassName: string;
 	outerWidth: number;
@@ -243,6 +269,7 @@ export abstract class CommonEditorConfiguration extends Disposable implements ed
 
 		this._register(EditorZoom.onDidChangeZoomLevel(_ => this._recomputeOptions()));
 		this._register(TabFocus.onDidChangeTabFocus(_ => this._recomputeOptions()));
+		this._register(ReadOnly.onDidChangeReadOnly(_ => this._recomputeOptions()));
 	}
 
 	public observeReferenceElement(dimension?: editorCommon.IDimension): void {
@@ -288,6 +315,7 @@ export abstract class CommonEditorConfiguration extends Disposable implements ed
 			emptySelectionClipboard: partialEnv.emptySelectionClipboard,
 			pixelRatio: partialEnv.pixelRatio,
 			tabFocusMode: TabFocus.getTabFocusMode(),
+			readOnlyMode: ReadOnly.getReadOnlyMode(),
 			accessibilitySupport: partialEnv.accessibilitySupport
 		};
 		return EditorConfiguration2.computeOptions(this._validatedOptions, env);

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -614,6 +614,7 @@ export interface IEnvironmentalOptions {
 	readonly emptySelectionClipboard: boolean;
 	readonly pixelRatio: number;
 	readonly tabFocusMode: boolean;
+	readonly readOnlyMode: boolean;
 	readonly accessibilitySupport: AccessibilitySupport;
 }
 
@@ -2475,6 +2476,22 @@ class EditorTabFocusMode extends ComputedEditorOption<EditorOption.tabFocusMode,
 
 //#endregion
 
+//#region readOnlyMode
+
+class EditorReadOnlyMode extends ComputedEditorOption<EditorOption.readOnlyMode, boolean> {
+
+	constructor() {
+		super(EditorOption.readOnlyMode, [EditorOption.readOnly]);
+	}
+
+	public compute(env: IEnvironmentalOptions, options: IComputedEditorOptions, _: boolean): boolean {
+		const readOnly = options.get(EditorOption.readOnly);
+		return (readOnly ? true : env.readOnlyMode);
+	}
+}
+
+//#endregion
+
 //#region wrappingIndent
 
 /**
@@ -2739,6 +2756,7 @@ export const enum EditorOption {
 	tabFocusMode,
 	layoutInfo,
 	wrappingInfo,
+	readOnlyMode
 }
 
 /**
@@ -3275,6 +3293,7 @@ export const EditorOptions = {
 	tabFocusMode: register(new EditorTabFocusMode()),
 	layoutInfo: register(new EditorLayoutInfoComputer()),
 	wrappingInfo: register(new EditorWrappingInfoComputer()),
+	readOnlyMode: register(new EditorReadOnlyMode()),
 };
 
 /**

--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -161,6 +161,9 @@ export class Cursor extends viewEvents.ViewEventEmitter implements ICursors {
 	private readonly _onDidAttemptReadOnlyEdit: Emitter<void> = this._register(new Emitter<void>());
 	public readonly onDidAttemptReadOnlyEdit: Event<void> = this._onDidAttemptReadOnlyEdit.event;
 
+	private readonly _onDidAttemptReadOnlyMode: Emitter<void> = this._register(new Emitter<void>());
+	public readonly onDidAttemptReadOnlyMode: Event<void> = this._onDidAttemptReadOnlyMode.event;
+
 	private readonly _onDidChange: Emitter<CursorStateChangedEvent> = this._register(new Emitter<CursorStateChangedEvent>());
 	public readonly onDidChange: Event<CursorStateChangedEvent> = this._onDidChange.event;
 
@@ -678,6 +681,11 @@ export class Cursor extends viewEvents.ViewEventEmitter implements ICursors {
 			// All the remaining handlers will try to edit the model,
 			// but we cannot edit when read only...
 			this._onDidAttemptReadOnlyEdit.fire(undefined);
+			return;
+		}
+
+		if (this._configuration.options.get(EditorOption.readOnlyMode)) {
+			this._onDidAttemptReadOnlyMode.fire(undefined);
 			return;
 		}
 

--- a/src/vs/editor/contrib/message/messageController.ts
+++ b/src/vs/editor/contrib/message/messageController.ts
@@ -48,6 +48,7 @@ export class MessageController extends Disposable implements editorCommon.IEdito
 		this._editor = editor;
 		this._visible = MessageController.MESSAGE_VISIBLE.bindTo(contextKeyService);
 		this._register(this._editor.onDidAttemptReadOnlyEdit(() => this._onDidAttemptReadOnlyEdit()));
+		this._register(this._editor.onDidAttemptReadOnlyMode(() => this._onDidAttemptReadOnlyMode()));
 	}
 
 	dispose(): void {
@@ -105,6 +106,12 @@ export class MessageController extends Disposable implements editorCommon.IEdito
 	private _onDidAttemptReadOnlyEdit(): void {
 		if (this._editor.hasModel()) {
 			this.showMessage(nls.localize('editor.readonly', "Cannot edit in read-only editor"), this._editor.getPosition());
+		}
+	}
+
+	private _onDidAttemptReadOnlyMode(): void {
+		if (this._editor.hasModel()) {
+			this.showMessage(nls.localize('editor.readonlymode', "Cannot edit in read-only mode"), this._editor.getPosition());
 		}
 	}
 }

--- a/src/vs/editor/contrib/toggleReadOnlyMode/toggleReadOnlyMode.ts
+++ b/src/vs/editor/contrib/toggleReadOnlyMode/toggleReadOnlyMode.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vs/nls';
+import { alert } from 'vs/base/browser/ui/aria/aria';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorAction, ServicesAccessor, registerEditorAction } from 'vs/editor/browser/editorExtensions';
+import { ReadOnly } from 'vs/editor/common/config/commonEditorConfig';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { MenuId } from 'vs/platform/actions/common/actions';
+
+export class ToggleReadOnlyModeAction extends EditorAction {
+
+	public static readonly ID = 'editor.action.toggleReadOnlyMode';
+
+	constructor() {
+		super({
+			id: ToggleReadOnlyModeAction.ID,
+			label: nls.localize({ key: 'toggle.readOnly', comment: ['Turn on/off read only mode around VS Code'] }, "Toggle Read Only Mode"),
+			alias: 'Toggle Tab Key Moves Focus',
+			precondition: undefined,
+			kbOpts: {
+				kbExpr: null,
+				primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_R,
+				mac: { primary: KeyMod.Alt | KeyMod.Shift | KeyCode.KEY_R },
+				weight: KeybindingWeight.EditorContrib
+			},
+			menubarOpts: {
+				menuId: MenuId.MenubarEditMenu,
+				group: '5_insert',
+				title: nls.localize({ key: 'miToggleReadOnlyMode', comment: ['&& denotes a mnemonic'] }, "Toggle &&Read Only Mode"),
+				order: 5
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		const oldValue = ReadOnly.getReadOnlyMode();
+		const newValue = !oldValue;
+		ReadOnly.setReadOnlyMode(newValue);
+		if (newValue) {
+			alert(nls.localize('toggle.readOnly.on', "Editor is read only mode now"));
+		} else {
+			alert(nls.localize('toggle.readOnly.off', "Editor is not red only mode now"));
+		}
+	}
+}
+
+registerEditorAction(ToggleReadOnlyModeAction);

--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -38,6 +38,7 @@ import 'vs/editor/contrib/snippet/snippetController2';
 import 'vs/editor/contrib/suggest/suggestController';
 import 'vs/editor/contrib/tokenization/tokenization';
 import 'vs/editor/contrib/toggleTabFocusMode/toggleTabFocusMode';
+import 'vs/editor/contrib/toggleReadOnlyMode/toggleReadOnlyMode';
 import 'vs/editor/contrib/wordHighlighter/wordHighlighter';
 import 'vs/editor/contrib/wordOperations/wordOperations';
 import 'vs/editor/contrib/wordPartOperations/wordPartOperations';

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -30,7 +30,7 @@ import { IModeService, ILanguageSelection } from 'vs/editor/common/services/mode
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
-import { TabFocus , ReadOnly} from 'vs/editor/common/config/commonEditorConfig';
+import { TabFocus, ReadOnly } from 'vs/editor/common/config/commonEditorConfig';
 import { ICommandService, CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ITextFileService, SUPPORTED_ENCODINGS } from 'vs/workbench/services/textfile/common/textfiles';
@@ -202,7 +202,7 @@ class State {
 	get tabFocusMode(): boolean | undefined { return this._tabFocusMode; }
 
 	private _readOnlyMode: boolean | undefined;
-	get readOnlyMode(): boolean | undefined { return this._readOnlyMode;}
+	get readOnlyMode(): boolean | undefined { return this._readOnlyMode; }
 
 	private _screenReaderMode: boolean | undefined;
 	get screenReaderMode(): boolean | undefined { return this._screenReaderMode; }
@@ -255,7 +255,7 @@ class State {
 			}
 		}
 
-		if ('readOnlyMode' in update){
+		if ('readOnlyMode' in update) {
 			if (this._readOnlyMode !== update.readOnlyMode) {
 				this._readOnlyMode = update.readOnlyMode;
 				change.readOnlyMode = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->
There is a command called ToggleReadOnlyMode, which toggled read-only mode.
When turned on, all files on editor are in read-only mode.
It can be switched by  Alt + Shift + R or menu bar.
This fixes #4873
It's my first time submitting a pull request , I apologize in advance if I made a mistake.

Result:
![readonly](https://user-images.githubusercontent.com/34494114/66981873-fb91d800-f0ef-11e9-8064-2cb17238843f.gif)
