### PR TITLE
web - avoid loading textmate grammars through file service

### DIFF
--- a/src/vs/workbench/services/textMate/browser/textMateService.ts
+++ b/src/vs/workbench/services/textMate/browser/textMateService.ts
@@ -8,7 +8,6 @@ import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { AbstractTextMateService } from 'vs/workbench/services/textMate/browser/abstractTextMateService';
 import { IOnigLib } from 'vscode-textmate';
 import { IModeService } from 'vs/editor/common/services/modeService';
-import { IFileService } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -20,13 +19,12 @@ export class TextMateService extends AbstractTextMateService {
 	constructor(
 		@IModeService modeService: IModeService,
 		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
-		@IFileService fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ILogService logService: ILogService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IStorageService storageService: IStorageService
 	) {
-		super(modeService, themeService, fileService, notificationService, logService, configurationService, storageService);
+		super(modeService, themeService, notificationService, logService, configurationService, storageService);
 	}
 
 	protected _loadVSCodeTextmate(): Promise<typeof import('vscode-textmate')> {

--- a/src/vs/workbench/services/textMate/electron-browser/textMateService.ts
+++ b/src/vs/workbench/services/textMate/electron-browser/textMateService.ts
@@ -142,14 +142,14 @@ export class TextMateService extends AbstractTextMateService {
 	constructor(
 		@IModeService modeService: IModeService,
 		@IWorkbenchThemeService themeService: IWorkbenchThemeService,
-		@IFileService fileService: IFileService,
+		@IFileService private _fileService: IFileService,
 		@INotificationService notificationService: INotificationService,
 		@ILogService logService: ILogService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IStorageService storageService: IStorageService,
 		@IModelService private readonly _modelService: IModelService,
 	) {
-		super(modeService, themeService, fileService, notificationService, logService, configurationService, storageService);
+		super(modeService, themeService, notificationService, logService, configurationService, storageService);
 		this._worker = null;
 		this._workerProxy = null;
 		this._tokenizers = Object.create(null);


### PR DESCRIPTION
This should speed up grammar loading in web as it allows the browser to cache these requests.