### PR TITLE
Force custom editors wrapper element in diff view to have 100% height

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts
+++ b/src/vs/workbench/contrib/webview/browser/dynamicWebviewEditorOverlay.ts
@@ -97,6 +97,12 @@ export class DynamicWebviewEditorOverlay extends Disposable implements WebviewOv
 		if (!this.container || !this.container.parentElement) {
 			return;
 		}
+
+		// Workaround for #94805
+		if ((element.classList.contains('details-editor-container') || element.classList.contains('master-editor-container')) && !element.style.height) {
+			element.style.height = '100%';
+		}
+
 		const frameRect = element.getBoundingClientRect();
 		const containerRect = this.container.parentElement.getBoundingClientRect();
 		this.container.style.position = 'absolute';


### PR DESCRIPTION
Fix for #96968

This is a scoped fix for #96968.

The cause of the issue is the following:

1. Webview must be rendered outside of the main editor DOM. We do this by absolutely positioning them over some element in the DOM.
1. In split views, we try to lay the webview out over an element that has 0 height.
1. Due to my workaround in ea07e9bbdc598480dadfd1297e9e817e40802bce, this causes the webview to either not show at all (because it also will have zero height) or partially show

This fix forces the webivew's parent in the split view to have 100%. That actually seems like a reasonable default but to play it safe I've scoped my fix to just webviews with this change 
