### PR TITLE
Question icon support for Dialog

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.ts
+++ b/src/vs/base/browser/ui/dialog/dialog.ts
@@ -215,9 +215,11 @@ export class Dialog extends Disposable {
 				case 'pending':
 					addClasses(this.iconElement, 'codicon-loading', 'codicon-animation-spin');
 					break;
+				case 'question':
+					addClass(this.iconElement, 'codicon-question');
+					break;
 				case 'none':
 				case 'info':
-				case 'question':
 				default:
 					addClass(this.iconElement, 'codicon-info');
 					break;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

I reviewed the code of the dialog component and found a misleading code. In the switch structure that judges the type of the icon, the icon of the question type is displayed as the info type. I think this is unreasonable. This usually misleads the developer, and there is no document to explain the reason for this.
```typescript                               
case 'none':
case 'info':
case 'question':
default:
    addClass(this.iconElement, 'codicon-info');
    break;
```
This PR fixes the problem that info icon is displayed in question type and the question icon is set to  `codicon-question`
