### PR TITLE
Add editorOverviewRuler.background colour customisation point

### DIFF
--- a/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
+++ b/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
@@ -10,7 +10,7 @@ import { ViewPart } from 'vs/editor/browser/view/viewPart';
 import { Position } from 'vs/editor/common/core/position';
 import { IConfiguration } from 'vs/editor/common/editorCommon';
 import { TokenizationRegistry } from 'vs/editor/common/modes';
-import { editorCursorForeground, editorOverviewRulerBorder } from 'vs/editor/common/view/editorColorRegistry';
+import { editorCursorForeground, editorOverviewRulerBorder, editorOverviewRulerBackground } from 'vs/editor/common/view/editorColorRegistry';
 import { RenderingContext, RestrictedRenderingContext } from 'vs/editor/common/view/renderingContext';
 import { ViewContext, EditorTheme } from 'vs/editor/common/view/viewContext';
 import * as viewEvents from 'vs/editor/common/view/viewEvents';
@@ -60,7 +60,10 @@ class Settings {
 		const minimapOpts = options.get(EditorOption.minimap);
 		const minimapEnabled = minimapOpts.enabled;
 		const minimapSide = minimapOpts.side;
-		const backgroundColor = (minimapEnabled ? TokenizationRegistry.getDefaultBackground() : null);
+		const backgroundColor = minimapEnabled
+			? theme.getColor(editorOverviewRulerBackground) || TokenizationRegistry.getDefaultBackground()
+			: null;
+
 		if (backgroundColor === null || minimapSide === 'left') {
 			this.backgroundColor = null;
 		} else {

--- a/src/vs/editor/common/view/editorColorRegistry.ts
+++ b/src/vs/editor/common/view/editorColorRegistry.ts
@@ -36,6 +36,7 @@ export const editorBracketMatchBackground = registerColor('editorBracketMatch.ba
 export const editorBracketMatchBorder = registerColor('editorBracketMatch.border', { dark: '#888', light: '#B9B9B9', hc: contrastBorder }, nls.localize('editorBracketMatchBorder', 'Color for matching brackets boxes'));
 
 export const editorOverviewRulerBorder = registerColor('editorOverviewRuler.border', { dark: '#7f7f7f4d', light: '#7f7f7f4d', hc: '#7f7f7f4d' }, nls.localize('editorOverviewRulerBorder', 'Color of the overview ruler border.'));
+export const editorOverviewRulerBackground = registerColor('editorOverviewRuler.background', null, nls.localize('editorOverviewRulerBackground', 'Background color of the editor overview ruler. Only used when the minimap is enabled and placed on the right side of the editor.'));
 
 export const editorGutter = registerColor('editorGutter.background', { dark: editorBackground, light: editorBackground, hc: editorBackground }, nls.localize('editorGutter', 'Background color of the editor gutter. The gutter contains the glyph margins and the line numbers.'));
 


### PR DESCRIPTION
Allow themes to customise the editor overview ruler's background colour. 🎨 This PR adds a new theme variable, `editorOverviewRuler.background`. The background colour is used in only certain circumstances:

- a theme or user must provide a value for this colour contribution (obviously 😄)
- the minimap must be enabled and must be placed on the right side of the editor to have this background colour, otherwise the ruler's background is transparent

You can see the background colour in action in the screenshots below.

#### Motivation

In my theme, [Remedy](https://marketplace.visualstudio.com/items?itemName=robertrossmann.remedy), I try to follow a simple rule - code gets its background colour and everything else (UI elements) get a different colour to distinguish UI from "codable area". The overview ruler did not fit into that scheme.


#### Screenshots

Before this PR / no colour configured for `editorOverviewRuler.background`
![original](https://user-images.githubusercontent.com/3058150/77899547-25dde900-727d-11ea-8a30-123cd6b4391f.png)

After this PR **and** a colour provided for `editorOverviewRuler.background`
![custom background](https://user-images.githubusercontent.com/3058150/77899714-44dc7b00-727d-11ea-8500-744ddd3474ac.png)

Minimap is on left side of the editor -> no background colour used
![minimap on left](https://user-images.githubusercontent.com/3058150/77899789-5c1b6880-727d-11ea-96e8-271231c988b1.png)

Minimap is disabled -> no background colour used
![minimap disabled](https://user-images.githubusercontent.com/3058150/77899913-8b31da00-727d-11ea-81c3-5bb8cc541010.png)

Diff views do not have a minimap -> no background colour used
![diff view](https://user-images.githubusercontent.com/3058150/77899946-9ab12300-727d-11ea-839c-56e8737876e5.png)