### PR TITLE
simple file dialog - add files to recently opened

### DIFF
--- a/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
@@ -20,6 +20,8 @@ import { IElectronService } from 'vs/platform/electron/node/electron';
 import { AbstractFileDialogService } from 'vs/workbench/services/dialogs/browser/abstractFileDialogService';
 import { Schemas } from 'vs/base/common/network';
 import { IModeService } from 'vs/editor/common/services/modeService';
+import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
+import { ILabelService } from 'vs/platform/label/common/label';
 
 export class FileDialogService extends AbstractFileDialogService implements IFileDialogService {
 
@@ -36,9 +38,11 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		@IOpenerService openerService: IOpenerService,
 		@IElectronService private readonly electronService: IElectronService,
 		@IDialogService dialogService: IDialogService,
-		@IModeService modeService: IModeService
+		@IModeService modeService: IModeService,
+		@IWorkspacesService workspacesService: IWorkspacesService,
+		@ILabelService labelService: ILabelService
 	) {
-		super(hostService, contextService, historyService, environmentService, instantiationService, configurationService, fileService, openerService, dialogService, modeService);
+		super(hostService, contextService, historyService, environmentService, instantiationService, configurationService, fileService, openerService, dialogService, modeService, workspacesService, labelService);
 	}
 
 	private toNativeOpenDialogOptions(options: IPickAndOpenOptions): INativeOpenDialogOptions {


### PR DESCRIPTION
@alexr00 I noticed that whenever the simple file dialog is used (e.g in remote or even in web), picked files are not showing up in this files section of the recently opened list:

![image](https://user-images.githubusercontent.com/900690/73736010-679c5880-4740-11ea-99d2-2f762de5d46d.png)

This list is filled from various places, e.g. whenever you open a workspace or folder an entry will be added. When opening files via command line or the native file dialog, we have code in `electron-main` that ensures to add them as well, but we do not have that code when using the simple file dialog because everything happens in the renderer. 

Suggested fix is to let the simple file dialog add the history entry for files picked. Let me know if you think it should be at a different place altogether.

PS: the idea of this list is to reflect files and folders that are opened into vscode from outside (e.g. through dialogs), NOT to reflect each file that was clicked on within VSCode.