### PR TITLE
Show a rename entry in the refactor/lightbulb menus

### DIFF
--- a/src/vs/workbench/contrib/codeActions/common/codeActions.contribution.ts
+++ b/src/vs/workbench/contrib/codeActions/common/codeActions.contribution.ts
@@ -12,6 +12,7 @@ import { CodeActionsContribution, editorConfiguration } from 'vs/workbench/contr
 import { CodeActionsExtensionPoint, codeActionsExtensionPointDescriptor } from 'vs/workbench/contrib/codeActions/common/codeActionsExtensionPoint';
 import { CodeActionDocumentationContribution } from 'vs/workbench/contrib/codeActions/common/documentationContribution';
 import { DocumentationExtensionPoint, documentationExtensionPointDescriptor } from 'vs/workbench/contrib/codeActions/common/documentationExtensionPoint';
+import { RenameRefactorContribution } from 'vs/workbench/contrib/codeActions/common/renameRefactorContribution';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 
 const codeActionsExtensionPoint = ExtensionsRegistry.registerExtensionPoint<CodeActionsExtensionPoint[]>(codeActionsExtensionPointDescriptor);
@@ -26,6 +27,7 @@ class WorkbenchConfigurationContribution {
 	) {
 		instantiationService.createInstance(CodeActionsContribution, codeActionsExtensionPoint);
 		instantiationService.createInstance(CodeActionDocumentationContribution, documentationExtensionPoint);
+		instantiationService.createInstance(RenameRefactorContribution);
 	}
 }
 

--- a/src/vs/workbench/contrib/codeActions/common/renameRefactorContribution.ts
+++ b/src/vs/workbench/contrib/codeActions/common/renameRefactorContribution.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Range } from 'vs/editor/common/core/range';
+import { Selection } from 'vs/editor/common/core/selection';
+import { ITextModel } from 'vs/editor/common/model';
+import * as modes from 'vs/editor/common/modes';
+import { CodeActionKind } from 'vs/editor/contrib/codeAction/types';
+import * as nls from 'vs/nls';
+import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
+
+const renameKind = CodeActionKind.Refactor.append('rename');
+
+export class RenameRefactorContribution extends Disposable implements IWorkbenchContribution, modes.CodeActionProvider {
+
+	private readonly emptyCodeActionsList = Object.freeze({
+		actions: [],
+		dispose: () => { }
+	});
+
+	constructor() {
+		super();
+		this._register(modes.CodeActionProviderRegistry.register('*', this));
+	}
+
+	public readonly providedCodeActionKinds = Object.freeze([renameKind.value]);
+
+	public async provideCodeActions(model: ITextModel, range: Range | Selection, _context: modes.CodeActionContext, token: CancellationToken): Promise<modes.CodeActionList> {
+		const position = range.getStartPosition();
+		for (const provider of modes.RenameProviderRegistry.all(model)) {
+			if (!provider.resolveRenameLocation) {
+				continue;
+			}
+			const result = await provider.resolveRenameLocation(model, position, token);
+			if (result?.rejectReason) {
+				continue;
+			}
+			const title = nls.localize('renameTitle', 'Rename symbol');
+			return {
+				actions: [{
+					title,
+					kind: renameKind.value,
+					command: {
+						id: 'editor.action.rename',
+						title,
+						arguments: [
+							model.uri,
+							position
+						]
+					}
+				}],
+				dispose: () => { }
+			};
+		}
+		return this.emptyCodeActionsList;
+	}
+}


### PR DESCRIPTION
Adds a new `Rename symbol` built-in refactoring. This refactoring uses existing rename providers (it requires that they implement resolveRenameLocation)

The goal is to make the refactor menu more useful and help people discover VS Code's `rename` functionality 