### PR TITLE
Adds codicons to hovers

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -22,7 +22,7 @@ export interface MarkdownRenderOptions extends FormattedTextRenderOptions {
 	codeBlockRenderCallback?: () => void;
 }
 
-const codiconsRegex = /^codicon:\/\/(.*)$/;
+const codiconsRegex = /^icon:\/\/vscode\.codicons\/(.*)$/;
 
 /**
  * Create html nodes for the given content element.
@@ -78,7 +78,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 		if (href) {
 			const match = codiconsRegex.exec(href);
 			if (match !== null) {
-				return renderCodicons(match[1]);
+				return renderCodicons(`$(${match[1]})`);
 			}
 		}
 

--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -15,11 +15,14 @@ import { cloneAndChange } from 'vs/base/common/objects';
 import { escape } from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
 import { Schemas } from 'vs/base/common/network';
+import { renderCodicons } from 'vs/base/browser/ui/codiconLabel/codiconLabel';
 
 export interface MarkdownRenderOptions extends FormattedTextRenderOptions {
 	codeBlockRenderer?: (modeId: string, value: string) => Promise<string>;
 	codeBlockRenderCallback?: () => void;
 }
+
+const codiconsRegex = /^codicon:\/\/(.*)$/;
 
 /**
  * Create html nodes for the given content element.
@@ -72,6 +75,13 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 
 	const renderer = new marked.Renderer();
 	renderer.image = (href: string, title: string, text: string) => {
+		if (href) {
+			const match = codiconsRegex.exec(href);
+			if (match !== null) {
+				return renderCodicons(match[1]);
+			}
+		}
+
 		let dimensions: string[] = [];
 		let attributes: string[] = [];
 		if (href) {
@@ -185,7 +195,8 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 			'a': ['href', 'name', 'target', 'data-href'],
 			'iframe': ['allowfullscreen', 'frameborder', 'src'],
 			'img': ['src', 'title', 'alt', 'width', 'height'],
-			'div': ['class', 'data-code']
+			'div': ['class', 'data-code'],
+			'span': ['class']
 		}
 	});
 

--- a/src/vs/editor/contrib/hover/hover.css
+++ b/src/vs/editor/contrib/hover/hover.css
@@ -104,3 +104,9 @@
 .monaco-editor-hover .hover-row.status-bar .actions .action-container .action .icon {
 	padding-right: 4px;
 }
+
+.monaco-editor-hover .markdown-hover .hover-contents .codicon {
+	color: inherit;
+	font-size: inherit;
+	vertical-align: middle;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #85579

This allows the use of codicons in markdown images (as the href), e.g. `![](codicon://$(git-commit))`. I opted for the `codicon://` to keep is more url-like and to make it easier (and more exact) to detect/parse

/cc @jrieken 