### PR TITLE
:speech_balloon: Fix grammar on Welcome Page

### DIFF
--- a/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
@@ -66,7 +66,7 @@ export default () => `
 					<div class="list">
 						<div class="item showCommands"><button data-href="command:workbench.action.showCommands"><h3 class="caption">${escape(localize('welcomePage.showCommands', "Find and run all commands"))}</h3> <span class="detail">${escape(localize('welcomePage.showCommandsDescription', "Rapidly access and search commands from the Command Palette ({0})")).replace('{0}', '<span class="shortcut" data-command="workbench.action.showCommands"></span>')}</span></button></div>
 						<div class="item showInterfaceOverview"><button data-href="command:workbench.action.showInterfaceOverview"><h3 class="caption">${escape(localize('welcomePage.interfaceOverview', "Interface overview"))}</h3> <span class="detail">${escape(localize('welcomePage.interfaceOverviewDescription', "Get a visual overlay highlighting the major components of the UI"))}</span></button></div>
-						<div class="item showInteractivePlayground"><button data-href="command:workbench.action.showInteractivePlayground"><h3 class="caption">${escape(localize('welcomePage.interactivePlayground', "Interactive playground"))}</h3> <span class="detail">${escape(localize('welcomePage.interactivePlaygroundDescription', "Try essential editor features out in a short walkthrough"))}</span></button></div>
+						<div class="item showInteractivePlayground"><button data-href="command:workbench.action.showInteractivePlayground"><h3 class="caption">${escape(localize('welcomePage.interactivePlayground', "Interactive playground"))}</h3> <span class="detail">${escape(localize('welcomePage.interactivePlaygroundDescription', "Try out essential editor features in a short walkthrough"))}</span></button></div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
**Why:**
For whatever reason this particular grammar offense was really driving
me batty. I try not to be a grammar nazi, hopefully this is a helpful
change for others and not just my sanity :)

**How:**
Move the preposition 'out' to the start of the prepositional phrase,
instead of the end of the phrase.

This PR fixes #88799 