### PR TITLE
potential leak: _updateOutline should honor cancellation token (repeat ca429b4)

### DIFF
--- a/src/vs/base/common/cache.ts
+++ b/src/vs/base/common/cache.ts
@@ -27,8 +27,7 @@ export class Cache<T> {
 			promise,
 			dispose: () => {
 				this.result = null;
-				cts.cancel();
-				cts.dispose();
+				cts.dispose(true);
 			}
 		};
 

--- a/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
+++ b/src/vs/workbench/browser/parts/quickopen/quickOpenController.ts
@@ -287,8 +287,7 @@ export class QuickOpenController extends Component implements IQuickOpenService 
 
 	private cancelPendingGetResultsInvocation(): void {
 		if (this.pendingGetResultsInvocation) {
-			this.pendingGetResultsInvocation.cancel();
-			this.pendingGetResultsInvocation.dispose();
+			this.pendingGetResultsInvocation.dispose(true);
 			this.pendingGetResultsInvocation = null;
 		}
 	}

--- a/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
@@ -441,8 +441,7 @@ class PreferencesRenderersController extends Disposable {
 		}
 
 		if (this._remoteFilterCancelToken) {
-			this._remoteFilterCancelToken.cancel();
-			this._remoteFilterCancelToken.dispose();
+			this._remoteFilterCancelToken.dispose(true);
 			this._remoteFilterCancelToken = null;
 		}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1122,8 +1122,7 @@ export class SettingsEditor2 extends BaseEditor {
 			this.localSearchDelayer.cancel();
 			this.remoteSearchThrottle.cancel();
 			if (this.searchInProgress) {
-				this.searchInProgress.cancel();
-				this.searchInProgress.dispose();
+				this.searchInProgress.dispose(true);
 				this.searchInProgress = null;
 			}
 

--- a/src/vs/workbench/contrib/quickopen/browser/gotoSymbolHandler.ts
+++ b/src/vs/workbench/contrib/quickopen/browser/gotoSymbolHandler.ts
@@ -549,8 +549,7 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 
 	private clearOutlineRequest(): void {
 		if (this.pendingOutlineRequest) {
-			this.pendingOutlineRequest.cancel();
-			this.pendingOutlineRequest.dispose();
+			this.pendingOutlineRequest.dispose(true);
 			this.pendingOutlineRequest = undefined;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR will repeat the previous change ca429b4 that was made by @jrieken.
Like the base changes, this PR will changes `xx.cancel()` and `xx.dispose()` to `dispose(true)`
And I made this PR automatically such as #87709.

Note:
I could not apply the same changes to the following file lines caused by `dispose` function settings.
Should I change them with depended [`dispose`  functions](https://github.com/microsoft/vscode/blob/ee8eb463a26aed6b728db81bcd85c21cf68beec5/src/vs/vscode.d.ts#L1415)?
* https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/tagClosing.ts#L41
* https://github.com/microsoft/vscode/blob/master/extensions/typescript-language-features/src/features/tagClosing.ts#L66