### PR TITLE
fix: create new guid for crash reporter

### DIFF
--- a/src/vs/platform/storage/node/storageIpc.ts
+++ b/src/vs/platform/storage/node/storageIpc.ts
@@ -12,7 +12,7 @@ import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';
 import { generateUuid } from 'vs/base/common/uuid';
-import { instanceStorageKey, firstSessionDateStorageKey, lastSessionDateStorageKey, currentSessionDateStorageKey } from 'vs/platform/telemetry/common/telemetry';
+import { instanceStorageKey, firstSessionDateStorageKey, lastSessionDateStorageKey, currentSessionDateStorageKey, crashReporterIdStorageKey } from 'vs/platform/telemetry/common/telemetry';
 
 type Key = string;
 type Value = string;
@@ -52,6 +52,16 @@ export class GlobalStorageDatabaseChannel extends Disposable implements IServerC
 		} catch (error) {
 			onUnexpectedError(error);
 			this.logService.error(error);
+		}
+
+		// This is unique to the application instance and thereby
+		// should be written from the main process once.
+		//
+		// THIS SHOULD NEVER BE SENT TO TELEMETRY.
+		//
+		const crashReporterId = this.storageMainService.get(crashReporterIdStorageKey, undefined);
+		if (crashReporterId === undefined) {
+			this.storageMainService.store(crashReporterIdStorageKey, generateUuid());
 		}
 
 		// Apply global telemetry values as part of the initialization

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -45,3 +45,4 @@ export const instanceStorageKey = 'telemetry.instanceId';
 export const currentSessionDateStorageKey = 'telemetry.currentSessionDate';
 export const firstSessionDateStorageKey = 'telemetry.firstSessionDate';
 export const lastSessionDateStorageKey = 'telemetry.lastSessionDate';
+export const crashReporterIdStorageKey = 'crashReporter.guid';

--- a/src/vs/workbench/electron-browser/window.ts
+++ b/src/vs/workbench/electron-browser/window.ts
@@ -13,7 +13,7 @@ import { IAction } from 'vs/base/common/actions';
 import { IFileService } from 'vs/platform/files/common/files';
 import { toResource, IUntitledTextResourceInput, SideBySideEditor, pathsToEditors } from 'vs/workbench/common/editor';
 import { IEditorService, IResourceEditor } from 'vs/workbench/services/editor/common/editorService';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { ITelemetryService, crashReporterIdStorageKey } from 'vs/platform/telemetry/common/telemetry';
 import { IWindowSettings, IOpenFileRequest, IWindowsConfiguration, IAddFoldersRequest, IRunActionInWindowRequest, IRunKeybindingInWindowRequest, getTitleBarStyle } from 'vs/platform/windows/common/windows';
 import { ITitleService } from 'vs/workbench/services/title/common/titleService';
 import { IWorkbenchThemeService, VS_HC_THEME } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -46,7 +46,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { MenubarControl } from '../browser/parts/titlebar/menubarControl';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IUpdateService } from 'vs/platform/update/common/update';
-import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { IPreferencesService } from '../services/preferences/common/preferences';
 import { IMenubarService, IMenubarData, IMenubarMenu, IMenubarKeybinding, IMenubarMenuItemSubmenu, IMenubarMenuItemAction, MenubarMenuItem } from 'vs/platform/menubar/node/menubar';
 import { withNullAsUndefined, assertIsDefined } from 'vs/base/common/types';
@@ -104,7 +104,8 @@ export class ElectronWindow extends Disposable {
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IElectronEnvironmentService private readonly electronEnvironmentService: IElectronEnvironmentService,
 		@IWorkingCopyService private readonly workingCopyService: IWorkingCopyService,
-		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService
+		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
+		@IStorageService private readonly storageService: IStorageService,
 	) {
 		super();
 
@@ -544,12 +545,13 @@ export class ElectronWindow extends Disposable {
 		const appCenterURL = isWindows ? appCenterConfig[process.arch === 'ia32' ? 'win32-ia32' : 'win32-x64']
 			: isLinux ? appCenterConfig[`linux-x64`] : appCenterConfig.darwin;
 		const info = await this.telemetryService.getTelemetryInfo();
+		const crashReporterId = this.storageService.get(crashReporterIdStorageKey, StorageScope.GLOBAL)!;
 
 		// base options with product info
 		const options: CrashReporterStartOptions = {
 			companyName,
 			productName,
-			submitURL: appCenterURL.concat('&uid=', info.machineId, '&iid=', info.instanceId),
+			submitURL: appCenterURL.concat('&uid=', crashReporterId, '&iid=', crashReporterId, '&sid=', info.sessionId),
 			extra: {
 				vscode_version: product.version,
 				vscode_commit: product.commit || ''


### PR DESCRIPTION
This id should never be sent to telemetry for GDPR reasons, hence we don't reuse any of existing
persistent ids like instanceId etc.

/cc @bpasero 
