### PR TITLE
Fixes rename preview "Group Changes By File" view doesn't show the reference type icon info

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEdit.css
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEdit.css
@@ -53,11 +53,13 @@
 	align-items: center;
 }
 
-.monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .theme-icon {
+.monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .theme-icon,
+.monaco-workbench .bulk-edit-panel .monaco-tl-contents.textedit .theme-icon {
 	margin-right: 4px;
 }
 
-.monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .uri-icon {
+.monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .uri-icon,
+.monaco-workbench .bulk-edit-panel .monaco-tl-contents.textedit .uri-icon {
 	background-repeat: no-repeat;
 	background-image: var(--background-light);
 	background-position: left center;
@@ -65,10 +67,18 @@
 	margin-right: 4px;
 	height: 100%;
 	width: 16px;
+	min-width: 16px;
 }
 
 .vs-dark .monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .uri-icon,
-.hc-black .monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .uri-icon
+.hc-black .monaco-workbench .bulk-edit-panel .monaco-tl-contents.category .uri-icon,
+.vs-dark .monaco-workbench .bulk-edit-panel .monaco-tl-contents.textedit .uri-icon,
+.hc-black .monaco-workbench .bulk-edit-panel .monaco-tl-contents.textedit .uri-icon
 {
 	background-image: var(--background-dark);
+}
+
+.monaco-workbench .bulk-edit-panel .monaco-tl-contents.textedit .monaco-highlighted-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }

--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkEditTree.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkEditTree.ts
@@ -525,17 +525,22 @@ class TextEditElementTemplate {
 	private readonly _localDisposables = new DisposableStore();
 
 	private readonly _checkbox: HTMLInputElement;
+	private readonly _icon: HTMLDivElement;
 	private readonly _label: HighlightedLabel;
 
 	constructor(container: HTMLElement) {
+		container.classList.add('textedit');
+
 		this._checkbox = document.createElement('input');
 		this._checkbox.className = 'edit-checkbox';
 		this._checkbox.type = 'checkbox';
 		this._checkbox.setAttribute('role', 'checkbox');
 		container.appendChild(this._checkbox);
 
+		this._icon = document.createElement('div');
+		container.appendChild(this._icon);
+
 		this._label = new HighlightedLabel(container, false);
-		dom.addClass(this._label.element, 'textedit');
 	}
 
 	dispose(): void {
@@ -575,7 +580,36 @@ class TextEditElementTemplate {
 			title = metadata.label;
 		}
 
+		const iconPath = metadata?.iconPath;
+		if (!iconPath) {
+			this._icon.style.display = 'none';
+		} else {
+			this._icon.style.display = 'block';
+
+			this._icon.style.setProperty('--background-dark', null);
+			this._icon.style.setProperty('--background-light', null);
+
+			if (ThemeIcon.isThemeIcon(iconPath)) {
+				// css
+				const className = ThemeIcon.asClassName(iconPath);
+				this._icon.className = className ? `theme-icon ${className}` : '';
+
+			} else if (URI.isUri(iconPath)) {
+				// background-image
+				this._icon.className = 'uri-icon';
+				this._icon.style.setProperty('--background-dark', `url("${iconPath.toString(true)}")`);
+				this._icon.style.setProperty('--background-light', `url("${iconPath.toString(true)}")`);
+
+			} else {
+				// background-image
+				this._icon.className = 'uri-icon';
+				this._icon.style.setProperty('--background-dark', `url("${iconPath.dark.toString(true)}")`);
+				this._icon.style.setProperty('--background-light', `url("${iconPath.light.toString(true)}")`);
+			}
+		}
+
 		this._label.set(value, [selectHighlight, insertHighlight], title, true);
+		this._icon.title = title || '';
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #94323

![image](https://user-images.githubusercontent.com/25115070/79033942-fd58c780-7b77-11ea-9475-92cfad57c755.png)

Not sure if it's fine to show the type icons when the text edits are grouped by type
![image](https://user-images.githubusercontent.com/25115070/79033989-4e68bb80-7b78-11ea-95b0-b1d506985c15.png)

