### PR TITLE
Remove `ViewPane.actionRunner`

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -12,7 +12,7 @@ import { SIDE_BAR_DRAG_AND_DROP_BACKGROUND, SIDE_BAR_SECTION_HEADER_FOREGROUND, 
 import { append, $, trackFocus, toggleClass, EventType, isAncestor, Dimension, addDisposableListener, removeClass, addClass } from 'vs/base/browser/dom';
 import { IDisposable, combinedDisposable, dispose, toDisposable, Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { firstIndex } from 'vs/base/common/arrays';
-import { IAction, IActionRunner, ActionRunner } from 'vs/base/common/actions';
+import { IAction } from 'vs/base/common/actions';
 import { IActionViewItem, ActionsOrientation, Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { prepareActions } from 'vs/workbench/browser/actions';
@@ -51,7 +51,6 @@ export interface IPaneColors extends IColorMapping {
 }
 
 export interface IViewPaneOptions extends IPaneOptions {
-	actionRunner?: IActionRunner;
 	id: string;
 	title: string;
 	showActionsAlways?: boolean;
@@ -169,7 +168,6 @@ export abstract class ViewPane extends Pane implements IView {
 
 	private readonly menuActions: ViewMenuActions;
 
-	protected actionRunner?: IActionRunner;
 	private toolbar?: ToolBar;
 	private readonly showActionsAlways: boolean = false;
 	private headerContainer?: HTMLElement;
@@ -196,7 +194,6 @@ export abstract class ViewPane extends Pane implements IView {
 
 		this.id = options.id;
 		this.title = options.title;
-		this.actionRunner = options.actionRunner;
 		this.showActionsAlways = !!options.showActionsAlways;
 		this.focusedViewContextKey = FocusedViewContext.bindTo(contextKeyService);
 
@@ -262,7 +259,6 @@ export abstract class ViewPane extends Pane implements IView {
 			actionViewItemProvider: action => this.getActionViewItem(action),
 			ariaLabel: nls.localize('viewToolbarAriaLabel', "{0} actions", this.title),
 			getKeyBinding: action => this.keybindingService.lookupKeybinding(action.id),
-			actionRunner: this.actionRunner
 		});
 
 		this._register(this.toolbar);
@@ -452,8 +448,6 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 
 	private didLayout = false;
 	private dimension: Dimension | undefined;
-
-	protected actionRunner: IActionRunner | undefined;
 
 	private readonly visibleViewsCountFromCache: number | undefined;
 	private readonly visibleViewsStorageId: string;
@@ -800,7 +794,6 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 				{
 					id: viewDescriptor.id,
 					title: viewDescriptor.name,
-					actionRunner: this.getActionRunner(),
 					expanded: !collapsed,
 					minimumBodySize: this.viewDescriptorService.getViewContainerLocation(this.viewContainer) === ViewContainerLocation.Panel ? 0 : 120
 				});
@@ -829,14 +822,6 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 			panes.push(pane);
 		}
 		return panes;
-	}
-
-	getActionRunner(): IActionRunner {
-		if (!this.actionRunner) {
-			this.actionRunner = new ActionRunner();
-		}
-
-		return this.actionRunner;
 	}
 
 	private onDidRemoveViewDescriptors(removed: IViewDescriptorRef[]): void {

--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -67,17 +67,6 @@
 	border-radius: 0; /* goes better when ellipsis shows up on narrow sidebar */
 }
 
-.explorer-viewlet .explorer-empty-view {
-	padding: 0 20px 0 20px;
-}
-
-.explorer-viewlet .explorer-empty-view .monaco-button {
-	max-width: 260px;
-	margin-left: auto;
-	margin-right: auto;
-	display: block;
-}
-
 .explorer-viewlet .explorer-item.nonexistent-root {
 	opacity: 0.5;
 }

--- a/src/vs/workbench/contrib/files/browser/views/emptyView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/emptyView.ts
@@ -27,6 +27,7 @@ import { isWeb } from 'vs/base/common/platform';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { ActionRunner } from 'vs/base/common/actions';
 
 export class EmptyView extends ViewPane {
 
@@ -71,14 +72,12 @@ export class EmptyView extends ViewPane {
 		this.button = new Button(messageContainer);
 		attachButtonStyler(this.button, this.themeService);
 
+		const actionRunner = new ActionRunner();
 		this._register(this.button.onDidClick(() => {
-			if (!this.actionRunner) {
-				return;
-			}
 			const action = this.contextService.getWorkbenchState() === WorkbenchState.WORKSPACE
 				? this.instantiationService.createInstance(AddRootFolderAction, AddRootFolderAction.ID, AddRootFolderAction.LABEL)
 				: this.instantiationService.createInstance(OpenFolderAction, OpenFolderAction.ID, OpenFolderAction.LABEL);
-			this.actionRunner.run(action).then(() => {
+			actionRunner.run(action).then(() => {
 				action.dispose();
 			}, err => {
 				action.dispose();

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -9,7 +9,7 @@ import * as aria from 'vs/base/browser/ui/aria/aria';
 import { MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IIdentityProvider } from 'vs/base/browser/ui/list/list';
 import { ITreeContextMenuEvent, ITreeElement } from 'vs/base/browser/ui/tree/tree';
-import { IAction } from 'vs/base/common/actions';
+import { IAction, ActionRunner } from 'vs/base/common/actions';
 import { Delayer } from 'vs/base/common/async';
 import * as errors from 'vs/base/common/errors';
 import { Event } from 'vs/base/common/event';
@@ -1584,6 +1584,7 @@ export class SearchView extends ViewPane {
 		const openFolderLink = dom.append(textEl,
 			$('a.pointer.prominent', { tabindex: 0 }, nls.localize('openFolder', "Open Folder")));
 
+		const actionRunner = new ActionRunner();
 		this.messageDisposables.push(dom.addDisposableListener(openFolderLink, dom.EventType.CLICK, (e: MouseEvent) => {
 			dom.EventHelper.stop(e, false);
 
@@ -1591,7 +1592,7 @@ export class SearchView extends ViewPane {
 				this.instantiationService.createInstance(OpenFileFolderAction, OpenFileFolderAction.ID, OpenFileFolderAction.LABEL) :
 				this.instantiationService.createInstance(OpenFolderAction, OpenFolderAction.ID, OpenFolderAction.LABEL);
 
-			this.actionRunner!.run(action).then(() => {
+			actionRunner.run(action).then(() => {
 				action.dispose();
 			}, err => {
 				action.dispose();


### PR DESCRIPTION
I was like _why is there an `actionRunner` property on `ViewPane`_? I couldn't really find a good answer...

cc @isidorn and @roblourens for the only current usages