### PR TITLE
progress - turn window progress into silent notification progress

### DIFF
--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -68,7 +68,14 @@ export class ProgressService extends Disposable implements IProgressService {
 			case ProgressLocation.Notification:
 				return this.withNotificationProgress({ ...options, location }, task, onDidCancel);
 			case ProgressLocation.Window:
-				return this.withWindowProgress({ ...options, location }, task);
+				if ((options as IProgressWindowOptions).command) {
+					// Window progress with command get's shown in the status bar
+					return this.withWindowProgress({ ...options, location }, task);
+				}
+				// Window progress without command can be shown as silent notification
+				// which will first appear in the status bar and can then be brought to
+				// the front when clicking.
+				return this.withNotificationProgress({ ...options, silent: true, location: ProgressLocation.Notification }, task, onDidCancel);
 			case ProgressLocation.Explorer:
 				return this.withViewletProgress('workbench.view.explorer', task, { ...options, location });
 			case ProgressLocation.Scm:


### PR DESCRIPTION
As discussed in https://github.com/microsoft/vscode-languageserver-node/issues/595 this turns window progress into silent notification progress, if a command is not provided. Otherwise we cannot do this because the command would never be executed on click.