### PR TITLE
Fix #89900 - improve text on editor.showFoldingControls setting

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3675,7 +3675,13 @@ export const EditorOptions = {
 		EditorOption.showFoldingControls, 'showFoldingControls',
 		'mouseover' as 'always' | 'mouseover',
 		['always', 'mouseover'] as const,
-		{ description: nls.localize('showFoldingControls', "Controls whether the fold controls on the gutter are automatically hidden.") }
+		{
+			enumDescriptions: [
+				nls.localize('showFoldingControls.always', "Always show the folding controls."),
+				nls.localize('showFoldingControls.mouseover', "Only show the folding controls when the mouse is over the gutter."),
+			],
+			description: nls.localize('showFoldingControls', "Controls when the folding controls on the gutter are shown.")
+		}
 	)),
 	showUnused: register(new EditorBooleanOption(
 		EditorOption.showUnused, 'showUnused', true,


### PR DESCRIPTION
This PR fixes #89900

As well as clarifying the meaning of the setting, descriptions have been added to the two values it can take.

![image](https://user-images.githubusercontent.com/6726799/73651526-846f5800-467c-11ea-9f8f-4c61148808cd.png)

![image](https://user-images.githubusercontent.com/6726799/73651566-95b86480-467c-11ea-847e-4cab5583148e.png)

