### PR TITLE
Update rust reserved keywords

### DIFF
--- a/extensions/rust/syntaxes/rust.tmLanguage.json
+++ b/extensions/rust/syntaxes/rust.tmLanguage.json
@@ -170,7 +170,7 @@
 		{
 			"comment": "Reserved keyword",
 			"name": "invalid.deprecated.rust",
-			"match": "\\b(abstract|alignof|become|do|final|macro|offsetof|override|priv|proc|pure|sizeof|typeof|virtual|yield)\\b"
+			"match": "\\b(abstract|become|do|final|macro|override|priv|typeof|unsized|virtual|yield)\\b"
 		},
 		{
 			"include": "#unsafe"


### PR DESCRIPTION
There is no issue for this. I can open one if required.

This removes 5 "reserved" keywords from Rust, all of which are no longer reserved. Also added one keyword which is currently reserved.

Official list is here: https://doc.rust-lang.org/reference/keywords.html#reserved-keywords

Proof that the removed and added keywords are accurate: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=16ceeadb190d1804eab3cf5e8439c1bc (the point is this compiles, even though the built-in highlighting appears outdated here as well)