### PR TITLE
CI Builds with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on: [push, pull_request]
 jobs:
   linux:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v1
     # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
@@ -38,4 +37,33 @@ jobs:
     - run: DISPLAY=:10 ./scripts/test.sh --tfs "Unit Tests"
       name: Run Unit Tests
     - run: DISPLAY=:10 ./scripts/test-integration.sh --tfs "Integration Tests"
+      name: Run Integration Tests
+
+  windows:
+    runs-on: windows-2016
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '2.x'
+    - run: yarn --frozen-lockfile
+      name: Install Dependencies
+    - run: yarn electron
+      name: Download Electron
+    - run: yarn gulp hygiene --skip-tslint
+      name: Run Hygiene Checks
+    - run: yarn gulp tslint
+      name: Run TSLint Checks
+    - run: yarn monaco-compile-check
+      name: Run Monaco Editor Checks
+    - run: yarn compile
+      name: Compile Sources
+    - run: yarn download-builtin-extensions
+      name: Download Built-in Extensions
+    - run: .\scripts\test.bat --tfs "Unit Tests"
+      name: Run Unit Tests
+    - run: .\scripts\test-integration.bat --tfs "Integration Tests"
       name: Run Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,29 @@ jobs:
       name: Run Unit Tests
     - run: .\scripts\test-integration.bat --tfs "Integration Tests"
       name: Run Integration Tests
+
+  darwin:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+    - run: yarn --frozen-lockfile
+      name: Install Dependencies
+    - run: yarn electron x64
+      name: Download Electron
+    - run: yarn gulp hygiene --skip-tslint
+      name: Run Hygiene Checks
+    - run: yarn gulp tslint
+      name: Run TSLint Checks
+    - run: yarn monaco-compile-check
+      name: Run Monaco Editor Checks
+    - run: yarn compile
+      name: Compile Sources
+    - run: yarn download-builtin-extensions
+      name: Download Built-in Extensions
+    - run: ./scripts/test.sh --tfs "Unit Tests"
+      name: Run Unit Tests
+    - run: ./scripts/test-integration.sh --tfs "Integration Tests"
+      name: Run Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    # TODO: rename azure-pipelines/linux/xvfb.init to github-actions
+    - run: |
+        sudo apt-get update
+        sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
+        sudo cp build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
+        sudo chmod +x /etc/init.d/xvfb
+        sudo update-rc.d xvfb defaults
+        sudo service xvfb start
+      name: Setup Build Environment
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+    # TODO: cache node modules
+    - run: yarn --frozen-lockfile
+      name: Install Dependencies
+    - run: yarn electron x64
+      name: Download Electron
+    - run: yarn gulp hygiene --skip-tslint
+      name: Run Hygiene Checks
+    - run: yarn gulp tslint
+      name: Run TSLint Checks
+    - run: yarn monaco-compile-check
+      name: Run Monaco Editor Checks
+    - run: yarn compile
+      name: Compile Sources
+    - run: yarn download-builtin-extensions
+      name: Download Built-in Extensions
+    - run: DISPLAY=:10 ./scripts/test.sh --tfs "Unit Tests"
+      name: Run Unit Tests
+    - run: DISPLAY=:10 ./scripts/test-integration.sh --tfs "Integration Tests"
+      name: Run Integration Tests


### PR DESCRIPTION
I wanted to see if there was any interest in adding GitHub Actions to the party for validating pull request builds and merges into master.

This should be _almost_ the same configuration as what you have for Azure Pipelines, except with a lack of caching.  (Artifact caching is coming :soon: to GitHub Actions, but I was curious how well it performed even without that.)

Also, there's no way to include pieces of other YAML (yet), so this is all declared in a single file.

/cc @joaomoreno 