### PR TITLE
build: use separate entitlements for different macOS helper executables

### DIFF
--- a/build/azure-pipelines/darwin/helper-gpu-entitlements.plist
+++ b/build/azure-pipelines/darwin/helper-gpu-entitlements.plist
@@ -2,5 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
 </dict>
 </plist>

--- a/build/azure-pipelines/darwin/helper-plugin-entitlements.plist
+++ b/build/azure-pipelines/darwin/helper-plugin-entitlements.plist
@@ -2,5 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>

--- a/build/azure-pipelines/darwin/helper-renderer-entitlements.plist
+++ b/build/azure-pipelines/darwin/helper-renderer-entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -154,13 +154,20 @@ steps:
 
 - script: |
     set -e
+    APP_ROOT=$(agent.builddirectory)/VSCode-darwin
+    APP_NAME="`ls $APP_ROOT | head -n 1`"
+    HELPER_APP_NAME="`echo $APP_NAME | sed -e 's/^Visual Studio //;s/\.app$//'`"
+    APP_FRAMEWORK_PATH="$APP_ROOT/$APP_NAME/Contents/Frameworks"
     security create-keychain -p pwd $(agent.tempdirectory)/buildagent.keychain
     security default-keychain -s $(agent.tempdirectory)/buildagent.keychain
     security unlock-keychain -p pwd $(agent.tempdirectory)/buildagent.keychain
     echo "$(macos-developer-certificate)" | base64 -D > $(agent.tempdirectory)/cert.p12
     security import $(agent.tempdirectory)/cert.p12 -k $(agent.tempdirectory)/buildagent.keychain -P "$(macos-developer-certificate-key)" -T /usr/bin/codesign
     security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k pwd $(agent.tempdirectory)/buildagent.keychain
-    codesign -s 99FM488X57 --deep --force --options runtime --entitlements build/azure-pipelines/darwin/entitlements.plist $(agent.builddirectory)/VSCode-darwin/*.app
+    codesign -s 99FM488X57 --deep --force --options runtime --entitlements build/azure-pipelines/darwin/entitlements.plist "$APP_ROOT"/*.app
+    codesign -s 99FM488X57 --force --options runtime --entitlements build/azure-pipelines/darwin/helper-gpu-entitlements.plist "$APP_FRAMEWORK_PATH/$HELPER_APP_NAME Helper (GPU).app"
+    codesign -s 99FM488X57 --force --options runtime --entitlements build/azure-pipelines/darwin/helper-plugin-entitlements.plist "$APP_FRAMEWORK_PATH/$HELPER_APP_NAME Helper (Plugin).app"
+    codesign -s 99FM488X57 --force --options runtime --entitlements build/azure-pipelines/darwin/helper-renderer-entitlements.plist "$APP_FRAMEWORK_PATH/$HELPER_APP_NAME Helper (Renderer).app"
   displayName: Set Hardened Entitlements
 
 - script: |


### PR DESCRIPTION
We currently bundle a single entitlement file for all the helper executables on macOS, currently we have `Code Helper (Renderer)` , `Code Helper (GPU)`, `Code Helper (Plugin)` and `Code Helper`, this is not good from a security perspective, whatever we shipped so far was not an issue but once we have sandboxed renderer we would limit the capabilities of the renderer helper.