### PR TITLE
Resolve and replace commands for next command

### DIFF
--- a/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
@@ -22,6 +22,7 @@ import { IQuickInputService, IInputOptions, IQuickPickItem, IPickOptions } from 
 import { ConfiguredInput, IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
 import { IProcessEnvironment } from 'vs/base/common/platform';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { deepClone } from 'vs/base/common/objects';
 
 export abstract class BaseConfigurationResolverService extends AbstractVariableResolverService {
 
@@ -165,7 +166,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 
 		// extract and dedupe all "input" and "command" variables and preserve their order in an array
 		const variableValues: IStringDictionary<string> = Object.create(null);
-		const config = { ...configuration };
+		const config = deepClone(configuration);
 		await this.findVariables(config, variableValues, async (variable, object) => {
 
 			const [type, name] = variable.split(':', 2);

--- a/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
@@ -220,24 +220,29 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 				if (matches.length === 4) {
 					const entry = matches[0];
 					const command = matches[1];
-					if (!(command in variables)) {
+					const found = command in variables;
+					if (!found) {
 						// NOTE this if assumes that the user will only ever want one computed value. (e.g. have two of the same command but only get the first output for both)
-						// TODO if value is undefined, we leave the raw value and need to skip to the next match.
 						const value = await resolveFn(command, root);
 						if (value !== undefined) {
 							variables[command] = value;
 							object = object.replace(entry, value);
 						}
+					} else if (found) {
+						object = object.replace(entry, variables[command]);
 					}
 				}
 			}
 			for (const [contributed] of this._contributedVariables) {
-				if (!(contributed in variables) && (object.indexOf('${' + contributed + '}') >= 0)) {
+				const found = contributed in variables;
+				if (!found && (object.indexOf('${' + contributed + '}') >= 0)) {
 					const value = await resolveFn(contributed, root);
 					if (value !== undefined) {
 						variables[contributed] = value;
 						object = object.replace('${' + contributed + '}', value);
 					}
+				} else if (found) {
+					object = object.replace('${' + contributed + '}', variables[contributed]);
 				}
 			}
 		} else if (Types.isArray(object)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #89758

Which will add support for the use case of using command and environment values in the configuration as they are resolved for subsequent command executions.  This enables the following use case.
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": ".NET Core Docker Attach",
            "type": "coreclr",
            "request": "attach",
            "pipeTransport": {
                "pipeProgram": "docker",
                "pipeArgs": [
                    "exec", "-i", "${command:vscode-docker.containers.select}"
                ],
                "debuggerPath": "/root/vsdbg/vsdbg",
                "pipeCwd": "${workspaceRoot}",
                "quoteArgs": false
            },
            "processId": "${command:pickRemoteProcess}",
            "sourceFileMap": {
                "/app": "${workspaceRoot}"
            },
            "justMyCode": true
        }
    ]
}
```

`resolveDebugConfigurationWithSubstitutedVariables` does not work for this use case as both commands are resolved/executed before replacement occurs.  `${command:pickRemoteProcess}` needs the value from `${command:vscode-docker.containers.select}` in the config object passed to it during execution.
