### PR TITLE
Make remote status bar item flush with activity bar

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -113,3 +113,12 @@
 	font-size: 14px;
 	color: inherit;
 }
+
+/* make leftmost item with background color flush with activity bar */
+.monaco-workbench .part.statusbar > .items-container > .statusbar-item.has-background-color.left.first-visible-item {
+	width: 48px;
+}
+
+.monaco-workbench .part.statusbar > .items-container > .statusbar-item.has-background-color.left.first-visible-item span.codicon {
+	margin: 0 auto;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Read our Pull Request guidelines:
  https://github.com/Microsoft/vscode/wiki/How-to-Contribute#pull-requests.
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them. 
-->

This PR fixes #96952 and improves visual consistency when the remote item is visible in the status bar.

Before:

![image](https://user-images.githubusercontent.com/7930239/81024209-9ac9b300-8e27-11ea-85a3-f56711ff32e2.png)

After:

![image](https://user-images.githubusercontent.com/7930239/81024378-1d527280-8e28-11ea-9074-a81bd54fdc01.png)
