### PR TITLE
Don't instrument any test code for coverage

### DIFF
--- a/test/coverage.js
+++ b/test/coverage.js
@@ -17,7 +17,7 @@ const REPO_PATH = toUpperDriveLetter(path.join(__dirname, '..'));
 exports.initialize = function (loaderConfig) {
 	const instrumenter = iLibInstrument.createInstrumenter();
 	loaderConfig.nodeInstrumenter = function (contents, source) {
-		if (minimatch(source, '**/test/**/*.test.js')) {
+		if (minimatch(source, '**/test/**')) {
 			// tests don't get instrumented
 			return contents;
 		}


### PR DESCRIPTION
This makes the coverage number more accurate by ignoring anything under a test directory - which includes many non-test.js files that provide other test-specific functionality. 

Coverage without change (includes test classes)

![image](https://user-images.githubusercontent.com/28519865/70458905-f43fd880-1a67-11ea-8c12-b78d2314c0f2.png)


Coverage with change (excludes test classes)

![image](https://user-images.githubusercontent.com/28519865/70458940-04f04e80-1a68-11ea-8924-cc7455ba707a.png)


