### PR TITLE
Fixed peekWidgetDefaultFocus configuration mispelling

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3577,7 +3577,7 @@ export const EditorOptions = {
 		['tree', 'editor'] as const,
 		{
 			enumDescriptions: [
-				nls.localize('peekWidgetDefaultFocus.tree', "Focus the tree when openeing peek"),
+				nls.localize('peekWidgetDefaultFocus.tree', "Focus the tree when opening peek"),
 				nls.localize('peekWidgetDefaultFocus.editor', "Focus the editor when opening peek")
 			],
 			description: nls.localize('peekWidgetDefaultFocus', "Controls whether to focus the inline editor or the tree in the peek widget.")


### PR DESCRIPTION
This PR fixes #89670.
Now spelling is correct.
