### PR TITLE
Use `argument` in addition to `folderUri` when conditionally resolving some variables.

### DIFF
--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -225,11 +225,7 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						return normalizeDriveLetter(getFolderUri().fsPath);
 
 					case 'cwd':
-						try {
-							return normalizeDriveLetter(getFolderUri().fsPath);
-						} catch (error) {
-							return process.cwd();
-						}
+						return ((folderUri || argument) ? normalizeDriveLetter(getFolderUri().fsPath) : process.cwd());
 
 					case 'workspaceRootFolderName':
 					case 'workspaceFolderBasename':
@@ -253,20 +249,17 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						return getFilePath();
 
 					case 'relativeFile':
-						const filePath = getFilePath();
-						try {
-							return paths.normalize(paths.relative(getFolderUri().fsPath, filePath));
-						} catch (error) {
-							return filePath;
+						if (folderUri || argument) {
+							return paths.normalize(paths.relative(getFolderUri().fsPath, getFilePath()));
 						}
+						return getFilePath();
 
 					case 'relativeFileDirname':
 						const dirname = paths.dirname(getFilePath());
-						try {
+						if (folderUri || argument) {
 							return paths.normalize(paths.relative(getFolderUri().fsPath, dirname));
-						} catch (error) {
-							return dirname;
 						}
+						return dirname;
 
 					case 'fileDirname':
 						return paths.dirname(getFilePath());

--- a/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
+++ b/src/vs/workbench/services/configurationResolver/common/variableResolver.ts
@@ -225,7 +225,11 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						return normalizeDriveLetter(getFolderUri().fsPath);
 
 					case 'cwd':
-						return (folderUri ? normalizeDriveLetter(getFolderUri().fsPath) : process.cwd());
+						try {
+							return normalizeDriveLetter(getFolderUri().fsPath);
+						} catch (error) {
+							return process.cwd();
+						}
 
 					case 'workspaceRootFolderName':
 					case 'workspaceFolderBasename':
@@ -249,17 +253,20 @@ export class AbstractVariableResolverService implements IConfigurationResolverSe
 						return getFilePath();
 
 					case 'relativeFile':
-						if (folderUri) {
-							return paths.normalize(paths.relative(getFolderUri().fsPath, getFilePath()));
+						const filePath = getFilePath();
+						try {
+							return paths.normalize(paths.relative(getFolderUri().fsPath, filePath));
+						} catch (error) {
+							return filePath;
 						}
-						return getFilePath();
 
 					case 'relativeFileDirname':
-						let dirname = paths.dirname(getFilePath());
-						if (folderUri) {
+						const dirname = paths.dirname(getFilePath());
+						try {
 							return paths.normalize(paths.relative(getFolderUri().fsPath, dirname));
+						} catch (error) {
+							return dirname;
 						}
-						return dirname;
 
 					case 'fileDirname':
 						return paths.dirname(getFilePath());

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -159,7 +159,7 @@ suite('Configuration Resolver Service', () => {
 	// 		'${workspaceRootFolderName}': '${lineNumber}',
 	// 		'hey ${env:key1} ': '${workspaceRootFolderName}'
 	// 	};
-	// 	assert.deepEqual(configurationResolverService!.resolve(workspaceFolder, myObject), {
+	// 	assert.deepEqual(configurationResolverService!.resolve(workspace, myObject), {
 	// 		'workspaceLocation': `${editorService.mockLineNumber}`,
 	// 		'hey Value for key1 ': 'workspaceLocation'
 	// 	});

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -56,8 +56,8 @@ suite('Configuration Resolver Service', () => {
 	let environmentService: MockWorkbenchEnvironmentService;
 	let mockCommandService: MockCommandService;
 	let editorService: TestEditorServiceWithActiveEditor;
-	let workspace: Workspace;
-	let workspaceFolder: IWorkspaceFolder;
+	let containingWorkspace: Workspace;
+	let workspace: IWorkspaceFolder;
 	let quickInputService: MockQuickInputService;
 
 	setup(() => {
@@ -65,9 +65,9 @@ suite('Configuration Resolver Service', () => {
 		editorService = new TestEditorServiceWithActiveEditor();
 		quickInputService = new MockQuickInputService();
 		environmentService = new MockWorkbenchEnvironmentService(envVariables);
-		workspace = testWorkspace(uri.parse('file:///VSCode/workspaceLocation'));
-		workspaceFolder = workspace.folders[0];
-		configurationResolverService = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, editorService, new MockInputsConfigurationService(), mockCommandService, new TestContextService(workspace), quickInputService);
+		containingWorkspace = testWorkspace(uri.parse('file:///VSCode/workspaceLocation'));
+		workspace = containingWorkspace.folders[0];
+		configurationResolverService = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, editorService, new MockInputsConfigurationService(), mockCommandService, new TestContextService(containingWorkspace), quickInputService);
 	});
 
 	teardown(() => {
@@ -76,17 +76,17 @@ suite('Configuration Resolver Service', () => {
 
 	test('substitute one', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceFolder} xyz'), 'abc \\VSCode\\workspaceLocation xyz');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder} xyz'), 'abc \\VSCode\\workspaceLocation xyz');
 		} else {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceFolder} xyz'), 'abc /VSCode/workspaceLocation xyz');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder} xyz'), 'abc /VSCode/workspaceLocation xyz');
 		}
 	});
 
 	test('workspace folder with argument', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceFolder:workspaceLocation} xyz'), 'abc \\VSCode\\workspaceLocation xyz');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder:workspaceLocation} xyz'), 'abc \\VSCode\\workspaceLocation xyz');
 		} else {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceFolder:workspaceLocation} xyz'), 'abc /VSCode/workspaceLocation xyz');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder:workspaceLocation} xyz'), 'abc /VSCode/workspaceLocation xyz');
 		}
 	});
 
@@ -103,19 +103,19 @@ suite('Configuration Resolver Service', () => {
 	});
 
 	test('workspace root folder name', () => {
-		assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceRootFolderName} xyz'), 'abc workspaceLocation xyz');
+		assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceRootFolderName} xyz'), 'abc workspaceLocation xyz');
 	});
 
 	test('current selected line number', () => {
-		assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${lineNumber} xyz'), `abc ${mockLineNumber} xyz`);
+		assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${lineNumber} xyz'), `abc ${mockLineNumber} xyz`);
 	});
 
 	test('relative file', () => {
-		assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${relativeFile} xyz'), 'abc file xyz');
+		assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${relativeFile} xyz'), 'abc file xyz');
 	});
 
 	test('relative file with argument', () => {
-		assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${relativeFile:workspaceLocation} xyz'), 'abc file xyz');
+		assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${relativeFile:workspaceLocation} xyz'), 'abc file xyz');
 	});
 
 	test('relative file with undefined workspace folder', () => {
@@ -132,25 +132,25 @@ suite('Configuration Resolver Service', () => {
 
 	test('substitute many', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, '${workspaceFolder} - ${workspaceFolder}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, '${workspaceFolder} - ${workspaceFolder}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation');
 		} else {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, '${workspaceFolder} - ${workspaceFolder}'), '/VSCode/workspaceLocation - /VSCode/workspaceLocation');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, '${workspaceFolder} - ${workspaceFolder}'), '/VSCode/workspaceLocation - /VSCode/workspaceLocation');
 		}
 	});
 
 	test('substitute one env variable', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc \\VSCode\\workspaceLocation Value for key1 xyz');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc \\VSCode\\workspaceLocation Value for key1 xyz');
 		} else {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc /VSCode/workspaceLocation Value for key1 xyz');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder} ${env:key1} xyz'), 'abc /VSCode/workspaceLocation Value for key1 xyz');
 		}
 	});
 
 	test('substitute many env variable', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '\\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
 		} else {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '/VSCode/workspaceLocation - /VSCode/workspaceLocation Value for key1 - Value for key2');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, '${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), '/VSCode/workspaceLocation - /VSCode/workspaceLocation Value for key1 - Value for key2');
 		}
 	});
 
@@ -168,9 +168,9 @@ suite('Configuration Resolver Service', () => {
 
 	test('substitute one env variable using platform case sensitivity', () => {
 		if (platform.isWindows) {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, '${env:key1} - ${env:Key1}'), 'Value for key1 - Value for key1');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - Value for key1');
 		} else {
-			assert.strictEqual(configurationResolverService!.resolve(workspaceFolder, '${env:key1} - ${env:Key1}'), 'Value for key1 - ');
+			assert.strictEqual(configurationResolverService!.resolve(workspace, '${env:key1} - ${env:Key1}'), 'Value for key1 - ');
 		}
 	});
 
@@ -187,7 +187,7 @@ suite('Configuration Resolver Service', () => {
 		});
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
-		assert.strictEqual(service.resolve(workspaceFolder, 'abc ${config:editor.fontFamily} xyz'), 'abc foo xyz');
+		assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} xyz'), 'abc foo xyz');
 	});
 
 	test('substitute many configuration variables', () => {
@@ -204,7 +204,7 @@ suite('Configuration Resolver Service', () => {
 		});
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
-		assert.strictEqual(service.resolve(workspaceFolder, 'abc ${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} xyz'), 'abc foo bar xyz');
+		assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} xyz'), 'abc foo bar xyz');
 	});
 
 	test('substitute one env variable and a configuration variable', () => {
@@ -222,9 +222,9 @@ suite('Configuration Resolver Service', () => {
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
 		if (platform.isWindows) {
-			assert.strictEqual(service.resolve(workspaceFolder, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo \\VSCode\\workspaceLocation Value for key1 xyz');
+			assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo \\VSCode\\workspaceLocation Value for key1 xyz');
 		} else {
-			assert.strictEqual(service.resolve(workspaceFolder, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo /VSCode/workspaceLocation Value for key1 xyz');
+			assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo /VSCode/workspaceLocation Value for key1 xyz');
 		}
 	});
 
@@ -243,9 +243,9 @@ suite('Configuration Resolver Service', () => {
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
 		if (platform.isWindows) {
-			assert.strictEqual(service.resolve(workspaceFolder, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar \\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
+			assert.strictEqual(service.resolve(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar \\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
 		} else {
-			assert.strictEqual(service.resolve(workspaceFolder, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar /VSCode/workspaceLocation - /VSCode/workspaceLocation Value for key1 - Value for key2');
+			assert.strictEqual(service.resolve(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar /VSCode/workspaceLocation - /VSCode/workspaceLocation Value for key1 - Value for key2');
 		}
 	});
 
@@ -276,7 +276,7 @@ suite('Configuration Resolver Service', () => {
 		});
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
-		assert.strictEqual(service.resolve(workspaceFolder, 'abc ${config:editor.fontFamily} ${config:editor.lineNumbers} ${config:editor.insertSpaces} xyz'), 'abc foo 123 false xyz');
+		assert.strictEqual(service.resolve(workspace, 'abc ${config:editor.fontFamily} ${config:editor.lineNumbers} ${config:editor.insertSpaces} xyz'), 'abc foo 123 false xyz');
 	});
 
 	test('uses original variable as fallback', () => {
@@ -286,8 +286,8 @@ suite('Configuration Resolver Service', () => {
 		});
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
-		assert.strictEqual(service.resolve(workspaceFolder, 'abc ${unknownVariable} xyz'), 'abc ${unknownVariable} xyz');
-		assert.strictEqual(service.resolve(workspaceFolder, 'abc ${env:unknownVariable} xyz'), 'abc  xyz');
+		assert.strictEqual(service.resolve(workspace, 'abc ${unknownVariable} xyz'), 'abc ${unknownVariable} xyz');
+		assert.strictEqual(service.resolve(workspace, 'abc ${env:unknownVariable} xyz'), 'abc  xyz');
 	});
 
 	test('configuration variables with invalid accessor', () => {
@@ -300,13 +300,13 @@ suite('Configuration Resolver Service', () => {
 
 		let service = new TestConfigurationResolverService({ getExecPath: () => undefined }, environmentService.userEnv, new TestEditorServiceWithActiveEditor(), configurationService, mockCommandService, new TestContextService(), quickInputService);
 
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${env} xyz'));
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${env:} xyz'));
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${config} xyz'));
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${config:} xyz'));
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${config:editor} xyz'));
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${config:editor..fontFamily} xyz'));
-		assert.throws(() => service.resolve(workspaceFolder, 'abc ${config:editor.none.none2} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${env} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${env:} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${config} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${config:} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${config:editor} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${config:editor..fontFamily} xyz'));
+		assert.throws(() => service.resolve(workspace, 'abc ${config:editor.none.none2} xyz'));
 	});
 
 	test('a single command variable', () => {
@@ -439,7 +439,7 @@ suite('Configuration Resolver Service', () => {
 			'outDir': null
 		};
 
-		return configurationResolverService!.resolveWithInteractionReplace(workspaceFolder, configuration, 'tasks').then(result => {
+		return configurationResolverService!.resolveWithInteractionReplace(workspace, configuration, 'tasks').then(result => {
 
 			assert.deepEqual(result, {
 				'name': 'Attach to Process',
@@ -466,7 +466,7 @@ suite('Configuration Resolver Service', () => {
 			'outDir': null
 		};
 
-		return configurationResolverService!.resolveWithInteractionReplace(workspaceFolder, configuration, 'tasks').then(result => {
+		return configurationResolverService!.resolveWithInteractionReplace(workspace, configuration, 'tasks').then(result => {
 
 			assert.deepEqual(result, {
 				'name': 'Attach to Process',
@@ -493,7 +493,7 @@ suite('Configuration Resolver Service', () => {
 			'outDir': null
 		};
 
-		return configurationResolverService!.resolveWithInteractionReplace(workspaceFolder, configuration, 'tasks').then(result => {
+		return configurationResolverService!.resolveWithInteractionReplace(workspace, configuration, 'tasks').then(result => {
 
 			assert.deepEqual(result, {
 				'name': 'Attach to Process',
@@ -521,7 +521,7 @@ suite('Configuration Resolver Service', () => {
 			'outDir': null
 		};
 
-		return configurationResolverService!.resolveWithInteractionReplace(workspaceFolder, configuration, 'tasks').then(result => {
+		return configurationResolverService!.resolveWithInteractionReplace(workspace, configuration, 'tasks').then(result => {
 
 			assert.deepEqual(result, {
 				'name': 'resolvedEnterinput3',
@@ -544,7 +544,7 @@ suite('Configuration Resolver Service', () => {
 			'name': '${' + variable + '}',
 		};
 		configurationResolverService!.contributeVariable(variable, async () => { return buildTask; });
-		return configurationResolverService!.resolveWithInteractionReplace(workspaceFolder, configuration).then(result => {
+		return configurationResolverService!.resolveWithInteractionReplace(workspace, configuration).then(result => {
 			assert.deepEqual(result, {
 				'name': `${buildTask}`
 			});

--- a/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-browser/configurationResolverService.test.ts
@@ -90,6 +90,10 @@ suite('Configuration Resolver Service', () => {
 		}
 	});
 
+	test('workspace folder with invalid argument', () => {
+		assert.throws(() => configurationResolverService!.resolve(workspace, 'abc ${workspaceFolder:invalidLocation} xyz'));
+	});
+
 	test('workspace folder with undefined workspace folder', () => {
 		assert.throws(() => configurationResolverService!.resolve(undefined, 'abc ${workspaceFolder} xyz'));
 	});
@@ -100,6 +104,10 @@ suite('Configuration Resolver Service', () => {
 		} else {
 			assert.strictEqual(configurationResolverService!.resolve(undefined, 'abc ${workspaceFolder:workspaceLocation} xyz'), 'abc /VSCode/workspaceLocation xyz');
 		}
+	});
+
+	test('workspace folder with invalid argument and undefined workspace folder', () => {
+		assert.throws(() => configurationResolverService!.resolve(undefined, 'abc ${workspaceFolder:invalidLocation} xyz'));
 	});
 
 	test('workspace root folder name', () => {
@@ -118,6 +126,10 @@ suite('Configuration Resolver Service', () => {
 		assert.strictEqual(configurationResolverService!.resolve(workspace, 'abc ${relativeFile:workspaceLocation} xyz'), 'abc file xyz');
 	});
 
+	test('relative file with invalid argument', () => {
+		assert.throws(() => configurationResolverService!.resolve(workspace, 'abc ${relativeFile:invalidLocation} xyz'));
+	});
+
 	test('relative file with undefined workspace folder', () => {
 		if (platform.isWindows) {
 			assert.strictEqual(configurationResolverService!.resolve(undefined, 'abc ${relativeFile} xyz'), 'abc \\VSCode\\workspaceLocation\\file xyz');
@@ -128,6 +140,10 @@ suite('Configuration Resolver Service', () => {
 
 	test('relative file with argument and undefined workspace folder', () => {
 		assert.strictEqual(configurationResolverService!.resolve(undefined, 'abc ${relativeFile:workspaceLocation} xyz'), 'abc file xyz');
+	});
+
+	test('relative file with invalid argument and undefined workspace folder', () => {
+		assert.throws(() => configurationResolverService!.resolve(undefined, 'abc ${relativeFile:invalidLocation} xyz'));
 	});
 
 	test('substitute many', () => {


### PR DESCRIPTION
Some variables were conditionally resolved by first checking `folderUri`. This is wrong, as `getFolderUri()` may return a valid one even when `folderUri` is undefined (when `argument` is used).

This PR changes the behavior so that `getFolderUri()` is always called, falling back to the original alternative if it fails to find one. By doing this, calls to resolve variables that do not provide a `folderUri` (aka workspace folder) will still do the right thing when an argument is provided (e.g. `${relativeFile:folder}`).

This PR fixes #95482
