### PR TITLE
Allow multiple api acquire in notebook webview

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -297,6 +297,7 @@ export class BackLayerWebView extends Disposable {
 		const webview = webviewService.createWebviewElement('' + UUID.generateUuid(), {
 			enableFindWidget: false,
 		}, {
+			allowMultipleAPIAcquire: true,
 			allowScripts: true,
 			localResourceRoots: this.localResourceRootsCache
 		});
@@ -409,6 +410,7 @@ export class BackLayerWebView extends Disposable {
 		const mixedResourceRoots = [...(this.localResourceRootsCache || []), ...this.rendererRootsCache];
 
 		this.webview.contentOptions = {
+			allowMultipleAPIAcquire: true,
 			allowScripts: true,
 			enableCommandUris: true,
 			localResourceRoots: mixedResourceRoots

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -125,6 +125,7 @@
 	}`;
 
 	/**
+	 * @param {boolean} allowMultipleAPIAcquire
 	 * @param {*} [state]
 	 * @return {string}
 	 */

--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -128,7 +128,7 @@
 	 * @param {*} [state]
 	 * @return {string}
 	 */
-	function getVsCodeApiScript(state) {
+	function getVsCodeApiScript(allowMultipleAPIAcquire, state) {
 		return `
 			const acquireVsCodeApi = (function() {
 				const originalPostMessage = window.parent.postMessage.bind(window.parent);
@@ -138,7 +138,7 @@
 				let state = ${state ? `JSON.parse(${JSON.stringify(state)})` : undefined};
 
 				return () => {
-					if (acquired) {
+					if (acquired && !${allowMultipleAPIAcquire}) {
 						throw new Error('An instance of the VS Code API has already been acquired');
 					}
 					acquired = true;
@@ -325,7 +325,7 @@
 			if (options.allowScripts) {
 				const defaultScript = newDocument.createElement('script');
 				defaultScript.id = '_vscodeApiScript';
-				defaultScript.textContent = getVsCodeApiScript(data.state);
+				defaultScript.textContent = getVsCodeApiScript(options.allowMultipleAPIAcquire, data.state);
 				newDocument.head.prepend(defaultScript);
 			}
 

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -59,6 +59,7 @@ export interface WebviewOptions {
 }
 
 export interface WebviewContentOptions {
+	readonly allowMultipleAPIAcquire?: boolean;
 	readonly allowScripts?: boolean;
 	readonly localResourceRoots?: ReadonlyArray<URI>;
 	readonly portMapping?: ReadonlyArray<modes.IWebviewPortMapping>;

--- a/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewWorkbenchService.ts
@@ -36,6 +36,7 @@ export function areWebviewInputOptionsEqual(a: WebviewInputOptions, b: WebviewIn
 	return a.enableCommandUris === b.enableCommandUris
 		&& a.enableFindWidget === b.enableFindWidget
 		&& a.allowScripts === b.allowScripts
+		&& a.allowMultipleAPIAcquire === b.allowMultipleAPIAcquire
 		&& a.retainContextWhenHidden === b.retainContextWhenHidden
 		&& a.tryRestoreScrollPosition === b.tryRestoreScrollPosition
 		&& equals(a.localResourceRoots, b.localResourceRoots, isEqual)


### PR DESCRIPTION
Notebook custom renderers live in the same webview so they already share the same messaging channel. To allow them send messages from the webview to the extension host, we can allow multiple api acquire. This feature is only turned on for Notebook.

We don't re-export `acquireVSCodeAPI` as we want renderers extensions to use it in the same way as a normal webview.