### PR TITLE
Fix empty item in explorer after clicking on Collapse Folders action while editing new file/folder

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -743,11 +743,6 @@ export class CollapseExplorerView extends Action {
 		const explorerView = explorerViewlet.getExplorerView();
 		if (explorerView) {
 			explorerView.collapseAll();
-			// If there is something being edited via input box make sure to close it #96198
-			const editable = this.explorerService.getEditable();
-			if (editable) {
-				await this.explorerService.setEditable(editable.stat, null);
-			}
 		}
 	}
 }

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -445,15 +445,12 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 			DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_UP, (e: IKeyboardEvent) => {
 				showInputBoxNotification();
 			}),
+			DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.BLUR, () => {
+				done(inputBox.isInputValid(), true);
+			}),
 			label,
 			styler
 		];
-		setTimeout(() => {
-			// Do not react immediatly on blur events due to tree refresh potentially causing an early blur #96566
-			toDispose.push(DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.BLUR, () => {
-				done(inputBox.isInputValid(), true);
-			}));
-		}, 100);
 
 		return toDisposable(() => {
 			done(false, false);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #96846

1. Call `this.tree.domFocus` in the `collapseAll` method only if we are editing the explorer to cancel it.
2. Add a `cancelEditing` (default `true`) parameter to the `refresh` method, the only place we don't want to cancel edit while refreshing is in the `setEditable` method. With this change the timeout in explorerViewer is not necessary.

Tested this locally on Ubuntu 18.04 on #96846, #96198, #96566