### PR TITLE
Add PowerShell herestring autoclosing pairs

### DIFF
--- a/extensions/powershell/language-configuration.json
+++ b/extensions/powershell/language-configuration.json
@@ -12,6 +12,8 @@
 		["{", "}"],
 		["[", "]"],
 		["(", ")"],
+		{ "open": "@'", "close": "\n'@", "notIn": ["string", "comment"]},
+		{ "open": "@\"", "close": "\n\"@", "notIn": ["string", "comment"]},
 		{ "open": "\"", "close": "\"", "notIn": ["string"]},
 		{ "open": "'", "close": "'", "notIn": ["string", "comment"]},
 		["<#", "#>"]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

fixes https://github.com/microsoft/vscode/issues/95244

```pwsh
$str = @"
I am a here string
"@

$str = @'
I am also a here string
'@
```

These `@''@` and `@""@` should autoclose.

NOTE: PowerShell syntax says that the here string open (`@'`) should be the _last characters on a line_ so we should include a newline in the close.

Proof:
![Screen-Cast-2020-04-14-at-85940](https://user-images.githubusercontent.com/2644648/79247881-ee03a380-7e2f-11ea-8759-93b5967f3ae3.gif)

