### PR TITLE
suggest: fix handling around long lines

### DIFF
--- a/src/vs/editor/contrib/suggest/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/media/suggest.css
@@ -176,7 +176,7 @@
 }
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .signature-label {
-	overflow: auto;
+	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
@@ -228,6 +228,7 @@
 
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left {
 	flex-shrink: 1;
+	flex-grow: 1;
 	overflow: hidden;
 }
 .monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .monaco-icon-label {

--- a/src/vs/editor/contrib/suggest/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/suggestWidget.ts
@@ -144,10 +144,9 @@ class ItemRenderer implements IListRenderer<CompletionItem, ISuggestionTemplateD
 		const text = append(container, $('.contents'));
 		const main = append(text, $('.main'));
 
+		data.iconContainer = append(main, $('.icon-label.codicon'));
 		data.left = append(main, $('span.left'));
 		data.right = append(main, $('span.right'));
-
-		data.iconContainer = append(data.left, $('.icon-label.codicon'));
 
 		data.iconLabel = new IconLabel(data.left, { supportHighlights: true, supportCodicons: true });
 		data.disposables.add(data.iconLabel);


### PR DESCRIPTION
See: https://github.com/microsoft/vscode/issues/90552#issuecomment-592680419

`overflow: hidden` should have been `overflow: auto`. Auto displays a
scrollbar which, depending on the platform, can make the items too high.

![image](https://user-images.githubusercontent.com/2230985/75583357-3bfc4d80-5a22-11ea-9426-a93f9cb7c640.png)

(manually moving the items up shows the scrollbar)

Also fixes names being cut off (see the loooong) cutoff in the linked
issue. `flex-shrink:0` is on the label, with a max-width of 100%. But
on the left there was the 18px icon, so the right side of the label was
18px off the end and not visible. Fix it by moving the icon outside of
the `.left` side. We could alternately `calc(100% - 18px)`, but since
the icon was not a hardcoded size in CSS I didn't want to implicitly
depend on that.

![image](https://user-images.githubusercontent.com/2230985/75583180-ffc8ed00-5a21-11ea-8fcd-e94697b8b8d6.png)
