### PR TITLE
fix(extensions:markdown-language-features): absolute path to relative path

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -239,11 +239,13 @@ export class MarkdownEngine {
 
 					// Relative paths should be resolved correctly inside the preview but we need to
 					// handle absolute paths specially (for images) to resolve them relative to the workspace root
+					// using relative path to replace absolute path to fix https://github.com/microsoft/vscode/issues/84728
 					if (uri.path[0] === '/') {
 						const root = vscode.workspace.getWorkspaceFolder(this.currentDocument!);
-						if (root) {
+						const currentDir = path.dirname(this.currentDocument!.fsPath || '');
+						if (root && currentDir) {
 							uri = uri.with({
-								path: path.join(root.uri.fsPath, uri.path),
+								path: path.relative(currentDir, path.join(root.uri.fsPath, uri.path)),
 							});
 						}
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

using a relative path to replace the absolute path to fix absolute path image preview in markdown

This PR fixes
#84728