### PR TITLE
Use flex layout for extension page header/body

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -6,6 +6,8 @@
 .extension-editor {
 	height: 100%;
 	overflow: hidden;
+	display: flex;
+	flex-direction: column;
 }
 
 .extension-editor .clickable {
@@ -188,7 +190,7 @@
 }
 
 .extension-editor > .body {
-	height: calc(100% - 168px);
+	flex: 1;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
Fixes #83209

**Bug**
The extension page currently uses hardcoded height values for the header. This hardcoded height breaks if the extension is recommended

**Fix**
Use flex layout instead
