### PR TITLE
add `babel.config.json` to JSON validation schema maps

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -95,6 +95,10 @@
         "url": "https://schemastore.azurewebsites.net/schemas/json/babelrc.json"
       },
       {
+        "fileMatch": "babel.config.json",
+        "url": "https://schemastore.azurewebsites.net/schemas/json/babelrc.json"
+      },
+      {
         "fileMatch": "jsconfig.json",
         "url": "https://schemastore.azurewebsites.net/schemas/json/jsconfig.json"
       },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #83774 by adding `babel.config.json` to the JSON validation schema maps.