### PR TITLE
Send data directly to appender in web telemetry, without formatting

### DIFF
--- a/src/vs/workbench/services/telemetry/browser/telemetryService.ts
+++ b/src/vs/workbench/services/telemetry/browser/telemetryService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ITelemetryService, ITelemetryInfo, ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
-import { NullTelemetryService, combinedAppender, LogAppender, ITelemetryAppender, validateTelemetryData } from 'vs/platform/telemetry/common/telemetryUtils';
+import { NullTelemetryService, combinedAppender, LogAppender, ITelemetryAppender } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -22,13 +22,8 @@ export class WebTelemetryAppender implements ITelemetryAppender {
 	constructor(private _logService: ILogService, private _appender: IRemoteAgentService) { }
 
 	log(eventName: string, data: any): void {
-		data = validateTelemetryData(data);
 		this._logService.trace(`telemetry/${eventName}`, data);
-
-		this._appender.logTelemetry(eventName, {
-			properties: data.properties,
-			measurements: data.measurements
-		});
+		this._appender.logTelemetry(eventName, data);
 	}
 
 	flush(): Promise<void> {


### PR DESCRIPTION
The `validate` method both performs some checks on the data, and sorts it into `properties` and `measurements` based on type. This is called again within the appender, which was causing data to be double-nested within "properties" properties