### PR TITLE
Custom Icons per project to project

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -575,6 +575,19 @@ export class CodeWindow extends Disposable implements ICodeWindow {
 			}
 
 			this._win.setTitle(product.nameLong);
+
+			if (isLinux) {
+				this._win.setIcon(nativeImage.createFromPath(path.join(this.environmentService.appRoot, 'resources/linux/code.png')));
+			}
+		}
+
+		// Custom Icons per project
+		if (isLinux && config.folderUri) {
+			const projectIconPath = path.join(config.folderUri.path, '.vscode', 'code.png');
+
+			if (this.fileService.exists(URI.parse(projectIconPath))) {
+				this._win.setIcon(nativeImage.createFromPath(projectIconPath));
+			}
 		}
 
 		// Load URL


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #84888 for Linux OS. With this PR VS code can change the icon per project to project when users store the project icon in `.vscode/code.png` path.
