### PR TITLE
Remove unnecessary focus inside webview

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -330,11 +330,6 @@ export class ElectronWebviewBasedWebview extends BaseWebview<WebviewTag> impleme
 		if (!this.element) {
 			return;
 		}
-		try {
-			this.element.focus();
-		} catch {
-			// noop
-		}
 		this._send('focus');
 
 		// Handle focus change programmatically (do not rely on event from <webview>)


### PR DESCRIPTION
This PR fixes #84156

I'm not sure about deleting these lines. Deleting them removes all the problems with stealing focus, but I'm pretty sure that calling this function is important for something, but I couldn't get into any issues without this function call.
It would be perfect if someone look into this and tell if this function is needed, and if so, how can we replace it (i _think_ it's a electron function, so we can do nothing about it) so it doesn't steal focus from textboxes.

And maybe deleting this function call is OK, since we have these functions called below?:
```
this._send('focus');
this.handleFocusChange(true);
```
