### PR TITLE
Fix zoom on first click

### DIFF
--- a/extensions/image-preview/media/main.js
+++ b/extensions/image-preview/media/main.js
@@ -70,7 +70,8 @@
 	let ctrlPressed = false;
 	let altPressed = false;
 	let hasLoadedImage = false;
-	let consumeClick = false;
+	let consumeClick = true;
+	let isActive = false;
 
 	// Elements
 	const container = document.body;
@@ -117,10 +118,10 @@
 		});
 	}
 
-	function changeActive(value) {
+	function setActive(value) {
+		isActive = value;
 		if (value) {
 			container.classList.add('zoom-in');
-			consumeClick = true;
 		} else {
 			ctrlPressed = false;
 			altPressed = false;
@@ -202,7 +203,7 @@
 			return;
 		}
 
-		consumeClick = false;
+		consumeClick = !isActive;
 	});
 
 	container.addEventListener('click', (/** @type {MouseEvent} */ e) => {
@@ -308,7 +309,7 @@
 				break;
 
 			case 'setActive':
-				changeActive(e.data.value);
+				setActive(e.data.value);
 				break;
 
 			case 'zoomIn':

--- a/extensions/image-preview/media/main.js
+++ b/extensions/image-preview/media/main.js
@@ -121,7 +121,13 @@
 	function setActive(value) {
 		isActive = value;
 		if (value) {
-			container.classList.add('zoom-in');
+			if (isMac ? altPressed : ctrlPressed) {
+				container.classList.remove('zoom-in');
+				container.classList.add('zoom-out');
+			} else {
+				container.classList.remove('zoom-out');
+				container.classList.add('zoom-in');
+			}
 		} else {
 			ctrlPressed = false;
 			altPressed = false;
@@ -203,6 +209,9 @@
 			return;
 		}
 
+		ctrlPressed = e.ctrlKey;
+		altPressed = e.altKey;
+
 		consumeClick = !isActive;
 	});
 
@@ -213,14 +222,6 @@
 
 		if (e.button !== 0) {
 			return;
-		}
-
-		ctrlPressed = e.ctrlKey;
-		altPressed = e.altKey;
-
-		if (isMac ? altPressed : ctrlPressed) {
-			container.classList.remove('zoom-in');
-			container.classList.add('zoom-out');
 		}
 
 		if (consumeClick) {

--- a/extensions/image-preview/src/preview.ts
+++ b/extensions/image-preview/src/preview.ts
@@ -115,6 +115,7 @@ class Preview extends Disposable {
 
 		this._register(webviewEditor.onDidChangeViewState(() => {
 			this.update();
+			this.webviewEditor.webview.postMessage({ type: 'setActive', value: this.webviewEditor.active });
 		}));
 
 		this._register(webviewEditor.onDidDispose(() => {
@@ -139,6 +140,7 @@ class Preview extends Disposable {
 
 		this.render();
 		this.update();
+		this.webviewEditor.webview.postMessage({ type: 'setActive', value: this.webviewEditor.active });
 	}
 
 	public zoomIn() {
@@ -175,7 +177,6 @@ class Preview extends Disposable {
 			}
 			this._previewState = PreviewState.Visible;
 		}
-		this.webviewEditor.webview.postMessage({ type: 'setActive', value: this.webviewEditor.active });
 	}
 
 	private getWebiewContents(): string {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #81877

The problem was that fast clicks would zoom on first click. I fixed this by adding the state variable ```isActive``` that keeps track of when the preview is active or not.

I also changed the name of a function from ```changeActive(value)``` to ```setActive(value)``` to make the code more intuitive.

I moved a ```postMessage``` call out of the ```update()``` function to avoid unnecessary calls.

Please let me know if any of these last two changes are unwanted and I'll revert them.
