### PR TITLE
Remove backreferences warning

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -15,7 +15,6 @@ import { Action } from 'vs/base/common/actions';
 import { Delayer } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import * as strings from 'vs/base/common/strings';
 import { CONTEXT_FIND_WIDGET_NOT_VISIBLE } from 'vs/editor/contrib/find/findModel';
 import * as nls from 'vs/nls';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';

--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -436,12 +436,6 @@ export class SearchWidget extends Widget {
 			return { content: e.message };
 		}
 
-		if (strings.regExpContainsBackreference(value)) {
-			if (!this.searchConfiguration.usePCRE2) {
-				return { content: nls.localize('regexp.backreferenceValidationFailure', "Backreferences are not supported") };
-			}
-		}
-
 		return null;
 	}
 

--- a/src/vs/workbench/contrib/search/common/queryBuilder.ts
+++ b/src/vs/workbench/contrib/search/common/queryBuilder.ts
@@ -92,7 +92,7 @@ export class QueryBuilder {
 		const fallbackToPCRE = folderResources && folderResources.some(folder => {
 			const folderConfig = this.configurationService.getValue<ISearchConfiguration>({ resource: folder });
 			return !folderConfig.search.useRipgrep;
-		});
+		}) || contentPattern.isRegExp && strings.regExpContainsBackreference(contentPattern.pattern);
 
 		const commonQuery = this.commonQuery(folderResources, options);
 		return <ITextQuery>{

--- a/src/vs/workbench/contrib/search/common/queryBuilder.ts
+++ b/src/vs/workbench/contrib/search/common/queryBuilder.ts
@@ -92,7 +92,7 @@ export class QueryBuilder {
 		const fallbackToPCRE = folderResources && folderResources.some(folder => {
 			const folderConfig = this.configurationService.getValue<ISearchConfiguration>({ resource: folder });
 			return !folderConfig.search.useRipgrep;
-		}) || contentPattern.isRegExp && strings.regExpContainsBackreference(contentPattern.pattern);
+		});
 
 		const commonQuery = this.commonQuery(folderResources, options);
 		return <ITextQuery>{


### PR DESCRIPTION
Ripgrep will fall back to using PCRE2's when backreferences are detected, so toss out the warning saying that it wont.