### PR TITLE
fix(debug): don't insert task boundaries between events

### DIFF
--- a/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
@@ -5,20 +5,19 @@
 
 import { Emitter, Event } from 'vs/base/common/event';
 import { IDebugAdapter } from 'vs/workbench/contrib/debug/common/debug';
-import { timeout, Queue } from 'vs/base/common/async';
+import { timeout } from 'vs/base/common/async';
 
 /**
  * Abstract implementation of the low level API for a debug adapter.
  * Missing is how this API communicates with the debug adapter.
  */
 export abstract class AbstractDebugAdapter implements IDebugAdapter {
-
 	private sequence: number;
 	private pendingRequests = new Map<number, (e: DebugProtocol.Response) => void>();
 	private requestCallback: ((request: DebugProtocol.Request) => void) | undefined;
 	private eventCallback: ((request: DebugProtocol.Event) => void) | undefined;
 	private messageCallback: ((message: DebugProtocol.ProtocolMessage) => void) | undefined;
-	private readonly queue = new Queue();
+	private queue: DebugProtocol.ProtocolMessage[] = [];
 	protected readonly _onError = new Emitter<Error>();
 	protected readonly _onExit = new Emitter<number | null>();
 
@@ -64,8 +63,7 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 	sendResponse(response: DebugProtocol.Response): void {
 		if (response.seq > 0) {
 			this._onError.fire(new Error(`attempt to send more than one response for command ${response.command}`));
-		}
-		else {
+		} else {
 			this.internalSend('response', response);
 		}
 	}
@@ -107,35 +105,72 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 	acceptMessage(message: DebugProtocol.ProtocolMessage): void {
 		if (this.messageCallback) {
 			this.messageCallback(message);
+		} else {
+			this.queue.push(message);
+			if (this.queue.length === 1) {
+				// first item = need to start processing loop
+				this.processQueue();
+			}
 		}
-		else {
-			this.queue.queue(() => {
-				switch (message.type) {
-					case 'event':
-						if (this.eventCallback) {
-							this.eventCallback(<DebugProtocol.Event>message);
-						}
-						break;
-					case 'request':
-						if (this.requestCallback) {
-							this.requestCallback(<DebugProtocol.Request>message);
-						}
-						break;
-					case 'response':
-						const response = <DebugProtocol.Response>message;
-						const clb = this.pendingRequests.get(response.request_seq);
-						if (clb) {
-							this.pendingRequests.delete(response.request_seq);
-							clb(response);
-						}
-						break;
-				}
+	}
 
-				// Artificially queueing protocol messages guarantees that any microtasks for
-				// previous message finish before next message is processed. This is essential
-				// to guarantee ordering when using promises anywhere along the call path.
-				return timeout(0);
-			});
+	/**
+	 * Returns whether we should insert a timeout between processing messageA
+	 * and messageB. Artificially queueing protocol messages guarantees that any
+	 * microtasks for previous message finish before next message is processed.
+	 * This is essential ordering when using promises anywhere along the call path.
+	 *
+	 * For example, take the following, where `chooseAndSendGreeting` returns
+	 * a person name and then emits a greeting event:
+	 *
+	 * ```
+	 * let person: string;
+	 * adapter.onGreeting(() => console.log('hello', person));
+	 * person = await adapter.chooseAndSendGreeting();
+	 * ```
+	 *
+	 * Because the event is dispatched synchronously, it may fire before person
+	 * is assigned if they're processed in the same task. Inserting a task
+	 * boundary avoids this issue.
+	 */
+	protected needsTaskBoundaryBetween(messageA: DebugProtocol.ProtocolMessage, messageB: DebugProtocol.ProtocolMessage) {
+		return messageA.type !== 'event' || messageB.type !== 'event';
+	}
+
+	/**
+	 * Reads and dispatches items from the queue until it is empty.
+	 */
+	private async processQueue() {
+		while (this.queue.length) {
+			if (this.queue.length < 2 || this.needsTaskBoundaryBetween(this.queue[0], this.queue[1])) {
+				await timeout(0);
+			}
+
+			const message = this.queue.shift();
+			if (!message) {
+				return; // may have been disposed of
+			}
+
+			switch (message.type) {
+				case 'event':
+					if (this.eventCallback) {
+						this.eventCallback(<DebugProtocol.Event>message);
+					}
+					break;
+				case 'request':
+					if (this.requestCallback) {
+						this.requestCallback(<DebugProtocol.Request>message);
+					}
+					break;
+				case 'response':
+					const response = <DebugProtocol.Response>message;
+					const clb = this.pendingRequests.get(response.request_seq);
+					if (clb) {
+						this.pendingRequests.delete(response.request_seq);
+						clb(response);
+					}
+					break;
+			}
 		}
 	}
 
@@ -172,6 +207,6 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 	}
 
 	dispose(): void {
-		this.queue.dispose();
+		this.queue = [];
 	}
 }

--- a/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts
@@ -141,12 +141,13 @@ export abstract class AbstractDebugAdapter implements IDebugAdapter {
 	 * Reads and dispatches items from the queue until it is empty.
 	 */
 	private async processQueue() {
+		let message: DebugProtocol.ProtocolMessage | undefined;
 		while (this.queue.length) {
-			if (this.queue.length < 2 || this.needsTaskBoundaryBetween(this.queue[0], this.queue[1])) {
+			if (!message || this.needsTaskBoundaryBetween(this.queue[0], message)) {
 				await timeout(0);
 			}
 
-			const message = this.queue.shift();
+			message = this.queue.shift();
 			if (!message) {
 				return; // may have been disposed of
 			}

--- a/src/vs/workbench/contrib/debug/test/common/rawDebugSession.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/rawDebugSession.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { MockDebugAdapter } from 'vs/workbench/contrib/debug/test/common/mockDebug';
+import { timeout } from 'vs/base/common/async';
+
+suite('Debug - AbstractDebugAdapter', () => {
+	suite('event ordering', () => {
+		let adapter: MockDebugAdapter;
+		let output: string[];
+		setup(() => {
+			adapter = new MockDebugAdapter();
+			output = [];
+			adapter.onEvent(ev => {
+				output.push((ev as DebugProtocol.OutputEvent).body.output);
+				Promise.resolve().then(() => output.push('--end microtask--'));
+			});
+		});
+
+		const evaluate = async (expression: string) => {
+			await new Promise(resolve => adapter.sendRequest('evaluate', { expression }, resolve));
+			output.push(`=${expression}`);
+			Promise.resolve().then(() => output.push('--end microtask--'));
+		};
+
+		test('inserts task boundary before response', async () => {
+			await evaluate('before.foo');
+			await timeout(0);
+
+			assert.deepStrictEqual(output, ['before.foo', '--end microtask--', '=before.foo', '--end microtask--']);
+		});
+
+		test('inserts task boundary after response', async () => {
+			await evaluate('after.foo');
+			await timeout(0);
+
+			assert.deepStrictEqual(output, ['=after.foo', '--end microtask--', 'after.foo', '--end microtask--']);
+		});
+
+		test('does not insert boundaries between events', async () => {
+			adapter.sendEventBody('output', { output: 'a' });
+			adapter.sendEventBody('output', { output: 'b' });
+			adapter.sendEventBody('output', { output: 'c' });
+			await timeout(0);
+
+			assert.deepStrictEqual(output, ['a', 'b', 'c', '--end microtask--', '--end microtask--', '--end microtask--']);
+		});
+	});
+});


### PR DESCRIPTION
See discussion in https://github.com/microsoft/vscode-js-debug/issues/206.

This PR adjusts logic such that we only assert task boundaries around
requests and responses, rather than around every single event. I believe
this will solve the primary case where misordering can happen, as given
in the existing unit test and described more verbosely in the doc
comment in this PR.

A more conservative approach would be to only omit the boundary between
events of the same type. That would be safer, but I browsing through
the code I didn't see any cases where it looked like we could get
tripped up by bucketing here (e.g. cases where we resolve a deferred
promise in an event handler).

Seems to fix the performance issue for me.

cc @dgozman and @sbatten @roblourens fyi