### PR TITLE
Fixes activity bar debug icon left white border not shown when debug startView is active

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/startView.ts
+++ b/src/vs/workbench/contrib/debug/browser/startView.ts
@@ -30,6 +30,7 @@ export class StartView extends ViewletPane {
 	static ID = 'workbench.debug.startView';
 	static LABEL = localize('start', "Start");
 
+	private container!: HTMLElement;
 	private debugButton!: Button;
 	private runButton!: Button;
 	private firstMessageContainer!: HTMLElement;
@@ -132,6 +133,8 @@ export class StartView extends ViewletPane {
 	}
 
 	protected renderBody(container: HTMLElement): void {
+		this.container = container;
+
 		this.firstMessageContainer = $('.top-section');
 		container.appendChild(this.firstMessageContainer);
 
@@ -161,6 +164,10 @@ export class StartView extends ViewletPane {
 	}
 
 	focus(): void {
-		this.runButton.focus();
+		if (this.runButton.enabled) {
+			this.runButton.focus();
+		} else {
+			(this.container.querySelector('span.click') as HTMLElement).focus();
+		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #86506
