### PR TITLE
add typescript command for missing imports and unused identifiers

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -894,6 +894,16 @@
         "command": "typescript.restartTsServer",
         "title": "%typescript.restartTsServer%",
         "category": "TypeScript"
+      },
+      {
+        "command": "typescript.fixMissingImport",
+        "title": "%typescript.fixMissingImport%",
+        "category": "TypeScript"
+      },
+      {
+        "command": "typescript.fixUnusedIdentifier",
+        "title": "%typescript.fixUnusedIdentifier%",
+        "category": "TypeScript"
       }
     ],
     "menus": {

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -43,6 +43,8 @@
 	"typescript.implementationsCodeLens.enabled": "Enable/disable implementations CodeLens. This CodeLens shows the implementers of an interface.",
 	"typescript.openTsServerLog.title": "Open TS Server log",
 	"typescript.restartTsServer": "Restart TS server",
+	"typescript.fixMissingImport": "Add all missing imports",
+	"typescript.fixUnusedIdentifier": "Delete all unused declarations",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version...",
 	"typescript.reportStyleChecksAsWarnings": "Report style checks as warnings.",
 	"javascript.implicitProjectConfig.checkJs": "Enable/disable semantic checking of JavaScript files. Existing jsconfig.json or tsconfig.json files override this setting. Requires using TypeScript 2.3.1 or newer in the workspace.",

--- a/extensions/typescript-language-features/src/commands/executeAllFixes.ts
+++ b/extensions/typescript-language-features/src/commands/executeAllFixes.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import type * as Proto from '../protocol';
+import TypeScriptServiceClientHost from '../typeScriptServiceClientHost';
+import { ITypeScriptServiceClient } from '../typescriptService';
+import { DiagnosticsManager } from '../features/diagnostics';
+import { nulToken } from '../utils/cancellation';
+import { applyCodeAction } from '../utils/codeAction';
+import { Command } from '../utils/commandManager';
+import * as typeConverters from '../utils/typeConverters';
+import { Lazy } from '../utils/lazy';
+
+const flatMapAsync = async <T, P>(arr: readonly T[], fn: (el: T) => Promise<P[]>) =>
+	(await Promise.all(arr.map(fn))).reduce((acc, arr) => [...acc, ...arr], []);
+
+export abstract class ExecuteAllFixesCommand implements Command {
+	public abstract readonly id: string;
+	protected abstract readonly fixName: string;
+	private readonly serviceClient: ITypeScriptServiceClient;
+	private readonly diagnosticsManager: DiagnosticsManager;
+
+	public constructor(lazyClientHost: Lazy<TypeScriptServiceClientHost>) {
+		const client = lazyClientHost.value;
+		this.serviceClient = client.serviceClient;
+		this.diagnosticsManager = client.serviceClient.diagnosticsManager;
+	}
+
+	public async execute() {
+		const editor = vscode.window.activeTextEditor;
+
+		if (!editor) {
+			return;
+		}
+
+		const documents = vscode.workspace.textDocuments;
+		const mainUri = editor?.document.uri.toString();
+		const document = documents.find(({ uri }) => uri.toString() === mainUri);
+
+		if (!document) {
+			return;
+		}
+
+		const diagnostics = this.diagnosticsManager.getDiagnostics(document.uri);
+		const fixActions = this.filterActions(
+			(
+				await flatMapAsync(diagnostics, (diagnostic) =>
+					this.getFixesForDiagnostic(document, diagnostic)
+				)
+			).filter(({ fixName }) => fixName === this.fixName)
+		);
+
+		if (fixActions.length === 0) {
+			return;
+		}
+
+		const combinedAction = fixActions.reduce((acc, action) => ({
+			...acc,
+			changes: [...acc.changes, ...action.changes]
+		}));
+		await applyCodeAction(this.serviceClient, combinedAction, nulToken);
+	}
+
+	private async getFixesForDiagnostic(
+		document: vscode.TextDocument,
+		diagnostic: vscode.Diagnostic
+	) {
+		const file = this.serviceClient.toOpenedFilePath(document) ?? '';
+
+		const args: Proto.CodeFixRequestArgs = {
+			...typeConverters.Range.toFileRangeRequestArgs(file, diagnostic.range),
+			errorCodes: [+diagnostic.code!]
+		};
+		const response = await this.serviceClient.execute('getCodeFixes', args, nulToken);
+		if (response.type !== 'response' || !response.body) {
+			return [];
+		}
+
+		return response.body;
+	}
+
+	protected filterActions(actions: Proto.CodeFixAction[]) {
+		return actions;
+	}
+}

--- a/extensions/typescript-language-features/src/commands/fixMissingImport.ts
+++ b/extensions/typescript-language-features/src/commands/fixMissingImport.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as Proto from '../protocol';
+import { ExecuteAllFixesCommand } from './executeAllFixes';
+
+export class FixMissingImportCommand extends ExecuteAllFixesCommand {
+	public readonly id = 'typescript.fixMissingImport';
+	protected readonly fixName = 'import';
+
+	protected filterActions(actions: Proto.CodeFixAction[]) {
+		const getImportName = (action: Proto.CodeFixAction) => action.changes[0].textChanges[0].newText.split(' ')[1];
+		const imports = new Set();
+		const checkImportName = (name: string) => !imports.has(name) && imports.add(name);
+		return actions.filter(action => checkImportName(getImportName(action)));
+	}
+}

--- a/extensions/typescript-language-features/src/commands/fixUnusedIdentifier.ts
+++ b/extensions/typescript-language-features/src/commands/fixUnusedIdentifier.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExecuteAllFixesCommand } from './executeAllFixes';
+
+export class FixUnusedIdentifierCommand extends ExecuteAllFixesCommand {
+	public readonly id = 'typescript.fixUnusedIdentifier';
+	protected readonly fixName = 'unusedIdentifier';
+}

--- a/extensions/typescript-language-features/src/commands/index.ts
+++ b/extensions/typescript-language-features/src/commands/index.ts
@@ -8,6 +8,8 @@ import { CommandManager } from '../utils/commandManager';
 import { Lazy } from '../utils/lazy';
 import { PluginManager } from '../utils/plugins';
 import { ConfigurePluginCommand } from './configurePlugin';
+import { FixMissingImportCommand } from './fixMissingImport';
+import { FixUnusedIdentifierCommand } from './fixUnusedIdentifier';
 import { JavaScriptGoToProjectConfigCommand, TypeScriptGoToProjectConfigCommand } from './goToProjectConfiguration';
 import { OpenTsServerLogCommand } from './openTsServerLog';
 import { ReloadJavaScriptProjectsCommand, ReloadTypeScriptProjectsCommand } from './reloadProject';
@@ -28,5 +30,7 @@ export function registerCommands(
 	commandManager.register(new TypeScriptGoToProjectConfigCommand(lazyClientHost));
 	commandManager.register(new JavaScriptGoToProjectConfigCommand(lazyClientHost));
 	commandManager.register(new ConfigurePluginCommand(pluginManager));
+	commandManager.register(new FixMissingImportCommand(lazyClientHost));
+	commandManager.register(new FixUnusedIdentifierCommand(lazyClientHost));
 	commandManager.register(new LearnMoreAboutRefactoringsCommand());
 }


### PR DESCRIPTION
I was pretty disappointed by the lack of commands for "Add all missing imports" and "Delete all unused declarations" in typescript, and the consequent lack of the possibility to assign keyboard shortcuts to them. I added those commands, as well as a simple API to add similar commands in the future. You can test those changes by doing `CTRL+SHIFT+P -> TypeScript: Add all missing imports / Delete all unused declarations`