### PR TITLE
Action commands to open settings/keybindings editor support query as argument

### DIFF
--- a/src/vs/workbench/common/actions.ts
+++ b/src/vs/workbench/common/actions.ts
@@ -113,7 +113,7 @@ Registry.add(Extensions.WorkbenchActions, new class implements IWorkbenchActionR
 		// otherwise run and dispose
 		try {
 			const from = args?.from || 'keybinding';
-			await actionInstance.run(undefined, { from });
+			await actionInstance.run(args, { from });
 		} finally {
 			actionInstance.dispose();
 		}

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -15,7 +15,6 @@ import { KeybindingLabel } from 'vs/base/browser/ui/keybindingLabel/keybindingLa
 import { IAction, Action } from 'vs/base/common/actions';
 import { ActionBar, Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
-import { EditorOptions } from 'vs/workbench/common/editor';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { KeybindingsEditorModel, IKeybindingItemEntry, IListEntry, KEYBINDING_ENTRY_TEMPLATE_ID } from 'vs/workbench/services/preferences/common/keybindingsEditorModel';
@@ -40,6 +39,7 @@ import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { WorkbenchList } from 'vs/platform/list/browser/listService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { KeybindingsEditorInput } from 'vs/workbench/services/preferences/common/preferencesEditorInput';
+import { SettingsEditorOptions } from 'vs/workbench/services/preferences/common/preferences';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { attachStylerCallback, attachInputBoxStyler } from 'vs/platform/theme/common/styler';
 import { IStorageService } from 'vs/platform/storage/common/storage';
@@ -135,10 +135,16 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor 
 		this.createBody(keybindingsEditorElement);
 	}
 
-	setInput(input: KeybindingsEditorInput, options: EditorOptions | undefined, token: CancellationToken): Promise<void> {
+	setInput(input: KeybindingsEditorInput, options: SettingsEditorOptions | undefined, token: CancellationToken): Promise<void> {
 		this.keybindingsEditorContextKey.set(true);
-		return super.setInput(input, options, token)
-			.then(() => this.render(!!(options && options.preserveFocus)));
+		return super.setInput(input, options, token).then(() => {
+			this.render(!!(options && options.preserveFocus)).then(() => {
+				options = options || SettingsEditorOptions.create({});
+				if (options.query) {
+					this.searchWidget.setValue(options.query);
+				}
+			});
+		});
 	}
 
 	clearInput(): void {

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -496,8 +496,8 @@ CommandsRegistry.registerCommand(OPEN_FOLDER_SETTINGS_COMMAND, function (accesso
 	return preferencesService.openFolderSettings(resource);
 });
 
-CommandsRegistry.registerCommand(OpenFolderSettingsAction.ID, serviceAccessor => {
-	serviceAccessor.get(IInstantiationService).createInstance(OpenFolderSettingsAction, OpenFolderSettingsAction.ID, OpenFolderSettingsAction.LABEL).run();
+CommandsRegistry.registerCommand(OpenFolderSettingsAction.ID, (serviceAccessor, args) => {
+	serviceAccessor.get(IInstantiationService).createInstance(OpenFolderSettingsAction, OpenFolderSettingsAction.ID, OpenFolderSettingsAction.LABEL).run(args);
 });
 MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 	command: {
@@ -508,8 +508,8 @@ MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 	when: WorkbenchStateContext.isEqualTo('workspace')
 });
 
-CommandsRegistry.registerCommand(OpenWorkspaceSettingsAction.ID, serviceAccessor => {
-	serviceAccessor.get(IInstantiationService).createInstance(OpenWorkspaceSettingsAction, OpenWorkspaceSettingsAction.ID, OpenWorkspaceSettingsAction.LABEL).run();
+CommandsRegistry.registerCommand(OpenWorkspaceSettingsAction.ID, (serviceAccessor, args) => {
+	serviceAccessor.get(IInstantiationService).createInstance(OpenWorkspaceSettingsAction, OpenWorkspaceSettingsAction.ID, OpenWorkspaceSettingsAction.LABEL).run(args);
 });
 MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 	command: {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesActions.ts
@@ -47,8 +47,9 @@ export class OpenSettings2Action extends Action {
 		super(id, label);
 	}
 
-	run(event?: any): Promise<any> {
-		return this.preferencesService.openSettings(false, undefined);
+	run(args: any): Promise<any> {
+		const query = typeof args === 'string' ? args : undefined;
+		return this.preferencesService.openSettings(query ? false : undefined, query);
 	}
 }
 
@@ -83,8 +84,9 @@ export class OpenGlobalSettingsAction extends Action {
 		super(id, label);
 	}
 
-	run(event?: any): Promise<any> {
-		return this.preferencesService.openGlobalSettings();
+	run(args: any): Promise<any> {
+		const query = typeof args === 'string' ? args : undefined;
+		return this.preferencesService.openGlobalSettings(query ? false : undefined, { query });
 	}
 }
 
@@ -118,8 +120,9 @@ export class OpenGlobalKeybindingsAction extends Action {
 		super(id, label);
 	}
 
-	run(event?: any): Promise<any> {
-		return this.preferencesService.openGlobalKeybindingSettings(false);
+	run(args: any): Promise<any> {
+		const query = typeof args === 'string' ? args : undefined;
+		return this.preferencesService.openGlobalKeybindingSettings(false, query);
 	}
 }
 
@@ -181,8 +184,9 @@ export class OpenWorkspaceSettingsAction extends Action {
 		this.enabled = this.workspaceContextService.getWorkbenchState() !== WorkbenchState.EMPTY;
 	}
 
-	run(event?: any): Promise<any> {
-		return this.preferencesService.openWorkspaceSettings();
+	run(args: any): Promise<any> {
+		const query = typeof args === 'string' ? args : undefined;
+		return this.preferencesService.openWorkspaceSettings(query ? false : undefined, { query });
 	}
 
 	dispose(): void {
@@ -214,12 +218,12 @@ export class OpenFolderSettingsAction extends Action {
 	private update(): void {
 		this.enabled = this.workspaceContextService.getWorkbenchState() === WorkbenchState.WORKSPACE && this.workspaceContextService.getWorkspace().folders.length > 0;
 	}
-
-	run(): Promise<any> {
+	run(args: any): Promise<any> {
 		return this.commandService.executeCommand<IWorkspaceFolder>(PICK_WORKSPACE_FOLDER_COMMAND_ID)
 			.then(workspaceFolder => {
 				if (workspaceFolder) {
-					return this.preferencesService.openFolderSettings(workspaceFolder.uri);
+					const query = typeof args === 'string' ? args : undefined;
+					return this.preferencesService.openFolderSettings(workspaceFolder.uri, query ? false : undefined, { query });
 				}
 
 				return undefined;

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -279,7 +279,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		}
 	}
 
-	openGlobalKeybindingSettings(textual: boolean): Promise<void> {
+	openGlobalKeybindingSettings(textual: boolean, query?: string): Promise<void> {
 		type OpenKeybindingsClassification = {
 			textual: { classification: 'SystemMetaData', purpose: 'FeatureInsight', isMeasurement: true };
 		};
@@ -304,7 +304,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 			});
 		}
 
-		return this.editorService.openEditor(this.instantiationService.createInstance(KeybindingsEditorInput), { pinned: true, revealIfOpened: true }).then(() => undefined);
+		return this.editorService.openEditor(this.instantiationService.createInstance(KeybindingsEditorInput), SettingsEditorOptions.create({ pinned: true, revealIfOpened: true, query })).then(() => undefined);
 	}
 
 	openDefaultKeybindingsFile(): Promise<IEditor | undefined> {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -200,7 +200,7 @@ export interface IPreferencesService {
 	openWorkspaceSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
 	openFolderSettings(folder: URI, jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
 	switchSettings(target: ConfigurationTarget, resource: URI, jsonEditor?: boolean): Promise<void>;
-	openGlobalKeybindingSettings(textual: boolean): Promise<void>;
+	openGlobalKeybindingSettings(textual: boolean, query?: string): Promise<void>;
 	openDefaultKeybindingsFile(): Promise<IEditor | undefined>;
 
 	configureSettingsForLanguage(language: string | null): void;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR makes some commands registered from `Action` class support query as arguments.

It enables extensions to provide pre-filled query to settings/keybindings editor, to help users better edit configurations or keybindings related to their extensions.

e.g., by executing command `openGlobalKeybindings` with query `leetcode`, the leetcode extension can prompt users to set key binding for `Open problem description` or `Submit solution`.

This PR fixes #72878.
