### PR TITLE
Don't include dom typings in extensions

### DIFF
--- a/extensions/git/src/fileSystemProvider.ts
+++ b/extensions/git/src/fileSystemProvider.ts
@@ -9,6 +9,7 @@ import { fromGitUri, toGitUri } from './uri';
 import { Model, ModelChangeEvent, OriginalResourceChangeEvent } from './model';
 import { filterEvent, eventToPromise, isDescendant, pathEquals, EmptyDisposable } from './util';
 import { Repository } from './repository';
+import { TextEncoder } from 'util';
 
 interface CacheRow {
 	uri: Uri;

--- a/extensions/markdown-language-features/preview-src/tsconfig.json
+++ b/extensions/markdown-language-features/preview-src/tsconfig.json
@@ -2,6 +2,11 @@
 	"extends": "../../shared.tsconfig.json",
 	"compilerOptions": {
 		"outDir": "./dist/",
-		"jsx": "react"
+		"jsx": "react",
+		"lib": [
+			"es2018",
+			"DOM",
+			"DOM.Iterable"
+		]
 	}
 }

--- a/extensions/shared.tsconfig.json
+++ b/extensions/shared.tsconfig.json
@@ -1,6 +1,9 @@
 {
 	"compilerOptions": {
 		"target": "es2018",
+		"lib": [
+			"es2018"
+		],
 		"module": "commonjs",
 		"strict": true,
 		"alwaysStrict": true,

--- a/extensions/vscode-api-tests/src/extension.ts
+++ b/extensions/vscode-api-tests/src/extension.ts
@@ -13,9 +13,13 @@
 //
 
 import * as vscode from 'vscode';
+import { URL } from 'url';
+import { TextEncoder, TextDecoder } from 'util';
 
 const textEncoder = new TextEncoder();
 const SCHEME = 'memfs';
+
+declare const window: unknown;
 
 export function activate(context: vscode.ExtensionContext) {
 	if (typeof window !== 'undefined') {	// do not run under node.js


### PR DESCRIPTION
**Problem**
All of our extensions currently are built using the dom typings. This can lead to runtime errors if you mistakenly use `window` in an extension

**Fix**
Exclude the dom typings from compile. Then explicitly import the node types for `URL` and `TextEncoder`
