### PR TITLE
Semantic highlighting fixes for 1.43.1

### DIFF
--- a/extensions/theme-abyss/themes/abyss-color-theme.json
+++ b/extensions/theme-abyss/themes/abyss-color-theme.json
@@ -434,5 +434,6 @@
 		"terminal.ansiBrightMagenta": "#d778ff",
 		"terminal.ansiBrightCyan": "#78ffff",
 		"terminal.ansiBrightWhite": "#ffffff"
-	}
+	},
+	"semanticHighlighting": true
 }

--- a/extensions/theme-defaults/themes/dark_defaults.json
+++ b/extensions/theme-defaults/themes/dark_defaults.json
@@ -18,5 +18,6 @@
 		"menu.foreground": "#CCCCCC",
 		"statusBarItem.remoteForeground": "#FFF",
 		"statusBarItem.remoteBackground": "#16825D"
-	}
+	},
+	"semanticHighlighting": true
 }

--- a/extensions/theme-defaults/themes/hc_black_defaults.json
+++ b/extensions/theme-defaults/themes/hc_black_defaults.json
@@ -337,5 +337,6 @@
 				"foreground": "#569cd6"
 			}
 		}
-	]
+	],
+	"semanticHighlighting": true
 }

--- a/extensions/theme-defaults/themes/light_defaults.json
+++ b/extensions/theme-defaults/themes/light_defaults.json
@@ -18,5 +18,6 @@
 		"settings.numberInputBorder": "#CECECE",
 		"statusBarItem.remoteForeground": "#FFF",
 		"statusBarItem.remoteBackground": "#16825D"
-	}
+	},
+	"semanticHighlighting": true
 }

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -394,5 +394,6 @@
 				"foreground": "#dc3958"
 			}
 		}
-	]
+	],
+	"semanticHighlighting": true
 }

--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -572,5 +572,6 @@
 				"foreground": "#c7444a"
 			}
 		}
-	]
+	],
+	"semanticHighlighting": true
 }

--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -476,5 +476,6 @@
 				"foreground": "#FD971F"
 			}
 		}
-	]
+	],
+	"semanticHighlighting": true
 }

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -494,5 +494,6 @@
 		"walkThrough.embeddedEditorBackground": "#00000014",
 		"editorIndentGuide.background": "#aaaaaa60",
 		"editorIndentGuide.activeBackground": "#777777b0"
-	}
+	},
+	"semanticHighlighting": true
 }

--- a/extensions/theme-red/themes/Red-color-theme.json
+++ b/extensions/theme-red/themes/Red-color-theme.json
@@ -385,5 +385,6 @@
 				"foreground": "#ec0d1e"
 			}
 		}
-	]
+	],
+	"semanticHighlighting": true
 }

--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -477,5 +477,6 @@
 		"terminal.ansiBrightMagenta": "#6c71c4",
 		"terminal.ansiBrightCyan": "#93a1a1",
 		"terminal.ansiBrightWhite": "#fdf6e3"
-	}
+	},
+	"semanticHighlighting": true
 }

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -484,5 +484,6 @@
 
 		// Interactive Playground
 		"walkThrough.embeddedEditorBackground": "#00000014"
-	}
+	},
+	"semanticHighlighting": true
 }

--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-theme.json
@@ -255,5 +255,6 @@
 				"foreground": "#b267e6"
 			}
 		}
-	]
+	],
+	"semanticHighlighting": true
 }

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -19,7 +19,7 @@
     "jsonc-parser": "^2.2.1",
     "rimraf": "^2.6.3",
     "semver": "5.5.1",
-    "typescript-vscode-sh-plugin": "^0.6.8",
+    "typescript-vscode-sh-plugin": "^0.6.10",
     "vscode-extension-telemetry": "0.1.1",
     "vscode-nls": "^4.1.1"
   },

--- a/extensions/typescript-language-features/yarn.lock
+++ b/extensions/typescript-language-features/yarn.lock
@@ -626,10 +626,10 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-typescript-vscode-sh-plugin@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/typescript-vscode-sh-plugin/-/typescript-vscode-sh-plugin-0.6.8.tgz#60d5025f2ab814496824ee997b5e9fc12c5b7f1a"
-  integrity sha512-XEh/GwBRsZKWQjPTODqWWiW8o8DyF7Yzfp/xvq1vyK5Z9JykFKAkx95BEmALv9x9dpc2RcLZHgVsKFXrtDABCw==
+typescript-vscode-sh-plugin@^0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/typescript-vscode-sh-plugin/-/typescript-vscode-sh-plugin-0.6.10.tgz#f9fdac506a3adb698d52fd01723ec78e8a5fc09e"
+  integrity sha512-cYycpwLnYT2oS48tac+UvVRtIFHHTcHAz/g3N2HpYftuMEBvBcsGfe2SrlnrGCa1gMheTbo+twIHhsQu9ygdvg==
 
 uri-js@^4.2.2:
   version "4.2.2"

--- a/src/vs/editor/common/services/modelServiceImpl.ts
+++ b/src/vs/editor/common/services/modelServiceImpl.ts
@@ -455,15 +455,16 @@ class SemanticColoringFeature extends Disposable {
 
 	private _watchers: Record<string, ModelSemanticColoring>;
 	private _semanticStyling: SemanticStyling;
-	private _configurationService: IConfigurationService;
 
 	constructor(modelService: IModelService, themeService: IThemeService, configurationService: IConfigurationService, logService: ILogService) {
 		super();
-		this._configurationService = configurationService;
 		this._watchers = Object.create(null);
 		this._semanticStyling = this._register(new SemanticStyling(themeService, logService));
 
 		const isSemanticColoringEnabled = (model: ITextModel) => {
+			if (!themeService.getTheme().semanticHighlighting) {
+				return false;
+			}
 			const options = configurationService.getValue<IEditorSemanticHighlightingOptions>(SemanticColoringFeature.SETTING_ID, { overrideIdentifier: model.getLanguageIdentifier().language, resource: model.uri });
 			return options && options.enabled;
 		};
@@ -473,6 +474,20 @@ class SemanticColoringFeature extends Disposable {
 		const deregister = (model: ITextModel, modelSemanticColoring: ModelSemanticColoring) => {
 			modelSemanticColoring.dispose();
 			delete this._watchers[model.uri.toString()];
+		};
+		const handleSettingOrThemeChange = () => {
+			for (let model of modelService.getModels()) {
+				const curr = this._watchers[model.uri.toString()];
+				if (isSemanticColoringEnabled(model)) {
+					if (!curr) {
+						register(model);
+					}
+				} else {
+					if (curr) {
+						deregister(model, curr);
+					}
+				}
+			}
 		};
 		this._register(modelService.onModelAdded((model) => {
 			if (isSemanticColoringEnabled(model)) {
@@ -485,22 +500,12 @@ class SemanticColoringFeature extends Disposable {
 				deregister(model, curr);
 			}
 		}));
-		this._configurationService.onDidChangeConfiguration(e => {
+		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(SemanticColoringFeature.SETTING_ID)) {
-				for (let model of modelService.getModels()) {
-					const curr = this._watchers[model.uri.toString()];
-					if (isSemanticColoringEnabled(model)) {
-						if (!curr) {
-							register(model);
-						}
-					} else {
-						if (curr) {
-							deregister(model, curr);
-						}
-					}
-				}
+				handleSettingOrThemeChange();
 			}
-		});
+		}));
+		this._register(themeService.onThemeChange(handleSettingOrThemeChange));
 	}
 }
 

--- a/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
+++ b/src/vs/editor/standalone/browser/standaloneThemeServiceImpl.ts
@@ -138,6 +138,8 @@ class StandaloneTheme implements IStandaloneTheme {
 	public get tokenColorMap(): string[] {
 		return [];
 	}
+
+	public readonly semanticHighlighting = false;
 }
 
 function isBuiltinTheme(themeName: string): themeName is BuiltinTheme {

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -60,6 +60,8 @@ suite('TokenizationSupport2Adapter', () => {
 					return undefined;
 				},
 
+				semanticHighlighting: false,
+
 				tokenColorMap: []
 			};
 		}

--- a/src/vs/platform/theme/common/themeService.ts
+++ b/src/vs/platform/theme/common/themeService.ts
@@ -112,6 +112,11 @@ export interface ITheme {
 	 * List of all colors used with tokens. <code>getTokenStyleMetadata</code> references the colors by index into this list.
 	 */
 	readonly tokenColorMap: string[];
+
+	/**
+	 * Defines whether semantic highlighting should be enabled for the theme.
+	 */
+	readonly semanticHighlighting: boolean;
 }
 
 export interface IIconTheme {

--- a/src/vs/platform/theme/test/common/testThemeService.ts
+++ b/src/vs/platform/theme/test/common/testThemeService.ts
@@ -28,6 +28,8 @@ export class TestTheme implements ITheme {
 		return undefined;
 	}
 
+	readonly semanticHighlighting = false;
+
 	get tokenColorMap(): string[] {
 		return [];
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens.ts
@@ -260,6 +260,9 @@ class InspectEditorTokensWidget extends Disposable implements IContentWidget {
 	}
 
 	private _isSemanticColoringEnabled() {
+		if (!this._themeService.getColorTheme().semanticHighlighting) {
+			return false;
+		}
 		const options = this._configurationService.getValue<IEditorSemanticHighlightingOptions>('editor.semanticHighlighting', { overrideIdentifier: this._model.getLanguageIdentifier().language, resource: this._model.uri });
 		return options && options.enabled;
 	}

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -18,6 +18,8 @@ import { IFileMatch } from 'vs/workbench/services/search/common/search';
 import { ReplaceAction } from 'vs/workbench/contrib/search/browser/searchActions';
 import { FileMatch, FileMatchOrMatch, Match } from 'vs/workbench/contrib/search/common/searchModel';
 import { MockObjectTree } from 'vs/workbench/contrib/search/test/browser/mockSearchTree';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 suite('Search Actions', () => {
 
@@ -153,6 +155,7 @@ suite('Search Actions', () => {
 
 	function stubModelService(instantiationService: TestInstantiationService): IModelService {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IThemeService, new TestThemeService());
 		return instantiationService.createInstance(ModelServiceImpl);
 	}
 });

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -15,6 +15,8 @@ import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { FileMatch, Match, searchMatchComparer, SearchResult } from 'vs/workbench/contrib/search/common/searchModel';
 import { TestContextService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { isWindows } from 'vs/base/common/platform';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 suite('Search - Viewlet', () => {
 	let instantiation: TestInstantiationService;
@@ -105,6 +107,7 @@ suite('Search - Viewlet', () => {
 
 	function stubModelService(instantiationService: TestInstantiationService): IModelService {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IThemeService, new TestThemeService());
 		return instantiationService.createInstance(ModelServiceImpl);
 	}
 });

--- a/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchModel.test.ts
@@ -19,6 +19,8 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 import { SearchModel } from 'vs/workbench/contrib/search/common/searchModel';
 import * as process from 'vs/base/common/process';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 const nullEvent = new class {
 	id: number = -1;
@@ -328,6 +330,7 @@ suite('SearchModel', () => {
 
 	function stubModelService(instantiationService: TestInstantiationService): IModelService {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IThemeService, new TestThemeService());
 		return instantiationService.createInstance(ModelServiceImpl);
 	}
 

--- a/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/searchResult.test.ts
@@ -16,6 +16,8 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 import { ModelServiceImpl } from 'vs/editor/common/services/modelServiceImpl';
 import { IModelService } from 'vs/editor/common/services/modelService';
 import { IReplaceService } from 'vs/workbench/contrib/search/common/replace';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 const lineOneRange = new OneLineRange(1, 0, 1);
 
@@ -352,6 +354,7 @@ suite('SearchResult', () => {
 
 	function stubModelService(instantiationService: TestInstantiationService): IModelService {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IThemeService, new TestThemeService());
 		return instantiationService.createInstance(ModelServiceImpl);
 	}
 });

--- a/src/vs/workbench/contrib/terminal/test/common/terminalColorRegistry.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/terminalColorRegistry.test.ts
@@ -21,8 +21,8 @@ function getMockTheme(type: ThemeType): ITheme {
 		getColor: (colorId: ColorIdentifier): Color | undefined => themingRegistry.resolveDefaultColor(colorId, theme),
 		defines: () => true,
 		getTokenStyleMetadata: () => undefined,
-		tokenColorMap: []
-
+		tokenColorMap: [],
+		semanticHighlighting: false
 	};
 	return theme;
 }

--- a/src/vs/workbench/services/keybinding/test/electron-browser/keybindingEditing.test.ts
+++ b/src/vs/workbench/services/keybinding/test/electron-browser/keybindingEditing.test.ts
@@ -54,6 +54,8 @@ import { IFilesConfigurationService, FilesConfigurationService } from 'vs/workbe
 import { WorkingCopyFileService, IWorkingCopyFileService } from 'vs/workbench/services/workingCopy/common/workingCopyFileService';
 import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { UndoRedoService } from 'vs/platform/undoRedo/common/undoRedoService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 class TestEnvironmentService extends NativeWorkbenchEnvironmentService {
 
@@ -106,6 +108,7 @@ suite('KeybindingsEditing', () => {
 			instantiationService.stub(IFilesConfigurationService, instantiationService.createInstance(FilesConfigurationService));
 			instantiationService.stub(ITextResourcePropertiesService, new TestTextResourcePropertiesService(instantiationService.get(IConfigurationService)));
 			instantiationService.stub(IUndoRedoService, instantiationService.createInstance(UndoRedoService));
+			instantiationService.stub(IThemeService, new TestThemeService());
 			instantiationService.stub(IModelService, instantiationService.createInstance(ModelServiceImpl));
 			const fileService = new FileService(new NullLogService());
 			const diskFileSystemProvider = new DiskFileSystemProvider(new NullLogService());

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -816,6 +816,10 @@ const tokenColorSchema: IJSONSchema = {
 		textMateRules: {
 			description: nls.localize('editorColors.textMateRules', 'Sets colors and styles using textmate theming rules (advanced).'),
 			$ref: textmateColorsSchemaId
+		},
+		semanticHighlighting: {
+			description: nls.localize('editorColors.semanticHighlighting', 'Whether semantic highlighting should be enabled for this theme.'),
+			type: 'boolean'
 		}
 	}
 };

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -289,9 +289,11 @@ export class ColorThemeData implements IColorTheme {
 						const settings = tokenColors[i].settings;
 						if (score >= foregroundScore && settings.foreground) {
 							foreground = settings.foreground;
+							foregroundScore = score;
 						}
 						if (score >= fontStyleScore && types.isString(settings.fontStyle)) {
 							fontStyle = settings.fontStyle;
+							fontStyleScore = score;
 						}
 					}
 				}
@@ -642,7 +644,7 @@ function nameMatcher(identifers: string[], scope: ProbeScope): number {
 	let lastScopeIndex = scope.length - 1;
 	let lastIdentifierIndex = findInIdents(scope[lastScopeIndex--], identifers.length);
 	if (lastIdentifierIndex >= 0) {
-		const score = (lastIdentifierIndex + 1) * 0x10000 + scope.length;
+		const score = (lastIdentifierIndex + 1) * 0x10000 + identifers[lastIdentifierIndex].length;
 		while (lastScopeIndex >= 0) {
 			lastIdentifierIndex = findInIdents(scope[lastScopeIndex--], lastIdentifierIndex);
 			if (lastIdentifierIndex === -1) {

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -222,6 +222,10 @@ const colorThemeSchema: IJSONSchema = {
 				$ref: textmateColorsSchemaId
 			}
 			]
+		},
+		semanticHighlighting: {
+			type: 'boolean',
+			description: nls.localize('schema.supportsSemanticHighlighting', 'Whether semantic highlighting should be enabled for this theme.')
 		}
 	}
 };

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -70,7 +70,7 @@ export interface IColorCustomizations {
 }
 
 export interface ITokenColorCustomizations {
-	[groupIdOrThemeSettingsId: string]: string | ITokenColorizationSetting | ITokenColorCustomizations | undefined | ITextMateThemingRule[];
+	[groupIdOrThemeSettingsId: string]: string | ITokenColorizationSetting | ITokenColorCustomizations | undefined | ITextMateThemingRule[] | boolean;
 	comments?: string | ITokenColorizationSetting;
 	strings?: string | ITokenColorizationSetting;
 	numbers?: string | ITokenColorizationSetting;
@@ -79,6 +79,7 @@ export interface ITokenColorCustomizations {
 	functions?: string | ITokenColorizationSetting;
 	variables?: string | ITokenColorizationSetting;
 	textMateRules?: ITextMateThemingRule[];
+	semanticHighlighting?: boolean;
 }
 
 export interface IExperimentalTokenStyleCustomizations {

--- a/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/electron-browser/tokenStyleResolving.test.ts
@@ -289,6 +289,41 @@ suite('Themes - TokenStyleResolving', () => {
 
 	});
 
+
+	test('resolveScopes - match most specific', async () => {
+		const themeData = ColorThemeData.createLoadedEmptyTheme('test', 'test');
+
+		const customTokenColors: ITokenColorCustomizations = {
+			textMateRules: [
+				{
+					scope: 'entity.name.type',
+					settings: {
+						fontStyle: 'underline',
+						foreground: '#A6E22E'
+					}
+				},
+				{
+					scope: 'entity.name.type.class',
+					settings: {
+						foreground: '#FF00FF'
+					}
+				},
+				{
+					scope: 'entity.name',
+					settings: {
+						foreground: '#FFFFFF'
+					}
+				},
+			]
+		};
+
+		themeData.setCustomTokenColors(customTokenColors);
+
+		const tokenStyle = themeData.resolveScopes([['entity.name.type.class']]);
+		assertTokenStyle(tokenStyle, ts('#FF00FF', { underline: true }), 'entity.name.type.class');
+
+	});
+
 	test('rule matching', async () => {
 		const themeData = ColorThemeData.createLoadedEmptyTheme('test', 'test');
 		themeData.setCustomColors({ 'editor.foreground': '#000000' });

--- a/src/vs/workbench/test/browser/parts/editor/editorModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorModel.test.ts
@@ -24,6 +24,8 @@ import { TestDialogService } from 'vs/platform/dialogs/test/common/testDialogSer
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 class MyEditorModel extends EditorModel { }
 class MyTextEditorModel extends BaseTextEditorModel {
@@ -84,6 +86,7 @@ suite('Workbench editor model', () => {
 		instantiationService.stub(IDialogService, dialogService);
 		instantiationService.stub(INotificationService, notificationService);
 		instantiationService.stub(IUndoRedoService, undoRedoService);
+		instantiationService.stub(IThemeService, new TestThemeService());
 		return instantiationService.createInstance(ModelServiceImpl);
 	}
 });

--- a/src/vs/workbench/test/browser/parts/editor/rangeDecorations.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/rangeDecorations.test.ts
@@ -22,6 +22,8 @@ import { CoreNavigationCommands } from 'vs/editor/browser/controller/coreCommand
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { createTextModel } from 'vs/editor/test/common/editorTestUtils';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 suite('Editor - Range decorations', () => {
 
@@ -157,6 +159,7 @@ suite('Editor - Range decorations', () => {
 
 	function stubModelService(instantiationService: TestInstantiationService): IModelService {
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IThemeService, new TestThemeService());
 		return instantiationService.createInstance(ModelServiceImpl);
 	}
 });

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -137,6 +137,7 @@ export function workbenchInstantiationService(overrides?: { textFileService?: (i
 	instantiationService.stub(IHistoryService, new TestHistoryService());
 	instantiationService.stub(ITextResourcePropertiesService, new TestTextResourcePropertiesService(configService));
 	instantiationService.stub(IUndoRedoService, instantiationService.createInstance(UndoRedoService));
+	instantiationService.stub(IThemeService, new TestThemeService());
 	instantiationService.stub(IModelService, instantiationService.createInstance(ModelServiceImpl));
 	instantiationService.stub(IFileService, new TestFileService());
 	instantiationService.stub(IBackupFileService, new TestBackupFileService());
@@ -151,7 +152,6 @@ export function workbenchInstantiationService(overrides?: { textFileService?: (i
 	instantiationService.stub(ITextFileService, overrides?.textFileService ? overrides.textFileService(instantiationService) : <ITextFileService>instantiationService.createInstance(TestTextFileService));
 	instantiationService.stub(IHostService, <IHostService>instantiationService.createInstance(TestHostService));
 	instantiationService.stub(ITextModelService, <ITextModelService>instantiationService.createInstance(TextModelResolverService));
-	instantiationService.stub(IThemeService, new TestThemeService());
 	instantiationService.stub(ILogService, new NullLogService());
 	const editorGroupService = new TestEditorGroupsService([new TestEditorGroupView(0)]);
 	instantiationService.stub(IEditorGroupsService, editorGroupService);


### PR DESCRIPTION
Semantic highlighting fixes for 1.43.1 as discussed in https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview#semantic-highlighting

https://github.com/microsoft/vscode/pull/92737/commits/f8a038284bde2e40a8fbb58000f2a9d76bbfb62f
- fix for the style lookup found in #92536. For a given Text Mate scope, find the the theming rule in the current theme. When there are multiple rules matching, use the most specific one. The bug was to take the last, but not most specific rule.

https://github.com/microsoft/vscode/pull/92737/commits/53619cda496ac3cc64901d41bf71bf48a5d3fcb0
- Contains multiple fixed in the TypeScript server plugin. All covered by test cases.
  - https://github.com/aeschli/typescript-vscode-sh-plugin/commit/48034c886eeae91426dead7c9f866ebc0914c505 if the type of a variable is callable, it becomes a function except if also has properties and is not used in a callExpression, Examples: `require`, `describe`
  - https://github.com/aeschli/typescript-vscode-sh-plugin/commit/d155c22e7da8740508c3706926914640f1339718 variables that resolve to a type with a constructor function become a class. Example `Promise`, `Number`, `String`
  - https://github.com/aeschli/typescript-vscode-sh-plugin/commit/653598165fa6f2b3bae86becc601d1412ea4cb55 No highlighting in import (reduce the number of color changes)
  - https://github.com/aeschli/typescript-vscode-sh-plugin/commit/4efdc9d1b2d4d97c68d7ad8617d3bf86563e9990 fix the bug that references to properties declared in constructors where classified as parameters, not properties
`constructor(private readonly name) { console.log(this.name); }`

https://github.com/microsoft/vscode/pull/92737/commits/76e9946d1c7db978ce9b24d9169a02c2b90f182b
- add a new property to color theme definition files: `semanticHighlighting: boolean`. Themes can control whether semanticHighlighting is enabled.
- all built-in themes have it enabled
- can be overwritten in the settings. For all themes, or per theme:
```
    "editor.tokenColorCustomizations": {
        "[Rouge 2]": {
            "semanticHighlighting": true
        }
    }
```
- part of the persisted properties for quick restore of theme
- onDidColorThemeChange is emited when property changes (by user settings, or load/reload)