### PR TITLE
Remove extra checks for non-nullable functions/properties

### DIFF
--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -80,15 +80,11 @@ export class StandardMouseEvent implements IMouseEvent {
 	}
 
 	public preventDefault(): void {
-		if (this.browserEvent.preventDefault) {
-			this.browserEvent.preventDefault();
-		}
+		this.browserEvent.preventDefault();
 	}
 
 	public stopPropagation(): void {
-		if (this.browserEvent.stopPropagation) {
-			this.browserEvent.stopPropagation();
-		}
+		this.browserEvent.stopPropagation();
 	}
 }
 
@@ -208,17 +204,13 @@ export class StandardWheelEvent {
 
 	public preventDefault(): void {
 		if (this.browserEvent) {
-			if (this.browserEvent.preventDefault) {
-				this.browserEvent.preventDefault();
-			}
+			this.browserEvent.preventDefault();
 		}
 	}
 
 	public stopPropagation(): void {
 		if (this.browserEvent) {
-			if (this.browserEvent.stopPropagation) {
-				this.browserEvent.stopPropagation();
-			}
+			this.browserEvent.stopPropagation();
 		}
 	}
 }

--- a/src/vs/editor/contrib/hover/hoverOperation.ts
+++ b/src/vs/editor/contrib/hover/hoverOperation.ts
@@ -143,9 +143,7 @@ export class HoverOperation<Result> {
 	}
 
 	private _onComplete(value: Result): void {
-		if (this._completeCallback) {
-			this._completeCallback(value);
-		}
+		this._completeCallback(value);
 	}
 
 	private _onError(error: any): void {
@@ -157,9 +155,7 @@ export class HoverOperation<Result> {
 	}
 
 	private _onProgress(value: Result): void {
-		if (this._progressCallback) {
-			this._progressCallback(value);
-		}
+		this._progressCallback(value);
 	}
 
 	public start(mode: HoverStartMode): void {

--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -1072,11 +1072,9 @@ class DirectDebugAdapter extends AbstractDebugAdapter {
 	constructor(private implementation: vscode.DebugAdapter) {
 		super();
 
-		if (this.implementation.onDidSendMessage) {
-			implementation.onDidSendMessage((message: vscode.DebugProtocolMessage) => {
-				this.acceptMessage(message as DebugProtocol.ProtocolMessage);
-			});
-		}
+		implementation.onDidSendMessage((message: vscode.DebugProtocolMessage) => {
+			this.acceptMessage(message as DebugProtocol.ProtocolMessage);
+		});
 	}
 
 	startSession(): Promise<void> {
@@ -1084,15 +1082,11 @@ class DirectDebugAdapter extends AbstractDebugAdapter {
 	}
 
 	sendMessage(message: DebugProtocol.ProtocolMessage): void {
-		if (this.implementation.handleMessage) {
-			this.implementation.handleMessage(message);
-		}
+		this.implementation.handleMessage(message);
 	}
 
 	stopSession(): Promise<void> {
-		if (this.implementation.dispose) {
-			this.implementation.dispose();
-		}
+		this.implementation.dispose();
 		return Promise.resolve(undefined);
 	}
 }

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -519,7 +519,7 @@ export class SettingMatches {
 			const valueMatches = or(matchesPrefix, matchesContiguousSubString)(searchString, setting.value);
 			valueRanges = valueMatches ? valueMatches.map(match => this.toValueRange(setting, match)) : this.getRangesForWords(words, this.valueMatchingWords, [this.keyMatchingWords, this.descriptionMatchingWords]);
 		} else {
-			valueRanges = this.valuesMatcher ? this.valuesMatcher(searchString, setting) : [];
+			valueRanges = this.valuesMatcher(searchString, setting);
 		}
 
 		return [...descriptionRanges, ...keyRanges, ...valueRanges];

--- a/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
@@ -801,9 +801,7 @@ export class RepositoryPane extends ViewPane {
 		const onDidChangeContentHeight = Event.filter(this.inputEditor.onDidContentSizeChange, e => e.contentHeightChanged);
 		this._register(onDidChangeContentHeight(() => this.layoutBody()));
 
-		if (this.repository.provider.onDidChangeCommitTemplate) {
-			this._register(this.repository.provider.onDidChangeCommitTemplate(this.onDidChangeCommitTemplate, this));
-		}
+		this._register(this.repository.provider.onDidChangeCommitTemplate(this.onDidChangeCommitTemplate, this));
 
 		this.onDidChangeCommitTemplate();
 

--- a/src/vs/workbench/contrib/webview/electron-browser/webviewCommands.ts
+++ b/src/vs/workbench/contrib/webview/electron-browser/webviewCommands.ts
@@ -153,7 +153,7 @@ function getActiveElectronBasedWebview(accessor: ServicesAccessor): ElectronWebv
 
 	if (webview instanceof ElectronWebviewBasedWebview) {
 		return webview;
-	} else if ((webview as WebviewOverlay).getInnerWebview) {
+	} else if ('getInnerWebview' in (webview as WebviewOverlay)) {
 		const innerWebview = (webview as WebviewOverlay).getInnerWebview();
 		if (innerWebview instanceof ElectronWebviewBasedWebview) {
 			return innerWebview;

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -614,9 +614,7 @@ export class QueryGlobTester {
 	 * Guaranteed async.
 	 */
 	includedInQuery(testPath: string, basename?: string, hasSibling?: (name: string) => boolean | Promise<boolean>): Promise<boolean> {
-		const excludeP = this._parsedExcludeExpression ?
-			Promise.resolve(this._parsedExcludeExpression(testPath, basename, hasSibling)).then(result => !!result) :
-			Promise.resolve(false);
+		const excludeP = Promise.resolve(this._parsedExcludeExpression(testPath, basename, hasSibling)).then(result => !!result);
 
 		return excludeP.then(excluded => {
 			if (excluded) {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1033,7 +1033,7 @@ export class TestFileEditorInput extends EditorInput implements IFileEditorInput
 
 	getTypeId() { return this.typeId; }
 	resolve(): Promise<IEditorModel | null> { return !this.fails ? Promise.resolve(null) : Promise.reject(new Error('fails')); }
-	matches(other: TestEditorInput): boolean { return other && other.resource && this.resource.toString() === other.resource.toString() && other instanceof TestFileEditorInput && other.getTypeId() === this.typeId; }
+	matches(other: EditorInput): boolean { return !!(other?.resource && this.resource.toString() === other.resource.toString() && other instanceof TestFileEditorInput && other.getTypeId() === this.typeId); }
 	setEncoding(encoding: string) { }
 	getEncoding() { return undefined; }
 	setPreferredEncoding(encoding: string) { }


### PR DESCRIPTION
TS 3.9 has gotten smarter about catching cases where an `if` condition will always be true. This revealed a few places in our codebase where we were checking to see if a function property exists before calling it, but the property we were checking cannot be undefined or null

This PR removes the extra checks. Please confirm that removing the conditional is correct or let me know if we need to fix our type annotations to say that a property is nullable:

- [x] `mouseEvent.ts` @alexdima?
- [x] `hoverOperation.ts` @alexdima?
- [x] `extHostDebugService.ts` @isidorn / @weinand 
- [x] `preferencesSearch.ts` @roblourens
- [x] `repositoryPane.ts` @joaomoreno 
- [x] `search.ts ` @roblourens 