### PR TITLE
Add default styles for <kbd> tags

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -91,6 +91,24 @@
 		border-color: var(--vscode-textBlockQuote-border);
 	}
 
+	kbd {
+		color: var(--vscode-editor-foreground);
+		border-radius: 3px;
+		vertical-align: middle;
+		padding: 1px 3px;
+
+		background-color: hsla(0,0%,50%,.17);
+		border: 1px solid rgba(71,71,71,.4);
+		border-bottom-color: rgba(88,88,88,.4);
+		box-shadow: inset 0 -1px 0 rgba(88,88,88,.4);
+	}
+	.vscode-light kbd {
+		background-color: hsla(0,0%,87%,.5);
+		border: 1px solid hsla(0,0%,80%,.7);
+		border-bottom-color: hsla(0,0%,73%,.7);
+		box-shadow: inset 0 -1px 0 hsla(0,0%,73%,.7);
+	}
+
 	::-webkit-scrollbar {
 		width: 10px;
 		height: 10px;


### PR DESCRIPTION
fixes #83299

|         |           |
| ------------- |-------------|
| ![Screenshot (91)](https://user-images.githubusercontent.com/9638156/67568599-51403300-f735-11e9-97e9-4586bb7af852.png)   | ![Screenshot (88)](https://user-images.githubusercontent.com/9638156/67568614-58674100-f735-11e9-8688-8054d2ac5267.png) |
| ![Screenshot (90)](https://user-images.githubusercontent.com/9638156/67568759-be53c880-f735-11e9-9124-9a339485edb9.png) | ![Screenshot (89)](https://user-images.githubusercontent.com/9638156/67568764-c1e74f80-f735-11e9-9de9-28d4caba76f9.png) |



Style taken from `Keyboard Shortcuts GUI` and modified a bit.

```
- [x] Cancel the mode on <kbd>Esc</kbd> press
- [x] Remove last typed character on <kbd>Backspace</kbd>
- [ ] Go to first match on <kbd>Enter</kbd>
```
