### PR TITLE
Support Copy Paste in Notebook webview

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookActions.ts
@@ -366,7 +366,7 @@ registerAction2(class extends Action2 {
 	}
 });
 
-function getActiveNotebookEditor(editorService: IEditorService): INotebookEditor | undefined {
+export function getActiveNotebookEditor(editorService: IEditorService): INotebookEditor | undefined {
 	// TODO can `isNotebookEditor` be on INotebookEditor to avoid a circular dependency?
 	const activeEditorPane = editorService.activeEditorPane as any | undefined;
 	return activeEditorPane?.isNotebookEditor ? activeEditorPane : undefined;

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -18,6 +18,7 @@ import { NOTEBOOK_EDITABLE_CONTEXT_KEY } from 'vs/workbench/contrib/notebook/bro
 import { OutputRenderer } from 'vs/workbench/contrib/notebook/browser/view/output/outputRenderer';
 import { CellViewModel, IModelDecorationsChangeAccessor, NotebookViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookViewModel';
 import { CellKind, IOutput, IRenderOutput, NotebookCellMetadata, NotebookDocumentMetadata } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { Webview } from 'vs/workbench/contrib/webview/browser/webview';
 
 export const KEYBINDING_CONTEXT_NOTEBOOK_FIND_WIDGET_FOCUSED = new RawContextKey<boolean>('notebookFindWidgetFocused', false);
 
@@ -87,6 +88,8 @@ export interface INotebookEditor {
 	viewModel: NotebookViewModel | undefined;
 
 	isNotebookEditor: boolean;
+
+	getInnerWebview(): Webview | undefined;
 
 	/**
 	 * Focus the notebook editor cell list

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditor.ts
@@ -43,6 +43,7 @@ import { CellViewModel, IModelDecorationsChangeAccessor, INotebookEditorViewStat
 import { CellKind, CellUri, IOutput } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { getExtraColor } from 'vs/workbench/contrib/welcome/walkThrough/common/walkThroughUtils';
 import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { Webview } from 'vs/workbench/contrib/webview/browser/webview';
 
 const $ = DOM.$;
 const NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'NotebookEditorViewState';
@@ -233,6 +234,10 @@ export class NotebookEditor extends BaseEditor implements INotebookEditor {
 
 	getControl() {
 		return this.control;
+	}
+
+	getInnerWebview(): Webview | undefined {
+		return this.webview?.webview;
 	}
 
 	onHide() {

--- a/src/vs/workbench/contrib/notebook/electron-browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/electron-browser/notebook.contribution.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isMacintosh } from 'vs/base/common/platform';
+import { registerAction2 } from 'vs/platform/actions/common/actions';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import * as webviewCommands from 'vs/workbench/contrib/webview/electron-browser/webviewCommands';
+import { NotebookEditor } from 'vs/workbench/contrib/notebook/browser/notebookEditor';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ElectronWebviewBasedWebview } from 'vs/workbench/contrib/webview/electron-browser/webviewElement';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { getActiveNotebookEditor } from 'vs/workbench/contrib/notebook/browser/contrib/notebookActions';
+
+function getActiveElectronBasedWebviewDelegate(accessor: ServicesAccessor): ElectronWebviewBasedWebview | undefined {
+
+	const editorService = accessor.get(IEditorService);
+	const editor = getActiveNotebookEditor(editorService);
+
+	const webview = editor?.getInnerWebview();
+
+	if (webview && webview instanceof ElectronWebviewBasedWebview) {
+		return webview;
+	}
+
+	return;
+}
+
+function registerNotebookCommands(editorId: string): void {
+	const contextKeyExpr = ContextKeyExpr.and(ContextKeyExpr.equals('activeEditor', editorId), ContextKeyExpr.not('editorFocus') /* https://github.com/Microsoft/vscode/issues/58668 */)!;
+
+	// These commands are only needed on MacOS where we have to disable the menu bar commands
+	if (isMacintosh) {
+		registerAction2(class extends webviewCommands.CopyWebviewEditorCommand { constructor() { super(contextKeyExpr, getActiveElectronBasedWebviewDelegate); } });
+		registerAction2(class extends webviewCommands.PasteWebviewEditorCommand { constructor() { super(contextKeyExpr, getActiveElectronBasedWebviewDelegate); } });
+		registerAction2(class extends webviewCommands.CutWebviewEditorCommand { constructor() { super(contextKeyExpr, getActiveElectronBasedWebviewDelegate); } });
+		registerAction2(class extends webviewCommands.UndoWebviewEditorCommand { constructor() { super(contextKeyExpr, getActiveElectronBasedWebviewDelegate); } });
+		registerAction2(class extends webviewCommands.RedoWebviewEditorCommand { constructor() { super(contextKeyExpr, getActiveElectronBasedWebviewDelegate); } });
+	}
+}
+
+registerNotebookCommands(NotebookEditor.ID);

--- a/src/vs/workbench/contrib/notebook/test/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/testNotebookEditor.ts
@@ -20,6 +20,7 @@ import { IUndoRedoService } from 'vs/platform/undoRedo/common/undoRedo';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { NotebookEventDispatcher } from 'vs/workbench/contrib/notebook/browser/viewModel/eventDispatcher';
+import { Webview } from 'vs/workbench/contrib/webview/browser/webview';
 
 export class TestCell implements ICell {
 	uri: URI;
@@ -80,6 +81,9 @@ export class TestNotebookEditor implements INotebookEditor {
 
 	constructor(
 	) { }
+	getInnerWebview(): Webview | undefined {
+		throw new Error('Method not implemented.');
+	}
 
 	executeNotebookCell(cell: ICellViewModel): Promise<void> {
 		throw new Error('Method not implemented.');

--- a/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
@@ -37,4 +37,3 @@ function registerWebViewCommands(editorId: string): void {
 }
 
 registerWebViewCommands(WebviewEditor.ID);
-registerWebViewCommands('workbench.editor.notebook');

--- a/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webview.contribution.ts
@@ -37,3 +37,4 @@ function registerWebViewCommands(editorId: string): void {
 }
 
 registerWebViewCommands(WebviewEditor.ID);
+registerWebViewCommands('workbench.editor.notebook');

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewCommands.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewCommands.ts
@@ -42,7 +42,7 @@ export class CopyWebviewEditorCommand extends Action2 {
 	public static readonly ID = 'editor.action.webvieweditor.copy';
 	public static readonly LABEL = nls.localize('editor.action.webvieweditor.copy', "Copy2");
 
-	constructor(contextKeyExpr: ContextKeyExpression) {
+	constructor(contextKeyExpr: ContextKeyExpression, readonly getActiveElectronBasedWebviewDelegate: (accessor: ServicesAccessor) => ElectronWebviewBasedWebview | undefined = getActiveElectronBasedWebview) {
 		super({
 			id: CopyWebviewEditorCommand.ID,
 			title: CopyWebviewEditorCommand.LABEL,
@@ -55,7 +55,7 @@ export class CopyWebviewEditorCommand extends Action2 {
 	}
 
 	public run(accessor: ServicesAccessor): void {
-		getActiveElectronBasedWebview(accessor)?.copy();
+		this.getActiveElectronBasedWebviewDelegate(accessor)?.copy();
 	}
 }
 
@@ -63,7 +63,7 @@ export class PasteWebviewEditorCommand extends Action2 {
 	public static readonly ID = 'editor.action.webvieweditor.paste';
 	public static readonly LABEL = nls.localize('editor.action.webvieweditor.paste', 'Paste');
 
-	constructor(contextKeyExpr: ContextKeyExpression) {
+	constructor(contextKeyExpr: ContextKeyExpression, readonly getActiveElectronBasedWebviewDelegate: (accessor: ServicesAccessor) => ElectronWebviewBasedWebview | undefined = getActiveElectronBasedWebview) {
 		super({
 			id: PasteWebviewEditorCommand.ID,
 			title: PasteWebviewEditorCommand.LABEL,
@@ -76,7 +76,7 @@ export class PasteWebviewEditorCommand extends Action2 {
 	}
 
 	public run(accessor: ServicesAccessor): void {
-		getActiveElectronBasedWebview(accessor)?.paste();
+		this.getActiveElectronBasedWebviewDelegate(accessor)?.paste();
 	}
 }
 
@@ -84,7 +84,7 @@ export class CutWebviewEditorCommand extends Action2 {
 	public static readonly ID = 'editor.action.webvieweditor.cut';
 	public static readonly LABEL = nls.localize('editor.action.webvieweditor.cut', 'Cut');
 
-	constructor(contextKeyExpr: ContextKeyExpression) {
+	constructor(contextKeyExpr: ContextKeyExpression, readonly getActiveElectronBasedWebviewDelegate: (accessor: ServicesAccessor) => ElectronWebviewBasedWebview | undefined = getActiveElectronBasedWebview) {
 		super({
 			id: CutWebviewEditorCommand.ID,
 			title: CutWebviewEditorCommand.LABEL,
@@ -97,7 +97,7 @@ export class CutWebviewEditorCommand extends Action2 {
 	}
 
 	public run(accessor: ServicesAccessor): void {
-		getActiveElectronBasedWebview(accessor)?.cut();
+		this.getActiveElectronBasedWebviewDelegate(accessor)?.cut();
 	}
 }
 
@@ -105,7 +105,7 @@ export class UndoWebviewEditorCommand extends Action2 {
 	public static readonly ID = 'editor.action.webvieweditor.undo';
 	public static readonly LABEL = nls.localize('editor.action.webvieweditor.undo', "Undo");
 
-	constructor(contextKeyExpr: ContextKeyExpression) {
+	constructor(contextKeyExpr: ContextKeyExpression, readonly getActiveElectronBasedWebviewDelegate: (accessor: ServicesAccessor) => ElectronWebviewBasedWebview | undefined = getActiveElectronBasedWebview) {
 		super({
 			id: UndoWebviewEditorCommand.ID,
 			title: UndoWebviewEditorCommand.LABEL,
@@ -118,7 +118,7 @@ export class UndoWebviewEditorCommand extends Action2 {
 	}
 
 	public run(accessor: ServicesAccessor): void {
-		getActiveElectronBasedWebview(accessor)?.undo();
+		this.getActiveElectronBasedWebviewDelegate(accessor)?.undo();
 	}
 }
 
@@ -126,7 +126,7 @@ export class RedoWebviewEditorCommand extends Action2 {
 	public static readonly ID = 'editor.action.webvieweditor.redo';
 	public static readonly LABEL = nls.localize('editor.action.webvieweditor.redo', "Redo");
 
-	constructor(contextKeyExpr: ContextKeyExpression) {
+	constructor(contextKeyExpr: ContextKeyExpression, readonly getActiveElectronBasedWebviewDelegate: (accessor: ServicesAccessor) => ElectronWebviewBasedWebview | undefined = getActiveElectronBasedWebview) {
 		super({
 			id: RedoWebviewEditorCommand.ID,
 			title: RedoWebviewEditorCommand.LABEL,
@@ -141,7 +141,7 @@ export class RedoWebviewEditorCommand extends Action2 {
 	}
 
 	public run(accessor: ServicesAccessor): void {
-		getActiveElectronBasedWebview(accessor)?.redo();
+		this.getActiveElectronBasedWebviewDelegate(accessor)?.redo();
 	}
 }
 

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -107,6 +107,9 @@ import 'vs/workbench/contrib/debug/electron-browser/extensionHostDebugService';
 // Webview
 import 'vs/workbench/contrib/webview/electron-browser/webview.contribution';
 
+// Notebook
+import 'vs/workbench/contrib/notebook/electron-browser/notebook.contribution';
+
 // Extensions Management
 import 'vs/workbench/contrib/extensions/electron-browser/extensions.contribution';
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #94088.

The Notebook Editor has inner webview but they don't support Copy/Paste as currently webview commands are only registered for Webview Editor. This PR attempts to register the same set of commands for Notebook.
