### PR TITLE
Fix file move for custom editors

### DIFF
--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -153,7 +153,7 @@ export interface IWorkingCopyFileService {
 	/**
 	 * Register a new provider for working copies.
 	 *
-	 * @return Disposable the unregisters the provider.
+	 * @return a disposable that unregisters the provider.
 	 */
 	registerWorkingCopyProvider(provider: WorkingCopyProvider): IDisposable;
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -192,6 +192,8 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 		super();
+
+		// register a default working copy provider that uses the working copy service
 		this.registerWorkingCopyProvider(resource => {
 			return this.workingCopyService.workingCopies.filter(workingCopy => {
 				if (this.fileService.canHandleResource(resource)) {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -151,7 +151,7 @@ export interface IWorkingCopyFileService {
 	//#region Path related
 
 	/**
-	 * Register a new provider for working copies.
+	 * Register a new provider for working copies based on a resource.
 	 *
 	 * @return a disposable that unregisters the provider.
 	 */

--- a/src/vs/workbench/services/workingCopy/test/common/workingCopyService.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/common/workingCopyService.test.ts
@@ -12,64 +12,65 @@ import { TestWorkingCopyService } from 'vs/workbench/test/common/workbenchTestSe
 import { ISaveOptions, IRevertOptions } from 'vs/workbench/common/editor';
 import { basename } from 'vs/base/common/resources';
 
-suite('WorkingCopyService', () => {
+export class TestWorkingCopy extends Disposable implements IWorkingCopy {
 
-	class TestWorkingCopy extends Disposable implements IWorkingCopy {
+	private readonly _onDidChangeDirty = this._register(new Emitter<void>());
+	readonly onDidChangeDirty = this._onDidChangeDirty.event;
 
-		private readonly _onDidChangeDirty = this._register(new Emitter<void>());
-		readonly onDidChangeDirty = this._onDidChangeDirty.event;
+	private readonly _onDidChangeContent = this._register(new Emitter<void>());
+	readonly onDidChangeContent = this._onDidChangeContent.event;
 
-		private readonly _onDidChangeContent = this._register(new Emitter<void>());
-		readonly onDidChangeContent = this._onDidChangeContent.event;
+	private readonly _onDispose = this._register(new Emitter<void>());
+	readonly onDispose = this._onDispose.event;
 
-		private readonly _onDispose = this._register(new Emitter<void>());
-		readonly onDispose = this._onDispose.event;
+	readonly capabilities = 0;
 
-		readonly capabilities = 0;
+	readonly name = basename(this.resource);
 
-		readonly name = basename(this.resource);
+	private dirty = false;
 
-		private dirty = false;
+	constructor(public readonly resource: URI, isDirty = false) {
+		super();
 
-		constructor(public readonly resource: URI, isDirty = false) {
-			super();
+		this.dirty = isDirty;
+	}
 
-			this.dirty = isDirty;
-		}
-
-		setDirty(dirty: boolean): void {
-			if (this.dirty !== dirty) {
-				this.dirty = dirty;
-				this._onDidChangeDirty.fire();
-			}
-		}
-
-		setContent(content: string): void {
-			this._onDidChangeContent.fire();
-		}
-
-		isDirty(): boolean {
-			return this.dirty;
-		}
-
-		async save(options?: ISaveOptions): Promise<boolean> {
-			return true;
-		}
-
-		async revert(options?: IRevertOptions): Promise<void> {
-			this.setDirty(false);
-		}
-
-		async backup(): Promise<IWorkingCopyBackup> {
-			return {};
-		}
-
-		dispose(): void {
-			this._onDispose.fire();
-
-			super.dispose();
+	setDirty(dirty: boolean): void {
+		if (this.dirty !== dirty) {
+			this.dirty = dirty;
+			this._onDidChangeDirty.fire();
 		}
 	}
+
+	setContent(content: string): void {
+		this._onDidChangeContent.fire();
+	}
+
+	isDirty(): boolean {
+		return this.dirty;
+	}
+
+	async save(options?: ISaveOptions): Promise<boolean> {
+		return true;
+	}
+
+	async revert(options?: IRevertOptions): Promise<void> {
+		this.setDirty(false);
+	}
+
+	async backup(): Promise<IWorkingCopyBackup> {
+		return {};
+	}
+
+	dispose(): void {
+		this._onDispose.fire();
+
+		super.dispose();
+	}
+}
+
+suite('WorkingCopyService', () => {
+
 
 	test('registry - basics', () => {
 		const service = new TestWorkingCopyService();


### PR DESCRIPTION
**Problem**
The working copy for custom editors uses a special scheme for its resource: `vscode-custom-editor` . However this broke file move. I investigate and determined the root cause:

- The WorkingCopyService monitors file change events: https://github.com/microsoft/vscode/blob/17cc949013df9abb021da74c77b9508cf8607849/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts#L193

- When one occurs, it tries to get all the dirty working copies for the moved resource

- However since our custom editor working copy now uses a `vscode-custom-editor` resource, we never match the moved resource.

**Fix**
My fix was to add an `editorResource` to the working copy. This is the actual resource on disk that the working copy represents.

I don't think this is a great fix. Please let me know if you have any other ideas on how to fix this @bpasero
