### PR TITLE
Added completion entry for @ts-expect-error directive

### DIFF
--- a/extensions/typescript-language-features/src/features/directiveCommentCompletions.ts
+++ b/extensions/typescript-language-features/src/features/directiveCommentCompletions.ts
@@ -15,7 +15,7 @@ interface Directive {
 	readonly description: string;
 }
 
-const directives260: Directive[] = [
+const directives: Directive[] = [
 	{
 		value: '@ts-check',
 		description: localize(
@@ -35,7 +35,7 @@ const directives260: Directive[] = [
 ];
 
 const directives390: Directive[] = [
-	...directives260,
+	...directives,
 	{
 		value: '@ts-expect-error',
 		description: localize(
@@ -52,9 +52,7 @@ class DirectiveCommentCompletionProvider implements vscode.CompletionItemProvide
 	) {
 		this.directives = client.apiVersion.gte(API.v390)
 			? directives390
-			: client.apiVersion.gte(API.v260)
-				? directives260
-				: [];
+			: directives;
 	}
 
 	public provideCompletionItems(

--- a/extensions/typescript-language-features/src/features/directiveCommentCompletions.ts
+++ b/extensions/typescript-language-features/src/features/directiveCommentCompletions.ts
@@ -30,6 +30,11 @@ const directives: Directive[] = [
 		description: localize(
 			'ts-ignore',
 			"Suppresses @ts-check errors on the next line of a file.")
+	}, {
+		value: '@ts-expect-error',
+		description: localize(
+			'ts-expect-error',
+			"Suppresses @ts-check errors on the next line of a file, expecting at least one to exist.")
 	}
 ];
 

--- a/extensions/typescript-language-features/src/utils/api.ts
+++ b/extensions/typescript-language-features/src/utils/api.ts
@@ -33,6 +33,7 @@ export default class API {
 	public static readonly v350 = API.fromSimpleString('3.5.0');
 	public static readonly v380 = API.fromSimpleString('3.8.0');
 	public static readonly v381 = API.fromSimpleString('3.8.1');
+	public static readonly v390 = API.fromSimpleString('3.9.0');
 
 	public static fromVersionString(versionString: string): API {
 		let version = semver.valid(versionString);

--- a/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.ts
+++ b/src/vs/workbench/contrib/welcome/walkThrough/browser/editor/vs_code_editor_walkthrough.ts
@@ -174,7 +174,7 @@ let easy = true;
 easy = 42;
 |||
 
->**Tip:** You can also enable the checks workspace or application wide by adding |"javascript.implicitProjectConfig.checkJs": true| to your workspace or user settings and explicitly ignoring files or lines using |// @ts-nocheck| and |// @ts-ignore|. Check out the docs on [JavaScript in VS Code](https://code.visualstudio.com/docs/languages/javascript) to learn more.
+>**Tip:** You can also enable the checks workspace or application wide by adding |"javascript.implicitProjectConfig.checkJs": true| to your workspace or user settings and explicitly ignoring files or lines using |// @ts-nocheck| and |// @ts-expect-error|. Check out the docs on [JavaScript in VS Code](https://code.visualstudio.com/docs/languages/javascript) to learn more.
 
 
 ## Thanks!


### PR DESCRIPTION
This PR follows up on https://github.com/microsoft/TypeScript/pull/36014 by adding `ts-expect-error` as a completion directive, and recommends it over `@ts-ignore` in the editor walkthrough.

~I'm happy to file a corresponding issue per the PR template if you'd prefer - figured a PR first would be easier if this is a no brainer. Thanks!~

Fixes #92116