### PR TITLE
Fix #83318. Absolute position compact menu in safari.

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.css
+++ b/src/vs/base/browser/ui/menu/menu.css
@@ -159,6 +159,10 @@
 	outline: 0;
 }
 
+.menubar.compact {
+	flex-shrink: 0;
+}
+
 .menubar.compact > .menubar-menu-button {
 	width: 100%;
 	height: 100%;
@@ -190,12 +194,14 @@
 }
 
 .menubar.compact .toolbar-toggle-more {
+	position: absolute;
+	left: 0px;
+	top: 0px;
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: 16px;
 	cursor: pointer;
 	width: 100%;
-	height: 100%;
 }
 
 .menubar .toolbar-toggle-more {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -450,6 +450,9 @@ export class ActivitybarPart extends Part implements IActivityBarService {
 		if (this.globalActivityActionBar) {
 			availableHeight -= (this.globalActivityActionBar.viewItems.length * ActivitybarPart.ACTION_HEIGHT); // adjust height for global actions showing
 		}
+		if (this.menubar) {
+			availableHeight -= this.menubar.clientHeight;
+		}
 		this.compositeBar.layout(new Dimension(width, availableHeight));
 	}
 

--- a/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
@@ -41,3 +41,8 @@
 	width: 100%;
 	height: 35px;
 }
+
+.monaco-workbench .activitybar .menubar.compact .toolbar-toggle-more {
+	width: 100%;
+	height: 35px;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #83318.
Also fixes #83637

Absolute positioned menu breaks its `flex` boxed container. We need to absolute position the compact menu (hambuger button) as well to ensure it's being displayed correctly. 
