### PR TITLE
Support for multiple values in git.path in settings.json

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1322,6 +1322,7 @@
         },
         "git.path": {
           "type": [
+            "array",
             "string",
             "null"
           ],

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -33,7 +33,7 @@ export async function deactivate(): Promise<any> {
 }
 
 async function createModel(context: ExtensionContext, outputChannel: OutputChannel, telemetryReporter: TelemetryReporter, disposables: Disposable[]): Promise<Model> {
-	const pathHint = workspace.getConfiguration('git').get<string>('path');
+	const pathHint = workspace.getConfiguration('git').get<string | string[]>('path');
 	const info = await findGit(pathHint, path => outputChannel.appendLine(localize('looking', "Looking for git in: {0}", path)));
 
 	let env: any = {};


### PR DESCRIPTION
This PR fixes #85734

Adding support for git.path in settings.json to be an array as well as a string. Since users can have multiple custom git paths and they work across different machines, this will be useful. The settings, though local to the machine, are being synced across machines using an extension.

Excited to contribute to vscode!