### PR TITLE
Tasks with failed dependsOn can't run

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -368,11 +368,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 		});
 	}
 
-	private removeFromActiveTasks(task: Task): void {
-		if (!this.activeTasks[task.getMapKey()]) {
-			return;
-		}
-		delete this.activeTasks[task.getMapKey()];
+	private removeInstances(task: Task) {
 		let commonKey = task._id.split('|')[0];
 		if (this.instances[commonKey]) {
 			this.instances[commonKey].removeInstance();
@@ -380,6 +376,14 @@ export class TerminalTaskSystem implements ITaskSystem {
 				delete this.instances[commonKey];
 			}
 		}
+	}
+
+	private removeFromActiveTasks(task: Task): void {
+		if (!this.activeTasks[task.getMapKey()]) {
+			return;
+		}
+		delete this.activeTasks[task.getMapKey()];
+		this.removeInstances(task);
 	}
 
 	public terminate(task: Task): Promise<TaskTerminateResponse> {
@@ -466,6 +470,7 @@ export class TerminalTaskSystem implements ITaskSystem {
 			return Promise.all(promises).then((summaries): Promise<ITaskSummary> | ITaskSummary => {
 				for (let summary of summaries) {
 					if (summary.exitCode !== 0) {
+						this.removeInstances(task);
 						return { exitCode: summary.exitCode };
 					}
 				}


### PR DESCRIPTION
The problem here is that we now track the number of instances of a task that run. However, we don't correctly clean up that instance count later when the a task that another task depends on fails. This fix ensures that when a depends on task fails, we still clean up the "parent" task's instance count.

Fixes #92814

