### PR TITLE
Fix failure of revealing webview with viewColumn which does not exist

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebview.ts
@@ -192,10 +192,8 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 			return;
 		}
 
-		const targetGroup = this._editorGroupService.getGroup(viewColumnToEditorGroup(this._editorGroupService, showOptions.viewColumn)) || this._editorGroupService.getGroup(webview.group || 0);
-		if (targetGroup) {
-			this._webviewWorkbenchService.revealWebview(webview, targetGroup, !!showOptions.preserveFocus);
-		}
+		const targetGroup = viewColumnToEditorGroup(this._editorGroupService, showOptions.viewColumn);
+		this._webviewWorkbenchService.revealWebview(webview, targetGroup, !!showOptions.preserveFocus);
 	}
 
 	public async $postMessage(handle: extHostProtocol.WebviewPanelHandle, message: any): Promise<boolean> {

--- a/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
@@ -68,7 +68,7 @@ export interface IWebviewWorkbenchService {
 
 	revealWebview(
 		webview: WebviewInput,
-		group: IEditorGroup,
+		group: IEditorGroup | GroupIdentifier | ACTIVE_GROUP_TYPE | SIDE_GROUP_TYPE,
 		preserveFocus: boolean
 	): void;
 
@@ -175,20 +175,22 @@ export class WebviewEditorService implements IWebviewWorkbenchService {
 
 	public revealWebview(
 		webview: WebviewInput,
-		group: IEditorGroup,
+		group: IEditorGroup | GroupIdentifier | ACTIVE_GROUP_TYPE | SIDE_GROUP_TYPE,
 		preserveFocus: boolean
 	): void {
-		if (webview.group === group.id) {
-			this._editorService.openEditor(webview, {
-				preserveFocus,
-				// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
-				// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
-				activation: preserveFocus ? EditorActivation.RESTORE : undefined
-			}, webview.group);
+		const editorOptions = {
+			preserveFocus,
+			// preserve pre 1.38 behaviour to not make group active when preserveFocus: true
+			// but make sure to restore the editor to fix https://github.com/microsoft/vscode/issues/79633
+			activation: preserveFocus ? EditorActivation.RESTORE : undefined
+		};
+		const targetGroup = this._editorService.findTargetGroup(webview, editorOptions, group);
+		if (webview.group === targetGroup.id) {
+			this._editorService.openEditor(webview, editorOptions, targetGroup);
 		} else {
 			const groupView = this._editorGroupService.getGroup(webview.group!);
 			if (groupView) {
-				groupView.moveEditor(webview, group, { preserveFocus });
+				groupView.moveEditor(webview, targetGroup, { preserveFocus });
 			}
 		}
 	}

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -312,7 +312,7 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return undefined;
 	}
 
-	private findTargetGroup(input: IEditorInput, options?: IEditorOptions, group?: OpenInEditorGroup): IEditorGroup {
+	findTargetGroup(input: IEditorInput, options?: IEditorOptions, group?: OpenInEditorGroup): IEditorGroup {
 		let targetGroup: IEditorGroup | undefined;
 
 		// Group: Instance of Group
@@ -868,6 +868,8 @@ export class DelegatingEditorService implements IEditorService {
 	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T { return this.editorService.invokeWithinEditorContext(fn); }
 
 	createInput(input: IResourceEditor): IEditorInput { return this.editorService.createInput(input); }
+
+	findTargetGroup(input: IEditorInput, options?: IEditorOptions, group?: OpenInEditorGroup): IEditorGroup { return this.editorService.findTargetGroup(input, options, group); }
 
 	save(editors: IEditorIdentifier | IEditorIdentifier[], options?: ISaveEditorsOptions): Promise<boolean> { return this.editorService.save(editors, options); }
 	saveAll(options?: ISaveAllEditorsOptions): Promise<boolean> { return this.editorService.saveAll(options); }

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -218,6 +218,11 @@ export interface IEditorService {
 	createInput(input: IResourceEditor): IEditorInput;
 
 	/**
+	 * Find target editor group according to a group, an indentifier or a placeholder.
+	 */
+	findTargetGroup(input: IEditorInput, options?: IEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): IEditorGroup;
+
+	/**
 	 * Save the provided list of editors.
 	 */
 	save(editors: IEditorIdentifier | IEditorIdentifier[], options?: ISaveEditorsOptions): Promise<boolean>;

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -957,6 +957,10 @@ export class TestEditorService implements EditorServiceImpl {
 		throw new Error('not implemented');
 	}
 
+	findTargetGroup(_input: IEditorInput, _options?: IEditorOptions, _group?: any): IEditorGroup {
+		throw new Error('not implemented');
+	}
+
 	save(editors: IEditorIdentifier[], options?: ISaveEditorsOptions): Promise<boolean> {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Currently, `create a webview` and `reveal a webview`'s behavior is not consistent, when a `viewColumn` option is provided, but that column(group) does not exist:
* Create a webview with `SIDE_GROUP` will open the webview on the active group's side
* Reveal a webview with `SIDE_GROUP` will do nothing (revealed on the webview's current group)

The root cause of such inconsistency is in that `createWebview` forward the viewColumn(group) information to `editorService.openEditor`, which will be handled by `editorService.findTargetGroup`. 

However, `revealWebview` gets hands dirty to find the target group by itself, and some important logic is missing, e.g. handling of `SIDE_GROUP`. So when passing `viewColumn` to be 1 (start from 0) when there's only 1 column, it will be revealed to column 0 instead of 1.

This PR makes `editorService.findTargetGroup` public, and foward the group number to it to reuse its logic, and keep the behavior of `revealing` and `creating` consistent.

This PR fixes #71608.
