### PR TITLE
Remove `will-change: transform` from the editor

### DIFF
--- a/src/vs/base/browser/fastDomNode.ts
+++ b/src/vs/base/browser/fastDomNode.ts
@@ -203,7 +203,7 @@ export class FastDomNode<T extends HTMLElement> {
 			return;
 		}
 		this._layerHint = layerHint;
-		(<any>this.domNode.style).willChange = this._layerHint ? 'transform' : 'auto';
+		this.domNode.style.transform = this._layerHint ? 'translate3d(0px, 0px, 0px)' : '';
 	}
 
 	public setAttribute(name: string, value: string): void {


### PR DESCRIPTION
- Adds a workaround Chromium's change which forces layers using will-change:transform to use greyscale antialising.

This PR fixes https://github.com/microsoft/vscode/issues/84698 (which is covering just the code editor text, it is a subset of https://github.com/microsoft/vscode/issues/84214)
