### PR TITLE
Only treat diff editors as matching if they have the same value for 'forceOpenABinaryEditor'

### DIFF
--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -28,6 +28,13 @@ export class DiffEditorInput extends SideBySideEditorInput {
 		super(name, description, original, modified);
 	}
 
+	matches(otherInput: unknown): boolean {
+		if (!super.matches(otherInput)) {
+			return false;
+		}
+		return otherInput instanceof DiffEditorInput && otherInput.forceOpenAsBinary === this.forceOpenAsBinary;
+	}
+
 	getTypeId(): string {
 		return DiffEditorInput.ID;
 	}


### PR DESCRIPTION
Fixes #88166

Custom editors used in diff views for binary files were broken. The root cause we were creating a `DiffEditorInput` that set `forceOpenAsBinary === true`, however this input was discarded as it was judged to be the same as the existing editor input which had `forceOpenAsBinary === undefined`

To fix this, I've updated the `matches` function so that it also considers `forceOpenAsBinary `