### PR TITLE
Fix #90897: check whole line for decreaseIndentPattern

### DIFF
--- a/src/vs/editor/common/modes/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/modes/languageConfigurationRegistry.ts
@@ -630,14 +630,17 @@ export class LanguageConfigurationRegistryImpl {
 			return null;
 		}
 
-		const scopedLineText = scopedLineTokens.getLineContent();
-		const beforeTypeText = scopedLineText.substr(0, range.startColumn - 1 - scopedLineTokens.firstCharOffset);
-
 		// selection support
+		let scopedLineText: string;
+		let beforeTypeText: string;
 		let afterTypeText: string;
 		if (range.isEmpty()) {
-			afterTypeText = scopedLineText.substr(range.startColumn - 1 - scopedLineTokens.firstCharOffset);
+			scopedLineText = model.getLineContent(range.startLineNumber);
+			beforeTypeText = scopedLineText.substr(0, range.startColumn - 1);
+			afterTypeText = scopedLineText.substr(range.startColumn - 1);
 		} else {
+			scopedLineText = scopedLineTokens.getLineContent();
+			beforeTypeText = scopedLineText.substr(0, range.startColumn - 1 - scopedLineTokens.firstCharOffset);
 			const endScopedLineTokens = this.getScopedLineTokens(model, range.endLineNumber, range.endColumn);
 			afterTypeText = endScopedLineTokens.getLineContent().substr(range.endColumn - 1 - scopedLineTokens.firstCharOffset);
 		}


### PR DESCRIPTION
This PR fixes #90897

Upon inspection the issue happens when `editor.autoIndent` is set to 'full'. Right after typing `}`, `beforeTypeText` was empty, and `beforeTypeText + ch + afterTypeText` was `}</p>` and was checked to have the `decreaseIndentPattern`, which I think is not the intended behavior(?). I think the whole line `(indent)<p>{}</p>` should be checked against the pattern. To fix this I take the whole line at `range.startLineNumber` and set `beforeTypeText` to everything before `range.startColumn - 1` in that line.

I'm not sure what selection support in the comment refers to and what the purpose of `scopedLineTokens.firstCharOffset` is, so logic change only happens in the `range.isEmpty()` branch. Also tried adding a test for this but it always passes, as in the indent was always right. Any insight as to why this happens? Looking forward to your feedback!