### PR TITLE
Show notification when extensionHostProcess.js is missing on disk

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -156,6 +156,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const checksums = computeChecksums(out, [
 			'vs/workbench/workbench.desktop.main.js',
 			'vs/workbench/workbench.desktop.main.css',
+			'vs/workbench/services/extensions/node/extensionHostProcess.js',
 			'vs/code/electron-browser/workbench/workbench.html',
 			'vs/code/electron-browser/workbench/workbench.js'
 		]);

--- a/src/vs/workbench/services/integrity/node/integrityService.ts
+++ b/src/vs/workbench/services/integrity/node/integrityService.ts
@@ -144,7 +144,7 @@ export class IntegrityServiceImpl implements IIntegrityService {
 		return new Promise<ChecksumPair>((resolve, reject) => {
 			fs.readFile(fileUri.fsPath, (err, buff) => {
 				if (err) {
-					return reject(err);
+					return resolve(IntegrityServiceImpl._createChecksumPair(fileUri, '', expected));
 				}
 				resolve(IntegrityServiceImpl._createChecksumPair(fileUri, this._computeChecksum(buff), expected));
 			});


### PR DESCRIPTION
This PR fixes #95237 on the `1.44` release branch.

Two changes:
1. compute the checksum for the `extensionHostProcess.js` at build time (similar to other files for which we are already doing this).
2. in the case where the file is quarantined, the file is deleted from disk. The integrity service now computes the checksum `''` for such a file, which will be different than the build-time computed checksum, which will result in the notification to show.

