### PR TITLE
Fix a small bug of JsonValidation

### DIFF
--- a/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/jsonValidationExtensionPoint.ts
@@ -69,7 +69,7 @@ export class JSONValidationExtensionPoint {
 						} catch (e) {
 							collector.error(nls.localize('invalid.url.fileschema', "'configuration.jsonValidation.url' is an invalid relative URL: {0}", e.message));
 						}
-					} else if (!strings.startsWith(uri, 'https:/') && strings.startsWith(uri, 'https:/')) {
+					} else if (!strings.startsWith(uri, 'http://') && !strings.startsWith(uri, 'https://')) {
 						collector.error(nls.localize('invalid.url.schema', "'configuration.jsonValidation.url' must start with 'http:', 'https:' or './' to reference schemas located in the extension"));
 						return;
 					}


### PR DESCRIPTION
The origin condition expression `(!strings.startsWith(uri, 'https:/') && strings.startsWith(uri, 'https:/'))` is always false.
According to the context code, it should be `(!strings.startsWith(uri, 'http://') && !strings.startsWith(uri, 'https://'))` instead.