### PR TITLE
Explorer: Allow ./ prefix when creating/renaming file

### DIFF
--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -158,7 +158,7 @@ export function isValidBasename(name: string | null | undefined, isWindowsOS: bo
 		return false; // check for certain invalid file names
 	}
 
-	if (name === '.' || name === '..') {
+	if (name === '..') {
 		return false; // check for reserved values
 	}
 

--- a/src/vs/workbench/contrib/files/test/browser/explorerModel.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/explorerModel.test.ts
@@ -222,6 +222,8 @@ suite('Files - View Model', function () {
 		const d = new Date().getTime();
 		const wsFolder = createStat.call(this, '/', 'workspaceFolder', true, false, 8096, d);
 
+		assert(validateFileName(wsFolder, './foo/bar') === null);
+		assert(validateFileName(wsFolder, '../foo/bar') !== null);
 		assert(validateFileName(wsFolder, 'foo/bar') === null);
 		assert(validateFileName(wsFolder, 'foo\\bar') === null);
 		assert(validateFileName(wsFolder, 'all/slashes/are/same') === null);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #96243 by allowing `.` in `extpath.isValidBasename()`
