### PR TITLE
Add undo support to Monaco when applying quickedits

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -648,7 +648,9 @@ export class SimpleBulkEditService implements IBulkEditService {
 		let totalEdits = 0;
 		let totalFiles = 0;
 		edits.forEach((edits, model) => {
-			model.applyEdits(edits.map(edit => EditOperation.replaceMove(Range.lift(edit.range), edit.text)));
+			model.pushStackElement();
+			model.pushEditOperations([], edits.map((e) => EditOperation.replaceMove(Range.lift(e.range), e.text)), () => []);
+			model.pushStackElement();
 			totalFiles += 1;
 			totalEdits += edits.length;
 		});


### PR DESCRIPTION
Fixes microsoft/monaco-editor#1548

Validated in the monaco playground.

![ED339593-3CDB-49BD-9ADC-7E41E8F72C64-89596-0000CF9F2C7B0918](https://user-images.githubusercontent.com/49038/68148699-7f2e3000-ff0a-11e9-8992-e5d59128d317.gif)
