### PR TITLE
Mark the schema of our built-in extension's snippets

### DIFF
--- a/extensions/bat/snippets/batchfile.snippets.json
+++ b/extensions/bat/snippets/batchfile.snippets.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/coffeescript/snippets/coffeescript.snippets.json
+++ b/extensions/coffeescript/snippets/coffeescript.snippets.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/cpp/snippets/c.json
+++ b/extensions/cpp/snippets/c.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/cpp/snippets/cpp.json
+++ b/extensions/cpp/snippets/cpp.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/csharp/snippets/csharp.json
+++ b/extensions/csharp/snippets/csharp.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/fsharp/snippets/fsharp.json
+++ b/extensions/fsharp/snippets/fsharp.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/groovy/snippets/groovy.json
+++ b/extensions/groovy/snippets/groovy.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"replace(dir: …, includes: …, token: …, value: …)": {
 		"prefix": "replace",
 		"body": "replace(dir:\"${1:dirName}\", includes:\"${2:*.*}\", token:\"${3:tokenName}\", value:\"\\${${4:value}}\")$0",

--- a/extensions/java/snippets/java.snippets.json
+++ b/extensions/java/snippets/java.snippets.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/javascript/snippets/javascript.json
+++ b/extensions/javascript/snippets/javascript.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"define module": {
 		"prefix": "define",
 		"body": [

--- a/extensions/markdown-basics/snippets/markdown.json
+++ b/extensions/markdown-basics/snippets/markdown.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Insert bold text": {
 		"prefix": "bold",
 		"body": "**${1:${TM_SELECTED_TEXT}}**$0",

--- a/extensions/php/snippets/php.snippets.json
+++ b/extensions/php/snippets/php.snippets.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"class …": {
 		"prefix": "class",
 		"body": [

--- a/extensions/powershell/snippets/powershell.json
+++ b/extensions/powershell/snippets/powershell.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Region Start": {
 		"prefix": "#region",
 		"body": [

--- a/extensions/swift/snippets/swift.json
+++ b/extensions/swift/snippets/swift.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"print": {
 		"prefix": "print",
 		"body": "print(\"$1\")\n$0",

--- a/extensions/typescript-basics/snippets/typescript.json
+++ b/extensions/typescript-basics/snippets/typescript.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"Constructor": {
 		"prefix": "ctor",
 		"body": [

--- a/extensions/vb/snippets/vb.json
+++ b/extensions/vb/snippets/vb.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "vscode://schemas/snippets",
 	"For Next Loop": {
 		"prefix": "for",
 		"body": [


### PR DESCRIPTION
Adds `"$schema": "vscode://schemas/snippets"` to all the snippet files for our built-in snippets. This gives us intellisense while editing the snippets

@aeschli Adding the schema works but I see a yellow warning on the `$schema`:

<img width="574" alt="Screen Shot 2020-04-07 at 11 21 10 AM" src="https://user-images.githubusercontent.com/12821956/78705269-19334380-78c2-11ea-8037-e195b4e87bf6.png">

I cannot figure out what this error means or how to fix it. Could you please take a look?