### PR TITLE
debug: show errros from scopes request

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
@@ -125,7 +125,8 @@
 	font-style: italic;
 }
 
-.monaco-workbench .monaco-list-row .expression .error {
+.monaco-workbench .monaco-list-row .expression .error,
+.monaco-workbench .debug-pane .debug-variables .scope .error {
 	color: #e51400;
 }
 
@@ -145,7 +146,8 @@
 	color: rgba(204, 204, 204, 0.6);
 }
 
-.vs-dark .monaco-workbench .monaco-list-row .expression .error {
+.vs-dark .monaco-workbench .monaco-list-row .expression .error,
+.vs-dark .monaco-workbench .debug-pane .debug-variables .scope .error {
 	color: #f48771;
 }
 
@@ -173,7 +175,8 @@
 	color: #ce9178;
 }
 
-.hc-black .monaco-workbench .monaco-list-row .expression .error {
+.hc-black .monaco-workbench .monaco-list-row .expression .error,
+.hc-black .monaco-workbench .debug-pane .debug-variables .scope .error {
 	color: #f48771;
 }
 

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -316,6 +316,14 @@
 	animation-name: debugViewletValueChanged;
 }
 
+.debug-pane .debug-variables .scope .error {
+	font-style: italic;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	font-family: var(--monaco-monospace-font);
+	font-weight: normal;
+}
+
 /* Breakpoints */
 
 .debug-pane .monaco-list-row {

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -217,7 +217,7 @@ function isViewModel(obj: any): obj is IViewModel {
 export class VariablesDataSource implements IAsyncDataSource<IViewModel, IExpression | IScope> {
 
 	hasChildren(element: IViewModel | IExpression | IScope): boolean {
-		if (isViewModel(element) || element instanceof Scope) {
+		if (isViewModel(element)) {
 			return true;
 		}
 
@@ -270,7 +270,8 @@ class ScopesRenderer implements ITreeRenderer<IScope, FuzzyScore, IScopeTemplate
 	}
 
 	renderElement(element: ITreeNode<IScope, FuzzyScore>, index: number, templateData: IScopeTemplateData): void {
-		templateData.label.set(element.element.name, createMatches(element.filterData));
+		const name = element.element.name;
+		templateData.label.set(name, element.element.reference === -1 ? [{ start: 0, end: name.length, extraClasses: 'error' }] : createMatches(element.filterData));
 	}
 
 	disposeTemplate(templateData: IScopeTemplateData): void {

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -9,7 +9,7 @@ import * as dom from 'vs/base/browser/dom';
 import { CollapseAction } from 'vs/workbench/browser/viewlet';
 import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
 import { IDebugService, IExpression, IScope, CONTEXT_VARIABLES_FOCUSED, IViewModel } from 'vs/workbench/contrib/debug/common/debug';
-import { Variable, Scope } from 'vs/workbench/contrib/debug/common/debugModel';
+import { Variable, Scope, ErrorScope } from 'vs/workbench/contrib/debug/common/debugModel';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { renderViewTree, renderVariable, IInputBoxOptions, AbstractExpressionsRenderer, IExpressionTemplateData } from 'vs/workbench/contrib/debug/browser/baseDebugView';
@@ -34,6 +34,7 @@ import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { escape } from 'vs/base/common/strings';
 
 const $ = dom.$;
 let forgetScopes = true;
@@ -271,7 +272,11 @@ class ScopesRenderer implements ITreeRenderer<IScope, FuzzyScore, IScopeTemplate
 
 	renderElement(element: ITreeNode<IScope, FuzzyScore>, index: number, templateData: IScopeTemplateData): void {
 		const name = element.element.name;
-		templateData.label.set(name, element.element.reference === -1 ? [{ start: 0, end: name.length, extraClasses: 'error' }] : createMatches(element.filterData));
+		if (element.element instanceof ErrorScope) {
+			templateData.name.innerHTML = `<span class="error">${escape(name)}</span>`;
+		} else {
+			templateData.label.set(name, createMatches(element.filterData));
+		}
 	}
 
 	disposeTemplate(templateData: IScopeTemplateData): void {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -301,6 +301,7 @@ export interface IScope extends IExpressionContainer {
 	readonly name: string;
 	readonly expensive: boolean;
 	readonly range?: IRange;
+	readonly hasChildren: boolean;
 }
 
 export interface IStackFrame extends ITreeElement {

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -276,7 +276,7 @@ export class ErrorScope extends Scope {
 		index: number,
 		message: string,
 	) {
-		super(stackFrame, index, message, -1, false);
+		super(stackFrame, index, message, 0, false);
 	}
 
 	toString(): string {

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -269,6 +269,21 @@ export class Scope extends ExpressionContainer implements IScope {
 	}
 }
 
+export class ErrorScope extends Scope {
+
+	constructor(
+		stackFrame: IStackFrame,
+		index: number,
+		message: string,
+	) {
+		super(stackFrame, index, message, -1, false);
+	}
+
+	toString(): string {
+		return this.name;
+	}
+}
+
 export class StackFrame implements IStackFrame {
 
 	private scopes: Promise<Scope[]> | undefined;
@@ -293,7 +308,7 @@ export class StackFrame implements IStackFrame {
 				return response && response.body && response.body.scopes ?
 					response.body.scopes.map((rs, index) => new Scope(this, index, rs.name, rs.variablesReference, rs.expensive, rs.namedVariables, rs.indexedVariables,
 						rs.line && rs.column && rs.endLine && rs.endColumn ? new Range(rs.line, rs.column, rs.endLine, rs.endColumn) : undefined)) : [];
-			}, err => []);
+			}, err => [new ErrorScope(this, 0, err.message)]);
 		}
 
 		return this.scopes;


### PR DESCRIPTION
Just used the existing highlight error styling, since changing that would be a larger change. Can do that though if we think it'd be better 🙂 

![](https://memes.peet.io/img/20-03-92699c30-2184-4511-8b24-872449855291.png)

Fixes https://github.com/microsoft/vscode/issues/92102