### PR TITLE
Fix firefox scroll speed

### DIFF
--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -165,12 +165,13 @@ export class StandardWheelEvent {
 				// https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
 				const ev = <WheelEvent><unknown>e;
 
+				let deltaInPx = -e.deltaY;
 				if (ev.deltaMode === ev.DOM_DELTA_LINE) {
 					// the deltas are expressed in lines
-					this.deltaY = -e.deltaY;
-				} else {
-					this.deltaY = -e.deltaY / 40;
+					// 1 line = 16px by default in firefox (which is the only browser that supports DOM_DELTA_LINE)
+					deltaInPx = -e.deltaY * 16;
 				}
+				this.deltaY = deltaInPx / 40;
 			}
 
 			// horizontal delta scroll
@@ -187,12 +188,13 @@ export class StandardWheelEvent {
 				// https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
 				const ev = <WheelEvent><unknown>e;
 
+				let deltaInPx = -e.deltaX;
 				if (ev.deltaMode === ev.DOM_DELTA_LINE) {
 					// the deltas are expressed in lines
-					this.deltaX = -e.deltaX;
-				} else {
-					this.deltaX = -e.deltaX / 40;
+					// 1 line = 16px by default in firefox (which is the only browser that supports DOM_DELTA_LINE)
+					deltaInPx = -e.deltaX * 16;
 				}
+				this.deltaX = deltaInPx / 40;
 			}
 
 			// Assume a vertical scroll if nothing else worked

--- a/src/vs/base/browser/mouseEvent.ts
+++ b/src/vs/base/browser/mouseEvent.ts
@@ -171,7 +171,7 @@ export class StandardWheelEvent {
 					// 1 line = 16px by default in firefox (which is the only browser that supports DOM_DELTA_LINE)
 					deltaInPx = -e.deltaY * 16;
 				}
-				this.deltaY = deltaInPx / 40;
+				this.deltaY = deltaInPx / 50;
 			}
 
 			// horizontal delta scroll
@@ -194,7 +194,7 @@ export class StandardWheelEvent {
 					// 1 line = 16px by default in firefox (which is the only browser that supports DOM_DELTA_LINE)
 					deltaInPx = -e.deltaX * 16;
 				}
-				this.deltaX = deltaInPx / 40;
+				this.deltaX = deltaInPx / 50;
 			}
 
 			// Assume a vertical scroll if nothing else worked


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/1861

Firefox seems to be the only browser which supports DOM_DELTA_LINE.

In that case, deltaY is a number of lines. By default, its value is 3 or -3 which is then multiplied by 50 to get the scroll offset, so 150px, which is obviously too fast

In other browsers, the deltaY/deltaX is 1 or -1, so the scroll offset is just 50px

see:
- https://stackoverflow.com/questions/20110224/what-is-the-height-of-a-line-in-a-wheel-event-deltamode-dom-delta-line/57788612#57788612
- https://github.com/vaadin/vaadin-grid/pull/1648
