### PR TITLE
Fixed gulp throwing "invalid glob argument" error

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -199,7 +199,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const productJsonStream = gulp.src(['product.json'], { base: '.' })
 			.pipe(json(productJsonUpdate));
 
-		const license = gulp.src(['LICENSES.chromium.html', product.licenseFileName, 'ThirdPartyNotices.txt', 'licenses/**'], { base: '.', allowEmpty: true });
+		const license = gulp.src(['LICENSES.chromium.html', product.licenseName, 'ThirdPartyNotices.txt', 'licenses/**'], { base: '.', allowEmpty: true });
 
 		// TODO the API should be copied to `out` during compile, not here
 		const api = gulp.src('src/vs/vscode.d.ts').pipe(rename('out/vs/vscode.d.ts'));


### PR DESCRIPTION
This PR fixes a build error from gulp during the `minify-vscode` stage of compilation. The error is as follows:
```
Error: Invalid glob argument: LICENSES.chromium.html,,ThirdPartyNotices.txt,licenses/**
    at Gulp.src (/home/lux/dev/codebuilds/code/node_modules/vinyl-fs/lib/src/index.js:20:11)
    at /home/lux/dev/codebuilds/code/build/gulpfile.vscode.js:296:24
    at Promise (/home/lux/dev/codebuilds/code/build/lib/task.js:44:28)
    at new Promise (<anonymous>)
    at _doExecute (/home/lux/dev/codebuilds/code/build/lib/task.js:33:12)
    at _execute (/home/lux/dev/codebuilds/code/build/lib/task.js:24:11)
    at result (/home/lux/dev/codebuilds/code/build/lib/task.js:63:19)
```

The build is failing because of an empty array element between "LICENSES.chromium.html" and "ThirdPartyNotices.txt.licenses" causing an invalid glob.

Strangely enough I'm the only one experiencing this issue as far as I know (as a google search yielded no results) and a simple typo to the license file is the fix. **Albeit** I'm compiling for an architecture not being built for, but this applies to all architectures.