### PR TITLE
Clarified git.confirmEmptyCommits description

### DIFF
--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -120,7 +120,7 @@
 	"config.scanRepositories": "List of paths to search for git repositories in.",
 	"config.showProgress": "Controls whether git actions should show progress.",
 	"config.rebaseWhenSync": "Force git to use rebase when running the sync command.",
-	"config.confirmEmptyCommits": "Always confirm the creation of empty commits.",
+	"config.confirmEmptyCommits": "Always confirm the creation of empty commits for the 'Git: Commit Empty' command.",
 	"config.fetchOnPull": "Fetch all branches when pulling or just the current one.",
 	"config.pullTags": "Fetch all tags when pulling.",
 	"config.autoStash": "Stash any changes before pulling and restore them after successful pull.",


### PR DESCRIPTION
Found a setting that could be clarified to avoid confusion.

This PR fixes #83061 
