### PR TITLE
Update compilerOptions for javascript.implicitProjectConfig.experimentalDecorators.

### DIFF
--- a/extensions/html-language-features/server/src/modes/languageModes.ts
+++ b/extensions/html-language-features/server/src/modes/languageModes.ts
@@ -95,8 +95,8 @@ export function getLanguageModes(supportedLanguages: { [languageId: string]: boo
 		modes['css'] = getCSSMode(cssLanguageService, documentRegions, workspace);
 	}
 	if (supportedLanguages['javascript']) {
-		modes['javascript'] = getJavaScriptMode(documentRegions, 'javascript');
-		modes['typescript'] = getJavaScriptMode(documentRegions, 'typescript');
+		modes['javascript'] = getJavaScriptMode(documentRegions, 'javascript', workspace);
+		modes['typescript'] = getJavaScriptMode(documentRegions, 'typescript', workspace);
 	}
 	return {
 		getModeAtPosition(document: TextDocument, position: Position): LanguageMode | undefined {


### PR DESCRIPTION
This PR fixes #92846 

Just as settings are passed into `getCSSMode`, I modified `getJavaScriptMode` to accept an additional parameter of  type `Workspace`. `Workspace.settings` is then passed into `doValidation` to update `experimentalDecorators` in `compilerOptions`, by modifying the object returned by `host.getCompilationSettings`.