### PR TITLE
debug - fix active line for column-free breakpoints not be decorated correctly

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -711,11 +711,18 @@ export function getBreakpointMessageAndClassName(debugService: IDebugService, br
 	if (focusedThread) {
 		const callStack = focusedThread ? focusedThread.getCallStack() : undefined;
 		const topStackFrame = callStack ? callStack[0] : undefined;
-		if (topStackFrame && topStackFrame.source.uri.toString() === breakpoint.uri.toString() && topStackFrame.range.startLineNumber === breakpoint.lineNumber && topStackFrame.range.startColumn === breakpoint.column) {
-			return {
-				className: 'debug-breakpoint-and-top-stack-frame',
-				message: breakpoint.message || nls.localize('breakpoint', "Breakpoint")
-			};
+		if (topStackFrame && topStackFrame.source.uri.toString() === breakpoint.uri.toString() && topStackFrame.range.startLineNumber === breakpoint.lineNumber) {
+			if (topStackFrame.range.startColumn === breakpoint.column) {
+				return {
+					className: 'debug-breakpoint-and-top-stack-frame-at-column',
+					message: breakpoint.message || nls.localize('breakpoint', "Breakpoint")
+				};
+			} else if (breakpoint.column === undefined) {
+				return {
+					className: 'debug-breakpoint-and-top-stack-frame',
+					message: breakpoint.message || nls.localize('breakpoint', "Breakpoint")
+				};
+			}
 		}
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
@@ -119,7 +119,8 @@
 	background: url('breakpoint-unsupported.svg') center center no-repeat;
 }
 
-.monaco-editor .inline-breakpoint-widget.debug-breakpoint-and-top-stack-frame {
+.monaco-editor .debug-top-stack-frame.debug-breakpoint-and-top-stack-frame,
+.monaco-editor .inline-breakpoint-widget.debug-breakpoint-and-top-stack-frame-at-column {
 	background: url('current-and-breakpoint.svg') center center no-repeat;
 }
 


### PR DESCRIPTION
In #81718 we adjusted breakpoint display logic to show an 'empty' arrow on the
line, and the arrow with a dot at the column where the debugger is running.
However, not all debuggers support column breakpoints. @bowdenk7 noticed, while
working on his Python demo for ignite, that breakpoints in Python code no
longer displayed correctly.

This PR tweaks the logic so that if we see a breakpoint that doesn't have
an associated column, we show the arrow with a dot on the line, rather than
assuming that there'll be an inline indicator arrow.

Python before this fix:

![image](https://user-images.githubusercontent.com/2230985/68047078-c1513a80-fc9a-11e9-935a-288cff8362fe.png)

Python with this fix:

![Screen Shot 2019-11-01 at 11 10 32 AM](https://user-images.githubusercontent.com/2230985/68047084-c4e4c180-fc9a-11e9-822e-60a7d221f001.png)

It doesn't appear to affect Node.js debugging (where columns are supported), the same before and after:

![Screen Shot 2019-11-01 at 11 22 11 AM](https://user-images.githubusercontent.com/2230985/68047123-d5953780-fc9a-11e9-946e-840a2fb6bcc0.png)

