### PR TITLE
xterm@4.4.0-beta.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "vscode-ripgrep": "^1.5.7",
     "vscode-sqlite3": "4.0.9",
     "vscode-textmate": "4.4.0",
-    "xterm": "4.3.0-beta.28.vscode.1",
+    "xterm": "4.4.0-beta.13",
     "xterm-addon-search": "0.4.0-beta4",
     "xterm-addon-web-links": "0.2.1",
-    "xterm-addon-webgl": "0.4.0-beta.11",
+    "xterm-addon-webgl": "0.5.0-beta.7",
     "yauzl": "^2.9.2",
     "yazl": "^2.4.3"
   },

--- a/remote/package.json
+++ b/remote/package.json
@@ -20,10 +20,10 @@
     "vscode-proxy-agent": "^0.5.2",
     "vscode-ripgrep": "^1.5.7",
     "vscode-textmate": "4.4.0",
-    "xterm": "4.3.0-beta.28.vscode.1",
+    "xterm": "4.4.0-beta.13",
     "xterm-addon-search": "0.4.0-beta4",
     "xterm-addon-web-links": "0.2.1",
-    "xterm-addon-webgl": "0.4.0-beta.11",
+    "xterm-addon-webgl": "0.5.0-beta.7",
     "yauzl": "^2.9.2",
     "yazl": "^2.4.3"
   },

--- a/remote/web/package.json
+++ b/remote/web/package.json
@@ -5,9 +5,9 @@
 		"onigasm-umd": "2.2.5",
 		"semver-umd": "^5.5.5",
 		"vscode-textmate": "4.4.0",
-		"xterm": "4.3.0-beta.28.vscode.1",
+		"xterm": "4.4.0-beta.13",
 		"xterm-addon-search": "0.4.0-beta4",
 		"xterm-addon-web-links": "0.2.1",
-		"xterm-addon-webgl": "0.4.0-beta.11"
+		"xterm-addon-webgl": "0.5.0-beta.7"
 	}
 }

--- a/remote/web/yarn.lock
+++ b/remote/web/yarn.lock
@@ -41,12 +41,12 @@ xterm-addon-web-links@0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.2.1.tgz#6d1f2ce613e09870badf17615e7a1170a31542b2"
   integrity sha512-2KnHtiq0IG7hfwv3jw2/jQeH1RBk2d5CH4zvgwQe00rLofSJqSfgnJ7gwowxxpGHrpbPr6Lv4AmH/joaNw2+HQ==
 
-xterm-addon-webgl@0.4.0-beta.11:
-  version "0.4.0-beta.11"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.4.0-beta.11.tgz#0e4a7242e2353cf74aba55e5a5bdc0b4ec87ad10"
-  integrity sha512-AteDxm1RFy1WnjY9r5iJSETozLebvUkR+jextdZk/ASsK21vsYK0DuVWwRI8afgiN2hUVhxcxuHEJUOV+CJDQA==
+xterm-addon-webgl@0.5.0-beta.7:
+  version "0.5.0-beta.7"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.5.0-beta.7.tgz#b7b95a362e942ad6f86fa286d7b7bd8ee3e7cf67"
+  integrity sha512-v6aCvhm1C6mvaurGwUYQfyhb2cAUyuVnzf3Ob/hy5ebtyzUj4wW0N9NbqDEJk67UeMi1lV2xZqrO5gNeTpVqFA==
 
-xterm@4.3.0-beta.28.vscode.1:
-  version "4.3.0-beta.28.vscode.1"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.3.0-beta.28.vscode.1.tgz#89b85398b5801708e833d08bf92b2124fa128943"
-  integrity sha512-JNHNZyDtAWnybJTrenPzD6g/yXpHOvPqmjau91Up4onRbjQYMSNlth17SqaES68DKn/+4kcIl2c/RG5SXJjvGw==
+xterm@4.4.0-beta.13:
+  version "4.4.0-beta.13"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.4.0-beta.13.tgz#f7c5fa0d2b098ce0dd8b7c96d3d5fcaee22b86ed"
+  integrity sha512-ZoDOVO3w84CXekBveGw1H2lcvM4HkJG5suXesE/3S+N4DnBhBcK/vw4kdooALGoorJV2GtgA1XEA6+m4N5Sgnw==

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -428,15 +428,15 @@ xterm-addon-web-links@0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.2.1.tgz#6d1f2ce613e09870badf17615e7a1170a31542b2"
   integrity sha512-2KnHtiq0IG7hfwv3jw2/jQeH1RBk2d5CH4zvgwQe00rLofSJqSfgnJ7gwowxxpGHrpbPr6Lv4AmH/joaNw2+HQ==
 
-xterm-addon-webgl@0.4.0-beta.11:
-  version "0.4.0-beta.11"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.4.0-beta.11.tgz#0e4a7242e2353cf74aba55e5a5bdc0b4ec87ad10"
-  integrity sha512-AteDxm1RFy1WnjY9r5iJSETozLebvUkR+jextdZk/ASsK21vsYK0DuVWwRI8afgiN2hUVhxcxuHEJUOV+CJDQA==
+xterm-addon-webgl@0.5.0-beta.7:
+  version "0.5.0-beta.7"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.5.0-beta.7.tgz#b7b95a362e942ad6f86fa286d7b7bd8ee3e7cf67"
+  integrity sha512-v6aCvhm1C6mvaurGwUYQfyhb2cAUyuVnzf3Ob/hy5ebtyzUj4wW0N9NbqDEJk67UeMi1lV2xZqrO5gNeTpVqFA==
 
-xterm@4.3.0-beta.28.vscode.1:
-  version "4.3.0-beta.28.vscode.1"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.3.0-beta.28.vscode.1.tgz#89b85398b5801708e833d08bf92b2124fa128943"
-  integrity sha512-JNHNZyDtAWnybJTrenPzD6g/yXpHOvPqmjau91Up4onRbjQYMSNlth17SqaES68DKn/+4kcIl2c/RG5SXJjvGw==
+xterm@4.4.0-beta.13:
+  version "4.4.0-beta.13"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.4.0-beta.13.tgz#f7c5fa0d2b098ce0dd8b7c96d3d5fcaee22b86ed"
+  integrity sha512-ZoDOVO3w84CXekBveGw1H2lcvM4HkJG5suXesE/3S+N4DnBhBcK/vw4kdooALGoorJV2GtgA1XEA6+m4N5Sgnw==
 
 yauzl@^2.9.2:
   version "2.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9610,15 +9610,15 @@ xterm-addon-web-links@0.2.1:
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.2.1.tgz#6d1f2ce613e09870badf17615e7a1170a31542b2"
   integrity sha512-2KnHtiq0IG7hfwv3jw2/jQeH1RBk2d5CH4zvgwQe00rLofSJqSfgnJ7gwowxxpGHrpbPr6Lv4AmH/joaNw2+HQ==
 
-xterm-addon-webgl@0.4.0-beta.11:
-  version "0.4.0-beta.11"
-  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.4.0-beta.11.tgz#0e4a7242e2353cf74aba55e5a5bdc0b4ec87ad10"
-  integrity sha512-AteDxm1RFy1WnjY9r5iJSETozLebvUkR+jextdZk/ASsK21vsYK0DuVWwRI8afgiN2hUVhxcxuHEJUOV+CJDQA==
+xterm-addon-webgl@0.5.0-beta.7:
+  version "0.5.0-beta.7"
+  resolved "https://registry.yarnpkg.com/xterm-addon-webgl/-/xterm-addon-webgl-0.5.0-beta.7.tgz#b7b95a362e942ad6f86fa286d7b7bd8ee3e7cf67"
+  integrity sha512-v6aCvhm1C6mvaurGwUYQfyhb2cAUyuVnzf3Ob/hy5ebtyzUj4wW0N9NbqDEJk67UeMi1lV2xZqrO5gNeTpVqFA==
 
-xterm@4.3.0-beta.28.vscode.1:
-  version "4.3.0-beta.28.vscode.1"
-  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.3.0-beta.28.vscode.1.tgz#89b85398b5801708e833d08bf92b2124fa128943"
-  integrity sha512-JNHNZyDtAWnybJTrenPzD6g/yXpHOvPqmjau91Up4onRbjQYMSNlth17SqaES68DKn/+4kcIl2c/RG5SXJjvGw==
+xterm@4.4.0-beta.13:
+  version "4.4.0-beta.13"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.4.0-beta.13.tgz#f7c5fa0d2b098ce0dd8b7c96d3d5fcaee22b86ed"
+  integrity sha512-ZoDOVO3w84CXekBveGw1H2lcvM4HkJG5suXesE/3S+N4DnBhBcK/vw4kdooALGoorJV2GtgA1XEA6+m4N5Sgnw==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
xterm-addon-webgl@0.5.0-beta.7

Diff: https://github.com/xtermjs/xterm.js/compare/8341c35...2a9e16b

- Include  in word separators xtermjs/xterm.js#2583
- Remove unused imports/functions xtermjs/xterm.js#2585
- force alpha to 1 when using background color as inverted foreground color xtermjs/xterm.js#2560
- Fix minimumContrastRatio on dom/truecolor xtermjs/xterm.js#2602
- v4.3.0 xtermjs/xterm.js#2605
- Avoid roundtrip to browser when double-disposing. xtermjs/xterm.js#2616
- Allow the thickness of the bar cursor to be configured xtermjs/xterm.js#2590
- update version of node-pty xtermjs/xterm.js#2621
- Implement hidden in DOM and WebGL renderers xtermjs/xterm.js#2625
- Expose texture atlas as API and use in demo xtermjs/xterm.js#2626
- Webgl v0.4.1 xtermjs/xterm.js#2628
- Add Linode to real world uses xtermjs/xterm.js#2636
- Added Gus to list of xterm real-world users xtermjs/xterm.js#2631
- Remove a large portion of InputHandler's dependency on Terminal xtermjs/xterm.js#2637
- Move back to reseting parser only on RIS xtermjs/xterm.js#2640
- Set glyph fg color based on original bg, not selection xtermjs/xterm.js#2650
- format color value to style '#rrggbbaa' xtermjs/xterm.js#2629
- Use register over add for APIs returning disposables xtermjs/xterm.js#2651
- Standardize how colors helper lib is structured xtermjs/xterm.js#2653
- Fullwidth handling in buffer writes xtermjs/xterm.js#2644
- Target es5 in attach addon xtermjs/xterm.js#2654

Fixes #86194
Fixes #87918
Part of #87456