### PR TITLE
Allow changing opacity of kbd in menus

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -374,6 +374,7 @@ export const menuSelectionForeground = registerColor('menu.selectionForeground',
 export const menuSelectionBackground = registerColor('menu.selectionBackground', { dark: listActiveSelectionBackground, light: listActiveSelectionBackground, hc: listActiveSelectionBackground }, nls.localize('menuSelectionBackground', "Background color of the selected menu item in menus."));
 export const menuSelectionBorder = registerColor('menu.selectionBorder', { dark: null, light: null, hc: activeContrastBorder }, nls.localize('menuSelectionBorder', "Border color of the selected menu item in menus."));
 export const menuSeparatorBackground = registerColor('menu.separatorBackground', { dark: '#BBBBBB', light: '#888888', hc: contrastBorder }, nls.localize('menuSeparatorBackground', "Color of a separator menu item in menus."));
+export const menuKeyboardShortcutOpacity = registerColor('menu.keyboardShortcutOpacity', { dark: foreground, light: foreground, hc: foreground }, nls.localize('menuKeyboardShortcutOpacity', "Opacity of keyboard shortcuts in menus. For example, \"#000000c0\" will render the code with 75% opacity."));
 
 /**
  * Snippet placeholder colors

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -44,6 +44,7 @@ import { optional } from 'vs/platform/instantiation/common/instantiation';
 // eslint-disable-next-line code-layering, code-import-patterns
 import { IElectronEnvironmentService } from 'vs/workbench/services/electron/electron-browser/electronEnvironmentService';
 import { BrowserFeatures } from 'vs/base/browser/canIUse';
+import { menuKeyboardShortcutOpacity } from 'vs/platform/theme/common/colorRegistry';
 
 export abstract class MenubarControl extends Disposable {
 
@@ -414,6 +415,15 @@ export class CustomMenubarControl extends MenubarControl {
 					.monaco-workbench .menubar > .menubar-menu-button:hover {
 						outline-offset: -1px;
 						outline-color: ${menubarSelectedBorderColor};
+					}
+				`);
+			}
+
+			const menubarKeyboardShortcut = theme.getColor(menuKeyboardShortcutOpacity);
+			if (menubarKeyboardShortcut) {
+				collector.addRule(`
+					.monaco-menu .keybinding {
+						opacity: ${menubarKeyboardShortcut.rgba.a};
 					}
 				`);
 			}


### PR DESCRIPTION
![Screenshot (122)](https://user-images.githubusercontent.com/9638156/71780878-fd758400-2fd8-11ea-8814-cd7e2ef90064.png)
![Screenshot (123)](https://user-images.githubusercontent.com/9638156/71780879-00707480-2fd9-11ea-8460-b67467fe02e3.png)

```js
"workbench.colorCustomizations": {
    "menu.keyboardShortcutOpacity": "#fff8",
},
```