### PR TITLE
Show call stack when only one session

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -723,16 +723,7 @@ class CallStackDataSource implements IAsyncDataSource<IDebugModel, CallStackItem
 	async getChildren(element: IDebugModel | CallStackItem): Promise<CallStackItem[]> {
 		if (isDebugModel(element)) {
 			const sessions = element.getSessions();
-			if (sessions.length === 0) {
-				return Promise.resolve([]);
-			}
-			if (sessions.length > 1 || this.debugService.getViewModel().isMultiSessionView()) {
-				return Promise.resolve(sessions.filter(s => !s.parentSession));
-			}
-
-			const threads = sessions[0].getAllThreads();
-			// Only show the threads in the call stack if there is more than 1 thread.
-			return threads.length === 1 ? this.getThreadChildren(<Thread>threads[0]) : Promise.resolve(threads);
+			return sessions.length ? Promise.resolve(sessions.filter(s => !s.parentSession)) : Promise.resolve([]);
 		} else if (isDebugSession(element)) {
 			const childSessions = this.debugService.getModel().getSessions().filter(s => s.parentSession === element);
 			const threads: CallStackItem[] = element.getAllThreads();
@@ -741,7 +732,6 @@ class CallStackDataSource implements IAsyncDataSource<IDebugModel, CallStackItem
 				const children = await this.getThreadChildren(<Thread>threads[0]);
 				return children.concat(childSessions);
 			}
-
 			return Promise.resolve(threads.concat(childSessions));
 		} else {
 			return this.getThreadChildren(<Thread>element);

--- a/src/vs/workbench/contrib/debug/browser/callStackView.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackView.ts
@@ -722,8 +722,7 @@ class CallStackDataSource implements IAsyncDataSource<IDebugModel, CallStackItem
 
 	async getChildren(element: IDebugModel | CallStackItem): Promise<CallStackItem[]> {
 		if (isDebugModel(element)) {
-			const sessions = element.getSessions();
-			return sessions.length ? Promise.resolve(sessions.filter(s => !s.parentSession)) : Promise.resolve([]);
+			return Promise.resolve(element.getSessions().filter(s => !s.parentSession));
 		} else if (isDebugSession(element)) {
 			const childSessions = this.debugService.getModel().getSessions().filter(s => s.parentSession === element);
 			const threads: CallStackItem[] = element.getAllThreads();


### PR DESCRIPTION
This PR fixes #91411

But also potentially breaks something. So I'd like to ask for a little insight in case this needs to be changed. 

The original issue was essentially that the call stack would only appear if there was more than one session. This is because we only return the sessions if there are more than one. If and only if there is exactly one session, we return its threads. But all of the debuggers I've tried so far have no threads, so this means if only one debugger is running, we return an empty array.

So my simple solution was to just return the sessions, even if there's only one. But this means the code for returning threads if there is exactly one session becomes unreachable.

Was that return necessary in the first place? It seems strange to me that it was only needed if there is exactly one session. But I don't have the background knowledge to be sure. I'd be happy to spend some more time on this and come up with a better solution if any issues are raised.