### PR TITLE
Revert vscode-textmate on stable

### DIFF
--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -219,10 +219,6 @@ function checkPackageJSON(actualPath) {
 			// missing in root is allowed
 			continue;
 		}
-		if (depName === 'vscode-textmate') {
-			// allow vscode-textmate to diverge for now
-			continue;
-		}
 		if (depVersion !== rootDepVersion) {
 			this.emit('error', `The dependency ${depName} in '${actualPath}' (${depVersion}) is different than in the root package.json (${rootDepVersion})`);
 		}

--- a/build/gulpfile.hygiene.js
+++ b/build/gulpfile.hygiene.js
@@ -219,6 +219,10 @@ function checkPackageJSON(actualPath) {
 			// missing in root is allowed
 			continue;
 		}
+		if (depName === 'vscode-textmate') {
+			// allow vscode-textmate to diverge for now
+			continue;
+		}
 		if (depVersion !== rootDepVersion) {
 			this.emit('error', `The dependency ${depName} in '${actualPath}' (${depVersion}) is different than in the root package.json (${rootDepVersion})`);
 		}

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -77,22 +77,6 @@
           "meta.import string.quoted": "other",
           "variable.other.jsdoc": "other"
         }
-      },
-      {
-        "scopeName": "documentation.injection.ts",
-        "path": "./syntaxes/jsdoc.ts.injection.tmLanguage.json",
-        "injectTo": [
-          "source.ts",
-          "source.tsx"
-        ]
-      },
-      {
-        "scopeName": "documentation.injection.js.jsx",
-        "path": "./syntaxes/jsdoc.js.injection.tmLanguage.json",
-        "injectTo": [
-          "source.js",
-          "source.js.jsx"
-        ]
       }
     ],
     "snippets": [

--- a/extensions/typescript-basics/test/colorize-results/test-jsdoc-example_ts.json
+++ b/extensions/typescript-basics/test/colorize-results/test-jsdoc-example_ts.json
@@ -23,7 +23,7 @@
 	},
 	{
 		"c": "@",
-		"t": "source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc",
+		"t": "source.ts comment.block.documentation.ts meta.example.jsdoc storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc",
 		"r": {
 			"dark_plus": "storage.type: #569CD6",
 			"light_plus": "storage.type: #0000FF",
@@ -34,7 +34,7 @@
 	},
 	{
 		"c": "example",
-		"t": "source.ts comment.block.documentation.ts storage.type.class.jsdoc",
+		"t": "source.ts comment.block.documentation.ts meta.example.jsdoc storage.type.class.jsdoc",
 		"r": {
 			"dark_plus": "storage.type: #569CD6",
 			"light_plus": "storage.type: #0000FF",
@@ -44,8 +44,8 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
+		"c": " * ",
+		"t": "source.ts comment.block.documentation.ts meta.example.jsdoc",
 		"r": {
 			"dark_plus": "comment: #6A9955",
 			"light_plus": "comment: #008000",
@@ -55,74 +55,19 @@
 		}
 	},
 	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts meta.embedded.block.example.source.ts",
+		"c": "1 + 1",
+		"t": "source.ts comment.block.documentation.ts meta.example.jsdoc source.embedded.ts",
 		"r": {
-			"dark_plus": "meta.embedded: #D4D4D4",
-			"light_plus": "meta.embedded: #000000",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "meta.embedded: #FFFFFF"
-		}
-	},
-	{
-		"c": "1",
-		"t": "source.ts comment.block.documentation.ts meta.embedded.block.example.source.ts constant.numeric.decimal.tsx",
-		"r": {
-			"dark_plus": "constant.numeric: #B5CEA8",
-			"light_plus": "constant.numeric: #09885A",
-			"dark_vs": "constant.numeric: #B5CEA8",
-			"light_vs": "constant.numeric: #09885A",
-			"hc_black": "constant.numeric: #B5CEA8"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts meta.embedded.block.example.source.ts",
-		"r": {
-			"dark_plus": "meta.embedded: #D4D4D4",
-			"light_plus": "meta.embedded: #000000",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "meta.embedded: #FFFFFF"
-		}
-	},
-	{
-		"c": "+",
-		"t": "source.ts comment.block.documentation.ts meta.embedded.block.example.source.ts keyword.operator.arithmetic.tsx",
-		"r": {
-			"dark_plus": "keyword.operator: #D4D4D4",
-			"light_plus": "keyword.operator: #000000",
-			"dark_vs": "keyword.operator: #D4D4D4",
-			"light_vs": "keyword.operator: #000000",
-			"hc_black": "keyword.operator: #D4D4D4"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts meta.embedded.block.example.source.ts",
-		"r": {
-			"dark_plus": "meta.embedded: #D4D4D4",
-			"light_plus": "meta.embedded: #000000",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "meta.embedded: #FFFFFF"
-		}
-	},
-	{
-		"c": "1",
-		"t": "source.ts comment.block.documentation.ts meta.embedded.block.example.source.ts constant.numeric.decimal.tsx",
-		"r": {
-			"dark_plus": "constant.numeric: #B5CEA8",
-			"light_plus": "constant.numeric: #09885A",
-			"dark_vs": "constant.numeric: #B5CEA8",
-			"light_vs": "constant.numeric: #09885A",
-			"hc_black": "constant.numeric: #B5CEA8"
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
 		}
 	},
 	{
 		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
+		"t": "source.ts comment.block.documentation.ts meta.example.jsdoc",
 		"r": {
 			"dark_plus": "comment: #6A9955",
 			"light_plus": "comment: #008000",
@@ -133,7 +78,7 @@
 	},
 	{
 		"c": " * ",
-		"t": "source.ts comment.block.documentation.ts",
+		"t": "source.ts comment.block.documentation.ts meta.example.jsdoc",
 		"r": {
 			"dark_plus": "comment: #6A9955",
 			"light_plus": "comment: #008000",

--- a/extensions/typescript-basics/test/colorize-results/test-jsdoc-markdown_ts.json
+++ b/extensions/typescript-basics/test/colorize-results/test-jsdoc-markdown_ts.json
@@ -11,7 +11,7 @@
 		}
 	},
 	{
-		"c": " * ",
+		"c": " * **Bold**",
 		"t": "source.ts comment.block.documentation.ts",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -22,40 +22,7 @@
 		}
 	},
 	{
-		"c": "**",
-		"t": "source.ts comment.block.documentation.ts markup.bold.markdown punctuation.definition.bold.markdown",
-		"r": {
-			"dark_plus": "markup.bold: #569CD6",
-			"light_plus": "markup.bold: #000080",
-			"dark_vs": "markup.bold: #569CD6",
-			"light_vs": "markup.bold: #000080",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "Bold",
-		"t": "source.ts comment.block.documentation.ts markup.bold.markdown",
-		"r": {
-			"dark_plus": "markup.bold: #569CD6",
-			"light_plus": "markup.bold: #000080",
-			"dark_vs": "markup.bold: #569CD6",
-			"light_vs": "markup.bold: #000080",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "**",
-		"t": "source.ts comment.block.documentation.ts markup.bold.markdown punctuation.definition.bold.markdown",
-		"r": {
-			"dark_plus": "markup.bold: #569CD6",
-			"light_plus": "markup.bold: #000080",
-			"dark_vs": "markup.bold: #569CD6",
-			"light_vs": "markup.bold: #000080",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": " *",
+		"c": " * ```js",
 		"t": "source.ts comment.block.documentation.ts",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -66,40 +33,7 @@
 		}
 	},
 	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "```",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown punctuation.definition.markdown",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "js",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown fenced_code.block.language.markdown",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": " *",
+		"c": " * 1 + code",
 		"t": "source.ts comment.block.documentation.ts",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -110,96 +44,8 @@
 		}
 	},
 	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown meta.embedded.block.javascript",
-		"r": {
-			"dark_plus": "meta.embedded: #D4D4D4",
-			"light_plus": "meta.embedded: #000000",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "meta.embedded: #FFFFFF"
-		}
-	},
-	{
-		"c": "1",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown meta.embedded.block.javascript constant.numeric.decimal.js",
-		"r": {
-			"dark_plus": "constant.numeric: #B5CEA8",
-			"light_plus": "constant.numeric: #09885A",
-			"dark_vs": "constant.numeric: #B5CEA8",
-			"light_vs": "constant.numeric: #09885A",
-			"hc_black": "constant.numeric: #B5CEA8"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown meta.embedded.block.javascript",
-		"r": {
-			"dark_plus": "meta.embedded: #D4D4D4",
-			"light_plus": "meta.embedded: #000000",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "meta.embedded: #FFFFFF"
-		}
-	},
-	{
-		"c": "+",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown meta.embedded.block.javascript keyword.operator.arithmetic.js",
-		"r": {
-			"dark_plus": "keyword.operator: #D4D4D4",
-			"light_plus": "keyword.operator: #000000",
-			"dark_vs": "keyword.operator: #D4D4D4",
-			"light_vs": "keyword.operator: #000000",
-			"hc_black": "keyword.operator: #D4D4D4"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown meta.embedded.block.javascript",
-		"r": {
-			"dark_plus": "meta.embedded: #D4D4D4",
-			"light_plus": "meta.embedded: #000000",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "meta.embedded: #FFFFFF"
-		}
-	},
-	{
-		"c": "code",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown meta.embedded.block.javascript variable.other.readwrite.js",
-		"r": {
-			"dark_plus": "variable: #9CDCFE",
-			"light_plus": "variable: #001080",
-			"dark_vs": "meta.embedded: #D4D4D4",
-			"light_vs": "meta.embedded: #000000",
-			"hc_black": "variable: #9CDCFE"
-		}
-	},
-	{
-		"c": " *",
+		"c": " * ```",
 		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "```",
-		"t": "source.ts comment.block.documentation.ts markup.fenced_code.block.markdown punctuation.definition.markdown",
 		"r": {
 			"dark_plus": "comment: #6A9955",
 			"light_plus": "comment: #008000",

--- a/extensions/typescript-basics/test/colorize-results/test-jsdoc-multiline-type_ts.json
+++ b/extensions/typescript-basics/test/colorize-results/test-jsdoc-multiline-type_ts.json
@@ -77,18 +77,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   id: number,",
+		"c": " *   id: number,",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -99,18 +88,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   fn: !Function,",
+		"c": " *   fn: !Function,",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -121,18 +99,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   context: (!Object|undefined)",
+		"c": " *   context: (!Object|undefined)",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -143,18 +110,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": " }",
+		"c": " * }",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -396,18 +352,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   measureTask: goog.dom.animationFrame.Task_,",
+		"c": " *   measureTask: goog.dom.animationFrame.Task_,",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -418,18 +363,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   mutateTask: goog.dom.animationFrame.Task_,",
+		"c": " *   mutateTask: goog.dom.animationFrame.Task_,",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -440,18 +374,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   state: (!Object|undefined),",
+		"c": " *   state: (!Object|undefined),",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -462,18 +385,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   args: (!Array|undefined),",
+		"c": " *   args: (!Array|undefined),",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -484,18 +396,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "   isScheduled: boolean",
+		"c": " *   isScheduled: boolean",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -506,18 +407,7 @@
 		}
 	},
 	{
-		"c": " *",
-		"t": "source.ts comment.block.documentation.ts",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": " }",
+		"c": " * }",
 		"t": "source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.40.0",
-  "distro": "be174eeecd6d4208440a9d339583746231264048",
+  "distro": "7b018144cd48a850e66100877f0a7b6327fe089a",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "vscode-proxy-agent": "^0.5.1",
     "vscode-ripgrep": "^1.5.7",
     "vscode-sqlite3": "4.0.8",
-    "vscode-textmate": "^4.3.0",
+    "vscode-textmate": "4.2.2",
     "xterm": "4.2.0-vscode1",
     "xterm-addon-search": "0.3.0",
     "xterm-addon-web-links": "0.2.1",

--- a/remote/package.json
+++ b/remote/package.json
@@ -19,7 +19,7 @@
     "vscode-minimist": "^1.2.1",
     "vscode-proxy-agent": "^0.5.1",
     "vscode-ripgrep": "^1.5.7",
-    "vscode-textmate": "^4.3.0",
+    "vscode-textmate": "4.2.2",
     "xterm": "4.2.0-vscode1",
     "xterm-addon-search": "0.3.0",
     "xterm-addon-web-links": "0.2.1",

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -4,7 +4,7 @@
 	"dependencies": {
 		"onigasm-umd": "^2.2.2",
 		"semver-umd": "^5.5.3",
-		"vscode-textmate": "^4.3.0",
+		"vscode-textmate": "4.2.2",
 		"xterm": "4.2.0-vscode1",
 		"xterm-addon-search": "0.3.0",
 		"xterm-addon-web-links": "0.2.1"

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -24,10 +24,10 @@ semver-umd@^5.5.3:
   resolved "https://registry.yarnpkg.com/semver-umd/-/semver-umd-5.5.3.tgz#b64d7a2d4f5a717b369d56e31940a38e47e34d1e"
   integrity sha512-HOnQrn2iKnVe/xlqCTzMXQdvSz3rPbD0DmQXYuQ+oK1dpptGFfPghonQrx5JHl2O7EJwDqtQnjhE7ME23q6ngw==
 
-vscode-textmate@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.3.0.tgz#6e1f0f273d84148cfa1e9c7ed85bd16c974f9f61"
-  integrity sha512-MhEZ3hvxOVuYGsrRzW/PZLDR2VdtG2+V6TIKPvmE9JT+RAq/OtPlrFd1+ZQwBefoHEhjRNuRJ0OktcFezuxPmg==
+vscode-textmate@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.2.2.tgz#0b4dabc69a6fba79a065cb6b615f66eac07c8f4c"
+  integrity sha512-1U4ih0E/KP1zNK/EbpUqyYtI7PY+Ccd2nDGTtiMR/UalLFnmaYkwoWhN1oI7B91ptBN8NdVwWuvyUnvJAulCUw==
   dependencies:
     oniguruma "^7.2.0"
 

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -399,10 +399,10 @@ vscode-ripgrep@^1.5.7:
   resolved "https://registry.yarnpkg.com/vscode-ripgrep/-/vscode-ripgrep-1.5.7.tgz#acb6b548af488a4bca5d0f1bb5faf761343289ce"
   integrity sha512-/Vsz/+k8kTvui0q3O74pif9FK0nKopgFTiGNVvxicZANxtSA8J8gUE9GQ/4dpi7D/2yI/YVORszwVskFbz46hQ==
 
-vscode-textmate@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.3.0.tgz#6e1f0f273d84148cfa1e9c7ed85bd16c974f9f61"
-  integrity sha512-MhEZ3hvxOVuYGsrRzW/PZLDR2VdtG2+V6TIKPvmE9JT+RAq/OtPlrFd1+ZQwBefoHEhjRNuRJ0OktcFezuxPmg==
+vscode-textmate@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.2.2.tgz#0b4dabc69a6fba79a065cb6b615f66eac07c8f4c"
+  integrity sha512-1U4ih0E/KP1zNK/EbpUqyYtI7PY+Ccd2nDGTtiMR/UalLFnmaYkwoWhN1oI7B91ptBN8NdVwWuvyUnvJAulCUw==
   dependencies:
     oniguruma "^7.2.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9007,10 +9007,10 @@ vscode-sqlite3@4.0.8:
   dependencies:
     nan "^2.14.0"
 
-vscode-textmate@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.3.0.tgz#6e1f0f273d84148cfa1e9c7ed85bd16c974f9f61"
-  integrity sha512-MhEZ3hvxOVuYGsrRzW/PZLDR2VdtG2+V6TIKPvmE9JT+RAq/OtPlrFd1+ZQwBefoHEhjRNuRJ0OktcFezuxPmg==
+vscode-textmate@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-4.2.2.tgz#0b4dabc69a6fba79a065cb6b615f66eac07c8f4c"
+  integrity sha512-1U4ih0E/KP1zNK/EbpUqyYtI7PY+Ccd2nDGTtiMR/UalLFnmaYkwoWhN1oI7B91ptBN8NdVwWuvyUnvJAulCUw==
   dependencies:
     oniguruma "^7.2.0"
 


### PR DESCRIPTION
This PR addresses #83541 for stable

- reverts `vscode-textmate` to the previous stable version (4.2.2)
- since reverting `vscode-textmate` would technically reopen #77990
- it addresses #77990 by removing the problematic injections
- furthermore, due to a `package.json` conflict, it also needs to update distro to a commit which manually resolved the conflict.

After merging, we need to verify both #83541 and #77990