### PR TITLE
Fixes #89675: Simplify logic for horizontal positioning

### DIFF
--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -317,28 +317,8 @@ class Widget {
 
 	private _layoutHorizontalSegmentInPage(windowSize: dom.Dimension, domNodePosition: dom.IDomNodePagePosition, left: number, width: number): [number, number] {
 		// Initially, the limits are defined as the dom node limits
-		let MIN_LIMIT = domNodePosition.left;
-		let MAX_LIMIT = domNodePosition.left + domNodePosition.width - 20;
-		if (MAX_LIMIT - MIN_LIMIT < width) {
-			// If the width is too large, we must expand the limits
-			const delta1 = Math.ceil((width - (MAX_LIMIT - MIN_LIMIT)) / 2);
-			MIN_LIMIT -= delta1;
-			MAX_LIMIT += delta1;
-
-			if (MAX_LIMIT > windowSize.width) {
-				// But we need to make sure we haven't expanded the limits over the page width
-				const delta2 = MAX_LIMIT - windowSize.width;
-				MIN_LIMIT -= delta2;
-				MAX_LIMIT -= delta2;
-			}
-
-			if (MIN_LIMIT < 0) {
-				// And we need to make sure we haven't expanded them before the page
-				const delta3 = -MIN_LIMIT;
-				MIN_LIMIT += delta3;
-				MAX_LIMIT += delta3;
-			}
-		}
+		const MIN_LIMIT = Math.max(0, domNodePosition.left - width);
+		const MAX_LIMIT = Math.min(domNodePosition.left + domNodePosition.width + width, windowSize.width);
 
 		let absoluteLeft = domNodePosition.left + left - dom.StandardWindow.scrollX;
 


### PR DESCRIPTION
This PR fixes #89675 for 1.42

This logic tries to validate a good horizontal position (`left` coordinate) for the layout of a content widget. A desired position has already been computed for the widget, and this method must validate that the widget is rendered entirely in the page (that it doesn't get cut off by the page boundaries) and that it is rendered in proximity with the editor (like in #88720).

The relevant inputs are:
* `windowSize.width`: The width of the entire page
* `domNodePosition.left`: The absolute left coordinate of the editor in the page
* `domNodePosition.width`: The width of the editor
* `left`: The desired absolute left coordinate for the content widget
* `width`: The width of the content widget

The old logic had a special case for when the content widget is larger than the editor and that special case was flawed.

The proposed change computes a `MIN_LIMIT` and a `MAX_LIMIT` by taking the editor's position/width and expanding on either side by the width of the content widget. The `MIN_LIMIT` and `MAX_LIMIT` are also enforced to be within the page (`>=0`, `<=windowSize.width`)

Then, the old logic that enforces that the content widget fits within `MIN_LIMIT` and `MAX_LIMIT` kicks in. The old logic was doing that correctly. 

