### PR TITLE
Make "alwaysExpand" the default search behaviour.

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -746,7 +746,7 @@ configurationRegistry.registerConfiguration({
 				'',
 				''
 			],
-			default: 'auto',
+			default: 'alwaysExpand',
 			description: nls.localize('search.collapseAllResults', "Controls whether the search results will be collapsed or expanded."),
 		},
 		'search.useReplacePreview': {


### PR DESCRIPTION
cc @kieferrm, @roblourens

This is possible now that adding/expanding many tree items is inexpensive. Kai requested this be the new default.