### PR TITLE
Fix async race condition in the tree

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -534,12 +534,18 @@ export class ExplorerView extends ViewletPanel {
 			.sort((first, second) => second.resource.path.length - first.resource.path.length)[0];
 
 		while (item && item.resource.toString() !== resource.toString()) {
+			if (item.isDisposed) {
+				return this.onSelectResource(resource, reveal);
+			}
 			await this.tree.expand(item);
 			item = first(values(item.children), i => isEqualOrParent(resource, i.resource));
 		}
 
 		if (item && item.parent) {
 			if (reveal) {
+				if (item.isDisposed) {
+					return this.onSelectResource(resource, reveal);
+				}
 				this.tree.reveal(item, 0.5);
 			}
 

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -75,6 +75,7 @@ export class ExplorerModel implements IDisposable {
 
 export class ExplorerItem {
 	private _isDirectoryResolved: boolean;
+	private _isDisposed: boolean;
 	public isError = false;
 
 	constructor(
@@ -87,6 +88,10 @@ export class ExplorerItem {
 		private _mtime?: number,
 	) {
 		this._isDirectoryResolved = false;
+	}
+
+	get isDisposed(): boolean {
+		return this._isDisposed;
 	}
 
 	get isDirectoryResolved(): boolean {
@@ -218,6 +223,7 @@ export class ExplorerItem {
 				if (formerLocalChild) {
 					ExplorerItem.mergeLocalWithDisk(diskChild, formerLocalChild);
 					local.addChild(formerLocalChild);
+					oldLocalChildren.delete(diskChild.resource);
 				}
 
 				// New child: add
@@ -225,6 +231,10 @@ export class ExplorerItem {
 					local.addChild(diskChild);
 				}
 			});
+
+			for (let child of oldLocalChildren.values()) {
+				child._dispose();
+			}
 		}
 	}
 
@@ -274,8 +284,18 @@ export class ExplorerItem {
 	}
 
 	forgetChildren(): void {
+		for (let c of this.children.values()) {
+			c._dispose();
+		}
 		this.children.clear();
 		this._isDirectoryResolved = false;
+	}
+
+	private _dispose() {
+		this._isDisposed = true;
+		for (let child of this.children.values()) {
+			child._dispose();
+		}
 	}
 
 	private getPlatformAwareName(name: string): string {


### PR DESCRIPTION
This PR fixes #82290

The following was done:
- Introduced _isDisposed field on the ExplorerItem class
- Set it to true when children are deleted from the active tree
- Check that nodes are not disposed in the code revealing resource, and if they are disposed start over