### PR TITLE
#13680 git support private key password

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1782,6 +1782,22 @@
         },
         "git.githubAuthentication": {
           "deprecationMessage": "This setting is now deprecated, please use `github.gitAuthentication` instead."
+        },
+        "git.sshPrivateKeyPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "markdownDescription": "%config.sshPrivateKeyPath%",
+          "default": null
+        },
+        "git.sshAgentDirectory": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "markdownDescription": "%config.sshAgentDirectory%",
+          "default": null
         }
       }
     },

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1988,17 +1988,19 @@
     "file-type": "^7.2.0",
     "iconv-lite-umd": "0.6.8",
     "jschardet": "2.2.1",
+    "node-pty": "^0.9.0",
+    "strip-ansi": "^6.0.0",
     "vscode-extension-telemetry": "0.1.1",
     "vscode-nls": "^4.0.0",
     "vscode-uri": "^2.0.0",
-    "which": "^1.3.0"
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@types/byline": "4.2.31",
     "@types/file-type": "^5.2.1",
     "@types/mocha": "2.2.43",
     "@types/node": "^12.12.31",
-    "@types/which": "^1.0.28",
+    "@types/which": "^1.3.2",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.23.3",
     "mocha-multi-reporters": "^1.1.7",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1989,7 +1989,6 @@
     "iconv-lite-umd": "0.6.8",
     "jschardet": "2.2.1",
     "node-pty": "^0.9.0",
-    "strip-ansi": "^6.0.0",
     "vscode-extension-telemetry": "0.1.1",
     "vscode-nls": "^4.0.0",
     "vscode-uri": "^2.0.0",

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -147,6 +147,8 @@
 	"config.untrackedChanges.hidden": "Untracked changes are hidden and excluded from several actions.",
 	"config.showCommitInput": "Controls whether to show the commit input in the Git source control panel.",
 	"config.terminalAuthentication": "Controls whether to enable VS Code to be the authentication handler for git processes spawned in the integrated terminal. Note: terminals need to be restarted to pick up a change in this setting.",
+	"config.sshPrivateKeyPath": "Path of the ssh private key associated with your remote.",
+	"config.sshAgentDirectory": "Path of the directory of the ssh-agent executable, e.g. `C:\\Program Files\\Git\\usr\\bin` (Windows).",
 	"submenu.commit": "Commit",
 	"submenu.commit.amend": "Amend",
 	"submenu.commit.signoff": "Sign Off",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -339,7 +339,7 @@ class SshAgent {
 			const passphraseMatch = data.toString().match(/^Enter passphrase for .*: $/);
 
 			if (passphraseMatch) {
-				window.showInputBox({ prompt: data.toString() }).then(password => {
+				window.showInputBox({ password: true, prompt: data.toString() }).then(password => {
 					sshAddProcess.stdin.write(`${password || ''}\n`);
 				});
 			}
@@ -401,7 +401,7 @@ export class Git {
 
 	readonly path: string;
 	private env: any;
-	private sshAgent: SshAgent;
+	readonly sshAgent = new SshAgent;
 
 	private _onOutput = new EventEmitter();
 	get onOutput(): EventEmitter { return this._onOutput; }
@@ -409,16 +409,10 @@ export class Git {
 	constructor(options: IGitOptions) {
 		this.path = options.gitPath;
 		this.env = options.env || {};
-		this.sshAgent = new SshAgent;
-		this.sshAgent.start();
 	}
 
 	open(repository: string, dotGit: string): Repository {
 		return new Repository(this, repository, dotGit);
-	}
-
-	addSshKey(privateKeyPath: string): void {
-		this.sshAgent.addKey(privateKeyPath);
 	}
 
 	async init(repository: string): Promise<void> {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -350,7 +350,6 @@ class SshAgent {
 
 		sshAddProcess.stderr.on('data', data => {
 			const message = data.toString();
-			console.error(message);
 
 			if (
 				message.match(/^Enter passphrase for .*: $/) ||

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -328,21 +328,25 @@ class SshAgent {
 
 		return this.getCommand('ssh-agent')
 			.then(sshAgentCommand => exec(cp.spawn(sshAgentCommand, ['-s'])))
-			.then(sshAgentResult => sshAgentResult.stdout
-				.toString()
-				.split('\n')
-				.forEach(outputLine => {
-					const sshAgentPidMatch = outputLine.match(/SSH_AGENT_PID=([^;]*)/);
-					if (sshAgentPidMatch && sshAgentPidMatch.length === 2) {
-						this._sshAgentPid = sshAgentPidMatch[1];
-					}
+			.then(sshAgentResult => {
+				if (sshAgentResult.exitCode !== 0) {
+					window.showErrorMessage(localize('failed to start ssh-agent', "Failed to start ssh-agent: {0}", sshAgentResult.stderr));
+				}
+				return sshAgentResult.stdout
+					.toString()
+					.split('\n')
+					.forEach(outputLine => {
+						const sshAgentPidMatch = outputLine.match(/SSH_AGENT_PID=([^;]*)/);
+						if (sshAgentPidMatch && sshAgentPidMatch.length === 2) {
+							this._sshAgentPid = sshAgentPidMatch[1];
+						}
 
-					const sshAuthSockMatch = outputLine.match(/SSH_AUTH_SOCK=([^;]*)/);
-					if (sshAuthSockMatch && sshAuthSockMatch.length === 2) {
-						this._sshAuthSock = sshAuthSockMatch[1];
-					}
-				})
-			);
+						const sshAuthSockMatch = outputLine.match(/SSH_AUTH_SOCK=([^;]*)/);
+						if (sshAuthSockMatch && sshAuthSockMatch.length === 2) {
+							this._sshAuthSock = sshAuthSockMatch[1];
+						}
+					});
+			});
 	}
 
 	async addKey(privateKeyPath: string): Promise<void> {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -314,10 +314,11 @@ class SshAgent {
 	private _sshBinDir: string | undefined;
 
 	get env() {
-		return Object.assign(this._sshBinDir ? { 'GIT_SSH': path.join(this._sshBinDir, 'ssh') } : {}, {
-			'SSH_AGENT_PID': this._sshAgentPid,
-			'SSH_AUTH_SOCK': this._sshAuthSock
-		});
+		return Object.assign(
+			this._sshBinDir ? { 'GIT_SSH': path.join(this._sshBinDir, 'ssh') } : {},
+			this._sshAgentPid ? { 'SSH_AGENT_PID': this._sshAgentPid } : {},
+			this._sshAuthSock ? { 'SSH_AUTH_SOCK': this._sshAuthSock } : {}
+		);
 	}
 
 	async start(): Promise<void> {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -380,8 +380,9 @@ class SshAgent {
 		] : [];
 
 		return directoriesToSearch
+			.map(directoryName => path.join(directoryName, commandName))
 			.reduce(
-				(previousPromise: Promise<string>, directoryName: string) => previousPromise.catch(() => this.checkIfCommandExists(directoryName)),
+				(previousPromise: Promise<string>, commandName: string) => previousPromise.catch(() => this.checkIfCommandExists(commandName)),
 				basePromise
 			).catch(reason => {
 				window.showErrorMessage(localize('failed to find command', "Failed to find command '{0}'", commandName));

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -44,7 +44,7 @@ async function createModel(context: ExtensionContext, outputChannel: OutputChann
 	disposables.push(terminalEnvironmentManager);
 
 	const git = new Git({ gitPath: info.path, version: info.version, env });
-	await git.sshAgent.start().catch(() => null);
+	await git.startSshAgent().catch(() => null);
 
 
 	const model = new Model(git, askpass, context.globalState, outputChannel);

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -46,7 +46,6 @@ async function createModel(context: ExtensionContext, outputChannel: OutputChann
 	const git = new Git({ gitPath: info.path, version: info.version, env });
 	await git.startSshAgent().catch(() => null);
 
-
 	const model = new Model(git, askpass, context.globalState, outputChannel);
 	disposables.push(model);
 

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -44,7 +44,7 @@ async function createModel(context: ExtensionContext, outputChannel: OutputChann
 	disposables.push(terminalEnvironmentManager);
 
 	const git = new Git({ gitPath: info.path, version: info.version, env });
-	await git.startSshAgent().catch(() => null);
+	await git.sshAgent.start().catch(() => null);
 
 	const model = new Model(git, askpass, context.globalState, outputChannel);
 	disposables.push(model);

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -44,6 +44,8 @@ async function createModel(context: ExtensionContext, outputChannel: OutputChann
 	disposables.push(terminalEnvironmentManager);
 
 	const git = new Git({ gitPath: info.path, version: info.version, env });
+	await git.sshAgent.start();
+
 	const model = new Model(git, askpass, context.globalState, outputChannel);
 	disposables.push(model);
 

--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -44,7 +44,8 @@ async function createModel(context: ExtensionContext, outputChannel: OutputChann
 	disposables.push(terminalEnvironmentManager);
 
 	const git = new Git({ gitPath: info.path, version: info.version, env });
-	await git.sshAgent.start();
+	await git.sshAgent.start().catch(() => null);
+
 
 	const model = new Model(git, askpass, context.globalState, outputChannel);
 	disposables.push(model);

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -275,11 +275,11 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 				.getConfiguration('git', Uri.file(repositoryRoot))
 				.get<string>('sshPrivateKeyPath');
 			if (sshPrivateKeyPath) {
-				this.git.sshAgent
+				await this.git.sshAgent
 					.addKey(sshPrivateKeyPath)
 					.then(success => {
 						if (!success) {
-							window.showErrorMessage(localize('failed to add ssh key', "Failed to add SSH key: {0}", sshPrivateKeyPath));
+							window.showErrorMessage(localize('failed to add ssh key', "Failed to add SSH key '{0}'", sshPrivateKeyPath));
 						}
 					});
 			}

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -275,7 +275,13 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 				.getConfiguration('git', Uri.file(repositoryRoot))
 				.get<string>('sshPrivateKeyPath');
 			if (sshPrivateKeyPath) {
-				await this.git.sshAgent.addKey(sshPrivateKeyPath);
+				this.git.sshAgent
+					.addKey(sshPrivateKeyPath)
+					.then(success => {
+						if (!success) {
+							window.showErrorMessage(localize('failed to add ssh key', "Failed to add SSH key: {0}", sshPrivateKeyPath));
+						}
+					});
 			}
 			const dotGit = await this.git.getRepositoryDotGit(repositoryRoot);
 			const repository = new Repository(this.git.open(repositoryRoot, dotGit), this, this, this.globalState, this.outputChannel);

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -271,6 +271,12 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 				return;
 			}
 
+			const sshPrivateKeyPath = workspace
+				.getConfiguration('git', Uri.file(repositoryRoot))
+				.get<string>('sshPrivateKeyPath');
+			if (sshPrivateKeyPath) {
+				await this.git.sshAgent.addKey(sshPrivateKeyPath);
+			}
 			const dotGit = await this.git.getRepositoryDotGit(repositoryRoot);
 			const repository = new Repository(this.git.open(repositoryRoot, dotGit), this, this, this.globalState, this.outputChannel);
 

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -277,10 +277,8 @@ export class Model implements IRemoteSourceProviderRegistry, IPushErrorHandlerRe
 			if (sshPrivateKeyPath) {
 				await this.git.sshAgent
 					.addKey(sshPrivateKeyPath)
-					.then(success => {
-						if (!success) {
-							window.showErrorMessage(localize('failed to add ssh key', "Failed to add SSH key '{0}'", sshPrivateKeyPath));
-						}
+					.catch(() => {
+						window.showErrorMessage(localize('failed to add ssh key', "Failed to add SSH key '{0}'", sshPrivateKeyPath));
 					});
 			}
 			const dotGit = await this.git.getRepositoryDotGit(repositoryRoot);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -792,12 +792,6 @@ export class Repository implements Disposable {
 		const onDidChangeCountBadge = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.countBadge', root));
 		onDidChangeCountBadge(this.setCountBadge, this, this.disposables);
 		this.setCountBadge();
-
-		const gitConfig = workspace.getConfiguration('git');
-		const sshPrivateKeyPath = gitConfig.get<string>('sshPrivateKeyPath');
-		if (sshPrivateKeyPath) {
-			this.repository.git.addSshKey(sshPrivateKeyPath);
-		}
 	}
 
 	validateInput(text: string, position: number): SourceControlInputBoxValidation | undefined {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -792,6 +792,12 @@ export class Repository implements Disposable {
 		const onDidChangeCountBadge = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.countBadge', root));
 		onDidChangeCountBadge(this.setCountBadge, this, this.disposables);
 		this.setCountBadge();
+
+		const gitConfig = workspace.getConfiguration('git');
+		const sshPrivateKeyPath = gitConfig.get<string>('sshPrivateKeyPath');
+		if (sshPrivateKeyPath) {
+			this.repository.git.addSshKey(sshPrivateKeyPath);
+		}
 	}
 
 	validateInput(text: string, position: number): SourceControlInputBoxValidation | undefined {

--- a/extensions/git/yarn.lock
+++ b/extensions/git/yarn.lock
@@ -58,11 +58,6 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
 applicationinsights@1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.8.tgz#db6e3d983cf9f9405fe1ee5ba30ac6e1914537b5"
@@ -812,13 +807,6 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
-  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
-  dependencies:
-    ansi-regex "^5.0.0"
 
 supports-color@3.1.2:
   version "3.1.2"

--- a/extensions/git/yarn.lock
+++ b/extensions/git/yarn.lock
@@ -31,10 +31,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.31.tgz#d6b4f9645fee17f11319b508fb1001797425da51"
   integrity sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg==
 
-"@types/which@^1.0.28":
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.0.28.tgz#016e387629b8817bed653fe32eab5d11279c8df6"
-  integrity sha1-AW44dim4gXvtZT/jLqtdESecjfY=
+"@types/which@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.2.tgz#9c246fc0c93ded311c8512df2891fb41f6227fdf"
+  integrity sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
@@ -57,6 +57,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 applicationinsights@1.0.8:
   version "1.0.8"
@@ -668,6 +673,18 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+nan@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
+
+node-pty@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
+  integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==
+  dependencies:
+    nan "^2.14.0"
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -796,6 +813,13 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
+
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -897,10 +921,10 @@ vscode@^1.1.36:
     url-parse "^1.4.4"
     vscode-test "^0.4.1"
 
-which@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
-  integrity sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==
+which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #13680.

The git extension starts an `ssh-agent` right after the Git object instantiation. Code looks for this command in the directory given by the `git.sshAgentDirectory` setting or in `C:\Program Files\Git\usr\bin` on Windows or `/usr/bin` on other platforms, before tyring to call the raw command.
It then stores the associated `SSH_AUTH_SOCK` and `SSH_AGENT_PID` environment variables and uses them for every subsequent `git` call.
When opening a git repository, Code checks for a `git.sshPrivateKeyPath`. If it is set, it adds it to the running ssh-agent.
