### PR TITLE
Fix screencast mode for webviews

### DIFF
--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -152,7 +152,7 @@ class ToggleScreencastModeAction extends Action {
 			}
 		}));
 
-		const onKeyDown = domEvent(container, 'keydown', true);
+		const onKeyDown = domEvent(window, 'keydown', true);
 		let keyboardTimeout: IDisposable = Disposable.None;
 		let length = 0;
 


### PR DESCRIPTION
Fixes #82113

Webviews always dispatch emulated keyboard events to the window. This causes them to bypass screencast mode's `keydown` handler

This change makes screencast mode instead listen for events on the `window` element so that it sees the fake keyboard events created by the webview
