### PR TITLE
Treat .envrc files as Shell scripts

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -14,7 +14,11 @@
 			"id": "shellscript",
 			"aliases": ["Shell Script", "shellscript", "bash", "sh", "zsh", "ksh"],
 			"extensions": [".sh", ".bash", ".bashrc", ".bash_aliases", ".bash_profile", ".bash_login", ".ebuild", ".install", ".profile", ".bash_logout", ".zsh", ".zshrc", ".zprofile", ".zlogin", ".zlogout", ".zshenv", ".zsh-theme", ".ksh"],
-			"filenames": ["APKBUILD", "PKGBUILD"],
+			"filenames": [
+        "APKBUILD",
+        "PKGBUILD",
+        ".envrc"
+      ],
 			"firstLine": "^#!.*\\b(bash|zsh|sh|tcsh|ksh|ash|qsh).*|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-",
 			"configuration": "./language-configuration.json",
 			"mimetypes": ["text/x-shellscript"]


### PR DESCRIPTION
This PR fixes #90824

This associates `.envrc` with the Shell Script file type.