### PR TITLE
Fix #90093

### DIFF
--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -234,7 +234,6 @@
 }
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right {
 	overflow: hidden;
-	margin-left: 16px;
 	flex-shrink: 0;
 	max-width: 45%;
 }


### PR DESCRIPTION
Fix #90093

Explanation:

We have roughly this display for suggest label:

```ts
/**
 * Flexbox
 * < ------- left ------- >     < -------- right -------- >
 * <icon><label><signature>     <qualifier><type><readmore>
 */
```

Previously I set a left margin for `right`, so left and right side wouldn't touch each other.
Now I set the margin for `qualifier`, `type` and `readmore` individually, so that if they are shown, they would have enough space to the left because of their own `margin-left`:

![image](https://user-images.githubusercontent.com/4033249/73875398-19ec2280-480a-11ea-9582-5af056c39012.png)
