### PR TITLE
Add `reopen with` command to editor title

### DIFF
--- a/src/vs/workbench/browser/contextkeys.ts
+++ b/src/vs/workbench/browser/contextkeys.ts
@@ -7,7 +7,7 @@ import { Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IContextKeyService, IContextKey, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { InputFocusedContext, IsMacContext, IsLinuxContext, IsWindowsContext, IsWebContext, IsMacNativeContext, IsDevelopmentContext } from 'vs/platform/contextkey/common/contextkeys';
-import { ActiveEditorContext, EditorsVisibleContext, TextCompareEditorVisibleContext, TextCompareEditorActiveContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, TEXT_DIFF_EDITOR_ID, SplitEditorsVertically, InEditorZenModeContext, IsCenteredLayoutContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorIsReadonlyContext, EditorAreaVisibleContext, DirtyWorkingCopiesContext } from 'vs/workbench/common/editor';
+import { ActiveEditorContext, EditorsVisibleContext, TextCompareEditorVisibleContext, TextCompareEditorActiveContext, ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext, TEXT_DIFF_EDITOR_ID, SplitEditorsVertically, InEditorZenModeContext, IsCenteredLayoutContext, ActiveEditorGroupIndexContext, ActiveEditorGroupLastContext, ActiveEditorIsReadonlyContext, EditorAreaVisibleContext, DirtyWorkingCopiesContext, ActiveEditorAvailableEditorsContext } from 'vs/workbench/common/editor';
 import { trackFocus, addDisposableListener, EventType } from 'vs/base/browser/dom';
 import { preferredSideBySideGroupDirection, GroupDirection, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -41,6 +41,7 @@ export class WorkbenchContextKeysHandler extends Disposable {
 
 	private activeEditorContext: IContextKey<string | null>;
 	private activeEditorIsReadonly: IContextKey<boolean>;
+	private activeEditorAvailableEditors: IContextKey<string>;
 
 	private activeEditorGroupEmpty: IContextKey<boolean>;
 	private activeEditorGroupIndex: IContextKey<number>;
@@ -91,6 +92,7 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		// Editors
 		this.activeEditorContext = ActiveEditorContext.bindTo(this.contextKeyService);
 		this.activeEditorIsReadonly = ActiveEditorIsReadonlyContext.bindTo(this.contextKeyService);
+		this.activeEditorAvailableEditors = ActiveEditorAvailableEditorsContext.bindTo(this.contextKeyService);
 		this.editorsVisibleContext = EditorsVisibleContext.bindTo(this.contextKeyService);
 		this.textCompareEditorVisibleContext = TextCompareEditorVisibleContext.bindTo(this.contextKeyService);
 		this.textCompareEditorActiveContext = TextCompareEditorActiveContext.bindTo(this.contextKeyService);
@@ -207,9 +209,13 @@ export class WorkbenchContextKeysHandler extends Disposable {
 		if (activeEditorPane) {
 			this.activeEditorContext.set(activeEditorPane.getId());
 			this.activeEditorIsReadonly.set(activeEditorPane.input.isReadonly());
+
+			const editors = this.editorService.getEditorOverrides(activeEditorPane.input, undefined, activeGroup);
+			this.activeEditorAvailableEditors.set(editors.map(([_, entry]) => entry.id).join(','));
 		} else {
 			this.activeEditorContext.reset();
 			this.activeEditorIsReadonly.reset();
+			this.activeEditorAvailableEditors.reset();
 		}
 	}
 

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -32,6 +32,7 @@ import { IFilesConfigurationService, AutoSaveMode } from 'vs/workbench/services/
 export const DirtyWorkingCopiesContext = new RawContextKey<boolean>('dirtyWorkingCopies', false);
 export const ActiveEditorContext = new RawContextKey<string | null>('activeEditor', null);
 export const ActiveEditorIsReadonlyContext = new RawContextKey<boolean>('activeEditorIsReadonly', false);
+export const ActiveEditorAvailableEditorsContext = new RawContextKey<string>('availableEditors', '');
 export const EditorsVisibleContext = new RawContextKey<boolean>('editorIsOpen', false);
 export const EditorPinnedContext = new RawContextKey<boolean>('editorPinned', false);
 export const EditorGroupActiveEditorDirtyContext = new RawContextKey<boolean>('groupActiveEditorDirty', false);

--- a/src/vs/workbench/contrib/customEditor/browser/commands.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/commands.ts
@@ -6,23 +6,18 @@
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { URI } from 'vs/base/common/uri';
 import { Command } from 'vs/editor/browser/editorExtensions';
-import * as nls from 'vs/nls';
-import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { InputFocusedContextKey } from 'vs/platform/contextkey/common/contextkeys';
 import type { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { EditorViewColumn, viewColumnToEditorGroup } from 'vs/workbench/api/common/shared/editor';
-import { IEditorCommandsContext } from 'vs/workbench/common/editor';
-import { defaultCustomEditor } from 'vs/workbench/contrib/customEditor/common/contributedCustomEditors';
 import { CustomEditorInput } from 'vs/workbench/contrib/customEditor/browser/customEditorInput';
+import { defaultCustomEditor } from 'vs/workbench/contrib/customEditor/common/contributedCustomEditors';
 import { CONTEXT_CUSTOM_EDITORS, CONTEXT_FOCUSED_CUSTOM_EDITOR_IS_EDITABLE, ICustomEditorService } from 'vs/workbench/contrib/customEditor/common/customEditor';
-import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-
-const viewCategory = nls.localize('viewCategory', "View");
 
 // #region Open With
 
@@ -33,65 +28,6 @@ CommandsRegistry.registerCommand('_workbench.openWith', (accessor: ServicesAcces
 	const [resource, viewType, options, position] = args;
 	const group = viewColumnToEditorGroup(editorGroupService, position);
 	customEditorService.openWith(resource, viewType, options, editorGroupService.getGroup(group));
-});
-
-// #endregion
-
-// #region Reopen With
-
-const REOPEN_WITH_COMMAND_ID = 'reOpenWith';
-const REOPEN_WITH_TITLE = { value: nls.localize('reopenWith.title', 'Reopen With...'), original: 'Reopen With...' };
-
-KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: REOPEN_WITH_COMMAND_ID,
-	weight: KeybindingWeight.WorkbenchContrib,
-	when: undefined,
-	handler: async (accessor: ServicesAccessor, resource?: URI, editorContext?: IEditorCommandsContext) => {
-		const customEditorService = accessor.get(ICustomEditorService);
-		const editorService = accessor.get(IEditorService);
-		const editorGroupService = accessor.get(IEditorGroupsService);
-
-		let group: IEditorGroup | undefined;
-		if (editorContext) {
-			group = editorGroupService.getGroup(editorContext.groupId);
-		} else if (!resource) {
-			if (editorService.activeEditor) {
-				resource = editorService.activeEditor.resource;
-				group = editorGroupService.activeGroup;
-			}
-		}
-
-		if (!resource) {
-			return;
-		}
-
-		// Make sure the context menu has been dismissed before we prompt.
-		// Otherwise with webviews, we will sometimes close the prompt instantly when the webview is
-		// refocused by the workbench
-		setTimeout(() => {
-			customEditorService.promptOpenWith(resource!, undefined, group);
-		}, 10);
-	}
-});
-
-MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
-	command: {
-		id: REOPEN_WITH_COMMAND_ID,
-		title: REOPEN_WITH_TITLE,
-		category: viewCategory,
-	},
-	when: CONTEXT_CUSTOM_EDITORS.notEqualsTo(''),
-});
-
-MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
-	command: {
-		id: REOPEN_WITH_COMMAND_ID,
-		title: REOPEN_WITH_TITLE,
-		category: viewCategory,
-	},
-	group: '6_reopen',
-	order: 20,
-	when: CONTEXT_CUSTOM_EDITORS.notEqualsTo(''),
 });
 
 // #endregion

--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -26,7 +26,7 @@ import { WorkspaceFolderCountContext } from 'vs/workbench/browser/contextkeys';
 import { IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { OpenFileFolderAction, OpenFileAction, OpenFolderAction, OpenWorkspaceAction } from 'vs/workbench/browser/actions/workspaceActions';
-import { ActiveEditorIsReadonlyContext, DirtyWorkingCopiesContext, ActiveEditorContext } from 'vs/workbench/common/editor';
+import { ActiveEditorIsReadonlyContext, DirtyWorkingCopiesContext, ActiveEditorContext, ActiveEditorAvailableEditorsContext } from 'vs/workbench/common/editor';
 import { SidebarFocusContext } from 'vs/workbench/common/viewlet';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 
@@ -181,6 +181,19 @@ export function appendEditorTitleContextMenuItem(id: string, title: string, when
 		group: group || '2_files'
 	});
 }
+
+// Reopen with editor title
+
+MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
+	command: {
+		id: ReopenResourcesAction.ID,
+		title: ReopenResourcesAction.LABEL,
+		category: fileCategory,
+	},
+	group: '6_reopen',
+	order: 20,
+	when: ActiveEditorAvailableEditorsContext,
+});
 
 // Editor Title Menu for Conflict Resolution
 appendSaveConflictEditorTitleAction('workbench.files.action.acceptLocalChanges', nls.localize('acceptLocalChanges', "Use your changes and overwrite file contents"), { id: 'codicon/check' }, -10, acceptLocalChangesCommand);


### PR DESCRIPTION
For #94408 

Adds a new editor title command for `reopen with` (custom editors already were doing this so I moved over the code required for this)

This also adds a `availableEditors` context key that consists of a comma separated list of editor ids that can be used for `reopen with`


