### PR TITLE
87229: Show the count of selected lines in code editor

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -552,6 +552,10 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 
 		if (info.selections.length === 1) {
 			if (info.charactersSelected) {
+
+				// Compute number of lines selected.
+				let selectedNumberOfLines = (info.selections[0].endLineNumber - info.selections[0].startLineNumber + 1);
+
 				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected);
 			}
 

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -134,6 +134,7 @@ function toEditorWithModeSupport(input: IEditorInput): IModeSupport | null {
 interface IEditorSelectionStatus {
 	selections?: Selection[];
 	charactersSelected?: number;
+	selectedNumberOfLines ?: number;
 }
 
 class StateChange {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -268,7 +268,7 @@ class State {
 	}
 }
 
-const nlsSingleSelectionRange = nls.localize('singleSelectionRange', "Ln {0}, Col {1} ({2} selected)");
+const nlsSingleSelectionRange = nls.localize('singleSelectionRange', "Ln {0}, Col {1} (Selected {2} | {3})");
 const nlsSingleSelection = nls.localize('singleSelection', "Ln {0}, Col {1}");
 const nlsMultiSelectionRange = nls.localize('multiSelectionRange', "{0} selections ({1} characters selected)");
 const nlsMultiSelection = nls.localize('multiSelection', "{0} selections");
@@ -556,7 +556,7 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 				// Compute number of lines selected.
 				let selectedNumberOfLines = (info.selections[0].endLineNumber - info.selections[0].startLineNumber + 1);
 
-				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected);
+				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected, selectedNumberOfLines);
 			}
 
 			return format(nlsSingleSelection, info.selections[0].positionLineNumber, info.selections[0].positionColumn);

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -134,7 +134,7 @@ function toEditorWithModeSupport(input: IEditorInput): IModeSupport | null {
 interface IEditorSelectionStatus {
 	selections?: Selection[];
 	charactersSelected?: number;
-	selectedNumberOfLines ?: number;
+	selectedNumberOfLines?: number;
 }
 
 class StateChange {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -554,9 +554,9 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 			if (info.charactersSelected) {
 
 				// Compute number of lines selected.
-				let selectedNumberOfLines = (info.selections[0].endLineNumber - info.selections[0].startLineNumber + 1);
+				info.selectedNumberOfLines = (info.selections[0].endLineNumber - info.selections[0].startLineNumber + 1);
 
-				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected, selectedNumberOfLines);
+				return format(nlsSingleSelectionRange, info.selections[0].positionLineNumber, info.selections[0].positionColumn, info.charactersSelected, info.selectedNumberOfLines);
 			}
 
 			return format(nlsSingleSelection, info.selections[0].positionLineNumber, info.selections[0].positionColumn);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #87229 

Now user can see selected number of lines in status bar, along with ln, cn, selected characters.
eg.  **Ln** 19, **Col** 12 (**Selected** 14 | 2) 
 **Ln:** current cursor line number
**Col:** current cursor column number
**Selected:** selected characters | selected number of lines