### PR TITLE
Use LabelService for SCM repo name (fixes #40548)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/mainPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/mainPane.ts
@@ -6,7 +6,6 @@
 import 'vs/css!./media/scmViewlet';
 import { localize } from 'vs/nls';
 import { Event, Emitter } from 'vs/base/common/event';
-import { basename } from 'vs/base/common/resources';
 import { IDisposable, dispose, Disposable, DisposableStore, combinedDisposable } from 'vs/base/common/lifecycle';
 import { ViewPane, IViewPaneOptions } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { append, $, toggleClass } from 'vs/base/browser/dom';
@@ -133,13 +132,8 @@ class ProviderRenderer implements IListRenderer<ISCMRepository, RepositoryTempla
 		templateData.disposable.dispose();
 		const disposables = new DisposableStore();
 
-		if (repository.provider.rootUri) {
-			templateData.title.textContent = basename(repository.provider.rootUri);
-			templateData.type.textContent = repository.provider.label;
-		} else {
-			templateData.title.textContent = repository.provider.label;
-			templateData.type.textContent = '';
-		}
+		templateData.title.textContent = repository.name;
+		templateData.type.textContent = repository.provider.rootUri ? repository.provider.label : '';
 
 		const actions: IAction[] = [];
 		const disposeActions = () => dispose(actions);

--- a/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/repositoryPane.ts
@@ -687,16 +687,8 @@ export class RepositoryPane extends ViewPane {
 	}
 
 	protected renderHeaderTitle(container: HTMLElement): void {
-		let title: string;
-		let type: string;
-
-		if (this.repository.provider.rootUri) {
-			title = basename(this.repository.provider.rootUri);
-			type = this.repository.provider.label;
-		} else {
-			title = this.repository.provider.label;
-			type = '';
-		}
+		let title = this.repository.name;
+		let type = this.repository.provider.rootUri ? this.repository.provider.label : '';
 
 		super.renderHeaderTitle(container, title);
 		addClass(container, 'scm-provider');

--- a/src/vs/workbench/contrib/scm/common/scm.ts
+++ b/src/vs/workbench/contrib/scm/common/scm.ts
@@ -98,6 +98,7 @@ export interface ISCMRepository extends IDisposable {
 	readonly onDidChangeSelection: Event<boolean>;
 	readonly provider: ISCMProvider;
 	readonly input: ISCMInput;
+	readonly name: string;
 	focus(): void;
 	setSelected(selected: boolean): void;
 }


### PR DESCRIPTION
This PR fixes #40548. In order to fix the ambiguity of having multiple repositories with the same name in the SCM panel due to having the same basename, we used the LabelService to generate a unique, yet short label for each repository's `rootUri`.

As we described in the PR, @juliapagnucco and I are first time contributors to VS Code, so we are unsure if there is any issues with the new dependency or any corner case we forgot to account for. We tested them by replicating the setup described in the issue and observing the names displayed were unique and easy to understand (screenshot shown below).

We also run the existing tests in our local platform and they all passed. It didn't seem like this model pane  had any existing tests (since none broke), so we did not include any additional tests. If the PR looks promising and they are needed, we might be able to add them.

We appreciate your feedback and hope you consider accepting it!

![fixed demo](https://user-images.githubusercontent.com/5330828/79784930-ffa5e900-8310-11ea-8430-a44fdcd69736.png)

