### PR TITLE
Change @ts-nocheck to @ts-check in the interactive walkthrough

### DIFF
--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.ts
@@ -168,7 +168,7 @@ ul>li.item$*5
 Sometimes type checking your JavaScript code can help you spot mistakes you might have not caught otherwise. You can run the TypeScript type checker against your existing JavaScript code by simply adding a |// @ts-check| comment to the top of your file.
 
 |||js
-// @ts-nocheck
+// @ts-check
 
 let easy = true;
 easy = 42;


### PR DESCRIPTION
This is a two character oneliner and I might be entirely wrong/confused, but I think this line in the interactive playground should be `ts-check`? maybe the idea was for the users to remove the no themselves