### PR TITLE
WIP: File nesting support

### DIFF
--- a/src/vs/base/browser/ui/tree/tree.ts
+++ b/src/vs/base/browser/ui/tree/tree.ts
@@ -173,6 +173,12 @@ export interface IAsyncDataSource<TInput, T> {
 	getChildren(element: TInput | T): T[] | Promise<T[]>;
 }
 
+type IGroupingRule<T> = (parent: T, siblings: T[]) => T[] | null;
+
+export interface IGroupingAsyncDataStore<TInput, T> extends IAsyncDataSource<TInput, T> {
+	groupingRules: IGroupingRule<T>[];
+}
+
 export const enum TreeDragOverBubble {
 	Down,
 	Up

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -29,7 +29,7 @@ import { DelayedDragHandler } from 'vs/base/browser/dnd';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { ILabelService } from 'vs/platform/label/common/label';
-import { ExplorerDelegate, ExplorerDataSource, FilesRenderer, ICompressedNavigationController, FilesFilter, FileSorter, FileDragAndDrop, ExplorerCompressionDelegate, isCompressedFolderName } from 'vs/workbench/contrib/files/browser/views/explorerViewer';
+import { ExplorerDelegate, ExplorerDataSource, FilesRenderer, ICompressedNavigationController, FilesFilter, FileSorter, FileDragAndDrop, ExplorerCompressionDelegate, isCompressedFolderName, GroupingExplorerDataSourceWrapper } from 'vs/workbench/contrib/files/browser/views/explorerViewer';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { ITreeContextMenuEvent } from 'vs/base/browser/ui/tree/tree';
@@ -370,7 +370,7 @@ export class ExplorerView extends ViewPane {
 		const isCompressionEnabled = () => this.configurationService.getValue<boolean>('explorer.compactFolders');
 
 		this.tree = this.instantiationService.createInstance<typeof WorkbenchCompressibleAsyncDataTree, WorkbenchCompressibleAsyncDataTree<ExplorerItem | ExplorerItem[], ExplorerItem, FuzzyScore>>(WorkbenchCompressibleAsyncDataTree, 'FileExplorer', container, new ExplorerDelegate(), new ExplorerCompressionDelegate(), [this.renderer],
-			this.instantiationService.createInstance(ExplorerDataSource), {
+			new GroupingExplorerDataSourceWrapper(this.instantiationService.createInstance(ExplorerDataSource)), {
 			compressionEnabled: isCompressionEnabled(),
 			accessibilityProvider: this.renderer,
 			ariaLabel: nls.localize('treeAriaLabel', "Files Explorer"),

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -253,6 +253,16 @@ export class ExplorerItem {
 		this.children.set(this.getPlatformAwareName(child.name), child);
 	}
 
+	/**
+	 * Adds a child element to this folder/file, preserving original parent.
+	 * TODO: Protect them from rewrites?
+	 */
+	addChildNoRewrite(child: ExplorerItem): void {
+		child._parent = this._parent;
+		child.updateResource(false);
+		this.children.set(this.getPlatformAwareName(child.name), child);
+	}
+
 	getChild(name: string): ExplorerItem | undefined {
 		return this.children.get(this.getPlatformAwareName(name));
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->
Basic support for file nesting

This PR fixes #6328 

To be done: 
- [ ] Configuration (Currently contains hardcoded grouping for suffixes (a.js, a.js.map) and typescript generated files (a.ts, a.js))
- [ ] Sanity checks (Bad grouping function can cause files to dissapear from tree view)
- [ ] Breadcrumbs support
- [ ] File tree updates handling
- [ ] Tests, maybe?

Before:
![изображение](https://user-images.githubusercontent.com/6235312/71534794-086a4d80-2923-11ea-8137-999c718e640a.png)

After:
![изображение](https://user-images.githubusercontent.com/6235312/71534756-c7723900-2922-11ea-8888-fa46820101f6.png)