### PR TITLE
bugfix  - typescript code completion doesn't recognize property modifiers when more than one exists

### DIFF
--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -97,7 +97,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 		}
 
 		if (tsEntry.kindModifiers) {
-			const kindModifiers = new Set(tsEntry.kindModifiers.split(','));
+			const kindModifiers = new Set(tsEntry.kindModifiers.split(/,|\s+/g));
 			if (kindModifiers.has(PConst.KindModifiers.optional)) {
 				if (!this.insertText) {
 					this.insertText = this.label;

--- a/extensions/typescript-language-features/src/features/completions.ts
+++ b/extensions/typescript-language-features/src/features/completions.ts
@@ -97,7 +97,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 		}
 
 		if (tsEntry.kindModifiers) {
-			const kindModifiers = new Set(tsEntry.kindModifiers.split(/\s+/g));
+			const kindModifiers = new Set(tsEntry.kindModifiers.split(','));
 			if (kindModifiers.has(PConst.KindModifiers.optional)) {
 				if (!this.insertText) {
 					this.insertText = this.label;


### PR DESCRIPTION
This PR fixes microsoft/TypeScript#37117 (this issue also contains an example of the bug)

This is a simple fix to a simple problem. According to the typescript language service API, the property `kindModifiers` is comma-separated. Here is the relevant interface:

https://github.com/microsoft/TypeScript/blob/9c4cbd64fb020970f47b4b068f4007810e388a81/src/services/types.ts#L1051-L1054

the problem occurs when more than one modifier exists, and then no modifier is recognized.