### PR TITLE
Clear out stale CSS style properties on webview

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/main.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/main.js
@@ -197,8 +197,21 @@
 			}
 
 			if (initData.styles) {
+				const documentStyle = document.documentElement.style;
+
+				// Remove stale properties
+				for (let i = documentStyle.length - 1; i >= 0; i--) {
+					const property = documentStyle[i];
+
+					// Don't remove properties that the webview might have added separately
+					if (property && property.startsWith('--vscode-')) {
+						documentStyle.removeProperty(property);
+					}
+				}
+
+				// Re-add new properties
 				for (const variable of Object.keys(initData.styles)) {
-					document.documentElement.style.setProperty(`--${variable}`, initData.styles[variable]);
+					documentStyle.setProperty(`--${variable}`, initData.styles[variable]);
 				}
 			}
 		};


### PR DESCRIPTION
This PR fixes #96621

Tested by loading an extension with a webview and switching themes, confirming that stale theme properties are removed, and all expected theme properties remain. Some gifs of before and after theme changes show that the blue terminal correctly switches to grey after this change:

Before:
![broken](https://user-images.githubusercontent.com/746020/80684698-ed4b4e00-8a7a-11ea-95d6-0d5180a0a3a7.gif)

After:
![fixed](https://user-images.githubusercontent.com/746020/80684704-efada800-8a7a-11ea-8414-6556fff0fb86.gif)
