### PR TITLE
Docs typo: missing ` in insertSpaces

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -90,7 +90,7 @@ export interface IGlobalEditorOptions {
 	tabSize?: number;
 	/**
 	 * Insert spaces when pressing `Tab`.
-	 * This setting is overridden based on the file contents when detectIndentation` is on.
+	 * This setting is overridden based on the file contents when `detectIndentation` is on.
 	 * Defaults to true.
 	 */
 	insertSpaces?: boolean;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1067,7 +1067,7 @@ declare namespace monaco.editor {
 		tabSize?: number;
 		/**
 		 * Insert spaces when pressing `Tab`.
-		 * This setting is overridden based on the file contents when detectIndentation` is on.
+		 * This setting is overridden based on the file contents when `detectIndentation` is on.
 		 * Defaults to true.
 		 */
 		insertSpaces?: boolean;


### PR DESCRIPTION
Following https://github.com/microsoft/monaco-editor/pull/1824.
