### PR TITLE
Fix undo/redo broken in non-editor webviews

### DIFF
--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -281,7 +281,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		];
 		this._hasCustomEditor.set(possibleEditors.length > 0);
 		this._focusedCustomEditorIsEditable.set(activeControl?.input instanceof CustomFileEditorInput);
-		this._webviewHasOwnEditFunctions.set(true);
+		this._webviewHasOwnEditFunctions.set(possibleEditors.length > 0);
 	}
 
 	private handleMovedFileInOpenedFileEditors(oldResource: URI, newResource: URI): void {


### PR DESCRIPTION
This PR fixes #89960

Undo/redo is broken in webviews due to the context key being overly aggressive in setting itself as `webviewHasOwnEditFunctions`. I think instead of true, this should set it to be based on if it has a custom editor. This fixes `webviewCommands.ts`, which uses this context key for undo/redo.

Repro:
1. open a webview with an `<input>` (e.g. modify the cat coding sample)
2. type into the input
3. undo & redo with cmd-z and cmd-shift-z work as expected
