### PR TITLE
Editor based terminals

### DIFF
--- a/src/vs/workbench/contrib/editorTerminals/contribution.ts
+++ b/src/vs/workbench/contrib/editorTerminals/contribution.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
+import { IEditorRegistry, EditorDescriptor, Extensions as EditorExtensions } from 'vs/workbench/browser/editor';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+
+import { TerminalEditor } from './editor';
+import { TerminalEditorInput } from './editorInput';
+import { ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
+
+const NEW_TERMINAL_COMMAND_ID = 'vs.workbench.contrib.editorTerminals.newTerminal';
+
+CommandsRegistry.registerCommand(NEW_TERMINAL_COMMAND_ID, async (accessor) => {
+	const editorService = accessor.get(IEditorService);
+	const instService = accessor.get(IInstantiationService);
+	const termService = accessor.get(ITerminalService);
+
+	const termInstance = termService.createTerminal({
+		hideFromUser: true
+	});
+
+	await termInstance.waitForTitle();
+	await editorService.openEditor(instService.createInstance(TerminalEditorInput, termInstance));
+});
+
+MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
+	command: {
+		id: NEW_TERMINAL_COMMAND_ID,
+		category: 'Terminals',
+		title: 'New Editor Terminal'
+	}
+});
+
+Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
+	new EditorDescriptor(TerminalEditor, TerminalEditor.ID, 'Terminal Editor'),
+	[new SyncDescriptor(TerminalEditorInput)]
+);
+

--- a/src/vs/workbench/contrib/editorTerminals/editor.ts
+++ b/src/vs/workbench/contrib/editorTerminals/editor.ts
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+
+import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { EditorInput, EditorOptions } from 'vs/workbench/common/editor';
+import { TerminalEditorInput } from 'vs/workbench/contrib/editorTerminals/editorInput';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import type { ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
+
+const PADDING = 5;
+
+export class TerminalEditor extends BaseEditor {
+	static readonly ID = 'vs.workbench.contrib.eitorTerminals.editor';
+
+	private container: HTMLElement | undefined;
+	private dimension: DOM.Dimension | undefined;
+
+	constructor(
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IThemeService themeService: IThemeService,
+		@IStorageService storageService: IStorageService
+	) {
+		super(TerminalEditor.ID, telemetryService, themeService, storageService);
+	}
+
+	protected createEditor(parent: HTMLElement): void {
+		this.container = document.createElement('div');
+		this.container.style.width = '100%';
+		this.container.style.height = '100%';
+		this.container.style.boxSizing = 'border-box';
+		this.container.style.padding = PADDING + 'px';
+
+		parent.appendChild(this.container);
+	}
+
+	layout(dimension: DOM.Dimension): void {
+		this.dimension = dimension;
+		this.terminalInstance?.layout({ width: dimension.width - 2 * PADDING, height: dimension.height - 2 * PADDING });
+	}
+
+	setVisible(visible: boolean): void {
+		super.setVisible(visible);
+		this.terminalInstance?.setVisible(visible);
+	}
+
+	private get terminalInput(): TerminalEditorInput | undefined {
+		return this.input as TerminalEditorInput;
+	}
+
+	private get terminalInstance(): ITerminalInstance | undefined {
+		return this.terminalInput?.terminalInstance;
+	}
+
+	clearInput() {
+		this.terminalInput?.release();
+		super.clearInput();
+	}
+
+	async setInput(input: EditorInput, options: EditorOptions | undefined, token: CancellationToken): Promise<void> {
+		if (this.container === undefined) {
+			throw new Error('No Container');
+		}
+
+		if (this.input !== undefined) {
+			throw new Error('Input should be undefined');
+		}
+
+		await super.setInput(input, options, token);
+		this.container.innerHTML = '';
+
+		const terminalInput: TerminalEditorInput | undefined = this.terminalInput;
+		if (terminalInput !== undefined && terminalInput.used) {
+			this.container.innerHTML = 'The terminal can\'t be opened two times in different editors';
+			return;
+		} else {
+			terminalInput?.use();
+		}
+
+		let target = document.createElement('div');
+		this.container.appendChild(target);
+
+		this.terminalInstance?.attachToElement(target);
+		if (this.dimension !== undefined) {
+			this.terminalInstance?.layout(this.dimension);
+		}
+		this.terminalInstance?.setVisible(this.isVisible());
+	}
+
+	focus(): void {
+		this.terminalInstance?.focusWhenReady();
+	}
+
+	dispose() {
+		this.terminalInput?.release();
+		super.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/editorTerminals/editorInput.ts
+++ b/src/vs/workbench/contrib/editorTerminals/editorInput.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
+import { URI } from 'vs/base/common/uri';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import type { ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
+
+export class TerminalEditorInput extends ResourceEditorInput {
+	static terminalCount = 0;
+
+	static readonly ID = 'vs.workbench.contrib.editorTerminals.editorInput';
+
+	private _used: boolean = false;
+
+	constructor(
+		public readonly terminalInstance: ITerminalInstance,
+		@ITextModelService textModelResolverService: ITextModelService,
+		@ITextFileService textFileService: ITextFileService,
+		@IEditorService editorService: IEditorService
+	) {
+		super(terminalInstance.title, terminalInstance.title,
+			URI.parse('terminal://editor-terminals/' + new Date().getTime() + (TerminalEditorInput.terminalCount++) + '/terminal'), undefined,
+			textModelResolverService, textFileService, editorService);
+	}
+
+	get used() {
+		return this._used;
+	}
+
+	use() {
+		if (this._used) {
+			throw new Error('Should not be used');
+		}
+		this._used = true;
+	}
+
+	release() {
+		if (!this._used) {
+			throw new Error('Should be used');
+		}
+		this._used = false;
+	}
+
+	getTypeId(): string {
+		return TerminalEditorInput.ID;
+	}
+
+	isDirty(): boolean {
+		return true;
+	}
+
+	dispose() {
+		this.terminalInstance.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -429,7 +429,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const wrapperElementStyle = getComputedStyle(this._wrapperElement);
 		const marginLeft = parseInt(wrapperElementStyle.marginLeft!.split('px')[0], 10);
 		const marginRight = parseInt(wrapperElementStyle.marginRight!.split('px')[0], 10);
-		const bottom = parseInt(wrapperElementStyle.bottom!.split('px')[0], 10);
+		let bottom = parseInt(wrapperElementStyle.bottom!.split('px')[0], 10);
+
+		// TODO this is a hack
+		if (isNaN(bottom)) {
+			bottom = 0;
+		}
 
 		const innerWidth = width - marginLeft - marginRight;
 		const innerHeight = height - bottom - 1;

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -263,4 +263,7 @@ import 'vs/workbench/contrib/userDataSync/browser/userDataSync.contribution';
 // Code Actions
 import 'vs/workbench/contrib/codeActions/common/codeActions.contribution';
 
+// Editor Terminals
+import 'vs/workbench/contrib/editorTerminals/contribution';
+
 //#endregion


### PR DESCRIPTION
# Context
VS Code users use terminal often. Unfortunately, the terminal area below isn't very good fit for it:
- It doesn't take good use of wide screen monitors
- It can only appear on the bottom of the screen
Also, there're usability problems with it:
- It's impossible to see all the terminals since the combo box is used for them.

# Implementation:
- I used editors and editor input API to create terminals
- In order to create terminal, I created a hidden terminal instance, and attach it to the editor DOM element
- In VS Code we use computeElementStyle API which sometimes returns 'auto' which leads to incorrect layout. I had to create a small hack to work this around.

Would be glad to fix any comments you want me to address.
![Screen Shot 2020-01-16 at 9 22 23 AM](https://user-images.githubusercontent.com/1268556/72548078-d32a8e80-3842-11ea-9315-e1c7abb96374.png)

