### PR TITLE
debugTestRunner: fix assignment expression / equality check mix up

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -94,7 +94,7 @@ export class DebugTaskRunner {
 
 
 			const debugAnyway = result.choice === 0;
-			const cancel = result.choice = 2;
+			const cancel = result.choice === 2;
 			if (result.checkboxChecked) {
 				this.configurationService.updateValue('debug.onTaskErrors', result.choice === 0 ? 'debugAnyway' : cancel ? 'cancel' : 'showErrors');
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes an issue from #90478, which was introduced in https://github.com/microsoft/vscode/commit/33d3f3ae4b348e62087fb24b0db796215a7f0758#diff-f2e055b61f441e17e7c3b024997b9bc6R97 

it currently will never get to the implementation of the other options:

https://github.com/microsoft/vscode/blob/33d3f3ae4b348e62087fb24b0db796215a7f0758/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts#L102-L110
