### PR TITLE
Fixes incorrect focused element when creating new file/folder and renaming in file explorer

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -83,7 +83,6 @@ export class ExplorerView extends ViewPane {
 	private compressedFocusContext: IContextKey<boolean>;
 	private compressedFocusFirstContext: IContextKey<boolean>;
 	private compressedFocusLastContext: IContextKey<boolean>;
-	private compressedNavigationController: ICompressedNavigationController | undefined;
 
 	// Refresh is needed on the initial explorer open
 	private shouldRefresh = true;
@@ -286,18 +285,17 @@ export class ExplorerView extends ViewPane {
 	getContext(respectMultiSelection: boolean): ExplorerItem[] {
 		let focusedStat: ExplorerItem | undefined;
 
-		if (this.compressedNavigationController) {
-			focusedStat = this.compressedNavigationController.current;
-		} else {
-			const focus = this.tree.getFocus();
-			focusedStat = focus.length ? focus[0] : undefined;
-		}
+		const focus = this.tree.getFocus();
+		focusedStat = focus.length ? focus[0] : undefined;
+
+		const compressedNavigationController = focusedStat && this.renderer.getCompressedNavigationController(focusedStat);
+		focusedStat = compressedNavigationController ? compressedNavigationController.current : focusedStat;
 
 		const selectedStats: ExplorerItem[] = [];
 
 		for (const stat of this.tree.getSelection()) {
 			const controller = this.renderer.getCompressedNavigationController(stat);
-			if (controller && focusedStat && controller === this.compressedNavigationController) {
+			if (controller && focusedStat && controller === compressedNavigationController) {
 				if (stat === focusedStat) {
 					selectedStats.push(stat);
 				}
@@ -532,16 +530,15 @@ export class ExplorerView extends ViewPane {
 			this.resourceMoveableToTrash.reset();
 		}
 
-		this.compressedNavigationController = stat && this.renderer.getCompressedNavigationController(stat);
+		const compressedNavigationController = stat && this.renderer.getCompressedNavigationController(stat);
 
-		if (!this.compressedNavigationController) {
+		if (!compressedNavigationController) {
 			this.compressedFocusContext.set(false);
 			return;
 		}
 
 		this.compressedFocusContext.set(true);
-		// this.compressedNavigationController.last();
-		this.updateCompressedNavigationContextKeys(this.compressedNavigationController);
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
 	}
 
 	// General methods
@@ -691,39 +688,47 @@ export class ExplorerView extends ViewPane {
 	}
 
 	previousCompressedStat(): void {
-		if (!this.compressedNavigationController) {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
 			return;
 		}
 
-		this.compressedNavigationController.previous();
-		this.updateCompressedNavigationContextKeys(this.compressedNavigationController);
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.previous();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
 	}
 
 	nextCompressedStat(): void {
-		if (!this.compressedNavigationController) {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
 			return;
 		}
 
-		this.compressedNavigationController.next();
-		this.updateCompressedNavigationContextKeys(this.compressedNavigationController);
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.next();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
 	}
 
 	firstCompressedStat(): void {
-		if (!this.compressedNavigationController) {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
 			return;
 		}
 
-		this.compressedNavigationController.first();
-		this.updateCompressedNavigationContextKeys(this.compressedNavigationController);
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.first();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
 	}
 
 	lastCompressedStat(): void {
-		if (!this.compressedNavigationController) {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
 			return;
 		}
 
-		this.compressedNavigationController.last();
-		this.updateCompressedNavigationContextKeys(this.compressedNavigationController);
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.last();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
 	}
 
 	private updateCompressedNavigationContextKeys(controller: ICompressedNavigationController): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #87044

The tree could rerender an element and not fire the `onFocusChanged` event making `this.compressedNavigationController` invalid.