### PR TITLE
Suggest widget set aria active descendent

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -425,7 +425,7 @@ export class TextAreaHandler extends ViewPart {
 		return this._lastRenderPosition;
 	}
 
-	public setAria(options: IEditorAriaOptions): void {
+	public setAriaOptions(options: IEditorAriaOptions): void {
 		if (options.activeDescendant) {
 			this.textArea.setAttribute('aria-haspopup', 'true');
 			this.textArea.setAttribute('aria-autocomplete', 'list');

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -426,10 +426,10 @@ export class TextAreaHandler extends ViewPart {
 	}
 
 	public setAria(options: IEditorAriaOptions): void {
-		if (options.activeDescendent) {
+		if (options.activeDescendant) {
 			this.textArea.setAttribute('aria-haspopup', 'true');
 			this.textArea.setAttribute('aria-autocomplete', 'list');
-			this.textArea.setAttribute('aria-activedescendant', options.activeDescendent);
+			this.textArea.setAttribute('aria-activedescendant', options.activeDescendant);
 		} else {
 			this.textArea.setAttribute('aria-haspopup', 'false');
 			this.textArea.setAttribute('aria-autocomplete', 'both');

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -29,6 +29,7 @@ import { RenderingContext, RestrictedRenderingContext, HorizontalPosition } from
 import { ViewContext } from 'vs/editor/common/view/viewContext';
 import * as viewEvents from 'vs/editor/common/view/viewEvents';
 import { AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
+import { IEditorAriaOptions } from 'vs/editor/browser/editorBrowser';
 
 export interface ITextAreaHandlerHelper {
 	visibleRangeForPositionRelativeToEditor(lineNumber: number, column: number): HorizontalPosition | null;
@@ -422,6 +423,18 @@ export class TextAreaHandler extends ViewPart {
 
 	public getLastRenderData(): Position | null {
 		return this._lastRenderPosition;
+	}
+
+	public setAria(options: IEditorAriaOptions): void {
+		if (options.activeDescendent) {
+			this.textArea.setAttribute('aria-haspopup', 'true');
+			this.textArea.setAttribute('aria-autocomplete', 'list');
+			this.textArea.setAttribute('aria-activedescendant', options.activeDescendent);
+		} else {
+			this.textArea.setAttribute('aria-haspopup', 'false');
+			this.textArea.setAttribute('aria-autocomplete', 'both');
+			this.textArea.removeAttribute('aria-activedescendant');
+		}
 	}
 
 	// --- end view API

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -320,6 +320,13 @@ export interface IOverviewRuler {
 }
 
 /**
+ * Editor aria options.
+ */
+export interface IEditorAriaOptions {
+	activeDescendent: string | undefined;
+}
+
+/**
  * A rich code editor.
  */
 export interface ICodeEditor extends editorCommon.IEditor {
@@ -688,6 +695,12 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	 * @internal
 	 */
 	setHiddenAreas(ranges: IRange[]): void;
+
+	/**
+	 * Sets the editor aria options, primarily the active descendent.
+	 * @internal
+	 */
+	setAria(options: IEditorAriaOptions): void;
 
 	/**
 	 * @internal

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -321,9 +321,10 @@ export interface IOverviewRuler {
 
 /**
  * Editor aria options.
+ * @internal
  */
 export interface IEditorAriaOptions {
-	activeDescendent: string | undefined;
+	activeDescendant: string | undefined;
 }
 
 /**
@@ -700,7 +701,7 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	 * Sets the editor aria options, primarily the active descendent.
 	 * @internal
 	 */
-	setAria(options: IEditorAriaOptions): void;
+	setAriaOptions(options: IEditorAriaOptions): void;
 
 	/**
 	 * @internal

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -11,7 +11,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 import { IPointerHandlerHelper } from 'vs/editor/browser/controller/mouseHandler';
 import { PointerHandler } from 'vs/editor/browser/controller/pointerHandler';
 import { ITextAreaHandlerHelper, TextAreaHandler } from 'vs/editor/browser/controller/textAreaHandler';
-import { IContentWidget, IContentWidgetPosition, IOverlayWidget, IOverlayWidgetPosition, IMouseTarget, IViewZoneChangeAccessor } from 'vs/editor/browser/editorBrowser';
+import { IContentWidget, IContentWidgetPosition, IOverlayWidget, IOverlayWidgetPosition, IMouseTarget, IViewZoneChangeAccessor, IEditorAriaOptions } from 'vs/editor/browser/editorBrowser';
 import { ICommandDelegate, ViewController } from 'vs/editor/browser/view/viewController';
 import { ViewOutgoingEvents } from 'vs/editor/browser/view/viewOutgoingEvents';
 import { ContentViewOverlays, MarginViewOverlays } from 'vs/editor/browser/view/viewOverlays';
@@ -510,6 +510,10 @@ export class View extends ViewEventHandler {
 		this._textAreaHandler.refreshFocusState();
 	}
 
+	public setAria(options: IEditorAriaOptions): void {
+		this._textAreaHandler.setAria(options);
+	}
+
 	public addContentWidget(widgetData: IContentWidgetData): void {
 		this.contentWidgets.addWidget(widgetData.widget);
 		this.layoutContentWidget(widgetData);
@@ -559,4 +563,3 @@ function safeInvokeNoArg(func: Function): any {
 		onUnexpectedError(e);
 	}
 }
-

--- a/src/vs/editor/browser/view/viewImpl.ts
+++ b/src/vs/editor/browser/view/viewImpl.ts
@@ -510,8 +510,8 @@ export class View extends ViewEventHandler {
 		this._textAreaHandler.refreshFocusState();
 	}
 
-	public setAria(options: IEditorAriaOptions): void {
-		this._textAreaHandler.setAria(options);
+	public setAriaOptions(options: IEditorAriaOptions): void {
+		this._textAreaHandler.setAriaOptions(options);
 	}
 
 	public addContentWidget(widgetData: IContentWidgetData): void {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1311,7 +1311,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._modelData.view.render(true, forceRedraw);
 	}
 
-	public setAria(options: editorBrowser.IEditorAriaOptions): void {
+	public setAriaOptions(options: editorBrowser.IEditorAriaOptions): void {
 		if (!this._modelData || !this._modelData.hasRealView) {
 			return;
 		}

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1315,7 +1315,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		if (!this._modelData || !this._modelData.hasRealView) {
 			return;
 		}
-		this._modelData.view.setAria(options);
+		this._modelData.view.setAriaOptions(options);
 	}
 
 	public applyFontInfo(target: HTMLElement): void {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -1311,6 +1311,13 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._modelData.view.render(true, forceRedraw);
 	}
 
+	public setAria(options: editorBrowser.IEditorAriaOptions): void {
+		if (!this._modelData || !this._modelData.hasRealView) {
+			return;
+		}
+		this._modelData.view.setAria(options);
+	}
+
 	public applyFontInfo(target: HTMLElement): void {
 		Configuration.applyFontInfoSlow(target, this._configuration.options.get(EditorOption.fontInfo));
 	}

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -22,7 +22,6 @@ import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition, IEditorMouseEvent } from 'vs/editor/browser/editorBrowser';
 import { Context as SuggestContext, CompletionItem } from './suggest';
 import { CompletionModel } from './completionModel';
-import { alert } from 'vs/base/browser/ui/aria/aria';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { attachListStyler } from 'vs/platform/theme/common/styler';
 import { IThemeService, ITheme, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
@@ -87,6 +86,10 @@ function canExpandCompletionItem(item: CompletionItem | null) {
 		return true;
 	}
 	return (suggestion.detail && suggestion.detail !== suggestion.label);
+}
+
+function getAriaId(index: number): string {
+	return `suggest-aria-id:${index}`;
 }
 
 class Renderer implements IListRenderer<CompletionItem, ISuggestionTemplateData> {
@@ -162,6 +165,7 @@ class Renderer implements IListRenderer<CompletionItem, ISuggestionTemplateData>
 		const data = <ISuggestionTemplateData>templateData;
 		const suggestion = (<CompletionItem>element).completion;
 
+		data.root.id = getAriaId(_index);
 		data.icon.className = 'icon ' + completionKindToCssClass(suggestion.kind);
 		data.colorspan.style.backgroundColor = '';
 
@@ -250,7 +254,6 @@ class SuggestionDetails {
 	private header: HTMLElement;
 	private type: HTMLElement;
 	private docs: HTMLElement;
-	private ariaLabel: string | null;
 	private readonly disposables: DisposableStore;
 	private renderDisposeable?: IDisposable;
 	private borderWidth: number = 1;
@@ -279,7 +282,6 @@ class SuggestionDetails {
 		this.type = append(this.header, $('p.type'));
 
 		this.docs = append(this.body, $('p.docs'));
-		this.ariaLabel = null;
 
 		this.configureFont();
 
@@ -318,7 +320,6 @@ class SuggestionDetails {
 			this.type.textContent = '';
 			this.docs.textContent = '';
 			addClass(this.el, 'no-docs');
-			this.ariaLabel = null;
 			return;
 		}
 		removeClass(this.el, 'no-docs');
@@ -358,15 +359,6 @@ class SuggestionDetails {
 
 		this.body.scrollTop = 0;
 		this.scrollbar.scanDomNode();
-
-		this.ariaLabel = strings.format(
-			'{0}{1}',
-			detail || '',
-			documentation ? (typeof documentation === 'string' ? documentation : documentation.value) : '');
-	}
-
-	getAriaLabel() {
-		return this.ariaLabel;
 	}
 
 	scrollDown(much = 8): void {
@@ -521,7 +513,22 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 		this.list = new List('SuggestWidget', this.listElement, this, [renderer], {
 			useShadows: false,
 			openController: { shouldOpen: () => false },
-			mouseSupport: false
+			mouseSupport: false,
+			accessibilityProvider: {
+				getAriaLabel: (item: CompletionItem) => {
+					if (this.expandDocsSettingFromStorage()) {
+						const { documentation, detail } = item.completion;
+						const docs = strings.format(
+							'{0}{1}',
+							detail || '',
+							documentation ? (typeof documentation === 'string' ? documentation : documentation.value) : '');
+
+						return nls.localize('ariaCurrenttSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, docs);
+					} else {
+						return item.completion.label;
+					}
+				}
+			}
 		});
 
 		this.toDispose.add(attachListStyler(this.list, themeService, {
@@ -610,25 +617,6 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 		this.editor.focus();
 	}
 
-	private _getSuggestionAriaAlertLabel(item: CompletionItem): string {
-		if (this.expandDocsSettingFromStorage()) {
-			return nls.localize('ariaCurrenttSuggestionReadDetails', "Item {0}, docs: {1}", item.completion.label, this.details.getAriaLabel());
-		} else {
-			return item.completion.label;
-		}
-	}
-
-	private _lastAriaAlertLabel: string | null = null;
-	private _ariaAlert(newAriaAlertLabel: string | null): void {
-		if (this._lastAriaAlertLabel === newAriaAlertLabel) {
-			return;
-		}
-		this._lastAriaAlertLabel = newAriaAlertLabel;
-		if (this._lastAriaAlertLabel) {
-			alert(this._lastAriaAlertLabel, true);
-		}
-	}
-
 	private onThemeChange(theme: ITheme) {
 		const backgroundColor = theme.getColor(editorSuggestWidgetBackground);
 		if (backgroundColor) {
@@ -662,7 +650,7 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 				this.focusedItem = null;
 			}
 
-			this._ariaAlert(null);
+			this.editor.setAria({ activeDescendent: undefined });
 			return;
 		}
 
@@ -711,7 +699,7 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 					removeClass(this.element, 'docs-side');
 				}
 
-				this._ariaAlert(this._getSuggestionAriaAlertLabel(item));
+				this.editor.setAria({ activeDescendent: getAriaId(index) });
 			}).catch(onUnexpectedError);
 		}
 
@@ -769,7 +757,6 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 				hide(this.messageElement);
 				show(this.details.element, this.listElement);
 				this.show();
-				this._ariaAlert(this.details.getAriaLabel());
 				break;
 		}
 	}
@@ -989,7 +976,6 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 
 			this.updateExpandDocsSetting(true);
 			this.showDetails(false);
-			this._ariaAlert(this.details.getAriaLabel());
 			this.telemetryService.publicLog2('suggestWidget:expandDetails');
 		}
 	}

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -516,7 +516,7 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 			mouseSupport: false,
 			accessibilityProvider: {
 				getAriaLabel: (item: CompletionItem) => {
-					if (this.expandDocsSettingFromStorage()) {
+					if (item.isResolved && this.expandDocsSettingFromStorage()) {
 						const { documentation, detail } = item.completion;
 						const docs = strings.format(
 							'{0}{1}',

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -650,7 +650,7 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 				this.focusedItem = null;
 			}
 
-			this.editor.setAria({ activeDescendent: undefined });
+			this.editor.setAriaOptions({ activeDescendant: undefined });
 			return;
 		}
 
@@ -699,7 +699,7 @@ export class SuggestWidget implements IContentWidget, IListVirtualDelegate<Compl
 					removeClass(this.element, 'docs-side');
 				}
 
-				this.editor.setAria({ activeDescendent: getAriaId(index) });
+				this.editor.setAriaOptions({ activeDescendant: getAriaId(index) });
 			}).catch(onUnexpectedError);
 		}
 

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -161,11 +161,11 @@ class Renderer implements IListRenderer<CompletionItem, ISuggestionTemplateData>
 		return data;
 	}
 
-	renderElement(element: CompletionItem, _index: number, templateData: ISuggestionTemplateData): void {
+	renderElement(element: CompletionItem, index: number, templateData: ISuggestionTemplateData): void {
 		const data = <ISuggestionTemplateData>templateData;
 		const suggestion = (<CompletionItem>element).completion;
 
-		data.root.id = getAriaId(_index);
+		data.root.id = getAriaId(index);
 		data.icon.className = 'icon ' + completionKindToCssClass(suggestion.kind);
 		data.colorspan.style.backgroundColor = '';
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3727,6 +3727,13 @@ declare namespace monaco.editor {
 	}
 
 	/**
+	 * Editor aria options.
+	 */
+	export interface IEditorAriaOptions {
+		activeDescendent: string | undefined;
+	}
+
+	/**
 	 * A rich code editor.
 	 */
 	export interface ICodeEditor extends IEditor {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3727,13 +3727,6 @@ declare namespace monaco.editor {
 	}
 
 	/**
-	 * Editor aria options.
-	 */
-	export interface IEditorAriaOptions {
-		activeDescendent: string | undefined;
-	}
-
-	/**
 	 * A rich code editor.
 	 */
 	export interface ICodeEditor extends IEditor {


### PR DESCRIPTION
This PR:
* Adds the `setAria` api to the Editor, that gets passed to the `textAreaHandler`
* Adopts the `setAria` api in the Suggest widget. This way the suggest widget no longer uses the `aria.alert`
* Refactors how aria labels are set for `CompletionItems` and the `details`. Overall things should be simpler now in the `SuggestWidget`

Fixes https://github.com/microsoft/vscode/issues/3787
Please note that I have tested this on my macOS Catalina and it works just fine. I plan to test it on windows when I am get back to the office next week.

@alexdima let me know what you think
fyi @zersiax @jrieken 
We can still fine tune what is exactly being read and if there are still issues.