### PR TITLE
fix #82457, markdown open, but unfocused source tab

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -490,6 +490,9 @@ export class DynamicMarkdownPreview extends Disposable {
 	}
 
 	private async onDidClickPreview(line: number): Promise<void> {
+		// fix #82457, find currently opened but unfocused source tab
+		await vscode.commands.executeCommand('markdown.showSource');
+
 		for (const visibleEditor of vscode.window.visibleTextEditors) {
 			if (this.isPreviewOf(visibleEditor.document.uri)) {
 				const editor = await vscode.window.showTextDocument(visibleEditor.document, visibleEditor.viewColumn);


### PR DESCRIPTION
This PR fixes #82457.

This fix first opens the source tab of the currently focused markdown file using the `showSource` command. This would make the source tab part of `vscode.window.visibleTextEditors`, which can be iterated over and the appropriate line to select can be set. This makes sure that if the source tab is already open but unfocused, double clicking on a line in markdown will not create another tab of the markdown source file.

Testing: steps for reproduction provided by @GehDoc in #82457

Current behavior: new tab opened for source markdown file
Expected behavior: unfocused source file tab is focused