### PR TITLE
Hide Help > Report Issue menu item when issue reporter is disabled in product.json

### DIFF
--- a/src/vs/workbench/electron-browser/desktop.contribution.ts
+++ b/src/vs/workbench/electron-browser/desktop.contribution.ts
@@ -21,6 +21,7 @@ import { IsMacContext, HasMacNativeTabsContext, IsDevelopmentContext } from 'vs/
 import { NoEditorsVisibleContext, SingleEditorGroupsContext } from 'vs/workbench/common/editor';
 import { IElectronService } from 'vs/platform/electron/node/electron';
 import { IJSONContributionRegistry, Extensions as JSONExtensions } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
+import product from 'vs/platform/product/common/product';
 
 // Actions
 (function registerActions(): void {
@@ -159,14 +160,16 @@ import { IJSONContributionRegistry, Extensions as JSONExtensions } from 'vs/plat
 		order: 3
 	});
 
-	MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
-		group: '3_feedback',
-		command: {
-			id: 'workbench.action.openIssueReporter',
-			title: nls.localize({ key: 'miReportIssue', comment: ['&& denotes a mnemonic', 'Translate this to "Report Issue in English" in all languages please!'] }, "Report &&Issue")
-		},
-		order: 3
-	});
+	if (!!product.reportIssueUrl) {
+		MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
+			group: '3_feedback',
+			command: {
+				id: 'workbench.action.openIssueReporter',
+				title: nls.localize({ key: 'miReportIssue', comment: ['&& denotes a mnemonic', 'Translate this to "Report Issue in English" in all languages please!'] }, "Report &&Issue")
+			},
+			order: 3
+		});
+	}
 
 	// Tools
 	MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {


### PR DESCRIPTION
This PR fixes #83560

When product.json "reportIssueUrl" is not included, all other entrypoints to Issue Reporter are hidden. However, the help menu still includes it.

We should hide this menu item when Issue Reporter is disabled.

## Manual Test
### Issue reporter enabled
- Use default product.json
- Verify "Help > Report Issue" menu item shows.
- Verify clicking "Help > Report Issue" opens the issue reporter.

### Issue reporter disabled
- Update product.json to remove "reportIssueUrl" line.
- Verify "Help > Report Issue" menu item does not exist.

