### PR TITLE
Don't encode image resource URI twice

### DIFF
--- a/extensions/image-preview/src/preview.ts
+++ b/extensions/image-preview/src/preview.ts
@@ -240,9 +240,9 @@ class Preview extends Disposable implements vscode.WebviewEditorEditingCapabilit
 			default:
 				// Avoid adding cache busting if there is already a query string
 				if (resource.query) {
-					return encodeURI(webviewEditor.webview.asWebviewUri(resource).toString(true));
+					return webviewEditor.webview.asWebviewUri(resource).toString(true);
 				}
-				return encodeURI(webviewEditor.webview.asWebviewUri(resource).toString(true) + `?version=${version}`);
+				return webviewEditor.webview.asWebviewUri(resource).with({ query: `version=${version}` }).toString(true);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->
After  #84667 and 8caf39ef37932f5b9492a88a7f921625ef120080, issue #84197 and #83165 are happening again.

This fixes both issues by encoding the resource URI just once so that it gets parsed correctly [here](https://github.com/microsoft/vscode/blob/9e899b556f10f09217239396af8ee95009612982/src/vs/workbench/contrib/webview/electron-browser/webviewProtocols.ts#L19)

This PR fixes #84197 and #83165

cc @mjbvz 
