### PR TITLE
Remove hyphen in formatter-related messages

### DIFF
--- a/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
@@ -106,7 +106,7 @@ class DefaultFormatter extends Disposable implements IWorkbenchContribution {
 		const langName = this._modeService.getLanguageName(document.getModeId()) || document.getModeId();
 		const silent = mode === FormattingMode.Silent;
 		const message = !defaultFormatterId
-			? nls.localize('config.needed', "There are multiple formatters for {0}-files. Select a default formatter to continue.", DefaultFormatter._maybeQuotes(langName))
+			? nls.localize('config.needed', "There are multiple formatters for '{0}' files. Select a default formatter to continue.", DefaultFormatter._maybeQuotes(langName))
 			: nls.localize('config.bad', "Extension '{0}' is configured as formatter but not available. Select a different default formatter to continue.", defaultFormatterId);
 
 		return new Promise<T | undefined>((resolve, reject) => {
@@ -134,7 +134,7 @@ class DefaultFormatter extends Disposable implements IWorkbenchContribution {
 			};
 		});
 		const langName = this._modeService.getLanguageName(document.getModeId()) || document.getModeId();
-		const pick = await this._quickInputService.pick(picks, { placeHolder: nls.localize('select', "Select a default formatter for {0}-files", DefaultFormatter._maybeQuotes(langName)) });
+		const pick = await this._quickInputService.pick(picks, { placeHolder: nls.localize('select', "Select a default formatter for '{0}' files", DefaultFormatter._maybeQuotes(langName)) });
 		if (!pick || !formatter[pick.index].extensionId) {
 			return undefined;
 		}
@@ -234,7 +234,7 @@ async function showFormatterPick(accessor: ServicesAccessor, model: ITextModel, 
 	} else if (pick === configurePick) {
 		// config default
 		const langName = modeService.getLanguageName(model.getModeId()) || model.getModeId();
-		const pick = await quickPickService.pick(picks, { placeHolder: nls.localize('select', "Select a default formatter for {0}-files", DefaultFormatter._maybeQuotes(langName)) });
+		const pick = await quickPickService.pick(picks, { placeHolder: nls.localize('select', "Select a default formatter for '{0}' files", DefaultFormatter._maybeQuotes(langName)) });
 		if (pick && formatters[pick.index].extensionId) {
 			configService.updateValue(DefaultFormatter.configName, formatters[pick.index].extensionId!.value, overrides);
 		}

--- a/src/vs/workbench/contrib/format/browser/formatActionsNone.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsNone.ts
@@ -50,7 +50,7 @@ registerEditorAction(class FormatDocumentMultipleAction extends EditorAction {
 			return commandService.executeCommand('editor.action.formatDocument');
 		} else {
 			const langName = model.getLanguageIdentifier().language;
-			const message = nls.localize('no.provider', "There is no formatter for '{0}'-files installed.", langName);
+			const message = nls.localize('no.provider', "There is no formatter for '{0}' files installed.", langName);
 			const choice = {
 				label: nls.localize('install.formatter', "Install Formatter..."),
 				run: () => showExtensionQuery(viewletService, `category:formatters ${langName}`)


### PR DESCRIPTION
This PR fixes #83452

I put single quotes around the language ID (e.g. `Select a default formatter for 'Flow' files`) because that seems consistent with usage elsewhere.
