### PR TITLE
 Make local and remote ports configurable

### DIFF
--- a/scripts/code-web.js
+++ b/scripts/code-web.js
@@ -35,8 +35,8 @@ const args = minimist(process.argv, {
 if(args.help){
 	console.log(
 		'yarn web [options]\n' +
-			' --no-launch   Launch browser\n' +
-			' --scheme      Potocol\n' +
+			' --no-launch   Do not start browser\n' +
+			' --scheme      Protocol (https or http)\n' +
 			' --host        Remote host\n' +
 			' --port        Remote/Local port\n' +
 			' --local_port  Local port override\n' +
@@ -84,7 +84,8 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(LOCAL_PORT, () => {
-	console.log(`Operating location at http://0.0.0.0:${LOCAL_PORT}`);
+	if(LOCAL_PORT !== PORT)
+		console.log(`Operating location at http://0.0.0.0:${LOCAL_PORT}`);
 	console.log(`Web UI available at   ${SCHEME}://${AUTHORITY}`);
 });
 

--- a/scripts/code-web.js
+++ b/scripts/code-web.js
@@ -20,16 +20,32 @@ const EXTENSIONS_ROOT = path.join(APP_ROOT, 'extensions');
 const WEB_MAIN = path.join(APP_ROOT, 'src', 'vs', 'code', 'browser', 'workbench', 'workbench-dev.html');
 
 const args = minimist(process.argv, {
-	string: [
+	boolean:[
 		'no-launch',
-		'scheme',
-		'host'
+		'help'
 	],
-	number: [
+	string: [
+		'scheme',
+		'host',
 		'port',
 		'local_port'
-	]
+	],
 });
+
+if(args.help){
+	console.log(
+		'yarn web [options]\n' +
+			' --no-launch   Launch browser\n' +
+			' --scheme      Potocol\n' +
+			' --host        Remote host\n' +
+			' --port        Remote/Local port\n' +
+			' --local_port  Local port override\n' +
+			' --help\n' +
+			'[Example]\n' +
+			' yarn web --no-launch --scheme https --host example.com --port 8080 --local_port 30000'
+	);
+	process.exit(0);
+}
 
 const PORT = args.port || process.env.PORT || 8080;
 const LOCAL_PORT = args.local_port || process.env.LOCAL_PORT || PORT;
@@ -68,7 +84,8 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(LOCAL_PORT, () => {
-	console.log(`Web UI available at ${SCHEME}://${AUTHORITY}`);
+	console.log(`Operating location at http://0.0.0.0:${LOCAL_PORT}`);
+	console.log(`Web UI available at   ${SCHEME}://${AUTHORITY}`);
 });
 
 server.on('error', err => {

--- a/scripts/code-web.js
+++ b/scripts/code-web.js
@@ -26,11 +26,13 @@ const args = minimist(process.argv, {
 		'host'
 	],
 	number: [
-		'port'
+		'port',
+		'local_port'
 	]
 });
 
 const PORT = args.port || process.env.PORT || 8080;
+const LOCAL_PORT = args.local_port || process.env.LOCAL_PORT || PORT;
 const SCHEME = args.scheme || process.env.VSCODE_SCHEME || 'http';
 const HOST = args.host || 'localhost';
 const AUTHORITY = process.env.VSCODE_AUTHORITY || `${HOST}:${PORT}`;
@@ -65,7 +67,7 @@ const server = http.createServer((req, res) => {
 	}
 });
 
-server.listen(PORT, () => {
+server.listen(LOCAL_PORT, () => {
 	console.log(`Web UI available at ${SCHEME}://${AUTHORITY}`);
 });
 


### PR DESCRIPTION
Modification to enable handling in cases where local port and remote port are different

#RemotePort=30000 LocalPort=8080
yarn web --port=30000 --local_port=8080