### PR TITLE
Register mimetype for *.code-workspace

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -52,6 +52,11 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@LICENSE@@', product.licenseName))
 			.pipe(rename('usr/share/appdata/' + product.applicationName + '.appdata.xml'));
 
+		const workspaceMime = gulp.src('resources/code-workspace.xml', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(rename('usr/share/mime/packages/' + product.applicationName + '-workspace.xml'));
+
 		const icon = gulp.src('resources/linux/code.png', { base: '.' })
 			.pipe(rename('usr/share/pixmaps/' + product.linuxIconName + '.png'));
 
@@ -95,7 +100,7 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@UPDATEURL@@', product.updateUrl || '@@UPDATEURL@@'))
 			.pipe(rename('DEBIAN/postinst'));
 
-		const all = es.merge(control, postinst, postrm, prerm, desktops, appdata, icon, bash_completion, zsh_completion, code);
+		const all = es.merge(control, postinst, postrm, prerm, desktops, appdata, workspaceMime, icon, bash_completion, zsh_completion, code);
 
 		return all.pipe(vfs.dest(destination));
 	};
@@ -143,6 +148,11 @@ function prepareRpmPackage(arch) {
 			.pipe(replace('@@LICENSE@@', product.licenseName))
 			.pipe(rename('usr/share/appdata/' + product.applicationName + '.appdata.xml'));
 
+		const workspaceMime = gulp.src('resources/code-workspace.xml', { base: '.' })
+			.pipe(replace('@@NAME_LONG@@', product.nameLong))
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(rename('BUILD/usr/share/mime/packages/' + product.applicationName + '-workspace.xml'));
+
 		const icon = gulp.src('resources/linux/code.png', { base: '.' })
 			.pipe(rename('BUILD/usr/share/pixmaps/' + product.linuxIconName + '.png'));
 
@@ -173,7 +183,7 @@ function prepareRpmPackage(arch) {
 		const specIcon = gulp.src('resources/linux/rpm/code.xpm', { base: '.' })
 			.pipe(rename('SOURCES/' + product.applicationName + '.xpm'));
 
-		const all = es.merge(code, desktops, appdata, icon, bash_completion, zsh_completion, spec, specIcon);
+		const all = es.merge(code, desktops, appdata, workspaceMime, icon, bash_completion, zsh_completion, spec, specIcon);
 
 		return all.pipe(vfs.dest(getRpmBuildPath(rpmArch)));
 	};

--- a/resources/linux/code-workspace.xml
+++ b/resources/linux/code-workspace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+   <mime-type type="application/x-@@NAME@@-workspace">
+     <comment>@@NAME_LONG@@ Workspace</comment>
+     <glob pattern="*.code-workspace"/>
+   </mime-type>
+</mime-info>

--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -8,7 +8,7 @@ Type=Application
 StartupNotify=false
 StartupWMClass=@@NAME_SHORT@@
 Categories=Utility;TextEditor;Development;IDE;
-MimeType=text/plain;inode/directory;
+MimeType=text/plain;inode/directory;application/x-@@NAME@@-workspace;
 Actions=new-empty-window;
 Keywords=vscode;
 

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -18,6 +18,11 @@ if hash desktop-file-install 2>/dev/null; then
 	desktop-file-install /usr/share/applications/@@NAME@@-url-handler.desktop
 fi
 
+# Update mimetype database to pickup workspace mimetype
+if hash update-mime-database 2>/dev/null; then
+	update-mime-database /usr/share/mime
+fi
+
 if [ "@@NAME@@" != "code-oss" ]; then
 	# Remove the legacy bin command if this is the stable build
 	if [ "@@NAME@@" = "code" ]; then

--- a/resources/linux/debian/postrm.template
+++ b/resources/linux/debian/postrm.template
@@ -4,3 +4,8 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 
 rm -f /usr/bin/@@NAME@@
+
+# Update mimetype database for removed workspace mimetype
+if hash update-mime-database 2>/dev/null; then
+	update-mime-database /usr/share/mime
+fi

--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -23,6 +23,7 @@ mkdir -p %{buildroot}/usr/share/zsh/site-functions
 cp -r usr/share/@@NAME@@/* %{buildroot}/usr/share/@@NAME@@
 cp -r usr/share/applications/@@NAME@@.desktop %{buildroot}/usr/share/applications
 cp -r usr/share/applications/@@NAME@@-url-handler.desktop %{buildroot}/usr/share/applications
+cp -r usr/share/mime/packages/@@NAME@@-workspace.xml %{buildroot}/usr/share/mime/packages/@@NAME-workspace.xml
 cp -r usr/share/pixmaps/@@ICON@@.png %{buildroot}/usr/share/pixmaps
 cp usr/share/bash-completion/completions/@@NAME@@ %{buildroot}/usr/share/bash-completion/completions/@@NAME@@
 cp usr/share/zsh/site-functions/_@@NAME@@ %{buildroot}/usr/share/zsh/site-functions/_@@NAME@@
@@ -46,10 +47,16 @@ ln -sf /usr/share/@@NAME@@/bin/@@NAME@@ %{_bindir}/@@NAME@@
 #	fi
 #fi
 
+# Update mimetype database to pickup workspace mimetype
+update-mime-database /usr/share/mime &> /dev/null || :
+
 %postun
 if [ $1 = 0 ]; then
   rm -f /usr/bin/@@NAME@@
 fi
+
+# Update mimetype database for removed workspace mimetype
+update-mime-database /usr/share/mime &> /dev/null || :
 
 %files
 %defattr(-,root,root)
@@ -57,6 +64,7 @@ fi
 /usr/share/@@NAME@@/
 /usr/share/applications/@@NAME@@.desktop
 /usr/share/applications/@@NAME@@-url-handler.desktop
+/usr/share/mime/packages/@@NAME-workspace.xml
 /usr/share/pixmaps/@@ICON@@.png
 /usr/share/bash-completion/completions/@@NAME@@
 /usr/share/zsh/site-functions/_@@NAME@@


### PR DESCRIPTION
Register a new mimetype for workspace files so that they aren't just classified as text/plain. This lets users specify VS Code to open workspace files without also associating it with every other text/plain type file.

Fixes: #59040 and #80818

The deb and rpm scripts were updated to install the mimetype but unfortunately Snap doesn't support this yet (see https://forum.snapcraft.io/t/allow-snaps-to-register-new-mime-types/6467/7).