### PR TITLE
fix #95510 'Reveal in Side Bar' confused by case-sensitive FileSystem…

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -659,7 +659,8 @@ export class ExplorerView extends ViewPane {
 		}
 
 		// Expand all stats in the parent chain.
-		let item: ExplorerItem | undefined = this.explorerService.roots.filter(i => isEqualOrParent(resource, i.resource))
+		const ignoreCase = !this.fileService.hasCapability(resource, FileSystemProviderCapabilities.PathCaseSensitive);
+		let item: ExplorerItem | undefined = this.explorerService.roots.filter(i => isEqualOrParent(resource, i.resource, ignoreCase))
 			// Take the root that is the closest to the stat #72299
 			.sort((first, second) => second.resource.path.length - first.resource.path.length)[0];
 
@@ -668,7 +669,7 @@ export class ExplorerView extends ViewPane {
 				return this.onSelectResource(resource, reveal, retry + 1);
 			}
 			await this.tree.expand(item);
-			item = first(values(item.children), i => isEqualOrParent(resource, i.resource));
+			item = first(values(item.children), i => isEqualOrParent(resource, i.resource, ignoreCase));
 		}
 
 		if (item) {


### PR DESCRIPTION
This PR fixes #95510

I initially considered making the fix at this line:

https://github.com/microsoft/vscode/blob/9c40c3518aad48867540207036b157e13b9d1b04/src/vs/base/common/resources.ts#L35

but didn't want to be responsible for the potential impact of doing it there.

Verify by following the repro in the original issue.
