### PR TITLE
#82352 Implement sorting for search results

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -51,7 +51,7 @@ import { ISearchHistoryService, SearchHistoryService } from 'vs/workbench/contri
 import { FileMatchOrMatch, ISearchWorkbenchService, RenderableMatch, SearchWorkbenchService, FileMatch, Match, FolderMatch } from 'vs/workbench/contrib/search/common/searchModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
-import { ISearchConfiguration, ISearchConfigurationProperties, PANEL_ID, VIEWLET_ID, VIEW_ID, VIEW_CONTAINER, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
+import { ISearchConfiguration, ISearchConfigurationProperties, PANEL_ID, VIEWLET_ID, VIEW_ID, VIEW_CONTAINER, SearchSortOrder } from 'vs/workbench/services/search/common/search';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { ExplorerViewPaneContainer } from 'vs/workbench/contrib/files/browser/explorerViewlet';
@@ -829,8 +829,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'search.sortOrder': {
 			'type': 'string',
-			'enum': [SearchSortOrderConfiguration.default, SearchSortOrderConfiguration.fileNames, SearchSortOrderConfiguration.type, SearchSortOrderConfiguration.modified, SearchSortOrderConfiguration.countDescending, SearchSortOrderConfiguration.countAscending],
-			'default': SearchSortOrderConfiguration.default,
+			'enum': [SearchSortOrder.Default, SearchSortOrder.FileNames, SearchSortOrder.Type, SearchSortOrder.Modified, SearchSortOrder.CountDescending, SearchSortOrder.CountAscending],
+			'default': SearchSortOrder.Default,
 			'enumDescriptions': [
 				nls.localize('searchSortOrder.default', 'Results are sorted by folder and file names, in alphabetical order.'),
 				nls.localize('searchSortOrder.filesOnly', 'Results are sorted by file names ignoring folder order, in alphabetical order.'),

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -51,7 +51,7 @@ import { ISearchHistoryService, SearchHistoryService } from 'vs/workbench/contri
 import { FileMatchOrMatch, ISearchWorkbenchService, RenderableMatch, SearchWorkbenchService, FileMatch, Match, FolderMatch } from 'vs/workbench/contrib/search/common/searchModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
-import { ISearchConfiguration, ISearchConfigurationProperties, PANEL_ID, VIEWLET_ID, VIEW_ID, VIEW_CONTAINER } from 'vs/workbench/services/search/common/search';
+import { ISearchConfiguration, ISearchConfigurationProperties, PANEL_ID, VIEWLET_ID, VIEW_ID, VIEW_CONTAINER, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
 import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { ExplorerViewPaneContainer } from 'vs/workbench/contrib/files/browser/explorerViewlet';
@@ -826,7 +826,21 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: false,
 			description: nls.localize('search.enableSearchEditorPreview', "Experimental: When enabled, allows opening workspace search results in an editor.")
-		}
+		},
+		'search.sortOrder': {
+			'type': 'string',
+			'enum': [SearchSortOrderConfiguration.DEFAULT, SearchSortOrderConfiguration.FILES_ONLY, SearchSortOrderConfiguration.TYPE, SearchSortOrderConfiguration.MODIFIED, SearchSortOrderConfiguration.COUNT_DESCENDING, SearchSortOrderConfiguration.COUNT_ASCENDING],
+			'default': SearchSortOrderConfiguration.DEFAULT,
+			'enumDescriptions': [
+				nls.localize('searchSortOrder.default', 'Results are sorted by folder and file names, in alphabetical order.'),
+				nls.localize('searchSortOrder.filesOnly', 'Results are sorted by file names ignoring folder order, in alphabetical order.'),
+				nls.localize('searchSortOrder.type', 'Results are sorted by file extensions, in alphabetical order.'),
+				nls.localize('searchSortOrder.modified', 'Results are sorted by file last modified date, in descending order.'),
+				nls.localize('searchSortOrder.countDescending', 'Results are sorted by count per file, in descending order.'),
+				nls.localize('searchSortOrder.countAscending', 'Results are sorted by count per file, in ascending order.')
+			],
+			'description': nls.localize('search.sortOrder', "Controls sorting order of search results.")
+		},
 	}
 });
 

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -829,8 +829,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'search.sortOrder': {
 			'type': 'string',
-			'enum': [SearchSortOrderConfiguration.DEFAULT, SearchSortOrderConfiguration.FILES_ONLY, SearchSortOrderConfiguration.TYPE, SearchSortOrderConfiguration.MODIFIED, SearchSortOrderConfiguration.COUNT_DESCENDING, SearchSortOrderConfiguration.COUNT_ASCENDING],
-			'default': SearchSortOrderConfiguration.DEFAULT,
+			'enum': [SearchSortOrderConfiguration.default, SearchSortOrderConfiguration.fileNames, SearchSortOrderConfiguration.type, SearchSortOrderConfiguration.modified, SearchSortOrderConfiguration.countDescending, SearchSortOrderConfiguration.countAscending],
+			'default': SearchSortOrderConfiguration.default,
 			'enumDescriptions': [
 				nls.localize('searchSortOrder.default', 'Results are sorted by folder and file names, in alphabetical order.'),
 				nls.localize('searchSortOrder.filesOnly', 'Results are sorted by file names ignoring folder order, in alphabetical order.'),

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -34,7 +34,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { TreeResourceNavigator2, WorkbenchObjectTree, getSelectionKeyboardEvent } from 'vs/platform/list/browser/listService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IProgressService, IProgressStep, IProgress } from 'vs/platform/progress/common/progress';
-import { IPatternInfo, ISearchComplete, ISearchConfiguration, ISearchConfigurationProperties, ITextQuery, VIEW_ID, VIEWLET_ID, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
+import { IPatternInfo, ISearchComplete, ISearchConfiguration, ISearchConfigurationProperties, ITextQuery, VIEW_ID, VIEWLET_ID, SearchSortOrder } from 'vs/workbench/services/search/common/search';
 import { ISearchHistoryService, ISearchHistoryValues } from 'vs/workbench/contrib/search/common/searchHistoryService';
 import { diffInserted, diffInsertedOutline, diffRemoved, diffRemovedOutline, editorFindMatchHighlight, editorFindMatchHighlightBorder, listActiveSelectionForeground, foreground } from 'vs/platform/theme/common/colorRegistry';
 import { ICssStyleCollector, ITheme, IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
@@ -196,7 +196,7 @@ export class SearchView extends ViewPane {
 		});
 		this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('search.sortOrder')) {
-				if (this.searchConfig.sortOrder === SearchSortOrderConfiguration.modified) {
+				if (this.searchConfig.sortOrder === SearchSortOrder.Modified) {
 					// If changing away from modified, remove all fileStats
 					// so that updated files are re-retrieved next time.
 					this.removeFileStats();
@@ -505,7 +505,7 @@ export class SearchView extends ViewPane {
 		const collapseResults = this.searchConfig.collapseResults;
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree
-			if (this.searchConfig.sortOrder === SearchSortOrderConfiguration.modified) {
+			if (this.searchConfig.sortOrder === SearchSortOrder.Modified) {
 				// Ensure all matches have retrieved their file stat
 				this.retrieveFileStats()
 					.then(() => this.tree.setChildren(null, this.createResultIterator(collapseResults)));
@@ -514,8 +514,8 @@ export class SearchView extends ViewPane {
 			}
 		} else {
 			// If updated counts affect our search order, re-sort the view.
-			if (this.searchConfig.sortOrder === SearchSortOrderConfiguration.countAscending ||
-				this.searchConfig.sortOrder === SearchSortOrderConfiguration.countDescending) {
+			if (this.searchConfig.sortOrder === SearchSortOrder.CountAscending ||
+				this.searchConfig.sortOrder === SearchSortOrder.CountDescending) {
 				this.tree.setChildren(null, this.createResultIterator(collapseResults));
 			} else {
 				// FileMatch modified, refresh those elements
@@ -1715,7 +1715,7 @@ export class SearchView extends ViewPane {
 	}
 
 	private onFilesChanged(e: FileChangesEvent): void {
-		if (!this.viewModel || (this.searchConfig.sortOrder !== SearchSortOrderConfiguration.modified && !e.gotDeleted())) {
+		if (!this.viewModel || (this.searchConfig.sortOrder !== SearchSortOrder.Modified && !e.gotDeleted())) {
 			return;
 		}
 
@@ -1727,7 +1727,7 @@ export class SearchView extends ViewPane {
 		} else {
 			// Check if the changed file contained matches
 			const changedMatches = matches.filter(m => e.contains(m.resource));
-			if (changedMatches.length && this.searchConfig.sortOrder === SearchSortOrderConfiguration.modified) {
+			if (changedMatches.length && this.searchConfig.sortOrder === SearchSortOrder.Modified) {
 				// No matches need to be removed, but modified files need to have their file stat updated.
 				this.updateFileStats(changedMatches).then(() => this.refreshTree());
 			}
@@ -1809,7 +1809,7 @@ export class SearchView extends ViewPane {
 	}
 
 	private async updateFileStats(elements: FileMatch[]): Promise<void> {
-		const files = this.searchResult.matches().map(f => f.resolveFileStat(this.fileService));
+		const files = elements.map(f => f.resolveFileStat(this.fileService));
 		await Promise.all(files);
 	}
 

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -194,6 +194,16 @@ export class SearchView extends ViewPane {
 				this.enableSearchEditorPreview.set(this.searchConfig.enableSearchEditorPreview);
 			}
 		});
+		this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('search.sortOrder')) {
+				if (this.searchConfig.sortOrder !== 'modified') {
+					// If changing away from modified, remove all fileStats
+					// so that updated files are re-retrieved next time.
+					this.removeFileStats();
+				}
+				this.refreshTree();
+			}
+		});
 
 		this.viewModel = this._register(this.searchWorkbenchService.searchModel);
 		this.queryBuilder = this.instantiationService.createInstance(QueryBuilder);
@@ -495,13 +505,24 @@ export class SearchView extends ViewPane {
 		const collapseResults = this.searchConfig.collapseResults;
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree
-			this.tree.setChildren(null, this.createResultIterator(collapseResults));
+			if (this.searchConfig.sortOrder === 'modified') {
+				// Ensure all matches have retrieved their file stat
+				this.retrieveFileStats()
+					.then(() => this.tree.setChildren(null, this.createResultIterator(collapseResults)));
+			} else {
+				this.tree.setChildren(null, this.createResultIterator(collapseResults));
+			}
 		} else {
-			// FileMatch modified, refresh those elements
-			event.elements.forEach(element => {
-				this.tree.setChildren(element, this.createIterator(element, collapseResults));
-				this.tree.rerender(element);
-			});
+			// If updated counts affect our search order, re-sort the view.
+			if (this.searchConfig.sortOrder === 'countAscending' || this.searchConfig.sortOrder === 'countDescending') {
+				this.tree.setChildren(null, this.createResultIterator(collapseResults));
+			} else {
+				// FileMatch modified, refresh those elements
+				event.elements.forEach(element => {
+					this.tree.setChildren(element, this.createIterator(element, collapseResults));
+					this.tree.rerender(element);
+				});
+			}
 		}
 	}
 
@@ -522,9 +543,10 @@ export class SearchView extends ViewPane {
 	}
 
 	private createFolderIterator(folderMatch: FolderMatch, collapseResults: ISearchConfigurationProperties['collapseResults']): Iterator<ITreeElement<RenderableMatch>> {
+		const sortOrder = this.searchConfig.sortOrder;
 		const filesIt = Iterator.fromArray(
 			folderMatch.matches()
-				.sort(searchMatchComparer));
+				.sort((a, b) => searchMatchComparer(a, b, sortOrder)));
 
 		return Iterator.map(filesIt, fileMatch => {
 			const children = this.createFileIterator(fileMatch);
@@ -1692,14 +1714,23 @@ export class SearchView extends ViewPane {
 	}
 
 	private onFilesChanged(e: FileChangesEvent): void {
-		if (!this.viewModel || !e.gotDeleted()) {
+		if (this.searchConfig.sortOrder !== 'modified' && (!this.viewModel || !e.gotDeleted())) {
 			return;
 		}
 
 		const matches = this.viewModel.searchResult.matches();
+		if (e.gotDeleted()) {
+			const deletedMatches = matches.filter(m => e.contains(m.resource, FileChangeType.DELETED));
 
-		const changedMatches = matches.filter(m => e.contains(m.resource, FileChangeType.DELETED));
-		this.viewModel.searchResult.remove(changedMatches);
+			this.viewModel.searchResult.remove(deletedMatches);
+		} else {
+			// Check if the changed file contained matches
+			const changedMatches = matches.filter(m => e.contains(m.resource));
+			if (changedMatches.length && this.searchConfig.sortOrder === 'modified') {
+				// No matches need to be removed, but modified files need to have their file stat updated.
+				this.updateFileStats(changedMatches).then(() => this.refreshTree());
+			}
+		}
 	}
 
 	getActions(): IAction[] {
@@ -1769,6 +1800,28 @@ export class SearchView extends ViewPane {
 		this.searchHistoryService.save(history);
 
 		super.saveState();
+	}
+
+	private async retrieveFileStats(): Promise<void> {
+		for (const fileMatch of this.searchResult.matches()) {
+			if (!fileMatch.fileStat) {
+				await fileMatch.resolveFileStat(this.fileService);
+			}
+		}
+		return Promise.resolve(undefined);
+	}
+
+	private async updateFileStats(elements: FileMatch[]): Promise<void> {
+		for (const fileMatch of elements) {
+			await fileMatch.resolveFileStat(this.fileService);
+		}
+		return Promise.resolve(undefined);
+	}
+
+	private removeFileStats(): void {
+		for (const fileMatch of this.searchResult.matches()) {
+			fileMatch.fileStat = undefined;
+		}
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -20,7 +20,7 @@ import { IModelService } from 'vs/editor/common/services/modelService';
 import { createDecorator, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IProgress, IProgressStep } from 'vs/platform/progress/common/progress';
 import { ReplacePattern } from 'vs/workbench/services/search/common/replace';
-import { IFileMatch, IPatternInfo, ISearchComplete, ISearchProgressItem, ISearchConfigurationProperties, ISearchService, ITextQuery, ITextSearchPreviewOptions, ITextSearchMatch, ITextSearchStats, resultIsMatch, ISearchRange, OneLineRange, ITextSearchContext, ITextSearchResult, SearchSortOrder, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, IPatternInfo, ISearchComplete, ISearchProgressItem, ISearchConfigurationProperties, ISearchService, ITextQuery, ITextSearchPreviewOptions, ITextSearchMatch, ITextSearchStats, resultIsMatch, ISearchRange, OneLineRange, ITextSearchContext, ITextSearchResult, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { overviewRulerFindMatchForeground, minimapFindMatch } from 'vs/platform/theme/common/colorRegistry';
 import { themeColorFromId } from 'vs/platform/theme/common/themeService';
@@ -411,7 +411,6 @@ export class FileMatch extends Disposable implements IFileMatch {
 
 	async resolveFileStat(fileService: IFileService): Promise<void> {
 		this._fileStat = await fileService.resolve(this.resource, { resolveMetadata: true });
-		return Promise.resolve();
 	}
 
 	public get fileStat(): IFileStatWithMetadata | undefined {
@@ -434,7 +433,6 @@ export interface IChangeEvent {
 	elements: FileMatch[];
 	added?: boolean;
 	removed?: boolean;
-	modified?: boolean;
 }
 
 export class FolderMatch extends Disposable {
@@ -645,22 +643,22 @@ export class FolderMatchWithResource extends FolderMatch {
  * Compares instances of the same match type. Different match types should not be siblings
  * and their sort order is undefined.
  */
-export function searchMatchComparer(elementA: RenderableMatch, elementB: RenderableMatch, sortOrder: SearchSortOrder = 'default'): number {
+export function searchMatchComparer(elementA: RenderableMatch, elementB: RenderableMatch, sortOrder: SearchSortOrderConfiguration = SearchSortOrderConfiguration.default): number {
 	if (elementA instanceof FolderMatch && elementB instanceof FolderMatch) {
 		return elementA.index() - elementB.index();
 	}
 
 	if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
 		switch (sortOrder) {
-			case SearchSortOrderConfiguration.COUNT_DESCENDING:
+			case SearchSortOrderConfiguration.countDescending:
 				return elementB.count() - elementA.count();
-			case SearchSortOrderConfiguration.COUNT_ASCENDING:
+			case SearchSortOrderConfiguration.countAscending:
 				return elementA.count() - elementB.count();
-			case SearchSortOrderConfiguration.TYPE:
+			case SearchSortOrderConfiguration.type:
 				return compareFileExtensions(elementA.name(), elementB.name());
-			case SearchSortOrderConfiguration.FILES_ONLY:
+			case SearchSortOrderConfiguration.fileNames:
 				return compareFileNames(elementA.name(), elementB.name());
-			case SearchSortOrderConfiguration.MODIFIED:
+			case SearchSortOrderConfiguration.modified:
 				const fileStatA = elementA.fileStat;
 				const fileStatB = elementB.fileStat;
 				if (fileStatA && fileStatB) {

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -20,7 +20,7 @@ import { IModelService } from 'vs/editor/common/services/modelService';
 import { createDecorator, IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IProgress, IProgressStep } from 'vs/platform/progress/common/progress';
 import { ReplacePattern } from 'vs/workbench/services/search/common/replace';
-import { IFileMatch, IPatternInfo, ISearchComplete, ISearchProgressItem, ISearchConfigurationProperties, ISearchService, ITextQuery, ITextSearchPreviewOptions, ITextSearchMatch, ITextSearchStats, resultIsMatch, ISearchRange, OneLineRange, ITextSearchContext, ITextSearchResult, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, IPatternInfo, ISearchComplete, ISearchProgressItem, ISearchConfigurationProperties, ISearchService, ITextQuery, ITextSearchPreviewOptions, ITextSearchMatch, ITextSearchStats, resultIsMatch, ISearchRange, OneLineRange, ITextSearchContext, ITextSearchResult, SearchSortOrder } from 'vs/workbench/services/search/common/search';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { overviewRulerFindMatchForeground, minimapFindMatch } from 'vs/platform/theme/common/colorRegistry';
 import { themeColorFromId } from 'vs/platform/theme/common/themeService';
@@ -643,22 +643,22 @@ export class FolderMatchWithResource extends FolderMatch {
  * Compares instances of the same match type. Different match types should not be siblings
  * and their sort order is undefined.
  */
-export function searchMatchComparer(elementA: RenderableMatch, elementB: RenderableMatch, sortOrder: SearchSortOrderConfiguration = SearchSortOrderConfiguration.default): number {
+export function searchMatchComparer(elementA: RenderableMatch, elementB: RenderableMatch, sortOrder: SearchSortOrder = SearchSortOrder.Default): number {
 	if (elementA instanceof FolderMatch && elementB instanceof FolderMatch) {
 		return elementA.index() - elementB.index();
 	}
 
 	if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
 		switch (sortOrder) {
-			case SearchSortOrderConfiguration.countDescending:
+			case SearchSortOrder.CountDescending:
 				return elementB.count() - elementA.count();
-			case SearchSortOrderConfiguration.countAscending:
+			case SearchSortOrder.CountAscending:
 				return elementA.count() - elementB.count();
-			case SearchSortOrderConfiguration.type:
+			case SearchSortOrder.Type:
 				return compareFileExtensions(elementA.name(), elementB.name());
-			case SearchSortOrderConfiguration.fileNames:
+			case SearchSortOrder.FileNames:
 				return compareFileNames(elementA.name(), elementB.name());
-			case SearchSortOrderConfiguration.modified:
+			case SearchSortOrder.Modified:
 				const fileStatA = elementA.fileStat;
 				const fileStatB = elementB.fileStat;
 				if (fileStatA && fileStatB) {

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -9,7 +9,7 @@ import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { IFileMatch, ITextSearchMatch, OneLineRange, QueryType } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, ITextSearchMatch, OneLineRange, QueryType, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { FileMatch, Match, searchMatchComparer, SearchResult } from 'vs/workbench/contrib/search/common/searchModel';
@@ -90,9 +90,9 @@ suite('Search - Viewlet', () => {
 		// By default, path < path2
 		assert(searchMatchComparer(fileMatch1, fileMatch2) < 0);
 		// By filenames, foo10 > foo1
-		assert(searchMatchComparer(fileMatch1, fileMatch2, 'filesOnly') > 0);
+		assert(searchMatchComparer(fileMatch1, fileMatch2, SearchSortOrderConfiguration.fileNames) > 0);
 		// By type, bar.a < bar.b
-		assert(searchMatchComparer(fileMatch3, fileMatch4, 'type') < 0);
+		assert(searchMatchComparer(fileMatch3, fileMatch4, SearchSortOrderConfiguration.type) < 0);
 	});
 
 	function aFileMatch(path: string, searchResult?: SearchResult, ...lineMatches: ITextSearchMatch[]): FileMatch {

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -9,7 +9,7 @@ import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { IFileMatch, ITextSearchMatch, OneLineRange, QueryType, SearchSortOrderConfiguration } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, ITextSearchMatch, OneLineRange, QueryType, SearchSortOrder } from 'vs/workbench/services/search/common/search';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { FileMatch, Match, searchMatchComparer, SearchResult } from 'vs/workbench/contrib/search/common/searchModel';
@@ -90,9 +90,9 @@ suite('Search - Viewlet', () => {
 		// By default, path < path2
 		assert(searchMatchComparer(fileMatch1, fileMatch2) < 0);
 		// By filenames, foo10 > foo1
-		assert(searchMatchComparer(fileMatch1, fileMatch2, SearchSortOrderConfiguration.fileNames) > 0);
+		assert(searchMatchComparer(fileMatch1, fileMatch2, SearchSortOrder.FileNames) > 0);
 		// By type, bar.a < bar.b
-		assert(searchMatchComparer(fileMatch3, fileMatch4, SearchSortOrderConfiguration.type) < 0);
+		assert(searchMatchComparer(fileMatch3, fileMatch4, SearchSortOrder.Type) < 0);
 	});
 
 	function aFileMatch(path: string, searchResult?: SearchResult, ...lineMatches: ITextSearchMatch[]): FileMatch {

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -14,6 +14,7 @@ import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace
 import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { FileMatch, Match, searchMatchComparer, SearchResult } from 'vs/workbench/contrib/search/common/searchModel';
 import { TestContextService } from 'vs/workbench/test/workbenchTestServices';
+import { isWindows } from 'vs/base/common/platform';
 
 suite('Search - Viewlet', () => {
 	let instantiation: TestInstantiationService;
@@ -63,9 +64,9 @@ suite('Search - Viewlet', () => {
 	});
 
 	test('Comparer', () => {
-		let fileMatch1 = aFileMatch('C:\\foo');
-		let fileMatch2 = aFileMatch('C:\\with\\path');
-		let fileMatch3 = aFileMatch('C:\\with\\path\\foo');
+		let fileMatch1 = aFileMatch(isWindows ? 'C:\\foo' : '/c/foo');
+		let fileMatch2 = aFileMatch(isWindows ? 'C:\\with\\path' : '/c/with/path');
+		let fileMatch3 = aFileMatch(isWindows ? 'C:\\with\\path\\foo' : '/c/with/path/foo');
 		let lineMatch1 = new Match(fileMatch1, ['bar'], new OneLineRange(0, 1, 1), new OneLineRange(0, 1, 1));
 		let lineMatch2 = new Match(fileMatch1, ['bar'], new OneLineRange(0, 1, 1), new OneLineRange(2, 1, 1));
 		let lineMatch3 = new Match(fileMatch1, ['bar'], new OneLineRange(0, 1, 1), new OneLineRange(2, 1, 1));
@@ -81,10 +82,10 @@ suite('Search - Viewlet', () => {
 	});
 
 	test('Advanced Comparer', () => {
-		let fileMatch1 = aFileMatch('C:\\with\\path\\foo10');
-		let fileMatch2 = aFileMatch('C:\\with\\path2\\foo1');
-		let fileMatch3 = aFileMatch('C:\\with\\path2\\bar.a');
-		let fileMatch4 = aFileMatch('C:\\with\\path2\\bar.b');
+		let fileMatch1 = aFileMatch(isWindows ? 'C:\\with\\path\\foo10' : '/c/with/path/foo10');
+		let fileMatch2 = aFileMatch(isWindows ? 'C:\\with\\path2\\foo1' : '/c/with/path2/foo1');
+		let fileMatch3 = aFileMatch(isWindows ? 'C:\\with\\path2\\bar.a' : '/c/with/path2/bar.a');
+		let fileMatch4 = aFileMatch(isWindows ? 'C:\\with\\path2\\bar.b' : '/c/with/path2/bar.b');
 
 		// By default, path < path2
 		assert(searchMatchComparer(fileMatch1, fileMatch2) < 0);
@@ -96,7 +97,7 @@ suite('Search - Viewlet', () => {
 
 	function aFileMatch(path: string, searchResult?: SearchResult, ...lineMatches: ITextSearchMatch[]): FileMatch {
 		let rawMatch: IFileMatch = {
-			resource: uri.file('C:\\' + path),
+			resource: uri.file(path),
 			results: lineMatches
 		};
 		return instantiation.createInstance(FileMatch, null, null, null, searchResult, rawMatch);

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -80,6 +80,20 @@ suite('Search - Viewlet', () => {
 		assert(searchMatchComparer(lineMatch2, lineMatch3) === 0);
 	});
 
+	test('Advanced Comparer', () => {
+		let fileMatch1 = aFileMatch('C:\\with\\path\\foo10');
+		let fileMatch2 = aFileMatch('C:\\with\\path2\\foo1');
+		let fileMatch3 = aFileMatch('C:\\with\\path2\\bar.a');
+		let fileMatch4 = aFileMatch('C:\\with\\path2\\bar.b');
+
+		// By default, path < path2
+		assert(searchMatchComparer(fileMatch1, fileMatch2) < 0);
+		// By filenames, foo10 > foo1
+		assert(searchMatchComparer(fileMatch1, fileMatch2, 'filesOnly') > 0);
+		// By type, bar.a < bar.b
+		assert(searchMatchComparer(fileMatch3, fileMatch4, 'type') < 0);
+	});
+
 	function aFileMatch(path: string, searchResult?: SearchResult, ...lineMatches: ITextSearchMatch[]): FileMatch {
 		let rawMatch: IFileMatch = {
 			resource: uri.file('C:\\' + path),

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -311,6 +311,17 @@ export class OneLineRange extends SearchRange {
 	}
 }
 
+export const SearchSortOrderConfiguration = {
+	DEFAULT: 'default',
+	FILES_ONLY: 'filesOnly',
+	TYPE: 'type',
+	MODIFIED: 'modified',
+	COUNT_DESCENDING: 'countDescending',
+	COUNT_ASCENDING: 'countAscending'
+};
+
+export type SearchSortOrder = 'default' | 'filesOnly' | 'type' | 'modified' | 'countDescending' | 'countAscending';
+
 export interface ISearchConfigurationProperties {
 	exclude: glob.IExpression;
 	useRipgrep: boolean;
@@ -333,6 +344,7 @@ export interface ISearchConfigurationProperties {
 	searchOnTypeDebouncePeriod: number;
 	enableSearchEditorPreview: boolean;
 	searchEditorPreviewForceAbsolutePaths: boolean;
+	sortOrder: SearchSortOrder;
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -311,13 +311,13 @@ export class OneLineRange extends SearchRange {
 	}
 }
 
-export const enum SearchSortOrderConfiguration {
-	default,
-	fileNames,
-	type,
-	modified,
-	countDescending,
-	countAscending
+export const enum SearchSortOrder {
+	Default = 'default',
+	FileNames = 'fileNames',
+	Type = 'type',
+	Modified = 'modified',
+	CountDescending = 'countDescending',
+	CountAscending = 'countAscending'
 }
 
 export interface ISearchConfigurationProperties {
@@ -342,7 +342,7 @@ export interface ISearchConfigurationProperties {
 	searchOnTypeDebouncePeriod: number;
 	enableSearchEditorPreview: boolean;
 	searchEditorPreviewForceAbsolutePaths: boolean;
-	sortOrder: SearchSortOrderConfiguration;
+	sortOrder: SearchSortOrder;
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -311,16 +311,14 @@ export class OneLineRange extends SearchRange {
 	}
 }
 
-export const SearchSortOrderConfiguration = {
-	DEFAULT: 'default',
-	FILES_ONLY: 'filesOnly',
-	TYPE: 'type',
-	MODIFIED: 'modified',
-	COUNT_DESCENDING: 'countDescending',
-	COUNT_ASCENDING: 'countAscending'
-};
-
-export type SearchSortOrder = 'default' | 'filesOnly' | 'type' | 'modified' | 'countDescending' | 'countAscending';
+export const enum SearchSortOrderConfiguration {
+	default,
+	fileNames,
+	type,
+	modified,
+	countDescending,
+	countAscending
+}
 
 export interface ISearchConfigurationProperties {
 	exclude: glob.IExpression;
@@ -344,7 +342,7 @@ export interface ISearchConfigurationProperties {
 	searchOnTypeDebouncePeriod: number;
 	enableSearchEditorPreview: boolean;
 	searchEditorPreviewForceAbsolutePaths: boolean;
-	sortOrder: SearchSortOrder;
+	sortOrder: SearchSortOrderConfiguration;
 }
 
 export interface ISearchConfiguration extends IFilesConfiguration {


### PR DESCRIPTION
This PR fixes #82352

Added a setting to allow sorting of search results.
Demo:
![wKM1bhwi6K](https://user-images.githubusercontent.com/20613660/70394467-560f2c80-19ed-11ea-88af-4e06018f1caa.gif)

The following are the possible options:

- **default**: As before, sorts by folder path first and then by file name. Uses `compareFileNames` to correct the ordering of numeral files (e.g. file1 is now in front of file10)
- **filesOnly**: Ignore the path name and sort only by file name
- **type**: Sort by extension name (Taken from Explorer sort)
- **modified**: Sort by last modified date (Taken from Explorer sort)
- **countDescending**: Sort by most results per file
- **countAscending**: Sort by least results per file (Should these fallback to name if results match?)

The `modified` sorting is implemented as follows:

- Whenever `refreshTree` is called, we ensure that if the `sortOrder === modified` all `fileMatch` items have a existing `IFileStatWithMetaData`, or it will retrieve it.
- Whenever `onFilesChanged` is called, modified files are retrieved and have their `fileStat` updated.
- Whenever `sortOrder` is set away from `modified`, remove `fileStat` information so it is re-calculated when it is set to `modified again`.

I think this is fair on performance, always tracking all meta-data would be performance intensive.
I'm not sure how I would add tests for the modified/count settings as you would have to set several properties.