### PR TITLE
Sort by category only once

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditPreview.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditPreview.ts
@@ -260,6 +260,17 @@ export class BulkFileOperations {
 			}
 		}
 
+		// sort (once) categories atop which have unconfirmed edits
+		this.categories.sort((a, b) => {
+			if (a.metadata.needsConfirmation === b.metadata.needsConfirmation) {
+				return a.metadata.label.localeCompare(b.metadata.label);
+			} else if (a.metadata.needsConfirmation) {
+				return -1;
+			} else {
+				return 1;
+			}
+		});
+
 		return this;
 	}
 

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditTree.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditTree.ts
@@ -258,19 +258,6 @@ export class BulkEditDataSource implements IAsyncDataSource<BulkFileOperations, 
 export class BulkEditSorter implements ITreeSorter<BulkEditElement> {
 
 	compare(a: BulkEditElement, b: BulkEditElement): number {
-		if (a instanceof CategoryElement && b instanceof CategoryElement) {
-			//
-			const aConfirm = BulkEditSorter._needsConfirmation(a.category);
-			const bConfirm = BulkEditSorter._needsConfirmation(b.category);
-			if (aConfirm === bConfirm) {
-				return a.category.metadata.label.localeCompare(b.category.metadata.label);
-			} else if (aConfirm) {
-				return -1;
-			} else {
-				return 1;
-			}
-		}
-
 		if (a instanceof FileElement && b instanceof FileElement) {
 			return compare(a.edit.uri.toString(), b.edit.uri.toString());
 		}
@@ -280,10 +267,6 @@ export class BulkEditSorter implements ITreeSorter<BulkEditElement> {
 		}
 
 		return 0;
-	}
-
-	private static _needsConfirmation(a: BulkCategory): boolean {
-		return a.fileOperations.some(ops => ops.needsConfirmation());
 	}
 }
 


### PR DESCRIPTION
This PR fixes #91900 

Categories/groups in the refactor view that have unconfirmed changes should be sort atop because they need user approval. However, this should happen only once, when the view's tree is populated and not all the time while the tree updates. This PR removes the category/group sort logic from the tree comparator to the generation of the tree input.

