### PR TITLE
Add check for shadow dom root before closing submenu

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -9,7 +9,7 @@ import * as strings from 'vs/base/common/strings';
 import { IActionRunner, IAction, Action } from 'vs/base/common/actions';
 import { ActionBar, IActionViewItemProvider, ActionsOrientation, Separator, ActionViewItem, IActionViewItemOptions, BaseActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
 import { ResolvedKeybinding, KeyCode } from 'vs/base/common/keyCodes';
-import { addClass, EventType, EventHelper, EventLike, removeTabIndexAndUpdateFocus, isAncestor, hasClass, addDisposableListener, removeClass, append, $, addClasses, removeClasses, clearNode } from 'vs/base/browser/dom';
+import { addClass, EventType, EventHelper, EventLike, removeTabIndexAndUpdateFocus, isAncestor, hasClass, addDisposableListener, removeClass, append, $, addClasses, removeClasses, clearNode, getShadowRoot } from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -653,8 +653,16 @@ class SubmenuMenuActionViewItem extends BaseMenuActionViewItem {
 
 		this.hideScheduler = new RunOnceScheduler(() => {
 			if (this.element && (!isAncestor(document.activeElement, this.element) && this.parentData.submenu === this.mysubmenu)) {
-				this.parentData.parent.focus(false);
-				this.cleanupExistingSubmenu(true);
+				const shadowRoot = getShadowRoot(this.element as Node)?.host;
+				if (shadowRoot) {
+					if (!isAncestor(document.activeElement, shadowRoot.parentNode)) {
+						this.parentData.parent.focus(false);
+						this.cleanupExistingSubmenu(true);
+					}
+				} else {
+					this.parentData.parent.focus(false);
+					this.cleanupExistingSubmenu(true);
+				}
 			}
 		}, 750);
 	}


### PR DESCRIPTION
When cleaning up the submenu, a check is added for the shadow dom element.  If it exist, then it checks the shadow dom ancestors.

This PR fixes [#1809](https://github.com/microsoft/monaco-editor/issues/1809) in monaco-editor.
