### PR TITLE
Update dependency 'opn' to 'open'

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "mkdirp": "^0.5.0",
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.17.0",
-    "opn": "^6.0.0",
+    "open": "^7.0.0",
     "optimist": "0.3.5",
     "p-all": "^1.0.0",
     "pump": "^1.0.1",

--- a/scripts/code-web.js
+++ b/scripts/code-web.js
@@ -12,7 +12,7 @@ const url = require('url');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
-const opn = require('opn');
+const open = require('open');
 const minimist = require('vscode-minimist');
 
 const APP_ROOT = path.dirname(__dirname);
@@ -271,5 +271,5 @@ async function serveFile(req, res, filePath, responseHeaders = Object.create(nul
 }
 
 if (args.launch !== false) {
-	opn(`${SCHEME}://${HOST}:${PORT}`);
+	open(`${SCHEME}://${HOST}:${PORT}`);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4769,10 +4769,10 @@ is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
-  integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+is-wsl@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 is@^3.1.0, is@^3.2.1:
   version "3.2.1"
@@ -6239,12 +6239,12 @@ oniguruma@^7.2.0:
   dependencies:
     nan "^2.14.0"
 
-opn@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
-  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
+open@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.0.tgz#7e52999b14eb73f90f0f0807fe93897c4ae73ec9"
+  integrity sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==
   dependencies:
-    is-wsl "^1.1.0"
+    is-wsl "^2.1.0"
 
 optimist@0.3.5:
   version "0.3.5"


### PR DESCRIPTION
As stated in https://www.npmjs.com/package/opn, the opn package is deprecated and should be replaced with 'open'.

This PR replaces and updates the dependency.