### PR TITLE
Correct explorer opening & add ctrl double click support

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -655,11 +655,20 @@ export class MouseController<T> implements IDisposable {
 		} else if (this.isSelectionSingleChangeEvent(e)) {
 			const selection = this.list.getSelection();
 			const newSelection = selection.filter(i => i !== focus);
+			const isCtrlDoubleClick = selection.indexOf(focus) !== -1 &&
+				e.browserEvent instanceof MouseEvent &&
+				e.browserEvent.ctrlKey &&
+				e.browserEvent.detail === 2;
 
 			this.list.setFocus([focus]);
 
-			if (selection.length === newSelection.length) {
-				this.list.setSelection([...newSelection, focus], e.browserEvent);
+			// On Ctrl + double click, do not modify selection but trigger a side-open
+			if (isCtrlDoubleClick) {
+				this.list.open([focus], e.browserEvent);
+			}
+			else if (selection.length === newSelection.length) {
+				// The open service will take the first selection element, so insert focus at the start.
+				this.list.setSelection([focus, ...newSelection], e.browserEvent);
 			} else {
 				this.list.setSelection(newSelection, e.browserEvent);
 			}

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -733,7 +733,7 @@ export class TreeResourceNavigator2<T, TFilterData> extends Disposable {
 		}
 	}
 
-	private onSelection(e: ITreeEvent<T | null> | ITreeMouseEvent<T | null>, doubleClick = false): void {
+	private onSelection(e: ITreeEvent<T | null> | ITreeMouseEvent<T | null>): void {
 		if (!e.browserEvent || e.browserEvent.type === 'contextmenu') {
 			return;
 		}
@@ -741,11 +741,13 @@ export class TreeResourceNavigator2<T, TFilterData> extends Disposable {
 		const isKeyboardEvent = e.browserEvent instanceof KeyboardEvent;
 		const isMiddleClick = e.browserEvent instanceof MouseEvent ? e.browserEvent.button === 1 : false;
 		const isDoubleClick = e.browserEvent.detail === 2;
+		const isCtrlDoubleClick = e.browserEvent instanceof MouseEvent && e.browserEvent.ctrlKey && isDoubleClick;
 		const preserveFocus = (e.browserEvent instanceof KeyboardEvent && typeof (<SelectionKeyboardEvent>e.browserEvent).preserveFocus === 'boolean') ?
 			!!(<SelectionKeyboardEvent>e.browserEvent).preserveFocus :
-			!isDoubleClick;
+			isCtrlDoubleClick || !isDoubleClick;
+		const selection = this.tree.getSelection();
 
-		if (this.tree.openOnSingleClick || isDoubleClick || isKeyboardEvent) {
+		if ((selection.length === 1 && (this.tree.openOnSingleClick || isDoubleClick)) || isCtrlDoubleClick || isKeyboardEvent) {
 			const sideBySide = e.browserEvent instanceof MouseEvent && (e.browserEvent.ctrlKey || e.browserEvent.metaKey || e.browserEvent.altKey);
 			this.open(preserveFocus, isDoubleClick || isMiddleClick, sideBySide, e.browserEvent);
 		}

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -412,18 +412,19 @@ export class ExplorerView extends ViewPane {
 		this._register(explorerNavigator);
 		// Open when selecting via keyboard
 		this._register(explorerNavigator.onDidOpenResource(async e => {
-			const selection = this.tree.getSelection();
+			const element = e.element;
 			// Do not react if the user is expanding selection via keyboard.
+			// Do not react if the user is expanding selection via shift+click
 			// Check if the item was previously also selected, if yes the user is simply expanding / collapsing current selection #66589.
-			const shiftDown = e.browserEvent instanceof KeyboardEvent && e.browserEvent.shiftKey;
-			if (selection.length === 1 && !shiftDown) {
-				if (selection[0].isDirectory || this.explorerService.isEditable(undefined)) {
+			const shiftDown = (e.browserEvent instanceof KeyboardEvent || e.browserEvent instanceof MouseEvent) && e.browserEvent.shiftKey;
+			if (element && !shiftDown) {
+				if (element.isDirectory || this.explorerService.isEditable(undefined)) {
 					// Do not react if user is clicking on explorer items while some are being edited #70276
 					// Do not react if clicking on directories
 					return;
 				}
 				this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: 'workbench.files.openFile', from: 'explorer' });
-				await this.editorService.openEditor({ resource: selection[0].resource, options: { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned } }, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
+				await this.editorService.openEditor({ resource: element.resource, options: { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned } }, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
 			}
 		}));
 


### PR DESCRIPTION
This PR fixes #87082 
@isidorn 
This PR consists of:

- Re-introducing [this](https://github.com/microsoft/vscode/commit/8b91600b08f5d88ba9d79785a7014c67f492629a) commit to respect the element that is passed in, instead of taking the first one from the selection.
- The above change was pushed and reverted by @isidorn as other parts of the code relied on the function catching incorrect opens with the `length === 1` check. The additional changes remedy that.
- Adding a shift-check for MouseEvent in `onDidOpenResource` such that opens are not triggered by shift-click selecting.
- Moving `focus` to be the first index in `setSelection` as `onSelection` always takes the first index, (This could also be changed to be last), as otherwise the first selected file is always the one incorrectly opened, as reported by #87082 
- Only triggering an `open` inside `onSelection` through a single click or double click when there is only one item in the selection, to prevent unnecessary calls.
- Adding the (somewhat hacky) ability to open a file to the side using Ctrl + double click, when you already have other files selected and want to keep the selection.
- This currently opens files to the side in _non-preview_ mode, which may not be wanted. This could be remedied by setting `doubleClick` to false again after `isCtrlDoubleClick` is true
