### PR TITLE
Add minimal support for JSON-LD. 

### DIFF
--- a/extensions/json-language-features/client/src/jsonMain.ts
+++ b/extensions/json-language-features/client/src/jsonMain.ts
@@ -101,7 +101,7 @@ export function activate(context: ExtensionContext) {
 		debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
 	};
 
-	const documentSelector = ['json', 'jsonc'];
+	const documentSelector = ['json', 'jsonc', 'jsonld'];
 
 	const schemaResolutionErrorStatusBarItem = window.createStatusBarItem({
 		id: 'status.json.resolveError',

--- a/extensions/json-language-features/server/README.md
+++ b/extensions/json-language-features/server/README.md
@@ -14,6 +14,8 @@ The JSON language server supports requests on documents of language id `json` an
 - `json` documents are parsed and validated following the [JSON specification](https://tools.ietf.org/html/rfc7159).
 - `jsonc` documents additionally accept single line (`//`) and multi-line comments (`/* ... */`). JSONC is a VSCode specific file format, intended for VSCode configuration files, without any aspirations to define a new common file format.
 
+The server also handles `jsonld` documents as regular JSON documents. For now it has no contextual/semantic capabilities, but in the future it may have language server features like hover, etc parsed from JSON-LD. In that case it would expect `.jsonld` files to use JSON-LD features like `@context`.
+
 The server implements the following capabilities of the language server protocol:
 
 - [Code completion](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion) for JSON properties and values based on the document's [JSON schema](http://json-schema.org/) or based on existing properties and values used at other places in the document. JSON schemas are configured through the server configuration options.

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -28,7 +28,8 @@
           ".webmanifest",
           ".js.map",
           ".css.map",
-          ".har"
+          ".har",
+          ".jsonld"
         ],
         "filenames": [
           "composer.lock",
@@ -37,7 +38,8 @@
         ],
         "mimetypes": [
           "application/json",
-          "application/manifest+json"
+          "application/manifest+json",
+          "application/ld+json"
         ],
         "configuration": "./language-configuration.json"
       },


### PR DESCRIPTION
This PR closes #95013 

I've tested based on the steps in the wiki. Screenshots below.

As you can see, it now treats `.jsonld` files like normal JSON files. Additionally, it makes the proper JSON language server calls as well, such as hover and completion requests.

![vscode-json-ld](https://user-images.githubusercontent.com/11166947/79051966-3be69480-7c01-11ea-98c2-e19bc6949ae6.png)
![Screenshot from 2020-04-11 14-34-13](https://user-images.githubusercontent.com/11166947/79052040-aef00b00-7c01-11ea-8ddf-50b8c955cb78.png)
