### PR TITLE
Fixes microsoft/monaco-editor#1818: check matchOnlyAtLineStart when e…

### DIFF
--- a/src/vs/editor/standalone/common/monarch/monarchLexer.ts
+++ b/src/vs/editor/standalone/common/monarch/monarchLexer.ts
@@ -501,7 +501,7 @@ export class MonarchTokenizer implements modes.ITokenizationSupport {
 			}
 
 			let result = line.search(regex);
-			if (result === -1) {
+			if (result === -1 || (result !== 0 && rule.matchOnlyAtLineStart)) {
 				continue;
 			}
 


### PR DESCRIPTION
This PR fixes microsoft/monaco-editor#1818.

I tested this by copying one of the `.html` files in `playground.generated` and changing the JavaScript to include the following:

```js
const DEMO_LANG_ID = "demo";

const languageConfiguration = {
  // The main tokenizer for our languages
  tokenizer: {
    root: [
      [/^\!/, { token: 'delimiter.curly', next: 'jsonInBang', nextEmbedded: 'json' }],
    ],
    jsonInBang: [
      [/^\!/, { token: 'delimiter.curly', next: '@pop', nextEmbedded: '@pop' }],
    ],
  },
};
monaco.languages.register({
  id: DEMO_LANG_ID,
  extensions: ['.example'],
});
monaco.languages.setMonarchTokensProvider(DEMO_LANG_ID, languageConfiguration);

      const value = `\
!
  {
    "foo": "b!ar"
  }
!
`;

var editor = monaco.editor.create(document.getElementById("container"), {
  value,
  language: DEMO_LANG_ID,

  lineNumbers: "off",
  roundedSelection: false,
  scrollBeyondLastLine: false,
  readOnly: false,
  theme: "vs-dark",
});
```

When I loaded the page, now the entire `"b!ar"` string literal was highlighted correctly. Previously, the syntax highlighting stopped at the `!`.
