### PR TITLE
Correct spelling of Implementation (from Implemenation)

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1307,7 +1307,7 @@ export interface IGotoLocationOptions {
 	multipleDefinitions?: GoToLocationValues;
 	multipleTypeDefinitions?: GoToLocationValues;
 	multipleDeclarations?: GoToLocationValues;
-	multipleImplemenations?: GoToLocationValues;
+	multipleImplementations?: GoToLocationValues;
 	multipleReferences?: GoToLocationValues;
 }
 
@@ -1321,7 +1321,7 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, GoT
 			multipleDefinitions: 'peek',
 			multipleTypeDefinitions: 'peek',
 			multipleDeclarations: 'peek',
-			multipleImplemenations: 'peek',
+			multipleImplementations: 'peek',
 			multipleReferences: 'peek',
 		};
 		const jsonSubset: IJSONSchema = {
@@ -1338,7 +1338,7 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, GoT
 			EditorOption.gotoLocation, 'gotoLocation', defaults,
 			{
 				'editor.gotoLocation.multiple': {
-					deprecationMessage: nls.localize('editor.gotoLocation.multiple.deprecated', "This setting is deprecated, please use separate settings like 'editor.editor.gotoLocation.multipleDefinitions' or 'editor.editor.gotoLocation.multipleImplemenations' instead."),
+					deprecationMessage: nls.localize('editor.gotoLocation.multiple.deprecated', "This setting is deprecated, please use separate settings like 'editor.editor.gotoLocation.multipleDefinitions' or 'editor.editor.gotoLocation.multipleImplementations' instead."),
 				},
 				'editor.gotoLocation.multipleDefinitions': {
 					description: nls.localize('editor.editor.gotoLocation.multipleDefinitions', "Controls the behavior the 'Go to Definition'-command when multiple target locations exist."),
@@ -1352,8 +1352,8 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, GoT
 					description: nls.localize('editor.editor.gotoLocation.multipleDeclarations', "Controls the behavior the 'Go to Declaration'-command when multiple target locations exist."),
 					...jsonSubset,
 				},
-				'editor.gotoLocation.multipleImplemenations': {
-					description: nls.localize('editor.editor.gotoLocation.multipleImplemenattions', "Controls the behavior the 'Go to Implemenations'-command when multiple target locations exist."),
+				'editor.gotoLocation.multipleImplementations': {
+					description: nls.localize('editor.editor.gotoLocation.multipleImplemenattions', "Controls the behavior the 'Go to Implementations'-command when multiple target locations exist."),
 					...jsonSubset,
 				},
 				'editor.gotoLocation.multipleReferences': {
@@ -1374,7 +1374,7 @@ class EditorGoToLocation extends BaseEditorOption<EditorOption.gotoLocation, GoT
 			multipleDefinitions: input.multipleDefinitions ?? EditorStringEnumOption.stringSet<GoToLocationValues>(input.multipleDefinitions, 'peek', ['peek', 'gotoAndPeek', 'goto']),
 			multipleTypeDefinitions: input.multipleTypeDefinitions ?? EditorStringEnumOption.stringSet<GoToLocationValues>(input.multipleTypeDefinitions, 'peek', ['peek', 'gotoAndPeek', 'goto']),
 			multipleDeclarations: input.multipleDeclarations ?? EditorStringEnumOption.stringSet<GoToLocationValues>(input.multipleDeclarations, 'peek', ['peek', 'gotoAndPeek', 'goto']),
-			multipleImplemenations: input.multipleImplemenations ?? EditorStringEnumOption.stringSet<GoToLocationValues>(input.multipleImplemenations, 'peek', ['peek', 'gotoAndPeek', 'goto']),
+			multipleImplementations: input.multipleImplementations ?? EditorStringEnumOption.stringSet<GoToLocationValues>(input.multipleImplementations, 'peek', ['peek', 'gotoAndPeek', 'goto']),
 			multipleReferences: input.multipleReferences ?? EditorStringEnumOption.stringSet<GoToLocationValues>(input.multipleReferences, 'peek', ['peek', 'gotoAndPeek', 'goto']),
 		};
 	}

--- a/src/vs/editor/contrib/gotoSymbol/goToCommands.ts
+++ b/src/vs/editor/contrib/gotoSymbol/goToCommands.ts
@@ -483,7 +483,7 @@ class ImplementationAction extends SymbolNavigationAction {
 	}
 
 	protected _getGoToPreference(editor: IActiveCodeEditor): GoToLocationValues {
-		return editor.getOption(EditorOption.gotoLocation).multipleImplemenations;
+		return editor.getOption(EditorOption.gotoLocation).multipleImplementations;
 	}
 }
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3073,7 +3073,7 @@ declare namespace monaco.editor {
 		multipleDefinitions?: GoToLocationValues;
 		multipleTypeDefinitions?: GoToLocationValues;
 		multipleDeclarations?: GoToLocationValues;
-		multipleImplemenations?: GoToLocationValues;
+		multipleImplementations?: GoToLocationValues;
 		multipleReferences?: GoToLocationValues;
 	}
 


### PR DESCRIPTION
This PR fixes #85142 

Correct the spelling of the editor.gotoLocation.multipleImplementation setting
![vcxsrv_2019-11-20_10-11-15](https://user-images.githubusercontent.com/20613660/69230111-9746b600-0b7e-11ea-8777-6e4bc2af67a8.png)
![vcxsrv_2019-11-20_10-11-41](https://user-images.githubusercontent.com/20613660/69230122-9a41a680-0b7e-11ea-80e8-4d753f3081f0.png)

