### PR TITLE
Prevent aggressive image name encoding

### DIFF
--- a/extensions/image-preview/src/preview.ts
+++ b/extensions/image-preview/src/preview.ts
@@ -179,7 +179,7 @@ class Preview extends Disposable {
 
 	private async render() {
 		if (this._previewState !== PreviewState.Disposed) {
-			this.webviewEditor.webview.html = await this.getWebiewContents();
+			this.webviewEditor.webview.html = await this.getWebviewContents();
 		}
 	}
 
@@ -203,7 +203,7 @@ class Preview extends Disposable {
 		}
 	}
 
-	private async getWebiewContents(): Promise<string> {
+	private async getWebviewContents(): Promise<string> {
 		const version = Date.now().toString();
 		const settings = {
 			isMac: process.platform === 'darwin',

--- a/extensions/image-preview/src/preview.ts
+++ b/extensions/image-preview/src/preview.ts
@@ -249,9 +249,9 @@ class Preview extends Disposable {
 
 		// Avoid adding cache busting if there is already a query string
 		if (resource.query) {
-			return webviewEditor.webview.asWebviewUri(resource).toString(true);
+			return webviewEditor.webview.asWebviewUri(resource).toString();
 		}
-		return webviewEditor.webview.asWebviewUri(resource).with({ query: `version=${version}` }).toString(true);
+		return webviewEditor.webview.asWebviewUri(resource).with({ query: `version=${version}` }).toString();
 	}
 
 	private extensionResource(path: string) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #96689

Following the discussion on the issue thread, I created this PR which prevents aggressive encoding of image names in the builtin _image-preview_ extension. I don't know why it was set this way. In comparison, the _markdown-language-features_ extension does not use it.

Anyway, disabling it seems to solve the issue.


Also, I fixed a typo in the same file.