### PR TITLE
Fix off-by-one typo to improve display of files in TS call hierarchy

### DIFF
--- a/extensions/typescript-language-features/src/features/callHierarchy.ts
+++ b/extensions/typescript-language-features/src/features/callHierarchy.ts
@@ -72,7 +72,7 @@ class TypeScriptCallHierarchySupport implements vscode.CallHierarchyProvider {
 }
 
 function isSourceFileItem(item: Proto.CallHierarchyItem) {
-	return item.kind === PConst.Kind.script || item.kind === PConst.Kind.module && item.selectionSpan.start.line === 0 && item.selectionSpan.start.offset === 0;
+	return item.kind === PConst.Kind.script || item.kind === PConst.Kind.module && item.selectionSpan.start.line === 1 && item.selectionSpan.start.offset === 1;
 }
 
 function fromProtocolCallHierarchyItem(item: Proto.CallHierarchyItem): vscode.CallHierarchyItem {


### PR DESCRIPTION
This fixes an issue where the call hierarchy item names are displaying incorrectly for files:

# Expected

![image](https://user-images.githubusercontent.com/3902892/73579528-85637800-4437-11ea-8295-4894ff18f158.png)

# Actual

![image](https://user-images.githubusercontent.com/3902892/73579507-7da3d380-4437-11ea-94d2-54d7697c63e4.png)

This was caused by an off-by-one typo in a function used to determine whether a call hierarchy item pointed to a TypeScript source file.