### PR TITLE
Use arrow keys to change focused comment in CommentThread overlay

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -57,7 +57,6 @@ export class CommentNode extends Disposable {
 	protected toolbar: ToolBar | undefined;
 	private _commentFormActions: CommentFormActions | null = null;
 
-	private readonly _onDidDelete = new Emitter<CommentNode>();
 	private readonly _onDidClick = new Emitter<CommentNode>();
 
 	public get domNode(): HTMLElement {
@@ -114,10 +113,6 @@ export class CommentNode extends Disposable {
 		this._clearTimeout = null;
 
 		this._register(dom.addDisposableListener(this._domNode, dom.EventType.CLICK, () => this.isEditing || this._onDidClick.fire(this)));
-	}
-
-	public get onDidDelete(): Event<CommentNode> {
-		return this._onDidDelete.event;
 	}
 
 	public get onDidClick(): Event<CommentNode> {

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -58,6 +58,7 @@ export class CommentNode extends Disposable {
 	private _commentFormActions: CommentFormActions | null = null;
 
 	private readonly _onDidDelete = new Emitter<CommentNode>();
+	private readonly _onDidClick = new Emitter<CommentNode>();
 
 	public get domNode(): HTMLElement {
 		return this._domNode;
@@ -89,7 +90,7 @@ export class CommentNode extends Disposable {
 		this._contextKeyService = contextKeyService.createScoped(this._domNode);
 		this._commentContextValue = this._contextKeyService.createKey('comment', comment.contextValue);
 
-		this._domNode.tabIndex = 0;
+		this._domNode.tabIndex = -1;
 		const avatar = dom.append(this._domNode, dom.$('div.avatar-container'));
 		if (comment.userIconPath) {
 			const img = <HTMLImageElement>dom.append(avatar, dom.$('img.avatar'));
@@ -111,10 +112,16 @@ export class CommentNode extends Disposable {
 		this._domNode.setAttribute('aria-label', `${comment.userName}, ${comment.body.value}`);
 		this._domNode.setAttribute('role', 'treeitem');
 		this._clearTimeout = null;
+
+		this._register(dom.addDisposableListener(this._domNode, dom.EventType.CLICK, () => this.isEditing || this._onDidClick.fire(this)));
 	}
 
 	public get onDidDelete(): Event<CommentNode> {
 		return this._onDidDelete.event;
+	}
+
+	public get onDidClick(): Event<CommentNode> {
+		return this._onDidClick.event;
 	}
 
 	private createHeader(commentDetailsContainer: HTMLElement): void {
@@ -430,19 +437,31 @@ export class CommentNode extends Disposable {
 		this._commentFormActions.setActions(menu);
 	}
 
+	setFocus(focused: boolean, visible: boolean = false) {
+		if (focused) {
+			this._domNode.focus();
+			this._actionsToolbarContainer.classList.remove('hidden');
+			this._actionsToolbarContainer.classList.add('tabfocused');
+			this._domNode.tabIndex = 0;
+		} else {
+			if (this._actionsToolbarContainer.classList.contains('tabfocused') && !this._actionsToolbarContainer.classList.contains('mouseover')) {
+				this._actionsToolbarContainer.classList.add('hidden');
+				this._domNode.tabIndex = -1;
+			}
+			this._actionsToolbarContainer.classList.remove('tabfocused');
+		}
+	}
+
 	private registerActionBarListeners(actionsContainer: HTMLElement): void {
 		this._register(dom.addDisposableListener(this._domNode, 'mouseenter', () => {
 			actionsContainer.classList.remove('hidden');
+			actionsContainer.classList.add('mouseover');
 		}));
-
-		this._register(dom.addDisposableListener(this._domNode, 'focus', () => {
-			actionsContainer.classList.remove('hidden');
-		}));
-
 		this._register(dom.addDisposableListener(this._domNode, 'mouseleave', () => {
-			if (!this._domNode.contains(document.activeElement)) {
+			if (actionsContainer.classList.contains('mouseover') && !actionsContainer.classList.contains('tabfocused')) {
 				actionsContainer.classList.add('hidden');
 			}
+			actionsContainer.classList.remove('mouseover');
 		}));
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -87,16 +87,6 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 	private _commentFormActions!: CommentFormActions;
 	private _scopedInstatiationService: IInstantiationService;
 	private _focusedComment: number | undefined = undefined;
-	private setFocusedComment(value: number | undefined) {
-		if (this._focusedComment !== undefined) {
-			this._commentElements[this._focusedComment!].setFocus(false);
-		}
-		this._focusedComment = value;
-		if (this._focusedComment !== undefined) {
-			this._commentElements[this._focusedComment!].setFocus(true);
-		}
-	}
-
 
 	public get owner(): string {
 		return this._owner;
@@ -392,6 +382,8 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		} else {
 			this._commentThreadContextValue.reset();
 		}
+
+		this.setFocusedComment(this._focusedComment);
 	}
 
 	protected _onWidth(widthInPixel: number): void {
@@ -593,6 +585,19 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		}));
 	}
 
+	private setFocusedComment(value: number | undefined) {
+		if (this._focusedComment !== undefined) {
+			this._commentElements[this._focusedComment]?.setFocus(false);
+		}
+
+		if (this._commentElements.length === 0 || value === undefined) {
+			this._focusedComment = undefined;
+		} else {
+			this._focusedComment = Math.min(value, this._commentElements.length - 1);
+			this._commentElements[this._focusedComment].setFocus(true);
+		}
+	}
+
 	private getActiveComment(): CommentNode | ReviewZoneWidget {
 		return this._commentElements.filter(node => node.isEditing)[0] || this;
 	}
@@ -641,29 +646,6 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			this._markdownRenderer);
 
 		this._disposables.add(newCommentNode);
-		this._disposables.add(newCommentNode.onDidDelete(deletedNode => {
-			const deletedNodeId = deletedNode.comment.uniqueIdInThread;
-			const deletedElementIndex = arrays.firstIndex(this._commentElements, commentNode => commentNode.comment.uniqueIdInThread === deletedNodeId);
-			if (deletedElementIndex > -1) {
-				this._commentElements.splice(deletedElementIndex, 1);
-			}
-
-			const deletedCommentIndex = arrays.firstIndex(this._commentThread.comments!, comment => comment.uniqueIdInThread === deletedNodeId);
-			if (deletedCommentIndex > -1) {
-				this._commentThread.comments!.splice(deletedCommentIndex, 1);
-			}
-
-			this._commentsElement.removeChild(deletedNode.domNode);
-			deletedNode.dispose();
-
-			if (this._commentThread.comments!.length === 0) {
-				this.dispose();
-			}
-
-			if (deletedElementIndex === this._focusedComment) { this.setFocusedComment(undefined); }
-			if (this._focusedComment && deletedElementIndex < this._focusedComment) { this.setFocusedComment(this._focusedComment - 1); }
-		}));
-
 		this._disposables.add(newCommentNode.onDidClick(clickedNode =>
 			this.setFocusedComment(arrays.firstIndex(this._commentElements, commentNode => commentNode.comment.uniqueIdInThread === clickedNode.comment.uniqueIdInThread))
 		));


### PR DESCRIPTION
Fixes Microsoft/vscode-pull-request-github#123. Allows navigating comment threads by using arrow keys, then tabbing to the action bar items. This is in line with the extensions viewlet's accessibility model.