### PR TITLE
quickInput: Always show input if screen reader attached

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -825,7 +825,13 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		if (!this.visible) {
 			return;
 		}
-		const hideInput = !!this._hideInput && this._items.length > 0; // do not allow to hide input without items
+		let hideInput: boolean;
+		if (this.ui.isScreenReaderOptimized()) {
+			// Always show input if screen reader attached https://github.com/microsoft/vscode/issues/94360
+			hideInput = false;
+		} else {
+			hideInput = !!this._hideInput && this._items.length > 0; // do not allow to hide input without items
+		}
 		dom.toggleClass(this.ui.container, 'hidden-input', hideInput);
 		const visibilities: Visibilities = {
 			title: !!this.title || !!this.step,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/94360

As discussed in that issue we do not hide input is screen reader is attached
I have verified this fixes the issue on Linux with Orca.