### PR TITLE
Add default keybindings for stage/revert/unstage selected ranges

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -411,6 +411,23 @@
         "category": "Git"
       }
     ],
+    "keybindings": [
+      {
+        "command": "git.stageSelectedRanges",
+        "key": "ctrl+k ctrl+alt+s",
+        "when": "isInDiffEditor"
+      },
+      {
+        "command": "git.unstageSelectedRanges",
+        "key": "ctrl+k ctrl+u",
+        "when": "isInDiffEditor"
+      },
+      {
+        "command": "git.revertSelectedRanges",
+        "key": "ctrl+k ctrl+r",
+        "when": "isInDiffEditor"
+      }
+    ],
     "menus": {
       "commandPalette": [
         {

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -415,16 +415,19 @@
       {
         "command": "git.stageSelectedRanges",
         "key": "ctrl+k ctrl+alt+s",
+        "mac": "cmd+k cmd+alt+s",
         "when": "isInDiffEditor"
       },
       {
         "command": "git.unstageSelectedRanges",
         "key": "ctrl+k ctrl+u",
+        "mac": "cmd+k cmd+u",
         "when": "isInDiffEditor"
       },
       {
         "command": "git.revertSelectedRanges",
         "key": "ctrl+k ctrl+r",
+        "mac": "cmd+k cmd+r",
         "when": "isInDiffEditor"
       }
     ],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #93564

Created default keybindings for the following commands

Git: Stage Selected Ranges   -> ctrl + k, ctrl + alt + s
Git: Unstage Selected Ranges -> ctrl + k, ctrl + u
Git: Revert Selected Ranges  -> ctrl + k, ctrl + r

![Screenshot (217)](https://user-images.githubusercontent.com/44088168/77864550-e3db8580-7231-11ea-97f6-e0c9f0236fdb.png)

**Note:**
ctrl + k, ctrl + u is also used by "Remove Line Comment". "Unstage Selected Ranges" now overrides it, however similar functionality can be achieved by using "Toggle Line Comment" (ctrl + /)