### PR TITLE
Correctly convert `getConfiguration('section', null)` to a resource scope config accessor 

### DIFF
--- a/src/vs/workbench/api/common/extHostConfiguration.ts
+++ b/src/vs/workbench/api/common/extHostConfiguration.ts
@@ -85,6 +85,9 @@ function scopeToOverrides(scope: vscode.ConfigurationScope | undefined | null): 
 	if (isWorkspaceFolder(scope)) {
 		return { resource: scope.uri };
 	}
+	if (scope === null) {
+		return { resource: null };
+	}
 	return undefined;
 }
 


### PR DESCRIPTION
For #87768

I believe that calling `vscode.workspace.getConfiguration('section', null)` is supposed to create  a specific config accessor that works for any resource. Currently it behaves the same as if you omitted the second param

