### PR TITLE
Fixes "Release notes appear on every window"

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -127,39 +127,41 @@ export class ProductContribution implements IWorkbenchContribution {
 		@IHostService hostService: IHostService,
 		@IProductService productService: IProductService
 	) {
-		if (!hostService.hasFocus) {
-			return;
-		}
+		hostService.hadLastFocus().then(hadLastFocus => {
+			if (!hadLastFocus) {
+				return;
+			}
 
-		const lastVersion = storageService.get(ProductContribution.KEY, StorageScope.GLOBAL, '');
-		const shouldShowReleaseNotes = configurationService.getValue<boolean>('update.showReleaseNotes');
+			const lastVersion = storageService.get(ProductContribution.KEY, StorageScope.GLOBAL, '');
+			const shouldShowReleaseNotes = configurationService.getValue<boolean>('update.showReleaseNotes');
 
-		// was there an update? if so, open release notes
-		const releaseNotesUrl = productService.releaseNotesUrl;
-		if (shouldShowReleaseNotes && !environmentService.args['skip-release-notes'] && releaseNotesUrl && lastVersion && productService.version !== lastVersion) {
-			showReleaseNotes(instantiationService, productService.version)
-				.then(undefined, () => {
-					notificationService.prompt(
-						severity.Info,
-						nls.localize('read the release notes', "Welcome to {0} v{1}! Would you like to read the Release Notes?", productService.nameLong, productService.version),
-						[{
-							label: nls.localize('releaseNotes', "Release Notes"),
-							run: () => {
-								const uri = URI.parse(releaseNotesUrl);
-								openerService.open(uri);
-							}
-						}],
-						{ sticky: true }
-					);
-				});
-		}
+			// was there an update? if so, open release notes
+			const releaseNotesUrl = productService.releaseNotesUrl;
+			if (shouldShowReleaseNotes && !environmentService.args['skip-release-notes'] && releaseNotesUrl && lastVersion && productService.version !== lastVersion) {
+				showReleaseNotes(instantiationService, productService.version)
+					.then(undefined, () => {
+						notificationService.prompt(
+							severity.Info,
+							nls.localize('read the release notes', "Welcome to {0} v{1}! Would you like to read the Release Notes?", productService.nameLong, productService.version),
+							[{
+								label: nls.localize('releaseNotes', "Release Notes"),
+								run: () => {
+									const uri = URI.parse(releaseNotesUrl);
+									openerService.open(uri);
+								}
+							}],
+							{ sticky: true }
+						);
+					});
+			}
 
-		// should we show the new license?
-		if (productService.licenseUrl && lastVersion && semver.satisfies(lastVersion, '<1.0.0') && semver.satisfies(productService.version, '>=1.0.0')) {
-			notificationService.info(nls.localize('licenseChanged', "Our license terms have changed, please click [here]({0}) to go through them.", productService.licenseUrl));
-		}
+			// should we show the new license?
+			if (productService.licenseUrl && lastVersion && semver.satisfies(lastVersion, '<1.0.0') && semver.satisfies(productService.version, '>=1.0.0')) {
+				notificationService.info(nls.localize('licenseChanged', "Our license terms have changed, please click [here]({0}) to go through them.", productService.licenseUrl));
+			}
 
-		storageService.store(ProductContribution.KEY, productService.version, StorageScope.GLOBAL);
+			storageService.store(ProductContribution.KEY, productService.version, StorageScope.GLOBAL);
+		});
 	}
 }
 

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -95,6 +95,10 @@ export class BrowserHostService extends Disposable implements IHostService {
 		return document.hasFocus();
 	}
 
+	async hadLastFocus(): Promise<boolean> {
+		return true;
+	}
+
 	async focus(): Promise<void> {
 		window.focus();
 	}

--- a/src/vs/workbench/services/host/browser/host.ts
+++ b/src/vs/workbench/services/host/browser/host.ts
@@ -26,6 +26,11 @@ export interface IHostService {
 	readonly hasFocus: boolean;
 
 	/**
+	 * Find out if the window had the last focus.
+	 */
+	hadLastFocus(): Promise<boolean>;
+
+	/**
 	 * Attempt to bring the window to the foreground and focus it.
 	 */
 	focus(): Promise<void>;

--- a/src/vs/workbench/services/host/electron-browser/desktopHostService.ts
+++ b/src/vs/workbench/services/host/electron-browser/desktopHostService.ts
@@ -36,6 +36,16 @@ export class DesktopHostService extends Disposable implements IHostService {
 		return document.hasFocus();
 	}
 
+	async hadLastFocus(): Promise<boolean> {
+		const activeWindowId = await this.electronService.getActiveWindowId();
+
+		if (typeof activeWindowId === 'undefined') {
+			return false;
+		}
+
+		return activeWindowId === this.electronEnvironmentService.windowId;
+	}
+
 	openWindow(options?: IOpenEmptyWindowOptions): Promise<void>;
 	openWindow(toOpen: IWindowOpenable[], options?: IOpenWindowOptions): Promise<void>;
 	openWindow(arg1?: IOpenEmptyWindowOptions | IWindowOpenable[], arg2?: IOpenWindowOptions): Promise<void> {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -865,6 +865,7 @@ export class TestHostService implements IHostService {
 	_serviceBrand: undefined;
 
 	readonly hasFocus: boolean = true;
+	async hadLastFocus(): Promise<boolean> { return true; }
 	readonly onDidChangeFocus: Event<boolean> = Event.None;
 
 	async restart(): Promise<void> { }


### PR DESCRIPTION
This issue was once already fixed in https://github.com/microsoft/vscode/issues/77583 with https://github.com/microsoft/vscode/commit/01c2f555539d9eeada4e4ef456f6bfbac11b0f26

Regressed with @bpasero https://github.com/microsoft/vscode/commit/f0b99530c857c74bd0cfba6d0f835afc7a56a40f#diff-10b67ccbd65ac0e04fe13cd734b466f4L128

---

Don't really know why `document.hasFocus()` would ever lie, but it appears it can!

Fixes #90632