### PR TITLE
Issue #93589: Rename 'renameShorthandProperties' setting to 'useAliasesForRenames'

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -674,6 +674,20 @@
           "description": "%typescript.preferences.importModuleSpecifierEnding%",
           "scope": "resource"
         },
+        "javascript.preferences.renameShorthandProperties": {
+          "type": "boolean",
+          "default": true,
+          "description": "%typescript.preferences.renameShorthandProperties%",
+          "deprecationMessage": "%typescript.preferences.renameShorthandProperties.deprecationMessage%",
+          "scope": "resource"
+        },
+        "typescript.preferences.renameShorthandProperties": {
+          "type": "boolean",
+          "default": true,
+          "description": "%typescript.preferences.renameShorthandProperties%",
+          "deprecationMessage": "%typescript.preferences.renameShorthandProperties.deprecationMessage%",
+          "scope": "resource"
+        },
         "javascript.preferences.useAliasesForRenames": {
           "type": "boolean",
           "default": true,

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -674,16 +674,16 @@
           "description": "%typescript.preferences.importModuleSpecifierEnding%",
           "scope": "resource"
         },
-        "javascript.preferences.renameShorthandProperties": {
+        "javascript.preferences.useAliasesForRenames": {
           "type": "boolean",
           "default": true,
-          "description": "%typescript.preferences.renameShorthandProperties%",
+          "description": "%typescript.preferences.useAliasesForRenames%",
           "scope": "resource"
         },
-        "typescript.preferences.renameShorthandProperties": {
+        "typescript.preferences.useAliasesForRenames": {
           "type": "boolean",
           "default": true,
-          "description": "%typescript.preferences.renameShorthandProperties%",
+          "description": "%typescript.preferences.useAliasesForRenames%",
           "scope": "resource"
         },
         "typescript.updateImportsOnFileMove.enabled": {

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -99,7 +99,7 @@
 	"configuration.tsserver.watchOptions.fallbackPolling.priorityPollingInterval": "Check every file for changes several times a second, but use heuristics to check certain types of files less frequently than others.",
 	"configuration.tsserver.watchOptions.fallbackPolling.dynamicPriorityPolling ": "Use a dynamic queue where less-frequently modified files will be checked less often.",
 	"configuration.tsserver.watchOptions.synchronousWatchDirectory": "Disable deferred watching on directories. Deferred watching is useful when lots of file changes might occur at once (e.g. a change in node_modules from running npm install), but you might want to disable it with this flag for some less-common setups.",
-	"typescript.preferences.renameShorthandProperties": "Enable/disable introducing aliases for object shorthand properties during renames. Requires using TypeScript 3.4 or newer in the workspace.",
+	"typescript.preferences.useAliasesForRenames": "Enable/disable introducing aliases for object shorthand properties during renames. Requires using TypeScript 3.4 or newer in the workspace.",
 	"codeActions.refactor.extract.constant.title": "Extract constant",
 	"codeActions.refactor.extract.constant.description": "Extract expression to constant.",
 	"codeActions.refactor.extract.function.title": "Extract function",

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -99,6 +99,7 @@
 	"configuration.tsserver.watchOptions.fallbackPolling.priorityPollingInterval": "Check every file for changes several times a second, but use heuristics to check certain types of files less frequently than others.",
 	"configuration.tsserver.watchOptions.fallbackPolling.dynamicPriorityPolling ": "Use a dynamic queue where less-frequently modified files will be checked less often.",
 	"configuration.tsserver.watchOptions.synchronousWatchDirectory": "Disable deferred watching on directories. Deferred watching is useful when lots of file changes might occur at once (e.g. a change in node_modules from running npm install), but you might want to disable it with this flag for some less-common setups.",
+	"typescript.preferences.renameShorthandProperties.deprecationMessage": "The setting 'typescript.preferences.renameShorthandProperties' has been deprecated in favor of 'typescript.preferences.useAliasesForRenames'",
 	"typescript.preferences.useAliasesForRenames": "Enable/disable introducing aliases for object shorthand properties during renames. Requires using TypeScript 3.4 or newer in the workspace.",
 	"codeActions.refactor.extract.constant.title": "Extract constant",
 	"codeActions.refactor.extract.constant.description": "Extract expression to constant.",

--- a/extensions/typescript-language-features/src/features/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/features/fileConfigurationManager.ts
@@ -186,7 +186,7 @@ export default class FileConfigurationManager extends Disposable {
 			importModuleSpecifierPreference: getImportModuleSpecifierPreference(config),
 			importModuleSpecifierEnding: getImportModuleSpecifierEndingPreference(config),
 			allowTextChangesInNewFiles: document.uri.scheme === fileSchemes.file,
-			providePrefixAndSuffixTextForRename: config.get<boolean>('renameShorthandProperties', true),
+			providePrefixAndSuffixTextForRename: config.get<boolean>('useAliasesForRenames', true),
 			allowRenameOfImportPath: true,
 		};
 

--- a/extensions/typescript-language-features/src/features/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/features/fileConfigurationManager.ts
@@ -186,7 +186,7 @@ export default class FileConfigurationManager extends Disposable {
 			importModuleSpecifierPreference: getImportModuleSpecifierPreference(config),
 			importModuleSpecifierEnding: getImportModuleSpecifierEndingPreference(config),
 			allowTextChangesInNewFiles: document.uri.scheme === fileSchemes.file,
-			providePrefixAndSuffixTextForRename: config.get<boolean>('useAliasesForRenames', true),
+			providePrefixAndSuffixTextForRename: config.get<boolean>('renameShorthandProperties', true) === false ? false : config.get<boolean>('useAliasesForRenames', true),
 			allowRenameOfImportPath: true,
 		};
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #93589

The original setting name 'renameShorthandProperties' represents what the setting will do when disabled—not what it will do when it's enabled (the default). Changing the setting name to 'useAliasesForRenames' is better suited. 