### PR TITLE
Add transition to backdrop-filter when dragging elements

### DIFF
--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -9,19 +9,21 @@
 }
 
 .monaco-workbench .part > .drop-block-overlay.visible {
-	display: block;
-	backdrop-filter: brightness(97%) blur(2px);
+	visibility: visible;
 	opacity: 1;
-	z-index: 10;
 }
 
 .monaco-workbench .part > .drop-block-overlay {
-	display: none;
-	width: 100%;
-	height: 100%;
 	position: absolute;
 	top: 0;
+	width: 100%;
+	height: 100%;
+	backdrop-filter: brightness(97%) blur(2px);
 	pointer-events: none;
+	visibility: hidden;
+    	opacity: 0;
+	transition: opacity .5s, visibility .5s;
+	z-index: 10;
 }
 
 .monaco-workbench .part > .title {

--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -21,7 +21,7 @@
 	backdrop-filter: brightness(97%) blur(2px);
 	pointer-events: none;
 	visibility: hidden;
-    	opacity: 0;
+	opacity: 0;
 	transition: opacity .5s, visibility .5s;
 	z-index: 10;
 }


### PR DESCRIPTION
Add transition to backdrop-filter when dragging elements

- There is no issue, I just think there should be a transition when the editor gets blurred
- You can test my change by dragging an icon from the left and watching for a transition on the editor from normal to blur.