### PR TITLE
Update findWidget.css to resolve node-sass build errors

### DIFF
--- a/src/vs/editor/contrib/find/findWidget.css
+++ b/src/vs/editor/contrib/find/findWidget.css
@@ -13,7 +13,7 @@
 	transition: transform 200ms linear;
 	padding: 0 4px;
 	box-sizing: border-box;
-	transform: translateY(Calc(-100% - 10px)); /* shadow (10px) */
+	transform: translateY(calc(-100% - 10px)); /* shadow (10px) */
 }
 
 .monaco-editor .find-widget textarea {


### PR DESCRIPTION
This PR is a workaround to solve node-sass Incompatible units error.

My project use sass-loader to resolve .css files.
But after importing monaco-editor, node-sass throw me some errors below.

![image](https://user-images.githubusercontent.com/8327041/71580277-e64b1800-2b3a-11ea-9eab-5b670c46052d.png)


After doing some research, i found that node-sass support calc() outputting.
sass/node-sass#2144

In monaco-editor project, it uses Calc().
To browser, Calc() is same to calc(), i think it is ok to change this function to make better support for sass-loader / node-sass.