### PR TITLE
debug: reload the extension host regardless of `supportsRestartRequest`

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -581,19 +581,19 @@ export class DebugService implements IDebugService {
 			return this.runTaskAndCheckErrors(session.root, session.configuration.preLaunchTask);
 		};
 
-		if (session.capabilities.supportsRestartRequest) {
+		if (isExtensionHostDebugging(session.configuration)) {
 			const taskResult = await runTasks();
 			if (taskResult === TaskRunResult.Success) {
-				await session.restart();
+				this.extensionHostDebugService.reload(session.getId());
 			}
 
 			return;
 		}
 
-		if (isExtensionHostDebugging(session.configuration)) {
+		if (session.capabilities.supportsRestartRequest) {
 			const taskResult = await runTasks();
 			if (taskResult === TaskRunResult.Success) {
-				this.extensionHostDebugService.reload(session.getId());
+				await session.restart();
 			}
 
 			return;


### PR DESCRIPTION
In PWA we set the flag `supportsRestartRequest`, since internally we
handle rebooting Node.js and Chrome targets. (The previous Node.js
adapter didn't set this flag.) This gets set on the adapter level,
before we know what kind of launch/attach request we might get. There
does not appear to be a correct way to restart the attached Code
instance from the adapter, however; we need invoke to the `.reload()`
method on the extension host, which as far as I know we can't access and
is only referenced here. In PWA I was trying to send a `terminate`
command with `{ restart: true }` in its body, but for adapters with
`supportsRestartRequest` this simply loops back to a `restart()` call.

This PR just moves the extension host check prior to
`supportsRestartRequest`. This allows PWA to restart correctly. It
shouldn't affect any third party extensions, since
`isExtensionHostDebugging` checks whether the debug type is
`extensionHost`, which is a debug type our 1st
party Node adapter 'owns'.

A more generic solution might be a way on the protocol for the adapter
to signal that, for whatever reason, it's unable to restart the current
session and would like the frontend to terminate and reboot it.
(However, I'm unsure if this would be useful outside the slightly magic
extension host scenario, since most adapters can probably handle it
behind the scenes like PWA does for Node.js targets today.)