### PR TITLE
Allow ./ prefix for file

### DIFF
--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -139,8 +139,8 @@ export function isUNC(path: string): boolean {
 }
 
 // Reference: https://en.wikipedia.org/wiki/Filename
-const WINDOWS_INVALID_FILE_CHARS = /\\|(?<!\.)\/|:|\*|\?|"|<|>|\|/g;
-const UNIX_INVALID_FILE_CHARS = /\\|(?<!\.)\//g;
+const WINDOWS_INVALID_FILE_CHARS = /\.\.\/|\\|(?<!\.)\/|:|\*|\?|"|<|>|\|/g;
+const UNIX_INVALID_FILE_CHARS = /\.\.\/|\\|(?<!\.)\//g;
 const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
 export function isValidBasename(name: string | null | undefined, isWindowsOS: boolean = isWindows): boolean {
 	const invalidFileChars = isWindowsOS ? WINDOWS_INVALID_FILE_CHARS : UNIX_INVALID_FILE_CHARS;

--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -139,7 +139,7 @@ export function isUNC(path: string): boolean {
 }
 
 // Reference: https://en.wikipedia.org/wiki/Filename
-const WINDOWS_INVALID_FILE_CHARS = /[\\/:\*\?"<>\|]/g;
+const WINDOWS_INVALID_FILE_CHARS = /\\|(?<!\.)\/|:|\*|\?|"|<|>|\|/g;
 const UNIX_INVALID_FILE_CHARS = /\\|(?<!\.)\//g;
 const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
 export function isValidBasename(name: string | null | undefined, isWindowsOS: boolean = isWindows): boolean {

--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -139,7 +139,7 @@ export function isUNC(path: string): boolean {
 }
 
 // Reference: https://en.wikipedia.org/wiki/Filename
-const WINDOWS_INVALID_FILE_CHARS = /\.\.\/|\\|(?<!\.)\/|:|\*|\?|"|<|>|\|/g;
+const WINDOWS_INVALID_FILE_CHARS = new RegExp('\.\./|(?<!\.)/|[\\:*?"<>|]');
 const UNIX_INVALID_FILE_CHARS = /\.\.\/|\\|(?<!\.)\//g;
 const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
 export function isValidBasename(name: string | null | undefined, isWindowsOS: boolean = isWindows): boolean {

--- a/src/vs/base/common/extpath.ts
+++ b/src/vs/base/common/extpath.ts
@@ -140,7 +140,7 @@ export function isUNC(path: string): boolean {
 
 // Reference: https://en.wikipedia.org/wiki/Filename
 const WINDOWS_INVALID_FILE_CHARS = /[\\/:\*\?"<>\|]/g;
-const UNIX_INVALID_FILE_CHARS = /[\\/]/g;
+const UNIX_INVALID_FILE_CHARS = /\\|(?<!\.)\//g;
 const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
 export function isValidBasename(name: string | null | undefined, isWindowsOS: boolean = isWindows): boolean {
 	const invalidFileChars = isWindowsOS ? WINDOWS_INVALID_FILE_CHARS : UNIX_INVALID_FILE_CHARS;

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -785,7 +785,7 @@ export function validateFileName(item: ExplorerItem, name: string): { content: s
 		};
 	}
 
-	const names = coalesce(name.split(/[\\/]/));
+	const names = coalesce(name.split(/\.\.\/|\\|(?<!\.)\//));
 	const parent = item.parent;
 
 	if (name !== item.name) {

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -785,7 +785,7 @@ export function validateFileName(item: ExplorerItem, name: string): { content: s
 		};
 	}
 
-	const names = coalesce(name.split(/\.\.\/|\\|(?<!\.)\//));
+	const names = coalesce(name.split(/\\|(?<!\.)\//));
 	const parent = item.parent;
 
 	if (name !== item.name) {

--- a/src/vs/workbench/contrib/files/test/browser/explorerModel.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/explorerModel.test.ts
@@ -222,6 +222,8 @@ suite('Files - View Model', function () {
 		const d = new Date().getTime();
 		const wsFolder = createStat.call(this, '/', 'workspaceFolder', true, false, 8096, d);
 
+		assert(validateFileName(wsFolder, './foo/bar') === null);
+		assert(validateFileName(wsFolder, '../foo/bar') !== null);
 		assert(validateFileName(wsFolder, 'foo/bar') === null);
 		assert(validateFileName(wsFolder, 'foo\\bar') === null);
 		assert(validateFileName(wsFolder, 'all/slashes/are/same') === null);

--- a/src/vs/workbench/contrib/files/test/browser/explorerModel.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/explorerModel.test.ts
@@ -222,13 +222,14 @@ suite('Files - View Model', function () {
 		const d = new Date().getTime();
 		const wsFolder = createStat.call(this, '/', 'workspaceFolder', true, false, 8096, d);
 
-		assert(validateFileName(wsFolder, './foo/bar') === null);
-		assert(validateFileName(wsFolder, '../foo/bar') !== null);
+
 		assert(validateFileName(wsFolder, 'foo/bar') === null);
 		assert(validateFileName(wsFolder, 'foo\\bar') === null);
 		assert(validateFileName(wsFolder, 'all/slashes/are/same') === null);
 		assert(validateFileName(wsFolder, 'theres/one/different\\slash') === null);
 		assert(validateFileName(wsFolder, '/slashAtBeginning') !== null);
+		assert(validateFileName(wsFolder, './foo/bar') === null);
+		assert(validateFileName(wsFolder, '../foo/bar') !== null);
 
 		// attempting to add a child to a deeply nested file
 		const s1 = createStat.call(this, '/path', 'path', true, false, 8096, d);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->
I changed Invalid file chars regexes for both UNIX and Windows to allow `./`, but not `/`.
This PR fixes #96243 
