### PR TITLE
Use inspect-port=0 for automatic extension host profiling,  #85328

### DIFF
--- a/src/vs/workbench/services/extensions/electron-browser/extensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionHost.ts
@@ -158,6 +158,8 @@ export class ExtensionHostProcessWorker implements IExtensionHostStarter {
 						'--nolazy',
 						(this._isExtensionDevDebugBrk ? '--inspect-brk=' : '--inspect=') + portNumber
 					];
+				} else {
+					opts.execArgv = ['--inspect-port=0'];
 				}
 
 				const crashReporterOptions = undefined; // TODO@electron pass this in as options to the extension host after verifying this actually works


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/85328