### PR TITLE
Address typo in command identifier for installMissingDependencies

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsDependencyChecker.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsDependencyChecker.ts
@@ -26,10 +26,10 @@ export class ExtensionDependencyChecker extends Disposable implements IWorkbench
 		@IHostService private readonly hostService: IHostService
 	) {
 		super();
-		CommandsRegistry.registerCommand('workbench.extensions.installMissingDepenencies', () => this.installMissingDependencies());
+		CommandsRegistry.registerCommand('workbench.extensions.installMissingDependencies', () => this.installMissingDependencies());
 		MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 			command: {
-				id: 'workbench.extensions.installMissingDepenencies',
+				id: 'workbench.extensions.installMissingDependencies',
 				category: localize('extensions', "Extensions"),
 				title: localize('auto install missing deps', "Install Missing Dependencies")
 			}


### PR DESCRIPTION
The command is currently registered with the identifier `workbench.extensions.installMissingDepenencies`. 

### Changes introduced in this PR

* Updates the command identifier `installMissingDepenencies` to `installMissingDependencies`

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes https://github.com/microsoft/vscode/issues/84055
