### PR TITLE
style: making colorBox circular & cursor for improving UX

### DIFF
--- a/src/vs/editor/contrib/colorPicker/colorDetector.ts
+++ b/src/vs/editor/contrib/colorPicker/colorDetector.ts
@@ -182,6 +182,8 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 					before: {
 						contentText: ' ',
 						border: 'solid 0.1em #000',
+						borderRadius: '50%',
+						cursor: 'default',
 						margin: '0.1em 0.2em 0 0.2em',
 						width: '0.8em',
 						height: '0.8em',


### PR DESCRIPTION
Made the color box to circular so that it will be less dominant while traversing through the code.
The default cursor says that color box is neither clickable nor selectable

This PR fixes no issue, it adds some styling to color box
