### PR TITLE
Fixes issue #94521: Make sure to always specify Uint32Array length

### DIFF
--- a/src/vs/workbench/api/common/shared/semanticTokensDto.ts
+++ b/src/vs/workbench/api/common/shared/semanticTokensDto.ts
@@ -55,12 +55,12 @@ function fromLittleEndianBuffer(buff: VSBuffer): Uint32Array {
 		reverseEndianness(uint8Arr);
 	}
 	if (uint8Arr.byteOffset % 4 === 0) {
-		return new Uint32Array(uint8Arr.buffer, uint8Arr.byteOffset);
+		return new Uint32Array(uint8Arr.buffer, uint8Arr.byteOffset, uint8Arr.length / 4);
 	} else {
 		// unaligned memory access doesn't work on all platforms
 		const data = new Uint8Array(uint8Arr.byteLength);
 		data.set(uint8Arr);
-		return new Uint32Array(data.buffer, data.byteOffset);
+		return new Uint32Array(data.buffer, data.byteOffset, data.length / 4);
 	}
 }
 


### PR DESCRIPTION
This PR fixes #94521 for the 1.44 release.

When the `decodeSemanticTokensDto` was called, it was possible that it was called with a `VSBuffer` that uses a `Uint8Array` which is misaligned on a backing `ArrayBuffer`. Think about a large data blob (a message from the ext host) and only a portion of it is the encoded semantic tokens dto.

The code handled the misaligned case before (see the check `uint8Arr.byteOffset % 4 === 0`), but the handling was incomplete because a length was not passed to the Uint32Array ctor. When the length is not passed in, the Uint32Array will try to use the `ArrayBuffer.byteLength / 4`, but that might be beyond the length of the passed in `VSBuffer` into memory of the backing `ArrayBuffer`, which might not be a multiple of 4.

The unit tests show this case clearly, but unfortunately there are no steps given this has to do with the way in which the extension host can end up serializing a batch of messages into a single blob...