### PR TITLE
Debounce on type history entries for "files to include/exclude" fields 

### DIFF
--- a/src/vs/workbench/contrib/search/browser/patternInputWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/patternInputWidget.ts
@@ -164,6 +164,7 @@ export class PatternInputWidget extends Widget {
 	private onInputKeyUp(keyboardEvent: IKeyboardEvent) {
 		switch (keyboardEvent.keyCode) {
 			case KeyCode.Enter:
+				this.onSearchSubmit();
 				this.searchOnTypeDelayer.trigger(() => this._onSubmit.fire(false), 0);
 				return;
 			case KeyCode.Escape:

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1286,9 +1286,11 @@ export class SearchView extends ViewPane {
 	}
 
 	private onQueryTriggered(query: ITextQuery, options: ITextQueryBuilderOptions, excludePatternText: string, includePatternText: string, triggeredOnType: boolean): void {
-		this.addToSearchHistoryDelayer.trigger(() => this.searchWidget.searchInput.onSearchSubmit());
-		this.inputPatternExcludes.onSearchSubmit();
-		this.inputPatternIncludes.onSearchSubmit();
+		this.addToSearchHistoryDelayer.trigger(() => {
+			this.searchWidget.searchInput.onSearchSubmit();
+			this.inputPatternExcludes.onSearchSubmit();
+			this.inputPatternIncludes.onSearchSubmit();
+		});
 
 		this.viewModel.cancelSearch();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #86288

While commit https://github.com/microsoft/vscode/commit/520c9998c3c3b8ffeee697f3b0b982c7826b0cb2 fixed problem with main Search field types in "files to include/exclude" fields still produced a ton of new history entries. This PR make history entries for these fields created on type delayed in the same way as Search field to prevent pollution.

[Alternative implementation](https://github.com/microsoft/vscode/compare/master...IllusionMH:debounce-search-on-type-alternative-86288?expand=1) can be used if there is need to handle immediate history submit in case when `triggeredOnType === false`, but it looks a bit overkill if only one field can be edited at the time and it will save own history entry on <kbd>Enter</kbd>. Other should be already saved (even by timeout) in general case (I doubt that users will <kbd>Tab</kbd> to next field and continue typing so "save" will be delayed for 2 fields at the same time).