### PR TITLE
Prompt for settings sync authentication only when the window is active

### DIFF
--- a/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
+++ b/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
@@ -284,6 +284,16 @@ export class UserDataSyncWorkbenchContribution extends Disposable implements IWo
 				return;
 			}
 
+			if (document.hidden) {
+				await new Promise(resolve => {
+					document.addEventListener(
+						'visibilitychange',
+						resolve,
+						{ once: true }
+					);
+				});
+			}
+
 			if (this.activeAccount) {
 				if (event.removed.length) {
 					const activeWasRemoved = !!event.removed.find(removed => removed === this.activeAccount!.id);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #94176
If the current window isn't visible, wait for it to become visible to show the prompt.
