### PR TITLE
Set a default keybinding for `cursorRedo`: Ctrl+Shift+J

### DIFF
--- a/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
+++ b/src/vs/editor/contrib/cursorUndo/cursorUndo.ts
@@ -141,7 +141,12 @@ export class CursorRedo extends EditorAction {
 			id: 'cursorRedo',
 			label: nls.localize('cursor.redo', "Soft Redo"),
 			alias: 'Soft Redo',
-			precondition: undefined
+			precondition: undefined,
+			kbOpts: {
+				kbExpr: EditorContextKeys.textInputFocus,
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_J,
+				weight: KeybindingWeight.EditorContrib
+			}
 		});
 	}
 


### PR DESCRIPTION
This PR fixes #82932

It sets a default keybinding to the `cursorRedo` command (called "Soft Redo" in the command palette): <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>J</kbd>