### PR TITLE
Add explorer.autoRevealExclude configuration option.

### DIFF
--- a/extensions/configuration-editing/src/settingsDocumentHelper.ts
+++ b/extensions/configuration-editing/src/settingsDocumentHelper.ts
@@ -28,7 +28,7 @@ export class SettingsDocument {
 		}
 
 		// files.exclude, search.exclude
-		if (location.path[0] === 'files.exclude' || location.path[0] === 'search.exclude') {
+		if (location.path[0] === 'files.exclude' || location.path[0] === 'search.exclude' || location.path[0] === 'explorer.autoRevealExclude') {
 			return this.provideExcludeCompletionItems(location, range);
 		}
 

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -196,37 +196,39 @@ const hotExitConfiguration: IConfigurationPropertySchema = platform.isNative ?
 		'description': nls.localize('hotExit', "Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.", HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE)
 	};
 
+const filesExcludeConfiguration: IConfigurationPropertySchema = {
+	'type': 'object',
+	'markdownDescription': nls.localize('exclude', "Configure glob patterns for excluding files and folders. For example, the files explorer decides which files and folders to show or hide based on this setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
+	'default': { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
+	'scope': ConfigurationScope.RESOURCE,
+	'additionalProperties': {
+		'anyOf': [
+			{
+				'type': 'boolean',
+				'description': nls.localize('files.exclude.boolean', "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."),
+			},
+			{
+				'type': 'object',
+				'properties': {
+					'when': {
+						'type': 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
+						'pattern': '\\w*\\$\\(basename\\)\\w*',
+						'default': '$(basename).ext',
+						'description': nls.localize('files.exclude.when', "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.")
+					}
+				}
+			}
+		]
+	}
+};
+
 configurationRegistry.registerConfiguration({
 	'id': 'files',
 	'order': 9,
 	'title': nls.localize('filesConfigurationTitle', "Files"),
 	'type': 'object',
 	'properties': {
-		'files.exclude': {
-			'type': 'object',
-			'markdownDescription': nls.localize('exclude', "Configure glob patterns for excluding files and folders. For example, the files explorer decides which files and folders to show or hide based on this setting. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
-			'default': { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
-			'scope': ConfigurationScope.RESOURCE,
-			'additionalProperties': {
-				'anyOf': [
-					{
-						'type': 'boolean',
-						'description': nls.localize('files.exclude.boolean', "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."),
-					},
-					{
-						'type': 'object',
-						'properties': {
-							'when': {
-								'type': 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
-								'pattern': '\\w*\\$\\(basename\\)\\w*',
-								'default': '$(basename).ext',
-								'description': nls.localize('files.exclude.when', "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.")
-							}
-						}
-					}
-				]
-			}
-		},
+		'files.exclude': filesExcludeConfiguration,
 		'files.associations': {
 			'type': 'object',
 			'markdownDescription': nls.localize('associations', "Configure file associations to languages (e.g. `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed."),
@@ -369,6 +371,11 @@ configurationRegistry.registerConfiguration({
 			'type': 'boolean',
 			'description': nls.localize('autoReveal', "Controls whether the explorer should automatically reveal and select files when opening them."),
 			'default': true
+		},
+		'explorer.autoRevealExclude': {
+			...filesExcludeConfiguration,
+			'markdownDescription': nls.localize('autoRevealExclude', "Configure glob patterns for excluding files from being automatically revealed. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
+			'default': platform.isWindows /* https://github.com/Microsoft/vscode/issues/23954 */ ? { '**/node_modules/*/**': true } : { '**/node_modules/**': true },
 		},
 		'explorer.enableDragAndDrop': {
 			'type': 'boolean',

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
+import * as glob from 'vs/base/common/glob';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IWorkbenchEditorConfiguration, IEditorIdentifier, IEditorInput, toResource, SideBySideEditor } from 'vs/workbench/common/editor';
 import { IFilesConfiguration as PlatformIFilesConfiguration, FileChangeType, IFileService } from 'vs/platform/files/common/files';
@@ -109,6 +110,7 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 			visible: number;
 		};
 		autoReveal: boolean;
+		autoRevealExclude: glob.IExpression;
 		enableDragAndDrop: boolean;
 		confirmDelete: boolean;
 		sortOrder: SortOrder;


### PR DESCRIPTION
This PR fixes #87956

Adds `explorer.autoRevealExclude` configuration option. It matches the schema and behavior of `files.exclude`. Normal `explorer.autoReveal` behavior is suppressed when navigating to or focusing an editor for any resource that matches the defined exclusion patterns.

Exclusion of `node_modules` has been added as a default exclusion. Test by navigating to the definition of a symbol declared within a file in `node_modules`. Note that `explorer.autoReveal` must be set to true.