### PR TITLE
Fix custom action registration id

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -313,13 +313,13 @@ export class StandaloneCodeEditor extends CodeEditorWidget implements IStandalon
 		// Register the keybindings
 		if (Array.isArray(keybindings)) {
 			for (const kb of keybindings) {
-				toDispose.add(this._standaloneKeybindingService.addDynamicKeybinding(uniqueId, kb, run, keybindingsWhen));
+				toDispose.add(this._standaloneKeybindingService.addDynamicKeybinding(id, kb, run, keybindingsWhen));
 			}
 		}
 
 		// Finally, register an internal editor action
 		let internalAction = new InternalEditorAction(
-			uniqueId,
+			id,
 			label,
 			label,
 			precondition,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes https://github.com/microsoft/monaco-editor/issues/1953

Currently, actions are registered using a generated global unique id. The reason is that we want to prevent conflicts between action sharing the same id across multiple editors.

We use the same generated id in the code that is specific to a single editor (in the standaloneKeybindingService). I see no reason to do so, since providing the same action id twice to an editor will result in an identical uniqueId as well.

It seems to cause no issue in the normal usage of monaco-editor, but it makes some tweaks impossible, especially in conjunction with monaco-languageclient