### PR TITLE
Change browser touch events to not be passive

### DIFF
--- a/src/vs/base/browser/touch.ts
+++ b/src/vs/base/browser/touch.ts
@@ -90,9 +90,9 @@ export class Gesture extends Disposable {
 		this.targets = [];
 		this.ignoreTargets = [];
 		this._lastSetTapCountTime = 0;
-		this._register(DomUtils.addDisposableListener(document, 'touchstart', (e: TouchEvent) => this.onTouchStart(e)));
+		this._register(DomUtils.addDisposableListener(document, 'touchstart', (e: TouchEvent) => this.onTouchStart(e), { passive: false }));
 		this._register(DomUtils.addDisposableListener(document, 'touchend', (e: TouchEvent) => this.onTouchEnd(e)));
-		this._register(DomUtils.addDisposableListener(document, 'touchmove', (e: TouchEvent) => this.onTouchMove(e)));
+		this._register(DomUtils.addDisposableListener(document, 'touchmove', (e: TouchEvent) => this.onTouchMove(e), { passive: false }));
 	}
 
 	public static addTarget(element: HTMLElement): IDisposable {

--- a/src/vs/editor/browser/viewParts/minimap/minimap.ts
+++ b/src/vs/editor/browser/viewParts/minimap/minimap.ts
@@ -1149,15 +1149,15 @@ class InnerMinimap extends Disposable {
 				this._gestureInProgress = true;
 				this.scrollDueToTouchEvent(e);
 			}
-		});
+		}, { passive: false });
 
-		this._sliderTouchMoveListener = dom.addStandardDisposableListener(this._domNode.domNode, EventType.Change, (e: GestureEvent) => {
+		this._sliderTouchMoveListener = dom.addDisposableListener(this._domNode.domNode, EventType.Change, (e: GestureEvent) => {
 			e.preventDefault();
 			e.stopPropagation();
 			if (this._lastRenderData && this._gestureInProgress) {
 				this.scrollDueToTouchEvent(e);
 			}
-		});
+		}, { passive: false });
 
 		this._sliderTouchEndListener = dom.addStandardDisposableListener(this._domNode.domNode, EventType.End, (e: GestureEvent) => {
 			e.preventDefault();


### PR DESCRIPTION
This adds `{prevent: false}` to `touchstart` and `touchmove` events that may call `e.preventDefault()`.  Otherwise, Chrome will throw an error.

This has to be tested with a touchscreen and I am unable to test it.

Open a monaco-editor.
Scroll through the editor as well as the minimap.
Errors should not be thrown, and scrolling should still work properly.


This PR fixes [#1382](https://github.com/microsoft/monaco-editor/issues/1382).
