### PR TITLE
File dialog: IEnvironmentService#userHome is deprecated

### DIFF
--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -218,15 +218,19 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 	}
 
 	private pickResource(options: IOpenDialogOptions): Promise<URI | undefined> {
-		const simpleFileDialog = this.instantiationService.createInstance(SimpleFileDialog);
+		const simpleFileDialog = this.createSimpleFileDialog();
 
 		return simpleFileDialog.showOpenDialog(options);
 	}
 
 	private saveRemoteResource(options: ISaveDialogOptions): Promise<URI | undefined> {
-		const remoteFileDialog = this.instantiationService.createInstance(SimpleFileDialog);
+		const remoteFileDialog = this.createSimpleFileDialog();
 
 		return remoteFileDialog.showSaveDialog(options);
+	}
+
+	protected createSimpleFileDialog(): SimpleFileDialog {
+		return this.instantiationService.createInstance(SimpleFileDialog);
 	}
 
 	protected getSchemeFilterForWindow(): string {

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -108,7 +108,7 @@ export class SimpleFileDialog {
 	private remoteAuthority: string | undefined;
 	private requiresTrailing: boolean = false;
 	private trailing: string | undefined;
-	private scheme: string = REMOTE_HOST_SCHEME;
+	protected scheme: string = REMOTE_HOST_SCHEME;
 	private contextKey: IContextKey<boolean>;
 	private userEnteredPathSegment: string = '';
 	private autoCompletePathSegment: string = '';
@@ -133,9 +133,9 @@ export class SimpleFileDialog {
 		@IFileDialogService private readonly fileDialogService: IFileDialogService,
 		@IModelService private readonly modelService: IModelService,
 		@IModeService private readonly modeService: IModeService,
-		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
+		@IWorkbenchEnvironmentService protected readonly environmentService: IWorkbenchEnvironmentService,
 		@IRemoteAgentService private readonly remoteAgentService: IRemoteAgentService,
-		@IRemotePathService private readonly remotePathService: IRemotePathService,
+		@IRemotePathService protected readonly remotePathService: IRemotePathService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
@@ -231,7 +231,7 @@ export class SimpleFileDialog {
 		return this.remoteAgentEnvironment;
 	}
 
-	private async getUserHome(): Promise<URI> {
+	protected async getUserHome(): Promise<URI> {
 		if (this.scheme !== Schemas.file) {
 			return this.remotePathService.userHome;
 		}

--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -232,10 +232,7 @@ export class SimpleFileDialog {
 	}
 
 	protected async getUserHome(): Promise<URI> {
-		if (this.scheme !== Schemas.file) {
-			return this.remotePathService.userHome;
-		}
-		return this.environmentService.userHome!;
+		return (await this.remotePathService.userHome) ?? URI.from({ scheme: this.scheme, authority: this.remoteAuthority, path: '/' });
 	}
 
 	private async pickResource(isSave: boolean = false): Promise<URI | undefined> {

--- a/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/fileDialogService.ts
@@ -22,6 +22,8 @@ import { Schemas } from 'vs/base/common/network';
 import { IModeService } from 'vs/editor/common/services/modeService';
 import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 import { ILabelService } from 'vs/platform/label/common/label';
+import { SimpleFileDialog } from 'vs/workbench/services/dialogs/browser/simpleFileDialog';
+import { NativeSimpleFileDialog } from 'vs/workbench/services/dialogs/electron-browser/simpleFileDialog';
 
 export class FileDialogService extends AbstractFileDialogService implements IFileDialogService {
 
@@ -189,6 +191,10 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 		// Include File schema unless the schema is web
 		// Don't allow untitled schema through.
 		return schema === Schemas.untitled ? [Schemas.file] : (schema !== Schemas.file ? [schema, Schemas.file] : [schema]);
+	}
+
+	protected createSimpleFileDialog(): SimpleFileDialog {
+		return this.instantiationService.createInstance(NativeSimpleFileDialog);
 	}
 }
 

--- a/src/vs/workbench/services/dialogs/electron-browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/simpleFileDialog.ts
@@ -22,7 +22,6 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-browser/environmentService';
 
 export class NativeSimpleFileDialog extends SimpleFileDialog {
-
 	constructor(
 		@IFileService fileService: IFileService,
 		@IQuickInputService quickInputService: IQuickInputService,
@@ -43,7 +42,7 @@ export class NativeSimpleFileDialog extends SimpleFileDialog {
 
 	protected async getUserHome(): Promise<URI> {
 		if (this.scheme !== Schemas.file) {
-			return this.remotePathService.userHome;
+			return super.getUserHome();
 		}
 		return this.environmentService.userHome;
 	}

--- a/src/vs/workbench/services/dialogs/electron-browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/electron-browser/simpleFileDialog.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import { SimpleFileDialog } from 'vs/workbench/services/dialogs/browser/simpleFileDialog';
+import { Schemas } from 'vs/base/common/network';
+import { IFileService } from 'vs/platform/files/common/files';
+import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IModelService } from 'vs/editor/common/services/modelService';
+import { IModeService } from 'vs/editor/common/services/modeService';
+import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
+import { IRemotePathService } from 'vs/workbench/services/path/common/remotePathService';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-browser/environmentService';
+
+export class NativeSimpleFileDialog extends SimpleFileDialog {
+
+	constructor(
+		@IFileService fileService: IFileService,
+		@IQuickInputService quickInputService: IQuickInputService,
+		@ILabelService labelService: ILabelService,
+		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
+		@INotificationService notificationService: INotificationService,
+		@IFileDialogService fileDialogService: IFileDialogService,
+		@IModelService modelService: IModelService,
+		@IModeService modeService: IModeService,
+		@IWorkbenchEnvironmentService protected environmentService: INativeWorkbenchEnvironmentService,
+		@IRemoteAgentService remoteAgentService: IRemoteAgentService,
+		@IRemotePathService protected remotePathService: IRemotePathService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService
+	) {
+		super(fileService, quickInputService, labelService, workspaceContextService, notificationService, fileDialogService, modelService, modeService, environmentService, remoteAgentService, remotePathService, keybindingService, contextKeyService);
+	}
+
+	protected async getUserHome(): Promise<URI> {
+		if (this.scheme !== Schemas.file) {
+			return this.remotePathService.userHome;
+		}
+		return this.environmentService.userHome;
+	}
+}


### PR DESCRIPTION
@alexr00 this is a wip for introducing the native environment service only on the layer of the native file dialog experience. 

What is still missing is that `getUserHome` probably needs to be typed that it may return `undefined` because that is the reality in the web. Maybe you could take over from here?

In the end, depending on the native environment service `userHome` is OK, it will stay. Only the `common` one should go away.