### PR TITLE
debug: fix contexts

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -818,7 +818,7 @@ class StopAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(STOP_ID, getContext(this.session));
+		return this.commandService.executeCommand(STOP_ID, undefined, getContext(this.session));
 	}
 }
 
@@ -832,7 +832,7 @@ class DisconnectAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(DISCONNECT_ID, getContext(this.session));
+		return this.commandService.executeCommand(DISCONNECT_ID, undefined, getContext(this.session));
 	}
 }
 
@@ -846,7 +846,7 @@ class RestartAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(RESTART_SESSION_ID, getContext(this.session));
+		return this.commandService.executeCommand(RESTART_SESSION_ID, undefined, getContext(this.session));
 	}
 }
 
@@ -860,7 +860,7 @@ class StepOverAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(STEP_OVER_ID, getContext(this.thread));
+		return this.commandService.executeCommand(STEP_OVER_ID, undefined, getContext(this.thread));
 	}
 }
 
@@ -874,7 +874,7 @@ class StepIntoAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(STEP_INTO_ID, getContext(this.thread));
+		return this.commandService.executeCommand(STEP_INTO_ID, undefined, getContext(this.thread));
 	}
 }
 
@@ -888,7 +888,7 @@ class StepOutAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(STEP_OUT_ID, getContext(this.thread));
+		return this.commandService.executeCommand(STEP_OUT_ID, undefined, getContext(this.thread));
 	}
 }
 
@@ -902,7 +902,7 @@ class PauseAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(PAUSE_ID, getContext(this.thread));
+		return this.commandService.executeCommand(PAUSE_ID, undefined, getContext(this.thread));
 	}
 }
 
@@ -916,6 +916,6 @@ class ContinueAction extends Action {
 	}
 
 	public run(): Promise<any> {
-		return this.commandService.executeCommand(CONTINUE_ID, getContext(this.thread));
+		return this.commandService.executeCommand(CONTINUE_ID, undefined, getContext(this.thread));
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -120,7 +120,7 @@ export function registerCommands(): void {
 	// Same for stackFrame commands and session commands.
 	CommandsRegistry.registerCommand({
 		id: COPY_STACK_TRACE_ID,
-		handler: async (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			const textResourcePropertiesService = accessor.get(ITextResourcePropertiesService);
 			const clipboardService = accessor.get(IClipboardService);
 			let frame = getFrame(accessor.get(IDebugService), context);
@@ -133,21 +133,21 @@ export function registerCommands(): void {
 
 	CommandsRegistry.registerCommand({
 		id: REVERSE_CONTINUE_ID,
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, thread => thread.reverseContinue());
 		}
 	});
 
 	CommandsRegistry.registerCommand({
 		id: STEP_BACK_ID,
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, thread => thread.stepBack());
 		}
 	});
 
 	CommandsRegistry.registerCommand({
 		id: TERMINATE_THREAD_ID,
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, thread => thread.terminate());
 		}
 	});
@@ -206,7 +206,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyMod.Shift | KeyMod.CtrlCmd | KeyCode.F5,
 		when: CONTEXT_IN_DEBUG_MODE,
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			const debugService = accessor.get(IDebugService);
 			let session: IDebugSession | undefined;
 			if (isSessionContext(context)) {
@@ -230,7 +230,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyCode.F10,
 		when: CONTEXT_DEBUG_STATE.isEqualTo('stopped'),
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, (thread: IThread) => thread.next());
 		}
 	});
@@ -240,7 +240,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib + 10, // Have a stronger weight to have priority over full screen when debugging
 		primary: KeyCode.F11,
 		when: CONTEXT_DEBUG_STATE.isEqualTo('stopped'),
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, (thread: IThread) => thread.stepIn());
 		}
 	});
@@ -250,7 +250,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyMod.Shift | KeyCode.F11,
 		when: CONTEXT_DEBUG_STATE.isEqualTo('stopped'),
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, (thread: IThread) => thread.stepOut());
 		}
 	});
@@ -260,7 +260,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyCode.F6,
 		when: CONTEXT_DEBUG_STATE.isEqualTo('running'),
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, thread => thread.pause());
 		}
 	});
@@ -279,7 +279,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyMod.Shift | KeyCode.F5,
 		when: CONTEXT_IN_DEBUG_MODE,
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			const debugService = accessor.get(IDebugService);
 			let session: IDebugSession | undefined;
 			if (isSessionContext(context)) {
@@ -301,7 +301,7 @@ export function registerCommands(): void {
 
 	CommandsRegistry.registerCommand({
 		id: RESTART_FRAME_ID,
-		handler: async (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			const debugService = accessor.get(IDebugService);
 			let frame = getFrame(debugService, context);
 			if (frame) {
@@ -315,7 +315,7 @@ export function registerCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyCode.F5,
 		when: CONTEXT_IN_DEBUG_MODE,
-		handler: (accessor: ServicesAccessor, context: CallStackContext | unknown) => {
+		handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
 			getThreadAndRun(accessor, context, thread => thread.continue());
 		}
 	});


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/86596

@connor4312 can you please look into the changes and approve this if you think it is good and verify the behavior. If we decide this is a candaite I will merge it into the release branch

The changes simply makes sure that for all the actions in the call stack view the internal elaborate context is always passed second.
The string context is important only for extensions - due to historic reasons (we ignore it inside vscode)

To verify:
Start debugging at least two debug sessions and verify all the context menu actions and all the inline actions in the call stack view work as expected.