### PR TITLE
Fix interactive playground's suggest widget styled everything as links

### DIFF
--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughPart.ts
@@ -529,16 +529,16 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const link = theme.getColor(textLinkForeground);
 	if (link) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .walkThroughContent a { color: ${link}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .walkThroughContent a[href] { color: ${link}; }`);
 	}
 	const activeLink = theme.getColor(textLinkActiveForeground);
 	if (activeLink) {
 		collector.addRule(`.monaco-workbench .part.editor > .content .walkThroughContent a:hover,
-			.monaco-workbench .part.editor > .content .walkThroughContent a:active { color: ${activeLink}; }`);
+			.monaco-workbench .part.editor > .content .walkThroughContent a[href]:active { color: ${activeLink}; }`);
 	}
 	const focusColor = theme.getColor(focusBorder);
 	if (focusColor) {
-		collector.addRule(`.monaco-workbench .part.editor > .content .walkThroughContent a:focus { outline-color: ${focusColor}; }`);
+		collector.addRule(`.monaco-workbench .part.editor > .content .walkThroughContent a[href]:focus { outline-color: ${focusColor}; }`);
 	}
 	const shortcut = theme.getColor(textPreformatForeground);
 	if (shortcut) {


### PR DESCRIPTION
This PR fixes #83024 

As I described [here](https://github.com/microsoft/vscode/issues/83024#issuecomment-582039826), changing CSS rules to style only such tags that have non-empty Href attribute fixes this issue 

![image](https://user-images.githubusercontent.com/15856982/73774107-81678b00-4794-11ea-9a50-b4cb0473ebb2.png)
