### PR TITLE
progress - remove options

### DIFF
--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -169,7 +169,7 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		// Instantiate composite from registry otherwise
 		const compositeDescriptor = this.registry.getComposite(id);
 		if (compositeDescriptor) {
-			const compositeProgressIndicator = this.instantiationService.createInstance(CompositeProgressIndicator, assertIsDefined(this.progressBar), compositeDescriptor.id, !!isActive, undefined);
+			const compositeProgressIndicator = this.instantiationService.createInstance(CompositeProgressIndicator, assertIsDefined(this.progressBar), compositeDescriptor.id, !!isActive);
 			const compositeInstantiationService = this.instantiationService.createChild(new ServiceCollection(
 				[IEditorProgressService, compositeProgressIndicator] // provide the editor progress service for any editors instantiated within the composite
 			));

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -345,7 +345,7 @@ export abstract class ViewPane extends Pane implements IView {
 		}
 
 		if (this.progressIndicator === undefined) {
-			this.progressIndicator = this.instantiationService.createInstance(CompositeProgressIndicator, assertIsDefined(this.progressBar), this.id, this.isVisible(), { exclusiveProgressBar: true });
+			this.progressIndicator = this.instantiationService.createInstance(CompositeProgressIndicator, assertIsDefined(this.progressBar), this.id, this.isVisible());
 		}
 		return this.progressIndicator;
 	}

--- a/src/vs/workbench/services/progress/browser/progressIndicator.ts
+++ b/src/vs/workbench/services/progress/browser/progressIndicator.ts
@@ -198,7 +198,6 @@ export class CompositeProgressIndicator extends CompositeScope implements IProgr
 		progressbar: ProgressBar,
 		scopeId: string,
 		isActive: boolean,
-		private readonly options: { exclusiveProgressBar?: boolean } | undefined,
 		@IViewletService viewletService: IViewletService,
 		@IPanelService panelService: IPanelService,
 		@IViewsService viewsService: IViewsService
@@ -212,9 +211,7 @@ export class CompositeProgressIndicator extends CompositeScope implements IProgr
 	onScopeDeactivated(): void {
 		this.isActive = false;
 
-		if (this.options?.exclusiveProgressBar) {
-			this.progressbar.stop().hide();
-		}
+		this.progressbar.stop().hide();
 	}
 
 	onScopeActivated(): void {
@@ -314,7 +311,7 @@ export class CompositeProgressIndicator extends CompositeScope implements IProgr
 			done: () => {
 				this.progressState = ProgressIndicatorState.Done;
 
-				if (this.isActive || this.options?.exclusiveProgressBar) {
+				if (this.isActive) {
 					this.progressbar.stop().hide();
 				}
 			}
@@ -345,7 +342,7 @@ export class CompositeProgressIndicator extends CompositeScope implements IProgr
 				// The while promise is either null or equal the promise we last hooked on
 				this.progressState = ProgressIndicatorState.None;
 
-				if (this.isActive || this.options?.exclusiveProgressBar) {
+				if (this.isActive) {
 					this.progressbar.stop().hide();
 				}
 			}

--- a/src/vs/workbench/services/progress/test/browser/progressIndicator.test.ts
+++ b/src/vs/workbench/services/progress/test/browser/progressIndicator.test.ts
@@ -129,7 +129,7 @@ suite('Progress Indicator', () => {
 		let viewletService = new TestViewletService();
 		let panelService = new TestPanelService();
 		let viewsService = new TestViewsService();
-		let service = new CompositeProgressIndicator((<any>testProgressBar), 'test.scopeId', true, undefined, viewletService, panelService, viewsService);
+		let service = new CompositeProgressIndicator((<any>testProgressBar), 'test.scopeId', true, viewletService, panelService, viewsService);
 
 		// Active: Show (Infinite)
 		let fn = service.show(true);


### PR DESCRIPTION
As I was thinking earlier, we should not need the options. The indicator is fit to replay progress even if a scope is not active and comes back so it should be fine.

I tested this with the code from https://github.com/microsoft/vscode/issues/92445 when switching between 2 viewlets. 