### PR TITLE
Turn off JSON item resolving. Fixes #91747

### DIFF
--- a/extensions/json-language-features/server/src/jsonServerMain.ts
+++ b/extensions/json-language-features/server/src/jsonServerMain.ts
@@ -160,7 +160,10 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 	formatterMaxNumberOfEdits = params.initializationOptions?.customCapabilities?.rangeFormatting?.editLimit || Number.MAX_VALUE;
 	const capabilities: ServerCapabilities = {
 		textDocumentSync: TextDocumentSyncKind.Incremental,
-		completionProvider: clientSnippetSupport ? { resolveProvider: true, triggerCharacters: ['"', ':'] } : undefined,
+		completionProvider: clientSnippetSupport ? {
+			resolveProvider: false, // turn off resolving as the current language service doesn't do anything on resolve. Also fixes #91747
+			triggerCharacters: ['"', ':']
+		} : undefined,
 		hoverProvider: true,
 		documentSymbolProvider: true,
 		documentRangeFormattingProvider: params.initializationOptions.provideFormatter === true,


### PR DESCRIPTION
This PR fixes #91747

Turn off resolving for JSON completion items as the current JSON language service does nothing in resolving (it used to when package.json NPM completions were part of it)
