### PR TITLE
CallStackView attempts to move the active frame to the top

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -289,7 +289,13 @@ export class CallStackView extends ViewPane {
 			this.ignoreSelectionChangedEvent = true;
 			try {
 				this.tree.setSelection([element]);
-				this.tree.reveal(element);
+				// If the element is outside of the screen bounds,
+				// position it in the middle
+				if (this.tree.getRelativeTop(element) === null) {
+					this.tree.reveal(element, 0.5);
+				} else {
+					this.tree.reveal(element);
+				}
 			} catch (e) { }
 			finally {
 				this.ignoreSelectionChangedEvent = false;


### PR DESCRIPTION
This PR fixes #88073

This is an attempt to fix the above issue.

If the element we're selecting is a StackFrame and it's not on the screen, I attempt to put the associated Thread at the very top of the list view. I don't force it as if the element is already on the screen, it'll scroll if up forcefully, which is not a good UX imo.

I'd appreciate any comments, there is a lot going in the code to render a stack trace, this seemed like an easy and non-invasive way to make this a little more intuitive.