### PR TITLE
Convert most ts-ignore-calls to ts-expect-error

### DIFF
--- a/build/builtin/browser-main.js
+++ b/build/builtin/browser-main.js
@@ -6,7 +6,6 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-// @ts-ignore review
 const { remote } = require('electron');
 const dialog = remote.dialog;
 

--- a/build/gulpfile.editor.js
+++ b/build/gulpfile.editor.js
@@ -455,10 +455,8 @@ function createTscCompileTask(watch) {
 						// e.g. src/vs/base/common/strings.ts(663,5): error TS2322: Type '1234' is not assignable to type 'string'.
 						let fullpath = path.join(root, match[1]);
 						let message = match[3];
-						// @ts-ignore
 						reporter(fullpath + message);
 					} else {
-						// @ts-ignore
 						reporter(str);
 					}
 				}

--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -37,10 +37,8 @@ const { compileBuildTask } = require('./gulpfile.compile');
 const { compileExtensionsBuildTask } = require('./gulpfile.extensions');
 
 const productionDependencies = deps.getProductionDependencies(path.dirname(__dirname));
-// @ts-ignore
 const baseModules = Object.keys(process.binding('natives')).filter(n => !/^_|\//.test(n));
 const nodeModules = ['electron', 'original-fs']
-	// @ts-ignore JSON checking: dependencies property is optional
 	.concat(Object.keys(product.dependencies || {}))
 	.concat(_.uniq(productionDependencies.map(d => d.name)))
 	.concat(baseModules);

--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -91,9 +91,7 @@ function prepareDebPackage(arch) {
 		const postinst = gulp.src('resources/linux/debian/postinst.template', { base: '.' })
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(replace('@@ARCHITECTURE@@', debArch))
-			// @ts-ignore JSON checking: quality is optional
 			.pipe(replace('@@QUALITY@@', product.quality || '@@QUALITY@@'))
-			// @ts-ignore JSON checking: updateUrl is optional
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(rename('DEBIAN/postinst'));
 
@@ -167,9 +165,7 @@ function prepareRpmPackage(arch) {
 			.pipe(replace('@@RELEASE@@', linuxPackageRevision))
 			.pipe(replace('@@ARCHITECTURE@@', rpmArch))
 			.pipe(replace('@@LICENSE@@', product.licenseName))
-			// @ts-ignore JSON checking: quality is optional
 			.pipe(replace('@@QUALITY@@', product.quality || '@@QUALITY@@'))
-			// @ts-ignore JSON checking: updateUrl is optional
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(replace('@@DEPENDENCIES@@', rpmDependencies[rpmArch].join(', ')))
 			.pipe(rename('SPECS/' + product.applicationName + '.spec'));

--- a/build/lib/watch/watch-win32.js
+++ b/build/lib/watch/watch-win32.js
@@ -25,7 +25,6 @@ function watch(root) {
 	var child = cp.spawn(watcherPath, [root]);
 
 	child.stdout.on('data', function (data) {
-		// @ts-ignore
 		var lines = data.toString('utf8').split('\n');
 		for (var i = 0; i < lines.length; i++) {
 			var line = lines[i].trim();
@@ -47,7 +46,6 @@ function watch(root) {
 				path: changePathFull,
 				base: root
 			});
-			//@ts-ignore
 			file.event = toChangeType(changeType);
 			result.emit('data', file);
 		}

--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -68,7 +68,7 @@ module.exports = function withDefaults(/**@type WebpackConfig*/extConfig) {
 		// yes, really source maps
 		devtool: 'source-map',
 		plugins: [
-			// @ts-ignore
+			// @ts-expect-error
 			new CopyWebpackPlugin([
 				{ from: 'src', to: '.', ignore: ['**/test/**', '*.ts'] }
 			]),

--- a/src/bootstrap-fork.js
+++ b/src/bootstrap-fork.js
@@ -142,13 +142,11 @@ function pipeLoggingToParent() {
 function handleExceptions() {
 
 	// Handle uncaught exceptions
-	// @ts-ignore
 	process.on('uncaughtException', function (err) {
 		console.error('Uncaught Exception: ', err);
 	});
 
 	// Handle unhandled promise rejections
-	// @ts-ignore
 	process.on('unhandledRejection', function (reason) {
 		console.error('Unhandled Promise Rejection: ', reason);
 	});

--- a/src/bootstrap-window.js
+++ b/src/bootstrap-window.js
@@ -25,7 +25,6 @@ exports.assign = function assign(destination, source) {
  */
 exports.load = function (modulePaths, resultCallback, options) {
 
-	// @ts-ignore
 	const webFrame = require('electron').webFrame;
 	const path = require('path');
 
@@ -49,7 +48,6 @@ exports.load = function (modulePaths, resultCallback, options) {
 	}
 
 	// Error handler
-	// @ts-ignore
 	process.on('uncaughtException', function (error) {
 		onUnexpectedError(error, enableDeveloperTools);
 	});
@@ -164,7 +162,6 @@ function parseURLQueryArgs() {
  */
 function registerDeveloperKeybindings(disallowReloadKeybinding) {
 
-	// @ts-ignore
 	const ipc = require('electron').ipcRenderer;
 
 	const extractKey = function (e) {
@@ -203,7 +200,6 @@ function registerDeveloperKeybindings(disallowReloadKeybinding) {
 
 function onUnexpectedError(error, enableDeveloperTools) {
 
-	// @ts-ignore
 	const ipc = require('electron').ipcRenderer;
 
 	if (enableDeveloperTools) {

--- a/src/paths.js
+++ b/src/paths.js
@@ -6,7 +6,7 @@
 //@ts-check
 'use strict';
 
-// @ts-ignore
+// @ts-expect-error
 const pkg = require('../package.json');
 const path = require('path');
 const os = require('os');

--- a/src/vs/base/test/node/path.test.ts
+++ b/src/vs/base/test/node/path.test.ts
@@ -401,9 +401,9 @@ suite('Paths (Node Implementation)', () => {
 		];
 		resolveTests.forEach((test) => {
 			const resolve = test[0];
-			//@ts-ignore
+			//@ts-expect-error
 			test[1].forEach((test) => {
-				//@ts-ignore
+				//@ts-expect-error
 				const actual = resolve.apply(null, test[0]);
 				let actualAlt;
 				const os = resolve === path.win32.resolve ? 'win32' : 'posix';
@@ -579,9 +579,9 @@ suite('Paths (Node Implementation)', () => {
 		];
 		relativeTests.forEach((test) => {
 			const relative = test[0];
-			//@ts-ignore
+			//@ts-expect-error
 			test[1].forEach((test) => {
-				//@ts-ignore
+				//@ts-expect-error
 				const actual = relative(test[0], test[1]);
 				const expected = test[2];
 				const os = relative === path.win32.relative ? 'win32' : 'posix';

--- a/src/vs/editor/test/node/classification/typescript.test.ts
+++ b/src/vs/editor/test/node/classification/typescript.test.ts
@@ -107,7 +107,7 @@ function parseTest(fileName: string): ITest {
 	return { content, assertions };
 }
 
-// @ts-ignore
+// @ts-expect-error
 function executeTest(fileName: string, parseFunc: IParseFunc): void {
 	const { content, assertions } = parseTest(fileName);
 	const actual = parseFunc(content);

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -54,7 +54,7 @@ export class BrowserClipboardService implements IClipboardService {
 	}
 
 	readFindText(): string {
-		// @ts-ignore
+		// @ts-expect-error
 		return undefined;
 	}
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -20,12 +20,10 @@ import { assertIsDefined } from 'vs/base/common/types';
 import { Schemas } from 'vs/base/common/network';
 
 function es5ClassCompat(target: Function): any {
-	///@ts-ignore
+	///@ts-expect-error
 	function _() { return Reflect.construct(target, arguments, this.constructor); }
 	Object.defineProperty(_, 'name', Object.getOwnPropertyDescriptor(target, 'name')!);
-	///@ts-ignore
 	Object.setPrototypeOf(_, target);
-	///@ts-ignore
 	Object.setPrototypeOf(_.prototype, target.prototype);
 	return _;
 }

--- a/src/vs/workbench/services/extensions/common/proxyIdentifier.ts
+++ b/src/vs/workbench/services/extensions/common/proxyIdentifier.ts
@@ -20,7 +20,6 @@ export interface IRPCProtocol {
 	assertRegistered(identifiers: ProxyIdentifier<any>[]): void;
 }
 
-// @ts-ignore
 export class ProxyIdentifier<T> {
 	public static count = 0;
 	_proxyIdentifierBrand: void;

--- a/test/unit/browser/index.js
+++ b/test/unit/browser/index.js
@@ -155,7 +155,7 @@ async function runTestsInBrowser(testModules, browserType) {
 	});
 
 	try {
-		// @ts-ignore
+		// @ts-expect-error
 		await page.evaluate(modules => loadAndRun(modules), testModules);
 	} catch (err) {
 		console.error(err);


### PR DESCRIPTION
Use `ts-expect-error` in places of `ts-ignore`: https://devblogs.microsoft.com/typescript/announcing-typescript-3-9-beta/#ts-expect-error-comments

This revealed a number of places where we no longer need to suppress errors

