### PR TITLE
Allow using Command in StatusBarItem

### DIFF
--- a/src/vs/vscode.d.ts
+++ b/src/vs/vscode.d.ts
@@ -4975,10 +4975,11 @@ declare module 'vscode' {
 		color: string | ThemeColor | undefined;
 
 		/**
-		 * The identifier of a command to run on click. The command must be
-		 * [known](#commands.getCommands).
+		 * [`Command`](#Command) or identifier of a command to run on click.
+		 *
+		 * The command must be [known](#commands.getCommands).
 		 */
-		command: string | undefined;
+		command: string | Command | undefined;
 
 		/**
 		 * Shows the entry in the status bar.

--- a/src/vs/workbench/api/browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/browser/mainThreadStatusBar.ts
@@ -8,6 +8,7 @@ import { MainThreadStatusBarShape, MainContext, IExtHostContext } from '../commo
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { extHostNamedCustomer } from 'vs/workbench/api/common/extHostCustomers';
 import { dispose } from 'vs/base/common/lifecycle';
+import { Command } from 'vs/editor/common/modes';
 
 @extHostNamedCustomer(MainContext.MainThreadStatusBar)
 export class MainThreadStatusBar implements MainThreadStatusBarShape {
@@ -24,7 +25,7 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 		this.entries.clear();
 	}
 
-	$setEntry(id: number, statusId: string, statusName: string, text: string, tooltip: string | undefined, command: string | undefined, color: string | ThemeColor | undefined, alignment: MainThreadStatusBarAlignment, priority: number | undefined): void {
+	$setEntry(id: number, statusId: string, statusName: string, text: string, tooltip: string | undefined, command: Command | undefined, color: string | ThemeColor | undefined, alignment: MainThreadStatusBarAlignment, priority: number | undefined): void {
 		const entry: IStatusbarEntry = { text, tooltip, command, color };
 
 		if (typeof priority === 'undefined') {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -143,7 +143,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostClipboard = new ExtHostClipboard(rpcProtocol);
 	const extHostMessageService = new ExtHostMessageService(rpcProtocol, extHostLogService);
 	const extHostDialogs = new ExtHostDialogs(rpcProtocol);
-	const extHostStatusBar = new ExtHostStatusBar(rpcProtocol);
+	const extHostStatusBar = new ExtHostStatusBar(rpcProtocol, extHostCommands.converter);
 	const extHostLanguages = new ExtHostLanguages(rpcProtocol, extHostDocuments);
 
 	// Register API-ish commands

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -533,7 +533,7 @@ export interface MainThreadQuickOpenShape extends IDisposable {
 }
 
 export interface MainThreadStatusBarShape extends IDisposable {
-	$setEntry(id: number, statusId: string, statusName: string, text: string, tooltip: string | undefined, command: string | undefined, color: string | ThemeColor | undefined, alignment: statusbar.StatusbarAlignment, priority: number | undefined): void;
+	$setEntry(id: number, statusId: string, statusName: string, text: string, tooltip: string | undefined, command: ICommandDto | undefined, color: string | ThemeColor | undefined, alignment: statusbar.StatusbarAlignment, priority: number | undefined): void;
 	$dispose(id: number): void;
 }
 

--- a/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
@@ -34,6 +34,7 @@ import { Separator } from 'vs/base/browser/ui/actionbar/actionbar';
 import { values } from 'vs/base/common/map';
 import { assertIsDefined } from 'vs/base/common/types';
 import { Emitter, Event } from 'vs/base/common/event';
+import { Command } from 'vs/editor/common/modes';
 
 interface IPendingStatusbarEntry {
 	id: string;
@@ -702,7 +703,7 @@ class StatusbarEntryItem extends Disposable {
 
 			const command = entry.command;
 			if (command) {
-				this.commandListener.value = addDisposableListener(this.labelContainer, EventType.CLICK, () => this.executeCommand(command, entry.arguments));
+				this.commandListener.value = addDisposableListener(this.labelContainer, EventType.CLICK, () => this.executeCommand(command));
 
 				removeClass(this.labelContainer, 'disabled');
 			} else {
@@ -738,8 +739,9 @@ class StatusbarEntryItem extends Disposable {
 		this.entry = entry;
 	}
 
-	private async executeCommand(id: string, args?: unknown[]): Promise<void> {
-		args = args || [];
+	private async executeCommand(command: string | Command): Promise<void> {
+		const id = typeof command === 'string' ? command : command.id;
+		const args = typeof command === 'string' ? [] : command.arguments ?? [];
 
 		// Maintain old behaviour of always focusing the editor here
 		const activeTextEditorControl = this.editorService.activeTextEditorControl;

--- a/src/vs/workbench/contrib/scm/browser/activity.ts
+++ b/src/vs/workbench/contrib/scm/browser/activity.ts
@@ -159,8 +159,7 @@ export class SCMStatusController implements IWorkbenchContribution {
 			disposables.add(this.statusbarService.addEntry({
 				text: c.title,
 				tooltip: `${label} - ${c.tooltip}`,
-				command: c.id,
-				arguments: c.arguments
+				command: c
 			}, 'status.scm', localize('status.scm', "Source Control"), MainThreadStatusBarAlignment.LEFT, 10000));
 		}
 

--- a/src/vs/workbench/services/statusbar/common/statusbar.ts
+++ b/src/vs/workbench/services/statusbar/common/statusbar.ts
@@ -7,6 +7,7 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { ThemeColor } from 'vs/platform/theme/common/themeService';
 import { Event } from 'vs/base/common/event';
+import { Command } from 'vs/editor/common/modes';
 
 export const IStatusbarService = createDecorator<IStatusbarService>('statusbarService');
 
@@ -45,12 +46,7 @@ export interface IStatusbarEntry {
 	/**
 	 * An optional id of a command that is known to the workbench to execute on click
 	 */
-	readonly command?: string;
-
-	/**
-	 * Optional arguments for the command.
-	 */
-	readonly arguments?: unknown[];
+	readonly command?: string | Command;
 
 	/**
 	 * Whether to show a beak above the status bar entry.


### PR DESCRIPTION
Fixes #22353

`StatusBarItem` is one of the few places in our API where we only allow extensions to give us a command as a `string` instead of as `Command` object. This change updates the API to also allow passing in a `vscode.Command` (which also allows arguments!)


