### PR TITLE
Move custom editor tests back into VS Code

### DIFF
--- a/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
+++ b/extensions/typescript-language-features/src/typeScriptServiceClientHost.ts
@@ -210,7 +210,7 @@ export default class TypeScriptServiceClientHost extends Disposable {
 
 			language.configFileDiagnosticsReceived(this.client.toResource(body.configFile), body.diagnostics.map(tsDiag => {
 				const range = tsDiag.start && tsDiag.end ? typeConverters.Range.fromTextSpan(tsDiag) : new vscode.Range(0, 0, 0, 1);
-				const diagnostic = new vscode.Diagnostic(range, body.diagnostics[0].text, this.getDiagnosticSeverity(tsDiag));
+				const diagnostic = new vscode.Diagnostic(range, tsDiag.text, this.getDiagnosticSeverity(tsDiag));
 				diagnostic.source = language.diagnosticSource;
 				return diagnostic;
 			}));

--- a/extensions/vscode-api-tests/customEditorMedia/abc.js
+++ b/extensions/vscode-api-tests/customEditorMedia/abc.js
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+// @ts-check
+(function () {
+	// @ts-ignore
+	const vscode = acquireVsCodeApi();
+
+	const textArea = document.querySelector('textarea');
+
+	const initialState = vscode.getState();
+	if (initialState) {
+		textArea.value = initialState.value;
+	}
+
+	window.addEventListener('message', e => {
+		switch (e.data.type) {
+			case 'fakeInput':
+				{
+					const value = e.data.value;
+					textArea.value = value;
+					onInput();
+					break;
+				}
+
+			case 'setValue':
+				{
+					const value = e.data.value;
+					textArea.value = value;
+					vscode.setState({ value });
+
+					vscode.postMessage({
+						type: 'didChangeContent',
+						value: value
+					});
+					break;
+				}
+		}
+	});
+
+	const onInput = () => {
+		const value = textArea.value;
+		vscode.setState({ value });
+		vscode.postMessage({
+			type: 'edit',
+			value: value
+		});
+		vscode.postMessage({
+			type: 'didChangeContent',
+			value: value
+		});
+	};
+
+	textArea.addEventListener('input', onInput);
+}());

--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -8,9 +8,10 @@
 	"private": true,
 	"activationEvents": [
 		"onFileSystem:memfs",
-		"onDebug"
+		"onDebug",
+		"onCustomEditor:testWebviewEditor.abc"
 	],
-  "main": "./out/extension",
+	"main": "./out/extension",
 	"engines": {
 		"vscode": "^1.25.0"
 	},
@@ -109,6 +110,17 @@
 					}
 				]
 			}
+		],
+		"customEditors": [
+			{
+				"viewType": "testWebviewEditor.abc",
+				"displayName": "Test ABC editor",
+				"selector": [
+					{
+						"filenamePattern": "*.abc"
+					}
+				]
+			}
 		]
 	},
 	"scripts": {
@@ -122,5 +134,8 @@
 		"mocha-multi-reporters": "^1.1.7",
 		"typescript": "^1.6.2",
 		"vscode": "1.1.5"
+	},
+	"dependencies": {
+		"p-limit": "^2.2.2"
 	}
 }

--- a/extensions/vscode-api-tests/src/abcEditor.ts
+++ b/extensions/vscode-api-tests/src/abcEditor.ts
@@ -35,7 +35,7 @@ export class AbcEditorProvider implements vscode.CustomTextEditorProvider {
 
 		const commands: vscode.Disposable[] = [];
 		commands.push(vscode.commands.registerCommand(Testing.abcEditorTypeCommand, (content: string) => {
-			this.activeEditor?.testing_fakeInput(content);
+			this.activeEditor!.testing_fakeInput(content);
 		}));
 
 		return vscode.Disposable.from(provider, ...commands);

--- a/extensions/vscode-api-tests/src/abcEditor.ts
+++ b/extensions/vscode-api-tests/src/abcEditor.ts
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import pLimit from 'p-limit';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { Disposable } from './dispose';
+
+export namespace Testing {
+	export const abcEditorContentChangeCommand = '_abcEditor.contentChange';
+	export const abcEditorTypeCommand = '_abcEditor.type';
+
+	export interface CustomEditorContentChangeEvent {
+		readonly content: string;
+		readonly source: vscode.Uri;
+	}
+}
+
+export class AbcEditorProvider implements vscode.CustomTextEditorProvider {
+
+	public static readonly viewType = 'testWebviewEditor.abc';
+
+	private activeEditor?: AbcEditor;
+
+	public constructor(
+		private readonly context: vscode.ExtensionContext,
+	) { }
+
+	public register(): vscode.Disposable {
+		const provider = vscode.window.registerCustomEditorProvider(AbcEditorProvider.viewType, this, {
+			enableFindWidget: true
+		});
+
+		const commands: vscode.Disposable[] = [];
+		commands.push(vscode.commands.registerCommand(Testing.abcEditorTypeCommand, (content: string) => {
+			this.activeEditor?.testing_fakeInput(content);
+		}));
+
+		return vscode.Disposable.from(provider, ...commands);
+	}
+
+	public async resolveCustomTextEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel) {
+		const editor = new AbcEditor(document, this.context.extensionPath, panel);
+
+		this.activeEditor = editor;
+
+		panel.onDidChangeViewState(({ webviewPanel }) => {
+			if (this.activeEditor === editor && !webviewPanel.active) {
+				this.activeEditor = undefined;
+			}
+			if (webviewPanel.active) {
+				this.activeEditor = editor;
+			}
+		});
+	}
+}
+
+class AbcEditor extends Disposable {
+
+	public readonly _onDispose = this._register(new vscode.EventEmitter<void>());
+	public readonly onDispose = this._onDispose.event;
+
+	private readonly limit = pLimit(1);
+	private syncedVersion: number = -1;
+	private currentWorkspaceEdit?: Thenable<void>;
+
+	constructor(
+		private readonly document: vscode.TextDocument,
+		private readonly _extensionPath: string,
+		private readonly panel: vscode.WebviewPanel,
+	) {
+		super();
+
+		panel.webview.options = {
+			enableScripts: true,
+		};
+		panel.webview.html = this.html;
+
+		this._register(vscode.workspace.onDidChangeTextDocument(e => {
+			if (e.document === this.document) {
+				this.update();
+			}
+		}));
+
+		this._register(panel.webview.onDidReceiveMessage(message => {
+			switch (message.type) {
+				case 'edit':
+					this.doEdit(message.value);
+					break;
+
+				case 'didChangeContent':
+					vscode.commands.executeCommand(Testing.abcEditorContentChangeCommand, {
+						content: message.value,
+						source: document.uri,
+					} as Testing.CustomEditorContentChangeEvent);
+					break;
+			}
+		}));
+
+		this._register(panel.onDidDispose(() => { this.dispose(); }));
+
+		this.update();
+	}
+
+	public testing_fakeInput(value: string) {
+		this.panel.webview.postMessage({
+			type: 'fakeInput',
+			value: value,
+		});
+	}
+
+	private async doEdit(value: string) {
+		const edit = new vscode.WorkspaceEdit();
+		edit.replace(this.document.uri, this.document.validateRange(new vscode.Range(new vscode.Position(0, 0), new vscode.Position(999999, 999999))), value);
+		this.limit(() => {
+			this.currentWorkspaceEdit = vscode.workspace.applyEdit(edit).then(() => {
+				this.syncedVersion = this.document.version;
+				this.currentWorkspaceEdit = undefined;
+			});
+			return this.currentWorkspaceEdit;
+		});
+	}
+
+	public dispose() {
+		if (this.isDisposed) {
+			return;
+		}
+
+		this._onDispose.fire();
+		super.dispose();
+	}
+
+	private get html() {
+		const contentRoot = path.join(this._extensionPath, 'customEditorMedia');
+		const scriptUri = vscode.Uri.file(path.join(contentRoot, 'abc.js'));
+		const nonce = Date.now() + '';
+		return /* html */`<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline';">
+				<title>Document</title>
+			</head>
+			<body>
+				<textarea style="width: 300px; height: 300px;"></textarea>
+				<script nonce=${nonce} src="${this.panel.webview.asWebviewUri(scriptUri)}"></script>
+			</body>
+			</html>`;
+	}
+
+	public async update() {
+		await this.currentWorkspaceEdit;
+
+		if (this.isDisposed || this.syncedVersion >= this.document.version) {
+			return;
+		}
+
+		this.panel.webview.postMessage({
+			type: 'setValue',
+			value: this.document.getText(),
+		});
+		this.syncedVersion = this.document.version;
+	}
+}

--- a/extensions/vscode-api-tests/src/dispose.ts
+++ b/extensions/vscode-api-tests/src/dispose.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { disposeAll } from './utils';
+
+export abstract class Disposable {
+	protected _isDisposed = false;
+
+	protected _disposables: vscode.Disposable[] = [];
+
+	public dispose(): any {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		disposeAll(this._disposables);
+	}
+
+	protected _register<T extends vscode.Disposable>(value: T): T {
+		if (this._isDisposed) {
+			value.dispose();
+		} else {
+			this._disposables.push(value);
+		}
+		return value;
+	}
+
+	protected get isDisposed() {
+		return this._isDisposed;
+	}
+}

--- a/extensions/vscode-api-tests/src/extension.ts
+++ b/extensions/vscode-api-tests/src/extension.ts
@@ -4,8 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { AbcEditorProvider } from './abcEditor';
 
-export function activate(_context: vscode.ExtensionContext) {
-	// noop
+export function activate(context: vscode.ExtensionContext) {
+	enableCustomEditors(context);
 }
 
+export function enableCustomEditors(context: vscode.ExtensionContext) {
+	context.subscriptions.push(new AbcEditorProvider(context).register());
+}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/customEditor.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/customEditor.test.ts
@@ -47,7 +47,8 @@ class CustomEditorUpdateListener {
 		this.commandSubscription = vscode.commands.registerCommand(Testing.abcEditorContentChangeCommand, (data: Testing.CustomEditorContentChangeEvent) => {
 			if (this.callbackQueue.length) {
 				const callback = this.callbackQueue.shift();
-				callback?.(data);
+				assert.ok(callback);
+				callback!(data);
 			} else {
 				this.unconsumedResponses.push(data);
 			}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/customEditor.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/customEditor.test.ts
@@ -1,0 +1,312 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { disposeAll, closeAllEditors, delay, randomFilePath } from '../utils';
+import { Testing } from '../abcEditor';
+
+assert.ok(vscode.workspace.rootPath);
+const testWorkspaceRoot = vscode.Uri.file(vscode.workspace.rootPath!);
+
+const commands = Object.freeze({
+	open: 'vscode.open',
+	openWith: 'vscode.openWith',
+	save: 'workbench.action.files.save',
+	undo: 'editor.action.customEditor.undo',
+});
+
+async function writeRandomFile(options: { root?: vscode.Uri; ext: string; contents: string; }): Promise<vscode.Uri> {
+	const fakeFile = randomFilePath({ root: options.root, ext: options.ext });
+	await fs.promises.writeFile(fakeFile.fsPath, Buffer.from(options.contents));
+	return fakeFile;
+}
+
+const disposables: vscode.Disposable[] = [];
+function _register<T extends vscode.Disposable>(disposable: T) {
+	disposables.push(disposable);
+	return disposable;
+}
+
+class CustomEditorUpdateListener {
+
+	public static create() {
+		return _register(new CustomEditorUpdateListener());
+	}
+
+	private readonly commandSubscription: vscode.Disposable;
+
+	private readonly unconsumedResponses: Array<Testing.CustomEditorContentChangeEvent> = [];
+	private readonly callbackQueue: Array<(data: Testing.CustomEditorContentChangeEvent) => void> = [];
+
+	private constructor() {
+		this.commandSubscription = vscode.commands.registerCommand(Testing.abcEditorContentChangeCommand, (data: Testing.CustomEditorContentChangeEvent) => {
+			if (this.callbackQueue.length) {
+				const callback = this.callbackQueue.shift();
+				callback?.(data);
+			} else {
+				this.unconsumedResponses.push(data);
+			}
+		});
+	}
+
+	dispose() {
+		this.commandSubscription.dispose();
+	}
+
+	async nextResponse(): Promise<Testing.CustomEditorContentChangeEvent> {
+		if (this.unconsumedResponses.length) {
+			return this.unconsumedResponses.shift()!;
+		}
+
+		return new Promise(resolve => {
+			this.callbackQueue.push(resolve);
+		});
+	}
+}
+
+
+suite('CustomEditor tests', () => {
+	setup(async () => {
+		resetTestWorkspace();
+	});
+
+	teardown(async () => {
+		await closeAllEditors();
+
+		disposeAll(disposables);
+
+		resetTestWorkspace();
+	});
+
+	test('Should load basic content from disk', async () => {
+		const startingContent = `load, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+
+		const { content } = await listener.nextResponse();
+		assert.equal(content, startingContent);
+	});
+
+	test('Should support basic edits', async () => {
+		const startingContent = `basic edit, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const newContent = `basic edit test`;
+		await vscode.commands.executeCommand(Testing.abcEditorTypeCommand, newContent);
+		const { content } = await listener.nextResponse();
+		assert.equal(content, newContent);
+	});
+
+	test('Should support single undo', async () => {
+		const startingContent = `single undo, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const newContent = `undo test`;
+		{
+			await vscode.commands.executeCommand(Testing.abcEditorTypeCommand, newContent);
+			const { content } = await listener.nextResponse();
+			assert.equal(content, newContent);
+		}
+		await delay(100);
+		{
+			await vscode.commands.executeCommand(commands.undo);
+			const { content } = await listener.nextResponse();
+			assert.equal(content, startingContent);
+		}
+	});
+
+	test('Should support multiple undo', async () => {
+		const startingContent = `multiple undo, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const count = 10;
+
+		// Make edits
+		for (let i = 0; i < count; ++i) {
+			await vscode.commands.executeCommand(Testing.abcEditorTypeCommand, `${i}`);
+			const { content } = await listener.nextResponse();
+			assert.equal(`${i}`, content);
+		}
+
+		// Then undo them in order
+		for (let i = count - 1; i; --i) {
+			await delay(100);
+			await vscode.commands.executeCommand(commands.undo);
+			const { content } = await listener.nextResponse();
+			assert.equal(`${i - 1}`, content);
+		}
+
+		{
+			await delay(100);
+			await vscode.commands.executeCommand(commands.undo);
+			const { content } = await listener.nextResponse();
+			assert.equal(content, startingContent);
+		}
+	});
+
+	test('Should update custom editor on file move', async () => {
+		const startingContent = `file move, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const newFileName = vscode.Uri.file(path.join(testWorkspaceRoot.fsPath, 'y.abc'));
+
+		const edit = new vscode.WorkspaceEdit();
+		edit.renameFile(testDocument, newFileName);
+
+		await vscode.workspace.applyEdit(edit);
+
+		const response = (await listener.nextResponse());
+		assert.equal(response.content, startingContent);
+		assert.equal(response.source.toString(), newFileName.toString());
+	});
+
+	test('Should support saving custom editors', async () => {
+		const startingContent = `save, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const newContent = `save, new`;
+		{
+			await vscode.commands.executeCommand(Testing.abcEditorTypeCommand, newContent);
+			const { content } = await listener.nextResponse();
+			assert.equal(content, newContent);
+		}
+		{
+			await vscode.commands.executeCommand(commands.save);
+			const fileContent = (await fs.promises.readFile(testDocument.fsPath)).toString();
+			assert.equal(fileContent, newContent);
+		}
+	});
+
+	test('Should undo after saving custom editor', async () => {
+		const startingContent = `undo after save, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const newContent = `undo after save, new`;
+		{
+			await vscode.commands.executeCommand(Testing.abcEditorTypeCommand, newContent);
+			const { content } = await listener.nextResponse();
+			assert.equal(content, newContent);
+		}
+		{
+			await vscode.commands.executeCommand(commands.save);
+			const fileContent = (await fs.promises.readFile(testDocument.fsPath)).toString();
+			assert.equal(fileContent, newContent);
+		}
+		await delay(100);
+		{
+			await vscode.commands.executeCommand(commands.undo);
+			const { content } = await listener.nextResponse();
+			assert.equal(content, startingContent);
+		}
+	});
+
+	test.skip('Should support untitled custom editors', async () => {
+		const listener = CustomEditorUpdateListener.create();
+
+		const untitledFile = randomFilePath({ ext: '.abc' }).with({ scheme: 'untitled' });
+
+		await vscode.commands.executeCommand(commands.open, untitledFile);
+		assert.equal((await listener.nextResponse()).content, '');
+
+		await vscode.commands.executeCommand(Testing.abcEditorTypeCommand, `123`);
+		assert.equal((await listener.nextResponse()).content, '123');
+
+		await vscode.commands.executeCommand(commands.save);
+		const content = await fs.promises.readFile(untitledFile.fsPath);
+		assert.equal(content.toString(), '123');
+	});
+
+	test.skip('When switching away from a non-default custom editors and then back, we should continue using the non-default editor', async () => {
+		const startingContent = `switch, init`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		{
+			await vscode.commands.executeCommand(commands.open, testDocument, { preview: false });
+			const { content } = await listener.nextResponse();
+			assert.equal(content, startingContent.toString());
+			assert.ok(!vscode.window.activeTextEditor);
+		}
+
+		// Switch to non-default editor
+		await vscode.commands.executeCommand(commands.openWith, testDocument, 'default', { preview: false });
+		assert.strictEqual(vscode.window.activeTextEditor?.document.uri.toString(), testDocument.toString());
+
+		// Then open a new document (hiding existing one)
+		const otherFile = vscode.Uri.file(path.join(testWorkspaceRoot.fsPath, 'other.json'));
+		await vscode.commands.executeCommand(commands.open, otherFile);
+		assert.strictEqual(vscode.window.activeTextEditor?.document.uri.toString(), otherFile.toString());
+
+		// And then back
+		await vscode.commands.executeCommand('workbench.action.navigateBack');
+		await vscode.commands.executeCommand('workbench.action.navigateBack');
+
+		// Make sure we have the file on as text
+		assert.ok(vscode.window.activeTextEditor);
+		assert.strictEqual(vscode.window.activeTextEditor?.document.uri.toString(), testDocument.toString());
+	});
+
+	test('Should release the text document when the editor is closed', async () => {
+		const startingContent = `release document init,`;
+		const testDocument = await writeRandomFile({ ext: '.abc', contents: startingContent });
+
+		const listener = CustomEditorUpdateListener.create();
+
+		await vscode.commands.executeCommand(commands.open, testDocument);
+		await listener.nextResponse();
+
+		const doc = vscode.workspace.textDocuments.find(x => x.uri.toString() === testDocument.toString());
+		assert.ok(doc);
+		assert.ok(!doc!.isClosed);
+
+		await closeAllEditors();
+		await delay(100);
+		assert.ok(doc!.isClosed);
+	});
+});
+
+function resetTestWorkspace() {
+	const root = testWorkspaceRoot.fsPath;
+	spawnSync(`git checkout -- "${root}"`, { shell: true, cwd: root });
+	spawnSync(`git clean -f "${root}"`, { shell: true, cwd: root });
+}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/languages.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/languages.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { join } from 'path';
 import * as vscode from 'vscode';
-import { createRandomFile, testFs } from '../utils';
+import { createRandomFile, getTestFs } from '../utils';
 
 suite('vscode API - languages', () => {
 
@@ -103,7 +103,7 @@ suite('vscode API - languages', () => {
 				return [new vscode.DocumentLink(range, target)];
 			}
 		};
-		vscode.languages.registerDocumentLinkProvider({ language: 'java', scheme: testFs.scheme }, linkProvider);
+		vscode.languages.registerDocumentLinkProvider({ language: 'java', scheme: getTestFs().scheme }, linkProvider);
 
 		const links = await vscode.commands.executeCommand<vscode.DocumentLink[]>('vscode.executeLinkProvider', doc.uri);
 		assert.equal(2, links && links.length);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { createRandomFile, deleteFile, closeAllEditors, pathEquals, rndName, disposeAll, testFs, delay, withLogDisabled } from '../utils';
+import { createRandomFile, deleteFile, closeAllEditors, pathEquals, randomFileName, disposeAll, testFs, delay, withLogDisabled } from '../utils';
 import { join, posix, basename } from 'path';
 import * as fs from 'fs';
 
@@ -709,7 +709,7 @@ suite('vscode API - workspace', () => {
 
 	test('WorkspaceEdit: edit and rename parent folder duplicates resource #42641', async function () {
 
-		let dir = vscode.Uri.parse(`${testFs.scheme}:/before-${rndName()}`);
+		let dir = vscode.Uri.parse(`${testFs.scheme}:/before-${randomFileName()}`);
 		await testFs.createDirectory(dir);
 
 		let docUri = await createRandomFile('', dir);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { createRandomFile, deleteFile, closeAllEditors, pathEquals, randomFileName, disposeAll, testFs, delay, withLogDisabled } from '../utils';
+import { createRandomFile, deleteFile, closeAllEditors, pathEquals, randomFileName, disposeAll, getTestFs, delay, withLogDisabled } from '../utils';
 import { join, posix, basename } from 'path';
 import * as fs from 'fs';
 
@@ -709,8 +709,8 @@ suite('vscode API - workspace', () => {
 
 	test('WorkspaceEdit: edit and rename parent folder duplicates resource #42641', async function () {
 
-		let dir = vscode.Uri.parse(`${testFs.scheme}:/before-${randomFileName()}`);
-		await testFs.createDirectory(dir);
+		let dir = vscode.Uri.parse(`${getTestFs().scheme}:/before-${randomFileName()}`);
+		await getTestFs().createDirectory(dir);
 
 		let docUri = await createRandomFile('', dir);
 		let docParent = docUri.with({ path: posix.dirname(docUri.path) });

--- a/extensions/vscode-api-tests/src/utils.ts
+++ b/extensions/vscode-api-tests/src/utils.ts
@@ -7,9 +7,19 @@ import * as vscode from 'vscode';
 import { MemFS } from './memfs';
 import * as assert from 'assert';
 
-export function rndName() {
-	return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10);
+export function randomFileName(extension?: string) {
+	return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10) + (extension || '');
 }
+
+export function randomFilePath(options: { readonly root?: vscode.Uri; readonly ext?: string; }): vscode.Uri {
+	let dir = options.root;
+	if (!dir) {
+		assert.ok(vscode.workspace.rootPath);
+		dir = vscode.Uri.file(vscode.workspace.rootPath!);
+	}
+	return dir.with({ path: dir.path + '/' + randomFileName(options.ext) });
+}
+
 
 export const testFs = new MemFS();
 vscode.workspace.registerFileSystemProvider(testFs.scheme, testFs);
@@ -18,9 +28,9 @@ export async function createRandomFile(contents = '', dir: vscode.Uri | undefine
 	let fakeFile: vscode.Uri;
 	if (dir) {
 		assert.equal(dir.scheme, testFs.scheme);
-		fakeFile = dir.with({ path: dir.path + '/' + rndName() + ext });
+		fakeFile = dir.with({ path: dir.path + '/' + randomFileName(ext) });
 	} else {
-		fakeFile = vscode.Uri.parse(`${testFs.scheme}:/${rndName() + ext}`);
+		fakeFile = vscode.Uri.parse(`${testFs.scheme}:/${randomFileName(ext)}`);
 	}
 	await testFs.writeFile(fakeFile, Buffer.from(contents), { create: true, overwrite: true });
 	return fakeFile;

--- a/extensions/vscode-api-tests/yarn.lock
+++ b/extensions/vscode-api-tests/yarn.lock
@@ -1406,6 +1406,18 @@ ordered-read-streams@^0.3.0:
     is-stream "^1.0.1"
     readable-stream "^2.0.1"
 
+p-limit@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
+  dependencies:
+    p-try "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"

--- a/extensions/vscode-web-playground/.vscode/launch.json
+++ b/extensions/vscode-web-playground/.vscode/launch.json
@@ -1,0 +1,21 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+	"version": "0.1.0",
+	"configurations": [
+		{
+			"name": "Launch Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"${workspaceFolder}/../../",
+				"${workspaceFolder}/testWorkspace",
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm"
+		}
+	]
+}


### PR DESCRIPTION
Moves the tests from https://github.com/mjbvz/vscode-experimental-webview-editor-extension into the VS Code repo