### PR TITLE
Added property to cancel progress notification when user closes it

### DIFF
--- a/src/vs/platform/progress/common/progress.ts
+++ b/src/vs/platform/progress/common/progress.ts
@@ -58,6 +58,7 @@ export interface IProgressNotificationOptions extends IProgressOptions {
 	readonly primaryActions?: ReadonlyArray<IAction>;
 	readonly secondaryActions?: ReadonlyArray<IAction>;
 	delay?: number;
+	cancelOnClose?: boolean;
 }
 
 export interface IProgressWindowOptions extends IProgressOptions {

--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -7767,6 +7767,13 @@ declare module 'vscode' {
 		 * button.
 		 */
 		cancellable?: boolean;
+
+		/**
+		 * Controls if cancel event should be fired on notification close.
+		 * Note that currently only `ProgressLocation.Notification` is supporting
+		 * cancellation.
+		 */
+		cancelOnClose?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -203,6 +203,9 @@ export class ProgressService extends Disposable implements IProgressService {
 			updateProgress(handle, increment);
 
 			Event.once(handle.onDidClose)(() => {
+				if (options.cancelOnClose && options.cancellable && typeof onDidCancel === 'function') {
+					onDidCancel();
+				}
 				toDispose.dispose();
 			});
 


### PR DESCRIPTION
This PR fixes #89169 by adding `cancelOnClose` property which supposed to control if progress should be cancelled when notification are closed. Unfortunately, I didn't found any tests for withProgress and would be grateful for example of how such a test can be written (if should).

Thanks!