### PR TITLE
Adds codicons to menu commands

### DIFF
--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -351,7 +351,7 @@ commandsExtensionPoint.setHandler(extensions => {
 		let absoluteIcon: { dark: URI; light?: URI; } | undefined;
 		if (icon) {
 			if (typeof icon === 'string') {
-				if (icon.indexOf('vscode-icon://vscode.codicons/') === 0) {
+				if (icon.indexOf('vscode-icon://codicon/') === 0) {
 					iconClassName = escape(`codicon-${URI.parse(icon).path.substr(1)}`);
 				}
 				else {

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -351,7 +351,7 @@ commandsExtensionPoint.setHandler(extensions => {
 		let absoluteIcon: { dark: URI; light?: URI; } | undefined;
 		if (icon) {
 			if (typeof icon === 'string') {
-				if (icon.indexOf('icon://vscode.codicons/') === 0) {
+				if (icon.indexOf('vscode-icon://vscode.codicons/') === 0) {
 					iconClassName = escape(`codicon-${URI.parse(icon).path.substr(1)}`);
 				}
 				else {

--- a/src/vs/workbench/api/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/api/common/menusExtensionPoint.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { isFalsyOrWhitespace } from 'vs/base/common/strings';
+import { escape, isFalsyOrWhitespace } from 'vs/base/common/strings';
 import * as resources from 'vs/base/common/resources';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { forEach } from 'vs/base/common/collections';
@@ -347,10 +347,16 @@ commandsExtensionPoint.setHandler(extensions => {
 
 		const { icon, enablement, category, title, command } = userFriendlyCommand;
 
+		let iconClassName: string | undefined;
 		let absoluteIcon: { dark: URI; light?: URI; } | undefined;
 		if (icon) {
 			if (typeof icon === 'string') {
-				absoluteIcon = { dark: resources.joinPath(extension.description.extensionLocation, icon) };
+				if (icon.indexOf('icon://vscode.codicons/') === 0) {
+					iconClassName = escape(`codicon-${URI.parse(icon).path.substr(1)}`);
+				}
+				else {
+					absoluteIcon = { dark: resources.joinPath(extension.description.extensionLocation, icon) };
+				}
 			} else {
 				absoluteIcon = {
 					dark: resources.joinPath(extension.description.extensionLocation, icon.dark),
@@ -367,7 +373,8 @@ commandsExtensionPoint.setHandler(extensions => {
 			title,
 			category,
 			precondition: ContextKeyExpr.deserialize(enablement),
-			iconLocation: absoluteIcon
+			iconLocation: absoluteIcon,
+			iconClassName: iconClassName
 		});
 		_commandRegistrations.add(registration);
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #84695

This allows the use of codicons in menu command icons using the uri form of `icon://vscode.codicons/git-commit`.

//cc @jrieken 

Related to: #85579 & #85624