### PR TITLE
Fix #88231

### DIFF
--- a/src/vs/editor/contrib/colorPicker/colorPickerModel.ts
+++ b/src/vs/editor/contrib/colorPicker/colorPickerModel.ts
@@ -64,7 +64,7 @@ export class ColorPickerModel {
 
 	guessColorPresentation(color: Color, originalText: string): void {
 		for (let i = 0; i < this.colorPresentations.length; i++) {
-			if (originalText === this.colorPresentations[i].label) {
+			if (originalText.toLowerCase() === this.colorPresentations[i].label) {
 				this.presentationIndex = i;
 				this._onDidChangePresentation.fire(this.presentation);
 				break;


### PR DESCRIPTION
This PR fixes #88231

The simplest solution to change this line:
```js
if (originalText === this.colorPresentations[i].label) {
```
to this:
```js
if (originalText.toLowerCase() === this.colorPresentations[i].label) {
```
`src\vs\editor\contrib\colorPicker\colorPickerModel.ts:67`

Now when I hover over `#1F1F1F` it will be recognized as `#1f1f1f` and when I edit color with the picker, a color will be replaced with lowercased hex representation

![Code - OSS Dev 2020-01-16 17-25-09](https://user-images.githubusercontent.com/15856982/72533176-c2e7d300-3885-11ea-8b20-c2bdf49b074b.gif)
