### PR TITLE
fix typing for proxy auth window options

### DIFF
--- a/src/vs/code/electron-main/auth.ts
+++ b/src/vs/code/electron-main/auth.ts
@@ -6,7 +6,7 @@
 import { localize } from 'vs/nls';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
-import { BrowserWindow, app, AuthInfo, WebContents, Event as ElectronEvent } from 'electron';
+import { BrowserWindow, BrowserWindowConstructorOptions, app, AuthInfo, WebContents, Event as ElectronEvent } from 'electron';
 
 type LoginEvent = {
 	event: ElectronEvent;
@@ -49,7 +49,7 @@ export class ProxyAuthHandler extends Disposable {
 
 		event.preventDefault();
 
-		const opts: any = {
+		const opts: BrowserWindowConstructorOptions = {
 			alwaysOnTop: true,
 			skipTaskbar: true,
 			resizable: false,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes a missing type for the construction options of the browser window which renders the proxy auth modal. It's a small change but it gives more control of the `opts` object and makes the code consistent with other files that also apply the `BrowserWindowConstructorOptions` typing, i.e.:

https://github.com/microsoft/vscode/blob/9eedabce7b8111258fa734689566237730156871/src/vs/code/electron-main/window.ts#L125
