### PR TITLE
Git: Fixed error when staging in empty repository

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -762,9 +762,12 @@ export class Repository {
 	async log(options?: LogOptions): Promise<Commit[]> {
 		const maxEntries = options && typeof options.maxEntries === 'number' && options.maxEntries > 0 ? options.maxEntries : 32;
 		const args = ['log', '-' + maxEntries, `--pretty=format:${COMMIT_FORMAT}%x00%x00`];
-		const gitResult = await this.run(args);
-		if (gitResult.exitCode) {
-			// An empty repo.
+
+		let gitResult: IExecutionResult<string>;
+		try {
+			gitResult = await this.run(args);
+		} catch (err) {
+			// An empty repo
 			return [];
 		}
 
@@ -1164,9 +1167,15 @@ export class Repository {
 
 		let mode: string;
 		let add: string = '';
+		let treeish: string = '';
+		const commits = await this.log({ maxEntries: 1 });
+
+		if (commits.length > 0) {
+			treeish = 'HEAD';
+		}
 
 		try {
-			const details = await this.getObjectDetails('HEAD', path);
+			const details = await this.getObjectDetails(treeish, path);
 			mode = details.mode;
 		} catch (err) {
 			if (err.gitErrorCode !== GitErrorCodes.UnknownPath) {


### PR DESCRIPTION
Trying to stage a commit in an empty repository (i.e. no prior commits)
results in a git fatal error. This is because in an empty repo, HEAD
doesn't point to anything causing `git ls-tree -l HEAD ...` to fail.

To fix this, send `treeish` as `'HEAD'` to `getObjectDetails()` only if
there is at least one commit in the repo. Else, send an empty string
causing `getObjectDetails()` to use `lsFiles` instead of `lsTree`.

Fixes #82026.
