### PR TITLE
codelens: don't apply icon color to codelens

### DIFF
--- a/src/vs/editor/contrib/codelens/codelensWidget.css
+++ b/src/vs/editor/contrib/codelens/codelensWidget.css
@@ -30,6 +30,7 @@
 	line-height: inherit;
 	font-size: 110%;
 	vertical-align: inherit;
+	color: currentColor !important;
 }
 
 .monaco-editor .codelens-decoration > a:hover .codicon::before {


### PR DESCRIPTION
It came up in standup today that inheriting the workbench colors for codelens icons may be distracting, especially if several lenses are shown for the same line. This adds a change that uses the current color instead.

Before:
![image](https://user-images.githubusercontent.com/2230985/72941707-8a814280-3d26-11ea-9c80-4949e943ac53.png)


After:
![image](https://user-images.githubusercontent.com/2230985/72941689-805f4400-3d26-11ea-99c4-36dcb006b804.png)
