### PR TITLE
Make ctrl+right in accessibility mode to jump to beginning of the word

### DIFF
--- a/src/vs/editor/common/controller/cursorWordOperations.ts
+++ b/src/vs/editor/common/controller/cursorWordOperations.ts
@@ -289,17 +289,26 @@ export class WordOperations {
 				column = model.getLineMaxColumn(lineNumber);
 			}
 		} else if (wordNavigationType === WordNavigationType.WordAccessibility) {
+			if (movedDown) {
+				// If we move to the next line, pretend that the cursor is right before the first character.
+				// This is needed when the first word starts right at the first character - and in order not to miss it,
+				// we need to start before.
+				column = 0;
+			}
 
 			while (
 				nextWordOnLine
-				&& nextWordOnLine.wordType === WordType.Separator
+				&& (nextWordOnLine.wordType === WordType.Separator
+					|| nextWordOnLine.start + 1 <= column
+				)
 			) {
 				// Skip over a word made up of one single separator
+				// Also skip over word if it begins before current cursor position to ascertain we're moving forward at least 1 character.
 				nextWordOnLine = WordOperations._findNextWordOnLine(wordSeparators, model, new Position(lineNumber, nextWordOnLine.end + 1));
 			}
 
 			if (nextWordOnLine) {
-				column = nextWordOnLine.end + 1;
+				column = nextWordOnLine.start + 1;
 			} else {
 				column = model.getLineMaxColumn(lineNumber);
 			}

--- a/src/vs/editor/contrib/wordOperations/test/wordOperations.test.ts
+++ b/src/vs/editor/contrib/wordOperations/test/wordOperations.test.ts
@@ -351,7 +351,7 @@ suite('WordOperations', () => {
 	});
 
 	test('cursorWordAccessibilityRight', () => {
-		const EXPECTED = ['   /* Just| some|   more|   text| a|+= 3| +5|-3| + 7| */  |'].join('\n');
+		const EXPECTED = ['   /* |Just |some   |more   |text |a+= |3 +|5-|3 + |7 */  |'].join('\n');
 		const [text,] = deserializePipePositions(EXPECTED);
 		const actualStops = testRepeatedActionAndExtractPositions(
 			text,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #83449

Changes:
In cursorWordOperations.ts in moveWordRight() I changed the logic when wordNavigationType === WordNavigationType.WordAccessibility.

Testing performed: I tested this change manually on my computer with the following screenreaders:
NVDA 2019.2
Jaws 2019

How to test:
Enable screenreader mode in the settings. IN any text document press Ctrl+Right and make sure that the cursor jumps to the beginning of each word, not the end (old behavior).
