### PR TITLE
add support for command line arguments in grunt task runner

### DIFF
--- a/extensions/grunt/package.json
+++ b/extensions/grunt/package.json
@@ -55,6 +55,10 @@
             "type": "string",
             "description": "%grunt.taskDefinition.type.description%"
           },
+          "args": {
+            "type": "array",
+            "description": "%grunt.taskDefinition.args.description%"
+          },
           "file": {
             "type": "string",
             "description": "%grunt.taskDefinition.file.description%"

--- a/extensions/grunt/package.nls.json
+++ b/extensions/grunt/package.nls.json
@@ -3,5 +3,6 @@
 	"displayName": "Grunt support for VS Code",
 	"config.grunt.autoDetect": "Controls whether auto detection of Grunt tasks is on or off. Default is on.",
 	"grunt.taskDefinition.type.description": "The Grunt task to customize.",
+	"grunt.taskDefinition.args.description": "Command line arguments to pass to the grunt task",
 	"grunt.taskDefinition.file.description": "The Grunt file that provides the task. Can be omitted."
 }

--- a/extensions/grunt/src/main.ts
+++ b/extensions/grunt/src/main.ts
@@ -67,6 +67,7 @@ function showError() {
 }
 interface GruntTaskDefinition extends vscode.TaskDefinition {
 	task: string;
+	args?: string[];
 	file?: string;
 }
 
@@ -121,14 +122,14 @@ class FolderDetector {
 	}
 
 	public async getTask(_task: vscode.Task): Promise<vscode.Task | undefined> {
-		const gruntTask = (<any>_task.definition).task;
+		const taskDefinition = <any>_task.definition;
+		const gruntTask = taskDefinition.task;
 		if (gruntTask) {
-			let kind: GruntTaskDefinition = (<any>_task.definition);
 			let options: vscode.ShellExecutionOptions = { cwd: this.workspaceFolder.uri.fsPath };
 			let source = 'grunt';
 			let task = gruntTask.indexOf(' ') === -1
-				? new vscode.Task(kind, this.workspaceFolder, gruntTask, source, new vscode.ShellExecution(`${await this._gruntCommand} ${gruntTask.name}`, options))
-				: new vscode.Task(kind, this.workspaceFolder, gruntTask, source, new vscode.ShellExecution(`${await this._gruntCommand} "${gruntTask.name}"`, options));
+				? new vscode.Task(taskDefinition, this.workspaceFolder, gruntTask, source, new vscode.ShellExecution(`${await this._gruntCommand}`, [gruntTask, ...taskDefinition.args], options))
+				: new vscode.Task(taskDefinition, this.workspaceFolder, gruntTask, source, new vscode.ShellExecution(`${await this._gruntCommand}`, [`"${gruntTask}"`, ...taskDefinition.args], options));
 			return task;
 		}
 		return undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #66748

This PR adds the support to pass task arguments from grunt task runner extension. I have created a sample repository (as suggested by @alexr00) for checking the functionality [here](https://github.com/sohailrajdev97/grunt-sandbox). Steps to check the functionality:

1. Clone the repository
1. Install the dependencies using `npm install`
1. Build vscode with this added functionality
1. Test the task which has been defined in `tasks.json` of the sample repository. This task passes a command line argument to the task runner
