### PR TITLE
Don't use locale strings

### DIFF
--- a/extensions/markdown-language-features/src/logger.ts
+++ b/extensions/markdown-language-features/src/logger.ts
@@ -41,7 +41,7 @@ export class Logger {
 
 	public log(message: string, data?: any): void {
 		if (this.trace === Trace.Verbose) {
-			this.appendLine(`[Log - ${(new Date().toLocaleTimeString())}] ${message}`);
+			this.appendLine(`[Log - ${(new Date().toTimeString())}] ${message}`);
 			if (data) {
 				this.appendLine(Logger.data2String(data));
 			}

--- a/extensions/typescript-language-features/src/utils/logger.ts
+++ b/extensions/typescript-language-features/src/utils/logger.ts
@@ -41,7 +41,7 @@ export default class Logger {
 	}
 
 	public logLevel(level: LogLevel, message: string, data?: any): void {
-		this.output.appendLine(`[${level}  - ${(new Date().toLocaleTimeString())}] ${message}`);
+		this.output.appendLine(`[${level}  - ${(new Date().toTimeString())}] ${message}`);
 		if (data) {
 			this.output.appendLine(this.data2String(data));
 		}


### PR DESCRIPTION
This change backports 5b428d2ec105fde9d61ec97e73f53db509b030db to the 1.40 branch

For #84803
