### PR TITLE
Fix to 'Markdown Preview of relative links drops 'host' from path'

### DIFF
--- a/extensions/markdown-language-features/src/features/preview.ts
+++ b/extensions/markdown-language-features/src/features/preview.ts
@@ -393,7 +393,8 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 		// We perviously already resolve absolute paths.
 		// Now make sure we handle relative file paths
 		if (hrefPath[0] !== '/') {
-			hrefPath = path.join(path.dirname(this.resource.path), hrefPath);
+			// Fix #93691, use this.resource.fsPath instead of this.resource.path
+			hrefPath = path.join(path.dirname(this.resource.fsPath), hrefPath);
 		}
 
 		const config = vscode.workspace.getConfiguration('markdown', this.resource);


### PR DESCRIPTION
This PR fixes #93961.

### Explanation

The `URI` class holds different information in the `path` property when the file was opened through a UNC location. For this fix I used the property `fsPath` instead of `path` in the `onDidClickPreviewLink` handler.

For a local file the `URI` class holds:
![image](https://user-images.githubusercontent.com/622679/79099394-4ec5aa00-7d64-11ea-8838-d58e7f793309.png)

where as for a UNC opened file the `URI` class holds:
![image](https://user-images.githubusercontent.com/622679/79099444-6f8dff80-7d64-11ea-8b48-d5daa9923c19.png)



Here is an excerpt from `uri.ts`:

```txt
      foo://example.com:8042/over/there?name=ferret#nose
      \_/   \______________/\_________/ \_________/ \__/
       |           |            |            |        |
    scheme     authority       path        query   fragment
       |   _____________________|__
      / \ /                        \
      urn:example:animal:ferret:nose
```

### Test the issue and the fix:

1. To test this issue create two md files (see below this list).

2. Open the `readme.md` file with an UNC path like `"\\server\sharedfolder\readme.md"`.

3. Open the preview of the markdown file `readme.md`.

4. In the preview window, click on the `Relative link to TEST.md` link.

5. The `test.md` file should open in the preview. Without the fix, an error message is being shown.

### Test files

**readme.md:**
`Here's a link: [Relative link to TEST.md](TEST.md)`

**test.md:**
`This is the test markdown file`

