### PR TITLE
extensions: allow built-in extensions on different qualities

### DIFF
--- a/build/builtInExtensions.json
+++ b/build/builtInExtensions.json
@@ -43,5 +43,21 @@
 			},
 			"publisherDisplayName": "Microsoft"
 		}
+	},
+	{
+		"name": "ms-vscode.js-debug-nightly",
+		"version": "latest",
+		"forQualities": ["insider"],
+		"repo": "https://github.com/Microsoft/vscode-js-debug",
+		"metadata": {
+			"id": "7acbb4ce-c85a-49d4-8d95-a8054406ae97",
+			"publisherId": {
+				"publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
+				"publisherName": "ms-vscode",
+				"displayName": "Microsoft",
+				"flags": "verified"
+			},
+			"publisherDisplayName": "Microsoft"
+		}
 	}
 ]

--- a/build/builtin/browser-main.js
+++ b/build/builtin/browser-main.js
@@ -10,6 +10,7 @@ const os = require('os');
 const { remote } = require('electron');
 const dialog = remote.dialog;
 
+const productJsonPath = path.join(__dirname, '..', '..', 'product.json');
 const builtInExtensionsPath = path.join(__dirname, '..', 'builtInExtensions.json');
 const controlFilePath = path.join(os.homedir(), '.vscode-oss-dev', 'extensions', 'control.json');
 
@@ -51,6 +52,7 @@ function render(el, state) {
 	}
 
 	const ul = document.createElement('ul');
+	const { quality } = readJson(productJsonPath);
 	const { builtin, control } = state;
 
 	for (const ext of builtin) {
@@ -61,6 +63,10 @@ function render(el, state) {
 
 		const name = document.createElement('code');
 		name.textContent = ext.name;
+		if (quality && ext.forQualities && !ext.forQualities.includes(quality)) {
+			name.textContent += ` (only on ${ext.forQualities.join(', ')})`;
+		}
+
 		li.appendChild(name);
 
 		const form = document.createElement('form');

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -27,6 +27,7 @@ const util = require('./util');
 const root = path.dirname(path.dirname(__dirname));
 const commit = util.getVersion(root);
 const sourceMappingURLBase = `https://ticino.blob.core.windows.net/sourcemaps/${commit}`;
+const product = require('../../product.json');
 
 function fromLocal(extensionPath: string): Stream {
 	const webpackFilename = path.join(extensionPath, 'extension.webpack.config.js');
@@ -219,16 +220,19 @@ const excludedExtensions = [
 	'vscode-test-resolver',
 	'ms-vscode.node-debug',
 	'ms-vscode.node-debug2',
+	'ms.vscode.js-debug-nightly'
 ];
 
 interface IBuiltInExtension {
 	name: string;
 	version: string;
 	repo: string;
+	forQualities?: ReadonlyArray<string>;
 	metadata: any;
 }
 
-const builtInExtensions: IBuiltInExtension[] = require('../builtInExtensions.json');
+const builtInExtensions = (<IBuiltInExtension[]>require('../builtInExtensions.json'))
+	.filter(({ forQualities }) => !product.quality || forQualities?.includes?.(product.quality) !== false);
 
 export function packageLocalExtensionsStream(): NodeJS.ReadWriteStream {
 	const localExtensionDescriptions = (<string[]>glob.sync('extensions/*/package.json'))

--- a/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
@@ -117,3 +117,24 @@ export function getMaliciousExtensionsSet(report: IReportedExtension[]): Set<str
 
 	return result;
 }
+
+export interface IBuiltInExtension {
+	name: string;
+	version: string;
+	repo: string;
+	forQualities?: ReadonlyArray<string>;
+	metadata: any;
+}
+
+/**
+ * Parses the built-in extension JSON data and filters it down to the
+ * extensions built into this product quality.
+ */
+export function parseBuiltInExtensions(rawJson: string, productQuality: string | undefined) {
+	const parsed: IBuiltInExtension[] = JSON.parse(rawJson);
+	if (!productQuality) {
+		return parsed;
+	}
+
+	return parsed.filter(ext => ext.forQualities?.indexOf?.(productQuality) !== -1);
+}


### PR DESCRIPTION
Adds a new optional `forQualities` property to built-in extensions,
and filters that as appropriate for different builds.
