### PR TITLE
add <path>:line <line> goto pattern #95856

### DIFF
--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -103,7 +103,7 @@ export function getOutOfWorkspaceEditorResources(accessor: ServicesAccessor): UR
 }
 
 // Supports patterns of <path><#|:|(><line><#|:|,><col?>
-const LINE_COLON_PATTERN = /\s?[#:\(](\d*)([#:,](\d*))?\)?\s*$/;
+const LINE_COLON_PATTERN = /\s?[#:\(](line )?(?<line>\d*)([#:,](?<col>\d*))?\)?\s*$/;
 
 export interface IFilterAndRange {
 	filter: string;
@@ -119,8 +119,10 @@ export function extractRangeFromFilter(filter: string, unless?: string[]): IFilt
 
 	// Find Line/Column number from search value using RegExp
 	const patternMatch = LINE_COLON_PATTERN.exec(filter);
-	if (patternMatch && patternMatch.length > 1) {
-		const startLineNumber = parseInt(patternMatch[1], 10);
+
+	if (patternMatch) {
+		const startLineNumber = parseInt(patternMatch.groups?.line ?? '', 10);
+		const startColumn = parseInt(patternMatch.groups?.col ?? '', 10);
 
 		// Line Number
 		if (isNumber(startLineNumber)) {
@@ -132,21 +134,18 @@ export function extractRangeFromFilter(filter: string, unless?: string[]): IFilt
 			};
 
 			// Column Number
-			if (patternMatch.length > 3) {
-				const startColumn = parseInt(patternMatch[3], 10);
-				if (isNumber(startColumn)) {
-					range = {
-						startLineNumber: range.startLineNumber,
-						startColumn: startColumn,
-						endLineNumber: range.endLineNumber,
-						endColumn: startColumn
-					};
-				}
+			if (isNumber(startColumn)) {
+				range = {
+					startLineNumber: range.startLineNumber,
+					startColumn: startColumn,
+					endLineNumber: range.endLineNumber,
+					endColumn: startColumn
+				};
 			}
 		}
 
 		// User has typed "something:" or "something#" without a line number, in this case treat as start of file
-		else if (patternMatch[1] === '') {
+		else if (patternMatch.groups?.line === '') {
 			range = {
 				startLineNumber: 1,
 				startColumn: 1,

--- a/src/vs/workbench/contrib/search/test/common/extractRange.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/extractRange.test.ts
@@ -13,7 +13,7 @@ suite('extractRangeFromFilter', () => {
 		assert.ok(!extractRangeFromFilter('/some/path'));
 		assert.ok(!extractRangeFromFilter('/some/path/file.txt'));
 
-		for (const lineSep of [':', '#', '(']) {
+		for (const lineSep of [':', '#', '(', ':line ']) {
 			for (const colSep of [':', '#', ',']) {
 				const base = '/some/path/file.txt';
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

Adds a `<path>:line <line>` pattern to `extractRangeFromFilter()`. Also, changes the regex to use named capture groups for (hopefully) better readability.

This PR fixes #95856
