### PR TITLE
fix #85938: prevent duplicate selections

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -997,7 +997,7 @@ class Trait<T> {
 	}
 
 	private _set(nodes: ITreeNode<T, any>[], silent: boolean, browserEvent?: UIEvent): void {
-		this.nodes = nodes.length > 1 && this.identityProvider ? distinct(nodes, node => this.identityProvider!.getId(node.element).toString()) : [...nodes];
+		this.nodes = [...nodes];
 		this.elements = undefined;
 		this._nodeSet = undefined;
 

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -1189,14 +1189,16 @@ export class CompressibleAsyncDataTree<TInput, T, TFilterData = void> extends As
 			if (compressedNode) {
 				for (let i = 0; i < compressedNode.elements.length; i++) {
 					const id = getId(compressedNode.elements[i].element as T);
+					const element = compressedNode.elements[compressedNode.elements.length - 1].element as T;
 
-					if (oldSelection.has(id)) {
-						selection.push(compressedNode.elements[compressedNode.elements.length - 1].element as T);
+					// github.com/microsoft/vscode/issues/85938
+					if (oldSelection.has(id) && selection.indexOf(element) === -1) {
+						selection.push(element);
 						didChangeSelection = true;
 					}
 
-					if (oldFocus.has(id)) {
-						focus.push(compressedNode.elements[compressedNode.elements.length - 1].element as T);
+					if (oldFocus.has(id) && focus.indexOf(element) === -1) {
+						focus.push(element);
 						didChangeFocus = true;
 					}
 				}


### PR DESCRIPTION
This PR fixes #85938 (and #85880 ?)
@isidorn 

When creating a new empty folder, upon focusing on it, duplicate selections can occur where `selection` already contains the object, but `oldSelection` has the id and will push it again.

Will this being a set cause any issues if the objects are not in the same order as before?