### PR TITLE
Define IIdentifiedSingleEditOperation.range as IRange instead of Range

### DIFF
--- a/src/vs/editor/common/core/range.ts
+++ b/src/vs/editor/common/core/range.ts
@@ -264,14 +264,28 @@ export class Range {
 	 * Return the end position (which will be after or equal to the start position)
 	 */
 	public getEndPosition(): Position {
-		return new Position(this.endLineNumber, this.endColumn);
+		return Range.getEndPosition(this);
+	}
+
+	/**
+	 * Return the end position (which will be after or equal to the start position)
+	 */
+	public static getEndPosition(range: IRange): Position {
+		return new Position(range.endLineNumber, range.endColumn);
 	}
 
 	/**
 	 * Return the start position (which will be before or equal to the end position)
 	 */
 	public getStartPosition(): Position {
-		return new Position(this.startLineNumber, this.startColumn);
+		return Range.getStartPosition(this);
+	}
+
+	/**
+	 * Return the start position (which will be before or equal to the end position)
+	 */
+	public static getStartPosition(range: IRange): Position {
+		return new Position(range.startLineNumber, range.startColumn);
 	}
 
 	/**

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -10,7 +10,7 @@ import { ConfigurationChangedEvent, IComputedEditorOptions, IEditorOptions } fro
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
-import { IIdentifiedSingleEditOperation, IModelDecorationsChangeAccessor, ITextModel, OverviewRulerLane, TrackedRangeStickiness } from 'vs/editor/common/model';
+import { IModelDecorationsChangeAccessor, ITextModel, OverviewRulerLane, TrackedRangeStickiness, IValidEditOperation } from 'vs/editor/common/model';
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 
 /**
@@ -22,7 +22,7 @@ export interface IEditOperationBuilder {
 	 * @param range The range to replace (delete). May be empty to represent a simple insert.
 	 * @param text The text to replace with. May be null to represent a simple delete.
 	 */
-	addEditOperation(range: Range, text: string | null, forceMoveMarkers?: boolean): void;
+	addEditOperation(range: IRange, text: string | null, forceMoveMarkers?: boolean): void;
 
 	/**
 	 * Add a new edit operation (a replace operation).
@@ -30,7 +30,7 @@ export interface IEditOperationBuilder {
 	 * @param range The range to replace (delete). May be empty to represent a simple insert.
 	 * @param text The text to replace with. May be null to represent a simple delete.
 	 */
-	addTrackedEditOperation(range: Range, text: string | null, forceMoveMarkers?: boolean): void;
+	addTrackedEditOperation(range: IRange, text: string | null, forceMoveMarkers?: boolean): void;
 
 	/**
 	 * Track `selection` when applying edit operations.
@@ -51,7 +51,7 @@ export interface ICursorStateComputerData {
 	/**
 	 * Get the inverse edit operations of the added edit operations.
 	 */
-	getInverseEditOperations(): IIdentifiedSingleEditOperation[];
+	getInverseEditOperations(): IValidEditOperation[];
 	/**
 	 * Get a previously tracked selection.
 	 * @param id The unique identifier returned by `trackSelection`.

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -335,7 +335,7 @@ export interface IIdentifiedSingleEditOperation {
 	/**
 	 * The range to replace. This can be empty to emulate a simple insert.
 	 */
-	range: Range;
+	range: IRange;
 	/**
 	 * The text to replace with. This can be null to emulate a simple delete.
 	 */

--- a/src/vs/editor/common/model/editStack.ts
+++ b/src/vs/editor/common/model/editStack.ts
@@ -5,11 +5,11 @@
 
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Selection } from 'vs/editor/common/core/selection';
-import { EndOfLineSequence, ICursorStateComputer, IIdentifiedSingleEditOperation } from 'vs/editor/common/model';
+import { EndOfLineSequence, ICursorStateComputer, IIdentifiedSingleEditOperation, IValidEditOperation } from 'vs/editor/common/model';
 import { TextModel } from 'vs/editor/common/model/textModel';
 
 interface IEditOperation {
-	operations: IIdentifiedSingleEditOperation[];
+	operations: IValidEditOperation[];
 }
 
 interface IStackElement {
@@ -174,7 +174,7 @@ export class EditStack {
 		return stackElement!.afterCursorState;
 	}
 
-	private static _computeCursorState(cursorStateComputer: ICursorStateComputer | null, inverseEditOperations: IIdentifiedSingleEditOperation[]): Selection[] | null {
+	private static _computeCursorState(cursorStateComputer: ICursorStateComputer | null, inverseEditOperations: IValidEditOperation[]): Selection[] | null {
 		try {
 			return cursorStateComputer ? cursorStateComputer(inverseEditOperations) : null;
 		} catch (e) {

--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.ts
@@ -6,7 +6,7 @@
 import * as strings from 'vs/base/common/strings';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
-import { ApplyEditsResult, EndOfLinePreference, FindMatch, IIdentifiedSingleEditOperation, IInternalModelContentChange, ISingleEditOperationIdentifier, ITextBuffer, ITextSnapshot } from 'vs/editor/common/model';
+import { ApplyEditsResult, EndOfLinePreference, FindMatch, IInternalModelContentChange, ISingleEditOperationIdentifier, ITextBuffer, ITextSnapshot, ValidAnnotatedEditOperation, IValidEditOperation } from 'vs/editor/common/model';
 import { PieceTreeBase, StringBuffer } from 'vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase';
 import { SearchData } from 'vs/editor/common/model/textModelSearch';
 
@@ -21,7 +21,7 @@ export interface IValidatedEditOperation {
 	isAutoWhitespaceEdit: boolean;
 }
 
-export interface IReverseSingleEditOperation extends IIdentifiedSingleEditOperation {
+export interface IReverseSingleEditOperation extends IValidEditOperation {
 	sortIndex: number;
 }
 
@@ -201,7 +201,7 @@ export class PieceTreeTextBuffer implements ITextBuffer {
 		this._pieceTree.setEOL(newEOL);
 	}
 
-	public applyEdits(rawOperations: IIdentifiedSingleEditOperation[], recordTrimAutoWhitespace: boolean): ApplyEditsResult {
+	public applyEdits(rawOperations: ValidAnnotatedEditOperation[], recordTrimAutoWhitespace: boolean): ApplyEditsResult {
 		let mightContainRTL = this._mightContainRTL;
 		let mightContainNonBasicASCII = this._mightContainNonBasicASCII;
 		let canReduceOperations = true;

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -11,7 +11,7 @@ import { URI } from 'vs/base/common/uri';
 import { EDITOR_MODEL_DEFAULTS } from 'vs/editor/common/config/editorOptions';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { Range } from 'vs/editor/common/core/range';
-import { DefaultEndOfLine, EndOfLinePreference, EndOfLineSequence, IIdentifiedSingleEditOperation, ITextBuffer, ITextBufferFactory, ITextModel, ITextModelCreationOptions } from 'vs/editor/common/model';
+import { DefaultEndOfLine, EndOfLinePreference, EndOfLineSequence, IIdentifiedSingleEditOperation, ITextBuffer, ITextBufferFactory, ITextModel, ITextModelCreationOptions, IValidEditOperation } from 'vs/editor/common/model';
 import { TextModel, createTextBuffer } from 'vs/editor/common/model/textModel';
 import { IModelLanguageChangedEvent, IModelContentChangedEvent } from 'vs/editor/common/model/textModelEvents';
 import { LanguageIdentifier, DocumentSemanticTokensProviderRegistry, DocumentSemanticTokensProvider, SemanticTokensLegend, SemanticTokens, SemanticTokensEdits, TokenMetadata, FontStyle, MetadataConsts } from 'vs/editor/common/modes';
@@ -305,7 +305,7 @@ export class ModelServiceImpl extends Disposable implements IModelService {
 		model.pushEditOperations(
 			[],
 			ModelServiceImpl._computeEdits(model, textBuffer),
-			(inverseEditOperations: IIdentifiedSingleEditOperation[]) => []
+			(inverseEditOperations: IValidEditOperation[]) => []
 		);
 		model.pushStackElement();
 	}

--- a/src/vs/editor/contrib/comment/blockCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/blockCommentCommand.ts
@@ -9,7 +9,7 @@ import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { Selection } from 'vs/editor/common/core/selection';
 import { ICommand, IEditOperationBuilder, ICursorStateComputerData } from 'vs/editor/common/editorCommon';
-import { IIdentifiedSingleEditOperation, ITextModel } from 'vs/editor/common/model';
+import { ITextModel, IIdentifiedSingleEditOperation } from 'vs/editor/common/model';
 import { LanguageConfigurationRegistry } from 'vs/editor/common/modes/languageConfigurationRegistry';
 
 export class BlockCommentCommand implements ICommand {

--- a/src/vs/editor/contrib/comment/lineCommentCommand.ts
+++ b/src/vs/editor/contrib/comment/lineCommentCommand.ts
@@ -205,7 +205,7 @@ export class LineCommentCommand implements ICommand {
 
 		for (let i = 0, len = ops.length; i < len; i++) {
 			builder.addEditOperation(ops[i].range, ops[i].text);
-			if (ops[i].range.isEmpty() && ops[i].range.getStartPosition().equals(cursorPosition)) {
+			if (Range.isEmpty(ops[i].range) && Range.getStartPosition(ops[i].range).equals(cursorPosition)) {
 				const lineContent = model.getLineContent(cursorPosition.lineNumber);
 				if (lineContent.length + 1 === cursorPosition.column) {
 					this._deltaColumn = (ops[i].text || '').length;

--- a/src/vs/editor/test/browser/testCommand.ts
+++ b/src/vs/editor/test/browser/testCommand.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { Range } from 'vs/editor/common/core/range';
-import { Selection } from 'vs/editor/common/core/selection';
+import { IRange } from 'vs/editor/common/core/range';
+import { Selection, ISelection } from 'vs/editor/common/core/selection';
 import { ICommand, Handler, IEditOperationBuilder } from 'vs/editor/common/editorCommon';
 import { IIdentifiedSingleEditOperation, ITextModel } from 'vs/editor/common/model';
 import { TextModel } from 'vs/editor/common/model/textModel';
@@ -50,7 +50,7 @@ export function testCommand(
 export function getEditOperation(model: ITextModel, command: ICommand): IIdentifiedSingleEditOperation[] {
 	let operations: IIdentifiedSingleEditOperation[] = [];
 	let editOperationBuilder: IEditOperationBuilder = {
-		addEditOperation: (range: Range, text: string, forceMoveMarkers: boolean = false) => {
+		addEditOperation: (range: IRange, text: string, forceMoveMarkers: boolean = false) => {
 			operations.push({
 				range: range,
 				text: text,
@@ -58,7 +58,7 @@ export function getEditOperation(model: ITextModel, command: ICommand): IIdentif
 			});
 		},
 
-		addTrackedEditOperation: (range: Range, text: string, forceMoveMarkers: boolean = false) => {
+		addTrackedEditOperation: (range: IRange, text: string, forceMoveMarkers: boolean = false) => {
 			operations.push({
 				range: range,
 				text: text,
@@ -67,7 +67,7 @@ export function getEditOperation(model: ITextModel, command: ICommand): IIdentif
 		},
 
 
-		trackSelection: (selection: Selection) => {
+		trackSelection: (selection: ISelection) => {
 			return '';
 		}
 	};

--- a/src/vs/editor/test/common/model/linesTextBuffer/textBufferAutoTestUtils.ts
+++ b/src/vs/editor/test/common/model/linesTextBuffer/textBufferAutoTestUtils.ts
@@ -5,7 +5,7 @@
 
 import { CharCode } from 'vs/base/common/charCode';
 import { Range } from 'vs/editor/common/core/range';
-import { DefaultEndOfLine, IIdentifiedSingleEditOperation, ITextBuffer, ITextBufferBuilder } from 'vs/editor/common/model';
+import { DefaultEndOfLine, ITextBuffer, ITextBufferBuilder, ValidAnnotatedEditOperation } from 'vs/editor/common/model';
 
 export function getRandomInt(min: number, max: number): number {
 	return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -31,7 +31,7 @@ export function getRandomString(minLength: number, maxLength: number): string {
 	return r;
 }
 
-export function generateRandomEdits(chunks: string[], editCnt: number): IIdentifiedSingleEditOperation[] {
+export function generateRandomEdits(chunks: string[], editCnt: number): ValidAnnotatedEditOperation[] {
 	let lines: string[] = [];
 	for (const chunk of chunks) {
 		let newLines = chunk.split(/\r\n|\r|\n/);
@@ -43,7 +43,7 @@ export function generateRandomEdits(chunks: string[], editCnt: number): IIdentif
 		}
 	}
 
-	let ops: IIdentifiedSingleEditOperation[] = [];
+	let ops: ValidAnnotatedEditOperation[] = [];
 
 	for (let i = 0; i < editCnt; i++) {
 		let line = getRandomInt(1, lines.length);
@@ -54,17 +54,14 @@ export function generateRandomEdits(chunks: string[], editCnt: number): IIdentif
 			text = getRandomString(5, 10);
 		}
 
-		ops.push({
-			text: text,
-			range: new Range(line, startColumn, line, endColumn)
-		});
+		ops.push(new ValidAnnotatedEditOperation(null, new Range(line, startColumn, line, endColumn), text, false, false, false));
 		lines[line - 1] = lines[line - 1].substring(0, startColumn - 1) + text + lines[line - 1].substring(endColumn - 1);
 	}
 
 	return ops;
 }
 
-export function generateSequentialInserts(chunks: string[], editCnt: number): IIdentifiedSingleEditOperation[] {
+export function generateSequentialInserts(chunks: string[], editCnt: number): ValidAnnotatedEditOperation[] {
 	let lines: string[] = [];
 	for (const chunk of chunks) {
 		let newLines = chunk.split(/\r\n|\r|\n/);
@@ -76,7 +73,7 @@ export function generateSequentialInserts(chunks: string[], editCnt: number): II
 		}
 	}
 
-	let ops: IIdentifiedSingleEditOperation[] = [];
+	let ops: ValidAnnotatedEditOperation[] = [];
 
 	for (let i = 0; i < editCnt; i++) {
 		let line = lines.length;
@@ -90,16 +87,13 @@ export function generateSequentialInserts(chunks: string[], editCnt: number): II
 			lines[line - 1] += text;
 		}
 
-		ops.push({
-			text: text,
-			range: new Range(line, column, line, column)
-		});
+		ops.push(new ValidAnnotatedEditOperation(null, new Range(line, column, line, column), text, false, false, false));
 	}
 
 	return ops;
 }
 
-export function generateRandomReplaces(chunks: string[], editCnt: number, searchStringLen: number, replaceStringLen: number): IIdentifiedSingleEditOperation[] {
+export function generateRandomReplaces(chunks: string[], editCnt: number, searchStringLen: number, replaceStringLen: number): ValidAnnotatedEditOperation[] {
 	let lines: string[] = [];
 	for (const chunk of chunks) {
 		let newLines = chunk.split(/\r\n|\r|\n/);
@@ -111,7 +105,7 @@ export function generateRandomReplaces(chunks: string[], editCnt: number, search
 		}
 	}
 
-	let ops: IIdentifiedSingleEditOperation[] = [];
+	let ops: ValidAnnotatedEditOperation[] = [];
 	let chunkSize = Math.max(1, Math.floor(lines.length / editCnt));
 	let chunkCnt = Math.floor(lines.length / chunkSize);
 	let replaceString = getRandomString(replaceStringLen, replaceStringLen);
@@ -125,10 +119,7 @@ export function generateRandomReplaces(chunks: string[], editCnt: number, search
 		let startColumn = getRandomInt(1, maxColumn);
 		let endColumn = Math.min(maxColumn, startColumn + searchStringLen);
 
-		ops.push({
-			text: replaceString,
-			range: new Range(line, startColumn, line, endColumn)
-		});
+		ops.push(new ValidAnnotatedEditOperation(null, new Range(line, startColumn, line, endColumn), replaceString, false, false, false));
 		previousChunksLength = endLine;
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -639,9 +639,17 @@ declare namespace monaco {
 		 */
 		getEndPosition(): Position;
 		/**
+		 * Return the end position (which will be after or equal to the start position)
+		 */
+		static getEndPosition(range: IRange): Position;
+		/**
 		 * Return the start position (which will be before or equal to the end position)
 		 */
 		getStartPosition(): Position;
+		/**
+		 * Return the start position (which will be before or equal to the end position)
+		 */
+		static getStartPosition(range: IRange): Position;
 		/**
 		 * Transform to a user presentable string representation.
 		 */
@@ -1508,7 +1516,7 @@ declare namespace monaco.editor {
 		/**
 		 * The range to replace. This can be empty to emulate a simple insert.
 		 */
-		range: Range;
+		range: IRange;
 		/**
 		 * The text to replace with. This can be null to emulate a simple delete.
 		 */
@@ -1520,6 +1528,22 @@ declare namespace monaco.editor {
 		forceMoveMarkers?: boolean;
 	}
 
+	export interface IValidEditOperation {
+		/**
+		 * The range to replace. This can be empty to emulate a simple insert.
+		 */
+		range: Range;
+		/**
+		 * The text to replace with. This can be null to emulate a simple delete.
+		 */
+		text: string | null;
+		/**
+		 * This indicates that this operation has "insert" semantics.
+		 * i.e. forceMoveMarkers = true => if `range` is collapsed, all markers at the position will be moved.
+		 */
+		forceMoveMarkers: boolean;
+	}
+
 	/**
 	 * A callback that can compute the cursor state after applying a series of edit operations.
 	 */
@@ -1527,7 +1551,7 @@ declare namespace monaco.editor {
 		/**
 		 * A callback that can compute the resulting cursors state after some edit operations have been executed.
 		 */
-		(inverseEditOperations: IIdentifiedSingleEditOperation[]): Selection[] | null;
+		(inverseEditOperations: IValidEditOperation[]): Selection[] | null;
 	}
 
 	export class TextModelResolvedOptions {
@@ -1867,7 +1891,7 @@ declare namespace monaco.editor {
 		 * @param operations The edit operations.
 		 * @return The inverse edit operations, that, when applied, will bring the model back to the previous state.
 		 */
-		applyEdits(operations: IIdentifiedSingleEditOperation[]): IIdentifiedSingleEditOperation[];
+		applyEdits(operations: IIdentifiedSingleEditOperation[]): IValidEditOperation[];
 		/**
 		 * Change the end of line sequence without recording in the undo stack.
 		 * This can have dire consequences on the undo stack! See @pushEOL for the preferred way.
@@ -1919,14 +1943,14 @@ declare namespace monaco.editor {
 		 * @param range The range to replace (delete). May be empty to represent a simple insert.
 		 * @param text The text to replace with. May be null to represent a simple delete.
 		 */
-		addEditOperation(range: Range, text: string | null, forceMoveMarkers?: boolean): void;
+		addEditOperation(range: IRange, text: string | null, forceMoveMarkers?: boolean): void;
 		/**
 		 * Add a new edit operation (a replace operation).
 		 * The inverse edits will be accessible in `ICursorStateComputerData.getInverseEditOperations()`
 		 * @param range The range to replace (delete). May be empty to represent a simple insert.
 		 * @param text The text to replace with. May be null to represent a simple delete.
 		 */
-		addTrackedEditOperation(range: Range, text: string | null, forceMoveMarkers?: boolean): void;
+		addTrackedEditOperation(range: IRange, text: string | null, forceMoveMarkers?: boolean): void;
 		/**
 		 * Track `selection` when applying edit operations.
 		 * A best effort will be made to not grow/expand the selection.
@@ -1946,7 +1970,7 @@ declare namespace monaco.editor {
 		/**
 		 * Get the inverse edit operations of the added edit operations.
 		 */
-		getInverseEditOperations(): IIdentifiedSingleEditOperation[];
+		getInverseEditOperations(): IValidEditOperation[];
 		/**
 		 * Get a previously tracked selection.
 		 * @param id The unique identifier returned by `trackSelection`.

--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -10,7 +10,7 @@ import { RenderLineNumbersType, TextEditorCursorStyle, cursorStyleToString, Edit
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { IDecorationOptions, ScrollType } from 'vs/editor/common/editorCommon';
-import { IIdentifiedSingleEditOperation, ISingleEditOperation, ITextModel, ITextModelUpdateOptions } from 'vs/editor/common/model';
+import { ISingleEditOperation, ITextModel, ITextModelUpdateOptions, IIdentifiedSingleEditOperation } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/snippetController2';
 import { IApplyEditsOptions, IEditorPropertiesChangeData, IResolvedTextEditorConfiguration, ITextEditorConfigurationUpdate, IUndoStopOptions, TextEditorRevealType } from 'vs/workbench/api/common/extHost.protocol';


### PR DESCRIPTION
With the upcoming changes in TypeScript 3.8 to support `import type`, it is even more compelling to declare weak references via types rather than strong references via concrete classes. Most APIs in Monaco already do this well, accepting `monaco.IRange` instead of `monaco.Range`, though `IIdentifiedSingleEditOperation` appears to be an exception in this regard, which means a strong dependency on `monaco.Range` is required to use `ITextModel.pushEditOperations()`.

It would be nice to relax this constraint, though I admit I have not yet attempted to trace through whether this breaks anything since I am submitting this via GitHub's web UI.

<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #
