### PR TITLE
Improved documentation of 'title' parameter on VSCode Proposed API

### DIFF
--- a/src/vs/vscode.proposed.d.ts
+++ b/src/vs/vscode.proposed.d.ts
@@ -1703,7 +1703,10 @@ declare module 'vscode' {
 	 */
 	export interface OpenDialogOptions {
 		/**
-		 * Dialog title
+		 * Dialog title.
+		 *
+		 * Depending on the underlying operating system this parameter might be ignored, since some
+		 * systems do not present title on open dialogs.
 		 */
 		title?: string;
 	}
@@ -1713,7 +1716,10 @@ declare module 'vscode' {
 	 */
 	export interface SaveDialogOptions {
 		/**
-		 * Dialog title
+		 * Dialog title.
+		 *
+		 * Depending on the underlying operating system this parameter might be ignored, since some
+		 * systems do not present title on save dialogs.
 		 */
 		title?: string;
 	}


### PR DESCRIPTION
This PR is related to #82871 and #91153.

Now the _title_ parameter documentation indicates that depending on the underlying operating system the title might be ignored, since some systems do not present title on open/save dialogs.