### PR TITLE
Add experimental prepareForHotExit method for custom editors

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1240,6 +1240,27 @@ declare module 'vscode' {
 		 * @return Thenable signaling that the change has completed.
 		 */
 		undoEdits(resource: Uri, edits: readonly EditType[]): Thenable<void>;
+
+		/**
+		 * Back up `resource` in its current state.
+		 *
+		 * Backups are used for hot exit and to prevent data loss. Your `backup` method should persist the resource in
+		 * its current state, i.e. with the edits applied. Most commonly this means saving the resource to disk in
+		 * the `ExtensionContext.storagePath`. When VS Code reloads and your custom editor is opened for a resource,
+		 * your extension should first check to see if any backups exist for the resource. If there is a backup, your
+		 * extension should load the file contents from there instead of from the resource in the workspace.
+		 *
+		 * `backup` is triggered whenever an edit it made. Calls to `backup` are debounced so that if multiple edits are
+		 * made in quick succession, `backup` is only triggered after the last one. `backup` is not invoked when
+		 * `auto save` is enabled (since auto save already persists resource ).
+		 *
+		 * @param resource The resource to back up.
+		 * @param cancellation Token that signals the current backup since a new backup is coming in. It is up to your
+		 * extension to decided how to respond to cancellation. If for example your extension is backing up a large file
+		 * in an operation that takes time to complete, your extension may decide to finish the ongoing backup rather
+		 * than cancelling it to ensure that VS Code has some valid backup.
+		 */
+		backup?(resource: Uri, cancellation: CancellationToken): Thenable<boolean>;
 	}
 
 	export interface WebviewCustomEditorProvider {

--- a/src/vs/workbench/api/browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebview.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { createCancelablePromise } from 'vs/base/common/async';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
@@ -355,7 +356,10 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 		});
 
 		if (capabilitiesSet.has(extHostProtocol.WebviewEditorCapabilities.SupportsHotExit)) {
-			// TODO: Hook up hot exit / backup logic
+			model.onBackup(() => {
+				return createCancelablePromise(token =>
+					this._proxy.$backup(model.resource.toJSON(), viewType, token));
+			});
 		}
 
 		return model;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -612,6 +612,8 @@ export interface ExtHostWebviewsShape {
 
 	$onSave(resource: UriComponents, viewType: string): Promise<void>;
 	$onSaveAs(resource: UriComponents, viewType: string, targetResource: UriComponents): Promise<void>;
+
+	$backup(resource: UriComponents, viewType: string, cancellation: CancellationToken): Promise<boolean>;
 }
 
 export interface MainThreadUrlsShape extends IDisposable {

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { distinct, find, mergeSort } from 'vs/base/common/arrays';
+import { CancelablePromise } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
 import * as glob from 'vs/base/common/glob';
 import { basename } from 'vs/base/common/resources';
@@ -74,6 +75,8 @@ export interface ICustomEditorModel extends IWorkingCopy {
 
 	readonly onWillSave: Event<CustomEditorSaveEvent>;
 	readonly onWillSaveAs: Event<CustomEditorSaveAsEvent>;
+
+	onBackup(f: () => CancelablePromise<boolean>): void;
 
 	undo(): void;
 	redo(): void;


### PR DESCRIPTION
For  #88719 

Adds an experimental `prepareForHotExit` method to the custom editor API proposal. This method allows custom editors to hook in to VS Code's hot exit behavior

If `prepareForHotExit` is not implemented, VS Code will assume that the custom editor cannot be hot exited.

If `prepareForHotExit` is implemented, VS Code will invoke the method after every edit (this is debounced). At this point, this extension should back up the current resource.  The result is a promise indicating if the backup was successful or not

VS Code will only hot exit if all backups were successful.

This is only a first draft of the potential API. I'm working on testing this with the example custom editor extensions. Some open questions:

- Does `prepareForHotExit` provide enough for extensions to impement hot exit?
- How do we notify extensions that they can get rid of their old backups (such as when the user enables auto save)
- Does this work properly on both web and desktop?

