### PR TITLE
Add missing documentation to CompletionItem's insertText

### DIFF
--- a/src/vs/editor/common/modes.ts
+++ b/src/vs/editor/common/modes.ts
@@ -436,7 +436,7 @@ export interface CompletionItem {
 	preselect?: boolean;
 	/**
 	 * A string or snippet that should be inserted in a document when selecting
-	 * this completion.
+	 * this completion. When `falsy` the [label](#CompletionItem.label)
 	 * is used.
 	 */
 	insertText: string;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4752,7 +4752,7 @@ declare namespace monaco.languages {
 		preselect?: boolean;
 		/**
 		 * A string or snippet that should be inserted in a document when selecting
-		 * this completion.
+		 * this completion. When `falsy` the [label](#CompletionItem.label)
 		 * is used.
 		 */
 		insertText: string;


### PR DESCRIPTION
If we look at the code in [`vscode.d.ts`](https://github.com/microsoft/vscode/blob/7bb8b0084fa60b9e476ac1140ed187516fa7d1e0/src/vs/vscode.d.ts#L3410-L3415), we can see that the `modes.ts` file is not up-to-date with regards to the `insertText` field in `CompletionItem`. As a result, `monaco.d.ts` also needs an update.