### PR TITLE
Filter out dead keys in tree keyboard navigation

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -657,6 +657,7 @@ class TypeFilterController<T, TFilterData> implements IDisposable {
 
 		const onKeyDown = Event.chain(domEvent(this.view.getHTMLElement(), 'keydown'))
 			.filter(e => !isInputElement(e.target as HTMLElement) || e.target === this.filterOnTypeDomNode)
+			.filter(e => e.key !== 'Dead')
 			.map(e => new StandardKeyboardEvent(e))
 			.filter(this.keyboardNavigationEventFilter || (() => true))
 			.filter(() => this.automaticKeyboardNavigation || this.triggered)


### PR DESCRIPTION
Fixes #80741 

Steps to reproduce original issue:

1. Set keyboard layout to Portuguese
2. Put focus on explorer section
3. Press one of the following keys:
- ^
- ´
- `
- ~

This PR should prevent these key presses from outputting 'Dead' in the tree keyboard navigation.