### PR TITLE
Clarify the docs for QuickPickItem.description and detail

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -1583,12 +1583,12 @@ declare module 'vscode' {
 		label: string;
 
 		/**
-		 * A human-readable string which is rendered less prominent.
+		 * A human-readable string which is rendered less prominent in the same line.
 		 */
 		description?: string;
 
 		/**
-		 * A human-readable string which is rendered less prominent.
+		 * A human-readable string which is rendered less prominent in a separate line.
 		 */
 		detail?: string;
 


### PR DESCRIPTION
I always have to guess which is which, since they have the exact same docs (and `description` somehow sounds "more in-depth" to me, so I always get it wrong).
