### PR TITLE
Fix contextmenu scrolling in monaco-editor

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -278,6 +278,10 @@ export class ContextView extends Disposable {
 		return !!this.delegate;
 	}
 
+	getView(): HTMLElement {
+		return this.view;
+	}
+
 	private onDOMEvent(e: Event, onCapture: boolean): void {
 		if (this.delegate) {
 			if (this.delegate.onDOMEvent) {

--- a/src/vs/editor/contrib/contextmenu/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/contextmenu.ts
@@ -49,8 +49,23 @@ export class ContextMenuController implements IEditorContribution {
 
 		this._toDispose.add(this._editor.onContextMenu((e: IEditorMouseEvent) => this._onContextMenu(e)));
 		this._toDispose.add(this._editor.onMouseWheel((e: IMouseWheelEvent) => {
+			let shouldHide = true;
 			if (this._contextMenuIsBeingShownCount > 0) {
-				this._contextViewService.hideContextView();
+				const view = this._contextViewService.getView();
+				const editor = this._editor.getDomNode();
+				let target = e.srcElement as HTMLElement;
+				while (target.parentElement && shouldHide !== false) {
+					if (target.parentElement === view) {
+						shouldHide = false;
+					} else if (target.parentElement === editor) {
+						shouldHide = true;
+					}
+					target = target.parentElement;
+				}
+				if (shouldHide) {
+					this._contextViewService.hideContextView();
+				}
+
 			}
 		}));
 		this._toDispose.add(this._editor.onKeyDown((e: IKeyboardEvent) => {

--- a/src/vs/platform/contextview/browser/contextView.ts
+++ b/src/vs/platform/contextview/browser/contextView.ts
@@ -18,6 +18,7 @@ export interface IContextViewService extends IContextViewProvider {
 	showContextView(delegate: IContextViewDelegate): void;
 	hideContextView(data?: any): void;
 	layout(): void;
+	getView(): HTMLElement;
 	anchorAlignment?: AnchorAlignment;
 }
 

--- a/src/vs/platform/contextview/browser/contextViewService.ts
+++ b/src/vs/platform/contextview/browser/contextViewService.ts
@@ -41,4 +41,8 @@ export class ContextViewService extends Disposable implements IContextViewServic
 	hideContextView(data?: any): void {
 		this.contextView.hide(data);
 	}
+
+	getView(): HTMLElement {
+		return this.contextView.getView();
+	}
 }


### PR DESCRIPTION
This fixes a bug that prevents the context menu from being scrolled with the mousewheel.

Shrink your window, so that there is not enough space for the context menu to expand completely.
Right click the editor.
Scroll inside the context menu.



This PR fixes [#1730](https://github.com/microsoft/monaco-editor/issues/1730).
