### PR TITLE
Add a clear button to settings editor search bar

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -44,7 +44,16 @@
 	padding: 0px 8px;
 	border-radius: 2px;
 	position: absolute;
-	right: 10px;
+	right: 35px;
+	top: 0;
+}
+
+.settings-editor > .settings-header > .search-container > .settings-clear-widget {
+	margin: 6px 0px;
+	padding: 0px 8px;
+	border-radius: 2px;
+	position: absolute;
+	right: 0px;
 	top: 0;
 }
 


### PR DESCRIPTION
I added a clear button to the settings editor search bar...
This clear button works the same as the one in the keyboard shortcuts editor, it clears the input that is in the search bar and then refocuses.

![image](https://user-images.githubusercontent.com/35276477/67152162-22dad780-f29f-11e9-978f-792fb9144bb3.png)

This is helpful if you want to clear the search bar while browsing results as the clear search option that is currently implemented doesn't pop up on search results. The button saves the extra step of having to backspace and retype your search as its just 1 click that does this.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #66141
