### PR TITLE
editor.accessibilityLinesPerPage

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -62,6 +62,7 @@ export class TextAreaHandler extends ViewPart {
 	private _scrollTop: number;
 
 	private _accessibilitySupport: AccessibilitySupport;
+	private _accessibilityLinesPerPage: number;
 	private _contentLeft: number;
 	private _contentWidth: number;
 	private _contentHeight: number;
@@ -92,6 +93,7 @@ export class TextAreaHandler extends ViewPart {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 
 		this._accessibilitySupport = options.get(EditorOption.accessibilitySupport);
+		this._accessibilityLinesPerPage = options.get(EditorOption.accessibilityLinesPerPage);
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
 		this._contentHeight = layoutInfo.contentHeight;
@@ -189,7 +191,7 @@ export class TextAreaHandler extends ViewPart {
 					return TextAreaState.EMPTY;
 				}
 
-				return PagedScreenReaderStrategy.fromEditorSelection(currentState, simpleModel, this._selections[0], this._accessibilitySupport === AccessibilitySupport.Unknown);
+				return PagedScreenReaderStrategy.fromEditorSelection(currentState, simpleModel, this._selections[0], this._accessibilityLinesPerPage, this._accessibilitySupport === AccessibilitySupport.Unknown);
 			},
 
 			deduceModelPosition: (viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position => {

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -62,7 +62,7 @@ export class TextAreaHandler extends ViewPart {
 	private _scrollTop: number;
 
 	private _accessibilitySupport: AccessibilitySupport;
-	private _accessibilityLinesPerPage: number;
+	private _accessibilityPageSize: number;
 	private _contentLeft: number;
 	private _contentWidth: number;
 	private _contentHeight: number;
@@ -93,7 +93,7 @@ export class TextAreaHandler extends ViewPart {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 
 		this._accessibilitySupport = options.get(EditorOption.accessibilitySupport);
-		this._accessibilityLinesPerPage = options.get(EditorOption.accessibilityLinesPerPage);
+		this._accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
 		this._contentHeight = layoutInfo.contentHeight;
@@ -191,7 +191,7 @@ export class TextAreaHandler extends ViewPart {
 					return TextAreaState.EMPTY;
 				}
 
-				return PagedScreenReaderStrategy.fromEditorSelection(currentState, simpleModel, this._selections[0], this._accessibilityLinesPerPage, this._accessibilitySupport === AccessibilitySupport.Unknown);
+				return PagedScreenReaderStrategy.fromEditorSelection(currentState, simpleModel, this._selections[0], this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
 			},
 
 			deduceModelPosition: (viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position => {
@@ -343,6 +343,7 @@ export class TextAreaHandler extends ViewPart {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 
 		this._accessibilitySupport = options.get(EditorOption.accessibilitySupport);
+		this._accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
 		this._contentHeight = layoutInfo.contentHeight;

--- a/src/vs/editor/browser/controller/textAreaState.ts
+++ b/src/vs/editor/browser/controller/textAreaState.ts
@@ -226,26 +226,24 @@ export class TextAreaState {
 }
 
 export class PagedScreenReaderStrategy {
-	private static readonly _LINES_PER_PAGE = 10;
-
-	private static _getPageOfLine(lineNumber: number): number {
-		return Math.floor((lineNumber - 1) / PagedScreenReaderStrategy._LINES_PER_PAGE);
+	private static _getPageOfLine(lineNumber: number, linesPerPage: number): number {
+		return Math.floor((lineNumber - 1) / linesPerPage);
 	}
 
-	private static _getRangeForPage(page: number): Range {
-		const offset = page * PagedScreenReaderStrategy._LINES_PER_PAGE;
+	private static _getRangeForPage(page: number, linesPerPage: number): Range {
+		const offset = page * linesPerPage;
 		const startLineNumber = offset + 1;
-		const endLineNumber = offset + PagedScreenReaderStrategy._LINES_PER_PAGE;
+		const endLineNumber = offset + linesPerPage;
 		return new Range(startLineNumber, 1, endLineNumber + 1, 1);
 	}
 
-	public static fromEditorSelection(previousState: TextAreaState, model: ISimpleModel, selection: Range, trimLongText: boolean): TextAreaState {
+	public static fromEditorSelection(previousState: TextAreaState, model: ISimpleModel, selection: Range, linesPerPage: number, trimLongText: boolean): TextAreaState {
 
-		const selectionStartPage = PagedScreenReaderStrategy._getPageOfLine(selection.startLineNumber);
-		const selectionStartPageRange = PagedScreenReaderStrategy._getRangeForPage(selectionStartPage);
+		const selectionStartPage = PagedScreenReaderStrategy._getPageOfLine(selection.startLineNumber, linesPerPage);
+		const selectionStartPageRange = PagedScreenReaderStrategy._getRangeForPage(selectionStartPage, linesPerPage);
 
-		const selectionEndPage = PagedScreenReaderStrategy._getPageOfLine(selection.endLineNumber);
-		const selectionEndPageRange = PagedScreenReaderStrategy._getRangeForPage(selectionEndPage);
+		const selectionEndPage = PagedScreenReaderStrategy._getPageOfLine(selection.endLineNumber, linesPerPage);
+		const selectionEndPageRange = PagedScreenReaderStrategy._getRangeForPage(selectionEndPage, linesPerPage);
 
 		const pretextRange = selectionStartPageRange.intersectRanges(new Range(1, 1, selection.startLineNumber, selection.startColumn))!;
 		let pretext = model.getValueInRange(pretextRange, EndOfLinePreference.LF);

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -332,6 +332,10 @@ export interface IEditorOptions {
 	 */
 	accessibilitySupport?: 'auto' | 'off' | 'on';
 	/**
+	 * Controls the number of lines in the editor that can be read out by a screen reader
+	 */
+	accessibilityLinesPerPage?: number;
+	/**
 	 * Suggest options.
 	 */
 	suggest?: ISuggestOptions;
@@ -980,7 +984,7 @@ class EditorAccessibilitySupport extends BaseEditorOption<EditorOption.accessibi
 	}
 }
 
-//#endregion
+
 
 //#region cursorBlinking
 
@@ -3001,6 +3005,7 @@ export const enum EditorOption {
 	acceptSuggestionOnCommitCharacter,
 	acceptSuggestionOnEnter,
 	accessibilitySupport,
+	accessibilityLinesPerPage,
 	ariaLabel,
 	autoClosingBrackets,
 	autoClosingOvertype,
@@ -3128,6 +3133,8 @@ export const EditorOptions = {
 		}
 	)),
 	accessibilitySupport: register(new EditorAccessibilitySupport()),
+	accessibilityLinesPerPage: register(new EditorIntOption(EditorOption.accessibilityLinesPerPage, 'accessibilityLinesPerPage', 10, 1, Constants.MAX_SAFE_SMALL_INTEGER,
+		{ description: nls.localize('accessibilityLinesPerPage', "Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.") })),
 	ariaLabel: register(new EditorStringOption(
 		EditorOption.ariaLabel, 'ariaLabel', nls.localize('editorViewAccessibleLabel', "Editor content")
 	)),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -334,7 +334,7 @@ export interface IEditorOptions {
 	/**
 	 * Controls the number of lines in the editor that can be read out by a screen reader
 	 */
-	accessibilityLinesPerPage?: number;
+	accessibilityPageSize?: number;
 	/**
 	 * Suggest options.
 	 */
@@ -984,7 +984,7 @@ class EditorAccessibilitySupport extends BaseEditorOption<EditorOption.accessibi
 	}
 }
 
-
+//#endregion
 
 //#region cursorBlinking
 
@@ -3005,7 +3005,7 @@ export const enum EditorOption {
 	acceptSuggestionOnCommitCharacter,
 	acceptSuggestionOnEnter,
 	accessibilitySupport,
-	accessibilityLinesPerPage,
+	accessibilityPageSize,
 	ariaLabel,
 	autoClosingBrackets,
 	autoClosingOvertype,
@@ -3133,8 +3133,8 @@ export const EditorOptions = {
 		}
 	)),
 	accessibilitySupport: register(new EditorAccessibilitySupport()),
-	accessibilityLinesPerPage: register(new EditorIntOption(EditorOption.accessibilityLinesPerPage, 'accessibilityLinesPerPage', 10, 1, Constants.MAX_SAFE_SMALL_INTEGER,
-		{ description: nls.localize('accessibilityLinesPerPage', "Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.") })),
+	accessibilityPageSize: register(new EditorIntOption(EditorOption.accessibilityPageSize, 'accessibilityPageSize', 10, 1, Constants.MAX_SAFE_SMALL_INTEGER,
+		{ description: nls.localize('accessibilityPageSize', "Controls the number of lines in the editor that can be read out by a screen reader. Warning: this has a performance implication for numbers larger than the default.") })),
 	ariaLabel: register(new EditorStringOption(
 		EditorOption.ariaLabel, 'ariaLabel', nls.localize('editorViewAccessibleLabel', "Editor content")
 	)),

--- a/src/vs/editor/test/browser/controller/imeTester.ts
+++ b/src/vs/editor/test/browser/controller/imeTester.ts
@@ -103,7 +103,7 @@ function doCreateTest(description: string, inputStr: string, expectedStr: string
 
 			const selection = new Range(1, 1 + cursorOffset, 1, 1 + cursorOffset + cursorLength);
 
-			return PagedScreenReaderStrategy.fromEditorSelection(currentState, model, selection, true);
+			return PagedScreenReaderStrategy.fromEditorSelection(currentState, model, selection, 10, true);
 		},
 		deduceModelPosition: (viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position => {
 			return null!;

--- a/src/vs/editor/test/browser/controller/textAreaState.test.ts
+++ b/src/vs/editor/test/browser/controller/textAreaState.test.ts
@@ -535,7 +535,7 @@ suite('TextAreaState', () => {
 
 		function testPagedScreenReaderStrategy(lines: string[], selection: Selection, expected: TextAreaState): void {
 			const model = TextModel.createFromString(lines.join('\n'));
-			const actual = PagedScreenReaderStrategy.fromEditorSelection(TextAreaState.EMPTY, model, selection, true);
+			const actual = PagedScreenReaderStrategy.fromEditorSelection(TextAreaState.EMPTY, model, selection, 10, true);
 			assert.ok(equalsTextAreaState(actual, expected));
 			model.dispose();
 		}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2733,7 +2733,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls the number of lines in the editor that can be read out by a screen reader
 		 */
-		accessibilityLinesPerPage?: number;
+		accessibilityPageSize?: number;
 		/**
 		 * Suggest options.
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2731,6 +2731,10 @@ declare namespace monaco.editor {
 		 */
 		accessibilitySupport?: 'auto' | 'off' | 'on';
 		/**
+		 * Controls the number of lines in the editor that can be read out by a screen reader
+		 */
+		accessibilityLinesPerPage?: number;
+		/**
 		 * Suggest options.
 		 */
 		suggest?: ISuggestOptions;


### PR DESCRIPTION
Refs: https://github.com/microsoft/vscode/issues/41423

This PR introduces the setting `editor.accessibilityPageSize` which allows the user to control how many lines will be set in the hidden text area.
Feedback on  naming would be great.

Are the changes to `monaco.d.ts` supposed to be checked in, right? Since I introduced a new setting?

We should also consider to not trimLongText if this setting is higher than some threshold. Though most users will have accessibilitySupport on so I am not so worried about that
