### PR TITLE
Preserve GNOME titlebar layout settings

### DIFF
--- a/src/vs/platform/electron/electron-main/electronMainService.ts
+++ b/src/vs/platform/electron/electron-main/electronMainService.ts
@@ -182,7 +182,7 @@ export class ElectronMainService implements IElectronMainService {
 		}
 	}
 
-	getToolbarButtonLayout(): ButtonLayout {
+	getTitlebarButtonLayout(): ButtonLayout {
 		let layout: ButtonLayout = ['maximize', 'minimize'];
 
 		if (isLinux) {

--- a/src/vs/platform/electron/electron-main/electronMainService.ts
+++ b/src/vs/platform/electron/electron-main/electronMainService.ts
@@ -10,7 +10,7 @@ import { INativeOpenWindowOptions } from 'vs/platform/windows/node/window';
 import { ILifecycleMainService } from 'vs/platform/lifecycle/electron-main/lifecycleMainService';
 import { IOpenedWindow, OpenContext, IWindowOpenable, IOpenEmptyWindowOptions } from 'vs/platform/windows/common/windows';
 import { INativeOpenDialogOptions } from 'vs/platform/dialogs/node/dialogs';
-import { isMacintosh } from 'vs/base/common/platform';
+import { isMacintosh, isLinux } from 'vs/base/common/platform';
 import { IElectronService } from 'vs/platform/electron/node/electron';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
@@ -20,6 +20,7 @@ import { dirExists } from 'vs/base/node/pfs';
 import { URI } from 'vs/base/common/uri';
 import { ITelemetryData, ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { ButtonLayout, getGnomeButtonLayout } from 'vs/platform/electron/node/buttonLayout';
 
 export interface IElectronMainService extends AddFirstParameterToFunctions<IElectronService, Promise<any> /* only methods, not events */, number | undefined /* window ID */> { }
 
@@ -179,6 +180,16 @@ export class ElectronMainService implements IElectronMainService {
 				window.win.focus();
 			}
 		}
+	}
+
+	getToolbarButtonLayout(): ButtonLayout {
+		let layout: ButtonLayout = ['maximize', 'minimize'];
+
+		if (isLinux) {
+			layout = getGnomeButtonLayout() ?? layout;
+		}
+
+		return layout;
 	}
 
 	//#endregion

--- a/src/vs/platform/electron/electron-main/electronMainService.ts
+++ b/src/vs/platform/electron/electron-main/electronMainService.ts
@@ -182,11 +182,11 @@ export class ElectronMainService implements IElectronMainService {
 		}
 	}
 
-	getTitlebarButtonLayout(): ButtonLayout {
+	async getTitlebarButtonLayout(): Promise<ButtonLayout> {
 		let layout: ButtonLayout = ['maximize', 'minimize'];
 
 		if (isLinux) {
-			layout = getGnomeButtonLayout() ?? layout;
+			layout = await getGnomeButtonLayout() ?? layout;
 		}
 
 		return layout;

--- a/src/vs/platform/electron/node/buttonLayout.ts
+++ b/src/vs/platform/electron/node/buttonLayout.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { spawnSync } from 'child_process';
+
+export type ButtonLayout = ('maximize' | 'minimize')[];
+
+export function getGnomeButtonLayout(): ButtonLayout | null {
+	let output = spawnSync('gsettings', ['get', 'org.gnome.desktop.wm.preferences', 'button-layout']);
+
+	if (output.status === 0) {
+		let stdout = output.stdout.toString().replace(/'/g, '');
+
+		if (stdout.length < 0) {
+			return null;
+		}
+
+		let layout = stdout.split(',').filter(item => item === 'maximize' || item === 'minimize');
+
+		return layout as ('maximize' | 'minimize')[];
+	}
+
+	return null;
+}

--- a/src/vs/platform/electron/node/electron.ts
+++ b/src/vs/platform/electron/node/electron.ts
@@ -47,7 +47,7 @@ export interface IElectronService {
 	isWindowFocused(): Promise<boolean>;
 	focusWindow(options?: { windowId?: number }): Promise<void>;
 
-	getTitlebarButtonLayout(): ButtonLayout;
+	getTitlebarButtonLayout(): Promise<ButtonLayout>;
 
 	// Dialogs
 	showMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue>;

--- a/src/vs/platform/electron/node/electron.ts
+++ b/src/vs/platform/electron/node/electron.ts
@@ -10,6 +10,7 @@ import { IWindowOpenable, IOpenEmptyWindowOptions, IOpenedWindow } from 'vs/plat
 import { INativeOpenDialogOptions } from 'vs/platform/dialogs/node/dialogs';
 import { ISerializableCommandAction } from 'vs/platform/actions/common/actions';
 import { INativeOpenWindowOptions } from 'vs/platform/windows/node/window';
+import { ButtonLayout } from 'vs/platform/electron/node/buttonLayout';
 
 export const IElectronService = createDecorator<IElectronService>('electronService');
 
@@ -45,6 +46,8 @@ export interface IElectronService {
 
 	isWindowFocused(): Promise<boolean>;
 	focusWindow(options?: { windowId?: number }): Promise<void>;
+
+	getToolbarButtonLayout(): ButtonLayout;
 
 	// Dialogs
 	showMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue>;

--- a/src/vs/platform/electron/node/electron.ts
+++ b/src/vs/platform/electron/node/electron.ts
@@ -47,7 +47,7 @@ export interface IElectronService {
 	isWindowFocused(): Promise<boolean>;
 	focusWindow(options?: { windowId?: number }): Promise<void>;
 
-	getToolbarButtonLayout(): ButtonLayout;
+	getTitlebarButtonLayout(): ButtonLayout;
 
 	// Dialogs
 	showMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue>;

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -105,7 +105,6 @@
 	z-index: 3000;
 	-webkit-app-region: no-drag;
 	height: 100%;
-	width: 138px;
 	margin-left: auto;
 }
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -418,7 +418,7 @@ export class TitlebarPart extends Part implements ITitleService {
 		// Window Controls (Native Windows/Linux)
 		if (!isMacintosh && !isWeb) {
 			this.windowControls = append(this.element, $('div.window-controls-container'));
-			let buttonLayout = this.electronService.getToolbarButtonLayout();
+			let buttonLayout = this.electronService.getTitlebarButtonLayout();
 
 			// Minimize
 			if ('minimize' in buttonLayout) {

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -418,23 +418,28 @@ export class TitlebarPart extends Part implements ITitleService {
 		// Window Controls (Native Windows/Linux)
 		if (!isMacintosh && !isWeb) {
 			this.windowControls = append(this.element, $('div.window-controls-container'));
+			let buttonLayout = this.electronService.getToolbarButtonLayout();
 
 			// Minimize
-			const minimizeIcon = append(this.windowControls, $('div.window-icon.window-minimize.codicon.codicon-chrome-minimize'));
-			this._register(addDisposableListener(minimizeIcon, EventType.CLICK, e => {
-				this.electronService.minimizeWindow();
-			}));
+			if ('minimize' in buttonLayout) {
+				const minimizeIcon = append(this.windowControls, $('div.window-icon.window-minimize.codicon.codicon-chrome-minimize'));
+				this._register(addDisposableListener(minimizeIcon, EventType.CLICK, e => {
+					this.electronService.minimizeWindow();
+				}));
+			}
 
 			// Restore
-			this.maxRestoreControl = append(this.windowControls, $('div.window-icon.window-max-restore.codicon'));
-			this._register(addDisposableListener(this.maxRestoreControl, EventType.CLICK, async e => {
-				const maximized = await this.electronService.isMaximized();
-				if (maximized) {
-					return this.electronService.unmaximizeWindow();
-				}
+			if ('maximize' in buttonLayout) {
+				this.maxRestoreControl = append(this.windowControls, $('div.window-icon.window-max-restore.codicon'));
+				this._register(addDisposableListener(this.maxRestoreControl, EventType.CLICK, async e => {
+					const maximized = await this.electronService.isMaximized();
+					if (maximized) {
+						return this.electronService.unmaximizeWindow();
+					}
 
-				return this.electronService.maximizeWindow();
-			}));
+					return this.electronService.maximizeWindow();
+				}));
+			}
 
 			// Close
 			const closeIcon = append(this.windowControls, $('div.window-icon.window-close.codicon.codicon-chrome-close'));

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -418,28 +418,35 @@ export class TitlebarPart extends Part implements ITitleService {
 		// Window Controls (Native Windows/Linux)
 		if (!isMacintosh && !isWeb) {
 			this.windowControls = append(this.element, $('div.window-controls-container'));
-			let buttonLayout = this.electronService.getTitlebarButtonLayout();
 
 			// Minimize
-			if ('minimize' in buttonLayout) {
-				const minimizeIcon = append(this.windowControls, $('div.window-icon.window-minimize.codicon.codicon-chrome-minimize'));
-				this._register(addDisposableListener(minimizeIcon, EventType.CLICK, e => {
-					this.electronService.minimizeWindow();
-				}));
-			}
+			const minimizeIcon = append(this.windowControls, $('div.window-icon.window-minimize.codicon.codicon-chrome-minimize'));
+			this._register(addDisposableListener(minimizeIcon, EventType.CLICK, e => {
+				this.electronService.minimizeWindow();
+			}));
 
 			// Restore
-			if ('maximize' in buttonLayout) {
-				this.maxRestoreControl = append(this.windowControls, $('div.window-icon.window-max-restore.codicon'));
-				this._register(addDisposableListener(this.maxRestoreControl, EventType.CLICK, async e => {
-					const maximized = await this.electronService.isMaximized();
-					if (maximized) {
-						return this.electronService.unmaximizeWindow();
-					}
+			this.maxRestoreControl = append(this.windowControls, $('div.window-icon.window-max-restore.codicon'));
+			this._register(addDisposableListener(this.maxRestoreControl, EventType.CLICK, async e => {
+				const maximized = await this.electronService.isMaximized();
+				if (maximized) {
+					return this.electronService.unmaximizeWindow();
+				}
 
-					return this.electronService.maximizeWindow();
-				}));
-			}
+				return this.electronService.maximizeWindow();
+			}));
+
+			this.electronService.getTitlebarButtonLayout().then(buttonLayout => {
+				console.log(buttonLayout);
+
+				if (!buttonLayout.includes('minimize')) {
+					minimizeIcon.remove();
+				}
+
+				if (!buttonLayout.includes('maximize')) {
+					this.maxRestoreControl?.remove();
+				}
+			});
 
 			// Close
 			const closeIcon = append(this.windowControls, $('div.window-icon.window-close.codicon.codicon-chrome-close'));

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -437,7 +437,6 @@ export class TitlebarPart extends Part implements ITitleService {
 			}));
 
 			this.electronService.getTitlebarButtonLayout().then(buttonLayout => {
-				console.log(buttonLayout);
 
 				if (!buttonLayout.includes('minimize')) {
 					minimizeIcon.remove();

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -97,6 +97,7 @@ import { IFilesConfigurationService, FilesConfigurationService } from 'vs/workbe
 import { IAccessibilityService, AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
 import { IDebugService } from 'vs/workbench/contrib/debug/common/debug';
 import { MockDebugService } from 'vs/workbench/contrib/debug/test/common/mockDebug';
+import { ButtonLayout } from 'vs/platform/electron/node/buttonLayout';
 
 export function createFileInput(instantiationService: IInstantiationService, resource: URI): FileEditorInput {
 	return instantiationService.createInstance(FileEditorInput, resource, undefined, undefined);
@@ -1432,6 +1433,7 @@ export class TestElectronService implements IElectronService {
 	async minimizeWindow(): Promise<void> { }
 	async isWindowFocused(): Promise<boolean> { return true; }
 	async focusWindow(options?: { windowId?: number | undefined; } | undefined): Promise<void> { }
+	getToolbarButtonLayout(): ButtonLayout { return []; }
 	async showMessageBox(options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> { throw new Error('Method not implemented.'); }
 	async showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue> { throw new Error('Method not implemented.'); }
 	async showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue> { throw new Error('Method not implemented.'); }

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -1433,7 +1433,7 @@ export class TestElectronService implements IElectronService {
 	async minimizeWindow(): Promise<void> { }
 	async isWindowFocused(): Promise<boolean> { return true; }
 	async focusWindow(options?: { windowId?: number | undefined; } | undefined): Promise<void> { }
-	getToolbarButtonLayout(): ButtonLayout { return []; }
+	getTitlebarButtonLayout(): ButtonLayout { return []; }
 	async showMessageBox(options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> { throw new Error('Method not implemented.'); }
 	async showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue> { throw new Error('Method not implemented.'); }
 	async showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue> { throw new Error('Method not implemented.'); }

--- a/src/vs/workbench/test/workbenchTestServices.ts
+++ b/src/vs/workbench/test/workbenchTestServices.ts
@@ -1430,7 +1430,7 @@ export class TestElectronService implements IElectronService {
 	async minimizeWindow(): Promise<void> { }
 	async isWindowFocused(): Promise<boolean> { return true; }
 	async focusWindow(options?: { windowId?: number | undefined; } | undefined): Promise<void> { }
-	getTitlebarButtonLayout(): ButtonLayout { return []; }
+	async getTitlebarButtonLayout(): Promise<ButtonLayout> { return []; }
 	async showMessageBox(options: Electron.MessageBoxOptions): Promise<Electron.MessageBoxReturnValue> { throw new Error('Method not implemented.'); }
 	async showSaveDialog(options: Electron.SaveDialogOptions): Promise<Electron.SaveDialogReturnValue> { throw new Error('Method not implemented.'); }
 	async showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue> { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
Use the title bar button layout from GNOME settings. Some people would like to see VSCode preserve OS preferences. This PR adds functionality that hides maximize or minimize buttons according to GNOME tweaks.

Issue: none (or I didn't find)

![image](https://user-images.githubusercontent.com/15856982/73199611-358a6580-4146-11ea-94d6-8147c6220530.png)
![image](https://user-images.githubusercontent.com/15856982/73199625-39b68300-4146-11ea-80cf-281fc1bd3ed0.png)


P.S I reopen my old PR #88298