### PR TITLE
Use dropdown.background color in debug dropdown

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugActionViewItems.ts
@@ -15,8 +15,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IDebugService, IDebugSession, IDebugConfiguration, IConfig, ILaunch } from 'vs/workbench/contrib/debug/common/debug';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { attachSelectBoxStyler, attachStylerCallback } from 'vs/platform/theme/common/styler';
-import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
-import { selectBorder } from 'vs/platform/theme/common/colorRegistry';
+import { selectBorder, selectBackground } from 'vs/platform/theme/common/colorRegistry';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
@@ -51,9 +50,7 @@ export class StartDebugActionViewItem implements IActionViewItem {
 		this.toDispose = [];
 		this.selectBox = new SelectBox([], -1, contextViewService, undefined, { ariaLabel: nls.localize('debugLaunchConfigurations', 'Debug Launch Configurations') });
 		this.toDispose.push(this.selectBox);
-		this.toDispose.push(attachSelectBoxStyler(this.selectBox, themeService, {
-			selectBackground: SIDE_BAR_BACKGROUND
-		}));
+		this.toDispose.push(attachSelectBoxStyler(this.selectBox, themeService));
 
 		this.registerListeners();
 	}
@@ -124,9 +121,10 @@ export class StartDebugActionViewItem implements IActionViewItem {
 				event.stopPropagation();
 			}
 		}));
-		this.toDispose.push(attachStylerCallback(this.themeService, { selectBorder }, colors => {
+		this.toDispose.push(attachStylerCallback(this.themeService, { selectBorder, selectBackground }, colors => {
 			this.container.style.border = colors.selectBorder ? `1px solid ${colors.selectBorder}` : '';
 			selectBoxContainer.style.borderLeft = colors.selectBorder ? `1px solid ${colors.selectBorder}` : '';
+			this.start.style.backgroundColor = colors.selectBackground ? `${colors.selectBackground}` : '';
 		}));
 		this.debugService.getConfigurationManager().getDynamicProviders().then(providers => {
 			this.providers = providers;

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -42,22 +42,15 @@
 
 .monaco-workbench .part > .title > .title-actions .start-debug-action-item .codicon {
 	line-height: inherit;
-	outline-offset: 0px;
 	flex-shrink: 0;
 	transition: transform 50ms ease;
-}
-
-.monaco-workbench .monaco-action-bar .start-debug-action-item .configuration.select-container {
-	margin-left: 1px;
 }
 
 .monaco-workbench .monaco-action-bar .start-debug-action-item .configuration .monaco-select-box {
 	border: none;
 	margin-top: 0px;
 	cursor: pointer;
-	font-size: inherit;
 	line-height: inherit;
-	outline-offset: 0px;
 }
 
 .monaco-workbench .monaco-action-bar .start-debug-action-item .configuration.disabled .monaco-select-box {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #95704

![image](https://user-images.githubusercontent.com/25115070/80598546-2807a480-89ef-11ea-982f-13ea71eb4f16.png)

Not sure if it's still required to fallback to `SIDE_BAR_BACKGROUND` for the background is there is no color customization for `dropdown.background`
Now it looks like this when there is no color customization

![image](https://user-images.githubusercontent.com/25115070/80601560-977f9300-89f3-11ea-91a6-17c0e74c060a.png)

Also removed some css rules (added in #95935) that were not needed.
