### PR TITLE
fix: add 'allow-forms' to sandbox attribute.

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -61,7 +61,7 @@ export class IFrameWebview extends BaseWebview<HTMLIFrameElement> implements Web
 	protected createElement(options: WebviewOptions) {
 		const element = document.createElement('iframe');
 		element.className = `webview ${options.customClasses || ''}`;
-		element.sandbox.add('allow-scripts', 'allow-same-origin');
+		element.sandbox.add('allow-scripts', 'allow-same-origin', 'allow-forms');
 		element.setAttribute('src', `${this.externalEndpoint}/index.html?id=${this.id}`);
 		element.style.border = 'none';
 		element.style.width = '100%';


### PR DESCRIPTION
Extensions like "mtxr.sqltools" using form to update configuration, this patch will help them to work with the VS Online Web Edition.

This PR fixes https://github.com/mtxr/vscode-sqltools/issues/469