### PR TITLE
separate notification center/notification toast background color

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -11,7 +11,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { NotificationsList } from 'vs/workbench/browser/parts/notifications/notificationsList';
 import { Event } from 'vs/base/common/event';
 import { IWorkbenchLayoutService, Parts } from 'vs/workbench/services/layout/browser/layoutService';
-import { Themable, NOTIFICATIONS_TOAST_BORDER, NOTIFICATIONS_BACKGROUND } from 'vs/workbench/common/theme';
+import { Themable, NOTIFICATIONS_TOAST_BORDER, NOTIFICATIONS_TOAST_BACKGROUND } from 'vs/workbench/common/theme';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { widgetShadow } from 'vs/platform/theme/common/colorRegistry';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
@@ -421,15 +421,19 @@ export class NotificationsToasts extends Themable {
 
 	protected updateStyles(): void {
 		this.mapNotificationToToast.forEach(t => {
-			const backgroundColor = this.getColor(NOTIFICATIONS_BACKGROUND);
-			t.toast.style.background = backgroundColor ? backgroundColor : '';
-
 			const widgetShadowColor = this.getColor(widgetShadow);
 			t.toast.style.boxShadow = widgetShadowColor ? `0 0px 8px ${widgetShadowColor}` : '';
 
 			const borderColor = this.getColor(NOTIFICATIONS_TOAST_BORDER);
 			t.toast.style.border = borderColor ? `1px solid ${borderColor}` : '';
 		});
+
+		document.querySelectorAll('.notification-toast-container .monaco-list-rows')
+			.forEach((element: HTMLElement) => {
+				const backgroundColor = this.getColor(NOTIFICATIONS_TOAST_BACKGROUND);
+				element.style.background = backgroundColor ? backgroundColor : '';
+			}
+		);
 	}
 
 	private getToasts(state: ToastVisibility): INotificationToast[] {

--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -433,7 +433,7 @@ export class NotificationsToasts extends Themable {
 				const backgroundColor = this.getColor(NOTIFICATIONS_TOAST_BACKGROUND);
 				element.style.background = backgroundColor ? backgroundColor : '';
 			}
-		);
+			);
 	}
 
 	private getToasts(state: ToastVisibility): INotificationToast[] {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -551,7 +551,13 @@ export const NOTIFICATIONS_BACKGROUND = registerColor('notifications.background'
 	dark: editorWidgetBackground,
 	light: editorWidgetBackground,
 	hc: editorWidgetBackground
-}, nls.localize('notificationsBackground', "Notifications background color. Notifications slide in from the bottom right of the window."));
+}, nls.localize('notificationsBackground', "Notification Center background color. Notifications shown as a list in the bottom right of the window."));
+
+export const NOTIFICATIONS_TOAST_BACKGROUND = registerColor('notificationsToast.background', {
+	dark: editorWidgetBackground,
+	light: editorWidgetBackground,
+	hc: editorWidgetBackground
+}, nls.localize('notificationsToastBackground', "Notification Toast background color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_LINKS = registerColor('notificationLink.foreground', {
 	dark: textLinkForeground,
@@ -566,9 +572,9 @@ export const NOTIFICATIONS_CENTER_HEADER_FOREGROUND = registerColor('notificatio
 }, nls.localize('notificationCenterHeaderForeground', "Notifications center header foreground color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_CENTER_HEADER_BACKGROUND = registerColor('notificationCenterHeader.background', {
-	dark: lighten(NOTIFICATIONS_BACKGROUND, 0.3),
-	light: darken(NOTIFICATIONS_BACKGROUND, 0.05),
-	hc: NOTIFICATIONS_BACKGROUND
+	dark: lighten(editorWidgetBackground, 0.3),
+	light: darken(editorWidgetBackground, 0.05),
+	hc: editorWidgetBackground
 }, nls.localize('notificationCenterHeaderBackground', "Notifications center header background color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_BORDER = registerColor('notifications.border', {

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -551,12 +551,12 @@ export const NOTIFICATIONS_BACKGROUND = registerColor('notifications.background'
 	dark: editorWidgetBackground,
 	light: editorWidgetBackground,
 	hc: editorWidgetBackground
-}, nls.localize('notificationsBackground', "Notification Center background color. Notifications shown as a list in the bottom right of the window."));
+}, nls.localize('notificationsBackground', "Notification background color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_TOAST_BACKGROUND = registerColor('notificationsToast.background', {
-	dark: editorWidgetBackground,
-	light: editorWidgetBackground,
-	hc: editorWidgetBackground
+	dark: NOTIFICATIONS_BACKGROUND,
+	light: NOTIFICATIONS_BACKGROUND,
+	hc: NOTIFICATIONS_BACKGROUND
 }, nls.localize('notificationsToastBackground', "Notification Toast background color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_LINKS = registerColor('notificationLink.foreground', {
@@ -572,9 +572,9 @@ export const NOTIFICATIONS_CENTER_HEADER_FOREGROUND = registerColor('notificatio
 }, nls.localize('notificationCenterHeaderForeground', "Notifications center header foreground color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_CENTER_HEADER_BACKGROUND = registerColor('notificationCenterHeader.background', {
-	dark: lighten(editorWidgetBackground, 0.3),
-	light: darken(editorWidgetBackground, 0.05),
-	hc: editorWidgetBackground
+	dark: lighten(NOTIFICATIONS_BACKGROUND, 0.3),
+	light: darken(NOTIFICATIONS_BACKGROUND, 0.05),
+	hc: NOTIFICATIONS_BACKGROUND
 }, nls.localize('notificationCenterHeaderBackground', "Notifications center header background color. Notifications slide in from the bottom right of the window."));
 
 export const NOTIFICATIONS_BORDER = registerColor('notifications.border', {


### PR DESCRIPTION
This PR fixes #85588 

Provides more customizable notification background coloring. This PR creates a new color called `notificationsToast.background` so notification toast can be customized separate from `notifications.background`. If `notificationsToast.background` is not set, the notification toast is use the color from `notifications.background`.

@Jabor047 would like further color customization such that onHover and onSelected background colors are changed as well, however, I couldn't think of an easy way of implementing this since it is implemented using CSS :hover :focus which cannot be changed using javascript. Please advise here.

----------------
Testing: Suggest to use extension called `Notification Tester`, edit settings.json for user and add properties like
```
{
	"workbench.colorCustomizations": {
		"notifications.background": ...,
                 "notificationsToast.background": ...
	}
}
```

