### PR TITLE
Don't drop current code lens promise if the current resolve promise has changed

### DIFF
--- a/src/vs/editor/contrib/codelens/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/codelensController.ts
@@ -326,7 +326,7 @@ export class CodeLensContribution implements editorCommon.IEditorContribution {
 			return;
 		}
 
-		this._currentResolveCodeLensSymbolsPromise = createCancelablePromise(token => {
+		const resolvePromise = createCancelablePromise(token => {
 
 			const promises = toResolve.map((request, i) => {
 
@@ -351,16 +351,21 @@ export class CodeLensContribution implements editorCommon.IEditorContribution {
 
 			return Promise.all(promises);
 		});
+		this._currentResolveCodeLensSymbolsPromise = resolvePromise;
 
 		this._currentResolveCodeLensSymbolsPromise.then(() => {
 			if (this._currentCodeLensModel) { // update the cached state with new resolved items
 				this._codeLensCache.put(model, this._currentCodeLensModel);
 			}
 			this._oldCodeLensModels.clear(); // dispose old models once we have updated the UI with the current model
-			this._currentResolveCodeLensSymbolsPromise = undefined;
+			if (resolvePromise === this._currentResolveCodeLensSymbolsPromise) {
+				this._currentResolveCodeLensSymbolsPromise = undefined;
+			}
 		}, err => {
 			onUnexpectedError(err); // can also be cancellation!
-			this._currentResolveCodeLensSymbolsPromise = undefined;
+			if (resolvePromise === this._currentResolveCodeLensSymbolsPromise) {
+				this._currentResolveCodeLensSymbolsPromise = undefined;
+			}
 		});
 	}
 }


### PR DESCRIPTION
Fixes #84185

Before clearing `this._currentResolveCodeLensSymbolsPromise`, make sure that a new value has not come in this meantime. The current behavior would not check this, which could cause some code lens requests to not be cancelled when they should have been