### PR TITLE
87180: Wrong Markdown preview format for files in UNC path

### DIFF
--- a/src/vs/workbench/contrib/webview/common/resourceLoader.ts
+++ b/src/vs/workbench/contrib/webview/common/resourceLoader.ts
@@ -104,5 +104,5 @@ function containsResource(root: URI, resource: URI): boolean {
 		resourceFsPath = resourceFsPath.toLowerCase();
 	}
 
-	return startsWith(resource.fsPath, rootPath);
+	return startsWith(resourceFsPath, rootPath);
 }


### PR DESCRIPTION
Fixing a typo in the code to fix this issue.

This PR fixes #87180
