### PR TITLE
Fixed bug where one could open 'peek' inside 'peek' on definition link

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition.ts
+++ b/src/vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition.ts
@@ -28,6 +28,9 @@ import { Position } from 'vs/editor/common/core/position';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
+import { PeekContext } from 'vs/editor/contrib/peekView/peekView';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 export class GotoDefinitionAtPositionEditorContribution implements IEditorContribution {
 
@@ -335,9 +338,17 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 
 	private gotoDefinition(position: Position, openToSide: boolean): Promise<any> {
 		this.editor.setPosition(position);
-		const openInPeek = this.editor.getOption(EditorOption.definitionLinkOpensInPeek);
-		const action = new DefinitionAction({ openToSide, openInPeek: openInPeek, muteMessage: true }, { alias: '', label: '', id: '', precondition: undefined });
-		return this.editor.invokeWithinContext(accessor => action.run(accessor, this.editor));
+		const definitionLinkOpensInPeek = this.editor.getOption(EditorOption.definitionLinkOpensInPeek);
+		return this.editor.invokeWithinContext((accessor) => {
+			const canPeek = definitionLinkOpensInPeek && !this.isInPeekEditor(accessor);
+			const action = new DefinitionAction({ openToSide, openInPeek: canPeek, muteMessage: true }, { alias: '', label: '', id: '', precondition: undefined });
+			return action.run(accessor, this.editor);
+		});
+	}
+
+	private isInPeekEditor(accessor: ServicesAccessor): boolean | undefined {
+		const contextKeyService = accessor.get(IContextKeyService);
+		return PeekContext.inPeekEditor.getValue(contextKeyService);
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
This PR fixes #90107.
When the new setting 'Definition Link Opens in Peek' is checked, a new peek widget will be opened **if and only if** there is no peek widget open yet (user is not inside a peek context).

Otherwise it performs a normal Go To Definition.

![Peek-solved](https://user-images.githubusercontent.com/10179520/73891248-a0c4ed80-4852-11ea-8bd2-ff3f3679ab6d.gif)
