### PR TITLE
fix #93610

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -386,7 +386,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 	private _matchOnLabel = true;
 	private _sortByLabel = true;
 	private _autoFocusOnList = true;
-	private _itemActivation = ItemActivation.FIRST;
+	private _itemActivation = this.ui.isScreenReaderOptimized() ? ItemActivation.NONE /* https://github.com/microsoft/vscode/issues/57501 */ : ItemActivation.FIRST;
 	private _activeItems: T[] = [];
 	private activeItemsUpdated = false;
 	private activeItemsToConfirm: T[] | null = [];
@@ -637,7 +637,7 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 
 	private trySelectFirst() {
 		if (this.autoFocusOnList) {
-			if (!this.ui.isScreenReaderOptimized() && !this.canSelectMany) {
+			if (!this.canSelectMany) {
 				this.ui.list.focus(QuickInputListFocus.First);
 			}
 		}
@@ -875,6 +875,9 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 			this.ui.visibleCount.setCount(this.ui.list.getVisibleCount());
 			this.ui.count.setCount(this.ui.list.getCheckedCount());
 			switch (this._itemActivation) {
+				case ItemActivation.NONE:
+					this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
+					break;
 				case ItemActivation.SECOND:
 					this.ui.list.focus(QuickInputListFocus.Second);
 					this._itemActivation = ItemActivation.FIRST; // only valid once, then unset

--- a/src/vs/base/parts/quickinput/common/quickInput.ts
+++ b/src/vs/base/parts/quickinput/common/quickInput.ts
@@ -183,7 +183,8 @@ export interface IQuickPickAcceptEvent {
 }
 
 export enum ItemActivation {
-	FIRST = 1,
+	NONE,
+	FIRST,
 	SECOND,
 	LAST
 }

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -90,7 +90,9 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		picker.placeholder = descriptor?.placeholder;
 		picker.quickNavigate = options?.quickNavigateConfiguration;
 		picker.hideInput = !!picker.quickNavigate && !visibleQuickAccess; // only hide input if there was no picker opened already
-		picker.itemActivation = options?.itemActivation || (options?.quickNavigateConfiguration ? ItemActivation.SECOND : ItemActivation.FIRST);
+		if (typeof options?.itemActivation === 'number' || options?.quickNavigateConfiguration) {
+			picker.itemActivation = options?.itemActivation ?? ItemActivation.SECOND /* quick nav is always second */;
+		}
 		picker.contextKey = descriptor?.contextKey;
 		picker.filterValue = (value: string) => value.substring(descriptor ? descriptor.prefix.length : 0);
 		if (descriptor?.placeholder) {


### PR DESCRIPTION
@chrmarti this builds on top of the `ItemActivation` I introduced earlier. When a screen reader is on, it will set `ItemActivation.None` by default but then switch to select the first item on any further updates.

Btw: on macOS it seems that the screen reader is announcing the aria label just fine from the picker, even if initially the first item is selected.