### PR TITLE
Fixes #90125 - Add a task instancePolicy to task runOptions

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -235,10 +235,10 @@ export class TerminalTaskSystem implements ITaskSystem {
 		let taskClone = undefined;
 		if (instance > 0) {
 			taskClone = task.clone();
-			taskClone._id += '|' + this.instances[commonKey].counter.toString();
+			taskClone._id = commonKey + '|' + this.instances[commonKey].counter.toString();
 		}
 		let taskToExecute = taskClone ?? task;
-		let lastTaskInstance = this.getLastInstance(task);
+		let lastTaskInstance = this.getNthInstance(task);
 		let terminalData = lastTaskInstance ? this.activeTasks[lastTaskInstance.getMapKey()] : undefined;
 		if (terminalData && terminalData.promise && !validInstance) {
 			this.lastTask = this.currentTask;
@@ -339,14 +339,20 @@ export class TerminalTaskSystem implements ITaskSystem {
 		return Object.keys(this.activeTasks).map(key => this.activeTasks[key].task);
 	}
 
-	public getLastInstance(task: Task): Task | undefined {
-		let lastInstance = undefined;
+	public getNthInstance(task: Task, n?: number): Task | undefined {
+		let lastInstance: Task | undefined = undefined;
 		let commonId = task._id.split('|')[0];
-		Object.keys(this.activeTasks).forEach((key) => {
-			if (commonId === this.activeTasks[key].task._id.split('|')[0]) {
-				lastInstance = this.activeTasks[key].task;
+		for (let task of this.getActiveTasks()) {
+			if (commonId === task._id.split('|')[0]) {
+				lastInstance = task;
+				if (n !== undefined && n !== null) {
+					if (n <= 0) {
+						return lastInstance;
+					}
+					n--;
+				}
 			}
-		});
+		}
 		return lastInstance;
 	}
 

--- a/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
@@ -337,6 +337,13 @@ const runOptions: IJSONSchema = {
 		instancePolicy: {
 			type: 'string',
 			enum: ['terminateNewest', 'terminateOldest', 'prompt', 'warn', 'silent'],
+			enumDescriptions: [
+				nls.localize('JsonSchema.tasks.instancePolicy.terminateNewest', 'Terminates the newest instance.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.terminateOldest', 'Terminates the oldest instance.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.prompt', 'Asks which instance to terminate.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.warn', 'Does nothing but warns that the instance limit has been reached.'),
+				nls.localize('JsonSchema.tasks.instancePolicy.silent', 'Does nothing.'),
+			],
 			description: nls.localize('JsonSchema.tasks.instancePolicy', 'Policy to apply when instance limit is reached.'),
 			default: 'prompt'
 		}

--- a/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
+++ b/src/vs/workbench/contrib/tasks/common/jsonSchema_v2.ts
@@ -334,6 +334,12 @@ const runOptions: IJSONSchema = {
 			description: nls.localize('JsonSchema.tasks.instanceLimit', 'The number of instances of the task that are allowed to run simultaneously.'),
 			default: 1
 		},
+		instancePolicy: {
+			type: 'string',
+			enum: ['terminateNewest', 'terminateOldest', 'prompt', 'warn', 'silent'],
+			description: nls.localize('JsonSchema.tasks.instancePolicy', 'Policy to apply when instance limit is reached.'),
+			default: 'prompt'
+		}
 	},
 	description: nls.localize('JsonSchema.tasks.runOptions', 'The task\'s run related options')
 };

--- a/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskConfiguration.ts
@@ -134,6 +134,7 @@ export interface RunOptionsConfig {
 	reevaluateOnRerun?: boolean;
 	runOn?: string;
 	instanceLimit?: number;
+	instancePolicy?: string;
 }
 
 export interface TaskIdentifier {
@@ -678,12 +679,34 @@ export namespace RunOnOptions {
 	}
 }
 
+export namespace InstancePolicy {
+	export function fromString(value: string | undefined): Tasks.InstancePolicy {
+		if (!value) {
+			return Tasks.InstancePolicy.prompt;
+		}
+		switch (value.toLowerCase()) {
+			case 'terminatenewest':
+				return Tasks.InstancePolicy.terminateNewest;
+			case 'terminateoldest':
+				return Tasks.InstancePolicy.terminateOldest;
+			case 'warn':
+				return Tasks.InstancePolicy.warn;
+			case 'silent':
+				return Tasks.InstancePolicy.silent;
+			case 'prompt':
+			default:
+				return Tasks.InstancePolicy.prompt;
+		}
+	}
+}
+
 export namespace RunOptions {
 	export function fromConfiguration(value: RunOptionsConfig | undefined): Tasks.RunOptions {
 		return {
 			reevaluateOnRerun: value ? value.reevaluateOnRerun : true,
 			runOn: value ? RunOnOptions.fromString(value.runOn) : Tasks.RunOnOptions.default,
-			instanceLimit: value ? value.instanceLimit : 1
+			instanceLimit: value ? value.instanceLimit : 1,
+			instancePolicy: value ? InstancePolicy.fromString(value.instancePolicy) : Tasks.InstancePolicy.prompt
 		};
 	}
 }

--- a/src/vs/workbench/contrib/tasks/common/taskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskSystem.ts
@@ -133,7 +133,7 @@ export interface ITaskSystem {
 	isActive(): Promise<boolean>;
 	isActiveSync(): boolean;
 	getActiveTasks(): Task[];
-	getLastInstance(task: Task): Task | undefined;
+	getNthInstance(task: Task, n?: number): Task | undefined;
 	getBusyTasks(): Task[];
 	canAutoTerminate(): boolean;
 	terminate(task: Task): Promise<TaskTerminateResponse>;

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -520,14 +520,23 @@ export enum RunOnOptions {
 	folderOpen = 2
 }
 
+export const enum InstancePolicy {
+	terminateNewest = 'terminateNewest',
+	terminateOldest = 'terminateOldest',
+	prompt = 'prompt',
+	warn = 'warn',
+	silent = 'silent'
+}
+
 export interface RunOptions {
 	reevaluateOnRerun?: boolean;
 	runOn?: RunOnOptions;
 	instanceLimit?: number;
+	instancePolicy?: InstancePolicy;
 }
 
 export namespace RunOptions {
-	export const defaults: RunOptions = { reevaluateOnRerun: true, runOn: RunOnOptions.default, instanceLimit: 1 };
+	export const defaults: RunOptions = { reevaluateOnRerun: true, runOn: RunOnOptions.default, instanceLimit: 1, instancePolicy: InstancePolicy.prompt };
 }
 
 export abstract class CommonTask {

--- a/src/vs/workbench/contrib/tasks/node/processTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/node/processTaskSystem.ts
@@ -94,7 +94,7 @@ export class ProcessTaskSystem implements ITaskSystem {
 		return result;
 	}
 
-	public getLastInstance(task: Task): Task | undefined {
+	public getNthInstance(task: Task): Task | undefined {
 		let result = undefined;
 		if (this.activeTask) {
 			result = this.activeTask;


### PR DESCRIPTION
# Summary
Fixes #90125. Added an `instancePolicy` to `runOptions`. The `instancePolicy` is applied when creating a new instance of a task once the `instanceLimit` has been reached.
The `instancePolicy` is as follows:
1. `terminateNewest`: the newest instance is terminated
2. `terminateOldest`: the oldest instance is terminated
3. `prompt`: the QuickPick is shown and the user picks an instance to restart (this is the default option)
4. `warn`: do nothing (do not terminate an existing instance or create a new one) and show a warning that indicates that the `instanceLimit` has been reached
5. `silent`: do nothing

# Implementation notes
* any task selected to be "terminated" by the `instancePolicy` is effectively *restarted*
* the `TerminalTaskSystem` `getLastInstance()` method has been expanded in scope and is now called `getNthInstance`. As the name suggests it returns the Nth instance of a task given a number. If no index is given, it returns the last instance by default. I used a `for` loop instead of doing a `forEach` on `Object.keys` so that I could exit early once the right instance was found
* when an instance is created, slightly changed the way I previously set its `id` so as to avoid cases in which an instance of an instance was being created and the `id` would be appended with `|<COUNTER>` multiple times

# Testing changes
Create a `tasks.json` and set the `instancLimit` and `instancePolicy` properties. Here is an example configuration:
```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "echo",
            "type": "shell",
            "command": "sleep 20 && echo Hello",
            "runOptions": {
                "instanceLimit": 2,
                "instancePolicy": "terminateOldest"
            }
        }
    ]
}
```
Ensure that once the `instanceLimit` is reached, the chosen `instancePolicy` behaves as described at the beginning of this PR.

### P.S.
I would suggest not having the `prompt` option as the default option simply because in the default case where `instanceLimit == 1`, the user would be shown the QuickPick which would contain only one entry since there is only one active instance. Personally, I think it would make more sense to have another `instancePolicy` option which would ask the user to terminate or restart the last instance. This would maintain the current behavior and use the current terminate/restart notification, while I think being the least confusing option in the case where `runOptions` is set to all default settings.