### PR TITLE
Feature/remove example from copied files

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -358,14 +358,14 @@ export function findValidPasteFileTarget(explorerService: IExplorerService, targ
 			break;
 		}
 
-		name = incrementFileName(name, !!fileToPaste.isDirectory, incrementalNaming, stripExample);
+		name = suggestFileName(name, !!fileToPaste.isDirectory, incrementalNaming, stripExample);
 		candidate = resources.joinPath(targetFolder.resource, name);
 	}
 
 	return candidate;
 }
 
-export function incrementFileName(name: string, isFolder: boolean, incrementalNaming: 'simple' | 'smart', stripExample: boolean): string {
+export function suggestFileName(name: string, isFolder: boolean, incrementalNaming: 'simple' | 'smart', stripExample: boolean): string {
 	const separators = '[\\.\\-_]';
 	const exampleFileGroup = '(sample|example)';
 

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -372,7 +372,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	if (stripExample) {
 		// name.sample(.txt) => name(.txt)
 		// name.example(.txt) => name(.txt)
-		const preExtensionExampleFileRegex = RegExp('(.*)(' + separators + exampleFileGroup + ')(\..*)$');
+		const preExtensionExampleFileRegex = RegExp(`(.*)(${separators}${exampleFileGroup})(\..*)$`);
 		if (!isFolder && name.match(preExtensionExampleFileRegex)) {
 			return name.replace(preExtensionExampleFileRegex, (match, g1?, g2?, g3?, g4?) => {
 				return strings.format('{0}{1}', g1, g4);
@@ -381,7 +381,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 
 		// name(.txt).sample => name(.txt)
 		// name(.txt).example => name(.txt)
-		const postExtensionExampleFileRegex = RegExp('(.*)(' + separators + exampleFileGroup + ')$');
+		const postExtensionExampleFileRegex = RegExp(`(.*)(${separators}${exampleFileGroup})$`);
 		if (!isFolder && name.match(postExtensionExampleFileRegex)) {
 			return name.replace(postExtensionExampleFileRegex, (match, g1?) => {
 				return strings.format('{0}', g1);
@@ -418,7 +418,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	const maxNumber = Constants.MAX_SAFE_SMALL_INTEGER;
 
 	// file.1.txt=>file.2.txt
-	let suffixFileRegex = RegExp('(.*' + separators + ')(\\d+)(\\..*)$');
+	let suffixFileRegex = RegExp(`(.*'${separators})(\\d+)(\\..*)$`);
 	if (!isFolder && name.match(suffixFileRegex)) {
 		return name.replace(suffixFileRegex, (match, g1?, g2?, g3?) => {
 			let number = parseInt(g2);
@@ -429,7 +429,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	}
 
 	// 1.file.txt=>2.file.txt
-	let prefixFileRegex = RegExp('(\\d+)(' + separators + '.*)(\\..*)$');
+	let prefixFileRegex = RegExp(`(\\d+)(${separators}.*)(\\..*)$`);
 	if (!isFolder && name.match(prefixFileRegex)) {
 		return name.replace(prefixFileRegex, (match, g1?, g2?, g3?) => {
 			let number = parseInt(g1);

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -403,7 +403,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 		const suffixRegex = /^(.+ copy)( \d+)?$/;
 		if (suffixRegex.test(namePrefix)) {
 			return namePrefix.replace(suffixRegex, (match, g1?, g2?) => {
-				let number = (g2 ? parseInt(g2) : 1);
+				const number = (g2 ? parseInt(g2) : 1);
 				return number === 0
 					? `${g1}`
 					: (number < maxNumber
@@ -417,10 +417,10 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	}
 
 	// file.1.txt=>file.2.txt
-	let suffixFileRegex = RegExp(`(.*'${separators})(\\d+)(\\..*)$`);
+	const suffixFileRegex = RegExp(`(.*'${separators})(\\d+)(\\..*)$`);
 	if (!isFolder && name.match(suffixFileRegex)) {
 		return name.replace(suffixFileRegex, (match, g1?, g2?, g3?) => {
-			let number = parseInt(g2);
+			const number = parseInt(g2);
 			return number < maxNumber
 				? g1 + strings.pad(number + 1, g2.length) + g3
 				: strings.format('{0}{1}.1{2}', g1, g2, g3);
@@ -428,10 +428,10 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	}
 
 	// 1.file.txt=>2.file.txt
-	let prefixFileRegex = RegExp(`(\\d+)(${separators}.*)(\\..*)$`);
+	const prefixFileRegex = RegExp(`(\\d+)(${separators}.*)(\\..*)$`);
 	if (!isFolder && name.match(prefixFileRegex)) {
 		return name.replace(prefixFileRegex, (match, g1?, g2?, g3?) => {
-			let number = parseInt(g1);
+			const number = parseInt(g1);
 			return number < maxNumber
 				? strings.pad(number + 1, g1.length) + g2 + g3
 				: strings.format('{0}{1}.1{2}', g1, g2, g3);
@@ -439,10 +439,10 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	}
 
 	// 1.txt=>2.txt
-	let prefixFileNoNameRegex = RegExp('(\\d+)(\\..*)$');
+	const prefixFileNoNameRegex = RegExp('(\\d+)(\\..*)$');
 	if (!isFolder && name.match(prefixFileNoNameRegex)) {
 		return name.replace(prefixFileNoNameRegex, (match, g1?, g2?) => {
-			let number = parseInt(g1);
+			const number = parseInt(g1);
 			return number < maxNumber
 				? strings.pad(number + 1, g1.length) + g2
 				: strings.format('{0}.1{1}', g1, g2);
@@ -458,7 +458,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	// folder.1=>folder.2
 	if (isFolder && name.match(/(\d+)$/)) {
 		return name.replace(/(\d+)$/, (match, ...groups) => {
-			let number = parseInt(groups[0]);
+			const number = parseInt(groups[0]);
 			return number < maxNumber
 				? strings.pad(number + 1, groups[0].length)
 				: strings.format('{0}.1', groups[0]);
@@ -468,7 +468,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 	// 1.folder=>2.folder
 	if (isFolder && name.match(/^(\d+)/)) {
 		return name.replace(/^(\d+)(.*)$/, (match, ...groups) => {
-			let number = parseInt(groups[0]);
+			const number = parseInt(groups[0]);
 			return number < maxNumber
 				? strings.pad(number + 1, groups[0].length) + groups[1]
 				: strings.format('{0}{1}.1', groups[0], groups[1]);

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -366,6 +366,7 @@ export function findValidPasteFileTarget(explorerService: IExplorerService, targ
 }
 
 export function suggestFileName(name: string, isFolder: boolean, incrementalNaming: 'simple' | 'smart', stripExample: boolean): string {
+	const maxNumber = Constants.MAX_SAFE_SMALL_INTEGER;
 	const separators = '[\\.\\-_]';
 	const exampleFileGroup = '(sample|example)';
 
@@ -405,7 +406,7 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 				let number = (g2 ? parseInt(g2) : 1);
 				return number === 0
 					? `${g1}`
-					: (number < Constants.MAX_SAFE_SMALL_INTEGER
+					: (number < maxNumber
 						? `${g1} ${number + 1}`
 						: `${g1}${g2} copy`);
 			}) + extSuffix;
@@ -414,8 +415,6 @@ export function suggestFileName(name: string, isFolder: boolean, incrementalNami
 		// name(.txt) => name copy(.txt)
 		return `${namePrefix} copy${extSuffix}`;
 	}
-
-	const maxNumber = Constants.MAX_SAFE_SMALL_INTEGER;
 
 	// file.1.txt=>file.2.txt
 	let suffixFileRegex = RegExp(`(.*'${separators})(\\d+)(\\..*)$`);

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -417,6 +417,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('explorer.incrementalNaming', "Controls what naming strategy to use when a giving a new name to a duplicated explorer item on paste."),
 			default: 'simple'
 		},
+		'explorer.stripExample': {
+			type: 'boolean',
+			description: nls.localize('explorer.stripExample', 'Controls whether files with "example" or "sample" before or after the extension should be pasted without "example" or "sample".'),
+			default: true,
+		},
 		'explorer.compactFolders': {
 			'type': 'boolean',
 			'description': nls.localize('compressSingleChildFolders', "Controls whether the explorer should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element. Useful for Java package structures, for example."),

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -1094,8 +1094,8 @@ export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
 	private async doHandleExplorerDrop(source: ExplorerItem, target: ExplorerItem, isCopy: boolean): Promise<void> {
 		// Reuse duplicate action if user copies
 		if (isCopy) {
-			const incrementalNaming = this.configurationService.getValue<IFilesConfiguration>().explorer.incrementalNaming;
-			const stat = await this.workingCopyFileService.copy(source.resource, findValidPasteFileTarget(this.explorerService, target, { resource: source.resource, isDirectory: source.isDirectory, allowOverwrite: false }, incrementalNaming));
+			const { incrementalNaming, stripExample } = this.configurationService.getValue<IFilesConfiguration>().explorer;
+			const stat = await this.workingCopyFileService.copy(source.resource, findValidPasteFileTarget(this.explorerService, target, { resource: source.resource, isDirectory: source.isDirectory, allowOverwrite: false }, incrementalNaming, stripExample));
 			if (!stat.isDirectory) {
 				await this.editorService.openEditor({ resource: stat.resource, options: { pinned: true } });
 			}

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -116,6 +116,7 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 			colors: boolean;
 			badges: boolean;
 		};
+		stripExample: boolean;
 		incrementalNaming: 'simple' | 'smart';
 	};
 	editor: IEditorOptions;

--- a/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
@@ -6,131 +6,181 @@
 import * as assert from 'assert';
 import { incrementFileName } from 'vs/workbench/contrib/files/browser/fileActions';
 
+suite('Files - Can remove example indicators from file names', () => {
+	test('Removes sample when has `.sample` before the extension', function () {
+		const name = 'test.sample.js';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `-sample` before the extension', function () {
+		const name = 'test-sample.js';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `.example` before the extension', function () {
+		const name = 'test.example.js';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `-example` before the extension', function () {
+		const name = 'test-example.js';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `.sample` after the extension', function () {
+		const name = 'test.js.sample';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `-sample` after the extension', function () {
+		const name = 'test.js-sample';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `.example` after the extension', function () {
+		const name = 'test.js.example';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+
+	test('Removes sample when has `-example` after the extension', function () {
+		const name = 'test.js-sample';
+		const result = incrementFileName(name, false, 'simple', true);
+		assert.strictEqual(result, 'test.js');
+	});
+});
+
 suite('Files - Increment file name simple', () => {
 
 	test('Increment file name without any version', function () {
 		const name = 'test.js';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy.js');
 	});
 
 	test('Increment file name with suffix version', function () {
 		const name = 'test copy.js';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 2.js');
 	});
 
 	test('Increment file name with suffix version with leading zeros', function () {
 		const name = 'test copy 005.js';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 6.js');
 	});
 
 	test('Increment file name with suffix version, too big number', function () {
 		const name = 'test copy 9007199254740992.js';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 9007199254740992 copy.js');
 	});
 
 	test('Increment file name with just version in name', function () {
 		const name = 'copy.js';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'copy copy.js');
 	});
 
 	test('Increment file name with just version in name, v2', function () {
 		const name = 'copy 2.js';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'copy 2 copy.js');
 	});
 
 	test('Increment file name without any extension or version', function () {
 		const name = 'test';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy');
 	});
 
 	test('Increment file name without any extension or version, trailing dot', function () {
 		const name = 'test.';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy.');
 	});
 
 	test('Increment file name without any extension or version, leading dot', function () {
 		const name = '.test';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, '.test copy');
 	});
 
 	test('Increment file name without any extension or version, leading dot v2', function () {
 		const name = '..test';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, '. copy.test');
 	});
 
 	test('Increment file name without any extension but with suffix version', function () {
 		const name = 'test copy 5';
-		const result = incrementFileName(name, false, 'simple');
+		const result = incrementFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 6');
 	});
 
 	test('Increment folder name without any version', function () {
 		const name = 'test';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy');
 	});
 
 	test('Increment folder name with suffix version', function () {
 		const name = 'test copy';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 2');
 	});
 
 	test('Increment folder name with suffix version, leading zeros', function () {
 		const name = 'test copy 005';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 6');
 	});
 
 	test('Increment folder name with suffix version, too big number', function () {
 		const name = 'test copy 9007199254740992';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 9007199254740992 copy');
 	});
 
 	test('Increment folder name with just version in name', function () {
 		const name = 'copy';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'copy copy');
 	});
 
 	test('Increment folder name with just version in name, v2', function () {
 		const name = 'copy 2';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'copy 2 copy');
 	});
 
 	test('Increment folder name "with extension" but without any version', function () {
 		const name = 'test.js';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test.js copy');
 	});
 
 	test('Increment folder name "with extension" and with suffix version', function () {
 		const name = 'test.js copy 5';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test.js copy 6');
 	});
 
 	test('Increment file/folder name with suffix version, special case 1', function () {
 		const name = 'test copy 0';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy');
 	});
 
 	test('Increment file/folder name with suffix version, special case 2', function () {
 		const name = 'test copy 1';
-		const result = incrementFileName(name, true, 'simple');
+		const result = incrementFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 2');
 	});
 
@@ -140,157 +190,157 @@ suite('Files - Increment file name smart', () => {
 
 	test('Increment file name without any version', function () {
 		const name = 'test.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.1.js');
 	});
 
 	test('Increment folder name without any version', function () {
 		const name = 'test';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.1');
 	});
 
 	test('Increment file name with suffix version', function () {
 		const name = 'test.1.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.2.js');
 	});
 
 	test('Increment file name with suffix version with trailing zeros', function () {
 		const name = 'test.001.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.002.js');
 	});
 
 	test('Increment file name with suffix version with trailing zeros, changing length', function () {
 		const name = 'test.009.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.010.js');
 	});
 
 	test('Increment file name with suffix version with `-` as separator', function () {
 		const name = 'test-1.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test-2.js');
 	});
 
 	test('Increment file name with suffix version with `-` as separator, trailing zeros', function () {
 		const name = 'test-001.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test-002.js');
 	});
 
 	test('Increment file name with suffix version with `-` as separator, trailing zeros, changnig length', function () {
 		const name = 'test-099.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test-100.js');
 	});
 
 	test('Increment file name with suffix version with `_` as separator', function () {
 		const name = 'test_1.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test_2.js');
 	});
 
 	test('Increment folder name with suffix version', function () {
 		const name = 'test.1';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.2');
 	});
 
 	test('Increment folder name with suffix version, trailing zeros', function () {
 		const name = 'test.001';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.002');
 	});
 
 	test('Increment folder name with suffix version with `-` as separator', function () {
 		const name = 'test-1';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test-2');
 	});
 
 	test('Increment folder name with suffix version with `_` as separator', function () {
 		const name = 'test_1';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test_2');
 	});
 
 	test('Increment file name with suffix version, too big number', function () {
 		const name = 'test.9007199254740992.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.9007199254740992.1.js');
 	});
 
 	test('Increment folder name with suffix version, too big number', function () {
 		const name = 'test.9007199254740992';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.9007199254740992.1');
 	});
 
 	test('Increment file name with prefix version', function () {
 		const name = '1.test.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2.test.js');
 	});
 
 	test('Increment file name with just version in name', function () {
 		const name = '1.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2.js');
 	});
 
 	test('Increment file name with just version in name, too big number', function () {
 		const name = '9007199254740992.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '9007199254740992.1.js');
 	});
 
 	test('Increment file name with prefix version, trailing zeros', function () {
 		const name = '001.test.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '002.test.js');
 	});
 
 	test('Increment file name with prefix version with `-` as separator', function () {
 		const name = '1-test.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2-test.js');
 	});
 
 	test('Increment file name with prefix version with `_` as separator', function () {
 		const name = '1_test.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2_test.js');
 	});
 
 	test('Increment file name with prefix version, too big number', function () {
 		const name = '9007199254740992.test.js';
-		const result = incrementFileName(name, false, 'smart');
+		const result = incrementFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '9007199254740992.test.1.js');
 	});
 
 	test('Increment folder name with prefix version', function () {
 		const name = '1.test';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '2.test');
 	});
 
 	test('Increment folder name with prefix version, too big number', function () {
 		const name = '9007199254740992.test';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '9007199254740992.test.1');
 	});
 
 	test('Increment folder name with prefix version, trailing zeros', function () {
 		const name = '001.test';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '002.test');
 	});
 
 	test('Increment folder name with prefix version  with `-` as separator', function () {
 		const name = '1-test';
-		const result = incrementFileName(name, true, 'smart');
+		const result = incrementFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '2-test');
 	});
 

--- a/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
@@ -258,7 +258,7 @@ suite('Files - Increment file name smart', () => {
 		assert.strictEqual(result, '2-test.js');
 	});
 
-	test('Increment file name with prefix version with `-` as separator', function () {
+	test('Increment file name with prefix version with `_` as separator', function () {
 		const name = '1_test.js';
 		const result = incrementFileName(name, false, 'smart');
 		assert.strictEqual(result, '2_test.js');

--- a/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/fileActions.test.ts
@@ -4,54 +4,54 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { incrementFileName } from 'vs/workbench/contrib/files/browser/fileActions';
+import { suggestFileName } from 'vs/workbench/contrib/files/browser/fileActions';
 
 suite('Files - Can remove example indicators from file names', () => {
 	test('Removes sample when has `.sample` before the extension', function () {
 		const name = 'test.sample.js';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `-sample` before the extension', function () {
 		const name = 'test-sample.js';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `.example` before the extension', function () {
 		const name = 'test.example.js';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `-example` before the extension', function () {
 		const name = 'test-example.js';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `.sample` after the extension', function () {
 		const name = 'test.js.sample';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `-sample` after the extension', function () {
 		const name = 'test.js-sample';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `.example` after the extension', function () {
 		const name = 'test.js.example';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 
 	test('Removes sample when has `-example` after the extension', function () {
 		const name = 'test.js-sample';
-		const result = incrementFileName(name, false, 'simple', true);
+		const result = suggestFileName(name, false, 'simple', true);
 		assert.strictEqual(result, 'test.js');
 	});
 });
@@ -60,127 +60,127 @@ suite('Files - Increment file name simple', () => {
 
 	test('Increment file name without any version', function () {
 		const name = 'test.js';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy.js');
 	});
 
 	test('Increment file name with suffix version', function () {
 		const name = 'test copy.js';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 2.js');
 	});
 
 	test('Increment file name with suffix version with leading zeros', function () {
 		const name = 'test copy 005.js';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 6.js');
 	});
 
 	test('Increment file name with suffix version, too big number', function () {
 		const name = 'test copy 9007199254740992.js';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 9007199254740992 copy.js');
 	});
 
 	test('Increment file name with just version in name', function () {
 		const name = 'copy.js';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'copy copy.js');
 	});
 
 	test('Increment file name with just version in name, v2', function () {
 		const name = 'copy 2.js';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'copy 2 copy.js');
 	});
 
 	test('Increment file name without any extension or version', function () {
 		const name = 'test';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy');
 	});
 
 	test('Increment file name without any extension or version, trailing dot', function () {
 		const name = 'test.';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy.');
 	});
 
 	test('Increment file name without any extension or version, leading dot', function () {
 		const name = '.test';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, '.test copy');
 	});
 
 	test('Increment file name without any extension or version, leading dot v2', function () {
 		const name = '..test';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, '. copy.test');
 	});
 
 	test('Increment file name without any extension but with suffix version', function () {
 		const name = 'test copy 5';
-		const result = incrementFileName(name, false, 'simple', false);
+		const result = suggestFileName(name, false, 'simple', false);
 		assert.strictEqual(result, 'test copy 6');
 	});
 
 	test('Increment folder name without any version', function () {
 		const name = 'test';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy');
 	});
 
 	test('Increment folder name with suffix version', function () {
 		const name = 'test copy';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 2');
 	});
 
 	test('Increment folder name with suffix version, leading zeros', function () {
 		const name = 'test copy 005';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 6');
 	});
 
 	test('Increment folder name with suffix version, too big number', function () {
 		const name = 'test copy 9007199254740992';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 9007199254740992 copy');
 	});
 
 	test('Increment folder name with just version in name', function () {
 		const name = 'copy';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'copy copy');
 	});
 
 	test('Increment folder name with just version in name, v2', function () {
 		const name = 'copy 2';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'copy 2 copy');
 	});
 
 	test('Increment folder name "with extension" but without any version', function () {
 		const name = 'test.js';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test.js copy');
 	});
 
 	test('Increment folder name "with extension" and with suffix version', function () {
 		const name = 'test.js copy 5';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test.js copy 6');
 	});
 
 	test('Increment file/folder name with suffix version, special case 1', function () {
 		const name = 'test copy 0';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy');
 	});
 
 	test('Increment file/folder name with suffix version, special case 2', function () {
 		const name = 'test copy 1';
-		const result = incrementFileName(name, true, 'simple', false);
+		const result = suggestFileName(name, true, 'simple', false);
 		assert.strictEqual(result, 'test copy 2');
 	});
 
@@ -190,157 +190,157 @@ suite('Files - Increment file name smart', () => {
 
 	test('Increment file name without any version', function () {
 		const name = 'test.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.1.js');
 	});
 
 	test('Increment folder name without any version', function () {
 		const name = 'test';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.1');
 	});
 
 	test('Increment file name with suffix version', function () {
 		const name = 'test.1.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.2.js');
 	});
 
 	test('Increment file name with suffix version with trailing zeros', function () {
 		const name = 'test.001.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.002.js');
 	});
 
 	test('Increment file name with suffix version with trailing zeros, changing length', function () {
 		const name = 'test.009.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.010.js');
 	});
 
 	test('Increment file name with suffix version with `-` as separator', function () {
 		const name = 'test-1.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test-2.js');
 	});
 
 	test('Increment file name with suffix version with `-` as separator, trailing zeros', function () {
 		const name = 'test-001.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test-002.js');
 	});
 
 	test('Increment file name with suffix version with `-` as separator, trailing zeros, changnig length', function () {
 		const name = 'test-099.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test-100.js');
 	});
 
 	test('Increment file name with suffix version with `_` as separator', function () {
 		const name = 'test_1.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test_2.js');
 	});
 
 	test('Increment folder name with suffix version', function () {
 		const name = 'test.1';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.2');
 	});
 
 	test('Increment folder name with suffix version, trailing zeros', function () {
 		const name = 'test.001';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.002');
 	});
 
 	test('Increment folder name with suffix version with `-` as separator', function () {
 		const name = 'test-1';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test-2');
 	});
 
 	test('Increment folder name with suffix version with `_` as separator', function () {
 		const name = 'test_1';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test_2');
 	});
 
 	test('Increment file name with suffix version, too big number', function () {
 		const name = 'test.9007199254740992.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, 'test.9007199254740992.1.js');
 	});
 
 	test('Increment folder name with suffix version, too big number', function () {
 		const name = 'test.9007199254740992';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, 'test.9007199254740992.1');
 	});
 
 	test('Increment file name with prefix version', function () {
 		const name = '1.test.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2.test.js');
 	});
 
 	test('Increment file name with just version in name', function () {
 		const name = '1.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2.js');
 	});
 
 	test('Increment file name with just version in name, too big number', function () {
 		const name = '9007199254740992.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '9007199254740992.1.js');
 	});
 
 	test('Increment file name with prefix version, trailing zeros', function () {
 		const name = '001.test.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '002.test.js');
 	});
 
 	test('Increment file name with prefix version with `-` as separator', function () {
 		const name = '1-test.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2-test.js');
 	});
 
 	test('Increment file name with prefix version with `_` as separator', function () {
 		const name = '1_test.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '2_test.js');
 	});
 
 	test('Increment file name with prefix version, too big number', function () {
 		const name = '9007199254740992.test.js';
-		const result = incrementFileName(name, false, 'smart', false);
+		const result = suggestFileName(name, false, 'smart', false);
 		assert.strictEqual(result, '9007199254740992.test.1.js');
 	});
 
 	test('Increment folder name with prefix version', function () {
 		const name = '1.test';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '2.test');
 	});
 
 	test('Increment folder name with prefix version, too big number', function () {
 		const name = '9007199254740992.test';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '9007199254740992.test.1');
 	});
 
 	test('Increment folder name with prefix version, trailing zeros', function () {
 		const name = '001.test';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '002.test');
 	});
 
 	test('Increment folder name with prefix version  with `-` as separator', function () {
 		const name = '1-test';
-		const result = incrementFileName(name, true, 'smart', false);
+		const result = suggestFileName(name, true, 'smart', false);
 		assert.strictEqual(result, '2-test');
 	});
 


### PR DESCRIPTION
Currently when a user pastes a file like `.env.example` it becomes `.env copy.example` or `.env.1.example` (depending on their incremental naming settings), and just makes more work for the user to rename the file to be just `.env`.

This change makes it so when a user copies a file that has `.example`, `-example`, `.sample`, or `-sample` before or after the extension, when the file is pasted it will remove the `example` or `sample` part.

If someone pastes an example file and already has what it would resolve to, it will just increment on the resolved name. So if someone already has `.env` and pasts `.env.example` it will just become `.env copy`.

The use case I had in mind was to assist when setting up projects that have example config files because the real ones are ignored (for security, or because they'd change between computers).

Here's a demonstration:
![Example File Copy Demo](https://user-images.githubusercontent.com/3896310/76277421-b022c680-6256-11ea-92c6-006cafc81124.gif)

This seems like something that could annoy some people, so I figured it'd be good as a setting. I made it enabled by default, but don't mind changing it to be disabled by default.

I tested this out by creating a few files with `example` and `sample` and just copied and pasted them in different ways.

I also did a bit of refactoring for maintainability, since it seemed relevant. I could undo it if it'd be preferred. I'm also open to doing more refactoring if there's anything else that seems relevant.