### PR TITLE
add shadow in editor hove and suggest-widget

### DIFF
--- a/src/vs/editor/contrib/hover/hover.ts
+++ b/src/vs/editor/contrib/hover/hover.ts
@@ -21,7 +21,7 @@ import { ModesContentHoverWidget } from 'vs/editor/contrib/hover/modesContentHov
 import { ModesGlyphHoverWidget } from 'vs/editor/contrib/hover/modesGlyphHover';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { editorHoverBackground, editorHoverBorder, editorHoverHighlight, textCodeBlockBackground, textLinkForeground, editorHoverStatusBarBackground, editorHoverForeground } from 'vs/platform/theme/common/colorRegistry';
+import { editorHoverBackground, editorHoverBorder, editorHoverHighlight, textCodeBlockBackground, textLinkForeground, editorHoverStatusBarBackground, editorHoverForeground, editorHoverShadow } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { IMarkerDecorationsService } from 'vs/editor/common/services/markersDecorationService';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -314,6 +314,7 @@ registerThemingParticipant((theme, collector) => {
 	if (hoverBackground) {
 		collector.addRule(`.monaco-editor .monaco-editor-hover { background-color: ${hoverBackground}; }`);
 	}
+
 	const hoverBorder = theme.getColor(editorHoverBorder);
 	if (hoverBorder) {
 		collector.addRule(`.monaco-editor .monaco-editor-hover { border: 1px solid ${hoverBorder}; }`);
@@ -321,6 +322,11 @@ registerThemingParticipant((theme, collector) => {
 		collector.addRule(`.monaco-editor .monaco-editor-hover hr { border-top: 1px solid ${hoverBorder.transparent(0.5)}; }`);
 		collector.addRule(`.monaco-editor .monaco-editor-hover hr { border-bottom: 0px solid ${hoverBorder.transparent(0.5)}; }`);
 	}
+	const hoverShadow = theme.getColor(editorHoverShadow);
+	if (hoverShadow) {
+		collector.addRule(`.monaco-editor .monaco-editor-hover { box-shadow: 0 1px 6px 0 ${hoverShadow}; border-radius: 4px ; border:none}`);
+	}
+
 	const link = theme.getColor(textLinkForeground);
 	if (link) {
 		collector.addRule(`.monaco-editor .monaco-editor-hover a { color: ${link}; }`);

--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -153,7 +153,8 @@
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .readMore,
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main > .type-label {
-	display: inline;
+	display: flex;
+	align-items: center;
 }
 
 /** Styles for each row in the list **/

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -60,6 +60,7 @@ interface ISuggestionTemplateData {
 export const editorSuggestWidgetBackground = registerColor('editorSuggestWidget.background', { dark: editorWidgetBackground, light: editorWidgetBackground, hc: editorWidgetBackground }, nls.localize('editorSuggestWidgetBackground', 'Background color of the suggest widget.'));
 export const editorSuggestWidgetBorder = registerColor('editorSuggestWidget.border', { dark: editorWidgetBorder, light: editorWidgetBorder, hc: editorWidgetBorder }, nls.localize('editorSuggestWidgetBorder', 'Border color of the suggest widget.'));
 export const editorSuggestWidgetForeground = registerColor('editorSuggestWidget.foreground', { dark: editorForeground, light: editorForeground, hc: editorForeground }, nls.localize('editorSuggestWidgetForeground', 'Foreground color of the suggest widget.'));
+export const editorSuggestWidgetShadowColor = registerColor('editorSuggestWidget.shadow', { dark: null, light: null, hc: null }, nls.localize('editorSuggestWidgetShaodw', 'Shaodw color of the suggest widget.'));
 export const editorSuggestWidgetSelectedBackground = registerColor('editorSuggestWidget.selectedBackground', { dark: listFocusBackground, light: listFocusBackground, hc: listFocusBackground }, nls.localize('editorSuggestWidgetSelectedBackground', 'Background color of the selected entry in the suggest widget.'));
 export const editorSuggestWidgetHighlightForeground = registerColor('editorSuggestWidget.highlightForeground', { dark: listHighlightForeground, light: listHighlightForeground, hc: listHighlightForeground }, nls.localize('editorSuggestWidgetHighlightForeground', 'Color of the match highlights in the suggest widget.'));
 
@@ -1208,7 +1209,11 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const foreground = theme.getColor(editorSuggestWidgetForeground);
 	if (foreground) {
-		collector.addRule(`.monaco-editor .suggest-widget { color: ${foreground}; }`);
+		collector.addRule(`.monaco-editor .suggest-widget { color: ${foreground};  }`);
+	}
+	const editorSuggestWidgetShadow = theme.getColor(editorSuggestWidgetShadowColor);
+	if (editorSuggestWidgetShadow) {
+		collector.addRule(`.monaco-editor .suggest-widget > .tree, .monaco-editor .suggest-widget > .details {box-shadow: 0 1px 6px 0 ${editorSuggestWidgetShadow}; border-radius:6px; overflow: hidden;}`);
 	}
 
 	const link = theme.getColor(textLinkForeground);

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -304,6 +304,8 @@ export const editorFindRangeHighlightBorder = registerColor('editor.findRangeHig
  */
 export const editorHoverHighlight = registerColor('editor.hoverHighlightBackground', { light: '#ADD6FF26', dark: '#264f7840', hc: '#ADD6FF26' }, nls.localize('hoverHighlight', 'Highlight below the word for which a hover is shown. The color must not be opaque so as not to hide underlying decorations.'), true);
 export const editorHoverBackground = registerColor('editorHoverWidget.background', { light: editorWidgetBackground, dark: editorWidgetBackground, hc: editorWidgetBackground }, nls.localize('hoverBackground', 'Background color of the editor hover.'));
+
+export const editorHoverShadow = registerColor('editorHoverShadow.color', { light: widgetShadow, dark: widgetShadow, hc: widgetShadow }, nls.localize('hoverShadow', 'Shaodw color of the editor hover.'));
 export const editorHoverForeground = registerColor('editorHoverWidget.foreground', { light: editorWidgetForeground, dark: editorWidgetForeground, hc: editorWidgetForeground }, nls.localize('hoverForeground', 'Foreground color of the editor hover.'));
 export const editorHoverBorder = registerColor('editorHoverWidget.border', { light: editorWidgetBorder, dark: editorWidgetBorder, hc: editorWidgetBorder }, nls.localize('hoverBorder', 'Border color of the editor hover.'));
 export const editorHoverStatusBarBackground = registerColor('editorHoverWidget.statusBarBackground', { dark: lighten(editorHoverBackground, 0.2), light: darken(editorHoverBackground, 0.05), hc: editorWidgetBackground }, nls.localize('statusBarBackground', "Background color of the editor hover status bar."));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #
add rules `editorSuggestWidget.shadow` , `editorHoverShadow.color`   for editor suggest-widget and hover-widget

these looks like 
![image](https://user-images.githubusercontent.com/18000037/68986219-158e1a00-0858-11ea-9da0-f94210828f2a.png)
![image](https://user-images.githubusercontent.com/18000037/68986230-26d72680-0858-11ea-806d-e305afd37afa.png)


