### PR TITLE
#85320 Allow seeding find box with multi-line text

### DIFF
--- a/src/vs/editor/contrib/find/test/find.test.ts
+++ b/src/vs/editor/contrib/find/test/find.test.ts
@@ -68,17 +68,17 @@ suite('Find', () => {
 			// Select first line and newline
 			editor.setSelection(new Range(1, 1, 2, 1));
 			let searchStringSelectionWholeLine = getSelectionSearchString(editor);
-			assert.equal(searchStringSelectionWholeLine, null);
+			assert.equal(searchStringSelectionWholeLine, 'ABC DEF\n');
 
 			// Select first line and chunk of second
 			editor.setSelection(new Range(1, 1, 2, 4));
 			let searchStringSelectionTwoLines = getSelectionSearchString(editor);
-			assert.equal(searchStringSelectionTwoLines, null);
+			assert.equal(searchStringSelectionTwoLines, 'ABC DEF\n012');
 
 			// Select end of first line newline and chunk of second
 			editor.setSelection(new Range(1, 7, 2, 4));
 			let searchStringSelectionSpanLines = getSelectionSearchString(editor);
-			assert.equal(searchStringSelectionSpanLines, null);
+			assert.equal(searchStringSelectionSpanLines, 'F\n012');
 
 		});
 	});

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -67,6 +67,7 @@ import { SIDE_BAR_BACKGROUND, PANEL_BACKGROUND } from 'vs/workbench/common/theme
 import { createEditorFromSearchResult } from 'vs/workbench/contrib/search/browser/searchEditor';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { Color, RGBA } from 'vs/base/common/color';
+import { EndOfLinePreference } from 'vs/editor/common/model';
 
 const $ = dom.$;
 
@@ -1031,25 +1032,7 @@ export class SearchView extends ViewletPane {
 		}
 
 		if (!range.isEmpty()) {
-			let searchText = '';
-			for (let i = range.startLineNumber; i <= range.endLineNumber; i++) {
-				let lineText = activeTextEditorWidget.getModel().getLineContent(i);
-				if (i === range.endLineNumber) {
-					lineText = lineText.substring(0, range.endColumn - 1);
-				}
-
-				if (i === range.startLineNumber) {
-					lineText = lineText.substring(range.startColumn - 1);
-				}
-
-				if (i !== range.startLineNumber) {
-					lineText = '\n' + lineText;
-				}
-
-				searchText += lineText;
-			}
-
-			return searchText;
+			return activeTextEditorWidget.getModel().getValueInRange(range, EndOfLinePreference.LF);
 		}
 
 		return null;


### PR DESCRIPTION
This PR fixes #85320

Initially it wasn't working, it turns out that the in-editor find does not sanitize \r\n -> \n, as the global search does.

It turns out that `ITextModel`'s getValueInRange comes with a EOL preference parameter, so I think the the global search should also use that instead of doing it itself.