### PR TITLE
#88125 Reverse action order in goToErrorWidget

### DIFF
--- a/src/vs/editor/contrib/gotoError/gotoError.ts
+++ b/src/vs/editor/contrib/gotoError/gotoError.ts
@@ -240,8 +240,8 @@ export class MarkerController implements editorCommon.IEditorContribution {
 		const prevMarkerKeybinding = this._keybindingService.lookupKeybinding(PrevMarkerAction.ID);
 		const nextMarkerKeybinding = this._keybindingService.lookupKeybinding(NextMarkerAction.ID);
 		const actions = [
-			new Action(PrevMarkerAction.ID, PrevMarkerAction.LABEL + (prevMarkerKeybinding ? ` (${prevMarkerKeybinding.getLabel()})` : ''), 'show-previous-problem codicon-chevron-up', this._model.canNavigate(), async () => { if (this._model) { this._model.move(false, true); } }),
-			new Action(NextMarkerAction.ID, NextMarkerAction.LABEL + (nextMarkerKeybinding ? ` (${nextMarkerKeybinding.getLabel()})` : ''), 'show-next-problem codicon-chevron-down', this._model.canNavigate(), async () => { if (this._model) { this._model.move(true, true); } })
+			new Action(NextMarkerAction.ID, NextMarkerAction.LABEL + (nextMarkerKeybinding ? ` (${nextMarkerKeybinding.getLabel()})` : ''), 'show-next-problem codicon-chevron-down', this._model.canNavigate(), async () => { if (this._model) { this._model.move(true, true); } }),
+			new Action(PrevMarkerAction.ID, PrevMarkerAction.LABEL + (prevMarkerKeybinding ? ` (${prevMarkerKeybinding.getLabel()})` : ''), 'show-previous-problem codicon-chevron-up', this._model.canNavigate(), async () => { if (this._model) { this._model.move(false, true); } })
 		];
 		this._widget = new MarkerNavigationWidget(this._editor, actions, this._themeService);
 		this._widgetVisible.set(true);

--- a/src/vs/editor/contrib/gotoError/gotoErrorWidget.ts
+++ b/src/vs/editor/contrib/gotoError/gotoErrorWidget.ts
@@ -228,7 +228,7 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 
 	protected _fillHead(container: HTMLElement): void {
 		super._fillHead(container);
-		this._actionbarWidget!.push(this.actions, { label: false, icon: true });
+		this._actionbarWidget!.push(this.actions, { label: false, icon: true, index: 0 });
 	}
 
 	protected _fillTitleIcon(container: HTMLElement): void {
@@ -237,7 +237,7 @@ export class MarkerNavigationWidget extends PeekViewWidget {
 
 	protected _getActionBarOptions(): IActionBarOptions {
 		return {
-			orientation: ActionsOrientation.HORIZONTAL_REVERSE
+			orientation: ActionsOrientation.HORIZONTAL
 		};
 	}
 


### PR DESCRIPTION
This PR fixes #88125 

I removed the use of `HORIZONTAL_REVERSE` and added the buttons in reverse order instead.
I believe you could set the `tabIndex` of the actions to be 2 and 1, but according to [this](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex) it is better to order the elements correctly.

Demo:
![MRya8gbIOn](https://user-images.githubusercontent.com/20613660/71850297-e6638e80-30cb-11ea-95bc-8d6404654210.gif)

