### PR TITLE
Fix history entries navigation taking extra navigates in debug console

### DIFF
--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -27,20 +27,18 @@ export class HistoryNavigator<T> implements INavigator<T> {
 		this._onChange();
 	}
 
-	public hasNext(): boolean {
-		return this._currentPosition() !== this._elements.length - 1;
-	}
-
 	public next(): T | null {
-		return this._navigator.next();
-	}
-
-	public hasPrevious(): boolean {
-		return this._currentPosition() !== 0;
+		if (this._currentPosition() !== this._elements.length - 1) {
+			return this._navigator.next();
+		}
+		return null;
 	}
 
 	public previous(): T | null {
-		return this._navigator.previous();
+		if (this._currentPosition() !== 0) {
+			return this._navigator.previous();
+		}
+		return null;
 	}
 
 	public current(): T | null {

--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -27,8 +27,16 @@ export class HistoryNavigator<T> implements INavigator<T> {
 		this._onChange();
 	}
 
+	public hasNext(): boolean {
+		return this._currentPosition() !== this._elements.length - 1;
+	}
+
 	public next(): T | null {
 		return this._navigator.next();
+	}
+
+	public hasPrevious(): boolean {
+		return this._currentPosition() !== 0;
 	}
 
 	public previous(): T | null {
@@ -71,6 +79,15 @@ export class HistoryNavigator<T> implements INavigator<T> {
 		if (data.length > this._limit) {
 			this._initialize(data.slice(data.length - this._limit));
 		}
+	}
+
+	private _currentPosition(): number {
+		const currentElement = this._navigator.current();
+		if (!currentElement) {
+			return -1;
+		}
+
+		return this._elements.indexOf(currentElement);
 	}
 
 	private _initialize(history: readonly T[]): void {

--- a/src/vs/base/test/common/history.test.ts
+++ b/src/vs/base/test/common/history.test.ts
@@ -106,38 +106,38 @@ suite('History Navigator', () => {
 		assert.deepEqual(['2', '3', '1'], toArray(testObject));
 	});
 
-	test('hasPrevious returns false if the current position is the first one', () => {
+	test('previous returns null if the current position is the first one', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3']);
 
 		testObject.first();
 
-		assert.deepEqual(testObject.hasPrevious(), false);
+		assert.deepEqual(testObject.previous(), null);
 	});
 
-	test('hasPrevious returns true if the current position is not the first one', () => {
+	test('previous returns object if the current position is not the first one', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3']);
 
 		testObject.first();
 		testObject.next();
 
-		assert.deepEqual(testObject.hasPrevious(), true);
+		assert.deepEqual(testObject.previous(), '1');
 	});
 
-	test('hasNext returns false if the current position is the last one', () => {
+	test('next returns null if the current position is the last one', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3']);
 
 		testObject.last();
 
-		assert.deepEqual(testObject.hasNext(), false);
+		assert.deepEqual(testObject.next(), null);
 	});
 
-	test('hasNext returns true if the current position is not the last one', () => {
+	test('next returns object if the current position is not the last one', () => {
 		const testObject = new HistoryNavigator(['1', '2', '3']);
 
 		testObject.last();
 		testObject.previous();
 
-		assert.deepEqual(testObject.hasNext(), true);
+		assert.deepEqual(testObject.next(), '3');
 	});
 
 	test('clear', () => {

--- a/src/vs/base/test/common/history.test.ts
+++ b/src/vs/base/test/common/history.test.ts
@@ -106,6 +106,40 @@ suite('History Navigator', () => {
 		assert.deepEqual(['2', '3', '1'], toArray(testObject));
 	});
 
+	test('hasPrevious returns false if the current position is the first one', () => {
+		const testObject = new HistoryNavigator(['1', '2', '3']);
+
+		testObject.first();
+
+		assert.deepEqual(testObject.hasPrevious(), false);
+	});
+
+	test('hasPrevious returns true if the current position is not the first one', () => {
+		const testObject = new HistoryNavigator(['1', '2', '3']);
+
+		testObject.first();
+		testObject.next();
+
+		assert.deepEqual(testObject.hasPrevious(), true);
+	});
+
+	test('hasNext returns false if the current position is the last one', () => {
+		const testObject = new HistoryNavigator(['1', '2', '3']);
+
+		testObject.last();
+
+		assert.deepEqual(testObject.hasNext(), false);
+	});
+
+	test('hasNext returns true if the current position is not the last one', () => {
+		const testObject = new HistoryNavigator(['1', '2', '3']);
+
+		testObject.last();
+		testObject.previous();
+
+		assert.deepEqual(testObject.hasNext(), true);
+	});
+
 	test('clear', () => {
 		const testObject = new HistoryNavigator(['a', 'b', 'c']);
 		assert.equal(testObject.previous(), 'c');

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -228,15 +228,11 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 	}
 
 	showPreviousValue(): void {
-		if (this.history.hasPrevious()) {
-			this.navigateHistory(true);
-		}
+		this.navigateHistory(true);
 	}
 
 	showNextValue(): void {
-		if (this.history.hasNext()) {
-			this.navigateHistory(false);
-		}
+		this.navigateHistory(false);
 	}
 
 	focusRepl(): void {

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -228,11 +228,15 @@ export class Repl extends ViewPane implements IHistoryNavigationWidget {
 	}
 
 	showPreviousValue(): void {
-		this.navigateHistory(true);
+		if (this.history.hasPrevious()) {
+			this.navigateHistory(true);
+		}
 	}
 
 	showNextValue(): void {
-		this.navigateHistory(false);
+		if (this.history.hasNext()) {
+			this.navigateHistory(false);
+		}
 	}
 
 	focusRepl(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes extra navigations done in History entries of debugger console, which cause problems navigating through the history, retrieving incorrect values.

This PR fixes #93102
