### PR TITLE
Update xterm to avoid rendering all lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "vscode-ripgrep": "^1.5.7",
     "vscode-sqlite3": "4.0.8",
     "vscode-textmate": "^4.3.0",
-    "xterm": "4.2.0",
+    "xterm": "4.2.0-vscode1",
     "xterm-addon-search": "0.3.0",
     "xterm-addon-web-links": "0.2.1",
     "yauzl": "^2.9.2",

--- a/remote/package.json
+++ b/remote/package.json
@@ -20,7 +20,7 @@
     "vscode-proxy-agent": "^0.5.1",
     "vscode-ripgrep": "^1.5.7",
     "vscode-textmate": "^4.3.0",
-    "xterm": "4.2.0",
+    "xterm": "4.2.0-vscode1",
     "xterm-addon-search": "0.3.0",
     "xterm-addon-web-links": "0.2.1",
     "yauzl": "^2.9.2",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,7 +5,7 @@
 		"onigasm-umd": "^2.2.2",
 		"semver-umd": "^5.5.3",
 		"vscode-textmate": "^4.3.0",
-		"xterm": "4.2.0",
+		"xterm": "4.2.0-vscode1",
 		"xterm-addon-search": "0.3.0",
 		"xterm-addon-web-links": "0.2.1"
 	}

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -41,7 +41,7 @@ xterm-addon-web-links@0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.2.1.tgz#6d1f2ce613e09870badf17615e7a1170a31542b2"
   integrity sha512-2KnHtiq0IG7hfwv3jw2/jQeH1RBk2d5CH4zvgwQe00rLofSJqSfgnJ7gwowxxpGHrpbPr6Lv4AmH/joaNw2+HQ==
 
-xterm@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.2.0.tgz#b9980b2ae18c64ed31bcc95eace3bcecffebbbd9"
-  integrity sha512-oNfLqt+LmghLPOt5UcskP5Km1fXpTBHsTZ99nxJKY2N0MNFXBKIVXUcNNhHCa74JGZFMGhLT58A/UN3HcPXSfg==
+xterm@4.2.0-vscode1:
+  version "4.2.0-vscode1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.2.0-vscode1.tgz#dbd67e52536578ea6b772d69a97da1487acf29e3"
+  integrity sha512-frw5Kprzkko8+G0vp4jOcwTeOpYFbSb2+QShpeQGJ7l3Hg3MTM7kt1G+nLxBPKnkFAmei/JcJTUGJdp/lldAfA==

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -428,10 +428,10 @@ xterm-addon-web-links@0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.2.1.tgz#6d1f2ce613e09870badf17615e7a1170a31542b2"
   integrity sha512-2KnHtiq0IG7hfwv3jw2/jQeH1RBk2d5CH4zvgwQe00rLofSJqSfgnJ7gwowxxpGHrpbPr6Lv4AmH/joaNw2+HQ==
 
-xterm@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.2.0.tgz#b9980b2ae18c64ed31bcc95eace3bcecffebbbd9"
-  integrity sha512-oNfLqt+LmghLPOt5UcskP5Km1fXpTBHsTZ99nxJKY2N0MNFXBKIVXUcNNhHCa74JGZFMGhLT58A/UN3HcPXSfg==
+xterm@4.2.0-vscode1:
+  version "4.2.0-vscode1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.2.0-vscode1.tgz#dbd67e52536578ea6b772d69a97da1487acf29e3"
+  integrity sha512-frw5Kprzkko8+G0vp4jOcwTeOpYFbSb2+QShpeQGJ7l3Hg3MTM7kt1G+nLxBPKnkFAmei/JcJTUGJdp/lldAfA==
 
 yauzl@^2.9.2:
   version "2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9304,10 +9304,10 @@ xterm-addon-web-links@0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.2.1.tgz#6d1f2ce613e09870badf17615e7a1170a31542b2"
   integrity sha512-2KnHtiq0IG7hfwv3jw2/jQeH1RBk2d5CH4zvgwQe00rLofSJqSfgnJ7gwowxxpGHrpbPr6Lv4AmH/joaNw2+HQ==
 
-xterm@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.2.0.tgz#b9980b2ae18c64ed31bcc95eace3bcecffebbbd9"
-  integrity sha512-oNfLqt+LmghLPOt5UcskP5Km1fXpTBHsTZ99nxJKY2N0MNFXBKIVXUcNNhHCa74JGZFMGhLT58A/UN3HcPXSfg==
+xterm@4.2.0-vscode1:
+  version "4.2.0-vscode1"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.2.0-vscode1.tgz#dbd67e52536578ea6b772d69a97da1487acf29e3"
+  integrity sha512-frw5Kprzkko8+G0vp4jOcwTeOpYFbSb2+QShpeQGJ7l3Hg3MTM7kt1G+nLxBPKnkFAmei/JcJTUGJdp/lldAfA==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Build done here: https://dev.azure.com/xtermjs/xterm.js/_build/results?buildId=2610

Based on this branch which was forked off from 4.2.0: https://github.com/xtermjs/xterm.js/tree/vscode-fix 