### PR TITLE
Use official Cache task for continuous builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   # Bump YARN_CACHE_SALT to reset the cache
   YARN_CACHE_SALT: 2
-  YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
+  YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules_snapshot/**/yarn.lock, !**/.*/**/yarn.lock'
 
 jobs:
 - job: Windows
@@ -16,8 +16,8 @@ jobs:
   steps:
   - template: build/azure-pipelines/linux/continuous-build-linux.yml
 
-- job: macOS
-  pool:
-    vmImage: macOS 10.13
-  steps:
-  - template: build/azure-pipelines/darwin/continuous-build-darwin.yml
+# - job: macOS
+#   pool:
+#     vmImage: macOS 10.13
+#   steps:
+#   - template: build/azure-pipelines/darwin/continuous-build-darwin.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   # Bump YARN_CACHE_SALT to reset the cache
-  YARN_CACHE_SALT: 0
+  YARN_CACHE_SALT: 1
   YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   # Bump YARN_CACHE_SALT to reset the cache
-  YARN_CACHE_SALT: 1
+  YARN_CACHE_SALT: 2
   YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,8 @@
+variables:
+  # Bump YARN_CACHE_SALT to reset the cache
+  YARN_CACHE_SALT: 0
+  YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
+
 jobs:
 - job: Windows
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   # Bump YARN_CACHE_SALT to reset the cache
   YARN_CACHE_SALT: 2
-  YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules_snapshot/**/yarn.lock, !**/.*/**/yarn.lock'
+  YARN_CACHE_KEY: '"$(Agent.OS) Salt=$(YARN_CACHE_SALT)" | .yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/node_modules_snapshot/**/yarn.lock, !**/.*/**/yarn.lock'
 
 jobs:
 - job: Windows

--- a/build/azure-pipelines/darwin/continuous-build-darwin.yml
+++ b/build/azure-pipelines/darwin/continuous-build-darwin.yml
@@ -5,20 +5,14 @@ steps:
 - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
   inputs:
     versionSpec: "1.x"
-- task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+- task: Cache@2
   inputs:
-    keyfile: '.yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
-    targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-    vstsFeed: 'vscode-build-cache'
+    key: $(YARN_CACHE_KEY)
+    path: $(System.DefaultWorkingDirectory)/node_modules
+    cacheHitVar: CacheRestored
 - script: |
     CHILD_CONCURRENCY=1 yarn --frozen-lockfile
   displayName: Install Dependencies
-  condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
-- task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-  inputs:
-    keyfile: '.yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
-    targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-    vstsFeed: 'vscode-build-cache'
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
 - script: |
     yarn electron x64

--- a/build/azure-pipelines/darwin/continuous-build-darwin.yml
+++ b/build/azure-pipelines/darwin/continuous-build-darwin.yml
@@ -2,7 +2,7 @@ steps:
 - task: NodeTool@0
   inputs:
     versionSpec: "12.13.0"
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 - task: Cache@2

--- a/build/azure-pipelines/darwin/continuous-build-darwin.yml
+++ b/build/azure-pipelines/darwin/continuous-build-darwin.yml
@@ -8,12 +8,23 @@ steps:
 - task: Cache@2
   inputs:
     key: $(YARN_CACHE_KEY)
-    path: $(System.DefaultWorkingDirectory)/node_modules
+    path: $(System.DefaultWorkingDirectory)/node_modules_snapshot
     cacheHitVar: CacheRestored
 - script: |
-    CHILD_CONCURRENCY=1 yarn --frozen-lockfile
-  displayName: Install Dependencies
+    yarn --frozen-lockfile
+  env:
+    CHILD_CONCURRENCY: "1"
+  displayName: Install Dependencies (on cache miss)
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
+- bash: |
+    mkdir node_modules_snapshot
+    cp --recursive --no-dereference --preserve=links node_modules/* node_modules_snapshot
+  displayName: Snapshot cache folder
+  condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
+- bash: |
+    mv node_modules_snapshot node_modules
+  displayName: Install Dependencies (on cache hit)
+  condition: and(succeeded(), eq(variables['CacheRestored'], 'true'))
 - script: |
     yarn electron x64
   displayName: Download Electron

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/linux/continuous-build-linux.yml
+++ b/build/azure-pipelines/linux/continuous-build-linux.yml
@@ -16,12 +16,23 @@ steps:
 - task: Cache@2
   inputs:
     key: $(YARN_CACHE_KEY)
-    path: $(System.DefaultWorkingDirectory)/node_modules
+    path: $(System.DefaultWorkingDirectory)/node_modules_snapshot
     cacheHitVar: CacheRestored
 - script: |
-    CHILD_CONCURRENCY=1 yarn --frozen-lockfile
-  displayName: Install Dependencies
+    yarn --frozen-lockfile
+  env:
+    CHILD_CONCURRENCY: "1"
+  displayName: Install Dependencies (on cache miss)
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
+- bash: |
+    mkdir node_modules_snapshot
+    cp --recursive --no-dereference --preserve=links node_modules/* node_modules_snapshot
+  displayName: Snapshot cache folder
+  condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
+- bash: |
+    mv node_modules_snapshot node_modules
+  displayName: Install Dependencies (on cache hit)
+  condition: and(succeeded(), eq(variables['CacheRestored'], 'true'))
 - script: |
     yarn electron x64
   displayName: Download Electron

--- a/build/azure-pipelines/linux/continuous-build-linux.yml
+++ b/build/azure-pipelines/linux/continuous-build-linux.yml
@@ -10,7 +10,7 @@ steps:
 - task: NodeTool@0
   inputs:
     versionSpec: "12.13.0"
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 - task: Cache@2

--- a/build/azure-pipelines/linux/continuous-build-linux.yml
+++ b/build/azure-pipelines/linux/continuous-build-linux.yml
@@ -13,20 +13,14 @@ steps:
 - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
   inputs:
     versionSpec: "1.x"
-- task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+- task: Cache@2
   inputs:
-    keyfile: '.yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
-    targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-    vstsFeed: 'vscode-build-cache'
+    key: $(YARN_CACHE_KEY)
+    path: $(System.DefaultWorkingDirectory)/node_modules
+    cacheHitVar: CacheRestored
 - script: |
     CHILD_CONCURRENCY=1 yarn --frozen-lockfile
   displayName: Install Dependencies
-  condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
-- task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-  inputs:
-    keyfile: '.yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
-    targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-    vstsFeed: 'vscode-build-cache'
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
 - script: |
     yarn electron x64

--- a/build/azure-pipelines/linux/product-build-linux-multiarch.yml
+++ b/build/azure-pipelines/linux/product-build-linux-multiarch.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/linux/snap-build-linux.yml
+++ b/build/azure-pipelines/linux/snap-build-linux.yml
@@ -3,7 +3,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -19,7 +19,7 @@ steps:
     versionSpec: "12.13.0"
   condition: and(succeeded(), ne(variables['CacheExists-Compilation'], 'true'))
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
   condition: and(succeeded(), ne(variables['CacheExists-Compilation'], 'true'))

--- a/build/azure-pipelines/publish-types/publish-types.yml
+++ b/build/azure-pipelines/publish-types/publish-types.yml
@@ -11,7 +11,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/release.yml
+++ b/build/azure-pipelines/release.yml
@@ -3,7 +3,7 @@ steps:
   inputs:
     versionSpec: "10.x"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/sync-mooncake.yml
+++ b/build/azure-pipelines/sync-mooncake.yml
@@ -3,7 +3,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/web/product-build-web.yml
+++ b/build/azure-pipelines/web/product-build-web.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 

--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -2,7 +2,7 @@ steps:
 - task: NodeTool@0
   inputs:
     versionSpec: "12.13.0"
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 - task: UsePythonVersion@0

--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -9,22 +9,16 @@ steps:
   inputs:
     versionSpec: '2.x'
     addToPath: true
-- task: 1ESLighthouseEng.PipelineArtifactCaching.RestoreCacheV1.RestoreCache@1
+- task: Cache@2
   inputs:
-    keyfile: '.yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
-    targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-    vstsFeed: 'vscode-build-cache'
+    key: $(YARN_CACHE_KEY)
+    path: $(System.DefaultWorkingDirectory)/node_modules
+    cacheHitVar: CacheRestored
 - powershell: |
     yarn --frozen-lockfile
   env:
     CHILD_CONCURRENCY: "1"
   displayName: Install Dependencies
-  condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
-- task: 1ESLighthouseEng.PipelineArtifactCaching.SaveCacheV1.SaveCache@1
-  inputs:
-    keyfile: '.yarnrc, remote/.yarnrc, **/yarn.lock, !**/node_modules/**/yarn.lock, !**/.*/**/yarn.lock'
-    targetfolder: '**/node_modules, !**/node_modules/**/node_modules'
-    vstsFeed: 'vscode-build-cache'
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
 - powershell: |
     yarn electron

--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -20,15 +20,13 @@ steps:
     CHILD_CONCURRENCY: "1"
   displayName: Install Dependencies (on cache miss)
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
-- script: |
-    mkdir $(System.DefaultWorkingDirectory)/node_modules_snapshot
-    robocopy /SL /E $(System.DefaultWorkingDirectory)/node_modules $(System.DefaultWorkingDirectory)/node_modules_snapshot *
+- bash: |
+    mkdir node_modules_snapshot
+    cp --recursive --no-dereference --preserve=links node_modules/* node_modules_snapshot
   displayName: Snapshot cache folder
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
-- script: |
-    move $(System.DefaultWorkingDirectory)/ode_modules_snapshot $(System.DefaultWorkingDirectory)/node_modules
-  env:
-    CHILD_CONCURRENCY: "1"
+- bash: |
+    mv node_modules_snapshot node_modules
   displayName: Install Dependencies (on cache hit)
   condition: and(succeeded(), eq(variables['CacheRestored'], 'true'))
 - powershell: |

--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -15,10 +15,15 @@ steps:
     path: $(System.DefaultWorkingDirectory)/node_modules_snapshot
     cacheHitVar: CacheRestored
 - script: |
-    yarn --frozen-lockfile && mkdir node_modules_snapshot && robocopy /SL /E $(System.DefaultWorkingDirectory)/node_modules $(System.DefaultWorkingDirectory)/node_modules_snapshot *
+    yarn --frozen-lockfile
   env:
     CHILD_CONCURRENCY: "1"
   displayName: Install Dependencies (on cache miss)
+  condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
+- script: |
+    mkdir $(System.DefaultWorkingDirectory)/node_modules_snapshot
+    robocopy /SL /E $(System.DefaultWorkingDirectory)/node_modules $(System.DefaultWorkingDirectory)/node_modules_snapshot *
+  displayName: Snapshot cache folder
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
 - script: |
     move $(System.DefaultWorkingDirectory)/ode_modules_snapshot $(System.DefaultWorkingDirectory)/node_modules

--- a/build/azure-pipelines/win32/continuous-build-win32.yml
+++ b/build/azure-pipelines/win32/continuous-build-win32.yml
@@ -12,14 +12,20 @@ steps:
 - task: Cache@2
   inputs:
     key: $(YARN_CACHE_KEY)
-    path: $(System.DefaultWorkingDirectory)/node_modules
+    path: $(System.DefaultWorkingDirectory)/node_modules_snapshot
     cacheHitVar: CacheRestored
-- powershell: |
-    yarn --frozen-lockfile
+- script: |
+    yarn --frozen-lockfile && mkdir node_modules_snapshot && robocopy /SL /E $(System.DefaultWorkingDirectory)/node_modules $(System.DefaultWorkingDirectory)/node_modules_snapshot *
   env:
     CHILD_CONCURRENCY: "1"
-  displayName: Install Dependencies
+  displayName: Install Dependencies (on cache miss)
   condition: and(succeeded(), ne(variables['CacheRestored'], 'true'))
+- script: |
+    move $(System.DefaultWorkingDirectory)/ode_modules_snapshot $(System.DefaultWorkingDirectory)/node_modules
+  env:
+    CHILD_CONCURRENCY: "1"
+  displayName: Install Dependencies (on cache hit)
+  condition: and(succeeded(), eq(variables['CacheRestored'], 'true'))
 - powershell: |
     yarn electron
 - script: |

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -23,7 +23,7 @@ steps:
   inputs:
     versionSpec: "12.13.0"
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3
   inputs:
     versionSpec: "1.x"
 


### PR DESCRIPTION
This moves continuous builds from the unofficial caching task to the official Pipeline Caching tasks now that it is GA. See more here: https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops

Note: I did not change the product builds.