### PR TITLE
Workbench editor renames

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -291,11 +291,11 @@ class MainThreadDocumentAndEditorStateComputer {
 	}
 
 	private _getActiveEditorFromEditorPart(): IEditor | undefined {
-		let result = this._editorService.activeTextEditorWidget;
-		if (isDiffEditor(result)) {
-			result = result.getModifiedEditor();
+		let activeTextEditorControl = this._editorService.activeTextEditorControl;
+		if (isDiffEditor(activeTextEditorControl)) {
+			activeTextEditorControl = activeTextEditorControl.getModifiedEditor();
 		}
-		return result;
+		return activeTextEditorControl;
 	}
 }
 

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -22,7 +22,7 @@ import { MainThreadTextEditors } from 'vs/workbench/api/browser/mainThreadEditor
 import { ExtHostContext, ExtHostDocumentsAndEditorsShape, IDocumentsAndEditorsDelta, IExtHostContext, IModelAddedData, ITextEditorAddData, MainContext } from 'vs/workbench/api/common/extHost.protocol';
 import { EditorViewColumn, editorGroupToViewColumn } from 'vs/workbench/api/common/shared/editor';
 import { BaseTextEditor } from 'vs/workbench/browser/parts/editor/textEditor';
-import { IEditor as IWorkbenchEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IPanelService } from 'vs/workbench/services/panel/common/panelService';
@@ -444,9 +444,9 @@ export class MainThreadDocumentsAndEditors {
 		return undefined;
 	}
 
-	findTextEditorIdFor(inputEditor: IWorkbenchEditor): string | undefined {
+	findTextEditorIdFor(editorPane: IEditorPane): string | undefined {
 		for (const [id, editor] of this._textEditors) {
-			if (editor.matches(inputEditor)) {
+			if (editor.matches(editorPane)) {
 				return id;
 			}
 		}

--- a/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadDocumentsAndEditors.ts
@@ -436,9 +436,9 @@ export class MainThreadDocumentsAndEditors {
 	}
 
 	private _findEditorPosition(editor: MainThreadTextEditor): EditorViewColumn | undefined {
-		for (const workbenchEditor of this._editorService.visibleControls) {
-			if (editor.matches(workbenchEditor)) {
-				return editorGroupToViewColumn(this._editorGroupService, workbenchEditor.group);
+		for (const editorPane of this._editorService.visibleEditorPanes) {
+			if (editor.matches(editorPane)) {
+				return editorGroupToViewColumn(this._editorGroupService, editorPane.group);
 			}
 		}
 		return undefined;

--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -14,7 +14,7 @@ import { ISingleEditOperation, ITextModel, ITextModelUpdateOptions, IIdentifiedS
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/snippetController2';
 import { IApplyEditsOptions, IEditorPropertiesChangeData, IResolvedTextEditorConfiguration, ITextEditorConfigurationUpdate, IUndoStopOptions, TextEditorRevealType } from 'vs/workbench/api/common/extHost.protocol';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { equals } from 'vs/base/common/arrays';
 
@@ -413,7 +413,7 @@ export class MainThreadTextEditor {
 		return false;
 	}
 
-	public matches(editor: IEditor): boolean {
+	public matches(editor: IEditorPane): boolean {
 		if (!editor) {
 			return false;
 		}

--- a/src/vs/workbench/api/browser/mainThreadEditors.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditors.ts
@@ -101,10 +101,10 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 
 	private _getTextEditorPositionData(): ITextEditorPositionData {
 		const result: ITextEditorPositionData = Object.create(null);
-		for (let workbenchEditor of this._editorService.visibleControls) {
-			const id = this._documentsAndEditors.findTextEditorIdFor(workbenchEditor);
+		for (let editorPane of this._editorService.visibleEditorPanes) {
+			const id = this._documentsAndEditors.findTextEditorIdFor(editorPane);
 			if (id) {
-				result[id] = editorGroupToViewColumn(this._editorGroupService, workbenchEditor.group);
+				result[id] = editorGroupToViewColumn(this._editorGroupService, editorPane.group);
 			}
 		}
 		return result;
@@ -151,10 +151,10 @@ export class MainThreadTextEditors implements MainThreadTextEditorsShape {
 	async $tryHideEditor(id: string): Promise<void> {
 		const mainThreadEditor = this._documentsAndEditors.getEditor(id);
 		if (mainThreadEditor) {
-			const editors = this._editorService.visibleControls;
-			for (let editor of editors) {
-				if (mainThreadEditor.matches(editor)) {
-					return editor.group.closeEditor(editor.input);
+			const editorPanes = this._editorService.visibleEditorPanes;
+			for (let editorPane of editorPanes) {
+				if (mainThreadEditor.matches(editorPane)) {
+					return editorPane.group.closeEditor(editorPane.input);
 				}
 			}
 		}

--- a/src/vs/workbench/api/browser/mainThreadWebview.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebview.ts
@@ -382,7 +382,7 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 			return;
 		}
 
-		const activeInput = this._editorService.activeControl && this._editorService.activeControl.input;
+		const activeInput = this._editorService.activeEditorPane?.input;
 		const viewStates: extHostProtocol.WebviewPanelViewStateData = {};
 
 		const updateViewStatesForInput = (group: IEditorGroup, topLevelInput: IEditorInput, editorInput: IEditorInput) => {

--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -176,13 +176,13 @@ export class WorkbenchContextKeysHandler extends Disposable {
 
 	private updateEditorContextKeys(): void {
 		const activeGroup = this.editorGroupService.activeGroup;
-		const activeControl = this.editorService.activeControl;
-		const visibleEditors = this.editorService.visibleControls;
+		const activeEditorPane = this.editorService.activeEditorPane;
+		const visibleEditorPanes = this.editorService.visibleEditorPanes;
 
-		this.textCompareEditorActiveContext.set(activeControl?.getId() === TEXT_DIFF_EDITOR_ID);
-		this.textCompareEditorVisibleContext.set(visibleEditors.some(control => control.getId() === TEXT_DIFF_EDITOR_ID));
+		this.textCompareEditorActiveContext.set(activeEditorPane?.getId() === TEXT_DIFF_EDITOR_ID);
+		this.textCompareEditorVisibleContext.set(visibleEditorPanes.some(editorPane => editorPane.getId() === TEXT_DIFF_EDITOR_ID));
 
-		if (visibleEditors.length > 0) {
+		if (visibleEditorPanes.length > 0) {
 			this.editorsVisibleContext.set(true);
 		} else {
 			this.editorsVisibleContext.reset();
@@ -204,9 +204,9 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		this.activeEditorGroupIndex.set(activeGroup.index + 1); // not zero-indexed
 		this.activeEditorGroupLast.set(activeGroup.index === groupCount - 1);
 
-		if (activeControl) {
-			this.activeEditorContext.set(activeControl.getId());
-			this.activeEditorIsReadonly.set(activeControl.input.isReadonly());
+		if (activeEditorPane) {
+			this.activeEditorContext.set(activeEditorPane.getId());
+			this.activeEditorIsReadonly.set(activeEditorPane.input.isReadonly());
 		} else {
 			this.activeEditorContext.reset();
 			this.activeEditorIsReadonly.reset();

--- a/src/vs/workbench/browser/dnd.ts
+++ b/src/vs/workbench/browser/dnd.ts
@@ -348,12 +348,12 @@ export function fillResourceDataTransfers(accessor: ServicesAccessor, resources:
 
 		// Try to find editor view state from the visible editors that match given resource
 		let viewState: IEditorViewState | undefined = undefined;
-		const textEditorWidgets = editorService.visibleTextEditorWidgets;
-		for (const textEditorWidget of textEditorWidgets) {
-			if (isCodeEditor(textEditorWidget)) {
-				const model = textEditorWidget.getModel();
+		const textEditorControls = editorService.visibleTextEditorControls;
+		for (const textEditorControl of textEditorControls) {
+			if (isCodeEditor(textEditorControl)) {
+				const model = textEditorControl.getModel();
 				if (model?.uri?.toString() === file.resource.toString()) {
-					viewState = withNullAsUndefined(textEditorWidget.saveViewState());
+					viewState = withNullAsUndefined(textEditorControl.saveViewState());
 					break;
 				}
 			}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -707,22 +707,22 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				editor.updateOptions({ lineNumbers });
 			};
 
-			const editorWidgetSet = this.state.zenMode.editorWidgetSet;
+			const editorControlSet = this.state.zenMode.editorWidgetSet;
 			if (!lineNumbers) {
 				// Reset line numbers on all editors visible and non-visible
-				for (const editor of editorWidgetSet) {
+				for (const editor of editorControlSet) {
 					setEditorLineNumbers(editor);
 				}
-				editorWidgetSet.clear();
+				editorControlSet.clear();
 			} else {
-				this.editorService.visibleTextEditorWidgets.forEach(editor => {
-					if (!editorWidgetSet.has(editor)) {
-						editorWidgetSet.add(editor);
-						this.state.zenMode.transitionDisposables.add(editor.onDidDispose(() => {
-							editorWidgetSet.delete(editor);
+				this.editorService.visibleTextEditorControls.forEach(editorControl => {
+					if (!editorControlSet.has(editorControl)) {
+						editorControlSet.add(editorControl);
+						this.state.zenMode.transitionDisposables.add(editorControl.onDidDispose(() => {
+							editorControlSet.delete(editorControl);
 						}));
 					}
-					setEditorLineNumbers(editor);
+					setEditorLineNumbers(editorControl);
 				});
 			}
 		};

--- a/src/vs/workbench/browser/parts/editor/baseEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/baseEditor.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Panel } from 'vs/workbench/browser/panel';
-import { EditorInput, EditorOptions, IEditor, GroupIdentifier, IEditorMemento } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, IEditorPane, GroupIdentifier, IEditorMemento } from 'vs/workbench/common/editor';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -33,7 +33,7 @@ import { indexOfPath } from 'vs/base/common/extpath';
  *
  * This class is only intended to be subclassed and not instantiated.
  */
-export abstract class BaseEditor extends Panel implements IEditor {
+export abstract class BaseEditor extends Panel implements IEditorPane {
 
 	private static readonly EDITOR_MEMENTOS: Map<string, EditorMemento<any>> = new Map<string, EditorMemento<any>>();
 

--- a/src/vs/workbench/browser/parts/editor/binaryDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/binaryDiffEditor.ts
@@ -29,8 +29,8 @@ export class BinaryResourceDiffEditor extends SideBySideEditor {
 	}
 
 	getMetadata(): string | undefined {
-		const master = this.masterEditor;
-		const details = this.detailsEditor;
+		const master = this.masterEditorPane;
+		const details = this.detailsEditorPane;
 
 		if (master instanceof BaseBinaryResourceEditor && details instanceof BaseBinaryResourceEditor) {
 			return nls.localize('metadataDiff', "{0} ↔ {1}", details.getMetadata(), master.getMetadata());

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -290,10 +290,10 @@ export class BreadcrumbsControl {
 	}
 
 	private _getActiveCodeEditor(): ICodeEditor | undefined {
-		if (!this._editorGroup.activeControl) {
+		if (!this._editorGroup.activeEditorPane) {
 			return undefined;
 		}
-		let control = this._editorGroup.activeControl.getControl();
+		let control = this._editorGroup.activeEditorPane.getControl();
 		let editor: ICodeEditor | undefined;
 		if (isCodeEditor(control)) {
 			editor = control as ICodeEditor;
@@ -713,8 +713,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		}
 		widget.setFocused(undefined);
 		widget.setSelection(undefined);
-		if (groups.activeGroup.activeControl) {
-			groups.activeGroup.activeControl.focus();
+		if (groups.activeGroup.activeEditorPane) {
+			groups.activeGroup.activeEditorPane.focus();
 		}
 	}
 });

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -126,7 +126,7 @@ export interface IEditorGroupView extends IDisposable, ISerializableView, IEdito
 }
 
 export function getActiveTextEditorOptions(group: IEditorGroup, expectedActiveEditor?: IEditorInput, presetOptions?: EditorOptions): EditorOptions {
-	const activeGroupCodeEditor = group.activeControl ? getCodeEditor(group.activeControl.getControl()) : undefined;
+	const activeGroupCodeEditor = group.activeEditorPane ? getCodeEditor(group.activeEditorPane.getControl()) : undefined;
 	if (activeGroupCodeEditor) {
 		if (!expectedActiveEditor || expectedActiveEditor.matches(group.activeEditor)) {
 			return TextEditorOptions.fromEditor(activeGroupCodeEditor, presetOptions);

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { GroupIdentifier, IWorkbenchEditorConfiguration, EditorOptions, TextEditorOptions, IEditorInput, IEditorIdentifier, IEditorCloseEvent, IEditor, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorInput } from 'vs/workbench/common/editor';
+import { GroupIdentifier, IWorkbenchEditorConfiguration, EditorOptions, TextEditorOptions, IEditorInput, IEditorIdentifier, IEditorCloseEvent, IEditorPane, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorInput } from 'vs/workbench/common/editor';
 import { EditorGroup } from 'vs/workbench/common/editor/editorGroup';
 import { IEditorGroup, GroupDirection, IAddGroupOptions, IMergeGroupOptions, GroupsOrder, GroupsArrangement } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -73,7 +73,7 @@ export interface IEditorOpeningEvent extends IEditorIdentifier {
 	 * to return a promise that resolves to `undefined` to prevent the opening
 	 * alltogether.
 	 */
-	prevent(callback: () => undefined | Promise<IEditor | undefined>): void;
+	prevent(callback: () => undefined | Promise<IEditorPane | undefined>): void;
 }
 
 export interface IEditorGroupsAccessor {

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -521,10 +521,10 @@ export class RevertAndCloseEditorAction extends Action {
 	}
 
 	async run(): Promise<void> {
-		const activeControl = this.editorService.activeControl;
-		if (activeControl) {
-			const editor = activeControl.input;
-			const group = activeControl.group;
+		const activeEditorPane = this.editorService.activeEditorPane;
+		if (activeEditorPane) {
+			const editor = activeEditorPane.input;
+			const group = activeEditorPane.group;
 
 			// first try a normal revert where the contents of the editor are restored
 			try {

--- a/src/vs/workbench/browser/parts/editor/editorAutoSave.ts
+++ b/src/vs/workbench/browser/parts/editor/editorAutoSave.ts
@@ -78,9 +78,9 @@ export class EditorAutoSave extends Disposable implements IWorkbenchContribution
 		this.lastActiveEditorControlDisposable.clear();
 
 		// Listen to focus changes on control for auto save
-		const activeEditorControl = this.editorService.activeControl;
-		if (activeEditor && activeEditorControl) {
-			this.lastActiveEditorControlDisposable.add(activeEditorControl.onDidBlur(() => {
+		const activeEditorPane = this.editorService.activeEditorPane;
+		if (activeEditor && activeEditorPane) {
+			this.lastActiveEditorControlDisposable.add(activeEditorPane.onDidBlur(() => {
 				this.maybeTriggerAutoSave(SaveReason.FOCUS_CHANGE, { groupId: activeGroup.id, editor: activeEditor });
 			}));
 		}

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import * as types from 'vs/base/common/types';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { TextCompareEditorVisibleContext, EditorInput, IEditorIdentifier, IEditorCommandsContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, CloseDirection, IEditorPane, IEditorInput, IVisibleEditor } from 'vs/workbench/common/editor';
+import { TextCompareEditorVisibleContext, EditorInput, IEditorIdentifier, IEditorCommandsContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, CloseDirection, IEditorPane, IEditorInput, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
@@ -131,7 +131,7 @@ function moveActiveEditor(args: ActiveEditorMoveArguments = Object.create(null),
 	}
 }
 
-function moveActiveTab(args: ActiveEditorMoveArguments, control: IVisibleEditor, accessor: ServicesAccessor): void {
+function moveActiveTab(args: ActiveEditorMoveArguments, control: IVisibleEditorPane, accessor: ServicesAccessor): void {
 	const group = control.group;
 	let index = group.getIndexOfEditor(control.input);
 	switch (args.to) {
@@ -159,7 +159,7 @@ function moveActiveTab(args: ActiveEditorMoveArguments, control: IVisibleEditor,
 	group.moveEditor(control.input, group, { index });
 }
 
-function moveActiveEditorToGroup(args: ActiveEditorMoveArguments, control: IVisibleEditor, accessor: ServicesAccessor): void {
+function moveActiveEditorToGroup(args: ActiveEditorMoveArguments, control: IVisibleEditorPane, accessor: ServicesAccessor): void {
 	const editorGroupService = accessor.get(IEditorGroupsService);
 	const configurationService = accessor.get(IConfigurationService);
 

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import * as types from 'vs/base/common/types';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { TextCompareEditorVisibleContext, EditorInput, IEditorIdentifier, IEditorCommandsContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, CloseDirection, IEditor, IEditorInput, IVisibleEditor } from 'vs/workbench/common/editor';
+import { TextCompareEditorVisibleContext, EditorInput, IEditorIdentifier, IEditorCommandsContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, CloseDirection, IEditorPane, IEditorInput, IVisibleEditor } from 'vs/workbench/common/editor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
@@ -708,7 +708,7 @@ function getCommandsContext(resourceOrContext: URI | IEditorCommandsContext, con
 	return undefined;
 }
 
-function resolveCommandsContext(editorGroupService: IEditorGroupsService, context?: IEditorCommandsContext): { group: IEditorGroup, editor?: IEditorInput, control?: IEditor } {
+function resolveCommandsContext(editorGroupService: IEditorGroupsService, context?: IEditorCommandsContext): { group: IEditorGroup, editor?: IEditorInput, control?: IEditorPane } {
 
 	// Resolve from context
 	let group = context && typeof context.groupId === 'number' ? editorGroupService.getGroup(context.groupId) : undefined;

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -17,16 +17,16 @@ import { Emitter } from 'vs/base/common/event';
 import { assertIsDefined } from 'vs/base/common/types';
 
 export interface IOpenEditorResult {
-	readonly control: BaseEditor;
+	readonly editorPane: BaseEditor;
 	readonly editorChanged: boolean;
 }
 
 export class EditorControl extends Disposable {
 
-	get minimumWidth() { return this._activeControl ? this._activeControl.minimumWidth : DEFAULT_EDITOR_MIN_DIMENSIONS.width; }
-	get minimumHeight() { return this._activeControl ? this._activeControl.minimumHeight : DEFAULT_EDITOR_MIN_DIMENSIONS.height; }
-	get maximumWidth() { return this._activeControl ? this._activeControl.maximumWidth : DEFAULT_EDITOR_MAX_DIMENSIONS.width; }
-	get maximumHeight() { return this._activeControl ? this._activeControl.maximumHeight : DEFAULT_EDITOR_MAX_DIMENSIONS.height; }
+	get minimumWidth() { return this._activeEditorPane ? this._activeEditorPane.minimumWidth : DEFAULT_EDITOR_MIN_DIMENSIONS.width; }
+	get minimumHeight() { return this._activeEditorPane ? this._activeEditorPane.minimumHeight : DEFAULT_EDITOR_MIN_DIMENSIONS.height; }
+	get maximumWidth() { return this._activeEditorPane ? this._activeEditorPane.maximumWidth : DEFAULT_EDITOR_MAX_DIMENSIONS.width; }
+	get maximumHeight() { return this._activeEditorPane ? this._activeEditorPane.maximumHeight : DEFAULT_EDITOR_MAX_DIMENSIONS.height; }
 
 	private readonly _onDidFocus = this._register(new Emitter<void>());
 	readonly onDidFocus = this._onDidFocus.event;
@@ -34,10 +34,10 @@ export class EditorControl extends Disposable {
 	private _onDidSizeConstraintsChange = this._register(new Emitter<{ width: number; height: number; } | undefined>());
 	readonly onDidSizeConstraintsChange = this._onDidSizeConstraintsChange.event;
 
-	private _activeControl: BaseEditor | null = null;
-	private controls: BaseEditor[] = [];
+	private _activeEditorPane: BaseEditor | null = null;
+	private editorPanes: BaseEditor[] = [];
 
-	private readonly activeControlDisposables = this._register(new DisposableStore());
+	private readonly activeEditorPaneDisposables = this._register(new DisposableStore());
 	private dimension: Dimension | undefined;
 	private editorOperation: LongRunningOperation;
 
@@ -53,119 +53,119 @@ export class EditorControl extends Disposable {
 		this.editorOperation = this._register(new LongRunningOperation(editorProgressService));
 	}
 
-	get activeControl(): IVisibleEditorPane | null {
-		return this._activeControl as IVisibleEditorPane | null;
+	get activeEditorPane(): IVisibleEditorPane | null {
+		return this._activeEditorPane as IVisibleEditorPane | null;
 	}
 
 	async openEditor(editor: EditorInput, options?: EditorOptions): Promise<IOpenEditorResult> {
 
-		// Editor control
+		// Editor pane
 		const descriptor = Registry.as<IEditorRegistry>(EditorExtensions.Editors).getEditor(editor);
 		if (!descriptor) {
 			throw new Error('No editor descriptor found');
 		}
-		const control = this.doShowEditorControl(descriptor);
+		const editorPane = this.doShowEditorPane(descriptor);
 
 		// Set input
-		const editorChanged = await this.doSetInput(control, editor, options);
-		return { control, editorChanged };
+		const editorChanged = await this.doSetInput(editorPane, editor, options);
+		return { editorPane, editorChanged };
 	}
 
-	private doShowEditorControl(descriptor: IEditorDescriptor): BaseEditor {
+	private doShowEditorPane(descriptor: IEditorDescriptor): BaseEditor {
 
-		// Return early if the currently active editor control can handle the input
-		if (this._activeControl && descriptor.describes(this._activeControl)) {
-			return this._activeControl;
+		// Return early if the currently active editor pane can handle the input
+		if (this._activeEditorPane && descriptor.describes(this._activeEditorPane)) {
+			return this._activeEditorPane;
 		}
 
 		// Hide active one first
-		this.doHideActiveEditorControl();
+		this.doHideActiveEditorPane();
 
-		// Create editor
-		const control = this.doCreateEditorControl(descriptor);
+		// Create editor pane
+		const editorPane = this.doCreateEditorPane(descriptor);
 
 		// Set editor as active
-		this.doSetActiveControl(control);
+		this.doSetActiveEditorPane(editorPane);
 
 		// Show editor
-		const container = assertIsDefined(control.getContainer());
+		const container = assertIsDefined(editorPane.getContainer());
 		this.parent.appendChild(container);
 		show(container);
 
 		// Indicate to editor that it is now visible
-		control.setVisible(true, this.groupView);
+		editorPane.setVisible(true, this.groupView);
 
 		// Layout
 		if (this.dimension) {
-			control.layout(this.dimension);
+			editorPane.layout(this.dimension);
 		}
 
-		return control;
+		return editorPane;
 	}
 
-	private doCreateEditorControl(descriptor: IEditorDescriptor): BaseEditor {
+	private doCreateEditorPane(descriptor: IEditorDescriptor): BaseEditor {
 
 		// Instantiate editor
-		const control = this.doInstantiateEditorControl(descriptor);
+		const editorPane = this.doInstantiateEditorPane(descriptor);
 
 		// Create editor container as needed
-		if (!control.getContainer()) {
-			const controlInstanceContainer = document.createElement('div');
-			addClass(controlInstanceContainer, 'editor-instance');
-			controlInstanceContainer.setAttribute('data-editor-id', descriptor.getId());
+		if (!editorPane.getContainer()) {
+			const editorPaneContainer = document.createElement('div');
+			addClass(editorPaneContainer, 'editor-instance');
+			editorPaneContainer.setAttribute('data-editor-id', descriptor.getId());
 
-			control.create(controlInstanceContainer);
+			editorPane.create(editorPaneContainer);
 		}
 
-		return control;
+		return editorPane;
 	}
 
-	private doInstantiateEditorControl(descriptor: IEditorDescriptor): BaseEditor {
+	private doInstantiateEditorPane(descriptor: IEditorDescriptor): BaseEditor {
 
 		// Return early if already instantiated
-		const existingControl = this.controls.filter(control => descriptor.describes(control))[0];
-		if (existingControl) {
-			return existingControl;
+		const existingEditorPane = this.editorPanes.filter(editorPane => descriptor.describes(editorPane))[0];
+		if (existingEditorPane) {
+			return existingEditorPane;
 		}
 
 		// Otherwise instantiate new
-		const control = this._register(descriptor.instantiate(this.instantiationService));
-		this.controls.push(control);
+		const editorPane = this._register(descriptor.instantiate(this.instantiationService));
+		this.editorPanes.push(editorPane);
 
-		return control;
+		return editorPane;
 	}
 
-	private doSetActiveControl(control: BaseEditor | null) {
-		this._activeControl = control;
+	private doSetActiveEditorPane(editorPane: BaseEditor | null) {
+		this._activeEditorPane = editorPane;
 
-		// Clear out previous active control listeners
-		this.activeControlDisposables.clear();
+		// Clear out previous active editor pane listeners
+		this.activeEditorPaneDisposables.clear();
 
-		// Listen to control changes
-		if (control) {
-			this.activeControlDisposables.add(control.onDidSizeConstraintsChange(e => this._onDidSizeConstraintsChange.fire(e)));
-			this.activeControlDisposables.add(control.onDidFocus(() => this._onDidFocus.fire()));
+		// Listen to editor pane changes
+		if (editorPane) {
+			this.activeEditorPaneDisposables.add(editorPane.onDidSizeConstraintsChange(e => this._onDidSizeConstraintsChange.fire(e)));
+			this.activeEditorPaneDisposables.add(editorPane.onDidFocus(() => this._onDidFocus.fire()));
 		}
 
 		// Indicate that size constraints could have changed due to new editor
 		this._onDidSizeConstraintsChange.fire(undefined);
 	}
 
-	private async doSetInput(control: BaseEditor, editor: EditorInput, options: EditorOptions | undefined): Promise<boolean> {
+	private async doSetInput(editorPane: BaseEditor, editor: EditorInput, options: EditorOptions | undefined): Promise<boolean> {
 
 		// If the input did not change, return early and only apply the options
 		// unless the options instruct us to force open it even if it is the same
 		const forceReload = options?.forceReload;
-		const inputMatches = control.input && control.input.matches(editor);
+		const inputMatches = editorPane.input && editorPane.input.matches(editor);
 		if (inputMatches && !forceReload) {
 
 			// Forward options
-			control.setOptions(options);
+			editorPane.setOptions(options);
 
 			// Still focus as needed
 			const focus = !options || !options.preserveFocus;
 			if (focus) {
-				control.focus();
+				editorPane.focus();
 			}
 
 			return false;
@@ -175,16 +175,16 @@ export class EditorControl extends Disposable {
 		// be more relaxed about progress showing by increasing the delay a little bit to reduce flicker.
 		const operation = this.editorOperation.start(this.layoutService.isRestored() ? 800 : 3200);
 
-		// Call into editor control
+		// Call into editor pane
 		const editorWillChange = !inputMatches;
 		try {
-			await control.setInput(editor, options, operation.token);
+			await editorPane.setInput(editor, options, operation.token);
 
 			// Focus (unless prevented or another operation is running)
 			if (operation.isCurrent()) {
 				const focus = !options || !options.preserveFocus;
 				if (focus) {
-					control.focus();
+					editorPane.focus();
 				}
 			}
 
@@ -194,47 +194,47 @@ export class EditorControl extends Disposable {
 		}
 	}
 
-	private doHideActiveEditorControl(): void {
-		if (!this._activeControl) {
+	private doHideActiveEditorPane(): void {
+		if (!this._activeEditorPane) {
 			return;
 		}
 
 		// Stop any running operation
 		this.editorOperation.stop();
 
-		// Remove control from parent and hide
-		const controlInstanceContainer = this._activeControl.getContainer();
-		if (controlInstanceContainer) {
-			this.parent.removeChild(controlInstanceContainer);
-			hide(controlInstanceContainer);
-			this._activeControl.onHide();
+		// Remove editor pane from parent and hide
+		const editorPaneContainer = this._activeEditorPane.getContainer();
+		if (editorPaneContainer) {
+			this.parent.removeChild(editorPaneContainer);
+			hide(editorPaneContainer);
+			this._activeEditorPane.onHide();
 		}
 
-		// Indicate to editor control
-		this._activeControl.clearInput();
-		this._activeControl.setVisible(false, this.groupView);
+		// Indicate to editor pane
+		this._activeEditorPane.clearInput();
+		this._activeEditorPane.setVisible(false, this.groupView);
 
-		// Clear active control
-		this.doSetActiveControl(null);
+		// Clear active editor pane
+		this.doSetActiveEditorPane(null);
 	}
 
 	closeEditor(editor: EditorInput): void {
-		if (this._activeControl && editor.matches(this._activeControl.input)) {
-			this.doHideActiveEditorControl();
+		if (this._activeEditorPane && editor.matches(this._activeEditorPane.input)) {
+			this.doHideActiveEditorPane();
 		}
 	}
 
 	setVisible(visible: boolean): void {
-		if (this._activeControl) {
-			this._activeControl.setVisible(visible, this.groupView);
+		if (this._activeEditorPane) {
+			this._activeEditorPane.setVisible(visible, this.groupView);
 		}
 	}
 
 	layout(dimension: Dimension): void {
 		this.dimension = dimension;
 
-		if (this._activeControl && this.dimension) {
-			this._activeControl.layout(this.dimension);
+		if (this._activeEditorPane && this.dimension) {
+			this._activeEditorPane.layout(this.dimension);
 		}
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorControl.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { EditorInput, EditorOptions, IVisibleEditor } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { Dimension, show, hide, addClass } from 'vs/base/browser/dom';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IEditorRegistry, Extensions as EditorExtensions, IEditorDescriptor } from 'vs/workbench/browser/editor';
@@ -53,8 +53,8 @@ export class EditorControl extends Disposable {
 		this.editorOperation = this._register(new LongRunningOperation(editorProgressService));
 	}
 
-	get activeControl(): IVisibleEditor | null {
-		return this._activeControl as IVisibleEditor | null;
+	get activeControl(): IVisibleEditorPane | null {
+		return this._activeControl as IVisibleEditorPane | null;
 	}
 
 	async openEditor(editor: EditorInput, options?: EditorOptions): Promise<IOpenEditorResult> {

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/editorgroupview';
 
 import { EditorGroup, IEditorOpenOptions, EditorCloseEvent, ISerializedEditorGroup, isSerializedEditorGroup } from 'vs/workbench/common/editor/editorGroup';
-import { EditorInput, EditorOptions, GroupIdentifier, SideBySideEditorInput, CloseDirection, IEditorCloseEvent, EditorGroupActiveEditorDirtyContext, IEditorPane, EditorGroupEditorsCountContext, SaveReason, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, GroupIdentifier, SideBySideEditorInput, CloseDirection, IEditorCloseEvent, EditorGroupActiveEditorDirtyContext, IEditorPane, EditorGroupEditorsCountContext, SaveReason, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { Event, Emitter, Relay } from 'vs/base/common/event';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { addClass, addClasses, Dimension, trackFocus, toggleClass, removeClass, addDisposableListener, EventType, EventHelper, findParentWithClass, clearNode, isAncestor } from 'vs/base/browser/dom';
@@ -733,7 +733,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		return this._group.count;
 	}
 
-	get activeControl(): IVisibleEditor | undefined {
+	get activeControl(): IVisibleEditorPane | undefined {
 		return this.editorControl ? withNullAsUndefined(this.editorControl.activeControl) : undefined;
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/editorgroupview';
 
 import { EditorGroup, IEditorOpenOptions, EditorCloseEvent, ISerializedEditorGroup, isSerializedEditorGroup } from 'vs/workbench/common/editor/editorGroup';
-import { EditorInput, EditorOptions, GroupIdentifier, SideBySideEditorInput, CloseDirection, IEditorCloseEvent, EditorGroupActiveEditorDirtyContext, IEditor, EditorGroupEditorsCountContext, SaveReason, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, GroupIdentifier, SideBySideEditorInput, CloseDirection, IEditorCloseEvent, EditorGroupActiveEditorDirtyContext, IEditorPane, EditorGroupEditorsCountContext, SaveReason, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
 import { Event, Emitter, Relay } from 'vs/base/common/event';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { addClass, addClasses, Dimension, trackFocus, toggleClass, removeClass, addDisposableListener, EventType, EventHelper, findParentWithClass, clearNode, isAncestor } from 'vs/base/browser/dom';
@@ -803,7 +803,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 	//#region openEditor()
 
-	async openEditor(editor: EditorInput, options?: EditorOptions): Promise<IEditor | null> {
+	async openEditor(editor: EditorInput, options?: EditorOptions): Promise<IEditorPane | null> {
 
 		// Guard against invalid inputs
 		if (!editor) {
@@ -822,7 +822,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		return withUndefinedAsNull(await this.doOpenEditor(editor, options));
 	}
 
-	private doOpenEditor(editor: EditorInput, options?: EditorOptions): Promise<IEditor | undefined> {
+	private doOpenEditor(editor: EditorInput, options?: EditorOptions): Promise<IEditorPane | undefined> {
 
 		// Guard against invalid inputs. Disposed inputs
 		// should never open because they emit no events
@@ -895,10 +895,10 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		return showEditorResult;
 	}
 
-	private async doShowEditor(editor: EditorInput, active: boolean, options?: EditorOptions): Promise<IEditor | undefined> {
+	private async doShowEditor(editor: EditorInput, active: boolean, options?: EditorOptions): Promise<IEditorPane | undefined> {
 
 		// Show in editor control if the active editor changed
-		let openEditorPromise: Promise<IEditor | undefined>;
+		let openEditorPromise: Promise<IEditorPane | undefined>;
 		if (active) {
 			openEditorPromise = (async () => {
 				try {
@@ -1015,7 +1015,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 	//#region openEditors()
 
-	async openEditors(editors: { editor: EditorInput, options?: EditorOptions }[]): Promise<IEditor | null> {
+	async openEditors(editors: { editor: EditorInput, options?: EditorOptions }[]): Promise<IEditorPane | null> {
 		if (!editors.length) {
 			return null;
 		}
@@ -1625,7 +1625,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 }
 
 class EditorOpeningEvent implements IEditorOpeningEvent {
-	private override: (() => Promise<IEditor | undefined>) | undefined = undefined;
+	private override: (() => Promise<IEditorPane | undefined>) | undefined = undefined;
 
 	constructor(
 		private _group: GroupIdentifier,
@@ -1646,11 +1646,11 @@ class EditorOpeningEvent implements IEditorOpeningEvent {
 		return this._options;
 	}
 
-	prevent(callback: () => Promise<IEditor | undefined>): void {
+	prevent(callback: () => Promise<IEditorPane | undefined>): void {
 		this.override = callback;
 	}
 
-	isPrevented(): (() => Promise<IEditor | undefined>) | undefined {
+	isPrevented(): (() => Promise<IEditorPane | undefined>) | undefined {
 		return this.override;
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -733,8 +733,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		return this._group.count;
 	}
 
-	get activeControl(): IVisibleEditorPane | undefined {
-		return this.editorControl ? withNullAsUndefined(this.editorControl.activeControl) : undefined;
+	get activeEditorPane(): IVisibleEditorPane | undefined {
+		return this.editorControl ? withNullAsUndefined(this.editorControl.activeEditorPane) : undefined;
 	}
 
 	get activeEditor(): EditorInput | null {
@@ -771,9 +771,9 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 	focus(): void {
 
-		// Pass focus to widgets
-		if (this.activeControl) {
-			this.activeControl.focus();
+		// Pass focus to editor panes
+		if (this.activeEditorPane) {
+			this.activeEditorPane.focus();
 		} else {
 			this.element.focus();
 		}
@@ -909,7 +909,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 						this._onDidGroupChange.fire({ kind: GroupChangeKind.EDITOR_ACTIVE, editor });
 					}
 
-					return result.control;
+					return result.editorPane;
 				} catch (error) {
 
 					// Handle errors but do not bubble them up
@@ -1041,7 +1041,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		// Opening many editors at once can put any editor to be
 		// the active one depending on options. As such, we simply
 		// return the active control after this operation.
-		return this.editorControl.activeControl;
+		return this.editorControl.activeEditorPane;
 	}
 
 	//#endregion

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -13,7 +13,7 @@ import { URI } from 'vs/base/common/uri';
 import { Action } from 'vs/base/common/actions';
 import { Language } from 'vs/base/common/platform';
 import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
-import { IFileEditorInput, EncodingMode, IEncodingSupport, toResource, SideBySideEditorInput, IEditor, IEditorInput, SideBySideEditor, IModeSupport } from 'vs/workbench/common/editor';
+import { IFileEditorInput, EncodingMode, IEncodingSupport, toResource, SideBySideEditorInput, IEditorPane, IEditorInput, SideBySideEditor, IModeSupport } from 'vs/workbench/common/editor';
 import { Disposable, MutableDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { IEditorAction } from 'vs/editor/common/editorCommon';
 import { EndOfLineSequence } from 'vs/editor/common/model';
@@ -733,7 +733,7 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 		this.updateState(update);
 	}
 
-	private onMetadataChange(editor: IEditor | undefined): void {
+	private onMetadataChange(editor: IEditorPane | undefined): void {
 		const update: StateDelta = { type: 'metadata', metadata: undefined };
 
 		if (editor instanceof BaseBinaryResourceEditor || editor instanceof BinaryResourceDiffEditor) {
@@ -832,7 +832,7 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 		this.updateState(info);
 	}
 
-	private onEncodingChange(editor: IEditor | undefined, editorWidget: ICodeEditor | undefined): void {
+	private onEncodingChange(editor: IEditorPane | undefined, editorWidget: ICodeEditor | undefined): void {
 		if (editor && !this.isActiveEditor(editor)) {
 			return;
 		}
@@ -876,7 +876,7 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 		this.updateState(info);
 	}
 
-	private isActiveEditor(control: IEditor): boolean {
+	private isActiveEditor(control: IEditorPane): boolean {
 		const activeControl = this.editorService.activeControl;
 
 		return !!activeControl && activeControl === control;

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -363,8 +363,8 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 	}
 
 	private async showIndentationPicker(): Promise<unknown> {
-		const activeTextEditorWidget = getCodeEditor(this.editorService.activeTextEditorWidget);
-		if (!activeTextEditorWidget) {
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl) {
 			return this.quickInputService.pick([{ label: nls.localize('noEditor', "No text editor active at this time") }]);
 		}
 
@@ -373,19 +373,19 @@ export class EditorStatus extends Disposable implements IWorkbenchContribution {
 		}
 
 		const picks: QuickPickInput<IQuickPickItem & { run(): void; }>[] = [
-			activeTextEditorWidget.getAction(IndentUsingSpaces.ID),
-			activeTextEditorWidget.getAction(IndentUsingTabs.ID),
-			activeTextEditorWidget.getAction(DetectIndentation.ID),
-			activeTextEditorWidget.getAction(IndentationToSpacesAction.ID),
-			activeTextEditorWidget.getAction(IndentationToTabsAction.ID),
-			activeTextEditorWidget.getAction(TrimTrailingWhitespaceAction.ID)
+			activeTextEditorControl.getAction(IndentUsingSpaces.ID),
+			activeTextEditorControl.getAction(IndentUsingTabs.ID),
+			activeTextEditorControl.getAction(DetectIndentation.ID),
+			activeTextEditorControl.getAction(IndentationToSpacesAction.ID),
+			activeTextEditorControl.getAction(IndentationToTabsAction.ID),
+			activeTextEditorControl.getAction(TrimTrailingWhitespaceAction.ID)
 		].map((a: IEditorAction) => {
 			return {
 				id: a.id,
 				label: a.label,
 				detail: (Language.isDefaultVariant() || a.label === a.alias) ? undefined : a.alias,
 				run: () => {
-					activeTextEditorWidget.focus();
+					activeTextEditorControl.focus();
 					a.run();
 				}
 			};
@@ -1047,13 +1047,13 @@ export class ChangeModeAction extends Action {
 	}
 
 	async run(): Promise<void> {
-		const activeTextEditorWidget = getCodeEditor(this.editorService.activeTextEditorWidget);
-		if (!activeTextEditorWidget) {
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl) {
 			await this.quickInputService.pick([{ label: nls.localize('noEditor', "No text editor active at this time") }]);
 			return;
 		}
 
-		const textModel = activeTextEditorWidget.getModel();
+		const textModel = activeTextEditorControl.getModel();
 		const resource = this.editorService.activeEditor ? toResource(this.editorService.activeEditor, { supportSideBySide: SideBySideEditor.MASTER }) : null;
 
 		let hasLanguageSupport = !!resource;
@@ -1248,8 +1248,8 @@ export class ChangeEOLAction extends Action {
 	}
 
 	async run(): Promise<void> {
-		const activeTextEditorWidget = getCodeEditor(this.editorService.activeTextEditorWidget);
-		if (!activeTextEditorWidget) {
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
+		if (!activeTextEditorControl) {
 			await this.quickInputService.pick([{ label: nls.localize('noEditor', "No text editor active at this time") }]);
 			return;
 		}
@@ -1259,7 +1259,7 @@ export class ChangeEOLAction extends Action {
 			return;
 		}
 
-		let textModel = activeTextEditorWidget.getModel();
+		let textModel = activeTextEditorControl.getModel();
 
 		const EOLOptions: IChangeEOLEntry[] = [
 			{ label: nlsEOLLF, eol: EndOfLineSequence.LF },
@@ -1270,7 +1270,7 @@ export class ChangeEOLAction extends Action {
 
 		const eol = await this.quickInputService.pick(EOLOptions, { placeHolder: nls.localize('pickEndOfLine', "Select End of Line Sequence"), activeItem: EOLOptions[selectedIndex] });
 		if (eol) {
-			const activeCodeEditor = getCodeEditor(this.editorService.activeTextEditorWidget);
+			const activeCodeEditor = getCodeEditor(this.editorService.activeTextEditorControl);
 			if (activeCodeEditor?.hasModel() && !this.editorService.activeEditor?.isReadonly()) {
 				textModel = activeCodeEditor.getModel();
 				textModel.pushStackElement();
@@ -1299,7 +1299,7 @@ export class ChangeEncodingAction extends Action {
 	}
 
 	async run(): Promise<void> {
-		if (!getCodeEditor(this.editorService.activeTextEditorWidget)) {
+		if (!getCodeEditor(this.editorService.activeTextEditorControl)) {
 			await this.quickInputService.pick([{ label: nls.localize('noEditor', "No text editor active at this time") }]);
 			return;
 		}

--- a/src/vs/workbench/browser/parts/editor/rangeDecorations.ts
+++ b/src/vs/workbench/browser/parts/editor/rangeDecorations.ts
@@ -63,7 +63,7 @@ export class RangeHighlightDecorations extends Disposable {
 		const resource = activeEditor && activeEditor.resource;
 		if (resource) {
 			if (resource.toString() === resourceRange.resource.toString()) {
-				return this.editorService.activeTextEditorWidget as ICodeEditor;
+				return this.editorService.activeTextEditorControl as ICodeEditor;
 			}
 		}
 

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -5,7 +5,7 @@
 
 import * as DOM from 'vs/base/browser/dom';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { EditorInput, EditorOptions, SideBySideEditorInput, IEditorControl, IEditor } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, SideBySideEditorInput, IEditorControl, IEditorPane } from 'vs/workbench/common/editor';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -155,11 +155,11 @@ export class SideBySideEditor extends BaseEditor {
 		return undefined;
 	}
 
-	getMasterEditor(): IEditor | undefined {
+	getMasterEditor(): IEditorPane | undefined {
 		return this.masterEditor;
 	}
 
-	getDetailsEditor(): IEditor | undefined {
+	getDetailsEditor(): IEditorPane | undefined {
 		return this.detailsEditor;
 	}
 

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -24,15 +24,15 @@ export class SideBySideEditor extends BaseEditor {
 	static readonly ID: string = 'workbench.editor.sidebysideEditor';
 	static MASTER: SideBySideEditor | undefined;
 
-	get minimumMasterWidth() { return this.masterEditor ? this.masterEditor.minimumWidth : 0; }
-	get maximumMasterWidth() { return this.masterEditor ? this.masterEditor.maximumWidth : Number.POSITIVE_INFINITY; }
-	get minimumMasterHeight() { return this.masterEditor ? this.masterEditor.minimumHeight : 0; }
-	get maximumMasterHeight() { return this.masterEditor ? this.masterEditor.maximumHeight : Number.POSITIVE_INFINITY; }
+	get minimumMasterWidth() { return this.masterEditorPane ? this.masterEditorPane.minimumWidth : 0; }
+	get maximumMasterWidth() { return this.masterEditorPane ? this.masterEditorPane.maximumWidth : Number.POSITIVE_INFINITY; }
+	get minimumMasterHeight() { return this.masterEditorPane ? this.masterEditorPane.minimumHeight : 0; }
+	get maximumMasterHeight() { return this.masterEditorPane ? this.masterEditorPane.maximumHeight : Number.POSITIVE_INFINITY; }
 
-	get minimumDetailsWidth() { return this.detailsEditor ? this.detailsEditor.minimumWidth : 0; }
-	get maximumDetailsWidth() { return this.detailsEditor ? this.detailsEditor.maximumWidth : Number.POSITIVE_INFINITY; }
-	get minimumDetailsHeight() { return this.detailsEditor ? this.detailsEditor.minimumHeight : 0; }
-	get maximumDetailsHeight() { return this.detailsEditor ? this.detailsEditor.maximumHeight : Number.POSITIVE_INFINITY; }
+	get minimumDetailsWidth() { return this.detailsEditorPane ? this.detailsEditorPane.minimumWidth : 0; }
+	get maximumDetailsWidth() { return this.detailsEditorPane ? this.detailsEditorPane.maximumWidth : Number.POSITIVE_INFINITY; }
+	get minimumDetailsHeight() { return this.detailsEditorPane ? this.detailsEditorPane.minimumHeight : 0; }
+	get maximumDetailsHeight() { return this.detailsEditorPane ? this.detailsEditorPane.maximumHeight : Number.POSITIVE_INFINITY; }
 
 	// these setters need to exist because this extends from BaseEditor
 	set minimumWidth(value: number) { /* noop */ }
@@ -45,8 +45,8 @@ export class SideBySideEditor extends BaseEditor {
 	get minimumHeight() { return this.minimumMasterHeight + this.minimumDetailsHeight; }
 	get maximumHeight() { return this.maximumMasterHeight + this.maximumDetailsHeight; }
 
-	protected masterEditor?: BaseEditor;
-	protected detailsEditor?: BaseEditor;
+	protected masterEditorPane?: BaseEditor;
+	protected detailsEditorPane?: BaseEditor;
 
 	private masterEditorContainer: HTMLElement | undefined;
 	private detailsEditorContainer: HTMLElement | undefined;
@@ -77,7 +77,7 @@ export class SideBySideEditor extends BaseEditor {
 		this.detailsEditorContainer = DOM.$('.details-editor-container');
 		this.splitview.addView({
 			element: this.detailsEditorContainer,
-			layout: size => this.detailsEditor && this.detailsEditor.layout(new DOM.Dimension(size, this.dimension.height)),
+			layout: size => this.detailsEditorPane && this.detailsEditorPane.layout(new DOM.Dimension(size, this.dimension.height)),
 			minimumSize: 220,
 			maximumSize: Number.POSITIVE_INFINITY,
 			onDidChange: Event.None
@@ -86,7 +86,7 @@ export class SideBySideEditor extends BaseEditor {
 		this.masterEditorContainer = DOM.$('.master-editor-container');
 		this.splitview.addView({
 			element: this.masterEditorContainer,
-			layout: size => this.masterEditor && this.masterEditor.layout(new DOM.Dimension(size, this.dimension.height)),
+			layout: size => this.masterEditorPane && this.masterEditorPane.layout(new DOM.Dimension(size, this.dimension.height)),
 			minimumSize: 220,
 			maximumSize: Number.POSITIVE_INFINITY,
 			onDidChange: Event.None
@@ -103,30 +103,30 @@ export class SideBySideEditor extends BaseEditor {
 	}
 
 	setOptions(options: EditorOptions | undefined): void {
-		if (this.masterEditor) {
-			this.masterEditor.setOptions(options);
+		if (this.masterEditorPane) {
+			this.masterEditorPane.setOptions(options);
 		}
 	}
 
 	protected setEditorVisible(visible: boolean, group: IEditorGroup | undefined): void {
-		if (this.masterEditor) {
-			this.masterEditor.setVisible(visible, group);
+		if (this.masterEditorPane) {
+			this.masterEditorPane.setVisible(visible, group);
 		}
 
-		if (this.detailsEditor) {
-			this.detailsEditor.setVisible(visible, group);
+		if (this.detailsEditorPane) {
+			this.detailsEditorPane.setVisible(visible, group);
 		}
 
 		super.setEditorVisible(visible, group);
 	}
 
 	clearInput(): void {
-		if (this.masterEditor) {
-			this.masterEditor.clearInput();
+		if (this.masterEditorPane) {
+			this.masterEditorPane.clearInput();
 		}
 
-		if (this.detailsEditor) {
-			this.detailsEditor.clearInput();
+		if (this.detailsEditorPane) {
+			this.detailsEditorPane.clearInput();
 		}
 
 		this.disposeEditors();
@@ -135,8 +135,8 @@ export class SideBySideEditor extends BaseEditor {
 	}
 
 	focus(): void {
-		if (this.masterEditor) {
-			this.masterEditor.focus();
+		if (this.masterEditorPane) {
+			this.masterEditorPane.focus();
 		}
 	}
 
@@ -148,19 +148,19 @@ export class SideBySideEditor extends BaseEditor {
 	}
 
 	getControl(): IEditorControl | undefined {
-		if (this.masterEditor) {
-			return this.masterEditor.getControl();
+		if (this.masterEditorPane) {
+			return this.masterEditorPane.getControl();
 		}
 
 		return undefined;
 	}
 
-	getMasterEditor(): IEditorPane | undefined {
-		return this.masterEditor;
+	getMasterEditorPane(): IEditorPane | undefined {
+		return this.masterEditorPane;
 	}
 
-	getDetailsEditor(): IEditorPane | undefined {
-		return this.detailsEditor;
+	getDetailsEditorPane(): IEditorPane | undefined {
+		return this.detailsEditorPane;
 	}
 
 	private async updateInput(oldInput: SideBySideEditorInput, newInput: SideBySideEditorInput, options: EditorOptions | undefined, token: CancellationToken): Promise<void> {
@@ -172,13 +172,13 @@ export class SideBySideEditor extends BaseEditor {
 			return this.setNewInput(newInput, options, token);
 		}
 
-		if (!this.detailsEditor || !this.masterEditor) {
+		if (!this.detailsEditorPane || !this.masterEditorPane) {
 			return;
 		}
 
 		await Promise.all([
-			this.detailsEditor.setInput(newInput.details, undefined, token),
-			this.masterEditor.setInput(newInput.master, options, token)
+			this.detailsEditorPane.setInput(newInput.details, undefined, token),
+			this.masterEditorPane.setInput(newInput.master, options, token)
 		]);
 	}
 
@@ -203,8 +203,8 @@ export class SideBySideEditor extends BaseEditor {
 	}
 
 	private async onEditorsCreated(details: BaseEditor, master: BaseEditor, detailsInput: EditorInput, masterInput: EditorInput, options: EditorOptions | undefined, token: CancellationToken): Promise<void> {
-		this.detailsEditor = details;
-		this.masterEditor = master;
+		this.detailsEditorPane = details;
+		this.masterEditorPane = master;
 
 		this._onDidSizeConstraintsChange.input = Event.any(
 			Event.map(details.onDidSizeConstraintsChange, () => undefined),
@@ -214,8 +214,8 @@ export class SideBySideEditor extends BaseEditor {
 		this.onDidCreateEditors.fire(undefined);
 
 		await Promise.all([
-			this.detailsEditor.setInput(detailsInput, undefined, token),
-			this.masterEditor.setInput(masterInput, options, token)]
+			this.detailsEditorPane.setInput(detailsInput, undefined, token),
+			this.masterEditorPane.setInput(masterInput, options, token)]
 		);
 	}
 
@@ -228,14 +228,14 @@ export class SideBySideEditor extends BaseEditor {
 	}
 
 	private disposeEditors(): void {
-		if (this.detailsEditor) {
-			this.detailsEditor.dispose();
-			this.detailsEditor = undefined;
+		if (this.detailsEditorPane) {
+			this.detailsEditorPane.dispose();
+			this.detailsEditorPane = undefined;
 		}
 
-		if (this.masterEditor) {
-			this.masterEditor.dispose();
-			this.masterEditor = undefined;
+		if (this.masterEditorPane) {
+			this.masterEditorPane.dispose();
+			this.masterEditorPane = undefined;
 		}
 
 		if (this.detailsEditorContainer) {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -9,7 +9,7 @@ import { isFunction, isObject, isArray, assertIsDefined } from 'vs/base/common/t
 import { IDiffEditor } from 'vs/editor/browser/editorBrowser';
 import { IDiffEditorOptions, IEditorOptions as ICodeEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { BaseTextEditor, IEditorConfiguration } from 'vs/workbench/browser/parts/editor/textEditor';
-import { TextEditorOptions, EditorInput, EditorOptions, TEXT_DIFF_EDITOR_ID, IEditorInputFactoryRegistry, Extensions as EditorInputExtensions, ITextDiffEditor, IEditorMemento } from 'vs/workbench/common/editor';
+import { TextEditorOptions, EditorInput, EditorOptions, TEXT_DIFF_EDITOR_ID, IEditorInputFactoryRegistry, Extensions as EditorInputExtensions, ITextDiffEditorPane, IEditorMemento } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { DiffNavigator } from 'vs/editor/browser/widget/diffNavigator';
 import { DiffEditorWidget } from 'vs/editor/browser/widget/diffEditorWidget';
@@ -34,7 +34,7 @@ import { EditorActivation, IEditorOptions } from 'vs/platform/editor/common/edit
 /**
  * The text editor that leverages the diff text editor for the editing experience.
  */
-export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditor {
+export class TextDiffEditor extends BaseTextEditor implements ITextDiffEditorPane {
 
 	static readonly ID = TEXT_DIFF_EDITOR_ID;
 

--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -10,7 +10,7 @@ import { Event } from 'vs/base/common/event';
 import { isObject, assertIsDefined, withNullAsUndefined, isFunction } from 'vs/base/common/types';
 import { Dimension } from 'vs/base/browser/dom';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
-import { EditorInput, EditorOptions, IEditorMemento, ITextEditor, TextEditorOptions } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, IEditorMemento, ITextEditorPane, TextEditorOptions } from 'vs/workbench/common/editor';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
 import { IEditorViewState, IEditor, ScrollType } from 'vs/editor/common/editorCommon';
 import { IStorageService } from 'vs/platform/storage/common/storage';
@@ -33,7 +33,7 @@ export interface IEditorConfiguration {
  * The base class of editors that leverage the text editor for the editing experience. This class is only intended to
  * be subclassed and not instantiated.
  */
-export abstract class BaseTextEditor extends BaseEditor implements ITextEditor {
+export abstract class BaseTextEditor extends BaseEditor implements ITextEditorPane {
 
 	static readonly TEXT_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'textEditorViewState';
 

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -158,12 +158,12 @@ export abstract class TitleControl extends Themable {
 	}
 
 	private actionViewItemProvider(action: IAction): IActionViewItem | undefined {
-		const activeControl = this.group.activeControl;
+		const activeEditorPane = this.group.activeEditorPane;
 
 		// Check Active Editor
 		let actionViewItem: IActionViewItem | undefined = undefined;
-		if (activeControl instanceof BaseEditor) {
-			actionViewItem = activeControl.getActionViewItem(action);
+		if (activeEditorPane instanceof BaseEditor) {
+			actionViewItem = activeEditorPane.getActionViewItem(action);
 		}
 
 		// Check extensions
@@ -225,9 +225,9 @@ export abstract class TitleControl extends Themable {
 		this.editorPinnedContext.set(this.group.activeEditor ? this.group.isPinned(this.group.activeEditor) : false);
 
 		// Editor actions require the editor control to be there, so we retrieve it via service
-		const activeControl = this.group.activeControl;
-		if (activeControl instanceof BaseEditor) {
-			const codeEditor = getCodeEditor(activeControl.getControl());
+		const activeEditorPane = this.group.activeEditorPane;
+		if (activeEditorPane instanceof BaseEditor) {
+			const codeEditor = getCodeEditor(activeEditorPane.getControl());
 			const scopedContextKeyService = codeEditor?.invokeWithinContext(accessor => accessor.get(IContextKeyService)) || this.contextKeyService;
 			const titleBarMenu = this.menuService.createMenu(MenuId.EditorTitle, scopedContextKeyService);
 			this.editorToolBarMenuDisposables.add(titleBarMenu);

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -742,9 +742,9 @@ class StatusbarEntryItem extends Disposable {
 		args = args || [];
 
 		// Maintain old behaviour of always focusing the editor here
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (activeTextEditorWidget) {
-			activeTextEditorWidget.focus();
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (activeTextEditorControl) {
+			activeTextEditorControl.focus();
 		}
 
 		this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id, from: 'status bar' });

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -9,7 +9,7 @@ import { assign } from 'vs/base/common/objects';
 import { withNullAsUndefined, assertIsDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IDisposable, Disposable, toDisposable } from 'vs/base/common/lifecycle';
-import { IEditor as ICodeEditor, IEditorViewState, ScrollType, IDiffEditor } from 'vs/editor/common/editorCommon';
+import { IEditor, IEditorViewState, ScrollType, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorModel, IEditorOptions, ITextEditorOptions, IBaseResourceInput, IResourceInput, EditorActivation, EditorOpenContext, ITextEditorSelection, TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
 import { IInstantiationService, IConstructorSignature0, ServicesAccessor, BrandedService } from 'vs/platform/instantiation/common/instantiation';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
@@ -125,7 +125,7 @@ export interface ITextEditorPane extends IEditorPane {
 	/**
 	 * Returns the underlying text editor widget of this editor.
 	 */
-	getControl(): ICodeEditor | undefined;
+	getControl(): IEditor | undefined;
 
 	/**
 	 * Returns the current view state of the text editor if any.
@@ -1181,7 +1181,7 @@ export class TextEditorOptions extends EditorOptions implements ITextEditorOptio
 	/**
 	 * Create a TextEditorOptions inline to be used when the editor is opening.
 	 */
-	static fromEditor(editor: ICodeEditor, settings?: IEditorOptions): TextEditorOptions {
+	static fromEditor(editor: IEditor, settings?: IEditorOptions): TextEditorOptions {
 		const options = TextEditorOptions.create(settings);
 
 		// View state
@@ -1195,7 +1195,7 @@ export class TextEditorOptions extends EditorOptions implements ITextEditorOptio
 	 *
 	 * @return if something was applied
 	 */
-	apply(editor: ICodeEditor, scrollType: ScrollType): boolean {
+	apply(editor: IEditor, scrollType: ScrollType): boolean {
 		let gotApplied = false;
 
 		// First try viewstate

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -61,7 +61,10 @@ export const TEXT_DIFF_EDITOR_ID = 'workbench.editors.textDiffEditor';
  */
 export const BINARY_DIFF_EDITOR_ID = 'workbench.editors.binaryResourceDiffEditor';
 
-export interface IEditor extends IPanel {
+/**
+ * The editor pane is the container for workbench editors.
+ */
+export interface IEditorPane extends IPanel {
 
 	/**
 	 * The assigned input of this editor.
@@ -112,12 +115,12 @@ export interface IEditor extends IPanel {
 /**
  * Overrides `IEditor` where `input` and `group` are known to be set.
  */
-export interface IVisibleEditor extends IEditor {
+export interface IVisibleEditor extends IEditorPane {
 	readonly input: IEditorInput;
 	readonly group: IEditorGroup;
 }
 
-export interface ITextEditor extends IEditor {
+export interface ITextEditor extends IEditorPane {
 
 	/**
 	 * Returns the underlying text editor widget of this editor.
@@ -130,13 +133,13 @@ export interface ITextEditor extends IEditor {
 	getViewState(): IEditorViewState | undefined;
 }
 
-export function isTextEditor(thing: IEditor | undefined): thing is ITextEditor {
+export function isTextEditor(thing: IEditorPane | undefined): thing is ITextEditor {
 	const candidate = thing as ITextEditor | undefined;
 
 	return typeof candidate?.getViewState === 'function';
 }
 
-export interface ITextDiffEditor extends IEditor {
+export interface ITextDiffEditor extends IEditorPane {
 
 	/**
 	 * Returns the underlying text editor widget of this editor.
@@ -144,7 +147,7 @@ export interface ITextDiffEditor extends IEditor {
 	getControl(): IDiffEditor | undefined;
 }
 
-export interface ITextSideBySideEditor extends IEditor {
+export interface ITextSideBySideEditor extends IEditorPane {
 
 	/**
 	 * Returns the underlying text editor widget of the master side

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -115,12 +115,12 @@ export interface IEditorPane extends IPanel {
 /**
  * Overrides `IEditor` where `input` and `group` are known to be set.
  */
-export interface IVisibleEditor extends IEditorPane {
+export interface IVisibleEditorPane extends IEditorPane {
 	readonly input: IEditorInput;
 	readonly group: IEditorGroup;
 }
 
-export interface ITextEditor extends IEditorPane {
+export interface ITextEditorPane extends IEditorPane {
 
 	/**
 	 * Returns the underlying text editor widget of this editor.
@@ -133,33 +133,18 @@ export interface ITextEditor extends IEditorPane {
 	getViewState(): IEditorViewState | undefined;
 }
 
-export function isTextEditor(thing: IEditorPane | undefined): thing is ITextEditor {
-	const candidate = thing as ITextEditor | undefined;
+export function isTextEditorPane(thing: IEditorPane | undefined): thing is ITextEditorPane {
+	const candidate = thing as ITextEditorPane | undefined;
 
 	return typeof candidate?.getViewState === 'function';
 }
 
-export interface ITextDiffEditor extends IEditorPane {
+export interface ITextDiffEditorPane extends IEditorPane {
 
 	/**
 	 * Returns the underlying text editor widget of this editor.
 	 */
 	getControl(): IDiffEditor | undefined;
-}
-
-export interface ITextSideBySideEditor extends IEditorPane {
-
-	/**
-	 * Returns the underlying text editor widget of the master side
-	 * of this side-by-side editor.
-	 */
-	getMasterEditor(): ITextEditor;
-
-	/**
-	 * Returns the underlying text editor widget of the details side
-	 * of this side-by-side editor.
-	 */
-	getDetailsEditor(): ITextEditor;
 }
 
 /**
@@ -265,19 +250,6 @@ export interface IResourceDiffInput extends IBaseResourceInput {
 	 * The right hand side URI to open inside a diff editor.
 	 */
 	readonly rightResource: URI;
-}
-
-export interface IResourceSideBySideInput extends IBaseResourceInput {
-
-	/**
-	 * The right hand side URI to open inside a side by side editor.
-	 */
-	readonly masterResource: URI;
-
-	/**
-	 * The left hand side URI to open inside a side by side editor.
-	 */
-	readonly detailResource: URI;
 }
 
 export const enum Verbosity {

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -739,21 +739,21 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 export function getActiveEditor(accessor: ServicesAccessor): IActiveCodeEditor | null {
-	let activeTextEditorWidget = accessor.get(IEditorService).activeTextEditorWidget;
+	let activeTextEditorControl = accessor.get(IEditorService).activeTextEditorControl;
 
-	if (isDiffEditor(activeTextEditorWidget)) {
-		if (activeTextEditorWidget.getOriginalEditor().hasTextFocus()) {
-			activeTextEditorWidget = activeTextEditorWidget.getOriginalEditor();
+	if (isDiffEditor(activeTextEditorControl)) {
+		if (activeTextEditorControl.getOriginalEditor().hasTextFocus()) {
+			activeTextEditorControl = activeTextEditorControl.getOriginalEditor();
 		} else {
-			activeTextEditorWidget = activeTextEditorWidget.getModifiedEditor();
+			activeTextEditorControl = activeTextEditorControl.getModifiedEditor();
 		}
 	}
 
-	if (!isCodeEditor(activeTextEditorWidget) || !activeTextEditorWidget.hasModel()) {
+	if (!isCodeEditor(activeTextEditorControl) || !activeTextEditorControl.hasModel()) {
 		return null;
 	}
 
-	return activeTextEditorWidget;
+	return activeTextEditorControl;
 }
 
 registerThemingParticipant((theme, collector) => {

--- a/src/vs/workbench/contrib/comments/browser/commentsView.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsView.ts
@@ -173,7 +173,7 @@ export class CommentsPanel extends ViewPane {
 		if (currentActiveResource && currentActiveResource.toString() === element.resource.toString()) {
 			const threadToReveal = element instanceof ResourceWithCommentThreads ? element.commentThreads[0].threadId : element.threadId;
 			const commentToReveal = element instanceof ResourceWithCommentThreads ? element.commentThreads[0].comment.uniqueIdInThread : element.comment.uniqueIdInThread;
-			const control = this.editorService.activeTextEditorWidget;
+			const control = this.editorService.activeTextEditorControl;
 			if (threadToReveal && isCodeEditor(control)) {
 				const controller = CommentController.get(control);
 				controller.revealCommentThread(threadToReveal, commentToReveal, false);

--- a/src/vs/workbench/contrib/customEditor/browser/commands.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/commands.ts
@@ -115,7 +115,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 
 	public runCommand(accessor: ServicesAccessor): void {
 		const editorService = accessor.get<IEditorService>(IEditorService);
-		const activeInput = editorService.activeControl?.input;
+		const activeInput = editorService.activeEditorPane?.input;
 		if (activeInput instanceof CustomEditorInput) {
 			activeInput.undo();
 		}
@@ -142,7 +142,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 
 	public runCommand(accessor: ServicesAccessor): void {
 		const editorService = accessor.get<IEditorService>(IEditorService);
-		const activeInput = editorService.activeControl?.input;
+		const activeInput = editorService.activeEditorPane?.input;
 		if (activeInput instanceof CustomEditorInput) {
 			activeInput.redo();
 		}
@@ -161,13 +161,13 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 
 	public runCommand(accessor: ServicesAccessor): void {
 		const editorService = accessor.get<IEditorService>(IEditorService);
-		const activeControl = editorService.activeControl;
-		if (!activeControl) {
+		const activeEditorPane = editorService.activeEditorPane;
+		if (!activeEditorPane) {
 			return;
 		}
 
-		const activeGroup = activeControl.group;
-		const activeEditor = activeControl.input;
+		const activeGroup = activeEditorPane.group;
+		const activeEditor = activeEditorPane.input;
 		const targetResource = activeEditor.resource;
 
 		if (!targetResource) {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -21,7 +21,7 @@ import * as colorRegistry from 'vs/platform/theme/common/colorRegistry';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { EditorServiceImpl } from 'vs/workbench/browser/parts/editor/editor';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
-import { EditorInput, EditorOptions, IEditor, IEditorInput } from 'vs/workbench/common/editor';
+import { EditorInput, EditorOptions, IEditorPane, IEditorInput } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { webviewEditorsExtensionPoint } from 'vs/workbench/contrib/customEditor/browser/extensionPoint';
 import { CONTEXT_CUSTOM_EDITORS, CONTEXT_FOCUSED_CUSTOM_EDITOR_IS_EDITABLE, CustomEditorInfo, CustomEditorInfoCollection, CustomEditorPriority, CustomEditorSelector, ICustomEditor, ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
@@ -161,7 +161,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		resource: URI,
 		options?: ITextEditorOptions,
 		group?: IEditorGroup,
-	): Promise<IEditor | undefined> {
+	): Promise<IEditorPane | undefined> {
 		const customEditors = new CustomEditorInfoCollection([
 			defaultEditorInfo,
 			...this.getUserConfiguredCustomEditors(resource).allEditors,
@@ -239,7 +239,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		viewType: string,
 		options?: ITextEditorOptions,
 		group?: IEditorGroup,
-	): Promise<IEditor | undefined> {
+	): Promise<IEditorPane | undefined> {
 		if (viewType === defaultEditorId) {
 			const fileInput = this.editorService.createInput({ resource, forceFile: true });
 			return this.openEditorForResource(resource, fileInput, { ...options, ignoreOverrides: true }, group);
@@ -279,7 +279,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		input: IEditorInput,
 		options?: IEditorOptions,
 		group?: IEditorGroup
-	): Promise<IEditor | undefined> {
+	): Promise<IEditorPane | undefined> {
 		const targetGroup = group || this.editorGroupService.activeGroup;
 
 		// Try to replace existing editors for resource

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -133,7 +133,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 	public get models() { return this._models; }
 
 	public get activeCustomEditor(): ICustomEditor | undefined {
-		const activeInput = this.editorService.activeControl?.input;
+		const activeInput = this.editorService.activeEditorPane?.input;
 		if (!(activeInput instanceof CustomEditorInput)) {
 			return undefined;
 		}
@@ -303,8 +303,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 	}
 
 	private updateContexts() {
-		const activeControl = this.editorService.activeControl;
-		const resource = activeControl?.input.resource;
+		const activeEditorPane = this.editorService.activeEditorPane;
+		const resource = activeEditorPane?.input.resource;
 		if (!resource) {
 			this._customEditorContextKey.reset();
 			this._focusedCustomEditorIsEditable.reset();
@@ -317,7 +317,7 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 			...this.getUserConfiguredCustomEditors(resource).allEditors,
 		];
 		this._customEditorContextKey.set(possibleEditors.map(x => x.id).join(','));
-		this._focusedCustomEditorIsEditable.set(activeControl?.input instanceof CustomEditorInput);
+		this._focusedCustomEditorIsEditable.set(activeEditorPane?.input instanceof CustomEditorInput);
 		this._webviewHasOwnEditFunctions.set(possibleEditors.length > 0);
 	}
 

--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -11,7 +11,7 @@ import { URI } from 'vs/base/common/uri';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IEditor, IEditorInput, IRevertOptions, ISaveOptions } from 'vs/workbench/common/editor';
+import { IEditorPane, IEditorInput, IRevertOptions, ISaveOptions } from 'vs/workbench/common/editor';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IDisposable, IReference } from 'vs/base/common/lifecycle';
 
@@ -38,8 +38,8 @@ export interface ICustomEditorService {
 
 	createInput(resource: URI, viewType: string, group: IEditorGroup | undefined, options?: { readonly customClasses: string }): IEditorInput;
 
-	openWith(resource: URI, customEditorViewType: string, options?: ITextEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
-	promptOpenWith(resource: URI, options?: ITextEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
+	openWith(resource: URI, customEditorViewType: string, options?: ITextEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined>;
+	promptOpenWith(resource: URI, options?: ITextEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined>;
 }
 
 export interface ICustomEditorModelManager {

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -18,7 +18,7 @@ import { Constants } from 'vs/base/common/uint';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
 import { Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IListVirtualDelegate, IListContextMenuEvent, IListRenderer } from 'vs/base/browser/ui/list/list';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { InputBox } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
@@ -617,7 +617,7 @@ class FunctionBreakpointInputRenderer implements IListRenderer<IFunctionBreakpoi
 	}
 }
 
-export function openBreakpointSource(breakpoint: IBreakpoint, sideBySide: boolean, preserveFocus: boolean, debugService: IDebugService, editorService: IEditorService): Promise<IEditor | undefined> {
+export function openBreakpointSource(breakpoint: IBreakpoint, sideBySide: boolean, preserveFocus: boolean, debugService: IDebugService, editorService: IEditorService): Promise<IEditorPane | undefined> {
 	if (breakpoint.uri.scheme === DEBUG_SCHEME && debugService.state === State.Inactive) {
 		return Promise.resolve(undefined);
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -158,13 +158,13 @@ export function registerCommands(): void {
 			const debugService = accessor.get(IDebugService);
 			const stackFrame = debugService.getViewModel().focusedStackFrame;
 			const editorService = accessor.get(IEditorService);
-			const activeEditor = editorService.activeTextEditorWidget;
+			const activeEditorControl = editorService.activeTextEditorControl;
 			const notificationService = accessor.get(INotificationService);
 			const quickInputService = accessor.get(IQuickInputService);
 
-			if (stackFrame && isCodeEditor(activeEditor) && activeEditor.hasModel()) {
-				const position = activeEditor.getPosition();
-				const resource = activeEditor.getModel().uri;
+			if (stackFrame && isCodeEditor(activeEditorControl) && activeEditorControl.hasModel()) {
+				const position = activeEditorControl.getPosition();
+				const resource = activeEditorControl.getModel().uri;
 				const source = stackFrame.thread.session.getSourceForUri(resource);
 				if (source) {
 					const response = await stackFrame.thread.session.gotoTargets(source.raw, position.lineNumber, position.column);
@@ -368,11 +368,11 @@ export function registerCommands(): void {
 		handler: (accessor) => {
 			const debugService = accessor.get(IDebugService);
 			const editorService = accessor.get(IEditorService);
-			const widget = editorService.activeTextEditorWidget;
-			if (isCodeEditor(widget)) {
-				const model = widget.getModel();
+			const control = editorService.activeTextEditorControl;
+			if (isCodeEditor(control)) {
+				const model = control.getModel();
 				if (model) {
-					const position = widget.getPosition();
+					const position = control.getPosition();
 					if (position) {
 						const bps = debugService.getModel().getBreakpoints({ uri: model.uri, lineNumber: position.lineNumber });
 						if (bps.length) {
@@ -514,11 +514,11 @@ export function registerCommands(): void {
 	const inlineBreakpointHandler = (accessor: ServicesAccessor) => {
 		const debugService = accessor.get(IDebugService);
 		const editorService = accessor.get(IEditorService);
-		const widget = editorService.activeTextEditorWidget;
-		if (isCodeEditor(widget)) {
-			const position = widget.getPosition();
-			if (position && widget.hasModel() && debugService.getConfigurationManager().canSetBreakpointsIn(widget.getModel())) {
-				const modelUri = widget.getModel().uri;
+		const control = editorService.activeTextEditorControl;
+		if (isCodeEditor(control)) {
+			const position = control.getPosition();
+			if (position && control.hasModel() && debugService.getConfigurationManager().canSetBreakpointsIn(control.getModel())) {
+				const modelUri = control.getModel().uri;
 				const breakpointAlreadySet = debugService.getModel().getBreakpoints({ lineNumber: position.lineNumber, uri: modelUri })
 					.some(bp => (bp.sessionAgnosticData.column === position.column || (!bp.column && position.column <= 1)));
 

--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -443,10 +443,10 @@ export class ConfigurationManager implements IConfigurationManager {
 			return Promise.resolve(adapter);
 		}
 
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
 		let candidates: Debugger[] | undefined;
-		if (isCodeEditor(activeTextEditorWidget)) {
-			const model = activeTextEditorWidget.getModel();
+		if (isCodeEditor(activeTextEditorControl)) {
+			const model = activeTextEditorControl.getModel();
 			const language = model ? model.getLanguageIdentifier().language : undefined;
 			const adapters = this.debuggers.filter(a => language && a.languages && a.languages.indexOf(language) >= 0);
 			if (adapters.length === 1) {

--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -12,7 +12,7 @@ import { URI as uri } from 'vs/base/common/uri';
 import * as resources from 'vs/base/common/resources';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { ITextModel } from 'vs/editor/common/model';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -573,7 +573,7 @@ class Launch extends AbstractLaunch implements ILaunch {
 		return this.configurationService.inspect<IGlobalConfig>('launch', { resource: this.workspace.uri }).workspaceFolderValue;
 	}
 
-	async openConfigFile(sideBySide: boolean, preserveFocus: boolean, type?: string, token?: CancellationToken): Promise<{ editor: IEditor | null, created: boolean }> {
+	async openConfigFile(sideBySide: boolean, preserveFocus: boolean, type?: string, token?: CancellationToken): Promise<{ editor: IEditorPane | null, created: boolean }> {
 		const resource = this.uri;
 		let created = false;
 		let content = '';
@@ -653,7 +653,7 @@ class WorkspaceLaunch extends AbstractLaunch implements ILaunch {
 		return this.configurationService.inspect<IGlobalConfig>('launch').workspaceValue;
 	}
 
-	async openConfigFile(sideBySide: boolean, preserveFocus: boolean): Promise<{ editor: IEditor | null, created: boolean }> {
+	async openConfigFile(sideBySide: boolean, preserveFocus: boolean): Promise<{ editor: IEditorPane | null, created: boolean }> {
 
 		const editor = await this.editorService.openEditor({
 			resource: this.contextService.getWorkspace().configuration!,
@@ -696,7 +696,7 @@ class UserLaunch extends AbstractLaunch implements ILaunch {
 		return this.configurationService.inspect<IGlobalConfig>('launch').userValue;
 	}
 
-	async openConfigFile(_: boolean, preserveFocus: boolean): Promise<{ editor: IEditor | null, created: boolean }> {
+	async openConfigFile(_: boolean, preserveFocus: boolean): Promise<{ editor: IEditorPane | null, created: boolean }> {
 		const editor = await this.preferencesService.openGlobalSettings(false, { preserveFocus });
 		return ({
 			editor: withUndefinedAsNull(editor),

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -244,12 +244,12 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 			return;
 		}
 
-		const activeEditor = this.editorService.activeTextEditorWidget;
-		if (isCodeEditor(activeEditor)) {
+		const activeEditorControl = this.editorService.activeTextEditorControl;
+		if (isCodeEditor(activeEditorControl)) {
 			this.modelChangeListener.dispose();
-			this.modelChangeListener = activeEditor.onDidChangeModelLanguage(() => this.setMode());
-			if (activeEditor.hasModel()) {
-				this.model.setMode(activeEditor.getModel().getLanguageIdentifier());
+			this.modelChangeListener = activeEditorControl.onDidChangeModelLanguage(() => this.setMode());
+			if (activeEditorControl.hasModel()) {
+				this.model.setMode(activeEditorControl.getModel().getLanguageIdentifier());
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/debug/browser/startView.ts
+++ b/src/vs/workbench/contrib/debug/browser/startView.ts
@@ -60,9 +60,9 @@ export class StartView extends ViewPane {
 		this.debugStartLanguageContext.set(lastSetLanguage);
 
 		const setContextKey = () => {
-			const editor = this.editorService.activeTextEditorWidget;
-			if (isCodeEditor(editor)) {
-				const model = editor.getModel();
+			const editorControl = this.editorService.activeTextEditorControl;
+			if (isCodeEditor(editorControl)) {
+				const model = editorControl.getModel();
 				const language = model ? model.getLanguageIdentifier().language : undefined;
 				if (language && this.debugService.getConfigurationManager().isDebuggerInterestedInLanguage(language)) {
 					this.debugStartLanguageContext.set(language);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -11,7 +11,7 @@ import { IJSONSchemaSnippet } from 'vs/base/common/jsonSchema';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { ITextModel as EditorIModel } from 'vs/editor/common/model';
-import { IEditor, ITextEditor } from 'vs/workbench/common/editor';
+import { IEditorPane, ITextEditor } from 'vs/workbench/common/editor';
 import { Position, IPosition } from 'vs/editor/common/core/position';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
 import { Range, IRange } from 'vs/editor/common/core/range';
@@ -709,7 +709,7 @@ export interface ILaunch {
 	/**
 	 * Opens the launch.json file. Creates if it does not exist.
 	 */
-	openConfigFile(sideBySide: boolean, preserveFocus: boolean, type?: string, token?: CancellationToken): Promise<{ editor: IEditor | null, created: boolean }>;
+	openConfigFile(sideBySide: boolean, preserveFocus: boolean, type?: string, token?: CancellationToken): Promise<{ editor: IEditorPane | null, created: boolean }>;
 }
 
 // Debug service interfaces

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -11,7 +11,7 @@ import { IJSONSchemaSnippet } from 'vs/base/common/jsonSchema';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import * as editorCommon from 'vs/editor/common/editorCommon';
 import { ITextModel as EditorIModel } from 'vs/editor/common/model';
-import { IEditorPane, ITextEditor } from 'vs/workbench/common/editor';
+import { IEditorPane, ITextEditorPane } from 'vs/workbench/common/editor';
 import { Position, IPosition } from 'vs/editor/common/core/position';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
 import { Range, IRange } from 'vs/editor/common/core/range';
@@ -316,7 +316,7 @@ export interface IStackFrame extends ITreeElement {
 	forgetScopes(): void;
 	restart(): Promise<any>;
 	toString(): string;
-	openInEditor(editorService: IEditorService, preserveFocus?: boolean, sideBySide?: boolean): Promise<ITextEditor | undefined>;
+	openInEditor(editorService: IEditorService, preserveFocus?: boolean, sideBySide?: boolean): Promise<ITextEditorPane | undefined>;
 	equals(other: IStackFrame): boolean;
 }
 

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -21,7 +21,7 @@ import { commonSuffixLength } from 'vs/base/common/strings';
 import { posix } from 'vs/base/common/path';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { ITextEditor } from 'vs/workbench/common/editor';
+import { ITextEditorPane } from 'vs/workbench/common/editor';
 import { mixin } from 'vs/base/common/objects';
 
 export class ExpressionContainer implements IExpressionContainer {
@@ -347,7 +347,7 @@ export class StackFrame implements IStackFrame {
 		return sourceToString === UNKNOWN_SOURCE_LABEL ? this.name : `${this.name} (${sourceToString})`;
 	}
 
-	async openInEditor(editorService: IEditorService, preserveFocus?: boolean, sideBySide?: boolean, pinned?: boolean): Promise<ITextEditor | undefined> {
+	async openInEditor(editorService: IEditorService, preserveFocus?: boolean, sideBySide?: boolean, pinned?: boolean): Promise<ITextEditorPane | undefined> {
 		if (this.source.available) {
 			return this.source.openInEditor(editorService, this.range, preserveFocus, sideBySide, pinned);
 		}

--- a/src/vs/workbench/contrib/debug/common/debugSource.ts
+++ b/src/vs/workbench/contrib/debug/common/debugSource.ts
@@ -12,7 +12,7 @@ import { IRange } from 'vs/editor/common/core/range';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { Schemas } from 'vs/base/common/network';
 import { isUri } from 'vs/workbench/contrib/debug/common/debugUtils';
-import { ITextEditor } from 'vs/workbench/common/editor';
+import { ITextEditorPane } from 'vs/workbench/common/editor';
 import { TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
 
 export const UNKNOWN_SOURCE_LABEL = nls.localize('unknownSource', "Unknown Source");
@@ -71,7 +71,7 @@ export class Source {
 		return this.uri.scheme === DEBUG_SCHEME;
 	}
 
-	openInEditor(editorService: IEditorService, selection: IRange, preserveFocus?: boolean, sideBySide?: boolean, pinned?: boolean): Promise<ITextEditor | undefined> {
+	openInEditor(editorService: IEditorService, selection: IRange, preserveFocus?: boolean, sideBySide?: boolean, pinned?: boolean): Promise<ITextEditorPane | undefined> {
 		return !this.available ? Promise.resolve(undefined) : editorService.openEditor({
 			resource: this.uri,
 			description: this.origin,

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -1463,9 +1463,9 @@ registerAction2(class StartExtensionEditorFindPreviousAction extends Action2 {
 });
 
 function getExtensionEditor(accessor: ServicesAccessor): ExtensionEditor | null {
-	const activeControl = accessor.get(IEditorService).activeControl as ExtensionEditor;
-	if (activeControl instanceof ExtensionEditor) {
-		return activeControl;
+	const activeEditorPane = accessor.get(IEditorService).activeEditorPane;
+	if (activeEditorPane instanceof ExtensionEditor) {
+		return activeEditorPane;
 	}
 	return null;
 }

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViews.ts
@@ -756,10 +756,10 @@ export class ExtensionsListView extends ViewPane {
 	}
 
 	private pin(): void {
-		const activeControl = this.editorService.activeControl;
-		if (activeControl) {
-			activeControl.group.pinEditor(activeControl.input);
-			activeControl.focus();
+		const activeEditorPane = this.editorService.activeEditorPane;
+		if (activeEditorPane) {
+			activeEditorPane.group.pinEditor(activeEditorPane.input);
+			activeEditorPane.focus();
 		}
 	}
 

--- a/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts
+++ b/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts
@@ -330,13 +330,13 @@ export const acceptLocalChangesCommand = async (accessor: ServicesAccessor, reso
 	const editorService = accessor.get(IEditorService);
 	const resolverService = accessor.get(ITextModelService);
 
-	const control = editorService.activeControl;
-	if (!control) {
+	const editorPane = editorService.activeEditorPane;
+	if (!editorPane) {
 		return;
 	}
 
-	const editor = control.input;
-	const group = control.group;
+	const editor = editorPane.input;
+	const group = editorPane.group;
 
 	const reference = await resolverService.createModelReference(resource);
 	const model = reference.object as IResolvedTextFileEditorModel;
@@ -359,13 +359,13 @@ export const revertLocalChangesCommand = async (accessor: ServicesAccessor, reso
 	const editorService = accessor.get(IEditorService);
 	const resolverService = accessor.get(ITextModelService);
 
-	const control = editorService.activeControl;
-	if (!control) {
+	const editorPane = editorService.activeEditorPane;
+	if (!editorPane) {
 		return;
 	}
 
-	const editor = control.input;
-	const group = control.group;
+	const editor = editorPane.input;
+	const group = editorPane.group;
 
 	const reference = await resolverService.createModelReference(resource);
 	const model = reference.object as ITextFileEditorModel;

--- a/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerViewlet.ts
@@ -28,7 +28,7 @@ import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/la
 import { DelegatingEditorService } from 'vs/workbench/services/editor/browser/editorService';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { ViewPane, ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { KeyChord, KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -208,7 +208,7 @@ export class ExplorerViewPaneContainer extends ViewPaneContainer {
 			// without causing the animation in the opened editors view to kick in and change scroll position.
 			// We try to be smart and only use the delay if we recognize that the user action is likely to cause
 			// a new entry in the opened editors view.
-			const delegatingEditorService = this.instantiationService.createInstance(DelegatingEditorService, async (delegate, group, editor, options): Promise<IEditor | null> => {
+			const delegatingEditorService = this.instantiationService.createInstance(DelegatingEditorService, async (delegate, group, editor, options): Promise<IEditorPane | null> => {
 				let openEditorsView = this.getOpenEditorsView();
 				if (openEditorsView) {
 					let delay = 0;

--- a/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
@@ -5,7 +5,7 @@
 
 import { localize } from 'vs/nls';
 import { URI } from 'vs/base/common/uri';
-import { EncodingMode, IFileEditorInput, Verbosity, TextResourceEditorInput, GroupIdentifier, IMoveResult, isTextEditor } from 'vs/workbench/common/editor';
+import { EncodingMode, IFileEditorInput, Verbosity, TextResourceEditorInput, GroupIdentifier, IMoveResult, isTextEditorPane } from 'vs/workbench/common/editor';
 import { BinaryEditorModel } from 'vs/workbench/common/editor/binaryEditorModel';
 import { FileOperationError, FileOperationResult, IFileService } from 'vs/platform/files/common/files';
 import { ITextFileService, TextFileEditorModelState, TextFileLoadReason, TextFileOperationError, TextFileOperationResult, ITextFileEditorModel } from 'vs/workbench/services/textfile/common/textfiles';
@@ -292,7 +292,7 @@ export class FileEditorInput extends TextResourceEditorInput implements IFileEdi
 	private getViewStateFor(group: GroupIdentifier): IEditorViewState | undefined {
 		for (const editor of this.editorService.visibleControls) {
 			if (editor.group.id === group && isEqual(editor.input.resource, this.resource)) {
-				if (isTextEditor(editor)) {
+				if (isTextEditorPane(editor)) {
 					return editor.getViewState();
 				}
 			}

--- a/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
+++ b/src/vs/workbench/contrib/files/common/editors/fileEditorInput.ts
@@ -290,10 +290,10 @@ export class FileEditorInput extends TextResourceEditorInput implements IFileEdi
 	}
 
 	private getViewStateFor(group: GroupIdentifier): IEditorViewState | undefined {
-		for (const editor of this.editorService.visibleControls) {
-			if (editor.group.id === group && isEqual(editor.input.resource, this.resource)) {
-				if (isTextEditorPane(editor)) {
-					return editor.getViewState();
+		for (const editorPane of this.editorService.visibleEditorPanes) {
+			if (editorPane.group.id === group && isEqual(editorPane.input.resource, this.resource)) {
+				if (isTextEditorPane(editorPane)) {
+					return editorPane.getViewState();
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/outline/browser/outlinePane.ts
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.ts
@@ -95,12 +95,12 @@ class RequestOracle {
 
 	private _update(): void {
 
-		let widget = this._editorService.activeTextEditorWidget;
+		let control = this._editorService.activeTextEditorControl;
 		let codeEditor: ICodeEditor | undefined = undefined;
-		if (isCodeEditor(widget)) {
-			codeEditor = widget;
-		} else if (isDiffEditor(widget)) {
-			codeEditor = widget.getModifiedEditor();
+		if (isCodeEditor(control)) {
+			codeEditor = control;
+		} else if (isDiffEditor(control)) {
+			codeEditor = control.getModifiedEditor();
 		}
 
 		if (!codeEditor || !codeEditor.hasModel()) {

--- a/src/vs/workbench/contrib/performance/electron-browser/startupTimings.ts
+++ b/src/vs/workbench/contrib/performance/electron-browser/startupTimings.ts
@@ -98,8 +98,8 @@ export class StartupTimings implements IWorkbenchContribution {
 		if (!activeViewlet || activeViewlet.getId() !== files.VIEWLET_ID) {
 			return false;
 		}
-		const visibleControls = this._editorService.visibleControls;
-		if (visibleControls.length !== 1 || !isCodeEditor(visibleControls[0].getControl())) {
+		const visibleEditorPanes = this._editorService.visibleEditorPanes;
+		if (visibleEditorPanes.length !== 1 || !isCodeEditor(visibleEditorPanes[0].getControl())) {
 			return false;
 		}
 		if (this._panelService.getActivePanel()) {

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -551,7 +551,7 @@ export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditorP
 					this.unAssignedKeybindingItemToRevealAndFocus = null;
 				} else if (currentSelectedIndex !== -1 && currentSelectedIndex < this.listEntries.length) {
 					this.selectEntry(currentSelectedIndex, preserveFocus);
-				} else if (this.editorService.activeControl === this && !preserveFocus) {
+				} else if (this.editorService.activeEditorPane === this && !preserveFocus) {
 					this.focus();
 				}
 			}

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -23,7 +23,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IKeybindingService, IUserFriendlyKeybinding } from 'vs/platform/keybinding/common/keybinding';
 import { DefineKeybindingWidget, KeybindingsSearchWidget, KeybindingsSearchOptions } from 'vs/workbench/contrib/preferences/browser/keybindingWidgets';
 import {
-	IKeybindingsEditor, CONTEXT_KEYBINDING_FOCUS, CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS, KEYBINDINGS_EDITOR_COMMAND_REMOVE, KEYBINDINGS_EDITOR_COMMAND_COPY,
+	IKeybindingsEditorPane, CONTEXT_KEYBINDING_FOCUS, CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS, KEYBINDINGS_EDITOR_COMMAND_REMOVE, KEYBINDINGS_EDITOR_COMMAND_COPY,
 	KEYBINDINGS_EDITOR_COMMAND_RESET, KEYBINDINGS_EDITOR_COMMAND_COPY_COMMAND, KEYBINDINGS_EDITOR_COMMAND_DEFINE, KEYBINDINGS_EDITOR_COMMAND_SHOW_SIMILAR,
 	KEYBINDINGS_EDITOR_COMMAND_RECORD_SEARCH_KEYS, KEYBINDINGS_EDITOR_COMMAND_SORTBY_PRECEDENCE, KEYBINDINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, KEYBINDINGS_EDITOR_COMMAND_DEFINE_WHEN
 } from 'vs/workbench/contrib/preferences/common/preferences';
@@ -55,7 +55,7 @@ interface ColumnItem {
 	width: number;
 }
 
-export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditor {
+export class KeybindingsEditor extends BaseEditor implements IKeybindingsEditorPane {
 
 	static readonly ID: string = 'workbench.editor.keybindings';
 
@@ -854,7 +854,7 @@ abstract class Column extends Disposable {
 	abstract readonly element: HTMLElement;
 	abstract render(keybindingItemEntry: IKeybindingItemEntry): void;
 
-	constructor(protected keybindingsEditor: IKeybindingsEditor) {
+	constructor(protected keybindingsEditor: IKeybindingsEditorPane) {
 		super();
 	}
 
@@ -867,7 +867,7 @@ class ActionsColumn extends Column {
 
 	constructor(
 		parent: HTMLElement,
-		keybindingsEditor: IKeybindingsEditor,
+		keybindingsEditor: IKeybindingsEditorPane,
 		@IKeybindingService private keybindingsService: IKeybindingService
 	) {
 		super(keybindingsEditor);
@@ -921,7 +921,7 @@ class CommandColumn extends Column {
 
 	constructor(
 		parent: HTMLElement,
-		keybindingsEditor: IKeybindingsEditor,
+		keybindingsEditor: IKeybindingsEditorPane,
 	) {
 		super(keybindingsEditor);
 		this.element = this.commandColumn = DOM.append(parent, $('.column.command', { id: 'command_' + ++Column.COUNTER }));
@@ -964,7 +964,7 @@ class KeybindingColumn extends Column {
 
 	constructor(
 		parent: HTMLElement,
-		keybindingsEditor: IKeybindingsEditor,
+		keybindingsEditor: IKeybindingsEditorPane,
 	) {
 		super(keybindingsEditor);
 
@@ -992,7 +992,7 @@ class SourceColumn extends Column {
 
 	constructor(
 		parent: HTMLElement,
-		keybindingsEditor: IKeybindingsEditor,
+		keybindingsEditor: IKeybindingsEditorPane,
 	) {
 		super(keybindingsEditor);
 		this.element = this.sourceColumn = DOM.append(parent, $('.column.source', { id: 'source_' + ++Column.COUNTER }));
@@ -1024,7 +1024,7 @@ class WhenColumn extends Column {
 
 	constructor(
 		parent: HTMLElement,
-		keybindingsEditor: IKeybindingsEditor,
+		keybindingsEditor: IKeybindingsEditorPane,
 		@IContextViewService private readonly contextViewService: IContextViewService,
 		@IThemeService private readonly themeService: IThemeService
 	) {

--- a/src/vs/workbench/contrib/preferences/browser/keyboardLayoutPicker.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keyboardLayoutPicker.ts
@@ -21,7 +21,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { IFileService } from 'vs/platform/files/common/files';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 
 export class KeyboardLayoutPickerContribution extends Disposable implements IWorkbenchContribution {
 	private readonly pickerElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
@@ -156,7 +156,7 @@ export class KeyboardLayoutPickerAction extends Action {
 
 			await this.fileService.resolve(file).then(undefined, (error) => {
 				return this.fileService.createFile(file, VSBuffer.fromString(KeyboardLayoutPickerAction.DEFAULT_CONTENT));
-			}).then((stat): Promise<IEditor | undefined> | undefined => {
+			}).then((stat): Promise<IEditorPane | undefined> | undefined => {
 				if (!stat) {
 					return undefined;
 				}

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -32,7 +32,7 @@ import { KeybindingsEditor } from 'vs/workbench/contrib/preferences/browser/keyb
 import { ConfigureLanguageBasedSettingsAction, OpenDefaultKeybindingsFileAction, OpenFolderSettingsAction, OpenGlobalKeybindingsAction, OpenGlobalKeybindingsFileAction, OpenGlobalSettingsAction, OpenRawDefaultSettingsAction, OpenRemoteSettingsAction, OpenSettings2Action, OpenSettingsJsonAction, OpenWorkspaceSettingsAction, OPEN_FOLDER_SETTINGS_COMMAND, OPEN_FOLDER_SETTINGS_LABEL } from 'vs/workbench/contrib/preferences/browser/preferencesActions';
 import { PreferencesEditor } from 'vs/workbench/contrib/preferences/browser/preferencesEditor';
 import { SettingsEditor2 } from 'vs/workbench/contrib/preferences/browser/settingsEditor2';
-import { CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS, CONTEXT_KEYBINDING_FOCUS, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_JSON_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, IKeybindingsEditor, KEYBINDINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, KEYBINDINGS_EDITOR_COMMAND_COPY, KEYBINDINGS_EDITOR_COMMAND_COPY_COMMAND, KEYBINDINGS_EDITOR_COMMAND_DEFINE, KEYBINDINGS_EDITOR_COMMAND_DEFINE_WHEN, KEYBINDINGS_EDITOR_COMMAND_FOCUS_KEYBINDINGS, KEYBINDINGS_EDITOR_COMMAND_RECORD_SEARCH_KEYS, KEYBINDINGS_EDITOR_COMMAND_REMOVE, KEYBINDINGS_EDITOR_COMMAND_RESET, KEYBINDINGS_EDITOR_COMMAND_SEARCH, KEYBINDINGS_EDITOR_COMMAND_SHOW_SIMILAR, KEYBINDINGS_EDITOR_COMMAND_SORTBY_PRECEDENCE, KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS, KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS, MODIFIED_SETTING_TAG, SETTINGS_COMMAND_OPEN_SETTINGS, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_EDIT_FOCUSED_SETTING, SETTINGS_EDITOR_COMMAND_FILTER_MODIFIED, SETTINGS_EDITOR_COMMAND_FILTER_ONLINE, SETTINGS_EDITOR_COMMAND_FOCUS_FILE, SETTINGS_EDITOR_COMMAND_FOCUS_NEXT_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_PREVIOUS_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_LIST, SETTINGS_EDITOR_COMMAND_SEARCH, SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU, SETTINGS_EDITOR_COMMAND_SWITCH_TO_JSON } from 'vs/workbench/contrib/preferences/common/preferences';
+import { CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS, CONTEXT_KEYBINDING_FOCUS, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_JSON_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, IKeybindingsEditorPane, KEYBINDINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, KEYBINDINGS_EDITOR_COMMAND_COPY, KEYBINDINGS_EDITOR_COMMAND_COPY_COMMAND, KEYBINDINGS_EDITOR_COMMAND_DEFINE, KEYBINDINGS_EDITOR_COMMAND_DEFINE_WHEN, KEYBINDINGS_EDITOR_COMMAND_FOCUS_KEYBINDINGS, KEYBINDINGS_EDITOR_COMMAND_RECORD_SEARCH_KEYS, KEYBINDINGS_EDITOR_COMMAND_REMOVE, KEYBINDINGS_EDITOR_COMMAND_RESET, KEYBINDINGS_EDITOR_COMMAND_SEARCH, KEYBINDINGS_EDITOR_COMMAND_SHOW_SIMILAR, KEYBINDINGS_EDITOR_COMMAND_SORTBY_PRECEDENCE, KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS, KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS, MODIFIED_SETTING_TAG, SETTINGS_COMMAND_OPEN_SETTINGS, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_EDIT_FOCUSED_SETTING, SETTINGS_EDITOR_COMMAND_FILTER_MODIFIED, SETTINGS_EDITOR_COMMAND_FILTER_ONLINE, SETTINGS_EDITOR_COMMAND_FOCUS_FILE, SETTINGS_EDITOR_COMMAND_FOCUS_NEXT_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_PREVIOUS_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_LIST, SETTINGS_EDITOR_COMMAND_SEARCH, SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU, SETTINGS_EDITOR_COMMAND_SWITCH_TO_JSON } from 'vs/workbench/contrib/preferences/common/preferences';
 import { PreferencesContribution } from 'vs/workbench/contrib/preferences/common/preferencesContribution';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -244,7 +244,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_K),
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor) {
 			control.defineKeybinding(control.activeKeybindingEntry!);
 		}
@@ -257,7 +257,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_E),
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor && control.activeKeybindingEntry!.keybindingItem.keybinding) {
 			control.defineWhenExpression(control.activeKeybindingEntry!);
 		}
@@ -273,7 +273,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.Backspace)
 	},
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor) {
 			control.removeKeybinding(control.activeKeybindingEntry!);
 		}
@@ -286,7 +286,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: 0,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor) {
 			control.resetKeybinding(control.activeKeybindingEntry!);
 		}
@@ -299,7 +299,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR),
 	primary: KeyMod.CtrlCmd | KeyCode.KEY_F,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor) {
 			control.focusSearch();
 		}
@@ -313,7 +313,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyMod.Alt | KeyCode.KEY_K,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_K },
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor) {
 			control.recordSearchKeys();
 		}
@@ -327,7 +327,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyMod.Alt | KeyCode.KEY_P,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_P },
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control && control instanceof KeybindingsEditor) {
 			control.toggleSortByPrecedence();
 		}
@@ -340,7 +340,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: 0,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control) {
 			control.showSimilarKeybindings(control.activeKeybindingEntry!);
 		}
@@ -353,7 +353,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: KeyMod.CtrlCmd | KeyCode.KEY_C,
 	handler: async (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control) {
 			await control.copyKeybinding(control.activeKeybindingEntry!);
 		}
@@ -366,7 +366,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: 0,
 	handler: async (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control) {
 			await control.copyKeybindingCommand(control.activeKeybindingEntry!);
 		}
@@ -379,7 +379,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS),
 	primary: KeyCode.DownArrow,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control) {
 			control.focusKeybindings();
 		}
@@ -526,7 +526,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS),
 	primary: KeyCode.Escape,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditor;
+		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 		if (control) {
 			control.clearSearchResults();
 		}
@@ -547,7 +547,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 });
 
 CommandsRegistry.registerCommand(KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as IKeybindingsEditor;
+	const control = serviceAccessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 	if (control) {
 		control.search('@source:default');
 	}
@@ -562,7 +562,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 });
 
 CommandsRegistry.registerCommand(KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as IKeybindingsEditor;
+	const control = serviceAccessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
 	if (control) {
 		control.search('@source:user');
 	}

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -32,7 +32,7 @@ import { KeybindingsEditor } from 'vs/workbench/contrib/preferences/browser/keyb
 import { ConfigureLanguageBasedSettingsAction, OpenDefaultKeybindingsFileAction, OpenFolderSettingsAction, OpenGlobalKeybindingsAction, OpenGlobalKeybindingsFileAction, OpenGlobalSettingsAction, OpenRawDefaultSettingsAction, OpenRemoteSettingsAction, OpenSettings2Action, OpenSettingsJsonAction, OpenWorkspaceSettingsAction, OPEN_FOLDER_SETTINGS_COMMAND, OPEN_FOLDER_SETTINGS_LABEL } from 'vs/workbench/contrib/preferences/browser/preferencesActions';
 import { PreferencesEditor } from 'vs/workbench/contrib/preferences/browser/preferencesEditor';
 import { SettingsEditor2 } from 'vs/workbench/contrib/preferences/browser/settingsEditor2';
-import { CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS, CONTEXT_KEYBINDING_FOCUS, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_JSON_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, IKeybindingsEditorPane, KEYBINDINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, KEYBINDINGS_EDITOR_COMMAND_COPY, KEYBINDINGS_EDITOR_COMMAND_COPY_COMMAND, KEYBINDINGS_EDITOR_COMMAND_DEFINE, KEYBINDINGS_EDITOR_COMMAND_DEFINE_WHEN, KEYBINDINGS_EDITOR_COMMAND_FOCUS_KEYBINDINGS, KEYBINDINGS_EDITOR_COMMAND_RECORD_SEARCH_KEYS, KEYBINDINGS_EDITOR_COMMAND_REMOVE, KEYBINDINGS_EDITOR_COMMAND_RESET, KEYBINDINGS_EDITOR_COMMAND_SEARCH, KEYBINDINGS_EDITOR_COMMAND_SHOW_SIMILAR, KEYBINDINGS_EDITOR_COMMAND_SORTBY_PRECEDENCE, KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS, KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS, MODIFIED_SETTING_TAG, SETTINGS_COMMAND_OPEN_SETTINGS, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_EDIT_FOCUSED_SETTING, SETTINGS_EDITOR_COMMAND_FILTER_MODIFIED, SETTINGS_EDITOR_COMMAND_FILTER_ONLINE, SETTINGS_EDITOR_COMMAND_FOCUS_FILE, SETTINGS_EDITOR_COMMAND_FOCUS_NEXT_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_PREVIOUS_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_LIST, SETTINGS_EDITOR_COMMAND_SEARCH, SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU, SETTINGS_EDITOR_COMMAND_SWITCH_TO_JSON } from 'vs/workbench/contrib/preferences/common/preferences';
+import { CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS, CONTEXT_KEYBINDING_FOCUS, CONTEXT_SETTINGS_EDITOR, CONTEXT_SETTINGS_JSON_EDITOR, CONTEXT_SETTINGS_SEARCH_FOCUS, CONTEXT_TOC_ROW_FOCUS, KEYBINDINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, KEYBINDINGS_EDITOR_COMMAND_COPY, KEYBINDINGS_EDITOR_COMMAND_COPY_COMMAND, KEYBINDINGS_EDITOR_COMMAND_DEFINE, KEYBINDINGS_EDITOR_COMMAND_DEFINE_WHEN, KEYBINDINGS_EDITOR_COMMAND_FOCUS_KEYBINDINGS, KEYBINDINGS_EDITOR_COMMAND_RECORD_SEARCH_KEYS, KEYBINDINGS_EDITOR_COMMAND_REMOVE, KEYBINDINGS_EDITOR_COMMAND_RESET, KEYBINDINGS_EDITOR_COMMAND_SEARCH, KEYBINDINGS_EDITOR_COMMAND_SHOW_SIMILAR, KEYBINDINGS_EDITOR_COMMAND_SORTBY_PRECEDENCE, KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS, KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS, MODIFIED_SETTING_TAG, SETTINGS_COMMAND_OPEN_SETTINGS, SETTINGS_EDITOR_COMMAND_CLEAR_SEARCH_RESULTS, SETTINGS_EDITOR_COMMAND_EDIT_FOCUSED_SETTING, SETTINGS_EDITOR_COMMAND_FILTER_MODIFIED, SETTINGS_EDITOR_COMMAND_FILTER_ONLINE, SETTINGS_EDITOR_COMMAND_FOCUS_FILE, SETTINGS_EDITOR_COMMAND_FOCUS_NEXT_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_PREVIOUS_SETTING, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_FROM_SEARCH, SETTINGS_EDITOR_COMMAND_FOCUS_SETTINGS_LIST, SETTINGS_EDITOR_COMMAND_SEARCH, SETTINGS_EDITOR_COMMAND_SHOW_CONTEXT_MENU, SETTINGS_EDITOR_COMMAND_SWITCH_TO_JSON } from 'vs/workbench/contrib/preferences/common/preferences';
 import { PreferencesContribution } from 'vs/workbench/contrib/preferences/common/preferencesContribution';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -244,9 +244,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_K),
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor) {
-			control.defineKeybinding(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.defineKeybinding(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -257,9 +257,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.KEY_E),
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor && control.activeKeybindingEntry!.keybindingItem.keybinding) {
-			control.defineWhenExpression(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor && editorPane.activeKeybindingEntry!.keybindingItem.keybinding) {
+			editorPane.defineWhenExpression(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -273,9 +273,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyMod.CtrlCmd | KeyCode.Backspace)
 	},
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor) {
-			control.removeKeybinding(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.removeKeybinding(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -286,9 +286,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: 0,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor) {
-			control.resetKeybinding(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.resetKeybinding(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -299,9 +299,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR),
 	primary: KeyMod.CtrlCmd | KeyCode.KEY_F,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor) {
-			control.focusSearch();
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.focusSearch();
 		}
 	}
 });
@@ -313,9 +313,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyMod.Alt | KeyCode.KEY_K,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_K },
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor) {
-			control.recordSearchKeys();
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.recordSearchKeys();
 		}
 	}
 });
@@ -327,9 +327,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: KeyMod.Alt | KeyCode.KEY_P,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_P },
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control && control instanceof KeybindingsEditor) {
-			control.toggleSortByPrecedence();
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.toggleSortByPrecedence();
 		}
 	}
 });
@@ -340,9 +340,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: 0,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control) {
-			control.showSimilarKeybindings(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.showSimilarKeybindings(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -353,9 +353,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: KeyMod.CtrlCmd | KeyCode.KEY_C,
 	handler: async (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control) {
-			await control.copyKeybinding(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			await editorPane.copyKeybinding(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -366,9 +366,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDING_FOCUS),
 	primary: 0,
 	handler: async (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control) {
-			await control.copyKeybindingCommand(control.activeKeybindingEntry!);
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			await editorPane.copyKeybindingCommand(editorPane.activeKeybindingEntry!);
 		}
 	}
 });
@@ -379,9 +379,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS),
 	primary: KeyCode.DownArrow,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control) {
-			control.focusKeybindings();
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.focusKeybindings();
 		}
 	}
 });
@@ -526,9 +526,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	when: ContextKeyExpr.and(CONTEXT_KEYBINDINGS_EDITOR, CONTEXT_KEYBINDINGS_SEARCH_FOCUS),
 	primary: KeyCode.Escape,
 	handler: (accessor, args: any) => {
-		const control = accessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-		if (control) {
-			control.clearSearchResults();
+		const editorPane = accessor.get(IEditorService).activeEditorPane;
+		if (editorPane instanceof KeybindingsEditor) {
+			editorPane.clearSearchResults();
 		}
 	}
 });
@@ -547,9 +547,9 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 });
 
 CommandsRegistry.registerCommand(KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-	if (control) {
-		control.search('@source:default');
+	const editorPane = serviceAccessor.get(IEditorService).activeEditorPane;
+	if (editorPane instanceof KeybindingsEditor) {
+		editorPane.search('@source:default');
 	}
 });
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
@@ -562,9 +562,9 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 });
 
 CommandsRegistry.registerCommand(KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as IKeybindingsEditorPane;
-	if (control) {
-		control.search('@source:user');
+	const editorPane = serviceAccessor.get(IEditorService).activeEditorPane;
+	if (editorPane instanceof KeybindingsEditor) {
+		editorPane.search('@source:user');
 	}
 });
 MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
@@ -577,9 +577,9 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 });
 
 function getPreferencesEditor(accessor: ServicesAccessor): PreferencesEditor | SettingsEditor2 | null {
-	const activeControl = accessor.get(IEditorService).activeControl;
-	if (activeControl instanceof PreferencesEditor || activeControl instanceof SettingsEditor2) {
-		return activeControl;
+	const activeEditorPane = accessor.get(IEditorService).activeEditorPane;
+	if (activeEditorPane instanceof PreferencesEditor || activeEditorPane instanceof SettingsEditor2) {
+		return activeEditorPane;
 	}
 
 	return null;
@@ -788,25 +788,25 @@ registerAction2(class extends Action2 {
 });
 
 CommandsRegistry.registerCommand(SETTINGS_EDITOR_COMMAND_SWITCH_TO_JSON, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as SettingsEditor2;
-	if (control instanceof SettingsEditor2) {
-		return control.switchToSettingsFile();
+	const editorPane = serviceAccessor.get(IEditorService).activeEditorPane;
+	if (editorPane instanceof SettingsEditor2) {
+		return editorPane.switchToSettingsFile();
 	}
 
 	return Promise.resolve(null);
 });
 
 CommandsRegistry.registerCommand(SETTINGS_EDITOR_COMMAND_FILTER_MODIFIED, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as SettingsEditor2;
-	if (control instanceof SettingsEditor2) {
-		control.focusSearch(`@${MODIFIED_SETTING_TAG}`);
+	const editorPane = serviceAccessor.get(IEditorService).activeEditorPane;
+	if (editorPane instanceof SettingsEditor2) {
+		editorPane.focusSearch(`@${MODIFIED_SETTING_TAG}`);
 	}
 });
 
 CommandsRegistry.registerCommand(SETTINGS_EDITOR_COMMAND_FILTER_ONLINE, serviceAccessor => {
-	const control = serviceAccessor.get(IEditorService).activeControl as SettingsEditor2;
-	if (control instanceof SettingsEditor2) {
-		control.focusSearch(`@tag:usesOnlineServices`);
+	const editorPane = serviceAccessor.get(IEditorService).activeEditorPane;
+	if (editorPane instanceof SettingsEditor2) {
+		editorPane.focusSearch(`@tag:usesOnlineServices`);
 	} else {
 		serviceAccessor.get(IPreferencesService).openSettings(false, '@tag:usesOnlineServices');
 	}

--- a/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesEditor.ts
@@ -249,7 +249,7 @@ export class PreferencesEditor extends BaseEditor {
 
 	private switchSettings(target: SettingsTarget): void {
 		// Focus the editor if this editor is not active editor
-		if (this.editorService.activeControl !== this) {
+		if (this.editorService.activeEditorPane !== this) {
 			this.focus();
 		}
 		const promise = this.input && this.input.isDirty() ? this.editorService.save({ editor: this.input, groupId: this.group!.id }) : Promise.resolve(true);

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -33,7 +33,7 @@ import { badgeBackground, badgeForeground, contrastBorder, editorForeground } fr
 import { attachStylerCallback } from 'vs/platform/theme/common/styler';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { BaseEditor } from 'vs/workbench/browser/parts/editor/baseEditor';
-import { IEditor, IEditorMemento } from 'vs/workbench/common/editor';
+import { IEditorPane, IEditorMemento } from 'vs/workbench/common/editor';
 import { attachSuggestEnabledInputBoxStyler, SuggestEnabledInput } from 'vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput';
 import { SettingsTarget, SettingsTargetsWidget } from 'vs/workbench/contrib/preferences/browser/preferencesWidgets';
 import { commonlyUsedData, tocData } from 'vs/workbench/contrib/preferences/browser/settingsLayout';
@@ -493,12 +493,12 @@ export class SettingsEditor2 extends BaseEditor {
 		}
 	}
 
-	switchToSettingsFile(): Promise<IEditor | undefined> {
+	switchToSettingsFile(): Promise<IEditorPane | undefined> {
 		const query = parseQuery(this.searchWidget.getValue());
 		return this.openSettingsFile(query.query);
 	}
 
-	private async openSettingsFile(query?: string): Promise<IEditor | undefined> {
+	private async openSettingsFile(query?: string): Promise<IEditorPane | undefined> {
 		const currentSettingsTarget = this.settingsTargetsWidget.settingsTarget;
 
 		const options: ISettingsEditorOptions = { query };

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -43,7 +43,7 @@ export interface ISearchProvider {
 	searchModel(preferencesModel: ISettingsEditorModel, token?: CancellationToken): Promise<ISearchResult | null>;
 }
 
-export interface IKeybindingsEditor extends IEditorPane {
+export interface IKeybindingsEditorPane extends IEditorPane {
 
 	readonly activeKeybindingEntry: IKeybindingItemEntry | null;
 	readonly onDefineWhenExpression: Event<IKeybindingItemEntry>;

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -6,7 +6,7 @@
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { ISettingsEditorModel, ISearchResult } from 'vs/workbench/services/preferences/common/preferences';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { IKeybindingItemEntry } from 'vs/workbench/services/preferences/common/keybindingsEditorModel';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Event } from 'vs/base/common/event';
@@ -43,7 +43,7 @@ export interface ISearchProvider {
 	searchModel(preferencesModel: ISettingsEditorModel, token?: CancellationToken): Promise<ISearchResult | null>;
 }
 
-export interface IKeybindingsEditor extends IEditor {
+export interface IKeybindingsEditor extends IEditorPane {
 
 	readonly activeKeybindingEntry: IKeybindingItemEntry | null;
 	readonly onDefineWhenExpression: Event<IKeybindingItemEntry>;

--- a/src/vs/workbench/contrib/quickopen/browser/commandsHandler.ts
+++ b/src/vs/workbench/contrib/quickopen/browser/commandsHandler.ts
@@ -461,10 +461,10 @@ export class CommandsHandler extends QuickOpenHandler implements IDisposable {
 		lastCommandPaletteInput = searchValue;
 
 		// Editor Actions
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
 		let editorActions: IEditorAction[] = [];
-		if (activeTextEditorWidget && isFunction(activeTextEditorWidget.getSupportedActions)) {
-			editorActions = activeTextEditorWidget.getSupportedActions();
+		if (activeTextEditorControl && isFunction(activeTextEditorControl.getSupportedActions)) {
+			editorActions = activeTextEditorControl.getSupportedActions();
 		}
 
 		const editorEntries = this.editorActionsToEntries(editorActions, searchValue);

--- a/src/vs/workbench/contrib/quickopen/browser/gotoLineHandler.ts
+++ b/src/vs/workbench/contrib/quickopen/browser/gotoLineHandler.ts
@@ -39,21 +39,21 @@ export class GotoLineAction extends QuickOpenAction {
 
 	run(): Promise<void> {
 
-		let activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (!activeTextEditorWidget) {
+		let activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (!activeTextEditorControl) {
 			return Promise.resolve();
 		}
 
-		if (isDiffEditor(activeTextEditorWidget)) {
-			activeTextEditorWidget = activeTextEditorWidget.getModifiedEditor();
+		if (isDiffEditor(activeTextEditorControl)) {
+			activeTextEditorControl = activeTextEditorControl.getModifiedEditor();
 		}
 		let restoreOptions: IEditorOptions | null = null;
 
-		if (isCodeEditor(activeTextEditorWidget)) {
-			const options = activeTextEditorWidget.getOptions();
+		if (isCodeEditor(activeTextEditorControl)) {
+			const options = activeTextEditorControl.getOptions();
 			const lineNumbers = options.get(EditorOption.lineNumbers);
 			if (lineNumbers.renderType === RenderLineNumbersType.Relative) {
-				activeTextEditorWidget.updateOptions({
+				activeTextEditorControl.updateOptions({
 					lineNumbers: 'on'
 				});
 				restoreOptions = {
@@ -66,7 +66,7 @@ export class GotoLineAction extends QuickOpenAction {
 
 		if (restoreOptions) {
 			Event.once(this._quickOpenService.onHide)(() => {
-				activeTextEditorWidget!.updateOptions(restoreOptions!);
+				activeTextEditorControl!.updateOptions(restoreOptions!);
 			});
 		}
 
@@ -99,8 +99,8 @@ class GotoLineEntry extends EditorQuickOpenEntry {
 		// Inform user about valid range if input is invalid
 		const maxLineNumber = this.getMaxLineNumber();
 
-		if (this.editorService.activeTextEditorWidget && this.invalidRange(maxLineNumber)) {
-			const position = this.editorService.activeTextEditorWidget.getPosition();
+		if (this.editorService.activeTextEditorControl && this.invalidRange(maxLineNumber)) {
+			const position = this.editorService.activeTextEditorControl.getPosition();
 			if (position) {
 
 				if (maxLineNumber > 0) {
@@ -120,12 +120,12 @@ class GotoLineEntry extends EditorQuickOpenEntry {
 	}
 
 	private getMaxLineNumber(): number {
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (!activeTextEditorWidget) {
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (!activeTextEditorControl) {
 			return -1;
 		}
 
-		let model = activeTextEditorWidget.getModel();
+		let model = activeTextEditorControl.getModel();
 		if (model && (<IDiffEditorModel>model).modified && (<IDiffEditorModel>model).original) {
 			model = (<IDiffEditorModel>model).modified; // Support for diff editor models
 		}
@@ -167,10 +167,10 @@ class GotoLineEntry extends EditorQuickOpenEntry {
 
 		// Apply selection and focus
 		const range = this.toSelection();
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (activeTextEditorWidget) {
-			activeTextEditorWidget.setSelection(range);
-			activeTextEditorWidget.revealRangeInCenter(range, ScrollType.Smooth);
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (activeTextEditorControl) {
+			activeTextEditorControl.setSelection(range);
+			activeTextEditorControl.revealRangeInCenter(range, ScrollType.Smooth);
 		}
 
 		return true;
@@ -187,13 +187,13 @@ class GotoLineEntry extends EditorQuickOpenEntry {
 
 		// Select Line Position
 		const range = this.toSelection();
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (activeTextEditorWidget) {
-			activeTextEditorWidget.revealRangeInCenter(range, ScrollType.Smooth);
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (activeTextEditorControl) {
+			activeTextEditorControl.revealRangeInCenter(range, ScrollType.Smooth);
 
 			// Decorate if possible
-			if (this.editorService.activeEditorPane && types.isFunction(activeTextEditorWidget.changeDecorations)) {
-				this.handler.decorateOutline(range, activeTextEditorWidget, this.editorService.activeEditorPane.group);
+			if (this.editorService.activeEditorPane && types.isFunction(activeTextEditorControl.changeDecorations)) {
+				this.handler.decorateOutline(range, activeTextEditorControl, this.editorService.activeEditorPane.group);
 			}
 		}
 
@@ -228,8 +228,8 @@ export class GotoLineHandler extends QuickOpenHandler {
 	}
 
 	getAriaLabel(): string {
-		if (this.editorService.activeTextEditorWidget) {
-			const position = this.editorService.activeTextEditorWidget.getPosition();
+		if (this.editorService.activeTextEditorControl) {
+			const position = this.editorService.activeTextEditorControl.getPosition();
 			if (position) {
 				return nls.localize('gotoLineLabelEmpty', "Current Line: {0}, Column: {1}. Type a line number to navigate to.", position.lineNumber, position.column);
 			}
@@ -243,9 +243,9 @@ export class GotoLineHandler extends QuickOpenHandler {
 
 		// Remember view state to be able to restore on cancel
 		if (!this.lastKnownEditorViewState) {
-			const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-			if (activeTextEditorWidget) {
-				this.lastKnownEditorViewState = activeTextEditorWidget.saveViewState();
+			const activeTextEditorControl = this.editorService.activeTextEditorControl;
+			if (activeTextEditorControl) {
+				this.lastKnownEditorViewState = activeTextEditorControl.saveViewState();
 			}
 		}
 
@@ -253,7 +253,7 @@ export class GotoLineHandler extends QuickOpenHandler {
 	}
 
 	canRun(): boolean | string {
-		const canRun = !!this.editorService.activeTextEditorWidget;
+		const canRun = !!this.editorService.activeTextEditorControl;
 
 		return canRun ? true : nls.localize('cannotRunGotoLine', "Open a text file first to go to a line.");
 	}
@@ -328,9 +328,9 @@ export class GotoLineHandler extends QuickOpenHandler {
 
 		// Restore selection if canceled
 		if (canceled && this.lastKnownEditorViewState) {
-			const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-			if (activeTextEditorWidget) {
-				activeTextEditorWidget.restoreViewState(this.lastKnownEditorViewState);
+			const activeTextEditorControl = this.editorService.activeTextEditorControl;
+			if (activeTextEditorControl) {
+				activeTextEditorControl.restoreViewState(this.lastKnownEditorViewState);
 			}
 		}
 

--- a/src/vs/workbench/contrib/quickopen/browser/gotoLineHandler.ts
+++ b/src/vs/workbench/contrib/quickopen/browser/gotoLineHandler.ts
@@ -192,8 +192,8 @@ class GotoLineEntry extends EditorQuickOpenEntry {
 			activeTextEditorWidget.revealRangeInCenter(range, ScrollType.Smooth);
 
 			// Decorate if possible
-			if (this.editorService.activeControl && types.isFunction(activeTextEditorWidget.changeDecorations)) {
-				this.handler.decorateOutline(range, activeTextEditorWidget, this.editorService.activeControl.group);
+			if (this.editorService.activeEditorPane && types.isFunction(activeTextEditorWidget.changeDecorations)) {
+				this.handler.decorateOutline(range, activeTextEditorWidget, this.editorService.activeEditorPane.group);
 			}
 		}
 
@@ -305,9 +305,9 @@ export class GotoLineHandler extends QuickOpenHandler {
 	clearDecorations(): void {
 		const rangeHighlightDecorationId = this.rangeHighlightDecorationId;
 		if (rangeHighlightDecorationId) {
-			this.editorService.visibleControls.forEach(editor => {
-				if (editor.group && editor.group.id === rangeHighlightDecorationId.groupId) {
-					const editorControl = <IEditor>editor.getControl();
+			this.editorService.visibleEditorPanes.forEach(editorPane => {
+				if (editorPane.group && editorPane.group.id === rangeHighlightDecorationId.groupId) {
+					const editorControl = <IEditor>editorPane.getControl();
 					editorControl.changeDecorations(changeAccessor => {
 						changeAccessor.deltaDecorations([
 							rangeHighlightDecorationId.lineDecorationId,

--- a/src/vs/workbench/contrib/quickopen/browser/gotoSymbolHandler.ts
+++ b/src/vs/workbench/contrib/quickopen/browser/gotoSymbolHandler.ts
@@ -264,8 +264,8 @@ class SymbolEntry extends EditorQuickOpenEntryGroup {
 			activeTextEditorWidget.revealRangeInCenter(range, ScrollType.Smooth);
 
 			// Decorate if possible
-			if (this.editorService.activeControl && types.isFunction(activeTextEditorWidget.changeDecorations)) {
-				this.handler.decorateOutline(this.range, range, activeTextEditorWidget, this.editorService.activeControl.group);
+			if (this.editorService.activeEditorPane && types.isFunction(activeTextEditorWidget.changeDecorations)) {
+				this.handler.decorateOutline(this.range, range, activeTextEditorWidget, this.editorService.activeEditorPane.group);
 			}
 		}
 
@@ -512,9 +512,9 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 	private clearDecorations(): void {
 		const rangeHighlightDecorationId = this.rangeHighlightDecorationId;
 		if (rangeHighlightDecorationId) {
-			this.editorService.visibleControls.forEach(editor => {
-				if (editor.group && editor.group.id === rangeHighlightDecorationId.groupId) {
-					const editorControl = <IEditor>editor.getControl();
+			this.editorService.visibleEditorPanes.forEach(editorPane => {
+				if (editorPane.group && editorPane.group.id === rangeHighlightDecorationId.groupId) {
+					const editorControl = <IEditor>editorPane.getControl();
 					editorControl.changeDecorations((changeAccessor: IModelDecorationsChangeAccessor) => {
 						changeAccessor.deltaDecorations([
 							rangeHighlightDecorationId.lineDecorationId,

--- a/src/vs/workbench/contrib/quickopen/browser/gotoSymbolHandler.ts
+++ b/src/vs/workbench/contrib/quickopen/browser/gotoSymbolHandler.ts
@@ -245,10 +245,10 @@ class SymbolEntry extends EditorQuickOpenEntryGroup {
 		// Apply selection and focus
 		else {
 			const range = Range.collapseToStart(this.revealRange);
-			const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-			if (activeTextEditorWidget) {
-				activeTextEditorWidget.setSelection(range);
-				activeTextEditorWidget.revealRangeInCenter(range, ScrollType.Smooth);
+			const activeTextEditorControl = this.editorService.activeTextEditorControl;
+			if (activeTextEditorControl) {
+				activeTextEditorControl.setSelection(range);
+				activeTextEditorControl.revealRangeInCenter(range, ScrollType.Smooth);
 			}
 		}
 
@@ -259,13 +259,13 @@ class SymbolEntry extends EditorQuickOpenEntryGroup {
 
 		// Select Outline Position
 		const range = Range.collapseToStart(this.revealRange);
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (activeTextEditorWidget) {
-			activeTextEditorWidget.revealRangeInCenter(range, ScrollType.Smooth);
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (activeTextEditorControl) {
+			activeTextEditorControl.revealRangeInCenter(range, ScrollType.Smooth);
 
 			// Decorate if possible
-			if (this.editorService.activeEditorPane && types.isFunction(activeTextEditorWidget.changeDecorations)) {
-				this.handler.decorateOutline(this.range, range, activeTextEditorWidget, this.editorService.activeEditorPane.group);
+			if (this.editorService.activeEditorPane && types.isFunction(activeTextEditorControl.changeDecorations)) {
+				this.handler.decorateOutline(this.range, range, activeTextEditorControl, this.editorService.activeEditorPane.group);
 			}
 		}
 
@@ -350,9 +350,9 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 
 		// Remember view state to be able to restore on cancel
 		if (!this.lastKnownEditorViewState) {
-			const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-			if (activeTextEditorWidget) {
-				this.lastKnownEditorViewState = activeTextEditorWidget.saveViewState();
+			const activeTextEditorControl = this.editorService.activeTextEditorControl;
+			if (activeTextEditorControl) {
+				this.lastKnownEditorViewState = activeTextEditorControl.saveViewState();
 			}
 		}
 
@@ -387,9 +387,9 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 	canRun(): boolean | string {
 		let canRun = false;
 
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (activeTextEditorWidget) {
-			let model = activeTextEditorWidget.getModel();
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (activeTextEditorControl) {
+			let model = activeTextEditorControl.getModel();
 			if (model && (<IDiffEditorModel>model).modified && (<IDiffEditorModel>model).original) {
 				model = (<IDiffEditorModel>model).modified; // Support for diff editor models
 			}
@@ -399,7 +399,7 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 			}
 		}
 
-		return canRun ? true : activeTextEditorWidget !== null ? nls.localize('cannotRunGotoSymbolInFile', "No symbol information for the file") : nls.localize('cannotRunGotoSymbol', "Open a text file first to go to a symbol");
+		return canRun ? true : activeTextEditorControl !== null ? nls.localize('cannotRunGotoSymbolInFile', "No symbol information for the file") : nls.localize('cannotRunGotoSymbol', "Open a text file first to go to a symbol");
 	}
 
 	getAutoFocus(searchValue: string): IAutoFocus {
@@ -446,9 +446,9 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 	}
 
 	private async doGetActiveOutline(): Promise<OutlineModel | null> {
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (activeTextEditorWidget) {
-			let model = activeTextEditorWidget.getModel();
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (activeTextEditorControl) {
+			let model = activeTextEditorControl.getModel();
 			if (model && (<IDiffEditorModel>model).modified && (<IDiffEditorModel>model).original) {
 				model = (<IDiffEditorModel>model).modified; // Support for diff editor models
 			}
@@ -538,9 +538,9 @@ export class GotoSymbolHandler extends QuickOpenHandler {
 
 		// Restore selection if canceled
 		if (canceled && this.lastKnownEditorViewState) {
-			const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-			if (activeTextEditorWidget) {
-				activeTextEditorWidget.restoreViewState(this.lastKnownEditorViewState);
+			const activeTextEditorControl = this.editorService.activeTextEditorControl;
+			if (activeTextEditorControl) {
+				activeTextEditorControl.restoreViewState(this.lastKnownEditorViewState);
 			}
 
 			this.lastKnownEditorViewState = null;

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -1317,7 +1317,7 @@ export class DirtyDiffWorkbenchController extends Disposable implements ext.IWor
 	// or not. Needs context from the editor, to know whether it is a diff editor, in place editor
 	// etc.
 	private onEditorsChanged(): void {
-		const models = this.editorService.visibleTextEditorWidgets
+		const models = this.editorService.visibleTextEditorControls
 
 			// only interested in code editor widgets
 			.filter(c => c instanceof CodeEditorWidget)

--- a/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
@@ -1004,10 +1004,10 @@ export class RepositoryPane extends ViewPane {
 	}
 
 	private pin(): void {
-		const activeControl = this.editorService.activeControl;
+		const activeEditorPane = this.editorService.activeEditorPane;
 
-		if (activeControl) {
-			activeControl.group.pinEditor(activeControl.input);
+		if (activeEditorPane) {
+			activeEditorPane.group.pinEditor(activeEditorPane.input);
 		}
 	}
 

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -72,7 +72,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: accessor => {
 		const contextService = accessor.get(IContextKeyService).getContext(document.activeElement);
 		if (contextService.getValue(SearchEditorConstants.InSearchEditor.serialize())) {
-			(accessor.get(IEditorService).activeControl as SearchEditor).toggleQueryDetails();
+			(accessor.get(IEditorService).activeEditorPane as SearchEditor).toggleQueryDetails();
 		} else if (contextService.getValue(Constants.SearchViewFocusedKey.serialize())) {
 			const searchView = getSearchView(accessor.get(IViewsService));
 			assertIsDefined(searchView).toggleQueryDetails();

--- a/src/vs/workbench/contrib/search/browser/searchActions.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActions.ts
@@ -96,7 +96,7 @@ export class FocusNextInputAction extends Action {
 		const input = this.editorService.activeEditor;
 		if (input instanceof SearchEditorInput) {
 			// cast as we cannot import SearchEditor as a value b/c cyclic dependency.
-			(this.editorService.activeControl as SearchEditor).focusNextInput();
+			(this.editorService.activeEditorPane as SearchEditor).focusNextInput();
 		}
 
 		const searchView = getSearchView(this.viewsService);
@@ -121,7 +121,7 @@ export class FocusPreviousInputAction extends Action {
 		const input = this.editorService.activeEditor;
 		if (input instanceof SearchEditorInput) {
 			// cast as we cannot import SearchEditor as a value b/c cyclic dependency.
-			(this.editorService.activeControl as SearchEditor).focusPrevInput();
+			(this.editorService.activeEditorPane as SearchEditor).focusPrevInput();
 		}
 
 		const searchView = getSearchView(this.viewsService);
@@ -498,7 +498,7 @@ export class FocusNextSearchResultAction extends Action {
 		const input = this.editorService.activeEditor;
 		if (input instanceof SearchEditorInput) {
 			// cast as we cannot import SearchEditor as a value b/c cyclic dependency.
-			return (this.editorService.activeControl as SearchEditor).focusNextResult();
+			return (this.editorService.activeEditorPane as SearchEditor).focusNextResult();
 		}
 
 		return openSearchView(this.viewsService).then(searchView => {
@@ -524,7 +524,7 @@ export class FocusPreviousSearchResultAction extends Action {
 		const input = this.editorService.activeEditor;
 		if (input instanceof SearchEditorInput) {
 			// cast as we cannot import SearchEditor as a value b/c cyclic dependency.
-			return (this.editorService.activeControl as SearchEditor).focusPreviousResult();
+			return (this.editorService.activeEditorPane as SearchEditor).focusPreviousResult();
 		}
 
 		return openSearchView(this.viewsService).then(searchView => {

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1054,26 +1054,26 @@ export class SearchView extends ViewPane {
 			return null;
 		}
 
-		let activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (isDiffEditor(activeTextEditorWidget)) {
-			if (activeTextEditorWidget.getOriginalEditor().hasTextFocus()) {
-				activeTextEditorWidget = activeTextEditorWidget.getOriginalEditor();
+		let activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (isDiffEditor(activeTextEditorControl)) {
+			if (activeTextEditorControl.getOriginalEditor().hasTextFocus()) {
+				activeTextEditorControl = activeTextEditorControl.getOriginalEditor();
 			} else {
-				activeTextEditorWidget = activeTextEditorWidget.getModifiedEditor();
+				activeTextEditorControl = activeTextEditorControl.getModifiedEditor();
 			}
 		}
 
-		if (!isCodeEditor(activeTextEditorWidget) || !activeTextEditorWidget.hasModel()) {
+		if (!isCodeEditor(activeTextEditorControl) || !activeTextEditorControl.hasModel()) {
 			return null;
 		}
 
-		const range = activeTextEditorWidget.getSelection();
+		const range = activeTextEditorControl.getSelection();
 		if (!range) {
 			return null;
 		}
 
 		if (range.isEmpty() && !this.searchWidget.searchInput.getValue() && allowUnselectedWord) {
-			const wordAtPosition = activeTextEditorWidget.getModel().getWordAtPosition(range.getStartPosition());
+			const wordAtPosition = activeTextEditorControl.getModel().getWordAtPosition(range.getStartPosition());
 			if (wordAtPosition) {
 				return wordAtPosition.word;
 			}
@@ -1082,7 +1082,7 @@ export class SearchView extends ViewPane {
 		if (!range.isEmpty()) {
 			let searchText = '';
 			for (let i = range.startLineNumber; i <= range.endLineNumber; i++) {
-				let lineText = activeTextEditorWidget.getModel().getLineContent(i);
+				let lineText = activeTextEditorControl.getModel().getLineContent(i);
 				if (i === range.endLineNumber) {
 					lineText = lineText.substring(0, range.endColumn - 1);
 				}

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -41,7 +41,7 @@ import { ICssStyleCollector, IColorTheme, IThemeService, registerThemingParticip
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { OpenFileFolderAction, OpenFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
 import { ResourceLabels } from 'vs/workbench/browser/labels';
-import { IEditor } from 'vs/workbench/common/editor';
+import { IEditorPane } from 'vs/workbench/common/editor';
 import { ExcludePatternInputWidget, PatternInputWidget } from 'vs/workbench/contrib/search/browser/patternInputWidget';
 import { CancelSearchAction, ClearSearchResultsAction, CollapseDeepestExpandedLevelAction, RefreshAction, IFindInFilesArgs, appendKeyBindingLabel, ExpandAllAction, ToggleCollapseAndExpandAction } from 'vs/workbench/contrib/search/browser/searchActions';
 import { FileMatchRenderer, FolderMatchRenderer, MatchRenderer, SearchAccessibilityProvider, SearchDelegate, SearchDND } from 'vs/workbench/contrib/search/browser/searchResultsView';
@@ -1540,7 +1540,7 @@ export class SearchView extends ViewPane {
 		this.openSettings('.exclude');
 	};
 
-	private openSettings(query: string): Promise<IEditor | undefined> {
+	private openSettings(query: string): Promise<IEditorPane | undefined> {
 		const options: ISettingsEditorOptions = { query };
 		return this.contextService.getWorkbenchState() !== WorkbenchState.EMPTY ?
 			this.preferencesService.openWorkspaceSettings(undefined, options) :

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -162,9 +162,9 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 CommandsRegistry.registerCommand(
 	SearchEditorConstants.CleanSearchEditorStateCommandId,
 	(accessor: ServicesAccessor) => {
-		const activeControl = accessor.get(IEditorService).activeControl;
-		if (activeControl instanceof SearchEditor) {
-			activeControl.cleanState();
+		const activeEditorPane = accessor.get(IEditorService).activeEditorPane;
+		if (activeEditorPane instanceof SearchEditor) {
+			activeEditorPane.cleanState();
 		}
 	});
 //#endregion

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
@@ -141,18 +141,18 @@ const openNewSearchEditor =
 		const instantiationService = accessor.get(IInstantiationService);
 		const configurationService = accessor.get(IConfigurationService);
 
-		const activeEditor = editorService.activeTextEditorWidget;
+		const activeEditorControl = editorService.activeTextEditorControl;
 		let activeModel: ICodeEditor | undefined;
 		let selected = '';
-		if (activeEditor) {
-			if (isDiffEditor(activeEditor)) {
-				if (activeEditor.getOriginalEditor().hasTextFocus()) {
-					activeModel = activeEditor.getOriginalEditor();
+		if (activeEditorControl) {
+			if (isDiffEditor(activeEditorControl)) {
+				if (activeEditorControl.getOriginalEditor().hasTextFocus()) {
+					activeModel = activeEditorControl.getOriginalEditor();
 				} else {
-					activeModel = activeEditor.getModifiedEditor();
+					activeModel = activeEditorControl.getModifiedEditor();
 				}
 			} else {
-				activeModel = activeEditor as ICodeEditor;
+				activeModel = activeEditorControl as ICodeEditor;
 			}
 			const selection = activeModel?.getSelection();
 			selected = (selection && activeModel?.getModel()?.getValueInRange(selection)) ?? '';

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
@@ -26,7 +26,7 @@ export const toggleSearchEditorCaseSensitiveCommand = (accessor: ServicesAccesso
 	const editorService = accessor.get(IEditorService);
 	const input = editorService.activeEditor;
 	if (input instanceof SearchEditorInput) {
-		(editorService.activeControl as SearchEditor).toggleCaseSensitive();
+		(editorService.activeEditorPane as SearchEditor).toggleCaseSensitive();
 	}
 };
 
@@ -34,7 +34,7 @@ export const toggleSearchEditorWholeWordCommand = (accessor: ServicesAccessor) =
 	const editorService = accessor.get(IEditorService);
 	const input = editorService.activeEditor;
 	if (input instanceof SearchEditorInput) {
-		(editorService.activeControl as SearchEditor).toggleWholeWords();
+		(editorService.activeEditorPane as SearchEditor).toggleWholeWords();
 	}
 };
 
@@ -42,7 +42,7 @@ export const toggleSearchEditorRegexCommand = (accessor: ServicesAccessor) => {
 	const editorService = accessor.get(IEditorService);
 	const input = editorService.activeEditor;
 	if (input instanceof SearchEditorInput) {
-		(editorService.activeControl as SearchEditor).toggleRegex();
+		(editorService.activeEditorPane as SearchEditor).toggleRegex();
 	}
 };
 
@@ -50,7 +50,7 @@ export const toggleSearchEditorContextLinesCommand = (accessor: ServicesAccessor
 	const editorService = accessor.get(IEditorService);
 	const input = editorService.activeEditor;
 	if (input instanceof SearchEditorInput) {
-		(editorService.activeControl as SearchEditor).toggleContextLines();
+		(editorService.activeEditorPane as SearchEditor).toggleContextLines();
 	}
 };
 
@@ -58,7 +58,7 @@ export const selectAllSearchEditorMatchesCommand = (accessor: ServicesAccessor) 
 	const editorService = accessor.get(IEditorService);
 	const input = editorService.activeEditor;
 	if (input instanceof SearchEditorInput) {
-		(editorService.activeControl as SearchEditor).focusAllResults();
+		(editorService.activeEditorPane as SearchEditor).focusAllResults();
 	}
 };
 
@@ -129,7 +129,7 @@ export class RerunSearchEditorSearchAction extends Action {
 	async run() {
 		const input = this.editorService.activeEditor;
 		if (input instanceof SearchEditorInput) {
-			(this.editorService.activeControl as SearchEditor).triggerSearch({ resetCursor: false });
+			(this.editorService.activeEditorPane as SearchEditor).triggerSearch({ resetCursor: false });
 		}
 	}
 }
@@ -158,7 +158,7 @@ const openNewSearchEditor =
 			selected = (selection && activeModel?.getModel()?.getValueInRange(selection)) ?? '';
 		} else {
 			if (editorService.activeEditor instanceof SearchEditorInput) {
-				const active = editorService.activeControl as SearchEditor;
+				const active = editorService.activeEditorPane as SearchEditor;
 				selected = active.getSelected();
 			}
 		}

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -74,7 +74,7 @@ import { IRemotePathService } from 'vs/workbench/services/path/common/remotePath
 import { format } from 'vs/base/common/jsonFormatter';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { applyEdits } from 'vs/base/common/jsonEdit';
-import { ITextEditor } from 'vs/workbench/common/editor';
+import { ITextEditorPane } from 'vs/workbench/common/editor';
 import { ITextEditorSelection, TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { find } from 'vs/base/common/arrays';
@@ -945,7 +945,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return false;
 	}
 
-	private openEditorAtTask(resource: URI | undefined, task: TaskConfig.CustomTask | TaskConfig.ConfiguringTask | string | undefined): Promise<ITextEditor | null | undefined> {
+	private openEditorAtTask(resource: URI | undefined, task: TaskConfig.CustomTask | TaskConfig.ConfiguringTask | string | undefined): Promise<ITextEditorPane | null | undefined> {
 		if (resource === undefined) {
 			return Promise.resolve(undefined);
 		}

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -67,11 +67,11 @@ export class ReleaseNotesManager {
 		const html = await this.renderBody(releaseNoteText);
 		const title = nls.localize('releaseNotesInputName', "Release Notes: {0}", version);
 
-		const activeControl = this._editorService.activeControl;
+		const activeEditorPane = this._editorService.activeEditorPane;
 		if (this._currentReleaseNotes) {
 			this._currentReleaseNotes.setName(title);
 			this._currentReleaseNotes.webview.html = html;
-			this._webviewWorkbenchService.revealWebview(this._currentReleaseNotes, activeControl ? activeControl.group : this._editorGroupService.activeGroup, false);
+			this._webviewWorkbenchService.revealWebview(this._currentReleaseNotes, activeEditorPane ? activeEditorPane.group : this._editorGroupService.activeGroup, false);
 		} else {
 			this._currentReleaseNotes = this._webviewWorkbenchService.createWebview(
 				generateUuid(),

--- a/src/vs/workbench/contrib/webview/browser/webviewCommands.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewCommands.ts
@@ -141,14 +141,14 @@ export class ReloadWebviewAction extends Action {
 	}
 
 	private getVisibleWebviews() {
-		return this.editorService.visibleControls
-			.filter(control => control && (control as WebviewEditor).isWebviewEditor)
-			.map(control => control as WebviewEditor);
+		return this.editorService.visibleEditorPanes
+			.filter(editorPane => editorPane && (editorPane as WebviewEditor).isWebviewEditor)
+			.map(editorPane => editorPane as WebviewEditor);
 	}
 }
 
 export function getActiveWebviewEditor(accessor: ServicesAccessor): WebviewEditor | undefined {
 	const editorService = accessor.get(IEditorService);
-	const activeControl = editorService.activeControl as WebviewEditor | undefined;
-	return activeControl?.isWebviewEditor ? activeControl : undefined;
+	const activeEditorPane = editorService.activeEditorPane as WebviewEditor | undefined;
+	return activeEditorPane?.isWebviewEditor ? activeEditorPane : undefined;
 }

--- a/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewEditor.ts
@@ -106,7 +106,7 @@ export class WebviewEditor extends BaseEditor {
 		if (!this._onFocusWindowHandler.value && !isWeb) {
 			// Make sure we restore focus when switching back to a VS Code window
 			this._onFocusWindowHandler.value = this._hostService.onDidChangeFocus(focused => {
-				if (focused && this._editorService.activeControl === this) {
+				if (focused && this._editorService.activeEditorPane === this) {
 					this.focus();
 				}
 			});

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughActions.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/walkThroughActions.ts
@@ -17,9 +17,9 @@ export const WalkThroughArrowUp: ICommandAndKeybindingRule = {
 	primary: KeyCode.UpArrow,
 	handler: accessor => {
 		const editorService = accessor.get(IEditorService);
-		const activeControl = editorService.activeControl;
-		if (activeControl instanceof WalkThroughPart) {
-			activeControl.arrowUp();
+		const activeEditorPane = editorService.activeEditorPane;
+		if (activeEditorPane instanceof WalkThroughPart) {
+			activeEditorPane.arrowUp();
 		}
 	}
 };
@@ -31,9 +31,9 @@ export const WalkThroughArrowDown: ICommandAndKeybindingRule = {
 	primary: KeyCode.DownArrow,
 	handler: accessor => {
 		const editorService = accessor.get(IEditorService);
-		const activeControl = editorService.activeControl;
-		if (activeControl instanceof WalkThroughPart) {
-			activeControl.arrowDown();
+		const activeEditorPane = editorService.activeEditorPane;
+		if (activeEditorPane instanceof WalkThroughPart) {
+			activeEditorPane.arrowDown();
 		}
 	}
 };
@@ -45,9 +45,9 @@ export const WalkThroughPageUp: ICommandAndKeybindingRule = {
 	primary: KeyCode.PageUp,
 	handler: accessor => {
 		const editorService = accessor.get(IEditorService);
-		const activeControl = editorService.activeControl;
-		if (activeControl instanceof WalkThroughPart) {
-			activeControl.pageUp();
+		const activeEditorPane = editorService.activeEditorPane;
+		if (activeEditorPane instanceof WalkThroughPart) {
+			activeEditorPane.pageUp();
 		}
 	}
 };
@@ -59,9 +59,9 @@ export const WalkThroughPageDown: ICommandAndKeybindingRule = {
 	primary: KeyCode.PageDown,
 	handler: accessor => {
 		const editorService = accessor.get(IEditorService);
-		const activeControl = editorService.activeControl;
-		if (activeControl instanceof WalkThroughPart) {
-			activeControl.pageDown();
+		const activeEditorPane = editorService.activeEditorPane;
+		if (activeEditorPane instanceof WalkThroughPart) {
+			activeEditorPane.pageDown();
 		}
 	}
 };

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -308,8 +308,8 @@ export class ElectronWindow extends Disposable {
 		// Close when empty: check if we should close the window based on the setting
 		// Overruled by: window has a workspace opened or this window is for extension development
 		// or setting is disabled. Also enabled when running with --wait from the command line.
-		const visibleEditors = this.editorService.visibleControls;
-		if (visibleEditors.length === 0 && this.contextService.getWorkbenchState() === WorkbenchState.EMPTY && !this.environmentService.isExtensionDevelopment) {
+		const visibleEditorPanes = this.editorService.visibleEditorPanes;
+		if (visibleEditorPanes.length === 0 && this.contextService.getWorkbenchState() === WorkbenchState.EMPTY && !this.environmentService.isExtensionDevelopment) {
 			const closeWhenEmpty = this.configurationService.getValue<boolean>('window.closeWhenEmpty');
 			if (closeWhenEmpty || this.environmentService.args.wait) {
 				this.closeEmptyWindowScheduler.schedule();
@@ -318,8 +318,8 @@ export class ElectronWindow extends Disposable {
 	}
 
 	private onAllEditorsClosed(): void {
-		const visibleEditors = this.editorService.visibleControls.length;
-		if (visibleEditors === 0) {
+		const visibleEditorPanes = this.editorService.visibleEditorPanes.length;
+		if (visibleEditorPanes === 0) {
 			this.electronService.closeWindow();
 		}
 	}

--- a/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
+++ b/src/vs/workbench/services/bulkEdit/browser/bulkEditService.ts
@@ -433,7 +433,7 @@ export class BulkEditService implements IBulkEditService {
 
 		// try to find code editor
 		if (!codeEditor) {
-			let candidate = this._editorService.activeTextEditorWidget;
+			let candidate = this._editorService.activeTextEditorControl;
 			if (isCodeEditor(candidate)) {
 				codeEditor = candidate;
 			}

--- a/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
@@ -62,10 +62,10 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 				return path.normalize(fileResource.fsPath);
 			},
 			getSelectedText: (): string | undefined => {
-				const activeTextEditorWidget = editorService.activeTextEditorWidget;
-				if (isCodeEditor(activeTextEditorWidget)) {
-					const editorModel = activeTextEditorWidget.getModel();
-					const editorSelection = activeTextEditorWidget.getSelection();
+				const activeTextEditorControl = editorService.activeTextEditorControl;
+				if (isCodeEditor(activeTextEditorControl)) {
+					const editorModel = activeTextEditorControl.getModel();
+					const editorSelection = activeTextEditorControl.getSelection();
 					if (editorModel && editorSelection) {
 						return editorModel.getValueInRange(editorSelection);
 					}
@@ -73,9 +73,9 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 				return undefined;
 			},
 			getLineNumber: (): string | undefined => {
-				const activeTextEditorWidget = editorService.activeTextEditorWidget;
-				if (isCodeEditor(activeTextEditorWidget)) {
-					const selection = activeTextEditorWidget.getSelection();
+				const activeTextEditorControl = editorService.activeTextEditorControl;
+				if (isCodeEditor(activeTextEditorControl)) {
+					const selection = activeTextEditorControl.getSelection();
 					if (selection) {
 						const lineNumber = selection.positionLineNumber;
 						return String(lineNumber);

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -24,7 +24,7 @@ import { NativeWorkbenchEnvironmentService } from 'vs/workbench/services/environ
 
 const mockLineNumber = 10;
 class TestEditorServiceWithActiveEditor extends TestEditorService {
-	get activeTextEditorWidget(): any {
+	get activeTextEditorControl(): any {
 		return {
 			getEditorType() {
 				return EditorType.ICodeEditor;

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -54,9 +54,9 @@ export namespace SaveLocalFileCommand {
 	export function handler(): ICommandHandler {
 		return accessor => {
 			const editorService = accessor.get(IEditorService);
-			const activeControl = editorService.activeControl;
-			if (activeControl) {
-				return editorService.save({ groupId: activeControl.group.id, editor: activeControl.input }, { saveAs: true, availableFileSystems: [Schemas.file], reason: SaveReason.EXPLICIT });
+			const activeEditorPane = editorService.activeEditorPane;
+			if (activeEditorPane) {
+				return editorService.save({ groupId: activeEditorPane.group.id, editor: activeEditorPane.input }, { saveAs: true, availableFileSystems: [Schemas.file], reason: SaveReason.EXPLICIT });
 			}
 
 			return Promise.resolve(undefined);

--- a/src/vs/workbench/services/editor/browser/codeEditorService.ts
+++ b/src/vs/workbench/services/editor/browser/codeEditorService.ts
@@ -23,13 +23,13 @@ export class CodeEditorService extends CodeEditorServiceImpl {
 	}
 
 	getActiveCodeEditor(): ICodeEditor | null {
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
-		if (isCodeEditor(activeTextEditorWidget)) {
-			return activeTextEditorWidget;
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
+		if (isCodeEditor(activeTextEditorControl)) {
+			return activeTextEditorControl;
 		}
 
-		if (isDiffEditor(activeTextEditorWidget)) {
-			return activeTextEditorWidget.getModifiedEditor();
+		if (isDiffEditor(activeTextEditorControl)) {
+			return activeTextEditorControl.getModifiedEditor();
 		}
 
 		return null;
@@ -40,17 +40,17 @@ export class CodeEditorService extends CodeEditorServiceImpl {
 		// Special case: If the active editor is a diff editor and the request to open originates and
 		// targets the modified side of it, we just apply the request there to prevent opening the modified
 		// side as separate editor.
-		const activeTextEditorWidget = this.editorService.activeTextEditorWidget;
+		const activeTextEditorControl = this.editorService.activeTextEditorControl;
 		if (
 			!sideBySide &&							// we need the current active group to be the taret
-			isDiffEditor(activeTextEditorWidget) && // we only support this for active text diff editors
+			isDiffEditor(activeTextEditorControl) && // we only support this for active text diff editors
 			input.options &&						// we need options to apply
 			input.resource &&						// we need a request resource to compare with
-			activeTextEditorWidget.getModel() &&	// we need a target model to compare with
-			source === activeTextEditorWidget.getModifiedEditor() && // we need the source of this request to be the modified side of the diff editor
-			input.resource.toString() === activeTextEditorWidget.getModel()!.modified.uri.toString() // we need the input resources to match with modified side
+			activeTextEditorControl.getModel() &&	// we need a target model to compare with
+			source === activeTextEditorControl.getModifiedEditor() && // we need the source of this request to be the modified side of the diff editor
+			input.resource.toString() === activeTextEditorControl.getModel()!.modified.uri.toString() // we need the input resources to match with modified side
 		) {
-			const targetEditor = activeTextEditorWidget.getModifiedEditor();
+			const targetEditor = activeTextEditorControl.getModifiedEditor();
 
 			const textOptions = TextEditorOptions.create(input.options);
 			textOptions.apply(targetEditor, ScrollType.Smooth);

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -389,14 +389,14 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	private readonly editorsObserver = this._register(this.instantiationService.createInstance(EditorsObserver));
 
-	get activeControl(): IVisibleEditorPane | undefined {
-		return this.editorGroupService.activeGroup?.activeControl;
+	get activeEditorPane(): IVisibleEditorPane | undefined {
+		return this.editorGroupService.activeGroup?.activeEditorPane;
 	}
 
 	get activeTextEditorWidget(): ICodeEditor | IDiffEditor | undefined {
-		const activeControl = this.activeControl;
-		if (activeControl) {
-			const activeControlWidget = activeControl.getControl();
+		const activeEditorPane = this.activeEditorPane;
+		if (activeEditorPane) {
+			const activeControlWidget = activeEditorPane.getControl();
 			if (isCodeEditor(activeControlWidget) || isDiffEditor(activeControlWidget)) {
 				return activeControlWidget;
 			}
@@ -446,12 +446,12 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return activeGroup ? withNullAsUndefined(activeGroup.activeEditor) : undefined;
 	}
 
-	get visibleControls(): IVisibleEditorPane[] {
-		return coalesce(this.editorGroupService.groups.map(group => group.activeControl));
+	get visibleEditorPanes(): IVisibleEditorPane[] {
+		return coalesce(this.editorGroupService.groups.map(group => group.activeEditorPane));
 	}
 
 	get visibleTextEditorWidgets(): Array<ICodeEditor | IDiffEditor> {
-		return this.visibleControls.map(control => control.getControl() as ICodeEditor | IDiffEditor).filter(widget => isCodeEditor(widget) || isDiffEditor(widget));
+		return this.visibleEditorPanes.map(editorPane => editorPane.getControl() as ICodeEditor | IDiffEditor).filter(widget => isCodeEditor(widget) || isDiffEditor(widget));
 	}
 
 	get visibleEditors(): IEditorInput[] {
@@ -993,9 +993,9 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 			// is untitled or we "Save As". This also allows the user to review
 			// the contents of the editor before making a decision.
 			let viewState: IEditorViewState | undefined = undefined;
-			const control = await this.openEditor(editor, undefined, groupId);
-			if (isTextEditorPane(control)) {
-				viewState = control.getViewState();
+			const editorPane = await this.openEditor(editor, undefined, groupId);
+			if (isTextEditorPane(editorPane)) {
+				viewState = editorPane.getViewState();
 			}
 
 			const result = options?.saveAs ? await editor.saveAs(groupId, options) : await editor.save(groupId, options);
@@ -1117,15 +1117,15 @@ export class DelegatingEditorService implements IEditorService {
 			const [resolvedGroup, resolvedEditor, resolvedOptions] = result;
 
 			// Pass on to editor open handler
-			const control = await this.editorOpenHandler(
+			const editorPane = await this.editorOpenHandler(
 				(group: IEditorGroup, editor: IEditorInput, options?: IEditorOptions) => group.openEditor(editor, options),
 				resolvedGroup,
 				resolvedEditor,
 				resolvedOptions
 			);
 
-			if (control) {
-				return control; // the opening was handled, so return early
+			if (editorPane) {
+				return editorPane; // the opening was handled, so return early
 			}
 
 			return withNullAsUndefined(await resolvedGroup.openEditor(resolvedEditor, resolvedOptions));
@@ -1140,11 +1140,11 @@ export class DelegatingEditorService implements IEditorService {
 	get onDidVisibleEditorsChange(): Event<void> { return this.editorService.onDidVisibleEditorsChange; }
 
 	get activeEditor(): IEditorInput | undefined { return this.editorService.activeEditor; }
-	get activeControl(): IVisibleEditorPane | undefined { return this.editorService.activeControl; }
+	get activeEditorPane(): IVisibleEditorPane | undefined { return this.editorService.activeEditorPane; }
 	get activeTextEditorWidget(): ICodeEditor | IDiffEditor | undefined { return this.editorService.activeTextEditorWidget; }
 	get activeTextEditorMode(): string | undefined { return this.editorService.activeTextEditorMode; }
 	get visibleEditors(): ReadonlyArray<IEditorInput> { return this.editorService.visibleEditors; }
-	get visibleControls(): ReadonlyArray<IVisibleEditorPane> { return this.editorService.visibleControls; }
+	get visibleEditorPanes(): ReadonlyArray<IVisibleEditorPane> { return this.editorService.visibleEditorPanes; }
 	get visibleTextEditorWidgets(): ReadonlyArray<ICodeEditor | IDiffEditor> { return this.editorService.visibleTextEditorWidgets; }
 	get editors(): ReadonlyArray<IEditorInput> { return this.editorService.editors; }
 	get count(): number { return this.editorService.count; }

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -393,12 +393,12 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return this.editorGroupService.activeGroup?.activeEditorPane;
 	}
 
-	get activeTextEditorWidget(): ICodeEditor | IDiffEditor | undefined {
+	get activeTextEditorControl(): ICodeEditor | IDiffEditor | undefined {
 		const activeEditorPane = this.activeEditorPane;
 		if (activeEditorPane) {
-			const activeControlWidget = activeEditorPane.getControl();
-			if (isCodeEditor(activeControlWidget) || isDiffEditor(activeControlWidget)) {
-				return activeControlWidget;
+			const activeControl = activeEditorPane.getControl();
+			if (isCodeEditor(activeControl) || isDiffEditor(activeControl)) {
+				return activeControl;
 			}
 		}
 
@@ -408,11 +408,11 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 	get activeTextEditorMode(): string | undefined {
 		let activeCodeEditor: ICodeEditor | undefined = undefined;
 
-		const activeTextEditorWidget = this.activeTextEditorWidget;
-		if (isDiffEditor(activeTextEditorWidget)) {
-			activeCodeEditor = activeTextEditorWidget.getModifiedEditor();
+		const activeTextEditorControl = this.activeTextEditorControl;
+		if (isDiffEditor(activeTextEditorControl)) {
+			activeCodeEditor = activeTextEditorControl.getModifiedEditor();
 		} else {
-			activeCodeEditor = activeTextEditorWidget;
+			activeCodeEditor = activeTextEditorControl;
 		}
 
 		return activeCodeEditor?.getModel()?.getLanguageIdentifier().language;
@@ -450,8 +450,8 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		return coalesce(this.editorGroupService.groups.map(group => group.activeEditorPane));
 	}
 
-	get visibleTextEditorWidgets(): Array<ICodeEditor | IDiffEditor> {
-		return this.visibleEditorPanes.map(editorPane => editorPane.getControl() as ICodeEditor | IDiffEditor).filter(widget => isCodeEditor(widget) || isDiffEditor(widget));
+	get visibleTextEditorControls(): Array<ICodeEditor | IDiffEditor> {
+		return this.visibleEditorPanes.map(editorPane => editorPane.getControl() as ICodeEditor | IDiffEditor).filter(control => isCodeEditor(control) || isDiffEditor(control));
 	}
 
 	get visibleEditors(): IEditorInput[] {
@@ -760,9 +760,9 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 	//#region invokeWithinEditorContext()
 
 	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T {
-		const activeTextEditorWidget = this.activeTextEditorWidget;
-		if (isCodeEditor(activeTextEditorWidget)) {
-			return activeTextEditorWidget.invokeWithinContext(fn);
+		const activeTextEditorControl = this.activeTextEditorControl;
+		if (isCodeEditor(activeTextEditorControl)) {
+			return activeTextEditorControl.invokeWithinContext(fn);
 		}
 
 		const activeGroup = this.editorGroupService.activeGroup;
@@ -1141,11 +1141,11 @@ export class DelegatingEditorService implements IEditorService {
 
 	get activeEditor(): IEditorInput | undefined { return this.editorService.activeEditor; }
 	get activeEditorPane(): IVisibleEditorPane | undefined { return this.editorService.activeEditorPane; }
-	get activeTextEditorWidget(): ICodeEditor | IDiffEditor | undefined { return this.editorService.activeTextEditorWidget; }
+	get activeTextEditorControl(): ICodeEditor | IDiffEditor | undefined { return this.editorService.activeTextEditorControl; }
 	get activeTextEditorMode(): string | undefined { return this.editorService.activeTextEditorMode; }
 	get visibleEditors(): ReadonlyArray<IEditorInput> { return this.editorService.visibleEditors; }
 	get visibleEditorPanes(): ReadonlyArray<IVisibleEditorPane> { return this.editorService.visibleEditorPanes; }
-	get visibleTextEditorWidgets(): ReadonlyArray<ICodeEditor | IDiffEditor> { return this.editorService.visibleTextEditorWidgets; }
+	get visibleTextEditorControls(): ReadonlyArray<ICodeEditor | IDiffEditor> { return this.editorService.visibleTextEditorControls; }
 	get editors(): ReadonlyArray<IEditorInput> { return this.editorService.editors; }
 	get count(): number { return this.editorService.count; }
 

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -5,7 +5,7 @@
 
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IResourceInput, ITextEditorOptions, IEditorOptions, EditorActivation } from 'vs/platform/editor/common/editor';
-import { SideBySideEditor as SideBySideEditorChoice, IEditorInput, IEditor, GroupIdentifier, IFileEditorInput, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, IEditorInputFactoryRegistry, Extensions as EditorExtensions, EditorInput, SideBySideEditorInput, IEditorInputWithOptions, isEditorInputWithOptions, EditorOptions, TextEditorOptions, IEditorIdentifier, IEditorCloseEvent, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IRevertOptions, SaveReason, EditorsOrder, isTextEditor, IWorkbenchEditorConfiguration, toResource, IVisibleEditor } from 'vs/workbench/common/editor';
+import { SideBySideEditor as SideBySideEditorChoice, IEditorInput, IEditorPane, GroupIdentifier, IFileEditorInput, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, IEditorInputFactoryRegistry, Extensions as EditorExtensions, EditorInput, SideBySideEditorInput, IEditorInputWithOptions, isEditorInputWithOptions, EditorOptions, TextEditorOptions, IEditorIdentifier, IEditorCloseEvent, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IRevertOptions, SaveReason, EditorsOrder, isTextEditor, IWorkbenchEditorConfiguration, toResource, IVisibleEditor } from 'vs/workbench/common/editor';
 import { ResourceEditorInput } from 'vs/workbench/common/editor/resourceEditorInput';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ResourceMap } from 'vs/base/common/map';
@@ -494,11 +494,11 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	//#region openEditor()
 
-	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: OpenInEditorGroup): Promise<IEditor | undefined>;
+	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: OpenInEditorGroup): Promise<IEditorPane | undefined>;
 	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: OpenInEditorGroup): Promise<ITextEditor | undefined>;
 	openEditor(editor: IResourceDiffInput, group?: OpenInEditorGroup): Promise<ITextDiffEditor | undefined>;
 	openEditor(editor: IResourceSideBySideInput, group?: OpenInEditorGroup): Promise<ITextSideBySideEditor | undefined>;
-	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | OpenInEditorGroup, group?: OpenInEditorGroup): Promise<IEditor | undefined> {
+	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | OpenInEditorGroup, group?: OpenInEditorGroup): Promise<IEditorPane | undefined> {
 		const result = this.doResolveEditorOpenRequest(editor, optionsOrGroup, group);
 		if (result) {
 			const [resolvedGroup, resolvedEditor, resolvedOptions] = result;
@@ -660,9 +660,9 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	//#region openEditors()
 
-	openEditors(editors: IEditorInputWithOptions[], group?: OpenInEditorGroup): Promise<IEditor[]>;
-	openEditors(editors: IResourceEditor[], group?: OpenInEditorGroup): Promise<IEditor[]>;
-	async openEditors(editors: Array<IEditorInputWithOptions | IResourceEditor>, group?: OpenInEditorGroup): Promise<IEditor[]> {
+	openEditors(editors: IEditorInputWithOptions[], group?: OpenInEditorGroup): Promise<IEditorPane[]>;
+	openEditors(editors: IResourceEditor[], group?: OpenInEditorGroup): Promise<IEditorPane[]>;
+	async openEditors(editors: Array<IEditorInputWithOptions | IResourceEditor>, group?: OpenInEditorGroup): Promise<IEditorPane[]> {
 
 		// Convert to typed editors and options
 		const typedEditors: IEditorInputWithOptions[] = [];
@@ -693,7 +693,7 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 		}
 
 		// Open in target groups
-		const result: Promise<IEditor | null>[] = [];
+		const result: Promise<IEditorPane | null>[] = [];
 		mapGroupToEditors.forEach((editorsWithOptions, group) => {
 			result.push(group.openEditors(editorsWithOptions));
 		});
@@ -1102,11 +1102,11 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 export interface IEditorOpenHandler {
 	(
-		delegate: (group: IEditorGroup, editor: IEditorInput, options?: IEditorOptions) => Promise<IEditor | null>,
+		delegate: (group: IEditorGroup, editor: IEditorInput, options?: IEditorOptions) => Promise<IEditorPane | null>,
 		group: IEditorGroup,
 		editor: IEditorInput,
 		options?: IEditorOptions | ITextEditorOptions
-	): Promise<IEditor | null>;
+	): Promise<IEditorPane | null>;
 }
 
 /**
@@ -1123,11 +1123,11 @@ export class DelegatingEditorService implements IEditorService {
 		@IEditorService private editorService: EditorService
 	) { }
 
-	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: OpenInEditorGroup): Promise<IEditor | undefined>;
+	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: OpenInEditorGroup): Promise<IEditorPane | undefined>;
 	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: OpenInEditorGroup): Promise<ITextEditor | undefined>;
 	openEditor(editor: IResourceDiffInput, group?: OpenInEditorGroup): Promise<ITextDiffEditor | undefined>;
 	openEditor(editor: IResourceSideBySideInput, group?: OpenInEditorGroup): Promise<ITextSideBySideEditor | undefined>;
-	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | OpenInEditorGroup, group?: OpenInEditorGroup): Promise<IEditor | undefined> {
+	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | OpenInEditorGroup, group?: OpenInEditorGroup): Promise<IEditorPane | undefined> {
 		const result = this.editorService.doResolveEditorOpenRequest(editor, optionsOrGroup, group);
 		if (result) {
 			const [resolvedGroup, resolvedEditor, resolvedOptions] = result;
@@ -1167,9 +1167,9 @@ export class DelegatingEditorService implements IEditorService {
 
 	getEditors(order: EditorsOrder): ReadonlyArray<IEditorIdentifier> { return this.editorService.getEditors(order); }
 
-	openEditors(editors: IEditorInputWithOptions[], group?: OpenInEditorGroup): Promise<IEditor[]>;
-	openEditors(editors: IResourceEditor[], group?: OpenInEditorGroup): Promise<IEditor[]>;
-	openEditors(editors: Array<IEditorInputWithOptions | IResourceEditor>, group?: OpenInEditorGroup): Promise<IEditor[]> {
+	openEditors(editors: IEditorInputWithOptions[], group?: OpenInEditorGroup): Promise<IEditorPane[]>;
+	openEditors(editors: IResourceEditor[], group?: OpenInEditorGroup): Promise<IEditorPane[]>;
+	openEditors(editors: Array<IEditorInputWithOptions | IResourceEditor>, group?: OpenInEditorGroup): Promise<IEditorPane[]> {
 		return this.editorService.openEditors(editors, group);
 	}
 

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -402,9 +402,9 @@ export interface IEditorGroup {
 	readonly ariaLabel: string;
 
 	/**
-	 * The active control is the currently visible control of the group.
+	 * The active ediotr pane is the currently visible editor pane of the group.
 	 */
-	readonly activeControl: IVisibleEditorPane | undefined;
+	readonly activeEditorPane: IVisibleEditorPane | undefined;
 
 	/**
 	 * The active editor is the currently visible editor of the group

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -5,7 +5,7 @@
 
 import { Event } from 'vs/base/common/event';
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { IEditorInput, IEditor, GroupIdentifier, IEditorInputWithOptions, CloseDirection, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
+import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, CloseDirection, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
 import { IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IDimension } from 'vs/editor/common/editorCommon';
@@ -451,7 +451,7 @@ export interface IEditorGroup {
 	 * @returns a promise that resolves around an IEditor instance unless
 	 * the call failed, or the editor was not opened as active editor.
 	 */
-	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions): Promise<IEditor | null>;
+	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions): Promise<IEditorPane | null>;
 
 	/**
 	 * Opens editors in this group.
@@ -461,7 +461,7 @@ export interface IEditorGroup {
 	 * a group can only ever have one active editor, even if many editors are
 	 * opened, the result will only be one editor.
 	 */
-	openEditors(editors: IEditorInputWithOptions[]): Promise<IEditor | null>;
+	openEditors(editors: IEditorInputWithOptions[]): Promise<IEditorPane | null>;
 
 	/**
 	 * Find out if the provided editor is opened in the group.

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -5,7 +5,7 @@
 
 import { Event } from 'vs/base/common/event';
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, CloseDirection, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
+import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, CloseDirection, IEditorPartOptions, IEditorPartOptionsChangeEvent, EditorsOrder, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IDimension } from 'vs/editor/common/editorCommon';
@@ -404,7 +404,7 @@ export interface IEditorGroup {
 	/**
 	 * The active control is the currently visible control of the group.
 	 */
-	readonly activeControl: IVisibleEditor | undefined;
+	readonly activeControl: IVisibleEditorPane | undefined;
 
 	/**
 	 * The active editor is the currently visible editor of the group

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -7,7 +7,7 @@ import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/com
 import { IResourceInput, IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, IUntitledTextResourceInput, IResourceDiffInput, ITextEditorPane, ITextDiffEditorPane, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { Event } from 'vs/base/common/event';
-import { IEditor as ICodeEditor, IDiffEditor } from 'vs/editor/common/editorCommon';
+import { IEditor, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorGroup, IEditorReplacement } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IDisposable } from 'vs/base/common/lifecycle';
 
@@ -98,7 +98,7 @@ export interface IEditorService {
 	 *
 	 * @see `IEditorService.activeEditor`
 	 */
-	readonly activeTextEditorWidget: ICodeEditor | IDiffEditor | undefined;
+	readonly activeTextEditorWidget: IEditor | IDiffEditor | undefined;
 
 	/**
 	 * The currently active text editor mode or `undefined` if there is currently no active
@@ -122,7 +122,7 @@ export interface IEditorService {
 	 * All text editor widgets that are currently visible across all editor groups. A text editor
 	 * widget is either a text or a diff editor.
 	 */
-	readonly visibleTextEditorWidgets: ReadonlyArray<ICodeEditor | IDiffEditor>;
+	readonly visibleTextEditorWidgets: ReadonlyArray<IEditor | IDiffEditor>;
 
 	/**
 	 * All editors that are opened across all editor groups in sequential order

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -5,7 +5,7 @@
 
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IResourceInput, IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
-import { IEditorInput, IEditor, GroupIdentifier, IEditorInputWithOptions, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
+import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
 import { Event } from 'vs/base/common/event';
 import { IEditor as ICodeEditor, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorGroup, IEditorReplacement } from 'vs/workbench/services/editor/common/editorGroupsService';
@@ -36,7 +36,7 @@ export interface IOpenEditorOverride {
 	 * If defined, will prevent the opening of an editor and replace the resulting
 	 * promise with the provided promise for the openEditor() call.
 	 */
-	override?: Promise<IEditor | undefined>;
+	override?: Promise<IEditorPane | undefined>;
 }
 
 export interface ISaveEditorsOptions extends ISaveOptions {
@@ -157,7 +157,7 @@ export interface IEditorService {
 	 * @returns the editor that opened or `undefined` if the operation failed or the editor was not
 	 * opened to be active.
 	 */
-	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditor | undefined>;
+	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined>;
 	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditor | undefined>;
 	openEditor(editor: IResourceDiffInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditor | undefined>;
 	openEditor(editor: IResourceSideBySideInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextSideBySideEditor | undefined>;
@@ -173,8 +173,8 @@ export interface IEditorService {
 	 * @returns the editors that opened. The array can be empty or have less elements for editors
 	 * that failed to open or were instructed to open as inactive.
 	 */
-	openEditors(editors: IEditorInputWithOptions[], group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ReadonlyArray<IEditor>>;
-	openEditors(editors: IResourceEditor[], group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ReadonlyArray<IEditor>>;
+	openEditors(editors: IEditorInputWithOptions[], group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ReadonlyArray<IEditorPane>>;
+	openEditors(editors: IResourceEditor[], group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ReadonlyArray<IEditorPane>>;
 
 	/**
 	 * Replaces editors in an editor group with the provided replacement.

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -5,7 +5,7 @@
 
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IResourceInput, IEditorOptions, ITextEditorOptions } from 'vs/platform/editor/common/editor';
-import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditor } from 'vs/workbench/common/editor';
+import { IEditorInput, IEditorPane, GroupIdentifier, IEditorInputWithOptions, IUntitledTextResourceInput, IResourceDiffInput, ITextEditorPane, ITextDiffEditorPane, IEditorIdentifier, ISaveOptions, IRevertOptions, EditorsOrder, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { Event } from 'vs/base/common/event';
 import { IEditor as ICodeEditor, IDiffEditor } from 'vs/editor/common/editorCommon';
 import { IEditorGroup, IEditorReplacement } from 'vs/workbench/services/editor/common/editorGroupsService';
@@ -13,7 +13,7 @@ import { IDisposable } from 'vs/base/common/lifecycle';
 
 export const IEditorService = createDecorator<IEditorService>('editorService');
 
-export type IResourceEditor = IResourceInput | IUntitledTextResourceInput | IResourceDiffInput | IResourceSideBySideInput;
+export type IResourceEditor = IResourceInput | IUntitledTextResourceInput | IResourceDiffInput;
 
 export interface IResourceEditorReplacement {
 	readonly editor: IResourceEditor;
@@ -90,7 +90,7 @@ export interface IEditorService {
 	 *
 	 * @see `IEditorService.activeEditor`
 	 */
-	readonly activeControl: IVisibleEditor | undefined;
+	readonly activeControl: IVisibleEditorPane | undefined;
 
 	/**
 	 * The currently active text editor widget or `undefined` if there is currently no active
@@ -116,7 +116,7 @@ export interface IEditorService {
 	/**
 	 * All editor controls that are currently visible across all editor groups.
 	 */
-	readonly visibleControls: ReadonlyArray<IVisibleEditor>;
+	readonly visibleControls: ReadonlyArray<IVisibleEditorPane>;
 
 	/**
 	 * All text editor widgets that are currently visible across all editor groups. A text editor
@@ -158,9 +158,8 @@ export interface IEditorService {
 	 * opened to be active.
 	 */
 	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined>;
-	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditor | undefined>;
-	openEditor(editor: IResourceDiffInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditor | undefined>;
-	openEditor(editor: IResourceSideBySideInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextSideBySideEditor | undefined>;
+	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditorPane | undefined>;
+	openEditor(editor: IResourceDiffInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditorPane | undefined>;
 
 	/**
 	 * Open editors in an editor group.

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -78,19 +78,19 @@ export interface IEditorService {
 	readonly onDidVisibleEditorsChange: Event<void>;
 
 	/**
+	 * The currently active editor pane or `undefined` if none. The editor pane is
+	 * the workbench container for editors of any kind.
+	 *
+	 * @see `IEditorService.activeEditor`
+	 */
+	readonly activeEditorPane: IVisibleEditorPane | undefined;
+
+	/**
 	 * The currently active editor or `undefined` if none. An editor is active when it is
 	 * located in the currently active editor group. It will be `undefined` if the active
 	 * editor group has no editors open.
 	 */
 	readonly activeEditor: IEditorInput | undefined;
-
-	/**
-	 * The currently active editor control or `undefined` if none. The editor control is
-	 * the workbench container for editors of any kind.
-	 *
-	 * @see `IEditorService.activeEditor`
-	 */
-	readonly activeControl: IVisibleEditorPane | undefined;
 
 	/**
 	 * The currently active text editor widget or `undefined` if there is currently no active
@@ -108,15 +108,15 @@ export interface IEditorService {
 	readonly activeTextEditorMode: string | undefined;
 
 	/**
+	 * All editor panes that are currently visible across all editor groups.
+	 */
+	readonly visibleEditorPanes: ReadonlyArray<IVisibleEditorPane>;
+
+	/**
 	 * All editors that are currently visible. An editor is visible when it is opened in an
 	 * editor group and active in that group. Multiple editor groups can be opened at the same time.
 	 */
 	readonly visibleEditors: ReadonlyArray<IEditorInput>;
-
-	/**
-	 * All editor controls that are currently visible across all editor groups.
-	 */
-	readonly visibleControls: ReadonlyArray<IVisibleEditorPane>;
 
 	/**
 	 * All text editor widgets that are currently visible across all editor groups. A text editor

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -93,16 +93,16 @@ export interface IEditorService {
 	readonly activeEditor: IEditorInput | undefined;
 
 	/**
-	 * The currently active text editor widget or `undefined` if there is currently no active
+	 * The currently active text editor control or `undefined` if there is currently no active
 	 * editor or the active editor widget is neither a text nor a diff editor.
 	 *
 	 * @see `IEditorService.activeEditor`
 	 */
-	readonly activeTextEditorWidget: IEditor | IDiffEditor | undefined;
+	readonly activeTextEditorControl: IEditor | IDiffEditor | undefined;
 
 	/**
 	 * The currently active text editor mode or `undefined` if there is currently no active
-	 * editor or the active editor widget is neither a text nor a diff editor. If the active
+	 * editor or the active editor control is neither a text nor a diff editor. If the active
 	 * editor is a diff editor, the modified side's mode will be taken.
 	 */
 	readonly activeTextEditorMode: string | undefined;
@@ -122,7 +122,7 @@ export interface IEditorService {
 	 * All text editor widgets that are currently visible across all editor groups. A text editor
 	 * widget is either a text or a diff editor.
 	 */
-	readonly visibleTextEditorWidgets: ReadonlyArray<IEditor | IDiffEditor>;
+	readonly visibleTextEditorControls: ReadonlyArray<IEditor | IDiffEditor>;
 
 	/**
 	 * All editors that are opened across all editor groups in sequential order

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -123,7 +123,7 @@ suite('EditorGroupsService', () => {
 		assert.equal(groupAddedCounter, 2);
 		assert.equal(part.groups.length, 3);
 		assert.ok(part.activeGroup === rightGroup);
-		assert.ok(!downGroup.activeControl);
+		assert.ok(!downGroup.activeEditorPane);
 		assert.equal(rootGroup.label, 'Group 1');
 		assert.equal(rightGroup.label, 'Group 2');
 		assert.equal(downGroup.label, 'Group 3');
@@ -425,7 +425,7 @@ suite('EditorGroupsService', () => {
 		assert.ok(!group.previewEditor);
 
 		assert.equal(group.activeEditor, input);
-		assert.equal(group.activeControl?.getId(), TEST_EDITOR_ID);
+		assert.equal(group.activeEditorPane?.getId(), TEST_EDITOR_ID);
 		assert.equal(group.count, 2);
 
 		const mru = group.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE);

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -94,13 +94,13 @@ suite('EditorService', () => {
 		let editor = await service.openEditor(input, { pinned: true });
 
 		assert.equal(editor?.getId(), TEST_EDITOR_ID);
-		assert.equal(editor, service.activeControl);
+		assert.equal(editor, service.activeEditorPane);
 		assert.equal(1, service.count);
 		assert.equal(input, service.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[0].editor);
 		assert.equal(input, service.getEditors(EditorsOrder.SEQUENTIAL)[0].editor);
 		assert.equal(input, service.activeEditor);
-		assert.equal(service.visibleControls.length, 1);
-		assert.equal(service.visibleControls[0], editor);
+		assert.equal(service.visibleEditorPanes.length, 1);
+		assert.equal(service.visibleEditorPanes[0], editor);
 		assert.ok(!service.activeTextEditorWidget);
 		assert.ok(!service.activeTextEditorMode);
 		assert.equal(service.visibleTextEditorWidgets.length, 0);
@@ -136,7 +136,7 @@ suite('EditorService', () => {
 		assert.equal(input, service.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[1].editor);
 		assert.equal(input, service.getEditors(EditorsOrder.SEQUENTIAL)[0].editor);
 		assert.equal(otherInput, service.getEditors(EditorsOrder.SEQUENTIAL)[1].editor);
-		assert.equal(service.visibleControls.length, 1);
+		assert.equal(service.visibleEditorPanes.length, 1);
 		assert.equal(service.isOpen(input), true);
 		assert.equal(service.isOpen({ resource: input.resource }), true);
 		assert.equal(service.isOpen(otherInput), true);
@@ -740,7 +740,7 @@ suite('EditorService', () => {
 		// Open untitled input
 		let editor = await service.openEditor({});
 
-		assert.equal(service.activeControl, editor);
+		assert.equal(service.activeEditorPane, editor);
 		assert.equal(service.activeTextEditorWidget, editor?.getControl());
 		assert.equal(service.activeTextEditorMode, 'plaintext');
 

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -101,9 +101,9 @@ suite('EditorService', () => {
 		assert.equal(input, service.activeEditor);
 		assert.equal(service.visibleEditorPanes.length, 1);
 		assert.equal(service.visibleEditorPanes[0], editor);
-		assert.ok(!service.activeTextEditorWidget);
+		assert.ok(!service.activeTextEditorControl);
 		assert.ok(!service.activeTextEditorMode);
-		assert.equal(service.visibleTextEditorWidgets.length, 0);
+		assert.equal(service.visibleTextEditorControls.length, 0);
 		assert.equal(service.isOpen(input), true);
 		assert.equal(service.isOpen({ resource: input.resource }), true);
 		assert.equal(activeEditorChangeEventCounter, 1);
@@ -732,7 +732,7 @@ suite('EditorService', () => {
 		part.dispose();
 	});
 
-	test('activeTextEditorWidget / activeTextEditorMode', async () => {
+	test('activeTextEditorControl / activeTextEditorMode', async () => {
 		const [part, service] = createEditorService();
 
 		await part.whenRestored;
@@ -741,7 +741,7 @@ suite('EditorService', () => {
 		let editor = await service.openEditor({});
 
 		assert.equal(service.activeEditorPane, editor);
-		assert.equal(service.activeTextEditorWidget, editor?.getControl());
+		assert.equal(service.activeTextEditorControl, editor?.getControl());
 		assert.equal(service.activeTextEditorMode, 'plaintext');
 
 		part.dispose();

--- a/src/vs/workbench/services/editor/test/browser/editorService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorService.test.ts
@@ -345,13 +345,6 @@ suite('EditorService', () => {
 		input = service.createInput({ resource: URI.parse('custom:resource') });
 		assert(input instanceof ResourceEditorInput);
 
-		// Untyped Input (side by side)
-		input = service.createInput({
-			masterResource: toResource.call(this, '/master.html'),
-			detailResource: toResource.call(this, '/detail.html')
-		});
-		assert(input instanceof SideBySideEditorInput);
-
 		// Untyped Input (diff)
 		input = service.createInput({
 			leftResource: toResource.call(this, '/master.html'),

--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -6,7 +6,7 @@
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { IEditor } from 'vs/editor/common/editorCommon';
 import { ITextEditorOptions, IResourceInput, TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
-import { IEditorInput, IEditor as IBaseEditor, Extensions as EditorExtensions, EditorInput, IEditorCloseEvent, IEditorInputFactoryRegistry, toResource, IEditorIdentifier, GroupIdentifier, EditorsOrder } from 'vs/workbench/common/editor';
+import { IEditorInput, IEditorPane, Extensions as EditorExtensions, EditorInput, IEditorCloseEvent, IEditorInputFactoryRegistry, toResource, IEditorIdentifier, GroupIdentifier, EditorsOrder } from 'vs/workbench/common/editor';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { FileChangesEvent, IFileService, FileChangeType, FILES_EXCLUDE_CONFIG } from 'vs/platform/files/common/files';
@@ -206,7 +206,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		}
 	}
 
-	private matchesEditor(identifier: IEditorIdentifier, editor?: IBaseEditor): boolean {
+	private matchesEditor(identifier: IEditorIdentifier, editor?: IEditorPane): boolean {
 		if (!editor || !editor.group) {
 			return false;
 		}
@@ -224,11 +224,11 @@ export class HistoryService extends Disposable implements IHistoryService {
 		}
 	}
 
-	private handleEditorSelectionChangeEvent(editor?: IBaseEditor, event?: ICursorPositionChangedEvent): void {
+	private handleEditorSelectionChangeEvent(editor?: IEditorPane, event?: ICursorPositionChangedEvent): void {
 		this.handleEditorEventInNavigationStack(editor, event);
 	}
 
-	private handleActiveEditorChange(editor?: IBaseEditor): void {
+	private handleActiveEditorChange(editor?: IEditorPane): void {
 		this.handleEditorEventInHistory(editor);
 		this.handleEditorEventInNavigationStack(editor);
 	}
@@ -344,7 +344,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		this.doNavigate(navigateToStackEntry).finally(() => this.navigatingInStack = false);
 	}
 
-	private doNavigate(location: IStackEntry): Promise<IBaseEditor | undefined> {
+	private doNavigate(location: IStackEntry): Promise<IEditorPane | undefined> {
 		const options: ITextEditorOptions = {
 			revealIfOpened: true, // support to navigate across editor groups,
 			selection: location.selection,
@@ -358,7 +358,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		return this.editorService.openEditor({ resource: (location.input as IResourceInput).resource, options });
 	}
 
-	private handleEditorEventInNavigationStack(control: IBaseEditor | undefined, event?: ICursorPositionChangedEvent): void {
+	private handleEditorEventInNavigationStack(control: IEditorPane | undefined, event?: ICursorPositionChangedEvent): void {
 		const codeEditor = control ? getCodeEditor(control.getControl()) : undefined;
 
 		// treat editor changes that happen as part of stack navigation specially
@@ -392,7 +392,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		}
 	}
 
-	private handleTextEditorEventInNavigationStack(editor: IBaseEditor, editorControl: IEditor, event?: ICursorPositionChangedEvent): void {
+	private handleTextEditorEventInNavigationStack(editor: IEditorPane, editorControl: IEditor, event?: ICursorPositionChangedEvent): void {
 		if (!editor.input) {
 			return;
 		}
@@ -413,7 +413,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		this.currentTextEditorState = stateCandidate;
 	}
 
-	private handleNonTextEditorEventInNavigationStack(editor: IBaseEditor): void {
+	private handleNonTextEditorEventInNavigationStack(editor: IEditorPane): void {
 		if (!editor.input) {
 			return;
 		}
@@ -730,7 +730,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		return getExcludes(scope ? this.configurationService.getValue<ISearchConfiguration>(scope) : this.configurationService.getValue<ISearchConfiguration>())!;
 	}
 
-	private handleEditorEventInHistory(editor?: IBaseEditor): void {
+	private handleEditorEventInHistory(editor?: IEditorPane): void {
 
 		// Ensure we have not configured to exclude input and don't track invalid inputs
 		const input = editor?.input;

--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -184,23 +184,23 @@ export class HistoryService extends Disposable implements IHistoryService {
 		this.handleActiveEditorChange(activeEditorPane);
 
 		// Apply listener for selection changes if this is a text editor
-		const activeTextEditorWidget = getCodeEditor(this.editorService.activeTextEditorWidget);
+		const activeTextEditorControl = getCodeEditor(this.editorService.activeTextEditorControl);
 		const activeEditor = this.editorService.activeEditor;
-		if (activeTextEditorWidget) {
+		if (activeTextEditorControl) {
 
 			// Debounce the event with a timeout of 0ms so that multiple calls to
 			// editor.setSelection() are folded into one. We do not want to record
 			// subsequent history navigations for such API calls.
-			this.activeEditorListeners.add(Event.debounce(activeTextEditorWidget.onDidChangeCursorPosition, (last, event) => event, 0)((event => {
+			this.activeEditorListeners.add(Event.debounce(activeTextEditorControl.onDidChangeCursorPosition, (last, event) => event, 0)((event => {
 				this.handleEditorSelectionChangeEvent(activeEditorPane, event);
 			})));
 
 			// Track the last edit location by tracking model content change events
 			// Use a debouncer to make sure to capture the correct cursor position
 			// after the model content has changed.
-			this.activeEditorListeners.add(Event.debounce(activeTextEditorWidget.onDidChangeModelContent, (last, event) => event, 0)((event => {
+			this.activeEditorListeners.add(Event.debounce(activeTextEditorControl.onDidChangeModelContent, (last, event) => event, 0)((event => {
 				if (activeEditor) {
-					this.rememberLastEditLocation(activeEditor, activeTextEditorWidget);
+					this.rememberLastEditLocation(activeEditor, activeTextEditorControl);
 				}
 			})));
 		}
@@ -677,11 +677,11 @@ export class HistoryService extends Disposable implements IHistoryService {
 
 	private lastEditLocation: IStackEntry | undefined;
 
-	private rememberLastEditLocation(activeEditor: IEditorInput, activeTextEditorWidget: ICodeEditor): void {
+	private rememberLastEditLocation(activeEditor: IEditorInput, activeTextEditorControl: ICodeEditor): void {
 		this.lastEditLocation = { input: activeEditor };
 		this.canNavigateToLastEditLocationContextKey.set(true);
 
-		const position = activeTextEditorWidget.getPosition();
+		const position = activeTextEditorControl.getPosition();
 		if (position) {
 			this.lastEditLocation.selection = new Selection(position.lineNumber, position.column, position.lineNumber, position.column);
 		}

--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -130,7 +130,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 		// if the service is created late enough that an editor is already opened
 		// make sure to trigger the onActiveEditorChanged() to track the editor
 		// properly (fixes https://github.com/Microsoft/vscode/issues/59908)
-		if (this.editorService.activeControl) {
+		if (this.editorService.activeEditorPane) {
 			this.onActiveEditorChanged();
 		}
 
@@ -169,19 +169,19 @@ export class HistoryService extends Disposable implements IHistoryService {
 	}
 
 	private onActiveEditorChanged(): void {
-		const activeControl = this.editorService.activeControl;
-		if (this.lastActiveEditor && this.matchesEditor(this.lastActiveEditor, activeControl)) {
+		const activeEditorPane = this.editorService.activeEditorPane;
+		if (this.lastActiveEditor && this.matchesEditor(this.lastActiveEditor, activeEditorPane)) {
 			return; // return if the active editor is still the same
 		}
 
 		// Remember as last active editor (can be undefined if none opened)
-		this.lastActiveEditor = activeControl?.input && activeControl.group ? { editor: activeControl.input, groupId: activeControl.group.id } : undefined;
+		this.lastActiveEditor = activeEditorPane?.input && activeEditorPane.group ? { editor: activeEditorPane.input, groupId: activeEditorPane.group.id } : undefined;
 
 		// Dispose old listeners
 		this.activeEditorListeners.clear();
 
 		// Propagate to history
-		this.handleActiveEditorChange(activeControl);
+		this.handleActiveEditorChange(activeEditorPane);
 
 		// Apply listener for selection changes if this is a text editor
 		const activeTextEditorWidget = getCodeEditor(this.editorService.activeTextEditorWidget);
@@ -192,7 +192,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 			// editor.setSelection() are folded into one. We do not want to record
 			// subsequent history navigations for such API calls.
 			this.activeEditorListeners.add(Event.debounce(activeTextEditorWidget.onDidChangeCursorPosition, (last, event) => event, 0)((event => {
-				this.handleEditorSelectionChangeEvent(activeControl, event);
+				this.handleEditorSelectionChangeEvent(activeEditorPane, event);
 			})));
 
 			// Track the last edit location by tracking model content change events

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -215,7 +215,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 	private openSettings2(options?: ISettingsEditorOptions): Promise<IEditorPane> {
 		const input = this.settingsEditor2Input;
 		return this.editorService.openEditor(input, options ? SettingsEditorOptions.create(options) : undefined)
-			.then(() => this.editorGroupService.activeGroup.activeControl!);
+			.then(() => this.editorGroupService.activeGroup.activeEditorPane!);
 	}
 
 	openGlobalSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
@@ -271,9 +271,9 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 			return this.doOpenSettings2(target, resource).then(() => undefined);
 		}
 
-		const activeControl = this.editorService.activeControl;
-		if (activeControl && activeControl.input instanceof PreferencesEditorInput) {
-			return this.doSwitchSettings(target, resource, activeControl.input, activeControl.group).then(() => undefined);
+		const activeEditorPane = this.editorService.activeEditorPane;
+		if (activeEditorPane?.input instanceof PreferencesEditorInput) {
+			return this.doSwitchSettings(target, resource, activeEditorPane.input, activeEditorPane.group).then(() => undefined);
 		} else {
 			return this.doOpenSettings(target, resource).then(() => undefined);
 		}
@@ -420,7 +420,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 						options: options ? SettingsEditorOptions.create(options) : undefined
 					}]).then(() => {
 						this.lastOpenedSettingsInput = replaceWith;
-						return group.activeControl!;
+						return group.activeEditorPane!;
 					});
 				});
 			});

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -28,7 +28,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
-import { EditorInput, IEditor } from 'vs/workbench/common/editor';
+import { EditorInput, IEditorPane } from 'vs/workbench/common/editor';
 import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { GroupDirection, IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
@@ -189,15 +189,15 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return null;
 	}
 
-	openRawDefaultSettings(): Promise<IEditor | undefined> {
+	openRawDefaultSettings(): Promise<IEditorPane | undefined> {
 		return this.editorService.openEditor({ resource: this.defaultSettingsRawResource });
 	}
 
-	openRawUserSettings(): Promise<IEditor | undefined> {
+	openRawUserSettings(): Promise<IEditorPane | undefined> {
 		return this.editorService.openEditor({ resource: this.userSettingsResource });
 	}
 
-	openSettings(jsonEditor: boolean | undefined, query: string | undefined): Promise<IEditor | undefined> {
+	openSettings(jsonEditor: boolean | undefined, query: string | undefined): Promise<IEditorPane | undefined> {
 		jsonEditor = typeof jsonEditor === 'undefined' ?
 			this.configurationService.getValue('workbench.settings.editor') === 'json' :
 			jsonEditor;
@@ -212,13 +212,13 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.openOrSwitchSettings(target, resource, { query: query });
 	}
 
-	private openSettings2(options?: ISettingsEditorOptions): Promise<IEditor> {
+	private openSettings2(options?: ISettingsEditorOptions): Promise<IEditorPane> {
 		const input = this.settingsEditor2Input;
 		return this.editorService.openEditor(input, options ? SettingsEditorOptions.create(options) : undefined)
 			.then(() => this.editorGroupService.activeGroup.activeControl!);
 	}
 
-	openGlobalSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined> {
+	openGlobalSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
 		jsonEditor = typeof jsonEditor === 'undefined' ?
 			this.configurationService.getValue('workbench.settings.editor') === 'json' :
 			jsonEditor;
@@ -228,7 +228,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 			this.openOrSwitchSettings2(ConfigurationTarget.USER_LOCAL, undefined, options, group);
 	}
 
-	async openRemoteSettings(): Promise<IEditor | undefined> {
+	async openRemoteSettings(): Promise<IEditorPane | undefined> {
 		const environment = await this.remoteAgentService.getEnvironment();
 		if (environment) {
 			await this.createIfNotExists(environment.settingsPath, emptyEditableSettingsContent);
@@ -237,7 +237,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return undefined;
 	}
 
-	openWorkspaceSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined> {
+	openWorkspaceSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
 		jsonEditor = typeof jsonEditor === 'undefined' ?
 			this.configurationService.getValue('workbench.settings.editor') === 'json' :
 			jsonEditor;
@@ -252,7 +252,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 			this.openOrSwitchSettings2(ConfigurationTarget.WORKSPACE, undefined, options, group);
 	}
 
-	async openFolderSettings(folder: URI, jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined> {
+	async openFolderSettings(folder: URI, jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
 		jsonEditor = typeof jsonEditor === 'undefined' ?
 			this.configurationService.getValue('workbench.settings.editor') === 'json' :
 			jsonEditor;
@@ -307,7 +307,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.editorService.openEditor(this.instantiationService.createInstance(KeybindingsEditorInput), { pinned: true, revealIfOpened: true }).then(() => undefined);
 	}
 
-	openDefaultKeybindingsFile(): Promise<IEditor | undefined> {
+	openDefaultKeybindingsFile(): Promise<IEditorPane | undefined> {
 		return this.editorService.openEditor({ resource: this.defaultKeybindingsResource, label: nls.localize('defaultKeybindings', "Default Keybindings") });
 	}
 
@@ -329,7 +329,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 				}));
 	}
 
-	private openOrSwitchSettings(configurationTarget: ConfigurationTarget, resource: URI, options?: ISettingsEditorOptions, group: IEditorGroup = this.editorGroupService.activeGroup): Promise<IEditor | undefined> {
+	private openOrSwitchSettings(configurationTarget: ConfigurationTarget, resource: URI, options?: ISettingsEditorOptions, group: IEditorGroup = this.editorGroupService.activeGroup): Promise<IEditorPane | undefined> {
 		const editorInput = this.getActiveSettingsEditorInput(group);
 		if (editorInput) {
 			const editorInputResource = editorInput.master.resource;
@@ -340,11 +340,11 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.doOpenSettings(configurationTarget, resource, options, group);
 	}
 
-	private openOrSwitchSettings2(configurationTarget: ConfigurationTarget, folderUri?: URI, options?: ISettingsEditorOptions, group: IEditorGroup = this.editorGroupService.activeGroup): Promise<IEditor | undefined> {
+	private openOrSwitchSettings2(configurationTarget: ConfigurationTarget, folderUri?: URI, options?: ISettingsEditorOptions, group: IEditorGroup = this.editorGroupService.activeGroup): Promise<IEditorPane | undefined> {
 		return this.doOpenSettings2(configurationTarget, folderUri, options, group);
 	}
 
-	private doOpenSettings(configurationTarget: ConfigurationTarget, resource: URI, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined> {
+	private doOpenSettings(configurationTarget: ConfigurationTarget, resource: URI, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
 		const openSplitJSON = !!this.configurationService.getValue(USE_SPLIT_JSON_SETTING);
 		if (openSplitJSON) {
 			return this.doOpenSplitJSON(configurationTarget, resource, options, group);
@@ -373,7 +373,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 			});
 	}
 
-	private doOpenSplitJSON(configurationTarget: ConfigurationTarget, resource: URI, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined> {
+	private doOpenSplitJSON(configurationTarget: ConfigurationTarget, resource: URI, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
 		return this.getOrCreateEditableSettingsEditorInput(configurationTarget, resource)
 			.then(editableSettingsEditorInput => {
 				if (!options) {
@@ -393,7 +393,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.instantiationService.createInstance(Settings2EditorModel, this.getDefaultSettings(ConfigurationTarget.USER_LOCAL));
 	}
 
-	private doOpenSettings2(target: ConfigurationTarget, folderUri: URI | undefined, options?: IEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined> {
+	private doOpenSettings2(target: ConfigurationTarget, folderUri: URI | undefined, options?: IEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined> {
 		const input = this.settingsEditor2Input;
 		const settingsOptions: ISettingsEditorOptions = {
 			...options,
@@ -404,7 +404,7 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return this.editorService.openEditor(input, SettingsEditorOptions.create(settingsOptions), group);
 	}
 
-	private async doSwitchSettings(target: ConfigurationTarget, resource: URI, input: PreferencesEditorInput, group: IEditorGroup, options?: ISettingsEditorOptions): Promise<IEditor> {
+	private async doSwitchSettings(target: ConfigurationTarget, resource: URI, input: PreferencesEditorInput, group: IEditorGroup, options?: ISettingsEditorOptions): Promise<IEditorPane> {
 		const settingsURI = await this.getEditableSettingsURI(target, resource);
 		if (!settingsURI) {
 			return Promise.reject(`Invalid settings URI - ${resource.toString()}`);

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -14,7 +14,7 @@ import { ConfigurationScope, IConfigurationExtensionInfo } from 'vs/platform/con
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { EditorOptions, IEditor } from 'vs/workbench/common/editor';
+import { EditorOptions, IEditorPane } from 'vs/workbench/common/editor';
 import { IEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { Settings2EditorModel } from 'vs/workbench/services/preferences/common/preferencesModels';
 
@@ -194,15 +194,15 @@ export interface IPreferencesService {
 	createPreferencesEditorModel<T>(uri: URI): Promise<IPreferencesEditorModel<T> | null>;
 	createSettings2EditorModel(): Settings2EditorModel; // TODO
 
-	openRawDefaultSettings(): Promise<IEditor | undefined>;
-	openSettings(jsonEditor: boolean | undefined, query: string | undefined): Promise<IEditor | undefined>;
-	openGlobalSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
-	openRemoteSettings(): Promise<IEditor | undefined>;
-	openWorkspaceSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
-	openFolderSettings(folder: URI, jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditor | undefined>;
+	openRawDefaultSettings(): Promise<IEditorPane | undefined>;
+	openSettings(jsonEditor: boolean | undefined, query: string | undefined): Promise<IEditorPane | undefined>;
+	openGlobalSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined>;
+	openRemoteSettings(): Promise<IEditorPane | undefined>;
+	openWorkspaceSettings(jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined>;
+	openFolderSettings(folder: URI, jsonEditor?: boolean, options?: ISettingsEditorOptions, group?: IEditorGroup): Promise<IEditorPane | undefined>;
 	switchSettings(target: ConfigurationTarget, resource: URI, jsonEditor?: boolean): Promise<void>;
 	openGlobalKeybindingSettings(textual: boolean): Promise<void>;
-	openDefaultKeybindingsFile(): Promise<IEditor | undefined>;
+	openDefaultKeybindingsFile(): Promise<IEditorPane | undefined>;
 
 	configureSettingsForLanguage(language: string | null): void;
 }

--- a/src/vs/workbench/test/browser/parts/editor/rangeDecorations.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/rangeDecorations.test.ts
@@ -42,7 +42,7 @@ suite('Editor - Range decorations', () => {
 		codeEditor = createTestCodeEditor({ model: model });
 
 		instantiationService.stub(IEditorService, 'activeEditor', { get resource() { return codeEditor.getModel()!.uri; } });
-		instantiationService.stub(IEditorService, 'activeTextEditorWidget', codeEditor);
+		instantiationService.stub(IEditorService, 'activeTextEditorControl', codeEditor);
 
 		testObject = instantiationService.createInstance(RangeHighlightDecorations);
 	});

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -10,7 +10,7 @@ import * as resources from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
-import { IEditorInputWithOptions, CloseDirection, IEditorIdentifier, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, IEditorInput, IEditor, IEditorCloseEvent, IEditorPartOptions, IRevertOptions, GroupIdentifier, EditorInput, EditorOptions, EditorsOrder, IFileEditorInput, IEditorInputFactoryRegistry, IEditorInputFactory, Extensions as EditorExtensions, ISaveOptions, IMoveResult, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IVisibleEditor } from 'vs/workbench/common/editor';
+import { IEditorInputWithOptions, CloseDirection, IEditorIdentifier, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, IEditorInput, IEditorPane, IEditorCloseEvent, IEditorPartOptions, IRevertOptions, GroupIdentifier, EditorInput, EditorOptions, EditorsOrder, IFileEditorInput, IEditorInputFactoryRegistry, IEditorInputFactory, Extensions as EditorExtensions, ISaveOptions, IMoveResult, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IVisibleEditor } from 'vs/workbench/common/editor';
 import { IEditorOpeningEvent, EditorServiceImpl, IEditorGroupView, IEditorGroupsAccessor } from 'vs/workbench/browser/parts/editor/editor';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IBackupFileService, IResolvedBackup } from 'vs/workbench/services/backup/common/backup';
@@ -539,8 +539,8 @@ export class TestEditorGroupView implements IEditorGroupView {
 	getEditors(_order?: EditorsOrder): ReadonlyArray<IEditorInput> { return []; }
 	getEditorByIndex(_index: number): IEditorInput { throw new Error('not implemented'); }
 	getIndexOfEditor(_editor: IEditorInput): number { return -1; }
-	openEditor(_editor: IEditorInput, _options?: IEditorOptions): Promise<IEditor> { throw new Error('not implemented'); }
-	openEditors(_editors: IEditorInputWithOptions[]): Promise<IEditor> { throw new Error('not implemented'); }
+	openEditor(_editor: IEditorInput, _options?: IEditorOptions): Promise<IEditorPane> { throw new Error('not implemented'); }
+	openEditors(_editors: IEditorInputWithOptions[]): Promise<IEditorPane> { throw new Error('not implemented'); }
 	isOpened(_editor: IEditorInput | IResourceInput): boolean { return false; }
 	isPinned(_editor: IEditorInput): boolean { return false; }
 	isActive(_editor: IEditorInput): boolean { return false; }
@@ -608,11 +608,11 @@ export class TestEditorService implements EditorServiceImpl {
 
 	getEditors() { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }
-	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditor | undefined>;
+	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined>;
 	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditor | undefined>;
 	openEditor(editor: IResourceDiffInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditor | undefined>;
 	openEditor(editor: IResourceSideBySideInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextSideBySideEditor | undefined>;
-	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditor | undefined> {
+	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined> {
 		throw new Error('not implemented');
 	}
 	doResolveEditorOpenRequest(editor: IEditorInput | IResourceEditor): [IEditorGroup, EditorInput, EditorOptions | undefined] | undefined {
@@ -622,7 +622,7 @@ export class TestEditorService implements EditorServiceImpl {
 
 		return [this.editorGroupService.activeGroup, editor as EditorInput, undefined];
 	}
-	openEditors(_editors: any, _group?: any): Promise<IEditor[]> { throw new Error('not implemented'); }
+	openEditors(_editors: any, _group?: any): Promise<IEditorPane[]> { throw new Error('not implemented'); }
 	isOpen(_editor: IEditorInput | IResourceInput): boolean { return false; }
 	replaceEditors(_editors: any, _group: any) { return Promise.resolve(undefined); }
 	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T { throw new Error('not implemented'); }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -10,7 +10,7 @@ import * as resources from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
-import { IEditorInputWithOptions, CloseDirection, IEditorIdentifier, IUntitledTextResourceInput, IResourceDiffInput, IResourceSideBySideInput, IEditorInput, IEditorPane, IEditorCloseEvent, IEditorPartOptions, IRevertOptions, GroupIdentifier, EditorInput, EditorOptions, EditorsOrder, IFileEditorInput, IEditorInputFactoryRegistry, IEditorInputFactory, Extensions as EditorExtensions, ISaveOptions, IMoveResult, ITextEditor, ITextDiffEditor, ITextSideBySideEditor, IVisibleEditor } from 'vs/workbench/common/editor';
+import { IEditorInputWithOptions, CloseDirection, IEditorIdentifier, IUntitledTextResourceInput, IResourceDiffInput, IEditorInput, IEditorPane, IEditorCloseEvent, IEditorPartOptions, IRevertOptions, GroupIdentifier, EditorInput, EditorOptions, EditorsOrder, IFileEditorInput, IEditorInputFactoryRegistry, IEditorInputFactory, Extensions as EditorExtensions, ISaveOptions, IMoveResult, ITextEditorPane, ITextDiffEditorPane, IVisibleEditorPane } from 'vs/workbench/common/editor';
 import { IEditorOpeningEvent, EditorServiceImpl, IEditorGroupView, IEditorGroupsAccessor } from 'vs/workbench/browser/parts/editor/editor';
 import { Event, Emitter } from 'vs/base/common/event';
 import { IBackupFileService, IResolvedBackup } from 'vs/workbench/services/backup/common/backup';
@@ -508,7 +508,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	constructor(public id: number) { }
 
 	get group(): EditorGroup { throw new Error('not implemented'); }
-	activeControl!: IVisibleEditor;
+	activeControl!: IVisibleEditorPane;
 	activeEditor!: IEditorInput;
 	previewEditor!: IEditorInput;
 	count!: number;
@@ -593,13 +593,13 @@ export class TestEditorService implements EditorServiceImpl {
 	onDidOpenEditorFail: Event<IEditorIdentifier> = Event.None;
 	onDidMostRecentlyActiveEditorsChange: Event<void> = Event.None;
 
-	activeControl: IVisibleEditor | undefined;
+	activeControl: IVisibleEditorPane | undefined;
 	activeTextEditorWidget: ICodeEditor | IDiffEditor | undefined;
 	activeTextEditorMode: string | undefined;
 	activeEditor: IEditorInput | undefined;
 	editors: ReadonlyArray<IEditorInput> = [];
 	mostRecentlyActiveEditors: ReadonlyArray<IEditorIdentifier> = [];
-	visibleControls: ReadonlyArray<IVisibleEditor> = [];
+	visibleControls: ReadonlyArray<IVisibleEditorPane> = [];
 	visibleTextEditorWidgets = [];
 	visibleEditors: ReadonlyArray<IEditorInput> = [];
 	count = this.editors.length;
@@ -609,9 +609,8 @@ export class TestEditorService implements EditorServiceImpl {
 	getEditors() { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }
 	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined>;
-	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditor | undefined>;
-	openEditor(editor: IResourceDiffInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditor | undefined>;
-	openEditor(editor: IResourceSideBySideInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextSideBySideEditor | undefined>;
+	openEditor(editor: IResourceInput | IUntitledTextResourceInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditorPane | undefined>;
+	openEditor(editor: IResourceDiffInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditorPane | undefined>;
 	async openEditor(editor: IEditorInput | IResourceEditor, optionsOrGroup?: IEditorOptions | ITextEditorOptions | IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined> {
 		throw new Error('not implemented');
 	}
@@ -626,7 +625,7 @@ export class TestEditorService implements EditorServiceImpl {
 	isOpen(_editor: IEditorInput | IResourceInput): boolean { return false; }
 	replaceEditors(_editors: any, _group: any) { return Promise.resolve(undefined); }
 	invokeWithinEditorContext<T>(fn: (accessor: ServicesAccessor) => T): T { throw new Error('not implemented'); }
-	createInput(_input: IResourceInput | IUntitledTextResourceInput | IResourceDiffInput | IResourceSideBySideInput): EditorInput { throw new Error('not implemented'); }
+	createInput(_input: IResourceInput | IUntitledTextResourceInput | IResourceDiffInput): EditorInput { throw new Error('not implemented'); }
 	save(editors: IEditorIdentifier[], options?: ISaveEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
 	saveAll(options?: ISaveEditorsOptions): Promise<boolean> { throw new Error('Method not implemented.'); }
 	revert(editors: IEditorIdentifier[], options?: IRevertOptions): Promise<void> { throw new Error('Method not implemented.'); }

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -594,13 +594,13 @@ export class TestEditorService implements EditorServiceImpl {
 	onDidMostRecentlyActiveEditorsChange: Event<void> = Event.None;
 
 	activeEditorPane: IVisibleEditorPane | undefined;
-	activeTextEditorWidget: ICodeEditor | IDiffEditor | undefined;
+	activeTextEditorControl: ICodeEditor | IDiffEditor | undefined;
 	activeTextEditorMode: string | undefined;
 	activeEditor: IEditorInput | undefined;
 	editors: ReadonlyArray<IEditorInput> = [];
 	mostRecentlyActiveEditors: ReadonlyArray<IEditorIdentifier> = [];
 	visibleEditorPanes: ReadonlyArray<IVisibleEditorPane> = [];
-	visibleTextEditorWidgets = [];
+	visibleTextEditorControls = [];
 	visibleEditors: ReadonlyArray<IEditorInput> = [];
 	count = this.editors.length;
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -508,7 +508,7 @@ export class TestEditorGroupView implements IEditorGroupView {
 	constructor(public id: number) { }
 
 	get group(): EditorGroup { throw new Error('not implemented'); }
-	activeControl!: IVisibleEditorPane;
+	activeEditorPane!: IVisibleEditorPane;
 	activeEditor!: IEditorInput;
 	previewEditor!: IEditorInput;
 	count!: number;
@@ -593,13 +593,13 @@ export class TestEditorService implements EditorServiceImpl {
 	onDidOpenEditorFail: Event<IEditorIdentifier> = Event.None;
 	onDidMostRecentlyActiveEditorsChange: Event<void> = Event.None;
 
-	activeControl: IVisibleEditorPane | undefined;
+	activeEditorPane: IVisibleEditorPane | undefined;
 	activeTextEditorWidget: ICodeEditor | IDiffEditor | undefined;
 	activeTextEditorMode: string | undefined;
 	activeEditor: IEditorInput | undefined;
 	editors: ReadonlyArray<IEditorInput> = [];
 	mostRecentlyActiveEditors: ReadonlyArray<IEditorIdentifier> = [];
-	visibleControls: ReadonlyArray<IVisibleEditorPane> = [];
+	visibleEditorPanes: ReadonlyArray<IVisibleEditorPane> = [];
 	visibleTextEditorWidgets = [];
 	visibleEditors: ReadonlyArray<IEditorInput> = [];
 	count = this.editors.length;


### PR DESCRIPTION
This changes the following to make workbench editors easier to distinguish from our code editor:
* (workbench) `IEditor` => `IEditorPane`
* `IVisibleEditor` => `IVisibleEditorPane`
* `ITextEditor` => `ITextEditorPane`
* `ITextDiffEditor` => `ITextDiffEditorPane`
* `IEditorService#activeControl` => `IEditorService#activeEditorPane`
* `IEditorService#visibleControls` => `IEditorService#visibleEditorPanes`
* `activeTextEditorWidget` => `activeTextEditorControl`
* `visibleTextEditorWidgets` => `visibleTextEditorControls`

This now means that the access to the actual `control` is consistent:
* `IEditorPane#getControl()`
* `IEditorService#activeControl` / `IEditorService#visibleControls`

Nothing changed with regards to the controls, they are still `IEditor` or `IDiffEditor`. We cannot easily bring in `ICodeEditor` as it lives in `browser` and editor service is used in many `common` places. 

//cc @jrieken 
//cc @rebornix 