### PR TITLE
Tweaks to the contextmenu

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/goToCommands.ts
+++ b/src/vs/editor/contrib/gotoSymbol/goToCommands.ts
@@ -280,10 +280,6 @@ registerEditorAction(class PeekDefinitionAction extends DefinitionAction {
 				primary: KeyMod.Alt | KeyCode.F12,
 				linux: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.F10 },
 				weight: KeybindingWeight.EditorContrib
-			},
-			menuOpts: {
-				group: 'navigation',
-				order: 1.2
 			}
 		});
 		CommandsRegistry.registerCommandAlias('editor.action.previewDeclaration', PeekDefinitionAction.id);
@@ -506,6 +502,10 @@ registerEditorAction(class GoToImplementationAction extends ImplementationAction
 				menuId: MenuId.MenubarGoMenu,
 				group: '4_symbol_nav',
 				order: 4, title: nls.localize({ key: 'miGotoImplementation', comment: ['&& denotes a mnemonic'] }, "Go to &&Implementation")
+			},
+			menuOpts: {
+				group: 'navigation',
+				order: 1.45
 			}
 		});
 	}
@@ -603,10 +603,6 @@ registerEditorAction(class PeekReferencesAction extends ReferencesAction {
 				kbExpr: EditorContextKeys.editorTextFocus,
 				primary: KeyMod.Shift | KeyCode.F12,
 				weight: KeybindingWeight.EditorContrib
-			},
-			menuOpts: {
-				group: 'navigation',
-				order: 1.5
 			}
 		});
 	}

--- a/src/vs/editor/contrib/gotoSymbol/goToCommands.ts
+++ b/src/vs/editor/contrib/gotoSymbol/goToCommands.ts
@@ -572,13 +572,17 @@ registerEditorAction(class GoToReferencesAction extends ReferencesAction {
 			muteMessage: false
 		}, {
 			id: 'editor.action.goToReferences',
-			label: nls.localize('goToReferences.label', "Go To References"),
-			alias: 'Go To References',
+			label: nls.localize('goToReferences.label', "Go to References"),
+			alias: 'Go to References',
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.hasReferenceProvider,
 				PeekContext.notInPeekEditor,
 				EditorContextKeys.isInEmbeddedEditor.toNegated()
-			)
+			),
+			menuOpts: {
+				group: 'navigation',
+				order: 1.45
+			}
 		});
 	}
 });


### PR DESCRIPTION
@jrieken

- add Go to Implementation
- add Go to References
- remove "Peek" commands
- move Find All References to its own group


| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5047891/68215675-eec21f00-ffdf-11e9-8924-7974381198bd.png) | ![image](https://user-images.githubusercontent.com/5047891/68215570-c3d7cb00-ffdf-11e9-8877-ce0ceaec5da7.png) |



