### PR TITLE
Correct LocationLink link syntax

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -2318,7 +2318,7 @@ declare module 'vscode' {
 
 	/**
 	 * The declaration of a symbol representation as one or many [locations](#Location)
-	 * or [location links][#LocationLink].
+	 * or [location links](#LocationLink).
 	 */
 	export type Declaration = Location | Location[] | LocationLink[];
 


### PR DESCRIPTION
This PR fixes #87559 

Before:
![Code_2019-12-23_21-25-51](https://user-images.githubusercontent.com/20613660/71381395-4ab22880-25cb-11ea-8d3c-e7734442ebd4.png)

After:
![Code_2019-12-23_21-26-02](https://user-images.githubusercontent.com/20613660/71381398-4e45af80-25cb-11ea-884c-132a4faa17a2.png)

Which goes to:
![Code_2019-12-23_21-26-58](https://user-images.githubusercontent.com/20613660/71381402-53a2fa00-25cb-11ea-9e56-b582f8a7a523.png)

