### PR TITLE
Treat `.gitignore_global` as an Ignore file by default.

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -1777,6 +1777,7 @@
           "ignore"
         ],
         "filenames": [
+          ".gitignore_global",
           ".gitignore"
         ],
         "configuration": "./languages/ignore.language-configuration.json"


### PR DESCRIPTION
This PR fixes #96079 .

To reproduce:

1. Create a `.gitignore_global` file, [for example in your home directory as recommended by GitHub](https://help.github.com/en/github/using-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer).
2. Open this file in Code and observe that its language mode is not set to `Ignore`, whereas `.gitignore` files are.

This PR fixes that.