### PR TITLE
Fix #92219 - skip word separator in settings search

### DIFF
--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -218,6 +218,8 @@ suite('Filters', () => {
 		filterOk(matchesWords, 'foo+bar', 'foo-bar');
 		filterOk(matchesWords, 'foo-bar', 'foo bar');
 		filterOk(matchesWords, 'foo:bar', 'foo:bar');
+
+		assert(!matchesWords('foo-bar', 'foo bar', false, false), 'foo-bar matched foo bar');
 	});
 
 	function assertMatches(pattern: string, word: string, decoratedWord: string | undefined, filter: FuzzyScorer, opts: { patternPos?: number, wordPos?: number, firstMatchCanBeWeak?: boolean } = {}) {

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -480,14 +480,14 @@ export class SettingMatches {
 		for (const word of words) {
 			if (this.searchDescription) {
 				for (let lineIndex = 0; lineIndex < setting.description.length; lineIndex++) {
-					const descriptionMatches = matchesWords(word, setting.description[lineIndex], true);
+					const descriptionMatches = matchesWords(word, setting.description[lineIndex], true, false);
 					if (descriptionMatches) {
 						this.descriptionMatchingWords.set(word, descriptionMatches.map(match => this.toDescriptionRange(setting, match, lineIndex)));
 					}
 				}
 			}
 
-			const keyMatches = or(matchesWords, matchesCamelCase)(word, settingKeyAsWords);
+			const keyMatches = matchesWords(word, settingKeyAsWords, false, false) || matchesCamelCase(word, settingKeyAsWords);
 			if (keyMatches) {
 				this.keyMatchingWords.set(word, keyMatches.map(match => this.toKeyRange(setting, match)));
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #92219 

Root cause: The dash('-') and dot('.') are both belong with word separator. If search dash('-') in settings, the dot('.') will also be shown. 

How to test: Search dash('-') in settings.
