### PR TITLE
Defaulted mirrorCursorOnMatchingTag to false

### DIFF
--- a/extensions/html-language-features/package.json
+++ b/extensions/html-language-features/package.json
@@ -164,7 +164,7 @@
         "html.mirrorCursorOnMatchingTag": {
           "type": "boolean",
           "scope": "resource",
-          "default": true,
+          "default": false,
           "description": "%html.mirrorCursorOnMatchingTag%"
         },
         "html.trace.server": {


### PR DESCRIPTION
Resolves #87737

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #87737 

Just a trivial change to set the default of the 'html.mirrorCursorOnMatchingTag' setting to false, seems since the default setting of this was true, it seems counter-intuitive in certain cases.

A simple test would be to build and run a version of the editor, and by default expect this setting to be false.
