### PR TITLE
Alert input box messages anytime shown

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -373,18 +373,6 @@ export class InputBox extends Widget {
 		const styles = this.stylesForType(this.message.type);
 		this.element.style.border = styles.border ? `1px solid ${styles.border}` : '';
 
-		// ARIA Support
-		let alertText: string;
-		if (message.type === MessageType.ERROR) {
-			alertText = nls.localize('alertErrorMessage', "Error: {0}", message.content);
-		} else if (message.type === MessageType.WARNING) {
-			alertText = nls.localize('alertWarningMessage', "Warning: {0}", message.content);
-		} else {
-			alertText = nls.localize('alertInfoMessage', "Info: {0}", message.content);
-		}
-
-		aria.alert(alertText);
-
 		if (this.hasFocus() || force) {
 			this._showMessage();
 		}
@@ -484,6 +472,18 @@ export class InputBox extends Widget {
 			},
 			layout: layout
 		});
+
+		// ARIA Support
+		let alertText: string;
+		if (this.message.type === MessageType.ERROR) {
+			alertText = nls.localize('alertErrorMessage', "Error: {0}", this.message.content);
+		} else if (this.message.type === MessageType.WARNING) {
+			alertText = nls.localize('alertWarningMessage', "Warning: {0}", this.message.content);
+		} else {
+			alertText = nls.localize('alertInfoMessage', "Info: {0}", this.message.content);
+		}
+
+		aria.alert(alertText);
 
 		this.state = 'open';
 	}


### PR DESCRIPTION
This is a fix for an issue that was brought up in an accessibility review of Azure Data Studio : https://github.com/microsoft/azuredatastudio/issues/9175

The issue is that if a message is shown the alert is read the first time - but if the user tabs out (hiding the message) and then back in (showing the message box again) the message is not read again which means that unless the user retained the context that a message was displayed they wouldn't know it was there. 

The fix here is to always fire the alert whenever the message is displayed instead of just when showMessage is called (which isn't called when focus is gained through other means such as tab for example). 