### PR TITLE
Shared editor association setting between custom editor and notebook

### DIFF
--- a/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditor.contribution.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
@@ -17,7 +16,6 @@ import { WebviewEditor } from 'vs/workbench/contrib/webview/browser/webviewEdito
 import './commands';
 import { CustomEditorInput } from './customEditorInput';
 import { CustomEditorContribution, CustomEditorService } from './customEditors';
-import { editorAssociationsConfigurationNode } from './editorAssociationsSetting';
 
 registerSingleton(ICustomEditorService, CustomEditorService);
 
@@ -41,6 +39,3 @@ Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactor
 
 Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories)
 	.registerCustomEditorInputFactory(CustomEditorInputFactory);
-
-Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
-	.registerConfiguration(editorAssociationsConfigurationNode);

--- a/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditors.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { coalesce } from 'vs/base/common/arrays';
+import { Event, Emitter } from 'vs/base/common/event';
 import { Lazy } from 'vs/base/common/lazy';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { basename, extname, isEqual } from 'vs/base/common/resources';
@@ -27,12 +28,12 @@ import { CustomEditorModelManager } from 'vs/workbench/contrib/customEditor/comm
 import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
 import { IWebviewService, webviewHasOwnEditFunctionsContext } from 'vs/workbench/contrib/webview/browser/webview';
 import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IEditorService, IOpenEditorOverride } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorService, IOpenEditorOverride, ICustomEditorViewTypesHandler, ICustomEditorInfo } from 'vs/workbench/services/editor/common/editorService';
 import { ContributedCustomEditors, defaultCustomEditor } from '../common/contributedCustomEditors';
 import { CustomEditorInput } from './customEditorInput';
-import { CustomEditorAssociation, CustomEditorAssociationsSettingIntelliSense, CustomEditorsAssociations, customEditorsAssociationsSettingId } from './editorAssociationsSetting';
+import { CustomEditorAssociation, CustomEditorsAssociations, customEditorsAssociationsSettingId } from 'vs/workbench/services/editor/browser/editorAssociationsSetting';
 
-export class CustomEditorService extends Disposable implements ICustomEditorService {
+export class CustomEditorService extends Disposable implements ICustomEditorService, ICustomEditorViewTypesHandler {
 	_serviceBrand: any;
 
 	private readonly _contributedEditors = this._register(new ContributedCustomEditors());
@@ -42,6 +43,8 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 	private readonly _customEditorContextKey: IContextKey<string>;
 	private readonly _focusedCustomEditorIsEditable: IContextKey<boolean>;
 	private readonly _webviewHasOwnEditFunctions: IContextKey<boolean>;
+	private readonly _onDidChangeViewTypes = new Emitter<void>();
+	onDidChangeViewTypes: Event<void> = this._onDidChangeViewTypes.event;
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService,
@@ -59,9 +62,10 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		this._focusedCustomEditorIsEditable = CONTEXT_FOCUSED_CUSTOM_EDITOR_IS_EDITABLE.bindTo(contextKeyService);
 		this._webviewHasOwnEditFunctions = webviewHasOwnEditFunctionsContext.bindTo(contextKeyService);
 
-		this._register(new CustomEditorAssociationsSettingIntelliSense(this._contributedEditors));
+		this._register(this.editorService.registerCustomEditorViewTypesHandler('Custom Editor', this));
 		this._register(this._contributedEditors.onChange(() => {
 			this.updateContexts();
+			this._onDidChangeViewTypes.fire();
 		}));
 		this._register(this.editorService.onDidActiveEditorChange(() => this.updateContexts()));
 
@@ -72,6 +76,10 @@ export class CustomEditorService extends Disposable implements ICustomEditorServ
 		}));
 
 		this.updateContexts();
+	}
+
+	getViewTypes(): ICustomEditorInfo[] {
+		return [...this._contributedEditors];
 	}
 
 	public get models() { return this._models; }

--- a/src/vs/workbench/services/editor/browser/editorAssociationsSetting.ts
+++ b/src/vs/workbench/services/editor/browser/editorAssociationsSetting.ts
@@ -7,23 +7,22 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 import { IConfigurationNode, IConfigurationRegistry, Extensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
-import { CustomEditorSelector } from 'vs/workbench/contrib/customEditor/common/customEditor';
-import { ContributedCustomEditors, defaultCustomEditor } from 'vs/workbench/contrib/customEditor/common/contributedCustomEditors';
-import { Disposable } from 'vs/base/common/lifecycle';
 import { Registry } from 'vs/platform/registry/common/platform';
+import { ICustomEditorInfo } from 'vs/workbench/services/editor/common/editorService';
 
 export const customEditorsAssociationsSettingId = 'workbench.editorAssociations';
 
-export type CustomEditorAssociation = CustomEditorSelector & {
-	readonly viewType: string;
-};
-
-export type CustomEditorsAssociations = readonly CustomEditorAssociation[];
-
-const viewTypeSchamaAddition: IJSONSchema = {
+export const viewTypeSchamaAddition: IJSONSchema = {
 	type: 'string',
 	enum: []
 };
+
+export type CustomEditorAssociation = {
+	readonly viewType: string;
+	readonly filenamePattern?: string;
+};
+
+export type CustomEditorsAssociations = readonly CustomEditorAssociation[];
 
 export const editorAssociationsConfigurationNode: IConfigurationNode = {
 	...workbenchConfigurationNodeBase,
@@ -59,30 +58,19 @@ export const editorAssociationsConfigurationNode: IConfigurationNode = {
 	}
 };
 
-export class CustomEditorAssociationsSettingIntelliSense extends Disposable {
 
-	constructor(
-		private readonly _contributedCustomEditors: ContributedCustomEditors,
-	) {
-		super();
+const builtinProviderDisplayName = nls.localize('builtinProviderDisplayName', "Built-in");
 
-		this._register(_contributedCustomEditors.onChange(() => {
-			this.updateSchema();
-		}));
-		this.updateSchema();
-	}
+export const DEFAULT_CUSTOM_EDITOR: ICustomEditorInfo = {
+	id: 'default',
+	displayName: nls.localize('promptOpenWith.defaultEditor.displayName', "Text Editor"),
+	providerDisplayName: builtinProviderDisplayName
+};
 
-	private updateSchema() {
-		const enumValues: string[] = [];
-		const enumDescriptions: string[] = [];
-		for (const info of [defaultCustomEditor, ...this._contributedCustomEditors]) {
-			enumValues.push(info.id);
-			enumDescriptions.push(nls.localize('editorAssociations.viewType.sourceDescription', "Source: {0}", info.providerDisplayName));
-		}
-		viewTypeSchamaAddition.enum = enumValues;
-		viewTypeSchamaAddition.enumDescriptions = enumDescriptions;
+export function updateViewTypeSchema(enumValues: string[], enumDescriptions: string[]): void {
+	viewTypeSchamaAddition.enum = enumValues;
+	viewTypeSchamaAddition.enumDescriptions = enumDescriptions;
 
-		Registry.as<IConfigurationRegistry>(Extensions.Configuration)
-			.notifyConfigurationSchemaUpdated(editorAssociationsConfigurationNode);
-	}
+	Registry.as<IConfigurationRegistry>(Extensions.Configuration)
+		.notifyConfigurationSchemaUpdated(editorAssociationsConfigurationNode);
 }

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as nls from 'vs/nls';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IResourceEditorInput, ITextEditorOptions, IEditorOptions, EditorActivation } from 'vs/platform/editor/common/editor';
 import { SideBySideEditor, IEditorInput, IEditorPane, GroupIdentifier, IFileEditorInput, IUntitledTextResourceEditorInput, IResourceDiffEditorInput, IEditorInputFactoryRegistry, Extensions as EditorExtensions, EditorInput, SideBySideEditorInput, IEditorInputWithOptions, isEditorInputWithOptions, EditorOptions, TextEditorOptions, IEditorIdentifier, IEditorCloseEvent, ITextEditorPane, ITextDiffEditorPane, IRevertOptions, SaveReason, EditorsOrder, isTextEditorPane, IWorkbenchEditorConfiguration, toResource, IVisibleEditorPane } from 'vs/workbench/common/editor';
@@ -17,7 +18,7 @@ import { URI } from 'vs/base/common/uri';
 import { basename, isEqualOrParent, joinPath } from 'vs/base/common/resources';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { IEditorGroupsService, IEditorGroup, GroupsOrder, IEditorReplacement, GroupChangeKind, preferredSideBySideGroupDirection } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IResourceEditorInputType, SIDE_GROUP, IResourceEditorReplacement, IOpenEditorOverrideHandler, IEditorService, SIDE_GROUP_TYPE, ACTIVE_GROUP_TYPE, ISaveEditorsOptions, ISaveAllEditorsOptions, IRevertAllEditorsOptions, IBaseSaveRevertAllEditorOptions, IOpenEditorOverrideEntry } from 'vs/workbench/services/editor/common/editorService';
+import { IResourceEditorInputType, SIDE_GROUP, IResourceEditorReplacement, IOpenEditorOverrideHandler, IEditorService, SIDE_GROUP_TYPE, ACTIVE_GROUP_TYPE, ISaveEditorsOptions, ISaveAllEditorsOptions, IRevertAllEditorsOptions, IBaseSaveRevertAllEditorOptions, IOpenEditorOverrideEntry, ICustomEditorViewTypesHandler, ICustomEditorInfo } from 'vs/workbench/services/editor/common/editorService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { Disposable, IDisposable, dispose, toDisposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { coalesce, distinct, insert } from 'vs/base/common/arrays';
@@ -33,6 +34,8 @@ import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/u
 import { timeout } from 'vs/base/common/async';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { indexOfPath } from 'vs/base/common/extpath';
+import { DEFAULT_CUSTOM_EDITOR, updateViewTypeSchema, editorAssociationsConfigurationNode } from 'vs/workbench/services/editor/browser/editorAssociationsSetting';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 
 type CachedEditorInput = ResourceEditorInput | IFileEditorInput | UntitledTextEditorInput;
 type OpenInEditorGroup = IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE;
@@ -1088,6 +1091,48 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 
 	//#endregion
 
+	//#region Custom View Type
+	private customEditorViewTypesHandlers = new Map<string, ICustomEditorViewTypesHandler>();
+	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable {
+		if (this.customEditorViewTypesHandlers.has(source)) {
+			throw new Error(`Use a different name for the custom editor component, ${source} is already occupied.`);
+		}
+
+		this.customEditorViewTypesHandlers.set(source, handler);
+		this.updateSchema();
+
+		const viewTypeChangeEvent = handler.onDidChangeViewTypes(() => {
+			this.updateSchema();
+		});
+
+		return {
+			dispose: () => {
+				viewTypeChangeEvent.dispose();
+				this.customEditorViewTypesHandlers.delete(source);
+				this.updateSchema();
+			}
+		};
+	}
+
+	private updateSchema() {
+		const enumValues: string[] = [];
+		const enumDescriptions: string[] = [];
+
+		const infos: ICustomEditorInfo[] = [DEFAULT_CUSTOM_EDITOR];
+
+		for (const [, handler] of this.customEditorViewTypesHandlers) {
+			infos.push(...handler.getViewTypes());
+		}
+
+		infos.forEach(info => {
+			enumValues.push(info.id);
+			enumDescriptions.push(nls.localize('editorAssociations.viewType.sourceDescription', "Source: {0}", info.providerDisplayName));
+		});
+
+		updateViewTypeSchema(enumValues, enumDescriptions);
+	}
+
+	//#endregion
 	dispose(): void {
 		super.dispose();
 
@@ -1195,7 +1240,14 @@ export class DelegatingEditorService implements IEditorService {
 	revert(editors: IEditorIdentifier | IEditorIdentifier[], options?: IRevertOptions): Promise<void> { return this.editorService.revert(editors, options); }
 	revertAll(options?: IRevertAllEditorsOptions): Promise<void> { return this.editorService.revertAll(options); }
 
+	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable {
+		throw new Error('Method not implemented.');
+	}
+
 	//#endregion
 }
 
 registerSingleton(IEditorService, EditorService);
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+	.registerConfiguration(editorAssociationsConfigurationNode);

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -67,6 +67,18 @@ export interface ISaveAllEditorsOptions extends ISaveEditorsOptions, IBaseSaveRe
 
 export interface IRevertAllEditorsOptions extends IRevertOptions, IBaseSaveRevertAllEditorOptions { }
 
+export interface ICustomEditorInfo {
+
+	readonly id: string;
+	readonly displayName: string;
+	readonly providerDisplayName: string;
+}
+
+export interface ICustomEditorViewTypesHandler {
+	readonly onDidChangeViewTypes: Event<void>;
+	getViewTypes(): ICustomEditorInfo[];
+}
+
 export interface IEditorService {
 
 	_serviceBrand: undefined;
@@ -220,6 +232,8 @@ export interface IEditorService {
 	 * operation to open a different editor.
 	 */
 	overrideOpenEditor(handler: IOpenEditorOverrideHandler): IDisposable;
+
+	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable;
 
 	/**
 	 * Invoke a function in the context of the services of the active editor.

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -52,7 +52,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IDecorationsService, IResourceDecorationChangeEvent, IDecoration, IDecorationData, IDecorationsProvider } from 'vs/workbench/services/decorations/browser/decorations';
 import { IDisposable, toDisposable, Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { IEditorGroupsService, IEditorGroup, GroupsOrder, GroupsArrangement, GroupDirection, IAddGroupOptions, IMergeGroupOptions, IMoveEditorOptions, ICopyEditorOptions, IEditorReplacement, IGroupChangeEvent, IFindGroupScope, EditorGroupLayout, ICloseEditorOptions, GroupOrientation } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IEditorService, IOpenEditorOverrideHandler, ISaveEditorsOptions, IRevertAllEditorsOptions, IResourceEditorInputType, SIDE_GROUP_TYPE, ACTIVE_GROUP_TYPE, IOpenEditorOverrideEntry } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorService, IOpenEditorOverrideHandler, ISaveEditorsOptions, IRevertAllEditorsOptions, IResourceEditorInputType, SIDE_GROUP_TYPE, ACTIVE_GROUP_TYPE, IOpenEditorOverrideEntry, ICustomEditorViewTypesHandler } from 'vs/workbench/services/editor/common/editorService';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { IEditorRegistry, EditorDescriptor, Extensions } from 'vs/workbench/browser/editor';
 import { EditorGroup } from 'vs/workbench/common/editor/editorGroup';
@@ -627,10 +627,12 @@ export class TestEditorService implements EditorServiceImpl {
 	count = this.editors.length;
 
 	constructor(private editorGroupService?: IEditorGroupsService) { }
-
 	getEditors() { return []; }
 	getEditorOverrides(editorInput: IEditorInput, options: IEditorOptions | undefined, group: IEditorGroup | undefined): [IOpenEditorOverrideHandler, IOpenEditorOverrideEntry][] { return []; }
 	overrideOpenEditor(_handler: IOpenEditorOverrideHandler): IDisposable { return toDisposable(() => undefined); }
+	registerCustomEditorViewTypesHandler(source: string, handler: ICustomEditorViewTypesHandler): IDisposable {
+		throw new Error('Method not implemented.');
+	}
 	openEditor(editor: IEditorInput, options?: IEditorOptions | ITextEditorOptions, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<IEditorPane | undefined>;
 	openEditor(editor: IResourceEditorInput | IUntitledTextResourceEditorInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextEditorPane | undefined>;
 	openEditor(editor: IResourceDiffEditorInput, group?: IEditorGroup | GroupIdentifier | SIDE_GROUP_TYPE | ACTIVE_GROUP_TYPE): Promise<ITextDiffEditorPane | undefined>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes # https://github.com/microsoft/vscode/issues/94408#issuecomment-611788259

Move the `editorAssociation` to editor service thus it can be contributed by both the custom editor and notebook. Custom Editor and Notebook viewtypes will all show up in the suggestion widget while modifying the setting.


<img width="852" alt="image" src="https://user-images.githubusercontent.com/876920/79023726-dbd6ec00-7b35-11ea-836c-3c8498c7c92c.png">
