### PR TITLE
Add absolute position and width to extensions-viewlet

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionsViewlet.css
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 .extensions-viewlet {
+	position: absolute;
 	height: 100%;
+	width: 100%;
 }
 
 .extensions-viewlet > .header {


### PR DESCRIPTION
Add position and width to `.extensions-viewlet` to avoid the content (and the placeholder text) from shifting after clicking on certain elements

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #84538
