### PR TITLE
Fix vertical alignment for quick-input count

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -111,7 +111,6 @@
 .quick-input-action .monaco-text-button {
 	font-size: 85%;
 	padding: 0 6px;
-	line-height: initial;
 	display: flex;
 	height: 100%;
 	align-items: center;

--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -95,6 +95,7 @@
 
 .quick-input-count {
 	align-self: center;
+	line-height: 11px;
 	position: absolute;
 	right: 4px;
 }


### PR DESCRIPTION
This PR fixes #89049

Since the pill itself has an explicit line-height: 11px we need to sent the same line-height for the container element so that the container element has the same heigh (11px) as the pill. Below is a screenshot of the quick-pick dialog with the proposed change.

![image](https://user-images.githubusercontent.com/3372902/80806558-47532d00-8bbb-11ea-8bac-bdf86035f3cd.png)