### PR TITLE
Use ResizeObserver for monaco editor automaticLayout

### DIFF
--- a/src/vs/editor/browser/config/elementSizeObserver.ts
+++ b/src/vs/editor/browser/config/elementSizeObserver.ts
@@ -3,9 +3,34 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { IDimension } from 'vs/editor/common/editorCommon';
-import * as dom from 'vs/base/browser/dom';
+
+interface ResizeObserver {
+	observe(target: Element): void;
+	unobserve(target: Element): void;
+	disconnect(): void;
+}
+
+interface ResizeObserverSize {
+	inlineSize: number;
+	blockSize: number;
+}
+
+interface ResizeObserverEntry {
+	readonly target: Element;
+	readonly contentRect: DOMRectReadOnly;
+	readonly borderBoxSize: ResizeObserverSize;
+	readonly contentBoxSize: ResizeObserverSize;
+}
+
+type ResizeObserverCallback = (entries: ReadonlyArray<ResizeObserverEntry>, observer: ResizeObserver) => void;
+
+declare const ResizeObserver: {
+	prototype: ResizeObserver;
+	new(callback: ResizeObserverCallback): ResizeObserver;
+};
+
 
 export class ElementSizeObserver extends Disposable {
 
@@ -13,8 +38,8 @@ export class ElementSizeObserver extends Disposable {
 	private readonly changeCallback: () => void;
 	private width: number;
 	private height: number;
-	private mutationObserver: MutationObserver | null;
-	private windowSizeListener: IDisposable | null;
+	private resizeObserver: ResizeObserver | null;
+	private measureReferenceDomElementToken: number;
 
 	constructor(referenceDomElement: HTMLElement | null, dimension: IDimension | undefined, changeCallback: () => void) {
 		super();
@@ -22,9 +47,9 @@ export class ElementSizeObserver extends Disposable {
 		this.changeCallback = changeCallback;
 		this.width = -1;
 		this.height = -1;
-		this.mutationObserver = null;
-		this.windowSizeListener = null;
+		this.resizeObserver = null;
 		this.measureReferenceDomElement(false, dimension);
+		this.measureReferenceDomElementToken = -1;
 	}
 
 	public dispose(): void {
@@ -41,38 +66,38 @@ export class ElementSizeObserver extends Disposable {
 	}
 
 	public startObserving(): void {
-		if (!this.mutationObserver && this.referenceDomElement) {
-			this.mutationObserver = new MutationObserver(() => this._onDidMutate());
-			this.mutationObserver.observe(this.referenceDomElement, {
-				attributes: true,
-			});
-		}
-		if (!this.windowSizeListener) {
-			this.windowSizeListener = dom.addDisposableListener(window, 'resize', () => this._onDidResizeWindow());
+		if (typeof ResizeObserver !== 'undefined') {
+			if (!this.resizeObserver && this.referenceDomElement) {
+				this.resizeObserver = new ResizeObserver((entries) => {
+					if (entries && entries[0]) {
+						this.observe({ width: entries[0].contentRect.width, height: entries[0].contentRect.height });
+					} else {
+						this.observe();
+					}
+				});
+				this.resizeObserver.observe(this.referenceDomElement);
+			}
+		} else {
+			if (this.measureReferenceDomElementToken === -1) {
+				// setInterval type defaults to NodeJS.Timeout instead of number, so specify it as a number
+				this.measureReferenceDomElementToken = setInterval(() => this.observe(), 100) as unknown as number;
+			}
 		}
 	}
 
 	public stopObserving(): void {
-		if (this.mutationObserver) {
-			this.mutationObserver.disconnect();
-			this.mutationObserver = null;
+		if (this.resizeObserver) {
+			this.resizeObserver.disconnect();
+			this.resizeObserver = null;
 		}
-		if (this.windowSizeListener) {
-			this.windowSizeListener.dispose();
-			this.windowSizeListener = null;
+		if (this.measureReferenceDomElementToken !== -1) {
+			clearInterval(this.measureReferenceDomElementToken);
+			this.measureReferenceDomElementToken = -1;
 		}
 	}
 
 	public observe(dimension?: IDimension): void {
 		this.measureReferenceDomElement(true, dimension);
-	}
-
-	private _onDidMutate(): void {
-		this.measureReferenceDomElement(true);
-	}
-
-	private _onDidResizeWindow(): void {
-		this.measureReferenceDomElement(true);
 	}
 
 	private measureReferenceDomElement(callChangeCallback: boolean, dimension?: IDimension): void {

--- a/src/vs/editor/browser/config/elementSizeObserver.ts
+++ b/src/vs/editor/browser/config/elementSizeObserver.ts
@@ -48,8 +48,8 @@ export class ElementSizeObserver extends Disposable {
 		this.width = -1;
 		this.height = -1;
 		this.resizeObserver = null;
-		this.measureReferenceDomElement(false, dimension);
 		this.measureReferenceDomElementToken = -1;
+		this.measureReferenceDomElement(false, dimension);
 	}
 
 	public dispose(): void {
@@ -69,7 +69,7 @@ export class ElementSizeObserver extends Disposable {
 		if (typeof ResizeObserver !== 'undefined') {
 			if (!this.resizeObserver && this.referenceDomElement) {
 				this.resizeObserver = new ResizeObserver((entries) => {
-					if (entries && entries[0]) {
+					if (entries && entries[0] && entries[0].contentRect) {
 						this.observe({ width: entries[0].contentRect.width, height: entries[0].contentRect.height });
 					} else {
 						this.observe();
@@ -80,7 +80,7 @@ export class ElementSizeObserver extends Disposable {
 		} else {
 			if (this.measureReferenceDomElementToken === -1) {
 				// setInterval type defaults to NodeJS.Timeout instead of number, so specify it as a number
-				this.measureReferenceDomElementToken = setInterval(() => this.observe(), 100) as unknown as number;
+				this.measureReferenceDomElementToken = <number><any>setInterval(() => this.observe(), 100);
 			}
 		}
 	}


### PR DESCRIPTION
Replaces the MutationObserver with ResizeObserver.  Uses a timeout for any browser that does not support ResizeObserver.  (Safari is the only one of the currently supported browsers without ResizeObserver.)
When resizing an editor with a dynamic size (i.e. a percentage for the width), the editor should resize automatically.

This PR fixes [#1855](https://github.com/microsoft/monaco-editor/issues/1855), fixes [#1878](https://github.com/microsoft/monaco-editor/issues/1878) in monaco-editor.
Might fix [#1884](https://github.com/microsoft/monaco-editor/issues/1884) as well.

This PR replaces [#90111](https://github.com/microsoft/vscode/pull/90111).
