### PR TITLE
reset to intial value by adding css selector

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/titlecontrol.css
@@ -44,6 +44,10 @@
 	line-height: initial;
 }
 
+.hc-black .monaco-workbench .part.editor > .content .editor-group-container > .title .title-actions .monaco-dropdown .action-label,
+.hc-black .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions .monaco-dropdown .action-label {
+	line-height: 35px;
+}
 .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions .action-label .label,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .title-actions .action-label .label {
 	display: none;


### PR DESCRIPTION
This PR fixes #83605

**Root Cause :** 
There are CSS styles applied to Editor "..." icon for high contrast mode but since '...' icon is under dropdown the icon is moving up 

**Fix :** 
applied CSS styles to reset the high contrast mode styles by adding a drop-down CSS selector 