### PR TITLE
fix VSCode can not use microphone and camera on MacOS 10.15

### DIFF
--- a/build/azure-pipelines/darwin/entitlements.plist
+++ b/build/azure-pipelines/darwin/entitlements.plist
@@ -10,5 +10,9 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #
    Start VSCode by click it's icon(DO NOT start VSCode via Terminal.app, DO NOT use code -n or other code command) on MacOS 10.15, than exec some command which use microphone, for example 'sox -d ~/test.wav'(may need to exec 'brew install sox' first) in VSCode's TERMINAL.
    There is no dialog shown to request microphone permission. Command sox record nothing in output file and no errors reported, and VSCode is not on Settings → Privacy → Microphone list

   With this patch, when we exec sox first time, there is a dialog shown to request microphone permission. Command sox can record, and VSCode will be on Settings → Privacy → Microphone list.