### PR TITLE
Fix resource scope access error logging

### DIFF
--- a/src/vs/workbench/api/common/extHostConfiguration.ts
+++ b/src/vs/workbench/api/common/extHostConfiguration.ts
@@ -301,7 +301,7 @@ export class ExtHostConfigProvider {
 		const scope = OVERRIDE_PROPERTY_PATTERN.test(key) ? ConfigurationScope.RESOURCE : this._configurationScopes.get(key);
 		const extensionIdText = extensionId ? `[${extensionId.value}] ` : '';
 		if (ConfigurationScope.RESOURCE === scope) {
-			if (overrides?.resource) {
+			if (typeof overrides?.resource === 'undefined') {
 				this._logService.warn(`${extensionIdText}Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for '${key}', provide the URI of a resource or 'null' for any resource.`);
 			}
 			return;


### PR DESCRIPTION
For #87768

It seems that this log message is meant to be fired when accessing a resource scoped config without a resource. Currently it is fired if you pass a resource
