### PR TITLE
add more json file extensions #95584

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -22,13 +22,12 @@
         "extensions": [
           ".json",
           ".bowerrc",
-          ".jshintrc",
           ".jscsrc",
-          ".swcrc",
           ".webmanifest",
           ".js.map",
           ".css.map",
           ".har",
+          ".jslintrc",
           ".jsonld"
         ],
         "filenames": [
@@ -52,7 +51,10 @@
           ".babelrc",
           ".jsonc",
           ".eslintrc",
-          ".eslintrc.json"
+          ".eslintrc.json",
+          ".jsfmtrc",
+          ".jshintrc",
+          ".swcrc"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Add some more common JSON file extensions, and review JSON/JSONC distinction for existing ones.

- `.jshint` is JSONC:

  https://github.com/jshint/jshint/blob/master/examples/.jshintrc

- `.jsfmt` is JSONC: 

  https://github.com/rdio/jsfmt#jsfmtrc

  > The file is parsed using rc

  https://github.com/dominictarr/rc#formatted-as-json

- `.swcrc` is JSONC:

  https://swc-project.github.io/docs/configuring-swc#jsctarget

This PR fixes #95584
