### PR TITLE
Recovery: 94742

### DIFF
--- a/src/vs/base/common/fuzzyScorer.ts
+++ b/src/vs/base/common/fuzzyScorer.ts
@@ -268,10 +268,10 @@ export type FuzzyScore2 = [number /* score*/, IMatch[]];
 
 const NO_SCORE2: FuzzyScore2 = [NO_MATCH, []];
 
-export function scoreFuzzy2(target: string, query: IPreparedQuery, patternStart = 0, matchOffset = 0): FuzzyScore2 {
+export function scoreFuzzy2(target: string, query: IPreparedQuery, patternStart = 0, matchOffset = 0, skipMultiMatching = false): FuzzyScore2 {
 
-	// Score: multiple inputs
-	if (query.values && query.values.length > 1) {
+	// Score: multiple inputs (unless disabled)
+	if (!skipMultiMatching && query.values && query.values.length > 1) {
 		return doScoreFuzzy2Multiple(target, query.values, patternStart, matchOffset);
 	}
 

--- a/src/vs/editor/contrib/quickAccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/gotoSymbolQuickAccess.ts
@@ -245,7 +245,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 				// case we want to skip the container query altogether.
 				let skipContainerQuery = false;
 				if (symbolQuery !== query) {
-					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, query, filterPos, symbolLabelIconOffset);
+					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, query, filterPos, symbolLabelIconOffset, true /* skip multi matching */);
 					if (symbolScore) {
 						skipContainerQuery = true; // since we consumed the query, skip any container matching
 					}

--- a/src/vs/editor/contrib/quickAccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/gotoSymbolQuickAccess.ts
@@ -220,6 +220,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 
 			const symbolLabel = trim(symbol.name);
 			const symbolLabelWithIcon = `$(symbol-${SymbolKinds.toString(symbol.kind) || 'property'}) ${symbolLabel}`;
+			const symbolLabelIconOffset = symbolLabelWithIcon.length - symbolLabel.length;
 
 			let containerLabel = symbol.containerName;
 			if (options?.extraContainerLabel) {
@@ -238,14 +239,28 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 
 			if (query.original.length > filterPos) {
 
-				// Score by symbol
-				[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, symbolQuery, filterPos, symbolLabelWithIcon.length - symbolLabel.length /* Readjust matches to account for codicons in label */);
+				// First: try to score on the entire query, it is possible that
+				// the symbol matches perfectly (e.g. searching for "change log"
+				// can be a match on a markdown symbol "change log"). In that
+				// case we want to skip the container query altogether.
+				let skipContainerQuery = false;
+				if (symbolQuery !== query) {
+					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, query, filterPos, symbolLabelIconOffset);
+					if (symbolScore) {
+						skipContainerQuery = true; // since we consumed the query, skip any container matching
+					}
+				}
+
+				// Otherwise: score on the symbol query and match on the container later
 				if (!symbolScore) {
-					continue;
+					[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, symbolQuery, filterPos, symbolLabelIconOffset);
+					if (!symbolScore) {
+						continue;
+					}
 				}
 
 				// Score by container if specified
-				if (containerQuery) {
+				if (!skipContainerQuery && containerQuery) {
 					if (containerLabel && containerQuery.original.length > 0) {
 						[containerScore, containerMatches] = scoreFuzzy2(containerLabel, containerQuery);
 					}

--- a/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/symbolsQuickAccess.ts
@@ -143,7 +143,7 @@ export class SymbolsQuickAccessProvider extends PickerQuickAccessProvider<ISymbo
 					// can be a match on a markdown symbol "change log"). In that
 					// case we want to skip the container query altogether.
 					if (symbolQuery !== query) {
-						[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, query, 0, symbolLabelIconOffset);
+						[symbolScore, symbolMatches] = scoreFuzzy2(symbolLabel, query, 0, symbolLabelIconOffset, true /* skip multi matching */);
 						if (symbolScore) {
 							skipContainerQuery = true; // since we consumed the query, skip any container matching
 						}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #94742

If a symbol includes spaces in its label we currently fail to properly return them as results in quick pick for editor symbols as well as workspace symbols because we treat the query value after space as a filter for the container (= description) of the symbol. 

Suggested fix is to first run the entire query over the symbol label and be OK with it if it matches. 
