### PR TITLE
GitHub Actions: only run on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release/*
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - release/*
 
 jobs:
   linux:


### PR DESCRIPTION
At present, GitHub Actions is configured to build on every pull request and push to any branch.

This means that CI runs will run in duplicate for pull requests that originate from branches in the repository (ie, those not from a fork).  That is to say: if you push a branch `foo` and then open a pull request from `foo` to `master`, you'll see duplicate builds, one for the push into `foo` and one for the pull request into `master`.

By limiting this to `push`es to master and `pull_request`s to master, this will remove the dual build problem.

/cc @joaomoreno 