### PR TITLE
Clarify language when creating new git branch

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1620,7 +1620,7 @@ export class CommandCenter {
 
 		const rawBranchName = defaultName || await window.showInputBox({
 			placeHolder: localize('branch name', "Branch name"),
-			prompt: localize('provide branch name', "Please provide a branch name"),
+			prompt: localize('provide branch name', "Please provide a new branch name"),
 			value: initialValue,
 			ignoreFocusOut: true,
 			validateInput: (name: string) => {


### PR DESCRIPTION
When using the git extension, the intent is clear when clicking on "+ Create new branch..." and immediately being prompted "Please provide a branch name". But, when clicking on "+ Create a new branch from..." the intent is ambiguous, since the statement "Please provide a branch name" could refer to the branch from which you wish to base the new branch on or the name of the new branch, the latter being what actually happens.

By specifying "Please provide a *new* branch name...", the intent is clear: the prompt is asking for the name you wish to call the new branch.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #90158
