### PR TITLE
fix: MarkdownPreview editor should not show icon when disabled file icons

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -512,7 +512,10 @@ export class DynamicMarkdownPreview extends Disposable {
 
 	private setContent(html: string): void {
 		this.editor.title = DynamicMarkdownPreview.getPreviewTitle(this._resource, this._locked);
-		this.editor.iconPath = this.iconPath;
+		const config = this._previewConfigurations.loadAndCacheConfiguration(this._resource);
+		if (config.showIcon) {
+			this.editor.iconPath = this.iconPath;
+		}
 		this.editor.webview.options = DynamicMarkdownPreview.getWebviewOptions(this._resource, this._contributionProvider.contributions);
 		this.editor.webview.html = html;
 	}

--- a/extensions/markdown-language-features/src/features/previewConfig.ts
+++ b/extensions/markdown-language-features/src/features/previewConfig.ts
@@ -22,9 +22,11 @@ export class MarkdownPreviewConfiguration {
 	public readonly fontSize: number;
 	public readonly fontFamily: string | undefined;
 	public readonly styles: string[];
+	public readonly showIcon: boolean;
 
 	private constructor(resource: vscode.Uri) {
 		const editorConfig = vscode.workspace.getConfiguration('editor', resource);
+		const workbenchConfig = vscode.workspace.getConfiguration('workbench', resource);
 		const markdownConfig = vscode.workspace.getConfiguration('markdown', resource);
 		const markdownEditorConfig = vscode.workspace.getConfiguration('[markdown]', resource);
 
@@ -34,7 +36,7 @@ export class MarkdownPreviewConfiguration {
 		if (markdownEditorConfig && markdownEditorConfig['editor.wordWrap']) {
 			this.wordWrap = markdownEditorConfig['editor.wordWrap'] !== 'off';
 		}
-
+		this.showIcon = workbenchConfig.get<boolean>('editor.showIcons', true);
 		this.scrollPreviewWithEditor = !!markdownConfig.get<boolean>('preview.scrollPreviewWithEditor', true);
 		this.scrollEditorWithPreview = !!markdownConfig.get<boolean>('preview.scrollEditorWithPreview', true);
 		this.lineBreaks = !!markdownConfig.get<boolean>('preview.breaks', false);


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #84962
