### PR TITLE
Fix #84145 when toggling terminal pane

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalPanel.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalPanel.ts
@@ -100,6 +100,7 @@ export class TerminalPanel extends Panel {
 				if (this._terminalService.terminalInstances.length > 0) {
 					this._updateFont();
 					this._updateTheme();
+					this._terminalService.getActiveTab()?.setVisible(visible);
 				} else {
 					// Check if instances were already restored as part of workbench restore
 					if (this._terminalService.terminalInstances.length === 0) {


### PR DESCRIPTION
This PR fixes #84145 (partially)

In the case in which you trigger the bug by toggling the Terminal pane you can force the active terminal instance to re-sync the viewport with the scrollbar using the setVisible method.
