### PR TITLE
Restore pre 1.40 way of setting disable-color-correct-rendering in electron (#84154)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -147,6 +147,8 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		if (argvValue === true || argvValue === 'true') {
 			if (argvKey === 'disable-hardware-acceleration') {
 				app.disableHardwareAcceleration(); // needs to be called explicitly
+			} else if (argvKey === 'disable-color-correct-rendering') {
+				app.commandLine.appendSwitch('disable-color-correct-rendering'); // needs to be called exactly like this (https://github.com/microsoft/vscode/issues/84154)
 			} else {
 				app.commandLine.appendArgument(argvKey);
 			}


### PR DESCRIPTION
Backports https://github.com/microsoft/vscode/pull/84269