### PR TITLE
Add Webview css var --vscode-editor-font-size-px

### DIFF
--- a/src/vs/workbench/contrib/webview/common/themeing.ts
+++ b/src/vs/workbench/contrib/webview/common/themeing.ts
@@ -69,6 +69,7 @@ export class WebviewThemeDataProvider extends Disposable {
 			'vscode-editor-font-family': editorFontFamily,
 			'vscode-editor-font-weight': editorFontWeight,
 			'vscode-editor-font-size': editorFontSize,
+			'vscode-editor-font-size-px': `${editorFontSize}px`,
 			...exportedColors
 		};
 


### PR DESCRIPTION
This var is like `--vscode-editor-font-size`, but has `px` appended to it. It enables styling Webviews with the editor font size directtly from css.

I added it as a separate var to avoid breaking existing extensions.

To test it, style something in a Webview with:

```css
font-size: var(--vscode-editor-font-size-px);
```

Then open the Webview and Settings side by side. Change the *Editor Font Size* setting. See that the change directly affect the Webview.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #86722
