### PR TITLE
Fix #89933

### DIFF
--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -857,6 +857,6 @@ registerThemingParticipant((theme, collector) => {
 	const linkFg = theme.getColor(textLinkForeground);
 	if (linkFg) {
 		collector.addRule(`.markers-panel .markers-panel-container .tree-container .monaco-tl-contents .details-container a.code-link .marker-code > span:hover { color: ${linkFg}; }`);
-		collector.addRule(`.markers-panel .markers-panel-container .tree-container .monaco-list:focus .monaco-tl-contents .details-container a.code-link .marker-code > span:hover { color: ${linkFg.lighten(.4)}; }`);
+		collector.addRule(`.markers-panel .markers-panel-container .tree-container .monaco-list:focus .monaco-tl-contents .details-container a.code-link .marker-code > span:hover { color: inherit; }`);
 	}
 });


### PR DESCRIPTION
Previously, in problems panel, we have hover color for links on both active selection and inactive ones.

My fix makes it so that links no longer change color on hover for active selection.

The crux of this problem is we have bad contrast between `textLink.foreground` and tree's `list.activeSelectionBackground`. We might need to introduce a new color for links in active selection, but that would be a large change I would do later.