### PR TITLE
Fix run active file in terminal not wrapping with quotes

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -690,6 +690,8 @@ export class RunActiveFileInTerminalAction extends Action {
 		if (!instance) {
 			return Promise.resolve(undefined);
 		}
+		await instance.processReady;
+
 		const editor = this.codeEditorService.getActiveCodeEditor();
 		if (!editor || !editor.hasModel()) {
 			return Promise.resolve(undefined);


### PR DESCRIPTION
Wait for processReady event before runnigs file.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #90415
