### PR TITLE
Handle custom editor filenamePattern for paths

### DIFF
--- a/src/vs/workbench/contrib/customEditor/common/customEditor.ts
+++ b/src/vs/workbench/contrib/customEditor/common/customEditor.ts
@@ -7,6 +7,7 @@ import { distinct, mergeSort } from 'vs/base/common/arrays';
 import { Event } from 'vs/base/common/event';
 import * as glob from 'vs/base/common/glob';
 import { IDisposable, IReference } from 'vs/base/common/lifecycle';
+import { posix } from 'vs/base/common/path';
 import { basename } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
@@ -96,7 +97,9 @@ export class CustomEditorInfo {
 
 	static selectorMatches(selector: CustomEditorSelector, resource: URI): boolean {
 		if (selector.filenamePattern) {
-			if (glob.match(selector.filenamePattern.toLowerCase(), basename(resource).toLowerCase())) {
+			const matchOnPath = selector.filenamePattern.indexOf(posix.sep) >= 0;
+			const target = matchOnPath ? resource.path : basename(resource);
+			if (glob.match(selector.filenamePattern.toLowerCase(), target.toLowerCase())) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Fixes #94383

This makes sure that when the `filenamePattern` for custom editors contains a `/`, we match against the complete file path instead of just against the file's name
