### PR TITLE
Use enum json schema for minimap scale

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1907,8 +1907,7 @@ class EditorMinimap extends BaseEditorOption<EditorOption.minimap, EditorMinimap
 				'editor.minimap.scale': {
 					type: 'number',
 					default: defaults.scale,
-					minimum: 1,
-					maximum: 3,
+					enum: [1, 2, 3],
 					description: nls.localize('minimap.scale', "Scale of content drawn in the minimap.")
 				},
 				'editor.minimap.renderCharacters': {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1907,6 +1907,8 @@ class EditorMinimap extends BaseEditorOption<EditorOption.minimap, EditorMinimap
 				'editor.minimap.scale': {
 					type: 'number',
 					default: defaults.scale,
+					minimum: 1,
+					maximum: 3,
 					enum: [1, 2, 3],
 					description: nls.localize('minimap.scale', "Scale of content drawn in the minimap.")
 				},


### PR DESCRIPTION
Switches to using dropdown in settings GUI / shows warning in `settings.json` when using non-integer value.

It's also possible to use type `integer` instead of enum (if that's preferable).