### PR TITLE
Enable ok button for extensions using quickpick

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1257,6 +1257,8 @@ export class QuickInputController extends Disposable {
 			input.autoFocusOnList = (options.autoFocusOnList === undefined) || options.autoFocusOnList; // default to true
 			input.quickNavigate = options.quickNavigate;
 			input.contextKey = options.contextKey;
+			input.ok = !!options.ok;
+
 			input.busy = true;
 			Promise.all<QuickPickInput<T>[], T | undefined>([picks, options.activeItem])
 				.then(([items, _activeItem]) => {

--- a/src/vs/base/parts/quickinput/common/quickInput.ts
+++ b/src/vs/base/parts/quickinput/common/quickInput.ts
@@ -85,6 +85,11 @@ export interface IPickOptions<T extends IQuickPickItem> {
 	 */
 	activeItem?: Promise<T> | T;
 
+	/**
+	 * an optional flag to show ok button
+	 */
+	ok?: boolean
+
 	onKeyMods?: (keyMods: IKeyMods) => void;
 	onDidFocus?: (entry: T) => void;
 	onDidTriggerItemButton?: (context: IQuickPickItemButtonContext<T>) => void;

--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1358,6 +1358,21 @@ declare module 'vscode' {
 
 	//#endregion
 
+	//#region allow QuickPicks to have an optional ok button at the end
+	export interface QuickPickOptions {
+		/**
+		 * An optional flag to make the picker show an ok button at the end of the picker. Default: false
+		 */
+		ok?: boolean;
+	}
+
+	export interface QuickPick<T extends QuickPickItem> extends QuickInput {
+		/**
+		 * An optional flag to make the picker show an ok button at the end of the picker. Default: false
+		 */
+		ok: boolean;
+	}
+
 	//#region Surfacing reasons why a code action cannot be applied to users: https://github.com/microsoft/vscode/issues/85160
 
 	export interface CodeAction {

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -272,7 +272,7 @@ class ExtHostQuickInput implements QuickInput {
 
 	set ok(ok: boolean) {
 		this._ok = ok;
-		this.update({ ok })
+		this.update({ ok });
 	}
 
 	get title() {

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -51,11 +51,12 @@ export class ExtHostQuickOpen implements ExtHostQuickOpenShape {
 		const instance = ++this._instances;
 
 		const quickPickWidget = this._proxy.$show(instance, {
-			placeHolder: options && options.placeHolder,
-			matchOnDescription: options && options.matchOnDescription,
-			matchOnDetail: options && options.matchOnDetail,
-			ignoreFocusLost: options && options.ignoreFocusOut,
-			canPickMany: options && options.canPickMany
+			placeHolder: options?.placeHolder,
+			matchOnDescription: options?.matchOnDescription,
+			matchOnDetail: options?.matchOnDetail,
+			ignoreFocusLost: options?.ignoreFocusOut,
+			canPickMany: options?.canPickMany,
+			ok: options?.ok
 		}, token);
 
 		const widgetClosedMarker = {};
@@ -252,6 +253,7 @@ class ExtHostQuickInput implements QuickInput {
 	private readonly _onDidHideEmitter = new Emitter<void>();
 	private _updateTimeout: any;
 	private _pendingUpdate: TransferQuickInput = { id: this._id };
+	private _ok: boolean = false;
 
 	private _disposed = false;
 	protected _disposables: IDisposable[] = [
@@ -262,6 +264,15 @@ class ExtHostQuickInput implements QuickInput {
 	];
 
 	constructor(protected _proxy: MainThreadQuickOpenShape, protected _extensionId: ExtensionIdentifier, private _onDidDispose: () => void) {
+	}
+
+	get ok(): boolean {
+		return this._ok;
+	}
+
+	set ok(ok: boolean) {
+		this._ok = ok;
+		this.update({ ok })
 	}
 
 	get title() {


### PR DESCRIPTION
I noticed that the okay button disappeared without a way to bring it back. This PR empowers extension owners to decide if they want the button or not.
