### PR TITLE
Extensions are only loaded if they are allowed by a blocklist

### DIFF
--- a/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/electron-browser/sharedProcess/sharedProcessMain.ts
@@ -15,6 +15,8 @@ import { EnvironmentService } from 'vs/platform/environment/node/environmentServ
 import { ExtensionManagementChannel } from 'vs/platform/extensionManagement/common/extensionManagementIpc';
 import { IExtensionManagementService, IExtensionGalleryService, IGlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionManagementService } from 'vs/platform/extensionManagement/node/extensionManagementService';
+import { IExtensionBlocklistService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
+import { ExtensionBlocklistService } from 'vs/workbench/services/extensionManagement/common/extensionBlocklistService';
 import { ExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionGalleryService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ConfigurationService } from 'vs/platform/configuration/common/configurationService';
@@ -184,6 +186,7 @@ async function main(server: Server, initData: ISharedProcessInitData, configurat
 		}
 		server.registerChannel('telemetryAppender', new TelemetryAppenderChannel(appInsightsAppender));
 
+		services.set(IExtensionBlocklistService, new SyncDescriptor(ExtensionBlocklistService));
 		services.set(IExtensionManagementService, new SyncDescriptor(ExtensionManagementService));
 		services.set(IExtensionGalleryService, new SyncDescriptor(ExtensionGalleryService));
 		services.set(ILocalizationsService, new SyncDescriptor(LocalizationsService));

--- a/src/vs/workbench/services/extensionManagement/common/extensionBlocklistService.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionBlocklistService.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IExtensionBlocklistService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+
+export interface IBlocklistConfiguration {
+	allowedPublishers: string[];
+	allowedPackages: string[];
+	prohibitedPackages: string[];
+}
+
+export class ExtensionBlocklistService extends Disposable implements IExtensionBlocklistService {
+
+	_serviceBrand: undefined;
+	private _blocklist: IBlocklistConfiguration;
+
+	constructor(
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) {
+		super();
+
+		this._blocklist = {
+			allowedPublishers: [],
+			allowedPackages: [],
+			prohibitedPackages: []
+		};
+
+		this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('extensions.blocklist')) {
+				this._blocklist = this._configurationService.getValue('extensions.blocklist');
+			}
+		});
+	}
+
+	isPermitted(extension: { publisher: string; name: string; version: string }): boolean {
+		const builtinPublishers = ['vscode', 'ms-vscode'];
+		const allowedPublishers = builtinPublishers.concat(this._blocklist.allowedPublishers);
+
+		return (allowedPublishers.indexOf(extension.publisher) !== -1 ||
+			this._blocklist.allowedPackages.indexOf(extension.publisher + '.' + extension.name) !== -1) &&
+			this._blocklist.prohibitedPackages.indexOf(extension.publisher + '.' + extension.name + '-' + extension.version) === -1;
+	}
+
+}
+
+registerSingleton(IExtensionBlocklistService, ExtensionBlocklistService, true);

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -73,6 +73,13 @@ export interface IWorkbenchExtensionEnablementService {
 	setEnablement(extensions: IExtension[], state: EnablementState): Promise<boolean[]>;
 }
 
+export const IExtensionBlocklistService = createDecorator<IExtensionBlocklistService>('extensionBlocklistService');
+
+export interface IExtensionBlocklistService {
+	_serviceBrand: undefined;
+	isPermitted(extension: { publisher: string; name: string; version: string} ): boolean;
+}
+
 export interface IExtensionsConfigContent {
 	recommendations: string[];
 	unwantedRecommendations: string[];

--- a/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/workbench/services/extensionManagement/common/extensionManagement.ts
@@ -77,7 +77,7 @@ export const IExtensionBlocklistService = createDecorator<IExtensionBlocklistSer
 
 export interface IExtensionBlocklistService {
 	_serviceBrand: undefined;
-	isPermitted(extension: { publisher: string; name: string; version: string} ): boolean;
+	isPermitted(extension: { publisher: string; name: string; version: string }): boolean;
 }
 
 export interface IExtensionsConfigContent {

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -43,6 +43,7 @@ import 'vs/workbench/services/remote/electron-browser/remoteAgentServiceImpl';
 import 'vs/workbench/services/telemetry/electron-browser/telemetryService';
 import 'vs/workbench/services/configurationResolver/electron-browser/configurationResolverService';
 import 'vs/workbench/services/extensionManagement/node/extensionManagementService';
+import 'vs/workbench/services/extensionManagement/common/extensionBlocklistService';
 import 'vs/workbench/services/accessibility/electron-browser/accessibilityService';
 import 'vs/workbench/services/remote/node/tunnelService';
 import 'vs/workbench/services/backup/node/backupFileService';


### PR DESCRIPTION
This PR begins to address #84756.

This PR includes functionality to allow certain extension publishers or to disallow certain extension publishers. It also includes the ability to disallow particular extensions.
In order to use it, add the following to your `settings.json`:
```
"extensions.blocklist": {
		"allowedPublishers": ["my-trusted-publisher"],
		"allowedPackages": [],
		"prohibitedPackages": []
	}
```
Attempting to install a forbidden extension will result in an error notification letting the user know that the extension is prohibited by local policy.

We wanted to open this PR to gather feedback and see if we are on the right track.
