### PR TITLE
Make image/dockerfile/dockerComposeFile optional

### DIFF
--- a/extensions/configuration-editing/schemas/devContainer.schema.json
+++ b/extensions/configuration-editing/schemas/devContainer.schema.json
@@ -282,33 +282,42 @@
 			]
 		}
 	},
-	"allOf": [
+	"oneOf": [
 		{
-			"oneOf": [
+			"allOf": [
 				{
-					"allOf": [
+					"oneOf": [
 						{
-							"oneOf": [
+							"allOf": [
 								{
-									"$ref": "#/definitions/dockerfileContainer"
+									"oneOf": [
+										{
+											"$ref": "#/definitions/dockerfileContainer"
+										},
+										{
+											"$ref": "#/definitions/imageContainer"
+										}
+									]
 								},
 								{
-									"$ref": "#/definitions/imageContainer"
+									"$ref": "#/definitions/nonComposeBase"
 								}
 							]
 						},
 						{
-							"$ref": "#/definitions/nonComposeBase"
+							"$ref": "#/definitions/composeContainer"
 						}
 					]
 				},
 				{
-					"$ref": "#/definitions/composeContainer"
+					"$ref": "#/definitions/devContainerCommon"
 				}
 			]
 		},
 		{
-			"$ref": "#/definitions/devContainerCommon"
+			"type": "object",
+			"$ref": "#/definitions/devContainerCommon",
+			"additionalProperties": false
 		}
 	]
 }


### PR DESCRIPTION
Making image/dockerfile/dockerComposeFile optional for Codespaces.

Making everything optional made IntelliSense no longer propose `image`, `dockerFile`, `dockerComposeFile` and other properties. With the current change the proposals are back to normal once one of the `image`, `dockerFile`, `dockerComposeFile` or `build` properties are added. E.g., once there is a `dockerComposeFile` property proposals for `service` and `workspaceFolder` show up. These would not be shown without the `"additionalProperties": false` rule.

/cc @egamma @Chuxel 