### PR TITLE
Rename `cursorUndo/Redo` commands from "Soft Undo/Redo" to "Cursor Undo/Redo"

### DIFF
--- a/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
+++ b/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
@@ -119,8 +119,8 @@ export class CursorUndo extends EditorAction {
 	constructor() {
 		super({
 			id: 'cursorUndo',
-			label: nls.localize('cursor.undo', "Soft Undo"),
-			alias: 'Soft Undo',
+			label: nls.localize('cursor.undo', "Cursor Undo"),
+			alias: 'Cursor Undo',
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -139,8 +139,8 @@ export class CursorRedo extends EditorAction {
 	constructor() {
 		super({
 			id: 'cursorRedo',
-			label: nls.localize('cursor.redo', "Soft Redo"),
-			alias: 'Soft Redo',
+			label: nls.localize('cursor.redo', "Cursor Redo"),
+			alias: 'Cursor Redo',
 			precondition: undefined
 		});
 	}


### PR DESCRIPTION
This PR fixes #82008

This changes the labels of the commands `cursorUndo` and `cursorRedo` in the command palette from `"Soft Undo"`/`"Soft Redo"` to `"Cursor Undo"`/`"Cursor Redo"`.
