### PR TITLE
views: No priroity, keep views sorted in the order they got registered

### DIFF
--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -262,7 +262,8 @@ function compareViewContentDescriptors(a: IViewContentDescriptor, b: IViewConten
 		return aPriority - bPriority;
 	}
 
-	return a.content < b.content ? -1 : 1;
+	// No priroity, keep views sorted in the order they got registered
+	return 0;
 }
 
 class ViewsRegistry extends Disposable implements IViewsRegistry {
@@ -601,4 +602,3 @@ export interface IViewPaneContainer {
 	getView(viewId: string): IView | undefined;
 	saveState(): void;
 }
-


### PR DESCRIPTION
Previosuly if there was no priority assigned the weclome view content would get sorted based on the content length.
This does not give a lot of choice to the contribution on how to sort views that do not have piriorty or have same priroiity.
With this change the views with same priroity are stable and kept in same order as they got registered.

To verify: open empty explorer, empty git viewlet and empty debug viewlet and make sure the order makes sense.

Fixes https://github.com/microsoft/vscode/issues/91955