### PR TITLE
disable semantic highlight for stable

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1608,7 +1608,7 @@ class EditorSemanticHighlighting extends BaseEditorOption<EditorOption.semanticH
 
 	constructor() {
 		const defaults: EditorSemanticHighlightingOptions = {
-			enabled: true
+			enabled: false
 		};
 		super(
 			EditorOption.semanticHighlighting, 'semanticHighlighting', defaults,


### PR DESCRIPTION
As discussed with @mjbvz and @egamma , we disable semantic highlight by default for stable 1.42.

As described in the release notes, interested user can enabled by setting `"editor.semanticHighlighting.enabled": true`.

This will give us more time to fix some remaining issues with the TypeScript semantic highlighting and react to feedback from C++ and Java.