### PR TITLE
Add empty classname to cursor options to allow style customizations

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -271,6 +271,9 @@ export class ViewCursors extends ViewPart {
 			case TextEditorCursorStyle.UnderlineThin:
 				result += ' cursor-underline-thin-style';
 				break;
+			case TextEditorCursorStyle.Empty:
+				result += ' cursor-empty-style';
+				break;
 			default:
 				result += ' cursor-line-style';
 		}
@@ -290,6 +293,9 @@ export class ViewCursors extends ViewPart {
 					break;
 				case TextEditorCursorBlinkingStyle.Solid:
 					result += ' cursor-solid';
+					break;
+				case TextEditorCursorBlinkingStyle.Empty:
+					result += ' cursor-empty';
 					break;
 				default:
 					result += ' cursor-solid';

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -176,7 +176,7 @@ export interface IEditorOptions {
 	 * Control the cursor animation style, possible values are 'blink', 'smooth', 'phase', 'expand' and 'solid'.
 	 * Defaults to 'blink'.
 	 */
-	cursorBlinking?: 'blink' | 'smooth' | 'phase' | 'expand' | 'solid';
+	cursorBlinking?: 'blink' | 'smooth' | 'phase' | 'expand' | 'solid' | 'empty';
 	/**
 	 * Zoom the font in the editor when using the mouse wheel in combination with holding Ctrl.
 	 * Defaults to false.
@@ -196,7 +196,7 @@ export interface IEditorOptions {
 	 * Control the cursor style, either 'block' or 'line'.
 	 * Defaults to 'line'.
 	 */
-	cursorStyle?: 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin';
+	cursorStyle?: 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin' | 'empty';
 	/**
 	 * Control the width of the cursor when cursorStyle is set to 'line'
 	 */
@@ -1103,16 +1103,21 @@ export const enum TextEditorCursorBlinkingStyle {
 	/**
 	 * No-Blinking
 	 */
-	Solid = 5
+	Solid = 5,
+	/**
+	 * Provides a class for attaching custom styles.
+	 */
+	Empty = 6
 }
 
-function _cursorBlinkingStyleFromString(cursorBlinkingStyle: 'blink' | 'smooth' | 'phase' | 'expand' | 'solid'): TextEditorCursorBlinkingStyle {
+function _cursorBlinkingStyleFromString(cursorBlinkingStyle: 'blink' | 'smooth' | 'phase' | 'expand' | 'solid' | 'empty'): TextEditorCursorBlinkingStyle {
 	switch (cursorBlinkingStyle) {
 		case 'blink': return TextEditorCursorBlinkingStyle.Blink;
 		case 'smooth': return TextEditorCursorBlinkingStyle.Smooth;
 		case 'phase': return TextEditorCursorBlinkingStyle.Phase;
 		case 'expand': return TextEditorCursorBlinkingStyle.Expand;
 		case 'solid': return TextEditorCursorBlinkingStyle.Solid;
+		case 'empty': return TextEditorCursorBlinkingStyle.Empty;
 	}
 }
 
@@ -1147,13 +1152,17 @@ export enum TextEditorCursorStyle {
 	/**
 	 * As a thin horizontal line (sitting under a character).
 	 */
-	UnderlineThin = 6
+	UnderlineThin = 6,
+	/**
+	 * Provides a class for attaching custom styles.
+	 */
+	Empty = 7
 }
 
 /**
  * @internal
  */
-export function cursorStyleToString(cursorStyle: TextEditorCursorStyle): 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin' {
+export function cursorStyleToString(cursorStyle: TextEditorCursorStyle): 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin' | 'empty' {
 	switch (cursorStyle) {
 		case TextEditorCursorStyle.Line: return 'line';
 		case TextEditorCursorStyle.Block: return 'block';
@@ -1161,10 +1170,11 @@ export function cursorStyleToString(cursorStyle: TextEditorCursorStyle): 'line' 
 		case TextEditorCursorStyle.LineThin: return 'line-thin';
 		case TextEditorCursorStyle.BlockOutline: return 'block-outline';
 		case TextEditorCursorStyle.UnderlineThin: return 'underline-thin';
+		case TextEditorCursorStyle.Empty: return 'empty';
 	}
 }
 
-function _cursorStyleFromString(cursorStyle: 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin'): TextEditorCursorStyle {
+function _cursorStyleFromString(cursorStyle: 'line' | 'block' | 'underline' | 'line-thin' | 'block-outline' | 'underline-thin' | 'empty'): TextEditorCursorStyle {
 	switch (cursorStyle) {
 		case 'line': return TextEditorCursorStyle.Line;
 		case 'block': return TextEditorCursorStyle.Block;
@@ -1172,6 +1182,7 @@ function _cursorStyleFromString(cursorStyle: 'line' | 'block' | 'underline' | 'l
 		case 'line-thin': return TextEditorCursorStyle.LineThin;
 		case 'block-outline': return TextEditorCursorStyle.BlockOutline;
 		case 'underline-thin': return TextEditorCursorStyle.UnderlineThin;
+		case 'empty': return TextEditorCursorStyle.Empty;
 	}
 }
 
@@ -3583,9 +3594,14 @@ export const EditorOptions = {
 	cursorBlinking: register(new EditorEnumOption(
 		EditorOption.cursorBlinking, 'cursorBlinking',
 		TextEditorCursorBlinkingStyle.Blink, 'blink',
-		['blink', 'smooth', 'phase', 'expand', 'solid'],
+		['blink', 'smooth', 'phase', 'expand', 'solid', 'empty'],
 		_cursorBlinkingStyleFromString,
-		{ description: nls.localize('cursorBlinking', "Control the cursor animation style.") }
+		{
+			description: nls.localize('cursorBlinking', "Control the cursor animation style."),
+			enumDescriptions: [
+				nls.localize('cursorBlinking.empty', "Provides an empty class name for attaching custom styles.")
+			]
+		}
 	)),
 	cursorSmoothCaretAnimation: register(new EditorBooleanOption(
 		EditorOption.cursorSmoothCaretAnimation, 'cursorSmoothCaretAnimation', false,
@@ -3594,9 +3610,14 @@ export const EditorOptions = {
 	cursorStyle: register(new EditorEnumOption(
 		EditorOption.cursorStyle, 'cursorStyle',
 		TextEditorCursorStyle.Line, 'line',
-		['line', 'block', 'underline', 'line-thin', 'block-outline', 'underline-thin'],
+		['line', 'block', 'underline', 'line-thin', 'block-outline', 'underline-thin', 'empty'],
 		_cursorStyleFromString,
-		{ description: nls.localize('cursorStyle', "Controls the cursor style.") }
+		{
+			description: nls.localize('cursorStyle', "Controls the cursor style."),
+			enumDescriptions: [
+				nls.localize('cursorStyle.empty', "Provides an empty class name for attaching custom styles.")
+			]
+		}
 	)),
 	cursorSurroundingLines: register(new EditorIntOption(
 		EditorOption.cursorSurroundingLines, 'cursorSurroundingLines',


### PR DESCRIPTION
Hello, I want to be able to change the style of cursor when
- typing
- focused but not typing
- not focused

**And I would appreciate your advice for a solution that fits vscode's direction best.**

https://codesandbox.io/s/vscode-cursor-vdvme

![vscode-cursor-customize](https://user-images.githubusercontent.com/2313018/77254397-0c2b1900-6c61-11ea-95c2-403578716edd.gif)



I see few possible solutions:


- add these styles and animations right to `editor.cursorStyle`, `editor.cursorBlinking`
  (or allow these properties to accept inline css)

- override style via theme or `workbench.colorCustomizations`
  _here? `src/vs/editor/common/view/editorColorRegistry.ts`_

	- this will require new properties, such as 
		`editorCursor.active` (focused window, typing, "solid")
		`editorCursor.animated` (focused window, not typing, "inactive")
		`editorCursor.unfocused` (unfocused window)

   note:
  Using `workbench.colorCustomizations` might not be as flexible as attaching custom styles to a class or the properties should accept a whole **`inline style`** string.
  This soulution will be probably easiest and can be done only within vscode codebase.


- add an empty class name to allow custom styles (draft in this PR)
	_(src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts:250)_
	custom styles can then be added via:
	- an injected css file (there is an [extension](https://github.com/be5invis/vscode-custom-css) for it)
	- create new extension that will possibly contribute new settings options and emit styles



<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 


This PR fixes #
-->

