### PR TITLE
Throttle status bar spinner animations to save CPU

### DIFF
--- a/src/vs/base/browser/ui/codicons/codicon/codicon-animations.css
+++ b/src/vs/base/browser/ui/codicons/codicon/codicon-animations.css
@@ -10,5 +10,6 @@
 }
 
 .codicon-animation-spin {
-	animation: codicon-spin 1.5s linear infinite;
+	/* Use steps to throttle FPS to reduce CPU usage */
+	animation: codicon-spin 1.5s steps(30) infinite;
 }

--- a/src/vs/base/browser/ui/tree/media/tree.css
+++ b/src/vs/base/browser/ui/tree/media/tree.css
@@ -61,5 +61,6 @@
 }
 
 .monaco-tl-twistie.codicon-tree-item-loading::before {
-	animation: codicon-spin 1.25s linear infinite;
+	/* Use steps to throttle FPS to reduce CPU usage */
+	animation: codicon-spin 1.25s steps(30) infinite;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes (well, _improves_) #96094, where spinners in the status bar cause higher-than-desired CPU usage in the "Code - Helper (GPU)" process. It's just showing a spinner, which should require very little CPU usage. If the animation is throttled to 20FPS, the CPU usage drops by a lot while still appearing visually smooth. In my typical usage with extensions and files open, my CPU usage in the GPU process goes from ~25% to ~10%. When repro'd on a blank build of OSS VS Code, this is less dramatic (5-8% to 2-3%) but still quite nice. This helps reduce battery drain, especially if you have a lot of extensions that show spinners. Note of course that the measurements here are specific to my machine and are kind of eye-balled.

The spinner still appears quite smooth after this:
![ezgif-6-e4fa8bc2e3ef](https://user-images.githubusercontent.com/1762690/80257292-60953000-8635-11ea-9cb2-7b4ccf50bf77.gif)
(Keep in mind this gif is capped at 25FPS, but it is still somewhat representative of how it looks)

I think it could go down to <20FPS and still look OK, with commensurate decreases in CPU usage (down to 5-8% instead of 10%).

Another option would be a "low power mode" setting for this, and allow this to go down to more like 15-18FPS for much bigger reductions in CPU. This PR just does the minimal change that maintains smoothness to be non-contentious. 


## How to test this change:
Add an extension which creates a status bar spinner, e.g.:
```js
const vscode = require('vscode');
export function activate(context) {
    const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
    statusBar.text = '$(sync~spin) Test';
    statusBar.show();
    context.subscriptions.push(statusBar);
}
```
When this is visible, look at activity monitor / some other process list. Notice CPU% usage of "Code - OSS Helper (GPU)". If you use devtools to reset the `steps` CSS change to `linear`, notice an increase in the activity monitor %CPU (or check before and after this PR for the same workspace).
