### PR TITLE
Reduce the minimum width to fix the bug #84164

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -59,7 +59,7 @@ const enum WindowError {
 
 export class CodeWindow extends Disposable implements ICodeWindow {
 
-	private static readonly MIN_WIDTH = 600;
+	private static readonly MIN_WIDTH = 300;
 	private static readonly MIN_HEIGHT = 270;
 
 	private static readonly MAX_URL_LENGTH = 2 * 1024 * 1024; // https://cs.chromium.org/chromium/src/url/url_constants.cc?l=32


### PR DESCRIPTION
This PR fixes #84164
It fixes the bug where you cannot reduce the width of a vscode window to less than 1200pixels on a second monitor which is not scaled when you have another montior that IS scaled.
There was already a PR that fixed this bug for the height here #84532 
However this fix is for the width.
