### PR TITLE
Allow users to make the scrollbars in the title area larger

### DIFF
--- a/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
+++ b/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
@@ -108,7 +108,9 @@ export class BreadcrumbsWidget {
 	}
 
 	setHorizontalScrollbarSize(size: number) {
-		this._scrollable.setHorizontalScrollbarSize(size);
+		this._scrollable.updateOptions({
+			horizontalScrollbarSize: size
+		});
 	}
 
 	dispose(): void {

--- a/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
+++ b/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
@@ -81,7 +81,8 @@ export class BreadcrumbsWidget {
 	private _dimension: dom.Dimension | undefined;
 
 	constructor(
-		container: HTMLElement
+		container: HTMLElement,
+		horizontalScrollbarSize: number,
 	) {
 		this._domNode = document.createElement('div');
 		this._domNode.className = 'monaco-breadcrumbs';
@@ -90,7 +91,7 @@ export class BreadcrumbsWidget {
 		this._scrollable = new DomScrollableElement(this._domNode, {
 			vertical: ScrollbarVisibility.Hidden,
 			horizontal: ScrollbarVisibility.Auto,
-			horizontalScrollbarSize: 3,
+			horizontalScrollbarSize: horizontalScrollbarSize,
 			useShadows: false,
 			scrollYToX: true
 		});
@@ -104,6 +105,10 @@ export class BreadcrumbsWidget {
 		this._disposables.add(focusTracker);
 		this._disposables.add(focusTracker.onDidBlur(_ => this._onDidChangeFocus.fire(false)));
 		this._disposables.add(focusTracker.onDidFocus(_ => this._onDidChangeFocus.fire(true)));
+	}
+
+	setHorizontalScrollbarSize(size: number) {
+		this._scrollable.setHorizontalScrollbarSize(size);
 	}
 
 	dispose(): void {

--- a/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
+++ b/src/vs/base/browser/ui/breadcrumbs/breadcrumbsWidget.ts
@@ -91,7 +91,7 @@ export class BreadcrumbsWidget {
 		this._scrollable = new DomScrollableElement(this._domNode, {
 			vertical: ScrollbarVisibility.Hidden,
 			horizontal: ScrollbarVisibility.Auto,
-			horizontalScrollbarSize: horizontalScrollbarSize,
+			horizontalScrollbarSize,
 			useShadows: false,
 			scrollYToX: true
 		});

--- a/src/vs/base/browser/ui/scrollbar/abstractScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/abstractScrollbar.ts
@@ -259,11 +259,13 @@ export abstract class AbstractScrollbar extends Widget {
 		this._scrollable.setScrollPositionNow(desiredScrollPosition);
 	}
 
-	public updateSize(size: number): void {
-		this._updateSize(size);
-		this._scrollbarState.setScrollbarSize(size);
+	public updateScrollbarSize(scrollbarSize: number): void {
+		this._updateScrollbarSize(scrollbarSize);
+		this._scrollbarState.setScrollbarSize(scrollbarSize);
 		this._shouldRender = true;
-		this.render();
+		if (!this._lazyRender) {
+			this.render();
+		}
 	}
 
 	// ----------------- Overwrite these
@@ -274,7 +276,7 @@ export abstract class AbstractScrollbar extends Widget {
 	protected abstract _mouseDownRelativePosition(offsetX: number, offsetY: number): number;
 	protected abstract _sliderMousePosition(e: ISimplifiedMouseEvent): number;
 	protected abstract _sliderOrthogonalMousePosition(e: ISimplifiedMouseEvent): number;
-	protected abstract _updateSize(size: number): void;
+	protected abstract _updateScrollbarSize(size: number): void;
 
 	public abstract writeScrollPosition(target: INewScrollPosition, scrollPosition: number): void;
 }

--- a/src/vs/base/browser/ui/scrollbar/abstractScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/abstractScrollbar.ts
@@ -259,6 +259,13 @@ export abstract class AbstractScrollbar extends Widget {
 		this._scrollable.setScrollPositionNow(desiredScrollPosition);
 	}
 
+	public updateSize(size: number): void {
+		this._updateSize(size);
+		this._scrollbarState.setScrollbarSize(size);
+		this._shouldRender = true;
+		this.render();
+	}
+
 	// ----------------- Overwrite these
 
 	protected abstract _renderDomNode(largeSize: number, smallSize: number): void;
@@ -267,6 +274,7 @@ export abstract class AbstractScrollbar extends Widget {
 	protected abstract _mouseDownRelativePosition(offsetX: number, offsetY: number): number;
 	protected abstract _sliderMousePosition(e: ISimplifiedMouseEvent): number;
 	protected abstract _sliderOrthogonalMousePosition(e: ISimplifiedMouseEvent): number;
+	protected abstract _updateSize(size: number): void;
 
 	public abstract writeScrollPosition(target: INewScrollPosition, scrollPosition: number): void;
 }

--- a/src/vs/base/browser/ui/scrollbar/horizontalScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/horizontalScrollbar.ts
@@ -92,7 +92,7 @@ export class HorizontalScrollbar extends AbstractScrollbar {
 		return e.posy;
 	}
 
-	public _updateSize(size: number): void {
+	protected _updateSize(size: number): void {
 		this.slider.setHeight(size);
 	}
 

--- a/src/vs/base/browser/ui/scrollbar/horizontalScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/horizontalScrollbar.ts
@@ -92,6 +92,10 @@ export class HorizontalScrollbar extends AbstractScrollbar {
 		return e.posy;
 	}
 
+	public _updateSize(size: number): void {
+		this.slider.setHeight(size);
+	}
+
 	public writeScrollPosition(target: INewScrollPosition, scrollPosition: number): void {
 		target.scrollLeft = scrollPosition;
 	}

--- a/src/vs/base/browser/ui/scrollbar/horizontalScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/horizontalScrollbar.ts
@@ -92,7 +92,7 @@ export class HorizontalScrollbar extends AbstractScrollbar {
 		return e.posy;
 	}
 
-	protected _updateSize(size: number): void {
+	protected _updateScrollbarSize(size: number): void {
 		this.slider.setHeight(size);
 	}
 

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -269,10 +269,6 @@ export abstract class AbstractScrollableElement extends Widget {
 		this._scrollable.setScrollDimensions(dimensions);
 	}
 
-	public setHorizontalScrollbarSize(size: number): void {
-		this._horizontalScrollbar.updateSize(size);
-	}
-
 	/**
 	 * Update the class name of the scrollable element.
 	 */
@@ -291,12 +287,22 @@ export abstract class AbstractScrollableElement extends Widget {
 	 * depend on Editor.
 	 */
 	public updateOptions(newOptions: ScrollableElementChangeOptions): void {
-		let massagedOptions = resolveOptions(newOptions);
-		this._options.handleMouseWheel = massagedOptions.handleMouseWheel;
-		this._options.mouseWheelScrollSensitivity = massagedOptions.mouseWheelScrollSensitivity;
-		this._options.fastScrollSensitivity = massagedOptions.fastScrollSensitivity;
-		this._options.scrollPredominantAxis = massagedOptions.scrollPredominantAxis;
-		this._setListeningToMouseWheel(this._options.handleMouseWheel);
+		if (typeof newOptions.handleMouseWheel !== 'undefined') {
+			this._options.handleMouseWheel = newOptions.handleMouseWheel;
+			this._setListeningToMouseWheel(this._options.handleMouseWheel);
+		}
+		if (typeof newOptions.mouseWheelScrollSensitivity !== 'undefined') {
+			this._options.mouseWheelScrollSensitivity = newOptions.mouseWheelScrollSensitivity;
+		}
+		if (typeof newOptions.fastScrollSensitivity !== 'undefined') {
+			this._options.fastScrollSensitivity = newOptions.fastScrollSensitivity;
+		}
+		if (typeof newOptions.scrollPredominantAxis !== 'undefined') {
+			this._options.scrollPredominantAxis = newOptions.scrollPredominantAxis;
+		}
+		if (typeof newOptions.horizontalScrollbarSize !== 'undefined') {
+			this._horizontalScrollbar.updateScrollbarSize(newOptions.horizontalScrollbarSize);
+		}
 
 		if (!this._options.lazyRender) {
 			this._render();

--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -269,6 +269,10 @@ export abstract class AbstractScrollableElement extends Widget {
 		this._scrollable.setScrollDimensions(dimensions);
 	}
 
+	public setHorizontalScrollbarSize(size: number): void {
+		this._horizontalScrollbar.updateSize(size);
+	}
+
 	/**
 	 * Update the class name of the scrollable element.
 	 */

--- a/src/vs/base/browser/ui/scrollbar/scrollableElementOptions.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElementOptions.ts
@@ -119,8 +119,9 @@ export interface ScrollableElementCreationOptions {
 export interface ScrollableElementChangeOptions {
 	handleMouseWheel?: boolean;
 	mouseWheelScrollSensitivity?: number;
-	fastScrollSensitivity: number;
-	scrollPredominantAxis: boolean;
+	fastScrollSensitivity?: number;
+	scrollPredominantAxis?: boolean;
+	horizontalScrollbarSize?: number;
 }
 
 export interface ScrollableElementResolvedOptions {

--- a/src/vs/base/browser/ui/scrollbar/scrollbarState.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollbarState.ts
@@ -14,7 +14,7 @@ export class ScrollbarState {
 	 * For the vertical scrollbar: the width.
 	 * For the horizontal scrollbar: the height.
 	 */
-	private readonly _scrollbarSize: number;
+	private _scrollbarSize: number;
 
 	/**
 	 * For the vertical scrollbar: the height of the pair horizontal scrollbar.
@@ -112,6 +112,10 @@ export class ScrollbarState {
 			return true;
 		}
 		return false;
+	}
+
+	public setScrollbarSize(scrollbarSize: number): void {
+		this._scrollbarSize = scrollbarSize;
 	}
 
 	private static _computeValues(oppositeScrollbarSize: number, arrowSize: number, visibleSize: number, scrollSize: number, scrollPosition: number) {

--- a/src/vs/base/browser/ui/scrollbar/verticalScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/verticalScrollbar.ts
@@ -93,7 +93,7 @@ export class VerticalScrollbar extends AbstractScrollbar {
 		return e.posx;
 	}
 
-	public _updateSize(size: number): void {
+	protected _updateSize(size: number): void {
 		this.slider.setWidth(size);
 	}
 

--- a/src/vs/base/browser/ui/scrollbar/verticalScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/verticalScrollbar.ts
@@ -93,6 +93,10 @@ export class VerticalScrollbar extends AbstractScrollbar {
 		return e.posx;
 	}
 
+	public _updateSize(size: number): void {
+		this.slider.setWidth(size);
+	}
+
 	public writeScrollPosition(target: INewScrollPosition, scrollPosition: number): void {
 		target.scrollTop = scrollPosition;
 	}

--- a/src/vs/base/browser/ui/scrollbar/verticalScrollbar.ts
+++ b/src/vs/base/browser/ui/scrollbar/verticalScrollbar.ts
@@ -93,7 +93,7 @@ export class VerticalScrollbar extends AbstractScrollbar {
 		return e.posx;
 	}
 
-	protected _updateSize(size: number): void {
+	protected _updateScrollbarSize(size: number): void {
 		this.slider.setWidth(size);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -13,7 +13,7 @@ import { Extensions, IConfigurationRegistry, ConfigurationScope } from 'vs/platf
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { GroupIdentifier } from 'vs/workbench/common/editor';
+import { GroupIdentifier, IEditorPartOptions } from 'vs/workbench/common/editor';
 
 export const IBreadcrumbsService = createDecorator<IBreadcrumbsService>('IEditorBreadcrumbsService');
 
@@ -72,7 +72,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static readonly SymbolPath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.symbolPath');
 	static readonly SymbolSortOrder = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.symbolSortOrder');
 	static readonly Icons = BreadcrumbsConfig._stub<boolean>('breadcrumbs.icons');
-	static readonly ScrollbarHeight = BreadcrumbsConfig._stub<number>('breadcrumbs.scrollbarHeight');
+	static readonly TitleScrollbarSizing = BreadcrumbsConfig._stub<IEditorPartOptions['titleScrollbarSizing']>('workbench.editor.titleScrollbarSizing');
 
 	static readonly FileExcludes = BreadcrumbsConfig._stub<glob.IExpression>('files.exclude');
 
@@ -319,11 +319,6 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
 			markdownDescription: localize('filteredTypes.typeParameter', "When enabled breadcrumbs show `typeParameter`-symbols.")
-		},
-		'breadcrumbs.scrollbarHeight': {
-			type: 'number',
-			default: 3,
-			markdownDescription: localize('filteredTypes.scrollbarHeight', "Controls the height of the scrollbar, which is visible when the breadcrumb width exceeds the window width.")
 		}
 	}
 });

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -72,6 +72,7 @@ export abstract class BreadcrumbsConfig<T> {
 	static readonly SymbolPath = BreadcrumbsConfig._stub<'on' | 'off' | 'last'>('breadcrumbs.symbolPath');
 	static readonly SymbolSortOrder = BreadcrumbsConfig._stub<'position' | 'name' | 'type'>('breadcrumbs.symbolSortOrder');
 	static readonly Icons = BreadcrumbsConfig._stub<boolean>('breadcrumbs.icons');
+	static readonly ScrollbarHeight = BreadcrumbsConfig._stub<number>('breadcrumbs.scrollbarHeight');
 
 	static readonly FileExcludes = BreadcrumbsConfig._stub<glob.IExpression>('files.exclude');
 
@@ -318,6 +319,11 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			default: true,
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
 			markdownDescription: localize('filteredTypes.typeParameter', "When enabled breadcrumbs show `typeParameter`-symbols.")
+		},
+		'breadcrumbs.scrollbarHeight': {
+			type: 'number',
+			default: 3,
+			markdownDescription: localize('filteredTypes.scrollbarHeight', "Controls the height of the scrollbar, which is visible when the breadcrumb width exceeds the window width.")
 		}
 	}
 });

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -148,6 +148,7 @@ export class BreadcrumbsControl {
 
 	private readonly _cfUseQuickPick: BreadcrumbsConfig<boolean>;
 	private readonly _cfShowIcons: BreadcrumbsConfig<boolean>;
+	private readonly _cfScrollbarHeight: BreadcrumbsConfig<number>;
 
 	readonly domNode: HTMLDivElement;
 	private readonly _widget: BreadcrumbsWidget;
@@ -180,7 +181,11 @@ export class BreadcrumbsControl {
 		dom.addClass(this.domNode, 'breadcrumbs-control');
 		dom.append(container, this.domNode);
 
-		this._widget = new BreadcrumbsWidget(this.domNode);
+		this._cfUseQuickPick = BreadcrumbsConfig.UseQuickPick.bindTo(_configurationService);
+		this._cfShowIcons = BreadcrumbsConfig.Icons.bindTo(_configurationService);
+		this._cfScrollbarHeight = BreadcrumbsConfig.ScrollbarHeight.bindTo(_configurationService);
+
+		this._widget = new BreadcrumbsWidget(this.domNode, this._cfScrollbarHeight.getValue());
 		this._widget.onDidSelectItem(this._onSelectEvent, this, this._disposables);
 		this._widget.onDidFocusItem(this._onFocusEvent, this, this._disposables);
 		this._widget.onDidChangeFocus(this._updateCkBreadcrumbsActive, this, this._disposables);
@@ -189,9 +194,6 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsPossible = BreadcrumbsControl.CK_BreadcrumbsPossible.bindTo(this._contextKeyService);
 		this._ckBreadcrumbsVisible = BreadcrumbsControl.CK_BreadcrumbsVisible.bindTo(this._contextKeyService);
 		this._ckBreadcrumbsActive = BreadcrumbsControl.CK_BreadcrumbsActive.bindTo(this._contextKeyService);
-
-		this._cfUseQuickPick = BreadcrumbsConfig.UseQuickPick.bindTo(_configurationService);
-		this._cfShowIcons = BreadcrumbsConfig.Icons.bindTo(_configurationService);
 
 		this._disposables.add(breadcrumbsService.register(this._editorGroup.id, this._widget));
 	}
@@ -276,6 +278,14 @@ export class BreadcrumbsControl {
 		this._breadcrumbsDisposables.add(model);
 		this._breadcrumbsDisposables.add(listener);
 		this._breadcrumbsDisposables.add(configListener);
+
+		const updateScrollbarSize = () => {
+			const size = this._cfScrollbarHeight.getValue();
+			this._widget.setHorizontalScrollbarSize(size);
+		};
+		updateScrollbarSize();
+		const updateScrollbarSizeListener = this._cfScrollbarHeight.onDidChange(updateScrollbarSize);
+		this._breadcrumbsDisposables.add(updateScrollbarSizeListener);
 
 		// close picker on hide/update
 		this._breadcrumbsDisposables.add({

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -133,9 +133,10 @@ export interface IBreadcrumbsControlOptions {
 export class BreadcrumbsControl {
 
 	static readonly HEIGHT = 22;
-	static readonly SCROLLBAR_SIZES = {
+
+	private static readonly SCROLLBAR_SIZES = {
 		default: 3,
-		large: 8,
+		large: 8
 	};
 
 	static readonly Payload_Reveal = {};

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -38,7 +38,7 @@ import { ResourceLabel } from 'vs/workbench/browser/labels';
 import { BreadcrumbsConfig, IBreadcrumbsService } from 'vs/workbench/browser/parts/editor/breadcrumbs';
 import { BreadcrumbElement, EditorBreadcrumbsModel, FileElement } from 'vs/workbench/browser/parts/editor/breadcrumbsModel';
 import { BreadcrumbsPicker, createBreadcrumbsPicker } from 'vs/workbench/browser/parts/editor/breadcrumbsPicker';
-import { SideBySideEditorInput } from 'vs/workbench/common/editor';
+import { SideBySideEditorInput, IEditorPartOptions } from 'vs/workbench/common/editor';
 import { ACTIVE_GROUP, ACTIVE_GROUP_TYPE, IEditorService, SIDE_GROUP, SIDE_GROUP_TYPE } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -133,6 +133,10 @@ export interface IBreadcrumbsControlOptions {
 export class BreadcrumbsControl {
 
 	static readonly HEIGHT = 22;
+	static readonly SCROLLBAR_SIZES = {
+		default: 3,
+		large: 8,
+	};
 
 	static readonly Payload_Reveal = {};
 	static readonly Payload_RevealAside = {};
@@ -148,7 +152,7 @@ export class BreadcrumbsControl {
 
 	private readonly _cfUseQuickPick: BreadcrumbsConfig<boolean>;
 	private readonly _cfShowIcons: BreadcrumbsConfig<boolean>;
-	private readonly _cfScrollbarHeight: BreadcrumbsConfig<number>;
+	private readonly _cfTitleScrollbarSizing: BreadcrumbsConfig<IEditorPartOptions['titleScrollbarSizing']>;
 
 	readonly domNode: HTMLDivElement;
 	private readonly _widget: BreadcrumbsWidget;
@@ -183,9 +187,10 @@ export class BreadcrumbsControl {
 
 		this._cfUseQuickPick = BreadcrumbsConfig.UseQuickPick.bindTo(_configurationService);
 		this._cfShowIcons = BreadcrumbsConfig.Icons.bindTo(_configurationService);
-		this._cfScrollbarHeight = BreadcrumbsConfig.ScrollbarHeight.bindTo(_configurationService);
+		this._cfTitleScrollbarSizing = BreadcrumbsConfig.TitleScrollbarSizing.bindTo(_configurationService);
 
-		this._widget = new BreadcrumbsWidget(this.domNode, this._cfScrollbarHeight.getValue());
+		const sizing = this._cfTitleScrollbarSizing.getValue() ?? 'default';
+		this._widget = new BreadcrumbsWidget(this.domNode, BreadcrumbsControl.SCROLLBAR_SIZES[sizing]);
 		this._widget.onDidSelectItem(this._onSelectEvent, this, this._disposables);
 		this._widget.onDidFocusItem(this._onFocusEvent, this, this._disposables);
 		this._widget.onDidChangeFocus(this._updateCkBreadcrumbsActive, this, this._disposables);
@@ -279,12 +284,12 @@ export class BreadcrumbsControl {
 		this._breadcrumbsDisposables.add(listener);
 		this._breadcrumbsDisposables.add(configListener);
 
-		const updateScrollbarSize = () => {
-			const size = this._cfScrollbarHeight.getValue();
-			this._widget.setHorizontalScrollbarSize(size);
+		const updateScrollbarSizing = () => {
+			const sizing = this._cfTitleScrollbarSizing.getValue() ?? 'default';
+			this._widget.setHorizontalScrollbarSize(BreadcrumbsControl.SCROLLBAR_SIZES[sizing]);
 		};
-		updateScrollbarSize();
-		const updateScrollbarSizeListener = this._cfScrollbarHeight.onDidChange(updateScrollbarSize);
+		updateScrollbarSizing();
+		const updateScrollbarSizeListener = this._cfTitleScrollbarSizing.onDidChange(updateScrollbarSizing);
 		this._breadcrumbsDisposables.add(updateScrollbarSizeListener);
 
 		// close picker on hide/update

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -30,6 +30,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	highlightModifiedTabs: false,
 	tabCloseButton: 'right',
 	tabSizing: 'fit',
+	titleScrollbarSizing: 'default',
 	focusRecentEditorAfterClose: true,
 	showIcons: true,
 	enablePreview: true,

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -172,7 +172,9 @@ export class TabsTitleControl extends TitleControl {
 	}
 
 	private updateTabsScrollbarSizing(): void {
-		this.tabsScrollbar?.setHorizontalScrollbarSize(this.getTabsScrollbarSizing());
+		this.tabsScrollbar?.updateOptions({
+			horizontalScrollbarSize: this.getTabsScrollbarSizing()
+		});
 	}
 
 	private getTabsScrollbarSizing(): number {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -55,6 +55,10 @@ interface IEditorInputLabel {
 type AugmentedLabel = IEditorInputLabel & { editor: IEditorInput };
 
 export class TabsTitleControl extends TitleControl {
+	private static readonly SCROLLBAR_SIZES = {
+		default: 3,
+		large: 10,
+	};
 
 	private titleContainer: HTMLElement | undefined;
 	private tabsContainer: HTMLElement | undefined;
@@ -105,8 +109,9 @@ export class TabsTitleControl extends TitleControl {
 	}
 
 	protected onDidEditorPartOptionsChange(e: IEditorPartOptionsChangeEvent) {
-		if (e.newPartOptions.tabScrollbarHeight !== undefined) {
-			this.tabsScrollbar?.setHorizontalScrollbarSize(e.newPartOptions.tabScrollbarHeight);
+		if (e.newPartOptions.titleScrollbarSizing !== undefined) {
+			const size = BreadcrumbsControl.SCROLLBAR_SIZES[e.newPartOptions.titleScrollbarSizing ?? 'default'];
+			this.tabsScrollbar?.setHorizontalScrollbarSize(size);
 		}
 	}
 
@@ -148,12 +153,15 @@ export class TabsTitleControl extends TitleControl {
 	}
 
 	private createTabsScrollbar(scrollable: HTMLElement): ScrollableElement {
+		const scrollbarSizing = this.configurationService
+			.getValue<IEditorPartOptions['titleScrollbarSizing']>('workbench.editor.titleScrollbarSizing') ?? 'default';
+
 		const tabsScrollbar = new ScrollableElement(scrollable, {
 			horizontal: ScrollbarVisibility.Auto,
 			vertical: ScrollbarVisibility.Hidden,
 			scrollYToX: true,
 			useShadows: false,
-			horizontalScrollbarSize: this.configurationService.getValue<number>('workbench.editor.tabScrollbarHeight'),
+			horizontalScrollbarSize: TabsTitleControl.SCROLLBAR_SIZES[scrollbarSizing],
 		});
 
 		tabsScrollbar.onScroll(e => {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/tabstitlecontrol';
 import { isMacintosh, isWindows } from 'vs/base/common/platform';
 import { shorten } from 'vs/base/common/labels';
-import { toResource, GroupIdentifier, IEditorInput, Verbosity, EditorCommandsContextActionRunner, IEditorPartOptions, SideBySideEditor } from 'vs/workbench/common/editor';
+import { toResource, GroupIdentifier, IEditorInput, Verbosity, EditorCommandsContextActionRunner, IEditorPartOptions, SideBySideEditor, IEditorPartOptionsChangeEvent } from 'vs/workbench/common/editor';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { EventType as TouchEventType, GestureEvent, Gesture } from 'vs/base/browser/touch';
 import { KeyCode } from 'vs/base/common/keyCodes';
@@ -101,6 +101,13 @@ export class TabsTitleControl extends TitleControl {
 		// If we are connected to remote, this accounts for the
 		// remote OS.
 		(async () => this.path = await this.remotePathService.path)();
+		this._register(this.accessor.onDidEditorPartOptionsChange(e => this.onDidEditorPartOptionsChange(e)));
+	}
+
+	protected onDidEditorPartOptionsChange(e: IEditorPartOptionsChangeEvent) {
+		if (e.newPartOptions.tabScrollbarHeight !== undefined) {
+			this.tabsScrollbar?.setHorizontalScrollbarSize(e.newPartOptions.tabScrollbarHeight);
+		}
 	}
 
 	protected create(parent: HTMLElement): void {
@@ -146,7 +153,7 @@ export class TabsTitleControl extends TitleControl {
 			vertical: ScrollbarVisibility.Hidden,
 			scrollYToX: true,
 			useShadows: false,
-			horizontalScrollbarSize: 3
+			horizontalScrollbarSize: this.configurationService.getValue<number>('workbench.editor.tabScrollbarHeight'),
 		});
 
 		tabsScrollbar.onScroll(e => {

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -93,7 +93,7 @@ export abstract class TitleControl extends Themable {
 		this.registerListeners();
 	}
 
-	private registerListeners(): void {
+	protected registerListeners(): void {
 
 		// Update actions toolbar when extension register that may contribute them
 		this._register(this.extensionService.onDidRegisterExtensions(() => this.updateEditorActionsToolbar()));

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -17,6 +17,11 @@ import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuratio
 	registry.registerConfiguration({
 		...workbenchConfigurationNodeBase,
 		'properties': {
+			'workbench.editor.tabScrollbarHeight': {
+				type: 'number',
+				description: nls.localize('tabScrollbarHeight', 'Controls the height of the scrollbar, which is visible when the width of tabs exceeds the window width'),
+				default: 3,
+			},
 			'workbench.editor.showTabs': {
 				'type': 'boolean',
 				'description': nls.localize('showEditorTabs', "Controls whether opened editors should show in tabs or not."),

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -17,10 +17,15 @@ import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuratio
 	registry.registerConfiguration({
 		...workbenchConfigurationNodeBase,
 		'properties': {
-			'workbench.editor.tabScrollbarHeight': {
-				type: 'number',
-				description: nls.localize('tabScrollbarHeight', 'Controls the height of the scrollbar, which is visible when the width of tabs exceeds the window width'),
-				default: 3,
+			'workbench.editor.titleScrollbarSizing': {
+				type: 'string',
+				enum: ['default', 'large'],
+				enumDescriptions: [
+					nls.localize('workbench.editor.titleScrollbarSizing.default', "The default size."),
+					nls.localize('workbench.editor.titleScrollbarSizing.large', "Increases the size, so it can be grabed more easily with the mouse")
+				],
+				description: nls.localize('tabScrollbarHeight', "Controls the height of all scrollbars visible in the title area (Tabs &Breadcrumbs)"),
+				default: 'default',
 			},
 			'workbench.editor.showTabs': {
 				'type': 'boolean',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -24,7 +24,7 @@ import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuratio
 					nls.localize('workbench.editor.titleScrollbarSizing.default', "The default size."),
 					nls.localize('workbench.editor.titleScrollbarSizing.large', "Increases the size, so it can be grabed more easily with the mouse")
 				],
-				description: nls.localize('tabScrollbarHeight', "Controls the height of all scrollbars visible in the title area (Tabs &Breadcrumbs)"),
+				description: nls.localize('tabScrollbarHeight', "Controls the height of the scrollbars used for tabs and breadcrumbs in the editor title area."),
 				default: 'default',
 			},
 			'workbench.editor.showTabs': {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1288,7 +1288,7 @@ interface IEditorPartConfiguration {
 	highlightModifiedTabs?: boolean;
 	tabCloseButton?: 'left' | 'right' | 'off';
 	tabSizing?: 'fit' | 'shrink';
-	tabScrollbarHeight?: number;
+	titleScrollbarSizing?: 'default' | 'large';
 	focusRecentEditorAfterClose?: boolean;
 	showIcons?: boolean;
 	enablePreview?: boolean;

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1288,6 +1288,7 @@ interface IEditorPartConfiguration {
 	highlightModifiedTabs?: boolean;
 	tabCloseButton?: 'left' | 'right' | 'off';
 	tabSizing?: 'fit' | 'shrink';
+	tabScrollbarHeight?: number;
 	focusRecentEditorAfterClose?: boolean;
 	showIcons?: boolean;
 	enablePreview?: boolean;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #32192
It introduces two new settings:
* `workbench.editor.tabScrollbarHeight` - Specify the size of the scrollbar used in the Tab list
* `breadcrumbs.scrollbarHeight` - Specify the size of the scrollbar used in the breadcrumbs list

It updates in real-time, a small demo can be seen here:
![image](https://i.imgur.com/YbNgFVB.gif)

Implementation wise, it's my first code change in VSCode, so I'm quite new to the architecture and I'm not sure if I chose the correct locations. Especially the `constructor` change in `breadcrumbsWidget.ts`. I'm looking forward to your feedback :)