### PR TITLE
add saveable option to do nothing for tasks

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -262,8 +262,8 @@ configurationRegistry.registerConfiguration({
 			default: true
 		},
 		'debug.onTaskErrors': {
-			enum: ['debugAnyway', 'showErrors', 'prompt'],
-			enumDescriptions: [nls.localize('debugAnyway', "Ignore task errors and start debugging."), nls.localize('showErrors', "Show the Problems view and do not start debugging."), nls.localize('prompt', "Prompt user.")],
+			enum: ['debugAnyway', 'showErrors', 'doNothing', 'prompt'],
+			enumDescriptions: [nls.localize('debugAnyway', "Ignore task errors and start debugging."), nls.localize('showErrors', "Show the Problems view and do not start debugging."), nls.localize('doNothing', "Do not change the view and do not start debugging."), nls.localize('prompt', "Prompt user.")],
 			description: nls.localize('debug.onTaskErrors', "Controls what to do when errors are encountered after running a preLaunchTask."),
 			default: 'prompt'
 		},

--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -72,6 +72,9 @@ export class DebugTaskRunner {
 				await this.viewsService.openView(Constants.MARKERS_VIEW_ID);
 				return Promise.resolve(TaskRunResult.Failure);
 			}
+			if (onTaskErrors === 'doNothing') {
+				return Promise.resolve(TaskRunResult.Failure);
+			}
 
 			const taskLabel = typeof taskId === 'string' ? taskId : taskId ? taskId.name : '';
 			const message = errorCount > 1
@@ -90,6 +93,9 @@ export class DebugTaskRunner {
 			});
 
 			if (result.choice === 2) {
+				if (resule.checkboxChecked) {
+					this.configurationService.updateValue('debug.onTaskErrors', 'doNothing');
+				}
 				return Promise.resolve(TaskRunResult.Failure);
 			}
 			const debugAnyway = result.choice === 0;

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -467,7 +467,7 @@ export interface IDebugConfiguration {
 		closeOnEnd: boolean;
 	};
 	focusWindowOnBreak: boolean;
-	onTaskErrors: 'debugAnyway' | 'showErrors' | 'prompt';
+	onTaskErrors: 'debugAnyway' | 'showErrors' | 'doNothing' | 'prompt';
 	showBreakpointsInOverviewRuler: boolean;
 	showInlineBreakpointCandidates: boolean;
 }


### PR DESCRIPTION
Took a quick stab at adding another saveable option for tasks. This should use cancel as a saveable option, but this may not be ideal.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #90478 
