### PR TITLE
change all instances of `wordHighligher` to `wordHighlighter`

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/wordHighlighter.ts
@@ -465,20 +465,20 @@ class WordHighlighterContribution extends Disposable implements IEditorContribut
 		return editor.getContribution<WordHighlighterContribution>(WordHighlighterContribution.ID);
 	}
 
-	private wordHighligher: WordHighlighter | null;
+	private wordHighlighter: WordHighlighter | null;
 
 	constructor(editor: ICodeEditor, @IContextKeyService contextKeyService: IContextKeyService) {
 		super();
-		this.wordHighligher = null;
+		this.wordHighlighter = null;
 		const createWordHighlighterIfPossible = () => {
 			if (editor.hasModel()) {
-				this.wordHighligher = new WordHighlighter(editor, contextKeyService);
+				this.wordHighlighter = new WordHighlighter(editor, contextKeyService);
 			}
 		};
 		this._register(editor.onDidChangeModel((e) => {
-			if (this.wordHighligher) {
-				this.wordHighligher.dispose();
-				this.wordHighligher = null;
+			if (this.wordHighlighter) {
+				this.wordHighlighter.dispose();
+				this.wordHighlighter = null;
 			}
 			createWordHighlighterIfPossible();
 		}));
@@ -486,34 +486,34 @@ class WordHighlighterContribution extends Disposable implements IEditorContribut
 	}
 
 	public saveViewState(): boolean {
-		if (this.wordHighligher && this.wordHighligher.hasDecorations()) {
+		if (this.wordHighlighter && this.wordHighlighter.hasDecorations()) {
 			return true;
 		}
 		return false;
 	}
 
 	public moveNext() {
-		if (this.wordHighligher) {
-			this.wordHighligher.moveNext();
+		if (this.wordHighlighter) {
+			this.wordHighlighter.moveNext();
 		}
 	}
 
 	public moveBack() {
-		if (this.wordHighligher) {
-			this.wordHighligher.moveBack();
+		if (this.wordHighlighter) {
+			this.wordHighlighter.moveBack();
 		}
 	}
 
 	public restoreViewState(state: boolean | undefined): void {
-		if (this.wordHighligher && state) {
-			this.wordHighligher.restore();
+		if (this.wordHighlighter && state) {
+			this.wordHighlighter.restore();
 		}
 	}
 
 	public dispose(): void {
-		if (this.wordHighligher) {
-			this.wordHighligher.dispose();
-			this.wordHighligher = null;
+		if (this.wordHighlighter) {
+			this.wordHighlighter.dispose();
+			this.wordHighlighter = null;
 		}
 		super.dispose();
 	}


### PR DESCRIPTION
Thanks to all contributors for this awesome editor.

Merging this PR is optional, as the code in `wordHighlighter.ts` works as intended (the property with the typo is private, and the typo is perfectly reproduced each time it is used in the `WordHighlighterContribution` class). However, I think it future-proofs any potential code re-use down the road to correct all occurrences of the typo now.
