### PR TITLE
Web telemetry - write machineId to local storage

### DIFF
--- a/src/vs/platform/telemetry/browser/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/browser/workbenchCommonProperties.ts
@@ -9,6 +9,7 @@ export const instanceStorageKey = 'telemetry.instanceId';
 export const currentSessionDateStorageKey = 'telemetry.currentSessionDate';
 export const firstSessionDateStorageKey = 'telemetry.firstSessionDate';
 export const lastSessionDateStorageKey = 'telemetry.lastSessionDate';
+export const machineIdKey = 'telemetry.machineId';
 
 import * as Platform from 'vs/base/common/platform';
 import * as uuid from 'vs/base/common/uuid';
@@ -19,13 +20,18 @@ export async function resolveWorkbenchCommonProperties(
 	storageService: IStorageService,
 	commit: string | undefined,
 	version: string | undefined,
-	machineId: string,
 	remoteAuthority?: string,
 	resolveAdditionalProperties?: () => { [key: string]: any }
 ): Promise<{ [name: string]: string | undefined }> {
 	const result: { [name: string]: string | undefined; } = Object.create(null);
 	const firstSessionDate = storageService.get(firstSessionDateStorageKey, StorageScope.GLOBAL)!;
 	const lastSessionDate = storageService.get(lastSessionDateStorageKey, StorageScope.GLOBAL)!;
+
+	let machineId = storageService.get(machineIdKey, StorageScope.GLOBAL);
+	if (!machineId) {
+		machineId = uuid.generateUuid();
+		storageService.store(machineIdKey, machineId, StorageScope.GLOBAL);
+	}
 
 	/**
 	 * Note: In the web, session date information is fetched from browser storage, so these dates are tied to a specific

--- a/src/vs/platform/telemetry/test/browser/commonProperties.test.ts
+++ b/src/vs/platform/telemetry/test/browser/commonProperties.test.ts
@@ -23,7 +23,7 @@ suite('Browser Telemetry - common properties', function () {
 			};
 		};
 
-		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, 'someMachineId', undefined, resolveCommonTelemetryProperties);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, resolveCommonTelemetryProperties);
 
 		assert.ok('commitHash' in props);
 		assert.ok('sessionID' in props);
@@ -53,10 +53,10 @@ suite('Browser Telemetry - common properties', function () {
 			});
 		};
 
-		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, 'someMachineId', undefined, resolveCommonTelemetryProperties);
+		const props = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, resolveCommonTelemetryProperties);
 		assert.equal(props['userId'], '1');
 
-		const props2 = await resolveWorkbenchCommonProperties(testStorageService, commit, version, 'someMachineId', undefined, resolveCommonTelemetryProperties);
+		const props2 = await resolveWorkbenchCommonProperties(testStorageService, commit, version, undefined, resolveCommonTelemetryProperties);
 		assert.equal(props2['userId'], '2');
 	});
 });

--- a/src/vs/platform/windows/common/windows.ts
+++ b/src/vs/platform/windows/common/windows.ts
@@ -219,7 +219,7 @@ export interface IAddFoldersRequest {
 }
 
 export interface IWindowConfiguration extends ParsedArgs {
-	machineId: string;
+	machineId?: string; // NOTE: This is undefined in the web, the telemetry service directly resolves this.
 	windowId: number; // TODO: should we deprecate this in favor of sessionId?
 	sessionId: string;
 	logLevel: LogLevel;

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -37,10 +37,6 @@ export class BrowserWindowConfiguration implements IWindowConfiguration {
 	@memoize
 	get backupWorkspaceResource(): URI { return joinPath(this.environment.backupHome, this.options.workspaceId); }
 
-	// TODO@rachel TODO@sbatten fix me, should be stable between sessions
-	@memoize
-	get machineId(): string { return generateUuid(); }
-
 	// Currently unsupported in web
 	get filesToOpenOrCreate(): IPath[] | undefined { return undefined; }
 	get filesToDiff(): IPath[] | undefined { return undefined; }

--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -55,7 +55,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 		if (!!productService.enableTelemetry) {
 			const config: ITelemetryServiceConfig = {
 				appender: combinedAppender(new WebTelemetryAppender(logService, remoteAgentService), new LogAppender(logService)),
-				commonProperties: resolveWorkbenchCommonProperties(storageService, productService.commit, productService.version, environmentService.configuration.machineId, environmentService.configuration.remoteAuthority)
+				commonProperties: resolveWorkbenchCommonProperties(storageService, productService.commit, productService.version, environmentService.configuration.remoteAuthority)
 			};
 
 			this.impl = this._register(new BaseTelemetryService(config, configurationService));

--- a/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/electron-browser/telemetryService.ts
@@ -38,7 +38,7 @@ export class TelemetryService extends Disposable implements ITelemetryService {
 			const channel = sharedProcessService.getChannel('telemetryAppender');
 			const config: ITelemetryServiceConfig = {
 				appender: combinedAppender(new TelemetryAppenderClient(channel), new LogAppender(logService)),
-				commonProperties: resolveWorkbenchCommonProperties(storageService, productService.commit, productService.version, environmentService.configuration.machineId, productService.msftInternalDomains, environmentService.installSourcePath, environmentService.configuration.remoteAuthority),
+				commonProperties: resolveWorkbenchCommonProperties(storageService, productService.commit, productService.version, environmentService.configuration.machineId!, productService.msftInternalDomains, environmentService.installSourcePath, environmentService.configuration.remoteAuthority),
 				piiPaths: environmentService.extensionsPath ? [environmentService.appRoot, environmentService.extensionsPath] : [environmentService.appRoot]
 			};
 


### PR DESCRIPTION
Uses local storage to get/set machineId.

Moved this logic to when telemetry properties are resolved, because in the web, the `storageService` depends on the `environmentService` so can't be used to resolve the machineId when the `environmentService` is created. I started creating separate interfaces to make it clearer that `machineId` isn't available from the `environmentService` in the web, but this was very messy. The `environmentService` is still used to pass around the `machineId` to other processes in the desktop case.