### PR TITLE
Use markdownDescription for snippet.body

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippets.contribution.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IJSONSchema } from 'vs/base/common/jsonSchema';
+import { IJSONSchema, IJSONSchemaMap } from 'vs/base/common/jsonSchema';
 import { Registry } from 'vs/platform/registry/common/platform';
 import * as JSONContributionRegistry from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import * as nls from 'vs/nls';
@@ -25,6 +25,25 @@ export interface ISnippetsService {
 }
 
 const languageScopeSchemaId = 'vscode://schemas/snippets';
+
+const snippetSchemaProperties: IJSONSchemaMap = {
+	prefix: {
+		description: nls.localize('snippetSchema.json.prefix', 'The prefix to used when selecting the snippet in intellisense'),
+		type: ['string', 'array']
+	},
+	body: {
+		markdownDescription: nls.localize('snippetSchema.json.body', 'The snippet content. Use `$1`, `${1:defaultText}` to define cursor positions, use `$0` for the final cursor position. Insert variable values with `${varName}` and `${varName:defaultText}`, e.g. `This is file: $TM_FILENAME`.'),
+		type: ['string', 'array'],
+		items: {
+			type: 'string'
+		}
+	},
+	description: {
+		description: nls.localize('snippetSchema.json.description', 'The snippet description.'),
+		type: ['string', 'array']
+	}
+};
+
 const languageScopeSchema: IJSONSchema = {
 	id: languageScopeSchemaId,
 	allowComments: true,
@@ -38,23 +57,7 @@ const languageScopeSchema: IJSONSchema = {
 	additionalProperties: {
 		type: 'object',
 		required: ['prefix', 'body'],
-		properties: {
-			prefix: {
-				description: nls.localize('snippetSchema.json.prefix', 'The prefix to used when selecting the snippet in intellisense'),
-				type: ['string', 'array']
-			},
-			body: {
-				description: nls.localize('snippetSchema.json.body', 'The snippet content. Use \'$1\', \'${1:defaultText}\' to define cursor positions, use \'$0\' for the final cursor position. Insert variable values with \'${varName}\' and \'${varName:defaultText}\', e.g. \'This is file: $TM_FILENAME\'.'),
-				type: ['string', 'array'],
-				items: {
-					type: 'string'
-				}
-			},
-			description: {
-				description: nls.localize('snippetSchema.json.description', 'The snippet description.'),
-				type: ['string', 'array']
-			}
-		},
+		properties: snippetSchemaProperties,
 		additionalProperties: false
 	}
 };
@@ -75,23 +78,9 @@ const globalSchema: IJSONSchema = {
 		type: 'object',
 		required: ['prefix', 'body'],
 		properties: {
-			prefix: {
-				description: nls.localize('snippetSchema.json.prefix', 'The prefix to used when selecting the snippet in intellisense'),
-				type: ['string', 'array']
-			},
+			...snippetSchemaProperties,
 			scope: {
 				description: nls.localize('snippetSchema.json.scope', "A list of language names to which this snippet applies, e.g. 'typescript,javascript'."),
-				type: 'string'
-			},
-			body: {
-				description: nls.localize('snippetSchema.json.body', 'The snippet content. Use \'$1\', \'${1:defaultText}\' to define cursor positions, use \'$0\' for the final cursor position. Insert variable values with \'${varName}\' and \'${varName:defaultText}\', e.g. \'This is file: $TM_FILENAME\'.'),
-				type: ['string', 'array'],
-				items: {
-					type: 'string'
-				}
-			},
-			description: {
-				description: nls.localize('snippetSchema.json.description', 'The snippet description.'),
 				type: 'string'
 			}
 		},


### PR DESCRIPTION
Also extracts the common fields shared between global snippets and language snippets so that I only had to make the `markdownDescription` in one place