### PR TITLE
Add padding above hover for second line

### DIFF
--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -350,7 +350,7 @@ class Widget {
 		const [belowLeft, absoluteBelowLeft] = this._layoutHorizontalSegmentInPage(windowSize, domNodePosition, bottomLeft.left - ctx.scrollLeft + this._contentLeft, width);
 
 		// Leave some clearance to the top/bottom
-		const TOP_PADDING = 22;
+		const TOP_PADDING = 22 + (this._range?.startLineNumber === 2 ? this._lineHeight : 0);
 		const BOTTOM_PADDING = 22;
 
 		const fitsAbove = (absoluteAboveTop >= TOP_PADDING);

--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -350,7 +350,7 @@ class Widget {
 		const [belowLeft, absoluteBelowLeft] = this._layoutHorizontalSegmentInPage(windowSize, domNodePosition, bottomLeft.left - ctx.scrollLeft + this._contentLeft, width);
 
 		// Leave some clearance to the top/bottom
-		const TOP_PADDING = 22 + (this._range?.startLineNumber === 2 ? this._lineHeight : 0);
+		const TOP_PADDING = 22;
 		const BOTTOM_PADDING = 22;
 
 		const fitsAbove = (absoluteAboveTop >= TOP_PADDING);
@@ -369,7 +369,7 @@ class Widget {
 
 		return {
 			fitsAbove,
-			aboveTop: Math.max(aboveTop, TOP_PADDING),
+			aboveTop: aboveTop,
 			aboveLeft,
 			fitsBelow,
 			belowTop,


### PR DESCRIPTION
Adds padding above the hover for the second line, so that the hover widget is not underneath the mouse.

Create a monaco editor.
Set the content to this.
```
function hello() {
	console.log("hello world");
}
```
Hover over `console`.  The hover should be beneath the word `console` instead of over it.

This PR fixes [#1810](https://github.com/microsoft/monaco-editor/issues/1810) in monaco-editor.
