### PR TITLE
editor.codeActionsOnSave: support both object and array configs

### DIFF
--- a/src/vs/workbench/contrib/codeActions/common/codeActionsContribution.ts
+++ b/src/vs/workbench/contrib/codeActions/common/codeActionsContribution.ts
@@ -26,11 +26,19 @@ const codeActionsOnSaveDefaultProperties = Object.freeze<IJSONSchemaMap>({
 });
 
 const codeActionsOnSaveSchema: IConfigurationPropertySchema = {
-	type: 'object',
-	properties: codeActionsOnSaveDefaultProperties,
-	'additionalProperties': {
-		type: 'boolean'
-	},
+	oneOf: [
+		{
+			type: 'object',
+			properties: codeActionsOnSaveDefaultProperties,
+			additionalProperties: {
+				type: 'boolean'
+			},
+		},
+		{
+			type: 'array',
+			items: { type: 'string' }
+		}
+	],
 	default: {},
 	description: nls.localize('codeActionsOnSave', "Code action kinds to be run on save."),
 	scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -241,14 +241,20 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 		const model = editorModel.textEditorModel;
 
 		const settingsOverrides = { overrideIdentifier: model.getLanguageIdentifier().language, resource: editorModel.resource };
-		const setting = this.configurationService.getValue<{ [kind: string]: boolean }>('editor.codeActionsOnSave', settingsOverrides);
+		const setting = this.configurationService.getValue<{ [kind: string]: boolean } | string[]>('editor.codeActionsOnSave', settingsOverrides);
 		if (!setting) {
 			return undefined;
 		}
 
-		const codeActionsOnSave = Object.keys(setting)
-			.filter(x => setting[x]).map(x => new CodeActionKind(x))
-			.sort((a, b) => {
+		const settingItems: string[] = Array.isArray(setting)
+			? setting
+			: Object.keys(setting).filter(x => setting[x]);
+
+		const codeActionsOnSave = settingItems
+			.map(x => new CodeActionKind(x));
+
+		if (!Array.isArray(setting)) {
+			codeActionsOnSave.sort((a, b) => {
 				if (CodeActionKind.SourceFixAll.contains(a)) {
 					if (CodeActionKind.SourceFixAll.contains(b)) {
 						return 0;
@@ -260,14 +266,17 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 				}
 				return 0;
 			});
+		}
 
 		if (!codeActionsOnSave.length) {
 			return undefined;
 		}
 
-		const excludedActions = Object.keys(setting)
-			.filter(x => setting[x] === false)
-			.map(x => new CodeActionKind(x));
+		const excludedActions = Array.isArray(setting)
+			? []
+			: Object.keys(setting)
+				.filter(x => setting[x] === false)
+				.map(x => new CodeActionKind(x));
 
 		progress.report({ message: localize('codeaction', "Quick Fixes") });
 		await this.applyOnSaveActions(model, codeActionsOnSave, excludedActions, progress, token);


### PR DESCRIPTION
Issue #88131 describes potential problems with VS Code's default ordering of the `editor.codeActionsOnSave` setting. This PR fixes  #88131 by adding support for that setting to be an array of strings.

Both of the following are now valid in `.vscode/settings.json`:

## Object form (unchanged)
```json
{
  "editor.codeActionsOnSave": {
    "source.organizeImports": true,
    "source.fixAll.eslint": true
  }
}
```
This will use VS Code's existing logic for ordering the code actions.

## Array form (new)
```
{
  "editor.codeActionsOnSave": [
    "source.organizeImports",
    "source.fixAll.eslint"
  ]
}
```
This will run all the code actions in order they are specified.