### PR TITLE
Fix the handling of tabs in quickinfo Markdown code blocks

### DIFF
--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -176,7 +176,6 @@ Lexer.lex = function(src, options) {
 Lexer.prototype.lex = function(src) {
   src = src
     .replace(/\r\n|\r/g, '\n')
-    .replace(/\t/g, '    ')
     .replace(/\u00a0/g, ' ')
     .replace(/\u2424/g, '\n');
 

--- a/src/vs/editor/contrib/hover/hover.css
+++ b/src/vs/editor/contrib/hover/hover.css
@@ -82,6 +82,7 @@
 }
 
 .monaco-editor-hover .monaco-tokenized-source {
+	tab-size: 4;
 	white-space: pre-wrap;
 	word-break: break-all;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #95096

This alters the behavior of Markdown parsed from JSDoc documentation comments and its appearance in the IntelliSense quickinfo boxes on mouseover. Previously, tabs were replaced by four spaces each. I don't know, why. Also, I set the tab size to 4 for code blocks in the quickinfo box. Testing instructions are in the issue thread.
