### PR TITLE
Fix to reveal the primary cursor in multi-cursor mode

### DIFF
--- a/src/vs/editor/common/controller/cursor.ts
+++ b/src/vs/editor/common/controller/cursor.ts
@@ -580,11 +580,8 @@ export class Cursor extends viewEvents.ViewEventEmitter implements ICursors {
 					viewPosition = viewPositions[i];
 				}
 			}
-		} else {
-			if (viewPositions.length > 1) {
-				// no revealing!
-				return;
-			}
+		} else if (revealTarget === RevealTarget.Primary) {
+			// Do nothing. The `viewPosition` to reveal is `viewPositions[0]` and it's already set above.
 		}
 
 		const viewRange = new Range(viewPosition.lineNumber, viewPosition.column, viewPosition.lineNumber, viewPosition.column);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #6995

As I suggested [here](https://github.com/microsoft/vscode/issues/6995#issuecomment-477229278), I changed the code to reveal the primary cursor when the editor is in multi-cursor mode.

![vscode-multicursor-reveal](https://user-images.githubusercontent.com/3135397/73855239-1d69c300-4877-11ea-9803-afc45d0e2d7b.gif)
