### PR TITLE
Rename "Reveal in Explorer" to "Reveal in Side Bar" on Search result filename context menu

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -333,7 +333,7 @@ CommandsRegistry.registerCommand({
 
 const RevealInSideBarForSearchResultsCommand: ICommandAction = {
 	id: Constants.RevealInSideBarForSearchResults,
-	title: nls.localize('revealInSideBar', "Reveal in Explorer")
+	title: nls.localize('revealInSideBar', "Reveal in Side Bar")
 };
 
 MenuRegistry.appendMenuItem(MenuId.SearchContext, {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #83139 as discussed there. The context menu option on a Search result filename that was previously captioned 'Reveal in Explorer' is now captioned 'Reveal in Side Bar'
