### PR TITLE
Add useActiveLanguage option to open new files with the language mode of the active editor

### DIFF
--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -790,6 +790,7 @@ export interface IFilesConfiguration {
 		encoding: string;
 		autoGuessEncoding: boolean;
 		defaultLanguage: string;
+		useActiveLanguage: boolean;
 		trimTrailingWhitespace: boolean;
 		autoSave: string;
 		autoSaveDelay: number;

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -359,7 +359,7 @@ export interface IEditorInput extends IDisposable {
 	getResource(): URI | undefined;
 
 	/**
-	 * Unique type identifier for this inpput.
+	 * Unique type identifier for this input.
 	 */
 	getTypeId(): string;
 

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -327,6 +327,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'string',
 			'description': nls.localize('defaultLanguage', "The default language mode that is assigned to new files.")
 		},
+		'files.useActiveLanguage': {
+			'type': 'boolean',
+			'default': false,
+			'description': 'When available, new files will be assigned the language mode of the currently active editor. Will fallback to files.defaultLanguage if not applicable.'
+		},
 		'files.maxMemoryForLargeFilesMB': {
 			'type': 'number',
 			'default': 4096,

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -576,7 +576,8 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		// Untitled file support
 		const untitledInput = input as IUntitledTextResourceInput;
 		if (untitledInput.forceUntitled || !untitledInput.resource || (untitledInput.resource && untitledInput.resource.scheme === Schemas.untitled)) {
-			return this.untitledTextEditorService.createOrGet(untitledInput.resource, untitledInput.mode, untitledInput.contents, untitledInput.encoding);
+			const activeLanguage = this.activeTextEditorWidget?.getModel()?.getLanguageIdentifier().language || undefined;
+			return this.untitledTextEditorService.createOrGet(untitledInput.resource, untitledInput.mode, untitledInput.contents, untitledInput.encoding, activeLanguage);
 		}
 
 		// Resource Editor Support

--- a/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
+++ b/src/vs/workbench/test/common/editor/untitledTextEditor.test.ts
@@ -234,6 +234,28 @@ suite('Workbench untitled text editors', () => {
 		input.dispose();
 	});
 
+	test('Untitled created with files.useActiveLanguage overrides files.defaultLanguage setting', () => {
+		const activeLanguage = 'typescript';
+		const defaultLanguage = 'javascript';
+		const config = accessor.testConfigurationService;
+		config.setUserConfiguration('files', {
+			'useActiveLanguage': true,
+			'defaultLanguage': defaultLanguage
+		});
+
+		const service = accessor.untitledTextEditorService;
+		const input = service.createOrGet(undefined, undefined, undefined, undefined, activeLanguage);
+
+		assert.equal(input.getMode(), activeLanguage);
+
+		config.setUserConfiguration('files', {
+			'useActiveLanguage': false,
+			'defaultLanguage': undefined
+		});
+
+		input.dispose();
+	});
+
 	test('Untitled created with mode overrides files.defaultLanguage setting', () => {
 		const mode = 'typescript';
 		const defaultLanguage = 'javascript';


### PR DESCRIPTION
This PR fixes #78903

Demo:
![6cZsyC6rvt](https://user-images.githubusercontent.com/20613660/70856465-b57da880-1ed5-11ea-90c7-61c147747d90.gif)

- When editor without language mode or no editor is open, default to files.useActiveLanguage
- If a valid editor is open, new untitled files will open in the same language mode.

This is different to what the issue originally proposed (having a "current" option for files.defaultLanguage), as it allows you to both have a files.defaultLanguage for fall-back and make use of this option.

- Ideally the UntitledEditorService can retrieve the current active TextModel by itself, but not sure how to do that.