### PR TITLE
Avoid duplicated element id in explorer tree

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -376,7 +376,7 @@ export class ExplorerView extends ViewPane {
 						return `new:${stat.resource}`;
 					}
 
-					return stat.resource;
+					return `${stat.root.resource}:${stat.resource}`;
 				}
 			},
 			keyboardNavigationLabelProvider: {


### PR DESCRIPTION
This PR fixes #90473

Makes the explorer tree element id unique by appending the corresponding root resource URI.

Another way could be to append the root index to the resource URI

```
const treeInput = this.tree.getInput()!;
const rootIdx = Array.isArray(treeInput) ? treeInput.indexOf(stat.root) : 0;
return `root${rootIdx}:${stat.resource}`;
```