### PR TITLE
(Peekview-widget) reverse title and actions

### DIFF
--- a/src/vs/editor/contrib/peekView/media/peekViewWidget.css
+++ b/src/vs/editor/contrib/peekView/media/peekViewWidget.css
@@ -6,6 +6,7 @@
 .monaco-editor .peekview-widget .head {
 	box-sizing:	border-box;
 	display: flex;
+	flex-direction: row-reverse;
 }
 
 .monaco-editor .peekview-widget .head .peekview-title {
@@ -13,6 +14,7 @@
 	align-items: center;
 	font-size: 13px;
 	margin-left: 20px;
+	margin-right: 2px;
 	cursor: pointer;
 }
 
@@ -32,8 +34,8 @@
 
 .monaco-editor .peekview-widget .head .peekview-actions {
 	flex: 1;
-	text-align: right;
-	padding-right: 2px;
+	text-align: left;
+	margin-left: 20px;
 }
 
 .monaco-editor .peekview-widget .head .peekview-actions > .monaco-action-bar {


### PR DESCRIPTION
Hi, I have not found an existing issue that this pull request solves.
I noticed that DX of `peekview-widget` could be improved. When I click on `dirty-diff bar` in the line numbers column and want to perform a vcs action I have to move my mouse cursor across the line width since vcs actions are located on the right side. While on the left side we have the file name (same as the tab name) which is not clickable but important for accessibility purposes. See the picture below.

<img width="1279" alt="Screenshot 2020-02-09 at 20 05 14 2" src="https://user-images.githubusercontent.com/38152408/74107539-45f90200-4b82-11ea-8375-41e6e4c0f84e.png">

I swapped title and actions with css to preserve the html elements order. Now you do not have to move your mouse cursor across the screen. See the picture below.

<img width="1280" alt="Screenshot 2020-02-09 at 21 01 06" src="https://user-images.githubusercontent.com/38152408/74107568-a1c38b00-4b82-11ea-86a2-500e57f10100.png">

