### PR TITLE
Invertible marker search

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -338,7 +338,7 @@ const fuzzyContiguousFilter = or(matchesPrefix, matchesCamelCase, matchesContigu
 const fuzzySeparateFilter = or(matchesPrefix, matchesCamelCase, matchesSubString);
 const fuzzyRegExpCache = new LRUCache<string, RegExp>(10000); // bounded to 10000 elements
 
-export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSeparateSubstringMatching = false, invertResult = false): IMatch[] | null {
+export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSeparateSubstringMatching = false): IMatch[] | null {
 	if (typeof word !== 'string' || typeof wordToMatchAgainst !== 'string') {
 		return null; // return early for invalid input
 	}
@@ -353,15 +353,7 @@ export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSep
 	// RegExp Filter
 	const match = regexp.exec(wordToMatchAgainst);
 	if (match) {
-		if (invertResult) {
-			// Default Filter
-			return enableSeparateSubstringMatching ? fuzzySeparateFilter(word, wordToMatchAgainst) : fuzzyContiguousFilter(word, wordToMatchAgainst);
-		}
-
 		return [{ start: match.index, end: match.index + match[0].length }];
-	}
-	else if (invertResult) {
-		return [{ start: 0, end: wordToMatchAgainst.length }];
 	}
 
 	// Default Filter

--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -12,6 +12,10 @@ export interface IFilter {
 	(word: string, wordToMatchAgainst: string): IMatch[] | null;
 }
 
+export interface IInvertibleFilter {
+	(word: string, wordToMatchAgainst: string, invertResult: boolean): IMatch[] | null;
+}
+
 export interface IMatch {
 	start: number;
 	end: number;
@@ -334,7 +338,7 @@ const fuzzyContiguousFilter = or(matchesPrefix, matchesCamelCase, matchesContigu
 const fuzzySeparateFilter = or(matchesPrefix, matchesCamelCase, matchesSubString);
 const fuzzyRegExpCache = new LRUCache<string, RegExp>(10000); // bounded to 10000 elements
 
-export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSeparateSubstringMatching = false): IMatch[] | null {
+export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSeparateSubstringMatching = false, invertResult = false): IMatch[] | null {
 	if (typeof word !== 'string' || typeof wordToMatchAgainst !== 'string') {
 		return null; // return early for invalid input
 	}
@@ -349,7 +353,15 @@ export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSep
 	// RegExp Filter
 	const match = regexp.exec(wordToMatchAgainst);
 	if (match) {
+		if (invertResult) {
+			// Default Filter
+			return enableSeparateSubstringMatching ? fuzzySeparateFilter(word, wordToMatchAgainst) : fuzzyContiguousFilter(word, wordToMatchAgainst);
+		}
+
 		return [{ start: match.index, end: match.index + match[0].length }];
+	}
+	else if (invertResult) {
+		return [{ start: 0, end: wordToMatchAgainst.length }];
 	}
 
 	// Default Filter

--- a/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
@@ -14,9 +14,17 @@ export class FilterOptions {
 	static readonly _filter: IFilter = matchesFuzzy2;
 	static readonly _messageFilter: IInvertibleFilter = (word, wordToMatchAgainst, invertResult) => {
 		let match = matchesFuzzy(word, wordToMatchAgainst);
-		if (invertResult) {
-			return [{ start: 0, end: wordToMatchAgainst.length }];
+		if (match) {
+			if (invertResult) {
+				return null;
+			}
 		}
+		else {
+			if (invertResult) {
+				return [{ start: 0, end: wordToMatchAgainst.length }];
+			}
+		}
+
 		return match;
 	}
 

--- a/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
@@ -13,7 +13,11 @@ export class FilterOptions {
 
 	static readonly _filter: IFilter = matchesFuzzy2;
 	static readonly _messageFilter: IInvertibleFilter = (word, wordToMatchAgainst, invertResult) => {
-		return matchesFuzzy(word, wordToMatchAgainst, false, invertResult);
+		let match = matchesFuzzy(word, wordToMatchAgainst);
+		if (invertResult) {
+			return [{ start: 0, end: wordToMatchAgainst.length }];
+		}
+		return match;
 	}
 
 	readonly showWarnings: boolean = false;

--- a/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersFilterOptions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IFilter, matchesFuzzy, matchesFuzzy2 } from 'vs/base/common/filters';
+import { IFilter, IInvertibleFilter, matchesFuzzy, matchesFuzzy2 } from 'vs/base/common/filters';
 import { IExpression, splitGlobAware, getEmptyExpression } from 'vs/base/common/glob';
 import * as strings from 'vs/base/common/strings';
 import { URI } from 'vs/base/common/uri';
@@ -12,7 +12,9 @@ import { ResourceGlobMatcher } from 'vs/base/common/resources';
 export class FilterOptions {
 
 	static readonly _filter: IFilter = matchesFuzzy2;
-	static readonly _messageFilter: IFilter = matchesFuzzy;
+	static readonly _messageFilter: IInvertibleFilter = (word, wordToMatchAgainst, invertResult) => {
+		return matchesFuzzy(word, wordToMatchAgainst, false, invertResult);
+	}
 
 	readonly showWarnings: boolean = false;
 	readonly showErrors: boolean = false;

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -6,6 +6,7 @@
 import * as dom from 'vs/base/browser/dom';
 import * as network from 'vs/base/common/network';
 import * as paths from 'vs/base/common/path';
+import * as strings from 'vs/base/common/strings';
 import { CountBadge } from 'vs/base/browser/ui/countBadge/countBadge';
 import { ResourceLabels, IResourceLabel } from 'vs/workbench/browser/labels';
 import { HighlightedLabel } from 'vs/base/browser/ui/highlightedlabel/highlightedLabel';
@@ -448,8 +449,16 @@ export class Filter implements ITreeFilter<TreeElement, FilterData> {
 		}
 
 		const lineMatches: IMatch[][] = [];
-		for (const line of marker.lines) {
-			lineMatches.push(FilterOptions._messageFilter(this.options.textFilter, line) || []);
+		if (strings.startsWith(this.options.textFilter, '@!')) {
+			let filter = strings.ltrim(this.options.textFilter, '@!');
+			for (const line of marker.lines) {
+				lineMatches.push(FilterOptions._messageFilter(filter, line, true) || []);
+			}
+		}
+		else {
+			for (const line of marker.lines) {
+				lineMatches.push(FilterOptions._messageFilter(this.options.textFilter, line, false) || []);
+			}
 		}
 		const sourceMatches = marker.marker.source && FilterOptions._filter(this.options.textFilter, marker.marker.source);
 		const codeMatches = marker.marker.code && FilterOptions._filter(this.options.textFilter, marker.marker.code);
@@ -467,7 +476,7 @@ export class Filter implements ITreeFilter<TreeElement, FilterData> {
 		}
 
 		const uriMatches = FilterOptions._filter(this.options.textFilter, basename(relatedInformation.raw.resource));
-		const messageMatches = FilterOptions._messageFilter(this.options.textFilter, paths.basename(relatedInformation.raw.message));
+		const messageMatches = FilterOptions._messageFilter(this.options.textFilter, paths.basename(relatedInformation.raw.message), false);
 
 		if (uriMatches || messageMatches) {
 			return { visibility: true, data: { type: FilterDataType.RelatedInformation, uriMatches: uriMatches || [], messageMatches: messageMatches || [] } };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #83775 

This change lets the user exclude line items from the "Problems" panel based on a text-based search. The filter string must begin with "@!" to denote a text-based exclusion.

For example: To exclude all problems that have the phrase "Expression expected.", the filter string will be: @!Expression expected.