### PR TITLE
lcd - revert layer promotion for now

### DIFF
--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -8,11 +8,6 @@
 	overflow: hidden;
 }
 
-.monaco-workbench.windows.chromium .part:focus-within,
-.monaco-workbench.linux.chromium .part:focus-within {
-	z-index: 500;
-}
-
 .monaco-workbench .part > .title {
 	display: none; /* Parts have to opt in to show title area */
 }

--- a/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
@@ -7,22 +7,6 @@
 	width: 48px;
 }
 
-.monaco-workbench.windows.chromium .part.activitybar,
-.monaco-workbench.linux.chromium .part.activitybar {
-	/*
-	 * Explicitly put the part onto its own layer to help Chrome to
-	 * render the content with LCD-anti-aliasing. By partioning the
-	 * workbench into multiple layers, we can ensure that a bad
-	 * behaving part is not making another part fallback to greyscale
-	 * rendering.
-	 *
-	 * macOS: does not render LCD-anti-aliased.
-	 */
-	transform: translate3d(0px, 0px, 0px);
-	overflow: visible; /* when a new layer is created, we need to set overflow visible to avoid clipping the menubar */
-	position: relative;
-}
-
 .monaco-workbench .activitybar > .content {
 	height: 100%;
 	display: flex;

--- a/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
@@ -48,20 +48,6 @@
 	overflow: hidden;
 }
 
-.monaco-workbench.windows.chromium .part.editor > .content .editor-group-container > .title,
-.monaco-workbench.linux.chromium .part.editor > .content .editor-group-container > .title {
-	/*
-	 * Explicitly put the part onto its own layer to help Chrome to
-	 * render the content with LCD-anti-aliasing. By partioning the
-	 * workbench into multiple layers, we can ensure that a bad
-	 * behaving part is not making another part fallback to greyscale
-	 * rendering.
-	 *
-	 * macOS: does not render LCD-anti-aliased.
-	 */
-	transform: translate3d(0px, 0px, 0px);
-}
-
 .monaco-workbench .part.editor > .content .editor-group-container > .title:not(.tabs) {
 	display: flex; /* when tabs are not shown, use flex layout */
 	flex-wrap: nowrap;

--- a/src/vs/workbench/browser/parts/panel/media/panelpart.css
+++ b/src/vs/workbench/browser/parts/panel/media/panelpart.css
@@ -12,20 +12,6 @@
 	z-index: initial;
 }
 
-.monaco-workbench.windows.chromium .part.panel,
-.monaco-workbench.linux.chromium .part.panel {
-	/*
-	 * Explicitly put the part onto its own layer to help Chrome to
-	 * render the content with LCD-anti-aliasing. By partioning the
-	 * workbench into multiple layers, we can ensure that a bad
-	 * behaving part is not making another part fallback to greyscale
-	 * rendering.
-	 *
-	 * macOS: does not render LCD-anti-aliased.
-	 */
-	transform: translate3d(0px, 0px, 0px);
-}
-
 .monaco-workbench .part.panel .title {
 	height: 35px;
 	display: flex;
@@ -114,7 +100,7 @@
 	text-align: center;
 	display: inline-block;
 	box-sizing: border-box;
-}
+	}
 
 /** Actions */
 

--- a/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
+++ b/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
@@ -3,20 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench.windows.chromium .part.sidebar,
-.monaco-workbench.linux.chromium .part.sidebar {
-	/*
-	 * Explicitly put the part onto its own layer to help Chrome to
-	 * render the content with LCD-anti-aliasing. By partioning the
-	 * workbench into multiple layers, we can ensure that a bad
-	 * behaving part is not making another part fallback to greyscale
-	 * rendering.
-	 *
-	 * macOS: does not render LCD-anti-aliased.
-	 */
-	transform: translate3d(0px, 0px, 0px);
-	overflow: visible;
-	position: relative;
+.monaco-workbench .sidebar > .content {
+	overflow: hidden;
 }
 
 .monaco-workbench.nosidebar > .part.sidebar {

--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -13,20 +13,6 @@
 	overflow: visible;
 }
 
-.monaco-workbench.windows.chromium .part.statusbar,
-.monaco-workbench.linux.chromium .part.statusbar {
-	/*
-	 * Explicitly put the part onto its own layer to help Chrome to
-	 * render the content with LCD-anti-aliasing. By partioning the
-	 * workbench into multiple layers, we can ensure that a bad
-	 * behaving part is not making another part fallback to greyscale
-	 * rendering.
-	 *
-	 * macOS: does not render LCD-anti-aliased.
-	 */
-	transform: translate3d(0px, 0px, 0px);
-}
-
 .monaco-workbench .part.statusbar.status-border-top::after {
 	content: '';
 	position: absolute;

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -26,7 +26,6 @@
 	position: absolute;
 	width: 100%;
 	height: 100%;
-	z-index: -1;
 	-webkit-app-region: drag;
 }
 
@@ -56,6 +55,11 @@
 .monaco-workbench.windows .part.titlebar > .window-title,
 .monaco-workbench.linux .part.titlebar > .window-title {
 	cursor: default;
+}
+
+.monaco-workbench .part.titlebar > .menubar {
+	/* move menubar above drag region as negative z-index on drag region cause greyscale AA */
+	z-index: 2000;
 }
 
 .monaco-workbench.linux .part.titlebar > .window-title {

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -19,22 +19,6 @@
 	display: flex;
 }
 
-.monaco-workbench.windows .part.titlebar,
-.monaco-workbench.linux .part.titlebar {
-	/*
-	 * Explicitly put the part onto its own layer to help Chrome to
-	 * render the content with LCD-anti-aliasing. By partioning the
-	 * workbench into multiple layers, we can ensure that a bad
-	 * behaving part is not making another part fallback to greyscale
-	 * rendering.
-	 *
-	 * macOS: does not render LCD-anti-aliased.
-	 */
-	transform: translate3d(0px, 0px, 0px);
-	position: relative;
-	z-index: 1500 !important; /* move the entire titlebar above the workbench, except modals/dialogs */
-}
-
 .monaco-workbench .part.titlebar > .titlebar-drag-region {
 	top: 0;
 	left: 0;
@@ -42,12 +26,8 @@
 	position: absolute;
 	width: 100%;
 	height: 100%;
+	z-index: -1;
 	-webkit-app-region: drag;
-}
-
-.monaco-workbench .part.titlebar > .menubar {
-	/* Move above drag region since negative z-index on that element causes AA issues */
-	z-index: 1;
 }
 
 .monaco-workbench .part.titlebar > .window-title {
@@ -100,7 +80,7 @@
 	width: 35px;
 	height: 100%;
 	position: relative;
-	z-index: 2; /* highest level of titlebar */
+	z-index: 3000;
 	background-image: url('code-icon.svg');
 	background-repeat: no-repeat;
 	background-position: center center;
@@ -118,12 +98,11 @@
 	flex-shrink: 0;
 	text-align: center;
 	position: relative;
-	z-index: 2; /* highest level of titlebar */
+	z-index: 3000;
 	-webkit-app-region: no-drag;
 	height: 100%;
 	width: 138px;
 	margin-left: auto;
-	transform: translate3d(0px, 0px, 0px);
 }
 
 .monaco-workbench.fullscreen .part.titlebar > .window-controls-container {

--- a/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
@@ -13,7 +13,7 @@ import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEdito
 import { TabCompletionController } from 'vs/workbench/contrib/snippets/browser/tabCompletion';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 
-export function getSimpleEditorOptions(fixedOverflowWidgets: boolean = true): IEditorOptions {
+export function getSimpleEditorOptions(): IEditorOptions {
 	return {
 		wordWrap: 'on',
 		overviewRulerLanes: 0,
@@ -30,7 +30,7 @@ export function getSimpleEditorOptions(fixedOverflowWidgets: boolean = true): IE
 		overviewRulerBorder: false,
 		scrollBeyondLastLine: false,
 		renderLineHighlight: 'none',
-		fixedOverflowWidgets: fixedOverflowWidgets,
+		fixedOverflowWidgets: true,
 		acceptSuggestionOnEnter: 'smart',
 		minimap: {
 			enabled: false

--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
@@ -72,7 +72,6 @@ interface SuggestEnabledInputOptions {
 	 * Context key tracking the focus state of this element
 	 */
 	focusContextKey?: IContextKey<boolean>;
-	fixedOverflowWidgets?: boolean;
 }
 
 export interface ISuggestEnabledInputStyleOverrides extends IStyleOverrides {
@@ -127,7 +126,7 @@ export class SuggestEnabledInput extends Widget implements IThemable {
 		this.placeholderText = append(this.stylingContainer, $('.suggest-input-placeholder', undefined, options.placeholderText || ''));
 
 		const editorOptions: IEditorOptions = mixin(
-			getSimpleEditorOptions(!!options.fixedOverflowWidgets),
+			getSimpleEditorOptions(false),
 			getSuggestEnabledInputOptions(ariaLabel));
 
 		this.inputWidget = instantiationService.createInstance(CodeEditorWidget, this.stylingContainer,

--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
@@ -126,7 +126,7 @@ export class SuggestEnabledInput extends Widget implements IThemable {
 		this.placeholderText = append(this.stylingContainer, $('.suggest-input-placeholder', undefined, options.placeholderText || ''));
 
 		const editorOptions: IEditorOptions = mixin(
-			getSimpleEditorOptions(false),
+			getSimpleEditorOptions(),
 			getSuggestEnabledInputOptions(ariaLabel));
 
 		this.inputWidget = instantiationService.createInstance(CodeEditorWidget, this.stylingContainer,

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -405,7 +405,7 @@ export class ExtensionsViewlet extends ViewContainerViewlet implements IExtensio
 				else { return 'd'; }
 			},
 			provideResults: (query: string) => Query.suggestions(query)
-		}, placeholder, 'extensions:searchinput', { placeholderText: placeholder, value: searchValue, fixedOverflowWidgets: false }));
+		}, placeholder, 'extensions:searchinput', { placeholderText: placeholder, value: searchValue }));
 
 		if (this.searchBox.getValue()) {
 			this.triggerSearch();

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -406,7 +406,6 @@ export class SettingsEditor2 extends BaseEditor {
 		}, searchBoxLabel, 'settingseditor:searchinput' + SettingsEditor2.NUM_INSTANCES++, {
 			placeholderText: searchBoxLabel,
 			focusContextKey: this.searchFocusContextKey,
-			fixedOverflowWidgets: true
 			// TODO: Aria-live
 		})
 		);


### PR DESCRIPTION
This milestone we promoted each workbench part to its own layer to isolate parts from each other that would result in dropped LCD rendering support. However we have seen issues with that approach and need to revisit this in December.

@sbatten can you please look into this today and merge before tomorrows insiders build. My approach for the revert was to go back to the 1.40 state for each CSS file of parts. `titlebarPart.css` had so many commits though that this file might have reverted good changes, can you please review by checking the history: https://github.com/microsoft/vscode/commits/master/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css

//cc @alexandrudima 