### PR TITLE
Close search editor references widget on new search

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/peek/referencesController.ts
+++ b/src/vs/editor/contrib/gotoSymbol/peek/referencesController.ts
@@ -216,14 +216,16 @@ export abstract class ReferencesController implements IEditorContribution {
 		}
 	}
 
-	closeWidget(): void {
+	closeWidget(focusEditor = true): void {
 		this._referenceSearchVisible.reset();
 		this._disposables.clear();
 		dispose(this._widget);
 		dispose(this._model);
 		this._widget = undefined;
 		this._model = undefined;
-		this._editor.focus();
+		if (focusEditor) {
+			this._editor.focus();
+		}
 		this._requestIdPool += 1; // Cancel pending requests
 	}
 

--- a/src/vs/workbench/contrib/search/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/search/browser/searchEditor.ts
@@ -41,6 +41,7 @@ import { IEditorProgressService, LongRunningOperation } from 'vs/platform/progre
 import type { SearchEditorInput, SearchConfiguration } from 'vs/workbench/contrib/search/browser/searchEditorInput';
 import { searchEditorFindMatchBorder, searchEditorFindMatch, registerColor, inputBorder } from 'vs/platform/theme/common/colorRegistry';
 import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
+import { ReferencesController } from 'vs/editor/contrib/gotoSymbol/peek/referencesController';
 
 const RESULT_LINE_REGEX = /^(\s+)(\d+)(:| )(\s+)(.*)$/;
 const FILE_LINE_REGEX = /^(\S.*):$/;
@@ -318,6 +319,8 @@ export class SearchEditor extends BaseEditor {
 			return;
 		}
 
+		const controller = ReferencesController.get(this.searchResultEditor);
+		controller.closeWidget(false);
 
 		const labelFormatter = (uri: URI): string => this.labelService.getUriLabel(uri, { relative: true });
 		const results = serializeSearchResultForEditor(searchModel.searchResult, config.includes, config.excludes, config.contextLines, labelFormatter, true);


### PR DESCRIPTION
Fixes #89449


@jrieken old behavior always focused the editor on close, but that doesn't work in search editor because focus may have been in the query input field.