### PR TITLE
Fixes explorer new folder inputbox duplicates parent folder children when toggling collapse state

### DIFF
--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -77,7 +77,7 @@ export class ExplorerModel implements IDisposable {
 }
 
 export class ExplorerItem {
-	private _isDirectoryResolved: boolean;
+	protected _isDirectoryResolved: boolean;
 	private _isDisposed: boolean;
 	public isError = false;
 
@@ -402,5 +402,6 @@ export class ExplorerItem {
 export class NewExplorerItem extends ExplorerItem {
 	constructor(fileService: IFileService, parent: ExplorerItem, isDirectory: boolean) {
 		super(URI.file(''), fileService, parent, isDirectory);
+		this._isDirectoryResolved = true;
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #90040
