### PR TITLE
Fix threads not fetched after restarting debug adapter

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -904,6 +904,7 @@ export class DebugSession implements IDebugSession {
 			this.raw.dispose();
 		}
 		this.raw = undefined;
+		this.fetchThreadsScheduler = undefined;
 		this.model.clearThreads(this.getId(), true);
 		this._onDidChangeState.fire();
 	}


### PR DESCRIPTION
A RunOnceScheduler (this.fetchThreadsScheduler) is used to throttle
fetching threads from debug adapters. this.fetchThreadsScheduler is
disposed when a debug adapter is restarted because of:

    this.rawListeners.push(this.fetchThreadsScheduler);

This causes threads to never be fetched after restarting the debug
adapter.

This is fixed by setting this.fetchThreadsScheduler to undefined after
it is disposed. This way, a new RunOnceScheduler is created after
restarting the debug adapter.

Fixes #88784

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #
