### PR TITLE
Don't ignore system keyboard shortcuts on webviews unless already handled

### DIFF
--- a/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewElement.ts
@@ -164,7 +164,9 @@ class WebviewKeyboardHandler extends Disposable {
 			this._register(_webviewHandle.onFirstLoad(contents => {
 				contents.on('before-input-event', (_event, input) => {
 					if (input.type === 'keyDown' && document.activeElement === this._webviewHandle.webview) {
-						this._ignoreMenuShortcut = input.control || input.meta;
+						// These commands are handled explicitly by webviewCommands.ts. Everything else doesn't need to be prevented.
+						const isHandledCommand = input.key === 'c' || input.key === 'v' || input.key === 'a' || input.key === 'x' || input.key === 'z';
+						this._ignoreMenuShortcut = (input.control || input.meta) && isHandledCommand;
 						this.setIgnoreMenuShortcuts(this._ignoreMenuShortcut);
 					}
 				});


### PR DESCRIPTION
This PR fixes #71800
The bug is that native OS shortcuts like cmd-m to minimize and cmd-h to hide are not respected when a webview is focused on macOS. To repro, open any webview like the Cat Coding sample webview and press cmd-h to try to hide the window.

The reason for this is that *all* shortcuts are captured and attempted to be handled by webviewCommands.ts (for copy, paste, etc). But some are missing from this list, including cmd-h and cmd-m. This capturing appears to only happen on macOS. Instead of capturing all events, we can just capture if the event looks like one that will be handled by webviewCommands (namely, cmd-c, cmd-v, cmd-z, cmd-x, cmd-a)
