### PR TITLE
monaco-editor: Find model by resource in SimpleEditorModelResolverService

### DIFF
--- a/src/vs/editor/standalone/browser/simpleServices.ts
+++ b/src/vs/editor/standalone/browser/simpleServices.ts
@@ -99,7 +99,12 @@ function withTypedEditor<T>(widget: editorCommon.IEditor, codeEditorCallback: (e
 export class SimpleEditorModelResolverService implements ITextModelService {
 	public _serviceBrand: undefined;
 
+	private readonly modelService: IModelService | undefined;
 	private editor?: editorCommon.IEditor;
+
+	constructor(modelService: IModelService | undefined) {
+		this.modelService = modelService;
+	}
 
 	public setEditor(editor: editorCommon.IEditor): void {
 		this.editor = editor;
@@ -132,7 +137,7 @@ export class SimpleEditorModelResolverService implements ITextModelService {
 	}
 
 	private findModel(editor: ICodeEditor, resource: URI): ITextModel | null {
-		let model = editor.getModel();
+		let model = this.modelService ? this.modelService.getModel(resource) : editor.getModel();
 		if (model && model.uri.toString() !== resource.toString()) {
 			return null;
 		}

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -47,7 +47,7 @@ function withAllStandaloneServices<T extends editorCommon.IEditor>(domElement: H
 
 	let simpleEditorModelResolverService: SimpleEditorModelResolverService | null = null;
 	if (!services.has(ITextModelService)) {
-		simpleEditorModelResolverService = new SimpleEditorModelResolverService();
+		simpleEditorModelResolverService = new SimpleEditorModelResolverService(StaticServices.modelService.get());
 		services.set(ITextModelService, simpleEditorModelResolverService);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/935

Currently, if you run the following code in the [Monaco Playground](https://microsoft.github.io/monaco-editor/playground.html) and use "Peek Definition", or "Peek References" on the method `next()` in line 3, you get the error "Model not found" on the browser console. This is because the [SimpleEditorModelResolverService](https://github.com/microsoft/vscode/blob/166f925a2bafef8b1068e5bd709dc9a92fb1c208/src/vs/editor/standalone/browser/simpleServices.ts#L135) only takes into account the currently attached model. This PR instead searches through all models.

```js
const lib = `declare class Facts {
	/**
	 * Returns the next fact
	 *
	 * [Online documentation](http://www.google.de)
	 */
	static next(): string;
}`;

const uri = monaco.Uri.file("filename/facts.d.ts");
monaco.languages.typescript.javascriptDefaults.addExtraLib(lib, uri.toString());
monaco.editor.createModel(lib, "typescript", uri);

monaco.editor.create(document.getElementById("container"), {
    value: `class Chuck {
    greet() {
        return Facts.next();
    }
}`,
    language: "javascript"
});
```

Thanks!