### PR TITLE
#8580 Adjust movecopy error messages

### DIFF
--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -693,7 +693,7 @@ export class FileService extends Disposable implements IFileService {
 
 			// Bail out if target exists and we are not about to overwrite
 			if (!overwrite) {
-				throw new FileOperationError(localize('unableToMoveCopyError3', "Unable to move/copy. File already exists at destination."), FileOperationResult.FILE_MOVE_CONFLICT);
+				throw new FileOperationError(localize('unableToMoveCopyError3', "Unable to move/copy as file already exists at destination."), FileOperationResult.FILE_MOVE_CONFLICT);
 			}
 
 			// Special case: if the target is a parent of the source, we cannot delete
@@ -701,7 +701,7 @@ export class FileService extends Disposable implements IFileService {
 			if (sourceProvider === targetProvider) {
 				const isPathCaseSensitive = !!(sourceProvider.capabilities & FileSystemProviderCapabilities.PathCaseSensitive);
 				if (isEqualOrParent(source, target, !isPathCaseSensitive)) {
-					throw new Error(localize('unableToMoveCopyError4', "Unable to move/copy. File would replace folder it is contained in."));
+					throw new Error(localize('unableToMoveCopyError4', "Unable to move/copy as file would replace folder it is contained in."));
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -1046,7 +1046,7 @@ export const pasteFileHandler = async (accessor: ServicesAccessor) => {
 				return await fileService.copy(fileToPaste, targetFile);
 			}
 		} catch (e) {
-			onError(notificationService, new Error(nls.localize('fileDeleted', "File to paste was deleted or moved meanwhile. {0}", getErrorMessage(e))));
+			onError(notificationService, new Error(nls.localize('fileDeleted', "File to paste was deleted or moved since copying. {0}", getErrorMessage(e))));
 			return undefined;
 		}
 	}));


### PR DESCRIPTION
This PR fixes #85080 

Adjust pasting error to be clearer.

Adjust unableToMoveCopy3/4 to be one sentence, this feels more fluid and is in line with unableToMoveCopy1/2
