### PR TITLE
editor groups - resolve #96725

### DIFF
--- a/src/vs/workbench/common/editor/editorGroup.ts
+++ b/src/vs/workbench/common/editor/editorGroup.ts
@@ -662,7 +662,7 @@ export class EditorGroup extends Disposable {
 			return null;
 		}));
 
-		this.mru = data.mru.map(i => this.editors[i]);
+		this.mru = coalesce(data.mru.map(i => this.editors[i]));
 
 		this.active = this.mru[0];
 


### PR DESCRIPTION
This PR fixes #96725

Editor groups use the editor input factories to serialize on shutdown and deserialize on startup. However, an editor factory is free to return `undefined` for both cases to signal the editor cannot be restored.

Upon serialization we alread make sure that `undefined` is handled properly, but not on startup when we deserialize for the list of MRU editors. We need to remove falsify values from the MRU array to ensure we are not storing undefined values in that set. Test added as well. 