### PR TITLE
Add CompletionItem conversion for additionalTextEdits

### DIFF
--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -417,7 +417,7 @@ export class ExtHostApiCommands {
 		};
 		return this._commands.executeCommand<modes.CompletionList>('_executeCompletionItemProvider', args).then(result => {
 			if (result) {
-				const items = result.suggestions.map(suggestion => typeConverters.CompletionItem.to(suggestion));
+				const items = result.suggestions.map(suggestion => typeConverters.CompletionItem.to(suggestion, this._commands.converter));
 				return new types.CompletionList(items, result.incomplete);
 			}
 			return undefined;


### PR DESCRIPTION
This PR fixes #87346 
Running the sample repo,
Before:
```
dantup
undefined
```
After:
![Code_-_OSS_2019-12-24_00-00-09](https://user-images.githubusercontent.com/20613660/71413737-7ecd2e00-264b-11ea-8cfd-a00886b8c31b.png)

