### PR TITLE
fix: don't use appendArgument to add switch values

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -147,10 +147,8 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		if (argvValue === true || argvValue === 'true') {
 			if (argvKey === 'disable-hardware-acceleration') {
 				app.disableHardwareAcceleration(); // needs to be called explicitly
-			} else if (argvKey === 'disable-color-correct-rendering') {
-				app.commandLine.appendSwitch('disable-color-correct-rendering'); // needs to be called exactly like this (https://github.com/microsoft/vscode/issues/84154)
 			} else {
-				app.commandLine.appendArgument(argvKey);
+				app.commandLine.appendSwitch(argvKey);
 			}
 		} else {
 			app.commandLine.appendSwitch(argvKey, argvValue);

--- a/src/main.js
+++ b/src/main.js
@@ -150,8 +150,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 			} else {
 				app.commandLine.appendSwitch(argvKey);
 			}
-		} else {
-			app.commandLine.appendSwitch(argvKey, argvValue);
 		}
 	});
 


### PR DESCRIPTION
The api electron uses for the `appendArgument` call doesn't actually work with switch values https://cs.chromium.org/chromium/src/base/command_line.h?l=200-204 