### PR TITLE
quick pick - support standalone editor (+ support indentation picker)

### DIFF
--- a/src/vs/editor/editor.all.ts
+++ b/src/vs/editor/editor.all.ts
@@ -26,6 +26,7 @@ import 'vs/editor/contrib/gotoSymbol/goToCommands';
 import 'vs/editor/contrib/gotoSymbol/link/goToDefinitionAtPosition';
 import 'vs/editor/contrib/gotoError/gotoError';
 import 'vs/editor/contrib/hover/hover';
+import 'vs/editor/contrib/indentation/indentation';
 import 'vs/editor/contrib/inPlaceReplace/inPlaceReplace';
 import 'vs/editor/contrib/linesOperations/linesOperations';
 import 'vs/editor/contrib/links/links';

--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInput.css
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInput.css
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.quick-input-widget {
+	font-size: 13px;
+}
+
+.quick-input-widget .monaco-highlighted-label .highlight,
+.quick-input-widget .monaco-highlighted-label .highlight {
+	color: #0066BF;
+}
+
+.vs-dark .quick-input-widget .monaco-highlighted-label .highlight,
+.vs-dark .quick-input-widget .monaco-highlighted-label .highlight {
+	color: #0097fb;
+}
+
+.hc-black .quick-input-widget .monaco-highlighted-label .highlight,
+.hc-black .quick-input-widget .monaco-highlighted-label .highlight {
+	color: #F38518;
+}

--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputServiceImpl.ts
@@ -1,0 +1,186 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./standaloneQuickInput';
+import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition, OverlayWidgetPositionPreference } from 'vs/editor/browser/editorBrowser';
+import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IQuickInputService, IQuickInputButton, IQuickPickItem, IQuickPick, IInputBox, IQuickNavigateConfiguration, IPickOptions, QuickPickInput, IInputOptions } from 'vs/platform/quickinput/common/quickInput';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { QuickInputController } from 'vs/base/parts/quickinput/browser/quickInput';
+import { QuickInputService, IQuickInputControllerHost } from 'vs/platform/quickinput/browser/quickInput';
+import { once } from 'vs/base/common/functional';
+
+export class EditorScopedQuickInputServiceImpl extends QuickInputService {
+
+	private host: IQuickInputControllerHost | undefined = undefined;
+
+	constructor(
+		editor: ICodeEditor,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IThemeService themeService: IThemeService,
+		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@ILayoutService layoutService: ILayoutService
+	) {
+		super({ args: Object.create(null) } as IEnvironmentService, configurationService, instantiationService, keybindingService, contextKeyService, themeService, accessibilityService, layoutService);
+
+		// Use the passed in code editor as host for the quick input widget
+		const contribution = QuickInputEditorContribution.get(editor);
+		this.host = {
+			_serviceBrand: undefined,
+			get container() { return contribution.widget.getDomNode(); },
+			get dimension() { return editor.getLayoutInfo(); },
+			get onLayout() { return editor.onDidLayoutChange; },
+			focus: () => editor.focus()
+		};
+	}
+
+	protected createController(): QuickInputController {
+		return super.createController(this.host);
+	}
+}
+
+export class StandaloneQuickInputServiceImpl implements IQuickInputService {
+
+	_serviceBrand: undefined;
+
+	private mapEditorToService = new Map<ICodeEditor, EditorScopedQuickInputServiceImpl>();
+	private get activeService(): IQuickInputService {
+		const editor = this.codeEditorService.getFocusedCodeEditor();
+		if (!editor) {
+			throw new Error('Quick input service needs a focused editor to work.');
+		}
+
+		// Find the quick input implementation for the focused
+		// editor or create it lazily if not yet created
+		let quickInputService = this.mapEditorToService.get(editor);
+		if (!quickInputService) {
+			const newQuickInputService = quickInputService = this.instantiationService.createInstance(EditorScopedQuickInputServiceImpl, editor);
+			this.mapEditorToService.set(editor, quickInputService);
+
+			once(editor.onDidDispose)(() => {
+				newQuickInputService.dispose();
+				this.mapEditorToService.delete(editor);
+			});
+		}
+
+		return quickInputService;
+	}
+
+	get backButton(): IQuickInputButton { return this.activeService.backButton; }
+
+	get onShow() { return this.activeService.onShow; }
+	get onHide() { return this.activeService.onHide; }
+
+	constructor(
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@ICodeEditorService private readonly codeEditorService: ICodeEditorService
+	) {
+	}
+
+	pick<T extends IQuickPickItem, O extends IPickOptions<T>>(picks: Promise<QuickPickInput<T>[]> | QuickPickInput<T>[], options: O = <O>{}, token: CancellationToken = CancellationToken.None): Promise<O extends { canPickMany: true } ? T[] : T> {
+		return (this.activeService as unknown as QuickInputController /* TS fail */).pick(picks, options, token);
+	}
+
+	input(options?: IInputOptions | undefined, token?: CancellationToken | undefined): Promise<string> {
+		return this.activeService.input(options, token);
+	}
+
+	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T> {
+		return this.activeService.createQuickPick();
+	}
+
+	createInputBox(): IInputBox {
+		return this.activeService.createInputBox();
+	}
+
+	focus(): void {
+		return this.activeService.focus();
+	}
+
+	toggle(): void {
+		return this.activeService.toggle();
+	}
+
+	navigate(next: boolean, quickNavigate?: IQuickNavigateConfiguration | undefined): void {
+		return this.activeService.navigate(next, quickNavigate);
+	}
+
+	accept(): Promise<void> {
+		return this.activeService.accept();
+	}
+
+	back(): Promise<void> {
+		return this.activeService.back();
+	}
+
+	cancel(): Promise<void> {
+		return this.activeService.cancel();
+	}
+
+	hide(focusLost?: boolean | undefined): void {
+		return this.activeService.hide(focusLost);
+	}
+}
+
+export class QuickInputEditorContribution implements IEditorContribution {
+
+	static readonly ID = 'editor.controller.quickInput';
+
+	static get(editor: ICodeEditor): QuickInputEditorContribution {
+		return editor.getContribution<QuickInputEditorContribution>(QuickInputEditorContribution.ID);
+	}
+
+	readonly widget = new QuickInputEditorWidget(this.editor);
+
+	constructor(private editor: ICodeEditor) { }
+
+	dispose(): void {
+		this.widget.dispose();
+	}
+}
+
+export class QuickInputEditorWidget implements IOverlayWidget {
+
+	private static readonly ID = 'editor.contrib.quickInputWidget';
+
+	private domNode: HTMLElement;
+
+	constructor(private codeEditor: ICodeEditor) {
+		this.domNode = document.createElement('div');
+
+		this.codeEditor.addOverlayWidget(this);
+	}
+
+	getId(): string {
+		return QuickInputEditorWidget.ID;
+	}
+
+	getDomNode(): HTMLElement {
+		return this.domNode;
+	}
+
+	getPosition(): IOverlayWidgetPosition | null {
+		return { preference: OverlayWidgetPositionPreference.TOP_CENTER };
+	}
+
+	dispose(): void {
+		this.codeEditor.removeOverlayWidget(this);
+	}
+}
+
+registerEditorContribution(QuickInputEditorContribution.ID, QuickInputEditorContribution);

--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -52,7 +52,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { BrowserClipboardService } from 'vs/platform/clipboard/browser/clipboardService';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { UndoRedoService } from 'vs/platform/undoRedo/common/undoRedoService';
-import { QuickInputService } from 'vs/platform/quickinput/browser/quickInput';
+import { StandaloneQuickInputServiceImpl } from 'vs/editor/standalone/browser/quickInput/standaloneQuickInputServiceImpl';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 
 export interface IEditorOverrideServices {
@@ -200,7 +200,7 @@ export class DynamicStandaloneServices extends Disposable {
 
 		let contextKeyService = ensure(IContextKeyService, () => this._register(new ContextKeyService(configurationService)));
 
-		let accessibilityService = ensure(IAccessibilityService, () => new AccessibilityService(contextKeyService, configurationService));
+		ensure(IAccessibilityService, () => new AccessibilityService(contextKeyService, configurationService));
 
 		ensure(IListService, () => new ListService(themeService));
 
@@ -210,7 +210,7 @@ export class DynamicStandaloneServices extends Disposable {
 
 		let layoutService = ensure(ILayoutService, () => new SimpleLayoutService(StaticServices.codeEditorService.get(ICodeEditorService), domElement));
 
-		ensure(IQuickInputService, () => new QuickInputService(Object.create(null), configurationService, _instantiationService, keybindingService, contextKeyService, themeService, accessibilityService, layoutService));
+		ensure(IQuickInputService, () => new StandaloneQuickInputServiceImpl(_instantiationService, StaticServices.codeEditorService.get(ICodeEditorService)));
 
 		let contextViewService = ensure(IContextViewService, () => this._register(new ContextViewService(layoutService)));
 

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -34,7 +34,7 @@ export class QuickInputService extends Themable implements IQuickInputService {
 	private _controller: QuickInputController | undefined;
 	private get controller(): QuickInputController {
 		if (!this._controller) {
-			this._controller = this.createController();
+			this._controller = this._register(this.createController());
 		}
 
 		return this._controller;


### PR DESCRIPTION
This brings support for `IQuickInputService` to the standalone editor and thus opens the door to having shared code between workbench and editor in this area. 

To proof it, there is now indentation support through the picker for standalone implemented by the same code that drives this from the workbench:

![Kapture 2020-03-05 at 16 06 26](https://user-images.githubusercontent.com/900690/75994454-4b383b00-5efb-11ea-8723-09623dc7621b.gif)

Since the standalone editor is a bit more complex around adding widgets into it, the standalone implementation is now a delegate to the currently focused editor and then uses an editor overlay widget as container. I hope this makes sense.

//cc @alexdima @chrmarti 