### PR TITLE
Support for tokens expanding to search include patterns

### DIFF
--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -12,6 +12,7 @@ import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { JSONValidationExtensionPoint } from 'vs/workbench/api/common/jsonValidationExtensionPoint';
 import { ColorExtensionPoint } from 'vs/workbench/services/themes/common/colorExtensionPoint';
 import { LanguageConfigurationFileHandler } from 'vs/workbench/contrib/codeEditor/browser/languageConfigurationExtensionPoint';
+import { SearchTokenExtensionPoint } from 'vs/workbench/api/common/searchTokenExtensionPoint';
 
 // --- mainThread participants
 import './mainThreadCodeInsets';
@@ -67,6 +68,7 @@ export class ExtensionPoints implements IWorkbenchContribution {
 		this.instantiationService.createInstance(JSONValidationExtensionPoint);
 		this.instantiationService.createInstance(ColorExtensionPoint);
 		this.instantiationService.createInstance(LanguageConfigurationFileHandler);
+		this.instantiationService.createInstance(SearchTokenExtensionPoint);
 	}
 }
 

--- a/src/vs/workbench/api/common/searchTokenExtensionPoint.ts
+++ b/src/vs/workbench/api/common/searchTokenExtensionPoint.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as extensionsRegistry from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import * as nls from 'vs/nls';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { ISearchTokenRegistry, SearchExtensions, ISearchTokenCommand } from 'vs/workbench/services/search/common/searchTokenRegistry';
+
+export class SearchTokenExtensionPoint {
+	constructor() {
+		searchTokenExtensionPoint.setHandler((_, { added, removed }) => {
+			if (removed.length) {
+				removed.map(extension => extension.value)
+					.forEach(tokens => searchTokenRegistry.deregisterTokens(tokens));
+			}
+
+			if (added.length) {
+				added.map(extension => extension.value)
+					.forEach(tokens => searchTokenRegistry.registerTokens(tokens));
+			}
+		});
+	}
+}
+
+const searchTokenRegistry = Registry.as<ISearchTokenRegistry>(SearchExtensions.SearchTokens);
+
+const searchTokenExtensionPoint = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<ISearchTokenCommand[]>({
+	extensionPoint: 'searchTokens',
+	jsonSchema: {
+		description: nls.localize('vscode.extension.contributes.searchTokens', 'Contributes search tokens that can be expanded into patterns or text.'),
+		type: 'array',
+	}
+});

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -776,6 +776,15 @@ configurationRegistry.registerConfiguration({
 			default: 'auto',
 			description: nls.localize('search.actionsPosition', "Controls the positioning of the actionbar on rows in the search view.")
 		},
+		'search.expandableTokens': {
+			type: 'object',
+			markdownDescription: nls.localize('expandableTokens', "Configure tokens for quick search. Read more about expanding tokens [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
+			default: {
+				'@config': ['**/*.config', 'src/**/*.cscfg'],
+				'@deploy': ['**/deploy', '@config']
+			},
+			scope: ConfigurationScope.RESOURCE
+		},
 		'search.searchOnType': {
 			type: 'boolean',
 			default: true,

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1222,21 +1222,20 @@ export class SearchView extends ViewletPane {
 			this.viewModel.searchResult.clear();
 		};
 
-		let query: ITextQuery;
-		try {
-			query = this.queryBuilder.text(content, folderResources.map(folder => folder.uri), options);
-		} catch (err) {
-			onQueryValidationError(err);
-			return;
-		}
+		this.queryBuilder.text(content, folderResources.map(folder => folder.uri), options)
+			.then(query => {
+				this.validateQuery(query).then(() => {
+					this.onQueryTriggered(query, options, excludePatternText, includePatternText, triggeredOnType);
 
-		this.validateQuery(query).then(() => {
-			this.onQueryTriggered(query, options, excludePatternText, includePatternText, triggeredOnType);
-
-			if (!preserveFocus) {
-				this.searchWidget.focus(false); // focus back to input field
-			}
-		}, onQueryValidationError);
+					if (!preserveFocus) {
+						this.searchWidget.focus(false); // focus back to input field
+					}
+				}, onQueryValidationError);
+			})
+			.catch(err => {
+				onQueryValidationError(err);
+				return;
+			});
 	}
 
 	private validateQuery(query: ITextQuery): Promise<void> {

--- a/src/vs/workbench/contrib/search/common/queryExpansion.ts
+++ b/src/vs/workbench/contrib/search/common/queryExpansion.ts
@@ -1,0 +1,248 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as arrays from 'vs/base/common/arrays';
+import * as strings from 'vs/base/common/strings';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { ISearchTokenRegistry, SearchExtensions } from 'vs/workbench/services/search/common/searchTokenRegistry';
+import { ISearchConfiguration } from 'vs/workbench/services/search/common/search';
+
+type ExpandableTokens = { [token: string]: string[] };
+
+export class QueryExpansion {
+	constructor(
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@ICommandService private readonly commandService: ICommandService) {
+	}
+
+	/**
+	 * Takes search pattern segments, i.e. parts from the include pattern, and expands queries like @open into
+	 * their searchable segments.
+	 */
+	expandQuerySegments(segments: string[]): Promise<string[]> {
+		if (!segments.some(segment => strings.startsWith(segment, '@'))) {
+			return Promise.resolve(segments);
+		}
+
+		const expanders = this.createExpanders();
+		const expanded = segments
+			.map(getTokenAndQuery)
+			.filter(tuple => !!tuple && expanders.has(tuple[0]))
+			.map(tuple => {
+				const [start, query] = <[string, string]>tuple;
+				const expander = <IQueryExpansion>expanders.get(start);
+				return expander.expand(query).then(expansion => new Expansion(query, expansion));
+			});
+
+		const result = segments.slice();
+
+		return Promise.all(expanded)
+			.then(expansions => {
+				expansions.forEach(e => {
+					const queryIndex = segments.indexOf(e.query);
+					result.splice(queryIndex, 1, ...<string[]>e.expansion);
+				});
+			})
+			.then(() => {
+				if (!!result.length) {
+					return result;
+				}
+
+				// No expanded result. Original segments only consists of tokens,
+				// so we return the original values to avoid an empty
+				// include/exclude pattern.
+				return segments.slice();
+			});
+	}
+
+	private createExpanders(): Map<string, IQueryExpansion> {
+		const result = new Map<string, IQueryExpansion>();
+
+		const searchTokenRegistry = Registry.as<ISearchTokenRegistry>(SearchExtensions.SearchTokens);
+		searchTokenRegistry.getTokens()
+			.map(t => {
+				const x = new CommandQueryExpansion(t.token, t.command, this.commandService);
+				return x;
+			})
+			.forEach(t => result.set(t.token, t));
+
+		const searchConfig = this.configurationService.getValue<ISearchConfiguration>();
+		ConfigQueryExpansion.create(searchConfig, result)
+			.forEach(e => result.set(e.token, e));
+
+		return result;
+	}
+}
+
+class Expansion {
+	constructor(
+		public readonly query: string,
+		public readonly expansion: string[] | undefined) { }
+}
+
+interface IQueryExpansion {
+	/**
+	 * The query that can be expanded.
+	 *
+	 * Must start with an '@'
+	 */
+	token: string;
+
+	/**
+	 * Expands a search query segment into components, e.g. expands '@git(modified)' into all modified files.
+	 */
+	expand(segment: string): Promise<string[] | undefined>;
+}
+
+class CommandQueryExpansion implements IQueryExpansion {
+	constructor(
+		private readonly commandToken: string,
+		private readonly command: string,
+		private readonly commandService: ICommandService) {
+	}
+
+	get token(): string {
+		return this.commandToken;
+	}
+
+	expand(segment: string): Promise<string[] | undefined> {
+		if (!strings.startsWith(segment, this.token)) {
+			return Promise.resolve(undefined);
+		}
+
+		const parameters = splitParametersFromQuery(segment);
+		return this.commandService.executeCommand<string[] | undefined>(this.command, ...parameters || []);
+	}
+}
+
+/**
+ * Support for configurable expansion of search tokens via configuration.
+ */
+class ConfigQueryExpansion implements IQueryExpansion {
+	constructor(
+		private readonly configToken: string,
+		private readonly expansions: string[],
+		private readonly coreExpanders: Map<string, IQueryExpansion>) {
+	}
+
+	get token(): string {
+		return this.configToken;
+	}
+
+	expand(segment: string): Promise<string[] | undefined> {
+		if (!strings.startsWith(segment, this.token)) {
+			return Promise.resolve(undefined);
+		}
+
+		const expanded = this.expansions.map(x => {
+			const [token, query] = getTokenAndQuery(x) || [undefined, undefined];
+			if (!token) {
+				return Promise.resolve([x]); // Normal path or pattern
+			}
+
+			if (!this.coreExpanders.has(token)) {
+				throw new Error('Cannot find token: ' + token);
+			}
+
+			return this.coreExpanders.get(token)!.expand(query!);
+		});
+
+		return Promise.all(expanded).then(maybeExpansions => {
+			const expansions = maybeExpansions.filter(arr => arr !== undefined);
+			if (expansions.length < 1) {
+				return undefined;
+			}
+
+			return arrays.flatten(<string[][]>expansions);
+		});
+	}
+
+	static create(searchConfig: ISearchConfiguration, coreExpanders: Map<string, IQueryExpansion>): IQueryExpansion[] {
+		if (!searchConfig.search.expandableTokens) {
+			return [];
+		}
+
+		const commandExpanders = new Map<string, IQueryExpansion>();
+		Array.from(coreExpanders.keys()).forEach(t => commandExpanders.set(t, coreExpanders.get(t)));
+		const tokens = ConfigQueryExpansion.resolveConfigTokens(
+			searchConfig.search.expandableTokens,
+			Array.from(commandExpanders.keys()));
+
+		return Object.keys(tokens).map(t => new ConfigQueryExpansion(t, tokens[t], commandExpanders));
+	}
+
+	/**
+	 * Resolves internal references between configured tokens.
+	 *
+	 * Example:
+	 *   {
+	 *     '@a': ['foo', 'foobar'],
+	 *     '@b': ['bar', @a],
+	 *   }
+	 * Resolves into:
+	 *   {
+	 *     '@a': ['foo', 'foobar'],
+	 *     '@b': ['bar', 'foo', 'foobar']
+	 *   }
+	 */
+	static resolveConfigTokens(tokens: ExpandableTokens, coreExpanderTokens: string[]): ExpandableTokens {
+		const resolved: ExpandableTokens = {};
+		Object.keys(tokens).forEach(t => {
+			tokens[t].forEach((expansion, i, arr) => {
+				const [token, query] = getTokenAndQuery(expansion) || [undefined, undefined];
+				if (!token || !query) {
+					return;
+				}
+
+				if (coreExpanderTokens.indexOf(token) !== -1) {
+					return;
+				}
+
+				// We (should) have a reference to a previously defined token
+				if (!resolved[expansion]) {
+					throw new Error('Could not find any reference to token ' + expansion);
+				}
+
+				arr.splice(i, 1, ...resolved[expansion]);
+			});
+
+			resolved[t] = tokens[t];
+		});
+
+		return resolved;
+	}
+}
+
+/**
+ * Turns a segment like '@git(modified)' into ['@git', '@git(modified)']
+ */
+function getTokenAndQuery(segment: string): [string, string] | undefined {
+	if (!strings.startsWith(segment, '@')) {
+		return undefined;
+	}
+
+	// WIP(discuss): Current format is @token(param), but the general pattern in vscode
+	// is @token:param, e.g. @category:themes
+	const parameterStart = segment.indexOf('(');
+	if (parameterStart === -1) {
+		return [segment, segment];
+	}
+
+	return [segment.substr(0, parameterStart), segment];
+}
+
+function splitParametersFromQuery(expandableQuery: string): string[] {
+	const matches = expandableQuery.match(/@\w+\((.*)\)/);
+	if (!matches) {
+		return [];
+	}
+
+	// WIP(discuss): You can give more than one parameter using @token(param1; param2).
+	// It would be nicer to use @token(param1, param2), but the comma is used as the
+	// normal separator.
+	return matches[1].split(';').map(p => p.trim());
+}

--- a/src/vs/workbench/contrib/search/test/browser/queryExpansion.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/queryExpansion.test.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { QueryExpansion } from 'vs/workbench/contrib/search/common/queryExpansion';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { TestCommandService } from 'vs/editor/test/browser/editorTestServices';
+
+const DEFAULT_USER_CONFIG = {
+	expandableTokens: {
+		'@src': ['**/src'],
+		'@all': ['@src', '*.foo']
+	}
+};
+
+suite('QueryExpansion', () => {
+	let instantiationService: TestInstantiationService;
+	let queryExpansion: QueryExpansion;
+	let mockConfigService: TestConfigurationService;
+	setup(() => {
+		instantiationService = new TestInstantiationService();
+
+		const commandService = new TestCommandService(instantiationService);
+		instantiationService.stub(ICommandService, commandService);
+
+		mockConfigService = new TestConfigurationService();
+		mockConfigService.setUserConfiguration('search', DEFAULT_USER_CONFIG);
+		instantiationService.stub(IConfigurationService, mockConfigService);
+
+		queryExpansion = instantiationService.createInstance(QueryExpansion);
+	});
+
+	suite('configuration', () => {
+		test('simple expansion into pattern', async () => {
+			const actual = await queryExpansion.expandQuerySegments(['@src']);
+			assertEqualSegments(actual, ['**/src']);
+		});
+
+		test('expansion into pattern from reference to other config token', async () => {
+			const actual = await queryExpansion.expandQuerySegments(['@all']);
+			assertEqualSegments(actual, ['**/src', '*.foo']);
+		});
+	});
+});
+
+function assertEqualSegments(actual: string[], expected: string[]) {
+	const actualNormalized = actual.map(normalizePath);
+	const expectedNormalized = expected.map(normalizePath);
+	assert.deepStrictEqual(actualNormalized, expectedNormalized);
+}
+
+function normalizePath(path: string) {
+	return path.replace(/\\/g, '/');
+}

--- a/src/vs/workbench/contrib/search/test/common/queryBuilder.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/queryBuilder.test.ts
@@ -51,9 +51,9 @@ suite('QueryBuilder', () => {
 		queryBuilder = instantiationService.createInstance(QueryBuilder);
 	});
 
-	test('simple text pattern', () => {
+	test('simple text pattern', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text(PATTERN_INFO),
+			await queryBuilder.text(PATTERN_INFO),
 			{
 				folderQueries: [],
 				contentPattern: PATTERN_INFO,
@@ -61,9 +61,9 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('normalize literal newlines', () => {
+	test('normalize literal newlines', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text({ pattern: 'foo\nbar', isRegExp: true }),
+			await queryBuilder.text({ pattern: 'foo\nbar', isRegExp: true }),
 			{
 				folderQueries: [],
 				contentPattern: {
@@ -75,7 +75,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text({ pattern: 'foo\nbar', isRegExp: false }),
+			await queryBuilder.text({ pattern: 'foo\nbar', isRegExp: false }),
 			{
 				folderQueries: [],
 				contentPattern: {
@@ -101,9 +101,9 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('folderResources', () => {
+	test('folderResources', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI]
 			),
@@ -114,7 +114,7 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('simple exclude setting', () => {
+	test('simple exclude setting', async () => {
 		mockConfigService.setUserConfiguration('search', {
 			...DEFAULT_USER_CONFIG,
 			exclude: {
@@ -126,7 +126,7 @@ suite('QueryBuilder', () => {
 		});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -148,9 +148,9 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('simple include', () => {
+	test('simple include', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -171,7 +171,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -190,10 +190,10 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('simple include with ./ syntax', () => {
+	test('simple include with ./ syntax', async () => {
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -214,7 +214,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -235,7 +235,7 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('exclude setting and searchPath', () => {
+	test('exclude setting and searchPath', async () => {
 		mockConfigService.setUserConfiguration('search', {
 			...DEFAULT_USER_CONFIG,
 			exclude: {
@@ -247,7 +247,7 @@ suite('QueryBuilder', () => {
 		});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -274,7 +274,7 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('multiroot exclude settings', () => {
+	test('multiroot exclude settings', async () => {
 		const ROOT_2 = fixPath('/project/root2');
 		const ROOT_2_URI = getUri(ROOT_2);
 		const ROOT_3 = fixPath('/project/root3');
@@ -294,7 +294,7 @@ suite('QueryBuilder', () => {
 
 		// There are 3 roots, the first two have search.exclude settings, test that the correct basic query is returned
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI, ROOT_2_URI, ROOT_3_URI]
 			),
@@ -311,7 +311,7 @@ suite('QueryBuilder', () => {
 
 		// Now test that it merges the root excludes when an 'include' is used
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI, ROOT_2_URI, ROOT_3_URI],
 				{
@@ -338,9 +338,9 @@ suite('QueryBuilder', () => {
 		);
 	});
 
-	test('simple exclude input pattern', () => {
+	test('simple exclude input pattern', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -372,9 +372,9 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('exclude ./ syntax', () => {
+	test('exclude ./ syntax', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -392,7 +392,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -410,7 +410,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -428,9 +428,9 @@ suite('QueryBuilder', () => {
 			});
 	});
 
-	test('extraFileResources', () => {
+	test('extraFileResources', async () => {
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{ extraFileResources: [getUri('/foo/bar.js')] }
@@ -445,7 +445,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -464,7 +464,7 @@ suite('QueryBuilder', () => {
 			});
 
 		assertEqualTextQueries(
-			queryBuilder.text(
+			await queryBuilder.text(
 				PATTERN_INFO,
 				[ROOT_1_URI],
 				{
@@ -484,38 +484,40 @@ suite('QueryBuilder', () => {
 	});
 
 	suite('parseSearchPaths', () => {
-		test('simple includes', () => {
-			function testSimpleIncludes(includePattern: string, expectedPatterns: string[]): void {
+		test('simple includes', async () => {
+			async function testSimpleIncludes(includePattern: string, expectedPatterns: string[]): Promise<void> {
 				assert.deepEqual(
-					queryBuilder.parseSearchPaths(includePattern),
+					await queryBuilder.parseSearchPaths(includePattern),
 					{
 						pattern: patternsToIExpression(...expectedPatterns)
 					},
 					includePattern);
 			}
 
-			[
+			const promises = [
 				['a', ['**/a/**', '**/a']],
 				['a/b', ['**/a/b', '**/a/b/**']],
 				['a/b,  c', ['**/a/b', '**/c', '**/a/b/**', '**/c/**']],
 				['a,.txt', ['**/a', '**/a/**', '**/*.txt', '**/*.txt/**']],
 				['a,,,b', ['**/a', '**/a/**', '**/b', '**/b/**']],
 				['**/a,b/**', ['**/a', '**/a/**', '**/b/**']]
-			].forEach(([includePattern, expectedPatterns]) => testSimpleIncludes(<string>includePattern, <string[]>expectedPatterns));
+			].map(([includePattern, expectedPatterns]) => testSimpleIncludes(<string>includePattern, <string[]>expectedPatterns));
+
+			await Promise.all(promises);
 		});
 
-		function testIncludes(includePattern: string, expectedResult: ISearchPathsInfo): void {
+		async function testIncludes(includePattern: string, expectedResult: ISearchPathsInfo): Promise<void> {
 			assertEqualSearchPathResults(
-				queryBuilder.parseSearchPaths(includePattern),
+				await queryBuilder.parseSearchPaths(includePattern),
 				expectedResult,
 				includePattern);
 		}
 
-		function testIncludesDataItem([includePattern, expectedResult]: [string, ISearchPathsInfo]): void {
-			testIncludes(includePattern, expectedResult);
+		async function testIncludesDataItem([includePattern, expectedResult]: [string, ISearchPathsInfo]): Promise<void> {
+			await testIncludes(includePattern, expectedResult);
 		}
 
-		test('absolute includes', () => {
+		test('absolute includes', async () => {
 			const cases: [string, ISearchPathsInfo][] = [
 				[
 					fixPath('/foo/bar'),
@@ -581,10 +583,10 @@ suite('QueryBuilder', () => {
 					}
 				]
 			];
-			cases.forEach(testIncludesDataItem);
+			await Promise.all(cases.map(testIncludesDataItem));
 		});
 
-		test('includes with tilde', () => {
+		test('includes with tilde', async () => {
 			const userHome = TestEnvironmentService.userHome;
 			const cases: [string, ISearchPathsInfo][] = [
 				[
@@ -607,10 +609,10 @@ suite('QueryBuilder', () => {
 					}
 				],
 			];
-			cases.forEach(testIncludesDataItem);
+			await Promise.all(cases.map(testIncludesDataItem));
 		});
 
-		test('relative includes w/single root folder', () => {
+		test('relative includes w/single root folder', async () => {
 			const cases: [string, ISearchPathsInfo][] = [
 				[
 					'./a',
@@ -686,10 +688,10 @@ suite('QueryBuilder', () => {
 					}
 				]
 			];
-			cases.forEach(testIncludesDataItem);
+			await Promise.all(cases.map(testIncludesDataItem));
 		});
 
-		test('relative includes w/two root folders', () => {
+		test('relative includes w/two root folders', async () => {
 			const ROOT_2 = '/project/root2';
 			mockWorkspace.folders = toWorkspaceFolders([{ path: ROOT_1_URI.fsPath }, { path: getUri(ROOT_2).fsPath }], WS_CONFIG_PATH);
 			mockWorkspace.configuration = uri.file(fixPath('config'));
@@ -726,10 +728,10 @@ suite('QueryBuilder', () => {
 					}
 				]
 			];
-			cases.forEach(testIncludesDataItem);
+			await Promise.all(cases.map(testIncludesDataItem));
 		});
 
-		test('include ./foldername', () => {
+		test('include ./foldername', async () => {
 			const ROOT_2 = '/project/root2';
 			const ROOT_1_FOLDERNAME = 'foldername';
 			mockWorkspace.folders = toWorkspaceFolders([{ path: ROOT_1_URI.fsPath, name: ROOT_1_FOLDERNAME }, { path: getUri(ROOT_2).fsPath }], WS_CONFIG_PATH);
@@ -754,10 +756,10 @@ suite('QueryBuilder', () => {
 					}
 				]
 			];
-			cases.forEach(testIncludesDataItem);
+			await Promise.all(cases.map(testIncludesDataItem));
 		});
 
-		test('relative includes w/multiple ambiguous root folders', () => {
+		test('relative includes w/multiple ambiguous root folders', async () => {
 			const ROOT_2 = '/project/rootB';
 			const ROOT_3 = '/otherproject/rootB';
 			mockWorkspace.folders = toWorkspaceFolders([{ path: ROOT_1_URI.fsPath }, { path: getUri(ROOT_2).fsPath }, { path: getUri(ROOT_3).fsPath }], WS_CONFIG_PATH);
@@ -830,13 +832,13 @@ suite('QueryBuilder', () => {
 					}
 				]
 			];
-			cases.forEach(testIncludesDataItem);
+			await Promise.all(cases.map(testIncludesDataItem));
 		});
 	});
 
 	suite('smartCase', () => {
-		test('no flags -> no change', () => {
-			const query = queryBuilder.text(
+		test('no flags -> no change', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'a'
 				},
@@ -845,8 +847,8 @@ suite('QueryBuilder', () => {
 			assert(!query.contentPattern.isCaseSensitive);
 		});
 
-		test('maintains isCaseSensitive when smartCase not set', () => {
-			const query = queryBuilder.text(
+		test('maintains isCaseSensitive when smartCase not set', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'a',
 					isCaseSensitive: true
@@ -856,8 +858,8 @@ suite('QueryBuilder', () => {
 			assert(query.contentPattern.isCaseSensitive);
 		});
 
-		test('maintains isCaseSensitive when smartCase set', () => {
-			const query = queryBuilder.text(
+		test('maintains isCaseSensitive when smartCase set', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'a',
 					isCaseSensitive: true
@@ -870,8 +872,8 @@ suite('QueryBuilder', () => {
 			assert(query.contentPattern.isCaseSensitive);
 		});
 
-		test('smartCase determines not case sensitive', () => {
-			const query = queryBuilder.text(
+		test('smartCase determines not case sensitive', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'abcd'
 				},
@@ -883,8 +885,8 @@ suite('QueryBuilder', () => {
 			assert(!query.contentPattern.isCaseSensitive);
 		});
 
-		test('smartCase determines case sensitive', () => {
-			const query = queryBuilder.text(
+		test('smartCase determines case sensitive', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'abCd'
 				},
@@ -896,8 +898,8 @@ suite('QueryBuilder', () => {
 			assert(query.contentPattern.isCaseSensitive);
 		});
 
-		test('smartCase determines not case sensitive (regex)', () => {
-			const query = queryBuilder.text(
+		test('smartCase determines not case sensitive (regex)', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'ab\\Sd',
 					isRegExp: true
@@ -910,8 +912,8 @@ suite('QueryBuilder', () => {
 			assert(!query.contentPattern.isCaseSensitive);
 		});
 
-		test('smartCase determines case sensitive (regex)', () => {
-			const query = queryBuilder.text(
+		test('smartCase determines case sensitive (regex)', async () => {
+			const query = await queryBuilder.text(
 				{
 					pattern: 'ab[A-Z]d',
 					isRegExp: true

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -329,6 +329,7 @@ export interface ISearchConfigurationProperties {
 	actionsPosition: 'auto' | 'right';
 	maintainFileSearchCache: boolean;
 	collapseResults: 'auto' | 'alwaysCollapse' | 'alwaysExpand';
+	expandableTokens: { [token: string]: string[] };
 	searchOnType: boolean;
 	searchOnTypeDebouncePeriod: number;
 }

--- a/src/vs/workbench/services/search/common/searchTokenRegistry.ts
+++ b/src/vs/workbench/services/search/common/searchTokenRegistry.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+
+export const SearchExtensions = {
+	SearchTokens: 'base.contributions.searchTokens'
+};
+
+export interface ISearchTokenRegistry {
+	getTokens(): ISearchTokenCommand[];
+	registerToken(token: ISearchTokenCommand): void;
+	registerTokens(tokens: ISearchTokenCommand[]): void;
+	deregisterToken(token: ISearchTokenCommand): void;
+	deregisterTokens(tokens: ISearchTokenCommand[]): void;
+}
+
+export interface ISearchTokenCommand {
+	token: string;
+	command: string;
+}
+
+Registry.add(SearchExtensions.SearchTokens, new class implements ISearchTokenRegistry {
+	private tokens: ISearchTokenCommand[] = [];
+
+	getTokens(): ISearchTokenCommand[] {
+		return this.tokens;
+	}
+
+	registerToken(token: ISearchTokenCommand): void {
+		this.tokens.push(token);
+	}
+
+	registerTokens(tokens: ISearchTokenCommand[]): void {
+		this.tokens.push(...tokens);
+	}
+
+	deregisterToken(token: ISearchTokenCommand): void {
+		this.tokens = this.tokens.filter(t => t.token !== token.token);
+	}
+
+	deregisterTokens(tokens: ISearchTokenCommand[]): void {
+		tokens.forEach(t => this.deregisterToken(t));
+	}
+});

--- a/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
+++ b/src/vs/workbench/test/electron-browser/textsearch.perf.integrationTest.ts
@@ -112,9 +112,9 @@ suite.skip('TextSearch performance (integration)', () => {
 				error = _error;
 
 				// Don't wait on this promise, we're waiting on the event fired above
-				searchModel.search(query).then(
+				query.then(q => searchModel.search(q).then(
 					null,
-					_error);
+					_error));
 			});
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes part of what is discussed in #20530. 

More precisely, this PR adds a new extension API allowing the definition of "search tokens" that can be expanded into search paths that can be used for the 'files to include'.

Example: For example, the token `@config` could be expanded into `'**/*.config', 'src/**/*.cscfg'`. 

While it is only possible to expand into patterns today, this can become super powerful in the future when searching in specific files are added. The same concept can then be reused to, for example, add support for searching in all open files or all staged changes (git).

Some things that are currently not part of this PR:
- UI support. The discoverability of potential search tokens is bad.
- Exclusive pattens. It was suggested that adding a `!` should add to the 'files to exclude'. This is currently not implemented.

