### PR TITLE
Removed a circular dependency between remote.ts and tunnelView.ts...

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/forwardedPortsViewEnabled.ts
+++ b/src/vs/workbench/contrib/remote/browser/forwardedPortsViewEnabled.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+
+export const forwardedPortsViewEnabled = new RawContextKey<boolean>('forwardedPortsViewEnabled', false);
+

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -17,7 +17,7 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { FilterViewPaneContainer } from 'vs/workbench/browser/parts/views/viewsViewlet';
 import { VIEWLET_ID, VIEW_CONTAINER } from 'vs/workbench/contrib/remote/common/remote.contribution';
-import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IViewDescriptor, IViewsRegistry, Extensions } from 'vs/workbench/common/views';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
@@ -44,6 +44,7 @@ import { isStringArray } from 'vs/base/common/types';
 import { IRemoteExplorerService, HelpInformation } from 'vs/workbench/services/remote/common/remoteExplorerService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { startsWith } from 'vs/base/common/strings';
+import { forwardedPortsViewEnabled } from 'vs/workbench/contrib/remote/browser/forwardedPortsViewEnabled';
 import { TunnelPanelDescriptor, TunnelViewModel } from 'vs/workbench/contrib/remote/browser/tunnelView';
 import { IAddedViewDescriptorRef } from 'vs/workbench/browser/parts/views/views';
 import { ViewPane } from 'vs/workbench/browser/parts/views/viewPaneContainer';
@@ -288,7 +289,8 @@ export class RemoteViewlet extends Viewlet {
 	}
 }
 
-export const forwardedPortsViewEnabled = new RawContextKey<boolean>('forwardedPortsViewEnabled', false);
+//Moved to forwardedPortsViewEnabled.ts to avoid circular reference: remote <-> tunnelView
+//export const forwardedPortsViewEnabled = new RawContextKey<boolean>('forwardedPortsViewEnabled', false);
 
 export class RemoteViewPaneContainer extends FilterViewPaneContainer {
 	private actions: IAction[] | undefined;

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -37,7 +37,10 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { URI } from 'vs/base/common/uri';
-import { forwardedPortsViewEnabled } from 'vs/workbench/contrib/remote/browser/remote';
+
+//Avoid circular reference
+//import { forwardedPortsViewEnabled } from 'vs/workbench/contrib/remote/browser/remote';
+import { forwardedPortsViewEnabled } from 'vs/workbench/contrib/remote/browser/forwardedPortsViewEnabled';
 
 class TunnelTreeVirtualDelegate implements IListVirtualDelegate<ITunnelItem> {
 	getHeight(element: ITunnelItem): number {


### PR DESCRIPTION
... in directory "vs/workbench/contrib/remote/browser/", which was producing a compile-time error.
Moved a single variable declaration from remote.ts to a new file called
forwardedPortsViewEnabled.ts
