### PR TITLE
Fix suggest details close button

### DIFF
--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -168,6 +168,11 @@
 	position: absolute;
 	top: 2px;
 	right: 2px;
+	opacity: 0;
+}
+
+.monaco-editor .suggest-widget .details:hover > .monaco-scrollable-element > .body > .header > .codicon-close {
+	opacity: 1
 }
 
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .header > .codicon-close:hover,
@@ -367,6 +372,7 @@
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .docs.markdown-docs {
 	padding: 0;
 	white-space: initial;
+	margin-right: 37px;
 }
 
 .monaco-editor .suggest-widget .details > .monaco-scrollable-element > .body > .docs.markdown-docs > div,


### PR DESCRIPTION
This PR fixes #88852

![image](https://user-images.githubusercontent.com/15856982/73429883-c1221300-434d-11ea-80a0-6b36492f74b2.png)
![image](https://user-images.githubusercontent.com/15856982/73429983-f7f82900-434d-11ea-958c-77490de74cc8.png)

Also, I added the right margin to details view to fix the case when details text overlapping with the close button

![image](https://user-images.githubusercontent.com/15856982/73430115-4efdfe00-434e-11ea-8e48-934bfeb9935f.png)


