### PR TITLE
Align welcome view ids, add enum to schema documentation

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1855,7 +1855,7 @@
         "when": "config.git.enabled && !git.missing && workbenchState == workspace && workspaceFolderCount == 0"
       },
       {
-        "view": "workbench.explorer.emptyView",
+        "view": "workbench.explorer",
         "contents": "%view.workbench.cloneRepository%"
       }
     ]

--- a/src/vs/workbench/contrib/debug/browser/startView.ts
+++ b/src/vs/workbench/contrib/debug/browser/startView.ts
@@ -31,7 +31,7 @@ const CONTEXT_DEBUGGER_INTERESTED_IN_ACTIVE_EDITOR = new RawContextKey<boolean>(
 
 export class StartView extends ViewPane {
 
-	static ID = 'workbench.debug.startView';
+	static ID = 'workbench.debug';
 	static LABEL = localize('start', "Start");
 
 	private debugStartLanguageContext: IContextKey<string | undefined>;

--- a/src/vs/workbench/contrib/files/browser/views/emptyView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/emptyView.ts
@@ -23,7 +23,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 export class EmptyView extends ViewPane {
 
-	static readonly ID: string = 'workbench.explorer.emptyView';
+	static readonly ID: string = 'workbench.explorer';
 	static readonly NAME = nls.localize('noWorkspace', "No Folder Opened");
 
 	constructor(

--- a/src/vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint.ts
+++ b/src/vs/workbench/contrib/welcome/common/viewsWelcomeExtensionPoint.ts
@@ -34,6 +34,11 @@ const viewsWelcomeExtensionPointSchema = Object.freeze<IConfigurationPropertySch
 			[ViewsWelcomeExtensionPointFields.view]: {
 				type: 'string',
 				description: nls.localize('contributes.viewsWelcome.view.view', "Target view identifier for this welcome content."),
+				enum: [
+					'workbench.explorer',
+					'workbench.debug',
+					'workbench.scm',
+				]
 			},
 			[ViewsWelcomeExtensionPointFields.contents]: {
 				type: 'string',


### PR DESCRIPTION
fixes #91466

@isidorn This would need some adoption from debug extensions if any already contributes to the debug view.