### PR TITLE
Modify 'Edit settings.json' button to visually replicate 'Add Pattern…

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -479,9 +479,11 @@
 .settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-value .edit-in-settings-button,
 .settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-value .edit-in-settings-button:hover,
 .settings-editor > .settings-body > .settings-tree-container .setting-item-contents .setting-item-value .edit-in-settings-button:active {
-	text-align: left;
-	text-decoration: underline;
-	padding-left: 0px;
+	text-align: center;
+	padding-top: 2px;
+	padding-right: 14px;
+	padding-bottom: 2px;
+	padding-left: 14px;
 }
 
 .settings-editor > .settings-body > .settings-tree-container .setting-item-contents .monaco-select-box {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -647,9 +647,9 @@ export class SettingComplexRenderer extends AbstractSettingRenderer implements I
 		openSettingsButton.element.classList.add('edit-in-settings-button');
 
 		common.toDispose.push(attachButtonStyler(openSettingsButton, this._themeService, {
-			buttonBackground: Color.transparent.toString(),
-			buttonHoverBackground: Color.transparent.toString(),
-			buttonForeground: 'foreground'
+			buttonBackground: Color.fromHex('#0E639C').toString(),
+			buttonHoverBackground: Color.fromHex('#1177BB').toString(),
+			buttonForeground: Color.white.toString()
 		}));
 
 		const template: ISettingComplexItemTemplate = {


### PR DESCRIPTION
I have modified the 'Edit in settings.json' button to visually replicate the 'Add Pattern' button in the settings editor.

Fixes #58923

![image](https://user-images.githubusercontent.com/35276477/68981473-81796f80-07d1-11ea-858f-10f45423e884.png)



<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

