### PR TITLE
Semantic tokens help for 1.43.1

### DIFF
--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1754,6 +1754,7 @@ export class TextModel extends Disposable implements model.ITextModel {
 		if (ranges.length > 0) {
 			this._emitModelTokensChangedEvent({
 				tokenizationSupportChanged: false,
+				semanticTokensApplied: false,
 				ranges: ranges
 			});
 		}
@@ -1764,6 +1765,7 @@ export class TextModel extends Disposable implements model.ITextModel {
 
 		this._emitModelTokensChangedEvent({
 			tokenizationSupportChanged: false,
+			semanticTokensApplied: tokens !== null,
 			ranges: [{ fromLineNumber: 1, toLineNumber: this.getLineCount() }]
 		});
 	}
@@ -1778,6 +1780,7 @@ export class TextModel extends Disposable implements model.ITextModel {
 		this._tokens.flush();
 		this._emitModelTokensChangedEvent({
 			tokenizationSupportChanged: true,
+			semanticTokensApplied: false,
 			ranges: [{
 				fromLineNumber: 1,
 				toLineNumber: this._buffer.getLineCount()
@@ -1790,6 +1793,7 @@ export class TextModel extends Disposable implements model.ITextModel {
 
 		this._emitModelTokensChangedEvent({
 			tokenizationSupportChanged: false,
+			semanticTokensApplied: true,
 			ranges: [{ fromLineNumber: 1, toLineNumber: this.getLineCount() }]
 		});
 	}

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -1793,7 +1793,7 @@ export class TextModel extends Disposable implements model.ITextModel {
 
 		this._emitModelTokensChangedEvent({
 			tokenizationSupportChanged: false,
-			semanticTokensApplied: true,
+			semanticTokensApplied: false,
 			ranges: [{ fromLineNumber: 1, toLineNumber: this.getLineCount() }]
 		});
 	}

--- a/src/vs/editor/common/model/textModelEvents.ts
+++ b/src/vs/editor/common/model/textModelEvents.ts
@@ -87,6 +87,7 @@ export interface IModelDecorationsChangedEvent {
  */
 export interface IModelTokensChangedEvent {
 	readonly tokenizationSupportChanged: boolean;
+	readonly semanticTokensApplied: boolean;
 	readonly ranges: {
 		/**
 		 * The start of the range (inclusive)

--- a/src/vs/workbench/contrib/codeEditor/browser/codeEditor.contribution.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/codeEditor.contribution.ts
@@ -10,6 +10,7 @@ import './inspectKeybindings';
 import './largeFileOptimizations';
 import './inspectEditorTokens/inspectEditorTokens';
 import './saveParticipants';
+import './semanticTokensHelp';
 import './toggleColumnSelection';
 import './toggleMinimap';
 import './toggleMultiCursorModifier';

--- a/src/vs/workbench/contrib/codeEditor/browser/semanticTokensHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/semanticTokensHelp.ts
@@ -48,7 +48,7 @@ export class SemanticTokensHelp extends Disposable implements IEditorContributio
 							'Variable 1 will be a theme name.'
 						]
 					},
-					"Semantic highlighting has been applied on top of the syntax highlighting of {0} as current the theme ({1}) has semantic highlighting enabled.",
+					"Semantic highlighting has been applied to '{0}' as the theme '{1}' has semantic highlighting enabled.",
 					path.basename(model.uri.path), _themeService.getColorTheme().label
 				);
 

--- a/src/vs/workbench/contrib/codeEditor/browser/semanticTokensHelp.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/semanticTokensHelp.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vs/nls';
+import * as path from 'vs/base/common/path';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { URI } from 'vs/base/common/uri';
+import { ITextModel } from 'vs/editor/common/model';
+import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+
+/**
+ * Shows a message when semantic tokens are shown the first time.
+ */
+export class SemanticTokensHelp extends Disposable implements IEditorContribution {
+
+	public static readonly ID = 'editor.contrib.semanticHighlightHelp';
+
+	constructor(
+		_editor: ICodeEditor,
+		@INotificationService _notificationService: INotificationService,
+		@IOpenerService _openerService: IOpenerService,
+		@IWorkbenchThemeService _themeService: IWorkbenchThemeService
+	) {
+		super();
+
+		const toDispose = this._register(new DisposableStore());
+		const localToDispose = toDispose.add(new DisposableStore());
+		const installChangeTokenListener = (model: ITextModel) => {
+			localToDispose.add(model.onDidChangeTokens((e) => {
+				if (!e.semanticTokensApplied) {
+					return;
+				}
+
+				toDispose.dispose(); // uninstall all listeners, makes sure the notification is only shown once per window
+
+				const message = nls.localize(
+					{
+						key: 'semanticTokensHelp',
+						comment: [
+							'Variable 0 will be a file name.',
+							'Variable 1 will be a theme name.'
+						]
+					},
+					"Semantic highlighting has been applied on top of the syntax highlighting of {0} as current the theme ({1}) has semantic highlighting enabled.",
+					path.basename(model.uri.path), _themeService.getColorTheme().label
+				);
+
+				_notificationService.prompt(Severity.Info, message, [
+					{
+						label: nls.localize('learnMoreButton', "Learn More"),
+						run: () => {
+							const url = 'https://go.microsoft.com/fwlink/?linkid=2122588';
+
+							_openerService.open(URI.parse(url));
+						}
+					}
+				], { neverShowAgain: { id: 'editor.contrib.semanticTokensHelp' } });
+			}));
+		};
+
+
+		const model = _editor.getModel();
+		if (model !== null) {
+			installChangeTokenListener(model);
+		}
+
+		toDispose.add(_editor.onDidChangeModel((e) => {
+			localToDispose.clear();
+
+			const model = _editor.getModel();
+			if (!model) {
+				return;
+			}
+			installChangeTokenListener(model);
+		}));
+	}
+}
+
+registerEditorContribution(SemanticTokensHelp.ID, SemanticTokensHelp);


### PR DESCRIPTION
Show a notification when semantic tokens are shown the first tome with a link to more information.
For #92740

The forward link points to https://code.visualstudio.com/docs/getstarted/themes#_semantic-highlighting which still needs to be published
