### PR TITLE
fix uri fragment slugification #94508

### DIFF
--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { MarkdownContributionProvider as MarkdownContributionProvider } from './markdownExtensions';
 import { Slugifier } from './slugify';
 import { SkinnyTextDocument } from './tableOfContentsProvider';
-import { Schemes, isOfScheme } from './util/links';
+import { MarkdownFileExtensions, Schemes, isOfScheme } from './util/links';
 
 const UNICODE_NEWLINE_REGEX = /\u2028|\u2029/g;
 
@@ -251,7 +251,9 @@ export class MarkdownEngine {
 						}
 					}
 
-					if (uri.fragment) {
+					const extname = path.extname(uri.fsPath);
+
+					if (uri.fragment && (extname === '' || MarkdownFileExtensions.includes(extname))) {
 						uri = uri.with({
 							fragment: this.slugifier.fromHeading(uri.fragment).value
 						});

--- a/extensions/markdown-language-features/src/util/links.ts
+++ b/extensions/markdown-language-features/src/util/links.ts
@@ -32,3 +32,15 @@ export function getUriForLinkWithKnownExternalScheme(link: string): vscode.Uri |
 export function isOfScheme(scheme: string, link: string): boolean {
 	return link.toLowerCase().startsWith(scheme);
 }
+
+export const MarkdownFileExtensions: readonly string[] = [
+	'.md',
+	'.mkd',
+	'.mdwn',
+	'.mdown',
+	'.markdown',
+	'.markdn',
+	'.mdtxt',
+	'.mdtext',
+	'.workbook',
+];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Previously, all links to local files had their fragment parts normalized (e.g. `foo.md#Bar baz` became `foo.md#bar-baz`). This allowed links to specific sections of other markdown files (`file#Section header`), but broke many other links.

This PR limits the normalization to paths without a file extension (as per [suggestion](https://github.com/microsoft/vscode/issues/94508#issuecomment-610620509)).

This may, however, have an unfortunate side effect of breaking some markdown links that do have an extension (e.g. `foo.md#Bar baz` won't work, but `foo#Bar baz` will).

This PR fixes #94508 
