### PR TITLE
Fix auto-indent on paste, second line and after

### DIFF
--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -568,13 +568,10 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						let lineContent = model.getLineContent(i);
 						let originalIndent = strings.getLeadingWhitespace(lineContent);
 						let originalSpacesCnt = indentUtils.getSpaceCnt(originalIndent, tabSize);
-						if (originalSpacesCnt === 0) {
-							continue;
-						}
 						let newSpacesCnt = originalSpacesCnt + spaceCntOffset;
 						let newIndent = indentUtils.generateIndent(newSpacesCnt, tabSize, insertSpaces);
 
-						if (newIndent !== originalIndent) {
+						if (newIndent > originalIndent) {
 							textEdits.push({
 								range: new Range(i, 1, i, originalIndent.length + 1),
 								text: newIndent

--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -568,10 +568,12 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						let lineContent = model.getLineContent(i);
 						let originalIndent = strings.getLeadingWhitespace(lineContent);
 						let originalSpacesCnt = indentUtils.getSpaceCnt(originalIndent, tabSize);
+						if (originalSpacesCnt <= firstLineSpacesCnt) {
+							continue;
+						}
 						let newSpacesCnt = originalSpacesCnt + spaceCntOffset;
 						let newIndent = indentUtils.generateIndent(newSpacesCnt, tabSize, insertSpaces);
-
-						if (newIndent.length > originalIndent.length) {
+						if (newIndent !== originalIndent) {
 							textEdits.push({
 								range: new Range(i, 1, i, originalIndent.length + 1),
 								text: newIndent

--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -568,6 +568,9 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						let lineContent = model.getLineContent(i);
 						let originalIndent = strings.getLeadingWhitespace(lineContent);
 						let originalSpacesCnt = indentUtils.getSpaceCnt(originalIndent, tabSize);
+						if (originalSpacesCnt === 0) {
+							continue;
+						}
 						let newSpacesCnt = originalSpacesCnt + spaceCntOffset;
 						let newIndent = indentUtils.generateIndent(newSpacesCnt, tabSize, insertSpaces);
 

--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -498,14 +498,14 @@ export class AutoIndentOnPaste implements IEditorContribution {
 		}
 
 		let firstLineText = model.getLineContent(startLineNumber);
+		let indentOfFirstLine = null
 		if (!/\S/.test(firstLineText.substring(0, range.startColumn - 1))) {
-			let indentOfFirstLine = LanguageConfigurationRegistry.getGoodIndentForLine(model, model.getLanguageIdentifier().id, startLineNumber, indentConverter);
+			indentOfFirstLine = LanguageConfigurationRegistry.getGoodIndentForLine(model, model.getLanguageIdentifier().id, startLineNumber, indentConverter);
 
 			if (indentOfFirstLine !== null) {
 				let oldIndentation = strings.getLeadingWhitespace(firstLineText);
 				let newSpaceCnt = indentUtils.getSpaceCnt(indentOfFirstLine, tabSize);
 				let oldSpaceCnt = indentUtils.getSpaceCnt(oldIndentation, tabSize);
-
 				if (newSpaceCnt !== oldSpaceCnt) {
 					let newIndent = indentUtils.generateIndent(newSpaceCnt, tabSize, insertSpaces);
 					textEdits.push({
@@ -513,6 +513,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						text: newIndent
 					});
 					firstLineText = newIndent + firstLineText.substr(oldIndentation.length);
+					indentOfFirstLine = newIndent
 				} else {
 					let indentMetadata = LanguageConfigurationRegistry.getIndentMetadata(model, startLineNumber);
 
@@ -557,6 +558,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 					}
 				}
 			};
+			let firstLineSpacesCnt = indentOfFirstLine!==null ? indentOfFirstLine.length : 0
 			let indentOfSecondLine = LanguageConfigurationRegistry.getGoodIndentForLine(virtualModel, model.getLanguageIdentifier().id, startLineNumber + 1, indentConverter);
 			if (indentOfSecondLine !== null) {
 				let newSpaceCntOfSecondLine = indentUtils.getSpaceCnt(indentOfSecondLine, tabSize);

--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -571,7 +571,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						let newSpacesCnt = originalSpacesCnt + spaceCntOffset;
 						let newIndent = indentUtils.generateIndent(newSpacesCnt, tabSize, insertSpaces);
 
-						if (newIndent > originalIndent) {
+						if (newIndent.length > originalIndent.length) {
 							textEdits.push({
 								range: new Range(i, 1, i, originalIndent.length + 1),
 								text: newIndent

--- a/src/vs/editor/contrib/indentation/indentation.ts
+++ b/src/vs/editor/contrib/indentation/indentation.ts
@@ -498,7 +498,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 		}
 
 		let firstLineText = model.getLineContent(startLineNumber);
-		let indentOfFirstLine = null
+		let indentOfFirstLine = null;
 		if (!/\S/.test(firstLineText.substring(0, range.startColumn - 1))) {
 			indentOfFirstLine = LanguageConfigurationRegistry.getGoodIndentForLine(model, model.getLanguageIdentifier().id, startLineNumber, indentConverter);
 
@@ -513,7 +513,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						text: newIndent
 					});
 					firstLineText = newIndent + firstLineText.substr(oldIndentation.length);
-					indentOfFirstLine = newIndent
+					indentOfFirstLine = newIndent;
 				} else {
 					let indentMetadata = LanguageConfigurationRegistry.getIndentMetadata(model, startLineNumber);
 
@@ -558,7 +558,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 					}
 				}
 			};
-			let firstLineSpacesCnt = indentOfFirstLine!==null ? indentOfFirstLine.length : 0
+			let firstLineSpacesCnt = indentOfFirstLine!==null ? indentUtils.getSpaceCnt(indentOfFirstLine, tabSize) : 0;
 			let indentOfSecondLine = LanguageConfigurationRegistry.getGoodIndentForLine(virtualModel, model.getLanguageIdentifier().id, startLineNumber + 1, indentConverter);
 			if (indentOfSecondLine !== null) {
 				let newSpaceCntOfSecondLine = indentUtils.getSpaceCnt(indentOfSecondLine, tabSize);
@@ -566,13 +566,13 @@ export class AutoIndentOnPaste implements IEditorContribution {
 
 				if (newSpaceCntOfSecondLine !== oldSpaceCntOfSecondLine) {
 					let spaceCntOffset = newSpaceCntOfSecondLine - oldSpaceCntOfSecondLine;
+					if (spaceCntOffset < tabSize) {
+						spaceCntOffset = firstLineSpacesCnt;
+					}
 					for (let i = startLineNumber + 1; i <= range.endLineNumber; i++) {
 						let lineContent = model.getLineContent(i);
 						let originalIndent = strings.getLeadingWhitespace(lineContent);
 						let originalSpacesCnt = indentUtils.getSpaceCnt(originalIndent, tabSize);
-						if (originalSpacesCnt <= firstLineSpacesCnt) {
-							continue;
-						}
 						let newSpacesCnt = originalSpacesCnt + spaceCntOffset;
 						let newIndent = indentUtils.generateIndent(newSpacesCnt, tabSize, insertSpaces);
 						if (newIndent !== originalIndent) {


### PR DESCRIPTION
This PR fixes #32320, fixes #31255.

In the method `AutoIndentOnPaste.trigger`, there's a logic to re-indent pasted lines based on editor tab/indent size (and optionally `editor.detectIndentation`). At the end of that calculation is a loop that re-indents the **second line and after**: it was adding unnecessary indents if any of the original lines had no indentation.

To illustrate, pasting the following:

```html
<div>
  <i></i>
</div>
```

..was resulting in:

```html
<div>
    <i></i>
  </div>
```

The only way for the user to fix this when it happened, was to undo once after pasting.

This PR adds a check to handle that case, by not adding indent if a pasted line had no indent to start with. In the above example, that's the third line.

It was somewhat tricky to reproduce the issue - although many people have reported variations of the symptoms in HTML, CSS, JS, etc. The common precondition seems to be when the tab/indent sizes detected for the document are different from the ones detected from the pasted lines. That leads to the loop that re-indents the second line and after.