### PR TITLE
Fix command `scm.mainPane.focus` does not focus Source Control Providers view

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/mainPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/mainPane.ts
@@ -249,6 +249,10 @@ export class MainPane extends ViewPane {
 		this.updateBodySize();
 	}
 
+	focus(): void {
+		this.list.domFocus();
+	}
+
 	protected layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
 		this.list.layout(height, width);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #96514
