### PR TITLE
Neonit/quickinfo text settings

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -367,6 +367,16 @@ export interface IEditorOptions {
 	 */
 	gotoLocation?: IGotoLocationOptions;
 	/**
+	 * Enable monospace font in quick info boxes.
+	 * Defaults to false.
+	 */
+	quickInfoMonospace?: boolean;
+	/**
+	 * Control whitespace treatment in quick info boxes. Values correspond to CSS white-space values.
+	 * Defaults to 'normal'.
+	 */
+	quickInfoWhitespace?: 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line';
+	/**
 	 * Enable quick suggestions (shadow suggestions)
 	 * Defaults to true.
 	 */
@@ -3404,6 +3414,8 @@ export const enum EditorOption {
 	parameterHints,
 	peekWidgetDefaultFocus,
 	definitionLinkOpensInPeek,
+	quickInfoWhitespace,
+	quickInfoMonospace,
 	quickSuggestions,
 	quickSuggestionsDelay,
 	readOnly,
@@ -3815,6 +3827,24 @@ export const EditorOptions = {
 	definitionLinkOpensInPeek: register(new EditorBooleanOption(
 		EditorOption.definitionLinkOpensInPeek, 'definitionLinkOpensInPeek', false,
 		{ description: nls.localize('definitionLinkOpensInPeek', "Controls whether the Go to Definition mouse gesture always opens the peek widget.") }
+	)),
+	quickInfoMonospace: register(new EditorBooleanOption(
+		EditorOption.quickInfoMonospace, 'quickInfoMonospace', false, { description: nls.localize('quickInfoMonospace', "Controls whether quick info boxes use a monospace font.") }
+	)),
+	quickInfoWhitespace: register(new EditorStringEnumOption(
+		EditorOption.quickInfoWhitespace, 'quickInfoWhitespace',
+		'normal' as 'normal' | 'nowrap' | 'pre' | 'pre-wrap' | 'pre-line',
+		['normal', 'nowrap', 'pre', 'pre-wrap', 'pre-line'] as const,
+		{
+			enumDescriptions: [
+				nls.localize('quickInfoWhitespace.normal', "Sequences of white space are collapsed. Newline characters in the source are handled the same as other white space. Lines are broken as necessary to fill line boxes."),
+				nls.localize('quickInfoWhitespace.nowrap', "Collapses white space as for 'normal', but suppresses line breaks (text wrapping) within the source."),
+				nls.localize('quickInfoWhitespace.pre', "Sequences of white space are preserved. Lines are only broken at newline characters in the source."),
+				nls.localize('quickInfoWhitespace.pre-wrap', "Sequences of white space are preserved. Lines are broken at newline characters and as necessary to fill line boxes."),
+				nls.localize('quickInfoWhitespace.pre-line', "Sequences of white space are collapsed. Lines are broken at newline characters and as necessary to fill line boxes.")
+			],
+			markdownDescription: nls.localize('quickInfoWhitespace', "Controls the treatment of whitespace characters in quick info boxes. The values correspond to the `white-space` CSS property.")
+		}
 	)),
 	quickSuggestions: register(new EditorQuickSuggestions()),
 	quickSuggestionsDelay: register(new EditorIntOption(

--- a/src/vs/editor/contrib/hover/hover.css
+++ b/src/vs/editor/contrib/hover/hover.css
@@ -24,6 +24,23 @@
 	padding: 4px 8px;
 }
 
+.monaco-editor-hover .hover-contents-ff-monospace {
+	font-family: var(--monaco-monospace-font);
+}
+
+.monaco-editor-hover .hover-contents-ws-nowrap p {
+	white-space: nowrap;
+}
+.monaco-editor-hover .hover-contents-ws-pre p {
+	white-space: pre;
+}
+.monaco-editor-hover .hover-contents-ws-pre-wrap p {
+	white-space: pre-wrap;
+}
+.monaco-editor-hover .hover-contents-ws-pre-line p {
+	white-space: pre-line;
+}
+
 .monaco-editor-hover .markdown-hover > .hover-contents:not(.code-hover-contents) {
 	max-width: 500px;
 	word-wrap: break-word;

--- a/src/vs/editor/contrib/hover/modesContentHover.ts
+++ b/src/vs/editor/contrib/hover/modesContentHover.ts
@@ -469,11 +469,7 @@ export class ModesContentHoverWidget extends ContentHoverWidget {
 							const markdownHoverElement = $('div.hover-row.markdown-hover');
 							const hoverContentsElement = dom.append(markdownHoverElement, $('div.hover-contents'));
 
-							// only apply the quick info text style to parts not formatted as code (e.g. function signature parts are completely wrapped in a code block for syntax highlighting)
-							// KNOWN ISSUE: normal text parts starting and ending with a code block will not be formatted according to the options; workaround would be to use one of the other code block fences like ~~~
-							if (!contents.value.startsWith('```') || !contents.value.endsWith('```')) {
-								hoverContentsElement.className += quickInfoSettingsClasses;
-							}
+							hoverContentsElement.className += quickInfoSettingsClasses;
 
 							const renderer = markdownDisposeables.add(new MarkdownRenderer(this._editor, this._modeService, this._openerService));
 							markdownDisposeables.add(renderer.onDidRenderCodeBlock(() => {

--- a/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsLayout.ts
@@ -60,6 +60,11 @@ export const tocData: ITOCEntry = {
 					settings: ['editor.minimap.*']
 				},
 				{
+					id: 'editor/quickInfo',
+					label: localize('quickInfo', "Quick Info"),
+					settings: ['editor.quickInfo*']
+				},
+				{
 					id: 'editor/suggestions',
 					label: localize('suggestions', "Suggestions"),
 					settings: ['editor.*suggest*']


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #96073

## How to test

1. In the editor settings, search for *quick info* to see the newly added options. Configure to your delight.
2. Open a file with a language with quick info documentation support, such as JavaScript or TypeScript. You can use the JavaScript code below for testing.
3. Hover over the symbol `markdownTest` until the quick info box gets displayed. Inspect the text and try out the different new options to see their effect.

## Test Code

```js
/**
 * # Markdown Test
 * 
 * ## Section 1
 * 
 * ### Subsection 1.1
 * This is a general test of inline formatting, such as **bold**, *italic*, ~~strikethrough~~ and `inline code`.
 * 
 * And this is a second paragraph.  
 * 
 * Within paragraphs, spaces        are preserved (also new
 * lines),
 * if the respective feature is enabled.     
 * 
 * ### Subsection 1.2
 * This is a test of various [links](https://code.visualstudio.com/) like this: https://code.visualstudio.com/.
 * 
 * ### Subsection 1.3
 * This is  a test of a code block.
 * 
 * ```js
 * function foo() {
 *     return 42;
 * }
 * ```
 * 
 * ## Section 2
 * 
 * ### Subsection 2.1
 * This is a test of a blockquote.
 * 
 * > I think, thus I am.
 * > Veni, vidi, vinci.
 * > There exist two things, which are infinite. The universe and the amount of files in an initialized node_modules folder.
 * 
 * ### Subsection 2.2
 * This is a test of [references][vscode].
 * 
 * ### Subsection 2.3
 * This is a test of lists.
 * - apple
 *     - sweet
 *     - sour
 * - banana
 *    - greenish
 *       - top
 *       - bottom
 *    - yellow
 *    - brownish
 *       - stains
 *       - stripes
 * - cherry
 * 
 * 1. wake up
 * 2. stretch
 * 3. bathroom
 *    1. wash face
 *    2. pee
 *    3. comb hair
 * 4. kitchen
 *    1. make breakfast
 *       1. toast toasts
 *       2. pour orange
 *          juice
 *    2. eat breakfast
 *       ```
 *       and read this code
 *       ```
 * 5. flee
 * 
 * ## Section 3
 * 
 * ### Subsection 3.1
 * This is a test of tables.
 * 
 * \*|1|2|3|4|5
 * ---|---|---|---|---|---
 * 1|1|2|3|4|5
 * 2|2|4|6|8|10
 * 3|3|6|9|12|15
 * 
 * [vscode]: https://code.visualstudio.com/ 'Visual Studio Code'
 */
function markdownTest() {}
```
