### PR TITLE
Normalize whitespace within snippets

### DIFF
--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -1061,9 +1061,15 @@ export interface ITextModel {
 	_setTrackedRange(id: string | null, newRange: Range, newStickiness: TrackedRangeStickiness): string;
 
 	/**
-	 * Normalize a string containing whitespace according to indentation rules (converts to spaces or to tabs).
+	 * Normalize a string containing only whitespace according to indentation rules (converts to spaces or to tabs).
 	 */
 	normalizeIndentation(str: string): string;
+
+
+	/**
+	 * Normalize a string whitespace according to indentation options (converts to spaces or to tabs).
+	 */
+	normalizeWhitespace(str: string): string;
 
 	/**
 	 * Change the options of this model.

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -659,6 +659,37 @@ export class TextModel extends Disposable implements model.ITextModel {
 		return result;
 	}
 
+	private static _normalizeWhitespace(str: string, indentSize: number, insertSpaces: boolean): string {
+		let result = '';
+
+		if (insertSpaces) {
+			const toReplace = ' '.repeat(indentSize);
+			for (let i = 0; i < str.length; i++) {
+				if (str.charAt(i) === '\t') {
+					result += toReplace;
+				} else {
+					result += str[i];
+				}
+			}
+		} else {
+			let lastSpaces = 0;
+			for (let i = 0; i < str.length; i++) {
+				if (str.charAt(i) === ' ') {
+					lastSpaces++;
+					if (lastSpaces === indentSize) {
+						result += '\t';
+						lastSpaces = 0;
+					}
+				} else {
+					result += ' '.repeat(lastSpaces) + str[i];
+					lastSpaces = 0;
+				}
+			}
+			result += ' '.repeat(lastSpaces);
+		}
+		return result;
+	}
+
 	public static normalizeIndentation(str: string, indentSize: number, insertSpaces: boolean): string {
 		let firstNonWhitespaceIndex = strings.firstNonWhitespaceIndex(str);
 		if (firstNonWhitespaceIndex === -1) {
@@ -671,6 +702,12 @@ export class TextModel extends Disposable implements model.ITextModel {
 		this._assertNotDisposed();
 		return TextModel.normalizeIndentation(str, this._options.indentSize, this._options.insertSpaces);
 	}
+
+	public normalizeWhitespace(str: string): string {
+		this._assertNotDisposed();
+		return TextModel._normalizeWhitespace(str, this._options.indentSize, this._options.insertSpaces);
+	}
+
 
 	//#endregion
 

--- a/src/vs/editor/contrib/snippet/snippetSession.ts
+++ b/src/vs/editor/contrib/snippet/snippetSession.ts
@@ -344,9 +344,9 @@ export class SnippetSession {
 				const lines = marker.value.split(/\r\n|\r|\n/);
 
 				if (adjustIndentation) {
+					lines[0] = model.normalizeWhitespace(lines[0]);
 					for (let i = 1; i < lines.length; i++) {
-						let templateLeadingWhitespace = getLeadingWhitespace(lines[i]);
-						lines[i] = model.normalizeIndentation(lineLeadingWhitespace + templateLeadingWhitespace) + lines[i].substr(templateLeadingWhitespace.length);
+						lines[i] = model.normalizeWhitespace(lineLeadingWhitespace + lines[i]);
 					}
 				}
 

--- a/src/vs/editor/test/common/model/textModel.test.ts
+++ b/src/vs/editor/test/common/model/textModel.test.ts
@@ -864,11 +864,7 @@ suite('Editor Model - TextModel', () => {
 	});
 
 	test('normalizeIndentation 1', () => {
-		let model = createTextModel('',
-			{
-				insertSpaces: false
-			}
-		);
+		let model = createTextModel('', { insertSpaces: false });
 
 		assert.equal(model.normalizeIndentation('\t'), '\t');
 		assert.equal(model.normalizeIndentation('    '), '\t');
@@ -908,6 +904,37 @@ suite('Editor Model - TextModel', () => {
 		assert.equal(model.normalizeIndentation(' \t  a'), '       a');
 		assert.equal(model.normalizeIndentation(' \t a'), '      a');
 		assert.equal(model.normalizeIndentation(' \ta'), '     a');
+
+		model.dispose();
+	});
+
+	test('normalizeWhitespace -> tabs', () => {
+		let model = createTextModel('', { insertSpaces: false });
+
+		assert.equal(model.normalizeWhitespace('\t'), '\t');
+		assert.equal(model.normalizeWhitespace(' '), ' ');
+		assert.equal(model.normalizeWhitespace('\t\t\t\t'), '\t\t\t\t');
+		assert.equal(model.normalizeWhitespace('    '), '\t');
+		assert.equal(model.normalizeWhitespace('   a    a'), '   a\ta');
+		assert.equal(model.normalizeWhitespace('   \ta'), '   \ta');
+		assert.equal(model.normalizeWhitespace('   a   '), '   a   ');
+		assert.equal(model.normalizeWhitespace('   a    '), '   a\t');
+		assert.equal(model.normalizeWhitespace('   \n    '), '   \n\t');
+		assert.equal(model.normalizeWhitespace('         '), '\t\t ');
+		assert.equal(model.normalizeWhitespace('\t    \t'), '\t\t\t');
+		assert.equal(model.normalizeWhitespace('   \n   '), '   \n   ');
+
+		model.dispose();
+	});
+
+	test('normalizeWhitespace -> spaces', () => {
+		let model = createTextModel('');
+
+		assert.equal(model.normalizeWhitespace('\t'), '    ');
+		assert.equal(model.normalizeWhitespace(' '), ' ');
+		assert.equal(model.normalizeWhitespace('\t   '), '       ');
+		assert.equal(model.normalizeWhitespace('\t\n\t'), '    \n    ');
+		assert.equal(model.normalizeWhitespace(' \t'), '     ');
 
 		model.dispose();
 	});

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1867,9 +1867,13 @@ declare namespace monaco.editor {
 		 */
 		getOverviewRulerDecorations(ownerId?: number, filterOutValidation?: boolean): IModelDecoration[];
 		/**
-		 * Normalize a string containing whitespace according to indentation rules (converts to spaces or to tabs).
+		 * Normalize a string containing only whitespace according to indentation rules (converts to spaces or to tabs).
 		 */
 		normalizeIndentation(str: string): string;
+		/**
+		 * Normalize a string whitespace according to indentation options (converts to spaces or to tabs).
+		 */
+		normalizeWhitespace(str: string): string;
 		/**
 		 * Change the options of this model.
 		 */


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #5355
The above issue has been closed but I still believe there could be benefit from implementing it.
The problem this PR solves is as follows:
When user sets his preferences to replace tabs with spaces, and uses some snippets which contain tabs in them, it is expected that tabs are replaced with spaces. That does already work for leading whitespace in each line of snippet output. But that does not occur in the tabs located in the middle of the snippet content. I started looking at this due to an issue created on my vscode extension [here](https://github.com/kdarkhan/vscode-mips-support/issues/6).

Now, regarding replacing spaces with tabs, I am not sure if it should be done. My current work on this does replacement both ways, but I can do it only for tabs-to-spaces direction if requested.

Below is an example to illustrate the problem I am trying to solve:
Given a snippet
`\tadd\t\t${1:\\$t0}, ${2:\\$t1}, ${3:\\$t2}\t\t# $1 = $2 + $3\n`
User preferences are setup to replace tabs with spaces. When snippet executes, `\t` characters should be replaced with spaces which does happen only to the first `\t`. All others remain as tabs.