### PR TITLE
Regression: Quickly closing a git commit message in VS code skips auto save

### DIFF
--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -613,6 +613,8 @@ export class ElectronWindow extends Disposable {
 	}
 
 	private trackClosedWaitFiles(waitMarkerFile: URI, resourcesToWaitFor: URI[]): IDisposable {
+		let remainingResourcesToWaitFor = resourcesToWaitFor.slice(0);
+
 		// In wait mode, listen to changes to the editors and wait until the files
 		// are closed that the user wants to wait for. When this happens we delete
 		// the wait marker file to signal to the outside that editing is done.
@@ -622,7 +624,7 @@ export class ElectronWindow extends Disposable {
 
 			// Remove from resources to wait for based on the
 			// resources from editors that got closed
-			resourcesToWaitFor = resourcesToWaitFor.filter(resourceToWaitFor => {
+			remainingResourcesToWaitFor = remainingResourcesToWaitFor.filter(resourceToWaitFor => {
 				if (isEqual(resourceToWaitFor, masterResource) || isEqual(resourceToWaitFor, detailsResource)) {
 					return false; // remove - the closing editor matches this resource
 				}
@@ -630,7 +632,7 @@ export class ElectronWindow extends Disposable {
 				return true; // keep - not yet closed
 			});
 
-			if (resourcesToWaitFor.length === 0) {
+			if (remainingResourcesToWaitFor.length === 0) {
 				// If auto save is configured with the default delay (1s) it is possible
 				// to close the editor while the save still continues in the background. As such
 				// we have to also check if the files to wait for are dirty and if so wait


### PR DESCRIPTION
fix #91709

The issue here is that I am removing elements from an array that I later check on for still being dirty or not. This basically invalidated that handling altogether. A regression from changes in 1.42 that I would like to fix for this release.
