### PR TITLE
 fixes cursor jump/scroll bug (x2)

### DIFF
--- a/src/vs/editor/contrib/find/findModel.ts
+++ b/src/vs/editor/contrib/find/findModel.ts
@@ -194,10 +194,6 @@ export class FindModelBoundToEditorModel {
 			this._decorations.getCount(),
 			undefined
 		);
-
-		if (moveCursor) {
-			this._moveToNextMatch(this._decorations.getStartPosition());
-		}
 	}
 
 	private _hasMatches(): boolean {


### PR DESCRIPTION
This PR fixes #60977 and fixes #70306 cursor jump/scroll bugs.  

It is functionally identical to my PR #91013, but without the minor refactoring that maybe made the original PR fail the automated tests. 

It's a very simple PR, so I'll leave the details in 91013, and just mention for reference: 
60977: Disable auto-searching while typing (editor scrolls wildly while typing into find widget)
70306: Editor jumps to random line when clicking into it (also related to find widget)
