### PR TITLE
Will-navigate event should forward to opener service

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -204,10 +204,9 @@ export class CodeApplication extends Disposable {
 				event.preventDefault();
 			});
 
-			contents.on('will-navigate', event => {
-				this.logService.error('webContents#will-navigate: Prevented webcontent navigation');
-
+			contents.on('will-navigate', (event, url) => {
 				event.preventDefault();
+				contents.send('vscode:open', url);
 			});
 
 			contents.on('new-window', (event: Event, url: string) => {

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -5,8 +5,6 @@
 
 import { IListVirtualDelegate, IListRenderer } from 'vs/base/browser/ui/list/list';
 import { clearNode, addClass, removeClass, toggleClass, addDisposableListener, EventType, EventHelper } from 'vs/base/browser/dom';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { ButtonGroup } from 'vs/base/browser/ui/button/button';
 import { attachButtonStyler, attachProgressBarStyler } from 'vs/platform/theme/common/styler';
@@ -126,14 +124,9 @@ export interface INotificationTemplateData {
 	renderer: NotificationTemplateRenderer;
 }
 
-interface IMessageActionHandler {
-	callback: (href: string) => void;
-	toDispose: DisposableStore;
-}
-
 class NotificationMessageRenderer {
 
-	static render(message: INotificationMessage, actionHandler?: IMessageActionHandler): HTMLElement {
+	static render(message: INotificationMessage): HTMLElement {
 		const messageContainer = document.createElement('span');
 
 		// Message has no links
@@ -155,10 +148,6 @@ class NotificationMessageRenderer {
 				anchor.textContent = link.name;
 				anchor.title = link.title;
 				anchor.href = link.href;
-
-				if (actionHandler) {
-					actionHandler.toDispose.add(addDisposableListener(anchor, EventType.CLICK, () => actionHandler.callback(link.href)));
-				}
 
 				messageContainer.appendChild(anchor);
 
@@ -294,7 +283,6 @@ export class NotificationTemplateRenderer extends Disposable {
 	constructor(
 		private template: INotificationTemplateData,
 		private actionRunner: IActionRunner,
-		@IOpenerService private readonly openerService: IOpenerService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IThemeService private readonly themeService: IThemeService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService
@@ -369,10 +357,7 @@ export class NotificationTemplateRenderer extends Disposable {
 
 	private renderMessage(notification: INotificationViewItem): boolean {
 		clearNode(this.template.message);
-		this.template.message.appendChild(NotificationMessageRenderer.render(notification.message, {
-			callback: link => this.openerService.open(URI.parse(link)),
-			toDispose: this.inputDisposables
-		}));
+		this.template.message.appendChild(NotificationMessageRenderer.render(notification.message));
 
 		const messageOverflows = notification.canCollapse && !notification.expanded && this.template.message.scrollWidth > this.template.message.clientWidth;
 		if (messageOverflows) {

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -169,7 +169,7 @@ export class ElectronWindow extends Disposable {
 			}
 		});
 
-		// Support open event for opener service
+		// Support open event for opener service in desktop only
 		ipc.on('vscode:open', (_: IpcEvent, url: string) => this.openerService.open(url));
 
 		// Support openFiles event for existing and new files

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -169,6 +169,9 @@ export class ElectronWindow extends Disposable {
 			}
 		});
 
+		// Support open event for opener service
+		ipc.on('vscode:open', (_: IpcEvent, url: string) => this.openerService.open(url));
+
 		// Support openFiles event for existing and new files
 		ipc.on('vscode:openFiles', (event: IpcEvent, request: IOpenFileRequest) => this.onOpenFiles(request));
 


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode/pull/89215

This makes it that attempts to navigate the page in VS Code just get forwarded to `OpenerService.open` calls. Eg. clicking something like `<a href="https://github.com">this</a>` will eventually call `openerService.open('https://github.com')`.

 This is useful in notifications, where we currently listen to click events, and empty view contents https://github.com/microsoft/vscode/pull/89215.

@bpasero @jrieken @mjbvz  Let me know your thoughts.