### PR TITLE
WIP: Support fingerprint verification confirmation

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1772,7 +1772,8 @@
     "vscode-extension-telemetry": "0.1.1",
     "vscode-nls": "^4.0.0",
     "vscode-uri": "^2.0.0",
-    "which": "^1.3.0"
+    "which": "^1.3.0",
+    "strip-ansi": "^5.2.1"
   },
   "devDependencies": {
     "@types/byline": "4.2.31",
@@ -1780,6 +1781,7 @@
     "@types/mocha": "2.2.43",
     "@types/node": "^12.11.7",
     "@types/which": "^1.0.28",
+    "@types/strip-ansi": "5.2.1",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.23.3",
     "mocha-multi-reporters": "^1.1.7",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -805,9 +805,7 @@ export class Repository {
 	}
 
 	spawn_pty(args: string[], options: PtySpawnOptions = {}): pty.IPty {
-		if (options.cwd === undefined) {
-			options.cwd = this.root;
-		}
+		options.cwd = options.cwd || this.root;
 
 		return this.git.spawn_pty(args, options);
 	}

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1615,15 +1615,21 @@ export class Repository {
 			const onData = (raw: string) => {
 				outputData += stripAnsi(raw);
 
+				if (/Are you sure you want to continue connecting \(yes\/no\)\? (yes|no)/i.test(outputData)) {
+					outputData = '';
+				}
+
 				if (/Are you sure you want to continue connecting/i.test(outputData)) {
 					let host = /host '(.*)' can't/.exec(outputData)![1];
 					let fingerprint = /ECDSA key fingerprint is (.*)./.exec(outputData)![1];
 
+					outputData = '';
 					userInputProvider.askFingerprintConfirmation(host, fingerprint).then(confirmation => {
 						if (confirmation) {
 							child.write('yes\r');
 						} else {
-							child.write('no\r');
+							child.kill();
+							e(new GitError({ message: 'Cancelled' }));
 						}
 					});
 				}
@@ -1736,15 +1742,21 @@ export class Repository {
 			const onData = (raw: string) => {
 				outputData += stripAnsi(raw);
 
+				if (/Are you sure you want to continue connecting \(yes\/no\)\? (yes|no)/i.test(outputData)) {
+					outputData = '';
+				}
+
 				if (/Are you sure you want to continue connecting/i.test(outputData)) {
 					let host = /host '(.*)' can't/.exec(outputData)![1];
 					let fingerprint = /ECDSA key fingerprint is (.*)./.exec(outputData)![1];
 
+					outputData = '';
 					userInputProvider.askFingerprintConfirmation(host, fingerprint).then(confirmation => {
 						if (confirmation) {
 							child.write('yes\r');
 						} else {
-							child.write('no\r');
+							child.kill();
+							e(new GitError({ message: 'Cancelled' }));
 						}
 					});
 				}
@@ -1843,15 +1855,21 @@ export class Repository {
 			const onData = (raw: string) => {
 				outputData += stripAnsi(raw);
 
+				if (/Are you sure you want to continue connecting \(yes\/no\)\? (yes|no)/i.test(outputData)) {
+					outputData = '';
+				}
+
 				if (/Are you sure you want to continue connecting/i.test(outputData)) {
 					let host = /host '(.*)' can't/.exec(outputData)![1];
 					let fingerprint = /ECDSA key fingerprint is (.*)./.exec(outputData)![1];
 
+					outputData = '';
 					userInputProvider.askFingerprintConfirmation(host, fingerprint).then(confirmation => {
 						if (confirmation) {
 							child.write('yes\r');
 						} else {
-							child.write('no\r');
+							child.kill();
+							e(new GitError({ message: 'Cancelled' }));
 						}
 					});
 				}

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -7,7 +7,7 @@ import { workspace, WorkspaceFoldersChangeEvent, Uri, window, Event, EventEmitte
 import { Repository, RepositoryState } from './repository';
 import { memoize, sequentialize, debounce } from './decorators';
 import { dispose, anyEvent, filterEvent, isDescendant, firstIndex, pathEquals } from './util';
-import { Git } from './git';
+import { Git, UserInputProvider } from './git';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as nls from 'vscode-nls';
@@ -76,7 +76,7 @@ export class Model {
 
 	private disposables: Disposable[] = [];
 
-	constructor(readonly git: Git, private globalState: Memento, private outputChannel: OutputChannel) {
+	constructor(readonly git: Git, private globalState: Memento, private outputChannel: OutputChannel, private userInputProvider: UserInputProvider) {
 		workspace.onDidChangeWorkspaceFolders(this.onDidChangeWorkspaceFolders, this, this.disposables);
 		window.onDidChangeVisibleTextEditors(this.onDidChangeVisibleTextEditors, this, this.disposables);
 		workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, this.disposables);
@@ -245,7 +245,7 @@ export class Model {
 			}
 
 			const dotGit = await this.git.getRepositoryDotGit(repositoryRoot);
-			const repository = new Repository(this.git.open(repositoryRoot, dotGit), this.globalState, this.outputChannel);
+			const repository = new Repository(this.git.open(repositoryRoot, dotGit), this.userInputProvider, this.globalState, this.outputChannel);
 
 			this.open(repository);
 			await repository.status();

--- a/extensions/git/yarn.lock
+++ b/extensions/git/yarn.lock
@@ -31,6 +31,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
   integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
 
+"@types/strip-ansi@5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@types/strip-ansi/-/strip-ansi-5.2.1.tgz#acd97f1f091e332bb7ce697c4609eb2370fa2a92"
+  integrity sha512-1l5iM0LBkVU8JXxnIoBqNvg+yyOXxPeN6DNoD+7A9AN1B8FhYPSeIXgyNqwIqg1uzipTgVC2hmuDzB0u9qw/PA==
+  dependencies:
+    strip-ansi "*"
+
 "@types/which@^1.0.28":
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/@types/which/-/which-1.0.28.tgz#016e387629b8817bed653fe32eab5d11279c8df6"
@@ -57,6 +64,16 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 applicationinsights@1.0.8:
   version "1.0.8"
@@ -801,12 +818,26 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+strip-ansi@*:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
+
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.2.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 supports-color@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
This PR fixes #89829

This PR is a work in progress. I opened it to receive feedback from the maintainers. 

The main idea is to use `node-pty` to call git methods that can request fingerprint confirmation. So git will run in the interactive mode that allows confirm or decline verification programmatically