### PR TITLE
Cleanup open-url handling

### DIFF
--- a/build/azure-pipelines/darwin/publish.sh
+++ b/build/azure-pipelines/darwin/publish.sh
@@ -24,4 +24,4 @@ node build/azure-pipelines/common/createAsset.js \
 # https://github.com/microsoft/vscode/issues/90491
 
 # upload configuration
-yarn gulp upload-vscode-configuration
+# yarn gulp upload-vscode-configuration

--- a/build/azure-pipelines/darwin/publish.sh
+++ b/build/azure-pipelines/darwin/publish.sh
@@ -24,4 +24,4 @@ node build/azure-pipelines/common/createAsset.js \
 # https://github.com/microsoft/vscode/issues/90491
 
 # upload configuration
-# yarn gulp upload-vscode-configuration
+yarn gulp upload-vscode-configuration

--- a/src/main.js
+++ b/src/main.js
@@ -136,7 +136,7 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		// override for the color profile to use
 		'force-color-profile'
 	];
-	
+
 	if (process.platform === 'linux') {
 		SUPPORTED_ELECTRON_SWITCHES.push('force-renderer-accessibility');
 	}
@@ -344,7 +344,7 @@ function setCurrentWorkingDirectory() {
 function registerListeners() {
 
 	/**
-	 * Mac: when someone drops a file to the not-yet running VSCode, the open-file event fires even before
+	 * macOS: when someone drops a file to the not-yet running VSCode, the open-file event fires even before
 	 * the app-ready event. We listen very early for open-file and remember this upon startup as path to open.
 	 *
 	 * @type {string[]}
@@ -356,7 +356,7 @@ function registerListeners() {
 	});
 
 	/**
-	 * React to open-url requests.
+	 * macOS: react to open-url requests.
 	 *
 	 * @type {string[]}
 	 */

--- a/src/vs/code/node/paths.ts
+++ b/src/vs/code/node/paths.ts
@@ -19,8 +19,8 @@ export function validatePaths(args: ParsedArgs): ParsedArgs {
 		args._ = [];
 	}
 
+	// Normalize paths and watch out for goto line mode
 	if (!args['remote']) {
-		// Normalize paths and watch out for goto line mode
 		const paths = doValidatePaths(args._, args.goto);
 		args._ = paths;
 	}

--- a/src/vs/platform/url/electron-main/electronUrlListener.ts
+++ b/src/vs/platform/url/electron-main/electronUrlListener.ts
@@ -12,7 +12,6 @@ import { URI } from 'vs/base/common/uri';
 import { IDisposable, DisposableStore, Disposable } from 'vs/base/common/lifecycle';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 import { isWindows } from 'vs/base/common/platform';
-import { coalesce } from 'vs/base/common/arrays';
 import { disposableTimeout } from 'vs/base/common/async';
 
 function uriFromRawUrl(url: string): URI | null {
@@ -41,20 +40,14 @@ export class ElectronURLListener {
 	private disposables = new DisposableStore();
 
 	constructor(
+		initialUrisToHandle: URI[],
 		private readonly urlService: IURLService,
 		windowsMainService: IWindowsMainService,
 		environmentService: IEnvironmentService
 	) {
 
-		// create the initial set of links we got on startup
-		this.uris = coalesce([
-
-			// Windows/Linux: protocol handler invokes CLI with --open-url
-			...environmentService.args['open-url'] ? environmentService.args._urls || [] : [],
-
-			// macOS: open-url events
-			...((<any>global).getOpenUrls() || []) as string[]
-		].map(uriFromRawUrl));
+		// the initial set of URIs we need to handle once the window is ready
+		this.uris = initialUrisToHandle;
 
 		// Windows: install as protocol handler
 		if (isWindows) {


### PR DESCRIPTION
The main motivation of this change is to allow the following scenario:
* a user clicks on "Open in Desktop" link in web
* VSCode should open on that workspace without showing any intermediate window

Before this change the flow was as follows due to how the URL listener was wired in:
* a user clicks on "Open in Desktop" link in web
* we open the first window which is just the last workspace that was opened
* we reload that window into the remote workspace from the "Open in Desktop" logic

This was due to how these URLs where always handled only after the initial window was opened. Now, if we have URLs to handle on startup, we do so immediately without opening the initial window too.

On top of that, a couple of changes that are related:
* adds a lot of docs how the URL handling works on different platforms
* moves the logic of finding the initial URLs to handle into one place and out of `ElectronURLListener` - it is now an argument to the class
* merges the 2 `urlService.registerHandler` we had into one in `app.ts`

//cc @joaomoreno 🎿 