### PR TITLE
Fix list service of TreeView mishandled in block for FileExplorer 

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -57,7 +57,7 @@ export function getMultiSelectedResources(resource: URI | object | undefined, li
 	const list = listService.lastFocusedList;
 	if (list?.getHTMLElement() === document.activeElement) {
 		// Explorer
-		if (list instanceof AsyncDataTree) {
+		if (list instanceof AsyncDataTree && list.getFocus().every(item => item instanceof ExplorerItem)) {
 			// Explorer
 			const context = explorerService.getContext(true);
 			if (context.length) {


### PR DESCRIPTION
This PR fixes #87804.

Though `getMultiSelectedResources` will be deprecated as described in #86268, this PR may add some cases for not breaking current behaviors when it gets removed.

There's a further scenario where `getMultiSelectedResources` will return a wrong resource:
1. An extension adds a command to ExplorerItem's right click context.
2. The command handler invokes `revealFileInOS`, but providing a uri different from selected file
3. `getMultiSelectedResources` will still return selected file's uri, not the uri desired by the extension.

But this scenario seems so rare, so not included in this PR, just for a testcase when removing `getMultiSelectedResources`.