### PR TITLE
#86176: Consider indenting with comments (that contain apostrophes)

### DIFF
--- a/extensions/typescript-language-features/src/features/languageConfiguration.ts
+++ b/extensions/typescript-language-features/src/features/languageConfiguration.ts
@@ -15,7 +15,7 @@ import * as languageModeIds from '../utils/languageModeIds';
 const jsTsLanguageConfiguration: vscode.LanguageConfiguration = {
 	indentationRules: {
 		decreaseIndentPattern: /^((?!.*?\/\*).*\*\/)?\s*[\}\]].*$/,
-		increaseIndentPattern: /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)$/
+		increaseIndentPattern: /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)(\/\/.*|\/\*.*?\*\/)?$/
 	},
 	wordPattern: /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g,
 	onEnterRules: [

--- a/src/vs/editor/test/browser/controller/cursor.test.ts
+++ b/src/vs/editor/test/browser/controller/cursor.test.ts
@@ -3641,7 +3641,7 @@ suite('Editor Controller - Indentation Rules', () => {
 						// ^(.*\*/)?\s*\}.*$
 						decreaseIndentPattern: /^((?!.*?\/\*).*\*\/)?\s*[\}\]\)].*$/,
 						// ^.*\{[^}"']*$
-						increaseIndentPattern: /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)$/
+						increaseIndentPattern: /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)(\/\/.*|\/\*.*?\*\/)?$/
 					},
 					onEnterRules: javascriptOnEnterRules
 				}));
@@ -3687,6 +3687,23 @@ suite('Editor Controller - Indentation Rules', () => {
 
 		model.dispose();
 		mode.dispose();
+	});
+
+	test('issue #86176: JS: increaseIndentPattern does not work for comments including apostrophes', () => {
+		usingCursor({
+			text: [
+				'if (true) { \\ \'Apostrophe comment \'console.log()',
+				'}'
+			],
+			languageIdentifier: mode.getLanguageIdentifier(),
+			editorOpts: { autoIndent: 'full' }
+		}, (model, cursor) => {
+			moveTo(cursor, 1, 30, false);
+			assertCursor(cursor, new Selection(1, 30, 1, 30));
+
+			cursorCommand(cursor, H.Type, { text: '\n' }, 'keyboard');
+			assertCursor(cursor, new Selection(2, 5, 2, 5));
+		});
 	});
 
 	test('issue #38261: TAB key results in bizarre indentation in C++ mode ', () => {


### PR DESCRIPTION
This PR fixes #86176 

I propose adding `(\/\/.*|\/\*.*?\*\/)?` to the increaseIndentPattern regex.

(
`\/\/.*` Allow for any // comment
| or
`\/\*.*?\*\/` Allow for any block comments that complete
)
`?` Optionally

This matches:
`if () { // <Any comment with ' or ">`
or
`if () { /* <Any comment with ' or "> */`

But not
`if () {  /* <Any comment with ' or "> (block comment does not finish)`

There may be edge cases that this does not consider that could cause issues?