### PR TITLE
Remove scheme restriction for Markdown/Emmet language features

### DIFF
--- a/extensions/emmet/src/extension.ts
+++ b/extensions/emmet/src/extension.ts
@@ -165,7 +165,7 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
 			completionProvidersMapping.delete(language);
 		}
 
-		const provider = vscode.languages.registerCompletionItemProvider([{ language }], completionProvider, ...LANGUAGE_MODES[includedLanguages[language]]);
+		const provider = vscode.languages.registerCompletionItemProvider({ language, scheme: '*' }, completionProvider, ...LANGUAGE_MODES[includedLanguages[language]]);
 		context.subscriptions.push(provider);
 
 		languageMappingForCompletionProviders.set(language, includedLanguages[language]);
@@ -174,7 +174,7 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
 
 	Object.keys(LANGUAGE_MODES).forEach(language => {
 		if (!languageMappingForCompletionProviders.has(language)) {
-			const provider = vscode.languages.registerCompletionItemProvider([{ language }], completionProvider, ...LANGUAGE_MODES[language]);
+			const provider = vscode.languages.registerCompletionItemProvider({ language, scheme: '*' }, completionProvider, ...LANGUAGE_MODES[language]);
 			context.subscriptions.push(provider);
 
 			languageMappingForCompletionProviders.set(language, language);

--- a/extensions/emmet/src/extension.ts
+++ b/extensions/emmet/src/extension.ts
@@ -165,7 +165,7 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
 			completionProvidersMapping.delete(language);
 		}
 
-		const provider = vscode.languages.registerCompletionItemProvider([{ language, scheme: 'file' }, { language, scheme: 'untitled' }], completionProvider, ...LANGUAGE_MODES[includedLanguages[language]]);
+		const provider = vscode.languages.registerCompletionItemProvider([{ language }], completionProvider, ...LANGUAGE_MODES[includedLanguages[language]]);
 		context.subscriptions.push(provider);
 
 		languageMappingForCompletionProviders.set(language, includedLanguages[language]);
@@ -174,7 +174,7 @@ function registerCompletionProviders(context: vscode.ExtensionContext) {
 
 	Object.keys(LANGUAGE_MODES).forEach(language => {
 		if (!languageMappingForCompletionProviders.has(language)) {
-			const provider = vscode.languages.registerCompletionItemProvider([{ language, scheme: 'file' }, { language, scheme: 'untitled' }], completionProvider, ...LANGUAGE_MODES[language]);
+			const provider = vscode.languages.registerCompletionItemProvider([{ language }], completionProvider, ...LANGUAGE_MODES[language]);
 			context.subscriptions.push(provider);
 
 			languageMappingForCompletionProviders.set(language, language);

--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -49,9 +49,7 @@ function registerMarkdownLanguageFeatures(
 	symbolProvider: MDDocumentSymbolProvider,
 	engine: MarkdownEngine
 ): vscode.Disposable {
-	const selector: vscode.DocumentSelector = [
-		{ language: 'markdown' }
-	];
+	const selector: vscode.DocumentSelector = { language: 'markdown', scheme: '*' };
 
 	const charPattern = '(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})';
 

--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -50,8 +50,7 @@ function registerMarkdownLanguageFeatures(
 	engine: MarkdownEngine
 ): vscode.Disposable {
 	const selector: vscode.DocumentSelector = [
-		{ language: 'markdown', scheme: 'file' },
-		{ language: 'markdown', scheme: 'untitled' }
+		{ language: 'markdown' }
 	];
 
 	const charPattern = '(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})';


### PR DESCRIPTION
This PR simply removes the scheme restriction from the Markdown and Emmet extension's language features. This allows these features to apply to virtual file systems (e.g. [GistPad](https://aka.ms/gistpad), in addition to just local files and untitled files. I tested all of these features in local files, non-file based files, as well as within a Live Share session, and everything works as expected 👍 

Fixed #87859

// CC @mattbierner 