### PR TITLE
feat: add editor.withSelectionFocus flag

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -1257,6 +1257,10 @@ export interface IEditorFindOptions {
 	 * Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found
 	 */
 	loop?: boolean;
+	/**
+	 * Controls whether the search with selection automatically focus the search input
+	 */
+	withSelectionFocus?: boolean;
 }
 
 export type EditorFindOptions = Readonly<Required<IEditorFindOptions>>;
@@ -1269,7 +1273,8 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 			autoFindInSelection: 'never',
 			globalFindClipboard: false,
 			addExtraSpaceOnTop: true,
-			loop: true
+			loop: true,
+			withSelectionFocus: false,
 		};
 		super(
 			EditorOption.find, 'find', defaults,
@@ -1306,6 +1311,11 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 					default: defaults.loop,
 					description: nls.localize('find.loop', "Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found.")
 				},
+				'editor.find.withSelectionFocus': {
+					type: 'boolean',
+					default: defaults.withSelectionFocus,
+					description: nls.localize('find.withSelectionFocus', "Controls whether the search with selection automatically focus the search input.")
+				},
 
 			}
 		);
@@ -1324,6 +1334,7 @@ class EditorFind extends BaseEditorOption<EditorOption.find, EditorFindOptions> 
 			globalFindClipboard: EditorBooleanOption.boolean(input.globalFindClipboard, this.defaultValue.globalFindClipboard),
 			addExtraSpaceOnTop: EditorBooleanOption.boolean(input.addExtraSpaceOnTop, this.defaultValue.addExtraSpaceOnTop),
 			loop: EditorBooleanOption.boolean(input.loop, this.defaultValue.loop),
+			withSelectionFocus: EditorBooleanOption.boolean(input.withSelectionFocus, this.defaultValue.withSelectionFocus),
 		};
 	}
 }

--- a/src/vs/editor/contrib/find/findController.ts
+++ b/src/vs/editor/contrib/find/findController.ts
@@ -507,12 +507,16 @@ export class StartFindWithSelectionAction extends EditorAction {
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
 		let controller = CommonFindController.get(editor);
+		const shouldFocus = editor.getOption(EditorOption.find).withSelectionFocus
+			? FindStartFocusAction.FocusFindInput
+			: FindStartFocusAction.NoFocusChange;
+
 		if (controller) {
 			controller.start({
 				forceRevealReplace: false,
 				seedSearchStringFromSelection: true,
 				seedSearchStringFromGlobalClipboard: false,
-				shouldFocus: FindStartFocusAction.NoFocusChange,
+				shouldFocus: shouldFocus,
 				shouldAnimate: true,
 				updateSearchScope: false,
 				loop: editor.getOption(EditorOption.find).loop

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3279,6 +3279,10 @@ declare namespace monaco.editor {
 		 * Controls whether the search automatically restarts from the beginning (or the end) when no further matches can be found
 		 */
 		loop?: boolean;
+		/**
+		 * Controls whether the search with selection automatically focus the search input
+		 */
+		withSelectionFocus?: boolean;
 	}
 
 	export type EditorFindOptions = Readonly<Required<IEditorFindOptions>>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #84223 #84778 #92801


Related to this comment: https://github.com/microsoft/vscode/issues/44093#issuecomment-546157573 this introduces a flag that allows people to have the original behavior of focusing the search input.