### PR TITLE
Make hover actions keyboard accessible

### DIFF
--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -607,6 +607,9 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 					showing = true;
 					const controller = QuickFixController.get(this._editor);
 					const elementPosition = dom.getDomNodePagePosition(target);
+					// Hide the hover pre-emptively, otherwise the editor can close the code actions
+					// context menu as well when using keyboard navigation
+					this.hide();
 					controller.showCodeActions(markerCodeActionTrigger, actions, {
 						x: elementPosition.left + 6,
 						y: elementPosition.top + elementPosition.height + 6
@@ -633,7 +636,7 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 	private renderAction(parent: HTMLElement, actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }): IDisposable {
 		const actionContainer = dom.append(parent, $('div.action-container'));
 		const action = dom.append(actionContainer, $('a.action'));
-		action.tabIndex = 0;
+		action.setAttribute('href', '#');
 		action.setAttribute('role', 'button');
 		if (actionOptions.iconClass) {
 			dom.append(action, $(`span.icon.${actionOptions.iconClass}`));

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -633,6 +633,8 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 	private renderAction(parent: HTMLElement, actionOptions: { label: string, iconClass?: string, run: (target: HTMLElement) => void, commandId: string }): IDisposable {
 		const actionContainer = dom.append(parent, $('div.action-container'));
 		const action = dom.append(actionContainer, $('a.action'));
+		action.tabIndex = 0;
+		action.setAttribute('role', 'button');
 		if (actionOptions.iconClass) {
 			dom.append(action, $(`span.icon.${actionOptions.iconClass}`));
 		}


### PR DESCRIPTION
Fixes #95702

This lets you focus the actions via tab and they are correctly marked as role=button

![image](https://user-images.githubusercontent.com/2193314/79771518-c0ad6e80-82e3-11ea-95fc-7073236e62dd.png)
