### PR TITLE
Issue 92279: New feature for adding multiple diff decorations

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -888,9 +888,9 @@ class DirtyDiffDecorator extends Disposable {
 		super();
 		this.editorModel = editorModel;
 		const decorations = configurationService.getValue<string>('scm.diffDecorations');
-		const gutter = decorations === 'all' || decorations === 'gutter';
-		const overview = decorations === 'all' || decorations === 'overview';
-		const minimap = decorations === 'all' || decorations === 'minimap';
+		const gutter = decorations.search(/gutter/) !== -1;
+		const overview = decorations.search(/overview/) !== -1;
+		const minimap = decorations.search(/minimap/) !== -1;
 
 		this.modifiedOptions = DirtyDiffDecorator.createDecoration('dirty-diff-modified', {
 			gutter,

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -63,6 +63,13 @@ Registry.as<IWorkbenchActionRegistry>(WorkbenchActionExtensions.WorkbenchActions
 	localize('view', "View")
 );
 
+let diffDecorationsDescription = localize('diffDecorations', "Controls diff decorations in the editor. Possible diff decorations (comma separated):");
+diffDecorationsDescription += '\n- ' + [
+	localize('scm.diffDecorations.gutter', "`gutter`: Show the diff decorations in the editor gutter."),
+	localize('scm.diffDecorations.overviewRuler', "`overview`: Show the diff decorations in the overview ruler."),
+	localize('scm.diffDecorations.minimap', "`minimap`: Show the diff decorations in the minimap."),
+].join('\n- '); // intentionally concatenated to not produce a string that is too long for translations
+
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'scm',
 	order: 5,
@@ -82,16 +89,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		'scm.diffDecorations': {
 			type: 'string',
-			enum: ['all', 'gutter', 'overview', 'minimap', 'none'],
-			enumDescriptions: [
-				localize('scm.diffDecorations.all', "Show the diff decorations in all available locations."),
-				localize('scm.diffDecorations.gutter', "Show the diff decorations only in the editor gutter."),
-				localize('scm.diffDecorations.overviewRuler', "Show the diff decorations only in the overview ruler."),
-				localize('scm.diffDecorations.minimap', "Show the diff decorations only in the minimap."),
-				localize('scm.diffDecorations.none', "Do not show the diff decorations.")
-			],
-			default: 'all',
-			description: localize('diffDecorations', "Controls diff decorations in the editor.")
+			default: 'gutter,overview,minimap',
+			markdownDescription: diffDecorationsDescription
 		},
 		'scm.diffDecorationsGutterWidth': {
 			type: 'number',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #92279

**What:**

Based on the problem described in #92279; I've updated the set of of configurable options for the diff decorations under the SCM section in the settings. The option is still named, "scm.diffDecorations", but instead of being `<gutter|overview|minimap|all|none>`, you can now select any combination of `<gutter|overview|minimap>` with a string separated by commas. I also have the default setting the same (gutter, overview, minimap all enabled).